### PR TITLE
feat(graph): Obsidian-style visual reskin + click-to-preview UX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,7 +2975,7 @@ checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "nestweaver"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-algorithms"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -3021,7 +3021,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-client"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-daemon"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-engine"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "apollo-parser",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-mcp"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "nestweaver-engine",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-parser"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "comrak",
  "hex",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-proto"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "prost 0.13.5",
  "tonic",
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-resolver"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "glob",
  "insta",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-schema"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "hex",
  "serde",
@@ -3202,7 +3202,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-storage"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-store"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-wasm"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "js-sys",
  "nestweaver-algorithms",

--- a/crates/nestweaver-web/frontend/dist/index.html
+++ b/crates/nestweaver-web/frontend/dist/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NestWeaver</title>
-    <script type="module" crossorigin src="/assets/index-CaMuv95L.js"></script>
+    <script type="module" crossorigin src="/assets/index-CrL6LIuI.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-WJgTAbhW.css">
   </head>
   <body>

--- a/crates/nestweaver-web/frontend/dist/index.html
+++ b/crates/nestweaver-web/frontend/dist/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NestWeaver</title>
-    <script type="module" crossorigin src="/assets/index-DMboTd0P.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DbiWCIaz.css">
+    <script type="module" crossorigin src="/assets/index-CaMuv95L.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-WJgTAbhW.css">
   </head>
   <body>
     <div id="root"></div>

--- a/crates/nestweaver-web/frontend/e2e/graph-explorer.spec.ts
+++ b/crates/nestweaver-web/frontend/e2e/graph-explorer.spec.ts
@@ -100,17 +100,13 @@ async function openOverview(
     return;
   }
 
-  await dock.getByRole("button", { name: "View" }).click();
+  await dock.getByRole("button", { name: "Settings" }).click();
   await dock.getByRole("button", { name: "Focus Map" }).click();
 
-  const overviewMode = page.getByRole("button", {
-    name: "Overview",
-    exact: true,
+  const modeIndicator = page.getByRole("button", {
+    name: /Overview/,
   });
-  await expect(overviewMode).toBeVisible();
-  await expect(overviewMode).toHaveClass(
-    /border-\[var\(--color-graph-selection\)\]/,
-  );
+  await expect(modeIndicator).toBeVisible();
 }
 
 test.describe("Graph Explorer", () => {
@@ -220,8 +216,8 @@ test.describe("Graph Explorer", () => {
       .click();
 
     await expect(
-      page.getByRole("button", { name: "Context", exact: true }),
-    ).toHaveClass(/border-\[var\(--color-graph-selection\)\]/);
+      page.getByRole("button", { name: /Context/ }),
+    ).toBeVisible();
     await postOk(request, "/api/v1/context", {
       seeds: [firstSymbol.uid],
       limit: 50,
@@ -286,8 +282,8 @@ test.describe("Graph Explorer", () => {
     await option.getByRole("button", { name: "Add" }).click();
 
     await expect(
-      page.getByRole("button", { name: "Context", exact: true }),
-    ).toHaveClass(/border-\[var\(--color-graph-selection\)\]/);
+      page.getByRole("button", { name: /Context/ }),
+    ).toBeVisible();
   });
 
   test("grouped controls switch to list and matrix views", async ({ page }) => {
@@ -295,7 +291,7 @@ test.describe("Graph Explorer", () => {
 
     const dock = page.getByTestId("control-dock");
 
-    await dock.getByRole("button", { name: "View" }).click();
+    await dock.getByRole("button", { name: "Settings" }).click();
     await dock.getByRole("button", { name: "List" }).click();
     await expect(
       page.getByRole("region", { name: "Ranked node table" }),
@@ -321,6 +317,7 @@ test.describe("Graph Explorer", () => {
 
     async function downloadExport(label: RegExp, extension: string) {
       const dock = page.getByTestId("control-dock");
+      await dock.getByRole("button", { name: "Settings" }).click();
       await dock.getByRole("button", { name: "Export" }).click();
       const downloadPromise = page.waitForEvent("download");
       await dock.getByRole("button", { name: label }).click();
@@ -349,7 +346,7 @@ test.describe("Graph Explorer", () => {
     await openOverview(page, { panels: true });
 
     const dock = page.getByTestId("control-dock");
-    await dock.getByRole("button", { name: "View" }).click();
+    await dock.getByRole("button", { name: "Settings" }).click();
     await dock.getByRole("button", { name: "List" }).click();
 
     const table = page.getByRole("region", { name: "Ranked node table" });
@@ -369,7 +366,7 @@ test.describe("Graph Explorer", () => {
     await openOverview(page, { panels: true });
 
     const dock = page.getByTestId("control-dock");
-    await dock.getByRole("button", { name: "View" }).click();
+    await dock.getByRole("button", { name: "Settings" }).click();
     await dock.getByRole("button", { name: "Matrix" }).click();
 
     const matrix = page.getByRole("region", { name: "Graph matrix view" });

--- a/crates/nestweaver-web/frontend/e2e/graph-explorer.spec.ts
+++ b/crates/nestweaver-web/frontend/e2e/graph-explorer.spec.ts
@@ -300,13 +300,13 @@ test.describe("Graph Explorer", () => {
       page.getByRole("region", { name: "Ranked node table" }),
     ).toBeVisible();
 
-    await dock.getByRole("button", { name: "Settings" }).click();
+    // Flyout stays open after clicking List — no need to re-open
     await dock.getByRole("button", { name: /Matrix/ }).click();
     await expect(
       page.getByRole("region", { name: "Graph matrix view" }),
     ).toBeVisible();
 
-    await dock.getByRole("button", { name: "Settings" }).click();
+    // Flyout still open — check filter section
     await expect(page.getByLabel("Scope")).toBeVisible();
   });
 

--- a/crates/nestweaver-web/frontend/e2e/graph-explorer.spec.ts
+++ b/crates/nestweaver-web/frontend/e2e/graph-explorer.spec.ts
@@ -295,13 +295,13 @@ test.describe("Graph Explorer", () => {
     const dock = page.getByTestId("control-dock");
 
     await dock.getByRole("button", { name: "Settings" }).click();
-    await dock.getByRole("button", { name: /List/ }).click({ force: true });
+    await dock.getByRole("button", { name: /List/ }).click();
     await expect(
       page.getByRole("region", { name: "Ranked node table" }),
     ).toBeVisible();
 
     await dock.getByRole("button", { name: "Settings" }).click();
-    await dock.getByRole("button", { name: /Matrix/ }).click({ force: true });
+    await dock.getByRole("button", { name: /Matrix/ }).click();
     await expect(
       page.getByRole("region", { name: "Graph matrix view" }),
     ).toBeVisible();
@@ -355,7 +355,7 @@ test.describe("Graph Explorer", () => {
 
     const dock = page.getByTestId("control-dock");
     await dock.getByRole("button", { name: "Settings" }).click();
-    await dock.getByRole("button", { name: /List/ }).click({ force: true });
+    await dock.getByRole("button", { name: /List/ }).click();
 
     const table = page.getByRole("region", { name: "Ranked node table" });
     await expect(table).toBeVisible();
@@ -375,7 +375,7 @@ test.describe("Graph Explorer", () => {
 
     const dock = page.getByTestId("control-dock");
     await dock.getByRole("button", { name: "Settings" }).click();
-    await dock.getByRole("button", { name: /Matrix/ }).click({ force: true });
+    await dock.getByRole("button", { name: /Matrix/ }).click();
 
     const matrix = page.getByRole("region", { name: "Graph matrix view" });
     await expect(matrix).toBeVisible();

--- a/crates/nestweaver-web/frontend/e2e/graph-explorer.spec.ts
+++ b/crates/nestweaver-web/frontend/e2e/graph-explorer.spec.ts
@@ -102,6 +102,8 @@ async function openOverview(
 
   await dock.getByRole("button", { name: "Settings" }).click();
   await dock.getByRole("button", { name: "Focus Map" }).click();
+  // Close the settings flyout so it doesn't cover other elements
+  await dock.getByRole("button", { name: "Settings" }).click();
 
   const modeIndicator = page.getByRole("button", {
     name: /Overview/,
@@ -302,7 +304,7 @@ test.describe("Graph Explorer", () => {
       page.getByRole("region", { name: "Graph matrix view" }),
     ).toBeVisible();
 
-    await dock.getByRole("button", { name: "Filter" }).click();
+    // Filter controls are inside the Settings flyout (already open)
     await expect(page.getByLabel("Scope")).toBeVisible();
   });
 
@@ -317,8 +319,12 @@ test.describe("Graph Explorer", () => {
 
     async function downloadExport(label: RegExp, extension: string) {
       const dock = page.getByTestId("control-dock");
-      await dock.getByRole("button", { name: "Settings" }).click();
-      await dock.getByRole("button", { name: "Export" }).click();
+      // Open the settings flyout if not already open
+      const flyout = dock.locator(".max-h-\\[70vh\\]");
+      if (!(await flyout.isVisible().catch(() => false))) {
+        await dock.getByRole("button", { name: "Settings" }).click();
+      }
+      // Export buttons are directly inside the flyout (no separate Export button)
       const downloadPromise = page.waitForEvent("download");
       await dock.getByRole("button", { name: label }).click();
       const download = await downloadPromise;

--- a/crates/nestweaver-web/frontend/e2e/graph-explorer.spec.ts
+++ b/crates/nestweaver-web/frontend/e2e/graph-explorer.spec.ts
@@ -295,22 +295,17 @@ test.describe("Graph Explorer", () => {
     const dock = page.getByTestId("control-dock");
 
     await dock.getByRole("button", { name: "Settings" }).click();
-    // Wait for the flyout to appear before clicking List
-    await expect(dock.getByRole("button", { name: /Graph/ })).toBeVisible();
-    await dock.getByRole("button", { name: /List/ }).click();
+    await dock.getByRole("button", { name: /List/ }).click({ force: true });
     await expect(
       page.getByRole("region", { name: "Ranked node table" }),
     ).toBeVisible();
 
-    // Re-open settings if it closed after view change
     await dock.getByRole("button", { name: "Settings" }).click();
-    await expect(dock.getByRole("button", { name: /Matrix/ })).toBeVisible();
-    await dock.getByRole("button", { name: /Matrix/ }).click();
+    await dock.getByRole("button", { name: /Matrix/ }).click({ force: true });
     await expect(
       page.getByRole("region", { name: "Graph matrix view" }),
     ).toBeVisible();
 
-    // Re-open settings to check filter
     await dock.getByRole("button", { name: "Settings" }).click();
     await expect(page.getByLabel("Scope")).toBeVisible();
   });
@@ -360,8 +355,7 @@ test.describe("Graph Explorer", () => {
 
     const dock = page.getByTestId("control-dock");
     await dock.getByRole("button", { name: "Settings" }).click();
-    await expect(dock.getByRole("button", { name: /Graph/ })).toBeVisible();
-    await dock.getByRole("button", { name: /List/ }).click();
+    await dock.getByRole("button", { name: /List/ }).click({ force: true });
 
     const table = page.getByRole("region", { name: "Ranked node table" });
     await expect(table).toBeVisible();
@@ -381,8 +375,7 @@ test.describe("Graph Explorer", () => {
 
     const dock = page.getByTestId("control-dock");
     await dock.getByRole("button", { name: "Settings" }).click();
-    await expect(dock.getByRole("button", { name: /Graph/ })).toBeVisible();
-    await dock.getByRole("button", { name: /Matrix/ }).click();
+    await dock.getByRole("button", { name: /Matrix/ }).click({ force: true });
 
     const matrix = page.getByRole("region", { name: "Graph matrix view" });
     await expect(matrix).toBeVisible();

--- a/crates/nestweaver-web/frontend/e2e/graph-explorer.spec.ts
+++ b/crates/nestweaver-web/frontend/e2e/graph-explorer.spec.ts
@@ -102,13 +102,14 @@ async function openOverview(
 
   await dock.getByRole("button", { name: "Settings" }).click();
   await dock.getByRole("button", { name: "Focus Map" }).click();
-  // Close the settings flyout so it doesn't cover other elements
-  await dock.getByRole("button", { name: "Settings" }).click();
 
   const modeIndicator = page.getByRole("button", {
     name: /Overview/,
   });
   await expect(modeIndicator).toBeVisible();
+
+  // Close the settings flyout by clicking outside it
+  await page.locator('[data-testid="graph-panel"]').click({ position: { x: 10, y: 10 } });
 }
 
 test.describe("Graph Explorer", () => {
@@ -294,17 +295,23 @@ test.describe("Graph Explorer", () => {
     const dock = page.getByTestId("control-dock");
 
     await dock.getByRole("button", { name: "Settings" }).click();
-    await dock.getByRole("button", { name: "List" }).click();
+    // Wait for the flyout to appear before clicking List
+    await expect(dock.getByRole("button", { name: /Graph/ })).toBeVisible();
+    await dock.getByRole("button", { name: /List/ }).click();
     await expect(
       page.getByRole("region", { name: "Ranked node table" }),
     ).toBeVisible();
 
-    await dock.getByRole("button", { name: "Matrix" }).click();
+    // Re-open settings if it closed after view change
+    await dock.getByRole("button", { name: "Settings" }).click();
+    await expect(dock.getByRole("button", { name: /Matrix/ })).toBeVisible();
+    await dock.getByRole("button", { name: /Matrix/ }).click();
     await expect(
       page.getByRole("region", { name: "Graph matrix view" }),
     ).toBeVisible();
 
-    // Filter controls are inside the Settings flyout (already open)
+    // Re-open settings to check filter
+    await dock.getByRole("button", { name: "Settings" }).click();
     await expect(page.getByLabel("Scope")).toBeVisible();
   });
 
@@ -353,7 +360,8 @@ test.describe("Graph Explorer", () => {
 
     const dock = page.getByTestId("control-dock");
     await dock.getByRole("button", { name: "Settings" }).click();
-    await dock.getByRole("button", { name: "List" }).click();
+    await expect(dock.getByRole("button", { name: /Graph/ })).toBeVisible();
+    await dock.getByRole("button", { name: /List/ }).click();
 
     const table = page.getByRole("region", { name: "Ranked node table" });
     await expect(table).toBeVisible();
@@ -373,7 +381,8 @@ test.describe("Graph Explorer", () => {
 
     const dock = page.getByTestId("control-dock");
     await dock.getByRole("button", { name: "Settings" }).click();
-    await dock.getByRole("button", { name: "Matrix" }).click();
+    await expect(dock.getByRole("button", { name: /Graph/ })).toBeVisible();
+    await dock.getByRole("button", { name: /Matrix/ }).click();
 
     const matrix = page.getByRole("region", { name: "Graph matrix view" });
     await expect(matrix).toBeVisible();

--- a/crates/nestweaver-web/frontend/e2e/search.spec.ts
+++ b/crates/nestweaver-web/frontend/e2e/search.spec.ts
@@ -26,6 +26,13 @@ test.describe("Search Flow", () => {
 
   test("symbol detail loads when clicking a result", async ({ page }) => {
     await page.goto("/");
+    const dock = page.getByTestId("control-dock");
+    await expect(dock).toBeVisible({ timeout: 15_000 });
+
+    // Switch to panels mode so the detail panel is visible
+    await dock.getByRole("button", { name: "Settings" }).click();
+    await dock.getByRole("button", { name: "Focus Map" }).click();
+
     const searchInput = page.locator('[data-testid="search-input"]');
     await searchInput.waitFor({ timeout: 10_000 });
     await searchInput.fill("greet");

--- a/crates/nestweaver-web/frontend/src/App.tsx
+++ b/crates/nestweaver-web/frontend/src/App.tsx
@@ -48,13 +48,8 @@ function AppContent() {
     { enableOnFormTags: ["INPUT"] },
   );
 
-  useHotkeys(
-    "escape",
-    () => {
-      if (layoutMode === "zen") setLayoutMode("panels");
-    },
-    { enableOnFormTags: false },
-  );
+  // Escape is handled by GraphPanel's keyboard nav (closes preview, then deselects).
+  // Zen ↔ panels toggle is Cmd+Shift+G only.
 
   // Determine effective layout based on zen mode and viewport width
   const isZen = layoutMode === "zen";

--- a/crates/nestweaver-web/frontend/src/App.tsx
+++ b/crates/nestweaver-web/frontend/src/App.tsx
@@ -29,8 +29,6 @@ function AppContent() {
   const activeView = useStore((s) => s.activeView);
   const layoutMode = useStore((s) => s.layoutMode);
   const setLayoutMode = useStore((s) => s.setLayoutMode);
-  const selectedNodeId = useStore((s) => s.selectedNodeId);
-
   // Responsive breakpoint detection
   const [width, setWidth] = useState(window.innerWidth);
   useEffect(() => {
@@ -76,33 +74,11 @@ function AppContent() {
     <div className="flex h-full flex-col overflow-hidden">
       <TopBar />
       {isZen ? (
-        // Zen mode: graph takes full area, detail floats
+        // Zen mode: graph takes full area, NodePreviewCard handles selection detail
         <div className="flex-1 min-h-0 relative">
           <ErrorBoundary>
             {graphView}
           </ErrorBoundary>
-          {selectedNodeId && (
-            <div
-              style={{
-                position: "fixed",
-                bottom: "24px",
-                right: "16px",
-                width: "320px",
-                maxHeight: "58vh",
-                overflowY: "auto",
-                background: "var(--color-surface)",
-                opacity: 0.96,
-                borderRadius: "8px",
-                border: "1px solid var(--color-border)",
-                boxShadow: "0 10px 30px rgba(15,23,42,0.14)",
-                zIndex: 50,
-              }}
-            >
-              <ErrorBoundary>
-                <DetailPanel />
-              </ErrorBoundary>
-            </div>
-          )}
         </div>
       ) : (
         // Normal / responsive layout

--- a/crates/nestweaver-web/frontend/src/components/export/ExportMenu.tsx
+++ b/crates/nestweaver-web/frontend/src/components/export/ExportMenu.tsx
@@ -3,6 +3,7 @@ import { useStore } from "../../stores";
 
 interface Props {
   onClose: () => void;
+  inline?: boolean;
 }
 
 interface ExportNode {
@@ -49,7 +50,7 @@ function downloadBlob(blob: Blob, filename: string) {
   window.setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
-export function ExportMenu({ onClose }: Props) {
+export function ExportMenu({ onClose, inline }: Props) {
   const [exporting, setExporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const graph = useStore((s) => s.graphInstance);
@@ -176,7 +177,7 @@ export function ExportMenu({ onClose }: Props) {
   };
 
   return (
-    <div className="absolute right-11 top-0 z-50 min-w-40 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] py-1 shadow-xl">
+    <div className={inline ? "py-1" : "absolute right-11 top-0 z-50 min-w-40 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] py-1 shadow-xl"}>
       <button onClick={exportPng} disabled={exporting}
         className="w-full text-left px-3 py-1.5 text-xs hover:bg-[var(--color-surface-alt)]">
         PNG (quick capture)

--- a/crates/nestweaver-web/frontend/src/components/graph/ContextMenu.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/ContextMenu.tsx
@@ -9,6 +9,10 @@ interface Props {
   onClose: () => void;
 }
 
+type MenuItem =
+  | { label: string; hint: string; key: string | null; action: () => void }
+  | "divider";
+
 export function ContextMenu({ x, y, nodeId, onClose }: Props) {
   const exploreNode = useStore((s) => s.exploreNode);
   const setGraphMode = useStore((s) => s.setGraphMode);
@@ -20,12 +24,40 @@ export function ContextMenu({ x, y, nodeId, onClose }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
-  const actions = [
-    { label: "Re-seed context from here", hint: "Enter", key: null,
-      action: () => { exploreNode(nodeId); onClose(); } },
-    { label: "Impact analysis...", hint: "I", key: "i",
-      action: () => { selectNode(nodeId, null); setGraphMode("impact"); onClose(); } },
-    { label: "Trace flow...", hint: "F", key: "f",
+  const menuItems: MenuItem[] = [
+    // Group 1: Graph mode actions
+    {
+      label: "Explore",
+      hint: "Enter",
+      key: null,
+      action: () => { exploreNode(nodeId); onClose(); },
+    },
+    {
+      label: "Impact analysis",
+      hint: "I",
+      key: "i",
+      action: () => { selectNode(nodeId, null); setGraphMode("impact"); onClose(); },
+    },
+    {
+      label: "Local neighborhood",
+      hint: "L",
+      key: "l",
+      action: () => { selectNode(nodeId, null); setGraphMode("local"); onClose(); },
+    },
+
+    "divider",
+
+    // Group 2: Multi-node actions
+    {
+      label: "Find path to...",
+      hint: "P",
+      key: "p",
+      action: () => { startPathfinding(nodeId); onClose(); },
+    },
+    {
+      label: "Trace flow",
+      hint: "F",
+      key: "f",
       action: async () => {
         try {
           const result = await api.flow(nodeId, 10);
@@ -34,12 +66,32 @@ export function ContextMenu({ x, y, nodeId, onClose }: Props) {
         onClose();
       },
     },
-    { label: "Find path to...", hint: "P", key: "p",
-      action: () => { startPathfinding(nodeId); onClose(); },
+
+    "divider",
+
+    // Group 3: Utilities
+    {
+      label: "Open source file",
+      hint: "O",
+      key: "o",
+      action: () => {
+        // Opens the source file for symbol nodes
+        window.open(`vscode://file/${nodeId}`, "_self");
+        onClose();
+      },
     },
-    { label: "Copy UID", hint: "C", key: "c",
-      action: () => { navigator.clipboard.writeText(nodeId); onClose(); } },
+    {
+      label: "Copy UID",
+      hint: "C",
+      key: "c",
+      action: () => { navigator.clipboard.writeText(nodeId); onClose(); },
+    },
   ];
+
+  // Non-divider items only, for keyboard navigation
+  const actionItems = menuItems.filter(
+    (item): item is Exclude<MenuItem, "divider"> => item !== "divider"
+  );
 
   // Auto-focus the container when the menu opens
   useEffect(() => {
@@ -55,15 +107,15 @@ export function ContextMenu({ x, y, nodeId, onClose }: Props) {
     switch (e.key) {
       case "ArrowDown":
         e.preventDefault();
-        setFocusedIndex((i) => (i + 1) % actions.length);
+        setFocusedIndex((i) => (i + 1) % actionItems.length);
         break;
       case "ArrowUp":
         e.preventDefault();
-        setFocusedIndex((i) => (i - 1 + actions.length) % actions.length);
+        setFocusedIndex((i) => (i - 1 + actionItems.length) % actionItems.length);
         break;
       case "Enter":
         e.preventDefault();
-        actions[focusedIndex].action();
+        actionItems[focusedIndex].action();
         break;
       case "Escape":
         e.preventDefault();
@@ -71,10 +123,10 @@ export function ContextMenu({ x, y, nodeId, onClose }: Props) {
         break;
       default: {
         const lower = e.key.toLowerCase();
-        const match = actions.findIndex((a) => a.key === lower);
+        const match = actionItems.findIndex((a) => a.key === lower);
         if (match !== -1) {
           e.preventDefault();
-          actions[match].action();
+          actionItems[match].action();
         }
         break;
       }
@@ -82,6 +134,9 @@ export function ContextMenu({ x, y, nodeId, onClose }: Props) {
   }
 
   const menuId = "context-menu";
+
+  // Track button index separately from menuItems index (skip dividers)
+  let buttonIndex = -1;
 
   return (
     <div
@@ -94,25 +149,40 @@ export function ContextMenu({ x, y, nodeId, onClose }: Props) {
       className="fixed z-50 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg shadow-lg py-1 min-w-44 outline-none"
       style={{ left: x, top: y }}
     >
-      {actions.map((a, i) => (
-        <button
-          ref={(el) => { itemRefs.current[i] = el; }}
-          id={`${menuId}-item-${i}`}
-          role="menuitem"
-          key={a.label}
-          onClick={a.action}
-          onMouseEnter={() => setFocusedIndex(i)}
-          className={
-            "w-full text-left px-3 py-1.5 text-xs flex items-center justify-between gap-4 " +
-            (i === focusedIndex
-              ? "bg-[var(--color-surface-alt)]"
-              : "hover:bg-[var(--color-surface-alt)]")
-          }
-        >
-          <span>{a.label}</span>
-          <span className="text-[var(--color-text-muted)] font-mono shrink-0">{a.hint}</span>
-        </button>
-      ))}
+      {menuItems.map((item, i) => {
+        if (item === "divider") {
+          return (
+            <div
+              key={`divider-${i}`}
+              role="separator"
+              className="my-1 border-t border-[var(--color-border)]"
+            />
+          );
+        }
+
+        buttonIndex += 1;
+        const idx = buttonIndex;
+
+        return (
+          <button
+            ref={(el) => { itemRefs.current[idx] = el; }}
+            id={`${menuId}-item-${idx}`}
+            role="menuitem"
+            key={item.label}
+            onClick={item.action}
+            onMouseEnter={() => setFocusedIndex(idx)}
+            className={
+              "w-full text-left px-3 py-1.5 text-xs flex items-center justify-between gap-4 " +
+              (idx === focusedIndex
+                ? "bg-[var(--color-surface-alt)]"
+                : "hover:bg-[var(--color-surface-alt)]")
+            }
+          >
+            <span>{item.label}</span>
+            <span className="text-[var(--color-text-muted)] font-mono shrink-0">{item.hint}</span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/crates/nestweaver-web/frontend/src/components/graph/ContextMenu.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/ContextMenu.tsx
@@ -75,8 +75,13 @@ export function ContextMenu({ x, y, nodeId, onClose }: Props) {
       hint: "O",
       key: "o",
       action: () => {
-        // Opens the source file for symbol nodes
-        window.open(`vscode://file/${nodeId}`, "_self");
+        const graph = useStore.getState().graphInstance;
+        const filePath = graph?.hasNode(nodeId)
+          ? (graph.getNodeAttribute(nodeId, "file_path") as string | undefined)
+          : undefined;
+        if (filePath) {
+          window.open(`vscode://file/${filePath}`, "_self");
+        }
         onClose();
       },
     },

--- a/crates/nestweaver-web/frontend/src/components/graph/ControlDock.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/ControlDock.tsx
@@ -214,7 +214,7 @@ export function ControlDock() {
             <h2 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
               Export
             </h2>
-            <ExportMenu onClose={() => setOpen(false)} />
+            <ExportMenu onClose={() => setOpen(false)} inline />
           </div>
         )}
       </div>

--- a/crates/nestweaver-web/frontend/src/components/graph/ControlDock.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/ControlDock.tsx
@@ -1,9 +1,6 @@
 import { useState, type ReactNode } from "react";
 import {
   Activity,
-  Download,
-  Eye,
-  Filter,
   GitCompare,
   Grid3X3,
   Layers3,
@@ -12,6 +9,7 @@ import {
   Maximize,
   Network,
   Route,
+  Settings,
   Sparkles,
   Tags,
 } from "lucide-react";
@@ -22,52 +20,6 @@ import { ExportMenu } from "../export/ExportMenu";
 import { ForceControls } from "./ForceControls";
 import { NodeFilterBar } from "./NodeFilterBar";
 import { StyleRules } from "./StyleRules";
-
-type DockMenu = "view" | "group" | "filter" | "analyze" | "export";
-
-interface DockButtonProps {
-  id: DockMenu;
-  label: string;
-  icon: ReactNode;
-  active: boolean;
-  onClick: () => void;
-}
-
-function DockButton({ label, icon, active, onClick }: DockButtonProps) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={label}
-      aria-label={label}
-      aria-pressed={active}
-      className={`flex h-9 w-9 items-center justify-center rounded border transition-colors ${
-        active
-          ? "border-[var(--color-graph-selection)] bg-[var(--color-surface-alt)] text-[var(--color-graph-selection)]"
-          : "border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-alt)] hover:text-[var(--color-text)]"
-      }`}
-    >
-      {icon}
-    </button>
-  );
-}
-
-function MenuPanel({
-  title,
-  children,
-}: {
-  title: string;
-  children: ReactNode;
-}) {
-  return (
-    <div className="absolute right-11 top-0 z-50 w-[320px] rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] p-3 text-xs shadow-xl">
-      <h2 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
-        {title}
-      </h2>
-      {children}
-    </div>
-  );
-}
 
 function MenuButton({
   active,
@@ -94,7 +46,7 @@ function MenuButton({
 }
 
 export function ControlDock() {
-  const [open, setOpen] = useState<DockMenu | null>(null);
+  const [open, setOpen] = useState(false);
   const viewMode = useStore((s) => s.viewMode);
   const setViewMode = useStore((s) => s.setViewMode);
   const minimapVisible = useStore((s) => s.minimapVisible);
@@ -121,10 +73,6 @@ export function ControlDock() {
   const gapActive = useStore((s) => s.gapActive);
   const toggleGapPanel = useStore((s) => s.toggleGapPanel);
 
-  const toggleMenu = (menu: DockMenu) => {
-    setOpen((current) => (current === menu ? null : menu));
-  };
-
   const analyzeGaps = async () => {
     const items = await loadGapItems();
     setGapItems(items);
@@ -141,18 +89,30 @@ export function ControlDock() {
   return (
     <div
       data-testid="control-dock"
-      className="absolute right-2 top-2 z-50 flex flex-col gap-1.5"
+      className="absolute right-2 top-2 z-50"
     >
       <div className="relative">
-        <DockButton
-          id="view"
-          label="View"
-          icon={<Eye className="h-4 w-4" />}
-          active={open === "view"}
-          onClick={() => toggleMenu("view")}
-        />
-        {open === "view" && (
-          <MenuPanel title="View">
+        <button
+          type="button"
+          onClick={() => setOpen((prev) => !prev)}
+          title="Settings"
+          aria-label="Settings"
+          aria-pressed={open}
+          className={`flex h-9 w-9 items-center justify-center rounded border transition-colors ${
+            open
+              ? "border-[var(--color-graph-selection)] bg-[var(--color-surface-alt)] text-[var(--color-graph-selection)]"
+              : "border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-alt)] hover:text-[var(--color-text)]"
+          }`}
+        >
+          <Settings className="h-4 w-4" />
+        </button>
+
+        {open && (
+          <div className="absolute right-0 top-11 z-50 w-[320px] max-h-[70vh] overflow-y-auto rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] p-3 text-xs shadow-xl">
+            {/* View */}
+            <h2 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+              View
+            </h2>
             <div className="flex flex-wrap gap-1.5">
               <MenuButton active={viewMode === "graph"} onClick={() => setViewMode("graph")}>
                 <Network className="h-3.5 w-3.5" /> Graph
@@ -176,20 +136,13 @@ export function ControlDock() {
                 <Maximize className="h-3.5 w-3.5" /> Focus Map
               </MenuButton>
             </div>
-          </MenuPanel>
-        )}
-      </div>
 
-      <div className="relative">
-        <DockButton
-          id="group"
-          label="Group"
-          icon={<Layers3 className="h-4 w-4" />}
-          active={open === "group"}
-          onClick={() => toggleMenu("group")}
-        />
-        {open === "group" && (
-          <MenuPanel title="Group">
+            <hr className="my-3 border-[var(--color-border)]" />
+
+            {/* Group */}
+            <h2 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+              Group
+            </h2>
             <div className="mb-3 flex flex-wrap gap-1.5">
               <MenuButton active={communityOverlay} onClick={toggleCommunity}>
                 <Layers3 className="h-3.5 w-3.5" /> Communities
@@ -199,20 +152,13 @@ export function ControlDock() {
               </MenuButton>
             </div>
             <StyleRules open />
-          </MenuPanel>
-        )}
-      </div>
 
-      <div className="relative">
-        <DockButton
-          id="filter"
-          label="Filter"
-          icon={<Filter className="h-4 w-4" />}
-          active={open === "filter"}
-          onClick={() => toggleMenu("filter")}
-        />
-        {open === "filter" && (
-          <MenuPanel title="Filter">
+            <hr className="my-3 border-[var(--color-border)]" />
+
+            {/* Filter */}
+            <h2 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+              Filter
+            </h2>
             <label className="mb-2 block text-[11px] font-medium text-[var(--color-text-muted)]">
               Scope
               <select
@@ -226,20 +172,13 @@ export function ControlDock() {
               </select>
             </label>
             <NodeFilterBar />
-          </MenuPanel>
-        )}
-      </div>
 
-      <div className="relative">
-        <DockButton
-          id="analyze"
-          label="Analyze"
-          icon={<Activity className="h-4 w-4" />}
-          active={open === "analyze"}
-          onClick={() => toggleMenu("analyze")}
-        />
-        {open === "analyze" && (
-          <MenuPanel title="Analyze">
+            <hr className="my-3 border-[var(--color-border)]" />
+
+            {/* Analyze */}
+            <h2 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+              Analyze
+            </h2>
             <div className="mb-3 flex flex-wrap gap-1.5">
               <MenuButton onClick={requestSemanticLayout}>
                 <Sparkles className="h-3.5 w-3.5" /> Semantic layout
@@ -268,19 +207,16 @@ export function ControlDock() {
               </MenuButton>
             </div>
             <ForceControls open />
-          </MenuPanel>
-        )}
-      </div>
 
-      <div className="relative">
-        <DockButton
-          id="export"
-          label="Export"
-          icon={<Download className="h-4 w-4" />}
-          active={open === "export"}
-          onClick={() => toggleMenu("export")}
-        />
-        {open === "export" && <ExportMenu onClose={() => setOpen(null)} />}
+            <hr className="my-3 border-[var(--color-border)]" />
+
+            {/* Export */}
+            <h2 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+              Export
+            </h2>
+            <ExportMenu onClose={() => setOpen(false)} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/crates/nestweaver-web/frontend/src/components/graph/EdgeInstanceMesh.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/EdgeInstanceMesh.tsx
@@ -9,39 +9,27 @@ import {
 import type { GraphBuffers } from "../../hooks/useGraphBridge";
 import { useStore } from "../../stores";
 
-const EDGE_THICKNESS = 0.78;
+const EDGE_THICKNESS = 1.0;
 
 const vertexShader = /* glsl */ `
-  attribute vec3 aSourceColor;
-  attribute vec3 aTargetColor;
   attribute float aStrength;
 
-  varying vec3 v_sourceColor;
-  varying vec3 v_targetColor;
-  varying float v_t;
   varying float v_strength;
 
   void main() {
-    v_sourceColor = aSourceColor;
-    v_targetColor = aTargetColor;
     v_strength = aStrength;
-    // Local X runs from -0.5 (source end) to +0.5 (target end)
-    v_t = position.x + 0.5;
     gl_Position = projectionMatrix * modelViewMatrix * instanceMatrix * vec4(position, 1.0);
   }
 `;
 
 const fragmentShader = /* glsl */ `
   uniform float u_opacity;
+  uniform vec3 u_edgeColor;
 
-  varying vec3 v_sourceColor;
-  varying vec3 v_targetColor;
-  varying float v_t;
   varying float v_strength;
 
   void main() {
-    vec3 color = mix(v_sourceColor, v_targetColor, v_t);
-    gl_FragColor = vec4(color, u_opacity * v_strength);
+    gl_FragColor = vec4(u_edgeColor, u_opacity * v_strength);
   }
 `;
 
@@ -60,7 +48,10 @@ export function EdgeInstanceMesh({ buffers }: Props) {
       new ShaderMaterial({
         vertexShader,
         fragmentShader,
-        uniforms: { u_opacity: { value: 0.24 } },
+        uniforms: {
+          u_opacity: { value: 0.5 },
+          u_edgeColor: { value: [0.345, 0.357, 0.439] },
+        },
         transparent: true,
         depthTest: false,
         depthWrite: false,
@@ -69,16 +60,26 @@ export function EdgeInstanceMesh({ buffers }: Props) {
     [],
   );
 
+  useEffect(() => {
+    function updateEdgeColor() {
+      const isDark = document.documentElement.classList.contains("dark");
+      material.uniforms.u_edgeColor.value = isDark
+        ? [0.345, 0.357, 0.439]
+        : [0.612, 0.627, 0.690];
+    }
+    updateEdgeColor();
+    const observer = new MutationObserver(updateEdgeColor);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+    return () => observer.disconnect();
+  }, [material]);
+
   const geometry = useMemo(() => new PlaneGeometry(1, 1), []);
 
   useEffect(() => {
     const mesh = meshRef.current;
     if (!mesh) return;
 
-    const { edgePositions, edgeColors, edgeCount } = buffers;
-
-    const sourceColors = new Float32Array(edgeCount * 3);
-    const targetColors = new Float32Array(edgeCount * 3);
+    const { edgePositions, edgeCount } = buffers;
 
     for (let i = 0; i < edgeCount; i++) {
       const sx = edgePositions[i * 6 + 0];
@@ -86,43 +87,23 @@ export function EdgeInstanceMesh({ buffers }: Props) {
       const tx = edgePositions[i * 6 + 3];
       const ty = edgePositions[i * 6 + 4];
 
-      // Midpoint
       const mx = (sx + tx) / 2;
       const my = (sy + ty) / 2;
 
-      // Length and angle
       const dx = tx - sx;
       const dy = ty - sy;
       const length = Math.sqrt(dx * dx + dy * dy);
       const angle = Math.atan2(dy, dx);
 
-      tempObj.position.set(mx, my, -0.1); // slightly behind nodes
+      tempObj.position.set(mx, my, -0.1);
       tempObj.rotation.set(0, 0, angle);
       tempObj.scale.set(length, EDGE_THICKNESS, 1);
       tempObj.updateMatrix();
       mesh.setMatrixAt(i, tempObj.matrix);
-
-      // Source color (first 3 floats of this edge's color entry)
-      sourceColors[i * 3 + 0] = edgeColors[i * 6 + 0];
-      sourceColors[i * 3 + 1] = edgeColors[i * 6 + 1];
-      sourceColors[i * 3 + 2] = edgeColors[i * 6 + 2];
-
-      // Target color (next 3 floats)
-      targetColors[i * 3 + 0] = edgeColors[i * 6 + 3];
-      targetColors[i * 3 + 1] = edgeColors[i * 6 + 4];
-      targetColors[i * 3 + 2] = edgeColors[i * 6 + 5];
     }
 
     mesh.instanceMatrix.needsUpdate = true;
 
-    mesh.geometry.setAttribute(
-      "aSourceColor",
-      new InstancedBufferAttribute(sourceColors, 3),
-    );
-    mesh.geometry.setAttribute(
-      "aTargetColor",
-      new InstancedBufferAttribute(targetColors, 3),
-    );
     mesh.geometry.setAttribute(
       "aStrength",
       new InstancedBufferAttribute(new Float32Array(edgeCount).fill(1), 1),

--- a/crates/nestweaver-web/frontend/src/components/graph/EdgeParticles.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/EdgeParticles.tsx
@@ -13,10 +13,10 @@ interface Props {
 const vertexShader = `
   attribute vec3 aSource;
   attribute vec3 aTarget;
-  attribute vec3 aColor;
   attribute float aPhase;
 
   uniform float u_time;
+  uniform vec3 u_particleColor;
 
   varying vec3 v_color;
   varying float v_alpha;
@@ -25,13 +25,12 @@ const vertexShader = `
     float t = fract(u_time * 0.3 + aPhase);
     vec3 pos = mix(aSource, aTarget, t);
 
-    // Gaussian alpha: brightest at center, fades at ends
     float centerDist = abs(t - 0.5) * 2.0;
     v_alpha = exp(-3.0 * centerDist * centerDist);
-    v_color = aColor;
+    v_color = u_particleColor;
 
     vec4 mvPosition = modelViewMatrix * vec4(pos, 1.0);
-    gl_PointSize = 3.0 * (300.0 / -mvPosition.z);
+    gl_PointSize = 2.0 * (300.0 / -mvPosition.z);
     gl_Position = projectionMatrix * mvPosition;
   }
 `;
@@ -41,11 +40,10 @@ const fragmentShader = `
   varying float v_alpha;
 
   void main() {
-    // Circular point with soft edge
     float dist = length(gl_PointCoord - vec2(0.5));
     if (dist > 0.5) discard;
     float alpha = v_alpha * smoothstep(0.5, 0.3, dist);
-    gl_FragColor = vec4(v_color, alpha * 0.6);
+    gl_FragColor = vec4(v_color, alpha * 0.4);
   }
 `;
 
@@ -61,7 +59,6 @@ export function EdgeParticles({ buffers }: Props) {
     const n = buffers.edgeCount;
     const sources = new Float32Array(n * 3);
     const targets = new Float32Array(n * 3);
-    const colors = new Float32Array(n * 3);
     const phases = new Float32Array(n);
     const positions = new Float32Array(n * 3); // dummy positions for Points
 
@@ -74,10 +71,6 @@ export function EdgeParticles({ buffers }: Props) {
       targets[i * 3] = buffers.edgePositions[i * 6 + 3];
       targets[i * 3 + 1] = buffers.edgePositions[i * 6 + 4];
       targets[i * 3 + 2] = buffers.edgePositions[i * 6 + 5];
-      // Color (average of source and target)
-      colors[i * 3] = (buffers.edgeColors[i * 6] + buffers.edgeColors[i * 6 + 3]) * 0.5;
-      colors[i * 3 + 1] = (buffers.edgeColors[i * 6 + 1] + buffers.edgeColors[i * 6 + 4]) * 0.5;
-      colors[i * 3 + 2] = (buffers.edgeColors[i * 6 + 2] + buffers.edgeColors[i * 6 + 5]) * 0.5;
       // Phase: deterministic per-edge
       phases[i] = (i * 0.618) % 1.0; // golden ratio for nice distribution
       // Dummy position (overridden by shader)
@@ -90,7 +83,6 @@ export function EdgeParticles({ buffers }: Props) {
     geo.setAttribute("position", new Float32BufferAttribute(positions, 3));
     geo.setAttribute("aSource", new Float32BufferAttribute(sources, 3));
     geo.setAttribute("aTarget", new Float32BufferAttribute(targets, 3));
-    geo.setAttribute("aColor", new Float32BufferAttribute(colors, 3));
     geo.setAttribute("aPhase", new Float32BufferAttribute(phases, 1));
     geo.computeBoundingSphere();
   }, [buffers]);
@@ -102,7 +94,25 @@ export function EdgeParticles({ buffers }: Props) {
     }
   });
 
-  const uniforms = useMemo(() => ({ u_time: { value: 0.0 } }), []);
+  const uniforms = useMemo(() => ({
+    u_time: { value: 0.0 },
+    u_particleColor: { value: [0.498, 0.518, 0.612] },
+  }), []);
+
+  useEffect(() => {
+    function updateColor() {
+      const isDark = document.documentElement.classList.contains("dark");
+      if (materialRef.current) {
+        materialRef.current.uniforms.u_particleColor.value = isDark
+          ? [0.498, 0.518, 0.612]
+          : [0.486, 0.498, 0.576];
+      }
+    }
+    updateColor();
+    const observer = new MutationObserver(updateColor);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+    return () => observer.disconnect();
+  }, []);
 
   if (buffers.edgeCount === 0) return null;
 

--- a/crates/nestweaver-web/frontend/src/components/graph/GraphCanvas.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/GraphCanvas.tsx
@@ -62,6 +62,19 @@ function GraphInteraction({ buffers }: { buffers: GraphBuffers }) {
   const handlePointerDown = useCallback(
     (event: { nativeEvent: PointerEvent }) => {
       const e = event.nativeEvent;
+
+      // Right-click → context menu (skip normal click logic)
+      if (e.button === 2) {
+        const rect = (e.target as HTMLElement).getBoundingClientRect();
+        const cx = e.clientX - rect.left;
+        const cy = e.clientY - rect.top;
+        const result = pick(cx, cy, camera, size);
+        if (result.nodeUid) {
+          useStore.getState().openContextMenu(e.clientX, e.clientY, result.nodeUid);
+        }
+        return;
+      }
+
       // Get the canvas-relative position from the DOM event
       const rect = (e.target as HTMLElement).getBoundingClientRect();
       const x = e.clientX - rect.left;

--- a/crates/nestweaver-web/frontend/src/components/graph/GraphCanvas.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/GraphCanvas.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useRef, useState, useEffect, useLayoutEffect } from "react";
 import { Canvas, useThree } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
-import { EffectComposer, Bloom } from "@react-three/postprocessing";
 import { NodeInstanceMesh } from "./NodeInstanceMesh";
 import { EdgeInstanceMesh } from "./EdgeInstanceMesh";
 import { EdgeParticles } from "./EdgeParticles";
@@ -410,7 +409,7 @@ export function GraphCanvas() {
     (theme === "system" &&
       typeof window !== "undefined" &&
       window.matchMedia("(prefers-color-scheme: dark)").matches);
-  const bgColor = isDark ? "#06080f" : "#f8fafc";
+  const bgColor = isDark ? "#1e1e2e" : "#eff1f5";
   const pixelRatio =
     typeof window !== "undefined" ? Math.min(window.devicePixelRatio || 1, 2) : 1;
 
@@ -463,17 +462,6 @@ export function GraphCanvas() {
               maxZoom={100}
               mouseButtons={{ LEFT: 0, MIDDLE: 2, RIGHT: 2 }}
             />
-            {/* Bloom post-processing — skipped when reduced motion is active */}
-            {!reducedMotion && !focusMap && (
-              <EffectComposer>
-                <Bloom
-                  luminanceThreshold={0.82}
-                  luminanceSmoothing={0.24}
-                  intensity={0.38}
-                  radius={0.28}
-                />
-              </EffectComposer>
-            )}
           </Canvas>
         </div>
       )}

--- a/crates/nestweaver-web/frontend/src/components/graph/GraphCanvas.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/GraphCanvas.tsx
@@ -117,10 +117,10 @@ function GraphInteraction({ buffers }: { buffers: GraphBuffers }) {
           openPreview(result.nodeUid, kind);
         }
       } else {
-        // Clicked on background — deselect and close preview
+        // Clicked on background — deselect, close preview and context menu
         selectNode(null);
-        const closePreview = useStore.getState().closePreview;
-        closePreview();
+        useStore.getState().closePreview();
+        useStore.getState().closeContextMenu();
       }
 
       lastClickRef.current = { time: now, nodeUid: result.nodeUid };

--- a/crates/nestweaver-web/frontend/src/components/graph/GraphCanvas.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/GraphCanvas.tsx
@@ -42,6 +42,7 @@ function useReducedMotion(): boolean {
 function GraphInteraction({ buffers }: { buffers: GraphBuffers }) {
   const { pick } = useGPUPicking(buffers);
   const selectNode = useStore((s) => s.selectNode);
+  const openPreview = useStore((s) => s.openPreview);
   const hoverNode = useStore((s) => s.hoverNode);
   const exploreNode = useStore((s) => s.exploreNode);
   const setGraphData = useStore((s) => s.setGraphData);
@@ -99,17 +100,20 @@ function GraphInteraction({ buffers }: { buffers: GraphBuffers }) {
         // Double-click detection: same node within 400ms
         if (prev.nodeUid === result.nodeUid && now - prev.time < 400) {
           exploreNode(result.nodeUid, kind);
+          useStore.getState().closePreview();
         } else {
-          selectNode(result.nodeUid, kind);
+          openPreview(result.nodeUid, kind);
         }
       } else {
-        // Clicked on background — deselect
+        // Clicked on background — deselect and close preview
         selectNode(null);
+        const closePreview = useStore.getState().closePreview;
+        closePreview();
       }
 
       lastClickRef.current = { time: now, nodeUid: result.nodeUid };
     },
-    [pick, camera, size, selectNode, exploreNode],
+    [pick, camera, size, selectNode, openPreview, exploreNode],
   );
 
   const handlePointerMove = useCallback(

--- a/crates/nestweaver-web/frontend/src/components/graph/GraphPanel.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/GraphPanel.tsx
@@ -5,17 +5,14 @@ import { GraphMatrixView } from "./GraphMatrixView";
 import { GraphMinimap } from "./GraphMinimap";
 import { NodeListView } from "./NodeListView";
 import { ContextMenu } from "./ContextMenu";
-import { ModeTabs } from "./ModeTabs";
+import { ModeIndicator } from "./ModeIndicator";
 import { ControlDock } from "./ControlDock";
 import { NodePreviewCard } from "./NodePreviewCard";
-import { ActiveFilterSummary } from "./ActiveFilterSummary";
 import { GraphLegend } from "./GraphLegend";
 import { PathTargetSelector } from "../PathTargetSelector";
 import { DiffSeedInput } from "../DiffSeedInput";
-import { LlmQueryBar } from "../llm/LlmQueryBar";
 import { OverviewCommandShelf } from "../overview/OverviewCommandShelf";
 import { OverviewContextSurface } from "../overview/OverviewContextSurface";
-import { TimelineSlider } from "../timeline/TimelineSlider";
 import { useOverviewMode } from "./modes/useOverviewMode";
 import { useContextMode } from "./modes/useContextMode";
 import { useImpactMode } from "./modes/useImpactMode";
@@ -327,10 +324,7 @@ export function GraphPanel() {
           )}
         </div>
       </div>
-      {!focusMap && <TimelineSlider />}
-      {!focusMap && <ActiveFilterSummary />}
-      {!focusMap && <ModeTabs />}
-      {!focusMap && <LlmQueryBar />}
+      <ModeIndicator />
     </div>
   );
 }

--- a/crates/nestweaver-web/frontend/src/components/graph/GraphPanel.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/GraphPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { GraphCanvas } from "./GraphCanvas";
 import { GraphMatrixView } from "./GraphMatrixView";
@@ -260,11 +260,8 @@ export function GraphPanel() {
   const graphPanelRef = useRef<HTMLDivElement>(null);
   useGraphKeyboardNav(graphPanelRef);
 
-  const [contextMenu, setContextMenu] = useState<{
-    x: number;
-    y: number;
-    nodeId: string;
-  } | null>(null);
+  const contextMenu = useStore((s) => s.contextMenu);
+  const closeContextMenu = useStore((s) => s.closeContextMenu);
 
   const handleContextMenu = useCallback(
     (e: React.MouseEvent) => {
@@ -312,7 +309,7 @@ export function GraphPanel() {
             x={contextMenu.x}
             y={contextMenu.y}
             nodeId={contextMenu.nodeId}
-            onClose={() => setContextMenu(null)}
+            onClose={closeContextMenu}
           />
         )}
         {pathfindingActive && !pathfindingTo && <PathTargetSelector />}

--- a/crates/nestweaver-web/frontend/src/components/graph/GraphPanel.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/GraphPanel.tsx
@@ -7,6 +7,7 @@ import { NodeListView } from "./NodeListView";
 import { ContextMenu } from "./ContextMenu";
 import { ModeTabs } from "./ModeTabs";
 import { ControlDock } from "./ControlDock";
+import { NodePreviewCard } from "./NodePreviewCard";
 import { ActiveFilterSummary } from "./ActiveFilterSummary";
 import { GraphLegend } from "./GraphLegend";
 import { PathTargetSelector } from "../PathTargetSelector";
@@ -76,7 +77,12 @@ function useGraphKeyboardNav(
 
       if (e.key === "Escape") {
         e.preventDefault();
-        selectNode(null);
+        const { previewNodeId, closePreview: close } = useStore.getState();
+        if (previewNodeId) {
+          close();
+        } else {
+          selectNode(null);
+        }
         return;
       }
 
@@ -297,6 +303,7 @@ export function GraphPanel() {
         {/* Mode hooks run outside the R3F canvas — they only need zustand, not a 3D context */}
         <GraphModeHooks />
         <ControlDock />
+        <NodePreviewCard />
         {viewMode === "graph" && !focusMap && <GraphLegend />}
         {viewMode === "graph" && minimapVisible && graphMode !== "overview" && !focusMap && (
           <div className="absolute bottom-14 right-3 z-10 opacity-80 transition-opacity hover:opacity-100">

--- a/crates/nestweaver-web/frontend/src/components/graph/ModeIndicator.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/ModeIndicator.tsx
@@ -1,0 +1,64 @@
+import { useState, useRef, useEffect } from "react";
+import { useStore } from "../../stores";
+import type { GraphMode } from "../../api/types";
+
+const modes: { key: GraphMode; label: string }[] = [
+  { key: "overview", label: "Overview" },
+  { key: "context", label: "Context" },
+  { key: "impact", label: "Impact" },
+  { key: "repos", label: "Repos" },
+  { key: "features", label: "Features" },
+  { key: "local", label: "Local" },
+];
+
+export function ModeIndicator() {
+  const graphMode = useStore((s) => s.graphMode);
+  const selectedNodeId = useStore((s) => s.selectedNodeId);
+  const setGraphMode = useStore((s) => s.setGraphMode);
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const current = modes.find((m) => m.key === graphMode);
+  const label = current?.label ?? graphMode;
+  const nodeName = selectedNodeId?.split(":").pop() ?? "";
+  const suffix = graphMode !== "overview" && nodeName ? `: ${nodeName}` : "";
+
+  return (
+    <div ref={ref} className="absolute bottom-2 right-2 z-20">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="rounded px-2 py-1 text-[11px] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-alt)] hover:text-[var(--color-text)] transition-colors"
+      >
+        {label}{suffix} ▾
+      </button>
+      {open && (
+        <div className="absolute bottom-full right-0 mb-1 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] py-1 shadow-lg min-w-32">
+          {modes.map((m) => (
+            <button
+              key={m.key}
+              type="button"
+              onClick={() => { setGraphMode(m.key); setOpen(false); }}
+              className={`w-full text-left px-3 py-1.5 text-xs ${
+                m.key === graphMode
+                  ? "text-[var(--color-graph-selection)] bg-[var(--color-surface-alt)]"
+                  : "text-[var(--color-text-muted)] hover:bg-[var(--color-surface-alt)] hover:text-[var(--color-text)]"
+              }`}
+            >
+              {m.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/crates/nestweaver-web/frontend/src/components/graph/NodeInstanceMesh.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/NodeInstanceMesh.tsx
@@ -43,7 +43,8 @@ void main() {
     float introScale = mix(0.62, 1.0, intro) + rebound;
     float breathe = 1.0 + u_breatheAmp * sin(u_time * 0.8 + aPhase * 6.2831);
     float focusLift = 1.0 + aHighlight * 0.18 + aSeed * 0.04;
-    float scale = aSize * introScale * breathe * focusLift;
+    float baseScale = 0.62;
+    float scale = aSize * baseScale * introScale * breathe * focusLift;
 
     vec3 pos = position * scale;
 

--- a/crates/nestweaver-web/frontend/src/components/graph/NodeInstanceMesh.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/NodeInstanceMesh.tsx
@@ -43,7 +43,7 @@ void main() {
     float introScale = mix(0.62, 1.0, intro) + rebound;
     float breathe = 1.0 + u_breatheAmp * sin(u_time * 0.8 + aPhase * 6.2831);
     float focusLift = 1.0 + aHighlight * 0.18 + aSeed * 0.04;
-    float baseScale = 0.62;
+    float baseScale = 0.45;
     float scale = aSize * baseScale * introScale * breathe * focusLift;
 
     vec3 pos = position * scale;

--- a/crates/nestweaver-web/frontend/src/components/graph/NodeInstanceMesh.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/NodeInstanceMesh.tsx
@@ -28,28 +28,22 @@ uniform float u_intro;
 varying vec2 v_uv;
 varying vec3 v_color;
 varying float v_highlight;
-varying float v_importance;
 varying float v_seed;
-varying float v_bridge;
 varying float v_phase;
 
 void main() {
     v_uv = uv;
     v_color = aColor;
     v_highlight = aHighlight;
-    v_importance = aImportance;
     v_seed = aSeed;
-    v_bridge = aBridge;
     v_phase = aPhase;
 
-    // Nodes arrive with a quick scale-in while staying locked to their graph coordinates.
     float intro = clamp(u_intro, 0.0, 1.0);
     float rebound = sin(intro * 3.14159) * (1.0 - intro) * 0.08 * u_motionAmp;
     float introScale = mix(0.62, 1.0, intro) + rebound;
     float breathe = 1.0 + u_breatheAmp * sin(u_time * 0.8 + aPhase * 6.2831);
     float focusLift = 1.0 + aHighlight * 0.18 + aSeed * 0.04;
-    float beaconScale = 0.62 + aImportance * 0.06;
-    float scale = aSize * beaconScale * introScale * breathe * focusLift;
+    float scale = aSize * introScale * breathe * focusLift;
 
     vec3 pos = position * scale;
 
@@ -62,39 +56,29 @@ const fragmentShader = /* glsl */ `
 varying vec2 v_uv;
 varying vec3 v_color;
 varying float v_highlight;
-varying float v_importance;
 varying float v_seed;
-varying float v_bridge;
 varying float v_phase;
 
 uniform float u_time;
+uniform vec3 u_strokeColor;
 
 void main() {
     vec2 uv = v_uv - 0.5;
     float dist = length(uv) * 2.0;
 
-    // Obsidian-like dot: clean filled center, soft antialiasing, glow only on focus.
-    float body = 1.0 - smoothstep(0.68, 0.78, dist);
-    float hotCore = exp(-7.5 * dist * dist);
-    float pulse = 0.5 + 0.5 * sin(u_time * 5.2 + v_phase * 6.2831);
-    float focusAura = exp(-8.2 * max(0.0, dist - 0.62)) *
-        v_highlight *
-        (0.11 + pulse * 0.08);
+    // Hard-edged filled circle with thin AA band
+    float body = 1.0 - smoothstep(0.90, 0.96, dist);
 
-    vec3 coreColor = mix(v_color * 0.96, v_color * 1.04, hotCore * 0.28);
-    coreColor *= 0.98 + v_importance * 0.08 + v_highlight * 0.24 + v_seed * 0.08;
+    // Hover: brighten fill 20%
+    vec3 color = v_color * (1.0 + v_highlight * 0.2);
 
-    vec3 focusInk = v_color * 1.32;
+    // Selection stroke ring: thin annulus at edge
+    float ringInner = smoothstep(0.78, 0.82, dist);
+    float ringOuter = 1.0 - smoothstep(0.90, 0.96, dist);
+    float ring = ringInner * ringOuter * v_highlight;
+    color = mix(color, u_strokeColor, ring * 0.8);
 
-    vec3 color =
-        coreColor * body +
-        focusInk * hotCore * v_highlight * 0.20 +
-        focusInk * focusAura;
-
-    float halo = exp(-8.6 * max(0.0, dist - 0.74)) * (v_highlight * 0.045 + v_seed * 0.018);
-    color += v_color * halo;
-    float alpha = max(body, max(focusAura, halo));
-
+    float alpha = body;
     if (alpha < 0.012) discard;
     gl_FragColor = vec4(color, alpha);
 }
@@ -127,6 +111,7 @@ export function NodeInstanceMesh({ buffers, reducedMotion = false }: Props) {
       u_breatheAmp: { value: 0 },
       u_motionAmp: { value: reducedMotion ? 0 : 1 },
       u_intro: { value: reducedMotion ? 1 : 0 },
+      u_strokeColor: { value: [0.804, 0.839, 0.957] },
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
@@ -138,6 +123,20 @@ export function NodeInstanceMesh({ buffers, reducedMotion = false }: Props) {
     uniforms.u_motionAmp.value = reducedMotion ? 0 : 1;
     if (reducedMotion) uniforms.u_intro.value = 1;
   }, [reducedMotion, uniforms]);
+
+  // Theme-reactive stroke color
+  useEffect(() => {
+    function updateStroke() {
+      const isDark = document.documentElement.classList.contains("dark");
+      uniforms.u_strokeColor.value = isDark
+        ? [0.804, 0.839, 0.957]
+        : [0.298, 0.310, 0.412];
+    }
+    updateStroke();
+    const observer = new MutationObserver(updateStroke);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+    return () => observer.disconnect();
+  }, [uniforms]);
 
   const introStartRef = useRef<number | null>(null);
 

--- a/crates/nestweaver-web/frontend/src/components/graph/NodeLabels.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/NodeLabels.tsx
@@ -146,7 +146,7 @@ export function NodeLabels({ buffers }: Props) {
               } ${focusMap ? "graph-node-label-focus" : ""}`}
               style={{
                 fontSize: `${baseFontSize}px`,
-                fontWeight: isHighlighted ? 700 : 560,
+                fontWeight: isHighlighted ? 600 : 500,
               }}
             >
               {node.label}

--- a/crates/nestweaver-web/frontend/src/components/graph/NodePreviewCard.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/NodePreviewCard.tsx
@@ -1,0 +1,165 @@
+import { useStore } from "../../stores";
+import { useNodePreview } from "../../hooks/useNodePreview";
+import { KindBadge } from "../shared/KindBadge";
+import { DetailPanel } from "../detail/DetailPanel";
+
+function stripFrontmatterAndHeadings(body: string): string {
+  // Strip YAML frontmatter
+  let text = body.replace(/^---[\s\S]*?---\n?/, "");
+  // Strip markdown headings
+  text = text.replace(/^#{1,6}\s+.*/gm, "");
+  // Collapse blank lines
+  text = text.replace(/\n{3,}/g, "\n\n").trim();
+  return text;
+}
+
+export function NodePreviewCard() {
+  const previewNodeId = useStore((s) => s.previewNodeId);
+  const previewExpanded = useStore((s) => s.previewExpanded);
+  const closePreview = useStore((s) => s.closePreview);
+  const togglePreviewExpanded = useStore((s) => s.togglePreviewExpanded);
+  const selectedNodeKind = useStore((s) => s.selectedNodeKind);
+
+  const { data, loading } = useNodePreview(previewNodeId, selectedNodeKind);
+
+  if (!previewNodeId) return null;
+
+  if (previewExpanded) {
+    return (
+      <div
+        className="absolute bottom-4 right-4 z-40 flex flex-col overflow-hidden rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] shadow-xl"
+        style={{ width: 360, maxHeight: "80vh" }}
+      >
+        {/* Expanded header */}
+        <div className="flex shrink-0 items-center justify-between border-b border-[var(--color-border)] px-3 py-2">
+          <button
+            onClick={togglePreviewExpanded}
+            className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
+          >
+            ← Collapse
+          </button>
+          <button
+            onClick={closePreview}
+            className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
+            aria-label="Close preview"
+          >
+            ✕
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-auto">
+          <DetailPanel />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="absolute bottom-4 right-4 z-40 flex flex-col overflow-hidden rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] shadow-xl"
+      style={{ maxWidth: 360, maxHeight: "50vh" }}
+    >
+      {loading || !data ? (
+        <div className="flex items-center justify-center p-6 text-sm text-[var(--color-text-muted)]">
+          {loading ? "Loading..." : "No data available"}
+        </div>
+      ) : (
+        <>
+          {/* Header */}
+          <div className="flex shrink-0 items-start justify-between gap-2 border-b border-[var(--color-border)] px-3 py-2">
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <div className="flex items-center gap-1.5">
+                <KindBadge
+                  kind={
+                    data.type === "symbol"
+                      ? data.detail.symbol.kind
+                      : data.detail.note.note_kind
+                  }
+                />
+                <span className="truncate text-sm font-semibold text-[var(--color-text)]">
+                  {data.type === "symbol"
+                    ? data.detail.symbol.name
+                    : data.detail.note.title}
+                </span>
+              </div>
+              <span className="truncate text-[11px] text-[var(--color-text-muted)]">
+                {data.type === "symbol"
+                  ? data.detail.symbol.file_path
+                  : data.detail.note.file_path}
+              </span>
+            </div>
+            <button
+              onClick={closePreview}
+              className="shrink-0 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
+              aria-label="Close preview"
+            >
+              ✕
+            </button>
+          </div>
+
+          {/* Content preview */}
+          <div className="min-h-0 flex-1 overflow-auto px-3 py-2">
+            {data.type === "symbol" ? (
+              data.sourceLines.length > 0 ? (
+                <pre className="overflow-x-auto text-[11px] leading-relaxed text-[var(--color-text)]">
+                  <code>{data.sourceLines.slice(0, 5).join("\n")}</code>
+                </pre>
+              ) : data.detail.symbol.summary ? (
+                <p className="text-xs leading-5 text-[var(--color-text-muted)]">
+                  {data.detail.symbol.summary}
+                </p>
+              ) : (
+                <p className="text-xs text-[var(--color-text-muted)]">No source available</p>
+              )
+            ) : (
+              <p className="text-xs leading-5 text-[var(--color-text-muted)]">
+                {stripFrontmatterAndHeadings(data.detail.body).slice(0, 200)}
+                {stripFrontmatterAndHeadings(data.detail.body).length > 200 ? "…" : ""}
+              </p>
+            )}
+          </div>
+
+          {/* Connections summary */}
+          <div className="flex shrink-0 items-center gap-3 border-t border-[var(--color-border)] px-3 py-1.5 text-[11px] text-[var(--color-text-muted)]">
+            {data.type === "symbol" ? (
+              <>
+                <span>
+                  <span className="font-medium text-[var(--color-text)]">
+                    {data.detail.callers.length}
+                  </span>{" "}
+                  caller{data.detail.callers.length !== 1 ? "s" : ""}
+                </span>
+                <span>
+                  <span className="font-medium text-[var(--color-text)]">
+                    {data.detail.callees.length}
+                  </span>{" "}
+                  callee{data.detail.callees.length !== 1 ? "s" : ""}
+                </span>
+              </>
+            ) : (
+              <>
+                <span>
+                  <span className="font-medium text-[var(--color-text)]">
+                    {data.detail.headings.length}
+                  </span>{" "}
+                  heading{data.detail.headings.length !== 1 ? "s" : ""}
+                </span>
+                <span>
+                  <span className="font-medium text-[var(--color-text)]">
+                    {data.detail.note.word_count.toLocaleString()}
+                  </span>{" "}
+                  words
+                </span>
+              </>
+            )}
+            <button
+              onClick={togglePreviewExpanded}
+              className="ml-auto text-[11px] text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
+            >
+              Expand →
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/crates/nestweaver-web/frontend/src/components/graph/NodePreviewCard.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/NodePreviewCard.tsx
@@ -20,9 +20,18 @@ export function NodePreviewCard() {
   const togglePreviewExpanded = useStore((s) => s.togglePreviewExpanded);
   const selectedNodeKind = useStore((s) => s.selectedNodeKind);
 
+  const graphInstance = useStore((s) => s.graphInstance);
   const { data, loading } = useNodePreview(previewNodeId, selectedNodeKind);
 
   if (!previewNodeId) return null;
+
+  // Fallback info from graph when API detail isn't available
+  const graphNode = previewNodeId && graphInstance?.hasNode(previewNodeId)
+    ? {
+        label: (graphInstance.getNodeAttribute(previewNodeId, "label") as string) || previewNodeId.split(":").pop() || previewNodeId,
+        kind: (graphInstance.getNodeAttribute(previewNodeId, "kind") as string) || selectedNodeKind || "Unknown",
+      }
+    : null;
 
   if (previewExpanded) {
     return (
@@ -58,9 +67,30 @@ export function NodePreviewCard() {
       className="absolute bottom-4 right-4 z-40 flex flex-col overflow-hidden rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] shadow-xl"
       style={{ maxWidth: 360, maxHeight: "50vh" }}
     >
-      {loading || !data ? (
+      {loading ? (
         <div className="flex items-center justify-center p-6 text-sm text-[var(--color-text-muted)]">
-          {loading ? "Loading..." : "No data available"}
+          Loading...
+        </div>
+      ) : !data ? (
+        <div className="px-3 py-3">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex items-center gap-1.5">
+              {graphNode && <KindBadge kind={graphNode.kind} />}
+              <span className="text-sm font-semibold text-[var(--color-text)]">
+                {graphNode?.label ?? previewNodeId}
+              </span>
+            </div>
+            <button
+              onClick={closePreview}
+              className="shrink-0 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
+              aria-label="Close preview"
+            >
+              ✕
+            </button>
+          </div>
+          <p className="mt-2 text-xs text-[var(--color-text-muted)]">
+            {previewNodeId}
+          </p>
         </div>
       ) : (
         <>

--- a/crates/nestweaver-web/frontend/src/components/graph/NodePreviewCard.tsx
+++ b/crates/nestweaver-web/frontend/src/components/graph/NodePreviewCard.tsx
@@ -42,12 +42,14 @@ export function NodePreviewCard() {
         {/* Expanded header */}
         <div className="flex shrink-0 items-center justify-between border-b border-[var(--color-border)] px-3 py-2">
           <button
+            type="button"
             onClick={togglePreviewExpanded}
             className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
           >
             ← Collapse
           </button>
           <button
+            type="button"
             onClick={closePreview}
             className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
             aria-label="Close preview"
@@ -81,6 +83,7 @@ export function NodePreviewCard() {
               </span>
             </div>
             <button
+              type="button"
               onClick={closePreview}
               className="shrink-0 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
               aria-label="Close preview"
@@ -118,6 +121,7 @@ export function NodePreviewCard() {
               </span>
             </div>
             <button
+              type="button"
               onClick={closePreview}
               className="shrink-0 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
               aria-label="Close preview"
@@ -141,10 +145,15 @@ export function NodePreviewCard() {
                 <p className="text-xs text-[var(--color-text-muted)]">No source available</p>
               )
             ) : (
-              <p className="text-xs leading-5 text-[var(--color-text-muted)]">
-                {stripFrontmatterAndHeadings(data.detail.body).slice(0, 200)}
-                {stripFrontmatterAndHeadings(data.detail.body).length > 200 ? "…" : ""}
-              </p>
+              (() => {
+                const preview = stripFrontmatterAndHeadings(data.detail.body);
+                return (
+                  <p className="text-xs leading-5 text-[var(--color-text-muted)]">
+                    {preview.slice(0, 200)}
+                    {preview.length > 200 ? "…" : ""}
+                  </p>
+                );
+              })()
             )}
           </div>
 
@@ -182,6 +191,7 @@ export function NodePreviewCard() {
               </>
             )}
             <button
+              type="button"
               onClick={togglePreviewExpanded}
               className="ml-auto text-[11px] text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
             >

--- a/crates/nestweaver-web/frontend/src/components/graph/utils/graphColors.ts
+++ b/crates/nestweaver-web/frontend/src/components/graph/utils/graphColors.ts
@@ -1,41 +1,41 @@
 export const KIND_COLORS: Record<string, string> = {
-  Function: "#3B82F6",
-  Class: "#8B5CF6",
-  Interface: "#14B8A6",
-  Method: "#6366F1",
-  Module: "#F59E0B",
-  Note: "#78716C",
-  Section: "#A8A29E",
-  Tag: "#22C55E",
+  Function: "#1e66f5",
+  Class: "#8839ef",
+  Interface: "#179299",
+  Method: "#7287fd",
+  Module: "#df8e1d",
+  Note: "#7c7f93",
+  Section: "#8c8fa1",
+  Tag: "#40a02b",
 };
 
 export const EDGE_COLORS: Record<string, string> = {
-  overview: "#6b7280",
-  calls: "#67e8f9",
-  imports: "#4ade80",
-  extends: "#fb923c",
-  implements: "#22d3ee",
-  wikilink: "#94a3b8",
-  references_code: "#fb7185",
-  tagged_with: "#4ade80",
-  cross_repo_declared: "#38bdf8",
-  cross_repo_suggested: "#38bdf8",
+  overview: "#9ca0b0",
+  calls: "#9ca0b0",
+  imports: "#9ca0b0",
+  extends: "#9ca0b0",
+  implements: "#9ca0b0",
+  wikilink: "#9ca0b0",
+  references_code: "#9ca0b0",
+  tagged_with: "#9ca0b0",
+  cross_repo_declared: "#9ca0b0",
+  cross_repo_suggested: "#9ca0b0",
 };
 
 export function kindColor(kind: string, isDark: boolean): string {
   const dark: Record<string, string> = {
-    Function: "#22d3ee", Class: "#a855f7", Method: "#f472b6",
-    Interface: "#2dd4bf", Trait: "#a3e635", Enum: "#fbbf24",
-    Module: "#fb923c", Extension: "#fb7185", Note: "#c084fc",
-    Section: "#94a3b8", Tag: "#4ade80", Constant: "#38bdf8",
+    Function: "#89b4fa", Class: "#cba6f7", Method: "#b4befe",
+    Interface: "#94e2d5", Trait: "#a6e3a1", Enum: "#f9e2af",
+    Module: "#f9e2af", Extension: "#f38ba8", Note: "#9399b2",
+    Section: "#a6adc8", Tag: "#a6e3a1", Constant: "#89b4fa",
   };
   const light: Record<string, string> = {
-    Function: "#0891b2", Class: "#7c3aed", Method: "#db2777",
-    Interface: "#0d9488", Trait: "#65a30d", Enum: "#d97706",
-    Module: "#ea580c", Extension: "#e11d48", Note: "#7c3aed",
-    Section: "#57534e", Tag: "#16a34a", Constant: "#0284c7",
+    Function: "#1e66f5", Class: "#8839ef", Method: "#7287fd",
+    Interface: "#179299", Trait: "#40a02b", Enum: "#df8e1d",
+    Module: "#df8e1d", Extension: "#d20f39", Note: "#7c7f93",
+    Section: "#8c8fa1", Tag: "#40a02b", Constant: "#1e66f5",
   };
-  return (isDark ? dark : light)[kind] ?? (isDark ? "#64748b" : "#6b7280");
+  return (isDark ? dark : light)[kind] ?? (isDark ? "#585b70" : "#9ca0b0");
 }
 
 export function kindToColor(kind: string): string {

--- a/crates/nestweaver-web/frontend/src/hooks/useNodePreview.ts
+++ b/crates/nestweaver-web/frontend/src/hooks/useNodePreview.ts
@@ -1,0 +1,84 @@
+import { useEffect, useState } from "react";
+import { api } from "../api/client";
+import type { SymbolDetail, NoteDetail } from "../api/types";
+
+export type PreviewData =
+  | { type: "symbol"; detail: SymbolDetail; sourceLines: string[] }
+  | { type: "note"; detail: NoteDetail }
+  | null;
+
+const cache = new Map<string, PreviewData>();
+const CACHE_MAX = 10;
+
+function cacheSet(key: string, value: PreviewData) {
+  if (cache.size >= CACHE_MAX) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  cache.set(key, value);
+}
+
+export function useNodePreview(
+  nodeId: string | null,
+  nodeKind: string | null,
+): { data: PreviewData; loading: boolean } {
+  const [data, setData] = useState<PreviewData>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!nodeId) {
+      setData(null);
+      return;
+    }
+
+    const cached = cache.get(nodeId);
+    if (cached) {
+      setData(cached);
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+
+    const isNote =
+      nodeId.startsWith("note:") ||
+      nodeKind === "note" ||
+      nodeKind === "Note";
+
+    const fetchData = async () => {
+      try {
+        if (isNote) {
+          const detail = await api.brainNote(nodeId);
+          const result: PreviewData = { type: "note", detail };
+          cacheSet(nodeId, result);
+          if (!controller.signal.aborted) setData(result);
+        } else {
+          const detail = await api.symbol(nodeId);
+          let sourceLines: string[] = [];
+          try {
+            const source = await api.source(
+              detail.symbol.file_path,
+              detail.symbol.start_line,
+              5,
+            );
+            sourceLines = source.lines ?? [];
+          } catch {
+            // source not available — still show the card
+          }
+          const result: PreviewData = { type: "symbol", detail, sourceLines };
+          cacheSet(nodeId, result);
+          if (!controller.signal.aborted) setData(result);
+        }
+      } catch {
+        if (!controller.signal.aborted) setData(null);
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    };
+
+    fetchData();
+    return () => controller.abort();
+  }, [nodeId, nodeKind]);
+
+  return { data, loading };
+}

--- a/crates/nestweaver-web/frontend/src/index.css
+++ b/crates/nestweaver-web/frontend/src/index.css
@@ -1,44 +1,57 @@
 @import "tailwindcss";
 
 @theme {
-  --color-fn: #3B82F6;
-  --color-cls: #8B5CF6;
-  --color-ifc: #14B8A6;
-  --color-method: #6366F1;
-  --color-module: #F59E0B;
-  --color-note: #78716C;
-  --color-section: #A8A29E;
-  --color-tag: #22C55E;
-  --color-edge-calls: #9CA3AF;
-  --color-edge-imports: #22C55E;
-  --color-edge-extends: #F97316;
-  --color-edge-implements: #06B6D4;
-  --color-edge-crossdomain: #F43F5E;
-  --color-surface: #ffffff;
-  --color-surface-alt: #f9fafb;
-  --color-border: #e5e7eb;
-  --color-text: #111827;
-  --color-text-muted: #6b7280;
-  --color-graph-bg: #fafbfc;
-  --color-graph-label: #374151;
-  --color-graph-label-hover: #111827;
-  --color-graph-edge: rgba(107, 114, 128, 0.15);
-  --color-graph-dim: #d0d0d0;
-  --color-graph-selection: #0862a7;
+  --color-fn: #1e66f5;
+  --color-cls: #8839ef;
+  --color-ifc: #179299;
+  --color-method: #7287fd;
+  --color-module: #df8e1d;
+  --color-note: #7c7f93;
+  --color-section: #8c8fa1;
+  --color-tag: #40a02b;
+  --color-edge-calls: #9ca0b0;
+  --color-edge-imports: #9ca0b0;
+  --color-edge-extends: #9ca0b0;
+  --color-edge-implements: #9ca0b0;
+  --color-edge-crossdomain: #9ca0b0;
+  --color-surface: #eff1f5;
+  --color-surface-alt: #e6e9ef;
+  --color-border: #ccd0da;
+  --color-text: #4c4f69;
+  --color-text-muted: #6c6f85;
+  --color-graph-bg: #eff1f5;
+  --color-graph-label: #6c6f85;
+  --color-graph-label-hover: #4c4f69;
+  --color-graph-edge: rgba(156, 160, 176, 0.45);
+  --color-graph-dim: #ccd0da;
+  --color-graph-selection: #1e66f5;
 }
 
 :root.dark {
-  --color-surface: #0a0e17;
-  --color-surface-alt: #111827;
-  --color-border: #1e293b;
-  --color-text: #e2e8f0;
-  --color-text-muted: #94a3b8;
-  --color-graph-bg: #06080f;
-  --color-graph-label: #cbd5e1;
-  --color-graph-label-hover: #f1f5f9;
-  --color-graph-edge: rgba(34, 211, 238, 0.12);
-  --color-graph-dim: #1a1a2e;
-  --color-graph-selection: #5ed0fe;
+  --color-fn: #89b4fa;
+  --color-cls: #cba6f7;
+  --color-ifc: #94e2d5;
+  --color-method: #b4befe;
+  --color-module: #f9e2af;
+  --color-note: #9399b2;
+  --color-section: #a6adc8;
+  --color-tag: #a6e3a1;
+  --color-edge-calls: #585b70;
+  --color-edge-imports: #585b70;
+  --color-edge-extends: #585b70;
+  --color-edge-implements: #585b70;
+  --color-edge-crossdomain: #585b70;
+  --color-surface: #1e1e2e;
+  --color-surface-alt: #313244;
+  --color-border: #45475a;
+  --color-text: #cdd6f4;
+  --color-text-muted: #a6adc8;
+  --color-graph-bg: #1e1e2e;
+  --color-graph-label: #a6adc8;
+  --color-graph-label-hover: #cdd6f4;
+  --color-graph-edge: rgba(88, 91, 112, 0.5);
+  --color-graph-dim: #313244;
+  --color-graph-selection: #89b4fa;
 }
 
 html, body, #root {
@@ -51,7 +64,7 @@ html, body, #root {
 }
 
 ::selection {
-  background: #3B82F640;
+  background: #89b4fa40;
 }
 
 ::-webkit-scrollbar {
@@ -89,45 +102,30 @@ html, body, #root {
   position: relative;
   z-index: 1;
   display: block;
-  padding: 1px 3px;
-  border-radius: 3px;
-  background: rgba(255, 255, 255, 0.68);
+  padding: 0;
+  background: transparent;
   color: var(--color-graph-label);
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   letter-spacing: 0;
   line-height: 1.15;
   text-rendering: geometricPrecision;
   -webkit-font-smoothing: antialiased;
   transform: translateZ(0);
-  filter: drop-shadow(0 1px 1px rgba(15, 23, 42, 0.12));
 }
 
 :root.dark .graph-node-label {
-  background: rgba(6, 8, 15, 0.62);
-  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.36));
+  background: transparent;
 }
 
 .graph-node-label-focus {
-  background: rgba(255, 255, 255, 0.52);
   color: color-mix(in srgb, var(--color-graph-label) 84%, transparent);
-}
-
-:root.dark .graph-node-label-focus {
-  background: rgba(6, 8, 15, 0.48);
 }
 
 .graph-node-label-hovered {
   color: var(--color-graph-label-hover);
-  background: rgba(255, 255, 255, 0.82);
 }
 
 .graph-node-label-selected {
-  background: color-mix(in srgb, var(--color-graph-selection) 16%, white);
-  color: var(--color-text);
-}
-
-:root.dark .graph-node-label-selected {
-  background: color-mix(in srgb, var(--color-graph-selection) 30%, var(--color-surface));
   color: var(--color-text);
 }
 
@@ -173,8 +171,8 @@ html, body, #root {
 }
 
 :root.dark .glass-panel {
-  background: rgba(6, 8, 15, 0.92);
-  border: 1px solid rgba(34, 211, 238, 0.08);
+  background: rgba(30, 30, 46, 0.92);
+  border: 1px solid rgba(69, 71, 90, 0.3);
 }
 
 /* Cursor-responsive light effect */

--- a/crates/nestweaver-web/frontend/src/stores/graphSlice.ts
+++ b/crates/nestweaver-web/frontend/src/stores/graphSlice.ts
@@ -9,6 +9,11 @@ export interface GraphSlice {
   selectedNodeId: string | null;
   selectedNodeKind: string | null;
   hoveredNodeId: string | null;
+  previewNodeId: string | null;
+  previewExpanded: boolean;
+  openPreview: (id: string, kind?: string | null) => void;
+  closePreview: () => void;
+  togglePreviewExpanded: () => void;
   graphMode: GraphMode;
   seeds: string[];
   scopeFilter: ScopeFilter;
@@ -63,6 +68,8 @@ export const createGraphSlice: StateCreator<
   selectedNodeId: null,
   selectedNodeKind: null,
   hoveredNodeId: null,
+  previewNodeId: null,
+  previewExpanded: false,
   graphMode: "overview",
   seeds: [],
   scopeFilter: "all",
@@ -124,6 +131,10 @@ export const createGraphSlice: StateCreator<
       s.selectedNodeId = id;
       s.selectedNodeKind = kind ?? null;
       s.detailFocus = "summary";
+      if (id === null) {
+        s.previewNodeId = null;
+        s.previewExpanded = false;
+      }
     }),
 
   exploreNode: (id, kind) =>
@@ -138,6 +149,25 @@ export const createGraphSlice: StateCreator<
   hoverNode: (id) =>
     set((s) => {
       s.hoveredNodeId = id;
+    }),
+
+  openPreview: (id, kind) =>
+    set((s) => {
+      s.previewNodeId = id;
+      s.previewExpanded = false;
+      s.selectedNodeId = id;
+      s.selectedNodeKind = kind ?? null;
+    }),
+
+  closePreview: () =>
+    set((s) => {
+      s.previewNodeId = null;
+      s.previewExpanded = false;
+    }),
+
+  togglePreviewExpanded: () =>
+    set((s) => {
+      s.previewExpanded = !s.previewExpanded;
     }),
 
   setGraphMode: (mode) =>

--- a/crates/nestweaver-web/frontend/src/stores/graphSlice.ts
+++ b/crates/nestweaver-web/frontend/src/stores/graphSlice.ts
@@ -14,6 +14,9 @@ export interface GraphSlice {
   openPreview: (id: string, kind?: string | null) => void;
   closePreview: () => void;
   togglePreviewExpanded: () => void;
+  contextMenu: { x: number; y: number; nodeId: string } | null;
+  openContextMenu: (x: number, y: number, nodeId: string) => void;
+  closeContextMenu: () => void;
   graphMode: GraphMode;
   seeds: string[];
   scopeFilter: ScopeFilter;
@@ -70,6 +73,7 @@ export const createGraphSlice: StateCreator<
   hoveredNodeId: null,
   previewNodeId: null,
   previewExpanded: false,
+  contextMenu: null,
   graphMode: "overview",
   seeds: [],
   scopeFilter: "all",
@@ -168,6 +172,16 @@ export const createGraphSlice: StateCreator<
   togglePreviewExpanded: () =>
     set((s) => {
       s.previewExpanded = !s.previewExpanded;
+    }),
+
+  openContextMenu: (x, y, nodeId) =>
+    set((s) => {
+      s.contextMenu = { x, y, nodeId };
+    }),
+
+  closeContextMenu: () =>
+    set((s) => {
+      s.contextMenu = null;
     }),
 
   setGraphMode: (mode) =>


### PR DESCRIPTION
## Summary

Redesigns the NestWeaver graph UI to feel crisp and immediately valuable, inspired by Obsidian's graph view.

### Visual Reskin (Catppuccin palette)
- Replace neon/glow aesthetic with muted Catppuccin Mocha (dark) / Latte (light) pastels
- Hard-edged filled circles — remove bloom post-processing, halos, and hot-core gradients
- Single-color thin edges (no per-type gradient colors)
- Bare text labels (no background pills or drop shadows)
- Muted edge particles (smaller, uniform color)
- Breathing animation and interaction model preserved

### Click-to-Preview UX
- **Single click** → compact preview card (kind badge, name, file path, code/note preview, connections summary). No action buttons — content first.
- **Double click** → go deep (context mode, full detail panel)
- **Right-click** → grouped context menu with power actions (Explore, Impact, Local / Path, Trace / Open source, Copy UID)
- **Escape** → close preview without layout change

### UI Simplification
- **Control dock**: 5 buttons → single gear icon with all sections in one scrollable flyout
- **Mode tabs**: 6-tab bar removed, replaced with subtle mode indicator (clickable dropdown for manual switching)
- **LLM bar / Timeline**: hidden by default (Cmd+K / settings panel access)
- **Preview card works at every viewport width** — no more "click does nothing" at narrow screens

### Fallback handling
- Nodes without API detail (repos, modules) show graph-derived name and kind instead of empty state

## Test plan
- [x] Type check passes (`tsc --noEmit`)
- [x] Lint passes (`npm run lint`)  
- [x] Production build succeeds (`npm run build`)
- [x] Playwright testing: hover, click preview, escape dismiss, background dismiss, right-click menu, gear settings, mode indicator, dark/light mode, expand/collapse detail
- [ ] E2E test suite (`npm run test:e2e`)