### PR TITLE
fix(mcp): use stable state_dir for daemon socket path, not $TMPDIR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,7 +2975,7 @@ checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "nestweaver"
-version = "0.25.1"
+version = "0.26.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-algorithms"
-version = "0.25.1"
+version = "0.26.2"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -3021,7 +3021,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-client"
-version = "0.25.1"
+version = "0.26.2"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-daemon"
-version = "0.25.1"
+version = "0.26.2"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-engine"
-version = "0.25.1"
+version = "0.26.2"
 dependencies = [
  "anyhow",
  "apollo-parser",
@@ -3099,9 +3099,10 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-mcp"
-version = "0.25.1"
+version = "0.26.2"
 dependencies = [
  "anyhow",
+ "dirs",
  "hyper-util",
  "libc",
  "nestweaver-engine",
@@ -3121,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-parser"
-version = "0.25.1"
+version = "0.26.2"
 dependencies = [
  "comrak",
  "hex",
@@ -3168,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-proto"
-version = "0.25.1"
+version = "0.26.2"
 dependencies = [
  "prost 0.13.5",
  "tonic",
@@ -3177,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-resolver"
-version = "0.25.1"
+version = "0.26.2"
 dependencies = [
  "glob",
  "insta",
@@ -3194,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-schema"
-version = "0.25.1"
+version = "0.26.2"
 dependencies = [
  "hex",
  "serde",
@@ -3205,7 +3206,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-storage"
-version = "0.25.1"
+version = "0.26.2"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3220,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-store"
-version = "0.25.1"
+version = "0.26.2"
 dependencies = [
  "anyhow",
  "cc",
@@ -3241,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-wasm"
-version = "0.25.1"
+version = "0.26.2"
 dependencies = [
  "js-sys",
  "nestweaver-algorithms",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ open = "5"
 uuid = { version = "1", features = ["v4", "serde"] }
 tempfile = "3"
 rayon = "1"
+dirs = "6"
 
 [package]
 name = "nestweaver"
@@ -86,7 +87,7 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1", features = ["full"] }
-dirs = "6"
+dirs = { workspace = true }
 signal-hook = "0.3"
 nestweaver-daemon = { workspace = true }
 nestweaver-client = { workspace = true }

--- a/crates/nestweaver-mcp/Cargo.toml
+++ b/crates/nestweaver-mcp/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "net"], optional = true 
 tokio-stream = { workspace = true, optional = true }
 tower = { version = "0.5", optional = true }
 hyper-util = { version = "0.1", optional = true }
+dirs = { workspace = true, optional = true }
 libc = { version = "0.2", optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -24,7 +25,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [features]
-daemon = ["dep:nestweaver-proto", "dep:tonic", "dep:tokio", "dep:tokio-stream", "dep:tower", "dep:hyper-util", "dep:libc"]
+daemon = ["dep:dirs", "dep:nestweaver-proto", "dep:tonic", "dep:tokio", "dep:tokio-stream", "dep:tower", "dep:hyper-util", "dep:libc"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -2946,17 +2946,22 @@ fn inline_ensure_daemon(db_path: &std::path::Path) -> anyhow::Result<std::path::
     canonical.hash(&mut hasher);
     let instance_id = format!("{:08x}", hasher.finish() & 0xFFFF_FFFF);
 
-    // Compute the runtime directory (same algorithm as lifecycle.rs).
+    // Must match nestweaver_daemon::lifecycle::runtime_dir() exactly.
+    // $TMPDIR is deliberately NOT consulted: on macOS, different launchers
+    // see different TMPDIR values, causing socket-path mismatch.
     let rt_dir = if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
         std::path::PathBuf::from(xdg)
             .join("nestweaver")
             .join(&instance_id)
     } else {
-        let uid = unsafe { libc::getuid() };
-        let base = std::env::var("TMPDIR")
-            .map(std::path::PathBuf::from)
-            .unwrap_or_else(|_| std::path::PathBuf::from("/tmp"));
-        base.join(format!("nw-{uid}")).join(&instance_id)
+        dirs::state_dir()
+            .unwrap_or_else(|| {
+                dirs::home_dir()
+                    .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+                    .join(".local/state")
+            })
+            .join("nestweaver")
+            .join(&instance_id)
     };
     let sock = rt_dir.join("daemon.sock");
 


### PR DESCRIPTION
## Summary

- The MCP server's `inline_ensure_daemon()` used `$TMPDIR` as the fallback for locating the daemon socket, but the daemon itself (fixed in #74) uses `dirs::state_dir()` (~/.local/state/). On macOS, Claude Code's MCP launcher sees a different `$TMPDIR` than interactive shells, so the two sides disagreed on the socket path — the MCP process could never connect to the running daemon.
- Each failed connection attempt spawned a phantom daemon and left an orphaned state directory (1,300+ accumulated).
- Aligned the MCP fallback with `lifecycle::runtime_dir()` by replacing the `$TMPDIR`/`libc::getuid()` logic with `dirs::state_dir()`.

## Test plan

- [x] `cargo build` passes
- [x] Verified MCP `brain_status` call connects to daemon via stdio test
- [x] Confirmed daemon socket at `~/.local/state/nestweaver/<id>/daemon.sock` is found by both daemon and MCP subprocess