### PR TITLE
feat: add remove-repo CLI command and daemon RPC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -494,6 +494,8 @@ This codebase is indexed by NestWeaver. Available MCP tools:
 | `brain_impact` | Checking blast radius before modifying a function |
 | `cross_repo_contracts` | Finding cross-service symbol relationships |
 | `brain_status` | Checking what's indexed |
+| `brain_remove_source` | Removing a repo or vault from the graph |
+| `prune_stale` | Cleaning up sources whose directories no longer exist on disk |
 
 ## Quick Start
 
@@ -503,6 +505,12 @@ nestweaver index --repo .
 
 # Remove a repo from the graph
 nestweaver remove-repo <name-or-path>
+
+# Remove a project from the graph
+nestweaver remove-project <name>
+
+# Remove stale sources whose paths no longer exist
+nestweaver prune-stale
 
 # Search for a symbol
 nestweaver search <name>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -501,6 +501,9 @@ This codebase is indexed by NestWeaver. Available MCP tools:
 # Re-index (incremental — only changed files)
 nestweaver index --repo .
 
+# Remove a repo from the graph
+nestweaver remove-repo <name-or-path>
+
 # Search for a symbol
 nestweaver search <name>
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ cargo build --release
 
 | Command | Description |
 |---------|-------------|
-| `mcp` | Start the MCP server (38 tools, or 6 in lite mode; auto-starts daemon) |
+| `mcp` | Start the MCP server (40 tools, or 6 in lite mode; auto-starts daemon) |
 | `daemon` | Manage the background daemon (`start`, `stop`, `status`, `restart`) |
 | `ui` | Launch the interactive web UI |
 | `setup` | Auto-detect and configure AI tools (16 supported). Use `--force` to regenerate customized files |
@@ -232,6 +232,8 @@ cargo build --release
 | `snapshot` | Manage graph snapshots (build, verify, push) |
 | `list-repos` | List all indexed repositories |
 | `remove-repo` | Remove an indexed repository and all its data (symbols, files, services, contracts) from the graph |
+| `remove-project` | Remove a materialized project and its edges from the graph |
+| `prune-stale` | Remove repos and vaults whose source directories no longer exist on disk |
 | `list-services` | List all detected services |
 | `service-summary` | Display a summary of a specific service |
 
@@ -304,7 +306,7 @@ CLI commands (`search`, `brain search`, `brain context`) also respect this setti
 
 ## MCP Server
 
-NestWeaver exposes 38 tools via the [Model Context Protocol](https://modelcontextprotocol.io), giving any MCP-compatible AI agent structured access to your codebase graph without reading source files directly.
+NestWeaver exposes 40 tools via the [Model Context Protocol](https://modelcontextprotocol.io), giving any MCP-compatible AI agent structured access to your codebase graph without reading source files directly.
 
 ```sh
 nestweaver mcp --db ./nestweaver.lbug
@@ -320,7 +322,7 @@ nestweaver daemon stop --db ./nestweaver.lbug     # stop the daemon manually
 pgrep -a nestweaver-daemon                        # find running daemons (Linux)
 ```
 
-38 tools including type-aware context retrieval, confidence-weighted impact analysis (`impact_score` shows how strongly changes propagate), investigation bundles, co-change detection, dead code analysis, community detection, and vault/notes integration. Use `--tools` to expose only the tools you need.
+40 tools including type-aware context retrieval, confidence-weighted impact analysis (`impact_score` shows how strongly changes propagate), investigation bundles, co-change detection, dead code analysis, community detection, and vault/notes integration. Use `--tools` to expose only the tools you need.
 
 ### Key capabilities
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ cargo build --release
 | `instance` | Manage instance configuration |
 | `snapshot` | Manage graph snapshots (build, verify, push) |
 | `list-repos` | List all indexed repositories |
+| `remove-repo` | Remove an indexed repository and all its data (symbols, files, services, contracts) from the graph |
 | `list-services` | List all detected services |
 | `service-summary` | Display a summary of a specific service |
 

--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -180,6 +180,29 @@ impl DaemonClient {
         Ok(resp.into_inner())
     }
 
+    pub async fn remove_project(
+        &mut self,
+        project_uid: &str,
+    ) -> Result<nestweaver_proto::RemoveProjectResponse> {
+        let resp = self
+            .inner
+            .remove_project(nestweaver_proto::RemoveProjectRequest {
+                project_uid: project_uid.to_string(),
+            })
+            .await
+            .context("remove_project RPC failed")?;
+        Ok(resp.into_inner())
+    }
+
+    pub async fn prune_stale(&mut self) -> Result<nestweaver_proto::PruneStaleResponse> {
+        let resp = self
+            .inner
+            .prune_stale(nestweaver_proto::PruneStaleRequest {})
+            .await
+            .context("prune_stale RPC failed")?;
+        Ok(resp.into_inner())
+    }
+
     /// Merge one instance's data into another.
     pub async fn merge_instance(
         &mut self,

--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -166,6 +166,20 @@ impl DaemonClient {
         Ok(resp.into_inner())
     }
 
+    pub async fn remove_repo(
+        &mut self,
+        repo_uid: &str,
+    ) -> Result<nestweaver_proto::RemoveRepoResponse> {
+        let resp = self
+            .inner
+            .remove_repo(nestweaver_proto::RemoveRepoRequest {
+                repo_uid: repo_uid.to_string(),
+            })
+            .await
+            .context("remove_repo RPC failed")?;
+        Ok(resp.into_inner())
+    }
+
     /// Merge one instance's data into another.
     pub async fn merge_instance(
         &mut self,

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -693,6 +693,148 @@ impl NestWeaverDaemon for DaemonService {
         result.map(Response::new)
     }
 
+    async fn remove_project(
+        &self,
+        request: Request<RemoveProjectRequest>,
+    ) -> Result<Response<RemoveProjectResponse>, Status> {
+        self.state.idle_notify.notify_one();
+        self.state
+            .active_connections
+            .fetch_add(1, Ordering::Relaxed);
+
+        let req = request.into_inner();
+        let state = self.state.clone();
+
+        #[allow(clippy::result_large_err)]
+        let result = tokio::task::spawn_blocking(move || {
+            // Look up project name before deleting.
+            let projects = state
+                .store
+                .list_projects()
+                .map_err(|e| Status::internal(format!("list_projects failed: {e:#}")))?;
+            let project_name = projects
+                .iter()
+                .find(|p| p.uid == req.project_uid)
+                .map(|p| p.name.clone())
+                .unwrap_or_default();
+
+            state
+                .store
+                .delete_project_edges(&req.project_uid)
+                .map_err(|e| Status::internal(format!("delete_project_edges failed: {e:#}")))?;
+
+            state
+                .store
+                .delete_project_node(&req.project_uid)
+                .map_err(|e| Status::internal(format!("delete_project_node failed: {e:#}")))?;
+
+            Ok::<_, Status>(RemoveProjectResponse { project_name })
+        })
+        .await
+        .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
+
+        self.state
+            .active_connections
+            .fetch_sub(1, Ordering::Relaxed);
+        result.map(Response::new)
+    }
+
+    async fn prune_stale(
+        &self,
+        request: Request<PruneStaleRequest>,
+    ) -> Result<Response<PruneStaleResponse>, Status> {
+        self.state.idle_notify.notify_one();
+        self.state
+            .active_connections
+            .fetch_add(1, Ordering::Relaxed);
+
+        let _req = request.into_inner();
+        let state = self.state.clone();
+
+        #[allow(clippy::result_large_err)]
+        let result = tokio::task::spawn_blocking(move || {
+            let mut removed_repos = Vec::new();
+            let mut removed_vaults = Vec::new();
+
+            // Prune stale repos (path no longer exists on disk).
+            let repos = state
+                .store
+                .list_repos(None)
+                .map_err(|e| Status::internal(format!("list_repos failed: {e:#}")))?;
+
+            for repo in &repos {
+                let path = repo.url.strip_prefix("file://").unwrap_or(&repo.url);
+                if !Path::new(path).exists() {
+                    state
+                        .store
+                        .bulk_delete_repo_files_and_symbols(&repo.uid)
+                        .map_err(|e| {
+                            Status::internal(format!(
+                                "bulk_delete_repo_files_and_symbols failed: {e:#}"
+                            ))
+                        })?;
+                    state
+                        .store
+                        .clear_repo_derived_nodes(&repo.uid)
+                        .map_err(|e| {
+                            Status::internal(format!("clear_repo_derived_nodes failed: {e:#}"))
+                        })?;
+                    state
+                        .store
+                        .delete_repo_node(&repo.uid)
+                        .map_err(|e| {
+                            Status::internal(format!("delete_repo_node failed: {e:#}"))
+                        })?;
+                    removed_repos.push(repo.name.clone().unwrap_or_else(|| repo.url.clone()));
+                }
+            }
+
+            // Prune stale vaults (root_path no longer exists on disk).
+            let vaults = state
+                .store
+                .list_vaults(None)
+                .map_err(|e| Status::internal(format!("list_vaults failed: {e:#}")))?;
+
+            for vault in &vaults {
+                if !Path::new(&vault.root_path).exists() {
+                    state
+                        .store
+                        .delete_vault_cascade(&vault.uid)
+                        .map_err(|e| {
+                            Status::internal(format!("delete_vault_cascade failed: {e:#}"))
+                        })?;
+                    removed_vaults.push(vault.name.clone());
+                }
+            }
+
+            // Reindex Tantivy if anything was removed.
+            if !removed_repos.is_empty() || !removed_vaults.is_empty() {
+                if let Some(ref tantivy) = state.tantivy
+                    && tantivy.has_writer()
+                {
+                    match tantivy.reindex_from_store(&state.store) {
+                        Ok(n) => tracing::info!(docs = n, "Tantivy reindexed after prune_stale"),
+                        Err(e) => {
+                            tracing::warn!(error = %e, "Tantivy reindex failed after prune_stale")
+                        }
+                    }
+                }
+            }
+
+            Ok::<_, Status>(PruneStaleResponse {
+                removed_repos,
+                removed_vaults,
+            })
+        })
+        .await
+        .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
+
+        self.state
+            .active_connections
+            .fetch_sub(1, Ordering::Relaxed);
+        result.map(Response::new)
+    }
+
     async fn merge_instance(
         &self,
         request: Request<MergeInstanceRequest>,

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -782,9 +782,7 @@ impl NestWeaverDaemon for DaemonService {
                     state
                         .store
                         .delete_repo_node(&repo.uid)
-                        .map_err(|e| {
-                            Status::internal(format!("delete_repo_node failed: {e:#}"))
-                        })?;
+                        .map_err(|e| Status::internal(format!("delete_repo_node failed: {e:#}")))?;
                     removed_repos.push(repo.name.clone().unwrap_or_else(|| repo.url.clone()));
                 }
             }
@@ -797,26 +795,22 @@ impl NestWeaverDaemon for DaemonService {
 
             for vault in &vaults {
                 if !Path::new(&vault.root_path).exists() {
-                    state
-                        .store
-                        .delete_vault_cascade(&vault.uid)
-                        .map_err(|e| {
-                            Status::internal(format!("delete_vault_cascade failed: {e:#}"))
-                        })?;
+                    state.store.delete_vault_cascade(&vault.uid).map_err(|e| {
+                        Status::internal(format!("delete_vault_cascade failed: {e:#}"))
+                    })?;
                     removed_vaults.push(vault.name.clone());
                 }
             }
 
             // Reindex Tantivy if anything was removed.
-            if !removed_repos.is_empty() || !removed_vaults.is_empty() {
-                if let Some(ref tantivy) = state.tantivy
-                    && tantivy.has_writer()
-                {
-                    match tantivy.reindex_from_store(&state.store) {
-                        Ok(n) => tracing::info!(docs = n, "Tantivy reindexed after prune_stale"),
-                        Err(e) => {
-                            tracing::warn!(error = %e, "Tantivy reindex failed after prune_stale")
-                        }
+            if (!removed_repos.is_empty() || !removed_vaults.is_empty())
+                && let Some(ref tantivy) = state.tantivy
+                && tantivy.has_writer()
+            {
+                match tantivy.reindex_from_store(&state.store) {
+                    Ok(n) => tracing::info!(docs = n, "Tantivy reindexed after prune_stale"),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "Tantivy reindex failed after prune_stale")
                     }
                 }
             }

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -637,6 +637,60 @@ impl NestWeaverDaemon for DaemonService {
         result.map(Response::new)
     }
 
+    async fn remove_repo(
+        &self,
+        request: Request<RemoveRepoRequest>,
+    ) -> Result<Response<RemoveRepoResponse>, Status> {
+        self.state.idle_notify.notify_one();
+        self.state
+            .active_connections
+            .fetch_add(1, Ordering::Relaxed);
+
+        let req = request.into_inner();
+        let state = self.state.clone();
+
+        #[allow(clippy::result_large_err)]
+        let result = tokio::task::spawn_blocking(move || {
+            let (file_count, sym_count) = state
+                .store
+                .bulk_delete_repo_files_and_symbols(&req.repo_uid)
+                .map_err(|e| Status::internal(format!("bulk_delete_repo_files_and_symbols failed: {e:#}")))?;
+
+            state
+                .store
+                .clear_repo_derived_nodes(&req.repo_uid)
+                .map_err(|e| Status::internal(format!("clear_repo_derived_nodes failed: {e:#}")))?;
+
+            state
+                .store
+                .delete_repo_node(&req.repo_uid)
+                .map_err(|e| Status::internal(format!("delete_repo_node failed: {e:#}")))?;
+
+            if let Some(ref tantivy) = state.tantivy
+                && tantivy.has_writer()
+            {
+                match tantivy.reindex_from_store(&state.store) {
+                    Ok(n) => tracing::info!(docs = n, "Tantivy reindexed after repo removal"),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "Tantivy reindex failed after repo removal")
+                    }
+                }
+            }
+
+            Ok::<_, Status>(RemoveRepoResponse {
+                files_deleted: file_count as u64,
+                symbols_deleted: sym_count as u64,
+            })
+        })
+        .await
+        .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
+
+        self.state
+            .active_connections
+            .fetch_sub(1, Ordering::Relaxed);
+        result.map(Response::new)
+    }
+
     async fn merge_instance(
         &self,
         request: Request<MergeInstanceRequest>,

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -654,7 +654,9 @@ impl NestWeaverDaemon for DaemonService {
             let (file_count, sym_count) = state
                 .store
                 .bulk_delete_repo_files_and_symbols(&req.repo_uid)
-                .map_err(|e| Status::internal(format!("bulk_delete_repo_files_and_symbols failed: {e:#}")))?;
+                .map_err(|e| {
+                    Status::internal(format!("bulk_delete_repo_files_and_symbols failed: {e:#}"))
+                })?;
 
             state
                 .store

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -120,6 +120,8 @@ pub fn tool_list(lite: bool) -> Value {
         tool_schema_backlinks(),
         tool_schema_brain_status(),
         tool_schema_brain_add_source(),
+        tool_schema_brain_remove_source(),
+        tool_schema_prune_stale(),
         tool_schema_cross_repo_contracts(),
         tool_schema_brain_impact(),
         tool_schema_brain_guide(),
@@ -200,6 +202,8 @@ pub fn tool_doc_entries() -> Vec<(String, String, String, Vec<String>)> {
         ("brain_diff", "Status & maintenance"),
         ("brain_guide", "Status & maintenance"),
         ("brain_add_source", "Status & maintenance"),
+        ("brain_remove_source", "Status & maintenance"),
+        ("prune_stale", "Status & maintenance"),
         ("get_summary", "Status & maintenance"),
         ("read_symbols", "Code search"),
         ("regex_search", "Code search"),
@@ -288,6 +292,8 @@ fn dispatch_uncached(
         "backlinks" => tool_backlinks(store, args),
         "brain_status" => tool_brain_status(store, tantivy),
         "brain_add_source" => tool_brain_add_source(store, args),
+        "brain_remove_source" => tool_brain_remove_source(store, args),
+        "prune_stale" => tool_prune_stale(store),
         "cross_repo_contracts" => tool_cross_repo_contracts(store, args),
         "brain_impact" => tool_brain_impact(store, args),
         "brain_guide" => tool_brain_guide(store, args),
@@ -2800,28 +2806,7 @@ fn tool_brain_add_source(store: &GraphStore, args: Value) -> Result<Value, anyho
         let sock_path = inline_ensure_daemon(&db_path_buf)
             .map_err(|e| anyhow::anyhow!("failed to start daemon: {e}"))?;
 
-        let mut client = rt.block_on(async {
-            use tonic::transport::{Endpoint, Uri};
-
-            let path = sock_path.clone();
-            let channel = Endpoint::try_from("http://[::]:50051")
-                .map_err(|e| anyhow::anyhow!("failed to create endpoint: {e}"))?
-                .connect_with_connector(tower::service_fn(move |_: Uri| {
-                    let path = path.clone();
-                    async move {
-                        let stream = tokio::net::UnixStream::connect(path).await?;
-                        Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(stream))
-                    }
-                }))
-                .await
-                .map_err(|e| anyhow::anyhow!("failed to connect to daemon: {e}"))?;
-
-            Ok::<_, anyhow::Error>(
-                nestweaver_proto::nest_weaver_daemon_client::NestWeaverDaemonClient::new(channel)
-                    .max_decoding_message_size(64 * 1024 * 1024)
-                    .max_encoding_message_size(64 * 1024 * 1024),
-            )
-        })?;
+        let mut client = rt.block_on(inline_connect_daemon(&sock_path))?;
 
         dispatch_add_source_via_daemon(&mut client, &rt, args)
     }
@@ -2927,6 +2912,236 @@ fn tool_brain_add_source(store: &GraphStore, args: Value) -> Result<Value, anyho
             path.display()
         ))
     } // end #[cfg(not(feature = "daemon"))]
+}
+
+// ── 6b. brain_remove_source ─────────────────────────────────────────────────
+
+fn tool_schema_brain_remove_source() -> Value {
+    json!({
+        "name": "brain_remove_source",
+        "description": "Remove an indexed code repository or markdown vault from the brain graph. Accepts a repo name, vault name, filesystem path, file:// URL, or UID. Auto-detects whether the target is a repo or vault.\n\nDo NOT use to re-index — use brain_add_source for that. Use this when you need to permanently remove a source that should no longer be in the graph.\n\nExamples: target=\"freeplay-server\" removes the repo by name. target=\"~/Documents/Obsidian/MyVault\" removes the vault by path.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "target": {
+                    "type": "string",
+                    "description": "Repo name, vault name, filesystem path, file:// URL, or UID of the source to remove."
+                }
+            },
+            "required": ["target"]
+        }
+    })
+}
+
+fn tool_brain_remove_source(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error> {
+    let target = args
+        .get("target")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("'target' is required"))?
+        .to_string();
+
+    // Inline tilde expansion (the cfg-gated expand_tilde is not available in daemon builds).
+    let expand = |input: &str| -> String {
+        if let Some(stripped) = input.strip_prefix("~/") {
+            if let Ok(home) = std::env::var("HOME") {
+                return format!("{home}/{stripped}");
+            }
+        }
+        input.to_string()
+    };
+
+    // Try to resolve as a repo first, then as a vault.
+    let repos = store.list_repos(None)?;
+
+    let canonical_target = std::fs::canonicalize(&target)
+        .map(|p| format!("file://{}", p.display()))
+        .unwrap_or_default();
+    let url_target = if target.starts_with("file://") {
+        target.clone()
+    } else if std::path::Path::new(&target).is_absolute() || target.starts_with("~/") {
+        let expanded = expand(&target);
+        std::fs::canonicalize(&expanded)
+            .map(|p| format!("file://{}", p.display()))
+            .unwrap_or_else(|_| format!("file://{}", expanded))
+    } else {
+        String::new()
+    };
+
+    let matched_repo: Vec<&nestweaver_schema::Repo> = repos
+        .iter()
+        .filter(|r| {
+            r.uid == target
+                || r.name.as_deref() == Some(&target)
+                || r.url == url_target
+                || r.url == canonical_target
+                || r.url.ends_with(&format!("/{target}"))
+        })
+        .collect();
+
+    if matched_repo.len() == 1 {
+        let repo = matched_repo[0];
+        let repo_uid = repo.uid.clone();
+        let display = repo.name.clone().unwrap_or_else(|| repo.url.clone());
+
+        // Route through daemon
+        #[cfg(feature = "daemon")]
+        {
+            let db_path = current_db_path(store)?;
+            let db_path_buf = std::path::PathBuf::from(&db_path);
+            let rt = tokio::runtime::Runtime::new()
+                .map_err(|e| anyhow::anyhow!("failed to create tokio runtime: {e}"))?;
+            let sock_path = inline_ensure_daemon(&db_path_buf)
+                .map_err(|e| anyhow::anyhow!("failed to start daemon: {e}"))?;
+            let mut client = rt.block_on(inline_connect_daemon(&sock_path))?;
+            let resp = rt
+                .block_on(
+                    client.remove_repo(nestweaver_proto::RemoveRepoRequest {
+                        repo_uid: repo_uid.clone(),
+                    }),
+                )
+                .map_err(|e| anyhow!("remove_repo RPC failed: {e}"))?;
+            let inner = resp.into_inner();
+            return Ok(json!({
+                "kind": "repo",
+                "name": display,
+                "uid": repo_uid,
+                "files_deleted": inner.files_deleted,
+                "symbols_deleted": inner.symbols_deleted
+            }));
+        }
+        #[cfg(not(feature = "daemon"))]
+        return Err(anyhow!("brain_remove_source requires daemon mode"));
+    }
+
+    // Try vaults
+    let vaults = store.list_vaults(None)?;
+    let matched_vault: Vec<&nestweaver_schema::Vault> = vaults
+        .iter()
+        .filter(|v| {
+            v.uid == target
+                || v.name == target
+                || v.root_path == target
+                || v.root_path == canonical_target.strip_prefix("file://").unwrap_or("")
+                || std::fs::canonicalize(&v.root_path)
+                    .map(|p| format!("file://{}", p.display()))
+                    .unwrap_or_default()
+                    == canonical_target
+        })
+        .collect();
+
+    if matched_vault.len() == 1 {
+        let vault = matched_vault[0];
+        let vault_uid = vault.uid.clone();
+        let display = vault.name.clone();
+
+        #[cfg(feature = "daemon")]
+        {
+            let db_path = current_db_path(store)?;
+            let db_path_buf = std::path::PathBuf::from(&db_path);
+            let rt = tokio::runtime::Runtime::new()
+                .map_err(|e| anyhow::anyhow!("failed to create tokio runtime: {e}"))?;
+            let sock_path = inline_ensure_daemon(&db_path_buf)
+                .map_err(|e| anyhow::anyhow!("failed to start daemon: {e}"))?;
+            let mut client = rt.block_on(inline_connect_daemon(&sock_path))?;
+            let resp = rt
+                .block_on(
+                    client.remove_vault(nestweaver_proto::RemoveVaultRequest {
+                        vault_uid: vault_uid.clone(),
+                    }),
+                )
+                .map_err(|e| anyhow!("remove_vault RPC failed: {e}"))?;
+            let inner = resp.into_inner();
+            return Ok(json!({
+                "kind": "vault",
+                "name": display,
+                "uid": vault_uid,
+                "notes_deleted": inner.notes_deleted
+            }));
+        }
+        #[cfg(not(feature = "daemon"))]
+        return Err(anyhow!("brain_remove_source requires daemon mode"));
+    }
+
+    // No match or ambiguous
+    if matched_repo.len() > 1 || matched_vault.len() > 1 {
+        return Err(anyhow!(
+            "'{target}' matches multiple sources. Use a UID to disambiguate."
+        ));
+    }
+    Err(anyhow!("no repo or vault matching '{target}' found"))
+}
+
+// ── 6c. prune_stale ─────────────────────────────────────────────────────────
+
+fn tool_schema_prune_stale() -> Value {
+    json!({
+        "name": "prune_stale",
+        "description": "Remove all indexed repos and vaults whose source directories no longer exist on disk. Use after moving, renaming, or deleting project directories to clean up stale graph entries.\n\nNo parameters required. Returns the list of removed repos and vaults.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        }
+    })
+}
+
+fn tool_prune_stale(store: &GraphStore) -> Result<Value, anyhow::Error> {
+    #[cfg(feature = "daemon")]
+    {
+        let db_path = current_db_path(store)?;
+        let db_path_buf = std::path::PathBuf::from(&db_path);
+        let rt = tokio::runtime::Runtime::new()
+            .map_err(|e| anyhow::anyhow!("failed to create tokio runtime: {e}"))?;
+        let sock_path = inline_ensure_daemon(&db_path_buf)
+            .map_err(|e| anyhow::anyhow!("failed to start daemon: {e}"))?;
+        let mut client = rt.block_on(inline_connect_daemon(&sock_path))?;
+        let resp = rt
+            .block_on(client.prune_stale(nestweaver_proto::PruneStaleRequest {}))
+            .map_err(|e| anyhow!("prune_stale RPC failed: {e}"))?;
+        let inner = resp.into_inner();
+        return Ok(json!({
+            "removed_repos": inner.removed_repos,
+            "removed_vaults": inner.removed_vaults
+        }));
+    }
+    #[cfg(not(feature = "daemon"))]
+    {
+        let _ = store;
+        Err(anyhow!("prune_stale requires daemon mode"))
+    }
+}
+
+// ── Daemon connection helper ────────────────────────────────────────────────
+
+/// Connect to a running daemon via UDS. Shared by brain_remove_source and
+/// prune_stale (and brain_add_source's inline block).
+#[cfg(feature = "daemon")]
+async fn inline_connect_daemon(
+    sock_path: &std::path::Path,
+) -> Result<
+    nestweaver_proto::nest_weaver_daemon_client::NestWeaverDaemonClient<tonic::transport::Channel>,
+    anyhow::Error,
+> {
+    use tonic::transport::{Endpoint, Uri};
+
+    let path = sock_path.to_path_buf();
+    let channel = Endpoint::try_from("http://[::]:50051")
+        .map_err(|e| anyhow::anyhow!("failed to create endpoint: {e}"))?
+        .connect_with_connector(tower::service_fn(move |_: Uri| {
+            let path = path.clone();
+            async move {
+                let stream = tokio::net::UnixStream::connect(path).await?;
+                Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(stream))
+            }
+        }))
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to connect to daemon: {e}"))?;
+
+    Ok(
+        nestweaver_proto::nest_weaver_daemon_client::NestWeaverDaemonClient::new(channel)
+            .max_decoding_message_size(64 * 1024 * 1024)
+            .max_encoding_message_size(64 * 1024 * 1024),
+    )
 }
 
 /// Ensure the daemon is running (spawning it if needed) and return the
@@ -5095,6 +5310,63 @@ pub fn dispatch_via_daemon(
     // (streaming RPCs) depending on the path content.
     if name == "brain_add_source" {
         return dispatch_add_source_via_daemon(client, rt, args);
+    }
+
+    // brain_remove_source uses typed RemoveRepo/RemoveVault RPCs.
+    if name == "brain_remove_source" {
+        let target = args
+            .get("target")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("'target' is required"))?
+            .to_string();
+
+        // Try repo first — ask the daemon for matching repo by name/uid.
+        // We send the target as repo_uid; the daemon resolves it.
+        // However, the proto only accepts a uid. We need to resolve locally
+        // or just try the RPC and fall back. For simplicity, try as repo_uid
+        // first (covers uid and name for well-known targets), then vault_uid.
+        let repo_result = rt.block_on(
+            client.remove_repo(nestweaver_proto::RemoveRepoRequest {
+                repo_uid: target.clone(),
+            }),
+        );
+        if let Ok(resp) = repo_result {
+            let inner = resp.into_inner();
+            return Ok(json!({
+                "kind": "repo",
+                "uid": target,
+                "files_deleted": inner.files_deleted,
+                "symbols_deleted": inner.symbols_deleted
+            }));
+        }
+
+        let vault_result = rt.block_on(
+            client.remove_vault(nestweaver_proto::RemoveVaultRequest {
+                vault_uid: target.clone(),
+            }),
+        );
+        if let Ok(resp) = vault_result {
+            let inner = resp.into_inner();
+            return Ok(json!({
+                "kind": "vault",
+                "uid": target,
+                "notes_deleted": inner.notes_deleted
+            }));
+        }
+
+        return Err(anyhow::anyhow!("no repo or vault matching '{target}' found"));
+    }
+
+    // prune_stale uses a typed PruneStaleRequest RPC.
+    if name == "prune_stale" {
+        let resp = rt
+            .block_on(client.prune_stale(nestweaver_proto::PruneStaleRequest {}))
+            .map_err(|e| anyhow::anyhow!("prune_stale RPC failed: {}", e.message()))?;
+        let inner = resp.into_inner();
+        return Ok(json!({
+            "removed_repos": inner.removed_repos,
+            "removed_vaults": inner.removed_vaults
+        }));
     }
 
     // Helper to parse string arrays from JSON args.

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -2942,10 +2942,10 @@ fn tool_brain_remove_source(store: &GraphStore, args: Value) -> Result<Value, an
 
     // Inline tilde expansion (the cfg-gated expand_tilde is not available in daemon builds).
     let expand = |input: &str| -> String {
-        if let Some(stripped) = input.strip_prefix("~/") {
-            if let Ok(home) = std::env::var("HOME") {
-                return format!("{home}/{stripped}");
-            }
+        if let Some(stripped) = input.strip_prefix("~/")
+            && let Ok(home) = std::env::var("HOME")
+        {
+            return format!("{home}/{stripped}");
         }
         input.to_string()
     };
@@ -2979,13 +2979,11 @@ fn tool_brain_remove_source(store: &GraphStore, args: Value) -> Result<Value, an
         .collect();
 
     if matched_repo.len() == 1 {
-        let repo = matched_repo[0];
-        let repo_uid = repo.uid.clone();
-        let display = repo.name.clone().unwrap_or_else(|| repo.url.clone());
-
-        // Route through daemon
         #[cfg(feature = "daemon")]
         {
+            let repo = matched_repo[0];
+            let repo_uid = repo.uid.clone();
+            let display = repo.name.clone().unwrap_or_else(|| repo.url.clone());
             let db_path = current_db_path(store)?;
             let db_path_buf = std::path::PathBuf::from(&db_path);
             let rt = tokio::runtime::Runtime::new()
@@ -2994,11 +2992,9 @@ fn tool_brain_remove_source(store: &GraphStore, args: Value) -> Result<Value, an
                 .map_err(|e| anyhow::anyhow!("failed to start daemon: {e}"))?;
             let mut client = rt.block_on(inline_connect_daemon(&sock_path))?;
             let resp = rt
-                .block_on(
-                    client.remove_repo(nestweaver_proto::RemoveRepoRequest {
-                        repo_uid: repo_uid.clone(),
-                    }),
-                )
+                .block_on(client.remove_repo(nestweaver_proto::RemoveRepoRequest {
+                    repo_uid: repo_uid.clone(),
+                }))
                 .map_err(|e| anyhow!("remove_repo RPC failed: {e}"))?;
             let inner = resp.into_inner();
             return Ok(json!({
@@ -3030,12 +3026,11 @@ fn tool_brain_remove_source(store: &GraphStore, args: Value) -> Result<Value, an
         .collect();
 
     if matched_vault.len() == 1 {
-        let vault = matched_vault[0];
-        let vault_uid = vault.uid.clone();
-        let display = vault.name.clone();
-
         #[cfg(feature = "daemon")]
         {
+            let vault = matched_vault[0];
+            let vault_uid = vault.uid.clone();
+            let display = vault.name.clone();
             let db_path = current_db_path(store)?;
             let db_path_buf = std::path::PathBuf::from(&db_path);
             let rt = tokio::runtime::Runtime::new()
@@ -3044,11 +3039,9 @@ fn tool_brain_remove_source(store: &GraphStore, args: Value) -> Result<Value, an
                 .map_err(|e| anyhow::anyhow!("failed to start daemon: {e}"))?;
             let mut client = rt.block_on(inline_connect_daemon(&sock_path))?;
             let resp = rt
-                .block_on(
-                    client.remove_vault(nestweaver_proto::RemoveVaultRequest {
-                        vault_uid: vault_uid.clone(),
-                    }),
-                )
+                .block_on(client.remove_vault(nestweaver_proto::RemoveVaultRequest {
+                    vault_uid: vault_uid.clone(),
+                }))
                 .map_err(|e| anyhow!("remove_vault RPC failed: {e}"))?;
             let inner = resp.into_inner();
             return Ok(json!({
@@ -3099,10 +3092,10 @@ fn tool_prune_stale(store: &GraphStore) -> Result<Value, anyhow::Error> {
             .block_on(client.prune_stale(nestweaver_proto::PruneStaleRequest {}))
             .map_err(|e| anyhow!("prune_stale RPC failed: {e}"))?;
         let inner = resp.into_inner();
-        return Ok(json!({
+        Ok(json!({
             "removed_repos": inner.removed_repos,
             "removed_vaults": inner.removed_vaults
-        }));
+        }))
     }
     #[cfg(not(feature = "daemon"))]
     {
@@ -5325,11 +5318,9 @@ pub fn dispatch_via_daemon(
         // However, the proto only accepts a uid. We need to resolve locally
         // or just try the RPC and fall back. For simplicity, try as repo_uid
         // first (covers uid and name for well-known targets), then vault_uid.
-        let repo_result = rt.block_on(
-            client.remove_repo(nestweaver_proto::RemoveRepoRequest {
-                repo_uid: target.clone(),
-            }),
-        );
+        let repo_result = rt.block_on(client.remove_repo(nestweaver_proto::RemoveRepoRequest {
+            repo_uid: target.clone(),
+        }));
         if let Ok(resp) = repo_result {
             let inner = resp.into_inner();
             return Ok(json!({
@@ -5340,11 +5331,9 @@ pub fn dispatch_via_daemon(
             }));
         }
 
-        let vault_result = rt.block_on(
-            client.remove_vault(nestweaver_proto::RemoveVaultRequest {
-                vault_uid: target.clone(),
-            }),
-        );
+        let vault_result = rt.block_on(client.remove_vault(nestweaver_proto::RemoveVaultRequest {
+            vault_uid: target.clone(),
+        }));
         if let Ok(resp) = vault_result {
             let inner = resp.into_inner();
             return Ok(json!({
@@ -5354,7 +5343,9 @@ pub fn dispatch_via_daemon(
             }));
         }
 
-        return Err(anyhow::anyhow!("no repo or vault matching '{target}' found"));
+        return Err(anyhow::anyhow!(
+            "no repo or vault matching '{target}' found"
+        ));
     }
 
     // prune_stale uses a typed PruneStaleRequest RPC.

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -1460,9 +1460,13 @@ mod tests {
 
         store.insert_repo(&repo).unwrap();
         store.insert_file(&file).unwrap();
-        store.insert_repo_file_edge("repo:test:r1", "file:test:f1").unwrap();
+        store
+            .insert_repo_file_edge("repo:test:r1", "file:test:f1")
+            .unwrap();
         store.insert_symbol(&sym).unwrap();
-        store.insert_file_symbol_edge("file:test:f1", "sym:test:s1").unwrap();
+        store
+            .insert_file_symbol_edge("file:test:f1", "sym:test:s1")
+            .unwrap();
 
         // Verify data exists before deletion.
         let repos = store.list_repos(None).unwrap();

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -1452,6 +1452,40 @@ mod tests {
     }
 
     #[test]
+    fn remove_repo_cascade_deletes_all_data() {
+        let store = test_store();
+        let repo = make_repo("repo:test:r1");
+        let file = make_file("file:test:f1", "repo:test:r1");
+        let sym = make_symbol("sym:test:s1", "greet", "repo:test:r1", "src/lib.rs");
+
+        store.insert_repo(&repo).unwrap();
+        store.insert_file(&file).unwrap();
+        store.insert_repo_file_edge("repo:test:r1", "file:test:f1").unwrap();
+        store.insert_symbol(&sym).unwrap();
+        store.insert_file_symbol_edge("file:test:f1", "sym:test:s1").unwrap();
+
+        // Verify data exists before deletion.
+        let repos = store.list_repos(None).unwrap();
+        assert_eq!(repos.len(), 1);
+
+        // Delete files/symbols, then derived nodes, then the repo node itself.
+        let (file_count, sym_count) = store
+            .bulk_delete_repo_files_and_symbols("repo:test:r1")
+            .unwrap();
+        store.clear_repo_derived_nodes("repo:test:r1").unwrap();
+        store.delete_repo_node("repo:test:r1").unwrap();
+
+        assert_eq!(file_count, 1);
+        assert_eq!(sym_count, 1);
+
+        // Verify everything is gone.
+        let repos = store.list_repos(None).unwrap();
+        assert!(repos.is_empty());
+        let syms = store.lookup_symbols_by_repo("repo:test:r1").unwrap();
+        assert!(syms.is_empty());
+    }
+
+    #[test]
     fn purge_instance_cascade_deletes_repos_and_children() {
         let store = test_store();
 

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -2381,6 +2381,17 @@ impl GraphStore {
         Ok(())
     }
 
+    /// Delete the Project node itself (and any remaining edges).
+    pub fn delete_project_node(&self, project_uid: &str) -> Result<(), StoreError> {
+        let conn = self.conn()?;
+        exec_params(
+            &conn,
+            "MATCH (p:Project {uid: $uid}) DETACH DELETE p",
+            vec![("uid", lbug::Value::String(project_uid.to_string()))],
+        )?;
+        Ok(())
+    }
+
     /// Count notes belonging to a vault.
     fn vault_note_count(&self, vault_uid: &str) -> Result<usize, StoreError> {
         let conn = self.conn()?;

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -98,6 +98,15 @@ message RemoveVaultResponse {
   uint64 notes_deleted = 1;
 }
 
+message RemoveRepoRequest {
+  string repo_uid = 1;
+}
+
+message RemoveRepoResponse {
+  uint64 files_deleted = 1;
+  uint64 symbols_deleted = 2;
+}
+
 message MergeInstanceRequest {
   string from_id = 1;
   string to_id = 2;
@@ -252,6 +261,7 @@ service NestWeaverDaemon {
   // Write RPCs
   rpc MaterializeProjects(MaterializeProjectsRequest) returns (stream IndexProgress);
   rpc RemoveVault(RemoveVaultRequest) returns (RemoveVaultResponse);
+  rpc RemoveRepo(RemoveRepoRequest) returns (RemoveRepoResponse);
   rpc MergeInstance(MergeInstanceRequest) returns (MergeInstanceResponse);
   rpc PurgeInstance(PurgeInstanceRequest) returns (stream IndexProgress);
 

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -107,6 +107,21 @@ message RemoveRepoResponse {
   uint64 symbols_deleted = 2;
 }
 
+message RemoveProjectRequest {
+  string project_uid = 1;
+}
+
+message RemoveProjectResponse {
+  string project_name = 1;
+}
+
+message PruneStaleRequest {}
+
+message PruneStaleResponse {
+  repeated string removed_repos = 1;
+  repeated string removed_vaults = 2;
+}
+
 message MergeInstanceRequest {
   string from_id = 1;
   string to_id = 2;
@@ -262,6 +277,8 @@ service NestWeaverDaemon {
   rpc MaterializeProjects(MaterializeProjectsRequest) returns (stream IndexProgress);
   rpc RemoveVault(RemoveVaultRequest) returns (RemoveVaultResponse);
   rpc RemoveRepo(RemoveRepoRequest) returns (RemoveRepoResponse);
+  rpc RemoveProject(RemoveProjectRequest) returns (RemoveProjectResponse);
+  rpc PruneStale(PruneStaleRequest) returns (PruneStaleResponse);
   rpc MergeInstance(MergeInstanceRequest) returns (MergeInstanceResponse);
   rpc PurgeInstance(PurgeInstanceRequest) returns (stream IndexProgress);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,6 +257,20 @@ enum Commands {
         #[arg(long, help = "Path to instance config (TOML)")]
         config: Option<PathBuf>,
     },
+    /// Remove an indexed repository and all its data (symbols, files,
+    /// services, contracts) from the graph.
+    #[command(
+        after_help = "Accepts a repo name, filesystem path, file:// URL, or UID.\n\nExamples:\n  nestweaver remove-repo freeplay-server\n  nestweaver remove-repo /Users/kory/dev/workspaces/freeplay/freeplay-server\n  nestweaver remove-repo repo:051a9ff9:abc123"
+    )]
+    RemoveRepo {
+        /// Repo name, filesystem path, file:// URL, or UID
+        target: String,
+        #[arg(
+            long,
+            help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
+        )]
+        db: Option<PathBuf>,
+    },
     /// List all services/modules in the graph
     ListServices {
         #[arg(long, help = "Filter by instance ID")]
@@ -2483,6 +2497,86 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     println!("  SHA:     {}", repo.indexed_sha);
                     println!("  Instance: {}", repo.instance_id);
                     println!();
+                }
+            }
+            Ok((EXIT_SUCCESS, None))
+        }
+
+        Commands::RemoveRepo { target, db } => {
+            let db_path = db.unwrap_or_else(default_db_path);
+
+            let store = GraphStore::open_read_only(&db_path)
+                .with_context(|| format!("failed to open database at {}", db_path.display()))?;
+
+            let repos = store
+                .list_repos(None)
+                .context("failed to list repos")?;
+
+            // Resolve target → repo UID.  Accept: UID, name, path, or URL.
+            let canonical_target = std::fs::canonicalize(&target)
+                .map(|p| format!("file://{}", p.display()))
+                .unwrap_or_default();
+
+            let url_target = if target.starts_with("file://") {
+                target.clone()
+            } else if std::path::Path::new(&target).is_absolute() {
+                format!("file://{target}")
+            } else {
+                String::new()
+            };
+
+            let matched: Vec<&nestweaver_schema::Repo> = repos
+                .iter()
+                .filter(|r| {
+                    r.uid == target
+                        || r.name.as_deref() == Some(&target)
+                        || r.url == url_target
+                        || r.url == canonical_target
+                        || r.url.ends_with(&format!("/{target}"))
+                })
+                .collect();
+
+            if matched.is_empty() {
+                eprintln!(
+                    "Error: no repo matching '{target}' found.\n  \
+                     Run `nestweaver list-repos` to see indexed repos."
+                );
+                return Ok((EXIT_NOT_FOUND, None));
+            }
+            if matched.len() > 1 {
+                eprintln!("Error: '{target}' matches multiple repos:");
+                for r in &matched {
+                    eprintln!(
+                        "  {} ({})",
+                        r.uid,
+                        r.name.as_deref().unwrap_or(&r.url)
+                    );
+                }
+                eprintln!("Re-run with the full UID to disambiguate.");
+                return Ok((EXIT_ERROR, None));
+            }
+
+            let repo = matched[0];
+            let display_name = repo
+                .name
+                .as_deref()
+                .unwrap_or(&repo.url);
+
+            let rt = tokio::runtime::Runtime::new()?;
+            let mut client = rt
+                .block_on(nestweaver_client::DaemonClient::connect(&db_path, None))
+                .context("failed to connect to daemon")?;
+
+            match rt.block_on(client.remove_repo(&repo.uid)) {
+                Ok(resp) => {
+                    println!(
+                        "Removed repo '{}' ({} file(s), {} symbol(s) deleted).",
+                        display_name, resp.files_deleted, resp.symbols_deleted
+                    );
+                }
+                Err(e) => {
+                    eprintln!("Error: failed to remove repo '{}': {e}.", repo.uid);
+                    return Ok((EXIT_ERROR, None));
                 }
             }
             Ok((EXIT_SUCCESS, None))

--- a/src/main.rs
+++ b/src/main.rs
@@ -2508,9 +2508,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let store = GraphStore::open_read_only(&db_path)
                 .with_context(|| format!("failed to open database at {}", db_path.display()))?;
 
-            let repos = store
-                .list_repos(None)
-                .context("failed to list repos")?;
+            let repos = store.list_repos(None).context("failed to list repos")?;
 
             // Resolve target → repo UID.  Accept: UID, name, path, or URL.
             let canonical_target = std::fs::canonicalize(&target)
@@ -2546,21 +2544,14 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             if matched.len() > 1 {
                 eprintln!("Error: '{target}' matches multiple repos:");
                 for r in &matched {
-                    eprintln!(
-                        "  {} ({})",
-                        r.uid,
-                        r.name.as_deref().unwrap_or(&r.url)
-                    );
+                    eprintln!("  {} ({})", r.uid, r.name.as_deref().unwrap_or(&r.url));
                 }
                 eprintln!("Re-run with the full UID to disambiguate.");
                 return Ok((EXIT_ERROR, None));
             }
 
             let repo = matched[0];
-            let display_name = repo
-                .name
-                .as_deref()
-                .unwrap_or(&repo.url);
+            let display_name = repo.name.as_deref().unwrap_or(&repo.url);
 
             let rt = tokio::runtime::Runtime::new()?;
             let mut client = rt

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,6 +271,30 @@ enum Commands {
         )]
         db: Option<PathBuf>,
     },
+    /// Remove a materialized project and its edges from the graph.
+    #[command(
+        after_help = "Accepts a project name or UID.\n\nExamples:\n  nestweaver remove-project freeplay\n  nestweaver remove-project proj:kory-brain:abc123"
+    )]
+    RemoveProject {
+        /// Project name or UID
+        target: String,
+        #[arg(
+            long,
+            help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
+        )]
+        db: Option<PathBuf>,
+    },
+    /// Remove repos and vaults whose paths no longer exist on disk.
+    #[command(
+        after_help = "Scans all indexed repos and vaults, removing any whose source\ndirectory has been deleted or moved.\n\nExamples:\n  nestweaver prune-stale\n  nestweaver prune-stale --db ~/brain/.nestweaver/brain.lbug"
+    )]
+    PruneStale {
+        #[arg(
+            long,
+            help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
+        )]
+        db: Option<PathBuf>,
+    },
     /// List all services/modules in the graph
     ListServices {
         #[arg(long, help = "Filter by instance ID")]
@@ -2567,6 +2591,85 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
                 Err(e) => {
                     eprintln!("Error: failed to remove repo '{}': {e}.", repo.uid);
+                    return Ok((EXIT_ERROR, None));
+                }
+            }
+            Ok((EXIT_SUCCESS, None))
+        }
+
+        Commands::RemoveProject { target, db } => {
+            let db_path = db.unwrap_or_else(default_db_path);
+
+            let store = GraphStore::open_read_only(&db_path)
+                .with_context(|| format!("failed to open database at {}", db_path.display()))?;
+
+            let projects = store.list_projects().context("failed to list projects")?;
+
+            let matched: Vec<&nestweaver_schema::Project> = projects
+                .iter()
+                .filter(|r| r.uid == target || r.name.eq_ignore_ascii_case(&target))
+                .collect();
+
+            if matched.is_empty() {
+                eprintln!(
+                    "Error: no project matching '{target}' found.\n  \
+                     Run `nestweaver list-projects` to see materialized projects."
+                );
+                return Ok((EXIT_NOT_FOUND, None));
+            }
+            if matched.len() > 1 {
+                eprintln!("Error: '{target}' matches multiple projects:");
+                for p in &matched {
+                    eprintln!("  {} ({})", p.uid, p.name);
+                }
+                eprintln!("Re-run with the full UID to disambiguate.");
+                return Ok((EXIT_ERROR, None));
+            }
+
+            let project = matched[0];
+            let display_name = &project.name;
+
+            let rt = tokio::runtime::Runtime::new()?;
+            let mut client = rt
+                .block_on(nestweaver_client::DaemonClient::connect(&db_path, None))
+                .context("failed to connect to daemon")?;
+
+            match rt.block_on(client.remove_project(&project.uid)) {
+                Ok(_resp) => {
+                    println!("Removed project '{display_name}'.");
+                }
+                Err(e) => {
+                    eprintln!("Error: failed to remove project '{}': {e}.", project.uid);
+                    return Ok((EXIT_ERROR, None));
+                }
+            }
+            Ok((EXIT_SUCCESS, None))
+        }
+
+        Commands::PruneStale { db } => {
+            let db_path = db.unwrap_or_else(default_db_path);
+            let rt = tokio::runtime::Runtime::new()?;
+            let mut client = rt
+                .block_on(nestweaver_client::DaemonClient::connect(&db_path, None))
+                .context("failed to connect to daemon")?;
+
+            match rt.block_on(client.prune_stale()) {
+                Ok(resp) => {
+                    let total = resp.removed_repos.len() + resp.removed_vaults.len();
+                    if total == 0 {
+                        println!("No stale sources found.");
+                    } else {
+                        for name in &resp.removed_repos {
+                            println!("  Removed repo: {name}");
+                        }
+                        for name in &resp.removed_vaults {
+                            println!("  Removed vault: {name}");
+                        }
+                        println!("Pruned {total} stale source(s).");
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Error: prune failed: {e}");
                     return Ok((EXIT_ERROR, None));
                 }
             }


### PR DESCRIPTION
## Summary

Adds graph-cleanup commands to NestWeaver — CLI and MCP parity for removing repos, vaults, projects, and stale sources.

### New CLI commands
- **`remove-repo <target>`** — Remove an indexed repository by name, path, URL, or UID
- **`remove-project <target>`** — Remove a materialized project by name or UID
- **`prune-stale`** — Scan all indexed repos/vaults, remove any whose source directory no longer exists on disk

### New MCP tools
- **`brain_remove_source`** — Mirrors `brain_add_source`. Accepts a target (name/path/URL/UID), auto-detects repo vs vault, removes it via daemon RPC
- **`prune_stale`** — No-param tool that cleans up stale sources via daemon RPC

### Stack changes
- Proto: `RemoveRepo`, `RemoveProject`, `PruneStale` request/response messages and RPCs
- Daemon: handlers for all three RPCs with Tantivy reindex after mutations
- Client: `remove_repo()`, `remove_project()`, `prune_stale()` methods
- Store: `delete_project_node()` method added
- MCP: `inline_connect_daemon()` helper extracted from `brain_add_source` to reduce duplication
- Docs: README.md (CLI reference, tool count 38→40), AGENTS.md (MCP tool table, Quick Start)

## Test plan

- [x] New store test: `remove_repo_cascade_deletes_all_data`
- [x] Full test suite: 23 passed, 0 failed
- [x] Clippy clean, rustfmt clean
- [x] Smoke tests: `remove-repo` by name (67→66→67), `prune-stale` (no stale found on clean DB), `remove-project --help`, error cases
- [x] `--help` output correct for all three new commands