### PR TITLE
feat: wire [limits].default_result_limit to runtime dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,7 +2975,7 @@ checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "nestweaver"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-algorithms"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -3021,7 +3021,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-client"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-daemon"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-engine"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "apollo-parser",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-mcp"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-parser"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "comrak",
  "hex",
@@ -3168,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-proto"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "prost 0.13.5",
  "tonic",
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-resolver"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "glob",
  "insta",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-schema"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "hex",
  "serde",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-storage"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3220,7 +3220,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-store"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "cc",
@@ -3241,7 +3241,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-wasm"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "js-sys",
  "nestweaver-algorithms",

--- a/README.md
+++ b/README.md
@@ -290,6 +290,15 @@ nestweaver suggest-links --db ./all.lbug
 nestweaver context --feature device-pairing --config ./nestweaver-instance.toml --db ./all.lbug
 ```
 
+**Runtime-configurable defaults** — set `[limits]` in your instance config to override the built-in pagination default (50) for all MCP tools and CLI commands:
+
+```toml
+[limits]
+default_result_limit = 100
+```
+
+CLI commands (`search`, `brain search`, `brain context`) also respect this setting when `--limit` is not explicitly passed. The `[response]` section controls inline body thresholds.
+
 </details>
 
 ## MCP Server

--- a/crates/nestweaver-engine/src/config.rs
+++ b/crates/nestweaver-engine/src/config.rs
@@ -273,10 +273,10 @@ pub const DEFAULT_RESULT_LIMIT: usize = 50;
 
 /// `[limits]` — default pagination limits for tool responses.
 ///
-/// NOTE: MCP tools currently use the compile-time `DEFAULT_RESULT_LIMIT`
-/// constant. This config is deserialized and stored but not yet plumbed
-/// through to the tool dispatch layer. A future change should pass the
-/// resolved limit from `InstanceConfig.limits` into the MCP server context.
+/// MCP tools read `default_result_limit` at dispatch time via the
+/// thread-local `InstanceConfig` (set by the daemon or direct MCP server).
+/// When no instance config is loaded, tools fall back to
+/// `DEFAULT_RESULT_LIMIT`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LimitsConfig {
     #[serde(default = "default_result_limit")]

--- a/crates/nestweaver-mcp/src/lib.rs
+++ b/crates/nestweaver-mcp/src/lib.rs
@@ -84,13 +84,31 @@ pub fn run_stdio_server(
 
     // Load instance config so tools can read [limits], [response], [ranking], etc.
     // Try explicit --config path first, then auto-discover instance.toml next to the DB.
-    let instance_cfg = config_path
-        .and_then(|p| nestweaver_engine::InstanceConfig::from_file(p).ok())
-        .or_else(|| {
-            let sibling = db_path.parent()?.join("instance.toml");
-            nestweaver_engine::InstanceConfig::from_file(&sibling).ok()
-        });
+    let (instance_cfg, cfg_source) = if let Some(p) = config_path {
+        match nestweaver_engine::InstanceConfig::from_file(p) {
+            Ok(c) => (Some(c), Some(p.display().to_string())),
+            Err(e) => {
+                tracing::warn!(path = %p.display(), error = %e, "failed to load --config");
+                (None, None)
+            }
+        }
+    } else {
+        let sibling = db_path.parent().map(|d| d.join("instance.toml"));
+        match sibling.as_deref().and_then(|s| {
+            nestweaver_engine::InstanceConfig::from_file(s)
+                .ok()
+                .map(|c| (c, s.display().to_string()))
+        }) {
+            Some((c, path)) => (Some(c), Some(path)),
+            None => (None, None),
+        }
+    };
     if let Some(cfg) = instance_cfg {
+        tracing::info!(
+            config = cfg_source.as_deref().unwrap_or("?"),
+            limits.default_result_limit = cfg.limits.default_result_limit,
+            "loaded instance config"
+        );
         if cfg.cache.max_size_mb > 0 {
             tools::set_cache_max_size_mb(cfg.cache.max_size_mb);
         }

--- a/crates/nestweaver-mcp/src/lib.rs
+++ b/crates/nestweaver-mcp/src/lib.rs
@@ -36,6 +36,7 @@ pub fn run_stdio_server(
     allow_add_sources: bool,
     lite: bool,
     track_interactions: bool,
+    config_path: Option<&Path>,
 ) -> Result<(), anyhow::Error> {
     let store = GraphStore::open_or_readonly(db_path)
         .with_context(|| format!("open GraphStore at {}", db_path.display()))?;
@@ -80,6 +81,21 @@ pub fn run_stdio_server(
     tools::set_current_db_path(canonical_db);
     tools::set_allow_add_sources(allow_add_sources);
     tools::set_lite_mode(lite);
+
+    // Load instance config so tools can read [limits], [response], [ranking], etc.
+    // Try explicit --config path first, then auto-discover instance.toml next to the DB.
+    let instance_cfg = config_path
+        .and_then(|p| nestweaver_engine::InstanceConfig::from_file(p).ok())
+        .or_else(|| {
+            let sibling = db_path.parent()?.join("instance.toml");
+            nestweaver_engine::InstanceConfig::from_file(&sibling).ok()
+        });
+    if let Some(cfg) = instance_cfg {
+        if cfg.cache.max_size_mb > 0 {
+            tools::set_cache_max_size_mb(cfg.cache.max_size_mb);
+        }
+        tools::set_current_instance_config(Some(std::sync::Arc::new(cfg)));
+    }
 
     let tracker: Option<nestweaver_engine::InteractionTracker> = if track_interactions {
         Some(nestweaver_engine::InteractionTracker::new(db_path))

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -705,7 +705,7 @@ fn tool_brain_broken_links(store: &GraphStore, args: Value) -> Result<Value, any
         .get("limit")
         .and_then(|v| v.as_u64())
         .map(|n| n as usize)
-        .unwrap_or(DEFAULT_RESULT_LIMIT);
+        .unwrap_or_else(configured_result_limit);
     let all_links = broken_links(store, max_suggestions)?;
     let total = all_links.len();
     let links: Vec<_> = all_links.into_iter().take(limit).collect();
@@ -744,7 +744,7 @@ fn tool_brain_orphan_documents(store: &GraphStore, args: Value) -> Result<Value,
         .get("limit")
         .and_then(|v| v.as_u64())
         .map(|n| n as usize)
-        .unwrap_or(DEFAULT_RESULT_LIMIT);
+        .unwrap_or_else(configured_result_limit);
     let all_orphans = orphan_documents(store, vault, path_prefix, &allowlist)?;
     let total = all_orphans.len();
     let orphans: Vec<_> = all_orphans.into_iter().take(limit).collect();
@@ -786,7 +786,7 @@ fn tool_brain_topic_clusters(store: &GraphStore, args: Value) -> Result<Value, a
         .get("limit")
         .and_then(|v| v.as_u64())
         .map(|n| n as usize)
-        .unwrap_or(DEFAULT_RESULT_LIMIT);
+        .unwrap_or_else(configured_result_limit);
     let all_clusters = topic_clusters(store, resolution)?;
     let total = all_clusters.len();
     let clusters: Vec<_> = all_clusters.into_iter().take(limit).collect();
@@ -822,7 +822,7 @@ fn tool_brain_tag_graph(store: &GraphStore, args: Value) -> Result<Value, anyhow
         .get("limit")
         .and_then(|v| v.as_u64())
         .map(|n| n as usize)
-        .unwrap_or(DEFAULT_RESULT_LIMIT);
+        .unwrap_or_else(configured_result_limit);
     // `tag` is optional. When present we accept only a string (reject other
     // JSON types); when absent we return the whole tag co-occurrence graph.
     match args.get("tag") {
@@ -903,7 +903,7 @@ fn tool_brain_memory_lint(store: &GraphStore, args: Value) -> Result<Value, anyh
         .get("limit")
         .and_then(|v| v.as_u64())
         .map(|n| n as usize)
-        .unwrap_or(DEFAULT_RESULT_LIMIT);
+        .unwrap_or_else(configured_result_limit);
     let mut report = serde_json::to_value(memory_lint(store, now_epoch_secs())?)?;
     // Truncate each lint category to `limit` and report totals.
     if let Some(obj) = report.as_object_mut() {
@@ -946,7 +946,7 @@ fn tool_brain_memory_consolidate(store: &GraphStore, args: Value) -> Result<Valu
         .get("limit")
         .and_then(|v| v.as_u64())
         .map(|n| n as usize)
-        .unwrap_or(DEFAULT_RESULT_LIMIT);
+        .unwrap_or_else(configured_result_limit);
     let mut manifest = serde_json::to_value(memory_consolidate(store, apply, now_epoch_secs())?)?;
     // Truncate proposals to limit and report total.
     if let Some(obj) = manifest.as_object_mut() {
@@ -1501,9 +1501,7 @@ fn tool_brain_context(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
     if include_bodies {
-        // The MCP server has no instance-config handle here, so use the
-        // built-in [response] defaults (threshold 0.75, cap 800 tokens).
-        let response_config = nestweaver_engine::ResponseConfig::default();
+        let response_config = configured_response();
         let root = args
             .get("root")
             .and_then(|v| v.as_str())
@@ -2102,7 +2100,7 @@ fn tool_brain_search(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
     if include_bodies && !concise {
-        let response_config = nestweaver_engine::ResponseConfig::default();
+        let response_config = configured_response();
         let root = args
             .get("root")
             .and_then(|v| v.as_str())
@@ -3034,7 +3032,7 @@ fn tool_cross_repo_contracts(store: &GraphStore, args: Value) -> Result<Value, a
         .get("limit")
         .and_then(|v| v.as_u64())
         .map(|n| n as usize)
-        .unwrap_or(DEFAULT_RESULT_LIMIT);
+        .unwrap_or_else(configured_result_limit);
 
     let refs = store
         .cross_repo_links(&uid)
@@ -3109,7 +3107,7 @@ fn tool_contract_drift(store: &GraphStore, args: Value) -> Result<Value, anyhow:
         .get("limit")
         .and_then(|v| v.as_u64())
         .map(|n| n as usize)
-        .unwrap_or(DEFAULT_RESULT_LIMIT);
+        .unwrap_or_else(configured_result_limit);
     let report = nestweaver_engine::contracts::drift_for_store(store, repo)
         .map_err(|e| anyhow!("drift_for_store: {e}"))?;
     let dni_total = report.declared_not_implemented.len();
@@ -3173,7 +3171,7 @@ fn tool_brain_impact(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
         .get("limit")
         .and_then(|v| v.as_u64())
         .map(|n| n as usize)
-        .unwrap_or(DEFAULT_RESULT_LIMIT);
+        .unwrap_or_else(configured_result_limit);
     let concise = is_concise(&args);
 
     let uid = resolve_symbol_uid(store, symbol)?;
@@ -3919,7 +3917,7 @@ fn tool_brain_diff(store: &GraphStore, args: Value) -> Result<Value, anyhow::Err
         .get("limit")
         .and_then(|v| v.as_u64())
         .map(|n| n as usize)
-        .unwrap_or(DEFAULT_RESULT_LIMIT);
+        .unwrap_or_else(configured_result_limit);
 
     // Find the repo in the graph.
     let repos = store.list_repos(None)?;
@@ -5014,6 +5012,23 @@ pub fn set_current_instance_config(cfg: Option<std::sync::Arc<nestweaver_engine:
 pub(crate) fn current_instance_config() -> Option<std::sync::Arc<nestweaver_engine::InstanceConfig>>
 {
     CURRENT_INSTANCE_CONFIG.with(|c| c.borrow().clone())
+}
+
+/// Read the configured default result limit from the instance config's
+/// `[limits]` section, falling back to the compile-time constant if no
+/// instance config is installed for this dispatch context.
+fn configured_result_limit() -> usize {
+    current_instance_config()
+        .map(|cfg| cfg.limits.default_result_limit)
+        .unwrap_or(DEFAULT_RESULT_LIMIT)
+}
+
+/// Read the configured `[response]` settings, falling back to defaults if no
+/// instance config is installed for this dispatch context.
+fn configured_response() -> nestweaver_engine::ResponseConfig {
+    current_instance_config()
+        .map(|cfg| cfg.response.clone())
+        .unwrap_or_default()
 }
 
 /// Set the F16 response-cache size cap in MiB (from `[cache] max_size_mb`).

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -5933,6 +5933,58 @@ mod cache_dispatch_tests {
 }
 
 #[cfg(test)]
+mod configured_limit_tests {
+    use super::*;
+
+    fn test_config(limit: usize) -> nestweaver_engine::InstanceConfig {
+        serde_json::from_value(serde_json::json!({
+            "instance_id": "test",
+            "repos": [],
+            "snapshot_storage": { "backend": "local", "path": "/tmp" },
+            "workspace": { "backend": "local", "path": "/tmp" },
+            "inference": { "endpoint": "", "embedding_model": "", "summary_model": "" },
+            "git": { "credential_method": "ssh" },
+            "limits": { "default_result_limit": limit }
+        }))
+        .expect("valid test config")
+    }
+
+    #[test]
+    fn configured_result_limit_uses_default_without_config() {
+        set_current_instance_config(None);
+        assert_eq!(configured_result_limit(), DEFAULT_RESULT_LIMIT);
+    }
+
+    #[test]
+    fn configured_result_limit_reads_from_instance_config() {
+        let cfg = test_config(7);
+        assert_eq!(cfg.limits.default_result_limit, 7);
+        set_current_instance_config(Some(std::sync::Arc::new(cfg)));
+        assert_eq!(configured_result_limit(), 7);
+        set_current_instance_config(None);
+    }
+
+    #[test]
+    fn configured_response_uses_default_without_config() {
+        set_current_instance_config(None);
+        let resp = configured_response();
+        assert!((resp.inline_body_threshold - 0.75).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn configured_response_reads_from_instance_config() {
+        let mut cfg = test_config(50);
+        cfg.response.inline_body_threshold = 0.5;
+        cfg.response.inline_max_body_tokens = 200;
+        set_current_instance_config(Some(std::sync::Arc::new(cfg)));
+        let resp = configured_response();
+        assert!((resp.inline_body_threshold - 0.5).abs() < f64::EPSILON);
+        assert_eq!(resp.inline_max_body_tokens, 200);
+        set_current_instance_config(None);
+    }
+}
+
+#[cfg(test)]
 mod tool_doc_tests {
     use super::*;
 

--- a/crates/nestweaver-web/frontend/dist/index.html
+++ b/crates/nestweaver-web/frontend/dist/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NestWeaver</title>
-    <script type="module" crossorigin src="/assets/index-CrL6LIuI.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-WJgTAbhW.css">
+    <script type="module" crossorigin src="/assets/index-DTYHqMZx.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-BWraBRzT.css">
   </head>
   <body>
     <div id="root"></div>

--- a/src/main.rs
+++ b/src/main.rs
@@ -672,6 +672,10 @@ enum Commands {
             help = "Record interaction telemetry to a sidecar file for usage-based ranking"
         )]
         track_interactions: bool,
+        /// Path to instance config (TOML) for [limits], [response], [ranking] settings.
+        /// In daemon mode, the daemon's own --config takes precedence.
+        #[arg(long)]
+        config: Option<PathBuf>,
         /// Open the database directly for reads instead of routing through the daemon.
         /// Write operations always go through the daemon regardless of this flag.
         #[arg(long)]
@@ -4053,6 +4057,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             lite,
             tools: tool_allowlist,
             track_interactions,
+            config,
             no_daemon,
         } => {
             if allow_mcp_add_sources {
@@ -4090,6 +4095,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     allow_mcp_add_sources,
                     lite,
                     track_interactions,
+                    config.as_deref(),
                 )
                 .context("mcp server")?;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,8 +290,11 @@ enum Commands {
     Search {
         /// Text to search for in symbol names
         query: String,
-        #[arg(long, default_value = "10", help = "Maximum number of results")]
-        limit: usize,
+        #[arg(
+            long,
+            help = "Maximum number of results (default: 10, or [limits].default_result_limit from config)"
+        )]
+        limit: Option<usize>,
         #[arg(long, help = "Output as JSON")]
         json: bool,
         #[arg(
@@ -299,6 +302,8 @@ enum Commands {
             help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
         )]
         db: Option<PathBuf>,
+        #[arg(long, help = "Path to instance config (TOML)")]
+        config: Option<PathBuf>,
     },
     /// Look up a symbol by name or UID
     ///
@@ -1559,8 +1564,11 @@ enum BrainCommands {
     Search {
         /// Search query string.
         query: String,
-        #[arg(long, default_value = "20", help = "Maximum results")]
-        limit: usize,
+        #[arg(
+            long,
+            help = "Maximum results (default: 20, or [limits].default_result_limit from config)"
+        )]
+        limit: Option<usize>,
         #[arg(long, help = "Output as JSON")]
         json: bool,
         #[arg(
@@ -1593,8 +1601,11 @@ enum BrainCommands {
         token_budget: Option<usize>,
         /// Hard cap on connected results. Used when --token-budget is not
         /// set; ignored when it is.
-        #[arg(long, default_value = "30", help = "Maximum connected results to show")]
-        limit: usize,
+        #[arg(
+            long,
+            help = "Maximum connected results (default: 30, or [limits].default_result_limit from config)"
+        )]
+        limit: Option<usize>,
         #[arg(long, help = "Output as JSON")]
         json: bool,
         #[arg(
@@ -2167,6 +2178,17 @@ fn load_instance_config_opt(path: Option<&Path>) -> Option<nestweaver_engine::In
             None
         }
     }
+}
+
+/// Resolve a CLI `--limit` value: explicit flag > instance config > built-in default.
+fn resolve_limit(
+    explicit: Option<usize>,
+    config: Option<&nestweaver_engine::InstanceConfig>,
+    builtin_default: usize,
+) -> usize {
+    explicit
+        .or_else(|| config.map(|c| c.limits.default_result_limit))
+        .unwrap_or(builtin_default)
 }
 
 fn detect_repo_root() -> PathBuf {
@@ -4159,7 +4181,10 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             limit,
             json,
             db,
+            config,
         } => {
+            let cfg = load_instance_config_opt(config.as_deref());
+            let limit = resolve_limit(limit, cfg.as_ref(), 10);
             let store = open_store(db.as_deref())?;
             let candidates = search_symbols(&store, &query, limit)?;
 
@@ -7765,6 +7790,8 @@ fn run_brain(
             prf,
         } => {
             let db_path = resolve_db_with_config(db, config.as_deref())?;
+            let cfg = load_instance_config_opt(config.as_deref());
+            let limit = resolve_limit(limit, cfg.as_ref(), 20);
 
             // Route through the daemon's typed `Search` RPC when running. The
             // daemon owns the writer-mode Tantivy index and shares dispatch
@@ -8063,6 +8090,8 @@ fn run_brain(
             prefer_instance,
         } => {
             let db_path = resolve_db_with_config(db, config_path.as_deref())?;
+            let cfg = load_instance_config_opt(config_path.as_deref());
+            let limit = resolve_limit(limit, cfg.as_ref(), 30);
 
             // Parse the optional --intent override into a `QueryIntent`.
             // Surface invalid values as a CLI error rather than silently


### PR DESCRIPTION
## Summary

- Wire `[limits].default_result_limit` from instance config to all 10 paginated MCP tools and 3 CLI commands at runtime, replacing the compile-time constant
- Wire `[response]` config (inline_body_threshold, inline_max_body_tokens) through the same path, replacing hardcoded defaults in brain_context and brain_search
- Add `--config` flag to `mcp` and `search` CLI commands for parity
- Direct MCP server (--no-daemon) auto-discovers instance.toml adjacent to the database file
- CLI commands respect config when `--limit` is not explicitly passed: `search` (builtin 10), `brain search` (builtin 20), `brain context` (builtin 30)

## Test plan

- [ ] `nestweaver search "foo"` without config uses builtin default (10)
- [ ] `nestweaver brain search "foo" --config <path>` with `[limits].default_result_limit = 5` returns 5 results
- [ ] `nestweaver brain search "foo" --config <path> --limit 2` explicit flag overrides config (returns 2)
- [ ] `nestweaver brain context "foo" --config <path>` respects config limit
- [ ] MCP tool dispatch with daemon reads config limit
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes (1326 tests)