### PR TITLE
feat: implement stubbed features, daemon-subsumes-watcher, production hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ cargo build --release
 | `brain status` | Show vault counts, per-vault staleness, and index health |
 | `brain watch` | Watch vaults for changes and re-index automatically |
 | `brain refresh` | Force re-index of all registered vaults |
+| `memory lint` | Health checks over the vault (stale notes, broken links, orphans) |
+| `memory consolidate` | Propose/apply tier promotions (logs → ideas → project files) |
+| `memory related` | Typed-edge traversal from a note (supersedes, depends-on, etc.) |
 
 </details>
 
@@ -218,7 +221,7 @@ cargo build --release
 | `embed` | Generate vector embeddings for indexed symbols |
 | `pull` | Pull a snapshot from a remote storage backend |
 | `instance` | Manage instance configuration |
-| `snapshot` | Create or restore database snapshots |
+| `snapshot` | Manage graph snapshots (build, verify, push) |
 | `list-repos` | List all indexed repositories |
 | `list-services` | List all detected services |
 | `service-summary` | Display a summary of a specific service |

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -161,12 +161,156 @@ impl NestWeaverDaemon for DaemonService {
         _request: Request<ShutdownRequest>,
     ) -> Result<Response<ShutdownResponse>, Status> {
         tracing::info!("shutdown requested via gRPC");
+
+        // Stop the file watcher if one is running.
+        if let Ok(mut guard) = self.state.watcher_stop.lock() {
+            if let Some(handle) = guard.take() {
+                tracing::info!("stopping active watcher before shutdown");
+                handle.stop();
+            }
+        }
+
         let tx = self.state.shutdown_tx.clone();
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(100)).await;
             let _ = tx.send(true);
         });
         Ok(Response::new(ShutdownResponse { ok: true }))
+    }
+
+    // ── Watching ─────────────────────────────────────────────────────
+
+    async fn watch_vault(
+        &self,
+        request: Request<WatchVaultRequest>,
+    ) -> Result<Response<WatchVaultResponse>, Status> {
+        self.state.idle_notify.notify_one();
+
+        // Check if a watcher is already running.
+        {
+            let guard = self
+                .state
+                .watcher_stop
+                .lock()
+                .map_err(|e| Status::internal(format!("watcher_stop lock poisoned: {e}")))?;
+            if guard.is_some() {
+                return Ok(Response::new(WatchVaultResponse {
+                    ok: false,
+                    message: "A watcher is already running. Stop it first with StopWatch."
+                        .to_string(),
+                }));
+            }
+        }
+
+        let req = request.into_inner();
+        let vault_path = PathBuf::from(&req.vault_path);
+        let vault_name = req.vault_name.clone();
+        let instance_id = if req.instance_id.is_empty() {
+            self.state.instance_id.clone()
+        } else {
+            req.instance_id.clone()
+        };
+        let extra_patterns = req.extra_ignore_patterns.clone();
+
+        // Validate vault path.
+        if !vault_path.exists() || !vault_path.is_dir() {
+            return Ok(Response::new(WatchVaultResponse {
+                ok: false,
+                message: format!(
+                    "vault path is not a directory: {}",
+                    vault_path.display()
+                ),
+            }));
+        }
+
+        let db_path = self.state.db_path.clone();
+        let vault_path_display = vault_path.display().to_string();
+
+        // Build the watcher with Tantivy support.
+        let tantivy_path = nestweaver_mcp::tantivy_sidecar_path(&db_path);
+        let tantivy_idx = TantivyIndex::open_or_create(&tantivy_path).ok();
+        let manifests_path = nestweaver_engine::sidecar_path(&db_path, ".manifests.json");
+
+        let mut watcher = nestweaver_engine::BrainWatcher::new(
+            &db_path,
+            &vault_path,
+            &instance_id,
+            &vault_name,
+        )
+        .with_manifests_path(&manifests_path)
+        .with_extra_ignore_patterns(&extra_patterns);
+
+        if let Some(idx) = tantivy_idx {
+            watcher = watcher.with_external_tantivy(idx);
+        } else {
+            watcher = watcher.with_tantivy_index(&tantivy_path);
+        }
+
+        let shutdown_handle = watcher.shutdown_handle();
+
+        // Store the shutdown handle so StopWatch and shutdown can use it.
+        {
+            let mut guard = self
+                .state
+                .watcher_stop
+                .lock()
+                .map_err(|e| Status::internal(format!("watcher_stop lock poisoned: {e}")))?;
+            *guard = Some(shutdown_handle);
+        }
+
+        // Increment active connections to prevent idle timeout.
+        self.state
+            .active_connections
+            .fetch_add(1, Ordering::Relaxed);
+
+        let state = self.state.clone();
+        let store = self.state.store.clone();
+
+        tokio::task::spawn_blocking(move || {
+            tracing::info!(
+                vault = %vault_path.display(),
+                "watcher thread started"
+            );
+
+            if let Err(e) = watcher.run_with_store(store, None) {
+                tracing::error!(error = %e, "watcher exited with error");
+            } else {
+                tracing::info!("watcher exited cleanly");
+            }
+
+            // Cleanup: decrement active connections and clear the stop handle.
+            state.active_connections.fetch_sub(1, Ordering::Relaxed);
+            if let Ok(mut guard) = state.watcher_stop.lock() {
+                *guard = None;
+            }
+        });
+
+        Ok(Response::new(WatchVaultResponse {
+            ok: true,
+            message: format!(
+                "Watcher started for {} (vault: {})",
+                vault_path_display, vault_name
+            ),
+        }))
+    }
+
+    async fn stop_watch(
+        &self,
+        _request: Request<StopWatchRequest>,
+    ) -> Result<Response<StopWatchResponse>, Status> {
+        let mut guard = self
+            .state
+            .watcher_stop
+            .lock()
+            .map_err(|e| Status::internal(format!("watcher_stop lock poisoned: {e}")))?;
+
+        if let Some(handle) = guard.take() {
+            tracing::info!("stop_watch: stopping active watcher");
+            handle.stop();
+            Ok(Response::new(StopWatchResponse { ok: true }))
+        } else {
+            Ok(Response::new(StopWatchResponse { ok: false }))
+        }
     }
 
     // ── Indexing ─────────────────────────────────────────────────────

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -186,9 +186,52 @@ impl NestWeaverDaemon for DaemonService {
     ) -> Result<Response<WatchVaultResponse>, Status> {
         self.state.idle_notify.notify_one();
 
-        // Check if a watcher is already running.
+        let req = request.into_inner();
+        let vault_path = PathBuf::from(&req.vault_path);
+        let vault_name = req.vault_name.clone();
+        let instance_id = if req.instance_id.is_empty() {
+            self.state.instance_id.clone()
+        } else {
+            req.instance_id.clone()
+        };
+        let extra_patterns = req.extra_ignore_patterns.clone();
+
+        if !vault_path.exists() || !vault_path.is_dir() {
+            return Ok(Response::new(WatchVaultResponse {
+                ok: false,
+                message: format!("vault path is not a directory: {}", vault_path.display()),
+            }));
+        }
+
+        let db_path = self.state.db_path.clone();
+        let manifests_path = nestweaver_engine::sidecar_path(&db_path, ".manifests.json");
+        let tantivy_path = nestweaver_mcp::tantivy_sidecar_path(&db_path);
+
+        // Build the watcher. Use the daemon's Tantivy index if it has a
+        // writer; otherwise let the watcher open from the path.
+        let mut watcher =
+            nestweaver_engine::BrainWatcher::new(&db_path, &vault_path, &instance_id, &vault_name)
+                .with_manifests_path(&manifests_path)
+                .with_extra_ignore_patterns(&extra_patterns);
+
+        if self.state.tantivy.as_ref().is_some_and(|t| t.has_writer()) {
+            // Open a reader-only handle for the watcher — the daemon's
+            // writer handle owns the lock, so open_or_create would fail.
+            // The watcher uses this for search queries; writes go through
+            // the daemon's writer via the shared store.
+            match TantivyIndex::open_reader_only(&tantivy_path) {
+                Ok(idx) => watcher = watcher.with_external_tantivy(idx),
+                Err(_) => watcher = watcher.with_tantivy_index(&tantivy_path),
+            }
+        } else {
+            watcher = watcher.with_tantivy_index(&tantivy_path);
+        }
+
+        let shutdown_handle = watcher.shutdown_handle();
+
+        // Hold the lock across check + store to prevent TOCTOU race.
         {
-            let guard = self
+            let mut guard = self
                 .state
                 .watcher_stop
                 .lock()
@@ -200,58 +243,9 @@ impl NestWeaverDaemon for DaemonService {
                         .to_string(),
                 }));
             }
-        }
-
-        let req = request.into_inner();
-        let vault_path = PathBuf::from(&req.vault_path);
-        let vault_name = req.vault_name.clone();
-        let instance_id = if req.instance_id.is_empty() {
-            self.state.instance_id.clone()
-        } else {
-            req.instance_id.clone()
-        };
-        let extra_patterns = req.extra_ignore_patterns.clone();
-
-        // Validate vault path.
-        if !vault_path.exists() || !vault_path.is_dir() {
-            return Ok(Response::new(WatchVaultResponse {
-                ok: false,
-                message: format!("vault path is not a directory: {}", vault_path.display()),
-            }));
-        }
-
-        let db_path = self.state.db_path.clone();
-        let vault_path_display = vault_path.display().to_string();
-
-        // Build the watcher with Tantivy support.
-        let tantivy_path = nestweaver_mcp::tantivy_sidecar_path(&db_path);
-        let tantivy_idx = TantivyIndex::open_or_create(&tantivy_path).ok();
-        let manifests_path = nestweaver_engine::sidecar_path(&db_path, ".manifests.json");
-
-        let mut watcher =
-            nestweaver_engine::BrainWatcher::new(&db_path, &vault_path, &instance_id, &vault_name)
-                .with_manifests_path(&manifests_path)
-                .with_extra_ignore_patterns(&extra_patterns);
-
-        if let Some(idx) = tantivy_idx {
-            watcher = watcher.with_external_tantivy(idx);
-        } else {
-            watcher = watcher.with_tantivy_index(&tantivy_path);
-        }
-
-        let shutdown_handle = watcher.shutdown_handle();
-
-        // Store the shutdown handle so StopWatch and shutdown can use it.
-        {
-            let mut guard = self
-                .state
-                .watcher_stop
-                .lock()
-                .map_err(|e| Status::internal(format!("watcher_stop lock poisoned: {e}")))?;
             *guard = Some(shutdown_handle);
         }
 
-        // Increment active connections to prevent idle timeout.
         self.state
             .active_connections
             .fetch_add(1, Ordering::Relaxed);
@@ -260,18 +254,18 @@ impl NestWeaverDaemon for DaemonService {
         let store = self.state.store.clone();
 
         tokio::task::spawn_blocking(move || {
-            tracing::info!(
-                vault = %vault_path.display(),
-                "watcher thread started"
-            );
+            tracing::info!(vault = %vault_path.display(), "watcher thread started");
 
-            if let Err(e) = watcher.run_with_store(store, None) {
-                tracing::error!(error = %e, "watcher exited with error");
-            } else {
-                tracing::info!("watcher exited cleanly");
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                watcher.run_with_store(store, None)
+            }));
+
+            match result {
+                Ok(Ok(())) => tracing::info!("watcher exited cleanly"),
+                Ok(Err(e)) => tracing::error!(error = %e, "watcher exited with error"),
+                Err(_) => tracing::error!("watcher thread panicked"),
             }
 
-            // Cleanup: decrement active connections and clear the stop handle.
             state.active_connections.fetch_sub(1, Ordering::Relaxed);
             if let Ok(mut guard) = state.watcher_stop.lock() {
                 *guard = None;
@@ -282,7 +276,7 @@ impl NestWeaverDaemon for DaemonService {
             ok: true,
             message: format!(
                 "Watcher started for {} (vault: {})",
-                vault_path_display, vault_name
+                req.vault_path, vault_name
             ),
         }))
     }

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -22,7 +22,7 @@ use crate::lifecycle;
 
 /// Shared state held by the daemon process.
 pub struct DaemonState {
-    pub store: GraphStore,
+    pub store: Arc<GraphStore>,
     pub tantivy: Option<TantivyIndex>,
     pub db_path: PathBuf,
     pub instance_id: String,
@@ -30,6 +30,7 @@ pub struct DaemonState {
     pub active_connections: AtomicU32,
     pub idle_notify: Arc<Notify>,
     pub shutdown_tx: tokio::sync::watch::Sender<bool>,
+    pub watcher_stop: std::sync::Mutex<Option<nestweaver_engine::ShutdownHandle>>,
 }
 
 /// The gRPC service implementation. Wraps shared state in an `Arc`.
@@ -969,7 +970,7 @@ pub async fn run_server(
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
 
     let state = Arc::new(DaemonState {
-        store,
+        store: Arc::new(store),
         tantivy,
         db_path: db_path.clone(),
         instance_id: instance_id.clone(),
@@ -977,6 +978,7 @@ pub async fn run_server(
         active_connections: AtomicU32::new(0),
         idle_notify: idle_notify.clone(),
         shutdown_tx: shutdown_tx.clone(),
+        watcher_stop: std::sync::Mutex::new(None),
     });
 
     let svc = NestWeaverDaemonServer::new(DaemonService::new(state.clone()))

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -163,11 +163,11 @@ impl NestWeaverDaemon for DaemonService {
         tracing::info!("shutdown requested via gRPC");
 
         // Stop the file watcher if one is running.
-        if let Ok(mut guard) = self.state.watcher_stop.lock() {
-            if let Some(handle) = guard.take() {
-                tracing::info!("stopping active watcher before shutdown");
-                handle.stop();
-            }
+        if let Ok(mut guard) = self.state.watcher_stop.lock()
+            && let Some(handle) = guard.take()
+        {
+            tracing::info!("stopping active watcher before shutdown");
+            handle.stop();
         }
 
         let tx = self.state.shutdown_tx.clone();
@@ -216,10 +216,7 @@ impl NestWeaverDaemon for DaemonService {
         if !vault_path.exists() || !vault_path.is_dir() {
             return Ok(Response::new(WatchVaultResponse {
                 ok: false,
-                message: format!(
-                    "vault path is not a directory: {}",
-                    vault_path.display()
-                ),
+                message: format!("vault path is not a directory: {}", vault_path.display()),
             }));
         }
 
@@ -231,14 +228,10 @@ impl NestWeaverDaemon for DaemonService {
         let tantivy_idx = TantivyIndex::open_or_create(&tantivy_path).ok();
         let manifests_path = nestweaver_engine::sidecar_path(&db_path, ".manifests.json");
 
-        let mut watcher = nestweaver_engine::BrainWatcher::new(
-            &db_path,
-            &vault_path,
-            &instance_id,
-            &vault_name,
-        )
-        .with_manifests_path(&manifests_path)
-        .with_extra_ignore_patterns(&extra_patterns);
+        let mut watcher =
+            nestweaver_engine::BrainWatcher::new(&db_path, &vault_path, &instance_id, &vault_name)
+                .with_manifests_path(&manifests_path)
+                .with_extra_ignore_patterns(&extra_patterns);
 
         if let Some(idx) = tantivy_idx {
             watcher = watcher.with_external_tantivy(idx);
@@ -1037,33 +1030,13 @@ pub async fn run_server(
     let store = match GraphStore::open_or_create(&db_path) {
         Ok(s) => s,
         Err(e) => {
-            // Check if a watcher is holding the lock (writes PID to <db>.lock).
-            let lock_path = {
-                let mut s = db_path.as_os_str().to_owned();
-                s.push(".lock");
-                std::path::PathBuf::from(s)
-            };
-            let mut hint = String::new();
-            if let Ok(pid_str) = std::fs::read_to_string(&lock_path)
-                && let Ok(pid) = pid_str.trim().parse::<i32>()
-                && unsafe { libc::kill(pid, 0) } == 0
-            {
-                hint = format!(
-                    "\n\nA brain watcher (PID {pid}) is holding the database lock.\n\
-                     Stop it with: nestweaver brain watch-stop --db {}\n\
-                     Or use --no-daemon to bypass the daemon.",
+            return Err(e).with_context(|| {
+                format!(
+                    "failed to open database with write access at {}; \
+                     another process may hold the write lock",
                     db_path.display()
-                );
-            }
-            if hint.is_empty() {
-                hint = format!(
-                    "\n\nAnother process may hold the write lock on {}.\n\
-                     Check for running nestweaver processes and stop them, or use --no-daemon.",
-                    db_path.display()
-                );
-            }
-            return Err(e)
-                .with_context(|| format!("failed to open database with write access{hint}"));
+                )
+            });
         }
     };
 

--- a/crates/nestweaver-engine/src/config.rs
+++ b/crates/nestweaver-engine/src/config.rs
@@ -166,6 +166,9 @@ pub struct InstanceConfig {
     /// Feature F16 — response cache tuning (`[cache]`).
     #[serde(default)]
     pub cache: CacheConfig,
+    /// Vault file-watching configuration (`[watch]`).
+    #[serde(default)]
+    pub watch: WatchConfig,
 }
 
 /// `[cache]` — tuning for the F16 response cache (Feature F16).
@@ -191,6 +194,31 @@ impl Default for CacheConfig {
     fn default() -> Self {
         Self {
             max_size_mb: default_cache_max_size_mb(),
+        }
+    }
+}
+
+/// `[watch]` — vault file-watching configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WatchConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_debounce_ms")]
+    pub debounce_ms: u64,
+}
+
+fn default_true() -> bool {
+    true
+}
+fn default_debounce_ms() -> u64 {
+    200
+}
+
+impl Default for WatchConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            debounce_ms: 200,
         }
     }
 }

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -895,10 +895,61 @@ fn index_into_store(
         .filter(|e| !e.target_uid.starts_with("unresolved:"))
         .collect();
 
-    let edges_count = insertable_edges.len();
+    let mut edges_count = insertable_edges.len();
     store
         .batch_insert_edges(&insertable_edges)
         .context("batch_insert_edges (resolved)")?;
+
+    // ── Structural MEMBER_OF edges ────────────────────────────────────────
+    // Build a lookup: (file_path, type_name) → type_symbol_uid for all
+    // container symbols (Class / Interface / Enum / Trait).  Then for every
+    // raw symbol that carries a parent_name, emit a MEMBER_OF edge from the
+    // member to its parent container.
+    {
+        use nestweaver_schema::{EdgeType, ResolvedEdge};
+
+        let container_kinds = [
+            nestweaver_schema::SymbolKind::Class,
+            nestweaver_schema::SymbolKind::Interface,
+            nestweaver_schema::SymbolKind::Enum,
+            nestweaver_schema::SymbolKind::Trait,
+        ];
+
+        // (file_path, type_name) → uid
+        let mut container_map: HashMap<(String, String), String> = HashMap::new();
+        for sym in &all_symbols {
+            if container_kinds.contains(&sym.kind) {
+                container_map.insert((sym.file_path.clone(), sym.name.clone()), sym.uid.clone());
+            }
+        }
+
+        let mut member_of_edges: Vec<ResolvedEdge> = Vec::new();
+        for (rel_path, raw_symbols, _) in &parsed_files_for_resolver {
+            for raw_sym in raw_symbols {
+                if let Some(parent_name) = &raw_sym.parent_name {
+                    let key = (rel_path.clone(), parent_name.clone());
+                    if let Some(parent_uid) = container_map.get(&key) {
+                        let child_uid = symbol_uid(&r_uid, rel_path, &raw_sym.name, raw_sym.start_line);
+                        member_of_edges.push(ResolvedEdge {
+                            source_uid: child_uid,
+                            target_uid: parent_uid.clone(),
+                            edge_type: EdgeType::MemberOf,
+                            confidence: 1.0,
+                            link_type: None,
+                        });
+                    }
+                }
+            }
+        }
+
+        if !member_of_edges.is_empty() {
+            edges_count += member_of_edges.len();
+            store
+                .batch_insert_edges(&member_of_edges)
+                .context("batch_insert_edges (member_of)")?;
+            tracing::debug!(count = member_of_edges.len(), "emitted MEMBER_OF edges");
+        }
+    }
 
     resolve_pb.finish_and_clear();
 
@@ -2104,5 +2155,49 @@ function hello(name) { return "Hello " + name; }
         );
         // files_count tracks only files that were actually processed (parsed).
         assert_eq!(result2.files_count, 0, "no files should be re-indexed");
+    }
+
+    #[test]
+    fn index_emits_member_of_edges_for_rust_struct_methods() {
+        // Task 4: MEMBER_OF edges must be emitted from methods to their parent
+        // struct (which the parser classifies as SymbolKind::Class via the impl
+        // block).
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("repo");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(
+            src.join("lib.rs"),
+            r#"
+pub struct Counter {
+    value: u32,
+}
+
+impl Counter {
+    pub fn new() -> Self {
+        Counter { value: 0 }
+    }
+
+    pub fn increment(&mut self) {
+        self.value += 1;
+    }
+}
+"#,
+        )
+        .unwrap();
+
+        let (_result, store) =
+            index_directory_in_memory(&src, "test", "https://example.com/repo", "abc123").unwrap();
+
+        let all_edges = store.load_typed_edges().unwrap();
+        let member_of: Vec<_> = all_edges
+            .iter()
+            .filter(|(_, _, edge_type, _)| edge_type == "MEMBER_OF")
+            .collect();
+
+        assert!(
+            member_of.len() >= 2,
+            "expected at least 2 MEMBER_OF edges (new + increment), got {}: {member_of:?}",
+            member_of.len()
+        );
     }
 }

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -929,7 +929,8 @@ fn index_into_store(
                 if let Some(parent_name) = &raw_sym.parent_name {
                     let key = (rel_path.clone(), parent_name.clone());
                     if let Some(parent_uid) = container_map.get(&key) {
-                        let child_uid = symbol_uid(&r_uid, rel_path, &raw_sym.name, raw_sym.start_line);
+                        let child_uid =
+                            symbol_uid(&r_uid, rel_path, &raw_sym.name, raw_sym.start_line);
                         member_of_edges.push(ResolvedEdge {
                             source_uid: child_uid,
                             target_uid: parent_uid.clone(),

--- a/crates/nestweaver-engine/src/snapshot.rs
+++ b/crates/nestweaver-engine/src/snapshot.rs
@@ -541,4 +541,32 @@ mod tests {
             "unexpected error: {msg}"
         );
     }
+
+    #[test]
+    fn verify_legacy_single_hash_checksum() {
+        let dir = tempfile::tempdir().unwrap();
+        let snap_dir = dir.path().join("snapshot");
+        let db = make_fake_db(dir.path());
+
+        let stamp = make_stamp(
+            "0.1.0",
+            "0.1.0",
+            "schema-hash-abc",
+            "text-embedding-3-small",
+        );
+        let manifest = make_manifest();
+        build_snapshot(&snap_dir, &stamp, &manifest, &db).unwrap();
+
+        // Replace the per-file checksum with a legacy single-hash checksum
+        // (SHA-256 of graph.lbug + manifest.json + stamp.json concatenated).
+        let mut hasher = Sha256::new();
+        for name in CORE_FILES {
+            hasher.update(std::fs::read(snap_dir.join(name)).unwrap());
+        }
+        let legacy_checksum = hex::encode(hasher.finalize());
+        std::fs::write(snap_dir.join(CHECKSUM_FILE), &legacy_checksum).unwrap();
+
+        let loaded = verify_snapshot(&snap_dir).unwrap();
+        assert_eq!(loaded.instance_id, "test-instance");
+    }
 }

--- a/crates/nestweaver-engine/src/watcher.rs
+++ b/crates/nestweaver-engine/src/watcher.rs
@@ -94,6 +94,8 @@ pub struct BrainWatcher {
     /// When set, manifest file changes (Cargo.toml, package.json, …) trigger
     /// a re-parse and sidecar update.
     manifests_path: Option<PathBuf>,
+    /// Debounce interval in milliseconds for filesystem events.
+    debounce_ms: u64,
     /// Compiled `.brainignore` glob patterns. Loaded once at construction
     /// from the vault root's `.brainignore` file (or built-in defaults).
     ignore_set: GlobSet,
@@ -125,6 +127,7 @@ impl BrainWatcher {
             stop_flag: Arc::new(AtomicBool::new(false)),
             tantivy_path: None,
             manifests_path: None,
+            debounce_ms: 200,
             ignore_set,
             external_tantivy: None,
         }
@@ -152,6 +155,12 @@ impl BrainWatcher {
     /// already holds the Tantivy writer.
     pub fn with_external_tantivy(mut self, tantivy: TantivyIndex) -> Self {
         self.external_tantivy = Some(tantivy);
+        self
+    }
+
+    /// Set the debounce interval for filesystem events.
+    pub fn with_debounce_ms(mut self, ms: u64) -> Self {
+        self.debounce_ms = ms;
         self
     }
 
@@ -239,7 +248,7 @@ impl BrainWatcher {
         // Channel from the debouncer into our loop.
         let (tx, rx) = std::sync::mpsc::channel::<DebounceResult>();
         let mut debouncer = new_debouncer(
-            Duration::from_millis(200),
+            Duration::from_millis(self.debounce_ms),
             move |res: Result<Vec<DebouncedEvent>, notify::Error>| {
                 let _ = tx.send(res);
             },

--- a/crates/nestweaver-engine/src/watcher.rs
+++ b/crates/nestweaver-engine/src/watcher.rs
@@ -97,6 +97,9 @@ pub struct BrainWatcher {
     /// Compiled `.brainignore` glob patterns. Loaded once at construction
     /// from the vault root's `.brainignore` file (or built-in defaults).
     ignore_set: GlobSet,
+    /// Pre-opened TantivyIndex from the caller (e.g. daemon). When set,
+    /// `run_inner` uses this instead of opening its own from `tantivy_path`.
+    external_tantivy: Option<TantivyIndex>,
 }
 
 impl BrainWatcher {
@@ -123,6 +126,7 @@ impl BrainWatcher {
             tantivy_path: None,
             manifests_path: None,
             ignore_set,
+            external_tantivy: None,
         }
     }
 
@@ -140,6 +144,14 @@ impl BrainWatcher {
     /// update the sidecar at this path.
     pub fn with_manifests_path(mut self, path: impl Into<PathBuf>) -> Self {
         self.manifests_path = Some(path.into());
+        self
+    }
+
+    /// Use a pre-opened TantivyIndex instead of opening one from
+    /// `tantivy_path`. Used when the daemon spawns the watcher and
+    /// already holds the Tantivy writer.
+    pub fn with_external_tantivy(mut self, tantivy: TantivyIndex) -> Self {
+        self.external_tantivy = Some(tantivy);
         self
     }
 
@@ -189,25 +201,28 @@ impl BrainWatcher {
 
     /// Shared implementation used by both `run` and `run_with_store`.
     fn run_inner(
-        self,
+        mut self,
         store: Arc<GraphStore>,
         on_change: Option<Box<dyn Fn() + Send>>,
     ) -> Result<(), anyhow::Error> {
-        // Open the Tantivy index sidecar if configured. Best-effort: a
-        // broken index logs a warning but doesn't block graph updates.
-        let tantivy: Option<TantivyIndex> = match &self.tantivy_path {
-            Some(p) => match TantivyIndex::open_or_create(p) {
-                Ok(idx) => Some(idx),
-                Err(e) => {
-                    tracing::warn!(
-                        path = %p.display(),
-                        error = %e,
-                        "BrainWatcher: Tantivy index unavailable; BM25 search will fall behind"
-                    );
-                    None
-                }
-            },
-            None => None,
+        // Use external Tantivy if provided (daemon mode), otherwise open from path.
+        let tantivy: Option<TantivyIndex> = if let Some(ext) = self.external_tantivy.take() {
+            Some(ext)
+        } else {
+            match &self.tantivy_path {
+                Some(p) => match TantivyIndex::open_or_create(p) {
+                    Ok(idx) => Some(idx),
+                    Err(e) => {
+                        tracing::warn!(
+                            path = %p.display(),
+                            error = %e,
+                            "BrainWatcher: Tantivy index unavailable; BM25 search will fall behind"
+                        );
+                        None
+                    }
+                },
+                None => None,
+            }
         };
 
         // Make sure the Vault node exists — first-time runs (no prior

--- a/crates/nestweaver-parser/src/parse.rs
+++ b/crates/nestweaver-parser/src/parse.rs
@@ -4765,12 +4765,7 @@ fn main() {
             .type_bindings
             .iter()
             .find(|b| b.type_name == "Point" && b.var_name.is_empty())
-            .or_else(|| {
-                parsed
-                    .type_bindings
-                    .iter()
-                    .find(|b| b.type_name == "Point")
-            })
+            .or_else(|| parsed.type_bindings.iter().find(|b| b.type_name == "Point"))
             .expect("should find a binding with type_name 'Point' from tuple struct pattern");
         assert_eq!(binding.type_name, "Point");
     }
@@ -4808,8 +4803,7 @@ fn main() {
 
     #[test]
     fn ast_extracts_go_short_var_composite_literal() {
-        let source =
-            "package main\nfunc main() {\n\tcfg := Config{Host: \"localhost\"}\n}\n";
+        let source = "package main\nfunc main() {\n\tcfg := Config{Host: \"localhost\"}\n}\n";
         let parsed = parse_source(Path::new("test.go"), source).unwrap();
         let binding = parsed.type_bindings.iter().find(|b| b.var_name == "cfg");
         assert!(
@@ -4837,10 +4831,7 @@ fn main() {
     fn ast_extracts_ts_class_property_constructor() {
         let source = "class Service { store = new Store(); }";
         let parsed = parse_source(Path::new("test.ts"), source).unwrap();
-        let binding = parsed
-            .type_bindings
-            .iter()
-            .find(|b| b.var_name == "store");
+        let binding = parsed.type_bindings.iter().find(|b| b.var_name == "store");
         assert!(
             binding.is_some(),
             "should find store binding: {:?}",

--- a/crates/nestweaver-parser/src/parse.rs
+++ b/crates/nestweaver-parser/src/parse.rs
@@ -4792,4 +4792,60 @@ fn main() {
             .expect("should find a binding with type_name 'Foo' from struct pattern");
         assert_eq!(binding.type_name, "Foo");
     }
+
+    #[test]
+    fn ast_extracts_python_constructor_call() {
+        let source = "store = GraphStore()\n";
+        let parsed = parse_source(Path::new("test.py"), source).unwrap();
+        let binding = parsed.type_bindings.iter().find(|b| b.var_name == "store");
+        assert!(
+            binding.is_some(),
+            "should find store binding: {:?}",
+            parsed.type_bindings
+        );
+        assert_eq!(binding.unwrap().type_name, "GraphStore");
+    }
+
+    #[test]
+    fn ast_extracts_go_short_var_composite_literal() {
+        let source =
+            "package main\nfunc main() {\n\tcfg := Config{Host: \"localhost\"}\n}\n";
+        let parsed = parse_source(Path::new("test.go"), source).unwrap();
+        let binding = parsed.type_bindings.iter().find(|b| b.var_name == "cfg");
+        assert!(
+            binding.is_some(),
+            "should find cfg binding: {:?}",
+            parsed.type_bindings
+        );
+        assert_eq!(binding.unwrap().type_name, "Config");
+    }
+
+    #[test]
+    fn ast_extracts_java_new_in_local_var() {
+        let source = "class Main { void run() { User u = new User(); } }";
+        let parsed = parse_source(Path::new("test.java"), source).unwrap();
+        let binding = parsed.type_bindings.iter().find(|b| b.var_name == "u");
+        assert!(
+            binding.is_some(),
+            "should find u binding: {:?}",
+            parsed.type_bindings
+        );
+        assert_eq!(binding.unwrap().type_name, "User");
+    }
+
+    #[test]
+    fn ast_extracts_ts_class_property_constructor() {
+        let source = "class Service { store = new Store(); }";
+        let parsed = parse_source(Path::new("test.ts"), source).unwrap();
+        let binding = parsed
+            .type_bindings
+            .iter()
+            .find(|b| b.var_name == "store");
+        assert!(
+            binding.is_some(),
+            "should find store binding: {:?}",
+            parsed.type_bindings
+        );
+        assert_eq!(binding.unwrap().type_name, "Store");
+    }
 }

--- a/crates/nestweaver-parser/src/parse.rs
+++ b/crates/nestweaver-parser/src/parse.rs
@@ -4695,4 +4695,101 @@ fn main() {
         assert_eq!(binding.type_name, "GraphStore");
         assert!(matches!(binding.kind, AstBindingKind::ReturnType));
     }
+
+    #[test]
+    fn ast_extracts_rust_struct_expression_constructor() {
+        let source = r#"
+fn main() {
+    let config = Config { host: "localhost", port: 8080 };
+}
+"#;
+        let parsed = parse_source(Path::new("test.rs"), source).unwrap();
+        let binding = parsed
+            .type_bindings
+            .iter()
+            .find(|b| b.var_name == "config")
+            .expect("should find 'config' binding from struct expression");
+        assert_eq!(binding.type_name, "Config");
+        assert!(matches!(binding.kind, AstBindingKind::Constructor));
+    }
+
+    #[test]
+    fn ast_extracts_rust_static_method_constructor() {
+        let source = r#"
+fn main() {
+    let store = GraphStore::new();
+    let map = HashMap::default();
+    let v = Vec::with_capacity(10);
+}
+"#;
+        let parsed = parse_source(Path::new("test.rs"), source).unwrap();
+
+        let store_binding = parsed
+            .type_bindings
+            .iter()
+            .find(|b| b.var_name == "store")
+            .expect("should find 'store' binding");
+        assert_eq!(store_binding.type_name, "GraphStore");
+        assert!(matches!(store_binding.kind, AstBindingKind::Constructor));
+
+        let map_binding = parsed
+            .type_bindings
+            .iter()
+            .find(|b| b.var_name == "map")
+            .expect("should find 'map' binding");
+        assert_eq!(map_binding.type_name, "HashMap");
+        assert!(matches!(map_binding.kind, AstBindingKind::Constructor));
+
+        let v_binding = parsed
+            .type_bindings
+            .iter()
+            .find(|b| b.var_name == "v")
+            .expect("should find 'v' binding");
+        assert_eq!(v_binding.type_name, "Vec");
+        assert!(matches!(v_binding.kind, AstBindingKind::Constructor));
+    }
+
+    #[test]
+    fn ast_extracts_rust_tuple_struct_destructuring() {
+        let source = r#"
+fn main() {
+    let point = Point(1, 2);
+    let Point(x, y) = point;
+}
+"#;
+        let parsed = parse_source(Path::new("test.rs"), source).unwrap();
+        // The destructuring pattern `let Point(x, y) = point` should yield a binding
+        // with type_name = "Point". var.name capture is absent for this pattern so
+        // the parser will emit it as a var.type-only match, but the query still fires.
+        let binding = parsed
+            .type_bindings
+            .iter()
+            .find(|b| b.type_name == "Point" && b.var_name.is_empty())
+            .or_else(|| {
+                parsed
+                    .type_bindings
+                    .iter()
+                    .find(|b| b.type_name == "Point")
+            })
+            .expect("should find a binding with type_name 'Point' from tuple struct pattern");
+        assert_eq!(binding.type_name, "Point");
+    }
+
+    #[test]
+    fn ast_extracts_rust_struct_pattern_destructuring() {
+        let source = r#"
+fn main() {
+    let foo = Foo { x: 1, y: 2 };
+    let Foo { x, y } = foo;
+}
+"#;
+        let parsed = parse_source(Path::new("test.rs"), source).unwrap();
+        // The struct pattern `let Foo { x, y } = foo` captures the type name.
+        let binding = parsed
+            .type_bindings
+            .iter()
+            .find(|b| b.type_name == "Foo")
+            .expect("should find a binding with type_name 'Foo' from struct pattern");
+        assert_eq!(binding.type_name, "Foo");
+    }
 }

--- a/crates/nestweaver-parser/src/parse.rs
+++ b/crates/nestweaver-parser/src/parse.rs
@@ -919,7 +919,13 @@ fn extract_types_from_tree(
                     kind = AstBindingKind::Constructor;
                 }
                 "ctor.type" => {
-                    var_type = Some(text.to_string());
+                    // For scoped paths (foo::bar::Baz), take the last segment.
+                    let base = text.rsplit("::").next().unwrap_or(text);
+                    // Only accept PascalCase types — filters out module-scoped
+                    // function calls like io::stdin() or env::var().
+                    if base.starts_with(|c: char| c.is_ascii_uppercase()) {
+                        var_type = Some(base.to_string());
+                    }
                 }
                 "return.name" => {
                     var_name = Some(text.to_string());

--- a/crates/nestweaver-resolver/src/resolve.rs
+++ b/crates/nestweaver-resolver/src/resolve.rs
@@ -123,12 +123,32 @@ pub fn resolve_references_with_context(
                 && let Some(envs) = _type_envs
                 && let Some(env) = envs.get(file_path.as_str())
             {
-                let receiver_type =
-                    if receiver == "self" || receiver == "this" || receiver == "$this" {
-                        env.lookup_self(reference.start_line)
-                    } else {
-                        env.lookup(receiver, reference.start_line)
-                    };
+                let receiver_type = if receiver == "self"
+                    || receiver == "this"
+                    || receiver == "$this"
+                {
+                    env.lookup_self(reference.start_line)
+                } else if receiver.contains('.') {
+                    let segments: Vec<&str> = receiver.split('.').collect();
+                    let mut current_type: Option<&crate::type_extractors::TypeBinding> = None;
+                    for (i, seg) in segments.iter().enumerate() {
+                        if i == 0 {
+                            current_type = if *seg == "self" || *seg == "this" || *seg == "$this" {
+                                env.lookup_self(reference.start_line)
+                            } else {
+                                env.lookup(seg, reference.start_line)
+                            };
+                        } else {
+                            current_type = env.lookup(seg, reference.start_line);
+                        }
+                        if current_type.is_none() {
+                            break;
+                        }
+                    }
+                    current_type
+                } else {
+                    env.lookup(receiver, reference.start_line)
+                };
 
                 if let Some(binding) = receiver_type {
                     let method_name = &reference.name;
@@ -1307,6 +1327,112 @@ mod tests {
         assert!(
             !call_edges.is_empty(),
             "should still produce edges via name-based fallback"
+        );
+    }
+
+    #[test]
+    fn type_aware_chained_dot_receiver_resolves_self_store_query() {
+        use crate::type_extractors::{BindingSource, TypeBinding};
+        use crate::types::TypeEnvironment;
+
+        // Store class with method `query`
+        let store_class = RawSymbol {
+            name: "Store".to_string(),
+            kind: SymbolKind::Class,
+            start_line: 1,
+            end_line: 20,
+            signature: "class Store".to_string(),
+            content_hash: String::new(),
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Public,
+            type_info: None,
+            parent_name: None,
+        };
+        let mut store_query = make_symbol("query", 5);
+        store_query.parent_name = Some("Store".to_string());
+
+        // MyService class with method `handle` that calls `self.store.query()`
+        let service_class = RawSymbol {
+            name: "MyService".to_string(),
+            kind: SymbolKind::Class,
+            start_line: 1,
+            end_line: 30,
+            signature: "class MyService".to_string(),
+            content_hash: String::new(),
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Public,
+            type_info: None,
+            parent_name: None,
+        };
+        let mut handle_method = make_symbol("handle", 10);
+        handle_method.parent_name = Some("MyService".to_string());
+
+        let chained_call = RawReference {
+            name: "query".to_string(),
+            kind: ReferenceKind::Call,
+            start_line: 12,
+            context: String::new(),
+            receiver: Some("self.store".to_string()),
+        };
+
+        let files = vec![
+            ("src/store.rs".to_string(), vec![store_class, store_query], vec![]),
+            (
+                "src/service.rs".to_string(),
+                vec![service_class, handle_method],
+                vec![chained_call],
+            ),
+        ];
+
+        // Type env for service.rs:
+        //   self → MyService at line 5 (enclosing class)
+        //   store → Store at line 2 (field binding)
+        let mut type_envs = std::collections::HashMap::new();
+        let env = TypeEnvironment::from_bindings(vec![
+            (
+                "self".to_string(),
+                5,
+                TypeBinding {
+                    type_name: "MyService".to_string(),
+                    line: 5,
+                    confidence: 1.0,
+                    source: BindingSource::SelfThis,
+                },
+            ),
+            (
+                "store".to_string(),
+                2,
+                TypeBinding {
+                    type_name: "Store".to_string(),
+                    line: 2,
+                    confidence: 0.9,
+                    source: BindingSource::Annotation,
+                },
+            ),
+        ]);
+        type_envs.insert("src/service.rs".to_string(), env);
+
+        let edges = resolve_references_with_context(
+            &files,
+            Language::TypeScript,
+            "repo:test:abc",
+            &WorkspaceContext::default(),
+            Some(&type_envs),
+        );
+
+        let call_edges: Vec<_> = edges
+            .iter()
+            .filter(|e| e.edge_type == EdgeType::Calls)
+            .collect();
+        assert_eq!(call_edges.len(), 1, "should have exactly one call edge");
+
+        let edge = &call_edges[0];
+        let expected_target = symbol_uid("repo:test:abc", "src/store.rs", "query", 5);
+        assert_eq!(
+            edge.target_uid, expected_target,
+            "self.store.query() should resolve to Store::query in store.rs"
         );
     }
 }

--- a/crates/nestweaver-resolver/src/resolve.rs
+++ b/crates/nestweaver-resolver/src/resolve.rs
@@ -127,24 +127,18 @@ pub fn resolve_references_with_context(
                     if receiver == "self" || receiver == "this" || receiver == "$this" {
                         env.lookup_self(reference.start_line)
                     } else if receiver.contains('.') {
-                        let segments: Vec<&str> = receiver.split('.').collect();
-                        let mut current_type: Option<&crate::type_extractors::TypeBinding> = None;
-                        for (i, seg) in segments.iter().enumerate() {
-                            if i == 0 {
-                                current_type =
-                                    if *seg == "self" || *seg == "this" || *seg == "$this" {
-                                        env.lookup_self(reference.start_line)
-                                    } else {
-                                        env.lookup(seg, reference.start_line)
-                                    };
-                            } else {
-                                current_type = env.lookup(seg, reference.start_line);
-                            }
-                            if current_type.is_none() {
-                                break;
-                            }
+                        // Decompose chained receivers: a.b.method() → look up
+                        // the type of `a`, then use it. For chains deeper than
+                        // 2 segments (a.b.c.method), only the first segment's
+                        // type is resolved — field-of-type resolution would
+                        // require a full type system, so we fall through to
+                        // name-based resolution for deeper chains.
+                        let first = receiver.split('.').next().unwrap_or(receiver);
+                        if first == "self" || first == "this" || first == "$this" {
+                            env.lookup_self(reference.start_line)
+                        } else {
+                            env.lookup(first, reference.start_line)
                         }
-                        current_type
                     } else {
                         env.lookup(receiver, reference.start_line)
                     };

--- a/crates/nestweaver-resolver/src/resolve.rs
+++ b/crates/nestweaver-resolver/src/resolve.rs
@@ -123,32 +123,31 @@ pub fn resolve_references_with_context(
                 && let Some(envs) = _type_envs
                 && let Some(env) = envs.get(file_path.as_str())
             {
-                let receiver_type = if receiver == "self"
-                    || receiver == "this"
-                    || receiver == "$this"
-                {
-                    env.lookup_self(reference.start_line)
-                } else if receiver.contains('.') {
-                    let segments: Vec<&str> = receiver.split('.').collect();
-                    let mut current_type: Option<&crate::type_extractors::TypeBinding> = None;
-                    for (i, seg) in segments.iter().enumerate() {
-                        if i == 0 {
-                            current_type = if *seg == "self" || *seg == "this" || *seg == "$this" {
-                                env.lookup_self(reference.start_line)
+                let receiver_type =
+                    if receiver == "self" || receiver == "this" || receiver == "$this" {
+                        env.lookup_self(reference.start_line)
+                    } else if receiver.contains('.') {
+                        let segments: Vec<&str> = receiver.split('.').collect();
+                        let mut current_type: Option<&crate::type_extractors::TypeBinding> = None;
+                        for (i, seg) in segments.iter().enumerate() {
+                            if i == 0 {
+                                current_type =
+                                    if *seg == "self" || *seg == "this" || *seg == "$this" {
+                                        env.lookup_self(reference.start_line)
+                                    } else {
+                                        env.lookup(seg, reference.start_line)
+                                    };
                             } else {
-                                env.lookup(seg, reference.start_line)
-                            };
-                        } else {
-                            current_type = env.lookup(seg, reference.start_line);
+                                current_type = env.lookup(seg, reference.start_line);
+                            }
+                            if current_type.is_none() {
+                                break;
+                            }
                         }
-                        if current_type.is_none() {
-                            break;
-                        }
-                    }
-                    current_type
-                } else {
-                    env.lookup(receiver, reference.start_line)
-                };
+                        current_type
+                    } else {
+                        env.lookup(receiver, reference.start_line)
+                    };
 
                 if let Some(binding) = receiver_type {
                     let method_name = &reference.name;
@@ -1378,7 +1377,11 @@ mod tests {
         };
 
         let files = vec![
-            ("src/store.rs".to_string(), vec![store_class, store_query], vec![]),
+            (
+                "src/store.rs".to_string(),
+                vec![store_class, store_query],
+                vec![],
+            ),
             (
                 "src/service.rs".to_string(),
                 vec![service_class, handle_method],

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -836,7 +836,7 @@ impl GraphStore {
             .map_err(|e| StoreError::Query(e.to_string()))?;
         for row in result {
             if let Ok(dim) = extract_i64(&row, 0) {
-                return Ok(dim as u32);
+                return Ok(u32::try_from(dim).unwrap_or(0));
             }
         }
         Ok(0)

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -825,6 +825,23 @@ impl GraphStore {
         Ok(result.count())
     }
 
+    /// Returns the dimension of stored embeddings, or 0 if none exist.
+    pub fn embedding_dimension(&self) -> Result<u32, StoreError> {
+        let conn = self.conn()?;
+        let result = conn
+            .query(
+                "MATCH (s:Symbol) WHERE s.embedding IS NOT NULL \
+                 RETURN list_len(s.embedding) LIMIT 1",
+            )
+            .map_err(|e| StoreError::Query(e.to_string()))?;
+        for row in result {
+            if let Ok(dim) = extract_i64(&row, 0) {
+                return Ok(dim as u32);
+            }
+        }
+        Ok(0)
+    }
+
     /// All symbols with full details including the embedding field.
     /// Used by vector KNN search to load embeddings for cosine similarity.
     pub fn list_all_symbols(&self) -> Result<Vec<nestweaver_schema::Symbol>, StoreError> {

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -38,6 +38,26 @@ message IndexVaultRequest {
 
 message RefreshBrainRequest {}
 
+// ─── Watching ───────────────────────────────────────────────────────
+
+message WatchVaultRequest {
+  string vault_path = 1;
+  string vault_name = 2;
+  string instance_id = 3;
+  repeated string extra_ignore_patterns = 4;
+}
+
+message WatchVaultResponse {
+  bool ok = 1;
+  string message = 2;
+}
+
+message StopWatchRequest {}
+
+message StopWatchResponse {
+  bool ok = 1;
+}
+
 enum Phase {
   DISCOVERING = 0;
   PARSING = 1;
@@ -176,6 +196,10 @@ service NestWeaverDaemon {
   rpc IndexRepo(IndexRepoRequest) returns (stream IndexProgress);
   rpc IndexVault(IndexVaultRequest) returns (stream IndexProgress);
   rpc RefreshBrain(RefreshBrainRequest) returns (stream IndexProgress);
+
+  // Watching
+  rpc WatchVault(WatchVaultRequest) returns (WatchVaultResponse);
+  rpc StopWatch(StopWatchRequest) returns (StopWatchResponse);
 
   // Read RPCs — typed hot-path
   rpc Search(BrainSearchRequest) returns (BrainSearchResponse);

--- a/queries/go_types.scm
+++ b/queries/go_types.scm
@@ -31,3 +31,19 @@
 (const_spec
   name: (identifier) @var.name
   type: (_) @var.type)
+
+; Short variable declaration with composite literal: x := Config{...}
+(short_var_declaration
+  left: (expression_list
+    (identifier) @ctor.name)
+  right: (expression_list
+    (composite_literal
+      type: (type_identifier) @ctor.type)))
+
+; Short variable declaration with qualified composite literal: x := pkg.Config{...}
+(short_var_declaration
+  left: (expression_list
+    (identifier) @ctor.name)
+  right: (expression_list
+    (composite_literal
+      type: (qualified_type) @ctor.type)))

--- a/queries/java_types.scm
+++ b/queries/java_types.scm
@@ -24,6 +24,18 @@
   type: (_) @param.type
   name: (identifier) @param.name)
 
-; Constructor new expression: new Foo(...)
+; Variable with new: Foo x = new Foo(...)
+(local_variable_declaration
+  declarator: (variable_declarator
+    name: (identifier) @ctor.name
+    value: (object_creation_expression
+      type: (type_identifier) @ctor.type)))
+
+; Enhanced for loop: for (Type item : collection)
+(enhanced_for_statement
+  type: (type_identifier) @var.type
+  name: (identifier) @var.name)
+
+; Constructor new expression (standalone): new Foo(...)
 (object_creation_expression
   type: (type_identifier) @ctor.type)

--- a/queries/python_types.scm
+++ b/queries/python_types.scm
@@ -16,3 +16,9 @@
 (typed_parameter
   (identifier) @param.name
   type: (type (_) @param.type))
+
+; Constructor call: x = Foo(...)
+(assignment
+  left: (identifier) @ctor.name
+  right: (call
+    function: (identifier) @ctor.type))

--- a/queries/rust_types.scm
+++ b/queries/rust_types.scm
@@ -32,9 +32,41 @@
   name: (identifier) @var.name
   type: (_) @var.type)
 
-; Constructor-style call: Foo::new(...)
-(call_expression
-  function: (scoped_identifier
-    path: (identifier) @ctor.type
-    name: (identifier) @_method)
-  (#eq? @_method "new")) @ctor.call
+; Struct expression constructor: let config = Config { host: "localhost" }
+(let_declaration
+  pattern: (identifier) @ctor.name
+  value: (struct_expression
+    name: (type_identifier) @ctor.type))
+
+; Scoped struct expression constructor: let v = std::collections::HashMap { }
+(let_declaration
+  pattern: (identifier) @ctor.name
+  value: (struct_expression
+    name: (scoped_type_identifier) @ctor.type))
+
+; Tuple struct destructuring: let Point(x, y) = value
+; Captures type as both ctor.name and ctor.type so the parser can form a binding.
+(let_declaration
+  pattern: (tuple_struct_pattern
+    type: (identifier) @ctor.name @ctor.type))
+
+; Struct pattern destructuring: let Foo { x, y } = value
+; Captures type as both ctor.name and ctor.type so the parser can form a binding.
+(let_declaration
+  pattern: (struct_pattern
+    type: (type_identifier) @ctor.name @ctor.type))
+
+; Constructor-style call with variable: let x = Foo::new(...)
+; Captures both the variable name and the type from the path
+(let_declaration
+  pattern: (identifier) @ctor.name
+  value: (call_expression
+    function: (scoped_identifier
+      path: (identifier) @ctor.type)))
+
+; Scoped constructor: let x = foo::bar::Baz::from(...)
+(let_declaration
+  pattern: (identifier) @ctor.name
+  value: (call_expression
+    function: (scoped_identifier
+      path: (scoped_identifier) @ctor.type)))

--- a/queries/typescript_types.scm
+++ b/queries/typescript_types.scm
@@ -47,3 +47,21 @@
 (public_field_definition
   name: (property_identifier) @var.name
   type: (type_annotation (_) @var.type))
+
+; Object destructuring with type: const { foo }: SomeType = ...
+(variable_declarator
+  name: (object_pattern)
+  type: (type_annotation
+    (type_identifier) @var.name @var.type))
+
+; Array destructuring with type: const [a, b]: SomeType = ...
+(variable_declarator
+  name: (array_pattern)
+  type: (type_annotation
+    (type_identifier) @var.name @var.type))
+
+; Class property with new: class Foo { prop = new Bar() }
+(public_field_definition
+  name: (property_identifier) @ctor.name
+  value: (new_expression
+    constructor: (identifier) @ctor.type))

--- a/queries/typescript_types.scm
+++ b/queries/typescript_types.scm
@@ -48,18 +48,6 @@
   name: (property_identifier) @var.name
   type: (type_annotation (_) @var.type))
 
-; Object destructuring with type: const { foo }: SomeType = ...
-(variable_declarator
-  name: (object_pattern)
-  type: (type_annotation
-    (type_identifier) @var.name @var.type))
-
-; Array destructuring with type: const [a, b]: SomeType = ...
-(variable_declarator
-  name: (array_pattern)
-  type: (type_annotation
-    (type_identifier) @var.name @var.type))
-
 ; Class property with new: class Foo { prop = new Bar() }
 (public_field_definition
   name: (property_identifier) @ctor.name

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,5 +1,5 @@
 name: nestweaver
-description: Code knowledge graph with 17 MCP tools for structural codebase understanding, cross-domain code-notes bridging, and AI agent context generation
+description: Code knowledge graph with 38 MCP tools for structural codebase understanding, cross-domain code-notes bridging, and AI agent context generation
 author: Kehl-io
 repository: https://github.com/Kehl-io/nestweaver
 install:

--- a/src/main.rs
+++ b/src/main.rs
@@ -6122,6 +6122,48 @@ fn run_brain(
             }
 
             let extra_patterns = parse_ignore_flag(&ignore);
+
+            if use_daemon {
+                let rt = tokio::runtime::Runtime::new()?;
+                let mut client =
+                    rt.block_on(nestweaver_client::DaemonClient::connect(&db_path))?;
+                let req = nestweaver_proto::WatchVaultRequest {
+                    vault_path: path.display().to_string(),
+                    vault_name: vault_name.clone(),
+                    instance_id: instance_id.clone(),
+                    extra_ignore_patterns: extra_patterns.clone(),
+                };
+                let resp = rt.block_on(async {
+                    client
+                        .inner_mut()
+                        .watch_vault(req)
+                        .await
+                        .map(|r| r.into_inner())
+                })?;
+                if !resp.ok {
+                    eprintln!("Error: {}", resp.message);
+                    return Ok((EXIT_ERROR, None));
+                }
+                out.status(&format!(
+                    "Watching {} via daemon (Ctrl-C to stop)",
+                    path.display()
+                ));
+
+                // Block until Ctrl-C, then send StopWatch to the daemon.
+                let (tx, rx) = std::sync::mpsc::channel();
+                let _ = ctrlc_handler(move || {
+                    let _ = tx.send(());
+                });
+                let _ = rx.recv();
+
+                let stop_req = nestweaver_proto::StopWatchRequest {};
+                let _ = rt.block_on(async {
+                    client.inner_mut().stop_watch(stop_req).await
+                });
+                out.status("Watcher stopped.");
+                return Ok((EXIT_SUCCESS, None));
+            }
+
             let tantivy_sidecar = tantivy_sidecar_path_for(&db_path);
             let manifests_path = db_path.with_extension("manifests.json");
             let wiki_instance_id = instance_id.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -6121,6 +6121,16 @@ fn run_brain(
                 ));
             }
 
+            // Respect watch.enabled config when --config is provided.
+            if let Some(cfg) = load_instance_config_opt(config.as_deref())
+                && !cfg.watch.enabled
+            {
+                out.status(
+                    "Watching disabled in instance config ([watch] enabled = false). Exiting.",
+                );
+                return Ok((EXIT_SUCCESS, None));
+            }
+
             let extra_patterns = parse_ignore_flag(&ignore);
 
             if use_daemon {
@@ -6148,15 +6158,37 @@ fn run_brain(
                     path.display()
                 ));
 
-                // Block until Ctrl-C, then send StopWatch to the daemon.
+                // Block until Ctrl-C or daemon death, then send StopWatch.
                 let (tx, rx) = std::sync::mpsc::channel();
                 let _ = ctrlc_handler(move || {
                     let _ = tx.send(());
                 });
-                let _ = rx.recv();
+
+                // Periodic health check so we notice daemon death.
+                loop {
+                    match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+                        Ok(()) => break,
+                        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                            let health = rt.block_on(async {
+                                client
+                                    .inner_mut()
+                                    .health_check(nestweaver_proto::HealthCheckRequest {})
+                                    .await
+                            });
+                            if health.is_err() {
+                                eprintln!("Daemon is no longer running.");
+                                return Ok((EXIT_ERROR, None));
+                            }
+                        }
+                        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                    }
+                }
 
                 let stop_req = nestweaver_proto::StopWatchRequest {};
-                let _ = rt.block_on(async { client.inner_mut().stop_watch(stop_req).await });
+                if let Err(e) = rt.block_on(async { client.inner_mut().stop_watch(stop_req).await })
+                {
+                    eprintln!("Warning: failed to stop watcher: {e}");
+                }
                 out.status("Watcher stopped.");
                 return Ok((EXIT_SUCCESS, None));
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7756,7 +7756,7 @@ fn run_snapshot(command: SnapshotCommands) -> anyhow::Result<i32> {
                 schema_hash_extensions: ext_hash,
                 schema_hash_effective: effective_hash,
                 embedding_model_id,
-                embedding_dimension: 0,
+                embedding_dimension: store.embedding_dimension().unwrap_or(0),
                 built_at,
                 repos: repo_stamps,
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -6121,10 +6121,11 @@ fn run_brain(
                 ));
             }
 
-            // Respect watch.enabled config when --config is provided.
-            if let Some(cfg) = load_instance_config_opt(config.as_deref())
-                && !cfg.watch.enabled
-            {
+            // Respect watch config when --config is provided.
+            let watch_cfg = load_instance_config_opt(config.as_deref())
+                .map(|c| c.watch)
+                .unwrap_or_default();
+            if !watch_cfg.enabled {
                 out.status(
                     "Watching disabled in instance config ([watch] enabled = false). Exiting.",
                 );
@@ -6199,7 +6200,8 @@ fn run_brain(
             let watcher = BrainWatcher::new(&db_path, &path, instance_id, vault_name)
                 .with_tantivy_index(&tantivy_sidecar)
                 .with_manifests_path(&manifests_path)
-                .with_extra_ignore_patterns(&extra_patterns);
+                .with_extra_ignore_patterns(&extra_patterns)
+                .with_debounce_ms(watch_cfg.debounce_ms);
             let stop = watcher.shutdown_handle();
 
             // Write a PID lock file so MCP servers and other readers know a

--- a/src/main.rs
+++ b/src/main.rs
@@ -613,11 +613,11 @@ enum Commands {
         #[command(subcommand)]
         command: InstanceCommands,
     },
-    /// Brain: unified knowledge graph over markdown vaults (walking skeleton)
+    /// Brain: unified knowledge graph over markdown vaults
     ///
-    /// First step toward the Project Brain — indexes a markdown vault into the
-    /// graph alongside any code repositories already indexed. Headings, sections,
-    /// wikilinks, and PPR-based retrieval arrive in later phases.
+    /// Indexes a markdown vault into the graph alongside code repositories.
+    /// Supports headings, sections, wikilinks, tags, PPR-based context
+    /// retrieval, topic clustering, memory tiers, and live file watching.
     Brain {
         #[command(subcommand)]
         command: Box<BrainCommands>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6125,8 +6125,7 @@ fn run_brain(
 
             if use_daemon {
                 let rt = tokio::runtime::Runtime::new()?;
-                let mut client =
-                    rt.block_on(nestweaver_client::DaemonClient::connect(&db_path))?;
+                let mut client = rt.block_on(nestweaver_client::DaemonClient::connect(&db_path))?;
                 let req = nestweaver_proto::WatchVaultRequest {
                     vault_path: path.display().to_string(),
                     vault_name: vault_name.clone(),
@@ -6157,9 +6156,7 @@ fn run_brain(
                 let _ = rx.recv();
 
                 let stop_req = nestweaver_proto::StopWatchRequest {};
-                let _ = rt.block_on(async {
-                    client.inner_mut().stop_watch(stop_req).await
-                });
+                let _ = rt.block_on(async { client.inner_mut().stop_watch(stop_req).await });
                 out.status("Watcher stopped.");
                 return Ok((EXIT_SUCCESS, None));
             }


### PR DESCRIPTION
## Summary

### Stubbed feature implementations
- **`snapshot build`** — gathers stamp metadata (schema hashes, repos, engine version, embedding dimension) from the graph store and calls the existing `build_snapshot()` engine function
- **`snapshot push`** — verifies integrity before pushing to configured storage backend. CLI flags override config values.
- **`memory consolidate --apply`** — moves files to their promoted tier, rewrites path-based wikilinks in referencing notes, warns user to re-index

### Snapshot hardening
- **Per-file checksums** — sha256sum-style format covering core files + sidecars (pagerank, manifests, tantivy). Backwards compatible with legacy single-hash snapshots.
- **`MIN_SNAPSHOT_READER_VERSION`** — decouples format version from build version to prevent unnecessary upgrade friction
- **`embedding_dimension`** — queried from the store instead of hardcoded to 0
- **`copy_dir_all`** — deduplicated into `nestweaver_storage` with explicit symlink skipping

### Bug fixes
- **`LocalBackend`** — push/pull now copy subdirectories recursively (tantivy was silently dropped)
- **`instance pull`** — verifies snapshot integrity after pulling

### Daemon subsumes watcher (write-lock race fix)
- **`WatchVault`/`StopWatch` RPCs** — daemon spawns the watcher as a thread sharing `Arc<GraphStore>`, eliminating the write-lock race
- **`DaemonState.store`** is now `Arc<GraphStore>` for safe sharing with the watcher thread
- **`BrainWatcher.with_external_tantivy()`** — accepts pre-opened TantivyIndex; watcher uses `open_reader_only` to avoid writer conflicts
- **`brain watch` CLI** routes through daemon when `use_daemon=true`, with 10s health-check polling to detect daemon death
- **`catch_unwind`** around watcher thread prevents `active_connections` leak on panic
- **TOCTOU race fix** — mutex held across check + store in `watch_vault`
- **Plist** updated to `KeepAlive=false`

### Parser/resolver improvements
- Type query expansions for Rust, TypeScript, Python, Go, Java (struct constructors, destructuring, parameters)
- PascalCase filter on constructor queries to avoid false positives from module-scoped calls
- MEMBER_OF edges emitted from `parent_name` during indexing
- Chained dot receiver decomposition for type-aware resolution

### Configuration
- **`WatchConfig`** — `enabled` (default true) and `debounce_ms` (default 200) in `[watch]` section of instance config, both wired into the watcher

## Test plan

- [x] All workspace tests pass (0 failures)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Legacy single-hash checksum verification test
- [x] Manual smoke tests: snapshot build→verify→push, memory consolidate, brain watch via daemon, index via daemon, brain status
- [x] Two rounds of code review: critical findings (Tantivy double-writer, TOCTOU race) fixed
- [x] Architecture validated against industry (Watchman, rust-analyzer, Syncthing, Bazel)