### PR TITLE
fix(daemon): derive socket path from stable per-user dir, not $TMPDIR

### DIFF
--- a/crates/nestweaver-client/src/autostart.rs
+++ b/crates/nestweaver-client/src/autostart.rs
@@ -69,6 +69,12 @@ pub fn ensure_daemon(db_path: &Path, config_path: Option<&Path>) -> Result<PathB
         let _ = fs::remove_file(&sock);
     }
 
+    // Before spawning, check for a legacy daemon that may hold the DB write
+    // lock at an old $TMPDIR-based socket path (pre-v0.26.2 used $TMPDIR
+    // which varies across launchers on macOS). If found, shut it down so
+    // the new daemon can acquire the lock.
+    stop_legacy_daemon(&instance_id);
+
     // Release the flock before spawning so the daemon can acquire it.
     unsafe { libc::flock(fd, libc::LOCK_UN) };
     drop(file);
@@ -121,6 +127,69 @@ fn spawn_daemon(db_path: &Path, config_path: Option<&Path>) -> Result<()> {
         .with_context(|| format!("failed to spawn daemon via {}", exe.display()))?;
 
     Ok(())
+}
+
+/// Check legacy $TMPDIR-based socket paths for an old daemon and stop it.
+///
+/// Pre-v0.26.2 derived the socket path from `$TMPDIR`, which varies across
+/// macOS launchers. On upgrade, the old daemon may still be running at a
+/// `$TMPDIR`-based path and holding the DB write lock. This function probes
+/// common legacy locations, and if it finds a live daemon, sends SIGTERM to
+/// allow the new daemon to start cleanly.
+fn stop_legacy_daemon(instance_id: &str) {
+    let uid = unsafe { libc::getuid() };
+    // Probe the two bases that the old $TMPDIR-derived logic would have used:
+    // the caller's current $TMPDIR and /tmp (the fallback when $TMPDIR is unset).
+    // These are the exact paths that diverge across macOS launchers.
+    let mut legacy_bases: Vec<PathBuf> = vec![PathBuf::from("/tmp")];
+    if let Ok(tmpdir) = std::env::var("TMPDIR") {
+        let p = PathBuf::from(&tmpdir);
+        if p.as_path() != Path::new("/tmp") {
+            legacy_bases.push(p);
+        }
+    }
+
+    for base in &legacy_bases {
+        let legacy_dir = base.join(format!("nw-{uid}")).join(instance_id);
+        let legacy_pid = legacy_dir.join("daemon.pid");
+        let legacy_sock = legacy_dir.join("daemon.sock");
+
+        if !legacy_pid.exists() && !legacy_sock.exists() {
+            continue;
+        }
+
+        if let Some(pid) = read_pid(&legacy_pid)
+            && is_process_alive(pid)
+        {
+            info!(
+                pid,
+                path = %legacy_dir.display(),
+                "stopping legacy daemon at old TMPDIR-based path"
+            );
+            unsafe {
+                libc::kill(pid, libc::SIGTERM);
+            }
+            let start = std::time::Instant::now();
+            while start.elapsed() < Duration::from_secs(2) && is_process_alive(pid) {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            if is_process_alive(pid) {
+                warn!(
+                    pid,
+                    "legacy daemon did not exit after SIGTERM, sending SIGKILL"
+                );
+                unsafe {
+                    libc::kill(pid, libc::SIGKILL);
+                }
+                std::thread::sleep(Duration::from_millis(200));
+            }
+        }
+
+        // Clean up stale files.
+        let _ = fs::remove_file(&legacy_sock);
+        let _ = fs::remove_file(&legacy_pid);
+        let _ = fs::remove_dir(&legacy_dir);
+    }
 }
 
 /// Poll for the socket file to appear with exponential backoff.

--- a/crates/nestweaver-daemon/src/lifecycle.rs
+++ b/crates/nestweaver-daemon/src/lifecycle.rs
@@ -35,22 +35,32 @@ pub fn instance_label_from_db_path(db_path: &Path) -> String {
 
 /// Runtime directory for the daemon socket and pidfile.
 ///
-/// Prefers `$XDG_RUNTIME_DIR/nestweaver/<instance>/`, falling back to
-/// `$TMPDIR/nw-<uid>/<instance>/` or `/tmp/nw-<uid>/<instance>/`.
+/// Prefers `$XDG_RUNTIME_DIR/nestweaver/<instance>/` (Linux with systemd),
+/// falling back to `~/.local/state/nestweaver/<instance>/` (macOS and
+/// everywhere else).
 ///
-/// The short `nw-` prefix (vs the old `nestweaver-`) is intentional:
-/// macOS limits `sun_path` to 104 bytes and `$TMPDIR` can be ~51 chars.
+/// **`$TMPDIR` is deliberately NOT consulted.** On macOS, different
+/// launchers see different `$TMPDIR` values (per-user
+/// `/var/folders/.../T/` from interactive shells vs. `/tmp/` from
+/// sanitized subprocess environments like Claude Code's MCP launcher).
+/// Using `$TMPDIR` caused a connection loop where two clients for the
+/// same DB instance would disagree on the socket location, each trying
+/// to spawn its own daemon.
 pub fn runtime_dir(instance_id: &str) -> PathBuf {
     if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
         return PathBuf::from(xdg).join("nestweaver").join(instance_id);
     }
 
-    let uid = unsafe { libc::getuid() };
-    let base = std::env::var("TMPDIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from("/tmp"));
-
-    base.join(format!("nw-{uid}")).join(instance_id)
+    // Stable per-user directory that doesn't depend on caller env.
+    // Co-located with daemon logs (which already use this path).
+    dirs::state_dir()
+        .unwrap_or_else(|| {
+            dirs::home_dir()
+                .unwrap_or_else(|| PathBuf::from("/tmp"))
+                .join(".local/state")
+        })
+        .join("nestweaver")
+        .join(instance_id)
 }
 
 /// Path to the Unix domain socket for the given instance.
@@ -142,11 +152,9 @@ mod tests {
     }
 
     #[test]
-    fn socket_path_under_sun_len_with_long_tmpdir() {
+    fn socket_path_under_sun_len() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let long_tmpdir = "/var/folders/0h/z2kcwz1j0mld0cbrkt15n7w80000gq/T";
         unsafe {
-            std::env::set_var("TMPDIR", long_tmpdir);
             std::env::remove_var("XDG_RUNTIME_DIR");
         }
         let id = "a1b2c3d4"; // 8-char hash
@@ -156,6 +164,26 @@ mod tests {
             path_len < 104,
             "socket path must be < 104 bytes for macOS, got {path_len}: {}",
             sock.display()
+        );
+    }
+
+    #[test]
+    fn runtime_dir_ignores_tmpdir() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            std::env::remove_var("XDG_RUNTIME_DIR");
+        }
+        let dir_before = runtime_dir("test1234");
+        unsafe {
+            std::env::set_var("TMPDIR", "/some/other/tmpdir");
+        }
+        let dir_after = runtime_dir("test1234");
+        unsafe {
+            std::env::remove_var("TMPDIR");
+        }
+        assert_eq!(
+            dir_before, dir_after,
+            "runtime_dir must not change when TMPDIR changes"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes a daemon connection loop on macOS where different launchers (interactive shell vs Claude Code MCP) see different `$TMPDIR` values, causing each to look for the daemon socket in a different location and attempt to spawn competing daemons.

**Root cause:** `runtime_dir()` used `$TMPDIR` to derive the socket path. On macOS, `$TMPDIR` is per-user per-session (`/var/folders/.../T/` from interactive shells, `/tmp/` from sanitized subprocess environments).

**Fix:** Replace `$TMPDIR`-based derivation with `dirs::state_dir()` (`~/.local/state/nestweaver/<instance>/`), which is stable across all launcher environments. This co-locates the socket with the daemon log directory that already uses this path.

`$XDG_RUNTIME_DIR` remains the top preference for Linux systems that set it.

## Test plan

- [ ] `runtime_dir_ignores_tmpdir` test: proves changing `$TMPDIR` doesn't alter the socket path
- [ ] `socket_path_under_sun_len` test: socket path stays under macOS 104-byte `sun_path` limit
- [ ] `runtime_dir_uses_xdg_when_set` test: `$XDG_RUNTIME_DIR` still takes precedence
- [ ] Kill any running daemon, start fresh — verify socket appears under `~/.local/state/nestweaver/`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes (1331 tests)