### PR TITLE
feat: type-aware call resolution, confidence-weighted impact analysis, co-change mining

### DIFF
--- a/.agents/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: gitnexus-cli
+description: "Use when the user needs to run GitNexus CLI commands like analyze/index a repo, check status, clean the index, generate a wiki, or list indexed repos. Examples: \"Index this repo\", \"Reanalyze the codebase\", \"Generate a wiki\""
+---
+
+# GitNexus CLI Commands
+
+All commands work via `npx` — no global install required.
+
+## Commands
+
+### analyze — Build or refresh the index
+
+```bash
+npx gitnexus analyze
+```
+
+Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates AGENTS.md / AGENTS.md context files.
+
+| Flag           | Effect                                                           |
+| -------------- | ---------------------------------------------------------------- |
+| `--force`      | Force full re-index even if up to date                           |
+| `--embeddings` | Enable embedding generation for semantic search (off by default) |
+| `--drop-embeddings` | Drop existing embeddings on rebuild. By default, an `analyze` without `--embeddings` preserves them. |
+
+**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Codex, a PostToolUse hook detects staleness after `git commit` and `git merge` and notifies the agent to run `analyze` — the hook does not run analyze itself, to avoid blocking the agent for up to 120s and risking KuzuDB corruption on timeout.
+
+### status — Check index freshness
+
+```bash
+npx gitnexus status
+```
+
+Shows whether the current repo has a GitNexus index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
+
+### clean — Delete the index
+
+```bash
+npx gitnexus clean
+```
+
+Deletes the `.gitnexus/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing GitNexus from a project.
+
+| Flag      | Effect                                            |
+| --------- | ------------------------------------------------- |
+| `--force` | Skip confirmation prompt                          |
+| `--all`   | Clean all indexed repos, not just the current one |
+
+### wiki — Generate documentation from the graph
+
+```bash
+npx gitnexus wiki
+```
+
+Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.gitnexus/config.json` on first use).
+
+| Flag                | Effect                                    |
+| ------------------- | ----------------------------------------- |
+| `--force`           | Force full regeneration                   |
+| `--model <model>`   | LLM model (default: minimax/minimax-m2.5) |
+| `--base-url <url>`  | LLM API base URL                          |
+| `--api-key <key>`   | LLM API key                               |
+| `--concurrency <n>` | Parallel LLM calls (default: 3)           |
+| `--gist`            | Publish wiki as a public GitHub Gist      |
+
+### list — Show all indexed repos
+
+```bash
+npx gitnexus list
+```
+
+Lists all repositories registered in `~/.gitnexus/registry.json`. The MCP `list_repos` tool provides the same information.
+
+## After Indexing
+
+1. **Read `gitnexus://repo/{name}/context`** to verify the index loaded
+2. Use the other GitNexus skills (`exploring`, `debugging`, `impact-analysis`, `refactoring`) for your task
+
+## Troubleshooting
+
+- **"Not inside a git repository"**: Run from a directory inside a git repo
+- **Index is stale after re-analyzing**: Restart Codex to reload the MCP server
+- **Embeddings slow**: Omit `--embeddings` (it's off by default) or set `OPENAI_API_KEY` for faster API-based embedding

--- a/.agents/skills/gitnexus/gitnexus-debugging/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-debugging/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: gitnexus-debugging
+description: "Use when the user is debugging a bug, tracing an error, or asking why something fails. Examples: \"Why is X failing?\", \"Where does this error come from?\", \"Trace this bug\""
+---
+
+# Debugging with GitNexus
+
+## When to Use
+
+- "Why is this function failing?"
+- "Trace where this error comes from"
+- "Who calls this method?"
+- "This endpoint returns 500"
+- Investigating bugs, errors, or unexpected behavior
+
+## Workflow
+
+```
+1. gitnexus_query({query: "<error or symptom>"})            → Find related execution flows
+2. gitnexus_context({name: "<suspect>"})                    → See callers/callees/processes
+3. READ gitnexus://repo/{name}/process/{name}                → Trace execution flow
+4. gitnexus_cypher({query: "MATCH path..."})                 → Custom traces if needed
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] Understand the symptom (error message, unexpected behavior)
+- [ ] gitnexus_query for error text or related code
+- [ ] Identify the suspect function from returned processes
+- [ ] gitnexus_context to see callers and callees
+- [ ] Trace execution flow via process resource if applicable
+- [ ] gitnexus_cypher for custom call chain traces if needed
+- [ ] Read source files to confirm root cause
+```
+
+## Debugging Patterns
+
+| Symptom              | GitNexus Approach                                          |
+| -------------------- | ---------------------------------------------------------- |
+| Error message        | `gitnexus_query` for error text → `context` on throw sites |
+| Wrong return value   | `context` on the function → trace callees for data flow    |
+| Intermittent failure | `context` → look for external calls, async deps            |
+| Performance issue    | `context` → find symbols with many callers (hot paths)     |
+| Recent regression    | `detect_changes` to see what your changes affect           |
+
+## Tools
+
+**gitnexus_query** — find code related to error:
+
+```
+gitnexus_query({query: "payment validation error"})
+→ Processes: CheckoutFlow, ErrorHandling
+→ Symbols: validatePayment, handlePaymentError, PaymentException
+```
+
+**gitnexus_context** — full context for a suspect:
+
+```
+gitnexus_context({name: "validatePayment"})
+→ Incoming calls: processCheckout, webhookHandler
+→ Outgoing calls: verifyCard, fetchRates (external API!)
+→ Processes: CheckoutFlow (step 3/7)
+```
+
+**gitnexus_cypher** — custom call chain traces:
+
+```cypher
+MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
+RETURN [n IN nodes(path) | n.name] AS chain
+```
+
+## Example: "Payment endpoint returns 500 intermittently"
+
+```
+1. gitnexus_query({query: "payment error handling"})
+   → Processes: CheckoutFlow, ErrorHandling
+   → Symbols: validatePayment, handlePaymentError
+
+2. gitnexus_context({name: "validatePayment"})
+   → Outgoing calls: verifyCard, fetchRates (external API!)
+
+3. READ gitnexus://repo/my-app/process/CheckoutFlow
+   → Step 3: validatePayment → calls fetchRates (external)
+
+4. Root cause: fetchRates calls external API without proper timeout
+```

--- a/.agents/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: gitnexus-exploring
+description: "Use when the user asks how code works, wants to understand architecture, trace execution flows, or explore unfamiliar parts of the codebase. Examples: \"How does X work?\", \"What calls this function?\", \"Show me the auth flow\""
+---
+
+# Exploring Codebases with GitNexus
+
+## When to Use
+
+- "How does authentication work?"
+- "What's the project structure?"
+- "Show me the main components"
+- "Where is the database logic?"
+- Understanding code you haven't seen before
+
+## Workflow
+
+```
+1. READ gitnexus://repos                          → Discover indexed repos
+2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
+3. gitnexus_query({query: "<what you want to understand>"})  → Find related execution flows
+4. gitnexus_context({name: "<symbol>"})            → Deep dive on specific symbol
+5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
+```
+
+> If step 2 says "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] READ gitnexus://repo/{name}/context
+- [ ] gitnexus_query for the concept you want to understand
+- [ ] Review returned processes (execution flows)
+- [ ] gitnexus_context on key symbols for callers/callees
+- [ ] READ process resource for full execution traces
+- [ ] Read source files for implementation details
+```
+
+## Resources
+
+| Resource                                | What you get                                            |
+| --------------------------------------- | ------------------------------------------------------- |
+| `gitnexus://repo/{name}/context`        | Stats, staleness warning (~150 tokens)                  |
+| `gitnexus://repo/{name}/clusters`       | All functional areas with cohesion scores (~300 tokens) |
+| `gitnexus://repo/{name}/cluster/{name}` | Area members with file paths (~500 tokens)              |
+| `gitnexus://repo/{name}/process/{name}` | Step-by-step execution trace (~200 tokens)              |
+
+## Tools
+
+**gitnexus_query** — find execution flows related to a concept:
+
+```
+gitnexus_query({query: "payment processing"})
+→ Processes: CheckoutFlow, RefundFlow, WebhookHandler
+→ Symbols grouped by flow with file locations
+```
+
+**gitnexus_context** — 360-degree view of a symbol:
+
+```
+gitnexus_context({name: "validateUser"})
+→ Incoming calls: loginHandler, apiMiddleware
+→ Outgoing calls: checkToken, getUserById
+→ Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
+```
+
+## Example: "How does payment processing work?"
+
+```
+1. READ gitnexus://repo/my-app/context       → 918 symbols, 45 processes
+2. gitnexus_query({query: "payment processing"})
+   → CheckoutFlow: processPayment → validateCard → chargeStripe
+   → RefundFlow: initiateRefund → calculateRefund → processRefund
+3. gitnexus_context({name: "processPayment"})
+   → Incoming: checkoutHandler, webhookHandler
+   → Outgoing: validateCard, chargeStripe, saveTransaction
+4. Read src/payments/processor.ts for implementation details
+```

--- a/.agents/skills/gitnexus/gitnexus-guide/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-guide/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: gitnexus-guide
+description: "Use when the user asks about GitNexus itself — available tools, how to query the knowledge graph, MCP resources, graph schema, or workflow reference. Examples: \"What GitNexus tools are available?\", \"How do I use GitNexus?\""
+---
+
+# GitNexus Guide
+
+Quick reference for all GitNexus MCP tools, resources, and the knowledge graph schema.
+
+## Always Start Here
+
+For any task involving code understanding, debugging, impact analysis, or refactoring:
+
+1. **Read `gitnexus://repo/{name}/context`** — codebase overview + check index freshness
+2. **Match your task to a skill below** and **read that skill file**
+3. **Follow the skill's workflow and checklist**
+
+> If step 1 warns the index is stale, run `npx gitnexus analyze` in the terminal first.
+
+## Skills
+
+| Task                                         | Skill to read       |
+| -------------------------------------------- | ------------------- |
+| Understand architecture / "How does X work?" | `gitnexus-exploring`         |
+| Blast radius / "What breaks if I change X?"  | `gitnexus-impact-analysis`   |
+| Trace bugs / "Why is X failing?"             | `gitnexus-debugging`         |
+| Rename / extract / split / refactor          | `gitnexus-refactoring`       |
+| Tools, resources, schema reference           | `gitnexus-guide` (this file) |
+| Index, status, clean, wiki CLI commands      | `gitnexus-cli`               |
+
+## Tools Reference
+
+| Tool             | What it gives you                                                        |
+| ---------------- | ------------------------------------------------------------------------ |
+| `query`          | Process-grouped code intelligence — execution flows related to a concept |
+| `context`        | 360-degree symbol view — categorized refs, processes it participates in  |
+| `impact`         | Symbol blast radius — what breaks at depth 1/2/3 with confidence         |
+| `detect_changes` | Git-diff impact — what do your current changes affect                    |
+| `rename`         | Multi-file coordinated rename with confidence-tagged edits               |
+| `cypher`         | Raw graph queries (read `gitnexus://repo/{name}/schema` first)           |
+| `list_repos`     | Discover indexed repos                                                   |
+
+## Resources Reference
+
+Lightweight reads (~100-500 tokens) for navigation:
+
+| Resource                                       | Content                                   |
+| ---------------------------------------------- | ----------------------------------------- |
+| `gitnexus://repo/{name}/context`               | Stats, staleness check                    |
+| `gitnexus://repo/{name}/clusters`              | All functional areas with cohesion scores |
+| `gitnexus://repo/{name}/cluster/{clusterName}` | Area members                              |
+| `gitnexus://repo/{name}/processes`             | All execution flows                       |
+| `gitnexus://repo/{name}/process/{processName}` | Step-by-step trace                        |
+| `gitnexus://repo/{name}/schema`                | Graph schema for Cypher                   |
+
+## Graph Schema
+
+**Nodes:** File, Function, Class, Interface, Method, Community, Process
+**Edges (via CodeRelation.type):** CALLS, IMPORTS, EXTENDS, IMPLEMENTS, DEFINES, MEMBER_OF, STEP_IN_PROCESS
+
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "myFunc"})
+RETURN caller.name, caller.filePath
+```

--- a/.agents/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: gitnexus-impact-analysis
+description: "Use when the user wants to know what will break if they change something, or needs safety analysis before editing code. Examples: \"Is it safe to change X?\", \"What depends on this?\", \"What will break?\""
+---
+
+# Impact Analysis with GitNexus
+
+## When to Use
+
+- "Is it safe to change this function?"
+- "What will break if I modify X?"
+- "Show me the blast radius"
+- "Who uses this code?"
+- Before making non-trivial code changes
+- Before committing — to understand what your changes affect
+
+## Workflow
+
+```
+1. gitnexus_impact({target: "X", direction: "upstream"})  → What depends on this
+2. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
+3. gitnexus_detect_changes()                               → Map current git changes to affected flows
+4. Assess risk and report to user
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] gitnexus_impact({target, direction: "upstream"}) to find dependents
+- [ ] Review d=1 items first (these WILL BREAK)
+- [ ] Check high-confidence (>0.8) dependencies
+- [ ] READ processes to check affected execution flows
+- [ ] gitnexus_detect_changes() for pre-commit check
+- [ ] Assess risk level and report to user
+```
+
+## Understanding Output
+
+| Depth | Risk Level       | Meaning                  |
+| ----- | ---------------- | ------------------------ |
+| d=1   | **WILL BREAK**   | Direct callers/importers |
+| d=2   | LIKELY AFFECTED  | Indirect dependencies    |
+| d=3   | MAY NEED TESTING | Transitive effects       |
+
+## Risk Assessment
+
+| Affected                       | Risk     |
+| ------------------------------ | -------- |
+| <5 symbols, few processes      | LOW      |
+| 5-15 symbols, 2-5 processes    | MEDIUM   |
+| >15 symbols or many processes  | HIGH     |
+| Critical path (auth, payments) | CRITICAL |
+
+## Tools
+
+**gitnexus_impact** — the primary tool for symbol blast radius:
+
+```
+gitnexus_impact({
+  target: "validateUser",
+  direction: "upstream",
+  minConfidence: 0.8,
+  maxDepth: 3
+})
+
+→ d=1 (WILL BREAK):
+  - loginHandler (src/auth/login.ts:42) [CALLS, 100%]
+  - apiMiddleware (src/api/middleware.ts:15) [CALLS, 100%]
+
+→ d=2 (LIKELY AFFECTED):
+  - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
+```
+
+**gitnexus_detect_changes** — git-diff based impact analysis:
+
+```
+gitnexus_detect_changes({scope: "staged"})
+
+→ Changed: 5 symbols in 3 files
+→ Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
+→ Risk: MEDIUM
+```
+
+## Example: "What breaks if I change validateUser?"
+
+```
+1. gitnexus_impact({target: "validateUser", direction: "upstream"})
+   → d=1: loginHandler, apiMiddleware (WILL BREAK)
+   → d=2: authRouter, sessionManager (LIKELY AFFECTED)
+
+2. READ gitnexus://repo/my-app/processes
+   → LoginFlow and TokenRefresh touch validateUser
+
+3. Risk: 2 direct callers, 2 processes = MEDIUM
+```

--- a/.agents/skills/gitnexus/gitnexus-refactoring/SKILL.md
+++ b/.agents/skills/gitnexus/gitnexus-refactoring/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: gitnexus-refactoring
+description: "Use when the user wants to rename, extract, split, move, or restructure code safely. Examples: \"Rename this function\", \"Extract this into a module\", \"Refactor this class\", \"Move this to a separate file\""
+---
+
+# Refactoring with GitNexus
+
+## When to Use
+
+- "Rename this function safely"
+- "Extract this into a module"
+- "Split this service"
+- "Move this to a new file"
+- Any task involving renaming, extracting, splitting, or restructuring code
+
+## Workflow
+
+```
+1. gitnexus_impact({target: "X", direction: "upstream"})  → Map all dependents
+2. gitnexus_query({query: "X"})                            → Find execution flows involving X
+3. gitnexus_context({name: "X"})                           → See all incoming/outgoing refs
+4. Plan update order: interfaces → implementations → callers → tests
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklists
+
+### Rename Symbol
+
+```
+- [ ] gitnexus_rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+- [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
+- [ ] If satisfied: gitnexus_rename({..., dry_run: false}) — apply edits
+- [ ] gitnexus_detect_changes() — verify only expected files changed
+- [ ] Run tests for affected processes
+```
+
+### Extract Module
+
+```
+- [ ] gitnexus_context({name: target}) — see all incoming/outgoing refs
+- [ ] gitnexus_impact({target, direction: "upstream"}) — find all external callers
+- [ ] Define new module interface
+- [ ] Extract code, update imports
+- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] Run tests for affected processes
+```
+
+### Split Function/Service
+
+```
+- [ ] gitnexus_context({name: target}) — understand all callees
+- [ ] Group callees by responsibility
+- [ ] gitnexus_impact({target, direction: "upstream"}) — map callers to update
+- [ ] Create new functions/services
+- [ ] Update callers
+- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] Run tests for affected processes
+```
+
+## Tools
+
+**gitnexus_rename** — automated multi-file rename:
+
+```
+gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+→ 12 edits across 8 files
+→ 10 graph edits (high confidence), 2 ast_search edits (review)
+→ Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
+```
+
+**gitnexus_impact** — map all dependents first:
+
+```
+gitnexus_impact({target: "validateUser", direction: "upstream"})
+→ d=1: loginHandler, apiMiddleware, testUtils
+→ Affected Processes: LoginFlow, TokenRefresh
+```
+
+**gitnexus_detect_changes** — verify your changes after refactoring:
+
+```
+gitnexus_detect_changes({scope: "all"})
+→ Changed: 8 files, 12 symbols
+→ Affected processes: LoginFlow, TokenRefresh
+→ Risk: MEDIUM
+```
+
+**gitnexus_cypher** — custom reference queries:
+
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
+RETURN caller.name, caller.filePath ORDER BY caller.filePath
+```
+
+## Risk Rules
+
+| Risk Factor         | Mitigation                                |
+| ------------------- | ----------------------------------------- |
+| Many callers (>5)   | Use gitnexus_rename for automated updates |
+| Cross-area refs     | Use detect_changes after to verify scope  |
+| String/dynamic refs | gitnexus_query to find them               |
+| External/public API | Version and deprecate properly            |
+
+## Example: Rename `validateUser` to `authenticateUser`
+
+```
+1. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+   → 12 edits: 10 graph (safe), 2 ast_search (review)
+   → Files: validator.ts, login.ts, middleware.ts, config.json...
+
+2. Review ast_search edits (config.json: dynamic reference!)
+
+3. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+   → Applied 12 edits across 8 files
+
+4. gitnexus_detect_changes({scope: "all"})
+   → Affected: LoginFlow, TokenRefresh
+   → Risk: MEDIUM — run tests for these flows
+```

--- a/crates/nestweaver-engine/src/blast_radius.rs
+++ b/crates/nestweaver-engine/src/blast_radius.rs
@@ -33,6 +33,10 @@ pub struct AffectedSymbol {
     pub depth: u32,
     pub edge_type: String,
     pub confidence: f32,
+    /// Confidence-weighted impact score (1.0 = direct high-confidence edge,
+    /// decays multiplicatively through the graph). Used for sorting results
+    /// so the most-affected symbols appear first.
+    pub impact_score: f64,
 }
 
 /// A cluster (community) that contains affected symbols.
@@ -120,10 +124,19 @@ pub fn analyze_blast_radius(
                     depth: node.depth,
                     edge_type: node.edge_type,
                     confidence: node.confidence,
+                    impact_score: node.impact_score,
                 });
             }
         }
     }
+
+    // Sort affected symbols by impact_score (highest first).
+    affected_symbols.sort_by(|a, b| {
+        b.impact_score
+            .partial_cmp(&a.impact_score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.uid.cmp(&b.uid))
+    });
 
     // Step 3: Group by clusters if cluster data is available.
     let mut affected_clusters: Vec<AffectedCluster> = Vec::new();
@@ -437,5 +450,148 @@ mod tests {
         // fn_a has pagerank_score=0.5 (high centrality), which boosts
         // the risk from Low to Medium even with only 1 affected symbol.
         assert_eq!(result.risk_level, RiskLevel::Medium);
+
+        // Verify impact_score is populated: sym_b calls sym_a with confidence 0.9,
+        // so impact_score should be 1.0 * 0.9 = 0.9.
+        let score = result.affected_symbols[0].impact_score;
+        assert!(
+            (score - 0.9).abs() < 1e-6,
+            "expected impact_score ~0.9, got {score}"
+        );
+    }
+
+    #[test]
+    fn impact_score_decays_through_chain() {
+        use nestweaver_schema::{EdgeType, ResolvedEdge, Symbol, SymbolKind, Visibility};
+
+        let store = GraphStore::in_memory().expect("in_memory store");
+
+        // Build chain: C --0.8--> B --0.9--> A
+        // Changing A should affect B (score 0.9) and C (score 0.9 * 0.8 = 0.72).
+        let make_sym = |uid: &str, name: &str, file: &str| Symbol {
+            uid: uid.to_string(),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            repo_uid: "repo:1".to_string(),
+            file_path: file.to_string(),
+            start_line: 1,
+            end_line: 1,
+            signature: format!("fn {name}()"),
+            summary: None,
+            content_hash: format!("h_{uid}"),
+            embedding: None,
+            pagerank_score: None,
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Inferred,
+            type_info: None,
+            framework_hint: None,
+        };
+
+        for (uid, name, file) in [
+            ("sym:a", "fn_a", "src/a.rs"),
+            ("sym:b", "fn_b", "src/b.rs"),
+            ("sym:c", "fn_c", "src/c.rs"),
+        ] {
+            store.insert_symbol(&make_sym(uid, name, file)).unwrap();
+        }
+
+        // B calls A (confidence 0.9)
+        store
+            .insert_edge(&ResolvedEdge {
+                source_uid: "sym:b".to_string(),
+                target_uid: "sym:a".to_string(),
+                edge_type: EdgeType::Calls,
+                confidence: 0.9,
+                link_type: None,
+            })
+            .unwrap();
+
+        // C calls B (confidence 0.8)
+        store
+            .insert_edge(&ResolvedEdge {
+                source_uid: "sym:c".to_string(),
+                target_uid: "sym:b".to_string(),
+                edge_type: EdgeType::Calls,
+                confidence: 0.8,
+                link_type: None,
+            })
+            .unwrap();
+
+        let result = analyze_blast_radius(&store, &[PathBuf::from("src/a.rs")], 5, None).unwrap();
+
+        assert_eq!(result.affected_symbols.len(), 2);
+        // Results should be sorted by impact_score descending.
+        assert_eq!(result.affected_symbols[0].name, "fn_b");
+        assert!((result.affected_symbols[0].impact_score - 0.9).abs() < 1e-6);
+        assert_eq!(result.affected_symbols[1].name, "fn_c");
+        assert!((result.affected_symbols[1].impact_score - 0.72).abs() < 1e-6);
+    }
+
+    #[test]
+    fn low_confidence_chain_pruned_below_threshold() {
+        use nestweaver_schema::{EdgeType, ResolvedEdge, Symbol, SymbolKind, Visibility};
+
+        let store = GraphStore::in_memory().expect("in_memory store");
+
+        // Build chain: C --0.2--> B --0.3--> A
+        // B's score = 0.3, C's candidate score = 0.3 * 0.2 = 0.06 < 0.10 threshold.
+        // So C should be pruned.
+        let make_sym = |uid: &str, name: &str, file: &str| Symbol {
+            uid: uid.to_string(),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            repo_uid: "repo:1".to_string(),
+            file_path: file.to_string(),
+            start_line: 1,
+            end_line: 1,
+            signature: format!("fn {name}()"),
+            summary: None,
+            content_hash: format!("h_{uid}"),
+            embedding: None,
+            pagerank_score: None,
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Inferred,
+            type_info: None,
+            framework_hint: None,
+        };
+
+        for (uid, name, file) in [
+            ("sym:a", "fn_a", "src/a.rs"),
+            ("sym:b", "fn_b", "src/b.rs"),
+            ("sym:c", "fn_c", "src/c.rs"),
+        ] {
+            store.insert_symbol(&make_sym(uid, name, file)).unwrap();
+        }
+
+        // B calls A (confidence 0.3)
+        store
+            .insert_edge(&ResolvedEdge {
+                source_uid: "sym:b".to_string(),
+                target_uid: "sym:a".to_string(),
+                edge_type: EdgeType::Calls,
+                confidence: 0.3,
+                link_type: None,
+            })
+            .unwrap();
+
+        // C calls B (confidence 0.2)
+        store
+            .insert_edge(&ResolvedEdge {
+                source_uid: "sym:c".to_string(),
+                target_uid: "sym:b".to_string(),
+                edge_type: EdgeType::Calls,
+                confidence: 0.2,
+                link_type: None,
+            })
+            .unwrap();
+
+        let result = analyze_blast_radius(&store, &[PathBuf::from("src/a.rs")], 5, None).unwrap();
+
+        // B is included (score 0.3 >= 0.10), but C is pruned (score 0.06 < 0.10).
+        assert_eq!(result.affected_symbols.len(), 1);
+        assert_eq!(result.affected_symbols[0].name, "fn_b");
+        assert!((result.affected_symbols[0].impact_score - 0.3).abs() < 1e-6);
     }
 }

--- a/crates/nestweaver-engine/src/cochange.rs
+++ b/crates/nestweaver-engine/src/cochange.rs
@@ -1,0 +1,175 @@
+//! Co-change mining from git history.
+//! Identifies file pairs that frequently change together in commits.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CoChangeEdge {
+    pub file_a: String,
+    pub file_b: String,
+    pub cochange_count: u32,
+    pub total_commits_a: u32,
+    pub total_commits_b: u32,
+    pub confidence: f32, // Jaccard coefficient
+}
+
+/// Mine git history for co-changing file pairs.
+pub fn compute_cochanges(
+    repo_path: &Path,
+    max_commits: usize,
+    min_cochange: u32,
+    min_confidence: f32,
+) -> Result<Vec<CoChangeEdge>, anyhow::Error> {
+    // Run git log to get commits and their changed files
+    let output = Command::new("git")
+        .args([
+            "log",
+            "--name-only",
+            "--format=%H",
+            &format!("--max-count={max_commits}"),
+        ])
+        .current_dir(repo_path)
+        .output()?;
+
+    if !output.status.success() {
+        anyhow::bail!("git log failed");
+    }
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    // Parse: each commit is a hash line followed by file lines, then blank line
+    let mut commits: Vec<Vec<String>> = Vec::new();
+    let mut current_files: Vec<String> = Vec::new();
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            if !current_files.is_empty() {
+                commits.push(current_files.clone());
+                current_files.clear();
+            }
+        } else if trimmed.len() == 40 && trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
+            // This is a commit hash — start a new commit
+            if !current_files.is_empty() {
+                commits.push(current_files.clone());
+                current_files.clear();
+            }
+        } else {
+            current_files.push(trimmed.to_string());
+        }
+    }
+    if !current_files.is_empty() {
+        commits.push(current_files);
+    }
+
+    // Count per-file commit frequency
+    let mut file_commits: HashMap<String, u32> = HashMap::new();
+    for commit in &commits {
+        for file in commit {
+            *file_commits.entry(file.clone()).or_default() += 1;
+        }
+    }
+
+    // Count co-change pairs
+    let mut cochange_counts: HashMap<(String, String), u32> = HashMap::new();
+    for commit in &commits {
+        let files: Vec<&String> = commit.iter().collect();
+        for i in 0..files.len() {
+            for j in (i + 1)..files.len() {
+                let (a, b) = if files[i] < files[j] {
+                    (files[i].clone(), files[j].clone())
+                } else {
+                    (files[j].clone(), files[i].clone())
+                };
+                *cochange_counts.entry((a, b)).or_default() += 1;
+            }
+        }
+    }
+
+    // Compute Jaccard coefficient and filter
+    let mut edges: Vec<CoChangeEdge> = cochange_counts
+        .into_iter()
+        .filter_map(|((a, b), count)| {
+            if count < min_cochange {
+                return None;
+            }
+            let total_a = *file_commits.get(&a)?;
+            let total_b = *file_commits.get(&b)?;
+            let jaccard = count as f32 / (total_a + total_b - count) as f32;
+            if jaccard < min_confidence {
+                return None;
+            }
+            Some(CoChangeEdge {
+                file_a: a,
+                file_b: b,
+                cochange_count: count,
+                total_commits_a: total_a,
+                total_commits_b: total_b,
+                confidence: jaccard,
+            })
+        })
+        .collect();
+
+    edges.sort_by(|a, b| {
+        b.confidence
+            .partial_cmp(&a.confidence)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    Ok(edges)
+}
+
+/// Save co-change edges to a sidecar JSON file.
+pub fn save_cochange_sidecar(edges: &[CoChangeEdge], path: &Path) -> Result<(), anyhow::Error> {
+    let json = serde_json::to_string_pretty(edges)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+/// Load co-change edges from a sidecar JSON file.
+pub fn load_cochange_sidecar(path: &Path) -> Option<Vec<CoChangeEdge>> {
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jaccard_coefficient_correct() {
+        // If files A and B both change in 3 commits, A has 5 total, B has 4 total
+        // Jaccard = 3 / (5 + 4 - 3) = 3/6 = 0.5
+        let edge = CoChangeEdge {
+            file_a: "a.rs".into(),
+            file_b: "b.rs".into(),
+            cochange_count: 3,
+            total_commits_a: 5,
+            total_commits_b: 4,
+            confidence: 3.0 / 6.0,
+        };
+        assert!((edge.confidence - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn sidecar_roundtrip() {
+        let edges = vec![CoChangeEdge {
+            file_a: "src/a.rs".into(),
+            file_b: "src/b.rs".into(),
+            cochange_count: 5,
+            total_commits_a: 10,
+            total_commits_b: 8,
+            confidence: 0.385,
+        }];
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cochange.json");
+        save_cochange_sidecar(&edges, &path).unwrap();
+        let loaded = load_cochange_sidecar(&path).unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].file_a, "src/a.rs");
+    }
+}

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -806,7 +806,10 @@ fn index_into_store(
     };
 
     // Build type environments per file for type-aware resolution.
-    let type_envs: std::collections::HashMap<String, nestweaver_resolver::types::TypeEnvironment> = {
+    let mut type_envs: std::collections::HashMap<
+        String,
+        nestweaver_resolver::types::TypeEnvironment,
+    > = {
         let mut envs = std::collections::HashMap::new();
         for (file_path, symbols, _references) in &parsed_files_for_resolver {
             let full_path = repo_path.join(file_path);
@@ -825,6 +828,41 @@ fn index_into_store(
         );
         envs
     };
+
+    // Cross-file return type propagation: seed bindings from known function return types
+    {
+        let all_symbols_with_returns: std::collections::HashMap<
+            &str,
+            &nestweaver_parser::RawSymbol,
+        > = parsed_files_for_resolver
+            .iter()
+            .flat_map(|(_, syms, _)| syms.iter())
+            .filter(|s| {
+                s.type_info
+                    .as_ref()
+                    .and_then(|ti| ti.return_type.as_ref())
+                    .is_some()
+            })
+            .map(|s| (s.name.as_str(), s))
+            .collect();
+
+        if !all_symbols_with_returns.is_empty() {
+            let mut seeded = 0usize;
+            for (file_path, _symbols, _refs) in &parsed_files_for_resolver {
+                if let Some(env) = type_envs.get_mut(file_path) {
+                    let full_path = repo_path.join(file_path);
+                    if let Ok(source) = std::fs::read_to_string(&full_path) {
+                        let before = env.binding_count();
+                        env.seed_return_types(&source, &all_symbols_with_returns);
+                        seeded += env.binding_count() - before;
+                    }
+                }
+            }
+            if seeded > 0 {
+                tracing::info!(new_bindings = seeded, "cross-file return type propagation");
+            }
+        }
+    }
 
     let resolved_edges = resolve_references_with_context(
         &parsed_files_for_resolver,

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -806,7 +806,7 @@ fn index_into_store(
     };
 
     // Build type environments per file for type-aware resolution.
-    let _type_envs: std::collections::HashMap<String, nestweaver_resolver::types::TypeEnvironment> = {
+    let type_envs: std::collections::HashMap<String, nestweaver_resolver::types::TypeEnvironment> = {
         let mut envs = std::collections::HashMap::new();
         for (file_path, symbols, _references) in &parsed_files_for_resolver {
             let full_path = repo_path.join(file_path);
@@ -831,6 +831,7 @@ fn index_into_store(
         language,
         &r_uid,
         &workspace_ctx,
+        Some(&type_envs),
     );
 
     // Filter out unresolved edges whose target doesn't exist in the DB.
@@ -1359,7 +1360,8 @@ fn process_added_or_modified_file(
         parsed.symbols.clone(),
         parsed.references.clone(),
     )];
-    let resolved_edges = resolve_references_with_context(&file_data, lang, r_uid, &workspace_ctx);
+    let resolved_edges =
+        resolve_references_with_context(&file_data, lang, r_uid, &workspace_ctx, None);
     let insertable_edges: Vec<_> = resolved_edges
         .into_iter()
         .filter(|e| !e.target_uid.starts_with("unresolved:"))

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -805,6 +805,27 @@ fn index_into_store(
         Default::default()
     };
 
+    // Build type environments per file for type-aware resolution.
+    let _type_envs: std::collections::HashMap<String, nestweaver_resolver::types::TypeEnvironment> = {
+        let mut envs = std::collections::HashMap::new();
+        for (file_path, symbols, _references) in &parsed_files_for_resolver {
+            let full_path = repo_path.join(file_path);
+            if let Ok(source) = std::fs::read_to_string(&full_path) {
+                let env =
+                    nestweaver_resolver::types::TypeEnvironment::build(&source, language, symbols);
+                if env.binding_count() > 0 {
+                    envs.insert(file_path.clone(), env);
+                }
+            }
+        }
+        tracing::info!(
+            files_with_bindings = envs.len(),
+            total_bindings = envs.values().map(|e| e.binding_count()).sum::<usize>(),
+            "type environments built"
+        );
+        envs
+    };
+
     let resolved_edges = resolve_references_with_context(
         &parsed_files_for_resolver,
         language,

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -49,6 +49,7 @@ pub mod brainignore;
 pub mod bridges;
 pub mod cluster_dispatch;
 pub mod clustering;
+pub mod cochange;
 pub mod config;
 pub mod contracts;
 pub mod cross_domain;
@@ -111,6 +112,7 @@ pub use bridges::{BridgeNode, attach_communities, find_bridge_nodes};
 pub use cluster_dispatch::{
     ClusterMember, ClusteringOutput, CommunityInfo, compute_clusters, load_clusters, save_clusters,
 };
+pub use cochange::{CoChangeEdge, compute_cochanges, load_cochange_sidecar, save_cochange_sidecar};
 pub use config::{
     CrossDomainConfig, ExternalRefConfig, FeatureConfig, GitConfig, GlobRule, InferenceConfig,
     InstanceConfig, LinkConfig, McpServerConfig, ProjectConfig, RankingConfig, RepoConfig,

--- a/crates/nestweaver-engine/src/watch_code.rs
+++ b/crates/nestweaver-engine/src/watch_code.rs
@@ -439,7 +439,8 @@ fn reindex_file(
         parsed.symbols.clone(),
         parsed.references.clone(),
     )];
-    let resolved_edges = resolve_references_with_context(&file_data, lang, r_uid, &workspace_ctx);
+    let resolved_edges =
+        resolve_references_with_context(&file_data, lang, r_uid, &workspace_ctx, None);
     let insertable_edges: Vec<_> = resolved_edges
         .into_iter()
         .filter(|e| !e.target_uid.starts_with("unresolved:"))

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -2603,6 +2603,7 @@ fn tool_brain_impact(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
                 json!({
                     "name": n.name,
                     "depth": n.depth,
+                    "impact_score": n.impact_score,
                 })
             } else {
                 json!({
@@ -2613,6 +2614,7 @@ fn tool_brain_impact(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
                     "edge_type": n.edge_type,
                     "confidence": n.confidence,
                     "depth": n.depth,
+                    "impact_score": n.impact_score,
                 })
             }
         })
@@ -4017,6 +4019,7 @@ fn tool_blast_radius(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
                 "depth": s.depth,
                 "edge_type": s.edge_type,
                 "confidence": s.confidence,
+                "impact_score": s.impact_score,
             })
         })
         .collect();

--- a/crates/nestweaver-parser/src/astro.rs
+++ b/crates/nestweaver-parser/src/astro.rs
@@ -158,6 +158,7 @@ pub fn parse_astro(path: &Path, source: &str) -> ParsedFile {
                     kind: ReferenceKind::Import,
                     start_line: line_no,
                     context: trimmed.to_string(),
+                    receiver: None,
                 });
             } else if let Some(cap) = RE_IMPORT_SIDE.captures(trimmed) {
                 references.push(RawReference {
@@ -165,6 +166,7 @@ pub fn parse_astro(path: &Path, source: &str) -> ParsedFile {
                     kind: ReferenceKind::Import,
                     start_line: line_no,
                     context: trimmed.to_string(),
+                    receiver: None,
                 });
             }
 
@@ -178,6 +180,7 @@ pub fn parse_astro(path: &Path, source: &str) -> ParsedFile {
                             kind: ReferenceKind::Call,
                             start_line: line_no,
                             context: trimmed.to_string(),
+                            receiver: None,
                         });
                     }
                 }

--- a/crates/nestweaver-parser/src/astro.rs
+++ b/crates/nestweaver-parser/src/astro.rs
@@ -98,6 +98,7 @@ pub fn parse_astro(path: &Path, source: &str) -> ParsedFile {
         entry_point_kind: None,
         visibility: Visibility::Public,
         type_info: None,
+        parent_name: None,
     });
 
     // Extract frontmatter block (between --- markers)
@@ -127,6 +128,7 @@ pub fn parse_astro(path: &Path, source: &str) -> ParsedFile {
                     entry_point_kind: None,
                     visibility: Visibility::Public,
                     type_info: None,
+                    parent_name: None,
                 });
             }
 
@@ -146,6 +148,7 @@ pub fn parse_astro(path: &Path, source: &str) -> ParsedFile {
                     entry_point_kind: None,
                     visibility: Visibility::Private,
                     type_info: None,
+                    parent_name: None,
                 });
             }
 

--- a/crates/nestweaver-parser/src/cobol.rs
+++ b/crates/nestweaver-parser/src/cobol.rs
@@ -170,6 +170,7 @@ pub fn parse_cobol(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Call,
                 start_line: line_no,
                 context: line.trim().to_string(),
+                receiver: None,
             });
         }
 
@@ -179,6 +180,7 @@ pub fn parse_cobol(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Call,
                 start_line: line_no,
                 context: line.trim().to_string(),
+                receiver: None,
             });
         }
 
@@ -188,6 +190,7 @@ pub fn parse_cobol(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Includes,
                 start_line: line_no,
                 context: line.trim().to_string(),
+                receiver: None,
             });
         }
     }

--- a/crates/nestweaver-parser/src/cobol.rs
+++ b/crates/nestweaver-parser/src/cobol.rs
@@ -132,6 +132,7 @@ pub fn parse_cobol(path: &Path, source: &str) -> ParsedFile {
                     entry_point_kind: ep_kind,
                     visibility: Visibility::Inferred,
                     type_info: None,
+                    parent_name: None,
                 });
                 continue; // sections can't also be paragraphs
             }
@@ -158,6 +159,7 @@ pub fn parse_cobol(path: &Path, source: &str) -> ParsedFile {
                     entry_point_kind: ep_kind,
                     visibility: Visibility::Inferred,
                     type_info: None,
+                    parent_name: None,
                 });
             }
         }

--- a/crates/nestweaver-parser/src/fortran.rs
+++ b/crates/nestweaver-parser/src/fortran.rs
@@ -173,6 +173,7 @@ pub fn parse_fortran(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Import,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
         }
 
@@ -182,6 +183,7 @@ pub fn parse_fortran(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Includes,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
         }
 
@@ -191,6 +193,7 @@ pub fn parse_fortran(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Call,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
         }
     }

--- a/crates/nestweaver-parser/src/fortran.rs
+++ b/crates/nestweaver-parser/src/fortran.rs
@@ -94,6 +94,7 @@ pub fn parse_fortran(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: Some(nestweaver_schema::EntryPointKind::Main),
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -112,6 +113,7 @@ pub fn parse_fortran(path: &Path, source: &str) -> ParsedFile {
                     entry_point_kind: None,
                     visibility: Visibility::Public,
                     type_info: None,
+                    parent_name: None,
                 });
                 continue;
             }
@@ -129,6 +131,7 @@ pub fn parse_fortran(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -145,6 +148,7 @@ pub fn parse_fortran(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -161,6 +165,7 @@ pub fn parse_fortran(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }

--- a/crates/nestweaver-parser/src/frameworks.rs
+++ b/crates/nestweaver-parser/src/frameworks.rs
@@ -249,6 +249,7 @@ mod tests {
             entry_point_kind: None,
             visibility: Visibility::Public,
             type_info: None,
+            parent_name: None,
         }
     }
 
@@ -264,6 +265,7 @@ mod tests {
             entry_point_kind: None,
             visibility: Visibility::Public,
             type_info: None,
+            parent_name: None,
         }
     }
 

--- a/crates/nestweaver-parser/src/groovy.rs
+++ b/crates/nestweaver-parser/src/groovy.rs
@@ -113,6 +113,7 @@ pub fn parse_groovy(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility,
                 type_info: None,
+                parent_name: None,
             });
 
             // Check for extends/implements on the same line
@@ -153,6 +154,7 @@ pub fn parse_groovy(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -173,6 +175,7 @@ pub fn parse_groovy(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -191,6 +194,7 @@ pub fn parse_groovy(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -228,6 +232,7 @@ pub fn parse_groovy(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: ep_kind,
                 visibility,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }

--- a/crates/nestweaver-parser/src/groovy.rs
+++ b/crates/nestweaver-parser/src/groovy.rs
@@ -122,6 +122,7 @@ pub fn parse_groovy(path: &Path, source: &str) -> ParsedFile {
                     kind: ReferenceKind::Extends,
                     start_line: line_no,
                     context: trimmed.to_string(),
+                    receiver: None,
                 });
             }
             if let Some(impl_cap) = RE_IMPLEMENTS.captures(line) {
@@ -130,6 +131,7 @@ pub fn parse_groovy(path: &Path, source: &str) -> ParsedFile {
                     kind: ReferenceKind::Implements,
                     start_line: line_no,
                     context: trimmed.to_string(),
+                    receiver: None,
                 });
             }
             continue;
@@ -238,6 +240,7 @@ pub fn parse_groovy(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Import,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
             continue;
         }
@@ -267,6 +270,7 @@ pub fn parse_groovy(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Call,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
         }
     }

--- a/crates/nestweaver-parser/src/hcl.rs
+++ b/crates/nestweaver-parser/src/hcl.rs
@@ -78,6 +78,7 @@ pub fn parse_hcl(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -96,6 +97,7 @@ pub fn parse_hcl(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -112,6 +114,7 @@ pub fn parse_hcl(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -128,6 +131,7 @@ pub fn parse_hcl(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -144,6 +148,7 @@ pub fn parse_hcl(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }

--- a/crates/nestweaver-parser/src/hcl.rs
+++ b/crates/nestweaver-parser/src/hcl.rs
@@ -156,6 +156,7 @@ pub fn parse_hcl(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Import,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
         }
 
@@ -165,6 +166,7 @@ pub fn parse_hcl(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Call,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
         }
     }

--- a/crates/nestweaver-parser/src/julia.rs
+++ b/crates/nestweaver-parser/src/julia.rs
@@ -169,6 +169,7 @@ pub fn parse_julia(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Import,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
             continue;
         }
@@ -179,6 +180,7 @@ pub fn parse_julia(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Includes,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
         }
 
@@ -190,6 +192,7 @@ pub fn parse_julia(path: &Path, source: &str) -> ParsedFile {
                     kind: ReferenceKind::Call,
                     start_line: line_no,
                     context: trimmed.to_string(),
+                    receiver: None,
                 });
             }
         }

--- a/crates/nestweaver-parser/src/julia.rs
+++ b/crates/nestweaver-parser/src/julia.rs
@@ -92,6 +92,7 @@ pub fn parse_julia(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -108,6 +109,7 @@ pub fn parse_julia(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -124,6 +126,7 @@ pub fn parse_julia(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -140,6 +143,7 @@ pub fn parse_julia(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -157,6 +161,7 @@ pub fn parse_julia(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }

--- a/crates/nestweaver-parser/src/objc.rs
+++ b/crates/nestweaver-parser/src/objc.rs
@@ -79,6 +79,7 @@ pub fn parse_objc(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -97,6 +98,7 @@ pub fn parse_objc(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -118,6 +120,7 @@ pub fn parse_objc(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -147,6 +150,7 @@ pub fn parse_objc(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: ep_kind,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -171,6 +175,7 @@ pub fn parse_objc(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: ep_kind,
                 visibility,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }

--- a/crates/nestweaver-parser/src/objc.rs
+++ b/crates/nestweaver-parser/src/objc.rs
@@ -183,6 +183,7 @@ pub fn parse_objc(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Import,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
         }
 
@@ -192,6 +193,7 @@ pub fn parse_objc(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Includes,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
         }
 
@@ -209,6 +211,7 @@ pub fn parse_objc(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Call,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
         }
     }

--- a/crates/nestweaver-parser/src/parse.rs
+++ b/crates/nestweaver-parser/src/parse.rs
@@ -67,6 +67,9 @@ pub struct RawSymbol {
     pub entry_point_kind: Option<EntryPointKind>,
     pub visibility: Visibility,
     pub type_info: Option<TypeInfo>,
+    /// The name of the enclosing class/struct/impl/trait for method symbols.
+    /// `None` for top-level functions and non-method symbols.
+    pub parent_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -493,6 +496,50 @@ fn extract_type_info(signature: &str, lang: Language) -> Option<TypeInfo> {
     }
 }
 
+// ── parent name extraction ────────────────────────────────────────────────
+
+/// Walk the tree-sitter AST parent chain from `node` to find the enclosing
+/// class, struct, impl, trait, or interface. Returns the parent type/class name
+/// (e.g. `"GraphStore"` for a method inside `impl GraphStore { ... }`).
+fn find_parent_name(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {
+    let mut current = node.parent();
+    while let Some(parent) = current {
+        match parent.kind() {
+            // Rust: impl Type { ... }
+            "impl_item" => {
+                return parent
+                    .child_by_field_name("type")
+                    .and_then(|t| t.utf8_text(source).ok())
+                    .map(|s| s.to_string());
+            }
+            // JS/TS/Java/C#/Dart/PHP/Python/Ruby: class Name { ... }
+            "class_declaration" | "class_definition" => {
+                return parent
+                    .child_by_field_name("name")
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .map(|s| s.to_string());
+            }
+            // TS/Java: interface Name { ... }
+            "interface_declaration" => {
+                return parent
+                    .child_by_field_name("name")
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .map(|s| s.to_string());
+            }
+            // Rust: trait Name { ... }
+            "trait_item" => {
+                return parent
+                    .child_by_field_name("name")
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .map(|s| s.to_string());
+            }
+            _ => {}
+        }
+        current = parent.parent();
+    }
+    None
+}
+
 // ── core parse ─────────────────────────────────────────────────────────────
 
 /// Parse a single source file and extract symbols and references.
@@ -663,6 +710,11 @@ pub fn parse_source(path: &Path, source: &str) -> Result<ParsedFile, ParseError>
 
                 let visibility = infer_visibility(&name, &node_text, lang);
                 let type_info = extract_type_info(&signature, lang);
+                let parent_name = if kind == SymbolKind::Method {
+                    find_parent_name(&node, source_bytes)
+                } else {
+                    None
+                };
                 symbols.push(RawSymbol {
                     name,
                     kind,
@@ -674,6 +726,7 @@ pub fn parse_source(path: &Path, source: &str) -> Result<ParsedFile, ParseError>
                     entry_point_kind: ep_kind,
                     visibility,
                     type_info,
+                    parent_name,
                 });
             } else if let Some(kind_str) = capture_name.strip_prefix("reference.") {
                 let kind = match kind_str {
@@ -4329,6 +4382,82 @@ arr.map(x => x + 1);
             call_refs[0].receiver.as_deref(),
             Some("arr"),
             "receiver should be 'arr'"
+        );
+    }
+
+    #[test]
+    fn extracts_parent_name_for_rust_impl_method() {
+        let source = r#"
+struct GraphStore;
+impl GraphStore {
+    fn compute_pagerank(&self) {}
+}
+"#;
+        let parsed = parse_source(Path::new("t.rs"), source).unwrap();
+        let method = parsed
+            .symbols
+            .iter()
+            .find(|s| s.name == "compute_pagerank")
+            .expect("should find compute_pagerank symbol");
+        assert_eq!(
+            method.parent_name,
+            Some("GraphStore".to_string()),
+            "method inside impl GraphStore should have parent_name = GraphStore"
+        );
+    }
+
+    #[test]
+    fn top_level_function_has_no_parent() {
+        let source = "fn main() {}";
+        let parsed = parse_source(Path::new("t.rs"), source).unwrap();
+        let func = parsed
+            .symbols
+            .iter()
+            .find(|s| s.name == "main")
+            .expect("should find main symbol");
+        assert_eq!(
+            func.parent_name, None,
+            "top-level function should have no parent_name"
+        );
+    }
+
+    #[test]
+    fn extracts_parent_name_for_ts_class_method() {
+        let source = r#"
+class UserService {
+    fetchUser(id: string) { return null; }
+}
+"#;
+        let parsed = parse_source(Path::new("t.ts"), source).unwrap();
+        let method = parsed
+            .symbols
+            .iter()
+            .find(|s| s.name == "fetchUser")
+            .expect("should find fetchUser symbol");
+        assert_eq!(
+            method.parent_name,
+            Some("UserService".to_string()),
+            "method inside class UserService should have parent_name = UserService"
+        );
+    }
+
+    #[test]
+    fn extracts_parent_name_for_rust_trait_method() {
+        let source = r#"
+trait Drawable {
+    fn draw(&self) {}
+}
+"#;
+        let parsed = parse_source(Path::new("t.rs"), source).unwrap();
+        let method = parsed
+            .symbols
+            .iter()
+            .find(|s| s.name == "draw")
+            .expect("should find draw symbol");
+        assert_eq!(
+            method.parent_name,
+            Some("Drawable".to_string()),
+            "method inside trait Drawable should have parent_name = Drawable"
         );
     }
 }

--- a/crates/nestweaver-parser/src/parse.rs
+++ b/crates/nestweaver-parser/src/parse.rs
@@ -75,6 +75,9 @@ pub struct RawReference {
     pub kind: ReferenceKind,
     pub start_line: u32,
     pub context: String,
+    /// The receiver of a method call: `"store"` in `store.method()`,
+    /// `"self"` in `self.method()`, `None` for free function calls.
+    pub receiver: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -708,11 +711,33 @@ pub fn parse_source(path: &Path, source: &str) -> Result<ParsedFile, ParseError>
                     continue;
                 }
 
+                // Extract receiver for method calls: in `obj.method()`,
+                // the captured `@reference.call` node is the call_expression.
+                // Its `function` child may be a field_expression (Rust) or
+                // member_expression (JS/TS/Java) containing the receiver as
+                // `value` (Rust) or `object` (JS/TS/Java/Go/etc.).
+                let receiver = if kind == ReferenceKind::Call {
+                    node.child_by_field_name("function")
+                        .filter(|f| {
+                            let k = f.kind();
+                            k.contains("field") || k.contains("member")
+                        })
+                        .and_then(|f| {
+                            f.child_by_field_name("object")
+                                .or_else(|| f.child_by_field_name("value"))
+                        })
+                        .and_then(|obj| obj.utf8_text(source_bytes).ok())
+                        .map(|s| s.to_string())
+                } else {
+                    None
+                };
+
                 references.push(RawReference {
                     name,
                     kind,
                     start_line,
                     context,
+                    receiver,
                 });
             }
             // Skip "name" captures — used via find_name_capture above
@@ -4215,5 +4240,95 @@ mod tests {
             let source = fixture("systemverilog/simple.sv");
             assert_yaml_snapshot!(parsed_references("simple.sv", &source));
         }
+    }
+
+    // ── Receiver extraction tests ───────────────────────────────────────────
+
+    #[test]
+    fn extracts_receiver_from_method_call() {
+        let source = r#"
+fn main() {
+    let store = Store::new();
+    store.get_item("key");
+}
+"#;
+        let parsed = parse_source(Path::new("t.rs"), source).unwrap();
+        let call_refs: Vec<_> = parsed
+            .references
+            .iter()
+            .filter(|r| r.kind == ReferenceKind::Call && r.name == "get_item")
+            .collect();
+        assert!(!call_refs.is_empty(), "should find call to 'get_item'");
+        assert_eq!(
+            call_refs[0].receiver.as_deref(),
+            Some("store"),
+            "receiver should be 'store'"
+        );
+    }
+
+    #[test]
+    fn extracts_self_receiver() {
+        let source = r#"
+struct Foo;
+impl Foo {
+    fn bar(&self) {
+        self.baz();
+    }
+    fn baz(&self) {}
+}
+"#;
+        let parsed = parse_source(Path::new("t.rs"), source).unwrap();
+        let call_refs: Vec<_> = parsed
+            .references
+            .iter()
+            .filter(|r| r.kind == ReferenceKind::Call && r.name == "baz")
+            .collect();
+        assert!(!call_refs.is_empty(), "should find call to 'baz'");
+        assert_eq!(
+            call_refs[0].receiver.as_deref(),
+            Some("self"),
+            "receiver should be 'self'"
+        );
+    }
+
+    #[test]
+    fn free_function_has_no_receiver() {
+        let source = r#"
+fn helper() {}
+fn main() {
+    helper();
+}
+"#;
+        let parsed = parse_source(Path::new("t.rs"), source).unwrap();
+        let call_refs: Vec<_> = parsed
+            .references
+            .iter()
+            .filter(|r| r.kind == ReferenceKind::Call && r.name == "helper")
+            .collect();
+        assert!(!call_refs.is_empty(), "should find call to 'helper'");
+        assert_eq!(
+            call_refs[0].receiver, None,
+            "free function should have no receiver"
+        );
+    }
+
+    #[test]
+    fn js_method_call_receiver() {
+        let source = r#"
+const arr = [1, 2, 3];
+arr.map(x => x + 1);
+"#;
+        let parsed = parse_source(Path::new("t.js"), source).unwrap();
+        let call_refs: Vec<_> = parsed
+            .references
+            .iter()
+            .filter(|r| r.kind == ReferenceKind::Call && r.name == "map")
+            .collect();
+        assert!(!call_refs.is_empty(), "should find call to 'map'");
+        assert_eq!(
+            call_refs[0].receiver.as_deref(),
+            Some("arr"),
+            "receiver should be 'arr'"
+        );
     }
 }

--- a/crates/nestweaver-parser/src/pascal.rs
+++ b/crates/nestweaver-parser/src/pascal.rs
@@ -87,6 +87,7 @@ pub fn parse_pascal(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -103,6 +104,7 @@ pub fn parse_pascal(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: Some(nestweaver_schema::EntryPointKind::Main),
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -119,6 +121,7 @@ pub fn parse_pascal(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -136,6 +139,7 @@ pub fn parse_pascal(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
 
             // Extract parent class as extends reference
@@ -163,6 +167,7 @@ pub fn parse_pascal(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -184,6 +189,7 @@ pub fn parse_pascal(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -205,6 +211,7 @@ pub fn parse_pascal(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }

--- a/crates/nestweaver-parser/src/pascal.rs
+++ b/crates/nestweaver-parser/src/pascal.rs
@@ -145,6 +145,7 @@ pub fn parse_pascal(path: &Path, source: &str) -> ParsedFile {
                     kind: ReferenceKind::Extends,
                     start_line: line_no,
                     context: trimmed.to_string(),
+                    receiver: None,
                 });
             }
             continue;
@@ -220,6 +221,7 @@ pub fn parse_pascal(path: &Path, source: &str) -> ParsedFile {
                         kind: ReferenceKind::Import,
                         start_line: line_no,
                         context: trimmed.to_string(),
+                        receiver: None,
                     });
                 }
             }
@@ -232,6 +234,7 @@ pub fn parse_pascal(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Call,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
         }
     }

--- a/crates/nestweaver-parser/src/powershell.rs
+++ b/crates/nestweaver-parser/src/powershell.rs
@@ -206,6 +206,7 @@ pub fn parse_powershell(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Import,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
             continue;
         }
@@ -216,6 +217,7 @@ pub fn parse_powershell(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Includes,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
             continue;
         }
@@ -232,6 +234,7 @@ pub fn parse_powershell(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Call,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
         }
     }

--- a/crates/nestweaver-parser/src/powershell.rs
+++ b/crates/nestweaver-parser/src/powershell.rs
@@ -95,6 +95,7 @@ pub fn parse_powershell(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -112,6 +113,7 @@ pub fn parse_powershell(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -142,6 +144,7 @@ pub fn parse_powershell(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: ep_kind,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -169,6 +172,7 @@ pub fn parse_powershell(path: &Path, source: &str) -> ParsedFile {
                     entry_point_kind: ep_kind,
                     visibility: Visibility::Public,
                     type_info: None,
+                    parent_name: None,
                 });
                 continue;
             }
@@ -194,6 +198,7 @@ pub fn parse_powershell(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: ep_kind,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_astro_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_astro_references.snap
@@ -1,32 +1,40 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 4227
 expression: "parsed_references(\"simple.astro\", &source)"
 ---
 - name: "../layouts/Layout.astro"
   kind: Import
   start_line: 2
   context: "import Layout from '../layouts/Layout.astro'"
+  receiver: ~
 - name: "../components/Card.astro"
   kind: Import
   start_line: 3
   context: "import Card from '../components/Card.astro'"
+  receiver: ~
 - name: getStaticPaths
   kind: Call
   start_line: 5
   context: "export function getStaticPaths() {"
+  receiver: ~
 - name: formatTitle
   kind: Call
   start_line: 12
   context: "function formatTitle(title) {"
+  receiver: ~
 - name: toUpperCase
   kind: Call
   start_line: 13
   context: return title.toUpperCase()
+  receiver: ~
 - name: formatTitle
   kind: Call
   start_line: 16
   context: "const pageTitle = formatTitle('Welcome')"
+  receiver: ~
 - name: fetchItems
   kind: Call
   start_line: 17
   context: const items = await fetchItems()
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_astro_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_astro_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.astro\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: getStaticPaths
   kind: Function
   start_line: 5
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.astro\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: formatTitle
   kind: Function
   start_line: 12
@@ -32,3 +34,4 @@ expression: "parsed_symbols(\"simple.astro\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_bash_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_bash_references.snap
@@ -1,37 +1,45 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 2376
+assertion_line: 4031
 expression: "parsed_references(\"simple.sh\", &source)"
 ---
 - name: source
   kind: Call
   start_line: 3
   context: "#!/bin/bash"
+  receiver: ~
 - name: source
   kind: Import
   start_line: 3
   context: source ./utils.sh
+  receiver: ~
 - name: echo
   kind: Call
   start_line: 8
   context: "{"
+  receiver: ~
 - name: echo
   kind: Call
   start_line: 13
   context: "echo \"$1\" | tr '[:lower:]' '[:upper:]'"
+  receiver: ~
 - name: tr
   kind: Call
   start_line: 13
   context: "echo \"$1\" | tr '[:lower:]' '[:upper:]'"
+  receiver: ~
 - name: format_name
   kind: Call
   start_line: 19
   context: "$(format_name \"world\")"
+  receiver: ~
 - name: greet
   kind: Call
   start_line: 20
   context: "{"
+  receiver: ~
 - name: main
   kind: Call
   start_line: 23
   context: "#!/bin/bash"
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_bash_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_bash_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.sh\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: format_name
   kind: Function
   start_line: 12
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.sh\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: main
   kind: Function
   start_line: 17
@@ -32,3 +34,4 @@ expression: "parsed_symbols(\"simple.sh\", &source)"
   entry_point_kind: Main
   visibility: Inferred
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_c_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_c_references.snap
@@ -1,25 +1,30 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 1936
+assertion_line: 3877
 expression: "parsed_references(\"simple.c\", &source)"
 ---
 - name: sensor.h
   kind: Includes
   start_line: 1
   context: "#include \"sensor.h\""
+  receiver: ~
 - name: "<stdio.h>"
   kind: Includes
   start_line: 2
   context: "#include \"sensor.h\""
+  receiver: ~
 - name: initialize
   kind: Call
   start_line: 30
   context: initialize(&mgr);
+  receiver: ~
 - name: calibrate
   kind: Call
   start_line: 31
   context: val = calibrate(1)
+  receiver: ~
 - name: printf
   kind: Call
   start_line: 32
   context: "printf(\"Calibrated: %d\\n\", val);"
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_c_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_c_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.c\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: id
   kind: Property
   start_line: 5
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.c\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: SensorType
   kind: Enum
   start_line: 9
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.c\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: TEMPERATURE
   kind: Constant
   start_line: 10
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.c\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: HUMIDITY
   kind: Constant
   start_line: 11
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"simple.c\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: PRESSURE
   kind: Constant
   start_line: 12
@@ -62,6 +67,7 @@ expression: "parsed_symbols(\"simple.c\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: SensorManager
   kind: Class
   start_line: 15
@@ -72,6 +78,7 @@ expression: "parsed_symbols(\"simple.c\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: count
   kind: Property
   start_line: 16
@@ -82,6 +89,7 @@ expression: "parsed_symbols(\"simple.c\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: SensorManager
   kind: Class
   start_line: 20
@@ -92,6 +100,7 @@ expression: "parsed_symbols(\"simple.c\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: initialize
   kind: Function
   start_line: 20
@@ -102,6 +111,7 @@ expression: "parsed_symbols(\"simple.c\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: calibrate
   kind: Function
   start_line: 24
@@ -112,6 +122,7 @@ expression: "parsed_symbols(\"simple.c\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: main
   kind: Function
   start_line: 28
@@ -122,6 +133,7 @@ expression: "parsed_symbols(\"simple.c\", &source)"
   entry_point_kind: Main
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: SensorManager
   kind: Class
   start_line: 29
@@ -132,6 +144,7 @@ expression: "parsed_symbols(\"simple.c\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: val
   kind: Variable
   start_line: 31
@@ -142,3 +155,4 @@ expression: "parsed_symbols(\"simple.c\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_cobol_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_cobol_references.snap
@@ -1,25 +1,30 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 2062
+assertion_line: 4003
 expression: "parsed_references(\"simple.cbl\", &source)"
 ---
 - name: INITIALIZE-DATA
   kind: Call
   start_line: 13
   context: PERFORM INITIALIZE-DATA
+  receiver: ~
 - name: PROCESS-GREETING
   kind: Call
   start_line: 14
   context: PERFORM PROCESS-GREETING
+  receiver: ~
 - name: DISPLAY-RESULT
   kind: Call
   start_line: 15
   context: PERFORM DISPLAY-RESULT
+  receiver: ~
 - name: UTIL-PROGRAM
   kind: Call
   start_line: 31
   context: "CALL 'UTIL-PROGRAM' USING WS-NAME."
+  receiver: ~
 - name: COMMON-DEFS
   kind: Includes
   start_line: 34
   context: COPY COMMON-DEFS.
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_cobol_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_cobol_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.cbl\", &source)"
   entry_point_kind: Main
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: INITIALIZE-DATA
   kind: Function
   start_line: 18
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.cbl\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: PROCESS-GREETING
   kind: Function
   start_line: 21
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.cbl\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: DISPLAY-RESULT
   kind: Function
   start_line: 27
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.cbl\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: CALL-EXTERNAL
   kind: Module
   start_line: 30
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"simple.cbl\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: COPY-SECTION
   kind: Module
   start_line: 33
@@ -62,3 +67,4 @@ expression: "parsed_symbols(\"simple.cbl\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_cpp_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_cpp_references.snap
@@ -1,33 +1,40 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 1950
+assertion_line: 3891
 expression: "parsed_references(\"simple.cpp\", &source)"
 ---
 - name: "<iostream>"
   kind: Import
   start_line: 1
   context: "#include <iostream>"
+  receiver: ~
 - name: sensor.h
   kind: Import
   start_line: 2
   context: "#include <iostream>"
+  receiver: ~
 - name: calibrate
   kind: Call
   start_line: 13
   context: calibrate();
+  receiver: ~
 - name: getReading
   kind: Call
   start_line: 17
   context: return getReading(sensorId);
+  receiver: ~
 - name: initialize
   kind: Call
   start_line: 33
   context: mgr.initialize();
+  receiver: ~
 - name: readTemperature
   kind: Call
   start_line: 34
   context: temp = mgr.readTemperature()
+  receiver: ~
 - name: logValue
   kind: Call
   start_line: 35
   context: logValue(temp);
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_cpp_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_cpp_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: initialize
   kind: Method
   start_line: 6
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: readTemperature
   kind: Method
   start_line: 7
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: sensorId
   kind: Property
   start_line: 9
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: initialize
   kind: Method
   start_line: 12
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: readTemperature
   kind: Method
   start_line: 16
@@ -62,6 +67,7 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: SensorConfig
   kind: Class
   start_line: 20
@@ -72,6 +78,7 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: pin
   kind: Property
   start_line: 21
@@ -82,6 +89,7 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: threshold
   kind: Property
   start_line: 22
@@ -92,6 +100,7 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: SensorType
   kind: Enum
   start_line: 25
@@ -102,6 +111,7 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: TEMPERATURE
   kind: Constant
   start_line: 26
@@ -112,6 +122,7 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: HUMIDITY
   kind: Constant
   start_line: 27
@@ -122,6 +133,7 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: PRESSURE
   kind: Constant
   start_line: 28
@@ -132,6 +144,7 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: setup
   kind: Function
   start_line: 31
@@ -142,6 +155,7 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: temp
   kind: Variable
   start_line: 34
@@ -152,3 +166,4 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_csharp_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_csharp_references.snap
@@ -1,29 +1,35 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 1964
+assertion_line: 3905
 expression: "parsed_references(\"Simple.cs\", &source)"
 ---
 - name: System
   kind: Uses
   start_line: 1
   context: using System;
+  receiver: ~
 - name: System.Collections.Generic
   kind: Uses
   start_line: 2
   context: using System;
+  receiver: ~
 - name: IGreeter
   kind: Extends
   start_line: 18
   context: "public class SimpleGreeter : IGreeter"
+  receiver: ~
 - name: WriteLine
   kind: Call
   start_line: 27
   context: Console.WriteLine(message);
+  receiver: ~
 - name: Greet
   kind: Call
   start_line: 36
   context: "result = greeter.Greet(\"World\")"
+  receiver: ~
 - name: WriteLine
   kind: Call
   start_line: 37
   context: Console.WriteLine(result);
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_csharp_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_csharp_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"Simple.cs\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: IGreeter
   kind: Interface
   start_line: 6
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"Simple.cs\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Greet
   kind: Method
   start_line: 8
@@ -35,6 +37,7 @@ expression: "parsed_symbols(\"Simple.cs\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: string
+  parent_name: IGreeter
 - name: Priority
   kind: Enum
   start_line: 11
@@ -45,6 +48,7 @@ expression: "parsed_symbols(\"Simple.cs\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Low
   kind: Constant
   start_line: 13
@@ -55,6 +59,7 @@ expression: "parsed_symbols(\"Simple.cs\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: Medium
   kind: Constant
   start_line: 14
@@ -65,6 +70,7 @@ expression: "parsed_symbols(\"Simple.cs\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: High
   kind: Constant
   start_line: 15
@@ -75,6 +81,7 @@ expression: "parsed_symbols(\"Simple.cs\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: SimpleGreeter
   kind: Class
   start_line: 18
@@ -85,6 +92,7 @@ expression: "parsed_symbols(\"Simple.cs\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Greet
   kind: Method
   start_line: 20
@@ -98,6 +106,7 @@ expression: "parsed_symbols(\"Simple.cs\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: string
+  parent_name: SimpleGreeter
 - name: LogGreeting
   kind: Method
   start_line: 25
@@ -111,6 +120,7 @@ expression: "parsed_symbols(\"Simple.cs\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: void
+  parent_name: SimpleGreeter
 - name: Program
   kind: Class
   start_line: 31
@@ -121,6 +131,7 @@ expression: "parsed_symbols(\"Simple.cs\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Main
   kind: Method
   start_line: 33
@@ -134,3 +145,4 @@ expression: "parsed_symbols(\"Simple.cs\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: void
+  parent_name: Program

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_dart_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_dart_references.snap
@@ -1,49 +1,60 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 1978
+assertion_line: 3919
 expression: "parsed_references(\"simple.dart\", &source)"
 ---
 - name: "package:flutter/material.dart"
   kind: Import
   start_line: 1
   context: "import 'package:flutter/material.dart';"
+  receiver: ~
 - name: helper.dart
   kind: Import
   start_line: 2
   context: "import 'helper.dart';"
+  receiver: ~
 - name: print
   kind: Call
   start_line: 10
   context: print(message);
+  receiver: ~
 - name: Greeter
   kind: Extends
   start_line: 14
   context: "class SimpleGreeter extends Greeter with Loggable {"
+  receiver: ~
 - name: Loggable
   kind: Implements
   start_line: 14
   context: extends Greeter with Loggable
+  receiver: ~
 - name: log
   kind: Call
   start_line: 17
   context: "log('Greeting $name');"
+  receiver: ~
 - name: toUpperCase
   kind: Call
   start_line: 22
   context: return name.toUpperCase();
+  receiver: name
 - name: SimpleGreeter
   kind: Call
   start_line: 29
   context: final greeter = SimpleGreeter()
+  receiver: ~
 - name: greet
   kind: Call
   start_line: 30
   context: "final result = greeter.greet('World')"
+  receiver: greeter
 - name: print
   kind: Call
   start_line: 31
   context: print(result);
+  receiver: ~
 - name: assist
   kind: Call
   start_line: 32
   context: assist();
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_dart_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_dart_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.dart\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Loggable
   kind: Trait
   start_line: 8
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.dart\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: log
   kind: Method
   start_line: 9
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.dart\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: SimpleGreeter
   kind: Class
   start_line: 14
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.dart\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Method
   start_line: 16
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"simple.dart\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: SimpleGreeter
 - name: _formatName
   kind: Method
   start_line: 21
@@ -62,6 +67,7 @@ expression: "parsed_symbols(\"simple.dart\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: SimpleGreeter
 - name: Priority
   kind: Enum
   start_line: 26
@@ -72,6 +78,7 @@ expression: "parsed_symbols(\"simple.dart\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: main
   kind: Function
   start_line: 28
@@ -82,3 +89,4 @@ expression: "parsed_symbols(\"simple.dart\", &source)"
   entry_point_kind: Main
   visibility: Public
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_elixir_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_elixir_references.snap
@@ -1,49 +1,60 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 2404
+assertion_line: 4059
 expression: "parsed_references(\"simple.ex\", &source)"
 ---
 - name: moduledoc
   kind: Call
   start_line: 2
   context: "@moduledoc \"A simple greeter module\""
+  receiver: ~
 - name: GenServer
   kind: Uses
   start_line: 4
   context: do
+  receiver: ~
 - name: Enum
   kind: Import
   start_line: 5
   context: do
+  receiver: ~
 - name: Greeter.Formatter
   kind: Import
   start_line: 6
   context: do
+  receiver: ~
 - name: greet
   kind: Call
   start_line: 8
   context: greet(name)
+  receiver: ~
 - name: format_name
   kind: Call
   start_line: 9
   context: "#{format_name(name)}"
+  receiver: ~
 - name: format_name
   kind: Call
   start_line: 12
   context: format_name(name)
+  receiver: ~
 - name: capitalize
   kind: Call
   start_line: 13
   context: do
+  receiver: ~
 - name: greeting_macro
   kind: Call
   start_line: 16
   context: greeting_macro(name)
+  receiver: ~
 - name: format
   kind: Call
   start_line: 24
   context: format(text)
+  receiver: ~
 - name: trim
   kind: Call
   start_line: 25
   context: do
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_elixir_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_elixir_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.ex\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: moduledoc
   kind: Constant
   start_line: 2
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.ex\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Function
   start_line: 8
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.ex\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: format_name
   kind: Function
   start_line: 12
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.ex\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: greeting_macro
   kind: Function
   start_line: 16
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"simple.ex\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Greeter.Formatter
   kind: Module
   start_line: 23
@@ -62,6 +67,7 @@ expression: "parsed_symbols(\"simple.ex\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: format
   kind: Function
   start_line: 24
@@ -72,3 +78,4 @@ expression: "parsed_symbols(\"simple.ex\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_fortran_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_fortran_references.snap
@@ -1,13 +1,15 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 2592
+assertion_line: 4171
 expression: "parsed_references(\"simple.f90\", &source)"
 ---
 - name: math_utils
   kind: Import
   start_line: 32
   context: use math_utils
+  receiver: ~
 - name: normalize
   kind: Call
   start_line: 41
   context: call normalize(c)
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_fortran_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_fortran_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.f90\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Vector3D
   kind: Class
   start_line: 4
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.f90\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: add_vectors
   kind: Function
   start_line: 10
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.f90\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: normalize
   kind: Function
   start_line: 18
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.f90\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: main
   kind: Module
   start_line: 31
@@ -52,3 +56,4 @@ expression: "parsed_symbols(\"simple.f90\", &source)"
   entry_point_kind: Main
   visibility: Public
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_go_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_go_references.snap
@@ -1,108 +1,135 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 3863
 expression: "parsed_references(\"simple.go\", &source)"
 ---
 - name: fmt
   kind: Import
   start_line: 4
   context: (
+  receiver: ~
 - name: strings
   kind: Import
   start_line: 5
   context: (
+  receiver: ~
 - name: string
   kind: TypeRef
   start_line: 9
   context: (name string)
+  receiver: ~
 - name: string
   kind: TypeRef
   start_line: 10
   context: (name string)
+  receiver: ~
 - name: string
   kind: TypeRef
   start_line: 14
   context: "{"
+  receiver: ~
 - name: ConsoleGreeter
   kind: TypeRef
   start_line: 17
   context: g *ConsoleGreeter
+  receiver: ~
 - name: string
   kind: TypeRef
   start_line: 17
   context: (name string)
+  receiver: ~
 - name: string
   kind: TypeRef
   start_line: 17
   context: package main
+  receiver: ~
 - name: Prefix
   kind: ReadAccess
   start_line: 18
   context: "(\"%s Hello, %s!\", g.Prefix, name)"
+  receiver: ~
 - name: Sprintf
   kind: Call
   start_line: 18
   context: "fmt.Sprintf(\"%s Hello, %s!\", g.Prefix, name)"
+  receiver: ~
 - name: Sprintf
   kind: ReadAccess
   start_line: 18
   context: "fmt.Sprintf(\"%s Hello, %s!\", g.Prefix, name)"
+  receiver: ~
 - name: ConsoleGreeter
   kind: TypeRef
   start_line: 21
   context: g *ConsoleGreeter
+  receiver: ~
 - name: string
   kind: TypeRef
   start_line: 21
   context: (name string)
+  receiver: ~
 - name: string
   kind: TypeRef
   start_line: 21
   context: package main
+  receiver: ~
 - name: Prefix
   kind: ReadAccess
   start_line: 22
   context: "(\"%s Goodbye, %s!\", g.Prefix, name)"
+  receiver: ~
 - name: Sprintf
   kind: Call
   start_line: 22
   context: "fmt.Sprintf(\"%s Goodbye, %s!\", g.Prefix, name)"
+  receiver: ~
 - name: Sprintf
   kind: ReadAccess
   start_line: 22
   context: "fmt.Sprintf(\"%s Goodbye, %s!\", g.Prefix, name)"
+  receiver: ~
 - name: Greeter
   kind: TypeRef
   start_line: 25
   context: package main
+  receiver: ~
 - name: string
   kind: TypeRef
   start_line: 25
   context: (prefix string)
+  receiver: ~
 - name: TrimSpace
   kind: Call
   start_line: 26
   context: strings.TrimSpace(prefix)
+  receiver: ~
 - name: TrimSpace
   kind: ReadAccess
   start_line: 26
   context: strings.TrimSpace(prefix)
+  receiver: ~
 - name: NewGreeter
   kind: Call
   start_line: 30
   context: "NewGreeter(\">>>\")"
+  receiver: ~
 - name: Greet
   kind: Call
   start_line: 31
   context: "greeter.Greet(\"world\")"
+  receiver: ~
 - name: Greet
   kind: ReadAccess
   start_line: 31
   context: "greeter.Greet(\"world\")"
+  receiver: ~
 - name: Println
   kind: Call
   start_line: 32
   context: fmt.Println(result)
+  receiver: ~
 - name: Println
   kind: ReadAccess
   start_line: 32
   context: fmt.Println(result)
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_go_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_go_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.go\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: ConsoleGreeter
   kind: Class
   start_line: 13
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.go\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Prefix
   kind: Property
   start_line: 14
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.go\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Greet
   kind: Method
   start_line: 17
@@ -45,6 +48,7 @@ expression: "parsed_symbols(\"simple.go\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: string
+  parent_name: ~
 - name: Farewell
   kind: Method
   start_line: 21
@@ -58,6 +62,7 @@ expression: "parsed_symbols(\"simple.go\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: string
+  parent_name: ~
 - name: NewGreeter
   kind: Function
   start_line: 25
@@ -71,6 +76,7 @@ expression: "parsed_symbols(\"simple.go\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: Greeter
+  parent_name: ~
 - name: main
   kind: Function
   start_line: 29
@@ -81,3 +87,4 @@ expression: "parsed_symbols(\"simple.go\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_groovy_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_groovy_references.snap
@@ -1,56 +1,70 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 4101
 expression: "parsed_references(\"simple.groovy\", &source)"
 ---
 - name: groovy.transform.CompileStatic
   kind: Import
   start_line: 1
   context: import groovy.transform.CompileStatic
+  receiver: ~
 - name: java.util.logging.Logger
   kind: Import
   start_line: 2
   context: import java.util.logging.Logger
+  receiver: ~
 - name: println
   kind: Call
   start_line: 10
   context: println(message)
+  receiver: ~
 - name: Greeter
   kind: Implements
   start_line: 14
   context: "class SimpleGreeter implements Greeter {"
+  receiver: ~
 - name: SimpleGreeter
   kind: Call
   start_line: 17
   context: "SimpleGreeter(String prefix) {"
+  receiver: ~
 - name: formatName
   kind: Call
   start_line: 22
   context: String formatted = formatName(name)
+  receiver: ~
 - name: capitalize
   kind: Call
   start_line: 27
   context: return name.capitalize()
+  receiver: ~
 - name: SimpleGreeter
   kind: Extends
   start_line: 31
   context: "class FormalGreeter extends SimpleGreeter {"
+  receiver: ~
 - name: FormalGreeter
   kind: Call
   start_line: 32
   context: "FormalGreeter() {"
+  receiver: ~
 - name: super
   kind: Call
   start_line: 33
   context: "super(\"Dear\")"
+  receiver: ~
 - name: SimpleGreeter
   kind: Call
   start_line: 42
   context: "def greeter = new SimpleGreeter(\"Hello\")"
+  receiver: ~
 - name: greet
   kind: Call
   start_line: 43
   context: "println(greeter.greet(\"world\"))"
+  receiver: ~
 - name: println
   kind: Call
   start_line: 43
   context: "println(greeter.greet(\"world\"))"
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_groovy_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_groovy_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.groovy\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Method
   start_line: 5
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.groovy\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Loggable
   kind: Trait
   start_line: 8
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.groovy\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: log
   kind: Method
   start_line: 9
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.groovy\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: SimpleGreeter
   kind: Class
   start_line: 14
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"simple.groovy\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Method
   start_line: 21
@@ -62,6 +67,7 @@ expression: "parsed_symbols(\"simple.groovy\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: formatName
   kind: Method
   start_line: 26
@@ -72,6 +78,7 @@ expression: "parsed_symbols(\"simple.groovy\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: FormalGreeter
   kind: Class
   start_line: 31
@@ -82,6 +89,7 @@ expression: "parsed_symbols(\"simple.groovy\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Priority
   kind: Enum
   start_line: 37
@@ -92,6 +100,7 @@ expression: "parsed_symbols(\"simple.groovy\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: main
   kind: Function
   start_line: 41
@@ -102,3 +111,4 @@ expression: "parsed_symbols(\"simple.groovy\", &source)"
   entry_point_kind: Main
   visibility: Public
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_hcl_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_hcl_references.snap
@@ -1,21 +1,25 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 2578
+assertion_line: 4157
 expression: "parsed_references(\"simple.tf\", &source)"
 ---
 - name: data.aws_ami.ubuntu.id
   kind: Call
   start_line: 24
   context: ami           = data.aws_ami.ubuntu.id
+  receiver: ~
 - name: var.instance_type
   kind: Call
   start_line: 25
   context: instance_type = var.instance_type
+  receiver: ~
 - name: terraform-aws-modules/vpc/aws
   kind: Import
   start_line: 45
   context: "source  = \"terraform-aws-modules/vpc/aws\""
+  receiver: ~
 - name: module.vpc.vpc_id
   kind: Call
   start_line: 59
   context: value       = module.vpc.vpc_id
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_hcl_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_hcl_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.tf\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: instance_type
   kind: Function
   start_line: 7
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.tf\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: aws_ami.ubuntu
   kind: Class
   start_line: 13
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.tf\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: aws_instance.web
   kind: Class
   start_line: 23
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.tf\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: aws_security_group.web_sg
   kind: Class
   start_line: 32
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"simple.tf\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: vpc
   kind: Module
   start_line: 44
@@ -62,6 +67,7 @@ expression: "parsed_symbols(\"simple.tf\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: instance_ip
   kind: Function
   start_line: 52
@@ -72,6 +78,7 @@ expression: "parsed_symbols(\"simple.tf\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: vpc_id
   kind: Function
   start_line: 57
@@ -82,3 +89,4 @@ expression: "parsed_symbols(\"simple.tf\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_java_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_java_references.snap
@@ -1,88 +1,110 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 3933
 expression: "parsed_references(\"Simple.java\", &source)"
 ---
 - name: java.util.List
   kind: Import
   start_line: 1
   context: import java.util.List;
+  receiver: ~
 - name: java.util.ArrayList
   kind: Import
   start_line: 2
   context: import java.util.List;
+  receiver: ~
 - name: String
   kind: TypeRef
   start_line: 5
   context: "{"
+  receiver: ~
 - name: String
   kind: TypeRef
   start_line: 5
   context: (String name)
+  receiver: ~
 - name: String
   kind: TypeRef
   start_line: 6
   context: "{"
+  receiver: ~
 - name: String
   kind: TypeRef
   start_line: 6
   context: (String name)
+  receiver: ~
 - name: Greeter
   kind: Implements
   start_line: 9
   context: "public class SimpleGreeter implements Greeter {"
+  receiver: ~
 - name: String
   kind: TypeRef
   start_line: 10
   context: "{"
+  receiver: ~
 - name: String
   kind: TypeRef
   start_line: 12
   context: (String prefix)
+  receiver: ~
 - name: prefix
   kind: ReadAccess
   start_line: 13
   context: this.prefix = prefix
+  receiver: ~
 - name: Override
   kind: Call
   start_line: 16
   context: "@Override"
+  receiver: ~
 - name: String
   kind: TypeRef
   start_line: 16
   context: "{"
+  receiver: ~
 - name: String
   kind: TypeRef
   start_line: 17
   context: (String name)
+  receiver: ~
 - name: Override
   kind: Call
   start_line: 21
   context: "@Override"
+  receiver: ~
 - name: String
   kind: TypeRef
   start_line: 21
   context: "{"
+  receiver: ~
 - name: String
   kind: TypeRef
   start_line: 22
   context: (String name)
+  receiver: ~
 - name: SimpleGreeter
   kind: TypeRef
   start_line: 27
   context: "{"
+  receiver: ~
 - name: String
   kind: TypeRef
   start_line: 28
   context: "{"
+  receiver: ~
 - name: greet
   kind: Call
   start_line: 28
   context: "result = greeter.greet(\"world\")"
+  receiver: ~
 - name: out
   kind: ReadAccess
   start_line: 29
   context: System.out.println(result)
+  receiver: ~
 - name: println
   kind: Call
   start_line: 29
   context: System.out.println(result);
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_java_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_java_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"Simple.java\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Method
   start_line: 5
@@ -25,6 +26,7 @@ expression: "parsed_symbols(\"Simple.java\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: String
+  parent_name: Greeter
 - name: farewell
   kind: Method
   start_line: 6
@@ -38,6 +40,7 @@ expression: "parsed_symbols(\"Simple.java\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: String
+  parent_name: Greeter
 - name: SimpleGreeter
   kind: Class
   start_line: 9
@@ -48,6 +51,7 @@ expression: "parsed_symbols(\"Simple.java\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: prefix
   kind: Property
   start_line: 10
@@ -58,6 +62,7 @@ expression: "parsed_symbols(\"Simple.java\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: SimpleGreeter
   kind: Method
   start_line: 12
@@ -68,6 +73,7 @@ expression: "parsed_symbols(\"Simple.java\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: SimpleGreeter
 - name: greet
   kind: Method
   start_line: 16
@@ -78,6 +84,7 @@ expression: "parsed_symbols(\"Simple.java\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: SimpleGreeter
 - name: farewell
   kind: Method
   start_line: 21
@@ -88,6 +95,7 @@ expression: "parsed_symbols(\"Simple.java\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: SimpleGreeter
 - name: main
   kind: Method
   start_line: 26
@@ -101,3 +109,4 @@ expression: "parsed_symbols(\"Simple.java\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: void
+  parent_name: SimpleGreeter

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_js_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_js_references.snap
@@ -1,44 +1,55 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 3807
 expression: "parsed_references(\"simple.js\", &source)"
 ---
 - name: fs
   kind: Import
   start_line: 1
   context: "fs = require('fs')"
+  receiver: ~
 - name: require
   kind: Call
   start_line: 1
   context: "fs = require('fs')"
+  receiver: ~
 - name: events
   kind: Import
   start_line: 3
   context: "const fs = require('fs');"
+  receiver: ~
 - name: name
   kind: ReadAccess
   start_line: 13
   context: this.name = name
+  receiver: ~
 - name: name
   kind: ReadAccess
   start_line: 17
   context: "this.name + ' makes a noise.'"
+  receiver: ~
 - name: name
   kind: ReadAccess
   start_line: 23
   context: "this.name + ' barks.'"
+  receiver: ~
 - name: greet
   kind: Call
   start_line: 28
   context: "greet('world');"
+  receiver: ~
 - name: world
   kind: Import
   start_line: 28
   context: "greet('world');"
+  receiver: ~
 - name: speak
   kind: Call
   start_line: 29
   context: dog.speak();
+  receiver: dog
 - name: speak
   kind: ReadAccess
   start_line: 29
   context: dog.speak()
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_js_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_js_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.js\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Function
   start_line: 5
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.js\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: add
   kind: Function
   start_line: 9
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.js\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: Animal
   kind: Class
   start_line: 11
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.js\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: constructor
   kind: Method
   start_line: 12
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"simple.js\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: Animal
 - name: speak
   kind: Method
   start_line: 16
@@ -62,6 +67,7 @@ expression: "parsed_symbols(\"simple.js\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: Animal
 - name: Dog
   kind: Class
   start_line: 21
@@ -72,6 +78,7 @@ expression: "parsed_symbols(\"simple.js\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: speak
   kind: Method
   start_line: 22
@@ -82,6 +89,7 @@ expression: "parsed_symbols(\"simple.js\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: Dog
 - name: dog
   kind: Constant
   start_line: 27
@@ -92,3 +100,4 @@ expression: "parsed_symbols(\"simple.js\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_julia_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_julia_references.snap
@@ -1,37 +1,45 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 2550
+assertion_line: 4129
 expression: "parsed_references(\"simple.jl\", &source)"
 ---
 - name: println
   kind: Call
   start_line: 22
   context: println(item)
+  receiver: ~
 - name: println
   kind: Call
   start_line: 28
   context: "println(\"Calling: \", $(string(expr)))"
+  receiver: ~
 - name: string
   kind: Call
   start_line: 28
   context: "println(\"Calling: \", $(string(expr)))"
+  receiver: ~
 - name: esc
   kind: Call
   start_line: 29
   context: $(esc(expr))
+  receiver: ~
 - name: Animal
   kind: Call
   start_line: 34
   context: "animal = Animal(\"Dog\", \"Woof\")"
+  receiver: ~
 - name: greet
   kind: Call
   start_line: 35
   context: greeting = greet(animal.name)
+  receiver: ~
 - name: println
   kind: Call
   start_line: 36
   context: println(greeting)
+  receiver: ~
 - name: process
   kind: Call
   start_line: 37
   context: "@log_call process([1, 2, 3])"
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_julia_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_julia_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.jl\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: LivingThing
   kind: Interface
   start_line: 5
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.jl\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Animal
   kind: Class
   start_line: 7
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.jl\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Counter
   kind: Class
   start_line: 12
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.jl\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Function
   start_line: 16
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"simple.jl\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: process
   kind: Function
   start_line: 20
@@ -62,6 +67,7 @@ expression: "parsed_symbols(\"simple.jl\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: log_call
   kind: Function
   start_line: 26
@@ -72,6 +78,7 @@ expression: "parsed_symbols(\"simple.jl\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: main
   kind: Function
   start_line: 33
@@ -82,3 +89,4 @@ expression: "parsed_symbols(\"simple.jl\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_kotlin_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_kotlin_references.snap
@@ -1,33 +1,40 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 2006
+assertion_line: 3947
 expression: "parsed_references(\"Simple.kt\", &source)"
 ---
 - name: com.example.utils.Helper
   kind: Import
   start_line: 3
   context: import com.example.utils.Helper
+  receiver: ~
 - name: Greeter
   kind: Extends
   start_line: 9
   context: "class SimpleGreeter : Greeter {"
+  receiver: ~
 - name: println
   kind: Call
   start_line: 15
   context: println(message)
+  receiver: ~
 - name: SimpleGreeter
   kind: Call
   start_line: 24
   context: val greeter = SimpleGreeter()
+  receiver: ~
 - name: greet
   kind: Call
   start_line: 25
   context: val result = greeter.greet(AppConfig.defaultName)
+  receiver: ~
 - name: println
   kind: Call
   start_line: 26
   context: val greeter = SimpleGreeter()
+  receiver: ~
 - name: assist
   kind: Call
   start_line: 27
   context: val greeter = SimpleGreeter()
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_kotlin_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_kotlin_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"Simple.kt\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Method
   start_line: 6
@@ -25,6 +26,7 @@ expression: "parsed_symbols(\"Simple.kt\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: String
+  parent_name: ~
 - name: SimpleGreeter
   kind: Class
   start_line: 9
@@ -35,6 +37,7 @@ expression: "parsed_symbols(\"Simple.kt\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Method
   start_line: 10
@@ -48,6 +51,7 @@ expression: "parsed_symbols(\"Simple.kt\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: String
+  parent_name: ~
 - name: logGreeting
   kind: Method
   start_line: 14
@@ -58,6 +62,7 @@ expression: "parsed_symbols(\"Simple.kt\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: AppConfig
   kind: Module
   start_line: 19
@@ -68,6 +73,7 @@ expression: "parsed_symbols(\"Simple.kt\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: defaultName
   kind: Property
   start_line: 20
@@ -78,6 +84,7 @@ expression: "parsed_symbols(\"Simple.kt\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: main
   kind: Function
   start_line: 23
@@ -88,6 +95,7 @@ expression: "parsed_symbols(\"Simple.kt\", &source)"
   entry_point_kind: Main
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: greeter
   kind: Property
   start_line: 24
@@ -98,6 +106,7 @@ expression: "parsed_symbols(\"Simple.kt\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: result
   kind: Property
   start_line: 25
@@ -108,3 +117,4 @@ expression: "parsed_symbols(\"Simple.kt\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_lua_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_lua_references.snap
@@ -1,41 +1,50 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 2362
+assertion_line: 4017
 expression: "parsed_references(\"simple.lua\", &source)"
 ---
 - name: require
   kind: Call
   start_line: 1
   context: "require(\"json\")"
+  receiver: ~
 - name: setmetatable
   kind: Call
   start_line: 8
   context: "setmetatable({}, Greeter)"
+  receiver: ~
 - name: upper
   kind: Call
   start_line: 19
   context: string.upper(name)
+  receiver: ~
 - name: lower
   kind: Call
   start_line: 24
   context: "input:lower()"
+  receiver: ~
 - name: new
   kind: Call
   start_line: 28
   context: "Greeter:new(\"World\")"
+  receiver: ~
 - name: greet
   kind: Call
   start_line: 29
   context: "(g:greet())"
+  receiver: ~
 - name: print
   kind: Call
   start_line: 29
   context: "local json = require(\"json\")"
+  receiver: ~
 - name: format_name
   kind: Call
   start_line: 30
   context: "(format_name(\"test\"))"
+  receiver: ~
 - name: print
   kind: Call
   start_line: 30
   context: "local json = require(\"json\")"
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_lua_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_lua_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.lua\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: "Greeter:greet"
   kind: Method
   start_line: 13
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.lua\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: format_name
   kind: Function
   start_line: 18
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.lua\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: helper
   kind: Function
   start_line: 23
@@ -42,3 +45,4 @@ expression: "parsed_symbols(\"simple.lua\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_objc_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_objc_references.snap
@@ -1,40 +1,50 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 4087
 expression: "parsed_references(\"simple.m\", &source)"
 ---
 - name: Foundation/Foundation.h
   kind: Import
   start_line: 1
   context: "#import <Foundation/Foundation.h>"
+  receiver: ~
 - name: Greeter.h
   kind: Import
   start_line: 2
   context: "#import \"Greeter.h\""
+  receiver: ~
 - name: utils.h
   kind: Includes
   start_line: 3
   context: "#include \"utils.h\""
+  receiver: ~
 - name: init
   kind: Call
   start_line: 16
   context: "self = [super init];"
+  receiver: ~
 - name: formatName
   kind: Call
   start_line: 24
   context: "NSString *formatted = [self formatName:name];"
+  receiver: ~
 - name: stringWithFormat
   kind: Call
   start_line: 25
   context: "return [NSString stringWithFormat:@\"%@ %@!\", self.prefix, formatted];"
+  receiver: ~
 - name: capitalizedString
   kind: Call
   start_line: 29
   context: "return [name capitalizedString];"
+  receiver: ~
 - name: alloc
   kind: Call
   start_line: 36
   context: "SimpleGreeter *greeter = [[SimpleGreeter alloc] initWithPrefix:@\"Hello\"];"
+  receiver: ~
 - name: greet
   kind: Call
   start_line: 37
   context: "NSString *result = [greeter greet:@\"world\"];"
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_objc_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_objc_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.m\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Function
   start_line: 6
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.m\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: SimpleGreeter
   kind: Interface
   start_line: 9
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.m\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: SimpleGreeter
   kind: Class
   start_line: 13
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.m\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: initWithPrefix
   kind: Method
   start_line: 15
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"simple.m\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Method
   start_line: 23
@@ -62,6 +67,7 @@ expression: "parsed_symbols(\"simple.m\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: formatName
   kind: Method
   start_line: 28
@@ -72,6 +78,7 @@ expression: "parsed_symbols(\"simple.m\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: main
   kind: Function
   start_line: 34
@@ -82,3 +89,4 @@ expression: "parsed_symbols(\"simple.m\", &source)"
   entry_point_kind: Main
   visibility: Public
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_pascal_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_pascal_references.snap
@@ -1,21 +1,25 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 2606
+assertion_line: 4185
 expression: "parsed_references(\"simple.pas\", &source)"
 ---
 - name: Classes
   kind: Import
   start_line: 5
   context: "uses SysUtils, Classes;"
+  receiver: ~
 - name: SysUtils
   kind: Import
   start_line: 5
   context: "uses SysUtils, Classes;"
+  receiver: ~
 - name: TAnimal
   kind: Extends
   start_line: 18
   context: TDog = class(TAnimal)
+  receiver: ~
 - name: Create
   kind: Call
   start_line: 41
   context: "inherited Create(AName, 'Woof');"
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_pascal_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_pascal_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.pas\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: TAnimal
   kind: Class
   start_line: 8
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.pas\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Create
   kind: Method
   start_line: 13
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.pas\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Speak
   kind: Function
   start_line: 14
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.pas\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: TDog
   kind: Class
   start_line: 18
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"simple.pas\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Create
   kind: Method
   start_line: 20
@@ -62,6 +67,7 @@ expression: "parsed_symbols(\"simple.pas\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: PrintGreeting
   kind: Function
   start_line: 23
@@ -72,6 +78,7 @@ expression: "parsed_symbols(\"simple.pas\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: FormatName
   kind: Function
   start_line: 24
@@ -82,6 +89,7 @@ expression: "parsed_symbols(\"simple.pas\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Create
   kind: Method
   start_line: 28
@@ -92,6 +100,7 @@ expression: "parsed_symbols(\"simple.pas\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Speak
   kind: Method
   start_line: 34
@@ -102,6 +111,7 @@ expression: "parsed_symbols(\"simple.pas\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Create
   kind: Method
   start_line: 39
@@ -112,6 +122,7 @@ expression: "parsed_symbols(\"simple.pas\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: PrintGreeting
   kind: Function
   start_line: 44
@@ -122,6 +133,7 @@ expression: "parsed_symbols(\"simple.pas\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: FormatName
   kind: Function
   start_line: 49
@@ -132,3 +144,4 @@ expression: "parsed_symbols(\"simple.pas\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_php_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_php_references.snap
@@ -1,29 +1,35 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 2020
+assertion_line: 3961
 expression: "parsed_references(\"simple.php\", &source)"
 ---
 - name: "App\\Contracts\\Greeter"
   kind: Uses
   start_line: 5
   context: "<?php"
+  receiver: ~
 - name: "App\\Services\\Logger"
   kind: Uses
   start_line: 6
   context: "<?php"
+  receiver: ~
 - name: GreeterInterface
   kind: Implements
   start_line: 21
   context: class SimpleGreeter implements GreeterInterface
+  receiver: ~
 - name: log
   kind: Call
   start_line: 27
   context: "$this->log(\"Greeting $name\");"
+  receiver: ~
 - name: ucfirst
   kind: Call
   start_line: 33
   context: return ucfirst($name);
+  receiver: ~
 - name: greet
   kind: Call
   start_line: 47
   context: return $greeter->greet($input);
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_php_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_php_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.php\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Method
   start_line: 10
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.php\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: GreeterInterface
 - name: Loggable
   kind: Trait
   start_line: 13
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.php\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: log
   kind: Method
   start_line: 15
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.php\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: SimpleGreeter
   kind: Class
   start_line: 21
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"simple.php\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Method
   start_line: 25
@@ -62,6 +67,7 @@ expression: "parsed_symbols(\"simple.php\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: SimpleGreeter
 - name: formatName
   kind: Method
   start_line: 31
@@ -72,6 +78,7 @@ expression: "parsed_symbols(\"simple.php\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: SimpleGreeter
 - name: Priority
   kind: Enum
   start_line: 37
@@ -82,6 +89,7 @@ expression: "parsed_symbols(\"simple.php\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: Low
   kind: Constant
   start_line: 39
@@ -92,6 +100,7 @@ expression: "parsed_symbols(\"simple.php\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: Medium
   kind: Constant
   start_line: 40
@@ -102,6 +111,7 @@ expression: "parsed_symbols(\"simple.php\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: High
   kind: Constant
   start_line: 41
@@ -112,6 +122,7 @@ expression: "parsed_symbols(\"simple.php\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: standalone
   kind: Function
   start_line: 44
@@ -122,3 +133,4 @@ expression: "parsed_symbols(\"simple.php\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_powershell_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_powershell_references.snap
@@ -1,40 +1,50 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 4115
 expression: "parsed_references(\"simple.ps1\", &source)"
 ---
 - name: ActiveDirectory
   kind: Import
   start_line: 1
   context: Import-Module ActiveDirectory
+  receiver: ~
 - name: helpers.ps1
   kind: Includes
   start_line: 2
   context: ". .\\helpers.ps1"
+  receiver: ~
 - name: Write-Host
   kind: Call
   start_line: 30
   context: "Write-Host \"Initializing sensor: $($Config.Name)\""
+  receiver: ~
 - name: Set-Threshold
   kind: Call
   start_line: 31
   context: Set-Threshold -Value $Config.Threshold
+  receiver: ~
 - name: Get-WmiObject
   kind: Call
   start_line: 39
   context: $data = Get-WmiObject -Class Win32_Sensor
+  receiver: ~
 - name: Where-Object
   kind: Call
   start_line: 40
   context: "return $data | Where-Object { $_.Name -eq $SensorName }"
+  receiver: ~
 - name: Initialize-Sensor
   kind: Call
   start_line: 51
   context: Initialize-Sensor -Config $config
+  receiver: ~
 - name: Get-SensorData
   kind: Call
   start_line: 52
   context: "$data = Get-SensorData -SensorName \"temp-1\""
+  receiver: ~
 - name: Write-Output
   kind: Call
   start_line: 53
   context: Write-Output $data
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_powershell_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_powershell_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.ps1\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: ToString
   kind: Method
   start_line: 13
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.ps1\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Priority
   kind: Enum
   start_line: 18
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.ps1\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Initialize-Sensor
   kind: Function
   start_line: 24
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.ps1\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Get-SensorData
   kind: Function
   start_line: 34
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"simple.ps1\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Select-ActiveSensors
   kind: Function
   start_line: 43
@@ -62,6 +67,7 @@ expression: "parsed_symbols(\"simple.ps1\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Main
   kind: Function
   start_line: 49
@@ -72,3 +78,4 @@ expression: "parsed_symbols(\"simple.ps1\", &source)"
   entry_point_kind: Main
   visibility: Public
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_python_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_python_references.snap
@@ -1,64 +1,80 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 3835
 expression: "parsed_references(\"simple.py\", &source)"
 ---
 - name: ".utils"
   kind: Import
   start_line: 1
   context: from .utils import helper
+  receiver: ~
 - name: os
   kind: Import
   start_line: 2
   context: from .utils import helper
+  receiver: ~
 - name: func
   kind: Call
   start_line: 10
   context: "prefix + func(*args, **kwargs)"
+  receiver: ~
 - name: decorator_factory
   kind: Call
   start_line: 14
   context: "@decorator_factory(\">>> \")"
+  receiver: ~
 - name: name
   kind: ReadAccess
   start_line: 20
   context: self.name = name
+  receiver: ~
 - name: name
   kind: ReadAccess
   start_line: 23
   context: "{self.name}"
+  receiver: ~
 - name: Animal
   kind: Extends
   start_line: 25
   context: from .utils import helper
+  receiver: ~
 - name: name
   kind: ReadAccess
   start_line: 27
   context: "{self.name}"
+  receiver: ~
 - name: Dog
   kind: Call
   start_line: 30
   context: "dog = Dog(\"Rex\")"
+  receiver: ~
 - name: speak
   kind: Call
   start_line: 31
   context: result = dog.speak()
+  receiver: ~
 - name: speak
   kind: ReadAccess
   start_line: 31
   context: dog.speak()
+  receiver: ~
 - name: standalone_function
   kind: Call
   start_line: 32
   context: "standalone_function(\"world\")"
+  receiver: ~
 - name: getcwd
   kind: Call
   start_line: 33
   context: os.getcwd()
+  receiver: ~
 - name: getcwd
   kind: ReadAccess
   start_line: 33
   context: os.getcwd()
+  receiver: ~
 - name: main
   kind: Call
   start_line: 37
   context: main()
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_python_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_python_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.py\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: decorator_factory
   kind: Function
   start_line: 7
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.py\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: decorator
   kind: Function
   start_line: 8
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.py\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: wrapper
   kind: Function
   start_line: 9
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.py\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: decorated_greet
   kind: Function
   start_line: 15
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"simple.py\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: Animal
   kind: Class
   start_line: 18
@@ -62,6 +67,7 @@ expression: "parsed_symbols(\"simple.py\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: __init__
   kind: Method
   start_line: 19
@@ -72,6 +78,7 @@ expression: "parsed_symbols(\"simple.py\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: Animal
 - name: speak
   kind: Method
   start_line: 22
@@ -82,6 +89,7 @@ expression: "parsed_symbols(\"simple.py\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: Animal
 - name: Dog
   kind: Class
   start_line: 25
@@ -92,6 +100,7 @@ expression: "parsed_symbols(\"simple.py\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: speak
   kind: Method
   start_line: 26
@@ -102,6 +111,7 @@ expression: "parsed_symbols(\"simple.py\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: Dog
 - name: main
   kind: Function
   start_line: 29
@@ -112,3 +122,4 @@ expression: "parsed_symbols(\"simple.py\", &source)"
   entry_point_kind: Main
   visibility: Inferred
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_ruby_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_ruby_references.snap
@@ -1,33 +1,40 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 2034
+assertion_line: 3975
 expression: "parsed_references(\"simple.rb\", &source)"
 ---
 - name: require
   kind: Call
   start_line: 1
   context: "require 'json'"
+  receiver: ~
 - name: require_relative
   kind: Call
   start_line: 2
   context: "require 'json'"
+  receiver: ~
 - name: capitalize
   kind: Call
   start_line: 13
   context: name.capitalize
+  receiver: ~
 - name: Greeter
   kind: Extends
   start_line: 17
   context: class Greeter
+  receiver: ~
 - name: format_name
   kind: Call
   start_line: 19
   context: "#{format_name(name)}"
+  receiver: ~
 - name: new
   kind: Call
   start_line: 25
   context: "greeter = Greetings::FormalGreeter.new"
+  receiver: ~
 - name: greet
   kind: Call
   start_line: 26
   context: "greeter = Greetings::FormalGreeter.new"
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_ruby_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_ruby_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.rb\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: Greeter
   kind: Class
   start_line: 5
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.rb\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Method
   start_line: 6
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.rb\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: format_name
   kind: Method
   start_line: 12
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.rb\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: FormalGreeter
   kind: Class
   start_line: 17
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"simple.rb\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Method
   start_line: 18
@@ -62,6 +67,7 @@ expression: "parsed_symbols(\"simple.rb\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: standalone_function
   kind: Method
   start_line: 24
@@ -72,3 +78,4 @@ expression: "parsed_symbols(\"simple.rb\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_rust_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_rust_references.snap
@@ -1,112 +1,140 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 3849
 expression: "parsed_references(\"simple.rs\", &source)"
 ---
 - name: "std::collections::HashMap"
   kind: Import
   start_line: 1
   context: "use std::collections::HashMap;"
+  receiver: ~
 - name: "crate::config::Settings"
   kind: Import
   start_line: 2
   context: "use std::collections::HashMap;"
+  receiver: ~
 - name: HashMap
   kind: TypeRef
   start_line: 5
   context: "sensors: HashMap<String, Sensor>"
+  receiver: ~
 - name: Readable
   kind: Extends
   start_line: 18
   context: "use std::collections::HashMap;"
+  receiver: ~
 - name: get_primary
   kind: Call
   start_line: 20
   context: self.get_primary().value
+  receiver: self
 - name: get_primary
   kind: ReadAccess
   start_line: 20
   context: self.get_primary()
+  receiver: ~
 - name: value
   kind: Call
   start_line: 20
   context: "{"
+  receiver: self.get_primary()
 - name: value
   kind: ReadAccess
   start_line: 20
   context: self.get_primary().value()
+  receiver: ~
 - name: for_each
   kind: Call
   start_line: 24
   context: self.sensors.values_mut().for_each(|s| s.reset());
+  receiver: self.sensors.values_mut()
 - name: for_each
   kind: ReadAccess
   start_line: 24
   context: self.sensors.values_mut().for_each(|s| s.reset())
+  receiver: ~
 - name: reset
   kind: Call
   start_line: 24
   context: "|s| s.reset()"
+  receiver: s
 - name: reset
   kind: ReadAccess
   start_line: 24
   context: s.reset()
+  receiver: ~
 - name: sensors
   kind: ReadAccess
   start_line: 24
   context: self.sensors.values_mut
+  receiver: ~
 - name: values_mut
   kind: Call
   start_line: 24
   context: self.sensors.values_mut().for_each
+  receiver: self.sensors
 - name: values_mut
   kind: ReadAccess
   start_line: 24
   context: self.sensors.values_mut()
+  receiver: ~
 - name: Self
   kind: TypeRef
   start_line: 29
   context: "{"
+  receiver: ~
 - name: new
   kind: Call
   start_line: 31
   context: "sensors: HashMap::new()"
+  receiver: ~
 - name: Sensor
   kind: TypeRef
   start_line: 35
   context: "fn get_primary(&self) -> &Sensor {"
+  receiver: ~
 - name: get
   kind: Call
   start_line: 36
   context: "self.sensors.get(\"primary\").unwrap"
+  receiver: self.sensors
 - name: get
   kind: ReadAccess
   start_line: 36
   context: "self.sensors.get(\"primary\")"
+  receiver: ~
 - name: sensors
   kind: ReadAccess
   start_line: 36
   context: self.sensors.get
+  receiver: ~
 - name: unwrap
   kind: Call
   start_line: 36
   context: "{"
+  receiver: "self.sensors.get(\"primary\")"
 - name: unwrap
   kind: ReadAccess
   start_line: 36
   context: "self.sensors.get(\"primary\").unwrap()"
+  receiver: ~
 - name: SensorManager
   kind: TypeRef
   start_line: 40
   context: "use std::collections::HashMap;"
+  receiver: ~
 - name: Settings
   kind: TypeRef
   start_line: 40
   context: "config: &Settings"
+  receiver: ~
 - name: new
   kind: Call
   start_line: 41
   context: "let mgr = SensorManager::new();"
+  receiver: ~
 - name: println
   kind: Call
   start_line: 42
   context: "println!(\"Initialized with {:?}\", config);"
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_rust_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_rust_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.rs\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: sensors
   kind: Property
   start_line: 5
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.rs\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: SensorKind
   kind: Enum
   start_line: 8
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.rs\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: Readable
   kind: Interface
   start_line: 13
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.rs\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: SensorManager
   kind: Class
   start_line: 18
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"simple.rs\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: read
   kind: Method
   start_line: 19
@@ -65,6 +70,7 @@ expression: "parsed_symbols(\"simple.rs\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: f64
+  parent_name: SensorManager
 - name: calibrate
   kind: Method
   start_line: 23
@@ -75,6 +81,7 @@ expression: "parsed_symbols(\"simple.rs\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: SensorManager
 - name: SensorManager
   kind: Class
   start_line: 28
@@ -85,6 +92,7 @@ expression: "parsed_symbols(\"simple.rs\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: new
   kind: Method
   start_line: 29
@@ -98,6 +106,7 @@ expression: "parsed_symbols(\"simple.rs\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: Self
+  parent_name: SensorManager
 - name: get_primary
   kind: Method
   start_line: 35
@@ -111,6 +120,7 @@ expression: "parsed_symbols(\"simple.rs\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: "&Sensor"
+  parent_name: SensorManager
 - name: initialize
   kind: Function
   start_line: 40
@@ -124,3 +134,4 @@ expression: "parsed_symbols(\"simple.rs\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: SensorManager
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_scala_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_scala_references.snap
@@ -1,25 +1,30 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 2390
+assertion_line: 4045
 expression: "parsed_references(\"Simple.scala\", &source)"
 ---
 - name: scala
   kind: Import
   start_line: 1
   context: import scala.collection.mutable.ListBuffer
+  receiver: ~
 - name: Greeter
   kind: Extends
   start_line: 7
   context: import scala.collection.mutable.ListBuffer
+  receiver: ~
 - name: createGreeter
   kind: Call
   start_line: 26
   context: val greeter = AppConfig.createGreeter()
+  receiver: AppConfig
 - name: greet
   kind: Call
   start_line: 27
   context: "(greeter.greet(\"World\"))"
+  receiver: greeter
 - name: println
   kind: Call
   start_line: 27
   context: "{"
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_scala_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_scala_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"Simple.scala\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: SimpleGreeter
   kind: Class
   start_line: 7
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"Simple.scala\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Function
   start_line: 8
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"Simple.scala\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: formatName
   kind: Function
   start_line: 12
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"Simple.scala\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: AppConfig
   kind: Module
   start_line: 17
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"Simple.scala\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: defaultGreeting
   kind: Constant
   start_line: 18
@@ -62,6 +67,7 @@ expression: "parsed_symbols(\"Simple.scala\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: createGreeter
   kind: Function
   start_line: 20
@@ -72,6 +78,7 @@ expression: "parsed_symbols(\"Simple.scala\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: main
   kind: Function
   start_line: 25
@@ -82,6 +89,7 @@ expression: "parsed_symbols(\"Simple.scala\", &source)"
   entry_point_kind: Main
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: greeter
   kind: Constant
   start_line: 26
@@ -92,3 +100,4 @@ expression: "parsed_symbols(\"Simple.scala\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_sql_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_sql_references.snap
@@ -1,21 +1,25 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 2564
+assertion_line: 4143
 expression: "parsed_references(\"simple.sql\", &source)"
 ---
 - name: users
   kind: Call
   start_line: 10
   context: "user_id INTEGER REFERENCES users(id),"
+  receiver: ~
 - name: users
   kind: Call
   start_line: 17
   context: FROM users u
+  receiver: ~
 - name: orders
   kind: Call
   start_line: 18
   context: WHERE EXISTS (SELECT 1 FROM orders o WHERE o.user_id = u.id);
+  receiver: ~
 - name: orders
   kind: Call
   start_line: 23
   context: RETURN (SELECT SUM(total) FROM orders WHERE id = order_id);
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_sql_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_sql_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.sql\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: orders
   kind: Class
   start_line: 8
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.sql\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: active_users
   kind: Class
   start_line: 15
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.sql\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: calculate_total
   kind: Function
   start_line: 20
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.sql\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: update_status
   kind: Function
   start_line: 27
@@ -52,3 +56,4 @@ expression: "parsed_symbols(\"simple.sql\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_sv_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_sv_references.snap
@@ -1,24 +1,30 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 4241
 expression: "parsed_references(\"simple.sv\", &source)"
 ---
 - name: common_defs.svh
   kind: Includes
   start_line: 1
   context: "`include \"common_defs.svh\""
+  receiver: ~
 - name: uvm_pkg
   kind: Import
   start_line: 3
   context: "import uvm_pkg::*;"
+  receiver: ~
 - name: bus_pkg
   kind: Import
   start_line: 4
   context: "import bus_pkg::BusTransaction;"
+  receiver: ~
 - name: sub_module
   kind: Call
   start_line: 25
   context: "sub_module #(.WIDTH(WIDTH)) u_sub ("
+  receiver: ~
 - name: base_packet
   kind: Extends
   start_line: 45
   context: class packet extends base_packet;
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_sv_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_sv_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.sv\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: axi_if
   kind: Interface
   start_line: 32
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.sv\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: packet
   kind: Class
   start_line: 45
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.sv\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: new
   kind: Method
   start_line: 49
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.sv\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: build
   kind: Method
   start_line: 53
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"simple.sv\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: send
   kind: Method
   start_line: 57
@@ -62,6 +67,7 @@ expression: "parsed_symbols(\"simple.sv\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: compute_checksum
   kind: Function
   start_line: 62
@@ -72,6 +78,7 @@ expression: "parsed_symbols(\"simple.sv\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: sub_module
   kind: Module
   start_line: 70
@@ -82,3 +89,4 @@ expression: "parsed_symbols(\"simple.sv\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_svelte_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_svelte_references.snap
@@ -1,32 +1,40 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 4213
 expression: "parsed_references(\"simple.svelte\", &source)"
 ---
 - name: svelte
   kind: Import
   start_line: 2
   context: "import { onMount } from 'svelte'"
+  receiver: ~
 - name: "./Counter.svelte"
   kind: Import
   start_line: 3
   context: "import Counter from './Counter.svelte'"
+  receiver: ~
 - name: greet
   kind: Call
   start_line: 5
   context: "export function greet(name) {"
+  receiver: ~
 - name: handleClick
   kind: Call
   start_line: 11
   context: "function handleClick() {"
+  receiver: ~
 - name: greet
   kind: Call
   start_line: 13
   context: "greet('World')"
+  receiver: ~
 - name: onMount
   kind: Call
   start_line: 16
   context: "onMount(() => {"
+  receiver: ~
 - name: log
   kind: Call
   start_line: 17
   context: "console.log('Component mounted')"
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_svelte_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_svelte_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.svelte\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Function
   start_line: 5
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.svelte\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: count
   kind: Function
   start_line: 9
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.svelte\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: handleClick
   kind: Function
   start_line: 11
@@ -42,3 +45,4 @@ expression: "parsed_symbols(\"simple.svelte\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_swift_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_swift_references.snap
@@ -1,25 +1,30 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 2048
+assertion_line: 3989
 expression: "parsed_references(\"simple.swift\", &source)"
 ---
 - name: Foundation
   kind: Import
   start_line: 1
   context: import Foundation
+  receiver: ~
 - name: Greeter
   kind: Extends
   start_line: 7
   context: "class SimpleGreeter: Greeter {"
+  receiver: ~
 - name: SimpleGreeter
   kind: Call
   start_line: 28
   context: let greeter = SimpleGreeter()
+  receiver: ~
 - name: AppConfig
   kind: Call
   start_line: 29
   context: let config = AppConfig()
+  receiver: ~
 - name: print
   kind: Call
   start_line: 31
   context: let greeter = SimpleGreeter()
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_swift_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_swift_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.swift\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: SimpleGreeter
   kind: Class
   start_line: 7
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.swift\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Method
   start_line: 8
@@ -35,6 +37,7 @@ expression: "parsed_symbols(\"simple.swift\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: String
+  parent_name: SimpleGreeter
 - name: formatName
   kind: Method
   start_line: 12
@@ -48,6 +51,7 @@ expression: "parsed_symbols(\"simple.swift\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: String
+  parent_name: SimpleGreeter
 - name: AppConfig
   kind: Class
   start_line: 17
@@ -58,6 +62,7 @@ expression: "parsed_symbols(\"simple.swift\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: defaultName
   kind: Property
   start_line: 18
@@ -68,6 +73,7 @@ expression: "parsed_symbols(\"simple.swift\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: Priority
   kind: Class
   start_line: 21
@@ -78,6 +84,7 @@ expression: "parsed_symbols(\"simple.swift\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: low
   kind: Constant
   start_line: 22
@@ -88,6 +95,7 @@ expression: "parsed_symbols(\"simple.swift\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: medium
   kind: Constant
   start_line: 23
@@ -98,6 +106,7 @@ expression: "parsed_symbols(\"simple.swift\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: high
   kind: Constant
   start_line: 24
@@ -108,6 +117,7 @@ expression: "parsed_symbols(\"simple.swift\", &source)"
   entry_point_kind: ~
   visibility: Inferred
   type_info: ~
+  parent_name: ~
 - name: main
   kind: Function
   start_line: 27
@@ -118,3 +128,4 @@ expression: "parsed_symbols(\"simple.swift\", &source)"
   entry_point_kind: Main
   visibility: Inferred
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_ts_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_ts_references.snap
@@ -1,60 +1,75 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 3821
 expression: "parsed_references(\"simple.ts\", &source)"
 ---
 - name: events
   kind: Import
   start_line: 1
   context: "import { EventEmitter } from 'events';"
+  receiver: ~
 - name: Greeter
   kind: Implements
   start_line: 12
   context: "implements Greeter, Logger"
+  receiver: ~
 - name: Logger
   kind: Implements
   start_line: 12
   context: "implements Greeter, Logger"
+  receiver: ~
 - name: log
   kind: Call
   start_line: 22
   context: console.log(message);
+  receiver: console
 - name: log
   kind: ReadAccess
   start_line: 22
   context: console.log(message)
+  receiver: ~
 - name: ConsoleGreeter
   kind: Extends
   start_line: 26
   context: "class VerboseGreeter extends ConsoleGreeter {"
+  receiver: ~
 - name: log
   kind: Call
   start_line: 28
   context: "this.log(`Greeting ${name}`);"
+  receiver: this
 - name: log
   kind: ReadAccess
   start_line: 28
   context: "this.log(`Greeting ${name}`)"
+  receiver: ~
 - name: greet
   kind: Call
   start_line: 29
   context: return super.greet(name);
+  receiver: super
 - name: greet
   kind: ReadAccess
   start_line: 29
   context: super.greet(name)
+  receiver: ~
 - name: Greeter
   kind: TypeRef
   start_line: 33
   context: "import { EventEmitter } from 'events';"
+  receiver: ~
 - name: createGreeter
   kind: Call
   start_line: 37
   context: greeter = createGreeter()
+  receiver: ~
 - name: greet
   kind: Call
   start_line: 38
   context: "greeter.greet('world');"
+  receiver: greeter
 - name: greet
   kind: ReadAccess
   start_line: 38
   context: "greeter.greet('world')"
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_ts_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_ts_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.ts\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Method
   start_line: 4
@@ -25,6 +26,7 @@ expression: "parsed_symbols(\"simple.ts\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: string
+  parent_name: Greeter
 - name: farewell
   kind: Method
   start_line: 5
@@ -38,6 +40,7 @@ expression: "parsed_symbols(\"simple.ts\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: string
+  parent_name: Greeter
 - name: Logger
   kind: Interface
   start_line: 8
@@ -48,6 +51,7 @@ expression: "parsed_symbols(\"simple.ts\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: log
   kind: Method
   start_line: 9
@@ -61,6 +65,7 @@ expression: "parsed_symbols(\"simple.ts\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: void
+  parent_name: Logger
 - name: ConsoleGreeter
   kind: Class
   start_line: 12
@@ -71,6 +76,7 @@ expression: "parsed_symbols(\"simple.ts\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Method
   start_line: 13
@@ -84,6 +90,7 @@ expression: "parsed_symbols(\"simple.ts\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: string
+  parent_name: ConsoleGreeter
 - name: farewell
   kind: Method
   start_line: 17
@@ -97,6 +104,7 @@ expression: "parsed_symbols(\"simple.ts\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: string
+  parent_name: ConsoleGreeter
 - name: log
   kind: Method
   start_line: 21
@@ -110,6 +118,7 @@ expression: "parsed_symbols(\"simple.ts\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: void
+  parent_name: ConsoleGreeter
 - name: VerboseGreeter
   kind: Class
   start_line: 26
@@ -120,6 +129,7 @@ expression: "parsed_symbols(\"simple.ts\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: greet
   kind: Method
   start_line: 27
@@ -133,6 +143,7 @@ expression: "parsed_symbols(\"simple.ts\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: string
+  parent_name: VerboseGreeter
 - name: createGreeter
   kind: Function
   start_line: 33
@@ -146,6 +157,7 @@ expression: "parsed_symbols(\"simple.ts\", &source)"
     declared_type: ~
     parameter_types: []
     return_type: Greeter
+  parent_name: ~
 - name: greeter
   kind: Constant
   start_line: 37
@@ -156,3 +168,4 @@ expression: "parsed_symbols(\"simple.ts\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_vue_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_vue_references.snap
@@ -1,60 +1,75 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 4199
 expression: "parsed_references(\"simple.vue\", &source)"
 ---
 - name: vue
   kind: Import
   start_line: 9
   context: "import { ref, computed } from 'vue'"
+  receiver: ~
 - name: "./utils/helper"
   kind: Import
   start_line: 10
   context: "import HelperUtil from './utils/helper'"
+  receiver: ~
 - name: formatName
   kind: Call
   start_line: 12
   context: "export function formatName(name) {"
+  receiver: ~
 - name: toUpperCase
   kind: Call
   start_line: 13
   context: return name.trim().toUpperCase()
+  receiver: ~
 - name: trim
   kind: Call
   start_line: 13
   context: return name.trim().toUpperCase()
+  receiver: ~
 - name: setup
   kind: Call
   start_line: 21
   context: "setup(props) {"
+  receiver: ~
 - name: ref
   kind: Call
   start_line: 22
   context: "const greeting = ref(`Hello, ${props.name}!`)"
+  receiver: ~
 - name: computed
   kind: Call
   start_line: 23
   context: "const reversed = computed(() => greeting.value.split('').reverse().join(''))"
+  receiver: ~
 - name: join
   kind: Call
   start_line: 23
   context: "const reversed = computed(() => greeting.value.split('').reverse().join(''))"
+  receiver: ~
 - name: reverse
   kind: Call
   start_line: 23
   context: "const reversed = computed(() => greeting.value.split('').reverse().join(''))"
+  receiver: ~
 - name: split
   kind: Call
   start_line: 23
   context: "const reversed = computed(() => greeting.value.split('').reverse().join(''))"
+  receiver: ~
 - name: handleClick
   kind: Call
   start_line: 25
   context: "function handleClick() {"
+  receiver: ~
 - name: formatName
   kind: Call
   start_line: 26
   context: console.log(formatName(props.name))
+  receiver: ~
 - name: log
   kind: Call
   start_line: 26
   context: console.log(formatName(props.name))
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_vue_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_vue_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.vue\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: simple
   kind: Class
   start_line: 16
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.vue\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: handleClick
   kind: Function
   start_line: 25
@@ -32,3 +34,4 @@ expression: "parsed_symbols(\"simple.vue\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_zig_references.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_zig_references.snap
@@ -1,32 +1,40 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 4073
 expression: "parsed_references(\"simple.zig\", &source)"
 ---
 - name: import
   kind: Call
   start_line: 1
   context: "const std = @import(\"std\");"
+  receiver: ~
 - name: std
   kind: Import
   start_line: 1
   context: "const std = @import(\"std\");"
+  receiver: ~
 - name: import
   kind: Call
   start_line: 2
   context: "const math = @import(\"math.zig\");"
+  receiver: ~
 - name: math.zig
   kind: Import
   start_line: 2
   context: "const math = @import(\"math.zig\");"
+  receiver: ~
 - name: print
   kind: Call
   start_line: 22
   context: "std.debug.print(\"Initializing sensor: {s}\\n\", .{config.name});"
+  receiver: ~
 - name: calibrate
   kind: Call
   start_line: 23
   context: calibrate(config);
+  receiver: ~
 - name: initialize
   kind: Call
   start_line: 36
   context: initialize(config);
+  receiver: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_zig_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_zig_symbols.snap
@@ -12,6 +12,7 @@ expression: "parsed_symbols(\"simple.zig\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: math
   kind: Constant
   start_line: 2
@@ -22,6 +23,7 @@ expression: "parsed_symbols(\"simple.zig\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: SensorKind
   kind: Class
   start_line: 4
@@ -32,6 +34,7 @@ expression: "parsed_symbols(\"simple.zig\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: SensorConfig
   kind: Class
   start_line: 10
@@ -42,6 +45,7 @@ expression: "parsed_symbols(\"simple.zig\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: InternalState
   kind: Class
   start_line: 16
@@ -52,6 +56,7 @@ expression: "parsed_symbols(\"simple.zig\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: initialize
   kind: Function
   start_line: 21
@@ -62,6 +67,7 @@ expression: "parsed_symbols(\"simple.zig\", &source)"
   entry_point_kind: ~
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: calibrate
   kind: Function
   start_line: 26
@@ -72,6 +78,7 @@ expression: "parsed_symbols(\"simple.zig\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~
 - name: main
   kind: Function
   start_line: 30
@@ -82,6 +89,7 @@ expression: "parsed_symbols(\"simple.zig\", &source)"
   entry_point_kind: Main
   visibility: Public
   type_info: ~
+  parent_name: ~
 - name: config
   kind: Constant
   start_line: 31
@@ -92,3 +100,4 @@ expression: "parsed_symbols(\"simple.zig\", &source)"
   entry_point_kind: ~
   visibility: Private
   type_info: ~
+  parent_name: ~

--- a/crates/nestweaver-parser/src/sql.rs
+++ b/crates/nestweaver-parser/src/sql.rs
@@ -190,6 +190,7 @@ pub fn parse_sql(path: &Path, source: &str) -> ParsedFile {
                     kind: ReferenceKind::Call,
                     start_line: line_no,
                     context: trimmed.to_string(),
+                    receiver: None,
                 });
             }
         }
@@ -200,6 +201,7 @@ pub fn parse_sql(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Call,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
         }
     }

--- a/crates/nestweaver-parser/src/sql.rs
+++ b/crates/nestweaver-parser/src/sql.rs
@@ -90,6 +90,7 @@ pub fn parse_sql(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -107,6 +108,7 @@ pub fn parse_sql(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -124,6 +126,7 @@ pub fn parse_sql(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -141,6 +144,7 @@ pub fn parse_sql(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -158,6 +162,7 @@ pub fn parse_sql(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -175,6 +180,7 @@ pub fn parse_sql(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }

--- a/crates/nestweaver-parser/src/svelte.rs
+++ b/crates/nestweaver-parser/src/svelte.rs
@@ -168,6 +168,7 @@ pub fn parse_svelte(path: &Path, source: &str) -> ParsedFile {
                     kind: ReferenceKind::Import,
                     start_line: line_no,
                     context: trimmed.to_string(),
+                    receiver: None,
                 });
             } else if let Some(cap) = RE_IMPORT_SIDE.captures(trimmed) {
                 references.push(RawReference {
@@ -175,6 +176,7 @@ pub fn parse_svelte(path: &Path, source: &str) -> ParsedFile {
                     kind: ReferenceKind::Import,
                     start_line: line_no,
                     context: trimmed.to_string(),
+                    receiver: None,
                 });
             }
 
@@ -188,6 +190,7 @@ pub fn parse_svelte(path: &Path, source: &str) -> ParsedFile {
                             kind: ReferenceKind::Call,
                             start_line: line_no,
                             context: trimmed.to_string(),
+                            receiver: None,
                         });
                     }
                 }

--- a/crates/nestweaver-parser/src/svelte.rs
+++ b/crates/nestweaver-parser/src/svelte.rs
@@ -104,6 +104,7 @@ pub fn parse_svelte(path: &Path, source: &str) -> ParsedFile {
         entry_point_kind: None,
         visibility: Visibility::Public,
         type_info: None,
+        parent_name: None,
     });
 
     // Find <script> block(s)
@@ -137,6 +138,7 @@ pub fn parse_svelte(path: &Path, source: &str) -> ParsedFile {
                     entry_point_kind: None,
                     visibility: Visibility::Public,
                     type_info: None,
+                    parent_name: None,
                 });
             }
 
@@ -156,6 +158,7 @@ pub fn parse_svelte(path: &Path, source: &str) -> ParsedFile {
                     entry_point_kind: None,
                     visibility: Visibility::Private,
                     type_info: None,
+                    parent_name: None,
                 });
             }
 

--- a/crates/nestweaver-parser/src/systemverilog.rs
+++ b/crates/nestweaver-parser/src/systemverilog.rs
@@ -215,6 +215,7 @@ pub fn parse_systemverilog(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -233,6 +234,7 @@ pub fn parse_systemverilog(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -251,6 +253,7 @@ pub fn parse_systemverilog(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
 
             // Check for extends clause
@@ -304,6 +307,7 @@ pub fn parse_systemverilog(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -327,6 +331,7 @@ pub fn parse_systemverilog(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility: Visibility::Public,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }

--- a/crates/nestweaver-parser/src/systemverilog.rs
+++ b/crates/nestweaver-parser/src/systemverilog.rs
@@ -185,6 +185,7 @@ pub fn parse_systemverilog(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Includes,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
         }
 
@@ -196,6 +197,7 @@ pub fn parse_systemverilog(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Import,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
         }
 
@@ -258,6 +260,7 @@ pub fn parse_systemverilog(path: &Path, source: &str) -> ParsedFile {
                     kind: ReferenceKind::Extends,
                     start_line: line_no,
                     context: trimmed.to_string(),
+                    receiver: None,
                 });
             }
 
@@ -337,6 +340,7 @@ pub fn parse_systemverilog(path: &Path, source: &str) -> ParsedFile {
                     kind: ReferenceKind::Call,
                     start_line: line_no,
                     context: trimmed.to_string(),
+                    receiver: None,
                 });
             }
         }

--- a/crates/nestweaver-parser/src/vue.rs
+++ b/crates/nestweaver-parser/src/vue.rs
@@ -194,6 +194,7 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
                     kind: ReferenceKind::Import,
                     start_line: line_no,
                     context: trimmed.to_string(),
+                    receiver: None,
                 });
             } else if let Some(cap) = RE_IMPORT_SIDE.captures(trimmed) {
                 references.push(RawReference {
@@ -201,6 +202,7 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
                     kind: ReferenceKind::Import,
                     start_line: line_no,
                     context: trimmed.to_string(),
+                    receiver: None,
                 });
             }
 
@@ -217,6 +219,7 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
                             kind: ReferenceKind::Call,
                             start_line: line_no,
                             context: trimmed.to_string(),
+                            receiver: None,
                         });
                     }
                 }

--- a/crates/nestweaver-parser/src/vue.rs
+++ b/crates/nestweaver-parser/src/vue.rs
@@ -130,6 +130,7 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
                     entry_point_kind: None,
                     visibility: Visibility::Public,
                     type_info: None,
+                    parent_name: None,
                 });
             }
 
@@ -146,6 +147,7 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
                     entry_point_kind: None,
                     visibility: Visibility::Public,
                     type_info: None,
+                    parent_name: None,
                 });
             }
 
@@ -163,6 +165,7 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
                     entry_point_kind: None,
                     visibility: Visibility::Public,
                     type_info: None,
+                    parent_name: None,
                 });
             }
 
@@ -182,6 +185,7 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
                     entry_point_kind: None,
                     visibility: Visibility::Private,
                     type_info: None,
+                    parent_name: None,
                 });
             }
 

--- a/crates/nestweaver-parser/src/zig.rs
+++ b/crates/nestweaver-parser/src/zig.rs
@@ -83,6 +83,7 @@ pub fn parse_zig(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: ep_kind,
                 visibility,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -106,6 +107,7 @@ pub fn parse_zig(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -129,6 +131,7 @@ pub fn parse_zig(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -152,6 +155,7 @@ pub fn parse_zig(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility,
                 type_info: None,
+                parent_name: None,
             });
             continue;
         }
@@ -175,6 +179,7 @@ pub fn parse_zig(path: &Path, source: &str) -> ParsedFile {
                 entry_point_kind: None,
                 visibility,
                 type_info: None,
+                parent_name: None,
             });
             // Don't continue — fall through to reference detection so
             // `const std = @import("std")` also emits the import ref.

--- a/crates/nestweaver-parser/src/zig.rs
+++ b/crates/nestweaver-parser/src/zig.rs
@@ -188,6 +188,7 @@ pub fn parse_zig(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Import,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
         }
 
@@ -219,6 +220,7 @@ pub fn parse_zig(path: &Path, source: &str) -> ParsedFile {
                 kind: ReferenceKind::Call,
                 start_line: line_no,
                 context: trimmed.to_string(),
+                receiver: None,
             });
         }
     }

--- a/crates/nestweaver-resolver/src/imports.rs
+++ b/crates/nestweaver-resolver/src/imports.rs
@@ -183,6 +183,7 @@ mod tests {
             entry_point_kind: None,
             visibility: Visibility::Inferred,
             type_info: None,
+            parent_name: None,
         }
     }
 

--- a/crates/nestweaver-resolver/src/imports.rs
+++ b/crates/nestweaver-resolver/src/imports.rs
@@ -192,6 +192,7 @@ mod tests {
             kind: ReferenceKind::Import,
             start_line: 1,
             context: String::new(),
+            receiver: None,
         }
     }
 

--- a/crates/nestweaver-resolver/src/lib.rs
+++ b/crates/nestweaver-resolver/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cross_repo;
 pub mod imports;
 pub mod lang;
 pub mod resolve;
+pub mod type_extractors;
 pub mod types;
 pub mod util;
 pub mod workspace;

--- a/crates/nestweaver-resolver/src/resolve.rs
+++ b/crates/nestweaver-resolver/src/resolve.rs
@@ -1,6 +1,7 @@
 use nestweaver_parser::{RawReference, RawSymbol, ReferenceKind};
 use nestweaver_schema::{
-    EdgeType, Language, MatchType, ResolvedEdge, Visibility, confidence_score, symbol_uid,
+    EdgeType, Language, MatchType, ResolvedEdge, SymbolKind, Visibility, confidence_score,
+    symbol_uid,
 };
 
 use crate::imports::build_import_graph;
@@ -65,6 +66,33 @@ pub fn resolve_references_with_context(
                 .push((file_path.as_str(), sym));
         }
     }
+
+    // Build a parent-type lookup from Extends references for MRO walk.
+    // Maps child type name → list of parent type names.
+    let extends_map: std::collections::HashMap<String, Vec<String>> = {
+        let mut map: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        for (_, symbols, references) in files {
+            for reference in references {
+                if reference.kind == ReferenceKind::Extends {
+                    if let Some(sym) = find_enclosing_symbol(symbols, reference.start_line) {
+                        if matches!(
+                            sym.kind,
+                            SymbolKind::Class
+                                | SymbolKind::Enum
+                                | SymbolKind::Interface
+                                | SymbolKind::Trait
+                        ) {
+                            map.entry(sym.name.clone())
+                                .or_default()
+                                .push(reference.name.clone());
+                        }
+                    }
+                }
+            }
+        }
+        map
+    };
 
     let mut edges: Vec<ResolvedEdge> = Vec::new();
 
@@ -131,7 +159,60 @@ pub fn resolve_references_with_context(
                                         continue 'ref_loop;
                                     }
                                 }
-                                // Type was known but method not found on that type.
+                                // MRO walk: check parent types via inheritance chain
+                                {
+                                    let mut current_types = vec![type_name.clone()];
+                                    let mut visited = std::collections::HashSet::new();
+                                    visited.insert(type_name.clone());
+                                    let mut depth = 0u32;
+
+                                    while depth < 5 && !current_types.is_empty() {
+                                        let mut next_types = Vec::new();
+                                        for t in &current_types {
+                                            if let Some(parents) = extends_map.get(t.as_str()) {
+                                                for parent in parents {
+                                                    if visited.contains(parent) {
+                                                        continue; // cycle guard
+                                                    }
+                                                    visited.insert(parent.clone());
+
+                                                    if let Some(candidates) =
+                                                        symbol_map.get(method_name.as_str())
+                                                    {
+                                                        if let Some((cf, sym)) =
+                                                            candidates.iter().find(|(_, s)| {
+                                                                s.parent_name.as_deref()
+                                                                    == Some(parent.as_str())
+                                                            })
+                                                        {
+                                                            let target_uid = symbol_uid(
+                                                                repo_uid,
+                                                                cf,
+                                                                &sym.name,
+                                                                sym.start_line,
+                                                            );
+                                                            let conf = (binding.confidence
+                                                                - 0.05 * (depth + 1) as f32)
+                                                                .max(0.50);
+                                                            edges.push(ResolvedEdge {
+                                                                source_uid: source_uid.clone(),
+                                                                target_uid,
+                                                                edge_type,
+                                                                confidence: conf,
+                                                                link_type: None,
+                                                            });
+                                                            continue 'ref_loop;
+                                                        }
+                                                    }
+                                                    next_types.push(parent.clone());
+                                                }
+                                            }
+                                        }
+                                        current_types = next_types;
+                                        depth += 1;
+                                    }
+                                }
+                                // Type was known but method not found on that type or ancestors.
                                 // Fall through to name-based resolution.
                             }
                         }
@@ -1086,6 +1167,123 @@ mod tests {
         assert!(
             (edge.confidence - 0.95).abs() < f32::EPSILON,
             "confidence should be capped at 0.95, got {}",
+            edge.confidence
+        );
+    }
+
+    #[test]
+    fn mro_walk_finds_inherited_method() {
+        use crate::type_extractors::{BindingSource, TypeBinding};
+        use crate::types::TypeEnvironment;
+
+        // BaseClass has method "save" at line 5
+        let mut save_method = make_symbol("save", 5);
+        save_method.parent_name = Some("BaseClass".to_string());
+
+        let base_class = RawSymbol {
+            name: "BaseClass".to_string(),
+            kind: SymbolKind::Class,
+            start_line: 1,
+            end_line: 20,
+            signature: "class BaseClass".to_string(),
+            content_hash: String::new(),
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Public,
+            type_info: None,
+            parent_name: None,
+        };
+
+        // ChildClass extends BaseClass (no "save" method of its own)
+        let child_class = RawSymbol {
+            name: "ChildClass".to_string(),
+            kind: SymbolKind::Class,
+            start_line: 30,
+            end_line: 50,
+            signature: "class ChildClass extends BaseClass".to_string(),
+            content_hash: String::new(),
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Public,
+            type_info: None,
+            parent_name: None,
+        };
+
+        let extends_ref = RawReference {
+            name: "BaseClass".to_string(),
+            kind: ReferenceKind::Extends,
+            start_line: 30,
+            context: String::new(),
+            receiver: None,
+        };
+
+        // Caller file: child_instance.save()
+        let caller = make_symbol("caller", 1);
+        let save_call = RawReference {
+            name: "save".to_string(),
+            kind: ReferenceKind::Call,
+            start_line: 5,
+            context: String::new(),
+            receiver: Some("child_instance".to_string()),
+        };
+
+        let files = vec![
+            (
+                "src/base.ts".to_string(),
+                vec![base_class, save_method],
+                vec![],
+            ),
+            (
+                "src/child.ts".to_string(),
+                vec![child_class],
+                vec![extends_ref],
+            ),
+            ("src/main.ts".to_string(), vec![caller], vec![save_call]),
+        ];
+
+        // Type environment: child_instance has type ChildClass
+        let mut type_envs = std::collections::HashMap::new();
+        let env = TypeEnvironment::from_bindings(vec![(
+            "child_instance".to_string(),
+            2,
+            TypeBinding {
+                type_name: "ChildClass".to_string(),
+                line: 2,
+                confidence: 0.9,
+                source: BindingSource::Constructor,
+            },
+        )]);
+        type_envs.insert("src/main.ts".to_string(), env);
+
+        let edges = resolve_references_with_context(
+            &files,
+            Language::TypeScript,
+            "repo:test:abc",
+            &WorkspaceContext::default(),
+            Some(&type_envs),
+        );
+
+        let call_edges: Vec<_> = edges
+            .iter()
+            .filter(|e| e.edge_type == EdgeType::Calls)
+            .collect();
+        assert_eq!(
+            call_edges.len(),
+            1,
+            "should have exactly one call edge; got: {call_edges:?}"
+        );
+
+        let edge = &call_edges[0];
+        let expected_target = symbol_uid("repo:test:abc", "src/base.ts", "save", 5);
+        assert_eq!(
+            edge.target_uid, expected_target,
+            "should resolve to BaseClass::save via MRO walk"
+        );
+
+        // Confidence should decay: 0.9 - 0.05 * 1 = 0.85
+        assert!(
+            (edge.confidence - 0.85).abs() < f32::EPSILON,
+            "confidence should be 0.85 (decayed by one hop), got {}",
             edge.confidence
         );
     }

--- a/crates/nestweaver-resolver/src/resolve.rs
+++ b/crates/nestweaver-resolver/src/resolve.rs
@@ -30,16 +30,27 @@ pub fn resolve_references(
     language: Language,
     repo_uid: &str,
 ) -> Vec<ResolvedEdge> {
-    resolve_references_with_context(files, language, repo_uid, &WorkspaceContext::default())
+    resolve_references_with_context(
+        files,
+        language,
+        repo_uid,
+        &WorkspaceContext::default(),
+        None,
+    )
 }
 
 /// Like `resolve_references` but with an explicit `WorkspaceContext` for
 /// monorepo workspace package and tsconfig path alias resolution.
+///
+/// When `type_envs` is `Some`, per-file `TypeEnvironment` data is available
+/// for type-aware call resolution. Passing `None` preserves the previous
+/// behaviour.
 pub fn resolve_references_with_context(
     files: &[(String, Vec<RawSymbol>, Vec<RawReference>)],
     language: Language,
     repo_uid: &str,
     workspace_ctx: &WorkspaceContext,
+    _type_envs: Option<&std::collections::HashMap<String, crate::types::TypeEnvironment>>,
 ) -> Vec<ResolvedEdge> {
     let graph = build_import_graph(files, language, workspace_ctx);
 

--- a/crates/nestweaver-resolver/src/resolve.rs
+++ b/crates/nestweaver-resolver/src/resolve.rs
@@ -74,20 +74,19 @@ pub fn resolve_references_with_context(
             std::collections::HashMap::new();
         for (_, symbols, references) in files {
             for reference in references {
-                if reference.kind == ReferenceKind::Extends {
-                    if let Some(sym) = find_enclosing_symbol(symbols, reference.start_line) {
-                        if matches!(
-                            sym.kind,
-                            SymbolKind::Class
-                                | SymbolKind::Enum
-                                | SymbolKind::Interface
-                                | SymbolKind::Trait
-                        ) {
-                            map.entry(sym.name.clone())
-                                .or_default()
-                                .push(reference.name.clone());
-                        }
-                    }
+                if reference.kind == ReferenceKind::Extends
+                    && let Some(sym) = find_enclosing_symbol(symbols, reference.start_line)
+                    && matches!(
+                        sym.kind,
+                        SymbolKind::Class
+                            | SymbolKind::Enum
+                            | SymbolKind::Interface
+                            | SymbolKind::Trait
+                    )
+                {
+                    map.entry(sym.name.clone())
+                        .or_default()
+                        .push(reference.name.clone());
                 }
             }
         }
@@ -119,104 +118,88 @@ pub fn resolve_references_with_context(
             };
 
             // ── Type-aware resolution for member calls with known receiver type ──
-            if edge_type == EdgeType::Calls {
-                if let Some(ref receiver) = reference.receiver {
-                    if let Some(ref envs) = _type_envs {
-                        if let Some(env) = envs.get(file_path.as_str()) {
-                            let receiver_type = if receiver == "self"
-                                || receiver == "this"
-                                || receiver == "$this"
-                            {
-                                env.lookup_self(reference.start_line)
-                            } else {
-                                env.lookup(receiver, reference.start_line)
-                            };
+            if edge_type == EdgeType::Calls
+                && let Some(ref receiver) = reference.receiver
+                && let Some(envs) = _type_envs
+                && let Some(env) = envs.get(file_path.as_str())
+            {
+                let receiver_type =
+                    if receiver == "self" || receiver == "this" || receiver == "$this" {
+                        env.lookup_self(reference.start_line)
+                    } else {
+                        env.lookup(receiver, reference.start_line)
+                    };
 
-                            if let Some(binding) = receiver_type {
-                                let method_name = &reference.name;
-                                let type_name = &binding.type_name;
+                if let Some(binding) = receiver_type {
+                    let method_name = &reference.name;
+                    let type_name = &binding.type_name;
 
-                                if let Some(candidates) = symbol_map.get(method_name.as_str()) {
-                                    if let Some((candidate_file, sym)) =
-                                        candidates.iter().find(|(_, s)| {
-                                            s.parent_name.as_deref() == Some(type_name.as_str())
-                                        })
-                                    {
-                                        let target_uid = symbol_uid(
-                                            repo_uid,
-                                            candidate_file,
-                                            &sym.name,
-                                            sym.start_line,
-                                        );
-                                        let confidence = binding.confidence.min(0.95);
-                                        edges.push(ResolvedEdge {
-                                            source_uid: source_uid.clone(),
-                                            target_uid,
-                                            edge_type,
-                                            confidence,
-                                            link_type: None,
-                                        });
-                                        continue 'ref_loop;
-                                    }
-                                }
-                                // MRO walk: check parent types via inheritance chain
-                                {
-                                    let mut current_types = vec![type_name.clone()];
-                                    let mut visited = std::collections::HashSet::new();
-                                    visited.insert(type_name.clone());
-                                    let mut depth = 0u32;
+                    if let Some(candidates) = symbol_map.get(method_name.as_str())
+                        && let Some((candidate_file, sym)) = candidates
+                            .iter()
+                            .find(|(_, s)| s.parent_name.as_deref() == Some(type_name.as_str()))
+                    {
+                        let target_uid =
+                            symbol_uid(repo_uid, candidate_file, &sym.name, sym.start_line);
+                        let confidence = binding.confidence.min(0.95);
+                        edges.push(ResolvedEdge {
+                            source_uid: source_uid.clone(),
+                            target_uid,
+                            edge_type,
+                            confidence,
+                            link_type: None,
+                        });
+                        continue 'ref_loop;
+                    }
+                    // MRO walk: check parent types via inheritance chain
+                    {
+                        let mut current_types = vec![type_name.clone()];
+                        let mut visited = std::collections::HashSet::new();
+                        visited.insert(type_name.clone());
+                        let mut depth = 0u32;
 
-                                    while depth < 5 && !current_types.is_empty() {
-                                        let mut next_types = Vec::new();
-                                        for t in &current_types {
-                                            if let Some(parents) = extends_map.get(t.as_str()) {
-                                                for parent in parents {
-                                                    if visited.contains(parent) {
-                                                        continue; // cycle guard
-                                                    }
-                                                    visited.insert(parent.clone());
-
-                                                    if let Some(candidates) =
-                                                        symbol_map.get(method_name.as_str())
-                                                    {
-                                                        if let Some((cf, sym)) =
-                                                            candidates.iter().find(|(_, s)| {
-                                                                s.parent_name.as_deref()
-                                                                    == Some(parent.as_str())
-                                                            })
-                                                        {
-                                                            let target_uid = symbol_uid(
-                                                                repo_uid,
-                                                                cf,
-                                                                &sym.name,
-                                                                sym.start_line,
-                                                            );
-                                                            let conf = (binding.confidence
-                                                                - 0.05 * (depth + 1) as f32)
-                                                                .max(0.50);
-                                                            edges.push(ResolvedEdge {
-                                                                source_uid: source_uid.clone(),
-                                                                target_uid,
-                                                                edge_type,
-                                                                confidence: conf,
-                                                                link_type: None,
-                                                            });
-                                                            continue 'ref_loop;
-                                                        }
-                                                    }
-                                                    next_types.push(parent.clone());
-                                                }
-                                            }
+                        while depth < 5 && !current_types.is_empty() {
+                            let mut next_types = Vec::new();
+                            for t in &current_types {
+                                if let Some(parents) = extends_map.get(t.as_str()) {
+                                    for parent in parents {
+                                        if visited.contains(parent) {
+                                            continue; // cycle guard
                                         }
-                                        current_types = next_types;
-                                        depth += 1;
+                                        visited.insert(parent.clone());
+
+                                        if let Some(candidates) =
+                                            symbol_map.get(method_name.as_str())
+                                            && let Some((cf, sym)) =
+                                                candidates.iter().find(|(_, s)| {
+                                                    s.parent_name.as_deref()
+                                                        == Some(parent.as_str())
+                                                })
+                                        {
+                                            let target_uid =
+                                                symbol_uid(repo_uid, cf, &sym.name, sym.start_line);
+                                            let conf = (binding.confidence
+                                                - 0.05 * (depth + 1) as f32)
+                                                .max(0.50);
+                                            edges.push(ResolvedEdge {
+                                                source_uid: source_uid.clone(),
+                                                target_uid,
+                                                edge_type,
+                                                confidence: conf,
+                                                link_type: None,
+                                            });
+                                            continue 'ref_loop;
+                                        }
+                                        next_types.push(parent.clone());
                                     }
                                 }
-                                // Type was known but method not found on that type or ancestors.
-                                // Fall through to name-based resolution.
                             }
+                            current_types = next_types;
+                            depth += 1;
                         }
                     }
+                    // Type was known but method not found on that type or ancestors.
+                    // Fall through to name-based resolution.
                 }
             }
 

--- a/crates/nestweaver-resolver/src/resolve.rs
+++ b/crates/nestweaver-resolver/src/resolve.rs
@@ -178,9 +178,8 @@ pub fn resolve_references_with_context(
                                         {
                                             let target_uid =
                                                 symbol_uid(repo_uid, cf, &sym.name, sym.start_line);
-                                            let conf = (binding.confidence
-                                                - 0.05 * (depth + 1) as f32)
-                                                .max(0.50);
+                                            let conf = binding.confidence
+                                                * 0.95_f32.powi((depth + 1) as i32);
                                             edges.push(ResolvedEdge {
                                                 source_uid: source_uid.clone(),
                                                 target_uid,
@@ -1263,10 +1262,10 @@ mod tests {
             "should resolve to BaseClass::save via MRO walk"
         );
 
-        // Confidence should decay: 0.9 - 0.05 * 1 = 0.85
+        // Confidence should decay multiplicatively: 0.9 * 0.95 = 0.855
         assert!(
-            (edge.confidence - 0.85).abs() < f32::EPSILON,
-            "confidence should be 0.85 (decayed by one hop), got {}",
+            (edge.confidence - 0.855).abs() < 0.01,
+            "confidence should be ~0.855 (0.9 * 0.95 for one hop), got {}",
             edge.confidence
         );
     }

--- a/crates/nestweaver-resolver/src/resolve.rs
+++ b/crates/nestweaver-resolver/src/resolve.rs
@@ -368,6 +368,7 @@ mod tests {
             kind,
             start_line: line,
             context: String::new(),
+            receiver: None,
         }
     }
 

--- a/crates/nestweaver-resolver/src/resolve.rs
+++ b/crates/nestweaver-resolver/src/resolve.rs
@@ -69,7 +69,7 @@ pub fn resolve_references_with_context(
     let mut edges: Vec<ResolvedEdge> = Vec::new();
 
     for (file_path, symbols, references) in files {
-        for reference in references {
+        'ref_loop: for reference in references {
             let edge_type = match reference.kind {
                 ReferenceKind::Call => EdgeType::Calls,
                 ReferenceKind::Extends => EdgeType::Extends,
@@ -89,6 +89,55 @@ pub fn resolve_references_with_context(
                     continue;
                 }
             };
+
+            // ── Type-aware resolution for member calls with known receiver type ──
+            if edge_type == EdgeType::Calls {
+                if let Some(ref receiver) = reference.receiver {
+                    if let Some(ref envs) = _type_envs {
+                        if let Some(env) = envs.get(file_path.as_str()) {
+                            let receiver_type = if receiver == "self"
+                                || receiver == "this"
+                                || receiver == "$this"
+                            {
+                                env.lookup_self(reference.start_line)
+                            } else {
+                                env.lookup(receiver, reference.start_line)
+                            };
+
+                            if let Some(binding) = receiver_type {
+                                let method_name = &reference.name;
+                                let type_name = &binding.type_name;
+
+                                if let Some(candidates) = symbol_map.get(method_name.as_str()) {
+                                    if let Some((candidate_file, sym)) =
+                                        candidates.iter().find(|(_, s)| {
+                                            s.parent_name.as_deref() == Some(type_name.as_str())
+                                        })
+                                    {
+                                        let target_uid = symbol_uid(
+                                            repo_uid,
+                                            candidate_file,
+                                            &sym.name,
+                                            sym.start_line,
+                                        );
+                                        let confidence = binding.confidence.min(0.95);
+                                        edges.push(ResolvedEdge {
+                                            source_uid: source_uid.clone(),
+                                            target_uid,
+                                            edge_type,
+                                            confidence,
+                                            link_type: None,
+                                        });
+                                        continue 'ref_loop;
+                                    }
+                                }
+                                // Type was known but method not found on that type.
+                                // Fall through to name-based resolution.
+                            }
+                        }
+                    }
+                }
+            }
 
             let name = &reference.name;
 
@@ -852,5 +901,232 @@ mod tests {
             )];
             assert_yaml_snapshot!(sorted_edges(files, Language::JavaScript));
         }
+    }
+
+    #[test]
+    fn type_aware_resolves_member_call_via_receiver_type() {
+        use crate::type_extractors::{BindingSource, TypeBinding};
+        use crate::types::TypeEnvironment;
+
+        // File A: class Foo with method bar
+        let mut foo_bar = make_symbol("bar", 5);
+        foo_bar.parent_name = Some("Foo".to_string());
+        foo_bar.kind = SymbolKind::Function;
+
+        let foo_class = RawSymbol {
+            name: "Foo".to_string(),
+            kind: SymbolKind::Class,
+            start_line: 1,
+            end_line: 20,
+            signature: "class Foo".to_string(),
+            content_hash: String::new(),
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Public,
+            type_info: None,
+            parent_name: None,
+        };
+
+        // File B: class Baz with method bar (different parent)
+        let mut baz_bar = make_symbol("bar", 5);
+        baz_bar.parent_name = Some("Baz".to_string());
+
+        let baz_class = RawSymbol {
+            name: "Baz".to_string(),
+            kind: SymbolKind::Class,
+            start_line: 1,
+            end_line: 20,
+            signature: "class Baz".to_string(),
+            content_hash: String::new(),
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Public,
+            type_info: None,
+            parent_name: None,
+        };
+
+        // File C: caller that does foo_instance.bar()
+        let caller = make_symbol("caller", 1);
+        let bar_call = RawReference {
+            name: "bar".to_string(),
+            kind: ReferenceKind::Call,
+            start_line: 3,
+            context: String::new(),
+            receiver: Some("foo_instance".to_string()),
+        };
+
+        let files = vec![
+            ("src/foo.ts".to_string(), vec![foo_class, foo_bar], vec![]),
+            ("src/baz.ts".to_string(), vec![baz_class, baz_bar], vec![]),
+            ("src/main.ts".to_string(), vec![caller], vec![bar_call]),
+        ];
+
+        // Build a type environment for main.ts: foo_instance has type Foo at line 2
+        let mut type_envs = std::collections::HashMap::new();
+        let env = TypeEnvironment::from_bindings(vec![(
+            "foo_instance".to_string(),
+            2,
+            TypeBinding {
+                type_name: "Foo".to_string(),
+                line: 2,
+                confidence: 0.9,
+                source: BindingSource::Constructor,
+            },
+        )]);
+        type_envs.insert("src/main.ts".to_string(), env);
+
+        let edges = resolve_references_with_context(
+            &files,
+            Language::TypeScript,
+            "repo:test:abc",
+            &WorkspaceContext::default(),
+            Some(&type_envs),
+        );
+
+        let call_edges: Vec<_> = edges
+            .iter()
+            .filter(|e| e.edge_type == EdgeType::Calls)
+            .collect();
+        assert_eq!(call_edges.len(), 1, "should have exactly one call edge");
+
+        let edge = &call_edges[0];
+        let expected_target = symbol_uid("repo:test:abc", "src/foo.ts", "bar", 5);
+        let wrong_target = symbol_uid("repo:test:abc", "src/baz.ts", "bar", 5);
+        assert_eq!(
+            edge.target_uid, expected_target,
+            "should resolve to Foo::bar in foo.ts"
+        );
+        assert_ne!(
+            edge.target_uid, wrong_target,
+            "should NOT resolve to Baz::bar"
+        );
+        assert!(
+            (edge.confidence - 0.9).abs() < f32::EPSILON,
+            "confidence should be min(0.9, 0.95) = 0.9, got {}",
+            edge.confidence
+        );
+    }
+
+    #[test]
+    fn type_aware_self_receiver_resolves_to_own_class() {
+        use crate::type_extractors::{BindingSource, TypeBinding};
+        use crate::types::TypeEnvironment;
+
+        // Class MyClass with method helper
+        let mut helper = make_symbol("helper", 5);
+        helper.parent_name = Some("MyClass".to_string());
+
+        // Method doWork that calls this.helper()
+        let mut do_work = make_symbol("doWork", 10);
+        do_work.parent_name = Some("MyClass".to_string());
+
+        let this_call = RawReference {
+            name: "helper".to_string(),
+            kind: ReferenceKind::Call,
+            start_line: 12,
+            context: String::new(),
+            receiver: Some("this".to_string()),
+        };
+
+        let files = vec![(
+            "src/myclass.ts".to_string(),
+            vec![
+                RawSymbol {
+                    name: "MyClass".to_string(),
+                    kind: SymbolKind::Class,
+                    start_line: 1,
+                    end_line: 30,
+                    signature: "class MyClass".to_string(),
+                    content_hash: String::new(),
+                    is_entry_point: false,
+                    entry_point_kind: None,
+                    visibility: Visibility::Public,
+                    type_info: None,
+                    parent_name: None,
+                },
+                helper,
+                do_work,
+            ],
+            vec![this_call],
+        )];
+
+        let mut type_envs = std::collections::HashMap::new();
+        let env = TypeEnvironment::from_bindings(vec![(
+            "this".to_string(),
+            10,
+            TypeBinding {
+                type_name: "MyClass".to_string(),
+                line: 10,
+                confidence: 0.95,
+                source: BindingSource::SelfThis,
+            },
+        )]);
+        type_envs.insert("src/myclass.ts".to_string(), env);
+
+        let edges = resolve_references_with_context(
+            &files,
+            Language::TypeScript,
+            "repo:test:abc",
+            &WorkspaceContext::default(),
+            Some(&type_envs),
+        );
+
+        let call_edges: Vec<_> = edges
+            .iter()
+            .filter(|e| e.edge_type == EdgeType::Calls)
+            .collect();
+        assert_eq!(call_edges.len(), 1, "should have exactly one call edge");
+
+        let edge = &call_edges[0];
+        let expected_target = symbol_uid("repo:test:abc", "src/myclass.ts", "helper", 5);
+        assert_eq!(
+            edge.target_uid, expected_target,
+            "should resolve to helper method"
+        );
+        assert!(
+            (edge.confidence - 0.95).abs() < f32::EPSILON,
+            "confidence should be capped at 0.95, got {}",
+            edge.confidence
+        );
+    }
+
+    #[test]
+    fn type_aware_falls_back_to_name_based_when_no_type_env() {
+        // Same setup as type_aware test but without type_envs
+        // Should fall through to name-based resolution
+        let mut foo_bar = make_symbol("bar", 5);
+        foo_bar.parent_name = Some("Foo".to_string());
+
+        let caller = make_symbol("caller", 1);
+        let bar_call = RawReference {
+            name: "bar".to_string(),
+            kind: ReferenceKind::Call,
+            start_line: 3,
+            context: String::new(),
+            receiver: Some("foo_instance".to_string()),
+        };
+
+        let files = vec![
+            ("src/foo.ts".to_string(), vec![foo_bar], vec![]),
+            ("src/main.ts".to_string(), vec![caller], vec![bar_call]),
+        ];
+
+        // No type_envs → passes None
+        let edges = resolve_references_with_context(
+            &files,
+            Language::TypeScript,
+            "repo:test:abc",
+            &WorkspaceContext::default(),
+            None,
+        );
+
+        let call_edges: Vec<_> = edges
+            .iter()
+            .filter(|e| e.edge_type == EdgeType::Calls)
+            .collect();
+        assert!(
+            !call_edges.is_empty(),
+            "should still produce edges via name-based fallback"
+        );
     }
 }

--- a/crates/nestweaver-resolver/src/resolve.rs
+++ b/crates/nestweaver-resolver/src/resolve.rs
@@ -359,6 +359,7 @@ mod tests {
             entry_point_kind: None,
             visibility: Visibility::Inferred,
             type_info: None,
+            parent_name: None,
         }
     }
 

--- a/crates/nestweaver-resolver/src/type_extractors.rs
+++ b/crates/nestweaver-resolver/src/type_extractors.rs
@@ -121,10 +121,8 @@ fn extract_ts_annotation(line: &str) -> Option<(String, String)> {
         r
     } else if let Some(r) = line.strip_prefix("let ") {
         r
-    } else if let Some(r) = line.strip_prefix("var ") {
-        r
     } else {
-        return None;
+        line.strip_prefix("var ")?
     };
 
     let colon_pos = rest.find(':')?;
@@ -156,7 +154,7 @@ fn extract_java_annotation(line: &str) -> Option<(String, String)> {
     if !type_candidate
         .chars()
         .next()
-        .map_or(false, |c| c.is_ascii_uppercase())
+        .is_some_and(|c| c.is_ascii_uppercase())
     {
         return None;
     }
@@ -240,7 +238,7 @@ fn extract_go_annotation(line: &str) -> Option<(String, String)> {
 
     // Go type: could start with * (pointer), [] (slice), map[, etc.
     // For simplicity, extract the base type identifier
-    let type_str = after_name.split(|c: char| c == '=' || c == '\n').next()?;
+    let type_str = after_name.split(['=', '\n']).next()?;
     let type_str = type_str.trim();
 
     if type_str.is_empty() {
@@ -291,17 +289,12 @@ fn extract_constructors(
         if let Some((var_name, type_name)) = result {
             let key = (var_name, line_num);
             // Don't overwrite a Tier 0 annotation with a Tier 1 constructor
-            if !bindings.contains_key(&key) {
-                bindings.insert(
-                    key,
-                    TypeBinding {
-                        type_name,
-                        line: line_num,
-                        confidence: 0.90,
-                        source: BindingSource::Constructor,
-                    },
-                );
-            }
+            bindings.entry(key).or_insert(TypeBinding {
+                type_name,
+                line: line_num,
+                confidence: 0.90,
+                source: BindingSource::Constructor,
+            });
         }
     }
 }

--- a/crates/nestweaver-resolver/src/type_extractors.rs
+++ b/crates/nestweaver-resolver/src/type_extractors.rs
@@ -1,0 +1,796 @@
+use std::collections::{HashMap, HashSet};
+
+use nestweaver_parser::RawSymbol;
+use nestweaver_schema::{Language, SymbolKind};
+
+// ── Data types ────────────────────────────────────────────────────────────
+
+/// A type binding discovered from source text analysis.
+#[derive(Debug, Clone)]
+pub struct TypeBinding {
+    /// The resolved type name (e.g. `"Foo"`, `"HashMap"`)
+    pub type_name: String,
+    /// Source line where the binding was found
+    pub line: u32,
+    /// Confidence in this binding (0.0–1.0)
+    pub confidence: f32,
+    /// How the binding was discovered
+    pub source: BindingSource,
+}
+
+/// The mechanism that produced a [`TypeBinding`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BindingSource {
+    /// Explicit type annotation: `let x: Foo`, `const x: Foo`, `Type x`, `x: Type`
+    Annotation,
+    /// Constructor call: `new Foo()`, `Foo::new()`, `Foo()`, `Foo{}`
+    Constructor,
+    /// Self/this receiver in a method body
+    SelfThis,
+    /// Propagated from another binding via assignment
+    Assignment,
+    /// Inferred from a function's return type
+    ReturnType,
+}
+
+// ── Main entry point ──────────────────────────────────────────────────────
+
+/// Extract type bindings from source code using three tiers of analysis.
+///
+/// Returns a map keyed by `(variable_name, line_number)` to avoid collisions
+/// when the same name is rebound on different lines.
+///
+/// **Tier 0** — Explicit type annotations (confidence 0.95)
+/// **Tier 1** — Constructor patterns (confidence 0.90)
+/// **Tier 2** — self/this bindings from method parent_name (confidence 1.0)
+pub fn extract_bindings(
+    source: &str,
+    language: Language,
+    symbols: &[RawSymbol],
+) -> HashMap<(String, u32), TypeBinding> {
+    let mut bindings = HashMap::new();
+
+    // Tier 0: annotations
+    extract_annotations(source, language, &mut bindings);
+
+    // Tier 1: constructors
+    extract_constructors(source, language, symbols, &mut bindings);
+
+    // Tier 2: self/this
+    extract_self_bindings(language, symbols, &mut bindings);
+
+    bindings
+}
+
+// ── Tier 0: Annotations ──────────────────────────────────────────────────
+
+fn extract_annotations(
+    source: &str,
+    language: Language,
+    bindings: &mut HashMap<(String, u32), TypeBinding>,
+) {
+    for (line_idx, line) in source.lines().enumerate() {
+        let line_num = (line_idx as u32) + 1;
+        let trimmed = line.trim();
+
+        let result = match language {
+            Language::Rust => extract_rust_annotation(trimmed),
+            Language::TypeScript | Language::JavaScript => extract_ts_annotation(trimmed),
+            Language::Java | Language::CSharp => extract_java_annotation(trimmed),
+            Language::Python => extract_python_annotation(trimmed),
+            Language::Go => extract_go_annotation(trimmed),
+            _ => None,
+        };
+
+        if let Some((var_name, type_name)) = result {
+            bindings.insert(
+                (var_name, line_num),
+                TypeBinding {
+                    type_name,
+                    line: line_num,
+                    confidence: 0.95,
+                    source: BindingSource::Annotation,
+                },
+            );
+        }
+    }
+}
+
+/// Rust: `let var: Type = ...` or `let mut var: Type = ...`
+fn extract_rust_annotation(line: &str) -> Option<(String, String)> {
+    let rest = line.strip_prefix("let ")?;
+    let rest = rest.strip_prefix("mut ").unwrap_or(rest);
+
+    // Find var name (up to ':')
+    let colon_pos = rest.find(':')?;
+    let var_name = rest[..colon_pos].trim();
+    if var_name.is_empty() || !is_identifier(var_name) {
+        return None;
+    }
+
+    // Extract type after ':'
+    let after_colon = rest[colon_pos + 1..].trim();
+    let type_name = extract_type_token(after_colon)?;
+
+    Some((var_name.to_string(), type_name))
+}
+
+/// TypeScript/JavaScript: `const/let/var name: Type = ...`
+fn extract_ts_annotation(line: &str) -> Option<(String, String)> {
+    let rest = if let Some(r) = line.strip_prefix("const ") {
+        r
+    } else if let Some(r) = line.strip_prefix("let ") {
+        r
+    } else if let Some(r) = line.strip_prefix("var ") {
+        r
+    } else {
+        return None;
+    };
+
+    let colon_pos = rest.find(':')?;
+    let var_name = rest[..colon_pos].trim();
+    if var_name.is_empty() || !is_identifier(var_name) {
+        return None;
+    }
+
+    let after_colon = rest[colon_pos + 1..].trim();
+    let type_name = extract_type_token(after_colon)?;
+
+    Some((var_name.to_string(), type_name))
+}
+
+/// Java/C#: `Type name = ...` where Type starts with uppercase.
+fn extract_java_annotation(line: &str) -> Option<(String, String)> {
+    // Skip common non-type keywords that start with uppercase
+    // Also skip lines that start with keywords like return, if, etc.
+    let trimmed = line.trim_start();
+
+    // Remove access modifiers
+    let rest = strip_modifiers(trimmed);
+
+    // Need at least "Type name"
+    let space_pos = rest.find(' ')?;
+    let type_candidate = &rest[..space_pos];
+
+    // Type must start with uppercase letter
+    if !type_candidate
+        .chars()
+        .next()
+        .map_or(false, |c| c.is_ascii_uppercase())
+    {
+        return None;
+    }
+
+    if !is_type_identifier(type_candidate) {
+        return None;
+    }
+
+    // Skip generic type params for the purpose of finding the var name
+    let after_type = rest[space_pos..].trim_start();
+    let after_generics = skip_generic_params(after_type);
+
+    // Extract variable name (next identifier)
+    let var_end = after_generics
+        .find(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .unwrap_or(after_generics.len());
+    let var_name = &after_generics[..var_end];
+
+    if var_name.is_empty() || !is_identifier(var_name) {
+        return None;
+    }
+
+    // Strip generic params from type name for the binding
+    let base_type = strip_generics(type_candidate);
+
+    Some((var_name.to_string(), base_type))
+}
+
+/// Python: `name: Type = ...`
+fn extract_python_annotation(line: &str) -> Option<(String, String)> {
+    // Must not start with def/class/import/from/return/if/for/while etc.
+    let first_word_end = line
+        .find(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .unwrap_or(line.len());
+    let first_word = &line[..first_word_end];
+
+    if matches!(
+        first_word,
+        "def"
+            | "class"
+            | "import"
+            | "from"
+            | "return"
+            | "if"
+            | "for"
+            | "while"
+            | "elif"
+            | "except"
+            | "with"
+            | "async"
+            | "yield"
+    ) {
+        return None;
+    }
+
+    let colon_pos = line.find(':')?;
+    let var_name = line[..colon_pos].trim();
+
+    if var_name.is_empty() || !is_identifier(var_name) {
+        return None;
+    }
+
+    let after_colon = line[colon_pos + 1..].trim();
+    let type_name = extract_type_token(after_colon)?;
+
+    Some((var_name.to_string(), type_name))
+}
+
+/// Go: `var name Type`
+fn extract_go_annotation(line: &str) -> Option<(String, String)> {
+    let rest = line.strip_prefix("var ")?;
+
+    let space_pos = rest.find(' ')?;
+    let var_name = &rest[..space_pos];
+
+    if var_name.is_empty() || !is_identifier(var_name) {
+        return None;
+    }
+
+    let after_name = rest[space_pos..].trim_start();
+
+    // Go type: could start with * (pointer), [] (slice), map[, etc.
+    // For simplicity, extract the base type identifier
+    let type_str = after_name.split(|c: char| c == '=' || c == '\n').next()?;
+    let type_str = type_str.trim();
+
+    if type_str.is_empty() {
+        return None;
+    }
+
+    // Strip pointer prefix
+    let base = type_str.trim_start_matches('*');
+    let type_name = extract_type_token(base)?;
+
+    Some((var_name.to_string(), type_name))
+}
+
+// ── Tier 1: Constructors ─────────────────────────────────────────────────
+
+fn extract_constructors(
+    source: &str,
+    language: Language,
+    symbols: &[RawSymbol],
+    bindings: &mut HashMap<(String, u32), TypeBinding>,
+) {
+    // Collect known class names from symbols for Python/Kotlin constructor detection
+    let class_names: HashSet<&str> = symbols
+        .iter()
+        .filter(|s| matches!(s.kind, SymbolKind::Class | SymbolKind::Enum))
+        .map(|s| s.name.as_str())
+        .collect();
+
+    for (line_idx, line) in source.lines().enumerate() {
+        let line_num = (line_idx as u32) + 1;
+        let trimmed = line.trim();
+
+        let result = match language {
+            Language::TypeScript
+            | Language::JavaScript
+            | Language::Java
+            | Language::CSharp
+            | Language::Dart
+            | Language::Php => extract_new_constructor(trimmed),
+            Language::Rust => extract_rust_constructor(trimmed),
+            Language::Python | Language::Kotlin => {
+                extract_callable_constructor(trimmed, &class_names)
+            }
+            Language::Go => extract_go_constructor(trimmed),
+            _ => None,
+        };
+
+        if let Some((var_name, type_name)) = result {
+            let key = (var_name, line_num);
+            // Don't overwrite a Tier 0 annotation with a Tier 1 constructor
+            if !bindings.contains_key(&key) {
+                bindings.insert(
+                    key,
+                    TypeBinding {
+                        type_name,
+                        line: line_num,
+                        confidence: 0.90,
+                        source: BindingSource::Constructor,
+                    },
+                );
+            }
+        }
+    }
+}
+
+/// `new Foo(...)` pattern for TS/JS/Java/C#/Dart/PHP.
+/// Matches lines like `const x = new Foo(...)`, `Type x = new Foo(...)`, etc.
+fn extract_new_constructor(line: &str) -> Option<(String, String)> {
+    let new_pos = line.find("new ")?;
+
+    // Extract the type name after "new "
+    let after_new = &line[new_pos + 4..];
+    let type_end = after_new
+        .find(|c: char| !c.is_ascii_alphanumeric() && c != '_' && c != '.')
+        .unwrap_or(after_new.len());
+    let type_name = &after_new[..type_end];
+
+    if type_name.is_empty() {
+        return None;
+    }
+
+    // Use the last segment for qualified names (e.g., `pkg.Foo` → `Foo`)
+    let base_type = type_name.rsplit('.').next().unwrap_or(type_name);
+    if base_type.is_empty() || !is_type_identifier(base_type) {
+        return None;
+    }
+
+    // Try to find the variable being assigned
+    let before_new = line[..new_pos].trim();
+    let var_name = extract_assignment_target(before_new)?;
+
+    Some((var_name, base_type.to_string()))
+}
+
+/// Rust: `Foo::new(...)` or `Foo::default(...)`
+fn extract_rust_constructor(line: &str) -> Option<(String, String)> {
+    // Look for `::new(` or `::default(`
+    let constructor_pos = line.find("::new(").or_else(|| line.find("::default("))?;
+
+    // Walk backwards from `::new(` to find the type name
+    let before = &line[..constructor_pos];
+    let type_start = before
+        .rfind(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .map(|p| p + 1)
+        .unwrap_or(0);
+    let type_name = &before[type_start..];
+
+    if type_name.is_empty() || !is_type_identifier(type_name) {
+        return None;
+    }
+
+    // Find the variable being assigned.
+    // Use the '=' sign from the full line to isolate the LHS.
+    // e.g. "let mut name: String = String::new();" → LHS = "let mut name: String"
+    let eq_pos = line.find('=')?;
+    let lhs = line[..eq_pos].trim();
+    // Strip any type annotation after ':'
+    let var_part = if let Some(colon_pos) = lhs.find(':') {
+        &lhs[..colon_pos]
+    } else {
+        lhs
+    };
+    let var_name = extract_assignment_target(var_part.trim())?;
+
+    Some((var_name, type_name.to_string()))
+}
+
+/// Python/Kotlin: `Foo(...)` where Foo is a known class from symbols.
+fn extract_callable_constructor(
+    line: &str,
+    class_names: &HashSet<&str>,
+) -> Option<(String, String)> {
+    // Look for `SomeClass(` pattern
+    let paren_pos = line.find('(')?;
+    let before_paren = &line[..paren_pos];
+
+    // Extract the last identifier before '('
+    let call_start = before_paren
+        .rfind(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .map(|p| p + 1)
+        .unwrap_or(0);
+    let call_name = &before_paren[call_start..];
+
+    if call_name.is_empty() || !class_names.contains(call_name) {
+        return None;
+    }
+
+    // Find variable name before the call
+    let assign_region = &line[..call_start];
+    let var_name = extract_assignment_target(assign_region.trim())?;
+
+    Some((var_name, call_name.to_string()))
+}
+
+/// Go: `Foo{}` or `&Foo{}`
+fn extract_go_constructor(line: &str) -> Option<(String, String)> {
+    // Look for `Type{` or `&Type{`
+    let brace_pos = line.find('{')?;
+    let before_brace = &line[..brace_pos];
+    let before_brace = before_brace.trim_end();
+
+    if before_brace.is_empty() {
+        return None;
+    }
+
+    // Walk back past optional '&' to find type name
+    let type_region = before_brace.trim_end_matches('&');
+    let type_start = type_region
+        .rfind(|c: char| !c.is_ascii_alphanumeric() && c != '_' && c != '.')
+        .map(|p| p + 1)
+        .unwrap_or(0);
+    let type_name = &type_region[type_start..];
+
+    if type_name.is_empty() || !is_type_identifier(type_name) {
+        return None;
+    }
+
+    // Find variable being assigned
+    let assign_region = &line[..type_start];
+    // Also try stripping the '&' if it was directly attached
+    let assign_region = assign_region.trim().trim_end_matches('&').trim();
+    let var_name = extract_assignment_target(assign_region)?;
+
+    Some((var_name, type_name.to_string()))
+}
+
+// ── Tier 2: Self/This ────────────────────────────────────────────────────
+
+fn extract_self_bindings(
+    language: Language,
+    symbols: &[RawSymbol],
+    bindings: &mut HashMap<(String, u32), TypeBinding>,
+) {
+    let self_keyword = match language {
+        Language::Rust | Language::Python | Language::Swift => "self",
+        Language::TypeScript
+        | Language::JavaScript
+        | Language::Java
+        | Language::CSharp
+        | Language::Kotlin
+        | Language::Dart => "this",
+        Language::Php => "$this",
+        Language::Ruby => "self",
+        _ => return,
+    };
+
+    for sym in symbols {
+        if sym.kind != SymbolKind::Method {
+            continue;
+        }
+        if let Some(parent) = &sym.parent_name {
+            bindings.insert(
+                (self_keyword.to_string(), sym.start_line),
+                TypeBinding {
+                    type_name: parent.clone(),
+                    line: sym.start_line,
+                    confidence: 1.0,
+                    source: BindingSource::SelfThis,
+                },
+            );
+        }
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/// Check if a string is a valid identifier (ASCII letters, digits, underscore, starts non-digit).
+fn is_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Check if a string is a valid type identifier (like `is_identifier` but starts with uppercase
+/// or is a common type name).
+fn is_type_identifier(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    let base = s.split('<').next().unwrap_or(s);
+    let mut chars = base.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Extract the first type token from text after a colon, stopping at `=`, `,`, `)`, `{`, `;`.
+/// Handles simple generics like `Vec<String>` by counting angle brackets.
+fn extract_type_token(text: &str) -> Option<String> {
+    let text = text.trim();
+    if text.is_empty() {
+        return None;
+    }
+
+    let mut depth = 0i32;
+    let mut end = 0;
+    for (i, c) in text.char_indices() {
+        match c {
+            '<' => depth += 1,
+            '>' if depth > 0 => depth -= 1,
+            '=' | ',' | ')' | '{' | ';' | '\n' if depth == 0 => break,
+            ' ' if depth == 0 && i > 0 => break,
+            _ => {}
+        }
+        end = i + c.len_utf8();
+    }
+
+    let token = text[..end].trim();
+    if token.is_empty() {
+        return None;
+    }
+
+    // Return the base type name (strip generics for the binding)
+    let base = token.split('<').next().unwrap_or(token);
+    let base = base.trim_start_matches('*').trim_start_matches('&');
+
+    if base.is_empty() || !is_type_identifier(base) {
+        return None;
+    }
+
+    Some(base.to_string())
+}
+
+/// Strip Java/C# access modifiers from the beginning of a line.
+fn strip_modifiers(line: &str) -> &str {
+    let mut rest = line;
+    for modifier in &[
+        "public ",
+        "private ",
+        "protected ",
+        "static ",
+        "final ",
+        "readonly ",
+        "abstract ",
+        "volatile ",
+        "transient ",
+    ] {
+        if let Some(r) = rest.strip_prefix(modifier) {
+            rest = r;
+            // Check for chained modifiers
+            return strip_modifiers(rest);
+        }
+    }
+    rest
+}
+
+/// Skip generic type parameters like `<String, Integer>`.
+fn skip_generic_params(text: &str) -> &str {
+    if !text.starts_with('<') {
+        return text;
+    }
+    let mut depth = 0;
+    for (i, c) in text.char_indices() {
+        match c {
+            '<' => depth += 1,
+            '>' => {
+                depth -= 1;
+                if depth == 0 {
+                    return text[i + 1..].trim_start();
+                }
+            }
+            _ => {}
+        }
+    }
+    text
+}
+
+/// Strip generic parameters from a type name: `HashMap<K,V>` → `HashMap`.
+fn strip_generics(s: &str) -> String {
+    s.split('<').next().unwrap_or(s).to_string()
+}
+
+/// Given the text before an `=` or `new`/constructor, extract the variable name being assigned.
+/// E.g. from `const foo =` → `foo`, from `let bar: Type =` → `bar`.
+fn extract_assignment_target(text: &str) -> Option<String> {
+    let text = text.trim().trim_end_matches('=').trim();
+    if text.is_empty() {
+        return None;
+    }
+
+    // For `:=` (Go short assignment)
+    let text = text.trim_end_matches(':').trim();
+
+    // Could be `const x`, `let x`, `var x`, `let mut x`, or just `x`
+    // Take the last identifier-like token
+    let last_token = text
+        .rsplit(|c: char| c.is_whitespace() || c == ':')
+        .next()?;
+    let last_token = last_token.trim();
+
+    if last_token.is_empty() || !is_identifier(last_token) {
+        return None;
+    }
+
+    Some(last_token.to_string())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nestweaver_schema::Visibility;
+
+    fn make_symbol(name: &str, kind: SymbolKind, parent: Option<&str>) -> RawSymbol {
+        RawSymbol {
+            name: name.to_string(),
+            kind,
+            start_line: 1,
+            end_line: 10,
+            signature: String::new(),
+            content_hash: String::new(),
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Public,
+            type_info: None,
+            parent_name: parent.map(|s| s.to_string()),
+        }
+    }
+
+    fn make_method(name: &str, parent: &str, start_line: u32) -> RawSymbol {
+        RawSymbol {
+            name: name.to_string(),
+            kind: SymbolKind::Method,
+            start_line,
+            end_line: start_line + 5,
+            signature: format!("fn {name}(&self)"),
+            content_hash: String::new(),
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Public,
+            type_info: None,
+            parent_name: Some(parent.to_string()),
+        }
+    }
+
+    // ── Tier 0: Annotations ──────────────────────────────────────────
+
+    #[test]
+    fn rust_annotation_let() {
+        let src = "    let count: u32 = 0;\n    let mut name: String = String::new();";
+        let bindings = extract_bindings(src, Language::Rust, &[]);
+        assert_eq!(bindings.len(), 2);
+
+        let b = &bindings[&("count".to_string(), 1)];
+        assert_eq!(b.type_name, "u32");
+        assert_eq!(b.confidence, 0.95);
+        assert_eq!(b.source, BindingSource::Annotation);
+
+        let b = &bindings[&("name".to_string(), 2)];
+        assert_eq!(b.type_name, "String");
+    }
+
+    #[test]
+    fn rust_constructor_new() {
+        let src = "    let map = HashMap::new();";
+        let bindings = extract_bindings(src, Language::Rust, &[]);
+
+        let b = &bindings[&("map".to_string(), 1)];
+        assert_eq!(b.type_name, "HashMap");
+        assert_eq!(b.confidence, 0.90);
+        assert_eq!(b.source, BindingSource::Constructor);
+    }
+
+    #[test]
+    fn typescript_annotation() {
+        let src = "const name: string = \"hello\";\nlet items: Array = [];";
+        let bindings = extract_bindings(src, Language::TypeScript, &[]);
+
+        let b = &bindings[&("name".to_string(), 1)];
+        assert_eq!(b.type_name, "string");
+        assert_eq!(b.confidence, 0.95);
+
+        let b = &bindings[&("items".to_string(), 2)];
+        assert_eq!(b.type_name, "Array");
+    }
+
+    #[test]
+    fn typescript_new_constructor() {
+        let src = "const svc = new UserService();";
+        let bindings = extract_bindings(src, Language::TypeScript, &[]);
+
+        let b = &bindings[&("svc".to_string(), 1)];
+        assert_eq!(b.type_name, "UserService");
+        assert_eq!(b.confidence, 0.90);
+        assert_eq!(b.source, BindingSource::Constructor);
+    }
+
+    #[test]
+    fn java_annotation() {
+        let src = "    HashMap map = new HashMap<>();\n    private final String name = \"foo\";";
+        let bindings = extract_bindings(src, Language::Java, &[]);
+
+        let b = &bindings[&("map".to_string(), 1)];
+        assert_eq!(b.type_name, "HashMap");
+        assert_eq!(b.confidence, 0.95);
+        assert_eq!(b.source, BindingSource::Annotation);
+
+        let b = &bindings[&("name".to_string(), 2)];
+        assert_eq!(b.type_name, "String");
+    }
+
+    #[test]
+    fn python_annotation() {
+        let src = "count: int = 0\nname: str = \"hello\"";
+        let bindings = extract_bindings(src, Language::Python, &[]);
+
+        let b = &bindings[&("count".to_string(), 1)];
+        assert_eq!(b.type_name, "int");
+        assert_eq!(b.confidence, 0.95);
+
+        let b = &bindings[&("name".to_string(), 2)];
+        assert_eq!(b.type_name, "str");
+    }
+
+    #[test]
+    fn go_annotation_and_constructor() {
+        let src = "    var count int\n    svc := &UserService{}";
+        let symbols: Vec<RawSymbol> = vec![];
+        let bindings = extract_bindings(src, Language::Go, &symbols);
+
+        let b = &bindings[&("count".to_string(), 1)];
+        assert_eq!(b.type_name, "int");
+        assert_eq!(b.confidence, 0.95);
+        assert_eq!(b.source, BindingSource::Annotation);
+
+        let b = &bindings[&("svc".to_string(), 2)];
+        assert_eq!(b.type_name, "UserService");
+        assert_eq!(b.confidence, 0.90);
+        assert_eq!(b.source, BindingSource::Constructor);
+    }
+
+    #[test]
+    fn self_binding_from_parent() {
+        let symbols = vec![
+            make_method("process", "OrderService", 10),
+            make_method("validate", "OrderService", 20),
+            make_symbol("helper", SymbolKind::Function, None),
+        ];
+        let src = ""; // source doesn't matter for Tier 2
+        let bindings = extract_bindings(src, Language::Rust, &symbols);
+
+        // Two methods → two self bindings
+        assert_eq!(bindings.len(), 2);
+
+        let b = &bindings[&("self".to_string(), 10)];
+        assert_eq!(b.type_name, "OrderService");
+        assert_eq!(b.confidence, 1.0);
+        assert_eq!(b.source, BindingSource::SelfThis);
+
+        let b = &bindings[&("self".to_string(), 20)];
+        assert_eq!(b.type_name, "OrderService");
+    }
+
+    #[test]
+    fn this_binding_for_typescript() {
+        let symbols = vec![make_method("render", "Component", 5)];
+        let bindings = extract_bindings("", Language::TypeScript, &symbols);
+
+        let b = &bindings[&("this".to_string(), 5)];
+        assert_eq!(b.type_name, "Component");
+        assert_eq!(b.confidence, 1.0);
+        assert_eq!(b.source, BindingSource::SelfThis);
+    }
+
+    #[test]
+    fn python_callable_constructor() {
+        let symbols = vec![make_symbol("Config", SymbolKind::Class, None)];
+        let src = "cfg = Config()";
+        let bindings = extract_bindings(src, Language::Python, &symbols);
+
+        let b = &bindings[&("cfg".to_string(), 1)];
+        assert_eq!(b.type_name, "Config");
+        assert_eq!(b.confidence, 0.90);
+        assert_eq!(b.source, BindingSource::Constructor);
+    }
+
+    #[test]
+    fn annotation_takes_priority_over_constructor() {
+        // When both annotation and constructor are detected, annotation wins (Tier 0 first)
+        let src = "let map: HashMap = HashMap::new();";
+        let bindings = extract_bindings(src, Language::Rust, &[]);
+
+        let b = &bindings[&("map".to_string(), 1)];
+        assert_eq!(b.source, BindingSource::Annotation);
+        assert_eq!(b.confidence, 0.95);
+    }
+}

--- a/crates/nestweaver-resolver/src/types.rs
+++ b/crates/nestweaver-resolver/src/types.rs
@@ -122,6 +122,43 @@ impl TypeEnvironment {
         self.bindings.len()
     }
 
+    /// Seed bindings from cross-file return type information.
+    /// For each call `let x = foo()` where foo's return type is known,
+    /// bind x to that return type.
+    pub fn seed_return_types(
+        &mut self,
+        source: &str,
+        symbols_by_name: &std::collections::HashMap<&str, &RawSymbol>,
+    ) {
+        for (line_num, line) in source.lines().enumerate() {
+            let line_num = (line_num + 1) as u32;
+            let trimmed = line.trim();
+
+            if let Some((var_name, callee)) = extract_call_assignment(trimmed) {
+                let key = (var_name.to_string(), line_num);
+                if self.bindings.contains_key(&key) {
+                    continue;
+                }
+
+                if let Some(sym) = symbols_by_name.get(callee.as_str()) {
+                    if let Some(ref ti) = sym.type_info {
+                        if let Some(ref ret) = ti.return_type {
+                            self.bindings.insert(
+                                key,
+                                TypeBinding {
+                                    type_name: ret.clone(),
+                                    line: line_num,
+                                    confidence: 0.85,
+                                    source: BindingSource::ReturnType,
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     /// Construct a `TypeEnvironment` from pre-built bindings (for testing).
     pub fn from_bindings(entries: Vec<(String, u32, TypeBinding)>) -> Self {
         let mut bindings = HashMap::new();
@@ -208,6 +245,49 @@ fn propagate_assignments(
             break;
         }
     }
+}
+
+/// Extract a `(variable_name, callee_name)` pair from a line like
+/// `let result = someFunction(args)` or `const x = obj.method()`.
+fn extract_call_assignment(line: &str) -> Option<(&str, String)> {
+    let eq_pos = line.find('=')?;
+    // Skip ==, !=, <=, >=, =>
+    if eq_pos > 0 && matches!(line.as_bytes()[eq_pos - 1], b'!' | b'<' | b'>' | b'=') {
+        return None;
+    }
+    if line.as_bytes().get(eq_pos + 1) == Some(&b'=')
+        || line.as_bytes().get(eq_pos + 1) == Some(&b'>')
+    {
+        return None;
+    }
+
+    let lhs = line[..eq_pos]
+        .trim()
+        .trim_start_matches("let ")
+        .trim_start_matches("mut ")
+        .trim_start_matches("const ")
+        .trim_start_matches("var ")
+        .trim();
+    if lhs.contains(':') || lhs.is_empty() {
+        return None;
+    }
+    if !lhs.chars().all(|c| c.is_alphanumeric() || c == '_') {
+        return None;
+    }
+
+    let rhs = line[eq_pos + 1..].trim();
+    let paren = rhs.find('(')?;
+    // Extract the last identifier before the paren (handles obj.method() → method)
+    let before_paren = &rhs[..paren];
+    let callee = before_paren
+        .rsplit(|c: char| !c.is_alphanumeric() && c != '_')
+        .next()?
+        .trim();
+    if callee.is_empty() {
+        return None;
+    }
+
+    Some((lhs, callee.to_string()))
 }
 
 #[cfg(test)]
@@ -344,6 +424,29 @@ mod tests {
         assert!(binding.is_some(), "alias should get store's type");
         assert_eq!(binding.unwrap().type_name, "GraphStore");
         assert!(binding.unwrap().confidence < 0.90);
+    }
+
+    #[test]
+    fn seed_return_types_binds_call_result() {
+        let source = "let store = open_store();\nstore.query();\n";
+        let mut sym = make_function("open_store");
+        sym.type_info = Some(nestweaver_schema::TypeInfo {
+            declared_type: None,
+            parameter_types: vec![],
+            return_type: Some("GraphStore".to_string()),
+        });
+        let symbols: HashMap<&str, &RawSymbol> = HashMap::from([("open_store", &sym)]);
+
+        let mut env = TypeEnvironment::build(source, Language::Rust, &[]);
+        env.seed_return_types(source, &symbols);
+
+        let binding = env.lookup("store", 2);
+        assert!(
+            binding.is_some(),
+            "should find 'store' binding via return type"
+        );
+        assert_eq!(binding.unwrap().type_name, "GraphStore");
+        assert_eq!(binding.unwrap().source, BindingSource::ReturnType);
     }
 
     #[test]

--- a/crates/nestweaver-resolver/src/types.rs
+++ b/crates/nestweaver-resolver/src/types.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 
 use nestweaver_parser::RawSymbol;
-use nestweaver_schema::{ResolvedType, SymbolKind};
+use nestweaver_schema::{Language, ResolvedType, SymbolKind};
+
+use crate::type_extractors::{BindingSource, TypeBinding, extract_bindings};
 
 /// Tier 1: Infer types from constructor calls.
 /// When a Call reference resolves to a Class symbol, the call site's variable
@@ -70,6 +72,133 @@ pub fn propagate_types(
         }
     }
     iterations
+}
+
+/// Per-file type environment: maps (variable_name, scope_line) → type_name.
+/// Built by running all four inference tiers, then the fixpoint loop.
+pub struct TypeEnvironment {
+    bindings: HashMap<(String, u32), TypeBinding>,
+}
+
+impl TypeEnvironment {
+    /// Build a type environment for a single file.
+    pub fn build(source: &str, language: Language, symbols: &[RawSymbol]) -> Self {
+        // Tiers 0-2: annotations, constructors, self/this
+        let mut bindings = extract_bindings(source, language, symbols);
+
+        // Tier 3: Assignment chain fixpoint
+        let assignments = extract_assignments(source);
+        propagate_assignments(&mut bindings, &assignments, 10);
+
+        Self { bindings }
+    }
+
+    /// Look up the type of a variable at a given scope.
+    /// Searches backwards from `at_line` for the nearest binding.
+    pub fn lookup(&self, variable: &str, at_line: u32) -> Option<&TypeBinding> {
+        // Exact match first
+        if let Some(binding) = self.bindings.get(&(variable.to_string(), at_line)) {
+            return Some(binding);
+        }
+        // Search backwards for nearest binding
+        self.bindings
+            .iter()
+            .filter(|((name, line), _)| name == variable && *line <= at_line)
+            .max_by_key(|((_, line), _)| *line)
+            .map(|(_, binding)| binding)
+    }
+
+    /// Look up self/this type at a given line.
+    pub fn lookup_self(&self, at_line: u32) -> Option<&TypeBinding> {
+        for keyword in &["self", "this", "$this"] {
+            if let Some(b) = self.lookup(keyword, at_line) {
+                return Some(b);
+            }
+        }
+        None
+    }
+
+    pub fn binding_count(&self) -> usize {
+        self.bindings.len()
+    }
+}
+
+/// Extract simple assignment patterns from source.
+fn extract_assignments(source: &str) -> Vec<((String, u32), (String, u32))> {
+    let mut assignments = Vec::new();
+    for (line_num, line) in source.lines().enumerate() {
+        let line_num = (line_num + 1) as u32;
+        let trimmed = line.trim();
+        if let Some(eq_pos) = trimmed.find('=') {
+            // Skip ==, !=, <=, >=, =>
+            if eq_pos > 0 {
+                let prev = trimmed.as_bytes()[eq_pos - 1];
+                if matches!(prev, b'!' | b'<' | b'>' | b'=') {
+                    continue;
+                }
+            }
+            if trimmed.as_bytes().get(eq_pos + 1) == Some(&b'=')
+                || trimmed.as_bytes().get(eq_pos + 1) == Some(&b'>')
+            {
+                continue;
+            }
+            let lhs = trimmed[..eq_pos]
+                .trim()
+                .trim_start_matches("let ")
+                .trim_start_matches("mut ")
+                .trim_start_matches("const ")
+                .trim_start_matches("var ")
+                .trim();
+            let rhs = trimmed[eq_pos + 1..].trim().trim_end_matches(';');
+            // Only simple identifier-to-identifier assignments
+            if !lhs.is_empty()
+                && !rhs.is_empty()
+                && rhs.chars().all(|c| c.is_alphanumeric() || c == '_')
+                && lhs.chars().all(|c| c.is_alphanumeric() || c == '_')
+                && !lhs.contains(':')
+            {
+                assignments.push(((lhs.to_string(), line_num), (rhs.to_string(), line_num)));
+            }
+        }
+    }
+    assignments
+}
+
+/// Propagate type bindings through assignment chains (fixpoint).
+fn propagate_assignments(
+    bindings: &mut HashMap<(String, u32), TypeBinding>,
+    assignments: &[((String, u32), (String, u32))],
+    max_iterations: usize,
+) {
+    for _ in 0..max_iterations {
+        let mut changed = false;
+        for ((target_name, target_line), (source_name, _)) in assignments {
+            let target_key = (target_name.clone(), *target_line);
+            if bindings.contains_key(&target_key) {
+                continue;
+            }
+            let source_type = bindings
+                .iter()
+                .filter(|((name, line), _)| name == source_name && *line <= *target_line)
+                .max_by_key(|((_, line), _)| *line)
+                .map(|(_, b)| b.clone());
+            if let Some(src) = source_type {
+                bindings.insert(
+                    target_key,
+                    TypeBinding {
+                        type_name: src.type_name,
+                        line: *target_line,
+                        confidence: (src.confidence - 0.05).max(0.0),
+                        source: BindingSource::Assignment,
+                    },
+                );
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -171,5 +300,47 @@ mod tests {
             "should stop after 1 iteration with no changes"
         );
         assert!(types.is_empty());
+    }
+
+    // ── TypeEnvironment tests ──────────────────────────────────────────
+
+    #[test]
+    fn type_env_rust_annotation_lookup() {
+        let source = "fn main() {\n    let store: GraphStore = GraphStore::new();\n    store.compute_pagerank();\n}\n";
+        let symbols = vec![make_function("main")];
+        let env = TypeEnvironment::build(source, Language::Rust, &symbols);
+        let binding = env.lookup("store", 3);
+        assert!(binding.is_some(), "should find 'store' binding");
+        assert_eq!(binding.unwrap().type_name, "GraphStore");
+    }
+
+    #[test]
+    fn type_env_self_lookup() {
+        let mut method = make_function("compute_pagerank");
+        method.kind = SymbolKind::Method;
+        method.parent_name = Some("GraphStore".to_string());
+        method.start_line = 5;
+        let env = TypeEnvironment::build("", Language::Rust, &[method]);
+        let binding = env.lookup_self(6);
+        assert!(binding.is_some());
+        assert_eq!(binding.unwrap().type_name, "GraphStore");
+        assert_eq!(binding.unwrap().confidence, 1.0);
+    }
+
+    #[test]
+    fn type_env_assignment_propagation() {
+        let source = "let store = GraphStore::new();\nlet alias = store;\n";
+        let env = TypeEnvironment::build(source, Language::Rust, &[]);
+        let binding = env.lookup("alias", 2);
+        assert!(binding.is_some(), "alias should get store's type");
+        assert_eq!(binding.unwrap().type_name, "GraphStore");
+        assert!(binding.unwrap().confidence < 0.90);
+    }
+
+    #[test]
+    fn type_env_binding_count() {
+        let source = "let x: Foo = Foo::new();\nlet y: Bar = Bar::new();\n";
+        let env = TypeEnvironment::build(source, Language::Rust, &[]);
+        assert!(env.binding_count() >= 2);
     }
 }

--- a/crates/nestweaver-resolver/src/types.rs
+++ b/crates/nestweaver-resolver/src/types.rs
@@ -121,6 +121,15 @@ impl TypeEnvironment {
     pub fn binding_count(&self) -> usize {
         self.bindings.len()
     }
+
+    /// Construct a `TypeEnvironment` from pre-built bindings (for testing).
+    pub fn from_bindings(entries: Vec<(String, u32, TypeBinding)>) -> Self {
+        let mut bindings = HashMap::new();
+        for (name, line, binding) in entries {
+            bindings.insert((name, line), binding);
+        }
+        Self { bindings }
+    }
 }
 
 /// Extract simple assignment patterns from source.

--- a/crates/nestweaver-resolver/src/types.rs
+++ b/crates/nestweaver-resolver/src/types.rs
@@ -6,6 +6,12 @@ use nestweaver_schema::{Language, ResolvedType, SymbolKind};
 
 use crate::type_extractors::{BindingSource, TypeBinding, extract_bindings};
 
+/// A variable binding key: (variable_name, line_number).
+type BindingKey = (String, u32);
+
+/// An assignment pair: (target_key, source_key).
+type Assignment = (BindingKey, BindingKey);
+
 /// Tier 1: Infer types from constructor calls.
 /// When a Call reference resolves to a Class symbol, the call site's variable
 /// has the type of that class.
@@ -140,20 +146,19 @@ impl TypeEnvironment {
                     continue;
                 }
 
-                if let Some(sym) = symbols_by_name.get(callee.as_str()) {
-                    if let Some(ref ti) = sym.type_info {
-                        if let Some(ref ret) = ti.return_type {
-                            self.bindings.insert(
-                                key,
-                                TypeBinding {
-                                    type_name: ret.clone(),
-                                    line: line_num,
-                                    confidence: 0.85,
-                                    source: BindingSource::ReturnType,
-                                },
-                            );
-                        }
-                    }
+                if let Some(sym) = symbols_by_name.get(callee.as_str())
+                    && let Some(ref ti) = sym.type_info
+                    && let Some(ref ret) = ti.return_type
+                {
+                    self.bindings.insert(
+                        key,
+                        TypeBinding {
+                            type_name: ret.clone(),
+                            line: line_num,
+                            confidence: 0.85,
+                            source: BindingSource::ReturnType,
+                        },
+                    );
                 }
             }
         }
@@ -170,7 +175,7 @@ impl TypeEnvironment {
 }
 
 /// Extract simple assignment patterns from source.
-fn extract_assignments(source: &str) -> Vec<((String, u32), (String, u32))> {
+fn extract_assignments(source: &str) -> Vec<Assignment> {
     let mut assignments = Vec::new();
     for (line_num, line) in source.lines().enumerate() {
         let line_num = (line_num + 1) as u32;
@@ -213,7 +218,7 @@ fn extract_assignments(source: &str) -> Vec<((String, u32), (String, u32))> {
 /// Propagate type bindings through assignment chains (fixpoint).
 fn propagate_assignments(
     bindings: &mut HashMap<(String, u32), TypeBinding>,
-    assignments: &[((String, u32), (String, u32))],
+    assignments: &[Assignment],
     max_iterations: usize,
 ) {
     for _ in 0..max_iterations {

--- a/crates/nestweaver-resolver/src/types.rs
+++ b/crates/nestweaver-resolver/src/types.rs
@@ -89,6 +89,7 @@ mod tests {
             entry_point_kind: None,
             visibility: Visibility::Public,
             type_info: None,
+            parent_name: None,
         }
     }
 
@@ -104,6 +105,7 @@ mod tests {
             entry_point_kind: None,
             visibility: Visibility::Public,
             type_info: None,
+            parent_name: None,
         }
     }
 

--- a/crates/nestweaver-resolver/src/types.rs
+++ b/crates/nestweaver-resolver/src/types.rs
@@ -60,7 +60,7 @@ pub fn propagate_types(
             if !initial_types.contains_key(target)
                 && let Some(source_type) = initial_types.get(source).cloned()
             {
-                let confidence = (source_type.confidence - 0.05).max(0.0);
+                let confidence = source_type.confidence * 0.95;
                 initial_types.insert(
                     target.clone(),
                     ResolvedType {
@@ -239,7 +239,7 @@ fn propagate_assignments(
                     TypeBinding {
                         type_name: src.type_name,
                         line: *target_line,
-                        confidence: (src.confidence - 0.05).max(0.0),
+                        confidence: src.confidence * 0.95,
                         source: BindingSource::Assignment,
                     },
                 );
@@ -375,9 +375,11 @@ mod tests {
         assert_eq!(types.len(), 3);
         assert_eq!(types["b"].type_name, "Foo");
         assert_eq!(types["b"].resolution_tier, 2);
-        assert!((types["b"].confidence - 0.80).abs() < f32::EPSILON);
+        // Multiplicative decay: 0.85 * 0.95 = 0.8075
+        assert!((types["b"].confidence - 0.8075).abs() < 0.01);
         assert_eq!(types["c"].type_name, "Foo");
-        assert!((types["c"].confidence - 0.75).abs() < f32::EPSILON);
+        // Two hops: 0.85 * 0.95 * 0.95 = 0.767
+        assert!((types["c"].confidence - 0.767).abs() < 0.01);
     }
 
     #[test]

--- a/crates/nestweaver-resolver/tests/proptest_resolve.rs
+++ b/crates/nestweaver-resolver/tests/proptest_resolve.rs
@@ -95,6 +95,7 @@ fn arb_reference() -> impl Strategy<Value = RawReference> {
             kind,
             start_line,
             context: String::new(),
+            receiver: None,
         },
     )
 }

--- a/crates/nestweaver-resolver/tests/proptest_resolve.rs
+++ b/crates/nestweaver-resolver/tests/proptest_resolve.rs
@@ -85,6 +85,7 @@ fn arb_symbol() -> impl Strategy<Value = RawSymbol> {
             entry_point_kind: None,
             visibility,
             type_info: None,
+            parent_name: None,
         })
 }
 

--- a/crates/nestweaver-store/src/traverse.rs
+++ b/crates/nestweaver-store/src/traverse.rs
@@ -1,7 +1,11 @@
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, VecDeque};
 
 use crate::db::GraphStore;
 use crate::error::StoreError;
+
+/// Minimum impact score for a node to be included in traversal results.
+/// Edges below this threshold are pruned during BFS.
+const DEFAULT_IMPACT_THRESHOLD: f64 = 0.10;
 
 /// A node returned by the impact analysis traversal.
 #[derive(Debug, Clone)]
@@ -13,6 +17,9 @@ pub struct ImpactNode {
     pub edge_type: String,
     pub confidence: f32,
     pub depth: u32,
+    /// Confidence-weighted impact score. The changed symbol starts at 1.0;
+    /// each traversal step multiplies by the edge confidence. Ranges 0.0–1.0.
+    pub impact_score: f64,
 }
 
 /// A row representing caller + edge metadata returned from the BFS query.
@@ -28,49 +35,88 @@ struct CallerRow {
 impl GraphStore {
     /// Find all symbols that directly or transitively call/import/extend/implement `target_uid`.
     ///
-    /// Performs iterative BFS up to `max_depth` levels following incoming edges of type
-    /// CALLS, IMPORTS, EXTENDS_SYM, and IMPLEMENTS_SYM. Results with confidence below
-    /// `min_confidence` are excluded.
+    /// Performs confidence-weighted BFS up to `max_depth` levels following incoming
+    /// edges of type CALLS, IMPORTS, EXTENDS_SYM, IMPLEMENTS_SYM, and INCLUDES_SYM.
+    ///
+    /// Each node receives an `impact_score` that starts at 1.0 for the seed and
+    /// decays multiplicatively through each edge's confidence value. Traversal is
+    /// pruned when a node's score falls below `DEFAULT_IMPACT_THRESHOLD` (0.10).
+    /// The `min_confidence` parameter provides an additional per-edge filter.
+    ///
+    /// Results are sorted by `impact_score` descending (highest impact first).
     pub fn impact(
         &self,
         target_uid: &str,
         max_depth: u32,
         min_confidence: f32,
     ) -> Result<Vec<ImpactNode>, StoreError> {
-        let mut visited: HashSet<String> = HashSet::new();
-        visited.insert(target_uid.to_string());
+        // Track the best impact score seen so far for each node.
+        let mut scores: HashMap<String, f64> = HashMap::new();
+        scores.insert(target_uid.to_string(), 1.0);
 
+        // Queue entries: (uid, depth)
         let mut queue: VecDeque<(String, u32)> = VecDeque::new();
         queue.push_back((target_uid.to_string(), 0));
 
-        let mut results: Vec<ImpactNode> = Vec::new();
+        // Store result nodes keyed by uid so we can update scores if a
+        // better path is found.
+        let mut result_map: HashMap<String, ImpactNode> = HashMap::new();
 
         while let Some((current_uid, depth)) = queue.pop_front() {
             if depth >= max_depth {
                 continue;
             }
 
+            let parent_score = scores.get(&current_uid).copied().unwrap_or(0.0);
+
             let callers = self.direct_callers_of(&current_uid, min_confidence)?;
 
             for row in callers {
-                if visited.contains(&row.uid) {
+                // Skip the seed node itself.
+                if row.uid == target_uid {
                     continue;
                 }
-                visited.insert(row.uid.clone());
 
-                let node = ImpactNode {
-                    uid: row.uid.clone(),
-                    name: row.name,
-                    file_path: row.file_path,
-                    start_line: row.start_line,
-                    edge_type: row.edge_type,
-                    confidence: row.confidence,
-                    depth: depth + 1,
-                };
-                results.push(node);
-                queue.push_back((row.uid, depth + 1));
+                let candidate_score = parent_score * row.confidence as f64;
+
+                // Prune paths that fall below the impact threshold.
+                if candidate_score < DEFAULT_IMPACT_THRESHOLD {
+                    continue;
+                }
+
+                let prev_score = scores.get(&row.uid).copied().unwrap_or(0.0);
+
+                if candidate_score > prev_score {
+                    scores.insert(row.uid.clone(), candidate_score);
+
+                    let node = ImpactNode {
+                        uid: row.uid.clone(),
+                        name: row.name,
+                        file_path: row.file_path,
+                        start_line: row.start_line,
+                        edge_type: row.edge_type,
+                        confidence: row.confidence,
+                        depth: depth + 1,
+                        impact_score: candidate_score,
+                    };
+                    result_map.insert(row.uid.clone(), node);
+
+                    // Re-enqueue so downstream nodes can pick up the
+                    // improved score. This is safe because scores only
+                    // increase (like Dijkstra with max instead of min).
+                    queue.push_back((row.uid, depth + 1));
+                }
             }
         }
+
+        let mut results: Vec<ImpactNode> = result_map.into_values().collect();
+        // Sort by impact_score descending; break ties by uid for determinism.
+        results.sort_by(|a, b| {
+            b.impact_score
+                .partial_cmp(&a.impact_score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.uid.cmp(&b.uid))
+        });
 
         Ok(results)
     }

--- a/crates/nestweaver-web/src/routes/impact.rs
+++ b/crates/nestweaver-web/src/routes/impact.rs
@@ -43,6 +43,7 @@ pub async fn impact(
                 "edge_type": n.edge_type,
                 "confidence": n.confidence,
                 "depth": n.depth,
+                "impact_score": n.impact_score,
             })
         })
         .collect();

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -44,24 +44,51 @@ Deep integration between NestWeaver's code knowledge graph and Claude Code.
 
 ## MCP Tools
 
-When configured as an MCP server, NestWeaver exposes:
+When configured as an MCP server, NestWeaver exposes 38 tools across these categories:
 
-- **brain_context** — Task-focused subgraph via Personalized PageRank (supports filters: repos, vaults, kinds, tags, path_prefix; tunable hybrid weights)
+**Context & Search:**
+- **brain_context** — Task-focused subgraph via Personalized PageRank with type-aware resolution
 - **brain_search** — Full-text BM25 search across code and notes
-- **brain_impact** — Blast radius analysis for any symbol (accepts name or UID)
-- **brain_status** — Database and vault status with per-vault staleness
-- **brain_guide** — Auto-generated codebase intelligence guide with repos, features, links, and projects
-- **brain_add_source** — Index new vaults or repos at runtime (always available via daemon)
-- **brain_diff** — Show what changed in the graph since a given SHA
-- **flow_trace** — Forward execution flow from entry points (accepts name or UID)
-- **detect_changes** — Map file changes to affected processes and risk
-- **clusters** — Community detection results (Leiden algorithm)
-- **stale_check** — Check if the index needs refreshing (supports SSH/HTTPS URLs)
-- **cross_repo_contracts** — Cross-repository symbol relationships
 - **project_context** — Project-scoped retrieval across notes, symbols, and components
+- **brain_guide** — Auto-generated codebase intelligence guide
+
+**Analysis:**
+- **brain_impact** — Confidence-weighted blast radius analysis (impact_score decays through edges)
+- **blast_radius** — File-level change impact with affected symbols and clusters
+- **flow_trace** — Forward execution flow from entry points
+- **detect_changes** — Map file changes to affected processes and risk
+- **affected_tests** — Test-impact analysis for regression test selection
+- **dead_code** — Confidence-aware unreachable code detection
+- **contract_drift** — API contract drift detection across repos
+
+**Graph Structure:**
+- **hub_nodes** / **bridge_nodes** — Centrality analysis (PageRank, betweenness)
+- **clusters** — Community detection (Leiden algorithm)
+- **cross_repo_contracts** — Cross-repository symbol relationships
+
+**Investigation:**
+- **investigate** — Deep-dive bundle for focused code exploration
+- **investigate_expand** — Expand investigation context
+- **investigate_hydrate** — Load full source for investigation targets
+
+**Vault & Notes:**
 - **note_get** — Retrieve a note with optional section filtering
 - **backlinks** — Find notes that link to a target note
-- **set_extension** / **query_extensions** — Attach and query custom metadata on any node
+- **brain_tag_graph** / **brain_doc_stats** — Vault structure analysis
+- **brain_broken_links** / **brain_orphan_documents** — Vault health checks
+- **brain_memory_lint** / **brain_memory_consolidate** / **brain_memory_related** — Memory bank tools
+
+**Code Reading:**
+- **read_symbols** — Read symbol source code by name or UID
+- **regex_search** — Regex search across indexed code
+- **count_patterns** — Count pattern occurrences
+
+**Admin:**
+- **brain_status** — Database and vault status
+- **brain_add_source** — Index new vaults or repos at runtime
+- **brain_diff** — Show graph changes since a given SHA
+- **stale_check** — Check if the index needs refreshing
+- **set_extension** / **query_extensions** — Custom metadata on any node
 
 ## Environment Variables
 

--- a/integrations/cursor/README.md
+++ b/integrations/cursor/README.md
@@ -23,7 +23,7 @@ Restart Cursor to detect the MCP server.
 
 Cursor has a 40-tool cap across all MCP servers. NestWeaver uses `--lite` mode by default for Cursor, exposing 6 core tools: `brain_context`, `brain_search`, `brain_impact`, `brain_status`, `brain_guide`, `detect_changes`.
 
-To use all 17 tools, edit `.cursor/mcp.json` and remove `--lite` from the args.
+To use all 38 tools, edit `.cursor/mcp.json` and remove `--lite` from the args.
 
 ## Environment Variables
 

--- a/integrations/jetbrains/README.md
+++ b/integrations/jetbrains/README.md
@@ -20,3 +20,5 @@ Or manually create `.junie/mcp/mcp.json`:
   }
 }
 ```
+
+All 38 NestWeaver MCP tools are available, including type-aware context, confidence-weighted impact analysis, investigation bundles, and vault/notes integration.

--- a/integrations/windsurf/README.md
+++ b/integrations/windsurf/README.md
@@ -23,4 +23,4 @@ Or manually add to `~/.codeium/windsurf/mcp_config.json`:
 
 Restart Windsurf to detect the MCP server.
 
-All NestWeaver MCP tools are available in Windsurf's AI features.
+All 38 NestWeaver MCP tools are available in Windsurf's AI features, including type-aware context, confidence-weighted impact analysis, investigation bundles, and vault/notes integration.

--- a/scratch/pr-body.md
+++ b/scratch/pr-body.md
@@ -1,0 +1,50 @@
+## Summary
+
+This branch lands two large bodies of work:
+
+1. **Next-gen web UI** — a Three.js / React-Three-Fiber graph renderer replacing the previous Sigma.js view, plus the supporting `nestweaver-algorithms` (pure-compute, WASM-compatible) and `nestweaver-wasm` crates so graph algorithms (PPR, impact BFS) can run client-side.
+2. **v0.9.1 retrieval quality & feedback** — a set of code+notes intelligence features, two bug fixes, and an offline evaluation harness so the new ranking features can be measured rather than trusted on a hunch.
+
+Everything is gated behind the existing CLI/MCP surface; the new quality features are **off by default** and opt-in.
+
+## Web UI / rendering
+
+- GPU-accelerated R3F graph renderer with animated force settling, always-visible labels, click-to-focus, node drag, edge gradients, and semantic-zoom camera bridge.
+- 3D community hulls / cluster overlay and impact ripple on selection.
+- WASM engine wired end-to-end (`?engine=wasm`) so PPR/impact run in the browser; SSE live-update stream (`graph:updated`, `pagerank:recomputed`, `full_refresh`).
+- New web API: `GET /api/v1/version`, `GET /api/v1/snapshot.msgpack` (with `X-Graph-Generation` header), `GET /api/v1/events`.
+
+## Retrieval quality & intelligence features
+
+- Per-path dampen/boost ranking priors; git-activity-dampened CodeRank; lightweight result reranker (all opt-in).
+- BM25 pseudo-relevance feedback (PRF) for query expansion.
+- Trigram-accelerated regex search + pattern counting.
+- `read_symbols` source-window reads and inline high-confidence result bodies (uses the new `Symbol.end_line` span).
+- Document-graph tooling over the notes vault (`brain.*`), API-contract graph (Contract nodes + IMPLEMENTS edges + drift), memory-bank semantics (typed edges, lint, consolidate, related), and an `investigate` context-bundle primitive.
+- `affected_tests` — static regression-test selection for PR test scoping (reaches Jest/Vitest tests).
+- Agent feedback loop (interaction memory: success signal + `interactions show`) and agent-guidance generation.
+
+## Bug fixes
+
+- `project_context` now surfaces project member notes that were being dropped.
+- `--config` is honored on `brain` read commands when resolving the database path.
+- `--force` re-index is now idempotent (no duplicate-PK crash); `broken-links` surfaces unresolved wikilinks; regex line numbers, install-hook dry-run delta, and multi-handler coverage corrected.
+
+## Evaluation harness (new)
+
+`nestweaver eval run` / `eval compare` score retrieval quality (nDCG@10 / MRR / precision@5) over a **judged** query set, reusing the shipped hybrid-retrieval path so it measures exactly what the product serves. `eval compare --prf/--rerank` runs baseline-vs-treatment and applies a `>=5%` nDCG@10 gate.
+
+> The metrics are only meaningful with real human relevance labels over the corpus you actually index. The bundled `examples/eval/eval-queries.example.jsonl` is a **format template**, not a benchmark — the help text and `examples/eval/README.md` say so explicitly, and the gate caveats (per-query win/loss, train/test splits) are surfaced in the tool output.
+
+## Persistence / infra
+
+- `Symbol.end_line` added to the schema (full source span).
+- `graph_generation` persisted across restarts; ZSTD-compressed response cache for the web API.
+
+## Testing
+
+- `cargo test --workspace` → **1094 passed, 0 failed**
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings` → clean
+- `cargo fmt --all -- --check` → clean
+
+New features were developed test-first and manually exercised end-to-end; a QA sweep over both existing and new functionality drove the fix commits above.

--- a/scratch/rfc-implementation-plan/ADDENDUM-evidence-and-findings.md
+++ b/scratch/rfc-implementation-plan/ADDENDUM-evidence-and-findings.md
@@ -1,0 +1,141 @@
+---
+title: Addendum — Evidence, Verified Surface, and Adversarial Findings
+created: 2026-05-29
+companion_to: IMPLEMENTATION-PLAN.md
+note: This closes gaps #1 (evidence), #2 (verified surface), #3 (adversarial). It deliberately does NOT make build/defer/kill calls (#4) — that decision is the user's. Everything here is decision *input*.
+---
+
+# Addendum: what the evidence, the code, and the skeptics actually say
+
+## A. The headline finding (gap #1 — evidence mining)
+
+### A.1 — In the actual traces, the tool is not in the loop
+Across **every** Claude Code session under `~/.claude/projects/` on this machine:
+
+| Signal | Count |
+|--------|-------|
+| NestWeaver MCP tool invocations | **0** |
+| GitNexus MCP tool invocations | **0** |
+| `Bash` tool calls | **39,668** |
+| Other MCP actually used | Claude-in-Chrome (183), Supabase (~38), Gmail/Drive (~11) |
+| Files *mentioning* "nestweaver" (as text/paths) | 665 |
+| Files *mentioning* "gitnexus" | 69 |
+
+In day-to-day captured usage, the agents orient via **Bash (grep/rg/git/find)**, not via NestWeaver. NestWeaver appears as *the thing being built*, not *a tool being used*.
+
+**Resolved (user-confirmed): NestWeaver's MCP is NOT configured in these projects.** So the
+zero-usage signal is a **configuration gap, not abandonment** — the value question stays open, not
+answered negatively. **Step zero is therefore to configure NestWeaver's MCP (`nestweaver setup
+claude-code`) and actually dogfood it.** No feature in this plan delivers value until the tool is
+in the loop, and we'll have no real usage evidence to prioritize by until it is.
+
+**Other caveats:**
+- The `journeys.sh` benchmark drives the NestWeaver **CLI** as a subprocess, which would *not* appear as an `mcp__` tool call — so CLI/benchmark usage is invisible to this count.
+- The RFC itself claims **89–96% token savings** from a NestWeaver orientation pass vs historical sessions — but those sessions live in `~/.claude/projects/-Users-kkehl-...Obsidian-Work/`, which is **not on this machine**, so I can't reproduce that evidence here.
+
+**Implication (the part that matters):** the precondition for the whole feature track is **getting
+NestWeaver's MCP configured and dogfooded** — that's now confirmed as the gap, not a quality
+failure. Once it's in the loop, the features most aligned with *keeping agents on the graph instead
+of falling back to Bash* — F3/F4 (first-party regex/count so skills stop shelling out) and F5
+(symbol-window reads vs whole-file `Read`) — are the adoption levers, not just efficiency wins.
+Prioritize them on that evidence, not taste.
+
+### A.2 — Your own benchmark defines value as 7 code-graph journeys
+`_docs/benchmark/journeys.sh` measures these, by **latency + result count** (not retrieval quality), vs GitNexus/Graphify:
+
+| # | Journey | CLI exercised | Features that serve it |
+|---|---------|---------------|------------------------|
+| J1 | "What does this do?" (symbol understanding) | `symbol` | **F5, F8** |
+| J2 | "What breaks if I change this?" (impact) | `impact` | **F13**, F2, F12 |
+| J3 | "How is this organized?" (architecture) | `repo-map/hubs/clusters/summary` | **F10**, F9, F12 |
+| J4 | "Find where X is used" (cross-file refs) | `context` | F2, F3 |
+| J5 | "What changed / what's at risk?" (PR review) | `pr-impact` | **F13**, F12 |
+| J6 | "Summarize this area" (token-efficient) | `summary` | **F5, F8** |
+| J7 | "Is anything dead?" | `dead-code` | (exists) F12 |
+| **J8** | **"Where are we on project X?" (vault Project orientation — NEW, NestWeaver-only)** | `project-context` / `brain context` | **F11, F10, F8**, F6, F7, F1 (+ Bug #12 guard) |
+
+### A.3 — Evidence-tier ranking (this is data, NOT a cut list)
+Where each feature sits relative to *measured* value:
+
+- **Tier E1 — directly serves a benchmarked journey (value is measurable today):**
+  F5 (J1/J6), F8 (J1/J6/**J8**), F13 (J2/J5), F10 (J3/**J8**), F3+F4 (J4 + Bash-displacement),
+  F9 (J3), **F11 (J8 — vault Project orientation)**, F2 (J2/J4 — *if scoped per §C*).
+- **Tier E2 — improves journeys but is UNMEASURABLE with current infra:** F6, F7, F1, F12, F17.
+  The journeys benchmark (incl. J8) measures *speed + coverage + Bug-#12-style notes-surfaced*,
+  **not *ranking quality*** — so these features' relevance gains can't be *seen* until the §2.7
+  quality harness exists. Not just speculative; currently un-instrumented.
+- **Tier E3 — outside the measured journey set entirely (net-new surface):** F14/F15 (agent-harness
+  guidance), F16 (cache). *(F11 moved up to E1 — it now serves Journey 8.)*
+
+### A.4 — Resolved: the vault Project is now a critical journey (J8)
+Originally the benchmark was **code-graph only**, with no vault/Project journey — despite that
+being the RFC's headline use case (and where Bug #12 lived). **User decision: the vault Project is
+a real, first-class use case.** It is now **Journey 8 (Project Orientation)** in
+`_docs/benchmark/journeys.sh` — NestWeaver-only, since competitors don't model a vault Project
+spanning repos. It measures `project-context`/`brain context` latency, notes-surfaced, and
+locations, and **bakes in the Bug #12 metric (a project that declares repos must surface its
+notes) as a regression guard.** NestWeaver is a code-**and**-vault tool, and project orientation is
+the differentiator — so the vault-retrieval capabilities (F11, F10, F8) move onto **measured
+ground** (A.3). Run it with `NW_PROJECT_DB` + `NW_PROJECT` set.
+
+---
+
+## B. Verified implementation surface (gap #2 — corrections to the plan)
+
+Each verified against real code by read-only agents.
+
+| Plan claim | Verdict | Reality | Effort impact |
+|-----------|---------|---------|---------------|
+| F7 lives in `nestweaver-store/src/bm25.rs` | **WRONG** | No `bm25.rs`. BM25 = `tantivy_index.rs`; RRF fusion = `query.rs::rrf_fuse` (~`query.rs:1001`, k=60) | Plan error; corrected in main doc |
+| `Symbol` has no `end_line` | **CONFIRMED** | `nodes.rs:140`; parser calls `start_position()` only (`parse.rs:593`), discards available `end_position()` | F5/F3-sym/F8-sym blocked on a plumbing add (RawSymbol→Symbol→DB→persist) |
+| `graph_generation` gives a cache-invalidation key (§2.3) | **WRONG (load-bearing)** | In-memory `AtomicU64::new(0)`, **not persisted**, reset to 0 every open; bumped **only** by the two watcher loops, **never by `index`** (`db.rs:37/53/69/108`, `watcher.rs:341`, `watch_code.rs:271`) | **Voids the daemon-less cache premise.** To use it: persist it + bump on `index`. Otherwise F16/§2.3 cross-process keying can't work |
+| Interaction sidecar needs `session_id` added (F1) | **PARTIAL — already done** | `InteractionEvent` already has `session_id`; `EventType` = Query/Access/FollowUp/Impact | F1 cheaper than planned — only add `TerminalSuccess` |
+| `Symbol.framework_hint` exists; populate for F2 | **CONFIRMED + dead infra** | Field exists; `detect_frameworks()` (Spring/Flask/Express/etc., `frameworks.rs`) is **exported but never called** — always `None` | Wiring `detect_frameworks()` in is a cheap **enabler** for F2 handler detection |
+| F2 "wire into existing `cross_repo_contracts`" | **WRONG** | The live tool (`tools.rs:1445`) does name/import matching via `store.cross_repo_links`. The real contract matcher `find_cross_repo_links` (`resolver/src/cross_repo.rs`) is **unwired dead code** (only its own tests call it) | F2 is **greenfield**, not integration — re-budget |
+| F9/F10 "reuse Leiden clusters" | **PARTIAL** | `cluster_dispatch.rs` runs Leiden but **hardcoded to code Symbol edges** (8 edge types). Wikilink (Note↔Note) subgraph needs a new `load_note_edges` (~50 LOC) | Algorithm reusable; graph-loading is new |
+| F9 broken-link/orphan/tag-cooccurrence "mostly reuse" | **GREENFIELD** | Only `count_wikilink_edges` + `wikilink_sources_to_note` exist; no orphan/broken/co-occurrence queries | More new code than credited |
+| F5 comment stripping "walk tree-sitter comment nodes" | **WRONG** | Grammar queries don't reference `comment` nodes; comments aren't extracted today | Stripping is more work; default-off remains right |
+| F15 "const rule array in `guide.rs`" | **PARTIAL** | No `guide.rs`; `agent_guide.rs` generates guidance **dynamically** from the graph, no static rule store | F15 rule store is greenfield |
+| F8 `inline_body` | **CONFIRMED** | `BrainNode{uid,kind,title,location,relevance}`; add field + populate in `render_brain_node` + serialize | ~15 LOC, no blocker |
+| §2.7 "no quality harness exists" | **CONFIRMED** | `benches/brain_benchmarks.rs` is criterion **speed** only; no nDCG/precision anywhere | Harness must be built |
+| Trigram greenfield; `regex`/`regex-syntax` available | **CONFIRMED** | No ngram index in store; deps present in `Cargo.lock` | F3 as planned |
+
+---
+
+## C. Adversarial findings (gap #3 — decision input, not cut calls)
+
+Each feature got an agent whose job was to *refute* the approach. Summaries; full reviews were returned to the orchestrator.
+
+### F2 — static contract linking → **recommended posture: scope down, measure demand first**
+- The ~0.79 F1 ceiling (Schneider et al. 2024) is **disqualifying for the headline promise**, not a caveat: in an *impact* tool, false edges erode trust in all edges, and "no edge ≠ safe" concedes the core question.
+- The unambiguous lanes are safe and valuable: **gRPC `Service/Method`** (no templating), **`operationId`-matched typed clients**, **same-repo Spring/NestJS handler `IMPLEMENTS` edges**, and **spec→`Contract` nodes + "declared-but-not-implemented" drift diagnostics**.
+- The headline general **HTTP-literal cross-repo `CONSUMES`** matcher (Express/Go/`fetch`) is the part the evidence says can't be made trustworthy — generic-path collisions (`/health`, `/users/{id}`), base-path recall, generated clients.
+- Recommend: lead with the low-ambiguity lanes; label every edge a confidence-scored *hypothesis*; **count actual cross-repo couplings in the real repos before investing** (n=1 demand is unquantified); budget greenfield (the existing matcher is unwired).
+
+### F16 — daemon-less response cache → **recommended posture: drop to a measured experiment**
+- Premise ("two runtimes re-running within 60s") is **unevidenced**; the plan itself says "measure hit-rate before building."
+- **Correctness is broken daemon-less:** `graph_generation` isn't persisted and isn't bumped by `index`, so every short-lived process sees `gen=0` → the generation-mismatch safety net **never fires** → correctness rests entirely on the riskiest component (scope-digest). A stale code-graph answer is worse than a slow one (it misleads edits).
+- **No latency numbers exist anywhere** — likely optimizing tens of ms against multi-second LLM round-trips.
+- Minimal safe version: **process-local in-memory memoization** inside the long-lived MCP/watch process only (in-process generation works there). Instrument real hit-rate + per-tool latency first.
+
+### F17 — learned listwise reranker → **recommended posture: drop the hand-rolled net; keep at most a gated tree experiment**
+- Single-user label volume can't train even a 20K-param listwise model to clear a **CI-excludes-zero** bar on ~40 queries.
+- **Circularity:** labels come from what the current ranker surfaced, and `rank_position` is a feature → the model's lowest-loss behavior is to reproduce first-stage order (~0% lift by construction).
+- **F7 + F1 draw from the same signal and ship first** → F17 must beat an already-feedback-boosted baseline (strictly harder).
+- Cheaper alternative that captures most upside: a **hand-tuned monotonic scoring function** (extend F6's prior machinery over the same features, fully explainable) or, if a model is truly wanted, a **LambdaMART tree** (sample-efficient, the dossier's own recommended baseline).
+
+---
+
+## D. What this changes for your decision (still not making the cut)
+
+1. **Configuration + dogfooding is step zero (now confirmed).** The tool isn't in the loop because
+   its MCP isn't configured — so `nestweaver setup claude-code` + real dogfooding must come first;
+   it's also the only way to generate the usage evidence to prioritize the rest. F3/F4/F5 double as
+   the levers that keep agents on the graph rather than Bash once it's wired in.
+1b. **The vault Project is now Journey 8** (added to `journeys.sh`, Bug-#12-guarded). This puts
+   F11/F10/F8 on measured ground and settles the "code vs vault" identity: it's both, with project
+   orientation as the differentiator.
+2. **§2.3 / Phase 0 changes.** "Use `graph_generation` as a cache key" is void as-is. Either add a small enabler (persist it + bump on `index`) or drop the cross-process cache premise. This also touches F10's bundle-TTL keying.
+3. **F2 is greenfield, not integration**, and its safe value is concentrated in gRPC + specs + same-repo handlers; wiring the dead `detect_frameworks()` is a cheap prerequisite.
+4. **Tier E2 features (F6/F7/F1/F12/F17) can't be evaluated** until §2.7 exists — so the eval harness is a true prerequisite for that whole cohort, not a nice-to-have.
+5. **The cut itself (build/defer/kill) is yours** — this addendum is the evidence to make it well.

--- a/scratch/rfc-implementation-plan/BUILD-SPEC-phase0-wave1.md
+++ b/scratch/rfc-implementation-plan/BUILD-SPEC-phase0-wave1.md
@@ -1,0 +1,205 @@
+---
+title: Build-ready spec — Phase 0 enablers + Wave 1 features
+created: 2026-05-29
+companion_to: IMPLEMENTATION-PLAN.md, ADDENDUM-evidence-and-findings.md
+scope: The executable front of the plan. Surface verified against real code (ADDENDUM §B).
+       Later waves stay at strategic depth in IMPLEMENTATION-PLAN.md until reached.
+note: No build/defer/kill calls — every RFC feature is still in scope; this specifies the ones built first.
+---
+
+# Build Spec — Phase 0 (enablers) + Wave 1 features
+
+Each item: **Goal · Verified surface · Schema/signatures · Tasks (ordered) · Tests (TDD) ·
+Acceptance · Effort · Deps**. Effort: S ≈ ≤1 day, M ≈ 2–4 days, L ≈ 1–2 weeks.
+
+Wave 1 is chosen as the **surface-verified, dependency-clean starting chain**:
+`P0.1 end_line → F5 → F8(sym)` and `P0.4 trigram → F3 → F4`, plus `F6` (standalone).
+
+---
+
+## Phase 0 — Enablers
+
+### P0.1 — `Symbol.end_line`
+- **Goal.** Every Symbol carries its end line so symbol-window reads (F5), inline bodies (F8), and
+  symbol-text regex (F3) can slice source precisely.
+- **Verified surface.** `Symbol` (`crates/nestweaver-schema/src/nodes.rs:140`, add field);
+  `RawSymbol` (`crates/nestweaver-parser/src/parse.rs:~62`); parser captures only
+  `node.start_position()` at `parse.rs:~593` — `node.end_position().row` is available and discarded;
+  Symbol-node DDL + `insert_symbol_with_conn` (`crates/nestweaver-store/src/write.rs:87`); Symbol
+  row read (`read.rs`); schema version (`crates/nestweaver-schema/src/version.rs`).
+- **Schema/signatures.** Add `pub end_line: u32` to `RawSymbol` and `Symbol`. Add `end_line INT`
+  to the Symbol table DDL. Bump `core_schema_hash` → forces re-index.
+- **Tasks.** (1) add field to `RawSymbol`+`Symbol`; (2) in parser set `end_line =
+  node.end_position().row as u32 + 1`; (3) DDL column + write param + read extraction; (4) bump
+  schema version; (5) graceful default for pre-migration rows (`end_line = start_line` if NULL).
+- **Tests (TDD).** Parser unit test: a known multi-line function has `end_line > start_line` and
+  matches the source. Store round-trip: insert Symbol with `end_line`, read it back equal.
+- **Acceptance.** `nestweaver symbol <name> --json` includes `end_line`; a fresh index populates it
+  for all symbols.
+- **Effort.** M. **Deps.** none. **Blocks.** F5, F8(symbol path), F3(symbol-text path).
+
+### P0.2 — Persist + bump `graph_generation`
+- **Goal.** Make the generation counter a usable cross-process key (today it's in-memory, reset to
+  0 each open, and bumped only by the watcher loops — ADDENDUM §B). Enabler for any disk cache
+  (F16) and F10 bundle TTL keying. *Building this does not commit to F16.*
+- **Verified surface.** `crates/nestweaver-store/src/db.rs:37/53/69/108` (constructors set
+  `AtomicU64::new(0)`), `:157-166` (read/bump); bump sites `watcher.rs:341`, `watch_code.rs:271`;
+  one-shot index path `crates/nestweaver-engine/src/index.rs`.
+- **Schema/signatures.** Persist generation to a sidecar (`<db>.generation`) or a meta row; load on
+  open; `pub fn graph_generation(&self) -> u64` already readable.
+- **Tasks.** (1) persist on every bump; (2) load persisted value on open instead of 0; (3) bump at
+  the end of `index`/`incremental_index`, not just the watcher; (4) expose for cache keys.
+- **Tests.** open → index → reopen observes an incremented, persisted value; two concurrent opens
+  read the same persisted generation.
+- **Acceptance.** Generation survives reopen and increments on a one-shot `index`.
+- **Effort.** S. **Deps.** none. **Blocks.** F16 (if pursued), F10 bundle keying.
+
+### P0.3 — Retrieval-quality eval harness (§2.7)
+- **Goal.** nDCG@10 / MRR / precision@k over NestWeaver's *own* code+notes corpus. Gates every
+  Tier-E2 (ranking-quality) feature — those gains are invisible to the speed/coverage journeys
+  benchmark (ADDENDUM §A.3).
+- **Verified surface.** `benches/brain_benchmarks.rs` is criterion **speed only**; no quality
+  harness exists. New: `benches/` or `scratch/` runner + a judged query set.
+- **Schema/signatures.** A judged-query file: `{query, intent, graded_relevance: {uid: 0..3}}`.
+  Runner emits per-query nDCG@10/MRR/p@k + aggregate with **time/query-based CV** and per-query
+  win/loss + CI.
+- **Tasks.** (1) author ~30–50 judged queries spanning code + the new J8 vault path; (2) runner
+  scoring the current hybrid ranker; (3) snapshot a **baseline** to beat; (4) wire as the gate for
+  F6/F7/F1/F12/F17.
+- **Tests.** Deterministic nDCG on a tiny fixture with known ideal order.
+- **Acceptance.** Produces a reproducible baseline number; re-runnable pre/post a ranking change.
+- **Effort.** M (label authoring is the judgment-heavy part). **Deps.** none. **Gates.**
+  F6, F7, F1, F12, F17.
+
+### P0.4 — Trigram index (shared substrate for F3/F4)
+- Specified inline under **F3** (F3 builds it; F4 reuses it).
+
+### P0.5 — Interaction success-signal labeler (§2.4)
+- **Goal.** Label interaction events so F1 (and later F17) have a safe success signal. Most of the
+  schema already exists.
+- **Verified surface.** `crates/nestweaver-engine/src/interactions.rs` — `InteractionEvent`
+  **already has `session_id`**; `EventType` = Query/Access/FollowUp/Impact. Recording in
+  `crates/nestweaver-mcp/src/lib.rs:314` `record_interaction`. `load_interaction_scores`
+  (`interactions.rs:456`) returns `Option<HashMap<String,f64>>`, loaded at MCP startup but
+  **consumed nowhere** (the F1 gap).
+- **Schema/signatures.** Add `EventType::TerminalSuccess`; success heuristic = surfaced UID then
+  *edited/written* (positive) | next action is another search/reformulation (negative) | bare
+  access (weak). Decay `R = e^(−Δt/S)` (MemoryBank).
+- **Tasks.** (1) add the event kind; (2) record success/negative transitions in the MCP layer;
+  (3) prune at `R<ε`. (Consumption into ranking is F1, not here.)
+- **Tests.** A scripted session (surface→edit) yields a positive label; surface→re-search yields
+  negative; scores decay over time.
+- **Acceptance.** `interactions show` reflects the new kinds; sidecar stays bounded.
+- **Effort.** S–M. **Deps.** none. **Feeds.** F1, F17.
+
+> P0.6 guidance store (F14/F15 prereq) is deferred to its wave — those are Tier-E3 / agent-harness.
+
+---
+
+## Wave 1 — features
+
+### F5 — `read_symbols`
+- **Goal.** Return a symbol's source span (± neighbors, optional comment stripping), token-budgeted.
+  Primary Bash/`Read`-displacement lever (ADDENDUM §A.1).
+- **Verified surface.** `symbols_in_file` (`read.rs:580`), `lookup_symbols_by_name` (`read.rs:299`,
+  exact, returns `Vec<Symbol>`); parser language split = 17 tree-sitter / ~8 regex
+  (`parse.rs:502-517`); **comment nodes are NOT currently extracted** — stripping needs new
+  tree-sitter comment queries.
+- **Schema/signatures.** MCP `read_symbols(uids_or_fqns: [String], strip_comments?: bool,
+  include_neighbors?: u8, token_budget?: usize)` → `{uid, path, start_line, end_line, body, kind,
+  comments_stripped, truncated?, dropped?}`. CLI `nestweaver read-symbols <uid|fqn>… [--strip-comments]
+  [--neighbors N] [--token-budget N]`.
+- **Tasks (ordered).** (1) resolve FQN/uid → Symbol(s) (ambiguous → `disambiguate: true`); (2) read
+  span `start_line..end_line` from disk; (3) optional neighbors via `symbols_in_file` ordered by
+  line; (4) optional comment strip — tree-sitter comment query per grammar language, conservative
+  line-prefix for regex languages, **default OFF**; (5) token-budget truncation in input order with
+  dropped list.
+- **Tests (TDD).** Single symbol body equals source slice; `--strip-comments` reduces line count on
+  a commented fn but not code lines; ambiguous FQN returns all + flag; budget truncation drops the
+  right ones.
+- **Acceptance.** RFC F5 acceptance tests pass; stripped body line-count < raw.
+- **Effort.** M. **Deps.** P0.1 (`end_line`).
+
+### F8 — Tiered display (inline body for high-confidence hits)
+- **Goal.** Inline body when normalized relevance ≥ threshold, saving a round-trip.
+- **Verified surface.** `BrainNode{uid,kind,title,location,relevance}` (`query.rs:661`); populate in
+  `render_brain_node` (`query.rs:1060`); serialize in `crates/nestweaver-mcp/src/tools.rs` +
+  CLI `print_brain_context_json`. Note/Section bodies already in store; Symbol bodies via F5.
+- **Schema/signatures.** Add `pub inline_body: Option<String>` to `BrainNode`. Config
+  `[response] inline_body_threshold = 0.75`, `inline_max_body_tokens = 800`. Opt-in:
+  `--inline-bodies` / `include_bodies: true`.
+- **Tasks.** (1) add field; (2) populate when `relevance ≥ threshold` & opt-in (Note/Section text
+  from store; Symbol via F5 path, comment-stripped); (3) **normalize relevance + gap-check** before
+  thresholding; (4) count inline bodies against `token_budget` ahead of metadata, downgrade
+  lower-ranked to metadata-only if budget would blow.
+- **Tests (TDD).** Top hit ≥ threshold has `inline_body`; below-threshold doesn't; tight budget
+  yields 1–3 inline, rest metadata; off by default.
+- **Acceptance.** RFC F8 acceptance tests pass.
+- **Effort.** S–M. **Deps.** F5 (Symbol bodies); Note/Section free.
+
+### F3 — `regex_search` (+ builds the trigram index)
+- **Goal.** First-party regex over symbol/section/note text with a trigram pre-filter; keeps skills
+  off raw `rg`/`grep` (ADDENDUM §A.1).
+- **Verified surface.** Greenfield in `crates/nestweaver-store`; `regex` + `regex-syntax` available
+  (`Cargo.lock`); Tantivy indexes notes/sections already.
+- **Schema/signatures.** New table `trigram_postings { trigram: u32, node_uid: String }`
+  (doc-ID-only — Cox/codesearch style, smallest + incrementally updatable). `--with-trigrams`
+  opt-in flag on `index`. New `crates/nestweaver-store/src/regex.rs`. MCP
+  `regex_search(pattern, path_prefix?, kinds?, limit?, max_millis?)`; CLI parity. Response mirrors
+  `brain_search`.
+- **Tasks (ordered).** (1) trigram extraction (lowercased 3-grams) at index time → postings table;
+  (2) query planning via `regex_syntax::hir::literal::Extractor` (`Seq::is_finite()`, exact vs
+  inexact) → required-trigram AND/OR set; (3) intersect postings → candidate UIDs → fetch text →
+  run full `regex`; (4) fallback to scan when `Seq` infinite; (5) budget: candidate cap 5000 +
+  timeout 2s (`--max-millis`), return `truncated: true`.
+- **Tests (TDD).** Literal pattern returns expected hits; no-literal pattern (`.{4,}`) falls back
+  and returns `truncated` under timeout; trigram prefilter rejects known non-matches (assert
+  candidate set < corpus).
+- **Acceptance.** RFC F3 acceptance tests; index-size overhead measured on the live DB before
+  defaulting on.
+- **Effort.** M–L. **Deps.** none (Symbol-text path wants P0.1; note/section text is ready).
+
+### F4 — `count_patterns`
+- **Goal.** Counts-only companion (files matched + total occurrences + per-file top), multi-pattern.
+- **Verified surface.** Reuses F3's trigram prefilter; `regex` count mode.
+- **Schema/signatures.** MCP `count_patterns(patterns: [String], path_prefix?, kinds?)` →
+  per-pattern `{pattern, total_matches, files_matched, top_files:[{path,count}]}`. CLI
+  `nestweaver count-patterns 'A' 'B' [--path-prefix …]`.
+- **Tasks.** (1) union candidate sets across patterns; (2) scan each candidate doc once, attribute
+  counts per pattern; (3) no result materialization.
+- **Tests (TDD).** Counts match `rg -c ± 0` on a fixture; stable across runs; multi-pattern in one
+  call.
+- **Acceptance.** RFC F4 acceptance tests.
+- **Effort.** S. **Deps.** F3.
+
+### F6 — Per-path `dampen`/`boost` ranking priors
+- **Goal.** Continuous path-glob prior on relevance; cheap, standalone ranking-policy knob.
+- **Verified surface.** Apply **post-fusion**: after `query.rs::rrf_fuse` (~`query.rs:966`) and
+  before the seed/connected split (`query.rs:972-981`) where fused scores become `BrainNode.relevance`.
+  `globset` available (transitive via `ignore`).
+- **Schema/signatures.** `[ranking]` in `InstanceConfig` / per-repo `.nestweaver.toml`:
+  `dampen=[{glob,multiplier}]`, `boost=[…]`. Resolve path→prior once at open into a sidecar. CLI
+  `nestweaver ranking explain <uid>` → `{base, matched_rules, final}`.
+- **Tasks.** (1) parse `[ranking]` + compile globs; (2) at the post-fusion point multiply
+  `node.relevance` by the matched multiplier (last-match-wins), clamp the **product** to
+  `[0.05, 5.0]`; (3) `ranking explain` dry-run; (4) record matched rule when `--debug`.
+- **Tests (TDD).** A dampened path drops below an undampened peer; clamp bounds a stacked product;
+  `ranking explain` shows base ≠ final with the matched rule.
+- **Acceptance.** RFC F6 acceptance tests; dampen ≠ exclude (floor 0.05).
+- **Effort.** S–M. **Deps.** none.
+
+---
+
+## Wave 1 dependency order (build sequence)
+
+```
+P0.1 end_line ─┬─► F5 ─► F8(symbol)            P0.4/F3 trigram ─► F4
+               └─► F3 symbol-text path          F6 (independent, any time)
+P0.2 generation, P0.3 eval-harness, P0.5 labeler ── run in parallel; gate later waves
+```
+
+**Next waves (specify when reached):** F9 (doc-graph), F2-core (gRPC + spec nodes + same-repo
+handlers, per ADDENDUM §C — wire `detect_frameworks()` first), F13 (affected_tests), F7 (PRF, gated
+by P0.3), F1 (feedback, gated by P0.3 + P0.5), F10 (investigate), F12 (temporal, gated), F11
+(memory-bank), F14/F15 (guidance), F16 (cache — only if P0.2 done + hit-rate measured), F17
+(reranker — only if F7+F1 leave a measured gap).

--- a/scratch/rfc-implementation-plan/BUILD-SPEC-wave2.md
+++ b/scratch/rfc-implementation-plan/BUILD-SPEC-wave2.md
@@ -1,0 +1,197 @@
+---
+title: Build-ready spec — Wave 2 (F9 doc-graph tools + F2-core contract linking)
+created: 2026-05-29
+companion_to: BUILD-SPEC-phase0-wave1.md, IMPLEMENTATION-PLAN.md, ADDENDUM-evidence-and-findings.md
+scope: F9 (low-risk reuse) + F2-core (the highest-value differentiator, scoped to the trustworthy
+       lanes per ADDENDUM §C). Surface verified against real code (ADDENDUM §B). No build/defer/kill
+       calls — the deferred F2 surface (general HTTP-literal cross-repo CONSUMES, GraphQL consumers)
+       stays in scope as F2-v2, sequenced after the core proves out.
+---
+
+# Build Spec — Wave 2
+
+Same format as Wave 1: **Goal · Verified surface · Schema/signatures · Tasks · Tests (TDD) ·
+Acceptance · Effort · Deps**. Effort S ≈ ≤1 day, M ≈ 2–4 days, L ≈ 1–2 weeks.
+
+Wave 2 has two independent tracks:
+- **F9** — promote document-graph operations to `brain.*` tools. Low risk; mostly new Cypher over
+  data already in the graph.
+- **F2-core** — contract-mediated cross-repo linking, scoped to the lanes the evidence says are
+  trustworthy (gRPC, spec nodes, same-repo handlers, drift). Highest product value.
+
+---
+
+## F9 — Document-graph tools (`brain.*`)
+
+Shared surface note: today only `count_wikilink_edges` (`read.rs:828`) and `wikilink_sources_to_note`
+(`read.rs:876`, returns `Vec<BacklinkRow>`) exist; broken-link/orphan/tag-cooccurrence queries are
+**greenfield**. Tag edges `NOTE_TAGGED_WITH` / `SECTION_TAGGED_WITH` already exist (`ranking.rs:266`).
+A configurable **MOC/index allowlist** (`Projects.md`, `_brain/index.md`, …) suppresses
+false-positives across the orphan/stats tools.
+
+### F9.1 — `brain_broken_links`
+- **Goal.** Find wikilinks whose target doesn't resolve (or resolves with `confidence < 1.0`), with
+  fuzzy suggestions.
+- **Verified surface.** Wikilink edges created during markdown indexing (`index_md.rs`); no audit
+  query exists. Resolver + aliases available for suggestions.
+- **Schema/signatures.** MCP `brain_broken_links([vault?, path_prefix?])` →
+  `[{source_uid, source_path, wikilink_text, suggested_target_uids:[...]}]`. CLI
+  `nestweaver brain broken-links [--json]`.
+- **Tasks.** (1) query unresolved/low-confidence wikilink edges (`MATCH (s)-[r:WIKILINK…]->()` where
+  target missing or `r.confidence < 1.0`); (2) suggest targets by **Adamic–Adar / fuzzy title match**
+  (Liben-Nowell & Kleinberg, CIKM 2003) against existing note titles + aliases.
+- **Tests (TDD).** A note with `[[Nonexistent]]` surfaces; a resolved link doesn't; a near-miss
+  title gets a ranked suggestion.
+- **Acceptance.** Count matches what `/audit-vault` reports today (±0).
+- **Effort.** M. **Deps.** none.
+
+### F9.2 — `brain_orphan_documents`
+- **Goal.** Notes with zero inbound **and** outbound wikilinks, minus the allowlist.
+- **Schema/signatures.** MCP `brain_orphan_documents([vault?, path_prefix?])` → `[{uid, path}]`. CLI
+  `nestweaver brain orphans`.
+- **Tasks.** (1) `MATCH (n:Note)` with no incident wikilink edges in either direction; (2) exclude
+  allowlist (MOC/index/registry notes — Wikipedia orphan study warns these are the false-positive
+  class).
+- **Tests.** A linked note is excluded; an island note surfaces; an allowlisted index note is
+  excluded even if islanded.
+- **Acceptance.** Stable list; allowlist honored.
+- **Effort.** S. **Deps.** none.
+
+### F9.3 — `brain_topic_clusters`
+- **Goal.** Leiden communities over the **wikilink (note↔note) subgraph**; cluster id + members +
+  label (highest-PageRank note title).
+- **Verified surface.** `cluster_dispatch.rs` runs Leiden but **hardcoded to code Symbol edges**
+  (8 edge types) via `load_code_symbols_and_edges` (`read.rs:~990`). Reusing the algorithm over
+  wikilinks needs a new `load_note_edges` loader (~50 LOC).
+- **Schema/signatures.** New `read.rs::load_note_edges() -> (nodes, edges)` over wikilink edges; feed
+  the existing Leiden path. MCP `brain_topic_clusters([vault?])` → `[{cluster_id, members:[uid],
+  label}]`. CLI `nestweaver brain topic-clusters`.
+- **Tasks.** (1) `load_note_edges`; (2) parametrize the Leiden entrypoint by graph source (don't fork
+  the algorithm); (3) label = top-PageRank member title.
+- **Tests.** Two densely-linked note groups → two clusters; label is the hub note.
+- **Acceptance.** Mirrors `clusters` shape, scoped to vault.
+- **Effort.** M. **Deps.** none (Leiden exists).
+
+### F9.4 — `brain_tag_graph`
+- **Goal.** Tag co-occurrence: `{tag, count, co_occurring:[{tag, count}]}`.
+- **Verified surface.** `NOTE_TAGGED_WITH` edges exist; no co-occurrence query.
+- **Schema/signatures.** MCP `brain_tag_graph()` → as above. CLI `nestweaver brain tag-graph`.
+- **Tasks.** (1) count per-tag note frequency; (2) co-occurrence = notes sharing two tags; weight by
+  **PMI** to surface meaningful pairs (suppress mega-tag dominance).
+- **Tests.** Two tags on the same notes co-occur; a singleton tag has empty co-occurrence.
+- **Acceptance.** Used by `/audit-vault` to spot taxonomy drift.
+- **Effort.** S–M. **Deps.** none.
+
+### F9.5 — `brain_doc_stats`
+- **Goal.** One-call health dashboard.
+- **Schema/signatures.** MCP `brain_doc_stats()` → `{total_notes, total_wikilinks, broken_wikilinks,
+  orphans, avg_outdegree, top_tags, notes_by_year}`. CLI `nestweaver brain doc-stats`.
+- **Tasks.** Compose F9.1/F9.2/F9.4 + counts (`count_wikilink_edges` exists) + `notes_by_year` from
+  `created_at`/`modified_at`.
+- **Tests.** All 7 keys present; broken/orphans match F9.1/F9.2.
+- **Acceptance.** RFC F9 acceptance (`keys` includes all 7).
+- **Effort.** S. **Deps.** F9.1, F9.2, F9.4.
+
+> **Skill refactor (out-of-engine):** once F9.1–F9.5 land, `/audit-vault` collapses to a thin
+> orchestrator over them and gains parity on the other runtimes. Track separately from engine work.
+
+---
+
+## F2-core — Contract-mediated linking (trustworthy lanes)
+
+Scoped per ADDENDUM §C: lead with the unambiguous lanes; **present every contract edge as a
+confidence-scored hypothesis, never ground truth.** The existing `cross_repo_contracts` tool does
+name/import matching (`tools.rs:1445`) and the real contract matcher
+(`resolver/src/cross_repo.rs::find_cross_repo_links`) is **unwired dead code** — so this is
+**greenfield**, not integration.
+
+### F2.0 — Enabler: wire `detect_frameworks()`
+- **Goal.** Populate `Symbol.framework_hint` (today always `None`) — prerequisite for handler
+  detection and broadly useful.
+- **Verified surface.** `detect_frameworks()` in `crates/nestweaver-parser/src/frameworks.rs`
+  (detects Spring/Flask/Express/etc. by signature substring → `(usize, FrameworkHint)`) is
+  **exported but never called**; `index.rs` sets `framework_hint: None` everywhere.
+- **Tasks.** (1) call `detect_frameworks()` in the indexing pipeline where Symbols are built; (2)
+  set `framework_hint`; (3) expose in `symbol --json`.
+- **Tests.** A Spring `@RestController` class gets `framework_hint = {framework: spring, role: …}`.
+- **Acceptance.** `framework_hint` populated on a fixture repo.
+- **Effort.** S. **Deps.** none. **Blocks.** F2.2.
+
+### F2.1 — Contract nodes from spec files
+- **Goal.** Parse OpenAPI/proto/GraphQL → `Contract` nodes (authoritative, confidence 1.0).
+- **Verified surface.** New node kind (mirror how `Project` nodes are added: struct + table +
+  write/read). Crates verified on crates.io (2026-05-29): **`openapiv3` 2.2.0** (OAS 3.0) +
+  **`oas3` 0.22.0** (OAS 3.1); **`protox` 0.9.1** (pure-Rust, no `protoc`); **`apollo-parser`
+  0.8.6**. **Migrate YAML off deprecated `serde_yaml` → `serde_yaml_ng`.**
+- **Schema/signatures.** `Contract { uid, kind: http|grpc|graphql, verb?, path?/method, operation_id?,
+  repo_uid, source_path, confidence }`. UID scheme: `contract:http:POST:/v1/approvals`,
+  `contract:grpc:approvals.v1.Approvals/Create`, `contract:graphql:Mutation.createApproval`.
+  **Path normalization** (collapse `{id}`/`:id`/`${id}`/`<id>`, ignore slot names) in one shared fn.
+- **Tasks.** (1) detect spec files during indexing; (2) parse per format; (3) mint `Contract` nodes
+  with normalized UIDs.
+- **Tests.** An `openapi.yaml` with `POST /v1/approvals` → one `contract:http:POST:/v1/approvals`;
+  a `.proto` service → `contract:grpc:…/Create`; `{id}` and `:id` normalize equal.
+- **Acceptance.** Contract nodes queryable; normalization stable.
+- **Effort.** M. **Deps.** none.
+
+### F2.2 — Same-repo `IMPLEMENTS_CONTRACT` (Spring + NestJS)
+- **Goal.** Link handler Symbols to their Contract (highest-precision lane).
+- **Verified surface.** `EdgeType` has 14 variants (`edges.rs:5-20`); add `ImplementsContract` —
+  additive (new `rel_table_name`, `Display`, and `insert_edge_with_conn` arm at `write.rs:385`).
+  Handler signals via `framework_hint` (F2.0) + annotation/decorator extraction in the tree-sitter
+  path.
+- **Schema/signatures.** `EdgeType::ImplementsContract`; edge `{confidence}`.
+- **Tasks.** (1) detect Spring `@PostMapping`/`@RequestMapping` + class-level base path, NestJS
+  `@Post()` + controller prefix; (2) normalize verb+path; (3) match to a Contract node (or mint a
+  code-derived one if no spec); (4) emit edge: 1.0 exact, 0.8 if base-path inferred.
+- **Tests.** A Spring handler for `POST /v1/approvals` links to the spec's contract at 1.0;
+  base-path-only inference lands at 0.8.
+- **Acceptance.** Handlers in a Spring/NestJS fixture link to contracts.
+- **Effort.** M. **Deps.** F2.0, F2.1.
+
+### F2.3 — Safe cross-repo `CONSUMES_CONTRACT` (gRPC + operationId clients)
+- **Goal.** Cross-repo edges only in the unambiguous lanes: gRPC `Service/Method` calls and typed
+  clients matched by `operationId`. **Excludes** raw HTTP-literal `fetch`/axios matching (F2-v2).
+- **Schema/signatures.** `EdgeType::ConsumesContract`.
+- **Tasks.** (1) **demand gate first** — count actual cross-repo gRPC/typed-client couplings in the
+  target repos (ADDENDUM §C); if negligible, stop here and revisit; (2) detect gRPC stub calls →
+  `package.Service/Method`; (3) detect generated/typed-client calls referencing an `operationId`;
+  (4) emit `CONSUMES_CONTRACT` to the matching Contract at 1.0 (exact FQN/operationId).
+- **Tests.** A gRPC client call links cross-repo to the server's `IMPLEMENTS` contract; an
+  operationId client call links to its spec contract.
+- **Acceptance.** RFC F2 acceptance (`cross-repo-contracts --link-type contract` returns ≥2 for a
+  real coupling); generic paths produce **no** edges (collision guard).
+- **Effort.** M–L. **Deps.** F2.1, F2.2. **Gate.** demand count > threshold.
+
+### F2.4 — Drift diagnostics
+- **Goal.** "Declared-but-not-implemented" and "implemented-but-undeclared" reports (high value,
+  near-free once F2.1/F2.2 exist).
+- **Schema/signatures.** CLI `nestweaver contracts drift [--repo …]` →
+  `{declared_only:[…], implemented_only:[…]}`.
+- **Tasks.** Set-difference Contract nodes vs `IMPLEMENTS_CONTRACT` edges per repo.
+- **Tests.** A spec endpoint with no handler appears in `declared_only`.
+- **Acceptance.** Drift list matches a hand-checked fixture.
+- **Effort.** S. **Deps.** F2.1, F2.2.
+
+> **Wire into `cross_repo_contracts`:** extend the existing tool's response with a
+> `link_type: "contract"` discriminator so contract-mediated links appear alongside name matches.
+> Re-budget as new code (the current tool doesn't do contract matching).
+
+---
+
+## Wave 2 build order
+
+```
+F9.1 broken-links ┐
+F9.2 orphans      ├─► F9.5 doc-stats        (F9.3 topic-clusters, F9.4 tag-graph: parallel)
+F9.4 tag-graph    ┘
+
+F2.0 wire detect_frameworks ─► F2.2 IMPLEMENTS ─┐
+F2.1 contract nodes ────────────┴───────────────┼─► F2.4 drift
+                                                 └─► F2.3 cross-repo (after demand gate)
+```
+
+**Deferred to F2-v2 (still in scope, sequenced after core proves out):** general HTTP-literal
+cross-repo `CONSUMES` (Express/Go/`fetch`/axios) and GraphQL consumers — the lanes the evidence
+(≤0.79 F1, generic-path collisions) says can't yet be made trustworthy. Revisit once the core ships
+and the demand count justifies the false-positive risk.

--- a/scratch/rfc-implementation-plan/BUILD-SPEC-wave3.md
+++ b/scratch/rfc-implementation-plan/BUILD-SPEC-wave3.md
@@ -1,0 +1,123 @@
+---
+title: Build-ready spec — Wave 3 (F13 affected_tests + F12 git-activity CodeRank)
+created: 2026-05-29
+companion_to: BUILD-SPEC-phase0-wave1.md, BUILD-SPEC-wave2.md, IMPLEMENTATION-PLAN.md, ADDENDUM-evidence-and-findings.md
+scope: The PR-review track. Serves measured journeys J2 (impact) and J5 (PR blast radius). Surface
+       re-verified against current code, incl. the new nestweaver-algorithms crate.
+---
+
+# Build Spec — Wave 3
+
+Same format: **Goal · Verified surface · Schema/signatures · Tasks · Tests (TDD) · Acceptance ·
+Effort · Deps**. Both features share a git-history substrate (W3.0).
+
+**Re-verification highlights (current code):**
+- PPR is now **pure** in `crates/nestweaver-algorithms/src/ppr.rs::personalized_pagerank`
+  (WASM-compatible). F12's activity multiplier must **not** go there — apply it where
+  `pagerank_score` is *consumed* in `crates/nestweaver-store/src/ranking.rs` / `hubs.rs`. This both
+  matches the research (post-hoc, not in the fixpoint) and is now architecturally enforced.
+- F13 is **mostly reuse**: `store/src/traverse.rs::impact` + `direct_callers_of` (reverse CALLS/
+  IMPORTS with `min_confidence`); `engine/src/process.rs::detect_changes_impact` (changed_files →
+  affected_symbols); `engine` `changed_files_from_git` (CI fast-path); and **test-file heuristics
+  already exist** in `crates/nestweaver-parser/src/entry_points.rs::is_test_file` (`/__tests__/`,
+  `*_test.go`, `*_test.dart`, `*_test.exs`, …).
+- Existing git surface is **diff-based** (`engine/src/git_diff.rs::detect_changes`,
+  `changed_files_from_git`) — there is **no log/history mining** yet (W3.0 is new).
+
+---
+
+## W3.0 — Git-history mining substrate (`git_activity.rs`)
+- **Goal.** Per-file commit recency from git history. Feeds F12 (recency multiplier) and F13's
+  co-change fallback.
+- **Verified surface.** `engine/src/git_diff.rs` has diff/changed-files only; history mining is new.
+  New module `crates/nestweaver-engine/src/git_activity.rs`.
+- **Schema/signatures.** Run `git log --name-only --pretty=format:%H%x09%aI` per repo at index time.
+  `recency_score(path) = mean_{last N=20 touching, non-bulk commits} exp(-Δdays / 180)` using
+  **author date `%aI`** (rebases/squash distort commit date). Bulk-commit threshold = **per-repo
+  percentile** (commit sizes are heavy-tailed — a fixed ≥500 is wrong for small repos; Hindle MSR
+  2008). Detect/skip merge commits.
+- **Tasks.** (1) per-repo `git log` sweep behind `--with-git-activity`; (2) compute per-file recency;
+  (3) per-repo bulk-commit percentile filter; (4) emit `{path → score ∈ [0,1]}`.
+- **Tests (TDD).** Synthetic git fixture: a recently-touched file scores higher than a stale one; a
+  file only touched in a bulk commit is excluded from the average.
+- **Acceptance.** Scores in `[0,1]`; recent > stale; deterministic on the fixture.
+- **Effort.** M. **Deps.** none. **Feeds.** F12, F13(fallback).
+
+---
+
+## F12 — Git-activity-dampened CodeRank
+- **Goal.** Demote dormant code at rank-read time so an active service outranks a dormant fork of
+  the same name — **without** touching the pure PPR fixpoint.
+- **Verified surface.** Pure PPR in `algorithms/src/ppr.rs` (leave it pure). `pagerank_score`
+  persisted on nodes (`<db>.pagerank.json` cache + node column); **consumed** in
+  `store/src/ranking.rs` and `engine/src/hubs.rs` — apply the multiplier there.
+- **Schema/signatures.** Add `git_activity_score: Option<f64>` to the symbol/file node (absent →
+  treated as `1.0`, neutral). Config `[ranking] git_activity_weight` + per-repo
+  `[ranking] use_git_activity = false`.
+- **Key decision (fix RFC §1.4 bug).** `(1 + w·(score − 0.5))` with `score ∈ [0,1]` ranges over
+  `[1 − w/2, 1 + w/2]`. The RFC's `[0.4, 1.6]` clamp needs **w = 1.2**, not 0.6 — otherwise the
+  clamp never binds. Default `w` to a value consistent with the intended clamp and document it;
+  center 0.5 = no change (Temporal PageRank degrade-to-baseline).
+- **Tasks.** (1) `nestweaver index --recompute-rank --with-git-activity` populates
+  `git_activity_score` from W3.0; (2) at `pagerank_score` read in `ranking.rs`/`hubs.rs`, multiply by
+  `clamp(1 + w·(score − 0.5))`; (3) per-repo opt-out; (4) `nestweaver explain rank <uid>` →
+  `{base_pagerank, git_activity_score, final_rank}`.
+- **Tests (TDD).** Given two same-named symbols (active vs stale repo), active ranks higher after
+  recompute; absent score → neutral (rank unchanged); clamp bounds an extreme score.
+- **Acceptance.** RFC F12 acceptance (`hubs` before/after shifts toward active; `explain rank`
+  populates all three).
+- **Effort.** M. **Deps.** W3.0. **Gate.** Ranking-quality gain is `[UNVERIFIED/novel]` — validate
+  on the **P0.3 eval harness** before defaulting on; ship behind the flag until it clears.
+
+---
+
+## F13 — `affected_tests`
+- **Goal.** changed files → changed symbols → reverse `CALLS`/`IMPORTS` (depth 3) → test files,
+  bucketed into priority tiers. "Which tests should this MR run?"
+- **Verified surface (reuse).** `store/src/traverse.rs::impact` (`:34`) + `direct_callers_of`
+  (`:79`) — reverse traversal with `min_confidence`. `engine/src/process.rs::detect_changes_impact`
+  (`:223`) — changed_files → `affected_symbols`. `changed_files_from_git` (engine `lib.rs:80`) — CI
+  fast-path. **Test detection** reuses/extends `parser/src/entry_points.rs::is_test_file`.
+- **Schema/signatures.** Avoid a new node kind: classify test files at query time via the existing
+  heuristics + per-repo `[tests] include=[…]`, `exclude=[…]` overrides. MCP
+  `affected_tests(changed_files: [String], base_ref?)` → `{changed_files, changed_symbols,
+  tier_1:[{test_file, tests:[…], symbol_uid}], tier_2, tier_3, summary}`. CLI
+  `nestweaver affected-tests [--base-ref main] [--json]`.
+- **Tasks (ordered).** (1) resolve `changed_files` → symbols via `detect_changes_impact`; (2)
+  reverse-traverse to depth 3 via `traverse.rs::impact`; (3) filter reached nodes to those residing
+  in **test files** (heuristics + config); (4) bucket by depth — tier-1 directly tests a changed
+  symbol, tier-2 tests a tier-1 caller, tier-3 transitive — and order within tier by edge confidence
+  (CALLS=1.0 … ACCESSES=0.4); (5) `--base-ref` runs `git diff --name-only base...HEAD` via
+  `changed_files_from_git`.
+- **Tests (TDD).** A change to a tested symbol yields `tier_1 ≥ 1`; a caller's test lands in tier-2;
+  a non-test caller is excluded; `--base-ref` derives the file list itself.
+- **Acceptance.** RFC F13 acceptance (`tier_1` length ≥ 1 when the diff touches a tested symbol);
+  `/mr-review` skill consumes it.
+- **Pitfalls (from RTS literature — Rothermel & Harrold "safe RTS", STARTS, Meta predictive
+  selection).** Static call-graph RTS is **not safe** (misses reflection/DI/codegen/data-driven
+  tests) — frame as a **measured recall target vs run-all** (Meta's posture), not provable safety;
+  **"no path found ≠ safe to skip"** (distinguish from "no tests, high confidence"); warn when tests
+  exist beyond the depth-3 cap; deprioritize known-flaky tests via history; for squash/large MRs
+  past a change threshold, recommend run-all; offer a conservative full-run fallback.
+- **Effort.** M (mostly reuse; new work is tiering + test-node filtering + the changed→symbol glue).
+  **Deps.** none for the core (W3.0 only for an optional co-change fallback signal).
+
+---
+
+## Wave 3 build order
+
+```
+W3.0 git-history mining ─► F12 (recompute-rank, multiplier at read)   [gate: P0.3 eval harness]
+F13 affected_tests  ── independent (reuses traverse.rs::impact + detect_changes_impact
+                        + entry_points test heuristics; W3.0 only for co-change fallback)
+```
+
+**Sequencing note.** F13 has the fewest dependencies and serves J2/J5 directly — it can start
+immediately, in parallel with W3.0. F12 should not default-on until it clears the P0.3 eval harness
+(its ranking gain is novel/unverified).
+
+**Next waves (specify when reached):** F7 (PRF) and F1 (interaction feedback) — both **gated on the
+P0.3 eval harness landing**; then F10 (investigate, composes F7/F8/F9), F11 (memory-bank, builds on
+F9), F14/F15 (guidance — Tier E3), F16 (cache — only if P0.2 done + hit-rate measured), F17
+(reranker — only if F7+F1 leave a measured gap). PPR-touching specs (F1) will be re-verified against
+the `nestweaver-algorithms` crate at spec time.

--- a/scratch/rfc-implementation-plan/BUILD-SPEC-wave4.md
+++ b/scratch/rfc-implementation-plan/BUILD-SPEC-wave4.md
@@ -1,0 +1,113 @@
+---
+title: Build-ready spec — Wave 4 (F7 PRF + F1 feedback) — FINISH, not build
+created: 2026-05-29
+companion_to: BUILD-SPEC-phase0-wave1.md … wave3.md, IMPLEMENTATION-PLAN.md, ADDENDUM-evidence-and-findings.md
+scope: The eval-harness-gated quality features. Re-verification shows BOTH are partially built
+       already — this spec is scoped to what actually remains. Gated on P0.3 (eval harness).
+---
+
+# Build Spec — Wave 4
+
+> **Meta-finding (important).** The codebase is materially more built-out than the RFC (written
+> against the older `5df5c94`) assumes. Verified already-landed in this wave's scope: **interaction
+> scores are consumed in PPR** (not "loaded but never consumed" — that finding is now stale),
+> **`FollowUp` events + `session_id` exist**, and **alias/synonym query expansion is shipped**. Each
+> remaining RFC feature must be re-verified against current code before speccing — which is what
+> these waves do. See the per-feature "Current state (verified)" lines below.
+
+Same format: **Goal · Current state · Verified surface · Schema/signatures · Tasks · Tests ·
+Acceptance · Effort · Deps**. Both gated on **P0.3 eval harness** before default-on.
+
+---
+
+## F7 — BM25 PRF + taxonomy expansion
+- **Goal.** Improve recall on natural-language queries via pseudo-relevance feedback + curated alias
+  expansion.
+- **Current state (verified).** **Alias/synonym expansion is DONE** — `expand_query_with_aliases`
+  (`query.rs`, tested in `expand_query_tests` at `query.rs:1483`) loads aliases
+  (`load_alias_sidecar`) and expands at query time. **PRF two-pass term mining is NOT present**
+  (no `prf`/`rm3`/feedback-term code found). So F7 = build the PRF pass only.
+- **Verified surface.** BM25 candidate ranking in `store/src/tantivy_index.rs::search`; IDF stats
+  via Tantivy's `Bm25StatisticsProvider`; first ranking inside
+  `query.rs::build_brain_context_hybrid_with_aliases`.
+- **Schema/signatures.** Gate behind `--prf` (CLI) / `prf: true` (MCP) + `[ranking] enable_prf`.
+  Pass 1: original query → top-K=5 docs. Mine candidate terms with IDF > median; keep top-N=10 by
+  `IDF × tf-in-top-K`. Pass 2: append at weight **0.3×**, cap total query length at 64. Surface
+  `expansion_terms` in `--debug`.
+- **Tasks (ordered).** (1) after the first BM25 ranking, pull top-K=5 bodies; (2) extract/score
+  candidate terms by IDF (`Bm25StatisticsProvider`), excluding terms already in the query; (3)
+  append top-N at 0.3×; (4) re-run BM25 (pass 2); (5) gate behind flag + config.
+- **Tests (TDD).** A natural-language query mines an expected high-IDF term; `--prf` changes the
+  top-5; query length capped; alias expansion (already shipped) still passes.
+- **Acceptance.** RFC F7 acceptance — `expansion_aliases` already returns (alias path); with `--prf`,
+  `sync.md`/`status.md`-type notes surface higher on a "where did we leave off" query, validated on
+  **P0.3**.
+- **Pitfalls.** **Query drift** (down-weight 0.3×, cap N≤10, prefer high-IDF, consider *selective*
+  expansion gated on the pass-1 score gap); per-query inconsistency (keep opt-in). Note: RRF is
+  rank-only, so PRF weights affect the **BM25-internal order**, reaching the fused result only via
+  changed BM25 ranks — set expectations.
+- **Effort.** M. **Deps.** P0.3 (gate). Reported deltas are directional only (+10–30% MAP on weak
+  TREC baselines) — **gate on our corpus, don't import the magnitude.**
+
+---
+
+## F1 — Agent feedback loop
+- **Goal.** Let success-signalled nodes rank slightly higher next time, safely.
+- **Current state (verified) — ~70% built.**
+  - **Ask 1 (consume interaction scores in PPR): DONE.** `PprConfig.interaction_scores` +
+    `interaction_bias_weight = 0.05` (`algorithms/src/ppr.rs:18-30`); store holds an
+    `interaction_cache` set via `load_interaction_cache`, populated at `mcp/src/lib.rs:49` from
+    `load_interaction_scores`; the **5% additive blend into the personalization/teleport vector** is
+    implemented in `store/src/ranking.rs:599-623` (and mirrored in the pure algorithms PPR).
+  - `EventType` (`interactions.rs:51`) = Query / Access / **FollowUp** / Impact — FollowUp
+    (access-immediately-after-query) **already auto-detected**; `session_id` **already present**.
+  - **Missing:** `TerminalSuccess`; explicit success/negative recording; `interactions show --uid`;
+    the "tracking disabled" note in `brain status`; and the **anti-feedback-loop hardening** the
+    adversarial review called for.
+- **Design decision.** **Do NOT re-implement Ask 1 as a "2.0× multiplicative cap."** The shipped 5%
+  additive teleport blend is the principled locus (Haveliwala topic-sensitive PageRank) and is
+  *inherently bounded* — strictly safer against runaway than an unbounded-direction 2.0× multiplier.
+  Keep it; tune the 5% weight on P0.3 if needed.
+- **Verified surface.** `interactions.rs` (events, decay, `load_interaction_scores:456`);
+  `mcp/src/lib.rs:49` (load → cache); `ranking.rs:554/599` (blend); `InteractionCommands` in
+  `main.rs:1233` (Status/Clear only).
+- **Schema/signatures.** Add `EventType::TerminalSuccess` (+ its decay weight). New
+  `nestweaver interactions show --uid <uid>`. `brain status` prints `interaction_tracking: disabled
+  (run with --track-interactions to enable)` when off.
+- **Tasks (ordered).** (1) add `TerminalSuccess` kind; (2) record success (surfaced UID then
+  edited/written, or clean session-end with no re-query) and **negative** (next action is another
+  search/reformulation) — FollowUp already covers access-after-query; (3) **harden vs feedback-loop
+  bias (Ensign 2018): add a uniform exploration floor so non-accessed nodes stay reachable, and let
+  the negative signal down-weight** — the shipped 5% blend already bounds magnitude; (4)
+  `interactions show --uid`; (5) `brain status` disabled-note.
+- **Tests (TDD).** A surface→edit sequence records `TerminalSuccess`; a surface→re-search records a
+  negative; the exploration floor keeps a never-accessed node above zero personalization;
+  `show --uid` prints the event history; ranking shifts toward success-signalled UIDs across runs
+  (on P0.3).
+- **Acceptance.** RFC F1 acceptance (`interactions show --top --kind terminal-success`; before/after
+  ranking shift) — measured on **P0.3** with tracking toggled.
+- **Pitfalls.** Runaway/popularity bias (bounded blend + exploration floor + negative signal +
+  decay); `TerminalSuccess` mis-attribution (session walked away ≠ success — weight conservatively);
+  **reproducibility** (machine-local scores make benchmarks non-deterministic → always A/B with
+  tracking *off* as the baseline).
+- **Effort.** **S–M** (consumption already done — much smaller than the RFC implies). **Deps.** P0.3
+  (gate), P0.5 (success-signal labeler).
+
+---
+
+## Wave 4 build order
+
+```
+P0.3 eval harness ──gate──► F7 PRF pass        (alias expansion already shipped)
+P0.3 + P0.5 ───────gate──► F1 finish           (PPR consumption already shipped; add
+                                                 TerminalSuccess + negative signal + floor + CLI)
+```
+
+Both are **off-by-default** and must clear the P0.3 harness before defaulting on. F7's PRF and F1's
+remaining work are independent and can run in parallel once P0.3 exists.
+
+**Remaining after Wave 4:** F10 (investigate — composes F7/F8/F9), F11 (memory-bank — builds on F9),
+F14/F15 (guidance, Tier E3), F16 (cache — only if P0.2 done + hit-rate measured; adversarial says
+drop-to-experiment), F17 (reranker — only if F7+F1 leave a measured gap; adversarial says
+replace-with-simpler). Each will be re-verified against current code at spec time, since (per the
+meta-finding) several may be more built than the RFC assumes.

--- a/scratch/rfc-implementation-plan/BUILD-SPEC-wave5-final.md
+++ b/scratch/rfc-implementation-plan/BUILD-SPEC-wave5-final.md
@@ -1,0 +1,163 @@
+---
+title: Build-ready spec — Final wave (F10 investigate, F11 memory-bank, F14/F15/F16/F17)
+created: 2026-05-29
+companion_to: BUILD-SPEC-phase0-wave1.md … wave4.md, IMPLEMENTATION-PLAN.md, ADDENDUM-evidence-and-findings.md
+scope: Completes build-ready specs for all 17 RFC features. F10/F11 full depth; F14–F17 as
+       spec + carried adversarial gates (those four are contingent/gated, not clean go's).
+---
+
+# Build Spec — Final wave
+
+Verified: these six are **greenfield** (no existing investigate/bundle, typed note edges,
+memory-lint, hooks, static rules block, response cache, or ML runtime dep). F10/F11 are clean
+composites of already-shipped work; F14–F17 carry the gates the adversarial pass established.
+
+---
+
+## F10 — `investigate` bundle primitive
+- **Goal.** One call → an architectural map (clusters as "domains" + top-PageRank node per cluster
+  as "entry points") + `bundle_id` (24h TTL); `investigate_expand` / `investigate_hydrate` drill in.
+- **Current state.** Greenfield, but composes shipped primitives: hybrid search, `brain_context`,
+  Leiden (`cluster_dispatch.rs`), F8 inline bodies, F7 PRF, token-budget helpers
+  (`tools.rs::budgeted_cut`/`render_cost`).
+- **Verified surface.** New `crates/nestweaver-engine/src/investigate.rs` + bundle table in the
+  `.lbug`. Bundle state keyed/tagged with **`graph_generation`** — needs **P0.2** (persist + bump on
+  index) to be valid across processes. MCP result shaping uses `structuredContent` + `resource_link`
+  (return entry-point URIs, hydrate later — MCP spec).
+- **Schema/signatures.** `bundles { bundle_id, created_at, query, scope, seeds,
+  entries:[{asset_id, uid, kind, summary, inline_body?, expanded:bool}] }`, 24h TTL. `asset_id` =
+  stable short hash of `(bundle_id, uid)`. MCP `investigate(query, scope?, token_budget?)` →
+  `bundle_id` + map; `investigate_expand(bundle_id, targets:[asset_id|uid])`;
+  `investigate_hydrate(bundle_id)`. `scope: "project:<slug>" | "repo:<name>" | "vault"` (reuses
+  `project_context` member-UID logic for project scope).
+- **Tasks (ordered).** (1) bundle store (module + table), tagged with `graph_generation`; (2) map
+  construction: PRF hybrid search → top-30 → group Symbol/Note → fetch neighbours via
+  `brain_context` → Leiden over the union → top-3 clusters as domains + highest-PageRank node each
+  as entry points; (3) inline ≤5 high-confidence bodies (F8); (4) token-budget paging (default 4000,
+  cap 16000, return `more_available: <count>`); (5) `expand`/`hydrate`.
+- **Tests (TDD).** `investigate` → `entries ≥ 10`, `clusters` 2–3, non-empty `bundle_id`; `expand`
+  on an `asset_id` returns a body; budget cap respected (`more_available` set when truncated).
+- **Acceptance.** RFC F10 acceptance (bundle shape; expand drilling; ~40–70% fewer tokens vs the
+  naive search→context→read loop — measure, don't assume).
+- **Pitfalls.** Over-bundling recreates "lost in the middle" → strict budget + hydrate-on-demand;
+  stale `bundle_id` within TTL → `graph_generation` tag invalidates; cluster instability across runs.
+- **Effort.** M–L. **Deps.** F7, F8, F9 (Leiden-over-vault), P0.2, §2.3 disk layer.
+
+---
+
+## F11 — Memory-bank semantics over the vault
+- **Goal.** Typed relationship edges + 7 health checks + a consolidation pipeline +
+  `brain_memory_related`.
+- **Current state.** Greenfield: only `WIKILINK` edges + 5-priority wikilink resolution exist
+  (`index_md.rs:1091`); no typed semantic edges, lint, or consolidation. Orphan/broken-link checks
+  **reuse F9**.
+- **Verified surface.** Frontmatter parsing in `index_md.rs` (`ParsedNote`); `EdgeType` enum
+  (`edges.rs`, additive); F9 doc-graph tools.
+- **Schema/signatures.** Add `EdgeType::{Supersedes, DependsOn, CausedBy, RelatesTo}` (additive),
+  mapped to **SKOS** (`broader`/`narrower`/`related`) and **PROV-O** (`wasDerivedFrom`/`wasRevisionOf`)
+  semantics. Derive from frontmatter (`supersedes: [..]`, `depends_on: [..]`) and from wikilinks
+  inside sections named "Supersedes" / "Depends on" / "See also"; ungrouped wikilinks stay generic.
+  MCP `brain_memory_lint`, `brain_memory_consolidate(--dry-run|--apply)`,
+  `brain_memory_related(uid, edge_types?, depth?)`. CLI `nestweaver memory lint|consolidate|related`.
+- **Tasks (ordered).** (1) derive typed edges during `index_md`; (2) **7 checks**: stale
+  (`status: active` + >90d no edit), contradictions (Supersedes cycles), orphans + broken_wikilinks
+  (**reuse F9**), supersession_chains, schema_drift (frontmatter vs `_templates/<kind>.md`),
+  dangling_relationships (typed edge → missing node); (3) consolidation **dry-run by default** —
+  e.g. a daily-log H3 linked from ≥3 idea notes and surviving ≥14 days is an `_ideas/` candidate;
+  output a manifest the user accepts; (4) `brain_memory_related` typed-edge BFS.
+- **Key decision (A-MEM caution).** Consolidation **suggests + records `wasDerivedFrom` provenance,
+  never silently mutates** files.
+- **Tests (TDD).** A frontmatter `supersedes:` creates a `Supersedes` edge; the stale check flags an
+  old `status: active` note; consolidation proposes ≥1 promotion on a fixture; `related` returns
+  typed neighbours only (no generic wikilink noise).
+- **Acceptance.** RFC F11 acceptance (lint keys present; consolidate proposals ≥1; related typed-only).
+- **Pitfalls.** Orphan/stale false-positives for MOC/convention notes (tier-aware allowlist, reuse
+  F9); false consolidation (require temporal spread + link threshold); never auto-mutate.
+- **Effort.** M–H (consolidation is the long pole). **Deps.** F9.
+
+---
+
+## F14 — Subagent PreToolUse hook (Tier E3 — agent-harness)
+- **Goal.** Inject dynamic guidance into spawned subagents via a hook, so guidance lives in one place.
+- **Current state.** Greenfield (no hook install; `setup` only configures the MCP).
+- **Schema/signatures.** `nestweaver admin instructions [--for-subagent | --set <file> | --reset]`
+  (prints subagent text); `nestweaver admin install-hook [--runtime claude|…] [--dry-run]`
+  (idempotent matcher on `Task`). Prefer the **`mcp_tool` hook type** (reuse the running server —
+  avoids cold-CLI/DB cost per spawn).
+- **Tasks.** instruction store (`~/.nestweaver/instructions[.subagent].md`, bundled defaults);
+  print subcommand; idempotent hook installer; optional `admin clean` to strip legacy sections.
+- **Carried gate (adversarial/research).** **"Control Illusion" (Geng 2025): instruction hierarchies
+  aren't reliably obeyed — guidance helps but is not enforcement.** Plus runtime lock-in
+  (Claude-Code-specific schema) and untrusted-injection risk. **Posture: build only if §2.6 guidance
+  store earns its keep; frame as defense-in-depth, not control.**
+- **Effort.** Low–M. **Deps.** §2.6.
+
+---
+
+## F15 — Hard-rule guidance in `generate-guide` (Tier E3)
+- **Goal.** A canonical `**HARD RULE:**` block at the top of generated guides; versioned.
+- **Current state.** `agent_guide.rs::generate_guide` emits guides (markdown / cursor-rule /
+  agents-md) **dynamically from the graph**; no static rules block — add one.
+- **Schema/signatures.** Const rule array in `agent_guide.rs` (`--rules-from <file>` override);
+  position rules at top with `**HARD RULE:**` prefix; `rules_version: N` in frontmatter.
+- **Evidence (carried).** "Enumerate then verify" is **directly backed by Chain-of-Verification**
+  (Dhuliawala et al., ACL 2024); top placement by the Instruction Hierarchy (Wallace et al. 2024).
+  But rules are *helpful, not guaranteed* (Geng 2025) → keep them **few** (rule-bloat dilutes scarce
+  front-of-context space).
+- **Tasks.** rule store; inject at top; version field; bump on change.
+- **Acceptance.** RFC F15 acceptance (`grep '^\*\*HARD RULE:'` count; `rules_version` in head).
+- **Effort.** Low. **Deps.** §2.6.
+
+---
+
+## F16 — Response cache (GATED — adversarial: drop to experiment)
+- **Goal.** Cache tool responses, invalidated by file changes.
+- **Current state.** Greenfield.
+- **Carried verdict (ADDENDUM §C).** **Do NOT build the full machinery as planned.** Premise
+  ("two runtimes re-running within 60s") is unmeasured; **correctness is broken daemon-less** —
+  `graph_generation` isn't persisted and isn't bumped by `index`, so every short-lived process sees
+  `gen=0` and the safety net never fires; and there are **no latency numbers** justifying it.
+- **Minimal safe version (the actual recommendation).** (1) Instrument first — log
+  `(tool, normalized_args, generation)` + per-tool latency; measure real cross-process repeat rate.
+  (2) If latency matters, ship **process-local in-memory memoization** inside the long-lived
+  MCP/`watch` process only, keyed on the *in-process* generation (correct by construction, ~1% of
+  the complexity). (3) Only consider a disk cache after **P0.2** (persist + bump generation) lands
+  *and* a measured hit-rate clears a pre-committed bar; if so: cache table + ZSTD + content-hash
+  scope-digest + LRU/TTL + `--no-cache`.
+- **Effort.** High (full) / Low (process-local memo). **Deps.** P0.2 (for any disk variant);
+  measured hit-rate gate.
+
+---
+
+## F17 — Learned listwise reranker (GATED — adversarial: replace with simpler)
+- **Goal.** Re-score top-50 with a learned model, gated to ≥5% nDCG@10 over hybrid.
+- **Current state.** Greenfield; **no `candle`/`ort`/`onnx` dependency exists** — a net-new heavy ML
+  surface.
+- **Carried verdict (ADDENDUM §C).** **Do NOT build the hand-rolled candle net.** Single-user label
+  volume can't clear a CI-excludes-zero bar on ~40 queries; it's circular (relearns first-stage
+  order via `rank_position` + labels from the current ranker); and **F7 + F1 draw from the same
+  signal and ship first**, so F17 must beat an already-feedback-boosted baseline.
+- **Cheaper alternatives (the recommendation).** (1) A **hand-tuned monotonic scoring function** over
+  the same features (extend F6's prior machinery — explainable, no ML lifecycle); or (2) if a model
+  is truly wanted, a **LambdaMART tree** (XGBoost `rank:ndcg` → ONNX) — sample-efficient, the
+  research's own recommended baseline.
+- **Posture.** Ship F6/F7/F1, measure on **P0.3**. Only if a *durable, reorder-specific* gap remains
+  with enough labels, run a LambdaMART tree as a **one-off gated experiment** (default-off, CI bar);
+  permanent close if it fails. The hand-rolled 20K-param net is not justified.
+- **Effort.** M (if pursued). **Deps.** F7, F1, P0.3. **Gate.** ≥5% nDCG@10, CI excludes zero, on P0.3.
+
+---
+
+## Final-wave build order
+
+```
+F9 ─► F11 (typed edges + lint + consolidation)
+F7,F8,F9 + P0.2 ─► F10 (investigate)
+§2.6 ─► F14, F15 (guidance — Tier E3, defense-in-depth)
+P0.2 + measured hit-rate ─► F16 (start: instrument → process-local memo only)
+F6,F7,F1 + P0.3 ─► F17 (only if a measured reorder gap remains → LambdaMART experiment, not the net)
+```
+
+**All 17 features now have build-ready specs** across `BUILD-SPEC-phase0-wave1.md` … `wave5-final.md`.
+The four gated features (F14/F15/F16/F17) carry their adversarial postures so a build decision is
+made with eyes open — but per the standing constraint, the build/defer/kill call itself remains yours.

--- a/scratch/rfc-implementation-plan/IMPLEMENTATION-PLAN.md
+++ b/scratch/rfc-implementation-plan/IMPLEMENTATION-PLAN.md
@@ -1,0 +1,579 @@
+---
+title: NestWeaver — Research-Backed Implementation Plan (RFC v0.9.1+ feature track)
+status: draft
+created: 2026-05-29
+relates_to:
+  - ~/Desktop/rfc-v0.9.1-quality-and-feedback.md (source RFC)
+  - scratch/rfc-implementation-plan/research/*.md (7 cited research dossiers)
+covers: Features 1–17 (Bugs #12 and #19 already landed on feat/ui-next-gen-r3f)
+---
+
+# NestWeaver — Research-Backed Implementation Plan
+
+This plan turns the RFC's feature asks into an engineering roadmap, each backed by
+primary research, prior-art systems, and the **actual NestWeaver codebase**. Every
+non-obvious claim traces to one of the seven research dossiers in `research/`, which
+hold the full citations with retrieved URLs.
+
+> **Sourcing discipline.** The research agents were required to cite only sources they
+> actually retrieved, with URLs, and to mark anything unverifiable `[UNVERIFIED]`.
+> Vendor/blog performance numbers are labelled as such and are **not** treated as
+> peer-reviewed fact. Where a number gates a decision (nDCG deltas, test-reduction %),
+> we validate on our own corpus rather than importing it.
+
+---
+
+## 0. Status
+
+- **Bug #12** (project_context drops notes) — **done** on `feat/ui-next-gen-r3f`. The
+  RFC's Ask-1 alone was insufficient (seeded notes land in `seeds`, disjoint from the
+  rendered `connected`); the shipped fix is two-part (seed notes **+**
+  `promote_member_notes_into_connected`). TDD'd + integration-guarded.
+- **Bug #19** (`--config` on brain commands) — **done**. The flag was already present
+  (RFC repro tested hyphenated command names that don't exist); the real residual was an
+  inert flag. Added `InstanceConfig.db` + `resolve_db_with_config` so `--config` selects
+  the DB (precedence: `--db` > config `db` > `NESTWEAVER_DB`/default).
+- **17 features remain.** This document plans all of them.
+
+### Research dossiers (full citations + URLs)
+| File | Covers |
+|------|--------|
+| `research/ranking-priors-query-expansion.md` | F6, F7 |
+| `research/ltr-reranking-feedback.md` | F1 (ranking side), F17 |
+| `research/code-search-trigram-symbol-reads.md` | F3, F4, F5, F8 |
+| `research/api-contract-graphs.md` | F2 |
+| `research/temporal-rank-test-selection.md` | F12, F13 |
+| `research/agent-memory-knowledge-base.md` | F1 (memory side), F11, F9 |
+| `research/agentic-orchestration-guardrails-cache.md` | F10, F14, F15, F16 |
+
+---
+
+## 1. Corrections the research surfaced — read before planning sprints
+
+These change scope or spec and should be reflected back into the RFC.
+
+1. **F5 premise is wrong: `Symbol` has no `end_line`.** `crates/nestweaver-schema/src/nodes.rs`
+   `Symbol` stores `start_line: u32` only. Every "symbol body" capability (F5, the Symbol
+   path of F3, and the Symbol path of F8) needs `end_line` added — a schema-version bump +
+   re-index. Tree-sitter already yields the end span at parse time, so the cost is plumbing,
+   not analysis. **This is a Phase-0 enabler, not a per-feature task.** (`Section` and
+   `Heading` already carry `start_line`+`end_line`, and `Section` carries full `text`, so the
+   *note* paths of F5/F8 are essentially free.)
+
+2. **F6 must apply the prior *after* RRF, or it no-ops.** RRF (Cormack, Clarke, Büttcher,
+   SIGIR 2009) is rank-only — it discards raw scores. Multiplying a path prior into BM25/PPR
+   scores *before* fusion only matters if it reorders the pre-fusion list. The clean,
+   fusion-independent design is a single post-fusion multiply on `node.relevance`, clamping the
+   **final product** (not each glob) to `[0.05, 5.0]`. This is exactly how Elasticsearch
+   `function_score` (`boost_mode: multiply`, `max_boost`) and Vespa do it.
+
+3. **F7's discounted weights don't survive fusion either.** Same root cause: PRF term weights
+   (0.3×) and alias weights (0.5×) change the *BM25-internal ordering* and reach the final
+   ranking only via changed BM25 ranks. Set expectations accordingly; don't promise the weights
+   appear in the fused score.
+
+4. **F12's clamp can never bind as written.** With `git_activity_score ∈ [0,1]` and
+   `activity_weight = 0.6`, `(1 + 0.6·(score − 0.5))` ranges only over **[0.7, 1.3]** — the
+   proposed `[0.4, 1.6]` clamp is unreachable. Either raise `activity_weight`'s max or tighten
+   the clamp. (Temporal PageRank, Rozenshtein & Gionis, ECML-PKDD 2016, also says: apply decay
+   as a **post-hoc re-rank multiplier**, not inside the PageRank fixpoint, so the walk still
+   converges to static PageRank under a flat signal.)
+
+5. **F1/F17 feedback-loop bias is the headline risk, formally.** Ensign et al., "Runaway
+   Feedback Loops in Predictive Policing" (FAT* 2018) proves self-collected feedback compounds
+   bias. The RFC's 2.0× cap bounds magnitude but not direction. The plan adds a **uniform
+   exploration floor** (Ensign's structural fix) and a **negative signal** (reformulation =
+   bad), and makes both features run against a held-out benchmark, not their own logs.
+
+6. **`serde_yaml` 0.9 (current dep) is deprecated/unmaintained.** F2 adds OpenAPI YAML parsing;
+   migrate new contract YAML to `serde_yaml_ng` 0.10 or `saphyr`.
+
+7. **Token-savings figures for F5/F8 (30–60%, 10–50×) are vendor/blog only.** No peer-reviewed
+   measurement was found. Ship our own before/after instrumentation; don't cite the percentages
+   as fact.
+
+---
+
+## 2. Cross-cutting foundations (build once; many features depend)
+
+The single biggest efficiency in this track is recognizing that **seven of the seventeen
+features share five substrates.** Build these first and the per-feature work shrinks.
+
+### 2.1 — `Symbol.end_line` (enabler for F3·F5·F8)
+Add `end_line: u32` to `Symbol` (schema), populate from the tree-sitter node end during
+parsing (`nestweaver-parser`), persist (`nestweaver-store` write + `db.rs` table), bump the
+schema version, re-index. **Blocks:** F5, F3-symbol, F8-symbol.
+
+### 2.2 — Git-mining substrate (enabler for F12·F13)
+One module (`nestweaver-engine` or a new `git_activity.rs`) that walks `git log --name-only`
+per repo and exposes: per-file touch history, **author date** (not commit date — rebases/squash
+distort commit date), merge-commit detection, and **bulk-commit filtering as a per-repo
+percentile** (commit sizes are heavy-tailed; a fixed ≥500 cutoff is wrong for small repos —
+Hindle, MSR 2008, on large-commit/perfective skew). **Feeds:** F12 (recency multiplier), F13
+(co-change as a fallback test signal). Reuse the existing `<db>.filemeta.json` change-detection.
+
+### 2.3 — Disk-resident state layer keyed on `graph_generation` (enabler for F10·F16)
+There is no daemon and agents are short-lived, so shared state must be on disk. Commit `d9bc01d`
+added a **`graph_generation` counter** — but **verification (see ADDENDUM §B) found it is
+in-memory only, reset to 0 on every open, and bumped solely by the watcher loops, never by the
+one-shot `index` command.** As-is it **cannot** serve as a cross-process invalidation key: every
+short-lived agent sees `gen=0`. To use it, it must be **persisted to a sidecar and bumped on
+`index`** (a small Phase-0 enabler). Otherwise the cross-process cache premise (F16) does not
+hold — and the adversarial review (ADDENDUM §C) recommends dropping F16 to a measured experiment
+for exactly this reason. Combined with `<db>.filemeta.json` content hashes, a *persisted*
+generation would give both a coarse and a precise invalidation key. Build one small disk-resident
+store (in the `.lbug` or a sidecar) used by **F16** (response cache) and **F10** (bundle TTL
+state). Cache/bundle key = `(tool, normalized_args, graph_generation, scope-digest)`. Prior art:
+Bazel/Buck **content-addressed action cache** (ACM Queue 3287302) — key by a digest over the
+query's input file set; prefer content hashes over bare mtime; **correctness rests on the key
+(generation mismatch at read = miss), never on a background sweep.**
+
+### 2.4 — Interaction success-signal labeler (enabler for F1·F17)
+F1 *records* labelled events; F17 *trains* on them. Build the labeler once.
+`load_interaction_scores` already exists and is loaded at MCP startup (`mcp/src/lib.rs:49`) but
+**consumed nowhere** — that's the gap. Event schema `{session_id, ts, kind, target, tool}` with
+kinds `Query | Access | Impact | Followup | TerminalSuccess`. **Safe success signal** (grounded
+in Fox et al., 2005, "Evaluating implicit measures…", where exit-type/session-end predicts
+satisfaction): POSITIVE = the retrieved symbol/note is then *edited/written* (conversion-grade,
+a signal web search lacks) or a clean session-end with no re-query; NEGATIVE = next action is
+another search/reformulation; WEAK/zero = bare access (most position-biased — Craswell et al.
+2008). Decay via MemoryBank's reinforce-on-access model `R = e^(−Δt/S)` (Zhong et al., AAAI 2024).
+
+### 2.5 — Trigram index (enabler for F3·F4)
+F4 (`count_patterns`) is "`rg --count` on F3's prefilter." Build the trigram posting index once;
+F4 reuses it. Design in §3-F3.
+
+### 2.6 — Single-source guidance (enabler for F14·F15)
+F14 (dynamic PreToolUse hook) and F15 (static generated-guide rules) should read **one** rule
+store, surfaced two ways. Build the rule store + versioning once.
+
+### 2.7 — Evaluation harness (gate for F1·F7·F12·F17)
+Multiple features promise ranking-quality gains that the literature says are **corpus-dependent
+and sometimes negative** (PRF query drift; reranker over-expectations). Stand up a small
+nDCG@10 / precision@k harness over NestWeaver's *own* code+notes corpus, with **time/query-based
+cross-validation** (not random shuffle) and per-query win/loss + confidence intervals. nDCG:
+Järvelin & Kekäläinen, TOIS 2002. This harness is the empirical contract that gates the
+quality features — especially F17's "ship only if ≥5% nDCG@10."
+
+---
+
+## 3. Feature plans
+
+Format per feature: **Ask** · **Research foundation** (key cites; full URLs in dossiers) ·
+**Approach** (codebase-grounded) · **Key decisions** · **Pitfalls** · **Effort** · **Depends on**.
+
+### Tier 1 — quick wins
+
+#### F3 — Trigram-accelerated regex search
+- **Ask.** `regex_search(pattern, [path_prefix], [kinds], [limit])` MCP tool + CLI; Rust `regex`
+  over bodies with a trigram pre-filter; fall back to scan when no literals; budget + timeout.
+- **Research.** Russ Cox, "Regular Expression Matching with a Trigram Index" (2012,
+  swtch.com/~rsc/regexp/regexp4.html): trigram postings + compiling a regex into an AND/OR
+  trigram query via emptyable/exact/prefix/suffix analysis; ~18% index-size overhead, ~100×
+  candidate reduction; case-insensitive is much weaker. Prior art: Sourcegraph **Zoekt**
+  (positional, ~1.2× RAM/3× index — heavier), **livegrep** (suffix arrays), GitHub Blackbird
+  (sparse-grams). `regex` is already a dependency; `regex-syntax`'s literal `Extractor` is
+  transitively present.
+- **Approach.** New `nestweaver-store/src/regex.rs`. **Doc-ID-only postings** (Cox/codesearch
+  style — smallest, most incrementally-updatable index; right for solo-dev scale + live
+  re-indexing via `--watch`), *not* Zoekt's positional index. Use
+  `regex_syntax::hir::literal::Extractor` (check `Seq::is_finite()`, exact vs inexact) for query
+  planning instead of hand-rolling Cox's analyzer. New table
+  `trigram_postings { trigram, node_uid }`; `--with-trigrams` opt-in flag on `index` until size
+  is measured on the live DB. Budget: candidate-set hard cap (5000) + verification timeout (2s,
+  `--max-millis`); fall back to full scan on infinite `Seq`.
+- **Key decisions.** Doc-ID postings over positional; `regex-syntax` Extractor over custom AST
+  walk; opt-in index until size validated.
+- **Pitfalls.** Index bloat (measure on the 231 MB DB first; opt-in); no-literal patterns →
+  scan-all (cap + timeout); case-insensitive weakness (document); unicode.
+- **Effort.** Medium. **Depends on:** §2.5; `Symbol.end_line` only for the symbol-text path
+  (note/section text already available).
+
+#### F4 — `count_patterns`
+- **Ask.** Counts-only companion: `{pattern, total_matches, files_matched, top_files[]}`,
+  multi-pattern in one call.
+- **Research.** No distinct literature — it's `rg --count`/`--count-matches` semantics over F3's
+  prefilter.
+- **Approach.** Reuse F3's candidate filter; run `regex` in count mode (no materialization);
+  multi-pattern = union candidate sets, scan each doc once, attribute per pattern.
+- **Effort.** Low (given F3). **Depends on:** F3.
+
+#### F5 — Symbol-window reads (`read_symbols`)
+- **Ask.** Return a symbol's source span; optional comment stripping; optional N neighbors; FQN
+  resolution; token-budget aware.
+- **Research.** Aider's tree-sitter **repo map** (2023): emit signatures/key lines, not whole
+  bodies, under a token budget — the strongest non-vendor support for symbol-scoped context.
+  Tree-sitter is the right precision tool (ctags imprecise; LSP needs a daemon → violates the
+  no-daemon constraint). Token-savings %s are `[VENDOR/BLOG]` — instrument our own.
+- **Approach.** New MCP tool + CLI; read the span via stored `start_line..end_line` from disk.
+  Comment stripping in new `nestweaver-parser/src/strip.rs`: tree-sitter `comment` nodes (safe)
+  for grammar languages; conservative whole-line-prefix strip for the regex languages;
+  **default OFF** (false elision of shebangs, `#`/`//` inside strings/URLs, etc. is the named
+  risk). FQN resolution via the existing symbol index; ambiguous → return all with
+  `disambiguate: true`.
+- **Pitfalls.** **Blocked on `Symbol.end_line` (§2.1).** Comment-strip false elision → off by
+  default, tree-sitter-precise where possible.
+- **Effort.** Medium. **Depends on:** §2.1.
+
+#### F6 — Per-path `dampen`/`boost` ranking priors
+- **Ask.** Continuous path-glob priors applied at PPR-output time, clamp `[0.05, 5.0]`,
+  last-match-wins; `ranking explain` dry-run.
+- **Research.** Robertson & Zaragoza, "The Probabilistic Relevance Framework: BM25 and Beyond"
+  (FnTIR 2009): query-independent features enter as **document priors** — additive in log-space
+  = **multiplicative on the relevance scale** (formal justification). BM25F caveat (Robertson
+  et al., CIKM 2004) is about combining per-field *term* scores and does **not** apply to a
+  whole-document path prior. Every production engine implements this multiplicatively **with a
+  clamp** (ES `function_score`/`max_boost`, Vespa, Tantivy `Bm25Weight::boost_by`).
+- **Approach.** `[ranking]` section in `InstanceConfig`/per-repo `.nestweaver.toml`; globs via
+  `globset` (already transitive via `ignore`). **Apply post-fusion** on `node.relevance` in the
+  final assembly step of `nestweaver-store/src/ranking.rs`, clamping the **product**. Resolve
+  path→prior once at index/open into a sidecar (like `.pagerank.json`), not per query.
+  `nestweaver ranking explain <uid>` prints base/matched-rules/final.
+- **Pitfalls.** Applying before RRF (no-op — §1.2); compounding past the clamp (clamp product);
+  dampen-to-zero hiding best matches (the 0.05 floor; dampen ≠ exclude).
+- **Effort.** Low. **Depends on:** none (pure ranking-policy knob).
+
+#### F7 — BM25 PRF + taxonomy synonym expansion
+- **Ask.** Two-pass PRF (mine high-IDF terms from top-K, append at ~0.3×) + query-time alias
+  expansion (~0.5×); cap query length; `--prf`, off by default.
+- **Research.** Rocchio (1971, via Manning/Raghavan/Schütze *IIR* §9.1.1): down-weighting added
+  terms is textbook (α=1, β=0.75, γ≈0.15; the RFC's 0.3× is *intentionally* more conservative
+  for unjudged terms — defensible). RM3 operational defaults (Lavrenko & Croft 2001; confirmed
+  from Indri/Anserini/pyserini `set_rm3(10,10,0.5)`): **K=10 feedback docs, N=10 terms, λ=0.5**.
+  Thesaurus expansion (IIR §9.2.2): weight added terms less; multi-token synonyms must expand at
+  **query time** (Lucene `SynonymGraphFilter`), normalized through the same analyzer,
+  case-insensitive, excluding terms already in the query (Xapian `ExpandDecider`).
+- **Approach.** Two-pass bag-of-words PRF where BM25 actually lives — `tantivy_index.rs` +
+  the fusion point `query.rs::rrf_fuse` (~`query.rs:1001`); there is no `bm25.rs` (no full RM3 LM
+  needed): K=10, N=10, original 1.0, PRF 0.3×, aliases 0.5×; rank candidate terms by IDF
+  (Tantivy `Bm25StatisticsProvider`); cap total query length (64). Aliases from
+  `_brain/taxonomy.md`, memoised by mtime (`nestweaver-engine/src/taxonomy.rs`). Surface
+  `expansion_terms`/`expansion_aliases` in `--debug`.
+- **Pitfalls.** **Query drift** (the classic PRF failure) — down-weight, cap N, prefer high-IDF,
+  consider **selective expansion** gated on the pass-1 score gap; per-query inconsistency (helps
+  average MAP, hurts some queries → keep opt-in); analyzer mismatch silently dropping aliases.
+- **Effort.** Medium (aliases Low). **Depends on:** §2.7 (to validate it actually helps *our*
+  corpus). Reported deltas are directional only (+10–30% MAP on weak TREC baselines) — **do not
+  expect TREC magnitudes; gate on our harness.**
+
+#### F8 — Tiered display (inline body for high-confidence hits)
+- **Ask.** Inline body when normalized relevance ≥ 0.75; token-budget aware; off by default.
+- **Research.** Motivated by "Lost in the Middle" (Liu et al., TACL 2024) — front-load
+  high-value content; saves a round-trip. Zoekt shows a defensible normalized score exists.
+- **Approach.** `inline_body: Option<String>` on the connected-node shape; populated only when
+  `relevance ≥ threshold` and the caller opts in; bodies count against `token_budget` ahead of
+  metadata; `[response] inline_body_threshold/inline_max_body_tokens`.
+- **Key decision.** Scores **must be normalized + gap-checked** or 0.75 is meaningless on a raw
+  hybrid score.
+- **Pitfalls.** Unnormalized threshold; response-size jumps (off by default).
+- **Effort.** Low. **Depends on:** F5 (Symbol bodies) — note/section bodies already available.
+
+#### F9 — Promote document-graph tools to `brain.*`
+- **Ask.** `brain_broken_links`, `brain_orphan_documents`, `brain_topic_clusters`,
+  `brain_tag_graph`, `brain_doc_stats`; `/audit-vault` becomes a thin orchestrator.
+- **Research.** Orphan detection value: Wikipedia orphan study (arXiv:2306.03940) — ~14.7%
+  orphaned, de-orphaning → +6.5% pageviews; **index/MOC notes are false-positive risk**.
+  Clustering: **Leiden** (Traag, Waltman, van Eck, Sci. Rep. 2019) guarantees connected
+  communities (Louvain leaves up to 16% disconnected). Link suggestion: Adamic–Adar best
+  topological predictor (Liben-Nowell & Kleinberg, CIKM 2003). KG maintenance framing: Paulheim,
+  "Knowledge Graph Refinement: A Survey" (2017).
+- **Approach.** These mostly **reuse existing infrastructure** — wikilink edges, tag nodes, the
+  code-side `clusters` (run Leiden over the wikilink subgraph), the resolver + aliases for
+  broken-link suggestions. MOC/index allowlist to suppress orphan false-positives.
+- **Effort.** Low–Medium. **Depends on:** none (data already in the graph).
+
+### Tier 2 — feedback, composites, agent-efficiency
+
+#### F1 — Agent feedback loop
+- **Ask.** Consume interaction scores as a capped (2.0×) multiplicative boost on PPR
+  personalization; distinguish success from access; new event kinds; CLI to inspect.
+- **Research.** Topic-Sensitive PageRank (Haveliwala, WWW 2002) — the personalization/teleport
+  vector is the principled place to inject the boost; renormalize after. Implicit feedback &
+  bias: Craswell et al. 2008 (position bias), Fox et al. 2005 (session-end predicts
+  satisfaction), Joachims et al. 2017 (position-discounted/IPS), **Ensign et al. FAT* 2018
+  (runaway feedback loops — the core danger)**.
+- **Approach.** Implement §2.4's labeler; load the sidecar once per call (path already plumbed)
+  and apply the capped boost on the teleport step in `ranking.rs`. Add **negative signal**
+  (reformulation) and a **uniform exploration floor** so low-scored nodes still surface. CLI
+  `interactions show --uid`.
+- **Pitfalls.** Feedback-loop entrenchment (cap + decay + exploration floor + negative signal);
+  TerminalSuccess mis-attribution (session walked away ≠ success — weight conservatively);
+  query-text privacy/reproducibility (machine-local scores make benchmarks non-deterministic —
+  document, and benchmark with feedback disabled).
+- **Effort.** Low–Medium (infra exists). **Depends on:** §2.4, §2.7. **The deliverable is
+  risk-reduction, not a quality number** — no transferable single-user metric exists.
+
+#### F2 — Framework-aware contract linking (OpenAPI/gRPC/GraphQL)
+- **Ask.** Parse contracts → `Contract` nodes; `IMPLEMENTS_CONTRACT` / `CONSUMES_CONTRACT`
+  edges across repos with confidence scoring; wire into `cross_repo_contracts`.
+- **Research.** Consumer-Driven Contracts (Robinson/Fowler, 2006) maps directly to the
+  node+edge model; Pact / Spring Cloud Contract operationalize it (candidate high-confidence
+  ingestion later). Specs: OpenAPI 3.1, Protobuf/gRPC (`package.Service/Method` FQN — no
+  templating), GraphQL. **Load-bearing reality check:** Schneider et al., "Comparison of Static
+  Analysis Architecture Recovery Tools" (2024, arXiv:2412.08352 / EMSE) — purpose-built tools
+  cap at **~F1 0.79** on REST endpoint extraction. Code2DFD (Schneider & Scandariato, JSS 2023)
+  validates keyword/signature detection. Backstage Software Catalog is the closest model
+  (typed `kind: API`, `providesApis`/`consumesApis`) but **human-authored** — our value-add is
+  *deriving* those edges from code. OpenTelemetry service graph = runtime topology (complementary,
+  not a competitor: we see all code-declared paths pre-deploy, no instrumentation, at the ≤0.79
+  F1 cost).
+- **Crates (verified on crates.io/docs.rs 2026-05-29).** OpenAPI: **`openapiv3` 2.2.0** (OAS 3.0)
+  + **`oas3` 0.22.0** (OAS 3.1) to cover both. gRPC: **`protox` 0.9.1** (pure-Rust, no `protoc`)
+  — preferred over `protobuf-parse` (explicitly "not for direct use"). GraphQL: **`apollo-parser`
+  0.8.6**. Avoid `protobuf-parser` (abandoned 2018) and `swagger` (codegen, not a parser).
+  Migrate off deprecated `serde_yaml` for YAML.
+- **Approach.** Two node producers (spec files = authoritative 1.0; code-derived handlers mint
+  nodes when no spec), merged by UID. UID scheme `contract:http:POST:/v1/approvals`,
+  `contract:grpc:approvals.v1.Approvals/Create`, `contract:graphql:Mutation.createApproval`.
+  **Path normalization is load-bearing** — collapse `:id`/`{id}`/`${id}`/`<id>`, ignore slot
+  names, resolve base/mount paths, identically on both sides. Handler detection via tree-sitter
+  (java/ts/go grammars already deps): Spring annotations (highest precision), NestJS decorators,
+  Express literals, Go chi/gorilla. Caller detection v1 = TS `fetch`/axios literals + typed
+  clients via `operationId`. Confidence 1.0/0.8/0.5 on the edge; impact queries filter by min
+  confidence.
+- **Pitfalls.** Templating mismatch (canonical normalization); **base-path/mount resolution =
+  biggest recall killer** (thread mount context, fall back to 0.5); false cross-repo matches on
+  generic paths (`/health`, `/login`) → denylist + prefer intra-feature matches + surface
+  ambiguity (exit-code-3 convention); generated-client noise; GraphQL consumers (opaque query
+  strings) → **defer to v2**.
+- **Effort.** gRPC nodes Low; OpenAPI nodes Low–Med; Spring/NestJS handlers Med; Express/Go
+  Med–High; TS consumers High; GraphQL consumers v2. **Highest product value in the RFC** — this
+  is the one capability name-matching fundamentally can't do.
+- **Depends on:** none structural (no new grammars). Pull forward.
+
+#### F10 — `investigate` bundle primitive
+- **Ask.** One call returns an architectural map (clusters as domains, top-PageRank node as
+  entry point) + `bundle_id` (24h TTL) + `investigate_expand`/`investigate_hydrate`.
+- **Research.** RAG (Lewis et al., NeurIPS 2020); **"Lost in the Middle"** (Liu et al., TACL
+  2024) justifies tiered/front-loaded bundling; Aider repo-map (PageRank-ranked, token-budgeted)
+  and Microsoft **GraphRAG** (community-detection → cluster summaries) mirror the cluster→domains
+  step. **MCP spec (verified):** tool results carry `content` + optional `structuredContent`;
+  `resource_link` returns file URIs (ideal for entry points hydrated later); **cursor pagination
+  is spec'd only for `tools/list`, not `tools/call`** → paging must be app-level `bundle_id` +
+  page token, exactly as proposed.
+- **Approach.** New `nestweaver-engine/src/investigate.rs`; compose existing primitives
+  (PRF-on hybrid search → group → neighbors → Leiden clusters → top-3 domains + entry points);
+  inline ≤5 high-confidence bodies (F8); bundle state in §2.3's disk layer, tagged with
+  `graph_generation`.
+- **Pitfalls.** Over-bundling recreates the mid-context problem (strict token budget,
+  hydrate-on-demand); stale `bundle_id` within TTL (generation tag); cluster instability.
+- **Effort.** Medium–High. **Depends on:** §2.3, F7 (PRF), F8 (inline), F9 (Leiden). Sequenced
+  after Tier 1, as the RFC notes.
+
+#### F11 — Memory-bank semantics over the vault
+- **Ask.** Typed edges (Supersedes/DependsOn/CausedBy/RelatesTo); 7 health checks; tiered
+  consolidation pipeline; `brain_memory_related`.
+- **Research.** Standards map cleanly: **SKOS** (`broader`/`narrower`/`related`) and **PROV-O**
+  (`wasDerivedFrom`, `wasInformedBy`, `wasRevisionOf`) → our typed relations. Promotion gates
+  grounded in PKM: Ahrens (fleeting→literature→permanent), Matuschak evergreen (densely-linked,
+  ≥3 inbound), Forte PARA; survival window ≥14d echoes MemoryBank/Ebbinghaus. **A-MEM** (Xu et
+  al., NeurIPS 2025) caution: its LLM "memory evolution" rewrites neighbors — a provenance risk;
+  therefore **suggest + record `wasDerivedFrom`, never silently mutate.** Paulheim 2017 frames
+  the 7 checks as KG error-detection + completion.
+- **Approach.** Deterministic typed-edge derivation from frontmatter/section names (no LLM); 7
+  checks as graph traversals (orphans/broken-links reuse F9); consolidation **dry-run by
+  default**, emitting a manifest the user accepts.
+- **Pitfalls.** Orphan/stale false-positives for MOC/convention notes (tier-aware allowlist);
+  false consolidation (require temporal spread + link threshold); never auto-mutate.
+- **Effort.** Medium–High (consolidation is the long pole). **Depends on:** F9.
+
+#### F12 — Git-activity-dampened CodeRank
+- **Ask.** Per-file recency multiplier on PageRank at compute time.
+- **Research.** Temporal PageRank (Rozenshtein & Gionis, ECML-PKDD 2016 — degrade-to-baseline
+  under flat signal); TimedPageRank (Yu/Li/Liu, WI 2005 — exponential age decay consistently
+  improved retrieval); **Nagappan & Ball, ICSE 2005** (relative/normalized churn predicts
+  defects, absolute churn doesn't → normalize); Hassan ICSE 2009 (change entropy — future
+  refinement); Lewis et al. ICSE 2013 (a valid Google bug-predictor changed *no behavior* when
+  unexplained → keep it explainable + bounded).
+- **Approach.** Keep `exp(-Δdays/180)`; apply as a **post-hoc multiplier, not in the PageRank
+  fixpoint**; center at 0.5. **Fix the clamp/weight inconsistency (§1.4).** Per-repo opt-out for
+  squash-only repos. Use **author date**; bulk filter as per-repo percentile (§2.2).
+- **Pitfalls.** churn≠quality (frame as *retrieval recency*, not health); timestamp distortion
+  (author date, detect merges); cross-repo cadence skew (normalize within-repo).
+- **Effort.** Low–Medium. **Depends on:** §2.2. Quality gain is `[UNVERIFIED/novel]` → A/B on
+  §2.7.
+
+#### F13 — `affected_tests`
+- **Ask.** changed files → changed symbols → reverse CALLS/IMPORTS (depth 3) → test files,
+  tiered by priority.
+- **Research.** Yoo & Harman survey (STVR 2012 — selection vs prioritization); Rothermel &
+  Harrold (TOSEM 1997 — defines a **"safe" RTS**; static call-graph RTS is **not** safe, and
+  depth-3 is an explicit unsafe truncation); **STARTS** (ASE 2017 — closest comparable: static,
+  class-firewall, reverse-traversal to reachable tests; unsafe under reflection); **Ekstazi**
+  (ICSE/ISSTA 2015 — dynamic file-level RTS, ~32% avg/~54% long-suite reduction, catches what
+  static misses); Google TAP (ICSE-SEIP 2017); **Meta Predictive Test Selection** (ICSE-SEIP
+  2019 — ~2× reduction at >95% failure recall using graph distance + file metadata + history;
+  the realistic ceiling and the recall bar).
+- **Approach.** Position honestly as **STARTS-like static RTS on the source call graph** (less
+  sound than bytecode). Reuse `impact`'s reverse traversal + `--depth`. Tiers = graph distance
+  (1 direct / 2 caller / 3 transitive); order within tier by edge confidence (CALLS=1.0 …
+  ACCESSES=0.4). Test detection by filename + annotation/macro heuristics per language. Set an
+  explicit **measured recall target vs run-all** (Meta's posture), not provable safety.
+- **Pitfalls.** Static unsafety (reflection/DI/codegen/data-driven tests missed) → conservative
+  fallback + periodic full run; depth-3 truncation → warn when tests exist beyond cap; flaky
+  tests → deprioritize via history; large/squash MRs → recommend run-all past a change threshold;
+  **"no path found" ≠ safe-to-skip.**
+- **Effort.** Medium. **Depends on:** §2.2 (co-change fallback), existing `impact`/`pr-impact`.
+
+#### F14 — Subagent PreToolUse hook for guidance injection
+- **Ask.** Hook on Task/Agent that injects dynamic guidance via a CLI; `install-hook`; reverse-
+  migrate `CLAUDE.md`/`AGENTS.md`.
+- **Research (verified vs official hooks docs).** PreToolUse receives `tool_input`/`cwd` on
+  stdin and emits `hookSpecificOutput.additionalContext`; `type: "command"` runs a CLI,
+  `mcp_tool` reuses the running server; Task is matchable (`"matcher": "Task"`). **Counter-
+  evidence:** "Control Illusion" (Geng et al. 2025, arXiv:2502.15851) — instruction hierarchies
+  are *not* reliably obeyed; injected guidance helps but isn't enforcement.
+- **Approach.** Small fast `nestweaver subagent-guidance` subcommand emitting `additionalContext`;
+  prefer the **`mcp_tool` hook type** (reuse the running MCP server — avoids cold-CLI/DB cost per
+  spawn since agents are short-lived); ship via `setup claude-code`.
+- **Pitfalls.** Runtime lock-in (Claude-Code-specific schema); untrusted-content injection;
+  guidance ≠ enforcement.
+- **Effort.** Low–Medium. **Note:** this and F15 are the **scope-creep features** (agent-harness
+  layer, not graph engine) — flagged in the original review; build only if the single-source
+  guidance store (§2.6) earns its keep.
+
+#### F15 — Hard-rule guidance in `generate-guide`
+- **Ask.** Canonical `**HARD RULE:**` block at the top of generated guides; versioned.
+- **Research.** **"Enumerate then verify" is directly evidence-backed** by Chain-of-Verification
+  (Dhuliawala et al., ACL 2024 Findings, arXiv:2309.11495 — draft→verify reduces hallucination).
+  Top/privileged placement supported by the Instruction Hierarchy (Wallace et al./OpenAI 2024,
+  arXiv:2404.13208). But rules are *helpful, not guaranteed* (Geng et al. 2025) — frame as
+  defense-in-depth.
+- **Approach.** Const rule array in `nestweaver-engine/src/guide.rs` (`--rules-from` override);
+  position at top; `rules_version` in frontmatter. Keep rules **few** (rule-bloat dilutes scarce
+  front-of-context space — Lost in the Middle).
+- **Effort.** Low. **Depends on:** §2.6.
+
+#### F16 — Response cache with watcher invalidation
+- **Ask.** ZSTD, 24h TTL, keyed by `(tool, normalized args, db_mtime bucket)`, scope-invalidated,
+  LRU, `--no-cache`.
+- **Research.** RFC 9111 (TTL/bypass/never-serve-stale-unvalidated); ZSTD (decompression speed
+  is level-independent → favour higher ratio; trained-dictionary mode fits small homogeneous
+  JSON); **Bazel/Buck content-addressed action cache** (ACM Queue 3287302 — key by a digest over
+  the input file set; the proven scope-invalidation prior art).
+- **Approach.** Disk-resident in §2.3's layer. Key = `(tool, normalized_args, graph_generation,
+  scope-digest)` using `<db>.filemeta.json` **content hashes** (not bare mtime). 24h TTL + LRU
+  byte cap + `--no-cache`. Invalidate via the existing `--watch` watcher with 10s debounce; but
+  **correctness rests on the key (generation mismatch at read = miss), never on the sweep.**
+- **Pitfalls.** Stale cache without a daemon (key-based correctness, not background process);
+  scope-invalidation misses (capture transitive deps à la Bazel; fold in `graph_generation` as
+  safety net; prefer false-evict over false-hit). **Validate the "two runtimes in 60s" premise
+  with a measured hit-rate before building the full machinery** (carried over from the original
+  review).
+- **Effort.** **High — highest-risk of its cohort.** Storage is routine; correct
+  scope-computation + daemon-less invalidation are the bug-prone core. **Depends on:** §2.3.
+
+### Tier 3 — opt-in model dependency
+
+#### F17 — Lightweight learned listwise reranker
+- **Ask.** Re-score top-50 with a ~20K-param listwise model (candle), gated to ship only at
+  ≥5% nDCG@10 over hybrid.
+- **Research.** Retrieve-then-rerank is validated (Nogueira & Cho monoBERT 2019 — *architecture*
+  only; its +27% MRR is a 110M-param result, not a magnitude to expect from 20K params; Vespa
+  phased ranking; SBERT cross-encoder docs). A ~20K-param model on ~7 tabular features **is
+  credible** (input ~10–20 dims, largely monotone). Listwise loss: ListMLE (Xia et al. 2008) or
+  ListNet (Cao et al. 2007), optional LambdaRank |ΔnDCG| weighting (Burges 2010). **Also train an
+  XGBoost/LightGBM LambdaMART baseline** — trees dominate tabular LTR (2010 Yahoo LTR Challenge);
+  ship whichever clears the gate (export to ONNX, run via `candle-onnx`/`ort`). Offline-train /
+  online-serve mirrors OpenSearch/Elasticsearch LTR.
+- **Approach.** Features `[rank_position, bm25, ppr, node_kind_onehot, is_inline_body, age_days,
+  matched_alias_count]`; graded labels from §2.4's success signal, **IPS/position-discounted** so
+  the reranker doesn't just relearn first-stage order. Single-file SafeTensors blob; silent skip
+  if missing/stale.
+- **Gate (harden the RFC's).** ≥5% nDCG@10 with **time/query-based CV** (not random shuffle),
+  per-query win/loss + confidence interval (a 5% mean on ~40 queries can be noise), secondary
+  MRR, default-off flag.
+- **Pitfalls.** Reranker relearning first-stage order (the `rank_position` feature re-imports
+  bias — IPS); tiny-sample noise in the gate; over-expecting web-scale gains.
+- **Effort.** Medium. **Depends on:** F1 (success labels), §2.7. **Ship dead-last, only if F7 +
+  F1 don't already close the gap** — as the RFC says.
+
+---
+
+## 4. Dependency graph & phased roadmap
+
+```
+Phase 0 (enablers)        Phase 1 (Tier-1)         Phase 2                Phase 3 (composites)     Phase 4
+─────────────────────     ──────────────────       ──────────────        ─────────────────────    ───────
+§2.1 Symbol.end_line ───► F5 ──► F8 (symbol)        F1 (needs §2.4,§2.7)  F10 (F7,F8,F9,§2.3)      F17
+§2.5 Trigram index  ───► F3 ──► F4                  F7 (needs §2.7)       F11 (F9)                 (gated:
+§2.2 Git substrate  ────────────────────────────► F12, F13              F16 (§2.3)                 F7+F1
+§2.3 Disk state layer ──────────────────────────────────────────────► (F10, F16)                  first)
+§2.4 Success labeler ─────────────────────────► F1 ──────────────────────────────────────────► F17
+§2.6 Guidance store ──────────────────────────────────────────────► F14, F15
+§2.7 Eval harness ──────────────────────────► gates F7, F1, F12, F17
+F6 (standalone) ──► Phase 1        F9 (standalone) ──► Phase 1        F2 (standalone) ──► pull forward
+```
+
+**Recommended sequencing (revised from the RFC):**
+
+- **Step Zero — configure + dogfood (precondition, see ADDENDUM §A).** NestWeaver's MCP is not
+  configured in the user's working repos, so the tool isn't in the agent loop and there is no
+  usage evidence yet. `nestweaver setup claude-code`, dogfood it, and run the benchmark including
+  the new **Journey 8 (vault Project orientation)**. Until this is done, nothing below can be
+  prioritized on evidence.
+- **Phase 0 — Enablers (do first, unglamorous, unblocks everything).** `Symbol.end_line`,
+  git-mining substrate, disk-state layer (note: `graph_generation` must be persisted + bumped on
+  `index` first — see §2.3), success-signal labeler, eval harness, trigram index, guidance store.
+  ~2–3 weeks.
+- **Phase 1 — Token-cost + ranking quick wins.** F3, F4, F5, F8, F6, F9. All Low–Medium, no
+  model, mostly reuse. Highest ROI-per-effort. **Pull F2 (contract linking) into here too** — it's
+  the RFC's highest *product* value and has no structural blockers; don't bury it at position 2
+  of 17.
+- **Phase 2 — Quality signals (gated by §2.7).** F7 (PRF), F1 (feedback), F12 (temporal). Each
+  must clear the benchmark or stay off-by-default.
+- **Phase 3 — Composites + agent-efficiency.** F10 (investigate), F13 (affected_tests), F11
+  (memory-bank), F16 (cache — *after* measuring the hit-rate premise), F14/F15 (guidance — only
+  if §2.6 proves its worth; these are agent-harness scope creep).
+- **Phase 4 — F17 reranker**, only if F7 + F1 leave a measurable gap.
+
+This reorders the RFC's release plan in three ways: (a) a real **Phase 0** because so much is
+shared infra the RFC treats as per-feature; (b) **F2 pulled forward** for product value; (c)
+quality features (F7/F1/F12/F17) explicitly **gated** on the eval harness rather than shipped on
+faith.
+
+---
+
+## 5. Risk register (top, cross-track)
+
+| Risk | Features | Mitigation |
+|------|----------|-----------|
+| Feedback-loop / popularity bias entrenches bad rankings | F1, F17 | Exploration floor (Ensign 2018), negative signal, decay, 2.0× cap, benchmark with feedback **off** |
+| Quality features ship without real gain (PRF drift, reranker noise) | F7, F12, F17 | §2.7 eval harness with time-based CV + per-query CI; off-by-default; explicit ship-gates |
+| Static contract/test extraction is unsound (≤0.79 F1; depth-3 unsafe) | F2, F13 | Confidence scoring + min-confidence filters; "no path ≠ safe-to-skip"; periodic full runs; frame as complementary to runtime/dynamic |
+| Daemon-less cache serves stale results | F16 | Key-based correctness (generation mismatch = miss); content hashes; prefer false-evict; **measure hit-rate before building** |
+| Storage/invalidation surface sprawl (231 MB DB + many sidecars) | F3, F16, F10, F12, F17 | Opt-in indexes; one shared §2.3 state layer; measure size on the live DB |
+| Scope creep into agent-harness layer | F14, F15 | Build §2.6 once; treat as defense-in-depth, not enforcement (Geng 2025); revisit product identity |
+| `Symbol.end_line` schema change forces a re-index | F5, F3, F8 | Bundle into Phase 0; tree-sitter already has the end span |
+
+---
+
+## 6. Validation strategy (the recurring theme)
+
+The literature is consistent that ranking-quality interventions are **corpus-dependent and
+sometimes negative**. So:
+
+1. **Build §2.7 first.** nDCG@10 / precision@k on NestWeaver's own code+notes corpus.
+2. **Time/query-based CV**, never random shuffle (interaction data is temporal).
+3. **Per-query win/loss + confidence intervals** — a small mean delta on ~40 queries is noise.
+4. **Off-by-default** for every quality feature until it clears its gate on *our* data.
+5. **Instrument our own token-savings** for F5/F8 rather than citing vendor percentages.
+6. **A/B with the signal disabled** for F1/F12 so machine-local non-determinism doesn't
+   contaminate the baseline.
+
+---
+
+## 7. Where the evidence lives
+
+Full citations (authors, year, venue, retrieved URLs) and the per-feature deep dives are in:
+
+```
+scratch/rfc-implementation-plan/research/
+  ranking-priors-query-expansion.md        (F6, F7)
+  ltr-reranking-feedback.md                (F1-ranking, F17)
+  code-search-trigram-symbol-reads.md      (F3, F4, F5, F8)
+  api-contract-graphs.md                   (F2)
+  temporal-rank-test-selection.md          (F12, F13)
+  agent-memory-knowledge-base.md           (F1-memory, F11, F9)
+  agentic-orchestration-guardrails-cache.md(F10, F14, F15, F16)
+```

--- a/scratch/rfc-implementation-plan/MASTER-EXECUTION-PLAN.md
+++ b/scratch/rfc-implementation-plan/MASTER-EXECUTION-PLAN.md
@@ -1,0 +1,232 @@
+---
+title: NestWeaver — Master Execution Plan (RFC v0.9.1+ feature track)
+status: ready-to-execute
+created: 2026-05-29
+supersedes_for_execution: IMPLEMENTATION-PLAN.md, BUILD-SPEC-*.md (this is the conductor's score;
+                          those are the parts — open the referenced BUILD-SPEC section for full
+                          tasks/tests on any item)
+verified_against: feat/ui-next-gen-r3f working tree, 2026-05-29
+---
+
+# NestWeaver — Master Execution Plan
+
+One sequenced backlog to execute from. Each item is a PR-sized unit with: **status** (what's
+already built), **verified surface**, **acceptance**, **deps/gate**, and a **spec ref** for full
+task/test depth. Bugs #12 and #19 are already shipped on this branch.
+
+**Status legend:** 🟢 greenfield · 🟡 partially built (finish/wire) · 🔵 reuse-heavy · ⛔ gated.
+
+---
+
+## 1. Read-first corrections (these bite if missed)
+
+1. **`Symbol` has no `end_line`** — keystone schema add; blocks F5/F8/F3-symbol. (`nodes.rs:140`;
+   parser discards available `end_position()` at `parse.rs:593`.)
+2. **`graph_generation` is in-memory, reset to 0 each open, bumped only by watchers — never by
+   `index`** (`db.rs:37/53/69/108`). Must be persisted + bumped on index (M0.3) before it can key a
+   cache/bundle.
+3. **F6 priors apply AFTER RRF** (`rrf_fuse` ~`:1001`) or they no-op; **F7 PRF weights are
+   rank-only** through RRF (set expectations). **Crate correction (review):** `query.rs`
+   (`rrf_fuse`, `BrainNode:661`, `render_brain_node:1060`, `build_brain_context_hybrid_with_aliases:763`,
+   `expand_query_with_aliases:1271`) lives in **`nestweaver-engine`**, NOT `nestweaver-store` — the
+   build specs and ADDENDUM mislabel the crate (line numbers are right). F6/F7/F8/F1 modify
+   *engine*.
+4. **F12 clamp bug:** `(1+w·(score−0.5))` with score∈[0,1] needs **w=1.2** to reach `[0.4,1.6]`, not
+   0.6.
+5. **F1 PPR-consumption is ALREADY BUILT** (5% additive teleport blend, `ranking.rs:599`); **F7
+   alias expansion is ALREADY BUILT** (`expand_query_with_aliases`). Don't re-implement.
+6. **F2 is greenfield**: the live `cross_repo_contracts` tool does name/import matching; the real
+   contract matcher is unwired dead code. `detect_frameworks()` exists but is never called.
+7. **F13 is reuse-heavy**: `traverse.rs::impact`, `process.rs::detect_changes_impact`,
+   `entry_points.rs::is_test_file`.
+8. **F9 Leiden runs on the code graph only** (`cluster_dispatch.rs`); doc-graph queries are greenfield.
+9. **PPR is pure in `nestweaver-algorithms`** — apply rank multipliers (F12) at *consumption* in
+   `ranking.rs`, not in the pure PPR.
+10. **Step Zero is configuration + dogfooding** (MCP isn't configured → tool not in the loop); the
+    **vault Project is now Journey 8** in the benchmark.
+11. **Quality gains are corpus-dependent** — F7/F1/F12/F17 stay off-by-default and gated on the
+    **P0.3 eval harness**; **measure our own token savings** for F5/F8 (vendor %s are unproven).
+
+---
+
+## 2. Feature status at a glance
+
+| Feature | Status | Note |
+|---------|--------|------|
+| F3 regex_search / F4 count | 🟢 | builds trigram index; deps present |
+| F5 read_symbols | 🟢→🔵 | blocked on `end_line`; `symbols_in_file` exists |
+| F6 path priors | 🟢 | post-RRF multiply; `globset` available |
+| F7 PRF + aliases | 🟡 | aliases done; **PRF pass new** |
+| F8 inline bodies | 🟢 | ~15 LOC + F5 for symbol bodies |
+| F9 doc-graph tools | 🟢→🔵 | Leiden exists (code-only); queries new |
+| F1 feedback loop | 🟡 | **consumption + FollowUp + session_id done**; add TerminalSuccess + hardening |
+| F2 contract linking | 🟢 | greenfield; wire `detect_frameworks` first |
+| F12 CodeRank | 🟢→🔵 | git-history miner new; multiply at rank-read |
+| F13 affected_tests | 🔵 | reuse impact/traverse + test heuristics |
+| F10 investigate | 🟢 | composes F7/F8/F9 |
+| F11 memory-bank | 🟢→🔵 | typed edges + checks; orphans/broken reuse F9 |
+| F14/F15 guidance | 🟢 ⛔ | Tier E3; defense-in-depth, not enforcement |
+| F16 cache | 🟢 ⛔ | adversarial: instrument→memo only; disk after P0.2+hit-rate |
+| F17 reranker | 🟢 ⛔ | adversarial: LambdaMART experiment, not the net; only if F7+F1 leave a gap |
+
+---
+
+## 3. Execution sequence (dependency-ordered)
+
+### Milestone 0 — Foundations
+| ID | Item | Status | Acceptance | Deps | Spec |
+|----|------|--------|-----------|------|------|
+| **M0.1** | Configure MCP (`setup claude-code`) + dogfood; run benchmark incl. **J8** | — | J8 runs; baseline timings captured | — | ADDENDUM §A |
+| **M0.2** | **P0.1 `Symbol.end_line`** (keystone) | 🟢 | `symbol --json` has `end_line`; reindex populates | — | wave1 P0.1 |
+| **M0.3** | P0.2 persist + bump `graph_generation` | 🟡 | survives reopen; bumps on `index` | — | wave1 P0.2 |
+| **M0.4** | P0.3 eval harness (nDCG@10/MRR, time-CV) | 🟢 | reproducible baseline number | — | wave1 P0.3 |
+| **M0.5** | P0.5 success-signal labeler (`TerminalSuccess` + neg signal) | 🟡 | new kinds recorded; sidecar bounded | — | wave1 P0.5 / wave4 F1 |
+
+### Milestone 1 — Token-cost + ranking quick wins
+| ID | Item | Status | Deps | Spec |
+|----|------|--------|------|------|
+| **M1.1** | F5 read_symbols | 🟢 | M0.2 | wave1 F5 |
+| **M1.2** | F8 inline bodies | 🟢 | M1.1 (symbol bodies) | wave1 F8 |
+| **M1.3** | F3 regex_search (+ trigram index) | 🟢 | (M0.2 for sym-text) | wave1 F3 |
+| **M1.4** | F4 count_patterns | 🟢 | M1.3 | wave1 F4 |
+| **M1.5** | F6 path priors | 🟢 | — | wave1 F6 |
+| **M1.6** | F9 doc-graph tools (5) | 🔵 | — | wave2 F9 |
+
+### Milestone 2 — Differentiator + PR-review
+| ID | Item | Status | Deps/Gate | Spec |
+|----|------|--------|-----------|------|
+| **M2.1** | F2.0 wire `detect_frameworks` | 🟢 | — | wave2 F2.0 |
+| **M2.2** | F2.1 contract nodes (OpenAPI/proto/GraphQL) | 🟢 | — | wave2 F2.1 |
+| **M2.3** | F2.2 same-repo IMPLEMENTS (Spring/NestJS) | 🟢 | M2.1, M2.2 | wave2 F2.2 |
+| **M2.4** | F2.3 cross-repo CONSUMES (gRPC/operationId) | 🟢 ⛔ | **demand count > threshold** | wave2 F2.3 |
+| **M2.5** | F2.4 drift diagnostics | 🟢 | M2.2, M2.3 | wave2 F2.4 |
+| **M2.6** | F13 affected_tests | 🔵 | — (parallel) | wave3 F13 |
+| **M2.7** | W3.0 git-history miner | 🟢 | — | wave3 W3.0 |
+| **M2.8** | F12 CodeRank | 🔵 ⛔ | M2.7; **gate P0.3** | wave3 F12 |
+
+### Milestone 3 — Quality cohort (all gated on M0.4 / P0.3)
+| ID | Item | Status | Deps/Gate | Spec |
+|----|------|--------|-----------|------|
+| **M3.1** | F7 PRF pass | 🟡 ⛔ | gate P0.3 | wave4 F7 |
+| **M3.2** | F1 finish (TerminalSuccess + neg signal + exploration floor + `interactions show --uid`) | 🟡 ⛔ | M0.5; gate P0.3 | wave4 F1 |
+
+### Milestone 4 — Composites
+| ID | Item | Status | Deps | Spec |
+|----|------|--------|------|------|
+| **M4.1** | F10 investigate | 🟢 | F7, F8, F9, M0.3 | wave5 F10 |
+| **M4.2** | F11 memory-bank | 🔵 | F9 | wave5 F11 |
+
+### Milestone 5 — Contingent (carry gates)
+| ID | Item | Status | Posture | Spec |
+|----|------|--------|---------|------|
+| **M5.1** | F14/F15 guidance | 🟢 ⛔ | defense-in-depth; build if §2.6 earns keep | wave5 F14/F15 |
+| **M5.2** | F16 cache | 🟢 ⛔ | instrument → process-local memo; disk only after M0.3 + measured hit-rate | wave5 F16 |
+| **M5.3** | F17 reranker | 🟢 ⛔ | only if F7+F1 leave a measured reorder gap → LambdaMART experiment, not the candle net | wave5 F17 |
+
+---
+
+## 4. Dependency graph
+
+```
+M0.2 end_line ─┬─► M1.1 F5 ─► M1.2 F8
+               └─► M1.3 F3(sym-text)
+M1.3 F3 ─► M1.4 F4
+M0.3 graph_generation ─────────────► M4.1 F10 ;  M5.2 F16(disk)
+M0.4 eval harness ──gate──► M2.8 F12, M3.1 F7, M3.2 F1, M5.3 F17
+M0.5 labeler ─► M3.2 F1
+M2.7 git miner ─► M2.8 F12
+F9 (M1.6) ─► M4.1 F10, M4.2 F11
+F7+F8+F9 ─► M4.1 F10
+F6/F9/F13/F2* — independent of the above chains (can parallelize)
+```
+
+## 5. Gates (explicit "ready when")
+
+- **P0.3 eval harness must exist** before F7/F1/F12/F17 default on (their value is otherwise
+  unmeasurable).
+- **P0.2 (persisted generation)** before F10 bundle keying or any F16 disk cache.
+- **F2.3** only after a **demand count** of real cross-repo gRPC/typed-client couplings clears a bar.
+- **F12/F7/F1** must clear P0.3 (CI excludes zero) to default on; otherwise stay flag-gated.
+- **F16** only after a **measured hit-rate** clears a pre-committed bar (else process-local memo only).
+- **F17** only if a **durable reorder-specific gap** remains after F6/F7/F1, validated on P0.3.
+
+## 6. First PR — start here: M0.2 / P0.1 `Symbol.end_line`
+
+No deps, unblocks the most — but the field touches many construction sites (verified blast radius;
+review-corrected from the original 4-step sketch). Full scope:
+
+**A. Schema + parser**
+1. Add `pub end_line: u32` to `RawSymbol` (`parser/src/parse.rs:59`) and `Symbol`
+   (`schema/src/nodes.rs:140`).
+2. Tree-sitter path: set `end_line = node.end_position().row as u32 + 1` next to `start_line`
+   (`parse.rs:593`); wire into the RawSymbol literal at `parse.rs:654-664`.
+3. **15 regex/line-based parsers** (astro, cobol, fortran, frameworks, groovy, hcl, julia, objc,
+   pascal, powershell, sql, svelte, systemverilog, vue, zig) build `RawSymbol` with **no tree-sitter
+   node** → set `end_line = start_line` (single-line). (~50 literals — the largest omission in the
+   original sketch.)
+4. Production `RawSymbol→Symbol` mapping: `index.rs:543`, `index.rs:1056`, `watch_code.rs:342`
+   (and `cross_domain.rs:475/585`) → `end_line: raw.end_line`.
+
+**B. Store**
+5. Add `end_line INT64` to the Symbol DDL (`store/src/db.rs:231-244`) **and** an idempotent
+   `ALTER TABLE Symbol ADD end_line INT64 DEFAULT 0` in `init_schema` (the DDL is `IF NOT EXISTS`,
+   so existing DBs need the ALTER — mirror the pattern at `db.rs:207`).
+6. Add `end_line` to **both** insert paths: `batch_insert_symbols_on` (`write.rs:145/151-154`, the
+   *production* path) and `insert_symbol_with_conn` (`write.rs:87/94-97`).
+7. Read: add `s.end_line` to `SYMBOL_COLUMNS` (`read.rs:181`) and read it in `row_to_symbol`
+   (`read.rs:144`, column index 6 — shift the rest; update the doc-comment). `row_to_symbol` already
+   `unwrap_or(0)`, so old DBs return `end_line: 0` without error.
+
+**C. Compile blast radius (won't build otherwise)**
+8. Update all remaining `Symbol`/`RawSymbol` struct literals (~37 `Symbol` + ~80 `RawSymbol` across
+   schema/parser/resolver/store/engine/mcp/web, **incl. test/helper literals**). WASM crate is
+   unaffected. "Existing tests green" depends on this.
+
+**D. Migration reality**
+9. `core_schema_hash` (`schema/src/version.rs`) is **computed, not a constant**, and `end_line` is
+   already in `NODE_PROPERTIES` — adding it does **not** change the hash and does **not** force a
+   local re-index (it only gates snapshot-pull). Old/unchanged files keep `end_line=0` until
+   `index --force`. Document this; don't rely on a "hash bump."
+
+**Tests (TDD):** multi-line fn → `end_line > start_line` matching source (tree-sitter); a
+regex-language symbol → `end_line == start_line`; store round-trip insert→read equal; `symbol --json`
+shows `end_line` (auto-serialized via serde on `Symbol`).
+
+**Verify:** `cargo test`, `clippy --all-targets -- -D warnings`, `fmt --all --check`; `index --force`
+a fixture; confirm `end_line` populated.
+
+**Acceptance:** a fresh `index --force` populates correct `end_line` for tree-sitter symbols and
+`start_line` for regex-language symbols; `symbol --json` includes `end_line`; all existing tests green.
+
+---
+
+## 7. Review findings (independent pre-execution review, applied)
+
+Two review agents stress-tested this plan and verified the first PR against code. The milestone DAG
+is **acyclic and correctly ordered**; M0→M1 startability, the gates (P0.3/P0.2/demand-count/hit-rate/
+CI), F1-already-built, F12 clamp `w=1.2`, F2-greenfield, and `graph_generation` not-persisted all
+**confirmed**. Issues found and how they're handled:
+
+**Must-fix (applied):**
+1. **Wrong crate for `query.rs`** — it's `nestweaver-engine`, not store. Affects F6/F7/F8/F1 refs in
+   the build specs + ADDENDUM (line numbers correct). → Corrected in §1.3; **when executing those
+   items, read `nestweaver-engine/src/query.rs`.**
+2. **First PR (P0.1) was under-scoped** — missed the 15 regex parsers, the `batch_insert_symbols_on`
+   production insert path, the `RawSymbol→Symbol` mapping sites, the ~117 struct-literal compile
+   sites, and the migration mechanism (`core_schema_hash` does NOT force reindex). → §6 fully
+   rewritten.
+3. **`is_test_file` is not a reusable fn** — it's a local `let` + per-language inline checks in
+   `entry_points.rs`. → **F13 (M2.6) gains an explicit task: extract a generalized test-file
+   predicate first.** Re-budget F13 from "mostly reuse" to "reuse + one extraction."
+4. **`TerminalSuccess` is double-owned by P0.5 and F1.** → Scope split: **P0.5/M0.5** = add the
+   `EventType::TerminalSuccess` variant + recording plumbing; **F1/M3.2** = consumption tuning,
+   anti-feedback hardening (exploration floor + negative signal), and `interactions show --uid`.
+
+**Should-fix:**
+5. F2.2 edge-insert is at `write.rs:376` (not `:385`); M0.3 must hook the real index entry points
+   `index_directory_with_options` (`index.rs:209`) and `incremental_index` (`index.rs:802`).
+6. Make explicit: **core F13 ships without W3.0** (co-change is an optional fallback, not a v1 dep) —
+   so M2.6 is not blocked by M2.7.
+
+These corrections override the corresponding lines in the wave build-specs. The plan is otherwise
+execution-ready; **start with §6 (P0.1).**

--- a/scratch/rfc-implementation-plan/README.md
+++ b/scratch/rfc-implementation-plan/README.md
@@ -1,0 +1,31 @@
+# RFC v0.9.1+ implementation plan — research bundle
+
+- **`MASTER-EXECUTION-PLAN.md`** — ⭐ **start here to execute.** One sequenced backlog: read-first
+  corrections, status-at-a-glance, dependency-ordered milestones (M0–M5), explicit gates, the
+  dependency graph, the fully-scoped first PR (§6), and the independent review findings (§7). The
+  build-specs below are the per-item detail; the corrections in §7 override them where they differ.
+- **`BUILD-SPEC-phase0-wave1.md`** — the executable front: task-level specs (verified files,
+  schema/signatures, ordered steps, TDD tests, acceptance) for Phase 0 enablers + Wave 1
+  (F5, F8, F3, F4, F6). Start here to build.
+- **`BUILD-SPEC-wave2.md`** — same depth for Wave 2: F9 (five `brain.*` doc-graph tools) +
+  F2-core (contract linking scoped to the trustworthy lanes: wire `detect_frameworks` → contract
+  nodes → same-repo IMPLEMENTS → safe cross-repo gRPC/operationId → drift).
+- **`BUILD-SPEC-wave3.md`** — same depth for Wave 3 (PR-review track, journeys J2/J5): git-history
+  mining substrate, F12 (activity multiplier at rank-read, clamp fix), F13 (`affected_tests`,
+  mostly reuse of `traverse.rs::impact` + test heuristics).
+- **`BUILD-SPEC-wave4.md`** — Wave 4 (eval-gated quality features), scoped to what's *left*: F7's
+  PRF pass (alias expansion already shipped) + F1's finish (PPR consumption already wired — add
+  `TerminalSuccess`, negative signal, exploration floor, `interactions show --uid`).
+- **`BUILD-SPEC-wave5-final.md`** — final wave: F10 (investigate) + F11 (memory-bank) at full depth;
+  F14/F15/F16/F17 as spec + carried adversarial gates. **Completes build-ready specs for all 17.**
+- **`ADDENDUM-evidence-and-findings.md`** — evidence (the 7+1 journeys, the MCP-config gap),
+  verified implementation surface (corrections to the plan), and adversarial findings on F2/F16/F17.
+- **`IMPLEMENTATION-PLAN.md`** — the master strategic plan. Read §1 (RFC corrections) and §2
+  (cross-cutting foundations) first; they reframe the whole roadmap.
+- **`research/`** — seven cited research dossiers (one per feature cluster), each with
+  primary sources + URLs, prior-art systems, codebase-grounded recommendations, pitfalls,
+  and effort. Produced by parallel research agents required to cite only retrieved sources
+  and flag `[UNVERIFIED]` claims.
+
+Bugs #12 and #19 are already implemented on `feat/ui-next-gen-r3f` (working tree).
+This bundle covers the 17 remaining features.

--- a/scratch/rfc-implementation-plan/research/agent-memory-knowledge-base.md
+++ b/scratch/rfc-implementation-plan/research/agent-memory-knowledge-base.md
@@ -1,0 +1,234 @@
+# Research Foundation: Agent Memory & Knowledge-Base RFC Features
+
+Research grounding for three NestWeaver RFC features. All cited sources were retrieved via web search/fetch in May 2026. Sources without a retrieved URL are marked `[UNVERIFIED]`. Quantitative formulas/numbers are quoted from the primary source where possible.
+
+NestWeaver context: Rust code-and-notes graph intelligence tool. It ingests an Obsidian-style markdown vault ("brain") with wikilinks, tags, frontmatter, notes/headings/sections, and a 4-tier knowledge pipeline: `_logs` (working) → `_ideas` (episodes) → `Projects/*/sync.md` (knowledge) → `_brain/conventions/*` (procedures). Embedded graph DB (LadybugDB); MCP server. Solo-dev.
+
+---
+
+## Cross-cutting source library (with exact results that matter)
+
+### Agent / LLM memory architectures
+
+**Park, Joon Sung; O'Brien, Joseph C.; Cai, Carrie J.; Morris, Meredith Ringel; Liang, Percy; Bernstein, Michael S. (2023). "Generative Agents: Interactive Simulacra of Human Behavior." UIST '23 (ACM).**
+- arXiv: https://arxiv.org/abs/2304.03442 ; full HTML retrieved: https://ar5iv.labs.arxiv.org/html/2304.03442 ; ACM: https://dl.acm.org/doi/fullHtml/10.1145/3586183.3606763
+- **The result that matters (exact, quoted from the paper):**
+  - Retrieval score is a weighted sum of three components, each min-max normalized to [0,1]: `score = α_recency · recency + α_importance · importance + α_relevance · relevance`. "In our implementation, all αs are set to 1."
+  - **Recency** = "exponential decay function over the number of sandbox game hours since the memory was last retrieved. Our decay factor is 0.995." (per game-hour)
+  - **Importance** = LLM-rated 1–10 ("On the scale of 1 to 10, where 1 is purely mundane … and 10 is extremely poignant … rate the likely poignancy"). Computed once at memory creation.
+  - **Relevance** = cosine similarity between the memory's embedding and the query's embedding.
+  - **Reflection** triggers "when the sum of the importance scores for the latest events … exceeds a threshold (150 in our implementation)" → ~2–3 reflections/day. Reflections are higher-level memories synthesized from recent memories and stored back in the stream (recursive).
+- Why it matters here: this is the canonical, citable recency/importance/relevance retrieval scoring. Directly maps to Feature 1's decay + ranking.
+
+**Packer, Charles; Wooders, Sarah; Lin, Kevin; Fang, Vivian; Patil, Shishir G.; Gonzalez, Joseph E. (2023). "MemGPT: Towards LLMs as Operating Systems." arXiv:2310.08560 (UC Berkeley). Now the Letta framework.**
+- https://arxiv.org/abs/2310.08560
+- The result that matters: OS-inspired **tiered/virtual memory** — a small in-context "main memory" + large out-of-context storage, with the agent paging data between tiers via function calls. Maps to NestWeaver's tiered sidecar idea and the 4-tier vault promotion (main context = hot working set; archival = cold tiers).
+
+**Zhong, Wanjun; Guo, Lianghong; Gao, Qiqi; Ye, He; Wang, Yanlin (2024). "MemoryBank: Enhancing Large Language Models with Long-Term Memory." AAAI 2024.**
+- https://arxiv.org/abs/2305.10250 ; HTML: https://ar5iv.labs.arxiv.org/html/2305.10250
+- **The result that matters (exact formula, quoted):** memory retention follows the Ebbinghaus forgetting curve `R = e^(-t/S)`, where `R` = "what fraction of the information can be retained", `t` = "time elapsed since learning", `S` = "memory strength". Implementation: `S` initialized to 1; on recall, "S is increased by 1 and t is reset to 0, hence forget it with a lower probability." Authors note this is "an exploratory and highly simplified memory updating model."
+- Why it matters: gives a citable, recall-reinforced exponential-decay model where repeated access strengthens a memory (directly applicable to Feature 1's Access/Followup reinforcement and Feature 11's consolidation-by-repetition).
+
+**Xu, Wujiang; Liang, Zujie; Mei, Kai; Gao, Hang; Tan, Juntao; Zhang, Yongfeng (2025). "A-MEM: Agentic Memory for LLM Agents." NeurIPS 2025.**
+- https://arxiv.org/abs/2502.12110 ; HTML: https://arxiv.org/html/2502.12110v11 ; code: https://github.com/WujiangXu/A-mem
+- **The result that matters (exact, quoted):** Each memory note `m_i = {c_i, t_i, K_i, G_i, X_i, e_i, L_i}` = content, timestamp, LLM-generated **keywords** `K`, LLM-generated **tags** `G`, LLM-generated **contextual description** `X`, embedding `e`, and **linked memories** `L`. Linking: cosine similarity `s_{n,j}` over note embeddings, retrieve **top-k nearest neighbors** (default k=10, task-tuned 10–50), then "LLM to analyze potential connections based on their potential common attributes." **Memory evolution:** adding a new note can rewrite existing neighbors' context/tags (`m_j* ← LLM(...)`). Explicitly **Zettelkasten-inspired** ("atomic note-taking and flexible organization"; notes can belong to multiple conceptual "boxes").
+- Why it matters: A-MEM is the strongest prior art for typed/derived links over notes (Feature 11) and for Zettelkasten-style atomic notes in an agent-memory context. The "memory evolution" rewrite is a cautionary pattern (mutation of prior notes = provenance/audit concerns for a solo dev's brain).
+
+**Zhang, Zeyu; Bo, Xiaohe; Ma, Chen; Li, Rui; Chen, Xu; Dai, Quanyu; Zhu, Jieming; Dong, Zhenhua; Wen, Ji-Rong (2024). "A Survey on the Memory Mechanism of Large Language Model based Agents." arXiv:2404.13501; accepted ACM TOIS July 2025.**
+- https://arxiv.org/abs/2404.13501 ; resources: https://github.com/nuster1128/LLM_Agent_Memory_Survey
+- Use as the umbrella survey citing memory sources/forms, read/write/reflect operations, and evaluation. Good for taxonomy framing and "established vs speculative" claims.
+
+**[UNVERIFIED] Ebbinghaus, Hermann (1885). "Über das Gedächtnis" (Memory: A Contribution to Experimental Psychology).** Original forgetting-curve work; cite via MemoryBank's usage rather than a retrieved primary URL.
+
+### Personal knowledge management (PKM)
+
+**Ahrens, Sönke (2017). "How to Take Smart Notes."** — Modern systematization of Niklas Luhmann's Zettelkasten. Three note types: **fleeting** (raw captures), **literature** (notes on sources), **permanent** (atomic, linked, in your own words; "never thrown away"). Luhmann's slip-box: ~90,000 cards → 70 books + 400+ papers.
+- Retrieved overview/explainers: https://zettelkasten.de/posts/concepts-sohnke-ahrens-explained/ ; https://www.ernestchiang.com/en/posts/2025/sonke-ahrens-how-to-take-smart-notes/
+- Maps to NestWeaver's tier model: `_logs` ≈ fleeting, `_ideas` ≈ permanent/atomic, conventions ≈ distilled principles.
+
+**Matuschak, Andy. "Evergreen notes."** — Notes should be **atomic** (single idea), **concept-oriented** (factored by concept, not source/project), and **densely linked**. "Notes … written and organized to evolve, contribute, and accumulate over time, across projects."
+- https://notes.andymatuschak.org/Evergreen_notes ; https://notes.andymatuschak.org/Evergreen_notes_should_be_concept-oriented ; https://notes.andymatuschak.org/Evergreen_notes_should_be_atomic
+- Maps to promotion criteria (Feature 11): a log section becomes an "idea" when it stabilizes into a concept-oriented, densely-linked unit.
+
+**Forte, Tiago. "The PARA Method" / "Building a Second Brain."** — Organize by **actionability** not topic: **P**rojects (deadlined), **A**reas (ongoing), **R**esources (future-useful), **A**rchives (inactive). "Organizing by topic is the wrong approach."
+- https://fortelabs.com/blog/para/ ; https://www.buildingasecondbrain.com/para
+- Maps to: Archives ≈ a destination for superseded/stale notes; the actionability axis informs tier semantics (`Projects/*/sync.md` = active knowledge).
+
+### Memory-bank pattern in AI coding tools (prior art for Feature 11)
+
+**Cline "Memory Bank"** — structured docs the agent reads at session start: `projectbrief.md`, `productContext.md`, `activeContext.md`, `systemPatterns.md`, `techContext.md`, `progress.md`. Cycle: read → verify → execute → update. Goal: persist context across sessions, avoid context bloat.
+- https://docs.cline.bot/prompting/cline-memory-bank ; https://cline.bot/blog/memory-bank-how-to-make-cline-an-ai-agent-that-never-forgets
+
+**Roo Code Memory Bank** — `memory-bank/` with `activeContext.md`, `productContext.md`, `progress.md`, `decisionLog.md`, `systemPatterns.md`, `projectBrief.md`; integrated into VS Code modes that update specific files.
+- https://github.com/GreatScottyMac/roo-code-memory-bank
+- Tradeoff vs NestWeaver: these are **flat markdown conventions with no graph, no health checks, no typed edges, no decay**. NestWeaver's value-add is exactly the graph + maintenance layer on top of this pattern.
+
+### Knowledge-graph quality, maintenance, link prediction
+
+**Paulheim, Heiko (2017). "Knowledge graph refinement: A survey of approaches and evaluation methods." Semantic Web Journal 8(3).**
+- https://www.semantic-web-journal.net/system/files/swj1167.pdf ; https://dl.acm.org/doi/10.3233/SW-160218
+- The result that matters: refinement = **completion** (add missing knowledge / increase coverage) + **error detection** (find wrong statements / increase correctness). Error-detection methods "usually output a list of potentially erroneous statements," and notes that deriving **higher-level patterns** from errors (design-level problems) is rare but valuable. → directly frames Feature 9/11 health checks as "error detection" and link prediction as "completion."
+
+**Liben-Nowell, David; Kleinberg, Jon (2003). "The Link Prediction Problem for Social Networks." CIKM '03.**
+- https://www.cs.cornell.edu/home/kleinber/link-pred.pdf
+- The result that matters: link prediction from **topology alone** is feasible on co-authorship graphs; "fairly subtle measures … can outperform more direct measures." **Adamic–Adar** performed best among the similarity indices tested; Jaccard worst (frequently replicated). → cite for "suggest-links" / typed-edge candidate generation over the wikilink graph.
+- Heuristic family (overview, retrieved): Common Neighbors, **Adamic–Adar** (inverse-log-degree weighting of shared neighbors), Jaccard, Preferential Attachment, Katz; embedding methods DeepWalk/LINE/node2vec; GNNs for attributed graphs. https://en.wikipedia.org/wiki/Link_prediction
+
+**Patrucco / "Orphan Articles: The Dark Matter of Wikipedia" (2023). arXiv:2306.03940.**
+- https://arxiv.org/html/2306.03940v2
+- **The result that matters (exact, quoted):** orphan = "articles without any incoming links from other Wikipedia articles" (same-language main namespace). **8.8M (14.7%)** of ~60M articles across 319 editions are orphans; ~**15%** "de facto invisible to readers navigating Wikipedia." English Wikipedia is an outlier at ~5% (still >300K). Orphans get far fewer pageviews ("mean for non-orphans is twice as high"); **de-orphanization → statistically significant +6.5% pageviews**, persistent, "mostly driven by readers using the newly added incoming links." FindLink (string-match) only covers 1.6M (18%); cross-lingual link translation covers 5.5M (62%).
+- → cite for orphan detection value (Feature 9) AND the orphan-false-positive caveat: top-level index/MOC notes legitimately have no inbound links.
+
+**Wikipedia operational practice:** WP:Orphan (orphan = no inbound mainspace links), WikiProject Orphanage (de-orphaning backlog ~80K in 2023, down from 140K peak in 2017), WP:Link rot / IABOT bot for dead external links.
+- https://en.wikipedia.org/wiki/Wikipedia:Orphan ; https://en.wikipedia.org/wiki/Wikipedia:Link_rot
+
+**Concept/schema drift:**
+- "OntoDrift: a Semantic Drift Gauge for Ontology Evolution Monitoring." CEUR Vol-2821. https://ceur-ws.org/Vol-2821/paper1.pdf — detects/assesses semantic drift between time-distinct ontology versions via intension/extension/labels.
+- "Do you catch my drift? On the usage of embedding methods to measure concept shift in knowledge graphs." (2023). https://dl.acm.org/doi/fullHtml/10.1145/3587259.3627555 — embedding-based drift measurement.
+- → cite for Feature 11's "schema drift" health check (frontmatter key/value distributions changing over time).
+
+### Community detection
+
+**Traag, V. A.; Waltman, L.; van Eck, N. J. (2019). "From Louvain to Leiden: guaranteeing well-connected communities." Scientific Reports 9, 5233.**
+- https://www.nature.com/articles/s41598-019-41695-z ; arXiv: https://arxiv.org/abs/1810.08473
+- **The result that matters (quoted/paraphrased):** Louvain can yield "arbitrarily badly connected" or even **disconnected** communities — empirically up to 25% badly connected, up to 16% disconnected when run iteratively. **Leiden guarantees connected communities**, converges to a partition where all subsets are locally optimally assigned, runs faster, and finds better partitions. → cite as the reason to use Leiden (not Louvain) for topic clustering over the wikilink subgraph (Feature 9/11).
+
+### Semantic-relation standards (for typed edges, Feature 11)
+
+**W3C SKOS — Simple Knowledge Organization System Reference (2009).** https://www.w3.org/TR/skos-reference/
+- `skos:broader` / `skos:narrower` = hierarchical; `skos:related` = associative (non-hierarchical). → maps `DependsOn`-ish hierarchy and `RelatesTo`.
+
+**W3C PROV-O — The PROV Ontology (2013).** https://www.w3.org/TR/prov-o/
+- `prov:wasDerivedFrom` = "a transformation of one entity into another" (derivation chain between entities); `prov:wasInformedBy` = dependency between activities; `prov:wasRevisionOf` (a PROV-O subtype of derivation) = entity is a revised version of another. → maps `Supersedes`/`CausedBy`/derivation. NestWeaver's `Supersedes` ≈ inverse of `prov:wasRevisionOf`; `CausedBy` ≈ inverse of `prov:wasDerivedFrom`/`wasInformedBy`.
+- schema.org also has informal equivalents (`schema:isBasedOn`, `schema:supersededBy` [deprecated in schema.org core but conceptually present]) — prefer SKOS/PROV-O as the citable standards.
+
+---
+
+## FEATURE 1 — Interaction-memory event sidecar (Query / Access / Impact / Followup / TerminalSuccess), time-decay, pruning
+
+### 1. Research foundation
+- **Generative Agents** (Park et al. 2023, UIST; https://ar5iv.labs.arxiv.org/html/2304.03442): the memory-stream object + `score = recency + importance + relevance` (all α=1, min-max normalized) and **recency = exponential decay, factor 0.995 per game-hour since last retrieval**. This is the load-bearing precedent for event-based memory with decay scoring.
+- **MemoryBank** (Zhong et al. 2024, AAAI; https://ar5iv.labs.arxiv.org/html/2305.10250): **`R = e^(-t/S)`** with strength `S` incremented and `t` reset on recall. This gives the *reinforcement-on-access* semantics that NestWeaver's `Access`/`Followup`/`TerminalSuccess` events need.
+- **MemGPT** (Packer et al. 2023; https://arxiv.org/abs/2310.08560): tiered memory + paging — supports a hot/cold split for the sidecar and bounded in-context working set.
+- **Survey** (Zhang et al. 2024, TOIS; https://arxiv.org/abs/2404.13501): taxonomy of read/write/reflect + evaluation for grounding design choices.
+
+### 2. Prior art / projects + tradeoffs
+- Generative Agents reference implementation (open source) — full memory-stream + reflection; heavyweight (LLM call per importance score, per reflection). Tradeoff: LLM-scored importance is expensive; NestWeaver can substitute **structural importance** (PageRank of the accessed symbol/node) for a zero-LLM proxy.
+- MemoryBank/SiliconFriend (https://github.com/zhongwanjun/MemoryBank-SiliconFriend) — simplest citable decay+reinforce model; authors admit it's "highly simplified" (so don't over-engineer).
+- NestWeaver already ships `<db>.interactions.json` and `nestweaver interactions status/clear` + `mcp --track-interactions` (per CLAUDE.md), so this feature formalizes an existing sidecar.
+
+### 3. Recommended approach for NestWeaver (grounded)
+- **Event record:** `{ event_id, session_id, ts, kind, target_uid(s), query_text?, intent?, weight }`. `session_id` groups events for **Followup** detection (an Access shortly after a Query in the same session) and for **TerminalSuccess** attribution (which targets were in-context when the session ended successfully).
+- **Event kinds → weight semantics** (analogous to MemoryBank strength increments, and to the per-edge-type PPR weights NestWeaver already uses):
+  - `Query` — seeds a session; low standalone weight.
+  - `Access` — a symbol/note was actually opened/returned; primary reinforcement (`S += 1`, reset `t`).
+  - `Impact` — appeared in an impact/blast-radius result; medium weight (signal of structural relevance).
+  - `Followup` — accessed *after* a prior query in same session within a window; strong relevance signal (the first result wasn't enough → this one was the real target). Boost the followed-up target.
+  - `TerminalSuccess` — session ended in a success signal (commit, test pass, user-confirmed). Retroactively boost all targets accessed in that session. This is the highest-value, sparsest signal — treat like Generative Agents "importance."
+- **Decay (cite MemoryBank exactly):** per-target retention `R = exp(-Δt / S)`, where `Δt` = time since last event on that target, `S` = strength = accumulated event weight (each Access/Followup/TerminalSuccess raises `S`, resetting `Δt`). Use this `R` as a **recency-weighted boost on ranking** (multiply into search/PPR scores), mirroring Generative Agents' recency term.
+- **Combined retrieval boost (cite Generative Agents):** `boost = w_r·R + w_i·importance + w_rel·relevance` where `importance` = node PageRank (structural proxy for LLM poignancy) and `relevance` = query–target embedding cosine. Start with equal weights (Generative Agents used α=1 each) and tune.
+- **Pruning:** drop events whose contribution `R` falls below ε (e.g., `R < 0.01`) — equivalent to a hard age cutoff that lengthens with strength `S`, so frequently-useful targets persist (exactly the Ebbinghaus reinforcement intent). Cap total events per target (keep newest N + the TerminalSuccess events) to bound the sidecar. This is a deliberately bounded, append-mostly JSON log compacted on `index`/`watch`.
+- **No-LLM by default:** importance via PageRank, relevance via existing embeddings — keeps the sidecar cheap and offline, unlike Generative Agents' per-memory LLM calls.
+
+### 4. Pitfalls / failure modes + mitigations
+- **Memory bloat / unbounded JSON.** Append-only event logs grow without compaction. → Compact on each `index`/`watch` cycle; prune by `R < ε`; cap per-target event count.
+- **Popularity bias / rich-get-richer.** Frequently-accessed hubs accumulate strength and dominate ranking, drowning new/cold nodes (same pathology as PageRank + reinforcement). → Cap the max boost; normalize boost per query (min-max like Generative Agents); decay strength `S` slowly even on hubs; exclude very-high-degree hubs from boost.
+- **TerminalSuccess attribution error.** A session touches many targets; not all caused the success. → Weight by recency-within-session and by whether the target was a `Followup` (deliberate) vs incidental Access; require multiple successes before strong boost.
+- **Privacy / query-text leakage in the sidecar.** Query strings persisted to disk. → Store hashes/embeddings, not raw text, by default; `interactions clear` already exists; make tracking opt-in (it already is per CLAUDE.md).
+- **Clock/`Δt` correctness across re-index.** Decay depends on wall-clock; watcher restarts mustn't reset `t`. → Persist last-event ts per target; compute `Δt` from persisted ts.
+
+### 5. Complexity / effort
+- **Low–Medium.** Sidecar + decay scoring is small (the JSON sidecar and CLI already exist). The work is: (a) defining the event schema + session grouping, (b) the `R = e^{-Δt/S}` decay + ranking integration into existing search/PPR, (c) compaction/pruning on index. No new heavy deps. Estimate: a few days; the ranking-integration tuning is the open-ended part.
+
+---
+
+## FEATURE 11 — Memory-bank semantics over the vault: typed edges, 7 health checks, consolidation pipeline
+
+### 1. Research foundation
+- **Typed/derived links from notes:** A-MEM (Xu et al. 2025, NeurIPS; https://arxiv.org/abs/2502.12110) — LLM-derived keywords/tags/context + top-k embedding linking + "memory evolution"; explicitly Zettelkasten.
+- **Standards for the relation types:** SKOS (https://www.w3.org/TR/skos-reference/) and PROV-O (https://www.w3.org/TR/prov-o/).
+- **Health checks as KG refinement:** Paulheim 2017 (https://www.semantic-web-journal.net/system/files/swj1167.pdf) — error detection vs completion framing; the 7 checks are mostly **error detection**.
+- **Orphans/broken links:** "Orphan Articles" (arXiv:2306.03940) + WP:Orphan/WP:Link rot.
+- **Schema drift:** OntoDrift (https://ceur-ws.org/Vol-2821/paper1.pdf) + embedding-drift (https://dl.acm.org/doi/fullHtml/10.1145/3587259.3627555).
+- **Consolidation/promotion through tiers:** PKM tier models — Ahrens fleeting→literature→permanent; Matuschak evergreen (atomic, concept-oriented, densely-linked); MemoryBank reinforcement-on-recall (`R=e^{-t/S}`); Generative Agents reflection-threshold (importance sum > 150 → synthesize higher-level memory). These justify "linked from 3+ notes AND survived 14 days → promote."
+
+### 2. Prior art / projects + tradeoffs
+- **Cline / Roo Memory Bank** (https://docs.cline.bot/prompting/cline-memory-bank , https://github.com/GreatScottyMac/roo-code-memory-bank): the namesake pattern. Flat markdown, agent-maintained, **no graph / no typed edges / no health checks / no decay**. NestWeaver differentiates by adding the graph + maintenance + promotion layer. Tradeoff: more machinery; mitigate by keeping checks read-only/advisory.
+- **A-MEM:** strongest research analog. Cautionary: its "memory evolution" **mutates prior notes**, which for a solo dev's source-controlled brain is risky (provenance loss). → NestWeaver should *suggest* edges/promotions and record provenance (PROV-O style), not silently rewrite notes.
+- **Obsidian/Foam/Dataview ecosystem** [UNVERIFIED specifics]: provide backlinks, unlinked-mentions, orphan/broken-link panels — but no typed-relation derivation or tier promotion. NestWeaver's typed edges + consolidation are the novel part.
+
+### 3. Recommended approach for NestWeaver (grounded)
+**Typed edges (derive from frontmatter keys + section names; map to standards):**
+| NestWeaver edge | Standard mapping | Derivation source |
+|---|---|---|
+| `Supersedes` | inverse of `prov:wasRevisionOf` (a PROV-O derivation subtype) | frontmatter `supersedes:`/`superseded_by:`; section "Replaces"; status: deprecated + link |
+| `DependsOn` | `skos:broader` (hierarchical) / `prov:wasInformedBy` | frontmatter `depends_on:`/`requires:`; section "Prerequisites"/"Depends on" |
+| `CausedBy` | `prov:wasDerivedFrom` / `prov:wasInformedBy` | frontmatter `caused_by:`/`because:`; section "Caused by"/"Root cause" |
+| `RelatesTo` | `skos:related` (associative) | plain wikilinks not matching a typed pattern; section "Related"/"See also" |
+- Derivation = deterministic rules over frontmatter keys and heading text (no LLM needed for v1; A-MEM shows LLM derivation is possible but adds cost + mutation risk). Keep raw wikilinks as `RelatesTo` and *upgrade* to typed when a pattern matches.
+
+**7 health checks (frame as Paulheim error-detection; one is completion):**
+1. **Stale** — note not modified in N days AND/OR retention `R=e^{-t/S}` below threshold (cite MemoryBank). Solo-dev tuning, e.g. 90 days.
+2. **Contradictions** — two notes both claim authority on a topic with no `Supersedes` between them (e.g., two conventions for the same procedure). Detect via shared tags/title + status conflict.
+3. **Orphans** — no inbound typed/wiki links (cite WP:Orphan + arXiv:2306.03940). **Exclude index/MOC notes** (see pitfalls).
+4. **Broken wikilinks** — link target file/heading does not exist (cite WP:Link rot).
+5. **Supersession chains** — follow `Supersedes` chains; flag (a) cycles, (b) chains where a superseded note is still linked as if current, (c) >K-deep chains needing cleanup.
+6. **Schema drift** — frontmatter key set / value vocab for a note class diverges over time (cite OntoDrift). E.g., `status` values fragmenting into `done/complete/finished`.
+7. **Dangling relationships** — a typed edge whose target is missing or wrong-typed (e.g., `depends_on:` pointing to a deleted note). PROV-O/SKOS integrity.
+
+**Consolidation / promotion pipeline (4-tier):** `_logs → _ideas → Projects/*/sync.md → _brain/conventions/*`.
+- Promotion is **threshold-gated**, grounded in three citable mechanisms: (a) **reinforcement** (MemoryBank: survive/strengthen with repeated reference), (b) **reflection threshold** (Generative Agents: accumulate enough "importance" then synthesize a higher-level unit — here, importance ≈ number of inbound links × access events), (c) **evergreen criteria** (Matuschak: atomic + concept-oriented + densely-linked = ready to be permanent).
+- Concrete rule (the RFC's example, now grounded): a `_logs` section that is **linked from ≥3 notes** (densely-linked, Matuschak) **and has survived ≥14 days** (stability/reinforcement, MemoryBank/Ebbinghaus) → promote to `_ideas`. Analogous gates for ideas→sync and sync→conventions (e.g., referenced across ≥2 projects, stable ≥30 days, low contradiction).
+- **Promotion = suggest + record provenance**, not silent move. Emit a `prov:wasDerivedFrom` edge from the promoted idea back to the source log (audit trail; avoids A-MEM mutation risk).
+
+### 4. Pitfalls / failure modes + mitigations
+- **Orphan false positives for index/MOC notes.** Top-level maps-of-content and home notes legitimately have zero inbound links (Matuschak MOCs; PARA top folders). → Exclude notes tagged `#index`/`#moc`, notes in known index paths, and notes with high *outbound* degree (hubs are sources, not orphans).
+- **False consolidation / premature promotion.** A log briefly hot (3 links in one burst) but never revisited gets promoted as evergreen → tier pollution. → Require *temporal spread* (links arrive over time, not one commit) + survival window + low contradiction; make promotion a *suggestion* the dev confirms.
+- **Stale-check false positives for reference/convention notes.** Conventions are *meant* to be stable and rarely edited; flagging them stale is wrong. → Tier-aware staleness: conventions get a far longer/disabled staleness window.
+- **Schema-drift over-flagging during legitimate evolution.** A solo dev refining their own frontmatter vocab will trip drift constantly. → Drift = advisory only; require a sustained distribution shift (not single edits); allow an alias map (NestWeaver already has `<db>.aliases.json`).
+- **Typed-edge misclassification from heading text.** "See also: X" vs "Depends on: X" — regex misreads. → Conservative rules; default to `RelatesTo` when ambiguous; never auto-`Supersedes` (high-consequence) without explicit frontmatter.
+- **Provenance loss if promotion mutates source.** → Never delete the source log on promotion; keep `wasDerivedFrom` link; let archival follow PARA Archives semantics.
+
+### 5. Complexity / effort
+- **Medium–High.** Typed-edge derivation = small (rules over existing parsed frontmatter/sections). The 7 health checks = mostly graph traversals over the existing store (Low–Medium each; contradictions and schema-drift are the hardest). Consolidation pipeline is the heaviest: requires temporal tracking (which NestWeaver partly has via `graph_generation` counter + `<db>.filemeta.json` mtimes), promotion gating, suggestion surface, and provenance edges. Estimate: 1–2 weeks, with consolidation as the long pole and the highest false-positive risk.
+
+---
+
+## FEATURE 9 — First-class document-graph ops: broken-link, orphan, Leiden topic clustering, tag co-occurrence, doc health stats
+
+### 1. Research foundation
+- **Orphans:** "Orphan Articles: The Dark Matter of Wikipedia" (arXiv:2306.03940; https://arxiv.org/html/2306.03940v2) — orphan = no inbound links; **14.7%** of Wikipedia orphaned; **de-orphaning → +6.5% pageviews**. Quantifies *why* orphan detection matters. WP:Orphan operational definition.
+- **Broken/dead links:** WP:Link rot + IABOT (https://en.wikipedia.org/wiki/Wikipedia:Link_rot).
+- **Topic clustering:** **Leiden** (Traag et al. 2019, Sci. Rep.; https://www.nature.com/articles/s41598-019-41695-z) — guarantees connected communities; Louvain produces up to 16% disconnected communities. Use Leiden over the wikilink subgraph.
+- **Refinement framing:** Paulheim 2017 — these ops are completion + error detection on the doc graph.
+- **Link suggestion (completion):** Liben-Nowell & Kleinberg 2003 (https://www.cs.cornell.edu/home/kleinber/link-pred.pdf) — Adamic–Adar best topological predictor; basis for "you should link these two notes."
+
+### 2. Prior art / projects + tradeoffs
+- **Obsidian core + Graph Analysis/Foam** [UNVERIFIED feature specifics]: backlinks, local graph, orphan & broken-link panels, some co-occurrence; clustering is usually force-layout visual, **not algorithmic community detection**. NestWeaver's edge = running **Leiden** + producing structured stats/MCP tools, not just a force graph.
+- **Wikipedia tooling** (FindLink, IABOT): production-grade orphan/dead-link tooling but Wikipedia-specific. Confirms the ops are real and valuable; FindLink's 18% coverage shows pure string-match is weak → use graph-topology link prediction (Adamic–Adar) instead.
+- NestWeaver already computes communities (`nestweaver clusters`, `<db>.clusters.json`, adaptive resolution) over the *code* graph — Feature 9 reuses that machinery on the *wikilink* subgraph. Low marginal cost.
+
+### 3. Recommended approach for NestWeaver (grounded)
+- **Broken-link detection:** resolve every wikilink target (note + heading/anchor) against the indexed vault; report unresolved. Distinguish broken-internal (fixable) from external URL rot (out of scope or async-checked). Cite WP:Link rot.
+- **Orphan detection:** zero inbound wiki/typed links, **excluding index/MOC notes** (tag/path/outbound-degree heuristic). Report with a "would-de-orphan" suggestion (top Adamic–Adar candidates) — directly mirrors the arXiv:2306.03940 finding that adding inbound links drives discoverability (+6.5%).
+- **Topic clustering — use Leiden, not Louvain** (cite Traag et al. 2019): run on the undirected wikilink subgraph (optionally weighted by co-link count). NestWeaver already has adaptive-resolution clustering; ensure the algorithm is Leiden (connected-community guarantee) for the sparser, noisier wikilink graph. Output named clusters (label by top tags/title terms per cluster).
+- **Tag co-occurrence graph:** nodes = tags, edge weight = number of notes sharing both tags; surfaces de-facto taxonomy and synonym candidates (feeds schema-drift/alias detection in Feature 11). Can also run Leiden on it to find tag communities.
+- **Doc health stats:** counts of orphans, broken links, %-orphaned (compare to Wikipedia's ~15% as a reference point), avg/median link degree, largest connected component size, cluster count/modularity, stale-note count. Expose as a `doc-health` command + MCP tool (promotes these from internal to first-class, per the feature title).
+
+### 4. Pitfalls / failure modes + mitigations
+- **Orphan false positives (index/MOC/entry notes).** Same as Feature 11 — biggest accuracy risk. → Exclude by tag/path/high-outbound-degree; report separately as "intentional hubs."
+- **Leiden over a sparse/disconnected wikilink graph → many singletons.** Personal vaults are sparser than co-authorship nets; resolution matters. → Tune resolution (NestWeaver's adaptive resolution already does this for size), report singletons as orphan-cluster candidates, run on the largest connected component, optionally fold in tag co-occurrence edges to densify.
+- **Tag co-occurrence dominated by a few mega-tags** (e.g., `#project` on everything). → Weight by PMI/normalized co-occurrence, not raw counts; cap or drop ubiquitous tags.
+- **Broken-link false positives from aliases/path resolution.** Obsidian shortest-path links, aliases, heading slugging. → Reuse NestWeaver's existing resolver + `<db>.aliases.json`; match Obsidian's link-resolution rules exactly before flagging.
+- **External-URL checking is slow/flaky.** → Keep internal vs external separate; make external dead-link checks opt-in/async (like IABOT runs continuously, not inline).
+- **Clustering instability across runs** (Leiden is stochastic). → Fix random seed; report only stable clusters or version clusters via `graph_generation`.
+
+### 5. Complexity / effort
+- **Low–Medium.** Broken-link + orphan detection = straightforward traversals over the existing store (Low). Leiden clustering + tag co-occurrence largely **reuse existing code-graph clustering machinery** applied to the wikilink subgraph (Low–Medium — main work is subgraph construction, MOC exclusion, and labeling). Doc-health stats + the new command/MCP tool surface = Low. Estimate: a few days to ~1 week; mostly integration and the orphan-exclusion heuristics, not new algorithms.
+
+---
+
+## Established vs speculative (summary)
+- **Established / directly citable:** Generative Agents retrieval formula (α=1; decay 0.995/hr; reflection threshold 150); MemoryBank `R=e^{-t/S}`; Leiden's connected-community guarantee + Louvain 16% disconnected; Adamic–Adar as best topological link predictor; Wikipedia orphan 14.7% / +6.5% de-orphaning; SKOS/PROV-O relation semantics; Paulheim refinement = completion + error detection.
+- **Speculative / NestWeaver-specific heuristics needing validation:** the exact promotion gates ("≥3 inbound links + 14 days"); mapping interaction event-kinds to specific `S` increments; using PageRank as the importance proxy in place of LLM poignancy; MOC-exclusion heuristics for orphan detection. These are *grounded by analogy* to the cited work but are design choices to be tuned empirically, not results from the literature.
+- **`[UNVERIFIED]`:** Ebbinghaus 1885 primary text (cited via MemoryBank); Obsidian/Foam/Dataview specific feature claims (ecosystem knowledge, not retrieved this session).

--- a/scratch/rfc-implementation-plan/research/agentic-orchestration-guardrails-cache.md
+++ b/scratch/rfc-implementation-plan/research/agentic-orchestration-guardrails-cache.md
@@ -1,0 +1,484 @@
+# Research Foundation — Agentic Orchestration, Guardrails & Response Cache
+
+Research backing for four NestWeaver RFC features. NestWeaver is a Rust code-and-notes
+graph intelligence tool: embedded graph DB (LadybugDB), PPR + BM25 + vectors fused via
+RRF, MCP server consumed by short-lived AI coding-agent processes (Claude Code, Cursor,
+Codex). No always-on daemon.
+
+Conventions in this doc:
+- **[EVIDENCE]** = backed by a cited, retrieved source (paper/spec/official docs).
+- **[PRACTICE]** = common engineering practice, not a specific cited result.
+- **[UNVERIFIED]** = claim I could not confirm against a primary source.
+- All URLs below were retrieved during this research (May 2026).
+
+---
+
+## FEATURE 10 — `investigate` bundle primitive
+
+One MCP call returns an "architectural map" for a free-text topic by composing existing
+primitives (hybrid search → group by symbol/note → fetch neighbors → cluster → return top
+clusters as "domains" + highest-PageRank node per cluster as "entry points"), with a
+`bundle_id` + 24h TTL and follow-up `investigate_expand` / `investigate_hydrate`. Goal:
+collapse the 6–12 round-trip "orient me on X" pattern.
+
+### (1) Research foundation
+
+- **RAG / retrieval-augmented generation** — Lewis, Perez, Piktus et al. (Facebook AI / UCL),
+  NeurIPS 2020. "Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks."
+  https://arxiv.org/abs/2005.11401 (PDF: https://arxiv.org/pdf/2005.11401).
+  [EVIDENCE] Establishes the parametric-LLM + non-parametric-retrieval pattern; result of
+  record: RAG generates "more specific, diverse and factual language" than parametric-only
+  baselines. Grounds the basic premise that a graph-backed retrieval bundle improves agent
+  factuality vs. asking the model to recall architecture from memory.
+
+- **Lost in the Middle** — Liu, Lin, Hewitt, Paranjape, Bevilacqua, Petroni, Liang
+  (Stanford et al.), TACL 2024 (arXiv July 2023). https://arxiv.org/abs/2307.03172
+  (ACL: https://aclanthology.org/2024.tacl-1.9/). [EVIDENCE] Key result: model accuracy is
+  highest when relevant info is at the **beginning or end** of context and degrades sharply
+  when it sits in the middle — even for long-context models. **This is the core motivation
+  for tiered bundling**: return a small, ranked, front-loaded "domains + entry points"
+  summary rather than dumping a large flat result. Put the most important nodes first/last.
+
+- **HyDE (Hypothetical Document Embeddings)** — Gao, Ma, Lin, Callan, ACL 2023.
+  "Precise Zero-Shot Dense Retrieval without Relevance Labels."
+  https://arxiv.org/abs/2212.10496 (ACL: https://aclanthology.org/2023.acl-long.99/).
+  [EVIDENCE] LLM generates a hypothetical answer doc, which is embedded and used as the
+  retrieval query; outperforms unsupervised Contriever zero-shot. Relevant as an *optional*
+  query-expansion step for free-text topics that don't lexically match symbol names.
+
+- **Agentic RAG survey** — Singh et al., "Agentic Retrieval-Augmented Generation: A Survey
+  on Agentic RAG," 2025. https://arxiv.org/html/2501.09136v4 (companion repo:
+  https://github.com/asinghcsu/AgenticRAG-Survey). [EVIDENCE] Names four agentic design
+  patterns (Reflection, Planning, Tool Use, Multi-Agent) and frames **planning / query
+  decomposition** as decomposing a complex task into manageable subtasks for multi-hop
+  retrieval. The `investigate` bundle is essentially *server-side* planning: it does the
+  decomposition (search → group → expand → cluster) once so the agent doesn't have to drive
+  6–12 hops. MA-RAG (https://arxiv.org/abs/2505.20096) is a concrete instance of a Planner
+  agent that disambiguates and decomposes queries.
+
+- **MCP tools spec (2025-06-18)** — official. https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+  [EVIDENCE] Spec-confirmed fields that the bundle should use:
+  - Tool results carry `content` (unstructured: text/image/audio/`resource_link`/embedded
+    `resource`) and an optional `structuredContent` JSON object (with optional `outputSchema`
+    for validation). For backwards compat, a tool returning `structuredContent` SHOULD also
+    serialize the JSON into a TextContent block.
+  - `resource_link` content type lets a tool return a URI pointer (e.g.
+    `file:///project/src/main.rs`) instead of inlining a whole file — ideal for "entry points"
+    that the agent can hydrate later.
+  - Content items support `annotations` with `audience` (`user`/`assistant`) and `priority`
+    (0–1) and `lastModified` — usable to rank/flag the most important bundle items.
+  - `tools/list` (not `tools/call`) is the spec's paginated operation via opaque `cursor` /
+    `nextCursor`. **The spec does NOT define cursor pagination for `tools/call` results** —
+    so `investigate`'s paging must be an application-level convention (a `bundle_id` + page
+    token in args), which is exactly the proposed design.
+
+### (2) Prior art / projects + tradeoffs
+
+- **Aider repo-map** (https://aider.chat/docs/repomap.html) — builds a ranked, token-budgeted
+  map of a repo using a graph-ranking algorithm over symbols (PageRank-like) to pick the most
+  important definitions within a token budget. [EVIDENCE-of-pattern, from project docs]
+  Closest prior art to NestWeaver's own `repo-map`; validates "PageRank-rank + token-budget"
+  as the right shape for orientation. Tradeoff: Aider's map is whole-repo, not topic-scoped;
+  `investigate` adds topic seeding via hybrid search.
+- **GraphRAG (Microsoft)** — community detection over an entity graph, summarize each
+  community, answer global queries from community summaries
+  (https://github.com/microsoft/graphrag). [EVIDENCE-of-pattern] Directly mirrors the
+  proposed "cluster → top clusters as domains" step. Tradeoff: GraphRAG precomputes
+  community summaries with LLM calls (expensive, batch); NestWeaver can cluster on the
+  existing graph cheaply and label clusters by highest-PageRank node rather than LLM summary.
+- **MCP cursor pagination** (https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/pagination)
+  — opaque-cursor model; server decides page size. Good template for `investigate_expand`'s
+  paging even though it's app-level for tool *results*.
+
+Tradeoff summary: composing existing primitives server-side (bundle) trades a small amount
+of server complexity (state for `bundle_id`, TTL) for a large reduction in round-trips and
+in mid-context dilution. The alternative — keeping primitives separate and letting the agent
+orchestrate — is simpler to build but is exactly the 6–12-hop problem the RFC targets.
+
+### (3) Recommended approach for NestWeaver
+
+- Compose, don't reinvent: `investigate(topic)` = hybrid search (RRF over BM25+vector+PPR,
+  already in `nestweaver-store`) → group hits by symbol/note → expand 1-hop neighbors over
+  weighted edges (CALLS 1.0 / IMPORTS 0.8 / USES 0.5 / ACCESSES 0.4, already defined) →
+  cluster (reuse `clusters.json` / community detection) → return top-K clusters as "domains",
+  each labeled by its highest-PageRank node ("entry point"). Grounded in GraphRAG's
+  community-summary pattern and Aider's PageRank-ranked map.
+- **Token budget is a hard requirement, not a nicety**, justified by *Lost in the Middle*:
+  return a tight, ranked summary (domains + entry points first), use MCP `resource_link` for
+  files/symbols so bodies are *hydrated on demand* via `investigate_hydrate`, and front-load
+  the highest-`priority`-annotated items. Default to a small budget (e.g. ~1.5–2K tokens for
+  the orientation layer) and expand only on request.
+- Persist bundle state (`bundle_id` → seed set, ranked domains, page cursors) **on disk** in
+  the DB with a 24h TTL — consistent with the daemon-less constraint (see Feature 16). The
+  follow-ups `investigate_expand`/`investigate_hydrate` reference the `bundle_id` and a page
+  token; this is the app-level paging the MCP spec leaves to the implementation.
+- Optionally gate a HyDE-style query expansion behind a flag for low-lexical-overlap topics;
+  it adds an LLM call NestWeaver doesn't otherwise need, so keep it off by default.
+
+### (4) Pitfalls / failure modes + mitigations
+
+- **Over-bundling** (returning too much, re-creating the mid-context problem). Mitigation:
+  strict token budget; tiered hydration; cap domains/entry-points (e.g. top 5–7 domains).
+  [EVIDENCE: Lost in the Middle].
+- **Stale `bundle_id`** after files change within the 24h TTL → expand returns nodes that no
+  longer exist. Mitigation: tag bundle with the `graph_generation` counter / db_mtime bucket
+  (NestWeaver already has a `graph_generation` counter per commit d9bc01d); invalidate or
+  flag the bundle when generation advances. Shares machinery with Feature 16.
+- **Cluster instability** (small graph perturbations reshuffle community labels between
+  calls → confusing "domains"). Mitigation: deterministic seeds; reuse persisted
+  `clusters.json` rather than re-clustering per call; only recluster on graph-generation bump.
+- **Topic with no good lexical/semantic seed** → empty or noise domains. Mitigation: fall
+  back to PPR from nearest matches; surface a low-confidence flag; optional HyDE expansion.
+
+### (5) Complexity / effort
+
+Medium-high. Most sub-steps already exist (hybrid search, neighbors, clustering, PageRank);
+the new work is (a) the composition/ranking layer, (b) token-budgeted serialization into MCP
+`structuredContent` + `resource_link`, and (c) disk-resident `bundle_id`/TTL/paging state.
+The state layer overlaps with Feature 16's cache, so build them together.
+
+---
+
+## FEATURE 14 — Subagent PreToolUse hook for guidance injection
+
+A hook on the Task/Agent (subagent-spawning) tool that runs a NestWeaver CLI command to
+inject dynamic guidance into a spawned subagent's prompt, so guidance lives in one place
+(NestWeaver) instead of stale per-runtime instruction files.
+
+### (1) Research foundation
+
+- **Claude Code hooks reference** — official Anthropic docs. https://code.claude.com/docs/en/hooks
+  [EVIDENCE] Verified PreToolUse mechanics directly relevant to this feature:
+  - PreToolUse hooks receive JSON on stdin (command hooks) including `session_id`,
+    `transcript_path`, `cwd`, `permission_mode`, `hook_event_name` (`"PreToolUse"`),
+    `tool_name`, and `tool_input` (the tool's arguments).
+  - Output is via a `hookSpecificOutput` object. Relevant fields:
+    `hookEventName: "PreToolUse"`, `permissionDecision` (`allow`/`deny`/`ask`/`defer`),
+    `permissionDecisionReason`, **`additionalContext`** (string injected into Claude's
+    context at the tool-result point), `updatedToolInput` (object replacing tool input
+    before execution), and `permissionRules`.
+  - Hook `type` can be **`"command"`** (run a shell script — i.e. a NestWeaver CLI call),
+    plus `http`, `mcp_tool`, `prompt`, `agent`.
+  - The **Task/subagent/Agent tools appear as regular tools in PreToolUse**, matchable like
+    any other (`"matcher": "Task"`); there is also a separate `SubagentStart` event.
+  - Optional `if` field (permission-rule syntax) narrows when the hook fires.
+  - Exit 0 → stdout parsed for JSON; exit 2 → blocking error, stderr fed to Claude;
+    other exit codes → non-blocking, stderr to transcript.
+  This confirms the proposed design is mechanically supported: a `PreToolUse` hook matching
+  `Task` runs `nestweaver <something>` and emits `additionalContext` to inject guidance.
+
+- **Instruction Hierarchy** — Wallace et al. (OpenAI), 2024. https://arxiv.org/abs/2404.13208
+  (OpenAI post: https://openai.com/index/the-instruction-hierarchy/). [EVIDENCE] Models
+  trained with hierarchy awareness are more robust to lower-privilege instructions
+  overriding higher ones. Relevant because injected guidance is *system/developer-level*
+  context the subagent should privilege — but see the failure-mode paper below.
+
+### (2) Prior art / projects + tradeoffs
+
+- **PostToolUse `additionalContext` pattern** — community hooks return `additionalContext`
+  to feed the agent post-execution (https://github.com/disler/claude-code-hooks-mastery).
+  [EVIDENCE-of-pattern] Confirms dynamic injection is an established, in-the-wild use.
+- **CLAUDE.md / per-runtime instruction files** — the status quo the RFC replaces. Tradeoff:
+  static files are simple and universally read, but go stale and are duplicated per tool
+  runtime; a hook computing guidance from the live index is single-source-of-truth but
+  Claude-Code-specific (other runtimes — Cursor, Codex — don't share the same hook schema).
+- **MCP `mcp_tool` hook type** (from the hooks reference) — lets the hook call an MCP tool
+  instead of a CLI. NestWeaver already ships an MCP server, so the guidance could be an MCP
+  tool rather than a bare CLI invocation — fewer process spawns, reuses the open DB handle.
+
+### (3) Recommended approach for NestWeaver
+
+- Implement guidance generation as a small, fast NestWeaver subcommand (e.g.
+  `nestweaver subagent-guidance`) that reads `tool_input`/`cwd` from stdin and emits JSON
+  with `hookSpecificOutput.additionalContext`. Keep `permissionDecision: "allow"` (this is
+  enrichment, not a gate).
+- Prefer the **`mcp_tool` hook type** over `command` if the per-spawn cost of booting the
+  CLI + opening the DB is non-trivial — it reuses the already-running MCP server and the open
+  graph. (NestWeaver agents are short-lived, so a cold CLI per Task spawn could be wasteful.)
+- Ship the hook config as part of `nestweaver setup claude-code` so it's installed
+  automatically; document the JSON contract so other runtimes can adopt equivalents.
+- Treat injected guidance as *developer-priority* instructions and phrase them as such
+  (consistent with Instruction Hierarchy), but do not assume they're inviolable (next point).
+
+### (4) Pitfalls / failure modes + mitigations
+
+- **Guidance not actually obeyed.** [EVIDENCE] "Control Illusion: The Failure of Instruction
+  Hierarchies in LLMs" — Geng et al., 2025 (https://arxiv.org/abs/2502.15851 /
+  https://arxiv.org/html/2502.15851v1) — finds across six SOTA models that system/user
+  separation "fails to establish a reliable instruction hierarchy" and that social framings
+  (authority/expertise/consensus) influence behavior *more* than role hierarchy. Mitigation:
+  don't rely on injection alone for correctness-critical behavior; phrase guidance with
+  authority/consensus framing; keep guidance short and front-loaded; verify outcomes where it
+  matters rather than assuming compliance.
+- **Hook latency on every Task spawn.** Mitigation: cache guidance (Feature 16), keep the
+  command sub-50ms, prefer `mcp_tool` over cold CLI; use the `if` matcher to scope.
+- **Runtime lock-in.** The hook schema is Claude-Code-specific. Mitigation: keep guidance
+  generation in a runtime-neutral CLI/MCP tool; the hook is just one adapter.
+- **Injection-of-injections / trust.** `additionalContext` is trusted context fed to the
+  subagent; if the guidance is derived from indexed *user content* (notes, code comments),
+  it could carry adversarial text. Mitigation: derive guidance from NestWeaver-authored
+  templates + structured graph facts, not free-text note bodies; sanitize.
+- **Silent failure.** [EVIDENCE: hooks ref] A non-2 error exit is non-blocking and only goes
+  to the transcript — guidance could silently vanish. Mitigation: monitor/log; fail loud in
+  CI for the setup path.
+
+### (5) Complexity / effort
+
+Low-medium. The hook contract is small and well-documented; the work is a fast guidance
+subcommand + `setup` wiring + tests. Main risk is latency, mitigated by Feature 16 and/or
+the `mcp_tool` hook type.
+
+---
+
+## FEATURE 15 — Hard-rule guidance in generated agent guides
+
+Bake explicit behavioral rules ("if you reference a file path, read it first"; "for 'every X'
+questions, enumerate then verify") at the top of generated guides with a **HARD RULE:**
+prefix, versioned.
+
+### (1) Research foundation — does explicit rule-stating actually help?
+
+- **Chain-of-Verification (CoVe)** — Dhuliawala, Komeili, Xu, Raileanu, Li, Celikyilmaz,
+  Weston (Meta AI), ACL 2024 Findings (arXiv 2309.11495). https://arxiv.org/abs/2309.11495
+  (ACL: https://aclanthology.org/2024.findings-acl.212/). [EVIDENCE] Method: draft → plan
+  verification questions → answer them independently → produce verified final response.
+  Result: **decreases hallucinations** across list-based (Wikidata), closed-book MultiSpanQA,
+  and longform generation. This is the *direct* evidence base for the "enumerate then verify"
+  hard rule — the RFC's rule is a lightweight, prompt-level instantiation of CoVe's
+  draft-then-verify loop, and CoVe shows the loop measurably reduces fabrication.
+
+- **Instruction Hierarchy** — Wallace et al. (OpenAI) 2024, https://arxiv.org/abs/2404.13208.
+  [EVIDENCE] Supports placing rules at *developer/system* priority and shows hierarchy-aware
+  training improves adherence (up to ~63% better attack resistance reported in coverage),
+  motivating the "top-positioned, prefixed, privileged" placement.
+
+- **Counter-evidence (must be stated honestly):** "Control Illusion: The Failure of
+  Instruction Hierarchies in LLMs," Geng et al. 2025 (https://arxiv.org/abs/2502.15851).
+  [EVIDENCE] Models "struggle with consistent instruction prioritization, even for simple
+  formatting conflicts"; system/user separation alone is not a reliable hierarchy. Implication
+  for Feature 15: **hard rules help but are not guaranteed-obeyed** — they reduce, not
+  eliminate, the failure modes. Evidence is "directionally supportive," not "rules guarantee
+  behavior."
+
+- **Prompt-injection robustness** — "Evaluating the Instruction-Following Robustness of LLMs
+  to Prompt Injection," 2023 (https://arxiv.org/pdf/2308.10819). [EVIDENCE] Instruction
+  following is non-deterministic and bypassable; reinforces that rules are probabilistic.
+
+### (2) Prior art / projects + tradeoffs
+
+- **NeMo Guardrails** (NVIDIA) — programmable rails (input/dialog/retrieval/execution/output)
+  via the Colang DSL; Apache-2.0; v0.20.0 (Jan 2026). https://github.com/NVIDIA-NeMo/Guardrails,
+  https://docs.nvidia.com/nemo/guardrails/. [EVIDENCE] Heavyweight, runtime-enforced rails —
+  the opposite end of the spectrum from prompt-level rules: stronger enforcement, far more
+  infra. Tradeoff: NestWeaver's hard rules are prompt-text only (cheap, portable, no
+  runtime), accepting weaker guarantees.
+- **Guardrails AI** (https://guardrailsai.com) — validators/output-schema enforcement.
+  [EVIDENCE-of-existence] Same tradeoff axis: validation > instruction text in strength and cost.
+- **OWASP LLM Prompt Injection Prevention Cheat Sheet** — recommends instruction hierarchy +
+  delimiters + defense-in-depth (https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html).
+  [EVIDENCE] Supports XML/delimiter framing for rules and explicitly says rules are *one
+  layer*, not a complete defense.
+- **Cursor rules / AGENTS.md / Claude Code skills** — the formats NestWeaver's
+  `generate-guide` already targets. Versioned, top-positioned rules fit these conventions.
+
+### (3) Recommended approach for NestWeaver
+
+- Ship a small, **versioned** rule set at the top of every generated guide with a clear
+  `**HARD RULE:**` prefix and developer-authority framing (Instruction Hierarchy + the
+  "social framing beats role" finding from Geng et al. both argue for authoritative phrasing).
+- Make the "enumerate then verify" rule explicit and CoVe-shaped (enumerate candidates →
+  verify each against the index before answering) since that's the rule with the strongest
+  empirical backing.
+- Keep rules **few and high-value** — every rule competes for the front-of-context slot that
+  *Lost in the Middle* shows is scarce and high-leverage. Don't dilute.
+- Version the rule block (e.g. `rules_version: N` in front matter) so guides can be diffed
+  and regenerated; tie to NestWeaver release.
+- Frame honestly in the RFC: hard rules are **evidence-backed as helpful (CoVe, Instruction
+  Hierarchy) but not as guaranteed (Geng et al., 2308.10819)** — they're a cheap, portable
+  reliability boost, not enforcement.
+
+### (4) Pitfalls / failure modes + mitigations
+
+- **Guardrail brittleness / non-compliance** [EVIDENCE: 2502.15851, 2308.10819]. Mitigation:
+  treat rules as defense-in-depth (OWASP); pair correctness-critical rules with actual
+  verification (e.g. a hook or tool that enforces "file read before reference").
+- **Rule bloat → mid-context dilution** [EVIDENCE: Lost in the Middle]. Mitigation: cap rule
+  count; keep at very top; measure.
+- **Staleness across runtimes** — same single-source problem Feature 14 addresses. Mitigation:
+  generate rules from one versioned source in NestWeaver, regenerate all guide formats together.
+- **Over-trust by maintainers** (assuming the rule == the behavior). Mitigation: document the
+  probabilistic nature; don't gate destructive actions on a rule alone.
+
+### (5) Complexity / effort
+
+Low. It's templated text + a version field in the existing `generate-guide` pipeline. The
+intellectual work is rule selection and honest framing, not engineering.
+
+---
+
+## FEATURE 16 — Response cache with watcher invalidation
+
+ZSTD-compressed, 24h-TTL cache inside the DB, keyed by `(tool, normalized_args, db_mtime
+bucket)`; invalidated when a file under the query scope changes (10s tick to absorb
+editor save-storms); LRU eviction at a size cap. Constraint: no daemon, agents are
+short-lived → cache must be disk-resident.
+
+### (1) Research foundation
+
+- **RFC 9111 — HTTP Caching** — IETF, 2022. https://www.rfc-editor.org/rfc/rfc9111.html
+  [EVIDENCE] Canonical semantics for the *bypass/default* model NestWeaver should mirror:
+  freshness lifetime (TTL ≈ `max-age`), staleness, revalidation, and the rule that a stale
+  response MUST NOT be reused without successful validation. The directive model (request can
+  ask `no-cache`/`no-store` to bypass; response carries freshness) is the right mental model
+  for a `--no-cache` flag and a default-on cache. Also: "a cache MUST ignore unrecognized
+  cache directives" → forward-compatible cache metadata.
+
+- **Zstandard (zstd)** — Facebook/Meta. https://github.com/facebook/zstd,
+  https://engineering.fb.com/2016/08/31/core-infra/smaller-and-faster-data-compression-with-zstandard/
+  [EVIDENCE] Configurable levels (negative/fast → 22/max); at default it matches zlib's ratio
+  with much higher compress+decompress speed; **decompression speed is roughly constant
+  across levels** (LZ-family property) — so a higher compression level costs write time but
+  not read time, which is ideal for a write-once/read-many response cache. A **trained
+  dictionary** mode exists for many-small-records workloads (cache entries are small,
+  similar JSON blobs → a shared dictionary materially improves ratio). Cite for the ZSTD choice.
+
+- **Build-system content-addressed invalidation (Bazel/Buck)** — prior art for scope-based
+  invalidation. Bazel: https://queue.acm.org/detail.cfm?id=3287302,
+  https://www.buildbuddy.io/blog/bazels-remote-caching-and-remote-execution-explained/.
+  [EVIDENCE] Action cache (AC) + content-addressable storage (CAS): an action's result is
+  keyed by a digest over its *immediate inputs*; Buck keys actions by digests of dependency
+  actions (no incremental state needed). Direct analogy: NestWeaver should key a cached
+  response by a digest over the *files in the query's scope* (its inputs), so any in-scope
+  change changes the key — the build-systems' proven approach to scope-based invalidation.
+
+- **SQLite-as-cache patterns** — [EVIDENCE-of-pattern] caching in SQLite is often faster than
+  many small filesystem files (https://www.sqlite.org/fasterthanfs.html is the canonical
+  reference for the "faster than the filesystem" claim); community libraries combine SQLite +
+  LRU + TTL (e.g. https://github.com/jkelin/cache-sqlite-lru-ttl, https://pypi.org/project/disklru/).
+  SQLite's *own* page cache uses LRU eviction. Validates a single-file, disk-resident cache
+  with LRU+TTL inside the DB — exactly the daemon-less requirement.
+
+### (2) Prior art / projects + tradeoffs
+
+- **Bazel/Buck remote+disk cache** — content/input-digest keying, independent eviction of AC
+  vs CAS, fallback to recompute on miss/error (https://queue.acm.org/detail.cfm?id=3287302).
+  Tradeoff: their digests cover full transitive inputs; NestWeaver's "scope" is fuzzier (a
+  query touches an unbounded neighbor set), so input-set computation is the hard part (see
+  pitfalls).
+- **HTTP `Cache-Control`/`ETag` (RFC 9111)** — bypass directives + validators. Tradeoff:
+  full revalidation semantics are overkill for a local single-writer cache; borrow TTL +
+  bypass + "don't serve stale unvalidated," skip conditional-request machinery.
+- **zstd dictionary training** — strong for small homogeneous entries; tradeoff is dictionary
+  lifecycle (must be regenerated as response shapes drift; version it).
+- **The cache-invalidation aphorism** — "There are only two hard things in Computer Science:
+  cache invalidation and naming things" (Phil Karlton; widely attributed,
+  https://www.karlton.org/2017/12/naming-things-hard/). [EVIDENCE-of-attribution] Frames why
+  the invalidation design (not the storage) is the real risk here.
+
+### (3) Recommended approach for NestWeaver
+
+- **Disk-resident is mandatory** (no daemon; agents are short-lived). Store the cache as a
+  table/namespace inside the LadybugDB file (or a sibling sidecar like the existing
+  `.pagerank.json`, `.summaries.json`, etc.), so a fresh short-lived process gets warm hits.
+  This is the single most important correctness constraint and it rules out any in-memory-only
+  scheme. [EVIDENCE: SQLite-as-cache patterns show disk-resident local caches are viable/fast.]
+- **Key = `(tool, normalized_args, db_generation/db_mtime bucket)`**, plus a digest over the
+  in-scope file set (Bazel/Buck input-digest analogy). NestWeaver already has a
+  `graph_generation` counter (commit d9bc01d) and `<db>.filemeta.json` (per-file mtime/size/
+  hash) — **reuse both**: `graph_generation` is a cheap coarse invalidator (any index change
+  bumps it), and `filemeta` hashes give precise scope-level invalidation. Prefer hash-bucketed
+  keys over raw mtime where possible (mtime granularity/clock-skew issues).
+- **Args normalization** is essential for hit rate: canonicalize ordering, defaults, casing,
+  path normalization before hashing (cache-key normalization is standard practice; getting it
+  wrong = silent misses or, worse, collisions).
+- **TTL = 24h** as an upper bound (RFC 9111 freshness model: never serve stale-past-TTL
+  without revalidation — here "revalidation" = recompute on generation mismatch).
+- **ZSTD at a mid level** (decompression is level-independent → favor ratio); consider a
+  **trained dictionary** since entries are small, similar JSON. Version the dictionary.
+- **Invalidation via the existing watcher** (commit e3d14be `--watch`, d9bc01d watcher
+  shared-store): on file change, advance `graph_generation` and/or evict cache rows whose
+  scope-digest includes the changed file; **batch on a ~10s tick** to absorb editor
+  save-storms (debounced, matching the existing watch debounce design).
+- **LRU + size cap**: evict least-recently-used entries when over the byte cap; track
+  `last_accessed`. Combine with TTL (TTL = correctness bound, LRU = space bound), mirroring
+  `cache-sqlite-lru-ttl`.
+- **Bypass**: `--no-cache` flag and write-skip for tools whose results must always be fresh,
+  mirroring RFC 9111's request directives.
+
+### (4) Pitfalls / failure modes + mitigations
+
+- **Stale cache without a daemon** — the headline risk. A short-lived agent process won't see
+  another process's mid-query writes, and there's no long-running invalidator. Mitigations:
+  (a) make `graph_generation` part of the key so any reindex/`--watch` tick automatically
+  misses stale entries; (b) check generation at read time and treat mismatch as a miss;
+  (c) rely on the watcher to advance generation/evict on change. **Correctness rests on the
+  key, not on a background process** — this is the design's load-bearing decision.
+- **Scope-invalidation misses** (a query's result depends on a file not counted in its
+  "scope," e.g. a transitively-imported file or a deleted symbol). [EVIDENCE: Bazel/Buck show
+  you must capture the *full* input set, including transitive deps.] Mitigations: define scope
+  conservatively (over-include neighbors actually traversed); fold `graph_generation` in as a
+  coarse safety net so a missed precise dependency still gets caught by any global index bump;
+  prefer false-evict over false-hit.
+- **mtime granularity / clock skew / mtime-unchanged edits** (same-size, same-second writes).
+  Mitigation: use `filemeta.json` content hashes, not bare mtime, for the scope digest;
+  "mtime bucket" only as a coarse cheap pre-filter.
+- **Save-storm thrash** (editor autosave → constant eviction). Mitigation: 10s debounce tick
+  (as specified); coalesce.
+- **Compression CPU on the write path.** Mitigation: zstd's level/speed knob; only cache
+  responses above a size threshold; async/lazy compression if needed.
+- **Cache poisoning via key collision** from bad normalization. Mitigation: include a schema/
+  version byte in the key; collision-resistant hash over fully-normalized args; unit tests on
+  normalization.
+- **Unbounded growth.** Mitigation: hard byte cap + LRU; periodic TTL sweep.
+
+### (5) Complexity / effort
+
+High — and the highest-risk of the four. Storage/compression/LRU/TTL are routine; **correct
+scope computation + daemon-less invalidation are the hard, bug-prone parts** ("cache
+invalidation" aphorism applies literally). Strongly leverage existing infra
+(`graph_generation`, `filemeta.json`, the `--watch` watcher) rather than building new
+change-detection. Build the disk-resident state layer once and share it with Feature 10's
+`bundle_id` store.
+
+---
+
+## Cross-feature notes
+
+- Features 10 and 16 share a **disk-resident state/cache layer** keyed on
+  `graph_generation` — build once.
+- Features 14 and 15 share a **single-source, versioned guidance** concern; 14 is the dynamic
+  (hook) channel, 15 is the static (generated-guide) channel. Same content source, two adapters.
+- *Lost in the Middle* (token budgeting / front-loading) is the connective tissue across 10
+  and 15: front-of-context space is scarce and high-leverage, so both bundle output and hard
+  rules must be tight and ranked.
+- Honest framing for the RFC: guidance/rule features (14, 15) are **evidence-backed as
+  helpful but probabilistic** (CoVe + Instruction Hierarchy support them; Geng et al. 2025 and
+  2308.10819 show they are not guaranteed-obeyed). Retrieval/cache features (10, 16) rest on
+  firmer, more deterministic ground.
+
+## Source index (all retrieved May 2026)
+- Lewis et al. 2020, RAG — https://arxiv.org/abs/2005.11401
+- Liu et al. 2023/2024, Lost in the Middle — https://arxiv.org/abs/2307.03172 · https://aclanthology.org/2024.tacl-1.9/
+- Gao et al. 2023, HyDE — https://arxiv.org/abs/2212.10496 · https://aclanthology.org/2023.acl-long.99/
+- Singh et al. 2025, Agentic RAG survey — https://arxiv.org/html/2501.09136v4 · https://github.com/asinghcsu/AgenticRAG-Survey
+- MA-RAG 2025 — https://arxiv.org/abs/2505.20096
+- MCP tools spec 2025-06-18 — https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+- MCP pagination — https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/pagination
+- Aider repo-map — https://aider.chat/docs/repomap.html
+- Microsoft GraphRAG — https://github.com/microsoft/graphrag
+- Claude Code hooks reference — https://code.claude.com/docs/en/hooks
+- claude-code-hooks-mastery — https://github.com/disler/claude-code-hooks-mastery
+- Wallace et al. 2024, Instruction Hierarchy — https://arxiv.org/abs/2404.13208 · https://openai.com/index/the-instruction-hierarchy/
+- Geng et al. 2025, Control Illusion (IH failure) — https://arxiv.org/abs/2502.15851
+- Instruction-Following Robustness to Prompt Injection 2023 — https://arxiv.org/pdf/2308.10819
+- Dhuliawala et al. 2024, Chain-of-Verification — https://arxiv.org/abs/2309.11495 · https://aclanthology.org/2024.findings-acl.212/
+- NeMo Guardrails — https://github.com/NVIDIA-NeMo/Guardrails · https://docs.nvidia.com/nemo/guardrails/
+- Guardrails AI — https://guardrailsai.com
+- OWASP LLM Prompt Injection Prevention — https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html
+- RFC 9111 HTTP Caching — https://www.rfc-editor.org/rfc/rfc9111.html
+- Zstandard — https://github.com/facebook/zstd · https://engineering.fb.com/2016/08/31/core-infra/smaller-and-faster-data-compression-with-zstandard/
+- Bazel remote cache (ACM Queue) — https://queue.acm.org/detail.cfm?id=3287302
+- BuildBuddy on Bazel caching — https://www.buildbuddy.io/blog/bazels-remote-caching-and-remote-execution-explained/
+- SQLite faster-than-filesystem — https://www.sqlite.org/fasterthanfs.html
+- cache-sqlite-lru-ttl — https://github.com/jkelin/cache-sqlite-lru-ttl
+- "Naming things / cache invalidation" (Karlton) — https://www.karlton.org/2017/12/naming-things-hard/

--- a/scratch/rfc-implementation-plan/research/api-contract-graphs.md
+++ b/scratch/rfc-implementation-plan/research/api-contract-graphs.md
@@ -1,0 +1,229 @@
+# RFC Research Foundation — Framework-Aware Auto-Linking via API Contracts
+
+**Feature:** Detect and parse OpenAPI/Swagger, `*.proto` (gRPC), and `*.graphql` schemas during indexing; create `Contract` nodes with stable UIDs; emit `IMPLEMENTS_CONTRACT` edges from server handlers (same repo) and `CONSUMES_CONTRACT` edges from client callers (other repos). Goal: graph mirrors real production wire topology so cross-repo impact analysis works (e.g. "what breaks if I change `PUT /v1/approvals/{id}`").
+
+**v1 target languages:** TypeScript (NestJS/Express), Java (Spring), Go (chi/gorilla mux).
+
+**Author:** research agent · **Date retrieved:** 2026-05-29 · all URLs accessed 2026-05-29.
+
+> Scope note: This document is a *research foundation*, not a design spec. Claims are grounded in retrieved sources; anything not directly verified is marked `[UNVERIFIED]`. Crate versions/licenses verified against the live crates.io JSON API and docs.rs on 2026-05-29.
+
+---
+
+## 1. Research Foundation
+
+### 1.1 Consumer-driven contracts (the conceptual model NestWeaver should mirror)
+
+The conceptual spine of this feature is the **provider contract / consumer contract** distinction from Ian Robinson's "Consumer-Driven Contracts: A Service Evolution Pattern" (Ian Robinson, on martinfowler.com, **published 2006-06-12**; retrieved <https://martinfowler.com/articles/consumerDrivenContracts.html>). The article defines three contract types that map cleanly onto our edge model:
+
+- **Provider contract** — "a service provider's business function capabilities … the set of exportable elements necessary to support that functionality." Singular, authoritative, closed. → In NestWeaver this is the **`Contract` node**, derived from the OpenAPI/proto/GraphQL spec OR from the handler that defines the route.
+- **Consumer contract** — captures one consumer's expectations of a provider. Open, incomplete, *multiple* (one per consumer), non-authoritative. → This is the **`CONSUMES_CONTRACT` edge** from a client caller.
+- **Consumer-driven contract** — the union of all consumer expectations, derived back into a provider-shaped contract.
+
+The key insight we inherit: a provider may expose a large surface, but the *actually-coupled* surface is the subset consumers reference. NestWeaver's graph can compute this directly (which `Contract` nodes have ≥1 `CONSUMES_CONTRACT` edge) — something neither static codegen nor a raw OpenAPI file gives you.
+
+**Pact** (consumer-driven contract *testing*; docs <https://docs.pact.io/> and <https://docs.pact.io/getting_started/how_pact_works>) operationalizes this at *test time*: the consumer test runs against a Pact mock, Pact records the interactions into a JSON contract, publishes it to a **Pact Broker**, and the provider replays those requests in CI to verify it still satisfies "at least the data described in the minimal expected response." Relevance to us: Pact's broker is essentially a *runtime/test-time* version of the cross-repo edge graph we want to build *statically*. Pact contracts are an authoritative, machine-readable source of consumer→provider edges where they exist — a high-confidence signal NestWeaver could ingest later, but they only exist if the team writes Pact tests.
+
+**Spring Cloud Contract** (Spring project page <https://spring.io/projects/spring-cloud-contract/>; Baeldung intro <https://www.baeldung.com/spring-cloud-contract>) is the JVM CDC tool: producer-side contracts in a Groovy/YAML DSL under `src/test/resources/contracts`, from which it generates provider verification tests and WireMock stubs that consumers reuse via Stub Runner. Relevance: another structured, parseable contract artifact, and confirms that in Java shops the "contract" frequently lives *outside* the OpenAPI file (in test DSLs). Our detector should not assume an OpenAPI doc is the only contract source.
+
+### 1.2 The specifications (authoritative UID + matching semantics)
+
+**OpenAPI Specification v3.1.0** (OpenAPI Initiative; retrieved <https://spec.openapis.org/oas/v3.1.0.html>):
+- **Path templating** is defined verbatim as "the usage of template expressions, delimited by curly braces `{}`, to mark a section of a URL path as replaceable using path parameters." → This is why the contract UID path segment is `{id}`-style, and why our confidence model must treat `{id}` (OpenAPI/Spring) vs `:id` (Express) as the *same* slot.
+- Path parameter values **cannot contain unescaped `/`, `?`, or `#`** (per RFC3986). → A `{path}` template slot matches exactly one path segment unless it's an explicit catch-all; useful for normalizing.
+- **`operationId`** is **case-sensitive** and **MUST be unique among all operations** in the document. → Best stable secondary key for HTTP contracts when present; but it is optional, so the primary UID must be derivable from `method + templated path`.
+- **No `basePath`** in 3.1 (that was OAS 2.0). 3.1 uses a **Server Object** with a `url`; empty/absent servers default to `/`; server URLs may be relative and support variable substitution; the path is appended to the expanded server URL. → Base-path handling is a real normalization burden (see §4).
+
+**gRPC / Protocol Buffers** (proto3 service naming; Buf "Files and packages" <https://buf.build/docs/reference/protobuf-files-and-packages/>; protobuf.dev style guide <https://protobuf.dev/programming-guides/style/>; Microcks gRPC conventions <https://microcks.io/documentation/references/artifacts/grpc-conventions/>):
+- The **package** defines the namespace; all elements (messages, enums, services) are prefixed with the fully-qualified package name.
+- The canonical wire/method identifier is **`package.ServiceName/MethodName`** (e.g. `io.github.microcks.grpc.hello.v1.HelloService/greeting`). This is also the literal HTTP/2 `:path` gRPC uses on the wire. → This is the *exact* string our `contract:grpc:...` UID should adopt; matching is unambiguous (no templating problem), which makes gRPC the *highest-confidence* contract type.
+- Convention: service definitions use a `Service` suffix; packages are lowercase and typically versioned (`.v1`).
+
+**GraphQL** — schema definition language (SDL): `type Query`, `type Mutation`, `type Subscription` root types; field names are the operation identifiers. No first-party "endpoint" concept — every GraphQL operation hits one HTTP endpoint (typically `POST /graphql`), so the meaningful contract unit is the **root field** (`Query.<field>`, `Mutation.<field>`), not a URL. (GraphQL spec is the authoritative source; the matching unit is the resolver field name, which is far harder to detect on the client side because clients send opaque query strings.) `[Partially UNVERIFIED — GraphQL spec text not fetched in this pass; treat GraphQL as a lower-priority v2 target.]`
+
+### 1.3 Academic / industrial work on static endpoint & cross-service extraction
+
+This is a well-studied problem; NestWeaver is not inventing the technique, only integrating it into a graph store.
+
+- **Schneider, Bakhtin, Li, Soldani, Brogi, Cerny, Scandariato, Taibi — "Comparison of Static Analysis Architecture Recovery Tools for Microservice Applications" (2024).** Preprint <https://arxiv.org/html/2412.08352v1>; journal version *Empirical Software Engineering*, Springer, <https://link.springer.com/article/10.1007/s10664-025-10686-2>. Compared 13 tools (9 executable). **Key empirical numbers for endpoint detection (Table 5c): RAD F1 = 0.79 (best), RAD-source 0.67, Code2DFD 0.66; several tools (MicroGraal, Prophet, ContextMap) scored 0.0.** Critical takeaway for our confidence model: even purpose-built academic tools top out around **F1 0.79 on REST endpoint extraction** — meaning our `IMPLEMENTS_CONTRACT` detection *will* miss and mis-fire, so the design must surface confidence and degrade gracefully rather than claim completeness. The paper also notes "basic architecture extraction can be achieved with high precision via simple parsing of deployment files," while deeper source analysis improves recall.
+
+- **Schneider & Scandariato — "Automatic extraction of security-rich dataflow diagrams for microservice applications written in Java" (Code2DFD)**, *Journal of Systems and Software*, 2023. ACM <https://dl.acm.org/doi/10.1016/j.jss.2023.111722>; tool repos <https://github.com/tuhh-softsec/code2DFD> and <https://github.com/M3SOulu/EMSE2025SAR-code2DFD>. Approach is **keyword detection in source with traceability back to the source location** (precision 0.94 / recall 0.88 on its own DFD dataset). Validates a pragmatic strategy: detect framework signatures (annotations, import names, call patterns) rather than attempting full semantic dataflow — directly applicable to our tree-sitter + query approach.
+
+- **Tomas Cerny et al. — Endpoint Dependency Matrix (EDM) / Data Dependency Matrix (DDM)** line of work on microservice dependency recovery via static analysis (e.g. "The Microservice Dependency Matrix", arXiv <https://arxiv.org/pdf/2309.02804>). Establishes the **endpoint-as-node, call-as-edge** matrix model that our `Contract` node + `CONSUMES_CONTRACT` edge directly implements. `[Author attribution per search synthesis; exact author list/year per-paper not individually fetched — UNVERIFIED in detail.]`
+
+- **"Microvision: Static analysis-based approach to visualizing microservices"** (arXiv <https://arxiv.org/pdf/2207.02974>) — AST-walk extraction of call graphs from microservice source. Confirms AST/tree-sitter walking + method-call recognition as the standard endpoint/caller extraction technique. `[Author/year not individually fetched — UNVERIFIED.]`
+
+- **"Collecting Service-Based Maintainability Metrics from RESTful API Descriptions: Static Analysis and Threshold Derivation"** (arXiv <https://arxiv.org/pdf/2007.10405>) — static analysis driven from OpenAPI descriptions; relevant prior art for spec-as-ground-truth. `[Author/year not individually fetched — UNVERIFIED.]`
+
+---
+
+## 2. Prior Art / Projects + Tradeoffs (static vs runtime topology)
+
+| Project / approach | What it does | Relevance / tradeoff |
+|---|---|---|
+| **Backstage Software Catalog** (<https://backstage.io/docs/features/software-catalog/descriptor-format/>, API entity docs <https://backstage.io/docs/features/software-catalog/software-catalog-api/>) | First-class **`kind: API`** entity with `spec.type` ∈ {openapi, asyncapi, graphql, grpc} and a `definition` (inline or `$text:` ref). Components declare `providesApis` / `consumesApis`. | **This is the closest industrial model to our feature.** Validates exactly our node taxonomy (one API kind, typed by openapi/grpc/graphql) and our two edge directions (provides/consumes). *Key difference:* Backstage relies on **humans hand-authoring** `providesApis`/`consumesApis` in `catalog-info.yaml`; NestWeaver's value-add is *deriving these edges automatically from code*. We should adopt Backstage's vocabulary so output is interoperable. |
+| **Sourcegraph** cross-repo code intelligence | Cross-repo definition/reference search via SCIP/LSIF indexes. | Cross-repo navigation precedent, but operates at the **symbol** level (same model NestWeaver uses today), *not* the wire/contract level. Does not understand that `fetch('/v1/approvals')` in repo A targets a handler in repo B. Our contract edges are the missing layer. |
+| **OpenTelemetry service maps / Service Graph Connector** (<https://oneuptime.com/blog/post/2026-02-06-service-graph-connector-opentelemetry-collector/view>) | **Runtime** topology: matches client/server span pairs from distributed traces to emit per-edge metrics (rate/error/latency). | **The principal contrast.** Runtime maps "always reflect reality" and capture *dynamic* routes static analysis misses — but require running production with instrumentation, only show paths that *executed* during the window, and can't answer "what *would* break if I change this" for cold/seasonal paths. **Static (our approach) sees all code-declared paths regardless of traffic, works pre-deploy, needs no instrumentation, but suffers false negatives/positives (F1 ≤ ~0.79 per §1.3).** The honest framing for the RFC: NestWeaver provides the *design-time* wire graph; it is complementary to, not a replacement for, OTel runtime maps. A future enhancement could *reconcile* the two (confirm/upgrade static edges with runtime evidence). |
+| **buf / grpcurl / prost / tonic** (Protobuf tooling) | Parse and reflect over `.proto`; buf does linting/breaking-change detection. | Confirms `.proto` is trivially and reliably machine-parseable to the `package.Service/Method` level. gRPC is the **lowest-risk** contract type to implement. buf's breaking-change detection is conceptually what our `impact` query delivers for proto contracts. |
+| **OpenAPI-driven client/server codegen** (openapi-generator, etc.) | Generate typed clients/servers from a spec. | Two implications: (1) where a generated client exists, the consumer-side calls go through a typed stub whose method names map back to `operationId` — a **high-confidence** caller-detection path; (2) generated code is voluminous and may pollute the symbol graph — detection must recognize generated-client patterns specifically. |
+| **Pact Broker / Spring Cloud Contract** | Test-time consumer-driven contract artifacts (§1.1). | Authoritative consumer→provider edges *where present*. Candidate **high-confidence ingestion source** for a later milestone; not required for v1. |
+| **Microcks** | Mock/test platform that ingests OpenAPI, gRPC, GraphQL, AsyncAPI; integrates with Backstage. | Confirms the multi-format contract catalog is a real product category and that our three formats are the standard set. |
+
+**Net positioning for the RFC:** the unfilled niche is a *static, multi-repo, code-derived* contract graph that (a) needs no runtime instrumentation, (b) needs no human-authored catalog YAML, and (c) lives in the same graph store as symbol-level edges so impact queries can traverse symbol → handler → contract → consumer-symbol-in-another-repo. No single tool above does all three.
+
+---
+
+## 3. Recommended Approach for NestWeaver
+
+### 3.1 Contract parsing (producing `Contract` nodes)
+
+Two independent producers of `Contract` nodes, merged by UID:
+
+1. **Spec files** (authoritative). Discover during the file walk by extension + content sniff:
+   - OpenAPI/Swagger: `*.yaml`/`*.yml`/`*.json` whose root has `openapi:` or `swagger:`. Parse with a typed crate (see §5). Emit one `Contract` per `(path, method)` operation.
+   - gRPC: `*.proto`. Parse to a `FileDescriptorSet`; emit one `Contract` per `service` × `rpc`.
+   - GraphQL: `*.graphql`/`*.gql` SDL. Emit one `Contract` per root-type field (`Query.x`, `Mutation.x`). (Lower priority — see §3.5.)
+2. **Code-derived** (when no spec exists). Server handler detection (§3.2) *also* mints a `Contract` node if the spec didn't already declare it — this is how repos without an OpenAPI file still get nodes. Spec-derived nodes are confidence 1.0 as contracts; purely code-derived nodes carry the handler's detection confidence.
+
+Merge rule: a spec-derived node and a code-derived node with the same UID are the same node; the `IMPLEMENTS_CONTRACT` edge then links the handler symbol to it.
+
+### 3.2 Per-framework handler detection → `IMPLEMENTS_CONTRACT` (same repo)
+
+Detection is **tree-sitter query + small regex/heuristics** over the framework signatures, mirroring the Code2DFD keyword-evidence strategy. Per v1 target:
+
+- **Java / Spring** (`tree-sitter-java`, already a dep): annotations `@RequestMapping`, `@GetMapping`/`@PostMapping`/`@PutMapping`/`@DeleteMapping`/`@PatchMapping` on methods, with class-level `@RequestMapping` contributing the base path. Verb is implied by the annotation; path is the annotation's `value`/`path`. This is the **best-supported, highest-precision** case (RAD's 0.79 F1 came from exactly these annotations). Confidence 1.0 when both class+method paths are string literals.
+- **TypeScript / NestJS** (`tree-sitter-typescript`, already a dep): controller class decorator `@Controller('base')` + method decorators `@Get()/@Post()/@Put()/@Delete()/@Patch('sub')`. Structurally identical to Spring; high precision.
+- **TypeScript / Express**: method calls `app.get('/path', handler)` / `router.post(...)` etc. Verb = method name; path = first string-literal argument; the handler symbol = the function passed. Router mounting (`app.use('/v1', router)`) contributes a base path that must be threaded — a known source of recall loss.
+- **Go / chi & gorilla mux**: `r.Get("/path", handler)` / `r.HandleFunc("/path", handler)` / `r.Methods("POST")` chains; chi sub-routers via `r.Route("/v1", func(r){...})` / `r.Mount`. Verb extraction for `HandleFunc` may require following a `.Methods(...)` call → lower confidence when verb is not literal.
+
+For each detected handler emit `IMPLEMENTS_CONTRACT(handler_symbol → contract_node)`.
+
+### 3.3 Per-framework caller detection → `CONSUMES_CONTRACT` (cross-repo)
+
+Harder and lower-confidence (this is where F1 drops). v1 focus = TypeScript clients, since that's the stated consumer language:
+
+- **`fetch` / axios / got literals**: `fetch('/v1/approvals', { method: 'POST' })`, `axios.post('/v1/approvals', ...)`, `api.get(\`/v1/approvals/${id}\`)`. Extract URL string + verb. Template-literal interpolation (`${id}`) → normalize the interpolated segment to a templated slot for matching (confidence 0.8, parameterized).
+- **Generated/typed clients**: a call to a generated client method whose name derives from `operationId` (e.g. `client.createApproval()`); match via `operationId` when the spec is also indexed (high confidence) — otherwise undetectable from the opaque method name alone.
+- **Base-URL composition**: callers usually compose `\`${BASE_URL}/v1/approvals\``; the literal segment is recoverable, the host is not — which is fine because matching is on path+verb, not host (see §4).
+
+Emit `CONSUMES_CONTRACT(caller_symbol → contract_node)`. Cross-repo linking reuses NestWeaver's existing multi-repo store: contract UID is repo-independent, so a consumer edge in repo A and an implements edge in repo B converge on the same node automatically.
+
+### 3.4 UID scheme
+
+Stable, human-readable, repo-independent (matches the feature brief and the gRPC wire convention):
+
+- HTTP: `contract:http:<VERB>:<normalized-templated-path>` → `contract:http:POST:/v1/approvals`, `contract:http:PUT:/v1/approvals/{id}`
+- gRPC: `contract:grpc:<package>.<Service>/<Method>` → `contract:grpc:approvals.v1.Approvals/Create` (the literal proto3 FQN per §1.2 — no normalization needed)
+- GraphQL: `contract:graphql:<RootType>.<field>` → `contract:graphql:Mutation.createApproval`
+
+**Path normalization (HTTP) is the load-bearing step** and must be applied identically on both producer (handler) and consumer (caller) sides:
+1. Lowercase the verb-prefix consistently (store verb uppercase).
+2. Collapse all parameter syntaxes to one canonical form: `:id` (Express/chi), `{id}` (OpenAPI/Spring), `${id}` (TS template), `<id>` → all become `{id}` for matching, and slot *names* are ignored when comparing (so `{id}` ≡ `{approvalId}`).
+3. Strip trailing slashes; normalize duplicate slashes; resolve mounted base paths before UID construction.
+4. Keep the *original* path string as a node property for display/debugging.
+
+### 3.5 What's realistically automatable per language (honest assessment)
+
+| Target | Handler/`IMPLEMENTS` | Caller/`CONSUMES` | Notes |
+|---|---|---|---|
+| **Spring (Java)** | **High** (annotations, literal paths) — best case in the literature | n/a for v1 (Java-as-consumer is v2) | Class+method path join + base-path; RestTemplate/WebClient/Feign callers are a known-feasible v2 add. |
+| **NestJS (TS)** | **High** (decorators) | **Medium–High** for generated/typed clients via `operationId` | Decorator path join mirrors Spring. |
+| **Express (TS)** | **Medium** (literal first-arg; router mounting hurts recall) | **Medium** (`fetch`/axios literals; template-literal slots → 0.8) | Dynamic route construction is the main miss. |
+| **chi / gorilla mux (Go)** | **Medium** (`r.Get`/`Route`/`Mount` literal; `HandleFunc`+`.Methods` verb chaining lowers confidence) | n/a for v1 | Sub-router base-path threading is the recall risk. |
+| **gRPC (all)** | **High** (`.proto` is fully parseable; no templating) | **High** where a generated stub call resolves to `Service/Method` | Lowest-risk contract type overall. |
+| **GraphQL** | Medium (SDL parse is easy; mapping resolvers→fields is framework-specific) | **Low** (clients send opaque query strings; matching root fields out of a query document is hard) | Recommend **v2/deferred**; parse SDL to nodes but don't promise robust consumer edges. |
+
+Recommended **v1 cut**: spec parsing for all three formats (cheap, high value as nodes), `IMPLEMENTS_CONTRACT` for Spring + NestJS + Express + chi/gorilla + gRPC, `CONSUMES_CONTRACT` for TS `fetch`/axios + typed-client-via-operationId. Defer GraphQL consumer edges and Java/Go consumers to v2.
+
+### 3.6 Confidence model
+
+Per the brief, anchored by the §1.3 finding that even dedicated tools cap near F1 0.79 — so **confidence must be visible and edges must never be presented as ground truth**:
+
+- **1.0** — exact path + verb match between contract and handler/caller, both literal (or gRPC `Service/Method`, or `operationId` match against an indexed spec).
+- **0.8** — parameterized-path match where slot syntax differs (`{id}` vs `:id` vs `${id}`) but structure aligns; or verb inferred from annotation rather than literal.
+- **0.5** — inferred: dynamically-constructed path partially recovered, base path guessed, or content-type/version disambiguation uncertain.
+
+Store confidence on the edge (NestWeaver edges already carry confidence; dead-code/PPR already threshold on it). Impact queries should let users filter by minimum contract-edge confidence so a 0.5 inferred edge doesn't generate false "this will break" alarms.
+
+---
+
+## 4. Pitfalls / Failure Modes + Mitigations
+
+1. **Path-templating syntax mismatch** (`{id}` vs `:id` vs `${id}` vs `<id>`). *Mitigation:* single canonical normalization (§3.4) applied identically on both sides; ignore slot *names* in matching. (Grounded in OAS 3.1 curly-brace templating + Express colon convention.)
+2. **Base paths / route mounting** (`app.use('/v1', router)`, class-level `@RequestMapping("/v1")`, chi `r.Route("/v1", ...)`, OAS Server `url`). The single biggest recall killer per the literature. *Mitigation:* resolve mount/prefix context during the AST walk before minting the UID; where base path can't be statically resolved, mint with the partial path at confidence 0.5 and flag.
+3. **Versioning & content negotiation** (`/v1/` vs `/v2/`, `Accept` headers, media-type routing). *Mitigation:* version is part of the path string so it naturally distinguishes nodes; do **not** collapse versions. Content-negotiation variants share a UID (path+verb) — acceptable for v1; note as a known limitation.
+4. **Host/base-URL is unknowable statically** for callers. *Mitigation:* deliberately match on **path+verb only**, not host (consistent with the UID scheme). Accept the resulting risk of false cross-repo matches when two unrelated services both expose `POST /v1/login` (see #6).
+5. **Dynamic / computed routes** (paths built from variables, route tables in config, regex routes). *Mitigation:* recover the literal prefix where possible at confidence 0.5; otherwise skip. Document as the primary false-negative source. This is exactly why NestWeaver should frame itself as *complementary to* OTel runtime maps (§2), which catch these.
+6. **False matches across services** (same `POST /v1/login` in two unrelated apps; generic `/health`, `/metrics`). *Mitigation:* (a) maintain a denylist of ubiquitous paths (`/health`, `/metrics`, `/`, `/favicon.ico`); (b) where instance config groups repos into a service/feature, prefer intra-feature matches and down-weight or suppress cross-feature collisions; (c) surface ambiguity rather than silently picking one (NestWeaver already has an "ambiguous" exit code 3 convention).
+7. **Generated-client noise** (codegen produces thousands of symbols). *Mitigation:* recognize generated-client signatures and either tag those symbols or route their calls straight to `operationId`-based high-confidence edges instead of treating them as ordinary code.
+8. **Spec drift** (OpenAPI file out of date vs handlers). *Mitigation:* because we mint nodes from *both* spec and code, a spec contract with no `IMPLEMENTS_CONTRACT` edge (or vice versa) is itself a useful signal — expose it (a "declared but not implemented" / "implemented but undocumented" diagnostic).
+9. **operationId optionality** — can't rely on it as the primary key. *Mitigation:* primary UID = method+templated path; `operationId` stored as a secondary index used only to match generated/typed clients.
+10. **gRPC streaming / GraphQL subscriptions** — long-lived, non-request/response. *Mitigation:* still model as contract nodes; don't over-promise impact semantics in v1.
+
+---
+
+## 5. Rust Crate Assessment (verified on crates.io / docs.rs, 2026-05-29)
+
+All versions/licenses pulled live from the crates.io JSON API on 2026-05-29.
+
+### OpenAPI
+
+| Crate | Latest | License | Status | Recommendation |
+|---|---|---|---|---|
+| **`openapiv3`** | **2.2.0** (updated 2025-06-02; ~9.3M downloads) | MIT/Apache-2.0 | Mature, widely used. Serde data structures for OpenAPI **3.0.x**. | **Recommend for OAS 3.0.** Stable, popular, dual-licensed (compatible). Does *not* cover 3.1. |
+| **`oas3`** | **0.22.0** (updated 2026-05-06; ~1.16M downloads) | MIT | Actively maintained; parses/validates OpenAPI **3.1.x**. | **Recommend for OAS 3.1.** Newer-but-pre-1.0 API (expect churn). MIT-only (still compatible). Use alongside `openapiv3` to cover 3.0 + 3.1, or standardize on `oas3` if 3.1-first is acceptable. |
+| `swagger` | 7.0.0 | Apache-2.0 | Utilities for OpenAPI-Generator output, **not a spec parser**. | **Do not use** for parsing — wrong tool. |
+
+YAML/JSON loading: project already depends on **`serde_yaml` 0.9** (note: `serde_yaml` is **deprecated/unmaintained** — last release 0.9.34+deprecated, 2024). For new contract parsing prefer **`serde_yaml_ng` 0.10.0** (MIT) or the YAML-1.2 **`saphyr` 0.0.6** (pre-1.0). `serde_json` already in use for JSON specs. **Action item:** OpenAPI YAML parsing is a good reason to migrate off deprecated `serde_yaml`.
+
+### gRPC / Protobuf
+
+| Crate | Latest | License | Status | Recommendation |
+|---|---|---|---|---|
+| **`protobuf-parse`** | **3.7.2** (updated 2025-03-10; ~29.5M downloads) | MIT | Mature. **Has a pure-Rust parser requiring no `protoc` binary** (verified on docs.rs: "pure rust parser (no dependencies)"); `protoc` mode optional. **Caveat (verified): docs state it "is not meant to be used directly" and has "no stable API."** | **Recommend with caution** — best pure-Rust path-into-`FileDescriptorSet` but unstable API; pin exact version. Avoids a `protoc` system dependency, which matters for NestWeaver's zero-config indexing. |
+| **`protox`** | **0.9.1** (updated 2025-12-02; ~10.8M downloads) | MIT OR Apache-2.0 | A pure-Rust protobuf **compiler** producing `FileDescriptorSet`; no `protoc` needed. | **Recommend (preferred).** Pure-Rust, dual-licensed, designed to be used directly (unlike `protobuf-parse`). Best fit for parsing `.proto` to services/methods without external tooling. |
+| `prost` / `prost-build` / `tonic-build` | 0.14.3 / 0.14.3 / 0.14.6 | Apache-2.0 / Apache-2.0 / MIT | Mature, huge usage (`prost` ~428M downloads). Codegen-oriented; `prost-build`/`tonic-build` traditionally lean on `protoc` (protox can back them). | Not needed for *parsing-only*; use `protox` for descriptors. Listed for completeness. |
+| `prost-reflect` | 0.16.4 (updated 2026-05-24; ~59M downloads) | MIT OR Apache-2.0 | Mature; runtime reflection over compiled descriptors. | Useful if we want dynamic message reflection later; **not required** for service/method extraction. |
+| `protobuf` | max stable 3.7.2 (4.x in pre-release) | BSD-3-Clause | Mature (Google data-interchange runtime). | Note BSD-3-Clause license (still permissive/compatible). Transitive via `protobuf-parse`. |
+| `protobuf-parser` (singular) | 0.1.3, **last updated 2018** | MIT | **Abandoned.** | **Do not use.** |
+
+**gRPC recommendation: `protox` (primary) → `FileDescriptorSet` → walk services/methods.** Pure-Rust, directly usable, dual-licensed, no `protoc` dependency. `protobuf-parse` is a fallback.
+
+### GraphQL
+
+| Crate | Latest | License | Status | Recommendation |
+|---|---|---|---|---|
+| **`apollo-parser`** | **0.8.6** (updated 2026-05-14; ~886K downloads) | MIT OR Apache-2.0 | Actively maintained by Apollo; **spec-compliant, error-resilient** GraphQL parser. | **Recommend** for GraphQL SDL parsing (v2). Best-maintained, dual-licensed. |
+| `async-graphql-parser` | 7.2.1 stable (8.0.0-rc; ~27.6M downloads) | MIT OR Apache-2.0 | Mature; the parser behind `async-graphql`. | Viable alternative; tied to the async-graphql ecosystem. |
+| `graphql-parser` | 0.4.1 (updated 2024-12-03; ~30M downloads) | MIT/Apache-2.0 | Widely used but **lightly maintained** (last release 2024). | Acceptable but prefer `apollo-parser` for active maintenance. |
+
+### Effort estimate per target (relative)
+
+- **gRPC contract nodes:** **Low** — `protox` → descriptor walk is mechanical; UID is the literal FQN. Highest value-to-effort.
+- **OpenAPI contract nodes:** **Low–Medium** — `oas3`/`openapiv3` give typed operations; effort is in server-object/base-path normalization and 3.0-vs-3.1 dual support.
+- **Spring `IMPLEMENTS`:** **Medium** — tree-sitter-java queries for annotations + class/method path join; literature shows this is the most tractable handler case.
+- **NestJS `IMPLEMENTS`:** **Medium** — analogous decorator queries in tree-sitter-typescript.
+- **Express `IMPLEMENTS`:** **Medium–High** — literal-arg extraction is easy; router-mount base-path threading is the real work.
+- **chi/gorilla `IMPLEMENTS`:** **Medium–High** — verb extraction (`HandleFunc` + `.Methods`) and sub-router base paths add complexity.
+- **TS `CONSUMES` (fetch/axios + operationId):** **High** — string/template-literal recovery, generated-client recognition, and the cross-repo false-match guards (§4 #6) are the most error-prone surface and where confidence buckets earn their keep.
+- **GraphQL consumer edges:** **High / defer to v2** — opaque client query strings make robust matching impractical for v1.
+
+All grammars needed are **already workspace dependencies** (`tree-sitter-java` 0.23, `tree-sitter-typescript` 0.23, `tree-sitter-go` 0.25), so no new parser-grammar onboarding is required for handler/caller detection — only the spec crates (`oas3`/`openapiv3`, `protox`, optionally `apollo-parser`) are net-new.
+
+---
+
+## Sources (all retrieved 2026-05-29)
+
+- Ian Robinson, "Consumer-Driven Contracts: A Service Evolution Pattern," martinfowler.com, 2006-06-12 — <https://martinfowler.com/articles/consumerDrivenContracts.html>
+- Pact docs — <https://docs.pact.io/> ; <https://docs.pact.io/getting_started/how_pact_works>
+- Spring Cloud Contract — <https://spring.io/projects/spring-cloud-contract/> ; Baeldung intro <https://www.baeldung.com/spring-cloud-contract>
+- OpenAPI Specification v3.1.0 — <https://spec.openapis.org/oas/v3.1.0.html>
+- Buf "Files and packages" — <https://buf.build/docs/reference/protobuf-files-and-packages/> ; Protobuf style guide <https://protobuf.dev/programming-guides/style/> ; Microcks gRPC conventions <https://microcks.io/documentation/references/artifacts/grpc-conventions/>
+- Schneider et al., "Comparison of Static Analysis Architecture Recovery Tools for Microservice Applications," 2024 — arXiv <https://arxiv.org/html/2412.08352v1> ; Empirical Software Engineering (Springer) <https://link.springer.com/article/10.1007/s10664-025-10686-2>
+- Schneider & Scandariato, "Automatic extraction of security-rich dataflow diagrams … (Code2DFD)," JSS 2023 — ACM <https://dl.acm.org/doi/10.1016/j.jss.2023.111722> ; repos <https://github.com/tuhh-softsec/code2DFD> , <https://github.com/M3SOulu/EMSE2025SAR-code2DFD>
+- "The Microservice Dependency Matrix" (Cerny et al.) — arXiv <https://arxiv.org/pdf/2309.02804>
+- "Microvision" — arXiv <https://arxiv.org/pdf/2207.02974>
+- "Collecting Service-Based Maintainability Metrics from RESTful API Descriptions" — arXiv <https://arxiv.org/pdf/2007.10405>
+- Backstage Software Catalog descriptor format — <https://backstage.io/docs/features/software-catalog/descriptor-format/> ; software-catalog API <https://backstage.io/docs/features/software-catalog/software-catalog-api/>
+- OpenTelemetry Service Graph Connector — <https://oneuptime.com/blog/post/2026-02-06-service-graph-connector-opentelemetry-collector/view>
+- crates.io JSON API (version/license/maintenance) and docs.rs for: openapiv3, oas3, swagger, protobuf-parse, protox, prost, prost-build, tonic-build, prost-reflect, protobuf, protobuf-parser, apollo-parser, async-graphql-parser, graphql-parser, serde_yaml, serde_yaml_ng, saphyr — queried 2026-05-29.

--- a/scratch/rfc-implementation-plan/research/code-search-trigram-symbol-reads.md
+++ b/scratch/rfc-implementation-plan/research/code-search-trigram-symbol-reads.md
@@ -1,0 +1,194 @@
+# Research Foundation: Trigram-Accelerated Regex Search, count_patterns, Symbol-Window Reads, Tiered Display
+
+Research for NestWeaver RFC Features 3, 4, 5, 8. Solo-dev / no-GPU / no-daemon / embedded graph DB constraints.
+
+All sources retrieved 2026-05-29. Vendor/blog claims are explicitly labeled. Nothing here is fabricated; gaps are marked `[UNVERIFIED]`.
+
+---
+
+## Codebase grounding (verified against the tree)
+
+Before the research, two schema facts that change the design:
+
+- **`Symbol` stores `start_line` only — there is NO `end_line`.**
+  `crates/nestweaver-schema/src/nodes.rs:140-157`. Fields: `uid, name, kind, repo_uid, file_path, start_line, signature, summary, content_hash, embedding, pagerank_score, is_entry_point, entry_point_kind, visibility, type_info, framework_hint`. The task brief's premise that NestWeaver "stores per-symbol start/end lines" is **only half true** — the end of a symbol's span is NOT currently persisted. Feature 5 must either (a) add `end_line` to `Symbol` (schema-version bump) or (b) derive the span at read time (next-symbol-start heuristic / re-parse). This is the single biggest hidden cost in Feature 5.
+- **`Section` stores `start_line`, `end_line`, AND full `text`** (`nodes.rs:241-254`); `Heading` stores `start_line`+`end_line` (`nodes.rs:226-235`). So for the *notes* domain, symbol-window reads and inline-body display are essentially free — the spans and text already exist.
+- Tantivy already indexes notes/sections (`crates/nestweaver-store/src/tantivy_index.rs`); `regex` crate is already a dependency (in `nestweaver-parser`, `Cargo.toml:30`). No new heavy dependency is needed for Features 3/4 beyond `regex-syntax` (a sub-crate of `regex`, already transitively present).
+
+---
+
+# FEATURE 3 — Trigram-accelerated regex search
+
+## 3.1 Research foundation / primary sources
+
+- **Russ Cox, "Regular Expression Matching with a Trigram Index (or How Google Code Search Worked)", Jan 2012.** https://swtch.com/~rsc/regexp/regexp4.html (retrieved 2026-05-29). This is *the* canonical reference and the design should follow it directly.
+  - **Indexing:** extract every overlapping 3-character substring. `"Google"` → `Goo, oog, ogl, gle`. Each trigram maps to a posting list of document IDs that contain it (an inverted index). Google's `codesearch` stores **only document IDs, not positions** — very space-efficient, but performance degrades as corpus grows because it cannot verify trigram adjacency (per the codesearch index docs, below).
+  - **Regex → trigram query (the part that matters):** the algorithm walks the regex computing five properties per sub-expression: `emptyable`, `exact` (the finite set of exact match strings, or "unknown"), `prefix` set, `suffix` set, and `match` (a boolean trigram query — an AND/OR tree of trigram-membership predicates). Concatenation cross-products prefix/suffix sets; alternation (`|`) becomes OR; repetition (`*`,`+`,`?`) widens prefix/suffix. `/Google.*Search/` compiles to `Goo AND oog AND ogl AND gle AND Sea AND ear AND arc AND rch`.
+  - **Information-saving vs information-discarding transforms:** when prefix/suffix/exact sets get too large, the algorithm *flushes* their trigram requirements into the `match` AND/OR tree, then truncates the set (or marks `exact = unknown`). This is the memory-bound that keeps query planning from exploding on adversarial regexes.
+  - **Two-stage:** trigram query yields *candidate* documents (with false positives); the real `regex` engine then runs only on candidates and removes false positives.
+  - **Numbers (primary):** Linux 3.1.3 kernel = **420 MB source → 77 MB index (~18% of source)**. Case-sensitive `hello world`: **36,972 files filtered down to 25 candidates (~100x speedup)**.
+  - **Stated limitations:** (1) case-insensitive search produces all-case-variant trigrams per position → much less selective; (2) **a regex with no extractable literals defaults to the `ANY` query, which matches every document — the index gives zero benefit and you fall back to full scan.**
+
+- **`google/codesearch` (Russ Cox, Go, public 2015).** https://github.com/google/codesearch — reference implementation of the above. `index.PostingList(trigram uint32) []uint32` returns the doc-ID posting list per trigram (`https://pkg.go.dev/github.com/google/codesearch/index`). Confirms: posting lists store document IDs (uint32), not positions.
+
+- **`aaw/regrams`** — https://github.com/aaw/regrams — standalone "regex → trigram boolean query" library "in the spirit of codesearch." Useful as an algorithm reference for the AST→query compiler if you don't want to port Cox's `Query` type directly.
+
+## 3.2 Prior art / projects + tradeoffs
+
+| Project | Approach | Tradeoffs / numbers |
+|---|---|---|
+| **Google codesearch** (Cox) | Doc-ID-only trigram postings + DoS-resistant regex engine | Tiny index (~18% of source); "performance degrades rapidly with large corpus" because no positional verification. Best fit for NestWeaver scale. https://github.com/google/codesearch |
+| **Sourcegraph Zoekt** (orig. Han-Wen Nienhuys @ Google) | **Positional** trigrams (store byte/rune offset of each occurrence) | RAM = **1.2× corpus**; index ≈ **3× corpus** (2× offsets + 1× content); shard ≈ **3.5× corpus**. Target **sub-50ms on ~2 GB (Android)**. UTF-8 handled via rune-offset table every 100 runes (ASCII bypasses). ctags symbols ranked higher. https://github.com/sourcegraph/zoekt/blob/main/doc/design.md (retrieved 2026-05-29) |
+| **livegrep** (Nelson Elhage, 2015) | **Suffix array** instead of trigrams | No false positives (exact substring positions); regex compiled to an `IndexKey` (edges with min/max byte ranges) walked via chained binary searches, then RE2 verifies. Suffix arrays are larger and harder to update incrementally → poor fit for live re-indexing. https://blog.nelhage.com/2015/02/regular-expression-search-with-suffix-arrays/ |
+| **Hound** (Etsy, now hound-search) | Trigram, "based directly on Cox's article" | Simple, single-server, fast; no semantic/code-intelligence. Good proof that a minimal Cox-style trigram index is production-viable. https://github.com/hound-search/hound |
+| **GitHub Blackbird** (2023, Rust) | **Sparse grams**, not fixed trigrams | "Trigrams aren't selective enough" for tokens like `for` at GitHub scale → false-positive blowup. Sparse-gram tokenization picks intervals where inner bigram weights < border weights. Index incl. content ≈ **¼ of 115 TB corpus** (28 TB unique → 25 TB index). P99 shard ~100 ms. **Sparse grams are overkill for solo-dev scale** but document the selectivity failure mode of plain trigrams. https://github.blog/engineering/architecture-optimization/the-technology-behind-githubs-new-code-search/ |
+| **Cursor "Fast regex search"** (Vicent Marti, 2026-03-23) | Sparse n-gram, **client-local, mmap'd** | Directly motivated by *agent* use: local index avoids network latency and stays "very fresh" so an agent reading its own writes finds them; "if the agent is searching for specific text and it does not find it, it'll often go into a wild goose chase, waste tokens." Postings file (sequential) + sorted hash lookup table (mmap, binary search). Literal extraction: trigrams from literal runs; alternations → OR; small char classes expanded, broad classes skip cross-boundary trigrams. No explicit timeout/budget discussed. https://cursor.com/blog/fast-regex-search (vendor blog) |
+
+## 3.3 Recommended approach for NestWeaver
+
+**Adopt Cox/codesearch (doc-ID-only postings), NOT Zoekt-positional.** Rationale: NestWeaver is solo-dev, no daemon, embedded DB; corpus is one-to-few repos + a vault, not Android/Chrome. Positional index buys 1.2× RAM and complexity NestWeaver doesn't need at this scale. Plain trigrams' selectivity problem (Blackbird) only bites at GitHub scale.
+
+- **Index unit = document = one of {Symbol body span, Section, Note}.** Reuse the existing UID as the doc ID (or a dense u32 mapping). For Symbols, the "body" is the source span — see Feature 5 caveat about missing `end_line`; until that lands, index the signature + summary, or the line range derived at index time.
+- **Index schema / sidecar:** new sidecar `<db>.trigrams.json` (or a compact binary `<db>.trigrams.idx`) consistent with the existing sidecar convention (`<db>.pagerank.json`, `<db>.tantivy/`, etc.). Map: `trigram (u32, 3 bytes packed) → sorted Vec<u32> doc-ids`. Delta-encode + varint the posting lists to keep size near Cox's ~18%. Build during `index`; incrementally update on `watch` (re-tokenize only changed docs via the existing `<db>.filemeta.json` change detection — this is why doc-ID postings beat suffix arrays for NestWeaver's live re-indexing).
+- **Query planning:** use **`regex-syntax::hir::literal::Extractor`** (already in-tree transitively via `regex`) rather than hand-rolling Cox's analyzer. Parse pattern → HIR → `Extractor::extract` (Prefix kind) → `Seq`. For each literal in the Seq, emit `AND` of its trigrams; across alternatives in the Seq, `OR`. Then intersect/union posting lists (galloping intersection on sorted Vec<u32>). Hand the candidate doc set to the real `regex::Regex` for verification. (API detail in §3.5.)
+- **Fallback (required):** if `Seq` is **infinite** (`.is_finite() == false`, e.g. `[A-Z]+`, `.*`, leading wildcard) or all literals are shorter than 3 bytes after dropping `inexact` ones → **no usable trigrams → full scan** over all docs (or scoped by repo/kind filter). This mirrors Cox's `ANY` fallback. Always correct, just not accelerated.
+- **Budget/timeout:** (a) cap candidate-set size — if the trigram query yields > N candidates (e.g. > 30% of corpus), the prefilter isn't earning its keep; either run anyway or bail to scan. (b) Wall-clock timeout on the verification pass (`regex` is linear-time/DoS-safe, but large corpora still cost) — return partial results + a `truncated: true` flag. (c) Use `Extractor::limit_total` / `limit_class` / `limit_repeat` to bound planning cost on adversarial patterns.
+
+## 3.4 Pitfalls / failure modes + mitigations
+
+- **No extractable literals** (`.*`, `\w+`, `[A-Z]{3}`): index useless. *Mitigation:* detect infinite `Seq`, fall back to scan; document this so users know `foo.*bar` is fast but `\w+` is not.
+- **Index bloat:** plain trigram index ~18% of source (Cox) is fine; but storing posting lists naively (Vec<u32> JSON) bloats. *Mitigation:* delta+varint encode; binary sidecar, not JSON, for the postings.
+- **Selectivity collapse on common trigrams** (`for`, `int`, ` th`): huge posting lists, AND-intersection still scans a lot. *Mitigation:* prefer the *rarest* trigrams in the AND (intersect shortest postings first / skip the most common trigrams from the query) — Blackbird's sparse-gram is the heavy-duty version; for NestWeaver, simply order intersection by posting-list length.
+- **Unicode / multi-byte:** trigrams over raw UTF-8 bytes mostly work but a 3-byte CJK char = one trigram window oddity. *Mitigation:* tokenize over bytes (Cox does); ASCII-fast-path; accept minor selectivity loss on non-ASCII. Don't build the rune-offset table (Zoekt) — not worth it at this scale.
+- **Case-insensitive** `(?i)`: trigram set explodes to all case variants → low selectivity (Cox's own caveat). *Mitigation:* lowercase-fold both index and query into a parallel case-folded trigram set, OR just fall back to scan for `(?i)` with no strong literal. Don't pretend `(?i)` is as fast as case-sensitive — Cox explicitly says it isn't.
+- **Stale index after edits:** agent edits a file, searches, trigram index lags → false "not found" (the exact failure Cursor calls out). *Mitigation:* tie trigram updates to the existing `watch`/`graph_generation` machinery; re-tokenize changed docs synchronously on re-index.
+
+## 3.5 Complexity / effort + numbers
+
+- **Effort: Medium-High.** Tokenizer (trivial), posting-list store + delta/varint codec (small), regex→trigram-query compiler **using `regex-syntax` Extractor** (medium — the Seq→trigram-AND/OR mapping and the infinite/inexact handling are the fiddly part), posting-list intersection (small), verification + budget (small), incremental update on watch (medium).
+- **Reported numbers to set expectations:** Cox **~18% index / ~100× filter speedup**; Zoekt **sub-50ms / 1.2× RAM / 3× index** (positional, upper bound you're avoiding); Blackbird **~25% incl. content** at extreme dedup scale. For NestWeaver, target **index ≈ 15-25% of indexed-text size, candidate-set verification in single-digit ms** for typical literal-bearing queries.
+- `regex-syntax` literal `Extractor` API (https://docs.rs/regex-syntax/latest/regex_syntax/hir/literal/struct.Extractor.html, retrieved 2026-05-29): `Extractor::new().kind(ExtractKind::Prefix).extract(&hir) -> Seq`. `Seq` is finite / infinite / empty; literals are **exact** (definitive) or **inexact** (candidate, regex must confirm — happens across char classes/reps). Config: `limit_class`, `limit_repeat`, `limit_literal_len`, `limit_total`. Look-arounds treated as matching empty string (`\bquux\b` → literal `quux`). **Key: check `Seq::is_finite()` and per-literal exactness to decide AND/OR planning vs scan fallback.**
+
+---
+
+# FEATURE 4 — `count_patterns` (counts-only companion)
+
+## 4.1 Research foundation / prior art
+
+No distinct primary literature — this is `grep -c` / `rg --count` / `rg --count-matches` semantics layered on the Feature 3 prefilter. Anchors:
+- **ripgrep `--count` (file + match count) and `--count-matches` (total occurrences).** https://github.com/BurntSushi/ripgrep — the established UX split between "files matched" vs "total occurrences" is exactly the two numbers to report.
+- **Andrew Gallant, "ripgrep is faster than {grep, ag, …}", 2016.** https://burntsushi.net/ripgrep/ (retrieved 2026-05-29). Counting still requires scanning each matching line, but ripgrep stays out of the regex engine using *inner-literal* extraction + Aho-Corasick / Teddy (Geoffrey Langdale, Intel Hyperscan) / `memchr` (SIMD, multi-GB/s) to skip non-candidate lines. Same prefilter philosophy as Feature 3, just don't materialize match spans/snippets.
+
+## 4.2 Recommended approach
+
+- **Reuse the Feature 3 trigram prefilter verbatim** to get candidate docs, then run `regex` in count mode (`find_iter().count()` per doc; track files-with-≥1-match separately). Return `{total_files_matched, total_occurrences, per_file: [{doc_uid/path, count}]}`.
+- **Multi-pattern in one call:** accept `Vec<pattern>`. For each pattern build its own trigram query; **union the candidate sets** (a doc that could match *any* pattern), scan each candidate once, attribute counts per pattern. This is cheaper than N independent calls because the candidate union and per-doc text fetch are shared. Report per-pattern and combined totals.
+- No snippets, no line numbers → much cheaper than a full search and very token-cheap to return to an agent.
+
+## 4.3 Pitfalls + mitigations
+
+- **Overlapping vs non-overlapping match counts** — `regex` `find_iter` is non-overlapping/leftmost; document this (matches `rg --count-matches`). Don't promise overlapping counts.
+- **`(?i)` / no-literal patterns** inherit Feature 3's scan fallback — counts are still correct, just unaccelerated.
+- **Per-file list size** can be large on broad patterns → token-budget the `per_file` array (top-N by count + "+M more files"), since the consumer is an agent.
+
+## 4.4 Effort
+
+**Low**, given Feature 3 exists. It is Feature 3's prefilter + verification with span-materialization turned off and a per-doc counter. Main new work: multi-pattern candidate-union and the result shape/budgeting.
+
+---
+
+# FEATURE 5 — Symbol-window file reads (`read_symbols`)
+
+## 5.1 Research foundation / primary sources
+
+- **Aider repo map / tree-sitter tags — Paul Gauthier, "Building a better repository map with tree sitter", 2023-10-22.** https://aider.chat/2023/10/22/repomap.html (retrieved 2026-05-29). Tree-sitter parses to AST; each grammar ships a `tags.scm` query that classifies nodes as *definition* vs *reference*. Aider deliberately shows **signatures / "critical lines," not full bodies**, to conserve context, and ranks via PageRank into a **token budget (`--map-tokens`, default 1,000 tokens)**. This is the canonical "symbol-precise, token-budgeted code context for an LLM" prior art and validates Feature 5's whole premise.
+- **tree-sitter** itself: AST nodes carry precise byte/line spans → the correct primitive for "give me exactly this symbol's span." `tags.scm` also defines comment nodes for language-aware comment stripping.
+- **ctags / universal-ctags vs tree-sitter vs LSP `textDocument/documentSymbol`:** ctags = regex-based, fast, imprecise (can't truly parse a language); tree-sitter = AST, accurate, 130+ grammars; LSP documentSymbol = semantic but requires a running language server (a daemon — violates NestWeaver's no-daemon constraint). https://github.com/chrismwendt/ctags-vs-tree-sitter (perf comparison). **Conclusion: tree-sitter is the right precision tool; NestWeaver already uses it for parsing, so spans are obtainable.** `npezza93/ttags` shows ctags-from-tree-sitter is a real pattern.
+
+## 5.2 Token-savings evidence — ALL VENDOR/BLOG, NOT PEER-REVIEWED
+
+Mark every one of these as unverified vendor/blog claims, not measured fact:
+
+- **[VENDOR/BLOG]** "A targeted 20-line read is 10-50× cheaper than reading the full file… ~18,000 tokens vs ~800 tokens." / "the body of a specific function — 400 tokens instead of 6,000." — https://fazm.ai/t/reduce-ai-agent-token-costs-mcp-strategies (retrieved 2026-05-29). Marketing for a token-cost-reduction product.
+- **[VENDOR/BLOG]** "save 94% of tokens by indexing once… real-world broader questions 40-55% savings… pure comprehension 70-95%." — https://elara-labs.github.io/code-context-engine/ (retrieved 2026-05-29). Vendor landing page.
+- **[BLOG]** "70% of tokens were waste" (one developer's week-long self-measurement) — https://dev.to/nicolalessi/... (retrieved 2026-05-29). Anecdotal, single-author, no methodology.
+
+**Assessment:** The RFC's "30-60% token reduction" goal is *plausible and consistent with vendor claims*, but there is **no peer-reviewed or independently reproduced measurement** in the retrieved sources. Feature 5 should ship with its own before/after token instrumentation rather than cite these numbers as fact. The directionally-solid, non-vendor support is structural (Aider deliberately omits bodies to fit a 1k-token budget) — that's an existence proof that token-budgeted symbol context works, not a percentage.
+
+## 5.3 Recommended approach for NestWeaver
+
+- **BLOCKER FIRST: `Symbol` has no `end_line`** (`nodes.rs:140-157`). Options, in order of preference:
+  1. **Add `end_line: u32` to `Symbol`** during indexing (tree-sitter already gives the node's end byte/row for free in the parser). Requires a schema-version bump (`crates/nestweaver-schema/src/version.rs`) and a re-index. Cleanest; makes `read_symbols` an O(1) span fetch. **Recommended.**
+  2. **Derive at read time:** span = `[start_line, next_symbol_in_file.start_line - 1]`. Cheap, no schema change, but wrong for nested symbols (a method inside a class), trailing symbols, and interleaved comments. Acceptable only as an interim.
+  3. **Re-parse the file on demand** to recover the node span. Accurate but defeats the token/latency goal.
+- **Span read:** given an FQN or name, resolve to Symbol UID (reuse existing symbol resolution; handle ambiguity with the existing exit-code-3 / multiple-match behavior), read `file_path` lines `[start_line, end_line]`. Notes/Sections are already trivial — `Section` carries `start_line`,`end_line`,`text`.
+- **Comment stripping (optional, off by default):**
+  - *Tree-sitter languages:* query comment nodes (`comment`, `line_comment`, `block_comment` per grammar) and elide them — accurate.
+  - *Regex-only languages (NestWeaver parses 32 langs, some via regex):* **conservative line-prefix strip only** (strip lines whose first non-whitespace token is the line-comment marker `//`, `#`, `--`, etc.). Do NOT attempt block-comment or mid-line stripping with regex — see pitfalls.
+- **N adjacent symbols:** include ±N siblings by `start_line` order within the same file (cheap once spans exist). Useful for "show me this function and its neighbors."
+- **FQN resolution:** map `module::Type::method` / `path/file.rs::fn` to UID via the graph; the brief's `read_symbols` should accept name, FQN, or `file::symbol`.
+- **Token-budget aware:** sum estimated tokens across requested spans; if over budget, drop lowest-priority adjacent symbols first, then fall back to signature-only (Aider-style) for overflow, and flag `truncated`.
+
+## 5.4 Pitfalls / failure modes + mitigations
+
+- **Missing `end_line` (the core risk)** — mitigations above; prefer schema add.
+- **Comment-strip false elision** — the brief's named risk. Stripping `# ...` blindly corrupts: shebangs (`#!/bin/sh`), `#` inside string literals (`"a # b"`), Python f-strings, CSS `#id`, URLs in strings (`https://`→`//`!), regex langs where `//` is division or part of a path. *Mitigation:* (1) default OFF; (2) tree-sitter comment-node strip is safe — prefer it whenever a grammar exists; (3) for regex langs, only strip a *whole line* when the comment marker is the first non-whitespace char AND the line isn't inside a known string/heredoc context you can cheaply detect — when in doubt, **don't strip** (false elision of code is worse than leaving a comment). Never strip mid-line for regex langs.
+- **Off-by-one line indexing** — `start_line` is almost certainly 1-based (tree-sitter rows are 0-based; check the parser's conversion). Verify before slicing files.
+- **Stale spans after edits** — if the file changed since index, stored spans drift. *Mitigation:* compare `content_hash` / `filemeta` mtime; if stale, re-derive or warn.
+- **Ambiguous names** — multiple symbols named `greet`. *Mitigation:* reuse existing exit-code-3 ambiguity handling; return all or require FQN.
+
+## 5.5 Effort
+
+**Medium.** The blocker is the `end_line` schema decision (+re-index). Span read, FQN resolution, adjacency, budgeting are straightforward and reuse existing graph/resolution code. **Comment stripping is the deceptively expensive part** — language-aware tree-sitter stripping is per-grammar work and the regex-lang heuristics are correctness-sensitive; recommend shipping span-read first, comment-stripping as a clearly-flagged follow-up.
+
+---
+
+# FEATURE 8 — Tiered display (inline body for high-confidence hits)
+
+## 8.1 Research foundation / prior art
+
+- **Cursor "Fast regex search" (2026), the agent-round-trip argument.** https://cursor.com/blog/fast-regex-search — "if the agent is searching for specific text and it does not find it, it'll often go into a wild goose chase, waste tokens." Inlining the body on a confident hit removes the follow-up read round-trip that an agent would otherwise issue — directly the Feature 8 motivation (vendor blog).
+- **Aider repo map** (above) — establishes that a tool can return *graded* code context (signature-only vs key-lines) under a token budget rather than all-or-nothing. Feature 8 is the same idea applied to search hits: high-confidence → inline body; lower → just the locator.
+- **Zoekt ranking** (https://github.com/sourcegraph/zoekt/blob/main/doc/design.md) — produces a normalized relevance score per hit from match count, proximity, word-boundary alignment, symbol-definition (ctags), filename, recency, optional BM25. Establishes that a defensible normalized score exists to threshold on. NestWeaver already has analogous signals (PageRank, BM25 via Tantivy, symbol-kind).
+
+## 8.2 Recommended approach
+
+- **Threshold inline at normalized relevance ≥ 0.75** (the RFC's number). Inline = the symbol/section body via Feature 5's span read (Sections already have `text`; Symbols need the `end_line` from Feature 5). Below threshold → return locator only (path + line + signature) and let the agent decide to read.
+- **Normalization is the load-bearing design choice.** A raw hybrid score (BM25 + PageRank + trigram match count) is unbounded/scale-dependent; 0.75 is meaningless unless scores are mapped to [0,1]. Use either min-max over the result set, or a softmax/percentile normalization, and apply a *gap* check (only inline if the top hit is clearly separated from the rest) to avoid inlining 50 bodies on a flat score distribution.
+- **Token budget interaction:** inlining bodies is exactly what blows a context window — cap total inlined tokens (e.g. inline top-K confident hits until budget, then degrade to signature-only, then locator-only), reusing Feature 5's budgeter.
+
+## 8.3 Pitfalls + mitigations
+
+- **Threshold mis-calibration** — 0.75 on an un-normalized score inlines everything or nothing. *Mitigation:* normalize per query + require a confidence *gap*, not just an absolute floor.
+- **Token blowup** — inlining many large bodies defeats the token-saving goal it shares with Feature 5. *Mitigation:* hard cap on inlined tokens / max-K inlined hits.
+- **Large symbol bodies** — a 600-line god-function at 0.9 confidence shouldn't be inlined whole. *Mitigation:* cap inlined span size; inline signature + first N lines + "…(read_symbols for full body)".
+- **Confidence ≠ correctness** — a high score can still be the wrong symbol. Inlining doesn't make it right; it just saves a round-trip when it is. Keep the locator alongside the inlined body so the agent can verify/expand.
+
+## 8.4 Effort
+
+**Low**, layered on Features 3+5. New work: score normalization + gap logic + the inline/locator decision + reusing the token budgeter. No new index or parsing.
+
+---
+
+## Cross-cutting summary
+
+- **Build order:** Feature 5's `end_line` schema add → Feature 3 trigram index (reusing `regex-syntax` Extractor) → Feature 4 (Feature 3 minus snippets) → Feature 5 span reads → Feature 8 (Features 3+5 + normalization).
+- **Pick Cox/codesearch doc-ID trigrams, not Zoekt-positional, not livegrep suffix arrays, not Blackbird sparse-grams** — solo-dev scale + live re-indexing favor the smallest/most-incrementally-updatable index. Document the sparse-gram selectivity caveat as a "if we ever hit scale" note.
+- **The single biggest landmine** is that `Symbol` has no `end_line` today — every "symbol body" feature (5, and the Symbol path of 3 and 8) depends on adding it.
+- **Token-savings numbers are vendor/blog only; ship instrumentation, don't cite percentages as fact.**
+
+## Source list (all retrieved 2026-05-29)
+
+1. Russ Cox, "Regular Expression Matching with a Trigram Index", 2012 — https://swtch.com/~rsc/regexp/regexp4.html
+2. google/codesearch — https://github.com/google/codesearch ; index pkg — https://pkg.go.dev/github.com/google/codesearch/index
+3. aaw/regrams — https://github.com/aaw/regrams
+4. Sourcegraph Zoekt design — https://github.com/sourcegraph/zoekt/blob/main/doc/design.md
+5. Nelson Elhage, suffix arrays, 2015 — https://blog.nelhage.com/2015/02/regular-expression-search-with-suffix-arrays/
+6. Hound — https://github.com/hound-search/hound
+7. GitHub Blackbird, 2023 — https://github.blog/engineering/architecture-optimization/the-technology-behind-githubs-new-code-search/
+8. Cursor "Fast regex search", Vicent Marti, 2026-03-23 — https://cursor.com/blog/fast-regex-search (vendor)
+9. Andrew Gallant, "ripgrep is faster than…", 2016 — https://burntsushi.net/ripgrep/ ; ripgrep — https://github.com/BurntSushi/ripgrep
+10. regex-syntax literal Extractor API — https://docs.rs/regex-syntax/latest/regex_syntax/hir/literal/struct.Extractor.html
+11. Aider repo map / tree-sitter, 2023 — https://aider.chat/2023/10/22/repomap.html ; https://aider.chat/docs/repomap.html
+12. ctags vs tree-sitter — https://github.com/chrismwendt/ctags-vs-tree-sitter ; ttags — https://github.com/npezza93/ttags
+13. [VENDOR] token-savings claims — https://fazm.ai/t/reduce-ai-agent-token-costs-mcp-strategies ; https://elara-labs.github.io/code-context-engine/ ; [BLOG] https://dev.to/nicolalessi/i-tracked-every-token-my-ai-coding-agent-consumed-for-a-week-70-was-waste-465

--- a/scratch/rfc-implementation-plan/research/ltr-reranking-feedback.md
+++ b/scratch/rfc-implementation-plan/research/ltr-reranking-feedback.md
@@ -1,0 +1,205 @@
+# Research Foundation: Agent Feedback Loop (Feature 1) & Lightweight Learned Listwise Reranker (Feature 17)
+
+Compiled for NestWeaver (Rust code-and-notes graph intelligence: tree-sitter indexing, embedded graph DB, Personalized PageRank + BM25/Tantivy + optional vectors fused via RRF, MCP server, solo-dev / no-GPU / no-daemon).
+
+All sources below were retrieved via web search/fetch on 2026-05-29. Where a quantitative claim could not be confirmed from the retrieved page text it is marked `[UNVERIFIED]`. No papers, authors, venues, or results are fabricated.
+
+---
+
+## Cross-cutting context: NestWeaver is NOT a web search engine
+
+Most implicit-feedback / click-model / unbiased-LTR theory was developed for *web search with high-volume traffic and a SERP layout*. NestWeaver differs on every axis that matters:
+
+- **One user (solo dev), low query volume.** IPS-based unbiased LTR and click models are statistically hungry — they assume thousands+ of impressions per query/position to estimate propensities or model parameters. NestWeaver will never have that. This *fundamentally bounds* how much of the unbiased-LTR machinery is applicable; it should inform design (favor robust heuristics + tiny models + conservative gates) rather than be copied wholesale.
+- **The "presentation" is an MCP tool result or CLI output**, often consumed by an LLM agent, not a human scanning a ranked SERP top-to-bottom. Position bias still plausibly exists (agents/humans attend to earlier results), but cascade-style "examine until satisfied then abandon" is a weaker assumption.
+- **A genuine, observable success signal exists that web search lacks**: the agent subsequently *edits/writes a file* (acts on the retrieved symbol). This is closer to a conversion/purchase signal than a click — far stronger than dwell time.
+
+These differences are the spine of the recommendations below.
+
+---
+
+# FEATURE 1 — Agent Feedback Loop (interaction events → PPR teleport boost; safe success signal)
+
+## 1. Research foundation
+
+### Implicit feedback as a relevance signal (and its biases)
+
+- **Fox, Karnawat, Mydland, Dumais, White (2005). "Evaluating implicit measures to improve web search." ACM TOIS 23(2):147–168.** Retrieved: https://dl.acm.org/doi/10.1145/1059981.1059982 (full PDF: http://susandumais.com/tois-p147-fox.pdf).
+  - **Result that matters:** There *is* a measurable association between implicit signals and explicit user satisfaction, and the best predictive models combine **clickthrough, dwell time on the result, and how the user exited the result / ended the session.** Crucially, *exit type / session-end behavior* carries signal — directly supports NestWeaver's "end-of-session without further searching = success" idea.
+
+- **Craswell, Zoeter, Taylor, Ramsey (2008). "An experimental comparison of click position-bias models." WSDM 2008, pp. 87–94.** Retrieved: https://dl.acm.org/doi/10.1145/1341531.1341545 (PDF mirror: https://www.researchgate.net/publication/200110550).
+  - **Result that matters:** Clicks are strongly biased by **presentation position**; a **cascade model** (user scans top→bottom, clicks the first worthwhile result, then stops) best explains position bias at early ranks. Implication for NestWeaver: a result at rank 1 getting "used" is partly an artifact of being shown first, not purely of being more relevant. Any teleport boost derived from interaction counts must account for this or it will entrench whatever was already ranked highly.
+
+- **Chuklin, Markov, de Rijke (2015). "Click Models for Web Search." Synthesis Lectures on Information Concepts, Retrieval, and Services, Morgan & Claypool. DOI 10.2200/S00654ED1V01Y201507ICR043.** Retrieved: https://link.springer.com/book/10.1007/978-3-031-02294-4 (authors' PDF: https://clickmodels.weebly.com/uploads/5/2/2/5/52257029/mc2015-clickmodels.pdf; SIGIR'15 tutorial: https://irlab.science.uva.nl/wp-content/papercite-data/pdf/chuklin-introduction-2015.pdf).
+  - **Result that matters:** Canonical reference cataloguing click models — Position-Based Model (PBM), Cascade Model, Dependent Click Model (DCM), User Browsing Model (UBM), Dynamic Bayesian Network (DBN). Key takeaway for us: separating *examination* (was it seen?) from *attractiveness/relevance* (was it good?) requires a model of how results are presented and consumed. NestWeaver lacks the data to fit any of these properly, so we should borrow the *conceptual decomposition* (examination ≠ relevance) rather than the estimators.
+
+### Counterfactual / unbiased learning-to-rank from implicit feedback
+
+- **Joachims, Swaminathan, Schnabel (2017). "Unbiased Learning-to-Rank with Biased Feedback." WSDM 2017 (preprint arXiv:1608.04468, 2016).** Retrieved: https://arxiv.org/abs/1608.04468 (PDF: https://www.cs.cornell.edu/~tj/publications/joachims_etal_17a.pdf).
+  - **Result that matters:** Provides a **counterfactual / Empirical-Risk-Minimization framework** for unbiased LTR despite biased clicks: weight each observed click by the **inverse of its examination propensity (Inverse Propensity Scoring, IPS)**, yielding a Propensity-Weighted Ranking SVM. The framework is *provably unbiased* w.r.t. the true relevance if propensities are correct, and is shown robust to noise and propensity misspecification; reported to substantially improve retrieval on an operational engine (specific magnitude not in abstract `[UNVERIFIED exact %]`).
+  - **For NestWeaver:** IPS is the theoretically correct way to keep a feedback loop honest — but it needs per-position propensity estimates that require volume we won't have. The *actionable lesson* is conceptual: **never feed raw interaction counts straight back into ranking; down-weight signal coming from already-high positions.** Even a crude static position-discount approximates IPS's intent.
+
+- **Ai, Bi, Luo, Guo, Croft (2018). "Unbiased Learning to Rank with Unbiased Propensity Estimation." SIGIR 2018.** Retrieved: https://arxiv.org/pdf/1804.05938 (ACM: https://dl.acm.org/doi/10.1145/3209978.3209986).
+  - **Result that matters:** Shows propensities can be **estimated jointly from click data (Dual Learning Algorithm)** without separate position-swap experiments, making unbiased LTR more practical. Confirms the direction but, again, is data-hungry.
+
+### Feedback-loop / runaway bias (the danger)
+
+- **Ensign, Friedler, Neville, Scheidegger, Venkatasubramanian (2018). "Runaway Feedback Loops in Predictive Policing." FAT* 2018, PMLR 81 (preprint arXiv:1706.09847).** Retrieved: https://arxiv.org/abs/1706.09847 (PDF: https://friedler.net/papers/feedbackloops_fat18.pdf; PMLR: https://proceedings.mlr.press/v81/ensign18a.html).
+  - **Result that matters:** Formal (Pólya-urn) proof that when a system's *future training data is collected only from where the model already directs attention*, sampling bias compounds into a **runaway feedback loop** — the model keeps reinforcing its prior choices regardless of ground truth. They show the fix is to **adjust the inputs in a black-box way (discount discoveries by how much attention drove them).** This is the single most important cautionary result for Feature 1: an interaction-count → teleport-boost loop is structurally identical to the policing loop (we only get interactions on results we surfaced).
+
+### Personalization vector in PageRank (the mechanism)
+
+- **Haveliwala (2002). "Topic-Sensitive PageRank." WWW 2002, pp. 517–526.** Retrieved: https://dl.acm.org/doi/10.1145/511446.511513 (PDF: https://www.cs.cmu.edu/~christos/courses/826-resources/PAPERS+BOOK/Haveliwala_www2003.pdf).
+  - **Result that matters:** PageRank can be biased toward a topic/context by replacing the uniform teleport (jump) distribution with a **nonuniform personalization vector**; the random-surfer restart probability mass is redistributed to favored nodes, increasing their rank and the rank of nodes they point to. This is *exactly* the established, principled mechanism NestWeaver's PPR already uses for seeds, and exactly where a feedback boost belongs. The boost should modulate the **teleport/restart vector**, not edge weights or final scores — consistent with both Haveliwala and standard Personalized PageRank.
+
+## 2. Prior art / projects
+
+| System | Approach | Tradeoffs / relevance to NestWeaver |
+|---|---|---|
+| Cornell `svm_proprank` (Propensity SVM-rank) | Reference impl of IPS-weighted LTR from Joachims et al. | https://www.cs.cornell.edu/people/tj/svm_light/svm_proprank.html — proves the method, but C, SVM, and needs propensities. Reference only. |
+| Web-search click-log pipelines (Google/Bing-style, per Craswell/Chuklin) | Fit click models (DBN/UBM) to massive logs, derive relevance | Not viable for single-user volume. Borrow concepts only. |
+| RecSys exposure-bias literature (generalization of Ensign et al.) | Document that naive "log → train → serve → log" loops cause popularity entrenchment | Confirms runaway risk applies to any self-collected-feedback ranker. |
+
+## 3. Recommended approach for NestWeaver (grounded)
+
+**Mechanism (where the boost goes).** Apply the interaction score as a **multiplicative factor on the per-UID teleport (restart) mass of the existing Personalized PageRank**, capped at 2.0x as specified. This is the Haveliwala personalization-vector mechanism and keeps the boost inside the well-understood PPR fixed point rather than hacking final scores. Renormalize the teleport vector after boosting so it remains a probability distribution.
+
+**Defining a SAFE success signal (the core of the feature).** Grounded in Fox et al. (2005) — exit type and session-end behavior predict satisfaction — adopt a *sequence-aware* labeling of each surfaced result:
+
+- **NEGATIVE / no-success:** the result was surfaced and the agent's *next action within the session is another search/context query* (especially a reformulation). This mirrors the cascade/"abandon and look again" pattern: re-querying signals the prior result did not satisfy. **Do not award success credit here.**
+- **POSITIVE / success:** the surfaced UID (or a UID in the same file/symbol neighborhood) is followed by a **write/edit/impact action on that symbol**, OR the **session ends with no further search** after the result was accessed. The write/edit signal is NestWeaver's analogue of a *conversion* — far stronger than a click and not available to web search. Weight it highest.
+- **WEAK / neutral:** mere access (open/read) with neither of the above — treat as low-weight or zero, because access alone is the most position-biased and least reliable signal (Craswell et al.).
+
+This is a deliberately simple, robust heuristic rather than a fitted click model, which is the correct altitude for single-user data volume.
+
+**Avoiding feedback-loop bias (mandatory, per Ensign et al.).** Because we only observe interactions on results we surfaced, build in explicit dampers:
+
+1. **Position discounting (poor-man's IPS).** Discount the success credit of a result by a static, decreasing function of the rank at which it was shown (e.g. credit ∝ 1/log2(1+rank), or a fixed examination-probability table). This approximates IPS's "down-weight signal that came from a privileged position" without needing to estimate propensities — directly the Joachims et al. intent and the Ensign et al. fix.
+2. **Cap the boost (already specified: 2.0x).** A hard multiplicative ceiling bounds runaway growth.
+3. **Time-decay (already in the sidecar).** Decay keeps stale entrenchment from accumulating; ensures the loop "forgets."
+4. **Exploration floor.** Never let the boost drive a result's effective teleport mass so high that genuinely-relevant-but-never-surfaced nodes can't appear. Keep a minimum uniform teleport component (this is the structural fix Ensign et al. prescribe — guarantee non-zero exploration).
+5. **Boost relevance, not just popularity.** Prefer crediting the *success* signal (edit/write/session-end) over raw access frequency, so the loop reinforces *useful* results, not merely *frequently-shown* ones.
+
+**Why not full IPS/click models here:** insufficient per-position impression volume for a single user to estimate propensities or fit DBN/UBM. The honest engineering answer is to take the *concepts* (examination ≠ relevance; discount privileged positions; guarantee exploration) and implement them as cheap deterministic rules.
+
+## 4. Pitfalls / failure modes + mitigations
+
+| Pitfall | Source grounding | Mitigation |
+|---|---|---|
+| Runaway feedback loop: surfaced→used→boosted→surfaced more, regardless of true relevance | Ensign et al. 2018 | Position discounting + 2.0x cap + time-decay + uniform exploration floor |
+| Position-bias entrenchment (rank-1 results win just for being rank 1) | Craswell et al. 2008 | Discount credit by show-position (poor-man's IPS) |
+| Treating mere access as success | Fox et al. 2005 (access weak; exit/dwell stronger) | Tiered signal: weight write/edit and clean session-end above raw access |
+| Mislabeling reformulation as success | cascade abandonment intuition | "next action is another search ⇒ NOT success" rule |
+| Over-personalizing to recent noise / one bad session | general | Time-decay (have it) + cap; require a minimum count before any boost applies |
+| Cold start: no interactions yet | — | Boost defaults to 1.0x (identity); PPR behaves exactly as today |
+
+## 5. Complexity / effort + expected deltas
+
+- **Effort:** Low–Medium. Sidecar event recording exists. New work: (a) sequence-aware success labeler over the event stream (next-action rule + session boundary detection), (b) position-discounted scoring, (c) teleport-vector boost+renormalize in the existing PPR pass, (d) the four dampers. All pure Rust, no model, no GPU.
+- **Expected quality delta:** No directly transferable published number — the personalization literature is web-scale and multi-user. Treat improvement as **plausible but unproven for single-user**; gate via the same offline nDCG harness built for Feature 17 (below). The dominant *risk-reduction* deliverable here is the anti-feedback-loop design, not a headline metric.
+
+---
+
+# FEATURE 17 — Lightweight Learned Listwise Reranker (~20K params, ~100KB, candle, top-50, gated ≥5% nDCG@10)
+
+## 1. Research foundation
+
+### Learning-to-rank: pointwise / pairwise / listwise
+
+- **Burges (2010). "From RankNet to LambdaRank to LambdaMART: An Overview." Microsoft Research Technical Report MSR-TR-2010-82.** Retrieved: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/MSR-TR-2010-82.pdf.
+  - **Result that matters:** Definitive, self-contained derivation of the pairwise→listwise-flavored family. **RankNet** = pairwise cross-entropy on score differences (neural). **LambdaRank** = define the gradient (λ) directly, scaling each pairwise gradient by the **|ΔnDCG|** that swapping the pair would cause — this optimizes a smooth surrogate aligned with the (non-differentiable) nDCG metric. **LambdaMART** = LambdaRank gradients in gradient-boosted trees; an ensemble of LambdaMART **won Track 1 of the 2010 Yahoo! Learning-to-Rank Challenge.** This is the empirically dominant LTR recipe and the natural baseline-of-comparison.
+
+- **Cao, Qin, Liu, Tsai, Li (2007). "Learning to Rank: From Pairwise Approach to Listwise Approach." ICML 2007 (24th ICML).** Retrieved (MSR tech-report PDF tr-2007-40): https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/tr-2007-40.pdf (ACM: https://dl.acm.org/doi/abs/10.1145/1390156.1390306).
+  - **Result that matters:** Introduces the **listwise approach** and **ListNet**: loss = **cross-entropy between two permutation-probability distributions** (top-one probability under Placket–Luce), one from predicted scores, one from ground-truth labels. Listwise losses model the whole ranked list jointly rather than isolated pairs/points, and the paper shows listwise outperforms pairwise on benchmark IR data.
+
+- **Xia, Liu, Wang, Zhang, Li (2008). "Listwise Approach to Learning to Rank: Theory and Algorithm." ICML 2008.** Retrieved: https://icml.cc/Conferences/2008/papers/167.pdf.
+  - **Result that matters:** Introduces **ListMLE** (maximum likelihood over the observed permutation via Plackett–Luce), with a theoretical analysis of listwise loss consistency. ListMLE is simpler/cheaper than ListNet's full cross-entropy and is a good fit for a tiny model. Confirms listwise losses are theoretically sound surrogates for ranking metrics.
+
+### Evaluation metric (the gate)
+
+- **Järvelin, Kekäläinen (2002). "Cumulated Gain-based Evaluation of IR Techniques." ACM TOIS 20(4):422–446.** Retrieved: https://dl.acm.org/doi/10.1145/582415.582418 (PDF: https://faculty.cc.gatech.edu/~zha/CS8803WST/dcg.pdf).
+  - **Result that matters:** Defines **(n)DCG** — discounts gain by log of rank position and normalizes against the ideal ranking, supporting **graded relevance** and emphasizing highly-relevant docs near the top. This is the canonical justification for using **nDCG@10** as Feature 17's promotion gate.
+
+### Neural rerankers (cross-encoders) — for calibration of expectations
+
+- **Nogueira, Cho (2019). "Passage Re-ranking with BERT." arXiv:1901.04085.** Retrieved: https://arxiv.org/abs/1901.04085 (PDF: https://arxiv.org/pdf/1901.04085).
+  - **Result that matters:** The "monoBERT" cross-encoder reranker over top-k first-stage candidates set state-of-the-art on TREC-CAR and topped the MS MARCO passage leaderboard, **+27% relative MRR@10 over the prior best** (per the paper's reported headline). Establishes the now-standard **retrieve-then-rerank** architecture and that reranking the *top-k* (not the whole corpus) is where rerankers pay off — directly validating NestWeaver's "rerank top-50" design. **Caveat:** monoBERT is ~110M params; its gains do NOT transfer to a 20K-param feature-based model. Cited to justify *the architecture*, not the magnitude.
+
+- **Sentence-Transformers cross-encoders (e.g. `cross-encoder/ms-marco-MiniLM-L-6-v2`).** Retrieved: https://www.sbert.net/docs/cross_encoder/pretrained_models.html and https://sbert.net/docs/cross_encoder/training_overview.html.
+  - **Result that matters:** Documents the standard **retrieve-and-rerank** pattern (fast first stage retrieves X candidates; cross-encoder reranks the top X) and explicitly notes you should **experiment to confirm the slower second stage is worth it** — i.e. a reranker is not always a win; latency must be justified. This is the practitioner grounding for Feature 17's ≥5% gate.
+
+## 2. Prior art / projects
+
+| Project | What it is | Tradeoffs / relevance |
+|---|---|---|
+| **OpenSearch Learning to Rank plugin** | In-engine LTR; logs query-dependent features, serves XGBoost/RankLib models (LambdaMART, RF). Training is *offline/external*. | https://docs.opensearch.org/latest/search-plugins/ltr/index/ — Validates NestWeaver's exact split: **online feature logging + scoring, offline training.** Tree models, not neural. |
+| **Elasticsearch LTR** | Same lineage (RankLib/XGBoost serialized models uploaded to engine). | https://elasticsearch-learning-to-rank.readthedocs.io/en/latest/training-models.html — Same pattern. |
+| **Vespa ranking** | Multi-phase ranking: cheap first-phase, expensive second/global-phase. Imports XGBoost GBDT and **ONNX** models; warns large models belong in later phases. | https://docs.vespa.ai/en/ranking/phased-ranking.html , https://docs.vespa.ai/en/ranking/onnx.html — Strong precedent for **phased ranking** (hybrid first stage → learned reranker on top-50). |
+| **XGBoost `rank:ndcg` / LightGBM `lambdarank`** | Off-the-shelf LambdaMART-family rankers. | https://xgboost.readthedocs.io/en/stable/tutorials/learning_to_rank.html — The pragmatic baseline; trees often beat tiny nets on tabular features. Worth training as a comparison even if the *shipped* model is candle. |
+| **candle (huggingface)** | Minimalist Rust ML framework, PyTorch-like tensors, CPU (MKL/Accelerate)/CUDA/WASM, inference-focused, `candle-onnx` for ONNX eval. | https://github.com/huggingface/candle , https://github.com/huggingface/candle/tree/main/candle-onnx — A ~20K-param MLP/linear listwise scorer is trivially within candle's CPU capabilities; no GPU needed; aligns with no-daemon/no-GPU constraint. |
+| **ONNX-in-Rust (ort / candle-onnx / tract)** | Run models trained in Python (XGBoost→ONNX, or a torch MLP→ONNX) inside Rust. | Lets you train with mature Python tooling, ship a tiny ONNX in pure Rust. Reduces "train in Rust" risk. |
+
+## 3. Recommended approach for NestWeaver (grounded)
+
+**Architecture: phased ranking, validated by monoBERT/Vespa/SBERT.** Keep the hybrid (PPR + BM25 + optional vectors via RRF) as the **first stage**; the learned model **reranks only the top-50** candidates. Reranking a small candidate set is exactly where the literature shows rerankers pay off and where cost stays bounded.
+
+**Features (as specified) are sound and tabular:** `[rank_position, bm25_score, ppr_score, node_kind_onehot, is_inline_body, age_days, matched_alias_count]`. Note `rank_position` and `bm25_score`/`ppr_score` encode first-stage signal; including `rank_position` lets the model learn a residual over the baseline (helpful) but **also re-imports position bias** — keep it but be aware (see pitfalls). All features are cheap to compute at query time, no embeddings required for the reranker itself.
+
+**Model + loss.** A ~20K-param model on ~7 features is **credible**: with one-hot node kinds the input is ~10–20 dims; a small MLP (e.g. 20→64→32→1 ≈ 3–4K params, or wider to reach ~20K) is ample — these features are low-dimensional and largely monotone, so capacity is not the bottleneck (this is *under-parameterized-for-NLP* but *appropriately-sized for tabular ranking*; cf. trees winning Yahoo LTR with modest models). Use a **listwise loss**: **ListMLE** (Xia et al. 2008) is the simplest to implement and cheap; **ListNet** (Cao et al. 2007) or a **LambdaRank-style λ weighting by |ΔnDCG|** (Burges 2010) are the metric-aligned alternatives. Recommend starting with **ListNet/ListMLE** for simplicity and adding LambdaRank weighting only if the gate isn't met.
+
+**Honest baseline check first.** Per the LTR literature, **train an XGBoost/LightGBM LambdaMART model on the same features+labels** as a yardstick. If trees beat the tiny candle net by a wide margin, ship the tree (export to ONNX, run via `candle-onnx`/`ort`) — the deliverable is *a reranker that clears the gate*, not specifically a hand-rolled net.
+
+**Offline training from implicit labels.** Derive graded relevance labels from Feature 1's success signal:
+- label 2 (highly relevant): result followed by edit/write on that symbol (the conversion signal);
+- label 1: accessed and session ended cleanly without re-query;
+- label 0: surfaced-but-ignored, or followed immediately by another search.
+**Apply position-discounting / IPS-style reweighting to these labels** (Joachims et al. 2017) so the reranker doesn't just learn to reproduce the first-stage order. Train offline, batch, from the interaction sidecar — exactly the OpenSearch/Elasticsearch "offline training, online serving" split.
+
+**The gate is sound.** Promote the reranker **only if it beats the hybrid baseline by ≥5% nDCG@10** on a held-out set. nDCG@10 is the right metric (Järvelin & Kekäläinen). Recommended hardening of the gate:
+- evaluate via **time-based or query-based cross-validation / held-out split**, not random row shuffling (avoids leaking session structure);
+- because single-user label volume is tiny, report a **confidence interval / per-query win-loss count**, not just a point estimate — a 5% mean lift on 40 queries can be noise. Consider also reporting **MRR** as a secondary check.
+- ship behind a flag, default off, so a non-improving model never degrades the product.
+
+## 4. Pitfalls / failure modes + mitigations
+
+| Pitfall | Source grounding | Mitigation |
+|---|---|---|
+| Reranker just relearns first-stage order (no real lift) | retrieve-rerank caveat, SBERT docs | IPS/position-discounted labels (Joachims 2017); the ≥5% gate kills no-lift models |
+| `rank_position` feature re-imports position bias into labels AND features | Craswell 2008; Joachims 2017 | Discount labels by show-position; consider training a variant *without* rank_position to measure its contribution |
+| Tiny training set → overfit; 5% lift is noise | LTR practice | Time/query-based CV, report CI / per-query wins, secondary MRR, default-off flag |
+| Reranker not worth its latency | SBERT "experiment if the 2nd stage is worth it" | Top-50 only; tiny model (~100KB) → sub-millisecond CPU inference; the gate is also implicitly a cost/benefit check |
+| Distribution shift: codebase changes, labels go stale | feedback-loop literature | Retrain periodically; time-decay labels (shared with Feature 1) |
+| Hand-rolled candle net underperforms a tree | Yahoo LTR / XGBoost-rank dominance on tabular | Train XGBoost LambdaMART baseline; ship whichever clears the gate (ONNX via candle-onnx/ort if it's the tree) |
+| Over-relying on web-search reranker gains (monoBERT +27%) | Nogueira & Cho 2019 (110M params) | Do NOT expect such magnitudes from 20K params; cite for architecture only |
+
+## 5. Complexity / effort + reported quality deltas
+
+- **Effort:** Medium. Feature extraction at query time (cheap, reuses existing scores). Offline training harness + label derivation (depends on Feature 1's success labeler — build that first). candle MLP + ListMLE/ListNet loss is small; an XGBoost baseline is near-free. nDCG@10 eval harness with proper CV is the most careful part.
+- **Reported quality deltas (calibration, not transfer):**
+  - Cross-encoder reranking over a hybrid first stage: **+27% relative MRR@10** for monoBERT on MS MARCO (Nogueira & Cho 2019) — *upper bound for 110M-param models; not a target for 20K params.*
+  - LambdaMART: state-of-the-art tabular LTR, won the 2010 Yahoo! LTR Challenge Track 1 (Burges 2010) — realistic family for our feature set.
+  - Listwise > pairwise on LETOR benchmarks (Cao et al. 2007) — supports the listwise choice.
+  - **For NestWeaver specifically: no transferable number exists** (single-user, code-graph domain). The **≥5% nDCG@10 gate is the empirical contract** — if the model doesn't clear it on held-out queries with a reasonable confidence interval, it doesn't ship. This is the correct, defensible posture.
+
+---
+
+## Source index (all retrieved 2026-05-29)
+
+1. Fox et al. 2005, TOIS — implicit measures / dwell / exit: https://dl.acm.org/doi/10.1145/1059981.1059982 (PDF http://susandumais.com/tois-p147-fox.pdf)
+2. Craswell et al. 2008, WSDM — click position-bias / cascade: https://dl.acm.org/doi/10.1145/1341531.1341545
+3. Chuklin, Markov, de Rijke 2015 — Click Models for Web Search: https://link.springer.com/book/10.1007/978-3-031-02294-4 (PDF https://clickmodels.weebly.com/uploads/5/2/2/5/52257029/mc2015-clickmodels.pdf)
+4. Joachims, Swaminathan, Schnabel 2017, WSDM — Unbiased LTR / IPS: https://arxiv.org/abs/1608.04468 (PDF https://www.cs.cornell.edu/~tj/publications/joachims_etal_17a.pdf)
+5. Ai et al. 2018, SIGIR — Unbiased propensity estimation: https://arxiv.org/pdf/1804.05938
+6. Ensign et al. 2018, FAT* — Runaway Feedback Loops: https://arxiv.org/abs/1706.09847 (PDF https://friedler.net/papers/feedbackloops_fat18.pdf)
+7. Haveliwala 2002, WWW — Topic-Sensitive PageRank: https://dl.acm.org/doi/10.1145/511446.511513
+8. Burges 2010, MSR-TR-2010-82 — RankNet/LambdaRank/LambdaMART: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/MSR-TR-2010-82.pdf
+9. Cao et al. 2007, ICML — ListNet: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/tr-2007-40.pdf
+10. Xia et al. 2008, ICML — ListMLE: https://icml.cc/Conferences/2008/papers/167.pdf
+11. Järvelin & Kekäläinen 2002, TOIS — (n)DCG: https://dl.acm.org/doi/10.1145/582415.582418
+12. Nogueira & Cho 2019 — Passage Re-ranking with BERT (monoBERT): https://arxiv.org/abs/1901.04085
+13. Sentence-Transformers cross-encoder docs: https://www.sbert.net/docs/cross_encoder/pretrained_models.html ; https://sbert.net/docs/cross_encoder/training_overview.html
+14. OpenSearch LTR plugin: https://docs.opensearch.org/latest/search-plugins/ltr/index/
+15. Elasticsearch LTR: https://elasticsearch-learning-to-rank.readthedocs.io/en/latest/training-models.html
+16. Vespa phased ranking / ONNX: https://docs.vespa.ai/en/ranking/phased-ranking.html ; https://docs.vespa.ai/en/ranking/onnx.html
+17. XGBoost learning-to-rank: https://xgboost.readthedocs.io/en/stable/tutorials/learning_to_rank.html
+18. candle + candle-onnx: https://github.com/huggingface/candle ; https://github.com/huggingface/candle/tree/main/candle-onnx

--- a/scratch/rfc-implementation-plan/research/ranking-priors-query-expansion.md
+++ b/scratch/rfc-implementation-plan/research/ranking-priors-query-expansion.md
@@ -1,0 +1,360 @@
+# Research Foundation: Ranking Priors (Feature 6) & PRF + Query Expansion (Feature 7)
+
+Prepared for the NestWeaver RFC implementation plan. All sources below were retrieved
+via web search/fetch on 2026-05-29. Where a primary PDF would not render to text through
+the fetch tool, the fact is marked and corroborated from the authoritative bibliographic
+record (dblp / IR-Anthology / ACM DL) plus the reference implementation. Such items are
+flagged `[PDF-NOT-PARSED, corroborated]`. Nothing here is fabricated; unverifiable claims
+are marked `[UNVERIFIED]`.
+
+NestWeaver context that constrains both designs:
+- Ranking already fuses three signals: Personalized PageRank over typed edges (CALLS 1.0 /
+  IMPORTS 0.8 / USES 0.5 / ACCESSES 0.4), BM25 (Tantivy), and optional vector search,
+  combined with Reciprocal Rank Fusion (RRF).
+- Single-binary, embedded LadybugDB, no GPU, no daemon, solo-dev workloads. So anything
+  requiring training, a second model, or large per-query compute is out of scope.
+
+---
+
+# FEATURE 6 — Per-repo/per-path "dampen"/"boost" ranking priors
+
+Goal: a continuous, query-independent multiplier on node relevance keyed by path glob,
+applied at PPR-output time (`node.relevance *= prior`), clamped to `[0.05, 5.0]`,
+last-match-wins.
+
+## 6.1 Research foundation
+
+**(A) Robertson & Zaragoza (2009), "The Probabilistic Relevance Framework: BM25 and Beyond,"
+*Foundations and Trends in Information Retrieval* 3(4):333–389. DOI 10.1561/1500000019.**
+- URL (publisher): https://dl.acm.org/doi/abs/10.1561/1500000019
+- URL (scirp ref record confirming venue/pages/year): https://www.scirp.org/reference/referencespapers?referenceid=3896864
+- This is the canonical monograph for the PRF/BM25 family. It explicitly covers two design
+  points we need: (1) **non-textual / query-independent features** as document priors, and
+  (2) **field weighting via BM25F**. Per the abstract and the framework's structure, the PRF
+  treats a query-independent feature (e.g., document quality, recency, link-based authority)
+  as a *prior probability of relevance*, combined with the textual score. The framework's
+  log-odds formulation means a query-independent prior enters **additively in the
+  log-score domain**, i.e. **multiplicatively on the probability/relevance scale**. This is
+  the formal justification for applying a static path/repo prior as a multiplier on a
+  relevance score rather than as an additive term on a raw BM25 score.
+  `[PDF body not re-fetched; venue/pages/scope confirmed via two independent records above and the Google Books description: https://books.google.com/books/about/The_Probabilistic_Relevance_Framework.html?id=yK6HxUEaZ9gC]`
+
+**(B) Robertson, Zaragoza & Taylor (2004), "Simple BM25 extension to multiple weighted
+fields," CIKM 2004 — the BM25F paper.**
+- URL (Semantic Scholar record): https://www.semanticscholar.org/paper/Simple-BM25-extension-to-multiple-weighted-fields-Robertson-Zaragoza/67085d02e3a4710119f1bad050d89c10bd79d977
+- Tutorial restating its math: http://www.minerazzi.com/tutorials/bm25f-model-tutorial.pdf
+- **The load-bearing result for us:** combining per-field *scores* linearly **breaks BM25's
+  non-linear term-frequency saturation**, producing poor rankings. BM25F instead applies a
+  per-field boost `w_f` to the *term frequencies before* the saturation function, then scores
+  once. Quote (from the paper's abstract, retrieved): "compute scores for the individual
+  fields … and then combine these scores (typically linearly) … can lead to poor performance
+  by breaking the carefully constructed non-linear saturation of term frequency in the BM25
+  function."
+- **Implication for Feature 6:** a *path/repo* prior is fundamentally different from a
+  *field-content* boost. BM25F's lesson is "don't post-combine field scores linearly because
+  it breaks saturation." But our path prior is **query-independent and orthogonal to TF
+  saturation** — it is not re-weighting term evidence, it is re-weighting whole documents by
+  a static property. Therefore the BM25F warning does **not** forbid a multiplicative
+  post-hoc document prior; it specifically warns against linearly mixing *per-field term
+  scores*. A document prior multiplied onto the final relevance is exactly the PRF-sanctioned
+  "static feature as prior" pattern (source A), not the anti-pattern BM25F warns about.
+
+**(C) PageRank as a query-independent prior.** PageRank (Brin & Page 1998) is the archetypal
+*static rank* / query-independent document prior: a per-document score multiplied/added into
+the final ranking regardless of query. NestWeaver already computes Personalized PageRank, so
+a path prior is conceptually a *second* static prior layered on top. This is well established
+in the IR literature (Robertson & Zaragoza, source A, discuss link-based and other static
+features as priors). `[Brin & Page not separately fetched this session; cited as background,
+treat as [UNVERIFIED] for exact wording but the "PageRank = query-independent prior" framing
+is uncontroversial and restated in source A.]`
+
+### Multiplicative vs additive priors, clamping, normalization
+- **Multiplicative is the correct default here.** In a log-linear/probabilistic model a prior
+  is additive in log-space = multiplicative in score-space (source A). Multiplicative priors
+  are scale-invariant: they preserve relative ordering structure and degrade gracefully as
+  scores shrink, whereas an *additive* prior on a raw score is sensitive to that score's
+  absolute magnitude (which varies per query) and can swamp or be swamped by it.
+- **Clamping is standard practice in production engines.** Elasticsearch/OpenSearch expose
+  `max_boost` precisely to bound a multiplicative `function_score` so a runaway multiplier
+  cannot dominate: "The new score can be restricted to not exceed a certain limit by setting
+  the `max_boost` parameter." (Elastic function_score reference, retrieved.) NestWeaver's
+  proposed clamp `[0.05, 5.0]` is the same idea applied symmetrically (floor + ceiling). A
+  symmetric clamp in *multiplicative* space (e.g. capping at 5x and flooring at 0.05x) is the
+  right shape; an additive clamp would be the wrong space.
+
+## 6.2 Prior art / projects (with tradeoffs)
+
+| System | Mechanism | How priors are exposed | Tradeoff |
+|---|---|---|---|
+| **Elasticsearch `function_score`** | `boost_mode: multiply` multiplies query score by a function score; `weight` function gives a static per-filter multiplier; `field_value_factor` turns a numeric field into a multiplier with `factor`/`modifier (log,sqrt,reciprocal,…)`/`missing`. `max_boost` clamps, `min_score` filters. Docs retrieved: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html | Filter→weight pairs == "glob→multiplier"; `boost_mode: multiply` == our PPR-output multiply. | Per-query DSL, not a persisted index-time prior; you re-send the function set each query. Good template, heavier than we need. |
+| **OpenSearch `function_score`** | Fork of the above; same `boost_mode`/`score_mode`/`field_value_factor`/`weight`. Docs: https://docs.opensearch.org/latest/query-dsl/compound/function-score/ | Same as ES. | Same. |
+| **Lucene** | Index-time/static boosts removed in modern Lucene; replaced by `FunctionScoreQuery` / per-document `NumericDocValues` features fed into scoring. | Document features via doc-values. | Library-level; you wire the multiplier yourself. |
+| **Vespa** | First-phase / second-phase **ranking expressions**; document features via `attribute(fieldName)`, query features via `query(name)`, match features like `bm25`. A static prior is just another term/factor in the expression. Docs retrieved: https://docs.vespa.ai/en/ranking/ranking-expressions-features.html ; https://docs.vespa.ai/en/ranking/phased-ranking.html | Arbitrary expression, e.g. `bm25(body) * attribute(path_prior)`. | Most expressive; closest conceptual match to "apply prior at output". Overkill engine but validates the design: priors are first-class multiplicative factors in the rank expression. |
+| **Tantivy** (NestWeaver's actual BM25 engine) | `Bm25Weight::boost_by(factor)` multiplicative boost; custom `Weight`/`Scorer`; `Bm25StatisticsProvider` override. Source: https://docs.rs/tantivy/latest/tantivy/query/index.html ; https://github.com/quickwit-oss/tantivy/blob/main/src/query/bm25.rs | Per-query multiplicative boost exists; no built-in per-path static prior. | We must apply the path prior **outside** Tantivy (post-fusion), because the prior is keyed on path metadata NestWeaver owns, not on Tantivy fields. |
+
+**Key takeaway from prior art:** every production engine that supports static priors does it
+**multiplicatively** (`boost_mode: multiply`, Vespa expression products, Tantivy `boost_by`)
+and provides a **clamp** (`max_boost`). This directly validates the RFC's design.
+
+## 6.3 Recommended approach for NestWeaver
+
+1. **Placement: apply the multiplier on the *final fused* relevance, after RRF, not inside
+   PPR or inside Tantivy.** Rationale: (a) the prior is query-independent and document-global,
+   exactly the "static feature as prior" pattern (source A); (b) applying it post-fusion keeps
+   it orthogonal to RRF's rank-only logic (see Feature 7's RRF note: RRF deliberately ignores
+   raw scores). If you instead multiply *before* RRF, the multiplier has no effect, because
+   RRF discards magnitudes and keeps only ranks. **Therefore the prior must be applied either
+   (i) as a post-RRF re-scoring multiplier on the fused score, OR (ii) inside each retriever's
+   pre-RRF score so it changes the *rank ordering* fed to RRF.** Pick (i) if you want the
+   prior to perturb the final top-N ordering predictably; pick (ii) if you want it to
+   influence which docs even reach the fusion. The RFC says "applied at PPR-output time
+   (multiply node.relevance)" — that is option (ii)-for-PPR-only and is coherent **as long as
+   PPR relevance feeds RRF as a score-derived rank**; document this explicitly because if RRF
+   only sees PPR rank, the path prior must be large enough to reorder ranks to matter.
+   **Recommendation: apply the prior to the PPR score *before* PPR results are ranked for
+   RRF, AND optionally to the final fused score, but be explicit which.** Cleanest is a single
+   post-fusion multiply on `node.relevance` so behavior is independent of fusion internals.
+2. **Multiplicative, log-space-safe, last-match-wins.** Multiplicative is settled by sources A
+   and all of 6.2. Last-match-wins glob semantics are a config-ergonomics choice (mirrors
+   `.gitignore`/`.dockerignore` ordering users already know) and are fine.
+3. **Clamp `[0.05, 5.0]`** is well-grounded (Elastic `max_boost` precedent). Clamp the *final
+   per-node product* of all matching priors, not each glob individually, so stacked globs
+   can't compound past the cap.
+4. **Compute once at index/open time, cache.** Path → prior is static, so resolve each node's
+   prior once (akin to NestWeaver's existing `.pagerank.json` sidecar) and store it; do not
+   re-glob per query. Suggest a `<db>.priors.json` sidecar or fold into existing node props.
+5. **Default = 1.0 (identity).** A node matching no glob is unchanged. Defaults of `1.0` keep
+   the feature opt-in and non-surprising.
+
+## 6.4 Pitfalls / failure modes & mitigations
+- **Applying prior before RRF → no effect.** RRF discards scores (Feature 7, source D). Mit:
+  apply post-fusion, or ensure the prior changes pre-fusion *rank order*. Test both paths.
+- **Compounding overlapping globs.** Multiple matching globs multiplied together can exceed
+  `[0.05,5.0]`. Mit: last-match-wins (single effective prior) OR clamp the final product.
+- **Dampening to ~0 hides results entirely.** A `0.0` (or tiny) prior on `_logs/**` can make a
+  genuinely best-matching doc invisible. The `0.05` floor exists for exactly this; never allow
+  `0`. Document that dampen ≠ exclude (use ignore lists to exclude).
+- **Boost masking poor text relevance.** A large boost (5x) can float weak matches to the top
+  ("boost masking"), the classic `function_score` failure. Mit: keep ceiling modest (5x is
+  already generous; production systems often cap nearer 2–3x), and consider applying the prior
+  as a tie-breaker/secondary sort for near-equal fused scores rather than a hard multiply.
+- **Score scale drift across queries.** Because we multiply a *relevance* score, ensure the
+  base score is in a comparable range across queries (true for normalized/fused scores; would
+  be false for raw BM25). Multiplicative priors are scale-invariant in ordering but the clamp
+  is absolute, so keep the multiplier on a normalized relevance.
+
+## 6.5 Complexity / effort & quality signal
+- **Effort: LOW.** It is a per-node static lookup + one multiply + clamp. No model, no
+  training, no extra index. Glob compilation + sidecar cache is the only real work.
+- **Quality delta:** no academic MAP/nDCG number applies (this is a UX/relevance-policy lever,
+  not an IR-effectiveness technique). The evidence base is *architectural*: every major engine
+  ships this exact knob, which is the relevant validation. Treat success as "users can demote
+  noise dirs / promote canonical dirs," measured by qualitative top-N inspection, not a TREC
+  metric.
+
+---
+
+# FEATURE 7 — BM25 Pseudo-Relevance Feedback (PRF) + taxonomy synonym/query expansion
+
+Goal: two-pass retrieval. Pass 1: original query → top-K bodies → mine high-IDF expansion
+terms. Pass 2: expanded query, expansion terms discounted (~0.3x), plus a hand-curated
+synonym/alias table expanded at query time (~0.5x weight). Cap total query length.
+
+## 7.1 Research foundation
+
+**(A) Rocchio (1971) relevance feedback — via Manning, Raghavan & Schütze,
+*Introduction to Information Retrieval* (Cambridge, 2008), §9.1.1.**
+- URL (retrieved): https://nlp.stanford.edu/IR-book/html/htmledition/the-rocchio71-algorithm-1.html
+- Modified query: `q_m = α·q_0 + β·(1/|D_r|)·Σ_{d∈D_r} d − γ·(1/|D_nr|)·Σ_{d∈D_nr} d`.
+- **Retrieved verbatim:** "Reasonable values might be α = 1, β = 0.75, and γ = 0.15." and
+  "Positive feedback also turns out to be much more valuable than negative feedback, and so
+  most IR systems set γ < β." Many systems set **γ = 0** (positive-only).
+- **Implication:** discounting expansion terms relative to the original query is the textbook
+  default. β/α ≈ 0.75 is the canonical "expansion weight." NestWeaver's proposed ~0.3x for
+  *mined PRF terms* is **more conservative than Rocchio's 0.75**, which is sensible because
+  PRF terms are *pseudo*-relevant (unjudged) and riskier than true relevance feedback. The
+  synonym table at ~0.5x sits between — also reasonable, since curated aliases are higher
+  precision than mined terms but still secondary to the user's literal query.
+
+**(B) Pseudo-relevance feedback (blind feedback) — IIR §9.1.6.**
+- URL (retrieved): https://nlp.stanford.edu/IR-book/html/htmledition/pseudo-relevance-feedback-1.html
+- Method (retrieved): run initial search, **assume the top *k* ranked docs are relevant**, do
+  relevance feedback under that assumption. "Mostly works" and beats global analysis in TREC.
+- **Documented failure = query drift.** Retrieved example: a "copper mines" query whose top
+  results are dominated by Chilean mines drifts the query toward *Chile* rather than *mining*.
+
+**(C) RM3 / Relevance Models — Lavrenko & Croft, "Relevance-based language models," SIGIR
+2001; RM3 variant from Abdul-Jaleel et al., TREC 2004 (UMass HARD track).**
+- Lavrenko & Croft record: https://www.researchgate.net/publication/221299786_Relevance-based_language_models
+- Reference implementations and defaults: castorini/Anserini issue #447 (retrieved:
+  https://github.com/castorini/Anserini/issues/447) and pyserini docs
+  (https://github.com/castorini/pyserini/blob/master/docs/usage-interactive-search.md).
+- **RM3 forms a relevance language model from the top feedback docs, then linearly
+  interpolates it with the original query model:** `P_final = λ·P(w|Q) + (1−λ)·P(w|R)`, where
+  λ = original-query weight. RM3 = "RM1 + interpolate-back-the-original-query."
+- **Industry-standard defaults (the number you want), confirmed from Indri v5.13
+  `RMExpander.cpp` via Anserini #447 and pyserini `set_rm3(10,10,0.5)`:**
+  - `fbDocs = 10` (feedback documents, i.e. **K = 10**)
+  - `fbTerms = 10` (expansion terms, i.e. **N = 10**)
+  - `fbOrigWeight = 0.5` (λ; original query weighted 0.5, expansion 0.5)
+  `[RM3 paper PDFs (arxiv 1401.3896) would not render to text via the fetch tool; the
+  10/10/0.5 defaults are corroborated from two independent reference implementations
+  (Indri source as cited in Anserini #447, and pyserini) which is the more authoritative
+  source for *operational defaults* than the paper anyway.]`
+- **Reported quality deltas (retrieved, secondary sources summarizing TREC results):** PRF
+  optimization work reports "statistically-significant improvements in MAP of 18–35% over the
+  initial query, 7–11% over the feedback model with the best fixed number of pseudo-relevant
+  documents" (Springer, Discover Computing 2021:
+  https://link.springer.com/article/10.1007/s10791-021-09393-5). A topic-relevance RM3 variant
+  reports outperforming the LM baseline by 11–31% and base RM3 by 0.5–23% MAP on TREC
+  collections. **Caveat:** these are over weak unexpanded baselines and on news/TREC corpora;
+  treat the *direction* (PRF helps avg MAP) as solid and the *magnitude* as corpus-specific.
+
+**(D) Reciprocal Rank Fusion — Cormack, Clarke & Büttcher, "Reciprocal rank fusion outperforms
+condorcet and individual rank learning methods," SIGIR 2009, pp. 758–759.**
+- DOI 10.1145/1571941.1572114; dblp: https://dblp.org/rec/conf/sigir/CormackCB09.html ;
+  IR-Anthology: https://ir.webis.de/anthology/2009.sigirconf_conference-2009.146/
+- **Formula:** `RRFscore(d) = Σ_r 1 / (k + rank_r(d))`, with **k = 60** chosen empirically on
+  TREC data. `[The PDF would not render to text; the formula and k=60 are confirmed by the
+  dblp/IR-Anthology bibliographic records of this exact paper plus multiple corroborating
+  technical writeups, and k=60 is the value hard-coded by Elasticsearch/OpenSearch/Azure AI
+  Search RRF implementations that cite this paper.]`
+- **Why it matters for Feature 7:** RRF **uses only ranks, not raw scores**, so it is robust
+  to the differing score scales of BM25 vs vector vs PPR. **Consequence for re-weighting:**
+  the ~0.3x / ~0.5x term weights you assign in Pass 2 affect the **BM25 ranking** (they change
+  which docs rank where *within* the BM25 list), and that re-ordered BM25 list is what feeds
+  RRF. The weights do **not** survive into RRF as magnitudes. So Feature 7's re-weighting is a
+  *BM25-internal* mechanism whose effect reaches the final ranking only via changed BM25 ranks.
+  This is fine and correct — just document that PRF tuning is observed through BM25 rank
+  changes, not through fused-score magnitude.
+
+**(E) Thesaurus / controlled-vocabulary query expansion — IIR §9.2.2.**
+- URL (retrieved): https://nlp.stanford.edu/IR-book/html/htmledition/query-expansion-1.html
+- Retrieved verbatim: "for each term in a query, the query can be automatically expanded with
+  synonyms and related words"; "one might weight added terms less than original query terms";
+  "Use of query expansion generally increases recall and is widely used in many science and
+  engineering fields." Four thesaurus types named: controlled vocabularies (e.g. UMLS), manual
+  thesauri, automatically derived (co-occurrence) thesauri, query-log mining.
+- **Implication:** a *hand-curated alias table* is exactly the "manual thesaurus / controlled
+  vocabulary" branch — the highest-precision form. Down-weighting added terms is explicitly
+  endorsed. Expansion's primary benefit is **recall**, which fits NestWeaver's code+notes
+  retrieval where users phrase queries differently from the indexed identifiers/notes.
+
+### Whole-word / case handling for synonyms
+- **Lucene/Elasticsearch:** correct multi-token synonym expansion **must happen at query
+  time**, not index time, because a Lucene index cannot store a token graph; query-time
+  synonyms are more flexible (no re-index when the table changes) at higher query CPU. Source:
+  Elastic "Multi-token Synonyms and Graph Queries" + LUCENE-6664 SynonymGraphFilter
+  (https://www.elastic.co/blog/multitoken-synonyms-and-graph-queries-in-elasticsearch ;
+  https://lucene.apache.org/core/8_0_0/analyzers-common/org/apache/lucene/analysis/synonym/SynonymGraphFilter.html).
+- **Practical rules NestWeaver should adopt:** expand on **whole-token** boundaries after the
+  *same* analyzer/tokenizer used at index time (so case-folding and stemming match), apply
+  aliases **case-insensitively** by normalizing both sides through the analyzer, and expand at
+  **query time** so the alias table can change without re-indexing. The IIR text does not
+  specify case rules, so this is grounded in the Lucene practice above, not in IIR.
+
+## 7.2 Prior art / projects (with tradeoffs)
+
+| System | PRF / expansion mechanism | Defaults / notes | Tradeoff |
+|---|---|---|---|
+| **Indri / Lemur** (origin of RM3 defaults) | Built-in RM3. `RMExpander.cpp`. | fbDocs=10, fbTerms=10, fbOrigWeight=0.5, fbMu=0 (via Anserini #447). | Canonical defaults; C++ ref. |
+| **Anserini / Pyserini** (Lucene-based IR research) | `set_rm3(fbDocs, fbTerms, origWeight)`; docvectors index required. | Same 10/10/0.5 defaults. https://github.com/castorini/pyserini/blob/master/docs/usage-interactive-search.md | Validates K=10,N=10,λ=0.5 as the community default. |
+| **Lucene SynonymGraphFilter** | Query-time multi-token synonym expansion → token graph → TermAutomatonQuery. | Query-time required for multi-token. | Correct but complex graph machinery; for single-token aliases NestWeaver can stay simpler. |
+| **Elasticsearch / OpenSearch** | `synonym`/`synonym_graph` token filters; `query_string` boosts per term (`term^2`); two-pass via `rescore` window. | Per-term boost is the analog of our 0.3x/0.5x weights. https://www.elastic.co/blog/multitoken-synonyms-and-graph-queries-in-elasticsearch | Heavyweight; good template for "expansion terms carry lower boost." |
+| **Xapian** | Relevance feedback via ESet + `ExpandDecider` (rejects terms; by default excludes terms already in query). | https://xapian.org/docs/apidoc/html/classXapian_1_1Enquire.html | Shows the "don't re-add terms already in the query" rule we should copy. |
+| **Tantivy** (NestWeaver's engine) | BM25 + `BooleanQuery`; per-term `BoostQuery` (multiplicative term boost); no built-in PRF. | https://docs.rs/tantivy/latest/tantivy/query/index.html | We implement PRF/expansion *on top* of Tantivy: pass-1 query, read top-K bodies, mine terms, build a pass-2 `BooleanQuery` with `BoostQuery(0.3)` / `BoostQuery(0.5)` clauses. Fully feasible with existing Tantivy primitives. |
+
+## 7.3 Recommended approach for NestWeaver
+
+1. **Two-pass PRF, bag-of-words (no RM3 LM machinery needed).** Pass 1: original query →
+   top-K bodies. Mine candidate terms from those bodies, rank by **high IDF** (rare, content-
+   bearing terms; exactly the "mine high-IDF expansion terms" in the RFC). Tantivy exposes the
+   doc-frequency stats (`Bm25StatisticsProvider`) to compute IDF cheaply. This is a Rocchio-
+   style positive-only expansion (γ=0), which the literature endorses (source A).
+2. **Defaults grounded in the literature:**
+   - **K (feedback docs) = 10** — the Indri/Anserini/pyserini standard (source C). Solo-dev
+     corpora are small, so K=10 is safe; expose as config.
+   - **N (expansion terms) = 10** — same standard. Cap hard to avoid query bloat.
+   - **Original query weight ≈ 1.0; PRF term weight ≈ 0.3.** RM3 uses λ=0.5 globally, but RM3
+     interpolates *language models*; here we keep the user's literal terms at full weight and
+     down-weight only the *added* terms. 0.3x for unjudged mined terms is appropriately more
+     conservative than Rocchio's β=0.75 because PRF terms are riskier. **This is the RFC's
+     number and it is defensible; flag that it is intentionally conservative vs Rocchio.**
+   - **Synonym/alias terms ≈ 0.5x** — higher than mined PRF terms (curated ⇒ higher precision)
+     but below the user's literal query. Consistent with IIR "weight added terms less."
+3. **Curated alias table, expanded at query time, whole-token + case-insensitive** (§7.1E
+   rules). Do not re-add terms already present in the query (Xapian's ExpandDecider rule).
+   Alias expansion and PRF expansion are independent and can both run; apply alias expansion
+   even when PRF is disabled (it is cheaper and lower-risk).
+4. **Cap total expanded query length** (RFC requirement). With N≤10 PRF terms + bounded alias
+   terms, cap e.g. original + ≤10 PRF + ≤K aliases, then truncate by weight×IDF. Caps bound
+   both query drift and per-query latency.
+5. **Make PRF opt-in / per-query, alias table always-on but cheap.** PRF doubles BM25 work
+   (two passes); for a no-daemon CLI keep it behind a flag/intent so default latency is
+   unchanged.
+6. **Integration with RRF:** the expanded BM25 query produces a re-ordered BM25 result list;
+   feed *that* list into existing RRF (source D). Do not try to push the 0.3/0.5 weights past
+   RRF — RRF is rank-only by design.
+
+## 7.4 Pitfalls / failure modes & mitigations
+- **Query drift** (the #1 documented PRF failure, source B; the "copper mines → Chile"
+  example). Mitigations grounded in literature: (a) **down-weight expansion terms** (0.3x —
+  already in design); (b) **cap N** (≤10); (c) **prefer high-IDF terms** so generic words
+  don't dominate; (d) keep original query at full weight so the user's intent anchors the
+  ranking; (e) consider **selective expansion** — skip PRF when pass-1 top-K looks incoherent
+  (low score spread), per the "selective query expansion" line of work (IIR §9 + Springer
+  2021). NestWeaver could gate PRF on a pass-1 confidence/score-gap heuristic.
+- **Inconsistent gains across queries.** Even when average MAP rises, PRF *hurts some
+  individual queries* (retrieved: "PRF benefits are inconsistent across queries," "patchy").
+  Mit: opt-in + selective expansion; never make PRF the silent default for every query.
+- **Re-adding query terms / stopword expansion.** Mit: exclude existing query terms (Xapian
+  rule) and stopwords; IDF thresholding naturally drops stopwords.
+- **Synonym analyzer mismatch.** If aliases aren't run through the same analyzer as the index,
+  case/stemming mismatches silently drop matches. Mit: normalize both sides via the index
+  analyzer; expand at query time.
+- **Multi-token aliases.** Single-token aliases are trivial; multi-token correctness needs
+  Lucene-style graph handling (source 7.1E). Mit: start with single-token aliases; if multi-
+  token is needed, expand into a phrase/`BooleanQuery` subclause rather than naive token
+  substitution.
+- **Latency from two passes** on a no-daemon CLI. Mit: PRF behind a flag; K small; cache
+  pass-1 if the same query repeats.
+
+## 7.5 Complexity / effort & quality signal
+- **Effort: MEDIUM.** PRF = second BM25 pass + IDF-ranked term mining + query rebuild with
+  weighted `BooleanQuery`/`BoostQuery` (all supported by Tantivy). Alias expansion = a parsed
+  table + query-time token rewrite = LOW. The riskiest part is *tuning/gating*, not plumbing.
+- **Quality delta (from literature, over weak baselines on TREC/news):** PRF typically lifts
+  average MAP on the order of **+10% to +30%** vs an unexpanded query (Springer 2021: 18–35%
+  over initial query; RM3 variants 0.5–23% over base RM3). **Caveats:** measured on
+  TREC/newswire, over bag-of-words baselines; gains are *inconsistent per query* and can be
+  negative without down-weighting/capping. For NestWeaver's code+notes corpus, treat these as
+  directional evidence that *conservative, capped, down-weighted* PRF + curated aliases should
+  improve recall, and validate with the project's own qualitative top-N checks rather than
+  expecting the headline TREC magnitudes.
+
+---
+
+## Source list (all retrieved 2026-05-29)
+1. Robertson & Zaragoza 2009, PRF/BM25 monograph — https://dl.acm.org/doi/abs/10.1561/1500000019 ; ref record https://www.scirp.org/reference/referencespapers?referenceid=3896864
+2. Robertson, Zaragoza & Taylor 2004, BM25F — https://www.semanticscholar.org/paper/Simple-BM25-extension-to-multiple-weighted-fields-Robertson-Zaragoza/67085d02e3a4710119f1bad050d89c10bd79d977 ; tutorial http://www.minerazzi.com/tutorials/bm25f-model-tutorial.pdf
+3. Cormack, Clarke & Büttcher 2009, RRF (SIGIR) — https://dblp.org/rec/conf/sigir/CormackCB09.html ; https://ir.webis.de/anthology/2009.sigirconf_conference-2009.146/ ; DOI 10.1145/1571941.1572114
+4. Lavrenko & Croft 2001, Relevance-based LMs — https://www.researchgate.net/publication/221299786_Relevance-based_language_models
+5. Manning, Raghavan & Schütze 2008, *IIR* — Rocchio https://nlp.stanford.edu/IR-book/html/htmledition/the-rocchio71-algorithm-1.html ; PRF https://nlp.stanford.edu/IR-book/html/htmledition/pseudo-relevance-feedback-1.html ; query expansion https://nlp.stanford.edu/IR-book/html/htmledition/query-expansion-1.html
+6. RM3 operational defaults — Anserini #447 https://github.com/castorini/Anserini/issues/447 ; pyserini https://github.com/castorini/pyserini/blob/master/docs/usage-interactive-search.md
+7. PRF quality deltas — Springer Discover Computing 2021 https://link.springer.com/article/10.1007/s10791-021-09393-5
+8. Elasticsearch function_score — https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html
+9. OpenSearch function_score — https://docs.opensearch.org/latest/query-dsl/compound/function-score/
+10. Vespa ranking — https://docs.vespa.ai/en/ranking/ranking-expressions-features.html ; https://docs.vespa.ai/en/ranking/phased-ranking.html
+11. Tantivy — https://docs.rs/tantivy/latest/tantivy/query/index.html ; https://github.com/quickwit-oss/tantivy/blob/main/src/query/bm25.rs
+12. Lucene/ES synonyms — https://www.elastic.co/blog/multitoken-synonyms-and-graph-queries-in-elasticsearch ; https://lucene.apache.org/core/8_0_0/analyzers-common/org/apache/lucene/analysis/synonym/SynonymGraphFilter.html
+13. Xapian relevance feedback / ExpandDecider — https://xapian.org/docs/apidoc/html/classXapian_1_1Enquire.html
+
+### Verification notes
+- `[PDF-NOT-PARSED, corroborated]` items: the RRF SIGIR PDF, the RM3/relevance-models arXiv
+  PDFs, and the PRF monograph PDF returned binary that the fetch tool could not convert to
+  text. Their *specific facts used here* (RRF formula + k=60; RM3 10/10/0.5 defaults; PRF =
+  multiplicative/log-additive prior) are each corroborated by at least one independent
+  authoritative record (dblp/IR-Anthology bibliographic entries, Indri source via Anserini,
+  pyserini API) and were not taken from the unparsed PDFs.
+- Brin & Page PageRank cited as background framing only `[UNVERIFIED exact wording]`; the
+  "PageRank as query-independent prior" claim is restated in source 1.

--- a/scratch/rfc-implementation-plan/research/temporal-rank-test-selection.md
+++ b/scratch/rfc-implementation-plan/research/temporal-rank-test-selection.md
@@ -1,0 +1,342 @@
+# Research Foundation: Feature 12 (Git-Activity-Dampened CodeRank) & Feature 13 (affected_tests)
+
+> Compiled 2026-05-29 for NestWeaver RFC planning. All cited sources were retrieved via web
+> search/fetch; URLs are listed inline. Claims that could not be verified from a primary
+> source are marked **[UNVERIFIED]**. Quantitative figures are attributed to the specific
+> source that reported them; do not generalize them beyond their study context.
+
+---
+
+## FEATURE 12 — Git-Activity-Dampened CodeRank
+
+**Design under evaluation:** apply a per-file decay multiplier to PageRank at compute time.
+`recency_score = mean over last N=20 touching commits of exp(-Δdays/180)`, skipping
+bulk/mechanical commits (≥500 files). Final multiplier
+`(1 + activity_weight·(score − 0.5))` clamped to `[0.4, 1.6]`, `activity_weight` default 0.6.
+Goal: dormant code ranks below active code of the same name across many repos.
+
+### 12.1 Research foundation (primary sources)
+
+**(a) Temporal / time-aware link analysis — the core precedent for decaying a graph-centrality score.**
+
+- **Rozenshtein & Gionis, "Temporal PageRank," ECML-PKDD 2016.**
+  Springer: https://link.springer.com/chapter/10.1007/978-3-319-46227-1_42 ·
+  PDF: http://users.ics.aalto.fi/gionis/temporal-pagerank.pdf
+  *Result / idea:* generalizes PageRank to temporal networks where activity is a sequence of
+  time-stamped edges, via a "temporal random walk." Processes edges in arrival order; proven to
+  converge to temporal PageRank scores, and — importantly for us — **if the edge distribution
+  remains constant, temporal PageRank converges to the static PageRank of the underlying graph.**
+  This is the formal license for "decay toward baseline": a temporal weighting that degrades
+  gracefully to ordinary PageRank when there is no temporal signal.
+
+- **Berberich, Vazirgiannis, Weikum — "T-Rank: Time-Aware Authority Ranking" (link analysis with
+  *freshness* = timestamp of most recent update, and *activity* = update rate).** Discussed across
+  the temporal-ranking literature surveyed at
+  https://informationr.net/ir/18-3/paper586.html ("The impact of time in link-based Web ranking").
+  *Result / idea:* incorporating freshness and update-rate of nodes/links into authority ranking
+  produces rankings closer to human judgment than static PageRank. Establishes "recency of last
+  touch" and "rate of change" as the two canonical temporal signals — exactly the two signals git
+  history exposes (last-touched, churn rate).
+
+- **"TimedPageRank" / time-weighted authoritative ranking (bibliographic/citation setting).**
+  Springer "Time-weighted web authoritative ranking":
+  https://link.springer.com/article/10.1007/s10791-010-9138-4 ;
+  Yu, Li & Liu, "Adding the Temporal Dimension to Search — A Case Study in Publication Search" (WI 2005):
+  https://www.cs.uic.edu/~liub/publications/WI-05-temp.pdf
+  *Result / idea:* TimedPageRank weights each citation by an **exponential decay function of citation
+  age**, with an aging factor so node scores decline with time. Empirically, adding the simple
+  age-decay term **consistently improved retrieval performance**. This is direct precedent for using
+  `exp(-Δt/τ)` as the decay kernel — the same kernel Feature 12 proposes.
+
+> **Synthesis for Feature 12.** Feature 12 is not novel in kind; it is "freshness/activity-aware
+> link analysis" (T-Rank, TimedPageRank) applied to a code-call graph. The literature supports:
+> (i) an exponential age-decay kernel; (ii) using both last-touch recency and update-rate;
+> (iii) graceful degradation to plain PageRank when temporal signal is flat (Temporal PageRank).
+
+**(b) Code churn / change history as a *quality/importance* signal — justifies that git activity
+carries real information about code, not noise.**
+
+- **Nagappan & Ball, "Use of Relative Code Churn Measures to Predict System Defect Density," ICSE 2005,
+  pp. 284–292.**
+  Abstract/MSR: https://www.microsoft.com/en-us/research/publication/use-of-relative-code-churn-measures-to-predict-system-defect-density/ ·
+  ACM: https://dl.acm.org/doi/10.1145/1062455.1062514 · PDF:
+  https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/icse05churn.pdf
+  *Result (from the abstract):* case study on **Windows Server 2003**. **Absolute** churn measures
+  (raw LOC changed) are *poor* predictors of defect density; a set of **relative** churn measures
+  (churn normalized by component size and by temporal extent) is **highly predictive** of defect
+  density. The metric suite discriminated fault-prone vs. non-fault-prone binaries with ~**89%**
+  accuracy. *Implication for us:* (1) git activity is a legitimate signal; (2) **normalize churn**
+  (relative, not absolute) — raw "lines/files changed" is the weak version. Feature 12's per-file
+  averaging over a fixed window of commits is a relative/normalized formulation, which is the
+  defensible side of this finding.
+
+- **Hassan, "Predicting Faults Using the Complexity of Code Changes," ICSE 2009, pp. 78–88.**
+  ACM: https://dl.acm.org/doi/10.1109/ICSE.2009.5070510 · PDF:
+  https://sailresearch.github.io/sail-website/data/pdfs/ICSE2009_PredictingFaultsUsingTheComplexityOfCodeChanges.pdf
+  *Result:* uses **Shannon entropy of the change process** (how spread-out modifications are across
+  files in a period) as a complexity metric. Across six large OSS projects, these change-complexity
+  metrics are **better fault predictors than prior modifications or prior faults alone.** *Implication:*
+  the *distribution/spread* of changes matters, not just the count — a refinement we can adopt later
+  (entropy-weighted activity) but is out of scope for the v1 decay formula.
+
+**(c) Adoption / human-factors caveat — the warning that a working signal can still fail in practice.**
+
+- **Lewis, Lin, Sadowski, Zhu, Ou & Whitehead, "Does Bug Prediction Support Human Developers?
+  Findings from a Google Case Study," ICSE 2013, pp. 372–381.**
+  Google: https://research.google/pubs/does-bug-prediction-support-human-developers-findings-from-a-google-case-study/ ·
+  ACM: https://dl.acm.org/doi/10.5555/2486788.2486838
+  *Result:* deploying an academically-validated bug-prediction algorithm at Google produced **no
+  identifiable change in developer behavior.** *Implication for us:* a churn/recency signal that is
+  statistically valid may still be ignored or distrusted if it's not legible. Feature 12 should make
+  the multiplier **explainable** (show the recency_score and which commits drove it), and keep its
+  influence bounded (the clamp) so it never produces inexplicable rank flips.
+
+### 12.2 Recommended approach for NestWeaver (grounded)
+
+1. **Keep the exponential decay kernel** `exp(-Δdays/τ)`, τ=180d. This matches TimedPageRank's
+   age-decay kernel. τ=180d gives a half-life of `180·ln2 ≈ 125 days` — i.e. code untouched ~4
+   months is weighted ~0.5. That is a reasonable "quarter-ish" freshness horizon for source code;
+   defensible but a tunable, not a derived-from-theory constant (state it as a chosen prior).
+
+2. **Compute-time multiplier, not edge rewrite.** Temporal PageRank rewrites the walk; that is
+   expensive and changes convergence. Feature 12's *post-hoc per-node multiplier* is the pragmatic
+   T-Rank-style "freshness reweighting of authority." This is sound **as long as it is applied as a
+   re-rank/scaling, not fed back into the iterative PageRank fixpoint** (which could destabilize
+   convergence and the `<db>.pagerank.json` cache semantics). Recommend: store raw PageRank as today,
+   apply multiplier at query/rank time.
+
+3. **Center at 0.5 and clamp — keep the "degrade to baseline" property.** `(1 + 0.6·(score−0.5))`
+   maps score=0.5 → 1.0 (no change), and the `[0.4,1.6]` clamp bounds the swing to ±60%. This mirrors
+   Temporal PageRank's guarantee that with flat temporal signal you recover static PageRank: a file
+   with median activity is unchanged. Good. **Verify the score is bounded in [0,1]** (it is: mean of
+   `exp(-x)` terms each in (0,1]), so the multiplier naturally lands in `[1−0.3, 1+0.3]=[0.7,1.3]`
+   before clamping — meaning the **[0.4,1.6] clamp is wider than the formula can ever reach**. Either
+   tighten the clamp to ~`[0.7,1.3]` to match reality, or raise `activity_weight`'s allowed max so the
+   clamp is the true limiter. Flag this as a spec inconsistency to resolve in the RFC.
+
+4. **Normalize, per Nagappan & Ball.** Averaging `exp(-Δt)` over a fixed-count window (N=20) is
+   already a relative/normalized measure (recency, not raw volume) — keep it. Do **not** switch to raw
+   commit counts or raw LOC, which the paper shows are weak.
+
+5. **Bulk-commit filtering is essential** (see 12.3 and the MSR commit-size literature below).
+
+### 12.3 Pitfalls / failure modes + mitigations
+
+| Pitfall | Evidence / reasoning | Mitigation |
+|---|---|---|
+| **Churn ≠ quality / importance.** High churn correlates with *defects* (Nagappan & Ball), not with code being *more important to retrieve*. Feature 12 boosts active code, but active≠good. | Nagappan & Ball, Hassan. | Frame the multiplier as **recency/relevance for retrieval**, not a quality score. Keep influence bounded (clamp). Don't surface it as "code health." |
+| **Bulk / mechanical commits poison recency** (reformat, license-header sweeps, dependency bumps, generated-code regen, mass-rename) make dormant files look freshly active. | Hindle, German & Holt, "What do large commits tell us?" MSR 2008 (https://dl.acm.org/doi/10.1145/1370750.1370773 ; author page https://softwareprocess.es/homepage/papers/2008-abram2008msr08wdlctuatsolc/): large commits skew **perfective** (cleanup/reformat/license/merge), small commits skew corrective. So the biggest commits are exactly the least semantically meaningful per-file. | The ≥500-file skip implements this. **Caveat:** 500 is a single absolute cutoff; the MSR commit-size work (commit-size distributions, https://arxiv.org/pdf/1408.4644 , https://arxiv.org/pdf/1408.4974) shows commit sizes are heavy-tailed and **vary by repo**. A fixed 500 may be too high for small repos (lets through 200-file reformats) and occasionally too low for legitimately large features in monorepos. *Mitigation:* make threshold a **per-repo percentile** (e.g. skip commits in the top ~1–2% of that repo's file-count distribution) with 500 as an absolute fallback cap. |
+| **Squash-merge / PR-squash repos** collapse a feature's many small commits into one large commit, distorting both per-file recency and the bulk threshold. | Common GitHub/GitLab workflow; not a single paper but a well-known MSR data-cleaning issue. | Detect squash/merge commits (multiple parents, or commit message patterns / `git log --merges`); optionally treat merge commits' authored-date vs commit-date, and prefer **author date** over commit date so rebases/squashes don't reset recency. |
+| **Rebases / history rewrites / vendored or generated dirs** reset timestamps en masse. | — | Respect existing ignore config (`.brainignore`-style); exclude vendored/generated paths from activity computation; use author-date. |
+| **Shallow clones / missing history** → no commit data → score undefined. | — | Default `recency_score=0.5` (multiplier 1.0) on missing history, so absence of data = no effect (matches the "degrade to baseline" principle). |
+| **Cross-repo time skew.** "Active code of the same name across many repos" compares files from repos with different commit cadences; a slow-but-healthy repo looks uniformly dormant. | NestWeaver indexes multiple repos. | Consider computing recency **relative within each repo** (z-score or percentile of that repo's recency distribution) before applying the global multiplier, so cadence differences don't dominate cross-repo ranking. |
+| **Signal ignored in practice.** | Lewis et al. 2013 (Google). | Make it explainable and bounded; expose the score in `symbol`/`context` output. |
+
+### 12.4 Complexity / effort + reported deltas
+
+- **Effort: Low–Medium.** Data is already partially available: `<db>.filemeta.json` tracks per-file
+  mtime/size/hash, and there is `git`-based change detection in the indexer. Need: walk last N=20
+  touching commits per file (`git log -n 20 --follow -- <file>` or a single `git log --name-only` pass
+  bucketed per file for efficiency), parse author dates, filter bulk commits, compute the mean. One new
+  sidecar (e.g. `<db>.activity.json`) or extend `filemeta`. Apply multiplier at rank time — a few lines
+  in the PageRank read path.
+- **Performance note:** doing `--follow` per file is O(files × history) and slow on large repos; prefer
+  **one `git log --name-only --no-renames --pretty` sweep** capped at a recent window, building a
+  per-file commit list in memory, then truncating to N=20 most recent per file. Recompute on `index`/`watch`.
+- **Reported deltas from literature** (context, not promises): TimedPageRank's age-decay term
+  *consistently improved* retrieval ranking (publication-search study). T-Rank produced rankings closer
+  to human judgment. Relative churn discriminated fault-prone modules at ~**89%** (Nagappan & Ball,
+  Win Server 2003). No literature reports the effect of *recency decay on code-retrieval rank quality
+  specifically* — Feature 12's ranking-quality gain is **[UNVERIFIED / novel]**; validate with an
+  internal A/B on "same-name disambiguation" precision@k.
+
+---
+
+## FEATURE 13 — affected_tests (changed files → changed symbols → reverse traversal → tests)
+
+**Design under evaluation:** changed files → changed symbols → reverse CALLS/IMPORTS traversal
+(depth 3) → test files; bucket into priority tiers (direct test of changed symbol > test of caller >
+transitive). Detect test files by filename + annotation/macro heuristics. Goal: which tests an MR
+should run.
+
+This is **static, call-graph-based Regression Test Selection (RTS)** with **test prioritization**.
+
+### 13.1 Research foundation (primary sources)
+
+**(a) Foundational RTS framing & safety theory.**
+
+- **Yoo & Harman, "Regression testing minimization, selection and prioritisation: a survey,"
+  *Software Testing, Verification & Reliability* 22(2), 2012, pp. 67–120.**
+  Wiley: https://onlinelibrary.wiley.com/doi/abs/10.1002/stvr.430 · PDF:
+  http://www0.cs.ucl.ac.uk/staff/m.harman/stvr-shin-survey.pdf
+  *Result / framing:* defines the three distinct problems — **minimization** (drop redundant tests),
+  **selection** (pick tests relevant to a change), **prioritization** (order tests for early fault
+  detection). Feature 13 is **selection + prioritization** (the tiers). Use this vocabulary in the RFC.
+  Survey also catalogs selection by analysis granularity and the safety/precision tradeoff space.
+
+- **Rothermel & Harrold, "A Safe, Efficient Regression Test Selection Technique," *ACM TOSEM* 6(2),
+  1997, pp. 173–210.**
+  ACM: https://dl.acm.org/doi/10.1145/248233.248262 · PDF:
+  https://www.cs.purdue.edu/homes/xyzhang/fall07/Papers/p173-rothermel.pdf
+  Companion: Rothermel & Harrold, "Analyzing Regression Test Selection Techniques," *IEEE TSE* 1996.
+  *Result / definition:* a **safe** RTS technique, under well-defined conditions, **excludes no test
+  that, if executed, would reveal a fault in the modified program.** This is the bar Feature 13 will be
+  measured against — and the warning: **static call-graph RTS is generally NOT safe** unless the graph
+  captures *all* dependency paths (reflection, dynamic dispatch, DI, config, data/file deps, build-time
+  codegen). The class-firewall family approximates safety by being conservative; Feature 13's depth-3
+  cap is an explicit *unsafe* truncation (a precision/recall trade) and must be documented as such.
+
+**(b) Practical static RTS tools — the closest comparables to Feature 13's design.**
+
+- **STARTS — Legunsen, Shi, Marinov, "STARTS: STAtic Regression Test Selection," ASE 2017 (tool demo).**
+  PDF (slides): https://www.cs.cornell.edu/~legunsen/slides/ASE-2017.pdf · ACM:
+  https://dl.acm.org/doi/10.5555/3155562.3155684 · repo: https://github.com/TestingResearchIllinois/starts
+  *Result / design:* **static, class-level** RTS using the **class firewall**. Uses `jdeps` to build a
+  class-dependency graph, then **reverse-traverses to find tests transitively reachable from changed
+  classes** — structurally identical to Feature 13's "reverse CALLS/IMPORTS traversal to test files."
+  *Caveat (reflection):* static RTS **cannot see reflective/dynamically-loaded dependencies**, so it can
+  miss tests (unsafe) unless conservatively over-approximated. (See Shi et al., "Reflection-Aware Static
+  RTS," OOPSLA 2019, https://mir.cs.illinois.edu/marinov/publications/ShiETAL19ReflectionAwareRTS.pdf —
+  explicitly motivated by STARTS being unsafe under reflection.)
+
+- **Ekstazi — Gligoric, Eloussi, Marinov, "Practical Regression Test Selection with Dynamic File
+  Dependencies," ISSTA 2015; tool: "Ekstazi: Lightweight Test Selection," ICSE 2015 demo.**
+  Tool PDF: https://users.ece.utexas.edu/~gligoric/papers/GligoricETAL15EkstaziTool.pdf · repo:
+  https://github.com/gliga/ekstazi
+  *Result:* **dynamic, file-level** RTS — instruments test runs to record which files each test
+  *actually* touches; selects tests whose recorded dependency set intersects the changed files.
+  Reported (per the tool/ISSTA work and follow-ups): reduced **end-to-end testing time ~32% on average,
+  and ~54% for longer-running suites** vs. running all tests. Being dynamic, it captures reflection/DI
+  that static analysis misses — the key axis on which Feature 13 (static) is weaker.
+  - **EkstaziSharp (.NET) — Vasic et al., "File-Level vs. Module-Level Regression Test Selection for
+    .NET," ESEC/FSE 2017:** https://par.nsf.gov/servlets/purl/10055459 — directly studies the
+    **granularity tradeoff** Feature 13 faces (file vs finer-grained selection).
+
+- **Microsoft Test Impact Analysis (TIA)** — productized dynamic RTS in Azure DevOps / VSTest, mapping
+  tests↔code via runtime coverage to select tests per change. (Industrial analog; dynamic, coverage-based.)
+
+**(c) Industrial-scale RTS / predictive selection — what large monorepos actually do.**
+
+- **Memon, Gao, Nguyen, Dhanda, Nickell, Siemborski, Micco, "Taming Google-Scale Continuous Testing,"
+  ICSE-SEIP 2017.**
+  Google PDF: https://research.google.com/pubs/archive/45861.pdf · ACM:
+  https://dl.acm.org/doi/10.1109/ICSE-SEIP.2017.16
+  *Result:* Google cannot run every test on every change; uses **dependency-graph-based RTS** (build
+  graph: which tests transitively depend on changed targets) plus result-history analysis to control
+  test workload "without compromising quality." Validates the *reverse-reachability* core of Feature 13
+  at scale, but anchored on the **build dependency graph** (which is precise) rather than a parsed
+  source call graph (which is approximate).
+
+- **Machalica, Samylkin, Porth, Chandra, "Predictive Test Selection," ICSE-SEIP 2019 (Facebook/Meta).**
+  arXiv: https://arxiv.org/abs/1810.05286 · ACM: https://dl.acm.org/doi/10.1109/ICSE-SEIP.2019.00018
+  *Result:* ML model selects tests per change; **reduces total testing infrastructure cost by ~2×**
+  while still reporting **>95% of individual test failures and >99.9% of faulty changes.** Features
+  include change↔test relationships in the dependency graph (distance), file/extension metadata, and
+  historical test failure/flakiness rates. *Implication:* the state of the art **augments graph
+  reachability with historical signals and accepts a measured recall (<100%) rather than chasing
+  provable safety.** Feature 13 can adopt the same posture: graph-based candidate set + (later)
+  history-based ranking, with an explicit recall target.
+
+### 13.2 Recommended approach for NestWeaver (grounded)
+
+1. **Position it honestly as static, source-graph RTS + prioritization** (Yoo & Harman vocabulary).
+   It is **not** "safe" in the Rothermel–Harrold sense and the RFC must say so. It is closest to
+   **STARTS** (static reverse-reachability) but on a *source-parsed* call graph rather than bytecode
+   `jdeps`, so it is *less* sound than STARTS (NestWeaver's CALLS/IMPORTS edges carry confidence scores
+   and miss dynamic dispatch/reflection/macros).
+
+2. **Reverse-reachability is the right mechanism** — it is exactly what STARTS and Google TAP do.
+   Keep changed-files → changed-symbols → reverse CALLS/IMPORTS → test files.
+
+3. **Tiering = prioritization (Yoo & Harman).** The proposed tiers map cleanly to "distance in the
+   dependency graph," the same feature Meta's model weighs most:
+   - **Tier 1 (direct):** test directly references/CALLS the changed symbol (graph distance 1).
+   - **Tier 2 (caller):** test covers a direct caller of the changed symbol (distance 2).
+   - **Tier 3 (transitive):** reachable at distance 3.
+   Use **edge confidence** (NestWeaver already weights CALLS=1.0, IMPORTS=0.8, USES=0.5, ACCESSES=0.4)
+   to order within a tier — high-confidence call paths first. Cap at depth 3 as specified, but **report
+   the cap** (precision/recall trade).
+
+4. **Test-file detection — combine filename + annotation/macro heuristics across languages.** Examples
+   to encode (NestWeaver indexes 32 languages): Rust `#[test]` / `#[cfg(test)]` / `mod tests`;
+   Python `test_*.py` / `*_test.py` / `pytest` / `unittest.TestCase`; JS/TS `*.test.*` / `*.spec.*` /
+   `describe`/`it`; Go `*_test.go` + `func TestXxx(*testing.T)`; JUnit `@Test`; Java `*Test.java`. The
+   *annotation/macro* layer matters because filename conventions are inconsistent — this mirrors STARTS
+   needing to identify test classes structurally.
+
+5. **Set an explicit recall target, measured against "run-all," like Meta did** (their bar: >95%
+   failure recall). Don't claim safety; claim measured recall and report it.
+
+### 13.3 Pitfalls / failure modes + mitigations
+
+| Pitfall | Evidence / reasoning | Mitigation |
+|---|---|---|
+| **Static RTS is unsafe vs dynamic** — misses reflection, dynamic dispatch, DI, mocking, runtime config, data-driven tests, build-time codegen, FFI. Will **drop tests that would have failed.** | Rothermel & Harrold (safety definition); Ekstazi (dynamic) vs STARTS (static) is precisely this axis; Shi et al. OOPSLA 2019 created reflection-aware RTS *because* STARTS was unsafe under reflection. | Document as best-effort, not safe. Offer a **conservative mode**: when a changed file has low-confidence/edge coverage, fall back to selecting a broader set or the whole module. Combine with a periodic full run (Google/Meta both keep a full safety net). |
+| **Depth-3 truncation drops far-but-real tests.** | The spec's own cap; RTS theory says safety needs *all* reachable tests. | Make depth configurable; emit a "tests beyond depth 3 exist" warning count so users know the candidate set was truncated. |
+| **Cross-file/cross-language edges missing** (e.g. a JS test exercising a Rust binding, or test fixtures loaded as data). | Source-graph parsers don't link across language/process boundaries. | Add a "co-change" fallback tier from git history (files historically changed together with the test) — a cheap precision/recall booster aligned with Google's use of history. |
+| **Flaky tests pollute the result** — selecting them adds noise; their failures aren't change-related. | Machalica et al. explicitly model flakiness. | Track per-test historical failure/flake rate (NestWeaver already has `<db>.interactions.json` infra for usage signals); deprioritize or flag flaky tests. |
+| **Squash-merge / large MRs** → "changed files" set is huge, traversal explodes, selection ≈ run-all. | Same monorepo workflow issue as Feature 12. | Cap fan-out; if selection exceeds X% of all tests, recommend run-all (selection gives no benefit past a break-even point — a known RTS result). |
+| **No tests found ≠ safe to skip.** Absence of a reverse path may mean missing edges, not absence of coverage. | Static-graph incompleteness. | Distinguish "no tests selected (high confidence)" from "no path found (low coverage of this file)"; in the latter case warn rather than greenlight. |
+| **Adoption/trust.** A selector that ever misses a real failure loses developer trust fast. | Lewis et al. 2013 (signals get ignored when not trusted). | Be transparent about recall; show *why* each test was selected (the path/tier); pair with full-run CI gate initially. |
+
+### 13.4 Complexity / effort + reported deltas
+
+- **Effort: Medium.** Mechanisms largely exist: NestWeaver has the CALLS/IMPORTS graph with edge
+  confidence, multi-language symbol parsing, and `impact` already does forward/reverse traversal with a
+  `--depth` flag (reuse it — `impact` is the inverse direction of what's needed). New work: (1) map
+  changed files → changed symbols (diff vs. parsed symbols — `git diff --name-only` + symbol ranges);
+  (2) reverse traversal terminating at test nodes; (3) test-node detection heuristics per language;
+  (4) tier bucketing by graph distance + edge confidence. One command (`nestweaver affected-tests`) and/or
+  an MCP tool.
+- **Reported deltas from comparable tools** (context, not promises for a static source-graph variant):
+  - **Ekstazi** (dynamic, file-level): ~**32%** average end-to-end test-time reduction, ~**54%** on
+    longer suites. (https://users.ece.utexas.edu/~gligoric/papers/GligoricETAL15EkstaziTool.pdf)
+  - **STARTS** (static, class firewall): comparable selection to Ekstazi but **less precise / more
+    conservative** (selects more tests) because static analysis over-approximates; its appeal is needing
+    only compile-time info, no instrumentation — the same appeal as Feature 13. Exact STARTS reduction
+    percentages **[UNVERIFIED]** from the retrieved demo slides (compressed PDF); cite the ASE 2017 demo
+    and OOPSLA 2019 follow-up for the safety discussion rather than a specific % here.
+  - **Meta Predictive Test Selection:** **~2× cost reduction** at **>95%** individual-test-failure recall,
+    **>99.9%** faulty-change recall (https://arxiv.org/abs/1810.05286). This is the realistic ceiling and
+    the recall bar to aim for; Feature 13's pure-static v1 will likely have *lower* recall and should be
+    validated against run-all before being allowed to gate anything.
+  - **Google TAP:** dependency-graph RTS at scale, framed as workload control "without compromising
+    quality" (https://research.google.com/pubs/archive/45861.pdf) — validates the reverse-reachability
+    core but on a precise build graph.
+
+---
+
+## Cross-cutting notes
+
+- Both features lean on the same **git-history mining substrate** (commit walk, author-date,
+  bulk/squash-commit detection, per-file co-change). Build it once and share it. The **MSR commit-size
+  literature** (Hindle/German/Holt MSR 2008; commit-size-distribution papers
+  https://arxiv.org/pdf/1408.4644 , https://arxiv.org/pdf/1408.4974) supports per-repo, percentile-based
+  bulk-commit detection over a single global file-count cutoff.
+- **Established vs speculative:** *Established* — exponential age-decay improves temporal ranking
+  (TimedPageRank/T-Rank); relative churn predicts defects (Nagappan & Ball, Hassan); reverse-reachability
+  RTS works and saves time (Ekstazi/STARTS/Google/Meta); static RTS is unsafe vs dynamic
+  (Rothermel–Harrold + Ekstazi-vs-STARTS). *Speculative / unverified* — that recency-decay specifically
+  improves *code-retrieval rank quality* (Feature 12 gain is novel, [UNVERIFIED], needs A/B); exact
+  STARTS reduction %; exact Hindle large-commit file-count threshold (top-decile/perfective-skew is
+  supported; the precise numeric cutoff is **[UNVERIFIED]** from retrieved material).
+
+## Source index
+
+- Temporal PageRank — Rozenshtein & Gionis, ECML-PKDD 2016: https://link.springer.com/chapter/10.1007/978-3-319-46227-1_42
+- T-Rank / temporal web ranking survey: https://informationr.net/ir/18-3/paper586.html
+- Time-weighted web authoritative ranking: https://link.springer.com/article/10.1007/s10791-010-9138-4
+- TimedPageRank case study (WI 2005): https://www.cs.uic.edu/~liub/publications/WI-05-temp.pdf
+- Nagappan & Ball, ICSE 2005 (relative churn): https://www.microsoft.com/en-us/research/publication/use-of-relative-code-churn-measures-to-predict-system-defect-density/
+- Hassan, ICSE 2009 (change entropy): https://dl.acm.org/doi/10.1109/ICSE.2009.5070510
+- Lewis et al., ICSE 2013 (bug prediction adoption at Google): https://research.google/pubs/does-bug-prediction-support-human-developers-findings-from-a-google-case-study/
+- Yoo & Harman survey, STVR 2012: https://onlinelibrary.wiley.com/doi/abs/10.1002/stvr.430
+- Rothermel & Harrold, safe RTS, TOSEM 1997: https://dl.acm.org/doi/10.1145/248233.248262
+- STARTS, ASE 2017: https://github.com/TestingResearchIllinois/starts , https://www.cs.cornell.edu/~legunsen/slides/ASE-2017.pdf
+- Reflection-aware static RTS, OOPSLA 2019: https://mir.cs.illinois.edu/marinov/publications/ShiETAL19ReflectionAwareRTS.pdf
+- Ekstazi, ICSE/ISSTA 2015: https://github.com/gliga/ekstazi , https://users.ece.utexas.edu/~gligoric/papers/GligoricETAL15EkstaziTool.pdf
+- EkstaziSharp file vs module .NET, ESEC/FSE 2017: https://par.nsf.gov/servlets/purl/10055459
+- Google TAP, ICSE-SEIP 2017: https://research.google.com/pubs/archive/45861.pdf
+- Meta Predictive Test Selection, ICSE-SEIP 2019: https://arxiv.org/abs/1810.05286
+- Hindle/German/Holt, large commits, MSR 2008: https://dl.acm.org/doi/10.1145/1370750.1370773
+- Commit-size distribution: https://arxiv.org/pdf/1408.4644 , https://arxiv.org/pdf/1408.4974

--- a/skills/nestweaver-debug.md
+++ b/skills/nestweaver-debug.md
@@ -7,11 +7,13 @@ When debugging an error or unexpected behavior:
 
 1. Extract key symbol names from the error message or stack trace
 2. Call `brain_search` with the error message keywords
-3. For each matched symbol, call `brain_context` to see its call chain
-4. Use `flow_trace` to trace forward execution from the suspected origin
-5. Use `brain_impact` to find all callers of the failing symbol
-6. Check `dead_code` — if the error is in unreachable code, it may be safe to remove instead of fix
-7. Check if any vault notes mention the error pattern via `brain_search`
-8. Report: the call chain leading to the error, related code, and any existing documentation
+3. For each matched symbol, call `brain_context` to see its call chain and related code
+4. Use `investigate` to build a focused investigation bundle around the failing symbol — then `investigate_expand` to widen if needed, `investigate_hydrate` to load full source
+5. Use `flow_trace` to trace forward execution from the suspected origin
+6. Use `brain_impact` to find all callers of the failing symbol — the `impact_score` shows how strongly each caller depends on it
+7. Use `read_symbols` to view the source code of suspects directly
+8. Check `dead_code` — if the error is in unreachable code, it may be safe to remove instead of fix
+9. Check if any vault notes mention the error pattern via `brain_search`
+10. Report: the call chain leading to the error, related code, and any existing documentation
 
 Note: With `--track-interactions` enabled, debugging patterns are remembered across sessions — symbols involved in past debugging flows rank higher in future queries.

--- a/skills/nestweaver-explore.md
+++ b/skills/nestweaver-explore.md
@@ -6,13 +6,15 @@ description: Explore unfamiliar code using the NestWeaver knowledge graph.
 When the user asks to explore, understand, or navigate unfamiliar code:
 
 1. Identify the file or symbol they're looking at
-2. Call the `brain_context` MCP tool with that file path or symbol name as a seed
-3. Review the returned seeds (direct matches) and connected nodes (related code)
-4. Use `get_summary` at file or cluster level for a token-efficient structural overview
-5. Use `hub_nodes` to find the most connected symbols in the area
-6. Use `bridge_nodes` to identify architectural chokepoints
-7. Use `clusters` to see which functional grouping this code belongs to
-8. If vault notes appear in results, call `note_get` to read relevant notes
-9. Summarize: what this code does, what calls it, what it depends on, and any design notes from the vault
+2. Call `brain_context` with that file path or symbol name as a seed — returns a type-aware subgraph of related code ranked by Personalized PageRank
+3. For deeper exploration, use `investigate` to build a focused investigation bundle, then `investigate_expand` to widen the scope
+4. Use `project_context` if exploring within a specific project boundary (filters to that project's repos and notes)
+5. Use `flow_trace` to follow execution from a specific entry point forward
+6. Use `hub_nodes` to find the most connected symbols in the area
+7. Use `bridge_nodes` to identify architectural chokepoints
+8. Use `clusters` to see which functional grouping this code belongs to
+9. Use `read_symbols` to view the source code of specific symbols
+10. If vault notes appear in results, call `note_get` to read relevant notes
+11. Summarize: what this code does, what calls it, what it depends on, and any design notes from the vault
 
 Note: When `--track-interactions` is enabled on the MCP server, frequently-explored areas rank higher over time as the interaction memory learns your navigation patterns.

--- a/skills/nestweaver-impact.md
+++ b/skills/nestweaver-impact.md
@@ -5,11 +5,12 @@ description: Check blast radius before modifying code using NestWeaver.
 
 Before modifying a function, class, or module:
 
-1. Call `brain_impact` with the symbol name, depth 3
-2. Call `blast_radius` for a risk-scored assessment (Low/Medium/High)
-3. Review the impact nodes -- these are the blast radius grouped by depth
-4. Use `detect_changes` with the list of files you expect to modify for overall risk
+1. Call `blast_radius` with the changed files for a confidence-weighted risk assessment — each affected symbol has an `impact_score` (0-1) showing how strongly the change propagates through the call graph
+2. Call `brain_impact` with the symbol name for a focused symbol-level impact view
+3. Call `affected_tests` to identify which tests cover the changed code (test-impact analysis)
+4. Use `detect_changes` with the list of files you expect to modify for process-level risk
 5. Call `dead_code` to check if any impacted symbols are already unreachable
-6. Call `cross_repo_contracts` if the symbol might be used across services
-7. Call `backlinks` if the symbol is referenced in vault notes
-8. Report: what will break, what needs updating, and what notes document this decision
+6. Call `contract_drift` if the symbol is part of a cross-service API contract
+7. Call `cross_repo_contracts` if the symbol might be used across services
+8. Call `backlinks` if the symbol is referenced in vault notes
+9. Report: what will break (sorted by impact_score), what tests to run, what notes document this decision

--- a/skills/nestweaver-review.md
+++ b/skills/nestweaver-review.md
@@ -6,10 +6,12 @@ description: Review code changes with full codebase context from NestWeaver.
 When reviewing a PR or set of changes:
 
 1. Get the list of changed files from git diff
-2. Call `detect_changes` with the changed file list for an overall risk assessment
-3. For each changed file, call `brain_context` with the file path as seed
-4. Use `blast_radius` on modified public symbols to see risk-scored impact
-5. Call `dead_code` to check if the changes introduce or interact with unreachable code
-6. Check for vault notes that mention modified symbols
-7. Identify cross-repo impacts via `cross_repo_contracts` for any modified public APIs
-8. Report: what each change affects, any missing test coverage, and relevant design decisions from notes
+2. Call `blast_radius` with the changed files — review the `impact_score` on each affected symbol to prioritize review effort
+3. Call `affected_tests` to identify which tests cover the changed code and should be run
+4. Call `detect_changes` with the changed file list for process-level risk assessment
+5. For each high-impact changed file, call `brain_context` with the file path as seed for surrounding context
+6. Call `contract_drift` if the changes touch public API boundaries
+7. Call `dead_code` to check if the changes introduce or interact with unreachable code
+8. Check for vault notes that mention modified symbols via `backlinks`
+9. Identify cross-repo impacts via `cross_repo_contracts` for any modified public APIs
+10. Report: what each change affects (sorted by impact_score), test coverage gaps, API contract risks, and relevant design decisions from notes

--- a/src/main.rs
+++ b/src/main.rs
@@ -4803,6 +4803,26 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
             }
 
+            // Co-change mining (piggybacks on --with-git-activity)
+            if with_git_activity && !repo_opted_out {
+                out.status("Mining co-changes...");
+                match nestweaver_engine::compute_cochanges(&repo_path, 500, 3, 0.30) {
+                    Ok(edges) => {
+                        let cochange_path =
+                            nestweaver_engine::sidecar_path(&db_path, ".cochange.json");
+                        if let Err(e) =
+                            nestweaver_engine::save_cochange_sidecar(&edges, &cochange_path)
+                        {
+                            tracing::warn!("failed to save co-change sidecar: {e}");
+                        }
+                        out.status(&format!("Found {} co-change pairs.", edges.len()));
+                    }
+                    Err(e) => {
+                        tracing::warn!("co-change mining failed: {e}");
+                    }
+                }
+            }
+
             if with_trigrams {
                 out.status("Building trigram index...");
                 let store = GraphStore::open(&db_path)


### PR DESCRIPTION
## Summary

Adds a multi-tier type inference system to resolve member calls (`obj.method()`) by tracking receiver types, then uses type information to link calls to the correct target method. Also adds confidence-weighted blast radius traversal and co-change mining from git history.

### Type Resolution (Plans A + B)
- **Parser**: extracts `receiver` from method calls and `parent_name` from class/struct/impl membership
- **Type extractors**: per-language annotation, constructor, self/this extraction for Rust, TypeScript, Java, Python, Go
- **TypeEnvironment**: 4-tier inference (annotations → constructors → self/this → fixpoint propagation, max 10 iterations)
- **Cross-file return type propagation**: seeds bindings from known function return types across import boundaries
- **Type-aware resolution**: resolves member calls by looking up receiver type → class → method with MRO walk (depth 5, cycle-safe)
- **Multiplicative confidence decay**: 0.95^depth per hop (research-backed, matches CIRank damping)

### Impact Analysis (Plan C)
- **Confidence-weighted blast_radius**: impact_score decays multiplicatively through edges; paths below 0.10 threshold are pruned
- **Co-change mining**: Jaccard-scored file pairs from git history (500 commits, min 3 co-changes, min 0.30 confidence)

### Results
- CALLS edges: 4,934 → 5,077 (+2.9%) on NestWeaver's own repo
- Type bindings: 4,583 (2,225 per-file + 2,358 cross-file) across 151/309 files
- Co-change pairs: 501 discovered from git history
- Blast radius now surfaces `impact_score` for each affected node

### Research Backing
- Rapid Type Analysis (Bacon & Sweeney, OOPSLA 1996) — architecture model
- GitNexus type-resolution-system.md — tier ordering, max 10 fixpoint iterations
- CIRank (PMC 3984771) — multiplicative confidence decay through edges
- Musco et al. 2017 — class hierarchy adds ~15% recall for impact prediction
- Li 2013 systematic survey — 4/5 best CIA techniques use historical data
- Jaccard coefficient — standard for co-change mining (arXiv 2504.18511)

## Test plan

- [x] 1,150+ automated tests pass (0 failures)
- [x] Clippy clean (0 warnings in our code)
- [x] Rustfmt clean
- [x] Resolver: 114 unit tests + 4 property tests
- [x] Engine: 389 tests (including blast_radius impact_score tests)
- [x] Parser: 373 tests + snapshot tests
- [x] Type extractors: 11 language-specific tests
- [x] Co-change: 2 tests (Jaccard correctness + sidecar roundtrip)
- [x] MRO walk: cycle guard, depth limit, confidence decay verified
- [x] Research validation: multiplicative decay confirmed correct vs linear