### PR TITLE
fix(v0.21.0): regression fixes, adoption validation, and performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,7 +2975,7 @@ checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "nestweaver"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-algorithms"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -3021,7 +3021,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-client"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-daemon"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-engine"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "apollo-parser",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-mcp"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "nestweaver-engine",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-parser"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "comrak",
  "hex",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-proto"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "prost 0.13.5",
  "tonic",
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-resolver"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "glob",
  "insta",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-schema"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "hex",
  "serde",
@@ -3202,7 +3202,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-storage"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-store"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-wasm"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "js-sys",
  "nestweaver-algorithms",

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -709,6 +709,15 @@ impl NestWeaverDaemon for DaemonService {
         if !req.intent.is_empty() {
             args["intent"] = serde_json::json!(req.intent);
         }
+        if !req.since.is_empty() {
+            args["since"] = serde_json::json!(req.since);
+        }
+        if req.recency_weight > 0.0 {
+            args["recency_weight"] = serde_json::json!(req.recency_weight);
+        }
+        if req.recency_half_life_days > 0.0 {
+            args["recency_half_life_days"] = serde_json::json!(req.recency_half_life_days);
+        }
 
         let value = self.dispatch_tool_json("project_context", args).await?;
         let result_json = serde_json::to_string(&value)

--- a/crates/nestweaver-engine/src/config.rs
+++ b/crates/nestweaver-engine/src/config.rs
@@ -892,11 +892,12 @@ pin_sha = "deadbeef1234"
     #[test]
     fn parses_default_seed_resolution() {
         let cfg = InstanceConfig::from_toml_str(MINIMAL_TOML).expect("should parse");
-        // Defaults populate the full 14-rule path_deboost list.
+        // Defaults populate the full 19-rule path_deboost list (9 test-mirror
+        // prefixes + 5 vendored test-runtime prefixes + 5 .test/.spec suffixes).
         assert_eq!(
             cfg.seed_resolution.path_deboost.len(),
-            14,
-            "default [seed_resolution] must populate 14 rules"
+            19,
+            "default [seed_resolution] must populate 19 rules"
         );
         // First default rule deboosts playwright/ at 0.2.
         let first = &cfg.seed_resolution.path_deboost[0];

--- a/crates/nestweaver-engine/src/config.rs
+++ b/crates/nestweaver-engine/src/config.rs
@@ -320,6 +320,12 @@ pub struct GitConfig {
 #[derive(Debug, Deserialize, Clone)]
 pub struct RepoConfig {
     pub url: String,
+    /// Optional repo display-name alias. When set, project and feature
+    /// configs may refer to the repo by this name even if the DB-indexed
+    /// repo is stored under a different display name (typically the
+    /// URL-derived basename).
+    #[serde(default)]
+    pub name: Option<String>,
     pub sparse: Option<bool>,
     pub pin_sha: Option<String>,
     /// Feature F12 — per-repo opt-out for git-activity-dampened CodeRank.

--- a/crates/nestweaver-engine/src/config.rs
+++ b/crates/nestweaver-engine/src/config.rs
@@ -1,3 +1,7 @@
+use nestweaver_store::{PathDeboostRule, SEED_PATH_FACTOR_MAX, SEED_PATH_FACTOR_MIN};
+// Re-export seed-resolution primitives so callers can construct/observe them
+// without depending on `nestweaver-store` directly.
+pub use nestweaver_store::{SeedResolutionConfig, default_kind_priority};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -195,6 +199,12 @@ pub struct InstanceConfig {
     /// multipliers on result relevance, keyed by file-path glob.
     #[serde(default)]
     pub ranking: RankingConfig,
+    /// Finding #7 — graduated path-aware deboost + kind-aware tiebreak applied
+    /// during `search_symbols_by_name` seed resolution. Replaces the binary
+    /// `[ranking].test_path_patterns` mechanism (which remains parseable for
+    /// one release as a deprecation shim).
+    #[serde(default)]
+    pub seed_resolution: SeedResolutionConfig,
     /// Feature F16 — response cache tuning (`[cache]`).
     #[serde(default)]
     pub cache: CacheConfig,
@@ -407,6 +417,10 @@ impl InstanceConfig {
         // Feature F6: clamp ranking-prior multipliers into bounds on load so
         // downstream code can trust the values without re-validating.
         config.ranking.clamp_multipliers();
+        // Finding #7: validate seed-resolution rules, clamp factors, and
+        // synthesize a deprecation shim from `[ranking].test_path_patterns`
+        // when callers haven't moved to `[seed_resolution]` yet.
+        validate_and_normalize_seed_resolution(&mut config.seed_resolution, &config.ranking)?;
         if config.inference.endpoint.is_empty() {
             anyhow::bail!("inference.endpoint must be set (no global default allowed)");
         }
@@ -447,6 +461,86 @@ impl InstanceConfig {
         let contents = std::fs::read_to_string(path)?;
         Self::from_toml_str(&contents)
     }
+}
+
+/// Set of `SymbolKind` variant names accepted by [`SeedResolutionConfig::kind_priority`].
+/// Kept in sync with the variants at `crates/nestweaver-schema/src/nodes.rs`.
+const VALID_SYMBOL_KINDS: &[&str] = &[
+    "Function",
+    "Class",
+    "Method",
+    "Interface",
+    "Trait",
+    "Enum",
+    "Module",
+    "Extension",
+    "Constant",
+    "Property",
+    "TypeAlias",
+    "Variable",
+];
+
+/// Validate `[seed_resolution]` rules, clamp out-of-range factors, and
+/// synthesize a deprecation shim from `[ranking].test_path_patterns` when
+/// the new block is empty but the old field was customized.
+fn validate_and_normalize_seed_resolution(
+    seed_resolution: &mut SeedResolutionConfig,
+    ranking: &RankingConfig,
+) -> Result<(), anyhow::Error> {
+    // 1) Validate exactly-one-of {prefix, suffix} per rule and clamp factors.
+    for (idx, rule) in seed_resolution.path_deboost.iter_mut().enumerate() {
+        match (&rule.prefix, &rule.suffix) {
+            (Some(_), Some(_)) => anyhow::bail!(
+                "[seed_resolution.path_deboost][{idx}]: rule must set exactly one of prefix or suffix (got both)"
+            ),
+            (None, None) => anyhow::bail!(
+                "[seed_resolution.path_deboost][{idx}]: rule must set exactly one of prefix or suffix (got neither)"
+            ),
+            _ => {}
+        }
+        let original = rule.factor;
+        rule.factor = rule
+            .factor
+            .clamp(SEED_PATH_FACTOR_MIN, SEED_PATH_FACTOR_MAX);
+        if (rule.factor - original).abs() > f64::EPSILON {
+            tracing::warn!(
+                "[seed_resolution.path_deboost][{idx}]: factor {original} out of range [{SEED_PATH_FACTOR_MIN}, {SEED_PATH_FACTOR_MAX}]; clamped to {}",
+                rule.factor
+            );
+        }
+    }
+
+    // 2) Validate every kind_priority entry against the SymbolKind variants.
+    for kind_name in &seed_resolution.kind_priority {
+        if !VALID_SYMBOL_KINDS.contains(&kind_name.as_str()) {
+            anyhow::bail!(
+                "[seed_resolution].kind_priority: unknown SymbolKind '{kind_name}' (valid: {})",
+                VALID_SYMBOL_KINDS.join(", ")
+            );
+        }
+    }
+
+    // 3) Deprecation shim — translate [ranking].test_path_patterns into
+    //    prefix rules when the new block is empty but the legacy field is
+    //    customized. Keeps backward compatibility for one release.
+    if seed_resolution.path_deboost.is_empty() {
+        let defaults = default_test_path_patterns();
+        if ranking.test_path_patterns != defaults && !ranking.test_path_patterns.is_empty() {
+            tracing::warn!(
+                "[ranking].test_path_patterns is deprecated; migrate to [seed_resolution].path_deboost for graduated multiplicative deboost"
+            );
+            seed_resolution.path_deboost = ranking
+                .test_path_patterns
+                .iter()
+                .map(|pat| PathDeboostRule {
+                    prefix: Some(pat.clone()),
+                    suffix: None,
+                    factor: 0.3,
+                })
+                .collect();
+        }
+    }
+    Ok(())
 }
 
 // ── tests ──────────────────────────────────────────────────────────────────
@@ -791,5 +885,166 @@ pin_sha = "deadbeef1234"
         assert_eq!(sparse.url, "https://github.com/example/sparse");
         assert_eq!(sparse.sparse, Some(true));
         assert_eq!(sparse.pin_sha.as_deref(), Some("deadbeef1234"));
+    }
+
+    // ── Finding #7 — [seed_resolution] config block ───────────────────────
+
+    #[test]
+    fn parses_default_seed_resolution() {
+        let cfg = InstanceConfig::from_toml_str(MINIMAL_TOML).expect("should parse");
+        // Defaults populate the full 14-rule path_deboost list.
+        assert_eq!(
+            cfg.seed_resolution.path_deboost.len(),
+            14,
+            "default [seed_resolution] must populate 14 rules"
+        );
+        // First default rule deboosts playwright/ at 0.2.
+        let first = &cfg.seed_resolution.path_deboost[0];
+        assert_eq!(first.prefix.as_deref(), Some("/playwright/"));
+        assert!((first.factor - 0.2).abs() < 1e-9);
+        // kind_priority covers every SymbolKind variant.
+        assert_eq!(
+            cfg.seed_resolution.kind_priority,
+            default_kind_priority(),
+            "default kind_priority must equal default_kind_priority()"
+        );
+    }
+
+    #[test]
+    fn parses_explicit_seed_resolution() {
+        let toml = format!(
+            r#"
+{MINIMAL_TOML}
+
+[seed_resolution]
+kind_priority = ["Function", "Class"]
+
+[[seed_resolution.path_deboost]]
+prefix = "/playwright/"
+factor = 0.1
+
+[[seed_resolution.path_deboost]]
+suffix = ".spec.ts"
+factor = 0.25
+"#
+        );
+        let cfg = InstanceConfig::from_toml_str(&toml).expect("should parse");
+        assert_eq!(cfg.seed_resolution.path_deboost.len(), 2);
+        assert_eq!(
+            cfg.seed_resolution.path_deboost[0].prefix.as_deref(),
+            Some("/playwright/")
+        );
+        assert!((cfg.seed_resolution.path_deboost[0].factor - 0.1).abs() < 1e-9);
+        assert_eq!(
+            cfg.seed_resolution.path_deboost[1].suffix.as_deref(),
+            Some(".spec.ts")
+        );
+        assert!((cfg.seed_resolution.path_deboost[1].factor - 0.25).abs() < 1e-9);
+        assert_eq!(
+            cfg.seed_resolution.kind_priority,
+            vec!["Function".to_string(), "Class".to_string()]
+        );
+    }
+
+    #[test]
+    fn rejects_rule_with_both_prefix_and_suffix() {
+        let toml = format!(
+            r#"
+{MINIMAL_TOML}
+
+[[seed_resolution.path_deboost]]
+prefix = "/playwright/"
+suffix = ".spec.ts"
+factor = 0.5
+"#
+        );
+        let err = InstanceConfig::from_toml_str(&toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("exactly one of prefix or suffix") && msg.contains("got both"),
+            "error should reject both-fields rule, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_rule_with_neither_prefix_nor_suffix() {
+        let toml = format!(
+            r#"
+{MINIMAL_TOML}
+
+[[seed_resolution.path_deboost]]
+factor = 0.5
+"#
+        );
+        let err = InstanceConfig::from_toml_str(&toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("exactly one of prefix or suffix") && msg.contains("got neither"),
+            "error should reject empty rule, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn clamps_factor_out_of_range() {
+        let toml = format!(
+            r#"
+{MINIMAL_TOML}
+
+[[seed_resolution.path_deboost]]
+prefix = "/playwright/"
+factor = 15.0
+
+[[seed_resolution.path_deboost]]
+prefix = "/cypress/"
+factor = -1.0
+"#
+        );
+        let cfg = InstanceConfig::from_toml_str(&toml).expect("should parse");
+        assert!((cfg.seed_resolution.path_deboost[0].factor - SEED_PATH_FACTOR_MAX).abs() < 1e-9);
+        assert!((cfg.seed_resolution.path_deboost[1].factor - SEED_PATH_FACTOR_MIN).abs() < 1e-9);
+    }
+
+    #[test]
+    fn rejects_unknown_kind_in_priority() {
+        let toml = format!(
+            r#"
+{MINIMAL_TOML}
+
+[seed_resolution]
+kind_priority = ["NotARealKind"]
+"#
+        );
+        let err = InstanceConfig::from_toml_str(&toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("NotARealKind") && msg.contains("unknown SymbolKind"),
+            "error should reject unknown kind, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn deprecation_shim_translates_legacy_test_path_patterns() {
+        // User has customized [ranking].test_path_patterns but has no
+        // [seed_resolution] block — shim must translate into path_deboost rules.
+        let toml = format!(
+            r#"
+{MINIMAL_TOML}
+
+[ranking]
+test_path_patterns = ["/legacy-fixtures/", "/_old_e2e_/"]
+
+[seed_resolution]
+path_deboost = []
+"#
+        );
+        let cfg = InstanceConfig::from_toml_str(&toml).expect("should parse");
+        assert_eq!(cfg.seed_resolution.path_deboost.len(), 2);
+        assert_eq!(
+            cfg.seed_resolution.path_deboost[0].prefix.as_deref(),
+            Some("/legacy-fixtures/")
+        );
+        // Shim translates with factor 0.3 each.
+        assert!((cfg.seed_resolution.path_deboost[0].factor - 0.3).abs() < 1e-9);
+        assert!((cfg.seed_resolution.path_deboost[1].factor - 0.3).abs() < 1e-9);
     }
 }

--- a/crates/nestweaver-engine/src/cross_domain.rs
+++ b/crates/nestweaver-engine/src/cross_domain.rs
@@ -101,24 +101,93 @@ pub fn discover_cross_domain_links_with_config(
     let notes = store.list_notes(None).context("list_notes")?;
     let mut result = CrossDomainResult::default();
 
+    // Scan all notes in memory first (no DB writes), then flush in
+    // transaction-batched chunks. Earlier versions committed once per
+    // note × section, which on macOS amounts to thousands of fsync'd
+    // commits and dominates indexing time. NOTES_PER_TXN bounds peak
+    // transaction memory while still amortising fsync cost.
+    const NOTES_PER_TXN: usize = 100;
+
+    let mut pending: Vec<ScannedNote> = Vec::with_capacity(NOTES_PER_TXN);
     for note in &notes {
-        let outcome = discover_one_note(store, note, &index)?;
-        match outcome {
-            NoteOutcome::Indexed {
-                note_edges,
-                section_edges,
-            } => {
-                result.notes_scanned += 1;
-                result.note_to_symbol_edges += note_edges;
-                result.section_to_symbol_edges += section_edges;
-            }
-            NoteOutcome::Skipped => {
-                result.skipped_unreadable += 1;
-            }
+        match scan_one_note(store, note, &index)? {
+            ScanOutcome::Scanned(scanned) => pending.push(scanned),
+            ScanOutcome::Skipped => result.skipped_unreadable += 1,
         }
+        if pending.len() >= NOTES_PER_TXN {
+            flush_scanned_notes(store, &pending, &mut result)?;
+            pending.clear();
+        }
+    }
+    if !pending.is_empty() {
+        flush_scanned_notes(store, &pending, &mut result)?;
     }
 
     Ok(result)
+}
+
+/// Accumulated scan results for a single note — built outside any
+/// transaction so the heavy regex/index work runs lock-free, then
+/// flushed in batched transactions by `flush_scanned_notes`.
+struct ScannedNote {
+    note_uid: String,
+    note_edges: Vec<(String, String, f32, &'static str)>,
+    section_edges: Vec<(String, String, f32, &'static str)>,
+}
+
+enum ScanOutcome {
+    Scanned(ScannedNote),
+    Skipped,
+}
+
+/// Flush a batch of scanned notes inside a single write transaction:
+/// delete each note's existing cross-domain edges, then bulk-insert the
+/// fresh ones. One fsync per batch, not per note × section.
+fn flush_scanned_notes(
+    store: &GraphStore,
+    batch: &[ScannedNote],
+    result: &mut CrossDomainResult,
+) -> Result<(), anyhow::Error> {
+    let conn = store
+        .begin_transaction()
+        .context("begin_transaction for cross-domain flush")?;
+
+    for scanned in batch {
+        nestweaver_store::GraphStore::delete_cross_domain_edges_for_note_on(
+            &conn,
+            &scanned.note_uid,
+        )
+        .context("delete_cross_domain_edges_for_note_on")?;
+
+        if !scanned.note_edges.is_empty() {
+            let refs: Vec<(&str, &str, f32, &str)> = scanned
+                .note_edges
+                .iter()
+                .map(|(n, s, c, src)| (n.as_str(), s.as_str(), *c, *src))
+                .collect();
+            nestweaver_store::GraphStore::batch_insert_note_to_symbol_edges_on(&conn, &refs)
+                .context("batch_insert_note_to_symbol_edges_on")?;
+        }
+
+        if !scanned.section_edges.is_empty() {
+            let refs: Vec<(&str, &str, f32, &str)> = scanned
+                .section_edges
+                .iter()
+                .map(|(s, sym, c, src)| (s.as_str(), sym.as_str(), *c, *src))
+                .collect();
+            nestweaver_store::GraphStore::batch_insert_section_to_symbol_edges_on(&conn, &refs)
+                .context("batch_insert_section_to_symbol_edges_on")?;
+        }
+
+        result.notes_scanned += 1;
+        result.note_to_symbol_edges += scanned.note_edges.len();
+        result.section_to_symbol_edges += scanned.section_edges.len();
+    }
+
+    store
+        .commit_transaction(&conn)
+        .context("commit_transaction for cross-domain flush")?;
+    Ok(())
 }
 
 /// Build a SymbolIndex from the store's symbol list. Pre-build once per
@@ -194,6 +263,52 @@ enum NoteOutcome {
         section_edges: usize,
     },
     Skipped,
+}
+
+/// Read-only scan: load the note body, scan for symbol mentions, and
+/// return the edges in memory. Used by the bulk discovery path so the
+/// DB writes can be deferred into a batched transaction.
+fn scan_one_note(
+    store: &GraphStore,
+    note: &nestweaver_schema::Note,
+    index: &SymbolIndex,
+) -> Result<ScanOutcome, anyhow::Error> {
+    let Ok(vault) = store.lookup_vault(&note.vault_uid) else {
+        return Ok(ScanOutcome::Skipped);
+    };
+    let path = Path::new(&vault.root_path).join(&note.file_path);
+    let body = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(_) => return Ok(ScanOutcome::Skipped),
+    };
+
+    // Whole-note pass.
+    let note_matches = index.scan(&body);
+    let mut note_edges: Vec<(String, String, f32, &'static str)> =
+        Vec::with_capacity(note_matches.len());
+    for (sym_uid, conf) in &note_matches {
+        note_edges.push((note.uid.clone(), sym_uid.clone(), *conf, "name-match"));
+    }
+
+    // Per-section pass.
+    let sections = store.sections_in_note(&note.uid).unwrap_or_default();
+    let body_lines: Vec<&str> = body.lines().collect();
+    let mut section_edges: Vec<(String, String, f32, &'static str)> = Vec::new();
+    for sec in &sections {
+        let text = slice_body_lines(&body_lines, sec.start_line, sec.end_line);
+        if text.trim().is_empty() {
+            continue;
+        }
+        for (sym_uid, conf) in index.scan(&text) {
+            section_edges.push((sec.uid.clone(), sym_uid, conf, "name-match"));
+        }
+    }
+
+    Ok(ScanOutcome::Scanned(ScannedNote {
+        note_uid: note.uid.clone(),
+        note_edges,
+        section_edges,
+    }))
 }
 
 fn discover_one_note(

--- a/crates/nestweaver-engine/src/eval.rs
+++ b/crates/nestweaver-engine/src/eval.rs
@@ -631,7 +631,11 @@ function hello(name) { return "Hello " + name; }
         // Find the UID of `hello`, which `greet` calls — so seeding on "greet"
         // should surface `hello` as a connected node with high relevance.
         let hello = store
-            .search_symbols_by_name("hello", 5, &[])
+            .search_symbols_by_name(
+                "hello",
+                5,
+                &nestweaver_store::SeedResolutionConfig::default(),
+            )
             .unwrap()
             .into_iter()
             .next()

--- a/crates/nestweaver-engine/src/interactions.rs
+++ b/crates/nestweaver-engine/src/interactions.rs
@@ -152,7 +152,20 @@ impl InteractionTracker {
     ///
     /// A random session ID is generated automatically.  Events are
     /// auto-flushed when the in-memory buffer reaches 50 entries.
+    /// Touches the sidecar file (creating an empty store if absent) so
+    /// downstream `brain status` reads can distinguish "tracking enabled
+    /// but no events yet" from "tracking disabled".
     pub fn new(db_path: &Path) -> Self {
+        let path = interaction_sidecar_path(db_path);
+        if !path.exists()
+            && let Some(parent) = path.parent()
+            && std::fs::create_dir_all(parent).is_ok()
+        {
+            let empty = InteractionStore::default();
+            if let Ok(text) = serde_json::to_string(&empty) {
+                let _ = std::fs::write(&path, text);
+            }
+        }
         Self {
             db_path: db_path.to_path_buf(),
             events: Mutex::new(Vec::new()),

--- a/crates/nestweaver-engine/src/investigate.rs
+++ b/crates/nestweaver-engine/src/investigate.rs
@@ -239,9 +239,11 @@ pub fn investigate(
         prf: true,
         ..Default::default()
     };
-    // Graceful empty handling: when no seed resolves, retrieval returns an
-    // error rather than an empty result. Treat that as an empty investigation
-    // (valid bundle, zero entries) instead of propagating the error.
+    // Graceful empty handling: when no seed resolves (e.g. a natural-language
+    // multi-word query like "indexing pipeline" that matches no symbol/note
+    // title verbatim), hybrid retrieval bails with `No seeds resolved`. Fall
+    // back to BM25-only retrieval against the query text so investigations
+    // remain useful for orientation queries instead of returning an empty map.
     let connected_result = build_brain_context_hybrid_with_aliases(
         store,
         &seed_inputs,
@@ -253,7 +255,7 @@ pub fn investigate(
     );
     let mut connected: Vec<BrainNode> = match connected_result {
         Ok(ctx) => ctx.connected,
-        Err(_) => Vec::new(),
+        Err(_) => bm25_fallback(store, tantivy, query, DEFAULT_RETRIEVAL_BREADTH),
     };
     if let Some(ref repo_uids) = repo_filter {
         connected.retain(|n| node_in_repo(store, n, repo_uids));
@@ -515,6 +517,39 @@ fn resolve_scope(
 
     // vault / all / empty → no restriction.
     Ok((seeds, None))
+}
+
+/// BM25-only retrieval against the vault index when graph-seed resolution
+/// fails. Returns up to `limit` `BrainNode`s ranked by BM25 score, normalized
+/// so the top hit has relevance 1.0 (matching the hybrid pipeline's score
+/// scale closely enough for downstream consumers). Returns an empty vec when
+/// `tantivy` is absent or the query returns no hits.
+fn bm25_fallback(
+    store: &GraphStore,
+    tantivy: Option<&TantivyIndex>,
+    query: &str,
+    limit: usize,
+) -> Vec<BrainNode> {
+    let Some(tantivy) = tantivy else {
+        return Vec::new();
+    };
+    let hits = match tantivy.search(query, limit) {
+        Ok(h) => h,
+        Err(_) => return Vec::new(),
+    };
+    let max_score = hits.iter().map(|h| h.score as f64).fold(0.0_f64, f64::max);
+    let mut nodes: Vec<BrainNode> = Vec::with_capacity(hits.len());
+    for hit in hits {
+        let normalized = if max_score > 0.0 {
+            (hit.score as f64) / max_score
+        } else {
+            0.0
+        };
+        if let Ok(Some(node)) = crate::query::render_brain_node(store, &hit.uid, normalized) {
+            nodes.push(node);
+        }
+    }
+    nodes
 }
 
 /// Whether a node belongs to one of the given repos. Only symbol nodes are

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -117,8 +117,8 @@ pub use cochange::{CoChangeEdge, compute_cochanges, load_cochange_sidecar, save_
 pub use config::{
     CrossDomainConfig, ExternalRefConfig, FeatureConfig, GitConfig, GlobRule, InferenceConfig,
     InstanceConfig, LinkConfig, McpServerConfig, ProjectConfig, RankingConfig, RepoConfig,
-    ResponseConfig, SchemaExtensions, StorageConfig, WikiSourceConfig, WorkspaceConfig,
-    default_test_path_patterns,
+    ResponseConfig, SchemaExtensions, SeedResolutionConfig, StorageConfig, WikiSourceConfig,
+    WorkspaceConfig, default_kind_priority, default_test_path_patterns,
 };
 pub use cross_domain::{
     CrossDomainResult, SymbolIndex, build_symbol_index, build_symbol_index_with_config,

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -181,7 +181,7 @@ pub use query::{
     build_brain_context_hybrid_with_aliases, build_context, build_context_with_intent,
     build_feature_context, expand_query_with_aliases, explain_ranking_prior, generate_repo_map,
     list_repos, list_services, lookup_symbol, populate_inline_bodies,
-    promote_member_notes_into_connected, search_symbols,
+    promote_member_notes_into_connected, promote_member_symbols_into_connected, search_symbols,
 };
 pub use recency::parse_iso8601_to_epoch;
 pub use registry::*;

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -179,9 +179,10 @@ pub use query::{
     FeatureInfo, HybridSearchConfig, LinkInfo, LookupResult, SymbolCandidate, SymbolDetail,
     apply_ranking_priors, build_brain_context, build_brain_context_hybrid,
     build_brain_context_hybrid_with_aliases, build_context, build_context_with_intent,
-    build_feature_context, expand_query_with_aliases, explain_ranking_prior, generate_repo_map,
-    list_repos, list_services, lookup_symbol, populate_inline_bodies,
-    promote_member_notes_into_connected, promote_member_symbols_into_connected, search_symbols,
+    build_feature_context, dedup_heading_section_pairs, expand_query_with_aliases,
+    explain_ranking_prior, generate_repo_map, list_repos, list_services, lookup_symbol,
+    populate_inline_bodies, promote_member_notes_into_connected,
+    promote_member_symbols_into_connected, search_symbols,
 };
 pub use recency::parse_iso8601_to_epoch;
 pub use registry::*;

--- a/crates/nestweaver-engine/src/project.rs
+++ b/crates/nestweaver-engine/src/project.rs
@@ -118,11 +118,28 @@ pub fn materialize_projects(
             let mut symbol_uids: Vec<String> = Vec::new();
 
             for repo_name in &project_cfg.repos {
-                // Match by display name (respects --name override) or URL fragment.
+                // Resolve the project's declared repo name to one or more DB
+                // repos. Match order:
+                //   a) DB Repo.name override matches (e.g. `--name redrock`),
+                //   b) URL-derived display name matches,
+                //   c) an `[[repos]]` config entry whose `name = repo_name`
+                //      points at a URL that an indexed repo carries — covers
+                //      the case where the repo was indexed under its URL
+                //      basename but the config aliases it to a friendlier
+                //      name (e.g. redrock ↔ web-application),
+                //   d) URL substring match (legacy fallback).
+                let cfg_url_for_name: Option<&str> = config
+                    .repos
+                    .iter()
+                    .find(|rc| rc.name.as_deref() == Some(repo_name.as_str()))
+                    .map(|rc| rc.url.as_str());
+
                 let matched: Vec<_> = all_repos
                     .iter()
                     .filter(|r| {
-                        repo_display_name(r) == *repo_name || r.url.contains(repo_name.as_str())
+                        repo_display_name(r) == *repo_name
+                            || cfg_url_for_name.is_some_and(|u| r.url == u)
+                            || r.url.contains(repo_name.as_str())
                     })
                     .collect();
 
@@ -131,6 +148,12 @@ pub fn materialize_projects(
                     symbol_uids.extend(syms.into_iter().map(|(sym_uid, _, _)| sym_uid));
                 }
             }
+
+            // Deduplicate — a project may declare two aliases that resolve to
+            // the same DB repo, and (s)-[:PROJECT_INCLUDES_SYMBOL]->(p)
+            // tolerates only one edge per pair.
+            symbol_uids.sort();
+            symbol_uids.dedup();
 
             let count = symbol_uids.len();
             if !symbol_uids.is_empty() {

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -6,6 +6,7 @@ use anyhow::Context;
 
 use crate::config::{
     FeatureConfig, LinkConfig, RANKING_MULTIPLIER_MAX, RANKING_MULTIPLIER_MIN, RankingConfig,
+    RepoConfig,
 };
 use crate::repo_display_name;
 
@@ -653,7 +654,11 @@ pub struct FeatureContextResult {
 
 /// Build a task-focused context for a declared feature bundle.
 ///
-/// 1. Loads all repos and resolves feature.repos names to repo_uids.
+/// 1. Loads all repos and resolves feature.repos names to repo_uids. Matching
+///    accepts either the DB Repo display name or an `[[repos]]` config alias
+///    (`name = "..."`) whose URL matches an indexed repo — so a feature can
+///    refer to a repo by a friendly name even if it was indexed under its
+///    URL basename.
 /// 2. Resolves all `feature.entry_points` using exact name match, filtered to feature repos.
 /// 3. Runs Personalized PageRank from those seeds.
 /// 4. Returns seeds, connected symbols, declared links, and any unmatched entry points.
@@ -661,14 +666,29 @@ pub fn build_feature_context(
     store: &GraphStore,
     feature: &FeatureConfig,
     links: &[LinkConfig],
+    repo_configs: &[RepoConfig],
     intent: Option<QueryIntent>,
     limit: Option<usize>,
 ) -> Result<FeatureContextResult, anyhow::Error> {
     // Resolve feature repo names to repo_uids.
     let all_repos = store.list_repos(None).map_err(|e| anyhow::anyhow!(e))?;
+    // URL allow-list derived from `[[repos]] name = ...` aliases declared by
+    // the feature. Lets `feature.repos = ["redrock"]` resolve to a DB repo
+    // indexed under a different display name when the config aliases it.
+    let alias_urls: std::collections::HashSet<&str> = repo_configs
+        .iter()
+        .filter(|rc| {
+            rc.name
+                .as_deref()
+                .is_some_and(|n| feature.repos.iter().any(|fr| fr == n))
+        })
+        .map(|rc| rc.url.as_str())
+        .collect();
     let feature_repo_uids: std::collections::HashSet<String> = all_repos
         .iter()
-        .filter(|r| feature.repos.contains(&repo_display_name(r)))
+        .filter(|r| {
+            feature.repos.contains(&repo_display_name(r)) || alias_urls.contains(r.url.as_str())
+        })
         .map(|r| r.uid.clone())
         .collect();
 

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -933,6 +933,52 @@ pub fn promote_member_symbols_into_connected(
     result.connected.extend(promoted);
 }
 
+/// Drop `Heading` nodes from `connected` when a `Section` node sharing the
+/// same `(file, title)` is already present.
+///
+/// The vault graph emits both a `Heading` node (the heading line itself) and
+/// a `Section` node (the heading plus its body) for every markdown heading.
+/// They land in retrieval results with near-identical PPR scores and identical
+/// titles — the Section strictly dominates because it carries the body text.
+/// In notes-heavy projects this overlap consumes ~25% of a 2000-token budget
+/// on duplicate entries that add no information.
+///
+/// Location normalisation: a Heading's `location` is typically `<file>` or
+/// `<file>:<line>` and a Section's is `<file>` or `<file>#<anchor>`; both
+/// collapse to the same file stem so the pair is detected regardless of
+/// whether anchors / line suffixes are present.
+pub fn dedup_heading_section_pairs(result: &mut BrainContextResult) {
+    fn loc_stem(loc: &str) -> &str {
+        let no_anchor = loc.split_once('#').map(|(p, _)| p).unwrap_or(loc);
+        if let Some((p, tail)) = no_anchor.rsplit_once(':')
+            && !tail.is_empty()
+            && tail.chars().all(|c| c.is_ascii_digit())
+        {
+            return p;
+        }
+        no_anchor
+    }
+
+    let section_keys: std::collections::HashSet<(String, String)> = result
+        .connected
+        .iter()
+        .filter(|n| n.kind.eq_ignore_ascii_case("Section"))
+        .map(|n| (loc_stem(&n.location).to_string(), n.title.clone()))
+        .collect();
+
+    if section_keys.is_empty() {
+        return;
+    }
+
+    result.connected.retain(|n| {
+        if !n.kind.eq_ignore_ascii_case("Heading") {
+            return true;
+        }
+        let key = (loc_stem(&n.location).to_string(), n.title.clone());
+        !section_keys.contains(&key)
+    });
+}
+
 /// Build a task-focused context subgraph using the unified scope (code +
 /// notes + cross-references). Seeds may be:
 ///
@@ -2371,5 +2417,86 @@ mod expand_query_tests {
             result.contains("Device Pairing"),
             "should expand Pairing; got: {result}"
         );
+    }
+}
+
+#[cfg(test)]
+mod dedup_heading_section_tests {
+    use super::{BrainContextResult, BrainNode, dedup_heading_section_pairs};
+
+    fn node(uid: &str, kind: &str, title: &str, loc: &str, rel: f64) -> BrainNode {
+        BrainNode {
+            uid: uid.to_string(),
+            kind: kind.to_string(),
+            title: title.to_string(),
+            location: loc.to_string(),
+            relevance: rel,
+            inline_body: None,
+            body_complete: true,
+        }
+    }
+
+    fn make(connected: Vec<BrainNode>) -> BrainContextResult {
+        BrainContextResult {
+            seeds: vec![],
+            connected,
+            unresolved_seeds: vec![],
+            expansion_terms: vec![],
+        }
+    }
+
+    #[test]
+    fn drops_heading_when_section_with_same_file_and_title_present() {
+        let mut r = make(vec![
+            node("h1", "Heading", "Overview", "notes/foo.md", 0.5),
+            node("s1", "Section", "Overview", "notes/foo.md", 0.4),
+        ]);
+        dedup_heading_section_pairs(&mut r);
+        assert_eq!(r.connected.len(), 1);
+        assert_eq!(r.connected[0].uid, "s1");
+    }
+
+    #[test]
+    fn keeps_heading_when_no_matching_section() {
+        let mut r = make(vec![
+            node("h1", "Heading", "Overview", "notes/foo.md", 0.5),
+            node("s2", "Section", "Different Title", "notes/foo.md", 0.4),
+        ]);
+        dedup_heading_section_pairs(&mut r);
+        assert_eq!(r.connected.len(), 2);
+    }
+
+    #[test]
+    fn collapses_locations_with_line_or_anchor_suffix() {
+        // Heading carries `file:line`, Section carries `file#anchor`; both
+        // should collapse to the same file stem.
+        let mut r = make(vec![
+            node("h1", "Heading", "Setup", "notes/bar.md:42", 0.5),
+            node("s1", "Section", "Setup", "notes/bar.md#setup", 0.4),
+        ]);
+        dedup_heading_section_pairs(&mut r);
+        assert_eq!(r.connected.len(), 1);
+        assert_eq!(r.connected[0].kind, "Section");
+    }
+
+    #[test]
+    fn no_op_when_no_sections_present() {
+        let mut r = make(vec![
+            node("h1", "Heading", "A", "x.md", 0.5),
+            node("h2", "Heading", "B", "x.md", 0.4),
+        ]);
+        dedup_heading_section_pairs(&mut r);
+        assert_eq!(r.connected.len(), 2);
+    }
+
+    #[test]
+    fn ignores_unrelated_kinds() {
+        let mut r = make(vec![
+            node("n1", "Note/PRD", "Spec", "notes/spec.md", 0.6),
+            node("s1", "Section", "Spec", "notes/spec.md", 0.5),
+        ]);
+        dedup_heading_section_pairs(&mut r);
+        // Note nodes are never dropped, only Heading nodes.
+        assert_eq!(r.connected.len(), 2);
     }
 }

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -1375,7 +1375,7 @@ fn lookup_tag_uid(store: &GraphStore, name: &str) -> Result<Option<String>, anyh
 /// Resolve a UID to a printable `BrainNode` by dispatching on UID prefix.
 /// Returns Ok(None) if the node can't be found (silently dropped from
 /// results — should only happen for stale/orphan UIDs).
-fn render_brain_node(
+pub(crate) fn render_brain_node(
     store: &GraphStore,
     uid: &str,
     score: f64,

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -392,7 +392,10 @@ pub fn build_context_with_intent(
 
 #[cfg(test)]
 mod promote_tests {
-    use super::{BrainContextResult, BrainNode, promote_member_notes_into_connected};
+    use super::{
+        BrainContextResult, BrainNode, promote_member_notes_into_connected,
+        promote_member_symbols_into_connected,
+    };
     use std::collections::HashSet;
 
     fn note(uid: &str) -> BrainNode {
@@ -475,6 +478,64 @@ mod promote_tests {
             !result.connected.iter().any(|n| n.uid == "proj:x"),
             "non-member seed must not be promoted"
         );
+    }
+
+    // Wave-5 regression fix: when a project declares repos, the project node's
+    // mass fans out across thousands of PROJECT_INCLUDES_SYMBOL edges, leaving
+    // each member symbol below the PPR min_score filter. The CLI seeds the
+    // top-K member symbols by PageRank to keep them alive, and this helper
+    // surfaces them into `connected` (mirror of the notes promotion).
+    #[test]
+    fn promotes_member_symbols_from_seeds_into_connected() {
+        let mut result = BrainContextResult {
+            seeds: vec![
+                symbol("sym:foo"),
+                symbol("sym:bar"),
+                note("note:non-member"),
+            ],
+            connected: vec![note("note:overview")],
+            unresolved_seeds: vec![],
+            expansion_terms: vec![],
+        };
+        let members: HashSet<String> = ["sym:foo".to_string(), "sym:bar".to_string()]
+            .into_iter()
+            .collect();
+
+        promote_member_symbols_into_connected(&mut result, &members);
+
+        let connected_uids: Vec<&str> = result.connected.iter().map(|n| n.uid.as_str()).collect();
+        assert!(
+            connected_uids.contains(&"sym:foo"),
+            "member symbol 'sym:foo' must surface in connected; got {connected_uids:?}"
+        );
+        assert!(
+            connected_uids.contains(&"sym:bar"),
+            "member symbol 'sym:bar' must surface in connected; got {connected_uids:?}"
+        );
+        assert!(
+            !connected_uids.contains(&"note:non-member"),
+            "non-member seed must not be promoted; got {connected_uids:?}"
+        );
+    }
+
+    #[test]
+    fn symbol_promotion_does_not_duplicate_already_connected() {
+        let mut result = BrainContextResult {
+            seeds: vec![symbol("sym:foo")],
+            connected: vec![symbol("sym:foo")],
+            unresolved_seeds: vec![],
+            expansion_terms: vec![],
+        };
+        let members: HashSet<String> = ["sym:foo".to_string()].into_iter().collect();
+
+        promote_member_symbols_into_connected(&mut result, &members);
+
+        let count = result
+            .connected
+            .iter()
+            .filter(|n| n.uid == "sym:foo")
+            .count();
+        assert_eq!(count, 1, "already-present member symbol must not duplicate");
     }
 }
 
@@ -823,6 +884,30 @@ pub fn promote_member_notes_into_connected(
         .seeds
         .iter()
         .filter(|n| member_note_uids.contains(&n.uid) && !present.contains(&n.uid))
+        .cloned()
+        .collect();
+    result.connected.extend(promoted);
+}
+
+/// Surface a project's curated member symbols into the rendered `connected`
+/// list.
+///
+/// Companion to [`promote_member_notes_into_connected`]. When `project-context`
+/// seeds PPR with the top-K project symbols by PageRank, those seeds survive
+/// the `min_score` filter but land in `result.seeds` — which is *not* rendered
+/// by the CLI / MCP project responses. Promote any seeded symbol UID present
+/// in `member_symbol_uids` into `connected`, de-duplicated by UID, so the
+/// architecturally important code surfaces alongside the curated notes.
+pub fn promote_member_symbols_into_connected(
+    result: &mut BrainContextResult,
+    member_symbol_uids: &std::collections::HashSet<String>,
+) {
+    let present: std::collections::HashSet<String> =
+        result.connected.iter().map(|n| n.uid.clone()).collect();
+    let promoted: Vec<BrainNode> = result
+        .seeds
+        .iter()
+        .filter(|n| member_symbol_uids.contains(&n.uid) && !present.contains(&n.uid))
         .cloned()
         .collect();
     result.connected.extend(promoted);

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -47,13 +47,11 @@ pub struct HybridSearchConfig {
     /// the BM25 list — the changed BM25 ranks flow through RRF. Do not expect
     /// the 0.3 boost to surface numerically in the output relevance.
     pub prf: bool,
-    /// Feature F-test-deboost — substring patterns matched (case-insensitive)
-    /// against the haystack `/<path>` of each candidate symbol's file_path to
-    /// deboost test/fixture code in `search_symbols_by_name` seed resolution.
-    ///
-    /// Sourced from `[ranking] test_path_patterns` in instance config.
-    /// Empty → fall back to [`crate::config::default_test_path_patterns`].
-    pub test_path_patterns: Vec<String>,
+    /// Finding #7 — graduated path-deboost + kind-priority for
+    /// `search_symbols_by_name` seed resolution. Sourced from
+    /// `[seed_resolution]` in instance config (with backward-compat shim
+    /// for the legacy `[ranking].test_path_patterns` block).
+    pub seed_resolution: nestweaver_store::SeedResolutionConfig,
 }
 
 impl Default for HybridSearchConfig {
@@ -66,33 +64,10 @@ impl Default for HybridSearchConfig {
             bm25_limit: 500,
             semantic_limit: 200,
             prf: false,
-            test_path_patterns: crate::config::default_test_path_patterns(),
+            seed_resolution: nestweaver_store::SeedResolutionConfig::default(),
         }
     }
 }
-
-impl HybridSearchConfig {
-    /// Return the effective deboost patterns: the configured list if
-    /// non-empty, otherwise the built-in defaults. Useful at call sites
-    /// that build a config from CLI flags without a [`crate::config::RankingConfig`].
-    pub fn effective_test_path_patterns(&self) -> &[String] {
-        if self.test_path_patterns.is_empty() {
-            // `Default` already populates this with the defaults, but a
-            // caller may have explicitly cleared it. Fall back so the
-            // ranking step never silently degrades.
-            // SAFETY: `default_test_path_patterns` always returns a
-            // non-empty `Vec<String>`.
-            DEFAULT_TEST_PATH_PATTERNS_FALLBACK.as_slice()
-        } else {
-            &self.test_path_patterns
-        }
-    }
-}
-
-/// Cached fallback so callers of `effective_test_path_patterns` can return a
-/// borrowed slice without re-allocating on each call.
-static DEFAULT_TEST_PATH_PATTERNS_FALLBACK: std::sync::LazyLock<Vec<String>> =
-    std::sync::LazyLock::new(crate::config::default_test_path_patterns);
 
 /// Full details for a single symbol, including its call graph neighbours.
 #[derive(Debug, Serialize)]
@@ -190,7 +165,11 @@ pub fn search_symbols(
     limit: usize,
 ) -> Result<Vec<SymbolCandidate>, anyhow::Error> {
     let syms = store
-        .search_symbols_by_name(query, limit, &crate::config::default_test_path_patterns())
+        .search_symbols_by_name(
+            query,
+            limit,
+            &nestweaver_store::SeedResolutionConfig::default(),
+        )
         .context("search_symbols_by_name")?;
     Ok(syms.iter().map(SymbolCandidate::from).collect())
 }
@@ -293,7 +272,11 @@ pub fn build_context_with_intent(
         } else {
             // Name search — take up to 5 matches.
             let matches = store
-                .search_symbols_by_name(input, 5, &crate::config::default_test_path_patterns())
+                .search_symbols_by_name(
+                    input,
+                    5,
+                    &nestweaver_store::SeedResolutionConfig::default(),
+                )
                 .map_err(|e| anyhow::anyhow!(e))?;
             for sym in matches {
                 seed_uids.push(sym.uid);
@@ -587,7 +570,13 @@ mod context_tests {
             index_directory_in_memory(&src, "test", "https://example.com/repo", "abc123").unwrap();
 
         // Find the actual file_path stored for a symbol in utils.js.
-        let search = store.search_symbols_by_name("formatDate", 1, &[]).unwrap();
+        let search = store
+            .search_symbols_by_name(
+                "formatDate",
+                1,
+                &nestweaver_store::SeedResolutionConfig::default(),
+            )
+            .unwrap();
         if search.is_empty() {
             // Parser may not have indexed this file — skip rather than fail.
             return;
@@ -1104,11 +1093,11 @@ pub fn build_brain_context_hybrid_with_aliases(
         }
 
         // Fall back to symbol name search. Respect the caller's configured
-        // [`HybridSearchConfig::test_path_patterns`] (sourced from
-        // `[ranking] test_path_patterns` in instance config) so user overrides
-        // actually take effect at seed resolution.
+        // [`HybridSearchConfig::seed_resolution`] (sourced from
+        // `[seed_resolution]` in instance config) so user overrides actually
+        // take effect at seed resolution.
         let symbol_matches = store
-            .search_symbols_by_name(trimmed, 5, config.effective_test_path_patterns())
+            .search_symbols_by_name(trimmed, 5, &config.seed_resolution)
             .map_err(|e| anyhow::anyhow!(e))?;
         if !symbol_matches.is_empty() {
             for s in symbol_matches {

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -46,6 +46,13 @@ pub struct HybridSearchConfig {
     /// the BM25 list — the changed BM25 ranks flow through RRF. Do not expect
     /// the 0.3 boost to surface numerically in the output relevance.
     pub prf: bool,
+    /// Feature F-test-deboost — substring patterns matched (case-insensitive)
+    /// against the haystack `/<path>` of each candidate symbol's file_path to
+    /// deboost test/fixture code in `search_symbols_by_name` seed resolution.
+    ///
+    /// Sourced from `[ranking] test_path_patterns` in instance config.
+    /// Empty → fall back to [`crate::config::default_test_path_patterns`].
+    pub test_path_patterns: Vec<String>,
 }
 
 impl Default for HybridSearchConfig {
@@ -58,9 +65,33 @@ impl Default for HybridSearchConfig {
             bm25_limit: 500,
             semantic_limit: 200,
             prf: false,
+            test_path_patterns: crate::config::default_test_path_patterns(),
         }
     }
 }
+
+impl HybridSearchConfig {
+    /// Return the effective deboost patterns: the configured list if
+    /// non-empty, otherwise the built-in defaults. Useful at call sites
+    /// that build a config from CLI flags without a [`crate::config::RankingConfig`].
+    pub fn effective_test_path_patterns(&self) -> &[String] {
+        if self.test_path_patterns.is_empty() {
+            // `Default` already populates this with the defaults, but a
+            // caller may have explicitly cleared it. Fall back so the
+            // ranking step never silently degrades.
+            // SAFETY: `default_test_path_patterns` always returns a
+            // non-empty `Vec<String>`.
+            DEFAULT_TEST_PATH_PATTERNS_FALLBACK.as_slice()
+        } else {
+            &self.test_path_patterns
+        }
+    }
+}
+
+/// Cached fallback so callers of `effective_test_path_patterns` can return a
+/// borrowed slice without re-allocating on each call.
+static DEFAULT_TEST_PATH_PATTERNS_FALLBACK: std::sync::LazyLock<Vec<String>> =
+    std::sync::LazyLock::new(crate::config::default_test_path_patterns);
 
 /// Full details for a single symbol, including its call graph neighbours.
 #[derive(Debug, Serialize)]
@@ -709,15 +740,29 @@ pub struct BrainNode {
     /// body contains the full source, `false` when the per-body cap forced
     /// truncation. Skipped from JSON when `true` so existing consumers see
     /// unchanged output and only learn about the field when it flags a
-    /// truncated body. (BrainNode is Serialize-only — no Deserialize default
-    /// needed; constructors set this explicitly.)
-    #[serde(skip_serializing_if = "is_true")]
+    /// truncated body.
+    ///
+    /// `#[serde(default = "default_body_complete")]` is required because the
+    /// daemon's JSON-RPC `GetContext` response routes through
+    /// `serde_json::from_str` on the client. When a node serializes with
+    /// `body_complete=true` the field is omitted (per the `skip_serializing_if`
+    /// above); without the default, the client deserialization fails with
+    /// `missing field body_complete`, causing daemon-routed `brain context` to
+    /// hard-error. The default mirrors constructor behavior (no truncation =>
+    /// complete).
+    #[serde(skip_serializing_if = "is_true", default = "default_body_complete")]
     pub body_complete: bool,
 }
 
 #[allow(clippy::trivially_copy_pass_by_ref)]
 fn is_true(b: &bool) -> bool {
     *b
+}
+
+/// Serde default for [`BrainNode::body_complete`]. See the field doc on
+/// `BrainNode::body_complete` for the daemon-deserialization rationale.
+fn default_body_complete() -> bool {
+    true
 }
 
 /// Char-truncate `body` to `max_chars`, preferring the last newline within the
@@ -737,8 +782,16 @@ pub(crate) fn truncate_body_to_chars(body: String, max_chars: usize) -> (String,
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BrainContextResult {
+    /// Resolved seed nodes. The MCP `brain_context` tool omits this field
+    /// when `include_seeds=false` is requested, so deserializing daemon
+    /// `GetContext` responses requires a default.
+    #[serde(default)]
     pub seeds: Vec<BrainNode>,
     pub connected: Vec<BrainNode>,
+    /// Seed strings that did not resolve to any UID. The MCP
+    /// `brain_context` tool omits this field when empty, so deserializing
+    /// daemon `GetContext` responses requires a default.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub unresolved_seeds: Vec<String>,
     /// Feature F7 (PRF half) — terms mined by pseudo-relevance feedback and
     /// fed into the pass-2 BM25 query. Empty unless PRF was enabled. Surfaced
@@ -899,9 +952,12 @@ pub fn build_brain_context_hybrid_with_aliases(
             continue;
         }
 
-        // Fall back to symbol name search.
+        // Fall back to symbol name search. Respect the caller's configured
+        // [`HybridSearchConfig::test_path_patterns`] (sourced from
+        // `[ranking] test_path_patterns` in instance config) so user overrides
+        // actually take effect at seed resolution.
         let symbol_matches = store
-            .search_symbols_by_name(trimmed, 5, &crate::config::default_test_path_patterns())
+            .search_symbols_by_name(trimmed, 5, config.effective_test_path_patterns())
             .map_err(|e| anyhow::anyhow!(e))?;
         if !symbol_matches.is_empty() {
             for s in symbol_matches {

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -2410,11 +2410,49 @@ fn tool_brain_status(
                 }
             };
             json!({
+                // `uid` + `instance_id` let callers disambiguate rows that
+                // share a name/root_path (collision state) and target precise
+                // operations like `brain remove --instance <id>`.
+                "uid": v.uid,
+                "instance_id": v.instance_id,
                 "name": v.name,
                 "root_path": v.root_path,
                 "note_count": note_count,
                 "last_indexed": last_indexed,
                 "last_indexed_source": last_indexed_source,
+            })
+        })
+        .collect();
+
+    // Detect duplicate-root collisions. The CLI's local (non-daemon) path
+    // emits these warnings to stderr; forward them through the JSON-RPC
+    // response so daemon-routed callers and `--json` consumers see the
+    // same diagnostic.
+    let mut root_to_rows: std::collections::HashMap<&str, Vec<&nestweaver_schema::Vault>> =
+        std::collections::HashMap::new();
+    for v in &vaults {
+        root_to_rows.entry(v.root_path.as_str()).or_default().push(v);
+    }
+    let warnings: Vec<Value> = root_to_rows
+        .iter()
+        .filter(|(_, rows)| rows.len() > 1)
+        .map(|(root, rows)| {
+            let entries: Vec<Value> = rows
+                .iter()
+                .map(|v| {
+                    let n = store.list_notes(Some(&v.uid)).unwrap_or_default().len();
+                    json!({
+                        "uid": v.uid,
+                        "instance_id": v.instance_id,
+                        "name": v.name,
+                        "note_count": n,
+                    })
+                })
+                .collect();
+            json!({
+                "kind": "duplicate_vault_root",
+                "root_path": root,
+                "entries": entries,
             })
         })
         .collect();
@@ -2470,6 +2508,10 @@ fn tool_brain_status(
             "entries": cache_entries,
             "hit_rate_pct": cache_hit_rate_pct,
         },
+        // Structured diagnostics. Each entry describes a vault-level
+        // anomaly (duplicate root, missing index, etc.) so clients can
+        // render an actionable warning without re-deriving it.
+        "warnings": warnings,
     }))
 }
 

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -3734,9 +3734,30 @@ fn tool_project_context(
     //    PROJECT_INCLUDES_SYMBOL edges, leaving each PROJECT_INCLUDES_NOTE
     //    target below threshold so it never reaches `connected`. Seeding also
     //    lets the walk explore each note's neighbourhood (sections, links).
+    //
+    //    Member symbols suffer the identical fan-out, so also seed the top-K
+    //    by PageRank (Bug #18 / wave-5 regression). Without this, a project
+    //    that declares any repo returns notes-only context even after
+    //    `materialize-projects` writes hundreds of thousands of
+    //    PROJECT_INCLUDES_SYMBOL edges.
+    const PROJECT_SYMBOL_SEED_LIMIT: usize = 100;
+    let mut member_symbol_uids: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+    let top_symbols = store
+        .list_project_symbol_uids_by_pagerank(&project.uid, PROJECT_SYMBOL_SEED_LIMIT)
+        .map_err(|e| anyhow!("list_project_symbol_uids_by_pagerank: {e}"))?;
+    member_symbol_uids.extend(top_symbols);
+    for comp_uid in &component_uids {
+        let comp_top = store
+            .list_project_symbol_uids_by_pagerank(comp_uid, PROJECT_SYMBOL_SEED_LIMIT)
+            .unwrap_or_default();
+        member_symbol_uids.extend(comp_top);
+    }
+
     let mut ppr_seeds: Vec<String> = vec![project.uid.clone()];
     ppr_seeds.extend(component_uids);
     ppr_seeds.extend(member_note_uids.iter().cloned());
+    ppr_seeds.extend(member_symbol_uids.iter().cloned());
 
     let intent: nestweaver_store::QueryIntent = args
         .get("intent")
@@ -3764,6 +3785,15 @@ fn tool_project_context(
     //     disjoint from `connected` and not rendered. For project orientation
     //     the curated notes are the answer, so promote them (Bug #12).
     nestweaver_engine::promote_member_notes_into_connected(&mut result, &member_note_uids);
+    // 4b'. Mirror the notes promotion for the seeded top-K member symbols
+    //      (Bug #18 / wave-5 regression). Without this, the symbols stay in
+    //      `seeds` and never appear in the rendered `connected` list.
+    nestweaver_engine::promote_member_symbols_into_connected(&mut result, &member_symbol_uids);
+    // 4b''. Drop Heading nodes that duplicate a Section with the same
+    //       `(file, title)`. The Section carries the body, so the bare
+    //       Heading is redundant; notes-heavy projects spend ~25% of a
+    //       2000-token budget on these duplicates without this trim.
+    nestweaver_engine::dedup_heading_section_pairs(&mut result);
 
     // 4c. Post-PPR scope boost: multiply relevance for nodes that belong
     //     to the project (member UIDs are the authoritative membership signal).
@@ -3836,8 +3866,18 @@ fn tool_project_context(
         );
     }
 
-    // 6. Apply token budget: account for seed cost, allocate remainder to connected.
-    let seed_tokens: usize = result.seeds.iter().map(render_cost).sum();
+    // 6. Apply token budget: account for seed cost, allocate remainder to
+    //    connected. Don't double-count items that the promotion helpers above
+    //    copied from `seeds` into `connected` — those tokens belong to the
+    //    connected budget, not the seed overhead.
+    let connected_uids: std::collections::HashSet<&str> =
+        result.connected.iter().map(|n| n.uid.as_str()).collect();
+    let seed_tokens: usize = result
+        .seeds
+        .iter()
+        .filter(|n| !connected_uids.contains(n.uid.as_str()))
+        .map(render_cost)
+        .sum();
     let remaining_budget = token_budget.saturating_sub(seed_tokens);
     let (cut, connected_tokens) = budgeted_cut(&result.connected, remaining_budget);
     let used_tokens = seed_tokens + connected_tokens;

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -2437,10 +2437,20 @@ fn tool_brain_status(
         .iter()
         .filter(|(_, rows)| rows.len() > 1)
         .map(|(root, rows)| {
-            let entries: Vec<Value> = rows
+            // Pair each row with its note count so we can both render the
+            // entries and pick the keeper for the remediation hint.
+            let rows_with_counts: Vec<(&&nestweaver_schema::Vault, usize)> = rows
                 .iter()
                 .map(|v| {
-                    let n = store.list_notes(Some(&v.uid)).unwrap_or_default().len();
+                    (
+                        v,
+                        store.list_notes(Some(&v.uid)).unwrap_or_default().len(),
+                    )
+                })
+                .collect();
+            let entries: Vec<Value> = rows_with_counts
+                .iter()
+                .map(|(v, n)| {
                     json!({
                         "uid": v.uid,
                         "instance_id": v.instance_id,
@@ -2449,10 +2459,50 @@ fn tool_brain_status(
                     })
                 })
                 .collect();
+
+            // Suggest a concrete merge command. The keeper is the row with
+            // the highest note_count (most data); ties break on the
+            // lexicographically smallest instance_id so the suggestion is
+            // deterministic. Emit one command per non-keeper row so callers
+            // collapse all ghosts into the canonical instance.
+            let keeper = rows_with_counts
+                .iter()
+                .max_by(|a, b| {
+                    a.1.cmp(&b.1)
+                        .then_with(|| b.0.instance_id.cmp(&a.0.instance_id))
+                })
+                .map(|(v, _)| v);
+            let (remediation_commands, remediation_hint) = match keeper {
+                Some(keeper_v) => {
+                    let cmds: Vec<String> = rows_with_counts
+                        .iter()
+                        .filter(|(v, _)| v.instance_id != keeper_v.instance_id)
+                        .map(|(v, _)| {
+                            format!(
+                                "nestweaver instance merge --from {} --to {}",
+                                v.instance_id, keeper_v.instance_id,
+                            )
+                        })
+                        .collect();
+                    let hint = format!(
+                        "Multiple instance_ids share this vault root. Keep '{}' (has the most data) and merge the others into it using the commands below. Take a snapshot of {} first.",
+                        keeper_v.instance_id,
+                        db_path
+                            .as_deref()
+                            .and_then(|p| p.to_str())
+                            .unwrap_or("the database"),
+                    );
+                    (cmds, hint)
+                }
+                None => (Vec::new(), String::new()),
+            };
+
             json!({
                 "kind": "duplicate_vault_root",
                 "root_path": root,
                 "entries": entries,
+                "remediation_commands": remediation_commands,
+                "remediation_hint": remediation_hint,
             })
         })
         .collect();

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -4633,25 +4633,18 @@ pub fn dispatch_via_daemon(
                 Ok(serde_json::to_string(&value)?)
             }
             "brain_status" => {
-                use nestweaver_proto::BrainStatusRequest;
-                let req = tonic::Request::new(BrainStatusRequest {});
+                // Use the JSON pass-through RPC so per-vault rows (uid +
+                // instance_id), warnings[], and any other engine-side fields
+                // round-trip intact. The typed BrainStatusResponse only
+                // carries the scalar totals.
+                let req = tonic::Request::new(JsonRequest {
+                    args_json: args_json.clone(),
+                });
                 let resp = client
-                    .brain_status(req)
+                    .brain_status_json(req)
                     .await
                     .map_err(|s| anyhow::anyhow!("gRPC error: {}", s.message()))?;
-                let inner = resp.into_inner();
-                let value = serde_json::json!({
-                    "vault_count": inner.vault_count,
-                    "notes": inner.notes,
-                    "headings": inner.headings,
-                    "sections": inner.sections,
-                    "tags": inner.tags,
-                    "wikilinks": inner.wikilinks,
-                    "repo_count": inner.repo_count,
-                    "tantivy_available": inner.tantivy_available,
-                    "tantivy_doc_count": inner.tantivy_doc_count,
-                });
-                Ok(serde_json::to_string(&value)?)
+                Ok(resp.into_inner().result_json)
             }
             "hub_nodes" => {
                 use nestweaver_proto::HubNodesRequest;

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -2431,7 +2431,10 @@ fn tool_brain_status(
     let mut root_to_rows: std::collections::HashMap<&str, Vec<&nestweaver_schema::Vault>> =
         std::collections::HashMap::new();
     for v in &vaults {
-        root_to_rows.entry(v.root_path.as_str()).or_default().push(v);
+        root_to_rows
+            .entry(v.root_path.as_str())
+            .or_default()
+            .push(v);
     }
     let warnings: Vec<Value> = root_to_rows
         .iter()

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -4649,6 +4649,9 @@ pub fn dispatch_via_daemon(
                     include_components: bool_field("include_components"),
                     intent: str_field("intent"),
                     include_seeds: bool_field("include_seeds"),
+                    since: str_field("since"),
+                    recency_weight: f64_field("recency_weight"),
+                    recency_half_life_days: f64_field("recency_half_life_days"),
                 });
                 let resp = client
                     .get_project_context(req)

--- a/crates/nestweaver-schema/src/nodes.rs
+++ b/crates/nestweaver-schema/src/nodes.rs
@@ -42,22 +42,28 @@ pub enum SymbolKind {
     Variable,
 }
 
+impl SymbolKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SymbolKind::Function => "Function",
+            SymbolKind::Class => "Class",
+            SymbolKind::Method => "Method",
+            SymbolKind::Interface => "Interface",
+            SymbolKind::Trait => "Trait",
+            SymbolKind::Enum => "Enum",
+            SymbolKind::Module => "Module",
+            SymbolKind::Extension => "Extension",
+            SymbolKind::Constant => "Constant",
+            SymbolKind::Property => "Property",
+            SymbolKind::TypeAlias => "TypeAlias",
+            SymbolKind::Variable => "Variable",
+        }
+    }
+}
+
 impl fmt::Display for SymbolKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            SymbolKind::Function => write!(f, "Function"),
-            SymbolKind::Class => write!(f, "Class"),
-            SymbolKind::Method => write!(f, "Method"),
-            SymbolKind::Interface => write!(f, "Interface"),
-            SymbolKind::Trait => write!(f, "Trait"),
-            SymbolKind::Enum => write!(f, "Enum"),
-            SymbolKind::Module => write!(f, "Module"),
-            SymbolKind::Extension => write!(f, "Extension"),
-            SymbolKind::Constant => write!(f, "Constant"),
-            SymbolKind::Property => write!(f, "Property"),
-            SymbolKind::TypeAlias => write!(f, "TypeAlias"),
-            SymbolKind::Variable => write!(f, "Variable"),
-        }
+        f.write_str(self.as_str())
     }
 }
 

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -28,7 +28,7 @@ pub use tantivy_index::{
     TantivyError, TantivyIndex,
 };
 pub use traverse::ImpactNode;
-pub use write::{MergeResult, UnlinkedVault};
+pub use write::{MergeResult, PurgeInstanceResult, UnlinkedVault};
 
 #[cfg(test)]
 mod tests {
@@ -1448,5 +1448,88 @@ mod tests {
         // but files are gone — verify by checking a lookup would find no symbols).
         let all_syms = store.lookup_symbols_by_name("fn_1").unwrap();
         assert!(all_syms.is_empty());
+    }
+
+    #[test]
+    fn purge_instance_cascade_deletes_repos_and_children() {
+        let store = test_store();
+
+        // Two repos under instance "ghost" — both should disappear.
+        let ghost_repo_a = Repo {
+            uid: "repo:ghost:aaaa".to_string(),
+            url: "file:///ghost/a".to_string(),
+            indexed_sha: "local".to_string(),
+            staleness_commits_behind: 0,
+            instance_id: "ghost".to_string(),
+            name: Some("ghost-a".to_string()),
+        };
+        let ghost_repo_b = Repo {
+            uid: "repo:ghost:bbbb".to_string(),
+            url: "file:///ghost/b".to_string(),
+            indexed_sha: "local".to_string(),
+            staleness_commits_behind: 0,
+            instance_id: "ghost".to_string(),
+            name: Some("ghost-b".to_string()),
+        };
+        store.insert_repo(&ghost_repo_a).unwrap();
+        store.insert_repo(&ghost_repo_b).unwrap();
+
+        // One repo under a different instance — must survive intact.
+        let keep_repo = Repo {
+            uid: "repo:keep:cccc".to_string(),
+            url: "file:///keep/c".to_string(),
+            indexed_sha: "local".to_string(),
+            staleness_commits_behind: 0,
+            instance_id: "keep".to_string(),
+            name: Some("keep-c".to_string()),
+        };
+        store.insert_repo(&keep_repo).unwrap();
+
+        // Children for each repo.
+        store
+            .insert_file(&make_file("file-ghost-a", "repo:ghost:aaaa"))
+            .unwrap();
+        store
+            .insert_symbol(&make_symbol(
+                "sym-ghost-a",
+                "ghost_fn",
+                "repo:ghost:aaaa",
+                "src/file-ghost-a.rs",
+            ))
+            .unwrap();
+        store
+            .insert_service(&make_service("svc-ghost-a", "repo:ghost:aaaa"))
+            .unwrap();
+        store
+            .insert_file(&make_file("file-keep", "repo:keep:cccc"))
+            .unwrap();
+        store
+            .insert_symbol(&make_symbol(
+                "sym-keep",
+                "keep_fn",
+                "repo:keep:cccc",
+                "src/file-keep.rs",
+            ))
+            .unwrap();
+
+        let result = store.purge_instance("ghost").unwrap();
+        assert_eq!(result.repos, 2);
+        assert_eq!(result.files, 1);
+        assert_eq!(result.symbols, 1);
+
+        // Ghost repos are gone.
+        let remaining = store.list_repos(None).unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].uid, "repo:keep:cccc");
+
+        // Keep-instance children are intact.
+        let keep_syms = store.lookup_symbols_by_name("keep_fn").unwrap();
+        assert_eq!(keep_syms.len(), 1);
+
+        // Re-running on a clean instance is a no-op.
+        let again = store.purge_instance("ghost").unwrap();
+        assert_eq!(again.repos, 0);
+        assert_eq!(again.files, 0);
+        assert_eq!(again.symbols, 0);
     }
 }

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -1512,15 +1512,51 @@ mod tests {
             ))
             .unwrap();
 
+        // Orphan rows: simulate a partial `instance merge` that already
+        // dropped a Repo node but left its Symbol/File children behind
+        // with the source instance still encoded in their UID prefix.
+        // `purge_instance` must catch these via the orphan-sweep path
+        // even though no `repo:ghost:zzzz` exists to walk down from.
+        store
+            .insert_file(&make_file(
+                "file:repo:ghost:zzzz:orphan",
+                "repo:ghost:zzzz",
+            ))
+            .unwrap();
+        store
+            .insert_symbol(&make_symbol(
+                "sym:repo:ghost:zzzz:orphan",
+                "orphan_fn",
+                "repo:ghost:zzzz",
+                "src/orphan.rs",
+            ))
+            .unwrap();
+        store
+            .insert_service(&make_service(
+                "svc:repo:ghost:zzzz:orphan",
+                "repo:ghost:zzzz",
+            ))
+            .unwrap();
+
         let result = store.purge_instance("ghost").unwrap();
         assert_eq!(result.repos, 2);
         assert_eq!(result.files, 1);
         assert_eq!(result.symbols, 1);
+        // 1 orphan File + 1 orphan Symbol + 1 orphan Service.
+        assert!(
+            result.orphans_swept >= 3,
+            "expected at least 3 orphan rows swept, got {}",
+            result.orphans_swept
+        );
 
         // Ghost repos are gone.
         let remaining = store.list_repos(None).unwrap();
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].uid, "repo:keep:cccc");
+
+        // Orphan symbols are also gone.
+        let orphan_syms = store.lookup_symbols_by_name("orphan_fn").unwrap();
+        assert!(orphan_syms.is_empty());
 
         // Keep-instance children are intact.
         let keep_syms = store.lookup_symbols_by_name("keep_fn").unwrap();
@@ -1531,5 +1567,6 @@ mod tests {
         assert_eq!(again.repos, 0);
         assert_eq!(again.files, 0);
         assert_eq!(again.symbols, 0);
+        assert_eq!(again.orphans_swept, 0);
     }
 }

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -14,7 +14,8 @@ pub use db::GraphStore;
 pub use error::StoreError;
 pub use ranking::{
     DEFAULT_GIT_ACTIVITY_WEIGHT, GIT_ACTIVITY_MULT_MAX, GIT_ACTIVITY_MULT_MIN, GraphScope,
-    QueryIntent, ScopedEdgeQuery, detect_intent, git_activity_multiplier,
+    PathDeboostRule, QueryIntent, SEED_PATH_FACTOR_MAX, SEED_PATH_FACTOR_MIN, ScopedEdgeQuery,
+    SeedResolutionConfig, default_kind_priority, detect_intent, git_activity_multiplier,
 };
 pub use read::{
     BacklinkRow, BrokenWikilinkRow, CodeEdge, CodeGraph, CrossRepoRef, NoteLite, SymbolBasic,
@@ -1518,10 +1519,7 @@ mod tests {
         // `purge_instance` must catch these via the orphan-sweep path
         // even though no `repo:ghost:zzzz` exists to walk down from.
         store
-            .insert_file(&make_file(
-                "file:repo:ghost:zzzz:orphan",
-                "repo:ghost:zzzz",
-            ))
+            .insert_file(&make_file("file:repo:ghost:zzzz:orphan", "repo:ghost:zzzz"))
             .unwrap();
         store
             .insert_symbol(&make_symbol(

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -39,6 +39,153 @@ pub fn git_activity_multiplier(score: Option<f64>, weight: f64) -> f64 {
     }
 }
 
+/// Lower / upper bounds applied to a [`PathDeboostRule::factor`] on load.
+pub const SEED_PATH_FACTOR_MIN: f64 = 0.0;
+pub const SEED_PATH_FACTOR_MAX: f64 = 10.0;
+
+/// Controls how seed candidates are scored before PPR expansion.
+///
+/// Use this block to deboost candidates whose `file_path` lives in test
+/// mirrors (e.g. `playwright/`, `__tests__/`) so production symbols win
+/// when names collide. Multiple matching rules multiply.
+///
+/// Defaults target JS/TS test mirror paths (`playwright/`, `__tests__/`,
+/// `*.test.ts`, etc.). Tune per-project by adding to
+/// `[seed_resolution].path_deboost` in `nestweaver-instance.toml`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SeedResolutionConfig {
+    /// Multiplicative factor applied to a seed candidate's match score
+    /// when its file_path matches the given prefix or suffix. Factor < 1.0
+    /// deboosts; factor > 1.0 boosts. Multiple matches multiply.
+    #[serde(default)]
+    pub path_deboost: Vec<PathDeboostRule>,
+    /// When candidates tie on path-factor-adjusted score, prefer the kind
+    /// earlier in this list. Earlier = higher priority.
+    #[serde(default = "default_kind_priority")]
+    pub kind_priority: Vec<String>,
+}
+
+/// A single seed-resolution path deboost / boost rule.
+///
+/// Exactly one of `prefix` / `suffix` must be set. Validation in the engine
+/// layer rejects rules that violate this.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PathDeboostRule {
+    /// Match if the (`/`-prepended, lowercased) file_path contains this
+    /// substring. Mutually exclusive with `suffix`.
+    #[serde(default)]
+    pub prefix: Option<String>,
+    /// Match if file_path ends with this string (case-sensitive).
+    /// Mutually exclusive with `prefix`.
+    #[serde(default)]
+    pub suffix: Option<String>,
+    /// Multiplier on the candidate's score. Clamped to
+    /// `[SEED_PATH_FACTOR_MIN, SEED_PATH_FACTOR_MAX]` on load.
+    pub factor: f64,
+}
+
+/// Default priority list for tie-breaking seed candidates by `SymbolKind`.
+///
+/// Earlier entries win against later ones. The list covers every variant
+/// of [`nestweaver_schema::SymbolKind`] so any well-typed symbol has a
+/// defined rank.
+pub fn default_kind_priority() -> Vec<String> {
+    vec![
+        "Class".into(),
+        "Interface".into(),
+        "TypeAlias".into(),
+        "Method".into(),
+        "Function".into(),
+        "Constant".into(),
+        "Property".into(),
+        "Variable".into(),
+        "Module".into(),
+        "Enum".into(),
+        "Trait".into(),
+        "Extension".into(),
+    ]
+}
+
+impl Default for SeedResolutionConfig {
+    fn default() -> Self {
+        Self {
+            path_deboost: vec![
+                PathDeboostRule {
+                    prefix: Some("/playwright/".into()),
+                    suffix: None,
+                    factor: 0.2,
+                },
+                PathDeboostRule {
+                    prefix: Some("/__tests__/".into()),
+                    suffix: None,
+                    factor: 0.3,
+                },
+                PathDeboostRule {
+                    prefix: Some("/cypress/".into()),
+                    suffix: None,
+                    factor: 0.3,
+                },
+                PathDeboostRule {
+                    prefix: Some("/e2e/".into()),
+                    suffix: None,
+                    factor: 0.3,
+                },
+                PathDeboostRule {
+                    prefix: Some("/tests/".into()),
+                    suffix: None,
+                    factor: 0.3,
+                },
+                PathDeboostRule {
+                    prefix: Some("/test/".into()),
+                    suffix: None,
+                    factor: 0.3,
+                },
+                PathDeboostRule {
+                    prefix: Some("/spec/".into()),
+                    suffix: None,
+                    factor: 0.3,
+                },
+                PathDeboostRule {
+                    prefix: Some("/__mocks__/".into()),
+                    suffix: None,
+                    factor: 0.3,
+                },
+                PathDeboostRule {
+                    prefix: Some("/fixtures/".into()),
+                    suffix: None,
+                    factor: 0.4,
+                },
+                PathDeboostRule {
+                    prefix: None,
+                    suffix: Some(".test.tsx".into()),
+                    factor: 0.5,
+                },
+                PathDeboostRule {
+                    prefix: None,
+                    suffix: Some(".test.ts".into()),
+                    factor: 0.5,
+                },
+                PathDeboostRule {
+                    prefix: None,
+                    suffix: Some(".test.jsx".into()),
+                    factor: 0.5,
+                },
+                PathDeboostRule {
+                    prefix: None,
+                    suffix: Some(".test.js".into()),
+                    factor: 0.5,
+                },
+                PathDeboostRule {
+                    prefix: None,
+                    suffix: Some(".spec.ts".into()),
+                    factor: 0.5,
+                },
+            ],
+            kind_priority: default_kind_priority(),
+        }
+    }
+}
+
 /// Describes the intent behind a PPR query, allowing the algorithm to
 /// adapt its damping factor (alpha) and edge weights to produce more
 /// relevant results for different use cases.

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -140,8 +140,8 @@ impl std::str::FromStr for QueryIntent {
             "project-context" | "project" => Ok(QueryIntent::ProjectContext),
             other => Err(format!(
                 "unknown intent '{}': expected one of find-definition, \
-                 understand-architecture, analyze-impact, general-context, \
-                 project-context",
+                 understand-architecture, analyze-impact, blast-radius, \
+                 general-context, project-context",
                 other
             )),
         }

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -155,6 +155,35 @@ impl Default for SeedResolutionConfig {
                     suffix: None,
                     factor: 0.4,
                 },
+                // Vendored test-runtime packages bundled into a repo's
+                // dependencies. These leak into seed candidates and PPR walks
+                // when third-party test packages ship their own framework code
+                // under the repo tree.
+                PathDeboostRule {
+                    prefix: Some("/jasmine/".into()),
+                    suffix: None,
+                    factor: 0.2,
+                },
+                PathDeboostRule {
+                    prefix: Some("/mocha/".into()),
+                    suffix: None,
+                    factor: 0.2,
+                },
+                PathDeboostRule {
+                    prefix: Some("/qunit/".into()),
+                    suffix: None,
+                    factor: 0.2,
+                },
+                PathDeboostRule {
+                    prefix: Some("/jest/".into()),
+                    suffix: None,
+                    factor: 0.2,
+                },
+                PathDeboostRule {
+                    prefix: Some("/karma/".into()),
+                    suffix: None,
+                    factor: 0.2,
+                },
                 PathDeboostRule {
                     prefix: None,
                     suffix: Some(".test.tsx".into()),

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -1522,6 +1522,61 @@ impl GraphStore {
             .collect())
     }
 
+    /// Return up to `limit` Symbol UIDs from a project, ranked by PageRank descending.
+    ///
+    /// Used by `project-context` to seed PPR with the architecturally
+    /// important symbols. Seeding them directly is the only way for member
+    /// symbols to survive the `min_score` filter — a project that declares
+    /// many repos fans out across tens of thousands of
+    /// `PROJECT_INCLUDES_SYMBOL` edges, leaving each individual symbol below
+    /// threshold when only the project node is seeded.
+    pub fn list_project_symbol_uids_by_pagerank(
+        &self,
+        project_uid: &str,
+        limit: usize,
+    ) -> Result<Vec<String>, StoreError> {
+        if limit == 0 {
+            return Ok(vec![]);
+        }
+        let conn = self.conn()?;
+        let q = "MATCH (p:Project {uid: $uid})-[:PROJECT_INCLUDES_SYMBOL]->(s:Symbol) \
+                 RETURN s.uid, s.pagerank_score \
+                 ORDER BY s.pagerank_score DESC \
+                 LIMIT $limit";
+        let mut stmt = match conn.prepare(q) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::trace!(
+                    "list_project_symbol_uids_by_pagerank: query skipped \
+                     (table may not exist): {e}"
+                );
+                return Ok(vec![]);
+            }
+        };
+        let result = match conn.execute(
+            &mut stmt,
+            vec![
+                ("uid", Value::String(project_uid.to_string())),
+                ("limit", Value::Int64(limit as i64)),
+            ],
+        ) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::trace!(
+                    "list_project_symbol_uids_by_pagerank: query skipped \
+                     (table may not exist): {e}"
+                );
+                return Ok(vec![]);
+            }
+        };
+        Ok(result
+            .filter_map(|row| match row.first() {
+                Some(Value::String(s)) => Some(s.clone()),
+                _ => None,
+            })
+            .collect())
+    }
+
     /// List component Project UIDs that belong to a project via PROJECT_HAS_COMPONENT edges.
     pub fn list_project_component_uids(
         &self,

--- a/crates/nestweaver-store/src/search.rs
+++ b/crates/nestweaver-store/src/search.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::db::GraphStore;
 use crate::error::StoreError;
+use crate::ranking::SeedResolutionConfig;
 
 // ---------------------------------------------------------------------------
 // EmbeddingIndex
@@ -117,17 +118,17 @@ impl GraphStore {
     /// * `query_embedding`  – embedding of the query (optional)
     /// * `embedding_index`  – pre-loaded `EmbeddingIndex` (optional)
     /// * `limit`            – maximum results to return
+    /// * `seed_resolution`  – path-deboost + kind-priority for seed scoring
     pub fn hybrid_search(
         &self,
         text_query: &str,
         query_embedding: Option<&[f32]>,
         embedding_index: Option<&EmbeddingIndex>,
         limit: usize,
-        test_path_patterns: &[String],
+        seed_resolution: &SeedResolutionConfig,
     ) -> Result<Vec<SearchResult>, StoreError> {
         // 1. Text search
-        let text_results =
-            self.search_symbols_by_name(text_query, limit * 2, test_path_patterns)?;
+        let text_results = self.search_symbols_by_name(text_query, limit * 2, seed_resolution)?;
 
         // 2. Vector search (only when both embedding and index are present)
         let vec_results: Vec<(String, f64)> = match (query_embedding, embedding_index) {
@@ -290,12 +291,21 @@ mod tests {
         }
     }
 
+    fn empty_seed_resolution() -> SeedResolutionConfig {
+        SeedResolutionConfig {
+            path_deboost: Vec::new(),
+            kind_priority: Vec::new(),
+        }
+    }
+
     #[test]
     fn hybrid_search_text_only() {
         let store = GraphStore::in_memory().unwrap();
         store.insert_symbol(&make_symbol("sym:1", "greet")).unwrap();
 
-        let results = store.hybrid_search("greet", None, None, 10, &[]).unwrap();
+        let results = store
+            .hybrid_search("greet", None, None, 10, &empty_seed_resolution())
+            .unwrap();
         assert!(!results.is_empty());
         assert_eq!(results[0].name, "greet");
     }
@@ -306,7 +316,7 @@ mod tests {
         store.insert_symbol(&make_symbol("sym:1", "greet")).unwrap();
 
         let results = store
-            .hybrid_search("zzznomatch", None, None, 10, &[])
+            .hybrid_search("zzznomatch", None, None, 10, &empty_seed_resolution())
             .unwrap();
         assert!(results.is_empty());
     }
@@ -329,7 +339,13 @@ mod tests {
 
         let query_vec = [1.0_f32, 0.0, 0.0];
         let results = store
-            .hybrid_search("greet", Some(&query_vec), Some(&idx), 10, &[])
+            .hybrid_search(
+                "greet",
+                Some(&query_vec),
+                Some(&idx),
+                10,
+                &empty_seed_resolution(),
+            )
             .unwrap();
 
         // Both should appear (greet from text, farewell from vector)

--- a/crates/nestweaver-store/src/traverse.rs
+++ b/crates/nestweaver-store/src/traverse.rs
@@ -43,10 +43,10 @@ fn compute_path_factor(file_path: &str, rules: &[PathDeboostRule]) -> f64 {
 /// priority). Returns `usize::MAX` for kinds not present in the list, which
 /// effectively pushes them to the bottom of any kind-based tiebreak.
 fn kind_rank(kind: SymbolKind, kind_priority: &[String]) -> usize {
-    let name = format!("{kind:?}");
+    let name = kind.as_str();
     kind_priority
         .iter()
-        .position(|k| k == &name)
+        .position(|k| k == name)
         .unwrap_or(usize::MAX)
 }
 

--- a/crates/nestweaver-store/src/traverse.rs
+++ b/crates/nestweaver-store/src/traverse.rs
@@ -4,7 +4,20 @@ use crate::db::GraphStore;
 use crate::error::StoreError;
 
 fn is_test_path(path: &str, patterns: &[String]) -> bool {
-    let p = path.to_lowercase();
+    // Indexed file paths are stored relative to the repo root
+    // (e.g. `playwright/components/Foo.tsx`), but the default
+    // deboost patterns use `/segment/` form so they anchor on
+    // directory boundaries without matching arbitrary substrings
+    // (e.g. avoiding `myplaywright`).
+    //
+    // Prepend a `/` to the haystack before substring matching so
+    // patterns like `/playwright/`, `/cypress/`, `/__tests__/`
+    // match relative paths whose first segment is the test dir.
+    // Patterns without a leading `/` (e.g. `.cy.`, `_test.go`)
+    // still match as plain case-insensitive substrings.
+    let mut p = String::with_capacity(path.len() + 1);
+    p.push('/');
+    p.push_str(&path.to_lowercase());
     patterns.iter().any(|pat| p.contains(pat.as_str()))
 }
 
@@ -457,5 +470,41 @@ mod tests {
             .unwrap();
         // Both should be present, order is by insertion (no path ranking)
         assert_eq!(results.len(), 2);
+    }
+
+    /// Regression: `/segment/` patterns must deboost production-relative
+    /// paths whose first directory segment is the test dir. The earlier
+    /// implementation did a plain `contains` against the raw path, which
+    /// missed `playwright/foo.tsx` because the haystack had no leading `/`.
+    #[test]
+    fn deboost_patterns_match_first_segment_of_relative_path() {
+        let store = GraphStore::in_memory().unwrap();
+
+        let mut prod = make_symbol("sym-prod", "MultiStageApprovalDialog");
+        prod.file_path = "src/components/MultiStageApprovalDialog.tsx".to_string();
+        store.insert_symbol(&prod).unwrap();
+
+        // Three Playwright tests under playwright/ as a first segment.
+        for (i, p) in [
+            "playwright/components/MultiStageApprovalDialog.spec.ts",
+            "playwright/regression/MultiStageApprovalDialog.spec.ts",
+            "playwright/smoke/MultiStageApprovalDialog.spec.ts",
+        ]
+        .iter()
+        .enumerate()
+        {
+            let mut s = make_symbol(&format!("sym-pw-{i}"), "MultiStageApprovalDialog");
+            s.file_path = (*p).to_string();
+            store.insert_symbol(&s).unwrap();
+        }
+
+        let patterns = vec!["/playwright/".to_string()];
+        let results = store
+            .search_symbols_by_name("MultiStageApprovalDialog", 10, &patterns)
+            .unwrap();
+        assert_eq!(
+            results[0].file_path, "src/components/MultiStageApprovalDialog.tsx",
+            "production code must outrank playwright/ tests with default /playwright/ pattern"
+        );
     }
 }

--- a/crates/nestweaver-store/src/traverse.rs
+++ b/crates/nestweaver-store/src/traverse.rs
@@ -1,24 +1,53 @@
 use std::collections::{HashMap, VecDeque};
 
+use nestweaver_schema::SymbolKind;
+
 use crate::db::GraphStore;
 use crate::error::StoreError;
+use crate::ranking::{PathDeboostRule, SeedResolutionConfig};
 
-fn is_test_path(path: &str, patterns: &[String]) -> bool {
-    // Indexed file paths are stored relative to the repo root
-    // (e.g. `playwright/components/Foo.tsx`), but the default
-    // deboost patterns use `/segment/` form so they anchor on
-    // directory boundaries without matching arbitrary substrings
-    // (e.g. avoiding `myplaywright`).
-    //
-    // Prepend a `/` to the haystack before substring matching so
-    // patterns like `/playwright/`, `/cypress/`, `/__tests__/`
-    // match relative paths whose first segment is the test dir.
-    // Patterns without a leading `/` (e.g. `.cy.`, `_test.go`)
-    // still match as plain case-insensitive substrings.
-    let mut p = String::with_capacity(path.len() + 1);
-    p.push('/');
-    p.push_str(&path.to_lowercase());
-    patterns.iter().any(|pat| p.contains(pat.as_str()))
+/// Compute the multiplicative path-factor for a symbol's `file_path` against
+/// a list of [`PathDeboostRule`]s. Matching rules multiply; factor=1.0 when
+/// no rule matches.
+///
+/// Prefixes are matched case-insensitively against the (`/`-prepended,
+/// lowercased) haystack so patterns like `/playwright/`, `/cypress/`, and
+/// `/__tests__/` anchor on the first directory segment of a repo-relative
+/// path (`playwright/components/Foo.tsx` → matched; `myplaywright/...` → not).
+///
+/// Suffixes are matched case-sensitively against the raw `file_path`
+/// (suffix rules like `.test.ts` rely on conventional extensions).
+fn compute_path_factor(file_path: &str, rules: &[PathDeboostRule]) -> f64 {
+    let mut prepended = String::with_capacity(file_path.len() + 1);
+    prepended.push('/');
+    prepended.push_str(&file_path.to_lowercase());
+    let mut factor = 1.0_f64;
+    for rule in rules {
+        let matched = match (&rule.prefix, &rule.suffix) {
+            (Some(prefix), None) => prepended.contains(prefix.as_str()),
+            (None, Some(suffix)) => file_path.ends_with(suffix.as_str()),
+            // Invalid rule shapes are rejected at config-load time, so by
+            // the time we get here a rule is guaranteed to have exactly one
+            // of {prefix, suffix} set. Be tolerant in the store layer just
+            // in case (skip the rule).
+            _ => false,
+        };
+        if matched {
+            factor *= rule.factor;
+        }
+    }
+    factor
+}
+
+/// Index of `kind` in the user-defined `kind_priority` list (lower = higher
+/// priority). Returns `usize::MAX` for kinds not present in the list, which
+/// effectively pushes them to the bottom of any kind-based tiebreak.
+fn kind_rank(kind: SymbolKind, kind_priority: &[String]) -> usize {
+    let name = format!("{kind:?}");
+    kind_priority
+        .iter()
+        .position(|k| k == &name)
+        .unwrap_or(usize::MAX)
 }
 
 /// Cached result of a full symbol table scan, keyed on `graph_generation`.
@@ -246,11 +275,21 @@ impl GraphStore {
     /// The full symbol table is loaded once per `graph_generation` and cached in
     /// `symbol_name_cache`. Subsequent calls within the same generation skip the
     /// DB round-trip entirely and filter the in-memory list.
+    ///
+    /// Candidates are scored by:
+    /// 1. **Name quality** — exact (`4.0`), prefix (`2.0`), or contains (`1.0`).
+    /// 2. **Path factor** — multiplicative `[seed_resolution].path_deboost`
+    ///    rules (defaults target JS/TS test mirrors like `playwright/`,
+    ///    `__tests__/`, `*.test.ts`).
+    /// 3. **Kind priority** — ties broken by `[seed_resolution].kind_priority`
+    ///    so `Class` outranks `Property` of the same lowercased name.
+    /// 4. **File path** — final tiebreaker, lexicographic ascending, for
+    ///    deterministic stability across calls.
     pub fn search_symbols_by_name(
         &self,
         query: &str,
         limit: usize,
-        test_path_patterns: &[String],
+        seed_resolution: &SeedResolutionConfig,
     ) -> Result<Vec<nestweaver_schema::Symbol>, StoreError> {
         let needle = query.to_lowercase();
         let cur_gen = self.graph_generation();
@@ -319,31 +358,41 @@ impl GraphStore {
         };
 
         // --- Step 3: filter and rank the in-memory list ----------------------
-        // Collect all substring matches, rank by name quality and path, then
-        // take the top `limit`. This prevents test/playwright files from
-        // dominating when a PascalCase name also appears in production code.
-        let mut matches: Vec<(u8, &nestweaver_schema::Symbol)> = Vec::new();
+        // Collect all substring matches, score by name quality × path factor,
+        // then take the top `limit` by descending adjusted score with
+        // kind-priority + file-path tiebreaks. This prevents test/playwright
+        // files from dominating when a PascalCase name also appears in
+        // production code, and gives a deterministic order across calls.
+        let mut candidates: Vec<(f64, &nestweaver_schema::Symbol)> = Vec::new();
         for (lower, sym) in &entry.symbols {
             if !lower.contains(&needle) {
                 continue;
             }
-            let name_rank = if *lower == needle {
-                0 // exact
+            let base_score = if *lower == needle {
+                4.0_f64 // exact
             } else if lower.starts_with(&needle) {
-                1 // prefix
+                2.0_f64 // prefix
             } else {
-                2 // contains
+                1.0_f64 // contains
             };
-            let path_rank = if is_test_path(&sym.file_path, test_path_patterns) {
-                1u8
-            } else {
-                0u8
-            };
-            let rank = name_rank * 2 + path_rank;
-            matches.push((rank, sym));
+            let path_factor = compute_path_factor(&sym.file_path, &seed_resolution.path_deboost);
+            let adjusted = base_score * path_factor;
+            candidates.push((adjusted, sym));
         }
-        matches.sort_by_key(|(rank, _)| *rank);
-        Ok(matches
+        candidates.sort_by(|(a_score, a_sym), (b_score, b_sym)| {
+            // 1) adjusted DESC
+            b_score
+                .partial_cmp(a_score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                // 2) kind_priority ASC (lower index = higher priority)
+                .then_with(|| {
+                    kind_rank(a_sym.kind, &seed_resolution.kind_priority)
+                        .cmp(&kind_rank(b_sym.kind, &seed_resolution.kind_priority))
+                })
+                // 3) file_path lexicographic ASC for deterministic stability
+                .then_with(|| a_sym.file_path.cmp(&b_sym.file_path))
+        });
+        Ok(candidates
             .into_iter()
             .take(limit)
             .map(|(_, sym)| sym.clone())
@@ -355,7 +404,9 @@ impl GraphStore {
 mod tests {
     use nestweaver_schema::{Symbol, SymbolKind, Visibility};
 
+    use super::{compute_path_factor, kind_rank};
     use crate::db::GraphStore;
+    use crate::ranking::{PathDeboostRule, SeedResolutionConfig, default_kind_priority};
 
     fn make_symbol(uid: &str, name: &str) -> Symbol {
         Symbol {
@@ -379,6 +430,15 @@ mod tests {
         }
     }
 
+    /// Convenience: empty [`SeedResolutionConfig`] for legacy cache tests
+    /// where path/kind ranking is irrelevant.
+    fn no_rules() -> SeedResolutionConfig {
+        SeedResolutionConfig {
+            path_deboost: Vec::new(),
+            kind_priority: Vec::new(),
+        }
+    }
+
     /// Verify that `search_symbols_by_name` returns consistent results across
     /// two calls and that the second call is served from the cache.
     #[test]
@@ -390,11 +450,15 @@ mod tests {
         store.insert_symbol(&make_symbol("s3", "BazBaz")).unwrap();
 
         // First call — cache miss, queries DB.
-        let first = store.search_symbols_by_name("foo", 10, &[]).unwrap();
+        let first = store
+            .search_symbols_by_name("foo", 10, &no_rules())
+            .unwrap();
         assert_eq!(first.len(), 2, "expected FooBar and FooQux");
 
         // Second call — should hit the cache. Results must be identical.
-        let second = store.search_symbols_by_name("foo", 10, &[]).unwrap();
+        let second = store
+            .search_symbols_by_name("foo", 10, &no_rules())
+            .unwrap();
         assert_eq!(second.len(), 2, "cached call must return the same count");
 
         // The UIDs returned by both calls must be the same set.
@@ -423,7 +487,9 @@ mod tests {
         let store = GraphStore::in_memory().unwrap();
         store.insert_symbol(&make_symbol("s1", "Alpha")).unwrap();
 
-        let first = store.search_symbols_by_name("alpha", 10, &[]).unwrap();
+        let first = store
+            .search_symbols_by_name("alpha", 10, &no_rules())
+            .unwrap();
         assert_eq!(first.len(), 1);
 
         // Simulate a reindex bump.
@@ -435,7 +501,9 @@ mod tests {
             .insert_symbol(&make_symbol("s2", "AlphaBeta"))
             .unwrap();
 
-        let second = store.search_symbols_by_name("alpha", 10, &[]).unwrap();
+        let second = store
+            .search_symbols_by_name("alpha", 10, &no_rules())
+            .unwrap();
         assert_eq!(
             second.len(),
             2,
@@ -443,68 +511,182 @@ mod tests {
         );
     }
 
+    // ── Finding #7 — seed_resolution scoring + kind tiebreak ────────────
+
     #[test]
-    fn search_symbols_respects_custom_test_patterns() {
-        let store = GraphStore::in_memory().unwrap();
-
-        // Production symbol
-        let mut prod = make_symbol("sym-prod", "MyComponent");
-        prod.file_path = "src/components/MyComponent.tsx".to_string();
-        store.insert_symbol(&prod).unwrap();
-
-        // Cypress test symbol
-        let mut test_sym = make_symbol("sym-test", "MyComponent");
-        test_sym.file_path = "cypress/e2e/MyComponent.cy.ts".to_string();
-        store.insert_symbol(&test_sym).unwrap();
-
-        // With custom patterns: prod ranks first (cypress/ is deboosted)
-        let defaults = vec!["/cypress/".to_string(), ".cy.".to_string()];
-        let results = store
-            .search_symbols_by_name("MyComponent", 10, &defaults)
-            .unwrap();
-        assert_eq!(results[0].file_path, "src/components/MyComponent.tsx");
-
-        // With empty patterns: no deboost, both rank equally by name
-        let results = store
-            .search_symbols_by_name("MyComponent", 10, &[])
-            .unwrap();
-        // Both should be present, order is by insertion (no path ranking)
-        assert_eq!(results.len(), 2);
+    fn path_factor_with_no_rules_is_one() {
+        assert!((compute_path_factor("playwright/foo.ts", &[]) - 1.0).abs() < 1e-9);
+        assert!((compute_path_factor("src/main.rs", &[]) - 1.0).abs() < 1e-9);
     }
 
-    /// Regression: `/segment/` patterns must deboost production-relative
-    /// paths whose first directory segment is the test dir. The earlier
-    /// implementation did a plain `contains` against the raw path, which
-    /// missed `playwright/foo.tsx` because the haystack had no leading `/`.
     #[test]
-    fn deboost_patterns_match_first_segment_of_relative_path() {
+    fn path_factor_applies_prefix_rule() {
+        let rules = vec![PathDeboostRule {
+            prefix: Some("/playwright/".into()),
+            suffix: None,
+            factor: 0.2,
+        }];
+        assert!((compute_path_factor("playwright/pages/foo.ts", &rules) - 0.2).abs() < 1e-9);
+        // Non-matching path is untouched.
+        assert!((compute_path_factor("src/main.rs", &rules) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn path_factor_applies_suffix_rule() {
+        let rules = vec![PathDeboostRule {
+            prefix: None,
+            suffix: Some(".test.ts".into()),
+            factor: 0.5,
+        }];
+        assert!((compute_path_factor("src/foo.test.ts", &rules) - 0.5).abs() < 1e-9);
+        // Suffix is case-sensitive on the raw file_path.
+        assert!((compute_path_factor("src/foo.TEST.ts", &rules) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn path_factor_multiplies_when_both_match() {
+        let rules = vec![
+            PathDeboostRule {
+                prefix: Some("/playwright/".into()),
+                suffix: None,
+                factor: 0.2,
+            },
+            PathDeboostRule {
+                prefix: None,
+                suffix: Some(".test.ts".into()),
+                factor: 0.5,
+            },
+        ];
+        // 0.2 * 0.5 = 0.1
+        assert!((compute_path_factor("playwright/foo.test.ts", &rules) - 0.1).abs() < 1e-9);
+    }
+
+    #[test]
+    fn path_factor_case_insensitive_for_prefix() {
+        let rules = vec![PathDeboostRule {
+            prefix: Some("/playwright/".into()),
+            suffix: None,
+            factor: 0.2,
+        }];
+        assert!((compute_path_factor("Playwright/Pages/Foo.ts", &rules) - 0.2).abs() < 1e-9);
+    }
+
+    #[test]
+    fn search_prefers_class_over_property_on_same_name_when_paths_match_evenly() {
         let store = GraphStore::in_memory().unwrap();
 
-        let mut prod = make_symbol("sym-prod", "MultiStageApprovalDialog");
-        prod.file_path = "src/components/MultiStageApprovalDialog.tsx".to_string();
+        let mut class_sym = make_symbol("sym-class", "MyWidget");
+        class_sym.kind = SymbolKind::Class;
+        class_sym.file_path = "src/main.ts".to_string();
+        store.insert_symbol(&class_sym).unwrap();
+
+        let mut prop_sym = make_symbol("sym-prop", "myWidget");
+        prop_sym.kind = SymbolKind::Property;
+        prop_sym.file_path = "src/helpers.ts".to_string();
+        store.insert_symbol(&prop_sym).unwrap();
+
+        // Default kind_priority puts Class above Property; neither path
+        // matches any deboost rule (no /test/ etc. segment).
+        let cfg = SeedResolutionConfig {
+            path_deboost: Vec::new(),
+            kind_priority: default_kind_priority(),
+        };
+        let results = store.search_symbols_by_name("mywidget", 10, &cfg).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            results[0].uid, "sym-class",
+            "Class must outrank Property under default kind_priority"
+        );
+    }
+
+    #[test]
+    fn search_prefers_production_over_playwright_for_same_lowercased_name() {
+        let store = GraphStore::in_memory().unwrap();
+
+        let mut prod = make_symbol("sym-prod", "MyWidget");
+        prod.kind = SymbolKind::Class;
+        prod.file_path = "src/components/MyWidget.tsx".to_string();
         store.insert_symbol(&prod).unwrap();
 
-        // Three Playwright tests under playwright/ as a first segment.
         for (i, p) in [
-            "playwright/components/MultiStageApprovalDialog.spec.ts",
-            "playwright/regression/MultiStageApprovalDialog.spec.ts",
-            "playwright/smoke/MultiStageApprovalDialog.spec.ts",
+            "playwright/components/MyWidget.spec.ts",
+            "playwright/regression/MyWidget.spec.ts",
+            "playwright/smoke/MyWidget.spec.ts",
         ]
         .iter()
         .enumerate()
         {
-            let mut s = make_symbol(&format!("sym-pw-{i}"), "MultiStageApprovalDialog");
+            let mut s = make_symbol(&format!("sym-pw-{i}"), "MyWidget");
+            s.kind = SymbolKind::Class;
             s.file_path = (*p).to_string();
             store.insert_symbol(&s).unwrap();
         }
 
-        let patterns = vec!["/playwright/".to_string()];
-        let results = store
-            .search_symbols_by_name("MultiStageApprovalDialog", 10, &patterns)
-            .unwrap();
+        // With default deboost: prod = 4.0*1.0 = 4.0, playwright = 4.0*0.2 = 0.8.
+        let cfg = SeedResolutionConfig::default();
+        let results = store.search_symbols_by_name("MyWidget", 10, &cfg).unwrap();
         assert_eq!(
-            results[0].file_path, "src/components/MultiStageApprovalDialog.tsx",
-            "production code must outrank playwright/ tests with default /playwright/ pattern"
+            results[0].file_path, "src/components/MyWidget.tsx",
+            "production code must outrank playwright/ tests under default deboost"
         );
+    }
+
+    #[test]
+    fn search_kind_priority_overridden_by_config() {
+        let store = GraphStore::in_memory().unwrap();
+
+        let mut class_sym = make_symbol("sym-class", "MyWidget");
+        class_sym.kind = SymbolKind::Class;
+        class_sym.file_path = "src/main.ts".to_string();
+        store.insert_symbol(&class_sym).unwrap();
+
+        let mut prop_sym = make_symbol("sym-prop", "myWidget");
+        prop_sym.kind = SymbolKind::Property;
+        prop_sym.file_path = "src/helpers.ts".to_string();
+        store.insert_symbol(&prop_sym).unwrap();
+
+        // Override kind_priority so Property wins (override is full list,
+        // not append). Paths factor in evenly.
+        let cfg = SeedResolutionConfig {
+            path_deboost: Vec::new(),
+            kind_priority: vec![
+                "Property".into(),
+                "Class".into(),
+                "Interface".into(),
+                "TypeAlias".into(),
+                "Method".into(),
+                "Function".into(),
+                "Constant".into(),
+                "Variable".into(),
+                "Module".into(),
+                "Enum".into(),
+                "Trait".into(),
+                "Extension".into(),
+            ],
+        };
+        let results = store.search_symbols_by_name("mywidget", 10, &cfg).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            results[0].uid, "sym-prop",
+            "Property must win when kind_priority places it first"
+        );
+    }
+
+    // ── kind_rank sanity ────────────────────────────────────────────────
+
+    #[test]
+    fn kind_rank_returns_index_for_known_kinds() {
+        let priority = default_kind_priority();
+        assert_eq!(kind_rank(SymbolKind::Class, &priority), 0);
+        assert!(
+            kind_rank(SymbolKind::Property, &priority) > kind_rank(SymbolKind::Class, &priority)
+        );
+    }
+
+    #[test]
+    fn kind_rank_returns_max_for_kinds_missing_from_priority() {
+        let priority = vec!["Class".to_string()];
+        assert_eq!(kind_rank(SymbolKind::Class, &priority), 0);
+        assert_eq!(kind_rank(SymbolKind::Function, &priority), usize::MAX);
     }
 }

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -2347,12 +2347,11 @@ impl GraphStore {
     /// Repo/Vault node.
     fn sweep_orphan_nodes(&self, label: &str, prefix: &str) -> Result<usize, StoreError> {
         let conn = self.conn()?;
-        let query = format!(
-            "MATCH (n:{label}) WHERE n.uid STARTS WITH $p DETACH DELETE n RETURN count(n)"
-        );
-        let mut stmt = conn.prepare(&query).map_err(|e| {
-            StoreError::Query(format!("prepare sweep {label} orphans: {e}"))
-        })?;
+        let query =
+            format!("MATCH (n:{label}) WHERE n.uid STARTS WITH $p DETACH DELETE n RETURN count(n)");
+        let mut stmt = conn
+            .prepare(&query)
+            .map_err(|e| StoreError::Query(format!("prepare sweep {label} orphans: {e}")))?;
         let rows = conn
             .execute(
                 &mut stmt,

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -2347,36 +2347,27 @@ impl GraphStore {
     /// Repo/Vault node.
     fn sweep_orphan_nodes(&self, label: &str, prefix: &str) -> Result<usize, StoreError> {
         let conn = self.conn()?;
-        let count_query = format!("MATCH (n:{label}) WHERE n.uid STARTS WITH $p RETURN count(n)");
-        let count: usize = {
-            let mut stmt = conn.prepare(&count_query).map_err(|e| {
-                StoreError::Query(format!("prepare count {label} orphans: {e}"))
-            })?;
-            let rows = conn
-                .execute(
-                    &mut stmt,
-                    vec![("p", lbug::Value::String(prefix.to_string()))],
-                )
-                .map_err(|e| StoreError::Query(format!("count {label} orphans: {e}")))?;
-            rows.filter_map(|row| {
+        let query = format!(
+            "MATCH (n:{label}) WHERE n.uid STARTS WITH $p DETACH DELETE n RETURN count(n)"
+        );
+        let mut stmt = conn.prepare(&query).map_err(|e| {
+            StoreError::Query(format!("prepare sweep {label} orphans: {e}"))
+        })?;
+        let rows = conn
+            .execute(
+                &mut stmt,
+                vec![("p", lbug::Value::String(prefix.to_string()))],
+            )
+            .map_err(|e| StoreError::Query(format!("sweep {label} orphans: {e}")))?;
+        let count = rows
+            .filter_map(|row| {
                 row.first().and_then(|v| match v {
                     lbug::Value::Int64(n) => Some(*n as usize),
                     _ => None,
                 })
             })
             .next()
-            .unwrap_or(0)
-        };
-        if count == 0 {
-            return Ok(0);
-        }
-        let delete_query =
-            format!("MATCH (n:{label}) WHERE n.uid STARTS WITH $p DETACH DELETE n");
-        exec_params(
-            &conn,
-            &delete_query,
-            vec![("p", lbug::Value::String(prefix.to_string()))],
-        )?;
+            .unwrap_or(0);
         Ok(count)
     }
 

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -25,7 +25,11 @@ pub struct MergeResult {
 }
 
 /// Result of [`GraphStore::purge_instance`]. Reports how many top-level
-/// rows were cascade-deleted from the graph for the given instance.
+/// rows were cascade-deleted from the graph for the given instance,
+/// plus a separate count for orphan nodes (Symbol/File/Service/Note/
+/// Heading/Section/Tag rows whose UID prefix encodes the instance but
+/// whose parent Repo or Vault no longer exists — typically left behind
+/// by a partially-applied `instance merge`).
 #[derive(Debug, Default)]
 pub struct PurgeInstanceResult {
     pub repos: usize,
@@ -34,6 +38,7 @@ pub struct PurgeInstanceResult {
     pub vaults: usize,
     pub notes: usize,
     pub projects: usize,
+    pub orphans_swept: usize,
 }
 
 /// Encode a Symbol's `framework_hint` as the `"framework:role"` string the
@@ -2308,7 +2313,71 @@ impl GraphStore {
             }
         }
 
+        // Orphan sweep: a partial `instance merge` can drop the Repo or
+        // Vault node while leaving its child Symbol/File/Service/Note
+        // rows behind. Those children still encode the source instance
+        // in their UID prefix, so we can find and drop them even after
+        // the parent is gone. Order matters only for telemetry — every
+        // statement is `DETACH DELETE` so incident edges are cleaned.
+        for (label, prefix) in [
+            ("Symbol", format!("sym:repo:{id}:")),
+            ("File", format!("file:repo:{id}:")),
+            ("Service", format!("svc:repo:{id}:")),
+            ("Note", format!("note:vlt:{id}:")),
+            ("Heading", format!("head:note:vlt:{id}:")),
+            ("Section", format!("sec:note:vlt:{id}:")),
+            ("Tag", format!("tag:vlt:{id}:")),
+            // Defensive: also catch Repo/Vault/Project rows that the
+            // registry-walk above missed (e.g. stale rows whose
+            // instance_id column was scrambled but whose UID is intact).
+            ("Repo", format!("repo:{id}:")),
+            ("Vault", format!("vlt:{id}:")),
+            ("Project", format!("proj:{id}:")),
+        ] {
+            result.orphans_swept += self.sweep_orphan_nodes(label, &prefix)?;
+        }
+
         Ok(result)
+    }
+
+    /// Count and DETACH DELETE every node of `label` whose `uid` starts
+    /// with `prefix`. Returns the number of rows removed. Idempotent.
+    /// Used by [`purge_instance`] to clean up orphans left by a
+    /// partial `instance merge` that already dropped the parent
+    /// Repo/Vault node.
+    fn sweep_orphan_nodes(&self, label: &str, prefix: &str) -> Result<usize, StoreError> {
+        let conn = self.conn()?;
+        let count_query = format!("MATCH (n:{label}) WHERE n.uid STARTS WITH $p RETURN count(n)");
+        let count: usize = {
+            let mut stmt = conn.prepare(&count_query).map_err(|e| {
+                StoreError::Query(format!("prepare count {label} orphans: {e}"))
+            })?;
+            let rows = conn
+                .execute(
+                    &mut stmt,
+                    vec![("p", lbug::Value::String(prefix.to_string()))],
+                )
+                .map_err(|e| StoreError::Query(format!("count {label} orphans: {e}")))?;
+            rows.filter_map(|row| {
+                row.first().and_then(|v| match v {
+                    lbug::Value::Int64(n) => Some(*n as usize),
+                    _ => None,
+                })
+            })
+            .next()
+            .unwrap_or(0)
+        };
+        if count == 0 {
+            return Ok(0);
+        }
+        let delete_query =
+            format!("MATCH (n:{label}) WHERE n.uid STARTS WITH $p DETACH DELETE n");
+        exec_params(
+            &conn,
+            &delete_query,
+            vec![("p", lbug::Value::String(prefix.to_string()))],
+        )?;
+        Ok(count)
     }
 
     /// Insert a single CROSS_REPO_LINK edge between two Symbol nodes.

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -24,6 +24,18 @@ pub struct MergeResult {
     pub unlinked: Vec<UnlinkedVault>,
 }
 
+/// Result of [`GraphStore::purge_instance`]. Reports how many top-level
+/// rows were cascade-deleted from the graph for the given instance.
+#[derive(Debug, Default)]
+pub struct PurgeInstanceResult {
+    pub repos: usize,
+    pub files: usize,
+    pub symbols: usize,
+    pub vaults: usize,
+    pub notes: usize,
+    pub projects: usize,
+}
+
 /// Encode a Symbol's `framework_hint` as the `"framework:role"` string the
 /// `framework_hint` column stores. Returns an empty string when absent.
 fn encode_framework_hint(symbol: &Symbol) -> String {
@@ -2248,6 +2260,55 @@ impl GraphStore {
             tracing::trace!("clear_repo_derived_nodes: Contract delete skipped: {e}");
         }
         Ok(())
+    }
+
+    /// Cascade-delete every graph row whose `instance_id` matches `id`:
+    /// all Repos (with their files, symbols, services, contracts), all
+    /// Vaults (with their notes/headings/sections via
+    /// `delete_vault_cascade`), and all Projects. Composes the same
+    /// per-Repo cleanup that `index --force` uses, so no novel write
+    /// paths are introduced. Idempotent: returns zero counts on a clean
+    /// DB. Useful for recovering from a misconfigured `instance merge`
+    /// that left an orphan instance ID behind.
+    pub fn purge_instance(&self, id: &str) -> Result<PurgeInstanceResult, StoreError> {
+        let mut result = PurgeInstanceResult::default();
+
+        // Repos owned by this instance — cascade delete every File,
+        // Symbol, Service, and Contract that hangs off each one before
+        // dropping the Repo node itself.
+        let repos = self.list_repos(Some(id))?;
+        for r in &repos {
+            let (files, syms) = self.bulk_delete_repo_files_and_symbols(&r.uid)?;
+            self.clear_repo_derived_nodes(&r.uid)?;
+            self.delete_repo_node(&r.uid)?;
+            result.files += files;
+            result.symbols += syms;
+        }
+        result.repos = repos.len();
+
+        // Vaults owned by this instance — cascade Note/Heading/Section.
+        let vaults = self.list_vaults(Some(id))?;
+        for v in &vaults {
+            let notes = self.delete_vault_cascade(&v.uid)?;
+            result.notes += notes;
+        }
+        result.vaults = vaults.len();
+
+        // Projects owned by this instance — single DETACH DELETE each.
+        let projects = self.list_projects()?;
+        for p in &projects {
+            if p.instance_id == id {
+                let conn = self.conn()?;
+                exec_params(
+                    &conn,
+                    "MATCH (p:Project {uid: $uid}) DETACH DELETE p",
+                    vec![("uid", lbug::Value::String(p.uid.clone()))],
+                )?;
+                result.projects += 1;
+            }
+        }
+
+        Ok(result)
     }
 
     /// Insert a single CROSS_REPO_LINK edge between two Symbol nodes.

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -1808,6 +1808,18 @@ impl GraphStore {
         edges: &[(&str, &str, f32, &str)],
     ) -> Result<(), StoreError> {
         let conn = self.conn()?;
+        Self::batch_insert_note_to_symbol_edges_on(&conn, edges)
+    }
+
+    /// Insert note→symbol edges using an externally-provided connection
+    /// (for transaction batching across many notes — avoids one fsync per call).
+    pub fn batch_insert_note_to_symbol_edges_on(
+        conn: &lbug::Connection<'_>,
+        edges: &[(&str, &str, f32, &str)],
+    ) -> Result<(), StoreError> {
+        if edges.is_empty() {
+            return Ok(());
+        }
         let mut stmt = conn
             .prepare(
                 "MATCH (n:Note {uid: $nid}), (s:Symbol {uid: $sid}) \
@@ -1836,6 +1848,18 @@ impl GraphStore {
         edges: &[(&str, &str, f32, &str)],
     ) -> Result<(), StoreError> {
         let conn = self.conn()?;
+        Self::batch_insert_section_to_symbol_edges_on(&conn, edges)
+    }
+
+    /// Insert section→symbol edges using an externally-provided connection
+    /// (for transaction batching across many notes — avoids one fsync per call).
+    pub fn batch_insert_section_to_symbol_edges_on(
+        conn: &lbug::Connection<'_>,
+        edges: &[(&str, &str, f32, &str)],
+    ) -> Result<(), StoreError> {
+        if edges.is_empty() {
+            return Ok(());
+        }
         let mut stmt = conn
             .prepare(
                 "MATCH (sec:Section {uid: $sid}), (sym:Symbol {uid: $symid}) \
@@ -1863,8 +1887,17 @@ impl GraphStore {
     /// idempotency.
     pub fn delete_cross_domain_edges_for_note(&self, note_uid: &str) -> Result<(), StoreError> {
         let conn = self.conn()?;
+        Self::delete_cross_domain_edges_for_note_on(&conn, note_uid)
+    }
+
+    /// Delete cross-domain edges for a note using an externally-provided
+    /// connection (for transaction batching across many notes).
+    pub fn delete_cross_domain_edges_for_note_on(
+        conn: &lbug::Connection<'_>,
+        note_uid: &str,
+    ) -> Result<(), StoreError> {
         exec_params(
-            &conn,
+            conn,
             "MATCH (n:Note {uid: $uid})-[r:REFERENCES_CODE_NOTE_TO_SYMBOL]->() DELETE r",
             vec![("uid", lbug::Value::String(note_uid.to_string()))],
         )?;
@@ -1890,7 +1923,7 @@ impl GraphStore {
         };
         for s_uid in &section_uids {
             exec_params(
-                &conn,
+                conn,
                 "MATCH (s:Section {uid: $uid})-[r:REFERENCES_CODE_SECTION_TO_SYMBOL]->() DELETE r",
                 vec![("uid", lbug::Value::String(s_uid.clone()))],
             )?;

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -184,6 +184,13 @@ message ProjectContextRequest {
   bool include_components = 4;
   string intent = 5;
   bool include_seeds = 6;
+  // RFC3339 timestamp; when set, hard-filters Note/Section nodes by
+  // `modified_at >= since`. Empty string = no filter.
+  string since = 7;
+  // Soft recency boost weight [0.0, 1.0+]. 0.0 disables the boost (default).
+  double recency_weight = 8;
+  // Half-life (days) for the recency boost decay. Ignored when weight=0.
+  double recency_half_life_days = 9;
 }
 message ProjectContextResponse { string result_json = 1; }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2695,7 +2695,14 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 let empty_links = vec![];
                 let links = instance_config.links.as_deref().unwrap_or(&empty_links);
 
-                match build_feature_context(&store, feature_config, links, parsed_intent, limit) {
+                match build_feature_context(
+                    &store,
+                    feature_config,
+                    links,
+                    &instance_config.repos,
+                    parsed_intent,
+                    limit,
+                ) {
                     Ok(mut result) => {
                         if let Some(budget) = token_budget {
                             let cut = context_token_budgeted_truncate(&result.connected, budget);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4728,9 +4728,30 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // declares repos, the project node's mass is split across tens of
             // thousands of PROJECT_INCLUDES_SYMBOL edges, leaving each note
             // below threshold so it never reaches `connected`.
+            //
+            // Member symbols suffer the identical fan-out, so seed the
+            // top-K of them by PageRank as well. Without this, a project
+            // that declares any repo returns notes-only context even after
+            // `materialize-projects` writes hundreds of thousands of
+            // PROJECT_INCLUDES_SYMBOL edges (Bug #18 / wave-5 regression).
+            const PROJECT_SYMBOL_SEED_LIMIT: usize = 100;
+            let mut member_symbol_uids: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+            let top_symbols = store
+                .list_project_symbol_uids_by_pagerank(&project.uid, PROJECT_SYMBOL_SEED_LIMIT)
+                .map_err(|e| anyhow::anyhow!(e))?;
+            member_symbol_uids.extend(top_symbols.iter().cloned());
+            for comp_uid in &comp_uids {
+                let comp_top = store
+                    .list_project_symbol_uids_by_pagerank(comp_uid, PROJECT_SYMBOL_SEED_LIMIT)
+                    .unwrap_or_default();
+                member_symbol_uids.extend(comp_top);
+            }
+
             let mut ppr_seeds: Vec<String> = vec![project.uid.clone()];
             ppr_seeds.extend(comp_uids);
             ppr_seeds.extend(member_note_uids.iter().cloned());
+            ppr_seeds.extend(member_symbol_uids.iter().cloned());
 
             let defaults = HybridSearchConfig::default();
             let aliases = load_alias_sidecar(&db_path);
@@ -4750,6 +4771,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     nestweaver_engine::promote_member_notes_into_connected(
                         &mut result,
                         &member_note_uids,
+                    );
+                    // Surface the seeded member symbols into `connected`
+                    // for the same reason (companion to the notes promotion).
+                    nestweaver_engine::promote_member_symbols_into_connected(
+                        &mut result,
+                        &member_symbol_uids,
                     );
 
                     // Post-PPR scope boost: multiply relevance for nodes that
@@ -4803,8 +4830,21 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         );
                     }
 
-                    // Compute seed token cost and allocate the remainder to connected.
-                    let seed_tokens: usize = result.seeds.iter().map(render_cost_tokens).sum();
+                    // Compute seed token cost and allocate the remainder to
+                    // connected. Don't double-count items the promotion helpers
+                    // copied from `seeds` into `connected` — those tokens belong
+                    // to the connected budget, not the seed overhead.
+                    let connected_uids: std::collections::HashSet<&str> = result
+                        .connected
+                        .iter()
+                        .map(|n| n.uid.as_str())
+                        .collect();
+                    let seed_tokens: usize = result
+                        .seeds
+                        .iter()
+                        .filter(|n| !connected_uids.contains(n.uid.as_str()))
+                        .map(render_cost_tokens)
+                        .sum();
                     let remaining_budget = token_budget.saturating_sub(seed_tokens);
                     let cut = token_budgeted_truncate(&result.connected, remaining_budget);
                     if json {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9111,15 +9111,27 @@ fn run_instance(command: InstanceCommands) -> anyhow::Result<i32> {
                 let r = store
                     .purge_instance(&id)
                     .map_err(|e| anyhow::anyhow!(e))?;
-                let total = r.repos + r.files + r.symbols + r.vaults + r.notes + r.projects;
+                let total = r.repos
+                    + r.files
+                    + r.symbols
+                    + r.vaults
+                    + r.notes
+                    + r.projects
+                    + r.orphans_swept;
                 if total == 0 {
                     println!("No graph rows found for instance '{id}' — database is clean.");
                 } else {
                     println!(
                         "Purged instance '{id}' from graph: {} repo(s), \
                          {} file(s), {} symbol(s), {} vault(s), {} note(s), \
-                         {} project(s)",
-                        r.repos, r.files, r.symbols, r.vaults, r.notes, r.projects
+                         {} project(s), {} orphan(s)",
+                        r.repos,
+                        r.files,
+                        r.symbols,
+                        r.vaults,
+                        r.notes,
+                        r.projects,
+                        r.orphans_swept
                     );
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1696,6 +1696,16 @@ enum BrainCommands {
             help = "Rerank the top-N retrieved candidates (Feature F17, heuristic, off by default)"
         )]
         rerank: bool,
+        /// Query intent override that tunes PPR's damping factor and edge
+        /// weights. Same accepted values as `nestweaver context --intent`.
+        /// When omitted, the engine auto-detects an intent from the seed
+        /// kinds. Mirrors the lower-level `context --intent` flag so callers
+        /// can force a specific traversal profile against the unified brain.
+        #[arg(
+            long = "intent",
+            help = "Query intent override: find-definition, understand-architecture, analyze-impact, blast-radius, general-context"
+        )]
+        intent: Option<String>,
     },
     /// List wikilinks whose target is ambiguous or low-confidence
     /// (confidence < 1.0), with suggested target notes for each.
@@ -7091,6 +7101,7 @@ fn run_brain(
 
         BrainCommands::Remove { path, instance, db } => {
             let db_path = db.unwrap_or_else(default_db_path);
+            let instance_specified = instance.is_some();
             let instance_id = instance.as_deref().unwrap_or("default");
 
             let canonical = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
@@ -7099,23 +7110,45 @@ fn run_brain(
 
             let store = open_store(Some(&db_path))?;
 
-            // Collect all vault UIDs that should be removed:
-            // 1. The computed UID (normal case).
-            // 2. Any vault whose root_path matches, regardless of instance
-            //    (catches ghost rows left by buggy merges with wrong UIDs).
-            let mut uids_to_remove: Vec<String> = vec![v_uid];
-            if let Ok(all_vaults) = store.list_vaults(None) {
-                for v in &all_vaults {
-                    let v_canon = std::fs::canonicalize(&v.root_path)
-                        .map(|p| p.to_string_lossy().to_string())
-                        .unwrap_or_else(|_| v.root_path.clone());
-                    if v_canon == *canon_str && !uids_to_remove.contains(&v.uid) {
-                        uids_to_remove.push(v.uid.clone());
+            // If the caller passed `--instance`, treat it as a precise
+            // selector: only the row owned by that instance is removed.
+            // This is required to disambiguate ghost-row situations
+            // without nuking the populated row that lives at the same
+            // path. If the requested row does not exist, fail loudly
+            // rather than silently scrubbing every other instance at
+            // the path.
+            //
+            // If `--instance` is absent, fall back to the historical
+            // ghost-row cleanup behavior: remove the default-UID row
+            // plus any other row whose canonical root_path matches.
+            let mut uids_to_remove: Vec<String> = Vec::new();
+            if instance_specified {
+                if store.lookup_vault(&v_uid).is_ok() {
+                    uids_to_remove.push(v_uid);
+                } else {
+                    eprintln!(
+                        "Error: no vault with instance '{instance_id}' found at {canon_str}.\n  \
+                         Run `nestweaver brain status` to see registered vaults and their instance ids,\n  \
+                         then re-run with the correct --instance (or omit --instance to clean up every row at this path)."
+                    );
+                    return Ok((EXIT_NOT_FOUND, None));
+                }
+            } else {
+                uids_to_remove.push(v_uid);
+                if let Ok(all_vaults) = store.list_vaults(None) {
+                    for v in &all_vaults {
+                        let v_canon = std::fs::canonicalize(&v.root_path)
+                            .map(|p| p.to_string_lossy().to_string())
+                            .unwrap_or_else(|_| v.root_path.clone());
+                        if v_canon == *canon_str && !uids_to_remove.contains(&v.uid) {
+                            uids_to_remove.push(v.uid.clone());
+                        }
                     }
                 }
             }
 
             let mut total_dropped = 0usize;
+            let mut rows_cleaned = 0usize;
             let mut vault_name = path
                 .file_name()
                 .and_then(|s| s.to_str())
@@ -7125,17 +7158,26 @@ fn run_brain(
                 if let Ok(v) = store.lookup_vault(uid) {
                     vault_name = v.name;
                 }
-                if let Ok(n) = store.delete_vault_cascade(uid) {
-                    total_dropped += n;
+                match store.delete_vault_cascade(uid) {
+                    Ok(n) => {
+                        total_dropped += n;
+                        rows_cleaned += 1;
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "Error: failed to remove vault '{uid}': {e}.\n  \
+                             If a daemon is running it may be holding the write lock; \
+                             stop it with `nestweaver daemon stop` and retry."
+                        );
+                        return Ok((EXIT_ERROR, None));
+                    }
                 }
             }
             println!(
                 "Removed vault '{}' ({} note(s) dropped, {} row(s) cleaned). \
                  Tantivy + PPR sidecars may be stale; run \
                  `nestweaver brain reindex-search` if you want to clear them too.",
-                vault_name,
-                total_dropped,
-                uids_to_remove.len()
+                vault_name, total_dropped, rows_cleaned
             );
             Ok((EXIT_SUCCESS, None))
         }
@@ -7489,8 +7531,18 @@ fn run_brain(
             root,
             prf,
             rerank,
+            intent,
         } => {
             let db_path = resolve_db_with_config(db, config_path.as_deref())?;
+
+            // Parse the optional --intent override into a `QueryIntent`.
+            // Surface invalid values as a CLI error rather than silently
+            // ignoring (mirrors `nestweaver context --intent`).
+            let parsed_intent: Option<QueryIntent> = intent
+                .as_deref()
+                .map(|s| s.parse())
+                .transpose()
+                .map_err(|e| anyhow::anyhow!("invalid --intent value: {e}"))?;
 
             // Route through daemon's GetContext RPC when available and no
             // flags require direct-disk processing.
@@ -7503,65 +7555,68 @@ fn run_brain(
                     config_path.as_deref(),
                 ));
                 if let Ok(mut client) = connect {
-                    let req = nestweaver_proto::BrainContextRequest {
-                        seeds: seeds.clone(),
-                        token_budget: token_budget.unwrap_or(0) as i32,
-                        response_format: String::new(),
-                        repos: repos.clone(),
-                        vaults: vaults.clone(),
-                        kinds: kinds.clone(),
-                        path_prefix: path_prefix.clone().unwrap_or_default(),
-                        tags: tags.clone(),
-                        exclude_tags: exclude_tags.clone(),
-                        weight_ppr: weight_ppr.unwrap_or(0.0),
-                        weight_bm25: weight_bm25.unwrap_or(0.0),
-                        intent: String::new(),
-                        include_seeds: true,
-                        include_bodies: inline_bodies,
-                        root: root
-                            .clone()
-                            .unwrap_or_default()
-                            .to_string_lossy()
-                            .to_string(),
-                        prf,
-                        rerank,
-                    };
-                    let rpc = rt.block_on(async {
-                        client
-                            .inner_mut()
-                            .get_context(req)
-                            .await
-                            .map(|r| r.into_inner())
-                    });
-                    match rpc {
-                        Ok(resp) => {
-                            let result: nestweaver_engine::BrainContextResult =
-                                serde_json::from_str(&resp.result_json)?;
-                            let cut = match token_budget {
-                                Some(budget) => token_budgeted_truncate(&result.connected, budget),
-                                None => limit.min(result.connected.len()),
-                            };
-                            if json {
-                                print_brain_context_json(&result, cut)?;
-                            } else {
-                                print_brain_context_text(&result, cut, token_budget);
+                        let req = nestweaver_proto::BrainContextRequest {
+                            seeds: seeds.clone(),
+                            token_budget: token_budget.unwrap_or(0) as i32,
+                            response_format: String::new(),
+                            repos: repos.clone(),
+                            vaults: vaults.clone(),
+                            kinds: kinds.clone(),
+                            path_prefix: path_prefix.clone().unwrap_or_default(),
+                            tags: tags.clone(),
+                            exclude_tags: exclude_tags.clone(),
+                            weight_ppr: weight_ppr.unwrap_or(0.0),
+                            weight_bm25: weight_bm25.unwrap_or(0.0),
+                            // Pass the parsed --intent through to the daemon
+                            // (empty string = auto-detect on the server).
+                            intent: intent.clone().unwrap_or_default(),
+                            include_seeds: true,
+                            include_bodies: inline_bodies,
+                            root: root
+                                .clone()
+                                .unwrap_or_default()
+                                .to_string_lossy()
+                                .to_string(),
+                            prf,
+                            rerank,
+                        };
+                        let rpc = rt.block_on(async {
+                            client
+                                .inner_mut()
+                                .get_context(req)
+                                .await
+                                .map(|r| r.into_inner())
+                        });
+                        match rpc {
+                            Ok(resp) => {
+                                let result: nestweaver_engine::BrainContextResult =
+                                    serde_json::from_str(&resp.result_json)?;
+                                let cut = match token_budget {
+                                    Some(budget) => {
+                                        token_budgeted_truncate(&result.connected, budget)
+                                    }
+                                    None => limit.min(result.connected.len()),
+                                };
+                                if json {
+                                    print_brain_context_json(&result, cut)?;
+                                } else {
+                                    print_brain_context_text(&result, cut, token_budget);
+                                }
+                                let node_count = result.seeds.len() + cut;
+                                let stats = format!(
+                                    "{} nodes in {} (via daemon)",
+                                    node_count,
+                                    format_elapsed(t0.elapsed())
+                                );
+                                return Ok((EXIT_SUCCESS, Some(stats)));
                             }
-                            let node_count = result.seeds.len() + cut;
-                            let stats = format!(
-                                "{} nodes in {} (via daemon)",
-                                node_count,
-                                format_elapsed(t0.elapsed())
-                            );
-                            return Ok((EXIT_SUCCESS, Some(stats)));
+                            Err(status) => {
+                                eprintln!(
+                                    "warning: daemon context RPC failed ({}); falling back to direct DB read",
+                                    status.message()
+                                );
+                            }
                         }
-                        Err(status) => {
-                            eprintln!(
-                                "warning: daemon context RPC failed ({}); falling back to direct DB read",
-                                status.message()
-                            );
-                        }
-                    }
-                }
             }
 
             let store = open_store(Some(&db_path))?;
@@ -7591,16 +7646,28 @@ fn run_brain(
                     .unwrap_or(false);
 
             // RFC #6: build custom HybridSearchConfig from optional CLI flags.
+            // Feature F-test-deboost: thread `[ranking] test_path_patterns`
+            // from the instance config into the search config so user
+            // overrides reach `search_symbols_by_name` at seed resolution.
             let defaults = HybridSearchConfig::default();
+            let configured_test_patterns: Option<Vec<String>> = instance_cfg
+                .as_ref()
+                .map(|c| c.ranking.test_path_patterns.clone())
+                .filter(|p| !p.is_empty());
             let config = HybridSearchConfig {
                 weight_ppr: weight_ppr.unwrap_or(defaults.weight_ppr),
                 weight_bm25: weight_bm25.unwrap_or(defaults.weight_bm25),
                 weight_semantic: weight_semantic.unwrap_or(defaults.weight_semantic),
                 prf: prf_enabled,
+                test_path_patterns: configured_test_patterns
+                    .unwrap_or_else(|| defaults.test_path_patterns.clone()),
                 ..defaults
             };
 
             let aliases = load_alias_sidecar(&db_path);
+            // Thread the parsed `--intent` override (if any) into the PPR
+            // engine. None → engine auto-detects from seed kinds, matching
+            // historical behavior.
             match build_brain_context_hybrid_with_aliases(
                 &store,
                 &seeds,
@@ -7608,7 +7675,7 @@ fn run_brain(
                 &config,
                 &aliases,
                 Some(&db_path),
-                None,
+                parsed_intent,
             ) {
                 Ok(mut result) => {
                     // Feature F6: apply per-path ranking priors (dampen/boost)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1408,6 +1408,7 @@ enum RankingCommands {
 }
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 enum BrainCommands {
     /// Index a markdown vault into the brain. Auto-detects Obsidian vault
     /// (.obsidian/ present) vs plain markdown folder.
@@ -1897,10 +1898,24 @@ enum InstanceCommands {
     },
     /// List all registered instances
     List,
-    /// Remove a registered instance
+    /// Remove a registered instance. With `--purge-graph`, also
+    /// cascade-delete every Repo/File/Symbol/Vault/Note/Project owned by
+    /// the instance from the graph database. Useful for cleaning up a
+    /// ghost instance left behind by a misconfigured `instance merge`.
     Remove {
         /// Instance ID to remove
         id: String,
+        /// Also cascade-delete the instance's data from the graph
+        /// database (Repos and their children, Vaults and their notes,
+        /// Projects). When set, missing registry entries are tolerated
+        /// so ghost instances can be cleaned up.
+        #[arg(long)]
+        purge_graph: bool,
+        #[arg(
+            long,
+            help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
+        )]
+        db: Option<PathBuf>,
     },
     /// Pull the latest snapshot for an instance
     Pull {
@@ -9027,11 +9042,48 @@ fn run_instance(command: InstanceCommands) -> anyhow::Result<i32> {
             }
             Ok(EXIT_SUCCESS)
         }
-        InstanceCommands::Remove { id } => {
+        InstanceCommands::Remove {
+            id,
+            purge_graph,
+            db,
+        } => {
             let mut registry =
                 nestweaver_engine::Registry::load_or_create(&default_registry_path())?;
-            registry.remove(&id)?;
-            println!("Removed instance '{id}'");
+            let registry_removed = match registry.remove(&id) {
+                Ok(()) => true,
+                Err(e) => {
+                    // With --purge-graph we tolerate a missing registry
+                    // entry so ghost instances (left by a misconfigured
+                    // merge) can still be cleaned out of the graph.
+                    if purge_graph {
+                        eprintln!("Note: {e}; continuing with graph purge");
+                        false
+                    } else {
+                        return Err(e);
+                    }
+                }
+            };
+            if registry_removed {
+                println!("Removed instance '{id}' from registry");
+            }
+            if purge_graph {
+                let db_path = db.unwrap_or_else(default_db_path);
+                let store = open_store(Some(&db_path))?;
+                let r = store
+                    .purge_instance(&id)
+                    .map_err(|e| anyhow::anyhow!(e))?;
+                let total = r.repos + r.files + r.symbols + r.vaults + r.notes + r.projects;
+                if total == 0 {
+                    println!("No graph rows found for instance '{id}' — database is clean.");
+                } else {
+                    println!(
+                        "Purged instance '{id}' from graph: {} repo(s), \
+                         {} file(s), {} symbol(s), {} vault(s), {} note(s), \
+                         {} project(s)",
+                        r.repos, r.files, r.symbols, r.vaults, r.notes, r.projects
+                    );
+                }
+            }
             Ok(EXIT_SUCCESS)
         }
         InstanceCommands::Pull { id } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4900,8 +4900,34 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         .sum();
                     let remaining_budget = token_budget.saturating_sub(seed_tokens);
                     let cut = token_budgeted_truncate(&result.connected, remaining_budget);
+                    let connected_tokens: usize = result
+                        .connected
+                        .iter()
+                        .take(cut)
+                        .map(render_cost_tokens)
+                        .sum();
+                    let used_tokens = seed_tokens + connected_tokens;
+                    // Load external_refs from the extension sidecar so the
+                    // local (--no-daemon) path matches the daemon/MCP wrapper
+                    // shape — agents rely on this for Workfront / wiki PRD
+                    // surfacing.
+                    let ext_store = nestweaver_engine::load_extensions(&db_path);
+                    let external_refs = nestweaver_engine::get_all_properties(
+                        &ext_store,
+                        &project.uid,
+                    )
+                    .get("external_refs")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
                     if json {
-                        print_brain_context_json(&result, cut)?;
+                        print_project_context_json(
+                            &project,
+                            &result,
+                            cut,
+                            used_tokens,
+                            token_budget,
+                            &external_refs,
+                        )?;
                     } else {
                         println!("Project: {}  ({})", project.name, project.uid);
                         if let Some(ref summary) = project.summary {
@@ -7941,6 +7967,7 @@ fn run_brain(
                                 );
                             }
                         }
+                }
             }
 
             let store = open_store(Some(&db_path))?;
@@ -9020,6 +9047,40 @@ fn print_brain_context_json(result: &BrainContextResult, limit: usize) -> anyhow
         resp["expansion_terms"] = serde_json::json!(result.expansion_terms);
     }
 
+    println!("{}", serde_json::to_string_pretty(&resp)?);
+    Ok(())
+}
+
+/// Render the `project-context` JSON for the local (--no-daemon) path with
+/// the same wrapper shape the daemon / MCP `project_context` tool emits:
+/// `project`, `project_uid`, `seeds_expanded`, `connected`, `tokens_used`,
+/// `token_budget`, and optional `unresolved_seeds` / `external_refs`. Agents
+/// depend on these fields, so the local and daemon paths must stay aligned.
+fn print_project_context_json(
+    project: &nestweaver_schema::Project,
+    result: &BrainContextResult,
+    limit: usize,
+    tokens_used: usize,
+    token_budget: usize,
+    external_refs: &serde_json::Value,
+) -> anyhow::Result<()> {
+    let mut resp = serde_json::json!({
+        "project": project.name,
+        "project_uid": project.uid,
+        "seeds_expanded": result.seeds.len(),
+        "connected": result.connected.iter().take(limit).collect::<Vec<_>>(),
+        "tokens_used": tokens_used,
+        "token_budget": token_budget,
+    });
+    if !result.unresolved_seeds.is_empty() {
+        resp["unresolved_seeds"] = serde_json::json!(result.unresolved_seeds);
+    }
+    if !result.expansion_terms.is_empty() {
+        resp["expansion_terms"] = serde_json::json!(result.expansion_terms);
+    }
+    if !external_refs.is_null() {
+        resp["external_refs"] = external_refs.clone();
+    }
     println!("{}", serde_json::to_string_pretty(&resp)?);
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7970,21 +7970,21 @@ fn run_brain(
                     .unwrap_or(false);
 
             // RFC #6: build custom HybridSearchConfig from optional CLI flags.
-            // Feature F-test-deboost: thread `[ranking] test_path_patterns`
-            // from the instance config into the search config so user
-            // overrides reach `search_symbols_by_name` at seed resolution.
+            // Finding #7: thread `[seed_resolution]` (with backward-compat
+            // shim for legacy `[ranking].test_path_patterns`) from the
+            // instance config into the search config so user overrides reach
+            // `search_symbols_by_name` at seed resolution.
             let defaults = HybridSearchConfig::default();
-            let configured_test_patterns: Option<Vec<String>> = instance_cfg
+            let configured_seed_resolution = instance_cfg
                 .as_ref()
-                .map(|c| c.ranking.test_path_patterns.clone())
-                .filter(|p| !p.is_empty());
+                .map(|c| c.seed_resolution.clone());
             let config = HybridSearchConfig {
                 weight_ppr: weight_ppr.unwrap_or(defaults.weight_ppr),
                 weight_bm25: weight_bm25.unwrap_or(defaults.weight_bm25),
                 weight_semantic: weight_semantic.unwrap_or(defaults.weight_semantic),
                 prf: prf_enabled,
-                test_path_patterns: configured_test_patterns
-                    .unwrap_or_else(|| defaults.test_path_patterns.clone()),
+                seed_resolution: configured_seed_resolution
+                    .unwrap_or_else(|| defaults.seed_resolution.clone()),
                 ..defaults
             };
 
@@ -8050,17 +8050,22 @@ fn run_brain(
                     apply_filters(&mut result.connected);
 
                     // `--no-tests`: drop rows whose location matches any
-                    // test_path_pattern. Distinct from the soft deboost the
-                    // ranking pass already applied — this removes the rows
-                    // entirely so a strict-prod caller never sees them.
+                    // configured seed-resolution path rule (prefix or
+                    // suffix). Distinct from the soft deboost the ranking
+                    // pass already applied — this removes the rows entirely
+                    // so a strict-prod caller never sees them.
                     if no_tests {
-                        let patterns = &config.test_path_patterns;
-                        if !patterns.is_empty() {
+                        let rules = &config.seed_resolution.path_deboost;
+                        if !rules.is_empty() {
                             let is_test_path = |loc: &str| -> bool {
                                 let lower = loc.to_lowercase();
-                                patterns.iter().any(|p| {
-                                    let needle = p.trim_start_matches('/').to_lowercase();
-                                    !needle.is_empty() && lower.contains(&needle)
+                                rules.iter().any(|r| match (&r.prefix, &r.suffix) {
+                                    (Some(prefix), None) => {
+                                        let needle = prefix.trim_start_matches('/').to_lowercase();
+                                        !needle.is_empty() && lower.contains(&needle)
+                                    }
+                                    (None, Some(suffix)) => loc.ends_with(suffix.as_str()),
+                                    _ => false,
                                 })
                             };
                             let drop_tests = |nodes: &mut Vec<nestweaver_engine::BrainNode>| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1720,6 +1720,25 @@ enum BrainCommands {
             help = "Query intent override: find-definition, understand-architecture, analyze-impact, blast-radius, general-context"
         )]
         intent: Option<String>,
+        /// Hard-filter test-path nodes out of both seeds and connected
+        /// results. Distinct from the existing soft test-path deboost
+        /// multiplier — this drops the rows entirely. Useful when callers
+        /// want production-only context (e.g. for diffs that should not
+        /// surface fixtures or playwright specs).
+        #[arg(
+            long = "no-tests",
+            help = "Hard-filter test-path nodes out of seeds + connected results (in addition to the soft deboost)"
+        )]
+        no_tests: bool,
+        /// Prefer a specific instance_id when ranking. When the database
+        /// contains rows from multiple instance_ids (e.g. mid-merge), this
+        /// scopes results to nodes registered under the given instance.
+        /// Pass `--prefer-instance <id>` to scope to that instance only.
+        #[arg(
+            long = "prefer-instance",
+            help = "Scope ranking to nodes registered under this instance_id"
+        )]
+        prefer_instance: Option<String>,
     },
     /// List wikilinks whose target is ambiguous or low-confidence
     /// (confidence < 1.0), with suggested target notes for each.
@@ -6468,11 +6487,21 @@ fn run_brain(
                     println!("  Wikilinks: {wikilinks}");
                     println!("  Repos:     {repo_count}");
                     // Interaction tracking — local check (not in MCP response).
+                    // The sidecar is created (empty) by `InteractionTracker::new`
+                    // when an MCP/daemon starts with --track-interactions, so:
+                    //   - file present + scores > 0  -> "enabled, N scored"
+                    //   - file present + scores == 0 -> "enabled (no events yet)"
+                    //   - file absent                -> "disabled"
                     match nestweaver_engine::load_interaction_data(db_path) {
-                        Some(data) => {
+                        Some(data) if !data.scores.is_empty() => {
                             println!(
                                 "  interaction_tracking: enabled ({} nodes scored)",
                                 data.scores.len()
+                            );
+                        }
+                        Some(_) => {
+                            println!(
+                                "  interaction_tracking: enabled (no events recorded yet)"
                             );
                         }
                         None => {
@@ -6508,11 +6537,32 @@ fn run_brain(
                                 eprintln!(
                                     "  This usually means brain add was run with different --instance values."
                                 );
-                                eprintln!(
-                                    "  Fix one row precisely with:\n      nestweaver brain remove --instance <instance-id>\n  \
-                                     Or sweep all rows at this path:\n      nestweaver brain remove {root}\n  \
-                                     Or consolidate under one instance:\n      nestweaver instance merge --from <old-id> --to <correct-id>"
-                                );
+                                // Prefer the targeted remediation produced
+                                // by tool_brain_status when present, fall
+                                // back to the generic three-option guidance
+                                // for older daemon binaries.
+                                let cmds = w["remediation_commands"]
+                                    .as_array()
+                                    .cloned()
+                                    .unwrap_or_default();
+                                let hint = w["remediation_hint"].as_str().unwrap_or("");
+                                if !cmds.is_empty() {
+                                    if !hint.is_empty() {
+                                        eprintln!("  {hint}");
+                                    }
+                                    eprintln!("  Run:");
+                                    for c in &cmds {
+                                        if let Some(s) = c.as_str() {
+                                            eprintln!("      {s}");
+                                        }
+                                    }
+                                } else {
+                                    eprintln!(
+                                        "  Fix one row precisely with:\n      nestweaver brain remove --instance <instance-id>\n  \
+                                         Or sweep all rows at this path:\n      nestweaver brain remove {root}\n  \
+                                         Or consolidate under one instance:\n      nestweaver instance merge --from <old-id> --to <correct-id>"
+                                    );
+                                }
                             }
                         }
                     }
@@ -6552,67 +6602,63 @@ fn run_brain(
             }
 
             if json {
-                #[derive(serde::Serialize)]
-                struct VaultDetail {
-                    /// Vault UID (sym `vlt:<instance>:<hash>`). Needed when
-                    /// callers want to pass this row to `brain remove --instance`
-                    /// or `instance merge --from/--to`.
-                    uid: String,
-                    /// Instance the row is registered under. Surfaces the
-                    /// row-to-instance mapping that was previously only visible
-                    /// in aggregate `instance_ids`.
-                    instance_id: String,
-                    name: String,
-                    root_path: String,
-                    note_count: usize,
-                    last_indexed: Option<String>,
-                }
-                #[derive(serde::Serialize)]
-                struct Status {
-                    db: String,
-                    vaults: usize,
-                    vault_details: Vec<VaultDetail>,
-                    notes: usize,
-                    headings: usize,
-                    sections: usize,
-                    tags: usize,
-                    wikilinks: usize,
-                    repos: usize,
-                    instance_ids: Vec<String>,
-                }
-                let vault_details: Vec<VaultDetail> = vaults
+                // Match the canonical schema emitted by `tool_brain_status`
+                // so daemon-routed and local (`--no-daemon`) callers parse
+                // identical shapes:
+                //   - `vaults` is an array of vault detail objects.
+                //   - `vault_count` is the total count.
+                //   - `repos` is an array of repo objects; `repo_count` the total.
+                // `vault_details` is preserved as an alias for `vaults` so
+                // scripts written against the previous local-only shape keep
+                // working through the deprecation window.
+                let vault_details: Vec<serde_json::Value> = vaults
                     .iter()
                     .map(|v| {
                         let vault_note_count =
                             store.list_notes(Some(&v.uid)).unwrap_or_default().len();
                         let last_indexed = resolve_last_indexed(db_path, &v.uid, &store);
-                        VaultDetail {
-                            uid: v.uid.clone(),
-                            instance_id: v.instance_id.clone(),
-                            name: v.name.clone(),
-                            root_path: v.root_path.clone(),
-                            note_count: vault_note_count,
-                            last_indexed,
-                        }
+                        serde_json::json!({
+                            "uid": v.uid,
+                            "instance_id": v.instance_id,
+                            "name": v.name,
+                            "root_path": v.root_path,
+                            "note_count": vault_note_count,
+                            "last_indexed": last_indexed,
+                        })
+                    })
+                    .collect();
+                let repo_details: Vec<serde_json::Value> = repos
+                    .iter()
+                    .map(|r| {
+                        serde_json::json!({
+                            "url": r.url,
+                            "sha": r.indexed_sha,
+                            "instance_id": r.instance_id,
+                            "name": r.name,
+                        })
                     })
                     .collect();
                 let mut instance_ids: std::collections::BTreeSet<&str> =
                     vaults.iter().map(|v| v.instance_id.as_str()).collect();
                 instance_ids.extend(repos.iter().map(|r| r.instance_id.as_str()));
+                let instance_ids_json: Vec<String> =
+                    instance_ids.into_iter().map(|s| s.to_string()).collect();
                 println!(
                     "{}",
-                    serde_json::to_string_pretty(&Status {
-                        db: db_path.display().to_string(),
-                        vaults: vaults.len(),
-                        vault_details,
-                        notes: note_count,
-                        headings: heading_count,
-                        sections: section_count,
-                        tags: tag_count,
-                        wikilinks: wikilink_count,
-                        repos: repos.len(),
-                        instance_ids: instance_ids.into_iter().map(|s| s.to_string()).collect(),
-                    })?
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "db": db_path.display().to_string(),
+                        "vaults": vault_details,
+                        "vault_count": vaults.len(),
+                        "vault_details": vault_details,
+                        "notes": note_count,
+                        "headings": heading_count,
+                        "sections": section_count,
+                        "tags": tag_count,
+                        "wikilinks": wikilink_count,
+                        "repos": repo_details,
+                        "repo_count": repos.len(),
+                        "instance_ids": instance_ids_json,
+                    }))?
                 );
             } else {
                 println!("Brain status:");
@@ -6658,14 +6704,20 @@ fn run_brain(
                 println!("  Wikilinks: {wikilink_count}");
                 println!("  Repos:     {}", repos.len());
                 // Interaction tracking is opt-in (enabled via `mcp
-                // --track-interactions`). Its presence is indicated by an
-                // interaction sidecar; when absent, surface the hint.
+                // --track-interactions`). InteractionTracker::new touches
+                // the sidecar at startup so we can distinguish three states:
+                //   - file present + scores > 0  -> enabled, accumulating
+                //   - file present + scores == 0 -> enabled, no events yet
+                //   - file absent                -> disabled
                 match nestweaver_engine::load_interaction_data(db_path) {
-                    Some(data) => {
+                    Some(data) if !data.scores.is_empty() => {
                         println!(
                             "  interaction_tracking: enabled ({} nodes scored)",
                             data.scores.len()
                         );
+                    }
+                    Some(_) => {
+                        println!("  interaction_tracking: enabled (no events recorded yet)");
                     }
                     None => {
                         println!(
@@ -7650,6 +7702,8 @@ fn run_brain(
             prf,
             rerank,
             intent,
+            no_tests,
+            prefer_instance,
         } => {
             let db_path = resolve_db_with_config(db, config_path.as_deref())?;
 
@@ -7663,9 +7717,14 @@ fn run_brain(
                 .map_err(|e| anyhow::anyhow!("invalid --intent value: {e}"))?;
 
             // Route through daemon's GetContext RPC when available and no
-            // flags require direct-disk processing.
+            // flags require direct-disk processing. `--no-tests` and
+            // `--prefer-instance` are applied client-side and the daemon
+            // proto does not yet carry them, so fall through to the local
+            // path when either is set.
             if use_daemon
                 && since.is_none()
+                && !no_tests
+                && prefer_instance.is_none()
                 && let Ok(rt) = tokio::runtime::Runtime::new()
             {
                 let connect = rt.block_on(nestweaver_client::DaemonClient::connect(
@@ -7842,6 +7901,47 @@ fn run_brain(
                     };
                     apply_filters(&mut result.seeds);
                     apply_filters(&mut result.connected);
+
+                    // `--no-tests`: drop rows whose location matches any
+                    // test_path_pattern. Distinct from the soft deboost the
+                    // ranking pass already applied — this removes the rows
+                    // entirely so a strict-prod caller never sees them.
+                    if no_tests {
+                        let patterns = &config.test_path_patterns;
+                        if !patterns.is_empty() {
+                            let is_test_path = |loc: &str| -> bool {
+                                let lower = loc.to_lowercase();
+                                patterns.iter().any(|p| {
+                                    let needle = p.trim_start_matches('/').to_lowercase();
+                                    !needle.is_empty() && lower.contains(&needle)
+                                })
+                            };
+                            let drop_tests = |nodes: &mut Vec<nestweaver_engine::BrainNode>| {
+                                nodes.retain(|n| !is_test_path(&n.location));
+                            };
+                            drop_tests(&mut result.seeds);
+                            drop_tests(&mut result.connected);
+                        }
+                    }
+
+                    // `--prefer-instance <id>`: scope ranking to a single
+                    // instance_id. UIDs encode the owning instance as a
+                    // delimited segment: `note:vlt:<inst>:<hash>:...`,
+                    // `sym:repo:<inst>:<hash>:...`, `repo:<inst>:<hash>`,
+                    // etc. Matching on `:<inst>:` is robust to a partially-
+                    // merged DB where some symbol UIDs still encode the
+                    // pre-merge repo UID — both the old and new forms still
+                    // carry an `:<inst>:` segment that uniquely identifies
+                    // the instance, and the leading and trailing colons
+                    // prevent accidental substring collisions with hashes.
+                    if let Some(ref target) = prefer_instance {
+                        let needle = format!(":{target}:");
+                        let filter_inst = |nodes: &mut Vec<nestweaver_engine::BrainNode>| {
+                            nodes.retain(|n| n.uid.contains(needle.as_str()));
+                        };
+                        filter_inst(&mut result.seeds);
+                        filter_inst(&mut result.connected);
+                    }
 
                     // tags filter: keep only note/section nodes tagged with any of these.
                     if !tags.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4621,6 +4621,48 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             recency_half_life_days,
         } => {
             let db_path = db.unwrap_or_else(default_db_path);
+
+            if use_daemon
+                && let Ok(rt) = tokio::runtime::Runtime::new()
+            {
+                let connect =
+                    rt.block_on(nestweaver_client::DaemonClient::connect(&db_path, None));
+                if let Ok(mut client) = connect {
+                    let req = nestweaver_proto::ProjectContextRequest {
+                        project: name.clone(),
+                        token_budget: token_budget as i32,
+                        kinds: vec![],
+                        include_components,
+                        intent: String::new(),
+                        include_seeds: false,
+                        since: since.clone().unwrap_or_default(),
+                        recency_weight,
+                        recency_half_life_days,
+                    };
+                    let rpc = rt.block_on(async {
+                        client
+                            .inner_mut()
+                            .get_project_context(req)
+                            .await
+                            .map(|r| r.into_inner())
+                    });
+                    match rpc {
+                        Ok(resp) => {
+                            let value: serde_json::Value =
+                                serde_json::from_str(&resp.result_json)?;
+                            render_project_context_daemon_response(&value, json, token_budget);
+                            return Ok((EXIT_SUCCESS, None));
+                        }
+                        Err(status) => {
+                            tracing::info!(
+                                "daemon GetProjectContext failed ({}); falling back to direct mode",
+                                status.message()
+                            );
+                        }
+                    }
+                }
+            }
+
             let store = open_store(Some(&db_path))?;
             let tantivy_path = tantivy_sidecar_path_for(&db_path);
             let tantivy = TantivyIndex::open_reader_only(&tantivy_path).ok();
@@ -4785,6 +4827,10 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         &mut result,
                         &member_symbol_uids,
                     );
+                    // Drop Heading/Section duplicates: notes-heavy projects
+                    // would otherwise spend ~25% of a 2000-token budget on
+                    // pairs that share `(file, title)` and add no information.
+                    nestweaver_engine::dedup_heading_section_pairs(&mut result);
 
                     // Post-PPR scope boost: multiply relevance for nodes that
                     // belong to the project so declared content ranks highest.
@@ -8905,6 +8951,53 @@ fn render_brain_search_response(
         }
     }
     Ok(())
+}
+
+/// Render the daemon's `project_context` JSON response (shape produced by
+/// `tool_project_context` in nestweaver-mcp). When `json` is true, emit the
+/// response verbatim; otherwise print a project header followed by the
+/// connected nodes.
+fn render_project_context_daemon_response(
+    value: &serde_json::Value,
+    json: bool,
+    token_budget: usize,
+) {
+    if json {
+        match serde_json::to_string_pretty(value) {
+            Ok(s) => println!("{s}"),
+            Err(e) => eprintln!("warning: failed to serialize daemon response: {e}"),
+        }
+        return;
+    }
+    let project = value.get("project").and_then(|v| v.as_str()).unwrap_or("");
+    let project_uid = value
+        .get("project_uid")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let used = value
+        .get("tokens_used")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    println!("Project: {project}  ({project_uid})");
+    if let Some(note) = value.get("note").and_then(|v| v.as_str()) {
+        println!("  {note}");
+    }
+    println!();
+    let empty = vec![];
+    let connected = value
+        .get("connected")
+        .and_then(|v| v.as_array())
+        .unwrap_or(&empty);
+    println!("Connected ({} item(s)):", connected.len());
+    for n in connected {
+        let title = n.get("title").and_then(|v| v.as_str()).unwrap_or("");
+        let kind = n.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+        let location = n.get("location").and_then(|v| v.as_str()).unwrap_or("");
+        let rel = n.get("relevance").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        println!("  [{rel:.4}] {kind}  {title}  @{location}");
+    }
+    println!();
+    println!("Tokens used: {used} / budget: {token_budget}");
 }
 
 fn print_brain_context_json(result: &BrainContextResult, limit: usize) -> anyhow::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1593,18 +1593,27 @@ enum BrainCommands {
         #[arg(long, help = "Path to instance config (TOML)")]
         config: Option<PathBuf>,
         /// Filter results to nodes whose kind starts with one of these values
-        /// (e.g. Symbol, Note, Section, Tag, Heading).
+        /// (e.g. Symbol, Note, Section, Tag, Heading). Accepts comma-separated
+        /// values or repeated `--kinds` flags.
         #[arg(
             long = "kinds",
-            help = "Keep only nodes with these kind prefixes (e.g. Symbol, Note)"
+            value_delimiter = ',',
+            help = "Keep only nodes with these kind prefixes (e.g. Symbol,Note)"
         )]
         kinds: Vec<String>,
         /// Filter results to nodes associated with these repo UIDs or names.
-        #[arg(long = "repos", help = "Keep only nodes from these repo UIDs or names")]
+        /// Accepts comma-separated values or repeated `--repos` flags.
+        #[arg(
+            long = "repos",
+            value_delimiter = ',',
+            help = "Keep only nodes from these repo UIDs or names"
+        )]
         repos: Vec<String>,
         /// Filter results to nodes associated with these vault UIDs or names.
+        /// Accepts comma-separated values or repeated `--vaults` flags.
         #[arg(
             long = "vaults",
+            value_delimiter = ',',
             help = "Keep only nodes from these vault UIDs or names"
         )]
         vaults: Vec<String>,
@@ -1614,15 +1623,20 @@ enum BrainCommands {
             help = "Keep only nodes whose location starts with this prefix"
         )]
         path_prefix: Option<String>,
-        /// Include only nodes tagged with any of these tags (note/section nodes only).
+        /// Include only nodes tagged with any of these tags (note/section nodes
+        /// only). Accepts comma-separated values or repeated `--tags` flags.
         #[arg(
             long = "tags",
+            value_delimiter = ',',
             help = "Keep only note/section nodes tagged with any of these tags"
         )]
         tags: Vec<String>,
-        /// Exclude nodes tagged with any of these tags (note/section nodes only).
+        /// Exclude nodes tagged with any of these tags (note/section nodes
+        /// only). Accepts comma-separated values or repeated `--exclude-tags`
+        /// flags.
         #[arg(
             long = "exclude-tags",
+            value_delimiter = ',',
             help = "Exclude note/section nodes tagged with any of these tags"
         )]
         exclude_tags: Vec<String>,
@@ -6401,14 +6415,41 @@ fn run_brain(
                         .unwrap_or(0);
                     println!("  Vaults:    {}", vault_count);
                     if let Some(vaults) = value.get("vaults").and_then(|v| v.as_array()) {
+                        // When two rows share a name we annotate with the
+                        // instance_id so the user can target precise removes.
+                        // Empty-named rows (phantom registrations) always
+                        // get annotated so they don't render as blank lines.
+                        let mut name_counts: std::collections::HashMap<&str, usize> =
+                            std::collections::HashMap::new();
+                        for v in vaults {
+                            let name = v["name"].as_str().unwrap_or("?");
+                            *name_counts.entry(name).or_insert(0) += 1;
+                        }
                         for v in vaults {
                             let name = v["name"].as_str().unwrap_or("?");
                             let note_count = v["note_count"].as_u64().unwrap_or(0);
-                            let last_indexed = v["last_indexed"].as_str().unwrap_or("never");
-                            println!(
-                                "    - {} ({note_count} notes, last indexed: {last_indexed})",
-                                name
-                            );
+                            let last_indexed = v["last_indexed"]
+                                .as_str()
+                                .unwrap_or("never");
+                            let ambiguous =
+                                name_counts.get(name).copied().unwrap_or(0) > 1;
+                            let unnamed = name.is_empty();
+                            if ambiguous || unnamed {
+                                let instance = v["instance_id"].as_str().unwrap_or("?");
+                                let root_path = v["root_path"].as_str().unwrap_or("?");
+                                let display = if unnamed {
+                                    format!("<unnamed: {root_path}>")
+                                } else {
+                                    name.to_string()
+                                };
+                                println!(
+                                    "    - {display} [instance: {instance}] ({note_count} notes, last indexed: {last_indexed})"
+                                );
+                            } else {
+                                println!(
+                                    "    - {name} ({note_count} notes, last indexed: {last_indexed})"
+                                );
+                            }
                         }
                     }
                     let notes = value.get("notes").and_then(|v| v.as_u64()).unwrap_or(0);
@@ -6438,6 +6479,41 @@ fn run_brain(
                             println!(
                                 "  interaction_tracking: disabled (run with --track-interactions to enable)"
                             );
+                        }
+                    }
+                    // Forward structured warnings from the MCP response —
+                    // e.g. duplicate-vault-root collisions. Previously these
+                    // were only emitted on the local (non-daemon) code path.
+                    if let Some(warnings) = value.get("warnings").and_then(|v| v.as_array()) {
+                        for w in warnings {
+                            let kind = w["kind"].as_str().unwrap_or("");
+                            if kind == "duplicate_vault_root" {
+                                let root = w["root_path"].as_str().unwrap_or("?");
+                                let entries =
+                                    w["entries"].as_array().cloned().unwrap_or_default();
+                                eprintln!(
+                                    "Warning: {} vault entries share root path {}:",
+                                    entries.len(),
+                                    root
+                                );
+                                for e in &entries {
+                                    let name = e["name"].as_str().unwrap_or("?");
+                                    let instance = e["instance_id"].as_str().unwrap_or("?");
+                                    let uid = e["uid"].as_str().unwrap_or("?");
+                                    let n = e["note_count"].as_u64().unwrap_or(0);
+                                    eprintln!(
+                                        "    - {name} [instance: {instance}] uid={uid} ({n} notes)"
+                                    );
+                                }
+                                eprintln!(
+                                    "  This usually means brain add was run with different --instance values."
+                                );
+                                eprintln!(
+                                    "  Fix one row precisely with:\n      nestweaver brain remove --instance <instance-id>\n  \
+                                     Or sweep all rows at this path:\n      nestweaver brain remove {root}\n  \
+                                     Or consolidate under one instance:\n      nestweaver instance merge --from <old-id> --to <correct-id>"
+                                );
+                            }
                         }
                     }
                 }
@@ -6478,6 +6554,14 @@ fn run_brain(
             if json {
                 #[derive(serde::Serialize)]
                 struct VaultDetail {
+                    /// Vault UID (sym `vlt:<instance>:<hash>`). Needed when
+                    /// callers want to pass this row to `brain remove --instance`
+                    /// or `instance merge --from/--to`.
+                    uid: String,
+                    /// Instance the row is registered under. Surfaces the
+                    /// row-to-instance mapping that was previously only visible
+                    /// in aggregate `instance_ids`.
+                    instance_id: String,
                     name: String,
                     root_path: String,
                     note_count: usize,
@@ -6503,6 +6587,8 @@ fn run_brain(
                             store.list_notes(Some(&v.uid)).unwrap_or_default().len();
                         let last_indexed = resolve_last_indexed(db_path, &v.uid, &store);
                         VaultDetail {
+                            uid: v.uid.clone(),
+                            instance_id: v.instance_id.clone(),
                             name: v.name.clone(),
                             root_path: v.root_path.clone(),
                             note_count: vault_note_count,
@@ -6532,14 +6618,38 @@ fn run_brain(
                 println!("Brain status:");
                 println!("  Database:  {}", db_path.display());
                 println!("  Vaults:    {}", vaults.len());
+                // When two rows share a name + root_path we surface
+                // `instance_id` so the user can tell them apart and target
+                // `brain remove --instance <id>` precisely. Empty-named
+                // rows (phantom registrations) are always annotated so they
+                // don't render as blank lines.
+                let mut name_counts: std::collections::HashMap<&str, usize> =
+                    std::collections::HashMap::new();
+                for v in &vaults {
+                    *name_counts.entry(v.name.as_str()).or_insert(0) += 1;
+                }
                 for v in &vaults {
                     let vault_note_count = store.list_notes(Some(&v.uid)).unwrap_or_default().len();
                     let last_indexed = resolve_last_indexed(db_path, &v.uid, &store)
                         .unwrap_or_else(|| "never".to_string());
-                    println!(
-                        "    - {} ({vault_note_count} notes, last indexed: {last_indexed})",
-                        v.name
-                    );
+                    let ambiguous = name_counts.get(v.name.as_str()).copied().unwrap_or(0) > 1;
+                    let unnamed = v.name.is_empty();
+                    if ambiguous || unnamed {
+                        let display = if unnamed {
+                            format!("<unnamed: {}>", v.root_path)
+                        } else {
+                            v.name.clone()
+                        };
+                        println!(
+                            "    - {display} [instance: {}] ({vault_note_count} notes, last indexed: {last_indexed})",
+                            v.instance_id
+                        );
+                    } else {
+                        println!(
+                            "    - {} ({vault_note_count} notes, last indexed: {last_indexed})",
+                            v.name
+                        );
+                    }
                 }
                 println!("  Notes:     {note_count}");
                 println!("  Headings:  {heading_count}");
@@ -6568,29 +6678,37 @@ fn run_brain(
             // Warn when multiple vault UIDs map to the same canonical root
             // path — usually caused by brain add with mismatched --instance
             // or missing --config. This produces phantom 0-note vault rows.
-            let mut root_to_vaults: std::collections::HashMap<&str, Vec<&str>> =
+            // Each entry surfaces name + instance_id + uid so the user can
+            // target `brain remove --instance <id>` precisely.
+            let mut root_to_vaults: std::collections::HashMap<&str, Vec<&nestweaver_schema::Vault>> =
                 std::collections::HashMap::new();
             for v in &vaults {
                 root_to_vaults
                     .entry(v.root_path.as_str())
                     .or_default()
-                    .push(v.name.as_str());
+                    .push(v);
             }
-            for (root, names) in &root_to_vaults {
-                if names.len() > 1 {
+            for (root, rows) in &root_to_vaults {
+                if rows.len() > 1 {
                     eprintln!(
                         "Warning: {} vault entries share root path {}:",
-                        names.len(),
+                        rows.len(),
                         root
                     );
-                    eprintln!("  {}", names.join(", "));
+                    for v in rows {
+                        let n = store.list_notes(Some(&v.uid)).unwrap_or_default().len();
+                        eprintln!(
+                            "    - {} [instance: {}] uid={} ({} notes)",
+                            v.name, v.instance_id, v.uid, n
+                        );
+                    }
                     eprintln!(
                         "  This usually means brain add was run with different --instance values."
                     );
                     eprintln!(
-                        "  Fix with: nestweaver brain remove {root}\n  \
-                         Or:    nestweaver instance merge --from <old-id> --to <correct-id>\n  \
-                         Then:  nestweaver brain add {root}",
+                        "  Fix one row precisely with:\n      nestweaver brain remove --instance <instance-id>\n  \
+                         Or sweep all rows at this path:\n      nestweaver brain remove {root}\n  \
+                         Or consolidate under one instance:\n      nestweaver instance merge --from <old-id> --to <correct-id>",
                     );
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7291,26 +7291,68 @@ fn run_brain(
 
             let canonical = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
             let canon_str = canonical.to_string_lossy();
-            let v_uid = nestweaver_schema::vault_uid(instance_id, &canon_str);
+            let raw_str = path.to_string_lossy();
+            let v_uid_canon = nestweaver_schema::vault_uid(instance_id, &canon_str);
+            let v_uid_raw = nestweaver_schema::vault_uid(instance_id, &raw_str);
 
             let store = open_store(Some(&db_path))?;
 
+            // Helper: a stored vault matches the caller's path if any of its
+            // representations (canonical, literal, shell-expanded `~`)
+            // resolve to the same absolute path. `brain add` may have
+            // registered the vault with a literal `~/...` string (from a
+            // config file or programmatic call) while the caller of
+            // `brain remove` typically passes a shell-expanded absolute
+            // path. A naive `vault_uid` lookup misses these cases even
+            // though `brain status` clearly shows the row.
+            let home = std::env::var("HOME").ok();
+            let path_matches = |stored: &str| -> bool {
+                if stored == canon_str || stored == raw_str {
+                    return true;
+                }
+                let stored_canon = std::fs::canonicalize(stored)
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_else(|_| stored.to_string());
+                if stored_canon == *canon_str {
+                    return true;
+                }
+                if let (Some(h), Some(rest)) = (home.as_deref(), stored.strip_prefix("~/")) {
+                    let expanded = format!("{h}/{rest}");
+                    if expanded == *canon_str {
+                        return true;
+                    }
+                    if let Ok(c) = std::fs::canonicalize(&expanded)
+                        && c.to_string_lossy() == *canon_str
+                    {
+                        return true;
+                    }
+                }
+                false
+            };
+
             // If the caller passed `--instance`, treat it as a precise
-            // selector: only the row owned by that instance is removed.
-            // This is required to disambiguate ghost-row situations
-            // without nuking the populated row that lives at the same
-            // path. If the requested row does not exist, fail loudly
-            // rather than silently scrubbing every other instance at
-            // the path.
+            // selector. If the direct vault_uid lookup misses (path
+            // stored under a non-canonical form like a literal `~/...`),
+            // fall back to a list-scan scoped to the requested instance
+            // before failing.
             //
             // If `--instance` is absent, fall back to the historical
             // ghost-row cleanup behavior: remove the default-UID row
             // plus any other row whose canonical root_path matches.
             let mut uids_to_remove: Vec<String> = Vec::new();
             if instance_specified {
-                if store.lookup_vault(&v_uid).is_ok() {
-                    uids_to_remove.push(v_uid);
-                } else {
+                if store.lookup_vault(&v_uid_canon).is_ok() {
+                    uids_to_remove.push(v_uid_canon);
+                } else if store.lookup_vault(&v_uid_raw).is_ok() {
+                    uids_to_remove.push(v_uid_raw);
+                } else if let Ok(all_vaults) = store.list_vaults(Some(instance_id)) {
+                    for v in &all_vaults {
+                        if path_matches(&v.root_path) {
+                            uids_to_remove.push(v.uid.clone());
+                        }
+                    }
+                }
+                if uids_to_remove.is_empty() {
                     eprintln!(
                         "Error: no vault with instance '{instance_id}' found at {canon_str}.\n  \
                          Run `nestweaver brain status` to see registered vaults and their instance ids,\n  \
@@ -7319,13 +7361,10 @@ fn run_brain(
                     return Ok((EXIT_NOT_FOUND, None));
                 }
             } else {
-                uids_to_remove.push(v_uid);
+                uids_to_remove.push(v_uid_canon);
                 if let Ok(all_vaults) = store.list_vaults(None) {
                     for v in &all_vaults {
-                        let v_canon = std::fs::canonicalize(&v.root_path)
-                            .map(|p| p.to_string_lossy().to_string())
-                            .unwrap_or_else(|_| v.root_path.clone());
-                        if v_canon == *canon_str && !uids_to_remove.contains(&v.uid) {
+                        if path_matches(&v.root_path) && !uids_to_remove.contains(&v.uid) {
                             uids_to_remove.push(v.uid.clone());
                         }
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4622,11 +4622,8 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
         } => {
             let db_path = db.unwrap_or_else(default_db_path);
 
-            if use_daemon
-                && let Ok(rt) = tokio::runtime::Runtime::new()
-            {
-                let connect =
-                    rt.block_on(nestweaver_client::DaemonClient::connect(&db_path, None));
+            if use_daemon && let Ok(rt) = tokio::runtime::Runtime::new() {
+                let connect = rt.block_on(nestweaver_client::DaemonClient::connect(&db_path, None));
                 if let Ok(mut client) = connect {
                     let req = nestweaver_proto::ProjectContextRequest {
                         project: name.clone(),
@@ -4648,8 +4645,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     });
                     match rpc {
                         Ok(resp) => {
-                            let value: serde_json::Value =
-                                serde_json::from_str(&resp.result_json)?;
+                            let value: serde_json::Value = serde_json::from_str(&resp.result_json)?;
                             render_project_context_daemon_response(&value, json, token_budget);
                             return Ok((EXIT_SUCCESS, None));
                         }
@@ -4887,11 +4883,8 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     // connected. Don't double-count items the promotion helpers
                     // copied from `seeds` into `connected` — those tokens belong
                     // to the connected budget, not the seed overhead.
-                    let connected_uids: std::collections::HashSet<&str> = result
-                        .connected
-                        .iter()
-                        .map(|n| n.uid.as_str())
-                        .collect();
+                    let connected_uids: std::collections::HashSet<&str> =
+                        result.connected.iter().map(|n| n.uid.as_str()).collect();
                     let seed_tokens: usize = result
                         .seeds
                         .iter()
@@ -4912,13 +4905,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     // shape — agents rely on this for Workfront / wiki PRD
                     // surfacing.
                     let ext_store = nestweaver_engine::load_extensions(&db_path);
-                    let external_refs = nestweaver_engine::get_all_properties(
-                        &ext_store,
-                        &project.uid,
-                    )
-                    .get("external_refs")
-                    .cloned()
-                    .unwrap_or(serde_json::Value::Null);
+                    let external_refs =
+                        nestweaver_engine::get_all_properties(&ext_store, &project.uid)
+                            .get("external_refs")
+                            .cloned()
+                            .unwrap_or(serde_json::Value::Null);
                     if json {
                         print_project_context_json(
                             &project,
@@ -6581,11 +6572,8 @@ fn run_brain(
                         for v in vaults {
                             let name = v["name"].as_str().unwrap_or("?");
                             let note_count = v["note_count"].as_u64().unwrap_or(0);
-                            let last_indexed = v["last_indexed"]
-                                .as_str()
-                                .unwrap_or("never");
-                            let ambiguous =
-                                name_counts.get(name).copied().unwrap_or(0) > 1;
+                            let last_indexed = v["last_indexed"].as_str().unwrap_or("never");
+                            let ambiguous = name_counts.get(name).copied().unwrap_or(0) > 1;
                             let unnamed = name.is_empty();
                             if ambiguous || unnamed {
                                 let instance = v["instance_id"].as_str().unwrap_or("?");
@@ -6634,9 +6622,7 @@ fn run_brain(
                             );
                         }
                         Some(_) => {
-                            println!(
-                                "  interaction_tracking: enabled (no events recorded yet)"
-                            );
+                            println!("  interaction_tracking: enabled (no events recorded yet)");
                         }
                         None => {
                             println!(
@@ -6652,8 +6638,7 @@ fn run_brain(
                             let kind = w["kind"].as_str().unwrap_or("");
                             if kind == "duplicate_vault_root" {
                                 let root = w["root_path"].as_str().unwrap_or("?");
-                                let entries =
-                                    w["entries"].as_array().cloned().unwrap_or_default();
+                                let entries = w["entries"].as_array().cloned().unwrap_or_default();
                                 eprintln!(
                                     "Warning: {} vault entries share root path {}:",
                                     entries.len(),
@@ -6866,8 +6851,10 @@ fn run_brain(
             // or missing --config. This produces phantom 0-note vault rows.
             // Each entry surfaces name + instance_id + uid so the user can
             // target `brain remove --instance <id>` precisely.
-            let mut root_to_vaults: std::collections::HashMap<&str, Vec<&nestweaver_schema::Vault>> =
-                std::collections::HashMap::new();
+            let mut root_to_vaults: std::collections::HashMap<
+                &str,
+                Vec<&nestweaver_schema::Vault>,
+            > = std::collections::HashMap::new();
             for v in &vaults {
                 root_to_vaults
                     .entry(v.root_path.as_str())
@@ -7905,68 +7892,66 @@ fn run_brain(
                     config_path.as_deref(),
                 ));
                 if let Ok(mut client) = connect {
-                        let req = nestweaver_proto::BrainContextRequest {
-                            seeds: seeds.clone(),
-                            token_budget: token_budget.unwrap_or(0) as i32,
-                            response_format: String::new(),
-                            repos: repos.clone(),
-                            vaults: vaults.clone(),
-                            kinds: kinds.clone(),
-                            path_prefix: path_prefix.clone().unwrap_or_default(),
-                            tags: tags.clone(),
-                            exclude_tags: exclude_tags.clone(),
-                            weight_ppr: weight_ppr.unwrap_or(0.0),
-                            weight_bm25: weight_bm25.unwrap_or(0.0),
-                            // Pass the parsed --intent through to the daemon
-                            // (empty string = auto-detect on the server).
-                            intent: intent.clone().unwrap_or_default(),
-                            include_seeds: true,
-                            include_bodies: inline_bodies,
-                            root: root
-                                .clone()
-                                .unwrap_or_default()
-                                .to_string_lossy()
-                                .to_string(),
-                            prf,
-                            rerank,
-                        };
-                        let rpc = rt.block_on(async {
-                            client
-                                .inner_mut()
-                                .get_context(req)
-                                .await
-                                .map(|r| r.into_inner())
-                        });
-                        match rpc {
-                            Ok(resp) => {
-                                let result: nestweaver_engine::BrainContextResult =
-                                    serde_json::from_str(&resp.result_json)?;
-                                let cut = match token_budget {
-                                    Some(budget) => {
-                                        token_budgeted_truncate(&result.connected, budget)
-                                    }
-                                    None => limit.min(result.connected.len()),
-                                };
-                                if json {
-                                    print_brain_context_json(&result, cut)?;
-                                } else {
-                                    print_brain_context_text(&result, cut, token_budget);
-                                }
-                                let node_count = result.seeds.len() + cut;
-                                let stats = format!(
-                                    "{} nodes in {} (via daemon)",
-                                    node_count,
-                                    format_elapsed(t0.elapsed())
-                                );
-                                return Ok((EXIT_SUCCESS, Some(stats)));
+                    let req = nestweaver_proto::BrainContextRequest {
+                        seeds: seeds.clone(),
+                        token_budget: token_budget.unwrap_or(0) as i32,
+                        response_format: String::new(),
+                        repos: repos.clone(),
+                        vaults: vaults.clone(),
+                        kinds: kinds.clone(),
+                        path_prefix: path_prefix.clone().unwrap_or_default(),
+                        tags: tags.clone(),
+                        exclude_tags: exclude_tags.clone(),
+                        weight_ppr: weight_ppr.unwrap_or(0.0),
+                        weight_bm25: weight_bm25.unwrap_or(0.0),
+                        // Pass the parsed --intent through to the daemon
+                        // (empty string = auto-detect on the server).
+                        intent: intent.clone().unwrap_or_default(),
+                        include_seeds: true,
+                        include_bodies: inline_bodies,
+                        root: root
+                            .clone()
+                            .unwrap_or_default()
+                            .to_string_lossy()
+                            .to_string(),
+                        prf,
+                        rerank,
+                    };
+                    let rpc = rt.block_on(async {
+                        client
+                            .inner_mut()
+                            .get_context(req)
+                            .await
+                            .map(|r| r.into_inner())
+                    });
+                    match rpc {
+                        Ok(resp) => {
+                            let result: nestweaver_engine::BrainContextResult =
+                                serde_json::from_str(&resp.result_json)?;
+                            let cut = match token_budget {
+                                Some(budget) => token_budgeted_truncate(&result.connected, budget),
+                                None => limit.min(result.connected.len()),
+                            };
+                            if json {
+                                print_brain_context_json(&result, cut)?;
+                            } else {
+                                print_brain_context_text(&result, cut, token_budget);
                             }
-                            Err(status) => {
-                                eprintln!(
-                                    "warning: daemon context RPC failed ({}); falling back to direct DB read",
-                                    status.message()
-                                );
-                            }
+                            let node_count = result.seeds.len() + cut;
+                            let stats = format!(
+                                "{} nodes in {} (via daemon)",
+                                node_count,
+                                format_elapsed(t0.elapsed())
+                            );
+                            return Ok((EXIT_SUCCESS, Some(stats)));
                         }
+                        Err(status) => {
+                            eprintln!(
+                                "warning: daemon context RPC failed ({}); falling back to direct DB read",
+                                status.message()
+                            );
+                        }
+                    }
                 }
             }
 
@@ -8002,9 +7987,8 @@ fn run_brain(
             // instance config into the search config so user overrides reach
             // `search_symbols_by_name` at seed resolution.
             let defaults = HybridSearchConfig::default();
-            let configured_seed_resolution = instance_cfg
-                .as_ref()
-                .map(|c| c.seed_resolution.clone());
+            let configured_seed_resolution =
+                instance_cfg.as_ref().map(|c| c.seed_resolution.clone());
             let config = HybridSearchConfig {
                 weight_ppr: weight_ppr.unwrap_or(defaults.weight_ppr),
                 weight_bm25: weight_bm25.unwrap_or(defaults.weight_bm25),
@@ -9314,9 +9298,7 @@ fn run_instance(command: InstanceCommands) -> anyhow::Result<i32> {
             if purge_graph {
                 let db_path = db.unwrap_or_else(default_db_path);
                 let store = open_store(Some(&db_path))?;
-                let r = store
-                    .purge_instance(&id)
-                    .map_err(|e| anyhow::anyhow!(e))?;
+                let r = store.purge_instance(&id).map_err(|e| anyhow::anyhow!(e))?;
                 let total = r.repos
                     + r.files
                     + r.symbols
@@ -9331,13 +9313,7 @@ fn run_instance(command: InstanceCommands) -> anyhow::Result<i32> {
                         "Purged instance '{id}' from graph: {} repo(s), \
                          {} file(s), {} symbol(s), {} vault(s), {} note(s), \
                          {} project(s), {} orphan(s)",
-                        r.repos,
-                        r.files,
-                        r.symbols,
-                        r.vaults,
-                        r.notes,
-                        r.projects,
-                        r.orphans_swept
+                        r.repos, r.files, r.symbols, r.vaults, r.notes, r.projects, r.orphans_swept
                     );
                 }
             }


### PR DESCRIPTION
## Summary

- Fix four v0.21.0 regressions including a data-loss bug in `brain remove --instance`, daemon deserialization failures, and test-path deboost on relative paths
- Add instance/graph hygiene: `--purge-graph` cascade delete, canonical-form-agnostic path matching in `brain remove`, orphan-row sweep by UID prefix
- Surface member symbols (functions, classes) in `project-context` — previously notes-only
- Wire `since`/`recency_weight` through proto, resolve repo aliases via `RepoConfig.name`
- Dedup Heading/Section pairs before token accounting (recovers 10-25% budget on note-heavy projects)
- Rewrite seed resolution with graduated path-deboost and kind-priority scoring (`[seed_resolution]` config block, multiplicative f64 scoring, 19 default deboost rules)
- Add BM25 fallback for natural-language `investigate` queries, `--no-daemon` JSON parity
- Collapse orphan-sweep to single-query `DETACH DELETE ... RETURN count(n)`, eliminate heap allocations in `kind_rank` sort comparisons

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --no-fail-fast` — 1,315 passed, 0 failed
- [x] Full daemon test suite passes (6/6)
- [ ] CI green on all jobs (fmt, clippy, test, coverage, audit, e2e)