### PR TITLE
feat!: embedding seed layer — local model semantic search with Metal acceleration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
-  clippy:
-    name: Clippy
+  build-and-check:
+    name: Build, Clippy & Tests
     runs-on: ubuntu-latest
     steps:
       - name: Free disk space
@@ -48,36 +48,19 @@ jobs:
         run: |
           cargo build -p nestweaver-store 2>/dev/null || true
           sleep 2
-          cargo build
-      - run: cargo clippy --workspace --all-targets -- -D warnings
-
-  test:
-    name: Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
-          sudo apt-get clean
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y cmake g++ libzstd-dev protobuf-compiler
-      - name: Configure linker for lbug+tantivy zstd coexistence
-        run: |
-          mkdir -p .cargo
-          printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]\n' > .cargo/config.toml
-      - name: Build (triggers lbug prebuilt download on first run)
-        run: |
-          cargo build -p nestweaver-store 2>/dev/null || true
-          sleep 2
           cargo build --tests
-      - run: cargo test --no-fail-fast -- --skip daemon_
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Tests
+        run: cargo test --no-fail-fast -- --skip daemon_
         env:
           NESTWEAVER_NO_DAEMON: "1"
+      - name: Upload binary for E2E
+        uses: actions/upload-artifact@v7
+        with:
+          name: nestweaver-debug
+          path: target/debug/nestweaver
+          retention-days: 1
 
   coverage:
     name: Coverage
@@ -94,6 +77,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          key: coverage
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Install build dependencies
@@ -130,37 +114,29 @@ jobs:
 
   e2e:
     name: E2E Tests
+    needs: build-and-check
     runs-on: ubuntu-latest
     steps:
       - name: Free disk space
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
           sudo apt-get clean
-          df -h /
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: crates/nestweaver-web/frontend/package-lock.json
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y cmake g++ libzstd-dev protobuf-compiler
-      - name: Configure linker for lbug+tantivy zstd coexistence
-        run: |
-          mkdir -p .cargo
-          printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]\n' > .cargo/config.toml
+      - name: Download binary
+        uses: actions/download-artifact@v7
+        with:
+          name: nestweaver-debug
+          path: target/debug
+      - name: Make binary executable
+        run: chmod +x target/debug/nestweaver
       - name: Install frontend dependencies
         working-directory: crates/nestweaver-web/frontend
         run: npm ci
-      - name: Build (triggers lbug prebuilt download on first run)
-        run: |
-          cargo build -p nestweaver-store 2>/dev/null || true
-          sleep 2
-          cargo build
       - name: Index test data
         run: ./target/debug/nestweaver --no-daemon index --repo testdata/js --db /tmp/test.lbug
       - name: Install Playwright browsers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,16 +39,8 @@ jobs:
         with:
           cache-on-failure: true
           shared-key: build
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          cache: "npm"
-          cache-dependency-path: crates/nestweaver-web/frontend/package-lock.json
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libzstd-dev protobuf-compiler
-      - name: Build frontend
-        working-directory: crates/nestweaver-web/frontend
-        run: npm ci && npm run build
       - name: Configure linker for lbug+tantivy zstd coexistence
         run: |
           mkdir -p .cargo
@@ -64,12 +56,6 @@ jobs:
         run: cargo test --no-fail-fast -- --skip daemon_
         env:
           NESTWEAVER_NO_DAEMON: "1"
-      - name: Upload binary for E2E
-        uses: actions/upload-artifact@v7
-        with:
-          name: nestweaver-debug
-          path: target/debug/nestweaver
-          retention-days: 1
 
   coverage:
     name: Coverage
@@ -123,7 +109,6 @@ jobs:
 
   e2e:
     name: E2E Tests
-    needs: build-and-check
     runs-on: ubuntu-latest
     env:
       NESTWEAVER_NO_DAEMON: "1"
@@ -132,22 +117,32 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
           sudo apt-get clean
+          df -h /
       - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: build
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: crates/nestweaver-web/frontend/package-lock.json
-      - name: Download binary
-        uses: actions/download-artifact@v7
-        with:
-          name: nestweaver-debug
-          path: target/debug
-      - name: Make binary executable
-        run: chmod +x target/debug/nestweaver
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake g++ libzstd-dev protobuf-compiler
+      - name: Configure linker for lbug+tantivy zstd coexistence
+        run: |
+          mkdir -p .cargo
+          printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]\n' > .cargo/config.toml
       - name: Install frontend dependencies
         working-directory: crates/nestweaver-web/frontend
         run: npm ci
+      - name: Build (triggers lbug prebuilt download on first run)
+        run: |
+          cargo build -p nestweaver-store 2>/dev/null || true
+          sleep 2
+          cargo build
       - name: Index test data
         run: ./target/debug/nestweaver --no-daemon index --repo testdata/js --db /tmp/test.lbug
       - name: Install Playwright browsers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          shared-key: build
       - uses: actions/setup-node@v6
         with:
           node-version: "22"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
+          sudo apt-get clean
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -51,6 +55,10 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
+          sudo apt-get clean
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -75,6 +83,10 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
+          sudo apt-get clean
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -120,6 +132,11 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
+          sudo apt-get clean
+          df -h /
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,16 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: crates/nestweaver-web/frontend/package-lock.json
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libzstd-dev protobuf-compiler
+      - name: Build frontend
+        working-directory: crates/nestweaver-web/frontend
+        run: npm ci && npm run build
       - name: Configure linker for lbug+tantivy zstd coexistence
         run: |
           mkdir -p .cargo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,8 @@ jobs:
     name: E2E Tests
     needs: build-and-check
     runs-on: ubuntu-latest
+    env:
+      NESTWEAVER_NO_DAEMON: "1"
     steps:
       - name: Free disk space
         run: |
@@ -154,8 +156,6 @@ jobs:
       - name: Run E2E tests
         working-directory: crates/nestweaver-web/frontend
         run: npx playwright test
-        env:
-          NESTWEAVER_NO_DAEMON: "1"
       - name: Upload test results
         if: failure()
         uses: actions/upload-artifact@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3862,6 +3862,7 @@ dependencies = [
  "html2md",
  "indicatif",
  "nestweaver-algorithms",
+ "nestweaver-embed",
  "nestweaver-parser",
  "nestweaver-resolver",
  "nestweaver-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +135,15 @@ dependencies = [
  "memchr",
  "rowan",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
 ]
 
 [[package]]
@@ -777,6 +800,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -805,18 +834,39 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -832,6 +882,12 @@ checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
 dependencies = [
  "crunchy",
 ]
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -867,7 +923,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -894,6 +950,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +992,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-core"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ccf5ee3532e66868516d9b315f73aec9f34ea1a37ae98514534d458915dbf1"
+dependencies = [
+ "byteorder",
+ "candle-metal-kernels",
+ "gemm 0.17.1",
+ "half",
+ "memmap2",
+ "metal 0.27.0",
+ "num-traits",
+ "num_cpus",
+ "rand 0.9.4",
+ "rand_distr",
+ "rayon",
+ "safetensors",
+ "thiserror 1.0.69",
+ "ug",
+ "ug-metal",
+ "yoke 0.7.5",
+ "zip",
+]
+
+[[package]]
+name = "candle-metal-kernels"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c85c21827c28db94e7112e364abe7e0cf8d2b022c014edf08642be6b94f21e"
+dependencies = [
+ "metal 0.27.0",
+ "once_cell",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "candle-nn"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1160c3b63f47d40d91110a3e1e1e566ae38edddbbf492a60b40ffc3bc1ff38"
+dependencies = [
+ "candle-core",
+ "half",
+ "num-traits",
+ "rayon",
+ "safetensors",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "candle-transformers"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a0900d49f8605e0e7e6693a1f560e6271279de98e5fa369e7abf3aac245020"
+dependencies = [
+ "byteorder",
+ "candle-core",
+ "candle-nn",
+ "fancy-regex",
+ "num-traits",
+ "rand 0.9.4",
+ "rayon",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "tracing",
+]
+
+[[package]]
 name = "caseless"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,6 +1076,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -1108,6 +1264,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "comrak"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1356,17 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "libc",
+]
 
 [[package]]
 name = "countme"
@@ -1413,12 +1595,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -1436,13 +1642,33 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1488,6 +1714,48 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -1565,6 +1833,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-stack"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e53799688f5632f364f8fb387488dd05db9fe45db7011be066fc20e7027f8b"
+dependencies = [
+ "bytemuck",
+ "reborrow",
+]
+
+[[package]]
+name = "dyn-stack"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
+dependencies = [
+ "bytemuck",
+ "dyn-stack-macros",
+]
+
+[[package]]
+name = "dyn-stack-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,6 +1920,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1650,6 +1956,26 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1693,6 +2019,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,6 +2054,48 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1852,6 +2230,243 @@ dependencies = [
 ]
 
 [[package]]
+name = "gemm"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab24cc62135b40090e31a76a9b2766a501979f3070fa27f689c27ec04377d32"
+dependencies = [
+ "dyn-stack 0.10.0",
+ "gemm-c32 0.17.1",
+ "gemm-c64 0.17.1",
+ "gemm-common 0.17.1",
+ "gemm-f16 0.17.1",
+ "gemm-f32 0.17.1",
+ "gemm-f64 0.17.1",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 10.7.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab96b703d31950f1aeddded248bc95543c9efc7ac9c4a21fda8703a83ee35451"
+dependencies = [
+ "dyn-stack 0.13.2",
+ "gemm-c32 0.18.2",
+ "gemm-c64 0.18.2",
+ "gemm-common 0.18.2",
+ "gemm-f16 0.18.2",
+ "gemm-f32 0.18.2",
+ "gemm-f64 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.6.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9c030d0b983d1e34a546b86e08f600c11696fde16199f971cd46c12e67512c0"
+dependencies = [
+ "dyn-stack 0.10.0",
+ "gemm-common 0.17.1",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 10.7.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6db9fd9f40421d00eea9dd0770045a5603b8d684654816637732463f4073847"
+dependencies = [
+ "dyn-stack 0.13.2",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.6.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb5f2e79fefb9693d18e1066a557b4546cd334b226beadc68b11a8f9431852a"
+dependencies = [
+ "dyn-stack 0.10.0",
+ "gemm-common 0.17.1",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 10.7.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfcad8a3d35a43758330b635d02edad980c1e143dc2f21e6fd25f9e4eada8edf"
+dependencies = [
+ "dyn-stack 0.13.2",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.6.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2e7ea062c987abcd8db95db917b4ffb4ecdfd0668471d8dc54734fdff2354e8"
+dependencies = [
+ "bytemuck",
+ "dyn-stack 0.10.0",
+ "half",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp 0.18.22",
+ "raw-cpuid 10.7.0",
+ "rayon",
+ "seq-macro",
+ "sysctl 0.5.5",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a352d4a69cbe938b9e2a9cb7a3a63b7e72f9349174a2752a558a8a563510d0f3"
+dependencies = [
+ "bytemuck",
+ "dyn-stack 0.13.2",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp 0.21.5",
+ "raw-cpuid 11.6.0",
+ "rayon",
+ "seq-macro",
+ "sysctl 0.6.0",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca4c06b9b11952071d317604acb332e924e817bd891bec8dfb494168c7cedd4"
+dependencies = [
+ "dyn-stack 0.10.0",
+ "gemm-common 0.17.1",
+ "gemm-f32 0.17.1",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 10.7.0",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff95ae3259432f3c3410eaa919033cd03791d81cebd18018393dc147952e109"
+dependencies = [
+ "dyn-stack 0.13.2",
+ "gemm-common 0.18.2",
+ "gemm-f32 0.18.2",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.6.0",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9a69f51aaefbd9cf12d18faf273d3e982d9d711f60775645ed5c8047b4ae113"
+dependencies = [
+ "dyn-stack 0.10.0",
+ "gemm-common 0.17.1",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 10.7.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc8d3d4385393304f407392f754cd2dc4b315d05063f62cf09f47b58de276864"
+dependencies = [
+ "dyn-stack 0.13.2",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.6.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa397a48544fadf0b81ec8741e5c0fba0043008113f71f2034def1935645d2b0"
+dependencies = [
+ "dyn-stack 0.10.0",
+ "gemm-common 0.17.1",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 10.7.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b2a4f76ce4b8b16eadc11ccf2e083252d8237c1b589558a49b0183545015bd"
+dependencies = [
+ "dyn-stack 0.13.2",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.6.0",
+ "seq-macro",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,8 +2598,12 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_distr",
  "zerocopy",
 ]
 
@@ -2037,6 +2656,30 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hf-hub"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
+dependencies = [
+ "dirs",
+ "futures",
+ "http 1.4.1",
+ "indicatif",
+ "libc",
+ "log",
+ "native-tls",
+ "num_cpus",
+ "rand 0.9.4",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "ureq",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "hmac"
@@ -2257,12 +2900,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2314,7 +2973,7 @@ dependencies = [
  "displaydoc",
  "potential_utf",
  "utf8_iter",
- "yoke",
+ "yoke 0.8.3",
  "zerofrom",
  "zerovec",
 ]
@@ -2381,7 +3040,7 @@ dependencies = [
  "displaydoc",
  "icu_locale_core",
  "writeable",
- "yoke",
+ "yoke 0.8.3",
  "zerofrom",
  "zerotrie",
  "zerovec",
@@ -2451,7 +3110,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.12.1",
  "inotify-sys",
  "libc",
 ]
@@ -2664,7 +3323,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags",
+ "bitflags 2.12.1",
  "libc",
 ]
 
@@ -2706,6 +3365,22 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -2814,6 +3489,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2886,6 +3586,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "metal"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+dependencies = [
+ "bitflags 2.12.1",
+ "block",
+ "core-graphics-types",
+ "foreign-types 0.5.0",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
+name = "metal"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+dependencies = [
+ "bitflags 2.12.1",
+ "block",
+ "core-graphics-types",
+ "foreign-types 0.5.0",
+ "log",
+ "objc",
+ "paste",
 ]
 
 [[package]]
@@ -2947,6 +3678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2962,6 +3694,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,8 +3728,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nestweaver"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2989,6 +3760,7 @@ dependencies = [
  "miette",
  "nestweaver-client",
  "nestweaver-daemon",
+ "nestweaver-embed",
  "nestweaver-engine",
  "nestweaver-mcp",
  "nestweaver-proto",
@@ -3013,7 +3785,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-algorithms"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -3021,7 +3793,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-client"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -3037,7 +3809,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-daemon"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3061,8 +3833,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "nestweaver-embed"
+version = "0.28.0"
+dependencies = [
+ "anyhow",
+ "candle-core",
+ "candle-nn",
+ "candle-transformers",
+ "dirs",
+ "hf-hub",
+ "indicatif",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokenizers",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "nestweaver-engine"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "apollo-parser",
@@ -3083,7 +3874,7 @@ dependencies = [
  "protox-parse",
  "rand 0.10.1",
  "rayon",
- "reqwest",
+ "reqwest 0.13.4",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -3101,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-mcp"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3124,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-parser"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "comrak",
  "hex",
@@ -3171,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-proto"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "prost 0.13.5",
  "tonic",
@@ -3180,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-resolver"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "glob",
  "insta",
@@ -3197,7 +3988,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-schema"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "hex",
  "serde",
@@ -3208,7 +3999,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-storage"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3223,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-store"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -3244,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-wasm"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "js-sys",
  "nestweaver-algorithms",
@@ -3309,7 +4100,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags",
+ "bitflags 2.12.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -3339,7 +4130,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -3349,6 +4140,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "bytemuck",
+ "num-traits",
 ]
 
 [[package]]
@@ -3367,12 +4192,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3386,10 +4234,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+ "objc_exception",
+]
+
+[[package]]
+name = "objc_exception"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "object"
@@ -3417,6 +4306,28 @@ name = "oneshot"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
+
+[[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags 2.12.1",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "oorandom"
@@ -3447,10 +4358,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.12.1",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -3532,6 +4480,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -3775,6 +4729,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3789,9 +4752,9 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.12.1",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha",
@@ -3896,6 +4859,32 @@ dependencies = [
  "miette",
  "prost-types 0.14.3",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "pulp"
+version = "0.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0a01a0dc67cf4558d279f0c25b0962bd08fc6dec0137699eae304103e882fe6"
+dependencies = [
+ "bytemuck",
+ "libm",
+ "num-complex",
+ "reborrow",
+]
+
+[[package]]
+name = "pulp"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b86df24f0a7ddd5e4b95c94fc9ed8a98f1ca94d3b01bdce2824097e7835907"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "reborrow",
+ "version_check",
 ]
 
 [[package]]
@@ -4046,12 +5035,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.4",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -4065,6 +5082,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools 0.14.0",
+ "rayon",
+]
+
+[[package]]
 name = "rayon-core"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4075,12 +5103,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -4131,11 +5165,55 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.14",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-rustls 0.27.9",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4312,7 +5390,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4338,7 +5416,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.13",
  "subtle",
@@ -4441,6 +5521,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safetensors"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44560c11236a6130a46ce36c836a62936dc81ebf8c36a37947423571be0e55b6"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4500,7 +5590,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.12.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4522,6 +5612,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -4587,6 +5683,15 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4735,6 +5840,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4804,6 +5915,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4820,10 +5942,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "streaming-iterator"
@@ -4927,12 +6067,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysctl"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea"
+dependencies = [
+ "bitflags 2.12.1",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags 2.12.1",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.12.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4955,7 +6123,7 @@ checksum = "edde6a10743fff00a4e1a8c9ef020bf5f3cbad301b7d2d39f2b07f123c4eac07"
 dependencies = [
  "aho-corasick",
  "arc-swap",
- "base64",
+ "base64 0.22.1",
  "bitpacking",
  "bon",
  "byteorder",
@@ -5275,6 +6443,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokenizers"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "indicatif",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.4",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5300,6 +6502,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -5372,6 +6584,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5394,7 +6618,7 @@ checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2 0.4.14",
  "http 1.4.1",
@@ -5454,7 +6678,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.12.1",
  "bytes",
  "futures-util",
  "http 1.4.1",
@@ -5901,6 +7125,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ug"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03719c61a91b51541f076dfdba45caacf750b230cefaa4b32d6f5411c3f7f437"
+dependencies = [
+ "gemm 0.18.2",
+ "half",
+ "libloading",
+ "memmap2",
+ "num",
+ "num-traits",
+ "num_cpus",
+ "rayon",
+ "safetensors",
+ "serde",
+ "thiserror 1.0.69",
+ "tracing",
+ "yoke 0.7.5",
+]
+
+[[package]]
+name = "ug-metal"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a02ddc17bf32f7dcaaf016b6735f7198082b82f122df7b3ca15d8ead5911ccef"
+dependencies = [
+ "half",
+ "metal 0.29.0",
+ "objc",
+ "serde",
+ "thiserror 1.0.69",
+ "ug",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5934,6 +7193,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5952,6 +7226,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5962,6 +7242,26 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "native-tls",
+ "once_cell",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"
@@ -6022,6 +7322,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -6165,12 +7471,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.12.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -6201,6 +7520,24 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6476,6 +7813,9 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wiremock"
@@ -6484,7 +7824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http 1.4.1",
@@ -6564,7 +7904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.12.1",
  "indexmap",
  "log",
  "serde",
@@ -6619,13 +7959,37 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive 0.7.5",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
- "yoke-derive",
+ "yoke-derive 0.8.2",
  "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -6694,7 +8058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
- "yoke",
+ "yoke 0.8.3",
  "zerofrom",
 ]
 
@@ -6704,7 +8068,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
- "yoke",
+ "yoke 0.8.3",
  "zerofrom",
  "zerovec-derive",
 ]
@@ -6718,6 +8082,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cc23c04387f4da0374be4533ad1208cbb091d5c11d070dfef13676ad6497164"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "indexmap",
+ "num_enum",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.1",
  "http-body 1.0.1",
- "lru",
+ "lru 0.16.4",
  "percent-encoding",
  "regex-lite",
  "sha2 0.11.0",
@@ -2619,6 +2619,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -3463,6 +3465,15 @@ dependencies = [
 
 [[package]]
 name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
@@ -4021,6 +4032,7 @@ dependencies = [
  "anyhow",
  "cc",
  "lbug",
+ "lru 0.12.5",
  "nestweaver-algorithms",
  "nestweaver-schema",
  "rayon",
@@ -6142,7 +6154,7 @@ dependencies = [
  "itertools 0.14.0",
  "levenshtein_automata",
  "log",
- "lru",
+ "lru 0.16.4",
  "lz4_flex",
  "measure_time",
  "memmap2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,7 +1035,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1160c3b63f47d40d91110a3e1e1e566ae38edddbbf492a60b40ffc3bc1ff38"
 dependencies = [
  "candle-core",
+ "candle-metal-kernels",
  "half",
+ "metal 0.27.0",
  "num-traits",
  "rayon",
  "safetensors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3814,6 +3814,7 @@ dependencies = [
  "anyhow",
  "dirs",
  "libc",
+ "nestweaver-embed",
  "nestweaver-engine",
  "nestweaver-mcp",
  "nestweaver-proto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4023,6 +4023,7 @@ dependencies = [
  "lbug",
  "nestweaver-algorithms",
  "nestweaver-schema",
+ "rayon",
  "regex",
  "regex-syntax",
  "rmp-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,3 +120,7 @@ hex = "0.4"
 [[bench]]
 name = "brain_benchmarks"
 harness = false
+
+[[bench]]
+name = "embed_latency"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ nestweaver-embed = { workspace = true, optional = true }
 
 [features]
 default = ["embed"]
-embed = ["dep:nestweaver-embed"]
+embed = ["dep:nestweaver-embed", "nestweaver-daemon/embed"]
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/nestweaver-proto",
     "crates/nestweaver-daemon",
     "crates/nestweaver-client",
+    "crates/nestweaver-embed",
 ]
 
 [workspace.package]
@@ -38,6 +39,7 @@ nestweaver-web = { path = "crates/nestweaver-web" }
 nestweaver-proto = { path = "crates/nestweaver-proto" }
 nestweaver-daemon = { path = "crates/nestweaver-daemon" }
 nestweaver-client = { path = "crates/nestweaver-client" }
+nestweaver-embed = { path = "crates/nestweaver-embed" }
 tonic = "0.13"
 prost = "0.13"
 tonic-build = "0.13"
@@ -98,6 +100,11 @@ libc = "0.2"
 sha2 = { workspace = true }
 hex = "0.4"
 tonic.workspace = true
+nestweaver-embed = { workspace = true, optional = true }
+
+[features]
+default = ["embed"]
+embed = ["dep:nestweaver-embed"]
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ nestweaver-embed = { workspace = true, optional = true }
 [features]
 default = ["embed"]
 embed = ["dep:nestweaver-embed", "nestweaver-daemon/embed"]
+metal = ["nestweaver-embed?/metal"]
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/benches/brain_benchmarks.rs
+++ b/benches/brain_benchmarks.rs
@@ -136,8 +136,15 @@ fn bench_brain_context_query(c: &mut Criterion) {
     c.bench_function(&format!("brain_context_query/notes={n}/seeds=3"), |b| {
         b.iter(|| {
             // No Tantivy here — measures pure-PPR end-to-end query latency.
-            build_brain_context_hybrid(&store, &seeds, None, &HybridSearchConfig::default(), None, None)
-                .unwrap()
+            build_brain_context_hybrid(
+                &store,
+                &seeds,
+                None,
+                &HybridSearchConfig::default(),
+                None,
+                None,
+            )
+            .unwrap()
         });
     });
 }

--- a/benches/brain_benchmarks.rs
+++ b/benches/brain_benchmarks.rs
@@ -136,7 +136,7 @@ fn bench_brain_context_query(c: &mut Criterion) {
     c.bench_function(&format!("brain_context_query/notes={n}/seeds=3"), |b| {
         b.iter(|| {
             // No Tantivy here — measures pure-PPR end-to-end query latency.
-            build_brain_context_hybrid(&store, &seeds, None, &HybridSearchConfig::default(), None)
+            build_brain_context_hybrid(&store, &seeds, None, &HybridSearchConfig::default(), None, None)
                 .unwrap()
         });
     });

--- a/benches/embed_latency.rs
+++ b/benches/embed_latency.rs
@@ -1,14 +1,18 @@
 fn main() {
     #[cfg(feature = "embed")]
     {
-        use std::time::Instant;
         use nestweaver_embed::{EmbedConfig, EmbedModel};
+        use std::time::Instant;
 
         let config = EmbedConfig::default();
         eprintln!("Loading model: {}...", config.model_id);
         let load_start = Instant::now();
         let model = EmbedModel::load(&config).expect("Failed to load model");
-        eprintln!("Model loaded in {:.1}ms (dim={})", load_start.elapsed().as_millis(), model.dimension());
+        eprintln!(
+            "Model loaded in {:.1}ms (dim={})",
+            load_start.elapsed().as_millis(),
+            model.dimension()
+        );
 
         let queries = [
             "how does authentication work",

--- a/benches/embed_latency.rs
+++ b/benches/embed_latency.rs
@@ -1,0 +1,46 @@
+fn main() {
+    #[cfg(feature = "embed")]
+    {
+        use std::time::Instant;
+        use nestweaver_embed::{EmbedConfig, EmbedModel};
+
+        let config = EmbedConfig::default();
+        eprintln!("Loading model: {}...", config.model_id);
+        let load_start = Instant::now();
+        let model = EmbedModel::load(&config).expect("Failed to load model");
+        eprintln!("Model loaded in {:.1}ms (dim={})", load_start.elapsed().as_millis(), model.dimension());
+
+        let queries = [
+            "how does authentication work",
+            "where is the upload pipeline",
+            "rate limiting middleware",
+            "database connection pool configuration",
+            "error handling in the payment flow",
+        ];
+
+        // Warm up
+        let _ = model.embed_query(queries[0]);
+
+        let mut times = Vec::new();
+        for q in &queries {
+            let start = Instant::now();
+            let _ = model.embed_query(q).expect("embed failed");
+            times.push(start.elapsed());
+        }
+
+        let avg_ms = times.iter().map(|t| t.as_millis()).sum::<u128>() as f64 / times.len() as f64;
+        let min_ms = times.iter().map(|t| t.as_millis()).min().unwrap();
+        let max_ms = times.iter().map(|t| t.as_millis()).max().unwrap();
+
+        eprintln!("\nQuery embedding latency ({} queries):", queries.len());
+        eprintln!("  avg: {avg_ms:.1}ms");
+        eprintln!("  min: {min_ms}ms");
+        eprintln!("  max: {max_ms}ms");
+        eprintln!("  target: <50ms Metal, <400ms CPU");
+    }
+
+    #[cfg(not(feature = "embed"))]
+    {
+        eprintln!("Benchmark requires --features embed");
+    }
+}

--- a/crates/nestweaver-algorithms/src/ppr.rs
+++ b/crates/nestweaver-algorithms/src/ppr.rs
@@ -705,8 +705,7 @@ mod tests {
             generation: 0,
         };
         let adj = graph.build_adjacency(&EdgeWeightConfig::default_config());
-        let result =
-            forward_push_ppr(&graph.uids, &adj, &["a".to_string()], &PprConfig::default());
+        let result = forward_push_ppr(&graph.uids, &adj, &["a".to_string()], &PprConfig::default());
         assert!(result.is_empty());
     }
 
@@ -765,8 +764,7 @@ mod tests {
             generation: 0,
         };
         let adj = graph.build_adjacency(&EdgeWeightConfig::default_config());
-        let result =
-            forward_push_ppr(&graph.uids, &adj, &["a".to_string()], &PprConfig::default());
+        let result = forward_push_ppr(&graph.uids, &adj, &["a".to_string()], &PprConfig::default());
 
         // Seed "a" should appear and have a positive score.
         let a_score = result.iter().find(|(uid, _)| uid == "a").unwrap().1;
@@ -839,8 +837,14 @@ mod tests {
 
         // Compare top-10 overlap (or fewer if results are shorter).
         let take = 10.min(pi_result.len()).min(fp_result.len());
-        let pi_top: HashSet<&str> = pi_result[..take].iter().map(|(uid, _)| uid.as_str()).collect();
-        let fp_top: HashSet<&str> = fp_result[..take].iter().map(|(uid, _)| uid.as_str()).collect();
+        let pi_top: HashSet<&str> = pi_result[..take]
+            .iter()
+            .map(|(uid, _)| uid.as_str())
+            .collect();
+        let fp_top: HashSet<&str> = fp_result[..take]
+            .iter()
+            .map(|(uid, _)| uid.as_str())
+            .collect();
         let overlap = pi_top.intersection(&fp_top).count();
 
         assert!(
@@ -866,8 +870,7 @@ mod tests {
             generation: 0,
         };
         let adj = graph.build_adjacency(&EdgeWeightConfig::default_config());
-        let result =
-            forward_push_ppr(&graph.uids, &adj, &["a".to_string()], &PprConfig::default());
+        let result = forward_push_ppr(&graph.uids, &adj, &["a".to_string()], &PprConfig::default());
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].0, "a");
         assert!(result[0].1 > 0.0);

--- a/crates/nestweaver-algorithms/src/ppr.rs
+++ b/crates/nestweaver-algorithms/src/ppr.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::graph::AdjacencyData;
 
@@ -155,6 +155,158 @@ pub fn personalized_pagerank(
         .collect();
 
     // Sort descending by score.
+    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    results
+}
+
+/// Run Personalized PageRank using the Forward Push (LocalPush) algorithm.
+///
+/// Produces the same output shape as [`personalized_pagerank`] — `(uid, score)`
+/// pairs sorted descending — but avoids iterating over every node each step.
+/// Instead it maintains a residual vector and only pushes mass from nodes whose
+/// residual exceeds a threshold, making it significantly faster on sparse
+/// graphs where PPR mass concentrates near the seeds.
+///
+/// Seeds are always included in the output regardless of score; non-seed nodes
+/// must exceed `config.min_score`.
+pub fn forward_push_ppr(
+    uids: &[String],
+    adjacency: &AdjacencyData,
+    seed_uids: &[String],
+    config: &PprConfig,
+) -> Vec<(String, f64)> {
+    let n = uids.len();
+    if n == 0 {
+        return vec![];
+    }
+
+    let seed_set: HashSet<usize> = seed_uids
+        .iter()
+        .filter_map(|uid| adjacency.uid_to_idx.get(uid).copied())
+        .collect();
+
+    let seed_count = seed_set.len();
+    if seed_count == 0 {
+        return vec![];
+    }
+
+    // -- Build outgoing edge list from incoming edges --
+    // adjacency.incoming[v] contains (u, w) meaning u→v with weight w.
+    // We need outgoing[u] = [(v, w)] for forward pushes.
+    let mut outgoing: Vec<Vec<(usize, f64)>> = vec![Vec::new(); n];
+    for v in 0..n {
+        for &(u, w) in &adjacency.incoming[v] {
+            outgoing[u].push((v, w));
+        }
+    }
+
+    // -- Build personalization vector (identical to power iteration) --
+    let personalization_val = 1.0 / seed_count as f64;
+    let mut personalization: Vec<f64> = (0..n)
+        .map(|i| {
+            if seed_set.contains(&i) {
+                personalization_val
+            } else {
+                0.0
+            }
+        })
+        .collect();
+
+    // -- Apply interaction memory bias (same exploration floor pattern) --
+    if let Some(ref scores) = config.interaction_scores {
+        let mut interaction_mass = 0.0;
+        let mut contributions: Vec<(usize, f64)> = Vec::new();
+        for (i, uid) in uids.iter().enumerate() {
+            if let Some(&score) = scores.get(uid)
+                && score > 0.0
+            {
+                contributions.push((i, score));
+                interaction_mass += score;
+            }
+        }
+        if interaction_mass > 0.0 {
+            for p in personalization.iter_mut() {
+                *p *= 1.0 - config.interaction_bias_weight;
+            }
+            for (i, score) in &contributions {
+                personalization[*i] += config.interaction_bias_weight * score / interaction_mass;
+            }
+        }
+    }
+
+    // -- Forward Push --
+    let alpha = 1.0 - config.damping; // teleport probability
+    let r_max = 1e-6; // residual threshold (matches power-iteration convergence)
+
+    let mut estimate = vec![0.0f64; n];
+    let mut residual = personalization.clone();
+
+    // Seed the queue with nodes that have nonzero residual.
+    let mut queue: VecDeque<usize> = VecDeque::new();
+    let mut in_queue = vec![false; n];
+    for i in 0..n {
+        if residual[i] > 0.0 {
+            queue.push_back(i);
+            in_queue[i] = true;
+        }
+    }
+
+    // Safety limit to prevent runaway on adversarial graphs.
+    let max_pushes = n * 10;
+    let mut push_count = 0;
+
+    while let Some(v) = queue.pop_front() {
+        in_queue[v] = false;
+        push_count += 1;
+        if push_count > max_pushes {
+            break;
+        }
+
+        let r_v = residual[v];
+        if r_v.abs() < r_max {
+            continue;
+        }
+
+        // Absorb: estimate accumulates α * residual (teleport fraction).
+        estimate[v] += alpha * r_v;
+
+        // Push: distribute (1 - α) * residual to outgoing neighbours.
+        if adjacency.out_weight[v] > 0.0 {
+            let push_mass = (1.0 - alpha) * r_v;
+            for &(u, w) in &outgoing[v] {
+                let delta = push_mass * w / adjacency.out_weight[v];
+                residual[u] += delta;
+                if !in_queue[u] && residual[u].abs() > r_max {
+                    queue.push_back(u);
+                    in_queue[u] = true;
+                }
+            }
+        } else {
+            // Dangling node: redistribute through the personalization vector
+            // (same semantics as power iteration's dangling-sum handling).
+            let push_mass = (1.0 - alpha) * r_v;
+            for (i, &p) in personalization.iter().enumerate() {
+                if p > 0.0 {
+                    residual[i] += push_mass * p;
+                    if !in_queue[i] && residual[i].abs() > r_max {
+                        queue.push_back(i);
+                        in_queue[i] = true;
+                    }
+                }
+            }
+        }
+
+        residual[v] = 0.0;
+    }
+
+    // -- Collect results (same filtering as power iteration) --
+    let mut results: Vec<(String, f64)> = uids
+        .iter()
+        .enumerate()
+        .filter(|&(i, _)| seed_set.contains(&i) || estimate[i] > config.min_score)
+        .map(|(i, uid)| (uid.clone(), estimate[i]))
+        .collect();
+
     results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     results
 }
@@ -540,5 +692,184 @@ mod tests {
         assert!(result.iter().any(|(uid, _)| uid == "b"));
         // c (called by both seeds) should also appear
         assert!(result.iter().any(|(uid, _)| uid == "c"));
+    }
+
+    // ---- Forward Push PPR tests ----
+
+    #[test]
+    fn forward_push_empty_graph() {
+        let graph = InMemoryGraph {
+            uids: vec![],
+            nodes: vec![],
+            edges: vec![],
+            generation: 0,
+        };
+        let adj = graph.build_adjacency(&EdgeWeightConfig::default_config());
+        let result =
+            forward_push_ppr(&graph.uids, &adj, &["a".to_string()], &PprConfig::default());
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn forward_push_no_matching_seeds() {
+        let graph = InMemoryGraph {
+            uids: vec!["a".to_string()],
+            nodes: vec![NodeMeta {
+                name: "a".into(),
+                kind: "Function".into(),
+                file_path: None,
+                pagerank_score: None,
+                is_entry_point: false,
+            }],
+            edges: vec![],
+            generation: 0,
+        };
+        let adj = graph.build_adjacency(&EdgeWeightConfig::default_config());
+        let result = forward_push_ppr(
+            &graph.uids,
+            &adj,
+            &["nonexistent".to_string()],
+            &PprConfig::default(),
+        );
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn forward_push_seeds_rank_highest() {
+        let graph = InMemoryGraph {
+            uids: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            nodes: vec![
+                NodeMeta {
+                    name: "a".into(),
+                    kind: "Function".into(),
+                    file_path: None,
+                    pagerank_score: None,
+                    is_entry_point: false,
+                },
+                NodeMeta {
+                    name: "b".into(),
+                    kind: "Function".into(),
+                    file_path: None,
+                    pagerank_score: None,
+                    is_entry_point: false,
+                },
+                NodeMeta {
+                    name: "c".into(),
+                    kind: "Function".into(),
+                    file_path: None,
+                    pagerank_score: None,
+                    is_entry_point: false,
+                },
+            ],
+            edges: vec![(0, 1, 1.0, EdgeKind::Calls), (1, 2, 1.0, EdgeKind::Calls)],
+            generation: 0,
+        };
+        let adj = graph.build_adjacency(&EdgeWeightConfig::default_config());
+        let result =
+            forward_push_ppr(&graph.uids, &adj, &["a".to_string()], &PprConfig::default());
+
+        // Seed "a" should appear and have a positive score.
+        let a_score = result.iter().find(|(uid, _)| uid == "a").unwrap().1;
+        assert!(a_score > 0.0);
+
+        // All nodes should appear.
+        assert!(result.iter().any(|(uid, _)| uid == "a"));
+        assert!(result.iter().any(|(uid, _)| uid == "b"));
+        assert!(result.iter().any(|(uid, _)| uid == "c"));
+
+        // b (closer to seed) should score higher than c.
+        let b_score = result.iter().find(|(uid, _)| uid == "b").unwrap().1;
+        let c_score = result.iter().find(|(uid, _)| uid == "c").unwrap().1;
+        assert!(b_score > c_score);
+    }
+
+    #[test]
+    fn forward_push_matches_power_iteration_top_nodes() {
+        // Build a graph with 15 nodes in a mix of chain and fan-out patterns.
+        // Compare top results between both algorithms: expect significant overlap.
+        let n = 15;
+        let uids: Vec<String> = (0..n).map(|i| format!("n{i}")).collect();
+        let nodes: Vec<NodeMeta> = (0..n)
+            .map(|i| NodeMeta {
+                name: format!("n{i}"),
+                kind: "Function".into(),
+                file_path: None,
+                pagerank_score: None,
+                is_entry_point: false,
+            })
+            .collect();
+
+        // Chain: 0->1->2->3->4->5
+        // Fan-out from 0: 0->6, 0->7, 0->8
+        // Cross links: 3->9, 5->10, 7->11, 8->12
+        // Extra: 9->13, 13->14
+        let edges = vec![
+            (0, 1, 1.0, EdgeKind::Calls),
+            (1, 2, 1.0, EdgeKind::Calls),
+            (2, 3, 1.0, EdgeKind::Calls),
+            (3, 4, 1.0, EdgeKind::Calls),
+            (4, 5, 1.0, EdgeKind::Calls),
+            (0, 6, 1.0, EdgeKind::Calls),
+            (0, 7, 1.0, EdgeKind::Calls),
+            (0, 8, 1.0, EdgeKind::Calls),
+            (3, 9, 1.0, EdgeKind::Accesses),
+            (5, 10, 1.0, EdgeKind::Accesses),
+            (7, 11, 1.0, EdgeKind::Calls),
+            (8, 12, 1.0, EdgeKind::Calls),
+            (9, 13, 1.0, EdgeKind::Calls),
+            (13, 14, 1.0, EdgeKind::Calls),
+        ];
+
+        let graph = InMemoryGraph {
+            uids: uids.clone(),
+            nodes,
+            edges,
+            generation: 0,
+        };
+        let adj = graph.build_adjacency(&EdgeWeightConfig::default_config());
+        let seeds = vec!["n0".to_string()];
+        let config = PprConfig::default();
+
+        let pi_result = personalized_pagerank(&uids, &adj, &seeds, &config);
+        let fp_result = forward_push_ppr(&uids, &adj, &seeds, &config);
+
+        // Both should be non-empty.
+        assert!(!pi_result.is_empty());
+        assert!(!fp_result.is_empty());
+
+        // Compare top-10 overlap (or fewer if results are shorter).
+        let take = 10.min(pi_result.len()).min(fp_result.len());
+        let pi_top: HashSet<&str> = pi_result[..take].iter().map(|(uid, _)| uid.as_str()).collect();
+        let fp_top: HashSet<&str> = fp_result[..take].iter().map(|(uid, _)| uid.as_str()).collect();
+        let overlap = pi_top.intersection(&fp_top).count();
+
+        assert!(
+            overlap >= take * 7 / 10,
+            "Expected >= 70% overlap in top-{take}, got {overlap}/{take}. \
+             PI top: {pi_top:?}, FP top: {fp_top:?}"
+        );
+    }
+
+    #[test]
+    fn forward_push_single_dangling_node() {
+        // Single node with no edges: all mass stays on the seed.
+        let graph = InMemoryGraph {
+            uids: vec!["a".to_string()],
+            nodes: vec![NodeMeta {
+                name: "a".into(),
+                kind: "Function".into(),
+                file_path: None,
+                pagerank_score: None,
+                is_entry_point: false,
+            }],
+            edges: vec![],
+            generation: 0,
+        };
+        let adj = graph.build_adjacency(&EdgeWeightConfig::default_config());
+        let result =
+            forward_push_ppr(&graph.uids, &adj, &["a".to_string()], &PprConfig::default());
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, "a");
+        assert!(result[0].1 > 0.0);
     }
 }

--- a/crates/nestweaver-daemon/Cargo.toml
+++ b/crates/nestweaver-daemon/Cargo.toml
@@ -12,6 +12,7 @@ nestweaver-store = { workspace = true }
 nestweaver-schema = { workspace = true }
 nestweaver-mcp = { workspace = true }
 nestweaver-web = { workspace = true }
+nestweaver-embed = { workspace = true, optional = true }
 tonic = { workspace = true }
 prost = { workspace = true }
 tokio = { version = "1", features = ["full"] }
@@ -25,3 +26,6 @@ serde_json = { workspace = true }
 rmp-serde = { workspace = true }
 libc = "0.2"
 dirs = "6"
+
+[features]
+embed = ["dep:nestweaver-embed", "nestweaver-engine/embed", "nestweaver-mcp/embed"]

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -156,6 +156,96 @@ impl DaemonService {
 
         result
     }
+
+    /// Build an `on_change` callback that queues un-embedded nodes for
+    /// background embedding after every watcher batch.  Returns `None`
+    /// when the `embed` feature is disabled or the model is not yet loaded.
+    #[cfg(feature = "embed")]
+    fn make_embed_on_change(
+        embed_model: Arc<tokio::sync::RwLock<Option<Arc<dyn nestweaver_engine::EmbedQueryFn>>>>,
+        store: Arc<nestweaver_store::GraphStore>,
+    ) -> Option<Box<dyn Fn() + Send>> {
+        Some(Box::new(move || {
+            // Peek at the model without blocking async code — we are already
+            // in a blocking thread (inside spawn_blocking).
+            let model = {
+                let guard = embed_model.blocking_read();
+                guard.clone()
+            };
+            let Some(model) = model else { return };
+
+            let store = store.clone();
+            // Fire-and-forget a new blocking task so the watcher callback
+            // returns quickly and the watcher loop is not stalled.
+            let _ = tokio::task::spawn_blocking(move || {
+                let mut embedded = 0u32;
+                let limit: usize = 64; // Max nodes per watcher cycle
+
+                // Symbols
+                if let Ok(symbols) = store.list_all_symbols() {
+                    for sym in symbols.iter().filter(|s| s.embedding.is_none()).take(limit) {
+                        let text = nestweaver_embed::preprocess::symbol_embed_text(
+                            &sym.kind.to_string(),
+                            &sym.name,
+                            None,
+                        );
+                        if let Ok(emb) = model.embed_query(&text) {
+                            let _ = store.update_symbol_embedding(&sym.uid, &emb);
+                            embedded += 1;
+                        }
+                    }
+                }
+
+                let remaining = limit.saturating_sub(embedded as usize);
+
+                // Notes
+                if remaining > 0 {
+                    if let Ok(notes) = store.list_notes(None) {
+                        for note in notes.iter().filter(|n| n.embedding.is_none()).take(remaining) {
+                            let text =
+                                nestweaver_embed::preprocess::note_embed_text(&note.title, None);
+                            if let Ok(emb) = model.embed_query(&text) {
+                                let _ = store.update_note_embedding(&note.uid, &emb);
+                                embedded += 1;
+                            }
+                        }
+                    }
+                }
+
+                let remaining = limit.saturating_sub(embedded as usize);
+
+                // Headings
+                if remaining > 0 {
+                    if let Ok(headings) = store.list_all_headings() {
+                        for heading in
+                            headings.iter().filter(|h| h.embedding.is_none()).take(remaining)
+                        {
+                            let text = nestweaver_embed::preprocess::heading_embed_text(
+                                "",
+                                &heading.text,
+                            );
+                            if let Ok(emb) = model.embed_query(&text) {
+                                let _ = store.update_heading_embedding(&heading.uid, &emb);
+                                embedded += 1;
+                            }
+                        }
+                    }
+                }
+
+                if embedded > 0 {
+                    tracing::debug!(count = embedded, "Embedded new nodes from watcher");
+                }
+            });
+        }))
+    }
+
+    #[cfg(not(feature = "embed"))]
+    fn make_embed_on_change(
+        _embed_model: Arc<tokio::sync::RwLock<Option<Arc<dyn nestweaver_engine::EmbedQueryFn>>>>,
+        _store: Arc<nestweaver_store::GraphStore>,
+    ) -> Option<Box<dyn Fn() + Send>> {
+        None
+    }
 }
 
 // ── Trait impl ──────────────────────────────────────────────────────
@@ -284,12 +374,14 @@ impl NestWeaverDaemon for DaemonService {
 
         let state = self.state.clone();
         let store = self.state.store.clone();
+        let on_change =
+            Self::make_embed_on_change(self.state.embed_model.clone(), self.state.store.clone());
 
         tokio::task::spawn_blocking(move || {
             tracing::info!(vault = %vault_path.display(), "watcher thread started");
 
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                watcher.run_with_store(store, None)
+                watcher.run_with_store(store, on_change)
             }));
 
             match result {
@@ -362,12 +454,14 @@ impl NestWeaverDaemon for DaemonService {
 
         let state = self.state.clone();
         let store = self.state.store.clone();
+        let on_change =
+            Self::make_embed_on_change(self.state.embed_model.clone(), self.state.store.clone());
 
         tokio::task::spawn_blocking(move || {
             tracing::info!(repo = %repo_path.display(), "code watcher thread started");
 
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                watcher.run_with_store(store, None)
+                watcher.run_with_store(store, on_change)
             }));
 
             match result {

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -95,7 +95,10 @@ impl DaemonService {
             nestweaver_mcp::tools::set_current_instance_config(state.instance_cfg.clone());
 
             let embed_ref = embed_arc.as_deref();
-            tracing::debug!(has_model = embed_ref.is_some(), "dispatch_json_tool embed_model status");
+            tracing::debug!(
+                has_model = embed_ref.is_some(),
+                "dispatch_json_tool embed_model status"
+            );
 
             let t_dispatch = std::time::Instant::now();
             let value = nestweaver_mcp::tools::dispatch(
@@ -225,7 +228,7 @@ impl DaemonService {
             let store = store.clone();
             // Fire-and-forget a new blocking task so the watcher callback
             // returns quickly and the watcher loop is not stalled.
-            let _ = tokio::task::spawn_blocking(move || {
+            drop(tokio::task::spawn_blocking(move || {
                 let mut embedded = 0u32;
                 let limit: usize = 64; // Max nodes per watcher cycle
 
@@ -252,19 +255,22 @@ impl DaemonService {
                 let remaining = limit.saturating_sub(embedded as usize);
 
                 // Notes
-                if remaining > 0 {
-                    if let Ok(notes) = store.list_notes(None) {
-                        for note in notes.iter().filter(|n| n.embedding.is_none()).take(remaining) {
-                            let text =
-                                nestweaver_embed::preprocess::note_embed_text(&note.title, None);
-                            match model.embed_query(&text) {
-                                Ok(emb) => {
-                                    store.add_embedding(&note.uid, emb);
-                                    embedded += 1;
-                                }
-                                Err(e) => {
-                                    tracing::warn!(uid = %note.uid, "embedding failed: {e}");
-                                }
+                if remaining > 0
+                    && let Ok(notes) = store.list_notes(None)
+                {
+                    for note in notes
+                        .iter()
+                        .filter(|n| n.embedding.is_none())
+                        .take(remaining)
+                    {
+                        let text = nestweaver_embed::preprocess::note_embed_text(&note.title, None);
+                        match model.embed_query(&text) {
+                            Ok(emb) => {
+                                store.add_embedding(&note.uid, emb);
+                                embedded += 1;
+                            }
+                            Err(e) => {
+                                tracing::warn!(uid = %note.uid, "embedding failed: {e}");
                             }
                         }
                     }
@@ -273,23 +279,23 @@ impl DaemonService {
                 let remaining = limit.saturating_sub(embedded as usize);
 
                 // Headings
-                if remaining > 0 {
-                    if let Ok(headings) = store.list_all_headings() {
-                        for heading in
-                            headings.iter().filter(|h| h.embedding.is_none()).take(remaining)
-                        {
-                            let text = nestweaver_embed::preprocess::heading_embed_text(
-                                "",
-                                &heading.text,
-                            );
-                            match model.embed_query(&text) {
-                                Ok(emb) => {
-                                    store.add_embedding(&heading.uid, emb);
-                                    embedded += 1;
-                                }
-                                Err(e) => {
-                                    tracing::warn!(uid = %heading.uid, "embedding failed: {e}");
-                                }
+                if remaining > 0
+                    && let Ok(headings) = store.list_all_headings()
+                {
+                    for heading in headings
+                        .iter()
+                        .filter(|h| h.embedding.is_none())
+                        .take(remaining)
+                    {
+                        let text =
+                            nestweaver_embed::preprocess::heading_embed_text("", &heading.text);
+                        match model.embed_query(&text) {
+                            Ok(emb) => {
+                                store.add_embedding(&heading.uid, emb);
+                                embedded += 1;
+                            }
+                            Err(e) => {
+                                tracing::warn!(uid = %heading.uid, "embedding failed: {e}");
                             }
                         }
                     }
@@ -301,7 +307,7 @@ impl DaemonService {
                     }
                     tracing::debug!(count = embedded, "embedded new nodes from watcher");
                 }
-            });
+            }));
         }))
     }
 
@@ -2489,11 +2495,9 @@ pub async fn run_server(
     // hits the cache instead of spending ~350ms rebuilding from the DB.
     {
         let store = state.store_read.clone();
-        tokio::task::spawn_blocking(move || {
-            match store.warm_ppr_cache() {
-                Ok(()) => tracing::info!("PPR adjacency cache warmed"),
-                Err(e) => tracing::warn!("failed to warm PPR cache: {e}"),
-            }
+        tokio::task::spawn_blocking(move || match store.warm_ppr_cache() {
+            Ok(()) => tracing::info!("PPR adjacency cache warmed"),
+            Err(e) => tracing::warn!("failed to warm PPR cache: {e}"),
         });
     }
 
@@ -2528,23 +2532,21 @@ pub async fn run_server(
                 Ok(Ok(model)) => {
                     tracing::info!(dim = model.dimension(), "Embedding model loaded");
                     // Check dimension compatibility with existing embeddings
-                    if let Some(stored_dim) = store_for_dim_check.embedding_index_dimension() {
-                        if stored_dim != model.dimension() {
-                            tracing::warn!(
-                                model_dim = model.dimension(),
-                                stored_dim,
-                                "Embedding model dimension ({}) does not match stored embeddings ({}). \
-                                 Semantic search will be disabled. Re-run `nestweaver embed --force` to re-embed.",
-                                model.dimension(),
-                                stored_dim
-                            );
-                            return;
-                        }
+                    if let Some(stored_dim) = store_for_dim_check.embedding_index_dimension()
+                        && stored_dim != model.dimension()
+                    {
+                        tracing::warn!(
+                            model_dim = model.dimension(),
+                            stored_dim,
+                            "Embedding model dimension ({}) does not match stored embeddings ({}). \
+                             Semantic search will be disabled. Re-run `nestweaver embed --force` to re-embed.",
+                            model.dimension(),
+                            stored_dim
+                        );
+                        return;
                     }
-                    *embed_state.write().await = Some(
-                        std::sync::Arc::new(model)
-                            as std::sync::Arc<dyn nestweaver_engine::EmbedQueryFn>,
-                    );
+                    *embed_state.write().await = Some(std::sync::Arc::new(model)
+                        as std::sync::Arc<dyn nestweaver_engine::EmbedQueryFn>);
                 }
                 Ok(Err(e)) => {
                     tracing::warn!("Failed to load embedding model: {e}");

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -2485,6 +2485,18 @@ pub async fn run_server(
         embed_model: Arc::new(tokio::sync::RwLock::new(None)),
     });
 
+    // Pre-warm PPR adjacency cache so the first PPR query after startup
+    // hits the cache instead of spending ~350ms rebuilding from the DB.
+    {
+        let store = state.store_read.clone();
+        tokio::task::spawn_blocking(move || {
+            match store.warm_ppr_cache() {
+                Ok(()) => tracing::info!("PPR adjacency cache warmed"),
+                Err(e) => tracing::warn!("failed to warm PPR cache: {e}"),
+            }
+        });
+    }
+
     // Spawn background embedding model loading when the `embed` feature is on.
     tracing::debug!("embed feature compiled in: {}", cfg!(feature = "embed"));
     #[cfg(feature = "embed")]

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -36,6 +36,9 @@ pub struct DaemonState {
     /// daemon start. Used by tool dispatch (e.g. F6 `[ranking]` priors in
     /// `brain_search`) via the `set_current_instance_config` thread-local.
     pub instance_cfg: Option<Arc<nestweaver_engine::InstanceConfig>>,
+    /// Lazily-loaded embedding model for semantic search. Populated by a
+    /// background task when the `embed` feature is enabled.
+    pub embed_model: Arc<tokio::sync::RwLock<Option<Arc<dyn nestweaver_engine::EmbedQueryFn>>>>,
 }
 
 /// The gRPC service implementation. Wraps shared state in an `Arc`.
@@ -66,6 +69,13 @@ impl DaemonService {
         let tool_name = tool_name.to_string();
         let args_json = args_json.to_string();
 
+        // Read the embed model Arc outside the blocking thread, then drop
+        // the RwLock guard before any further awaits.
+        let embed_arc = {
+            let guard = self.state.embed_model.read().await;
+            guard.clone()
+        };
+
         #[allow(clippy::result_large_err)]
         let result = tokio::task::spawn_blocking(move || -> Result<String, Status> {
             let args: serde_json::Value = serde_json::from_str(&args_json)
@@ -75,12 +85,13 @@ impl DaemonService {
             nestweaver_mcp::tools::set_lite_mode(false);
             nestweaver_mcp::tools::set_current_instance_config(state.instance_cfg.clone());
 
+            let embed_ref = embed_arc.as_deref();
             let value = nestweaver_mcp::tools::dispatch(
                 &state.store_read,
                 state.tantivy.as_deref(),
                 &tool_name,
                 args,
-                None,
+                embed_ref,
             )
             .map_err(|e| Status::internal(format!("tool {tool_name} failed: {e}")))?;
 
@@ -113,18 +124,26 @@ impl DaemonService {
         let state = self.state.clone();
         let tool_name = tool_name.to_string();
 
+        // Read the embed model Arc outside the blocking thread, then drop
+        // the RwLock guard before any further awaits.
+        let embed_arc = {
+            let guard = self.state.embed_model.read().await;
+            guard.clone()
+        };
+
         #[allow(clippy::result_large_err)]
         let result = tokio::task::spawn_blocking(move || -> Result<serde_json::Value, Status> {
             nestweaver_mcp::tools::set_current_db_path(state.db_path.clone());
             nestweaver_mcp::tools::set_lite_mode(false);
             nestweaver_mcp::tools::set_current_instance_config(state.instance_cfg.clone());
 
+            let embed_ref = embed_arc.as_deref();
             nestweaver_mcp::tools::dispatch(
                 &state.store_read,
                 state.tantivy.as_deref(),
                 &tool_name,
                 args,
-                None,
+                embed_ref,
             )
             .map_err(|e| Status::internal(format!("tool {tool_name} failed: {e}")))
         })
@@ -2303,7 +2322,51 @@ pub async fn run_server(
         shutdown_tx: shutdown_tx.clone(),
         watcher_stop: std::sync::Mutex::new(None),
         instance_cfg,
+        embed_model: Arc::new(tokio::sync::RwLock::new(None)),
     });
+
+    // Spawn background embedding model loading when the `embed` feature is on.
+    #[cfg(feature = "embed")]
+    {
+        let embed_state = state.embed_model.clone();
+        let embedding_cfg = state.instance_cfg.as_ref().map(|c| c.embedding.clone());
+        tokio::spawn(async move {
+            let cfg = embedding_cfg.unwrap_or_default();
+            // Expand tilde in cache_dir using the home directory.
+            let cache_dir = if cfg.cache_dir.starts_with("~/") {
+                if let Some(home) = dirs::home_dir() {
+                    home.join(&cfg.cache_dir[2..])
+                } else {
+                    std::path::PathBuf::from(&cfg.cache_dir)
+                }
+            } else {
+                std::path::PathBuf::from(&cfg.cache_dir)
+            };
+            let config = nestweaver_embed::EmbedConfig {
+                model_id: cfg.model_id.clone(),
+                cache_dir,
+                external_endpoint: cfg.external_endpoint.clone(),
+                external_model: cfg.external_model.clone(),
+            };
+            match tokio::task::spawn_blocking(move || nestweaver_embed::EmbedModel::load(&config))
+                .await
+            {
+                Ok(Ok(model)) => {
+                    tracing::info!(dim = model.dimension(), "Embedding model loaded");
+                    *embed_state.write().await = Some(
+                        std::sync::Arc::new(model)
+                            as std::sync::Arc<dyn nestweaver_engine::EmbedQueryFn>,
+                    );
+                }
+                Ok(Err(e)) => {
+                    tracing::warn!("Failed to load embedding model: {e}");
+                }
+                Err(e) => {
+                    tracing::warn!("Embedding model load task panicked: {e}");
+                }
+            }
+        });
+    }
 
     let svc = NestWeaverDaemonServer::new(DaemonService::new(state.clone()))
         .max_decoding_message_size(256 * 1024 * 1024)

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -190,9 +190,14 @@ impl DaemonService {
                             &sym.name,
                             None,
                         );
-                        if let Ok(emb) = model.embed_query(&text) {
-                            let _ = store.update_symbol_embedding(&sym.uid, &emb);
-                            embedded += 1;
+                        match model.embed_query(&text) {
+                            Ok(emb) => {
+                                store.add_embedding(&sym.uid, emb);
+                                embedded += 1;
+                            }
+                            Err(e) => {
+                                tracing::warn!(uid = %sym.uid, "embedding failed: {e}");
+                            }
                         }
                     }
                 }
@@ -205,9 +210,14 @@ impl DaemonService {
                         for note in notes.iter().filter(|n| n.embedding.is_none()).take(remaining) {
                             let text =
                                 nestweaver_embed::preprocess::note_embed_text(&note.title, None);
-                            if let Ok(emb) = model.embed_query(&text) {
-                                let _ = store.update_note_embedding(&note.uid, &emb);
-                                embedded += 1;
+                            match model.embed_query(&text) {
+                                Ok(emb) => {
+                                    store.add_embedding(&note.uid, emb);
+                                    embedded += 1;
+                                }
+                                Err(e) => {
+                                    tracing::warn!(uid = %note.uid, "embedding failed: {e}");
+                                }
                             }
                         }
                     }
@@ -225,16 +235,24 @@ impl DaemonService {
                                 "",
                                 &heading.text,
                             );
-                            if let Ok(emb) = model.embed_query(&text) {
-                                let _ = store.update_heading_embedding(&heading.uid, &emb);
-                                embedded += 1;
+                            match model.embed_query(&text) {
+                                Ok(emb) => {
+                                    store.add_embedding(&heading.uid, emb);
+                                    embedded += 1;
+                                }
+                                Err(e) => {
+                                    tracing::warn!(uid = %heading.uid, "embedding failed: {e}");
+                                }
                             }
                         }
                     }
                 }
 
                 if embedded > 0 {
-                    tracing::debug!(count = embedded, "Embedded new nodes from watcher");
+                    if let Err(e) = store.flush_embedding_index() {
+                        tracing::warn!("failed to flush embedding index: {e}");
+                    }
+                    tracing::debug!(count = embedded, "embedded new nodes from watcher");
                 }
             });
         }))
@@ -2421,11 +2439,12 @@ pub async fn run_server(
     });
 
     // Spawn background embedding model loading when the `embed` feature is on.
-    eprintln!("[daemon] embed feature compiled in: {}", cfg!(feature = "embed"));
+    tracing::debug!("embed feature compiled in: {}", cfg!(feature = "embed"));
     #[cfg(feature = "embed")]
     {
         let embed_state = state.embed_model.clone();
         let embedding_cfg = state.instance_cfg.as_ref().map(|c| c.embedding.clone());
+        let store_for_dim_check = state.store_read.clone();
         tokio::spawn(async move {
             let cfg = embedding_cfg.unwrap_or_default();
             // Expand tilde in cache_dir using the home directory.
@@ -2448,7 +2467,21 @@ pub async fn run_server(
                 .await
             {
                 Ok(Ok(model)) => {
-                    eprintln!("[daemon] Embedding model loaded (dim={})", model.dimension());
+                    tracing::info!(dim = model.dimension(), "Embedding model loaded");
+                    // Check dimension compatibility with existing embeddings
+                    if let Some(stored_dim) = store_for_dim_check.embedding_index_dimension() {
+                        if stored_dim != model.dimension() {
+                            tracing::warn!(
+                                model_dim = model.dimension(),
+                                stored_dim,
+                                "Embedding model dimension ({}) does not match stored embeddings ({}). \
+                                 Semantic search will be disabled. Re-run `nestweaver embed --force` to re-embed.",
+                                model.dimension(),
+                                stored_dim
+                            );
+                            return;
+                        }
+                    }
                     *embed_state.write().await = Some(
                         std::sync::Arc::new(model)
                             as std::sync::Arc<dyn nestweaver_engine::EmbedQueryFn>,
@@ -2538,7 +2571,6 @@ pub async fn run_server(
         .context("gRPC server error")?;
 
     // Cleanup — runs on graceful shutdown (not skipped like process::exit would).
-    eprintln!("[daemon] shutting down, cleaning up");
     tracing::info!("daemon shutting down, cleaning up");
     let _ = std::fs::remove_file(&sock_path);
     let _ = std::fs::remove_file(&pid_path);

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -60,6 +60,7 @@ impl DaemonService {
         tool_name: &str,
         args_json: &str,
     ) -> Result<Response<JsonResponse>, Status> {
+        let t0 = std::time::Instant::now();
         self.state.idle_notify.notify_one();
         self.state
             .active_connections
@@ -76,10 +77,18 @@ impl DaemonService {
             guard.clone()
         };
 
+        let tool_name_for_log = tool_name.clone();
+
         #[allow(clippy::result_large_err)]
         let result = tokio::task::spawn_blocking(move || -> Result<String, Status> {
+            let t_parse = std::time::Instant::now();
             let args: serde_json::Value = serde_json::from_str(&args_json)
                 .map_err(|e| Status::invalid_argument(format!("invalid JSON in args_json: {e}")))?;
+            tracing::debug!(
+                tool = %tool_name,
+                elapsed_us = t_parse.elapsed().as_micros(),
+                "arg parse completed"
+            );
 
             nestweaver_mcp::tools::set_current_db_path(state.db_path.clone());
             nestweaver_mcp::tools::set_lite_mode(false);
@@ -87,6 +96,8 @@ impl DaemonService {
 
             let embed_ref = embed_arc.as_deref();
             tracing::debug!(has_model = embed_ref.is_some(), "dispatch_json_tool embed_model status");
+
+            let t_dispatch = std::time::Instant::now();
             let value = nestweaver_mcp::tools::dispatch(
                 &state.store_read,
                 state.tantivy.as_deref(),
@@ -95,9 +106,22 @@ impl DaemonService {
                 embed_ref,
             )
             .map_err(|e| Status::internal(format!("tool {tool_name} failed: {e}")))?;
+            tracing::debug!(
+                tool = %tool_name,
+                elapsed_ms = t_dispatch.elapsed().as_millis(),
+                "dispatch completed"
+            );
 
-            serde_json::to_string(&value)
-                .map_err(|e| Status::internal(format!("failed to serialize result: {e}")))
+            let t_ser = std::time::Instant::now();
+            let json = serde_json::to_string(&value)
+                .map_err(|e| Status::internal(format!("failed to serialize result: {e}")))?;
+            tracing::debug!(
+                tool = %tool_name,
+                elapsed_us = t_ser.elapsed().as_micros(),
+                bytes = json.len(),
+                "response serialization completed"
+            );
+            Ok(json)
         })
         .await
         .map_err(|e| Status::internal(format!("dispatch task panicked: {e}")))?;
@@ -105,6 +129,12 @@ impl DaemonService {
         self.state
             .active_connections
             .fetch_sub(1, Ordering::Relaxed);
+
+        tracing::debug!(
+            tool = %tool_name_for_log,
+            elapsed_ms = t0.elapsed().as_millis(),
+            "dispatch_json_tool total completed"
+        );
 
         result.map(|json| Response::new(JsonResponse { result_json: json }))
     }
@@ -117,6 +147,7 @@ impl DaemonService {
         tool_name: &str,
         args: serde_json::Value,
     ) -> Result<serde_json::Value, Status> {
+        let t0 = std::time::Instant::now();
         self.state.idle_notify.notify_one();
         self.state
             .active_connections
@@ -132,6 +163,8 @@ impl DaemonService {
             guard.clone()
         };
 
+        let tool_name_for_log = tool_name.clone();
+
         #[allow(clippy::result_large_err)]
         let result = tokio::task::spawn_blocking(move || -> Result<serde_json::Value, Status> {
             nestweaver_mcp::tools::set_current_db_path(state.db_path.clone());
@@ -139,17 +172,31 @@ impl DaemonService {
             nestweaver_mcp::tools::set_current_instance_config(state.instance_cfg.clone());
 
             let embed_ref = embed_arc.as_deref();
-            nestweaver_mcp::tools::dispatch(
+
+            let t_dispatch = std::time::Instant::now();
+            let value = nestweaver_mcp::tools::dispatch(
                 &state.store_read,
                 state.tantivy.as_deref(),
                 &tool_name,
                 args,
                 embed_ref,
             )
-            .map_err(|e| Status::internal(format!("tool {tool_name} failed: {e}")))
+            .map_err(|e| Status::internal(format!("tool {tool_name} failed: {e}")))?;
+            tracing::debug!(
+                tool = %tool_name,
+                elapsed_ms = t_dispatch.elapsed().as_millis(),
+                "dispatch_tool_json dispatch completed"
+            );
+            Ok(value)
         })
         .await
         .map_err(|e| Status::internal(format!("dispatch task panicked: {e}")))?;
+
+        tracing::debug!(
+            tool = %tool_name_for_log,
+            elapsed_ms = t0.elapsed().as_millis(),
+            "dispatch_tool_json total completed"
+        );
 
         self.state
             .active_connections

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -86,6 +86,7 @@ impl DaemonService {
             nestweaver_mcp::tools::set_current_instance_config(state.instance_cfg.clone());
 
             let embed_ref = embed_arc.as_deref();
+            tracing::debug!(has_model = embed_ref.is_some(), "dispatch_json_tool embed_model status");
             let value = nestweaver_mcp::tools::dispatch(
                 &state.store_read,
                 state.tantivy.as_deref(),
@@ -2420,6 +2421,7 @@ pub async fn run_server(
     });
 
     // Spawn background embedding model loading when the `embed` feature is on.
+    eprintln!("[daemon] embed feature compiled in: {}", cfg!(feature = "embed"));
     #[cfg(feature = "embed")]
     {
         let embed_state = state.embed_model.clone();
@@ -2446,7 +2448,7 @@ pub async fn run_server(
                 .await
             {
                 Ok(Ok(model)) => {
-                    tracing::info!(dim = model.dimension(), "Embedding model loaded");
+                    eprintln!("[daemon] Embedding model loaded (dim={})", model.dimension());
                     *embed_state.write().await = Some(
                         std::sync::Arc::new(model)
                             as std::sync::Arc<dyn nestweaver_engine::EmbedQueryFn>,

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -80,6 +80,7 @@ impl DaemonService {
                 state.tantivy.as_deref(),
                 &tool_name,
                 args,
+                None,
             )
             .map_err(|e| Status::internal(format!("tool {tool_name} failed: {e}")))?;
 
@@ -123,6 +124,7 @@ impl DaemonService {
                 state.tantivy.as_deref(),
                 &tool_name,
                 args,
+                None,
             )
             .map_err(|e| Status::internal(format!("tool {tool_name} failed: {e}")))
         })

--- a/crates/nestweaver-embed/Cargo.toml
+++ b/crates/nestweaver-embed/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "nestweaver-embed"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Local embedding inference for NestWeaver semantic search"
+
+[dependencies]
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+candle-core = "0.8"
+candle-nn = "0.8"
+candle-transformers = "0.8"
+hf-hub = { version = "0.4", features = ["tokio"] }
+tokenizers = "0.21"
+reqwest = { version = "0.12", features = ["json", "blocking"] }
+tracing = "0.1"
+indicatif = "0.17"
+dirs = "6"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+
+[features]
+default = ["metal"]
+metal = ["candle-core/metal"]

--- a/crates/nestweaver-embed/Cargo.toml
+++ b/crates/nestweaver-embed/Cargo.toml
@@ -24,4 +24,4 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [features]
 default = ["metal"]
-metal = ["candle-core/metal"]
+metal = ["candle-core/metal", "candle-nn/metal"]

--- a/crates/nestweaver-embed/Cargo.toml
+++ b/crates/nestweaver-embed/Cargo.toml
@@ -23,5 +23,5 @@ dirs = "6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [features]
-default = ["metal"]
+default = []
 metal = ["candle-core/metal", "candle-nn/metal"]

--- a/crates/nestweaver-embed/src/external.rs
+++ b/crates/nestweaver-embed/src/external.rs
@@ -39,11 +39,7 @@ pub fn embed_via_api(endpoint: &str, model: &str, texts: &[&str]) -> Result<Vec<
         .json()
         .context("Failed to parse embedding response")?;
 
-    let mut embeddings: Vec<Vec<f32>> = response
-        .data
-        .into_iter()
-        .map(|d| d.embedding)
-        .collect();
+    let mut embeddings: Vec<Vec<f32>> = response.data.into_iter().map(|d| d.embedding).collect();
 
     if embeddings.len() != texts.len() {
         anyhow::bail!(

--- a/crates/nestweaver-embed/src/external.rs
+++ b/crates/nestweaver-embed/src/external.rs
@@ -1,0 +1,67 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize)]
+struct EmbeddingRequest<'a> {
+    model: &'a str,
+    input: Vec<&'a str>,
+}
+
+#[derive(Deserialize)]
+struct EmbeddingResponse {
+    data: Vec<EmbeddingData>,
+}
+
+#[derive(Deserialize)]
+struct EmbeddingData {
+    embedding: Vec<f32>,
+}
+
+pub fn embed_via_api(endpoint: &str, model: &str, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+    let url = format!("{}/v1/embeddings", endpoint.trim_end_matches('/'));
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()?;
+
+    let request = EmbeddingRequest {
+        model,
+        input: texts.to_vec(),
+    };
+
+    let response: EmbeddingResponse = client
+        .post(&url)
+        .json(&request)
+        .send()
+        .context("Failed to reach embedding API")?
+        .error_for_status()
+        .context("Embedding API returned error")?
+        .json()
+        .context("Failed to parse embedding response")?;
+
+    let mut embeddings: Vec<Vec<f32>> = response
+        .data
+        .into_iter()
+        .map(|d| d.embedding)
+        .collect();
+
+    if embeddings.len() != texts.len() {
+        anyhow::bail!(
+            "API returned {} embeddings for {} inputs",
+            embeddings.len(),
+            texts.len()
+        );
+    }
+
+    // L2 normalize
+    for emb in &mut embeddings {
+        let norm: f32 = emb.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for x in emb.iter_mut() {
+                *x /= norm;
+            }
+        }
+    }
+
+    Ok(embeddings)
+}

--- a/crates/nestweaver-embed/src/lib.rs
+++ b/crates/nestweaver-embed/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod local;
 pub mod preprocess;
+mod external;
 
 use std::path::PathBuf;
 
@@ -33,8 +34,6 @@ fn default_cache_dir() -> PathBuf {
 
 pub struct EmbedModel {
     local: local::LocalModel,
-    /// Retained for Task 3 (external API fallback).
-    #[allow(dead_code)]
     config: EmbedConfig,
 }
 
@@ -52,7 +51,15 @@ impl EmbedModel {
     }
 
     pub fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
-        // External API will be added in Task 3 — for now, always use local
+        if let Some(ref endpoint) = self.config.external_endpoint {
+            let model = self.config.external_model.as_deref().unwrap_or("text-embedding-3-small");
+            match external::embed_via_api(endpoint, model, texts) {
+                Ok(embeddings) => return Ok(embeddings),
+                Err(e) => {
+                    tracing::warn!("External embedding API failed, falling back to local model: {e}");
+                }
+            }
+        }
         self.local.embed(texts)
     }
 

--- a/crates/nestweaver-embed/src/lib.rs
+++ b/crates/nestweaver-embed/src/lib.rs
@@ -1,6 +1,6 @@
+mod external;
 pub mod local;
 pub mod preprocess;
-mod external;
 
 use std::path::PathBuf;
 
@@ -52,11 +52,17 @@ impl EmbedModel {
 
     pub fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
         if let Some(ref endpoint) = self.config.external_endpoint {
-            let model = self.config.external_model.as_deref().unwrap_or("text-embedding-3-small");
+            let model = self
+                .config
+                .external_model
+                .as_deref()
+                .unwrap_or("text-embedding-3-small");
             match external::embed_via_api(endpoint, model, texts) {
                 Ok(embeddings) => return Ok(embeddings),
                 Err(e) => {
-                    tracing::warn!("External embedding API failed, falling back to local model: {e}");
+                    tracing::warn!(
+                        "External embedding API failed, falling back to local model: {e}"
+                    );
                 }
             }
         }

--- a/crates/nestweaver-embed/src/lib.rs
+++ b/crates/nestweaver-embed/src/lib.rs
@@ -1,0 +1,59 @@
+pub mod preprocess;
+
+use std::path::PathBuf;
+use anyhow::Result;
+
+#[derive(Debug, Clone)]
+pub struct EmbedConfig {
+    pub model_id: String,
+    pub cache_dir: PathBuf,
+    pub external_endpoint: Option<String>,
+    pub external_model: Option<String>,
+}
+
+impl Default for EmbedConfig {
+    fn default() -> Self {
+        Self {
+            model_id: "sentence-transformers/all-MiniLM-L6-v2".to_string(),
+            cache_dir: default_cache_dir(),
+            external_endpoint: None,
+            external_model: None,
+        }
+    }
+}
+
+fn default_cache_dir() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from(".cache"))
+        .join("nestweaver")
+        .join("models")
+}
+
+pub struct EmbedModel {
+    _config: EmbedConfig,
+}
+
+impl EmbedModel {
+    pub fn load(_config: &EmbedConfig) -> Result<Self> {
+        // Stub — will be implemented in Task 2 (local.rs) and Task 3 (external.rs)
+        Ok(Self {
+            _config: _config.clone(),
+        })
+    }
+
+    pub fn dimension(&self) -> usize {
+        384 // MiniLM default — will be dynamic in Task 2
+    }
+
+    pub fn embed(&self, _texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        anyhow::bail!("EmbedModel not yet implemented — see Task 2")
+    }
+
+    pub fn embed_query(&self, query: &str) -> Result<Vec<f32>> {
+        let results = self.embed(&[query])?;
+        results
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("embed returned empty results"))
+    }
+}

--- a/crates/nestweaver-embed/src/lib.rs
+++ b/crates/nestweaver-embed/src/lib.rs
@@ -1,6 +1,8 @@
+pub mod local;
 pub mod preprocess;
 
 use std::path::PathBuf;
+
 use anyhow::Result;
 
 #[derive(Debug, Clone)]
@@ -30,23 +32,28 @@ fn default_cache_dir() -> PathBuf {
 }
 
 pub struct EmbedModel {
-    _config: EmbedConfig,
+    local: local::LocalModel,
+    /// Retained for Task 3 (external API fallback).
+    #[allow(dead_code)]
+    config: EmbedConfig,
 }
 
 impl EmbedModel {
-    pub fn load(_config: &EmbedConfig) -> Result<Self> {
-        // Stub — will be implemented in Task 2 (local.rs) and Task 3 (external.rs)
+    pub fn load(config: &EmbedConfig) -> Result<Self> {
+        let local = local::LocalModel::load(config)?;
         Ok(Self {
-            _config: _config.clone(),
+            local,
+            config: config.clone(),
         })
     }
 
     pub fn dimension(&self) -> usize {
-        384 // MiniLM default — will be dynamic in Task 2
+        self.local.dimension()
     }
 
-    pub fn embed(&self, _texts: &[&str]) -> Result<Vec<Vec<f32>>> {
-        anyhow::bail!("EmbedModel not yet implemented — see Task 2")
+    pub fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        // External API will be added in Task 3 — for now, always use local
+        self.local.embed(texts)
     }
 
     pub fn embed_query(&self, query: &str) -> Result<Vec<f32>> {

--- a/crates/nestweaver-embed/src/local.rs
+++ b/crates/nestweaver-embed/src/local.rs
@@ -41,7 +41,7 @@ impl LocalModel {
             info!(device = ?device, model = %config.model_id, "Loading embedding model");
             let vb = unsafe {
                 VarBuilder::from_mmaped_safetensors(
-                    &[weights_path.clone()],
+                    std::slice::from_ref(&weights_path),
                     candle_core::DType::F32,
                     &device,
                 )?

--- a/crates/nestweaver-embed/src/local.rs
+++ b/crates/nestweaver-embed/src/local.rs
@@ -15,9 +15,6 @@ pub struct LocalModel {
 
 impl LocalModel {
     pub fn load(config: &crate::EmbedConfig) -> Result<Self> {
-        let device = select_device();
-        info!(device = ?device, model = %config.model_id, "Loading embedding model");
-
         let api = Api::new()?;
         let repo = api.model(config.model_id.clone());
 
@@ -38,22 +35,40 @@ impl LocalModel {
         let tokenizer = Tokenizer::from_file(&tokenizer_path)
             .map_err(|e| anyhow::anyhow!("Failed to load tokenizer: {e}"))?;
 
-        let vb = unsafe {
-            VarBuilder::from_mmaped_safetensors(
-                &[weights_path],
-                candle_core::DType::F32,
-                &device,
-            )?
-        };
-        let model = BertModel::load(vb, &bert_config)?;
+        // Try Metal first, fall back to CPU if forward pass fails
+        // (candle 0.8 Metal backend lacks some ops like layer-norm)
+        for device in candidate_devices() {
+            info!(device = ?device, model = %config.model_id, "Loading embedding model");
+            let vb = unsafe {
+                VarBuilder::from_mmaped_safetensors(
+                    &[weights_path.clone()],
+                    candle_core::DType::F32,
+                    &device,
+                )?
+            };
+            let model = BertModel::load(vb, &bert_config)?;
+            let tok = tokenizer.clone();
+            let mut candidate = Self {
+                model,
+                tokenizer: tok,
+                device,
+                dimension,
+            };
 
-        info!(dimension, "Embedding model loaded");
-        Ok(Self {
-            model,
-            tokenizer,
-            device,
-            dimension,
-        })
+            // Probe with a short text to verify the device works end-to-end
+            match candidate.embed(&["test"]) {
+                Ok(_) => {
+                    candidate.tokenizer = tokenizer;
+                    info!(dimension, device = ?candidate.device, "Embedding model loaded");
+                    return Ok(candidate);
+                }
+                Err(e) => {
+                    tracing::warn!(device = ?candidate.device, "Device probe failed ({e}), trying next");
+                }
+            }
+        }
+
+        anyhow::bail!("No working device found for embedding model")
     }
 
     pub fn dimension(&self) -> usize {
@@ -108,12 +123,14 @@ impl LocalModel {
     }
 }
 
-fn select_device() -> Device {
+fn candidate_devices() -> Vec<Device> {
+    let mut devices = Vec::new();
     #[cfg(feature = "metal")]
     {
         if let Ok(device) = Device::new_metal(0) {
-            return device;
+            devices.push(device);
         }
     }
-    Device::Cpu
+    devices.push(Device::Cpu);
+    devices
 }

--- a/crates/nestweaver-embed/src/local.rs
+++ b/crates/nestweaver-embed/src/local.rs
@@ -123,14 +123,14 @@ impl LocalModel {
     }
 }
 
+#[allow(unused_mut)]
 fn candidate_devices() -> Vec<Device> {
-    let mut devices = Vec::new();
+    let mut devices = vec![Device::Cpu];
     #[cfg(feature = "metal")]
     {
         if let Ok(device) = Device::new_metal(0) {
-            devices.push(device);
+            devices.insert(0, device);
         }
     }
-    devices.push(Device::Cpu);
     devices
 }

--- a/crates/nestweaver-embed/src/local.rs
+++ b/crates/nestweaver-embed/src/local.rs
@@ -1,0 +1,119 @@
+use anyhow::{Context, Result};
+use candle_core::{Device, Tensor};
+use candle_nn::VarBuilder;
+use candle_transformers::models::bert::{BertModel, Config as BertConfig};
+use hf_hub::api::sync::Api;
+use tokenizers::Tokenizer;
+use tracing::info;
+
+pub struct LocalModel {
+    model: BertModel,
+    tokenizer: Tokenizer,
+    device: Device,
+    dimension: usize,
+}
+
+impl LocalModel {
+    pub fn load(config: &crate::EmbedConfig) -> Result<Self> {
+        let device = select_device();
+        info!(device = ?device, model = %config.model_id, "Loading embedding model");
+
+        let api = Api::new()?;
+        let repo = api.model(config.model_id.clone());
+
+        let config_path = repo
+            .get("config.json")
+            .context("Failed to download config.json")?;
+        let tokenizer_path = repo
+            .get("tokenizer.json")
+            .context("Failed to download tokenizer.json")?;
+        let weights_path = repo
+            .get("model.safetensors")
+            .context("Failed to download model weights")?;
+
+        let config_str = std::fs::read_to_string(&config_path)?;
+        let bert_config: BertConfig = serde_json::from_str(&config_str)?;
+        let dimension = bert_config.hidden_size;
+
+        let tokenizer = Tokenizer::from_file(&tokenizer_path)
+            .map_err(|e| anyhow::anyhow!("Failed to load tokenizer: {e}"))?;
+
+        let vb = unsafe {
+            VarBuilder::from_mmaped_safetensors(
+                &[weights_path],
+                candle_core::DType::F32,
+                &device,
+            )?
+        };
+        let model = BertModel::load(vb, &bert_config)?;
+
+        info!(dimension, "Embedding model loaded");
+        Ok(Self {
+            model,
+            tokenizer,
+            device,
+            dimension,
+        })
+    }
+
+    pub fn dimension(&self) -> usize {
+        self.dimension
+    }
+
+    pub fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        let mut all_embeddings = Vec::with_capacity(texts.len());
+
+        for text in texts {
+            let encoding = self
+                .tokenizer
+                .encode(*text, true)
+                .map_err(|e| anyhow::anyhow!("Tokenization failed: {e}"))?;
+
+            let ids = encoding.get_ids().to_vec();
+            let type_ids = encoding.get_type_ids().to_vec();
+            let attention_mask: Vec<u32> = encoding.get_attention_mask().to_vec();
+            let len = ids.len();
+
+            let input_ids = Tensor::new(ids, &self.device)?.unsqueeze(0)?;
+            let token_type_ids = Tensor::new(type_ids, &self.device)?.unsqueeze(0)?;
+            let attention_mask_tensor = Tensor::new(attention_mask, &self.device)?
+                .to_dtype(candle_core::DType::F32)?
+                .unsqueeze(0)?;
+
+            let output =
+                self.model
+                    .forward(&input_ids, &token_type_ids, Some(&attention_mask_tensor))?;
+
+            // Mean pooling over non-padding tokens
+            let mask_expanded = attention_mask_tensor
+                .unsqueeze(2)?
+                .broadcast_as(output.shape())?;
+            let masked = (output * mask_expanded)?;
+            let summed = masked.sum(1)?;
+            let count = Tensor::new(vec![len as f32], &self.device)?
+                .unsqueeze(0)?
+                .broadcast_as(summed.shape())?;
+            let mean_pooled = (summed / count)?;
+
+            // L2 normalize
+            let norm = mean_pooled.sqr()?.sum(1)?.sqrt()?;
+            let norm_expanded = norm.unsqueeze(1)?.broadcast_as(mean_pooled.shape())?;
+            let normalized = (mean_pooled / norm_expanded)?;
+
+            let embedding: Vec<f32> = normalized.squeeze(0)?.to_vec1()?;
+            all_embeddings.push(embedding);
+        }
+
+        Ok(all_embeddings)
+    }
+}
+
+fn select_device() -> Device {
+    #[cfg(feature = "metal")]
+    {
+        if let Ok(device) = Device::new_metal(0) {
+            return device;
+        }
+    }
+    Device::Cpu
+}

--- a/crates/nestweaver-embed/src/preprocess.rs
+++ b/crates/nestweaver-embed/src/preprocess.rs
@@ -1,6 +1,6 @@
 pub fn split_identifier(fqn: &str) -> String {
     let mut words = Vec::new();
-    for segment in fqn.split(|c: char| c == ':' || c == '.' || c == '/' || c == '\\') {
+    for segment in fqn.split([':', '.', '/', '\\']) {
         if segment.is_empty() {
             continue;
         }
@@ -19,7 +19,7 @@ fn split_camel_snake(s: &str, out: &mut Vec<String>) {
         for i in 0..chars.len() {
             let c = chars[i];
             if c.is_uppercase() && !current.is_empty() {
-                let next_is_lower = chars.get(i + 1).map_or(false, |n| n.is_lowercase());
+                let next_is_lower = chars.get(i + 1).is_some_and(|n| n.is_lowercase());
                 let prev_is_lower = i > 0 && chars[i - 1].is_lowercase();
                 if prev_is_lower || next_is_lower {
                     out.push(current.clone());

--- a/crates/nestweaver-embed/src/preprocess.rs
+++ b/crates/nestweaver-embed/src/preprocess.rs
@@ -1,0 +1,115 @@
+pub fn split_identifier(fqn: &str) -> String {
+    let mut words = Vec::new();
+    for segment in fqn.split(|c: char| c == ':' || c == '.' || c == '/' || c == '\\') {
+        if segment.is_empty() {
+            continue;
+        }
+        split_camel_snake(segment, &mut words);
+    }
+    words.join(" ").to_lowercase()
+}
+
+fn split_camel_snake(s: &str, out: &mut Vec<String>) {
+    for part in s.split('_') {
+        if part.is_empty() {
+            continue;
+        }
+        let mut current = String::new();
+        let chars: Vec<char> = part.chars().collect();
+        for i in 0..chars.len() {
+            let c = chars[i];
+            if c.is_uppercase() && !current.is_empty() {
+                let next_is_lower = chars.get(i + 1).map_or(false, |n| n.is_lowercase());
+                let prev_is_lower = i > 0 && chars[i - 1].is_lowercase();
+                if prev_is_lower || next_is_lower {
+                    out.push(current.clone());
+                    current.clear();
+                }
+            }
+            current.push(c);
+        }
+        if !current.is_empty() {
+            out.push(current);
+        }
+    }
+}
+
+pub fn symbol_embed_text(kind: &str, fqn: &str, docstring: Option<&str>) -> String {
+    let split = split_identifier(fqn);
+    let kind_lower = kind.to_lowercase();
+    match docstring {
+        Some(doc) => {
+            let truncated = &doc[..doc.len().min(256)];
+            format!("{kind_lower} {split} {truncated}")
+        }
+        None => format!("{kind_lower} {split}"),
+    }
+}
+
+pub fn note_embed_text(title: &str, body: Option<&str>) -> String {
+    match body {
+        Some(b) => {
+            let truncated = &b[..b.len().min(512)];
+            format!("{title}\n{truncated}")
+        }
+        None => title.to_string(),
+    }
+}
+
+pub fn heading_embed_text(note_title: &str, heading_text: &str) -> String {
+    format!("{note_title} > {heading_text}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_snake_case() {
+        assert_eq!(split_identifier("validate_token"), "validate token");
+    }
+
+    #[test]
+    fn test_split_camel_case() {
+        assert_eq!(split_identifier("PaymentProcessor"), "payment processor");
+    }
+
+    #[test]
+    fn test_split_namespace() {
+        assert_eq!(
+            split_identifier("auth::middleware::validate_token"),
+            "auth middleware validate token"
+        );
+    }
+
+    #[test]
+    fn test_split_dotted() {
+        assert_eq!(
+            split_identifier("PaymentProcessor.processRefund"),
+            "payment processor process refund"
+        );
+    }
+
+    #[test]
+    fn test_split_acronym() {
+        assert_eq!(split_identifier("HTTPSConnection"), "https connection");
+    }
+
+    #[test]
+    fn test_symbol_embed_text() {
+        let text = symbol_embed_text("function", "auth::validate_token", Some("Validates JWT"));
+        assert_eq!(text, "function auth validate token Validates JWT");
+    }
+
+    #[test]
+    fn test_note_embed_text() {
+        let text = note_embed_text("Architecture Overview", Some("This document describes..."));
+        assert_eq!(text, "Architecture Overview\nThis document describes...");
+    }
+
+    #[test]
+    fn test_heading_embed_text() {
+        let text = heading_embed_text("Auth Guide", "Configuration");
+        assert_eq!(text, "Auth Guide > Configuration");
+    }
+}

--- a/crates/nestweaver-engine/Cargo.toml
+++ b/crates/nestweaver-engine/Cargo.toml
@@ -37,6 +37,10 @@ rand = "0.10"
 rayon = "1.10"
 globset = "0.4"
 html2md = "0.2"
+nestweaver-embed = { path = "../nestweaver-embed", optional = true }
+
+[features]
+embed = ["dep:nestweaver-embed"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/nestweaver-engine/src/config.rs
+++ b/crates/nestweaver-engine/src/config.rs
@@ -214,6 +214,90 @@ pub struct InstanceConfig {
     /// Default pagination limits for tool responses (`[limits]`).
     #[serde(default)]
     pub limits: LimitsConfig,
+    /// Local embedding model and hybrid-search blend configuration (`[embedding]`).
+    #[serde(default)]
+    pub embedding: EmbeddingConfig,
+}
+
+/// `[embedding]` — local embedding model and hybrid-search blend configuration.
+///
+/// Controls which sentence-transformer model is used for semantic search,
+/// where the model weights are cached, and the BM25/PPR/semantic fusion weights
+/// applied when blending result sets.
+#[derive(Debug, Deserialize, Clone)]
+pub struct EmbeddingConfig {
+    /// HuggingFace model ID (or local path) for the sentence-transformer.
+    /// Default: `"sentence-transformers/all-MiniLM-L6-v2"`.
+    #[serde(default = "default_model_id")]
+    pub model_id: String,
+    /// Directory where downloaded model weights are stored.
+    /// Default: `"~/.cache/nestweaver/models"`.
+    #[serde(default = "default_embedding_cache_dir")]
+    pub cache_dir: String,
+    /// Optional HTTP endpoint for an external embedding service (e.g. Ollama,
+    /// OpenAI-compatible). When set, the local model is not loaded.
+    pub external_endpoint: Option<String>,
+    /// Model name to pass to the external endpoint. Required when
+    /// `external_endpoint` is set.
+    pub external_model: Option<String>,
+    /// Blend weight for PPR (Personalized PageRank) scores. Default 0.40.
+    #[serde(default = "default_weight_ppr")]
+    pub weight_ppr: f64,
+    /// Blend weight for BM25 scores. Default 0.25.
+    #[serde(default = "default_weight_bm25")]
+    pub weight_bm25: f64,
+    /// Blend weight for semantic (embedding cosine-similarity) scores. Default 0.35.
+    #[serde(default = "default_weight_semantic")]
+    pub weight_semantic: f64,
+    /// When `true`, semantic scores are always mixed in even if the query
+    /// matched zero BM25 results. Default `true`.
+    #[serde(default = "default_true")]
+    pub always_blend_semantic: bool,
+    /// Maximum number of seeds passed to the semantic re-ranker. Default 5.
+    #[serde(default = "default_semantic_seed_limit")]
+    pub semantic_seed_limit: usize,
+    /// Candidate pool size for the semantic ANN search. Default 200.
+    #[serde(default = "default_semantic_search_limit")]
+    pub semantic_search_limit: usize,
+}
+
+fn default_model_id() -> String {
+    "sentence-transformers/all-MiniLM-L6-v2".to_string()
+}
+fn default_embedding_cache_dir() -> String {
+    "~/.cache/nestweaver/models".to_string()
+}
+fn default_weight_ppr() -> f64 {
+    0.40
+}
+fn default_weight_bm25() -> f64 {
+    0.25
+}
+fn default_weight_semantic() -> f64 {
+    0.35
+}
+fn default_semantic_seed_limit() -> usize {
+    5
+}
+fn default_semantic_search_limit() -> usize {
+    200
+}
+
+impl Default for EmbeddingConfig {
+    fn default() -> Self {
+        Self {
+            model_id: default_model_id(),
+            cache_dir: default_embedding_cache_dir(),
+            external_endpoint: None,
+            external_model: None,
+            weight_ppr: default_weight_ppr(),
+            weight_bm25: default_weight_bm25(),
+            weight_semantic: default_weight_semantic(),
+            always_blend_semantic: true,
+            semantic_seed_limit: default_semantic_seed_limit(),
+            semantic_search_limit: default_semantic_search_limit(),
+        }
+    }
 }
 
 /// `[cache]` — tuning for the F16 response cache (Feature F16).

--- a/crates/nestweaver-engine/src/cross_domain.rs
+++ b/crates/nestweaver-engine/src/cross_domain.rs
@@ -570,6 +570,7 @@ mod tests {
                 created_at: None,
                 modified_at: None,
                 pagerank_score: None,
+                embedding: None,
             })
             .unwrap();
 
@@ -683,6 +684,7 @@ mod tests {
                 created_at: None,
                 modified_at: None,
                 pagerank_score: None,
+                embedding: None,
             })
             .unwrap();
         let r_uid = repo_uid("default", "https://example.com/r");

--- a/crates/nestweaver-engine/src/embedding.rs
+++ b/crates/nestweaver-engine/src/embedding.rs
@@ -28,6 +28,49 @@ pub async fn generate_embedding(
     Ok(embedding)
 }
 
+/// Batch-embed multiple texts in a single API call. The endpoint must be
+/// OpenAI-compatible (`POST /v1/embeddings` with `input` as an array).
+/// Returns one embedding per input text, in the same order.
+pub async fn generate_embeddings_batch(
+    endpoint: &str,
+    model: &str,
+    texts: &[&str],
+) -> Result<Vec<Vec<f32>>, anyhow::Error> {
+    if texts.is_empty() {
+        return Ok(vec![]);
+    }
+    let url = format!("{}/v1/embeddings", endpoint.trim_end_matches('/'));
+    let client = reqwest::Client::new();
+
+    #[derive(serde::Serialize)]
+    struct Req<'a> {
+        model: &'a str,
+        input: Vec<&'a str>,
+    }
+    #[derive(serde::Deserialize)]
+    struct Resp {
+        data: Vec<RespData>,
+    }
+    #[derive(serde::Deserialize)]
+    struct RespData {
+        embedding: Vec<f32>,
+    }
+
+    let resp: Resp = client
+        .post(&url)
+        .json(&Req {
+            model,
+            input: texts.to_vec(),
+        })
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    Ok(resp.data.into_iter().map(|d| d.embedding).collect())
+}
+
 pub fn cache_embedding(
     cache_dir: &Path,
     hash: &str,

--- a/crates/nestweaver-engine/src/eval.rs
+++ b/crates/nestweaver-engine/src/eval.rs
@@ -267,6 +267,7 @@ fn ranked_uids_for_query(
         aliases,
         db_path,
         jq.parsed_intent(),
+        None,
     )?;
     // Feature F17: optionally rerank the leading candidates before scoring, so
     // the harness measures exactly the ordering a `--rerank` caller would get.

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -413,6 +413,7 @@ fn reinsert_single_note(
             created_at,
             modified_at,
             pagerank_score: None,
+            embedding: None,
         })
         .context("insert_note")?;
     store
@@ -438,6 +439,7 @@ fn reinsert_single_note(
             start_line: h.start_line,
             end_line: h.end_line,
             content_hash: sha256_hex_short(&h.text),
+            embedding: None,
         })
         .collect();
     store
@@ -915,6 +917,7 @@ fn index_into_store(
                 created_at,
                 modified_at,
                 pagerank_score: None,
+                embedding: None,
             };
             let vault_note_edge = (v_uid.clone(), n_uid.clone());
 
@@ -937,6 +940,7 @@ fn index_into_store(
                     start_line: h.start_line,
                     end_line: h.end_line,
                     content_hash: sha256_hex_short(&h.text),
+                    embedding: None,
                 });
                 n_h_edges.push((n_uid.clone(), h_uid));
             }

--- a/crates/nestweaver-engine/src/investigate.rs
+++ b/crates/nestweaver-engine/src/investigate.rs
@@ -21,7 +21,8 @@ use nestweaver_store::{GraphStore, TantivyIndex};
 use serde::{Deserialize, Serialize};
 
 use crate::query::{
-    BrainNode, HybridSearchConfig, build_brain_context_hybrid_with_aliases, populate_inline_bodies,
+    BrainNode, EmbedQueryFn, HybridSearchConfig, build_brain_context_hybrid_with_aliases,
+    populate_inline_bodies,
 };
 
 /// Bundle time-to-live: entries older than this are dropped when the sidecar
@@ -226,6 +227,7 @@ pub fn investigate(
     query: &str,
     scope: &str,
     token_budget: Option<usize>,
+    embed_model: Option<&dyn EmbedQueryFn>,
 ) -> Result<InvestigateResult, anyhow::Error> {
     let budget = token_budget
         .unwrap_or(DEFAULT_TOKEN_BUDGET)
@@ -252,6 +254,7 @@ pub fn investigate(
         &HashMap::new(),
         db_path,
         None,
+        embed_model,
     );
     let mut connected: Vec<BrainNode> = match connected_result {
         Ok(ctx) => ctx.connected,
@@ -804,6 +807,7 @@ mod tests {
             "greet",
             "vault",
             Some(4000),
+            None,
         )
         .unwrap();
 
@@ -842,7 +846,7 @@ mod tests {
         let db_path = dir.path().join("nestweaver.lbug");
 
         let result =
-            investigate(&store, None, Some(&db_path), &src, "greet", "vault", None).unwrap();
+            investigate(&store, None, Some(&db_path), &src, "greet", "vault", None, None).unwrap();
 
         // Pick a symbol entry to expand.
         let target = result
@@ -887,6 +891,7 @@ mod tests {
             "greet",
             "vault",
             Some(50),
+            None,
         )
         .unwrap();
         // With a tiny budget, most entries lack inline bodies.
@@ -949,6 +954,7 @@ mod tests {
             "greet",
             "vault",
             Some(50),
+            None,
         )
         .unwrap();
 
@@ -1029,6 +1035,7 @@ mod tests {
             &src,
             "zzz_no_such_symbol_xyz",
             "vault",
+            None,
             None,
         )
         .unwrap();

--- a/crates/nestweaver-engine/src/investigate.rs
+++ b/crates/nestweaver-engine/src/investigate.rs
@@ -219,6 +219,7 @@ pub fn load_bundle(db_path: &Path, bundle_id: &str) -> Option<Bundle> {
 /// When `db_path` is `Some`, the resulting bundle is persisted to the sidecar.
 /// When `None` (e.g. an in-memory store), the bundle is returned but not saved;
 /// follow-up calls would not find it.
+#[allow(clippy::too_many_arguments)]
 pub fn investigate(
     store: &GraphStore,
     tantivy: Option<&TantivyIndex>,
@@ -845,8 +846,17 @@ mod tests {
         let (dir, src, store) = make_store();
         let db_path = dir.path().join("nestweaver.lbug");
 
-        let result =
-            investigate(&store, None, Some(&db_path), &src, "greet", "vault", None, None).unwrap();
+        let result = investigate(
+            &store,
+            None,
+            Some(&db_path),
+            &src,
+            "greet",
+            "vault",
+            None,
+            None,
+        )
+        .unwrap();
 
         // Pick a symbol entry to expand.
         let target = result

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -176,12 +176,12 @@ pub use project::{ProjectMaterializationResult, detect_implicit_projects, materi
 pub use pull::*;
 pub use query::{
     BrainContextResult, BrainNode, ContextNode, ContextResult, CrossRepoLink, EmbedQueryFn,
-    FeatureContextResult, FeatureInfo, HybridSearchConfig, LinkInfo, LookupResult,
-    SymbolCandidate, SymbolDetail, apply_ranking_priors, build_brain_context,
-    build_brain_context_hybrid, build_brain_context_hybrid_with_aliases, build_context,
-    build_context_with_intent, build_feature_context, dedup_heading_section_pairs,
-    expand_query_with_aliases, explain_ranking_prior, generate_repo_map, list_repos,
-    list_services, lookup_symbol, populate_inline_bodies, promote_member_notes_into_connected,
+    FeatureContextResult, FeatureInfo, HybridSearchConfig, LinkInfo, LookupResult, SymbolCandidate,
+    SymbolDetail, apply_ranking_priors, build_brain_context, build_brain_context_hybrid,
+    build_brain_context_hybrid_with_aliases, build_context, build_context_with_intent,
+    build_feature_context, dedup_heading_section_pairs, expand_query_with_aliases,
+    explain_ranking_prior, generate_repo_map, list_repos, list_services, lookup_symbol,
+    populate_inline_bodies, promote_member_notes_into_connected,
     promote_member_symbols_into_connected, search_symbols,
 };
 pub use recency::parse_iso8601_to_epoch;

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -175,13 +175,13 @@ pub use process::{
 pub use project::{ProjectMaterializationResult, detect_implicit_projects, materialize_projects};
 pub use pull::*;
 pub use query::{
-    BrainContextResult, BrainNode, ContextNode, ContextResult, CrossRepoLink, FeatureContextResult,
-    FeatureInfo, HybridSearchConfig, LinkInfo, LookupResult, SymbolCandidate, SymbolDetail,
-    apply_ranking_priors, build_brain_context, build_brain_context_hybrid,
-    build_brain_context_hybrid_with_aliases, build_context, build_context_with_intent,
-    build_feature_context, dedup_heading_section_pairs, expand_query_with_aliases,
-    explain_ranking_prior, generate_repo_map, list_repos, list_services, lookup_symbol,
-    populate_inline_bodies, promote_member_notes_into_connected,
+    BrainContextResult, BrainNode, ContextNode, ContextResult, CrossRepoLink, EmbedQueryFn,
+    FeatureContextResult, FeatureInfo, HybridSearchConfig, LinkInfo, LookupResult,
+    SymbolCandidate, SymbolDetail, apply_ranking_priors, build_brain_context,
+    build_brain_context_hybrid, build_brain_context_hybrid_with_aliases, build_context,
+    build_context_with_intent, build_feature_context, dedup_heading_section_pairs,
+    expand_query_with_aliases, explain_ranking_prior, generate_repo_map, list_repos,
+    list_services, lookup_symbol, populate_inline_bodies, promote_member_notes_into_connected,
     promote_member_symbols_into_connected, search_symbols,
 };
 pub use recency::parse_iso8601_to_epoch;

--- a/crates/nestweaver-engine/src/project.rs
+++ b/crates/nestweaver-engine/src/project.rs
@@ -310,6 +310,7 @@ pub fn materialize_projects(
                             created_at: None,
                             modified_at: None,
                             pagerank_score: None,
+                            embedding: None,
                         };
 
                         if let Err(e) = store.upsert_note(&note) {
@@ -346,6 +347,7 @@ pub fn materialize_projects(
                                     start_line: h.start_line,
                                     end_line: h.end_line,
                                     content_hash: truncated_hash(&h.text),
+                                    embedding: None,
                                 })
                                 .collect();
 

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -1215,13 +1215,6 @@ pub fn build_brain_context_hybrid_with_aliases(
     let mut seen = std::collections::HashSet::new();
     seed_uids.retain(|u| seen.insert(u.clone()));
 
-    if seed_uids.is_empty() {
-        anyhow::bail!(
-            "No seeds resolved. Tried as UIDs, note titles, tags (with or without '#'), and symbol names. Unresolved: {:?}",
-            unresolved,
-        );
-    }
-
     // ── Semantic seed blending ────────────────────────────────────────────
     // When an embedding model is available and the semantic weight is nonzero,
     // run a vector KNN search over the entire graph. The top-k hits are
@@ -1234,7 +1227,6 @@ pub fn build_brain_context_hybrid_with_aliases(
             let query_text = inputs.join(" ");
             if let Ok(query_emb) = model.embed_query(&query_text) {
                 if let Ok(hits) = crate::vector_search::vector_knn_all(store, &query_emb, config.semantic_limit) {
-                    // Inject top-5 semantic hits as PPR seeds (always-blend).
                     for (uid, _score) in hits.iter().take(5) {
                         if !seed_uids.contains(uid) {
                             seed_uids.push(uid.clone());
@@ -1244,6 +1236,13 @@ pub fn build_brain_context_hybrid_with_aliases(
                 }
             }
         }
+    }
+
+    if seed_uids.is_empty() {
+        anyhow::bail!(
+            "No seeds resolved. Tried as UIDs, note titles, tags (with or without '#'), symbol names, and semantic search. Unresolved: {:?}",
+            unresolved,
+        );
     }
 
     // Run unified PPR with optional intent tuning.

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -1896,6 +1896,7 @@ mod render_brain_node_tests {
             created_at: None,
             modified_at: None,
             pagerank_score: None,
+            embedding: None,
         };
         store.insert_note(&note).unwrap();
 
@@ -1908,6 +1909,7 @@ mod render_brain_node_tests {
             start_line: 1,
             end_line: 5,
             content_hash: "def".to_string(),
+            embedding: None,
         };
         store.insert_heading(&heading).unwrap();
 
@@ -1946,6 +1948,7 @@ mod render_brain_node_tests {
             created_at: None,
             modified_at: None,
             pagerank_score: None,
+            embedding: None,
         };
         store.insert_note(&note).unwrap();
 
@@ -2156,6 +2159,7 @@ mod inline_body_tests {
             created_at: None,
             modified_at: None,
             pagerank_score: None,
+            embedding: None,
         };
         store.insert_note(&note).unwrap();
         let sec = Section {

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -61,6 +61,12 @@ pub struct HybridSearchConfig {
     /// `[seed_resolution]` in instance config (with backward-compat shim
     /// for the legacy `[ranking].test_path_patterns` block).
     pub seed_resolution: nestweaver_store::SeedResolutionConfig,
+    /// When `true`, semantic scores are always mixed in even when the query
+    /// matched zero BM25 results. Sourced from `[embedding].always_blend_semantic`.
+    pub always_blend_semantic: bool,
+    /// Maximum number of top semantic hits injected as PPR seeds.
+    /// Sourced from `[embedding].semantic_seed_limit`.
+    pub semantic_seed_limit: usize,
 }
 
 impl Default for HybridSearchConfig {
@@ -73,6 +79,8 @@ impl Default for HybridSearchConfig {
             semantic_limit: 200,
             prf: false,
             seed_resolution: nestweaver_store::SeedResolutionConfig::default(),
+            always_blend_semantic: true,
+            semantic_seed_limit: 5,
         }
     }
 }
@@ -1227,9 +1235,11 @@ pub fn build_brain_context_hybrid_with_aliases(
             let query_text = inputs.join(" ");
             if let Ok(query_emb) = model.embed_query(&query_text) {
                 if let Ok(hits) = crate::vector_search::vector_knn_all(store, &query_emb, config.semantic_limit) {
-                    for (uid, _score) in hits.iter().take(5) {
-                        if !seed_uids.contains(uid) {
-                            seed_uids.push(uid.clone());
+                    if config.always_blend_semantic {
+                        for (uid, _score) in hits.iter().take(config.semantic_seed_limit) {
+                            if !seed_uids.contains(uid) {
+                                seed_uids.push(uid.clone());
+                            }
                         }
                     }
                     semantic_hits = hits;
@@ -1353,7 +1363,7 @@ fn tanh_normalize(scores: &[f64]) -> Vec<f64> {
     let median = {
         let mut sorted = nonzero.clone();
         sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        sorted[sorted.len() / 2]
+        sorted[(sorted.len() - 1) / 2]
     };
     let scale = if median > 0.0 { median } else { 1.0 };
     scores.iter().map(|s| (s / scale).tanh()).collect()

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -10,6 +10,23 @@ use crate::config::{
 };
 use crate::repo_display_name;
 
+// ── Embed abstraction ─────────────────────────────────────────────────────
+/// Trait abstracting over an embedding model's query-embedding capability.
+///
+/// This is feature-gated behind `embed` so that callers without the
+/// `nestweaver-embed` crate can still compile: they simply pass
+/// `None::<&dyn EmbedQueryFn>` at each call site.
+pub trait EmbedQueryFn: Send + Sync {
+    fn embed_query(&self, text: &str) -> anyhow::Result<Vec<f32>>;
+}
+
+#[cfg(feature = "embed")]
+impl EmbedQueryFn for nestweaver_embed::EmbedModel {
+    fn embed_query(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+        nestweaver_embed::EmbedModel::embed_query(self, text)
+    }
+}
+
 /// Tuning knobs for hybrid PPR + BM25 + semantic retrieval.
 ///
 /// Defaults reflect empirical tuning for weighted score fusion
@@ -975,7 +992,7 @@ pub fn build_brain_context(
     store: &GraphStore,
     inputs: &[String],
 ) -> Result<BrainContextResult, anyhow::Error> {
-    build_brain_context_hybrid(store, inputs, None, &HybridSearchConfig::default(), None)
+    build_brain_context_hybrid(store, inputs, None, &HybridSearchConfig::default(), None, None)
 }
 
 /// Hybrid PPR + BM25 retrieval.
@@ -996,6 +1013,7 @@ pub fn build_brain_context_hybrid(
     tantivy: Option<&TantivyIndex>,
     config: &HybridSearchConfig,
     intent: Option<QueryIntent>,
+    embed_model: Option<&dyn EmbedQueryFn>,
 ) -> Result<BrainContextResult, anyhow::Error> {
     build_brain_context_hybrid_with_aliases(
         store,
@@ -1005,6 +1023,7 @@ pub fn build_brain_context_hybrid(
         &std::collections::HashMap::new(),
         None,
         intent,
+        embed_model,
     )
 }
 
@@ -1027,6 +1046,7 @@ pub fn build_brain_context_hybrid_with_aliases(
     aliases: &std::collections::HashMap<String, Vec<String>>,
     db_path: Option<&std::path::Path>,
     intent: Option<QueryIntent>,
+    embed_model: Option<&dyn EmbedQueryFn>,
 ) -> Result<BrainContextResult, anyhow::Error> {
     // Build a reverse lookup: alias (lowercase) → canonical name.
     // A single alias may appear under multiple canonicals — we collect all.
@@ -1202,19 +1222,42 @@ pub fn build_brain_context_hybrid_with_aliases(
         );
     }
 
+    // ── Semantic seed blending ────────────────────────────────────────────
+    // When an embedding model is available and the semantic weight is nonzero,
+    // run a vector KNN search over the entire graph. The top-k hits are
+    // injected as PPR seeds (always-blend) so the walk explores semantically
+    // relevant neighborhoods even when the textual seeds miss them. The full
+    // hit list is passed to weighted_score_fuse as the semantic signal.
+    let mut semantic_hits: Vec<(String, f64)> = Vec::new();
+    if let Some(model) = embed_model {
+        if config.weight_semantic > 0.0 {
+            let query_text = inputs.join(" ");
+            if let Ok(query_emb) = model.embed_query(&query_text) {
+                if let Ok(hits) = crate::vector_search::vector_knn_all(store, &query_emb, config.semantic_limit) {
+                    // Inject top-5 semantic hits as PPR seeds (always-blend).
+                    for (uid, _score) in hits.iter().take(5) {
+                        if !seed_uids.contains(uid) {
+                            seed_uids.push(uid.clone());
+                        }
+                    }
+                    semantic_hits = hits;
+                }
+            }
+        }
+    }
+
     // Run unified PPR with optional intent tuning.
     let damping = intent.map_or(0.85, |i| i.damping());
     let ppr = store
         .personalized_pagerank_with_intent(&seed_uids, damping, 20, &GraphScope::unified(), intent)
         .map_err(|e| anyhow::anyhow!(e))?;
 
-    // ── Hybrid retrieval: fuse PPR + BM25 via Reciprocal Rank Fusion ───
+    // ── Hybrid retrieval: fuse PPR + BM25 + semantic ──────────────────────
     //
     // Feature F7 (PRF half): when `config.prf` is set, the BM25 leg runs a
     // two-pass pseudo-relevance-feedback expansion (`search_prf`) instead of a
     // single-pass `search`. The mined expansion terms are surfaced on the
-    // result for auditing. RRF is rank-only, so PRF affects the fused result
-    // solely via the reordered BM25 ranks (see `HybridSearchConfig::prf`).
+    // result for auditing.
     let mut expansion_terms: Vec<String> = Vec::new();
     let fused: Vec<(String, f64)> = if let Some(tantivy) = tantivy {
         let bm25_query = inputs.join(" ");
@@ -1236,7 +1279,7 @@ pub fn build_brain_context_hybrid_with_aliases(
         weighted_score_fuse(
             &ppr,
             &bm25_hits,
-            &[],
+            &semantic_hits,
             config.weight_ppr,
             config.weight_bm25,
             config.weight_semantic,

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -1000,7 +1000,14 @@ pub fn build_brain_context(
     store: &GraphStore,
     inputs: &[String],
 ) -> Result<BrainContextResult, anyhow::Error> {
-    build_brain_context_hybrid(store, inputs, None, &HybridSearchConfig::default(), None, None)
+    build_brain_context_hybrid(
+        store,
+        inputs,
+        None,
+        &HybridSearchConfig::default(),
+        None,
+        None,
+    )
 }
 
 /// Hybrid PPR + BM25 retrieval.
@@ -1046,6 +1053,7 @@ pub fn build_brain_context_hybrid(
 ///
 /// The optional `intent` parameter tunes PPR's damping factor and edge
 /// weights. When `None`, the standard damping (0.85) is used.
+#[allow(clippy::too_many_arguments)]
 pub fn build_brain_context_hybrid_with_aliases(
     store: &GraphStore,
     inputs: &[String],
@@ -1230,21 +1238,22 @@ pub fn build_brain_context_hybrid_with_aliases(
     // relevant neighborhoods even when the textual seeds miss them. The full
     // hit list is passed to weighted_score_fuse as the semantic signal.
     let mut semantic_hits: Vec<(String, f64)> = Vec::new();
-    if let Some(model) = embed_model {
-        if config.weight_semantic > 0.0 {
-            let query_text = inputs.join(" ");
-            if let Ok(query_emb) = model.embed_query(&query_text) {
-                if let Ok(hits) = crate::vector_search::vector_knn_all(store, &query_emb, config.semantic_limit) {
-                    if config.always_blend_semantic {
-                        for (uid, _score) in hits.iter().take(config.semantic_seed_limit) {
-                            if !seed_uids.contains(uid) {
-                                seed_uids.push(uid.clone());
-                            }
-                        }
+    if let Some(model) = embed_model
+        && config.weight_semantic > 0.0
+    {
+        let query_text = inputs.join(" ");
+        if let Ok(query_emb) = model.embed_query(&query_text)
+            && let Ok(hits) =
+                crate::vector_search::vector_knn_all(store, &query_emb, config.semantic_limit)
+        {
+            if config.always_blend_semantic {
+                for (uid, _score) in hits.iter().take(config.semantic_seed_limit) {
+                    if !seed_uids.contains(uid) {
+                        seed_uids.push(uid.clone());
                     }
-                    semantic_hits = hits;
                 }
             }
+            semantic_hits = hits;
         }
     }
 
@@ -1401,15 +1410,28 @@ pub fn weighted_score_fuse(
     }
 
     let mut all_uids: Vec<&str> = Vec::new();
-    for uid in ppr_scores.keys().chain(bm25_scores.keys()).chain(sem_scores.keys()) {
+    for uid in ppr_scores
+        .keys()
+        .chain(bm25_scores.keys())
+        .chain(sem_scores.keys())
+    {
         if !all_uids.contains(uid) {
             all_uids.push(uid);
         }
     }
 
-    let ppr_raw: Vec<f64> = all_uids.iter().map(|u| ppr_scores.get(u).copied().unwrap_or(0.0)).collect();
-    let bm25_raw: Vec<f64> = all_uids.iter().map(|u| bm25_scores.get(u).copied().unwrap_or(0.0)).collect();
-    let sem_raw: Vec<f64> = all_uids.iter().map(|u| sem_scores.get(u).copied().unwrap_or(0.0)).collect();
+    let ppr_raw: Vec<f64> = all_uids
+        .iter()
+        .map(|u| ppr_scores.get(u).copied().unwrap_or(0.0))
+        .collect();
+    let bm25_raw: Vec<f64> = all_uids
+        .iter()
+        .map(|u| bm25_scores.get(u).copied().unwrap_or(0.0))
+        .collect();
+    let sem_raw: Vec<f64> = all_uids
+        .iter()
+        .map(|u| sem_scores.get(u).copied().unwrap_or(0.0))
+        .collect();
 
     let ppr_norm = tanh_normalize(&ppr_raw);
     let bm25_norm = tanh_normalize(&bm25_raw);
@@ -2613,8 +2635,20 @@ mod fusion_tests {
     fn test_weighted_score_fuse_three_signals() {
         let ppr = vec![("a".to_string(), 0.5), ("b".to_string(), 0.3)];
         let bm25 = vec![
-            SearchHit { uid: "b".to_string(), kind: "function".into(), title: "b".into(), vault_uid: "v".into(), score: 10.0 },
-            SearchHit { uid: "c".to_string(), kind: "function".into(), title: "c".into(), vault_uid: "v".into(), score: 8.0 },
+            SearchHit {
+                uid: "b".to_string(),
+                kind: "function".into(),
+                title: "b".into(),
+                vault_uid: "v".into(),
+                score: 10.0,
+            },
+            SearchHit {
+                uid: "c".to_string(),
+                kind: "function".into(),
+                title: "c".into(),
+                vault_uid: "v".into(),
+                score: 8.0,
+            },
         ];
         let semantic = vec![("a".to_string(), 0.9), ("c".to_string(), 0.7)];
 
@@ -2628,9 +2662,13 @@ mod fusion_tests {
     #[test]
     fn test_weighted_score_fuse_empty_semantic() {
         let ppr = vec![("a".to_string(), 0.5)];
-        let bm25 = vec![
-            SearchHit { uid: "a".to_string(), kind: "function".into(), title: "a".into(), vault_uid: "v".into(), score: 5.0 },
-        ];
+        let bm25 = vec![SearchHit {
+            uid: "a".to_string(),
+            kind: "function".into(),
+            title: "a".into(),
+            vault_uid: "v".into(),
+            score: 5.0,
+        }];
         let results = weighted_score_fuse(&ppr, &bm25, &[], 0.70, 0.30, 0.0);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].0, "a");

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -1366,7 +1366,7 @@ fn tanh_normalize(scores: &[f64]) -> Vec<f64> {
 /// as: `score(d) = w_ppr * norm_ppr(d) + w_bm25 * norm_bm25(d) + w_semantic * norm_sem(d)`.
 ///
 /// Returns a fused list sorted descending by combined score.
-fn weighted_score_fuse(
+pub fn weighted_score_fuse(
     ppr: &[(String, f64)],
     bm25: &[nestweaver_store::SearchHit],
     semantic: &[(String, f64)],

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -12,26 +12,19 @@ use crate::repo_display_name;
 
 /// Tuning knobs for hybrid PPR + BM25 + semantic retrieval.
 ///
-/// Defaults reflect empirical recommendations from the cited research:
-/// - `rrf_k = 60.0` — Cormack-Clarke-Buettcher 2009 standard.
-/// - `weight_ppr = 0.7`, `weight_bm25 = 0.3` — PPR is the primary
-///   structural signal; BM25 covers what graph structure misses
-///   (lexical relevance, freshly-mentioned terms). The 70/30 split is
-///   a defensible default but tunable — callers may set unit weights
-///   (0.5 / 0.5) if their workload is more lexically-driven.
-/// - `weight_semantic = 0.0` — disabled by default until embeddings are
-///   generated via `nestweaver embed`. Set to a non-zero value (e.g.
-///   0.2, reducing ppr/bm25 proportionally) to enable the third signal.
+/// Defaults reflect empirical tuning for weighted score fusion
+/// (convex combination with tanh normalization):
+/// - `weight_ppr = 0.40` — structural signal from Personalized PageRank.
+/// - `weight_bm25 = 0.25` — lexical relevance covers what graph
+///   structure misses (freshly-mentioned terms, exact matches).
+/// - `weight_semantic = 0.35` — embedding-based similarity; set to 0.0
+///   if embeddings are not generated yet (`nestweaver embed`).
 /// - `bm25_limit = 500` — large enough that BM25's tail is comparable
-///   to PPR's. The audit flagged 100 as too low (PPR returns variable-
-///   length results often into the hundreds); 500 keeps the candidate
-///   pool symmetric while staying well under the size where RRF
-///   sorting cost matters.
-/// - `semantic_limit = 200` — cap on the number of vector KNN results
-///   fed into RRF. Bounded to keep the in-process cosine scan tractable.
+///   to PPR's. 500 keeps the candidate pool symmetric.
+/// - `semantic_limit = 200` — cap on vector KNN results fed into
+///   fusion. Bounded to keep the in-process cosine scan tractable.
 #[derive(Debug, Clone)]
 pub struct HybridSearchConfig {
-    pub rrf_k: f64,
     pub weight_ppr: f64,
     pub weight_bm25: f64,
     pub weight_semantic: f64,
@@ -41,11 +34,10 @@ pub struct HybridSearchConfig {
     /// runs a two-pass pseudo-relevance-feedback expansion before fusion.
     /// Off by default → identical behaviour to before.
     ///
-    /// RRF CAVEAT: RRF fuses by *rank only*, so the PRF expansion weight
-    /// ([`nestweaver_store::PRF_EXPANSION_WEIGHT`] = 0.3) never appears in the
-    /// final fused score. PRF reaches the fused result purely by reordering
-    /// the BM25 list — the changed BM25 ranks flow through RRF. Do not expect
-    /// the 0.3 boost to surface numerically in the output relevance.
+    /// PRF NOTE: with weighted score fusion the PRF expansion weight
+    /// ([`nestweaver_store::PRF_EXPANSION_WEIGHT`] = 0.3) affects the raw BM25
+    /// scores that flow into tanh normalization. The expansion terms boost
+    /// matching documents' BM25 scores, which then carry through fusion.
     pub prf: bool,
     /// Finding #7 — graduated path-deboost + kind-priority for
     /// `search_symbols_by_name` seed resolution. Sourced from
@@ -57,10 +49,9 @@ pub struct HybridSearchConfig {
 impl Default for HybridSearchConfig {
     fn default() -> Self {
         Self {
-            rrf_k: 60.0,
-            weight_ppr: 0.7,
-            weight_bm25: 0.3,
-            weight_semantic: 0.0,
+            weight_ppr: 0.40,
+            weight_bm25: 0.25,
+            weight_semantic: 0.35,
             bm25_limit: 500,
             semantic_limit: 200,
             prf: false,
@@ -1242,14 +1233,13 @@ pub fn build_brain_context_hybrid_with_aliases(
                 .search(&bm25_query, config.bm25_limit)
                 .unwrap_or_default()
         };
-        rrf_fuse(
+        weighted_score_fuse(
             &ppr,
             &bm25_hits,
             &[],
-            config.rrf_k,
             config.weight_ppr,
             config.weight_bm25,
-            0.0,
+            config.weight_semantic,
         )
     } else {
         ppr.clone()
@@ -1305,49 +1295,85 @@ pub fn nestweaver_store_stoplist() -> &'static [&'static str] {
     })
 }
 
-/// Reciprocal Rank Fusion of PPR scores, BM25 hits, and semantic (vector) hits.
+/// Tanh-based score normalization.
 ///
-/// Standard RRF formula: `score(d) = Σ_i w_i / (k + rank_i(d))`, where
-/// each retrieval method's contribution is weighted by `w_i` and `k`
-/// dampens the curve so ties between top-of-list items in one method
-/// don't completely override the other method.
+/// Divides each score by the median of non-zero scores, then applies `tanh`
+/// to compress into (0, 1]. This is robust to outliers and works across
+/// heterogeneous score distributions (PPR, BM25, cosine similarity).
+fn tanh_normalize(scores: &[f64]) -> Vec<f64> {
+    if scores.is_empty() {
+        return vec![];
+    }
+    let nonzero: Vec<f64> = scores.iter().copied().filter(|s| *s > 0.0).collect();
+    if nonzero.is_empty() {
+        return vec![0.0; scores.len()];
+    }
+    let median = {
+        let mut sorted = nonzero.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        sorted[sorted.len() / 2]
+    };
+    let scale = if median > 0.0 { median } else { 1.0 };
+    scores.iter().map(|s| (s / scale).tanh()).collect()
+}
+
+/// Weighted score fusion (convex combination) of PPR, BM25, and semantic signals.
 ///
-/// Returns a fused list sorted descending by combined score. PPR rank
-/// is by descending score (highest score = rank 1). BM25 rank comes
-/// from the hit list's natural order. Semantic rank is by descending
-/// cosine similarity score (highest similarity = rank 1).
-fn rrf_fuse(
+/// Each signal's raw scores are normalized via [`tanh_normalize`], then combined
+/// as: `score(d) = w_ppr * norm_ppr(d) + w_bm25 * norm_bm25(d) + w_semantic * norm_sem(d)`.
+///
+/// Returns a fused list sorted descending by combined score.
+fn weighted_score_fuse(
     ppr: &[(String, f64)],
     bm25: &[nestweaver_store::SearchHit],
     semantic: &[(String, f64)],
-    k: f64,
     w_ppr: f64,
     w_bm25: f64,
     w_semantic: f64,
 ) -> Vec<(String, f64)> {
     use std::collections::HashMap;
-    let mut scores: HashMap<String, f64> = HashMap::new();
 
-    // PPR list is already sorted descending by score.
-    for (rank0, (uid, _)) in ppr.iter().enumerate() {
-        let rank = (rank0 + 1) as f64;
-        *scores.entry(uid.clone()).or_insert(0.0) += w_ppr / (k + rank);
+    let mut ppr_scores: HashMap<&str, f64> = HashMap::new();
+    for (uid, score) in ppr {
+        ppr_scores.insert(uid, *score);
     }
 
-    for (rank0, hit) in bm25.iter().enumerate() {
-        let rank = (rank0 + 1) as f64;
-        *scores.entry(hit.uid.clone()).or_insert(0.0) += w_bm25 / (k + rank);
+    let mut bm25_scores: HashMap<&str, f64> = HashMap::new();
+    for hit in bm25 {
+        bm25_scores.insert(&hit.uid, hit.score as f64);
     }
 
-    // Semantic list is sorted descending by similarity score.
-    for (rank0, (uid, _)) in semantic.iter().enumerate() {
-        let rank = (rank0 + 1) as f64;
-        *scores.entry(uid.clone()).or_insert(0.0) += w_semantic / (k + rank);
+    let mut sem_scores: HashMap<&str, f64> = HashMap::new();
+    for (uid, score) in semantic {
+        sem_scores.insert(uid, *score);
     }
 
-    let mut merged: Vec<(String, f64)> = scores.into_iter().collect();
-    merged.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-    merged
+    let mut all_uids: Vec<&str> = Vec::new();
+    for uid in ppr_scores.keys().chain(bm25_scores.keys()).chain(sem_scores.keys()) {
+        if !all_uids.contains(uid) {
+            all_uids.push(uid);
+        }
+    }
+
+    let ppr_raw: Vec<f64> = all_uids.iter().map(|u| ppr_scores.get(u).copied().unwrap_or(0.0)).collect();
+    let bm25_raw: Vec<f64> = all_uids.iter().map(|u| bm25_scores.get(u).copied().unwrap_or(0.0)).collect();
+    let sem_raw: Vec<f64> = all_uids.iter().map(|u| sem_scores.get(u).copied().unwrap_or(0.0)).collect();
+
+    let ppr_norm = tanh_normalize(&ppr_raw);
+    let bm25_norm = tanh_normalize(&bm25_raw);
+    let sem_norm = tanh_normalize(&sem_raw);
+
+    let mut results: Vec<(String, f64)> = all_uids
+        .iter()
+        .enumerate()
+        .map(|(i, uid)| {
+            let score = w_ppr * ppr_norm[i] + w_bm25 * bm25_norm[i] + w_semantic * sem_norm[i];
+            (uid.to_string(), score)
+        })
+        .collect();
+
+    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    results
 }
 
 fn lookup_note_uids_by_title(
@@ -2495,5 +2521,62 @@ mod dedup_heading_section_tests {
         dedup_heading_section_pairs(&mut r);
         // Note nodes are never dropped, only Heading nodes.
         assert_eq!(r.connected.len(), 2);
+    }
+}
+
+#[cfg(test)]
+mod fusion_tests {
+    use super::*;
+    use nestweaver_store::SearchHit;
+
+    #[test]
+    fn test_tanh_normalize_basic() {
+        let scores = vec![0.5, 0.3, 0.1, 0.05, 0.01];
+        let normalized = tanh_normalize(&scores);
+        for v in &normalized {
+            assert!(*v > 0.0 && *v <= 1.0);
+        }
+        for i in 1..normalized.len() {
+            assert!(normalized[i - 1] >= normalized[i]);
+        }
+    }
+
+    #[test]
+    fn test_tanh_normalize_empty() {
+        let normalized = tanh_normalize(&[]);
+        assert!(normalized.is_empty());
+    }
+
+    #[test]
+    fn test_tanh_normalize_all_zero() {
+        let normalized = tanh_normalize(&[0.0, 0.0, 0.0]);
+        assert_eq!(normalized, vec![0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn test_weighted_score_fuse_three_signals() {
+        let ppr = vec![("a".to_string(), 0.5), ("b".to_string(), 0.3)];
+        let bm25 = vec![
+            SearchHit { uid: "b".to_string(), kind: "function".into(), title: "b".into(), vault_uid: "v".into(), score: 10.0 },
+            SearchHit { uid: "c".to_string(), kind: "function".into(), title: "c".into(), vault_uid: "v".into(), score: 8.0 },
+        ];
+        let semantic = vec![("a".to_string(), 0.9), ("c".to_string(), 0.7)];
+
+        let results = weighted_score_fuse(&ppr, &bm25, &semantic, 0.40, 0.25, 0.35);
+        let uids: Vec<&str> = results.iter().map(|(u, _)| u.as_str()).collect();
+        assert!(uids.contains(&"a"));
+        assert!(uids.contains(&"b"));
+        assert!(uids.contains(&"c"));
+    }
+
+    #[test]
+    fn test_weighted_score_fuse_empty_semantic() {
+        let ppr = vec![("a".to_string(), 0.5)];
+        let bm25 = vec![
+            SearchHit { uid: "a".to_string(), kind: "function".into(), title: "a".into(), vault_uid: "v".into(), score: 5.0 },
+        ];
+        let results = weighted_score_fuse(&ppr, &bm25, &[], 0.70, 0.30, 0.0);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "a");
     }
 }

--- a/crates/nestweaver-engine/src/vector_search.rs
+++ b/crates/nestweaver-engine/src/vector_search.rs
@@ -11,3 +11,15 @@ pub fn vector_knn_all(
 ) -> Result<Vec<(String, f64)>, anyhow::Error> {
     Ok(store.vector_search(query_embedding, limit))
 }
+
+/// Like `vector_knn_all`, but pre-filters to embeddings whose UID contains
+/// `scope`. Useful for restricting vector search to a specific repo or vault
+/// without scanning all 140K+ embeddings.
+pub fn vector_knn_filtered(
+    store: &GraphStore,
+    query_embedding: &[f32],
+    limit: usize,
+    scope: Option<&str>,
+) -> Result<Vec<(String, f64)>, anyhow::Error> {
+    Ok(store.vector_search_filtered(query_embedding, limit, scope))
+}

--- a/crates/nestweaver-engine/src/vector_search.rs
+++ b/crates/nestweaver-engine/src/vector_search.rs
@@ -44,6 +44,44 @@ pub fn vector_knn(
     Ok(scored)
 }
 
+/// Search across symbols, notes, AND headings by cosine similarity.
+/// Returns (uid, similarity) pairs sorted descending, limited to `limit`.
+pub fn vector_knn_all(
+    store: &GraphStore,
+    query_embedding: &[f32],
+    limit: usize,
+) -> Result<Vec<(String, f64)>, anyhow::Error> {
+    let mut scored: Vec<(String, f64)> = Vec::new();
+
+    // Symbols
+    for sym in store.list_all_symbols()? {
+        if let Some(ref emb) = sym.embedding {
+            let sim = cosine_similarity(emb, query_embedding);
+            scored.push((sym.uid, sim));
+        }
+    }
+
+    // Notes
+    for note in store.list_notes(None)? {
+        if let Some(ref emb) = note.embedding {
+            let sim = cosine_similarity(emb, query_embedding);
+            scored.push((note.uid, sim));
+        }
+    }
+
+    // Headings
+    for heading in store.list_all_headings()? {
+        if let Some(ref emb) = heading.embedding {
+            let sim = cosine_similarity(emb, query_embedding);
+            scored.push((heading.uid, sim));
+        }
+    }
+
+    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    scored.truncate(limit);
+    Ok(scored)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -75,5 +113,19 @@ mod tests {
         let b = vec![1.0, 2.0, 3.0];
         let sim = cosine_similarity(&a, &b);
         assert_eq!(sim, 0.0);
+    }
+
+    #[test]
+    fn test_cosine_similarity_identical() {
+        let a = vec![1.0f32, 0.0, 0.0];
+        let b = vec![1.0f32, 0.0, 0.0];
+        assert!((cosine_similarity(&a, &b) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_cosine_similarity_orthogonal() {
+        let a = vec![1.0f32, 0.0, 0.0];
+        let b = vec![0.0f32, 1.0, 0.0];
+        assert!(cosine_similarity(&a, &b).abs() < 1e-6);
     }
 }

--- a/crates/nestweaver-engine/src/vector_search.rs
+++ b/crates/nestweaver-engine/src/vector_search.rs
@@ -20,66 +20,26 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
 
 /// Search for nodes whose stored embedding is closest to `query_embedding`.
 /// Returns (uid, similarity) pairs sorted descending, limited to `limit`.
-/// Loads all embeddings from the store and computes similarity in Rust.
+/// Delegates to the sidecar `EmbeddingIndex` on the store which persists
+/// across DB sessions.
 pub fn vector_knn(
     store: &GraphStore,
     query_embedding: &[f32],
     limit: usize,
 ) -> Result<Vec<(String, f64)>, anyhow::Error> {
-    // Get all symbols with embeddings
-    let symbols = store.list_all_symbols()?;
-    let mut scored: Vec<(String, f64)> = Vec::new();
-
-    for sym in &symbols {
-        if let Some(ref emb) = sym.embedding {
-            let sim = cosine_similarity(query_embedding, emb);
-            if sim > 0.0 {
-                scored.push((sym.uid.clone(), sim));
-            }
-        }
-    }
-
-    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-    scored.truncate(limit);
-    Ok(scored)
+    Ok(store.vector_search(query_embedding, limit))
 }
 
 /// Search across symbols, notes, AND headings by cosine similarity.
 /// Returns (uid, similarity) pairs sorted descending, limited to `limit`.
+/// Delegates to the sidecar `EmbeddingIndex` which stores all node kinds
+/// in a single index (keyed by UID prefix: `sym:`, `note:`, `heading:`).
 pub fn vector_knn_all(
     store: &GraphStore,
     query_embedding: &[f32],
     limit: usize,
 ) -> Result<Vec<(String, f64)>, anyhow::Error> {
-    let mut scored: Vec<(String, f64)> = Vec::new();
-
-    // Symbols
-    for sym in store.list_all_symbols()? {
-        if let Some(ref emb) = sym.embedding {
-            let sim = cosine_similarity(emb, query_embedding);
-            scored.push((sym.uid, sim));
-        }
-    }
-
-    // Notes
-    for note in store.list_notes(None)? {
-        if let Some(ref emb) = note.embedding {
-            let sim = cosine_similarity(emb, query_embedding);
-            scored.push((note.uid, sim));
-        }
-    }
-
-    // Headings
-    for heading in store.list_all_headings()? {
-        if let Some(ref emb) = heading.embedding {
-            let sim = cosine_similarity(emb, query_embedding);
-            scored.push((heading.uid, sim));
-        }
-    }
-
-    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-    scored.truncate(limit);
-    Ok(scored)
+    Ok(store.vector_search(query_embedding, limit))
 }
 
 #[cfg(test)]

--- a/crates/nestweaver-engine/src/vector_search.rs
+++ b/crates/nestweaver-engine/src/vector_search.rs
@@ -1,35 +1,5 @@
 use nestweaver_store::GraphStore;
 
-/// Cosine similarity between two embedding vectors.
-pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
-    if a.len() != b.len() || a.is_empty() {
-        return 0.0;
-    }
-    let dot: f64 = a
-        .iter()
-        .zip(b.iter())
-        .map(|(x, y)| *x as f64 * *y as f64)
-        .sum();
-    let norm_a: f64 = a.iter().map(|x| (*x as f64).powi(2)).sum::<f64>().sqrt();
-    let norm_b: f64 = b.iter().map(|x| (*x as f64).powi(2)).sum::<f64>().sqrt();
-    if norm_a == 0.0 || norm_b == 0.0 {
-        return 0.0;
-    }
-    dot / (norm_a * norm_b)
-}
-
-/// Search for nodes whose stored embedding is closest to `query_embedding`.
-/// Returns (uid, similarity) pairs sorted descending, limited to `limit`.
-/// Delegates to the sidecar `EmbeddingIndex` on the store which persists
-/// across DB sessions.
-pub fn vector_knn(
-    store: &GraphStore,
-    query_embedding: &[f32],
-    limit: usize,
-) -> Result<Vec<(String, f64)>, anyhow::Error> {
-    Ok(store.vector_search(query_embedding, limit))
-}
-
 /// Search across symbols, notes, AND headings by cosine similarity.
 /// Returns (uid, similarity) pairs sorted descending, limited to `limit`.
 /// Delegates to the sidecar `EmbeddingIndex` which stores all node kinds
@@ -40,52 +10,4 @@ pub fn vector_knn_all(
     limit: usize,
 ) -> Result<Vec<(String, f64)>, anyhow::Error> {
     Ok(store.vector_search(query_embedding, limit))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn cosine_similarity_identical_vectors() {
-        let a = vec![1.0, 2.0, 3.0];
-        let sim = cosine_similarity(&a, &a);
-        assert!((sim - 1.0).abs() < 1e-6);
-    }
-
-    #[test]
-    fn cosine_similarity_orthogonal_vectors() {
-        let a = vec![1.0, 0.0];
-        let b = vec![0.0, 1.0];
-        let sim = cosine_similarity(&a, &b);
-        assert!(sim.abs() < 1e-6);
-    }
-
-    #[test]
-    fn cosine_similarity_empty_vectors() {
-        let sim = cosine_similarity(&[], &[]);
-        assert_eq!(sim, 0.0);
-    }
-
-    #[test]
-    fn cosine_similarity_different_lengths() {
-        let a = vec![1.0, 2.0];
-        let b = vec![1.0, 2.0, 3.0];
-        let sim = cosine_similarity(&a, &b);
-        assert_eq!(sim, 0.0);
-    }
-
-    #[test]
-    fn test_cosine_similarity_identical() {
-        let a = vec![1.0f32, 0.0, 0.0];
-        let b = vec![1.0f32, 0.0, 0.0];
-        assert!((cosine_similarity(&a, &b) - 1.0).abs() < 1e-6);
-    }
-
-    #[test]
-    fn test_cosine_similarity_orthogonal() {
-        let a = vec![1.0f32, 0.0, 0.0];
-        let b = vec![0.0f32, 1.0, 0.0];
-        assert!(cosine_similarity(&a, &b).abs() < 1e-6);
-    }
 }

--- a/crates/nestweaver-engine/src/watcher.rs
+++ b/crates/nestweaver-engine/src/watcher.rs
@@ -737,6 +737,7 @@ fn reinsert_note(
             created_at,
             modified_at,
             pagerank_score: None,
+            embedding: None,
         })
         .context("insert_note")?;
     store
@@ -760,6 +761,7 @@ fn reinsert_note(
             start_line: h.start_line,
             end_line: h.end_line,
             content_hash: sha256_short(&h.text),
+            embedding: None,
         });
     }
     store.batch_insert_headings(&headings)?;

--- a/crates/nestweaver-engine/tests/semantic_integration.rs
+++ b/crates/nestweaver-engine/tests/semantic_integration.rs
@@ -1,0 +1,41 @@
+//! Integration test: verify that weighted_score_fuse produces
+//! correct rankings when combining PPR, BM25, and semantic signals.
+
+use nestweaver_engine::query::HybridSearchConfig;
+
+#[test]
+fn test_semantic_leg_improves_nl_query() {
+    // Scenario: user queries "how does authentication work"
+    // PPR found nothing (no seed resolved)
+    let ppr: Vec<(String, f64)> = vec![];
+
+    // BM25 found a note with "authentication" in the title
+    let bm25 = vec![
+        nestweaver_store::SearchHit {
+            uid: "note:auth-guide".to_string(),
+            kind: "note".to_string(),
+            title: "Authentication Guide".to_string(),
+            vault_uid: "v1".to_string(),
+            score: 12.5,
+        },
+    ];
+
+    // Semantic search found the actual auth middleware symbol
+    let semantic = vec![
+        ("sym:auth-validate".to_string(), 0.87),
+        ("note:auth-guide".to_string(), 0.82),
+        ("head:auth-config".to_string(), 0.75),
+    ];
+
+    let config = HybridSearchConfig::default();
+    let results = nestweaver_engine::query::weighted_score_fuse(
+        &ppr, &bm25, &semantic,
+        config.weight_ppr, config.weight_bm25, config.weight_semantic,
+    );
+
+    // With empty PPR, semantic results should dominate
+    assert!(results.len() >= 3);
+    let top_uids: Vec<&str> = results.iter().take(3).map(|(u, _)| u.as_str()).collect();
+    assert!(top_uids.contains(&"sym:auth-validate"));
+    assert!(top_uids.contains(&"note:auth-guide"));
+}

--- a/crates/nestweaver-engine/tests/semantic_integration.rs
+++ b/crates/nestweaver-engine/tests/semantic_integration.rs
@@ -10,15 +10,13 @@ fn test_semantic_leg_improves_nl_query() {
     let ppr: Vec<(String, f64)> = vec![];
 
     // BM25 found a note with "authentication" in the title
-    let bm25 = vec![
-        nestweaver_store::SearchHit {
-            uid: "note:auth-guide".to_string(),
-            kind: "note".to_string(),
-            title: "Authentication Guide".to_string(),
-            vault_uid: "v1".to_string(),
-            score: 12.5,
-        },
-    ];
+    let bm25 = vec![nestweaver_store::SearchHit {
+        uid: "note:auth-guide".to_string(),
+        kind: "note".to_string(),
+        title: "Authentication Guide".to_string(),
+        vault_uid: "v1".to_string(),
+        score: 12.5,
+    }];
 
     // Semantic search found the actual auth middleware symbol
     let semantic = vec![
@@ -29,8 +27,12 @@ fn test_semantic_leg_improves_nl_query() {
 
     let config = HybridSearchConfig::default();
     let results = nestweaver_engine::query::weighted_score_fuse(
-        &ppr, &bm25, &semantic,
-        config.weight_ppr, config.weight_bm25, config.weight_semantic,
+        &ppr,
+        &bm25,
+        &semantic,
+        config.weight_ppr,
+        config.weight_bm25,
+        config.weight_semantic,
     );
 
     // With empty PPR, semantic results should dominate

--- a/crates/nestweaver-mcp/Cargo.toml
+++ b/crates/nestweaver-mcp/Cargo.toml
@@ -26,6 +26,7 @@ tracing = { workspace = true }
 
 [features]
 daemon = ["dep:dirs", "dep:nestweaver-proto", "dep:tonic", "dep:tokio", "dep:tokio-stream", "dep:tower", "dep:hyper-util", "dep:libc"]
+embed = ["nestweaver-engine/embed"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/nestweaver-mcp/src/lib.rs
+++ b/crates/nestweaver-mcp/src/lib.rs
@@ -537,7 +537,7 @@ fn dispatch_method(
                 ));
             };
 
-            match tools::dispatch(store, tantivy, &name, arguments.clone()) {
+            match tools::dispatch(store, tantivy, &name, arguments.clone(), None) {
                 Ok(result) => {
                     if let Some(tracker) = tracker {
                         record_interaction(tracker, &name, &arguments, &result);

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -5930,6 +5930,7 @@ mod project_context_bug12_tests {
             created_at: None,
             modified_at: None,
             pagerank_score: None,
+            embedding: None,
         }
     }
 
@@ -6019,6 +6020,7 @@ mod project_context_bug12_tests {
             &store,
             None,
             json!({ "project": "Parallel Paths", "token_budget": 5000 }),
+            None,
         )
         .unwrap();
 
@@ -6058,6 +6060,7 @@ mod project_context_bug12_tests {
             &store,
             None,
             json!({ "seeds": ["greet"], "token_budget": 5000, "include_seeds": true }),
+            None,
         )
         .unwrap();
         let any_body_off = off["connected"]
@@ -6078,6 +6081,7 @@ mod project_context_bug12_tests {
                 "include_bodies": true,
                 "root": root,
             }),
+            None,
         )
         .unwrap();
         let connected = on["connected"].as_array().unwrap();

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -13,8 +13,8 @@ use std::path::Path;
 use anyhow::{Context, anyhow};
 use nestweaver_engine::config::DEFAULT_RESULT_LIMIT;
 use nestweaver_engine::{
-    BrainContextResult, DeadCodeConfidence, HybridSearchConfig, SummaryLevel, affected_tests,
-    analyze_blast_radius, attach_cluster_ids, attach_communities, broken_links,
+    BrainContextResult, DeadCodeConfidence, EmbedQueryFn, HybridSearchConfig, SummaryLevel,
+    affected_tests, analyze_blast_radius, attach_cluster_ids, attach_communities, broken_links,
     build_brain_context_hybrid_with_aliases, compute_clusters, detect_changes_impact,
     detect_dead_code, doc_stats, expand_query_with_aliases, filter_by_target, find_bridge_nodes,
     find_hub_nodes, generate_guide, generate_summaries, get_all_properties, get_last_indexed_at,
@@ -257,6 +257,7 @@ pub fn dispatch(
     tantivy: Option<&TantivyIndex>,
     name: &str,
     args: Value,
+    embed_model: Option<&dyn EmbedQueryFn>,
 ) -> Result<Value, anyhow::Error> {
     // Enforce tool allowlist when configured.
     let allowed = ALLOWED_TOOLS.with(|c| c.borrow().clone());
@@ -272,10 +273,10 @@ pub fn dispatch(
     // F16: serve cacheable read tools from (or populate) the response cache.
     // Correctness rests on the cache KEY — see `maybe_cached`.
     if is_cacheable_tool(name) && !cache_bypassed(&args) {
-        return maybe_cached(store, tantivy, name, args);
+        return maybe_cached(store, tantivy, name, args, embed_model);
     }
 
-    dispatch_uncached(store, tantivy, name, args)
+    dispatch_uncached(store, tantivy, name, args, embed_model)
 }
 
 /// The actual tool dispatch table, after cache handling.
@@ -284,9 +285,10 @@ fn dispatch_uncached(
     tantivy: Option<&TantivyIndex>,
     name: &str,
     args: Value,
+    embed_model: Option<&dyn EmbedQueryFn>,
 ) -> Result<Value, anyhow::Error> {
     match name {
-        "brain_context" => tool_brain_context(store, tantivy, args),
+        "brain_context" => tool_brain_context(store, tantivy, args, embed_model),
         "brain_search" => tool_brain_search(store, tantivy, args),
         "note_get" => tool_note_get(store, args),
         "backlinks" => tool_backlinks(store, args),
@@ -304,7 +306,7 @@ fn dispatch_uncached(
         "set_extension" => tool_set_extension(args),
         "query_extensions" => tool_query_extensions(args),
         "brain_diff" => tool_brain_diff(store, args),
-        "project_context" => tool_project_context(store, tantivy, args),
+        "project_context" => tool_project_context(store, tantivy, args, embed_model),
         "dead_code" => tool_dead_code(store, args),
         "hub_nodes" => tool_hub_nodes(store, args),
         "bridge_nodes" => tool_bridge_nodes(store, args),
@@ -319,7 +321,7 @@ fn dispatch_uncached(
         "brain_tag_graph" => tool_brain_tag_graph(store, args),
         "brain_doc_stats" => tool_brain_doc_stats(store, args),
         "affected_tests" => tool_affected_tests(store, args),
-        "investigate" => tool_investigate(store, tantivy, args),
+        "investigate" => tool_investigate(store, tantivy, args, embed_model),
         "investigate_expand" => tool_investigate_expand(store, args),
         "investigate_hydrate" => tool_investigate_hydrate(store, args),
         "contract_drift" => tool_contract_drift(store, args),
@@ -430,9 +432,10 @@ fn maybe_cached(
     tantivy: Option<&TantivyIndex>,
     name: &str,
     args: Value,
+    embed_model: Option<&dyn EmbedQueryFn>,
 ) -> Result<Value, anyhow::Error> {
     let Ok(db_path) = current_db_path(store) else {
-        return dispatch_uncached(store, tantivy, name, args);
+        return dispatch_uncached(store, tantivy, name, args, embed_model);
     };
 
     let max_mb = CACHE_MAX_SIZE_MB.with(|c| c.get());
@@ -458,7 +461,7 @@ fn maybe_cached(
     }
 
     CACHE_MISSES.with(|c| c.set(c.get() + 1));
-    let result = dispatch_uncached(store, tantivy, name, args)?;
+    let result = dispatch_uncached(store, tantivy, name, args, embed_model)?;
     match serde_json::to_vec(&result) {
         Ok(bytes) => {
             // Insert into the in-process cache, then decide whether to flush.
@@ -1186,6 +1189,7 @@ fn tool_brain_context(
     store: &GraphStore,
     tantivy: Option<&TantivyIndex>,
     args: Value,
+    embed_model: Option<&dyn EmbedQueryFn>,
 ) -> Result<Value, anyhow::Error> {
     let seeds: Vec<String> = args
         .get("seeds")
@@ -1289,6 +1293,7 @@ fn tool_brain_context(
         &aliases,
         Some(&db_path),
         intent,
+        embed_model,
     )?;
 
     // Feature F6 (per-path ranking priors) is a deliberate no-op here: the MCP
@@ -4344,6 +4349,7 @@ fn tool_project_context(
     store: &GraphStore,
     tantivy: Option<&TantivyIndex>,
     args: Value,
+    embed_model: Option<&dyn EmbedQueryFn>,
 ) -> Result<Value, anyhow::Error> {
     let project_str = args
         .get("project")
@@ -4511,6 +4517,7 @@ fn tool_project_context(
         &aliases,
         Some(&db_path),
         Some(intent),
+        embed_model,
     )?;
 
     // 4b. Surface the project's curated member notes into `connected`. They
@@ -5772,6 +5779,7 @@ fn tool_investigate(
     store: &GraphStore,
     tantivy: Option<&TantivyIndex>,
     args: Value,
+    embed_model: Option<&dyn EmbedQueryFn>,
 ) -> Result<Value, anyhow::Error> {
     let query = args
         .get("query")
@@ -5795,6 +5803,7 @@ fn tool_investigate(
         query,
         scope,
         token_budget,
+        embed_model,
     )?;
     Ok(serde_json::to_value(result)?)
 }
@@ -6109,8 +6118,8 @@ mod cache_dispatch_tests {
             .unwrap();
 
         let args = json!({ "limit": 5 });
-        let first = dispatch(&store, None, "hub_nodes", args.clone()).unwrap();
-        let second = dispatch(&store, None, "hub_nodes", args.clone()).unwrap();
+        let first = dispatch(&store, None, "hub_nodes", args.clone(), None).unwrap();
+        let second = dispatch(&store, None, "hub_nodes", args.clone(), None).unwrap();
 
         assert_eq!(
             first, second,
@@ -6141,7 +6150,7 @@ mod cache_dispatch_tests {
             .unwrap();
         let gen_before = store.graph_generation();
         let args = json!({ "limit": 5 });
-        let _ = dispatch(&store, None, "hub_nodes", args.clone()).unwrap();
+        let _ = dispatch(&store, None, "hub_nodes", args.clone(), None).unwrap();
         drop(store);
 
         // Re-index with a new file → generation bumps + persists.
@@ -6164,7 +6173,7 @@ mod cache_dispatch_tests {
         );
 
         reset_session();
-        let _ = dispatch(&store2, None, "hub_nodes", args).unwrap();
+        let _ = dispatch(&store2, None, "hub_nodes", args, None).unwrap();
         // The old entry's generation no longer matches → MISS (recomputed).
         assert_eq!(CACHE_MISSES.with(|c| c.get()), 1, "stale entry must miss");
         assert_eq!(CACHE_HITS.with(|c| c.get()), 0);
@@ -6181,7 +6190,7 @@ mod cache_dispatch_tests {
             .unwrap();
 
         // Prime the cache.
-        let _ = dispatch(&store, None, "hub_nodes", json!({ "limit": 5 })).unwrap();
+        let _ = dispatch(&store, None, "hub_nodes", json!({ "limit": 5 }), None).unwrap();
         reset_session();
         // cache:"bypass" skips the cache entirely (no hit recorded).
         let _ = dispatch(
@@ -6189,6 +6198,7 @@ mod cache_dispatch_tests {
             None,
             "hub_nodes",
             json!({ "limit": 5, "cache": "bypass" }),
+            None,
         )
         .unwrap();
         // no_cache:true likewise.
@@ -6197,6 +6207,7 @@ mod cache_dispatch_tests {
             None,
             "hub_nodes",
             json!({ "limit": 5, "no_cache": true }),
+            None,
         )
         .unwrap();
         assert_eq!(CACHE_HITS.with(|c| c.get()), 0, "bypass must never hit");
@@ -6230,6 +6241,7 @@ mod cache_dispatch_tests {
             None,
             "set_extension",
             json!({ "uid": "sym:x", "key": "k", "value": "v" }),
+            None,
         );
         let cache = nestweaver_store::cache::ResponseCache::open(
             &db_path,

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -1232,7 +1232,22 @@ fn tool_brain_context(
         .map(String::from);
 
     // RFC #6: optional hybrid search weight overrides.
-    let defaults = HybridSearchConfig::default();
+    // Read blend weights and limits from the instance config's [embedding]
+    // section when available, falling back to compiled defaults.
+    let defaults = {
+        match current_instance_config() {
+            Some(cfg) => HybridSearchConfig {
+                weight_ppr: cfg.embedding.weight_ppr,
+                weight_bm25: cfg.embedding.weight_bm25,
+                weight_semantic: cfg.embedding.weight_semantic,
+                semantic_limit: cfg.embedding.semantic_search_limit,
+                always_blend_semantic: cfg.embedding.always_blend_semantic,
+                semantic_seed_limit: cfg.embedding.semantic_seed_limit,
+                ..HybridSearchConfig::default()
+            },
+            None => HybridSearchConfig::default(),
+        }
+    };
     let weight_ppr = args
         .get("weight_ppr")
         .and_then(|v| v.as_f64())
@@ -4508,7 +4523,18 @@ fn tool_project_context(
 
     let db_path = current_db_path(store).unwrap_or_default();
     let aliases = load_alias_sidecar(&db_path);
-    let config = HybridSearchConfig::default();
+    let config = match current_instance_config() {
+        Some(cfg) => HybridSearchConfig {
+            weight_ppr: cfg.embedding.weight_ppr,
+            weight_bm25: cfg.embedding.weight_bm25,
+            weight_semantic: cfg.embedding.weight_semantic,
+            semantic_limit: cfg.embedding.semantic_search_limit,
+            always_blend_semantic: cfg.embedding.always_blend_semantic,
+            semantic_seed_limit: cfg.embedding.semantic_seed_limit,
+            ..HybridSearchConfig::default()
+        },
+        None => HybridSearchConfig::default(),
+    };
     let mut result = build_brain_context_hybrid_with_aliases(
         store,
         &ppr_seeds,

--- a/crates/nestweaver-schema/src/nodes.rs
+++ b/crates/nestweaver-schema/src/nodes.rs
@@ -229,6 +229,7 @@ pub struct Note {
     pub created_at: Option<String>,
     pub modified_at: Option<String>,
     pub pagerank_score: Option<f64>,
+    pub embedding: Option<Vec<f32>>,
 }
 
 /// A heading inside a note. Addressable target of `[[Note#Heading]]` links.
@@ -242,6 +243,7 @@ pub struct Heading {
     pub start_line: u32,
     pub end_line: u32,
     pub content_hash: String,
+    pub embedding: Option<Vec<f32>>,
 }
 
 /// The body text under a heading (or the preamble before the first heading).

--- a/crates/nestweaver-store/Cargo.toml
+++ b/crates/nestweaver-store/Cargo.toml
@@ -18,6 +18,7 @@ tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
+rayon = { workspace = true }
 zstd = "0.13"
 rmp-serde = "1"
 

--- a/crates/nestweaver-store/Cargo.toml
+++ b/crates/nestweaver-store/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 nestweaver-algorithms = { workspace = true }
 nestweaver-schema = { workspace = true }
 lbug = "0.16.1"
+lru = "0.12"
 tantivy = { version = "0.26", default-features = false, features = ["mmap", "stopwords", "lz4-compression", "stemmer"] }
 regex = "1.12"
 regex-syntax = "0.8"

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -361,10 +361,10 @@ impl GraphStore {
     /// Returns an empty index when neither file exists or both are corrupt.
     fn load_embedding_index(db_path: &Path) -> crate::search::EmbeddingIndex {
         let binary_path = Self::embedding_sidecar_binary_for(db_path);
-        if binary_path.exists() {
-            if let Ok(idx) = crate::search::EmbeddingIndex::load_binary(&binary_path) {
-                return idx;
-            }
+        if binary_path.exists()
+            && let Ok(idx) = crate::search::EmbeddingIndex::load_binary(&binary_path)
+        {
+            return idx;
         }
         let json_path = Self::embedding_sidecar_json_for(db_path);
         crate::search::EmbeddingIndex::load(&json_path).unwrap_or_default()
@@ -395,20 +395,29 @@ impl GraphStore {
     /// Add an embedding to the in-memory index without saving to disk.
     /// Use `flush_embedding_index` after a batch of additions to persist.
     pub fn add_embedding(&self, uid: &str, embedding: Vec<f32>) {
-        let mut idx = self.embedding_index.lock().unwrap_or_else(|e| e.into_inner());
+        let mut idx = self
+            .embedding_index
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         idx.add(uid, embedding);
     }
 
     /// Check whether the embedding index already has an entry for `uid`.
     pub fn has_embedding(&self, uid: &str) -> bool {
-        let idx = self.embedding_index.lock().unwrap_or_else(|e| e.into_inner());
+        let idx = self
+            .embedding_index
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         idx.get(uid).is_some()
     }
 
     /// Persist the in-memory embedding index to the binary sidecar file.
     /// No-op for in-memory stores.
     pub fn flush_embedding_index(&self) -> Result<(), StoreError> {
-        let idx = self.embedding_index.lock().unwrap_or_else(|e| e.into_inner());
+        let idx = self
+            .embedding_index
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         if let Some(path) = self.embedding_sidecar_path() {
             idx.save_binary(&path)
                 .map_err(|e| StoreError::Query(format!("save binary embedding sidecar: {e}")))?;
@@ -419,7 +428,10 @@ impl GraphStore {
     /// Perform a vector similarity search over the embedding index.
     /// Returns `(uid, cosine_similarity)` pairs sorted descending.
     pub fn vector_search(&self, query_embedding: &[f32], limit: usize) -> Vec<(String, f64)> {
-        let idx = self.embedding_index.lock().unwrap_or_else(|e| e.into_inner());
+        let idx = self
+            .embedding_index
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         idx.vector_search(query_embedding, limit)
     }
 
@@ -432,20 +444,29 @@ impl GraphStore {
         limit: usize,
         uid_prefix: Option<&str>,
     ) -> Vec<(String, f64)> {
-        let idx = self.embedding_index.lock().unwrap_or_else(|e| e.into_inner());
+        let idx = self
+            .embedding_index
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         idx.vector_search_filtered(query_embedding, limit, uid_prefix)
     }
 
     /// Return the dimensionality of embeddings in the sidecar index,
     /// or `None` if no embeddings are stored.
     pub fn embedding_index_dimension(&self) -> Option<usize> {
-        let idx = self.embedding_index.lock().unwrap_or_else(|e| e.into_inner());
+        let idx = self
+            .embedding_index
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         idx.dimension()
     }
 
     /// Number of embeddings in the sidecar index.
     pub fn embedding_count(&self) -> usize {
-        let idx = self.embedding_index.lock().unwrap_or_else(|e| e.into_inner());
+        let idx = self
+            .embedding_index
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         idx.len()
     }
 

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -340,23 +340,40 @@ impl GraphStore {
 
     // ── Embedding sidecar helpers ────────────────────────────────────────
 
-    /// Load the embedding index from the `<db>.embeddings` sidecar.
-    /// Returns an empty index when the file is absent or corrupt.
+    /// Load the embedding index from the binary sidecar (`<db>.embeddings.bin`),
+    /// falling back to the legacy JSON sidecar (`<db>.embeddings`).
+    /// Returns an empty index when neither file exists or both are corrupt.
     fn load_embedding_index(db_path: &Path) -> crate::search::EmbeddingIndex {
-        let sidecar = Self::embedding_sidecar_for(db_path);
-        crate::search::EmbeddingIndex::load(&sidecar).unwrap_or_default()
+        let binary_path = Self::embedding_sidecar_binary_for(db_path);
+        if binary_path.exists() {
+            if let Ok(idx) = crate::search::EmbeddingIndex::load_binary(&binary_path) {
+                return idx;
+            }
+        }
+        let json_path = Self::embedding_sidecar_json_for(db_path);
+        crate::search::EmbeddingIndex::load(&json_path).unwrap_or_default()
     }
 
-    /// Compute the sidecar path for a given database path.
-    fn embedding_sidecar_for(db_path: &Path) -> std::path::PathBuf {
+    /// Compute the legacy JSON sidecar path for a given database path.
+    fn embedding_sidecar_json_for(db_path: &Path) -> std::path::PathBuf {
         let mut s = db_path.as_os_str().to_owned();
         s.push(".embeddings");
         std::path::PathBuf::from(s)
     }
 
-    /// Return the path to the embedding sidecar file, or `None` for in-memory stores.
+    /// Compute the binary sidecar path for a given database path.
+    fn embedding_sidecar_binary_for(db_path: &Path) -> std::path::PathBuf {
+        let mut s = db_path.as_os_str().to_owned();
+        s.push(".embeddings.bin");
+        std::path::PathBuf::from(s)
+    }
+
+    /// Return the path to the embedding sidecar file (binary format),
+    /// or `None` for in-memory stores.
     pub fn embedding_sidecar_path(&self) -> Option<std::path::PathBuf> {
-        self.db_path.as_ref().map(|p| Self::embedding_sidecar_for(p))
+        self.db_path
+            .as_ref()
+            .map(|p| Self::embedding_sidecar_binary_for(p))
     }
 
     /// Add an embedding to the in-memory index without saving to disk.
@@ -372,13 +389,13 @@ impl GraphStore {
         idx.get(uid).is_some()
     }
 
-    /// Persist the in-memory embedding index to the sidecar file.
+    /// Persist the in-memory embedding index to the binary sidecar file.
     /// No-op for in-memory stores.
     pub fn flush_embedding_index(&self) -> Result<(), StoreError> {
         let idx = self.embedding_index.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(path) = self.embedding_sidecar_path() {
-            idx.save(&path)
-                .map_err(|e| StoreError::Query(format!("save embedding sidecar: {e}")))?;
+            idx.save_binary(&path)
+                .map_err(|e| StoreError::Query(format!("save binary embedding sidecar: {e}")))?;
         }
         Ok(())
     }
@@ -388,6 +405,19 @@ impl GraphStore {
     pub fn vector_search(&self, query_embedding: &[f32], limit: usize) -> Vec<(String, f64)> {
         let idx = self.embedding_index.lock().unwrap_or_else(|e| e.into_inner());
         idx.vector_search(query_embedding, limit)
+    }
+
+    /// Perform a filtered vector similarity search over the embedding index.
+    /// Only embeddings whose UID contains `uid_prefix` are considered.
+    /// When `uid_prefix` is `None`, behaves identically to `vector_search`.
+    pub fn vector_search_filtered(
+        &self,
+        query_embedding: &[f32],
+        limit: usize,
+        uid_prefix: Option<&str>,
+    ) -> Vec<(String, f64)> {
+        let idx = self.embedding_index.lock().unwrap_or_else(|e| e.into_inner());
+        idx.vector_search_filtered(query_embedding, limit, uid_prefix)
     }
 
     /// Return the dimensionality of embeddings in the sidecar index,

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -762,6 +762,19 @@ impl GraphStore {
         )
         .map_err(|e| StoreError::Query(e.to_string()))?;
 
+        // ── DB-level metadata (key/value singletons) ────────────────────────
+        // Used to persist configuration that applies to the whole database,
+        // e.g. which embedding model was used to generate stored vectors and
+        // the expected vector dimension. One node per logical key; the upsert
+        // pattern (DETACH DELETE + CREATE) keeps it idempotent.
+        conn.query(
+            "CREATE NODE TABLE IF NOT EXISTS Meta(\
+                key STRING, \
+                value STRING, \
+                PRIMARY KEY(key))",
+        )
+        .map_err(|e| StoreError::Query(e.to_string()))?;
+
         Ok(())
     }
 }

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -81,6 +81,10 @@ pub struct GraphStore {
     /// LadybugDB (which has no float-array column type). Loaded on open,
     /// saved on mutation via `flush_embedding_index`.
     pub(crate) embedding_index: Mutex<crate::search::EmbeddingIndex>,
+    /// LRU cache for PPR result vectors keyed by a hash of
+    /// `(sorted seed_uids, damping, max_iterations, scope_hash, intent, graph_generation)`.
+    /// Repeated queries with the same seeds skip the iterative PPR computation entirely.
+    pub(crate) ppr_result_cache: Mutex<lru::LruCache<u64, Vec<(String, f64)>>>,
 }
 
 impl GraphStore {
@@ -99,6 +103,9 @@ impl GraphStore {
             ppr_graph_cache: Mutex::new(None),
             symbol_name_cache: Mutex::new(None),
             embedding_index: Mutex::new(Self::load_embedding_index(path)),
+            ppr_result_cache: Mutex::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(128).unwrap(),
+            )),
         };
         store.init_schema()?;
         store.load_graph_generation(&store.generation_sidecar_path());
@@ -122,6 +129,9 @@ impl GraphStore {
             ppr_graph_cache: Mutex::new(None),
             symbol_name_cache: Mutex::new(None),
             embedding_index: Mutex::new(Self::load_embedding_index(path)),
+            ppr_result_cache: Mutex::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(128).unwrap(),
+            )),
         };
         store.init_schema()?;
         store.load_graph_generation(&store.generation_sidecar_path());
@@ -145,6 +155,9 @@ impl GraphStore {
             ppr_graph_cache: Mutex::new(None),
             symbol_name_cache: Mutex::new(None),
             embedding_index: Mutex::new(Self::load_embedding_index(path)),
+            ppr_result_cache: Mutex::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(128).unwrap(),
+            )),
         };
         store.load_graph_generation(&store.generation_sidecar_path());
         Ok(store)
@@ -192,6 +205,9 @@ impl GraphStore {
             ppr_graph_cache: Mutex::new(None),
             symbol_name_cache: Mutex::new(None),
             embedding_index: Mutex::new(crate::search::EmbeddingIndex::new()),
+            ppr_result_cache: Mutex::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(128).unwrap(),
+            )),
         };
         store.init_schema()?;
         Ok(store)

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -76,6 +76,11 @@ pub struct GraphStore {
     /// Avoids full-table scans on every seed-resolution call for brain_context,
     /// flow_trace, blast_radius, etc.
     pub(crate) symbol_name_cache: Mutex<Option<Arc<crate::traverse::SymbolNameCached>>>,
+    /// In-memory embedding index backed by a JSON sidecar file
+    /// (`<db>.embeddings`). Embeddings are stored here instead of in
+    /// LadybugDB (which has no float-array column type). Loaded on open,
+    /// saved on mutation via `flush_embedding_index`.
+    pub(crate) embedding_index: Mutex<crate::search::EmbeddingIndex>,
 }
 
 impl GraphStore {
@@ -93,6 +98,7 @@ impl GraphStore {
             db_path: Some(path.to_path_buf()),
             ppr_graph_cache: Mutex::new(None),
             symbol_name_cache: Mutex::new(None),
+            embedding_index: Mutex::new(Self::load_embedding_index(path)),
         };
         store.init_schema()?;
         store.load_graph_generation(&store.generation_sidecar_path());
@@ -115,6 +121,7 @@ impl GraphStore {
             db_path: Some(path.to_path_buf()),
             ppr_graph_cache: Mutex::new(None),
             symbol_name_cache: Mutex::new(None),
+            embedding_index: Mutex::new(Self::load_embedding_index(path)),
         };
         store.init_schema()?;
         store.load_graph_generation(&store.generation_sidecar_path());
@@ -137,6 +144,7 @@ impl GraphStore {
             db_path: Some(path.to_path_buf()),
             ppr_graph_cache: Mutex::new(None),
             symbol_name_cache: Mutex::new(None),
+            embedding_index: Mutex::new(Self::load_embedding_index(path)),
         };
         store.load_graph_generation(&store.generation_sidecar_path());
         Ok(store)
@@ -183,6 +191,7 @@ impl GraphStore {
             db_path: None,
             ppr_graph_cache: Mutex::new(None),
             symbol_name_cache: Mutex::new(None),
+            embedding_index: Mutex::new(crate::search::EmbeddingIndex::new()),
         };
         store.init_schema()?;
         Ok(store)
@@ -327,6 +336,71 @@ impl GraphStore {
             }
             None => PathBuf::from(".generation"),
         }
+    }
+
+    // ── Embedding sidecar helpers ────────────────────────────────────────
+
+    /// Load the embedding index from the `<db>.embeddings` sidecar.
+    /// Returns an empty index when the file is absent or corrupt.
+    fn load_embedding_index(db_path: &Path) -> crate::search::EmbeddingIndex {
+        let sidecar = Self::embedding_sidecar_for(db_path);
+        crate::search::EmbeddingIndex::load(&sidecar).unwrap_or_default()
+    }
+
+    /// Compute the sidecar path for a given database path.
+    fn embedding_sidecar_for(db_path: &Path) -> std::path::PathBuf {
+        let mut s = db_path.as_os_str().to_owned();
+        s.push(".embeddings");
+        std::path::PathBuf::from(s)
+    }
+
+    /// Return the path to the embedding sidecar file, or `None` for in-memory stores.
+    pub fn embedding_sidecar_path(&self) -> Option<std::path::PathBuf> {
+        self.db_path.as_ref().map(|p| Self::embedding_sidecar_for(p))
+    }
+
+    /// Add an embedding to the in-memory index without saving to disk.
+    /// Use `flush_embedding_index` after a batch of additions to persist.
+    pub fn add_embedding(&self, uid: &str, embedding: Vec<f32>) {
+        let mut idx = self.embedding_index.lock().unwrap_or_else(|e| e.into_inner());
+        idx.add(uid, embedding);
+    }
+
+    /// Check whether the embedding index already has an entry for `uid`.
+    pub fn has_embedding(&self, uid: &str) -> bool {
+        let idx = self.embedding_index.lock().unwrap_or_else(|e| e.into_inner());
+        idx.get(uid).is_some()
+    }
+
+    /// Persist the in-memory embedding index to the sidecar file.
+    /// No-op for in-memory stores.
+    pub fn flush_embedding_index(&self) -> Result<(), StoreError> {
+        let idx = self.embedding_index.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(path) = self.embedding_sidecar_path() {
+            idx.save(&path)
+                .map_err(|e| StoreError::Query(format!("save embedding sidecar: {e}")))?;
+        }
+        Ok(())
+    }
+
+    /// Perform a vector similarity search over the embedding index.
+    /// Returns `(uid, cosine_similarity)` pairs sorted descending.
+    pub fn vector_search(&self, query_embedding: &[f32], limit: usize) -> Vec<(String, f64)> {
+        let idx = self.embedding_index.lock().unwrap_or_else(|e| e.into_inner());
+        idx.vector_search(query_embedding, limit)
+    }
+
+    /// Return the dimensionality of embeddings in the sidecar index,
+    /// or `None` if no embeddings are stored.
+    pub fn embedding_index_dimension(&self) -> Option<usize> {
+        let idx = self.embedding_index.lock().unwrap_or_else(|e| e.into_inner());
+        idx.dimension()
+    }
+
+    /// Number of embeddings in the sidecar index.
+    pub fn embedding_count(&self) -> usize {
+        let idx = self.embedding_index.lock().unwrap_or_else(|e| e.into_inner());
+        idx.len()
     }
 
     /// P0.2: bump the `graph_generation` counter and persist it to this

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -332,6 +332,7 @@ mod tests {
             created_at: None,
             modified_at: None,
             pagerank_score: None,
+            embedding: None,
         };
         store.insert_note(&note).unwrap();
 
@@ -367,6 +368,7 @@ mod tests {
                     created_at: None,
                     modified_at: None,
                     pagerank_score: None,
+                    embedding: None,
                 })
                 .unwrap();
         }
@@ -393,6 +395,7 @@ mod tests {
                 created_at: None,
                 modified_at: None,
                 pagerank_score: None,
+                embedding: None,
             })
             .unwrap();
 
@@ -428,6 +431,7 @@ mod tests {
                 created_at: None,
                 modified_at: None,
                 pagerank_score: None,
+                embedding: None,
             })
             .unwrap();
 
@@ -440,6 +444,7 @@ mod tests {
             start_line: 1,
             end_line: 1,
             content_hash: "h1".to_string(),
+            embedding: None,
         };
         let h2 = Heading {
             uid: "head:o:2:5".to_string(),
@@ -450,6 +455,7 @@ mod tests {
             start_line: 5,
             end_line: 5,
             content_hash: "h2".to_string(),
+            embedding: None,
         };
         store
             .batch_insert_headings(&[h1.clone(), h2.clone()])
@@ -535,6 +541,7 @@ mod tests {
                 created_at: None,
                 modified_at: None,
                 pagerank_score: None,
+                embedding: None,
             })
             .unwrap();
 
@@ -568,6 +575,7 @@ mod tests {
                 created_at: None,
                 modified_at: None,
                 pagerank_score: None,
+                embedding: None,
             })
             .unwrap();
         store
@@ -580,6 +588,7 @@ mod tests {
                 start_line: 1,
                 end_line: 1,
                 content_hash: "h".to_string(),
+                embedding: None,
             })
             .unwrap();
         store
@@ -835,6 +844,7 @@ mod tests {
             created_at: None,
             modified_at: None,
             pagerank_score: None,
+            embedding: None,
         };
 
         // First insert.
@@ -874,6 +884,7 @@ mod tests {
             created_at: None,
             modified_at: None,
             pagerank_score: None,
+            embedding: None,
         };
         store.upsert_note(&note_v2).unwrap();
 
@@ -903,6 +914,7 @@ mod tests {
                 created_at: None,
                 modified_at: None,
                 pagerank_score: None,
+                embedding: None,
             })
             .unwrap();
 
@@ -1052,6 +1064,7 @@ mod tests {
                 created_at: None,
                 modified_at: None,
                 pagerank_score: None,
+                embedding: None,
             },
             Note {
                 uid: "note:txn:2".to_string(),
@@ -1065,6 +1078,7 @@ mod tests {
                 created_at: None,
                 modified_at: None,
                 pagerank_score: None,
+                embedding: None,
             },
         ];
 
@@ -1105,6 +1119,7 @@ mod tests {
                 created_at: None,
                 modified_at: None,
                 pagerank_score: None,
+                embedding: None,
             },
             Note {
                 uid: "note:bvw:n2".to_string(),
@@ -1118,6 +1133,7 @@ mod tests {
                 created_at: None,
                 modified_at: None,
                 pagerank_score: None,
+                embedding: None,
             },
         ];
 
@@ -1130,6 +1146,7 @@ mod tests {
             start_line: 1,
             end_line: 5,
             content_hash: "hh1".to_string(),
+            embedding: None,
         }];
 
         let sections = vec![Section {
@@ -1259,6 +1276,7 @@ mod tests {
             created_at: None,
             modified_at: None,
             pagerank_score: None,
+            embedding: None,
         };
 
         let notes = vec![
@@ -1285,6 +1303,7 @@ mod tests {
                 start_line: 1,
                 end_line: 1,
                 content_hash: "hh1".to_string(),
+                embedding: None,
             },
             Heading {
                 uid: "hdg:cas:2".to_string(),
@@ -1295,6 +1314,7 @@ mod tests {
                 start_line: 1,
                 end_line: 1,
                 content_hash: "hh2".to_string(),
+                embedding: None,
             },
         ];
         store.batch_insert_headings(&headings).unwrap();
@@ -1633,6 +1653,7 @@ mod tests {
                 created_at: None,
                 modified_at: None,
                 pagerank_score: None,
+                embedding: None,
             },
             Note {
                 uid: "note:rp:2".to_string(),
@@ -1646,6 +1667,7 @@ mod tests {
                 created_at: None,
                 modified_at: None,
                 pagerank_score: None,
+                embedding: None,
             },
         ];
         store.batch_insert_notes(&notes).unwrap();
@@ -1662,6 +1684,7 @@ mod tests {
             start_line: 1,
             end_line: 1,
             content_hash: "hh1".to_string(),
+            embedding: None,
         };
         store.insert_heading(&heading).unwrap();
         store
@@ -1781,6 +1804,7 @@ mod tests {
             created_at: None,
             modified_at: None,
             pagerank_score: None,
+            embedding: None,
         };
         let notes = vec![
             make_note("note:m:1", 1),
@@ -1839,6 +1863,7 @@ mod tests {
             created_at: None,
             modified_at: None,
             pagerank_score: None,
+            embedding: None,
         };
         let src_notes = vec![
             make_src_note("note:cs:1", 1),
@@ -1875,6 +1900,7 @@ mod tests {
             created_at: None,
             modified_at: None,
             pagerank_score: None,
+            embedding: None,
         };
         store.insert_note(&tgt_note).unwrap();
         store

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -4,7 +4,7 @@ use std::hash::{Hash, Hasher};
 
 use lbug::Value;
 use nestweaver_algorithms::graph::AdjacencyData;
-use nestweaver_algorithms::ppr::{PprConfig, personalized_pagerank as algo_ppr, forward_push_ppr};
+use nestweaver_algorithms::ppr::{PprConfig, forward_push_ppr};
 use nestweaver_schema::{EdgeType, Symbol};
 use serde::{Deserialize, Serialize};
 
@@ -854,10 +854,8 @@ impl GraphStore {
             current_gen.hash(&mut hasher);
             // Hash interaction scores so cache is invalidated when they change.
             if let Some(ref scores) = interaction_scores_for_key {
-                let mut sorted_scores: Vec<(&String, u64)> = scores
-                    .iter()
-                    .map(|(k, v)| (k, v.to_bits()))
-                    .collect();
+                let mut sorted_scores: Vec<(&String, u64)> =
+                    scores.iter().map(|(k, v)| (k, v.to_bits())).collect();
                 sorted_scores.sort_by_key(|(k, _)| k.as_str());
                 sorted_scores.hash(&mut hasher);
             }
@@ -865,7 +863,10 @@ impl GraphStore {
         };
 
         {
-            let mut cache = self.ppr_result_cache.lock().unwrap_or_else(|e| e.into_inner());
+            let mut cache = self
+                .ppr_result_cache
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             if let Some(cached) = cache.get(&ppr_cache_key) {
                 return Ok(cached.clone());
             }
@@ -937,7 +938,10 @@ impl GraphStore {
         let results = forward_push_ppr(&uids, &adjacency, seed_uids, &config);
 
         {
-            let mut cache = self.ppr_result_cache.lock().unwrap_or_else(|e| e.into_inner());
+            let mut cache = self
+                .ppr_result_cache
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             cache.put(ppr_cache_key, results.clone());
         }
 

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -4,7 +4,7 @@ use std::hash::{Hash, Hasher};
 
 use lbug::Value;
 use nestweaver_algorithms::graph::AdjacencyData;
-use nestweaver_algorithms::ppr::{PprConfig, personalized_pagerank as algo_ppr};
+use nestweaver_algorithms::ppr::{PprConfig, personalized_pagerank as algo_ppr, forward_push_ppr};
 use nestweaver_schema::{EdgeType, Symbol};
 use serde::{Deserialize, Serialize};
 
@@ -900,7 +900,7 @@ impl GraphStore {
             interaction_bias_weight: 0.05,
         };
 
-        Ok(algo_ppr(&uids, &adjacency, seed_uids, &config))
+        Ok(forward_push_ppr(&uids, &adjacency, seed_uids, &config))
     }
 
     /// Return all Symbol nodes that have a pagerank_score set, ordered descending by score.

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -670,7 +670,7 @@ impl GraphStore {
     ///
     /// Both forward and reverse directions are included so that PPR propagates
     /// relevance through the full neighbourhood.
-    fn load_ppr_graph(
+    pub(crate) fn load_ppr_graph(
         &self,
         scope: &GraphScope,
         intent: Option<QueryIntent>,
@@ -1030,6 +1030,19 @@ impl GraphStore {
         if let Err(e) = self.compute_pagerank(0.85, 20, &GraphScope::code_only()) {
             tracing::warn!("lazy PageRank computation failed: {e}");
         }
+    }
+
+    /// Pre-build the PPR adjacency cache for the unified graph scope.
+    ///
+    /// Calling this at daemon startup eliminates the ~350ms first-query
+    /// latency caused by building the adjacency list from the database on
+    /// the first PPR request. The result is stored in `ppr_graph_cache`
+    /// and will be reused by subsequent `personalized_pagerank*` calls
+    /// until the graph generation changes.
+    pub fn warm_ppr_cache(&self) -> Result<(), StoreError> {
+        let scope = GraphScope::unified();
+        self.load_ppr_graph(&scope, None)?;
+        Ok(())
     }
 }
 

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -1252,6 +1252,7 @@ mod tests {
                     created_at: None,
                     modified_at: None,
                     pagerank_score: None,
+                    embedding: None,
                 })
                 .unwrap();
         }
@@ -1323,6 +1324,7 @@ mod tests {
                     created_at: None,
                     modified_at: None,
                     pagerank_score: None,
+                    embedding: None,
                 })
                 .unwrap();
         }
@@ -1339,6 +1341,7 @@ mod tests {
                     start_line: 1,
                     end_line: 1,
                     content_hash: "h".to_string(),
+                    embedding: None,
                 })
                 .unwrap();
         }
@@ -1430,6 +1433,7 @@ mod tests {
                     created_at: None,
                     modified_at: None,
                     pagerank_score: None,
+                    embedding: None,
                 })
                 .unwrap();
         }
@@ -2013,6 +2017,7 @@ mod tests {
             created_at: None,
             modified_at: None,
             pagerank_score: None,
+            embedding: None,
         };
         let member_note_b = Note {
             uid: "note:member_b".to_string(),
@@ -2026,6 +2031,7 @@ mod tests {
             created_at: None,
             modified_at: None,
             pagerank_score: None,
+            embedding: None,
         };
         store.upsert_note(&member_note_a).unwrap();
         store.upsert_note(&member_note_b).unwrap();
@@ -2043,6 +2049,7 @@ mod tests {
             created_at: None,
             modified_at: None,
             pagerank_score: None,
+            embedding: None,
         };
         let popular_note_y = Note {
             uid: "note:popular_y".to_string(),
@@ -2056,6 +2063,7 @@ mod tests {
             created_at: None,
             modified_at: None,
             pagerank_score: None,
+            embedding: None,
         };
         store.upsert_note(&popular_note_x).unwrap();
         store.upsert_note(&popular_note_y).unwrap();
@@ -2077,6 +2085,7 @@ mod tests {
                 created_at: None,
                 modified_at: None,
                 pagerank_score: None,
+                embedding: None,
             };
             store.upsert_note(&filler).unwrap();
 

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -833,6 +833,44 @@ impl GraphStore {
         let current_gen = self.graph_generation();
         let s_hash = scope_hash(scope);
 
+        // PPR result cache: compute a key from all inputs that affect the result,
+        // including the interaction cache content so that loading new interaction
+        // scores correctly bypasses the cache.
+        let interaction_scores_for_key = self
+            .interaction_cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        let ppr_cache_key = {
+            use std::hash::{Hash, Hasher};
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            let mut sorted_seeds = seed_uids.to_vec();
+            sorted_seeds.sort();
+            sorted_seeds.hash(&mut hasher);
+            damping.to_bits().hash(&mut hasher);
+            max_iterations.hash(&mut hasher);
+            s_hash.hash(&mut hasher);
+            intent.hash(&mut hasher);
+            current_gen.hash(&mut hasher);
+            // Hash interaction scores so cache is invalidated when they change.
+            if let Some(ref scores) = interaction_scores_for_key {
+                let mut sorted_scores: Vec<(&String, u64)> = scores
+                    .iter()
+                    .map(|(k, v)| (k, v.to_bits()))
+                    .collect();
+                sorted_scores.sort_by_key(|(k, _)| k.as_str());
+                sorted_scores.hash(&mut hasher);
+            }
+            hasher.finish()
+        };
+
+        {
+            let mut cache = self.ppr_result_cache.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some(cached) = cache.get(&ppr_cache_key) {
+                return Ok(cached.clone());
+            }
+        }
+
         // Step 1: check cache (lock, compare key, unlock).
         let cache_hit = {
             let guard = self
@@ -875,12 +913,8 @@ impl GraphStore {
             .as_ref()
             .expect("ppr_graph_cache must be Some after fill");
 
-        // Clone interaction scores out of the mutex for the algorithms crate.
-        let interaction_scores = self
-            .interaction_cache
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone();
+        // Use the interaction scores already read for the cache key above.
+        let interaction_scores = interaction_scores_for_key;
 
         let adjacency = AdjacencyData {
             uid_to_idx: cached.uid_to_idx.clone(),
@@ -900,7 +934,14 @@ impl GraphStore {
             interaction_bias_weight: 0.05,
         };
 
-        Ok(forward_push_ppr(&uids, &adjacency, seed_uids, &config))
+        let results = forward_push_ppr(&uids, &adjacency, seed_uids, &config);
+
+        {
+            let mut cache = self.ppr_result_cache.lock().unwrap_or_else(|e| e.into_inner());
+            cache.put(ppr_cache_key, results.clone());
+        }
+
+        Ok(results)
     }
 
     /// Return all Symbol nodes that have a pagerank_score set, ordered descending by score.

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -921,8 +921,13 @@ impl GraphStore {
     }
 
     /// Returns the dimension of stored embeddings, or 0 if none exist.
+    ///
+    /// Checks Symbol embeddings first (most common), then Note, then Heading.
+    /// Returns the first non-zero dimension found, or 0 if none are stored.
     pub fn embedding_dimension(&self) -> Result<u32, StoreError> {
         let conn = self.conn()?;
+
+        // Check Symbol embeddings first.
         let result = conn
             .query(
                 "MATCH (s:Symbol) WHERE s.embedding IS NOT NULL \
@@ -931,9 +936,42 @@ impl GraphStore {
             .map_err(|e| StoreError::Query(e.to_string()))?;
         for row in result {
             if let Ok(dim) = extract_i64(&row, 0) {
-                return Ok(u32::try_from(dim).unwrap_or(0));
+                if dim > 0 {
+                    return Ok(u32::try_from(dim).unwrap_or(0));
+                }
             }
         }
+
+        // Fall back to Note embeddings.
+        let result = conn
+            .query(
+                "MATCH (n:Note) WHERE n.embedding IS NOT NULL \
+                 RETURN list_len(n.embedding) LIMIT 1",
+            )
+            .map_err(|e| StoreError::Query(e.to_string()))?;
+        for row in result {
+            if let Ok(dim) = extract_i64(&row, 0) {
+                if dim > 0 {
+                    return Ok(u32::try_from(dim).unwrap_or(0));
+                }
+            }
+        }
+
+        // Fall back to Heading embeddings.
+        let result = conn
+            .query(
+                "MATCH (h:Heading) WHERE h.embedding IS NOT NULL \
+                 RETURN list_len(h.embedding) LIMIT 1",
+            )
+            .map_err(|e| StoreError::Query(e.to_string()))?;
+        for row in result {
+            if let Ok(dim) = extract_i64(&row, 0) {
+                if dim > 0 {
+                    return Ok(u32::try_from(dim).unwrap_or(0));
+                }
+            }
+        }
+
         Ok(0)
     }
 

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -922,56 +922,12 @@ impl GraphStore {
 
     /// Returns the dimension of stored embeddings, or 0 if none exist.
     ///
-    /// Checks Symbol embeddings first (most common), then Note, then Heading.
-    /// Returns the first non-zero dimension found, or 0 if none are stored.
+    /// Checks the sidecar `EmbeddingIndex` (the authoritative source since
+    /// lbug has no float-array columns). Returns 0 when the index is empty.
     pub fn embedding_dimension(&self) -> Result<u32, StoreError> {
-        let conn = self.conn()?;
-
-        // Check Symbol embeddings first.
-        let result = conn
-            .query(
-                "MATCH (s:Symbol) WHERE s.embedding IS NOT NULL \
-                 RETURN list_len(s.embedding) LIMIT 1",
-            )
-            .map_err(|e| StoreError::Query(e.to_string()))?;
-        for row in result {
-            if let Ok(dim) = extract_i64(&row, 0) {
-                if dim > 0 {
-                    return Ok(u32::try_from(dim).unwrap_or(0));
-                }
-            }
+        if let Some(dim) = self.embedding_index_dimension() {
+            return Ok(u32::try_from(dim).unwrap_or(0));
         }
-
-        // Fall back to Note embeddings.
-        let result = conn
-            .query(
-                "MATCH (n:Note) WHERE n.embedding IS NOT NULL \
-                 RETURN list_len(n.embedding) LIMIT 1",
-            )
-            .map_err(|e| StoreError::Query(e.to_string()))?;
-        for row in result {
-            if let Ok(dim) = extract_i64(&row, 0) {
-                if dim > 0 {
-                    return Ok(u32::try_from(dim).unwrap_or(0));
-                }
-            }
-        }
-
-        // Fall back to Heading embeddings.
-        let result = conn
-            .query(
-                "MATCH (h:Heading) WHERE h.embedding IS NOT NULL \
-                 RETURN list_len(h.embedding) LIMIT 1",
-            )
-            .map_err(|e| StoreError::Query(e.to_string()))?;
-        for row in result {
-            if let Ok(dim) = extract_i64(&row, 0) {
-                if dim > 0 {
-                    return Ok(u32::try_from(dim).unwrap_or(0));
-                }
-            }
-        }
-
         Ok(0)
     }
 

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -2036,4 +2036,55 @@ impl GraphStore {
             })
             .collect())
     }
+
+    // ── DB-level metadata ───────────────────────────────────────────────────
+
+    /// Read the stored embedding metadata (model ID and dimension).
+    ///
+    /// Returns `Some((model_id, dimension))` when a record has been written
+    /// by [`GraphStore::set_embedding_metadata`], or `None` if the Meta table
+    /// does not exist yet (old DB) or the `"embedding"` key has never been set.
+    pub fn get_embedding_metadata(&self) -> Result<Option<(String, u32)>, StoreError> {
+        let conn = self.conn()?;
+        let q = "MATCH (m:Meta {key: $k}) RETURN m.value";
+        let mut stmt = match conn.prepare(q) {
+            Ok(s) => s,
+            Err(_) => {
+                // Meta table doesn't exist on older databases — treat as absent.
+                return Ok(None);
+            }
+        };
+        let mut result = match conn.execute(
+            &mut stmt,
+            vec![("k", Value::String("embedding".to_string()))],
+        ) {
+            Ok(r) => r,
+            Err(_) => return Ok(None),
+        };
+        let row = match result.next() {
+            Some(r) => r,
+            None => return Ok(None),
+        };
+        let value = extract_string(&row, 0)?;
+        if value.is_empty() {
+            return Ok(None);
+        }
+        // Parse the JSON value stored by set_embedding_metadata.
+        // Expected format: {"model_id":"<id>","dimension":<n>}
+        let parsed: serde_json::Value = serde_json::from_str(&value)
+            .map_err(|e| StoreError::Query(format!("parse embedding metadata: {e}")))?;
+        let model_id = parsed
+            .get("model_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let dimension = parsed
+            .get("dimension")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+        if model_id.is_empty() || dimension == 0 {
+            return Ok(None);
+        }
+        Ok(Some((model_id, dimension)))
+    }
 }

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -258,6 +258,7 @@ pub(crate) fn row_to_heading(row: &[Value]) -> Result<Heading, StoreError> {
         start_line,
         end_line,
         content_hash,
+        embedding: None,
     })
 }
 
@@ -328,6 +329,7 @@ pub(crate) fn row_to_note(row: &[Value]) -> Result<Note, StoreError> {
         created_at,
         modified_at,
         pagerank_score: Some(pagerank_score),
+        embedding: None,
     })
 }
 

--- a/crates/nestweaver-store/src/regex.rs
+++ b/crates/nestweaver-store/src/regex.rs
@@ -508,6 +508,7 @@ mod tests {
                 created_at: None,
                 modified_at: None,
                 pagerank_score: None,
+                embedding: None,
             })
             .unwrap();
         store

--- a/crates/nestweaver-store/src/search.rs
+++ b/crates/nestweaver-store/src/search.rs
@@ -246,6 +246,7 @@ impl EmbeddingIndex {
     }
 }
 
+#[cfg(test)]
 fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
     if a.len() != b.len() || a.is_empty() {
         return 0.0;
@@ -559,7 +560,7 @@ mod tests {
         let path = dir.path().join("short.bin");
         std::fs::write(&path, b"NWEM").unwrap(); // only 4 bytes, need 16
 
-        assert!(matches!(EmbeddingIndex::load_binary(&path), Err(_)));
+        assert!(EmbeddingIndex::load_binary(&path).is_err());
     }
 
     #[test]

--- a/crates/nestweaver-store/src/search.rs
+++ b/crates/nestweaver-store/src/search.rs
@@ -168,7 +168,7 @@ impl EmbeddingIndex {
 
         let mut scores: Vec<(String, f64)> = self
             .embeddings
-            .iter()
+            .par_iter()
             .map(|(uid, emb)| {
                 // Stored embeddings are L2-normalized, so cosine = dot / query_norm.
                 let dot: f64 = emb
@@ -219,7 +219,7 @@ impl EmbeddingIndex {
 
         let mut scores: Vec<(String, f64)> = self
             .embeddings
-            .iter()
+            .par_iter()
             .filter(|(uid, _)| match uid_prefix {
                 Some(prefix) => uid.contains(prefix),
                 None => true,
@@ -432,12 +432,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("embeddings.json");
         let mut idx = EmbeddingIndex::new();
-        idx.add("sym:test", vec![0.1, 0.2, 0.3]);
+        // Use an L2-normalized vector (vector_search assumes pre-normalized embeddings)
+        let norm = (0.1_f32 * 0.1 + 0.2 * 0.2 + 0.3 * 0.3).sqrt();
+        let v = vec![0.1 / norm, 0.2 / norm, 0.3 / norm];
+        idx.add("sym:test", v.clone());
         idx.save(&path).unwrap();
 
         let loaded = EmbeddingIndex::load(&path).unwrap();
         assert_eq!(loaded.len(), 1);
-        let results = loaded.vector_search(&[0.1, 0.2, 0.3], 1);
+        let results = loaded.vector_search(&v, 1);
         assert_eq!(results[0].0, "sym:test");
         assert!((results[0].1 - 1.0).abs() < 1e-5);
     }

--- a/crates/nestweaver-store/src/search.rs
+++ b/crates/nestweaver-store/src/search.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::db::GraphStore;
@@ -11,7 +12,21 @@ use crate::ranking::SeedResolutionConfig;
 // EmbeddingIndex
 // ---------------------------------------------------------------------------
 
-/// In-memory embedding index backed by a JSON sidecar file.
+/// In-memory embedding index backed by a binary sidecar file.
+///
+/// Binary format (v1):
+/// ```text
+/// [header: 16 bytes]
+///   magic: b"NWEM" (4 bytes)
+///   version: u32 LE (4 bytes) = 1
+///   dimension: u32 LE (4 bytes)
+///   count: u32 LE (4 bytes)
+/// [uid table: count entries]
+///   uid_len: u16 LE (2 bytes)
+///   uid: [u8; uid_len]
+/// [vectors: count * dimension * 4 bytes]
+///   Contiguous f32 LE array, one vector per row
+/// ```
 pub struct EmbeddingIndex {
     embeddings: HashMap<String, Vec<f32>>, // uid -> embedding vector
 }
@@ -45,13 +60,127 @@ impl EmbeddingIndex {
         Ok(Self { embeddings })
     }
 
-    /// Return the top-`limit` (uid, cosine_similarity) pairs sorted descending.
+    // -- Binary persistence -------------------------------------------------
+
+    /// Write the index in the compact binary sidecar format.
+    pub fn save_binary(&self, path: &Path) -> Result<(), anyhow::Error> {
+        use std::io::Write;
+        let dim = self.dimension().unwrap_or(0);
+        let count = self.embeddings.len() as u32;
+
+        let mut file = std::io::BufWriter::new(std::fs::File::create(path)?);
+
+        // Header
+        file.write_all(b"NWEM")?;
+        file.write_all(&1u32.to_le_bytes())?; // version
+        file.write_all(&(dim as u32).to_le_bytes())?;
+        file.write_all(&count.to_le_bytes())?;
+
+        // Collect keys in deterministic order
+        let mut entries: Vec<(&String, &Vec<f32>)> = self.embeddings.iter().collect();
+        entries.sort_by_key(|(k, _)| k.as_str());
+
+        // UID table
+        for (uid, _) in &entries {
+            let bytes = uid.as_bytes();
+            file.write_all(&(bytes.len() as u16).to_le_bytes())?;
+            file.write_all(bytes)?;
+        }
+
+        // Vectors (contiguous f32 LE)
+        for (_, vec) in &entries {
+            for &val in vec.iter() {
+                file.write_all(&val.to_le_bytes())?;
+            }
+        }
+
+        file.flush()?;
+        Ok(())
+    }
+
+    /// Read the index from the compact binary sidecar format.
+    pub fn load_binary(path: &Path) -> Result<Self, anyhow::Error> {
+        let data = std::fs::read(path)?;
+        if data.len() < 16 {
+            anyhow::bail!("embedding file too small");
+        }
+        if &data[0..4] != b"NWEM" {
+            anyhow::bail!("invalid embedding file magic");
+        }
+        let version = u32::from_le_bytes(data[4..8].try_into()?);
+        if version != 1 {
+            anyhow::bail!("unsupported embedding file version {version}");
+        }
+        let dim = u32::from_le_bytes(data[8..12].try_into()?) as usize;
+        let count = u32::from_le_bytes(data[12..16].try_into()?) as usize;
+
+        let mut offset = 16;
+        let mut uids = Vec::with_capacity(count);
+
+        // Read UID table
+        for _ in 0..count {
+            if offset + 2 > data.len() {
+                anyhow::bail!("truncated uid table");
+            }
+            let uid_len = u16::from_le_bytes(data[offset..offset + 2].try_into()?) as usize;
+            offset += 2;
+            if offset + uid_len > data.len() {
+                anyhow::bail!("truncated uid");
+            }
+            let uid = std::str::from_utf8(&data[offset..offset + uid_len])?.to_string();
+            offset += uid_len;
+            uids.push(uid);
+        }
+
+        // Read vectors
+        let vec_bytes = count * dim * 4;
+        if offset + vec_bytes > data.len() {
+            anyhow::bail!("truncated vectors");
+        }
+
+        let mut embeddings = HashMap::with_capacity(count);
+        for (i, uid) in uids.into_iter().enumerate() {
+            let start = offset + i * dim * 4;
+            let vec: Vec<f32> = (0..dim)
+                .map(|j| {
+                    f32::from_le_bytes(data[start + j * 4..start + j * 4 + 4].try_into().unwrap())
+                })
+                .collect();
+            embeddings.insert(uid, vec);
+        }
+
+        Ok(Self { embeddings })
+    }
+
+    /// Return the top-`limit` (uid, similarity) pairs sorted descending.
+    ///
+    /// Uses rayon for parallel iteration and assumes stored embeddings are
+    /// L2-normalized, so cosine similarity reduces to dot-product / query_norm.
     pub fn vector_search(&self, query_vec: &[f32], limit: usize) -> Vec<(String, f64)> {
+        let query_norm: f64 = query_vec
+            .iter()
+            .map(|x| (*x as f64) * (*x as f64))
+            .sum::<f64>()
+            .sqrt();
+        if query_norm == 0.0 {
+            return vec![];
+        }
+
         let mut scores: Vec<(String, f64)> = self
             .embeddings
             .iter()
-            .map(|(uid, emb)| (uid.clone(), cosine_similarity(query_vec, emb)))
+            .map(|(uid, emb)| {
+                // Stored embeddings are L2-normalized, so cosine = dot / query_norm.
+                let dot: f64 = emb
+                    .iter()
+                    .zip(query_vec.iter())
+                    .map(|(a, b)| (*a as f64) * (*b as f64))
+                    .sum();
+                let sim = dot / query_norm;
+                (uid.clone(), sim)
+            })
             .collect();
+
         scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
         scores.truncate(limit);
         scores
@@ -69,6 +198,46 @@ impl EmbeddingIndex {
     /// vector found), or `None` if the index is empty.
     pub fn dimension(&self) -> Option<usize> {
         self.embeddings.values().next().map(|v| v.len())
+    }
+
+    /// Like `vector_search`, but pre-filters embeddings whose UID contains `uid_prefix`.
+    /// When `uid_prefix` is `None`, behaves identically to `vector_search`.
+    pub fn vector_search_filtered(
+        &self,
+        query_vec: &[f32],
+        limit: usize,
+        uid_prefix: Option<&str>,
+    ) -> Vec<(String, f64)> {
+        let query_norm: f64 = query_vec
+            .iter()
+            .map(|x| (*x as f64) * (*x as f64))
+            .sum::<f64>()
+            .sqrt();
+        if query_norm == 0.0 {
+            return vec![];
+        }
+
+        let mut scores: Vec<(String, f64)> = self
+            .embeddings
+            .iter()
+            .filter(|(uid, _)| match uid_prefix {
+                Some(prefix) => uid.contains(prefix),
+                None => true,
+            })
+            .map(|(uid, emb)| {
+                let dot: f64 = emb
+                    .iter()
+                    .zip(query_vec.iter())
+                    .map(|(a, b)| (*a as f64) * (*b as f64))
+                    .sum();
+                let sim = dot / query_norm;
+                (uid.clone(), sim)
+            })
+            .collect();
+
+        scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        scores.truncate(limit);
+        scores
     }
 
     /// Look up the embedding for a given UID.
@@ -330,6 +499,64 @@ mod tests {
             .hybrid_search("zzznomatch", None, None, 10, &empty_seed_resolution())
             .unwrap();
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn binary_save_and_load_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("embeddings.bin");
+
+        let mut idx = EmbeddingIndex::new();
+        idx.add("sym:alpha", vec![0.1, 0.2, 0.3]);
+        idx.add("sym:beta", vec![0.4, 0.5, 0.6]);
+        idx.add("sym:gamma", vec![0.7, 0.8, 0.9]);
+        idx.save_binary(&path).unwrap();
+
+        let loaded = EmbeddingIndex::load_binary(&path).unwrap();
+        assert_eq!(loaded.len(), 3);
+
+        // Verify each vector survived the round-trip
+        for uid in &["sym:alpha", "sym:beta", "sym:gamma"] {
+            let orig = idx.get(uid).unwrap();
+            let rt = loaded.get(uid).unwrap();
+            assert_eq!(orig, rt, "round-trip mismatch for {uid}");
+        }
+    }
+
+    #[test]
+    fn binary_empty_index_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.bin");
+
+        let idx = EmbeddingIndex::new();
+        idx.save_binary(&path).unwrap();
+
+        let loaded = EmbeddingIndex::load_binary(&path).unwrap();
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn binary_load_rejects_bad_magic() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.bin");
+        std::fs::write(&path, b"BADMxxxxxxxxxxxx").unwrap();
+
+        match EmbeddingIndex::load_binary(&path) {
+            Ok(_) => panic!("should reject bad magic"),
+            Err(e) => assert!(
+                format!("{e}").contains("invalid embedding file magic"),
+                "unexpected error: {e}",
+            ),
+        }
+    }
+
+    #[test]
+    fn binary_load_rejects_truncated() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("short.bin");
+        std::fs::write(&path, b"NWEM").unwrap(); // only 4 bytes, need 16
+
+        assert!(matches!(EmbeddingIndex::load_binary(&path), Err(_)));
     }
 
     #[test]

--- a/crates/nestweaver-store/src/search.rs
+++ b/crates/nestweaver-store/src/search.rs
@@ -64,6 +64,17 @@ impl EmbeddingIndex {
     pub fn is_empty(&self) -> bool {
         self.embeddings.is_empty()
     }
+
+    /// Return the dimensionality of the stored embeddings (length of the first
+    /// vector found), or `None` if the index is empty.
+    pub fn dimension(&self) -> Option<usize> {
+        self.embeddings.values().next().map(|v| v.len())
+    }
+
+    /// Look up the embedding for a given UID.
+    pub fn get(&self, uid: &str) -> Option<&Vec<f32>> {
+        self.embeddings.get(uid)
+    }
 }
 
 fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {

--- a/crates/nestweaver-store/src/tantivy_index.rs
+++ b/crates/nestweaver-store/src/tantivy_index.rs
@@ -902,6 +902,7 @@ mod tests {
                     created_at: None,
                     modified_at: None,
                     pagerank_score: None,
+                    embedding: None,
                 })
                 .unwrap();
         }

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -1985,6 +1985,100 @@ impl GraphStore {
         Ok(())
     }
 
+    /// Update the `embedding` field of a Note node.
+    ///
+    /// LadybugDB does not support `SET`, so the note is read, deleted with
+    /// DETACH DELETE, and re-inserted with the embedding set. This preserves
+    /// all other fields. The embedding is held only in the in-memory `Note`
+    /// struct returned by `list_notes`; callers that need cross-session
+    /// persistence should use an `EmbeddingIndex` sidecar file.
+    pub fn update_note_embedding(&self, uid: &str, embedding: &[f32]) -> Result<(), StoreError> {
+        use crate::read::{NOTE_COLUMNS, row_to_note};
+
+        let conn = self.conn()?;
+
+        // Read the existing note.
+        let q = format!("MATCH (n:Note {{uid: $uid}}) RETURN {NOTE_COLUMNS}");
+        let mut stmt = conn
+            .prepare(&q)
+            .map_err(|e| StoreError::Query(format!("prepare: {e}")))?;
+        let mut result = conn
+            .execute(
+                &mut stmt,
+                vec![("uid", lbug::Value::String(uid.to_string()))],
+            )
+            .map_err(|e| StoreError::Query(format!("execute: {e}")))?;
+        let row = result.next().ok_or(StoreError::NotFound)?;
+        let mut note = row_to_note(&row)?;
+
+        // Set the embedding in memory.
+        note.embedding = Some(embedding.to_vec());
+
+        // Delete the existing node (DETACH removes all edges).
+        exec_params(
+            &conn,
+            "MATCH (n:Note {uid: $uid}) DETACH DELETE n",
+            vec![("uid", lbug::Value::String(uid.to_string()))],
+        )?;
+
+        // Re-insert with all fields preserved. insert_note does not store
+        // the embedding as a DB column (LadybugDB has no native float-array
+        // column), but the in-memory Note struct carries it so callers can
+        // use it immediately after the round-trip.
+        self.insert_note(&note)?;
+
+        Ok(())
+    }
+
+    /// Update the `embedding` field of a Heading node.
+    ///
+    /// LadybugDB does not support `SET`, so the heading is read, deleted with
+    /// DETACH DELETE, and re-inserted with the embedding set. This preserves
+    /// all other fields. The embedding is held only in the in-memory `Heading`
+    /// struct returned by `list_all_headings`; callers that need cross-session
+    /// persistence should use an `EmbeddingIndex` sidecar file.
+    pub fn update_heading_embedding(
+        &self,
+        uid: &str,
+        embedding: &[f32],
+    ) -> Result<(), StoreError> {
+        use crate::read::{HEADING_COLUMNS, row_to_heading};
+
+        let conn = self.conn()?;
+
+        // Read the existing heading.
+        let q = format!("MATCH (h:Heading {{uid: $uid}}) RETURN {HEADING_COLUMNS}");
+        let mut stmt = conn
+            .prepare(&q)
+            .map_err(|e| StoreError::Query(format!("prepare: {e}")))?;
+        let mut result = conn
+            .execute(
+                &mut stmt,
+                vec![("uid", lbug::Value::String(uid.to_string()))],
+            )
+            .map_err(|e| StoreError::Query(format!("execute: {e}")))?;
+        let row = result.next().ok_or(StoreError::NotFound)?;
+        let mut heading = row_to_heading(&row)?;
+
+        // Set the embedding in memory.
+        heading.embedding = Some(embedding.to_vec());
+
+        // Delete the existing node (DETACH removes all edges).
+        exec_params(
+            &conn,
+            "MATCH (h:Heading {uid: $uid}) DETACH DELETE h",
+            vec![("uid", lbug::Value::String(uid.to_string()))],
+        )?;
+
+        // Re-insert with all fields preserved. insert_heading does not store
+        // the embedding as a DB column (LadybugDB has no native float-array
+        // column), but the in-memory Heading struct carries it so callers can
+        // use it immediately after the round-trip.
+        self.insert_heading(&heading)?;
+
+        Ok(())
+    }
+
     /// Update the `embedding` field of a Symbol node.
     ///
     /// LadybugDB does not support `SET`, so the symbol is read, deleted with

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -1987,149 +1987,38 @@ impl GraphStore {
 
     /// Update the `embedding` field of a Note node.
     ///
-    /// LadybugDB does not support `SET`, so the note is read, deleted with
-    /// DETACH DELETE, and re-inserted with the embedding set. This preserves
-    /// all other fields. The embedding is held only in the in-memory `Note`
-    /// struct returned by `list_notes`; callers that need cross-session
-    /// persistence should use an `EmbeddingIndex` sidecar file.
+    /// Persist a Note embedding to the sidecar `EmbeddingIndex`.
+    ///
+    /// The embedding is added to the in-memory index and immediately flushed
+    /// to disk. For batch operations, prefer `add_embedding` +
+    /// `flush_embedding_index` to avoid O(n^2) writes.
     pub fn update_note_embedding(&self, uid: &str, embedding: &[f32]) -> Result<(), StoreError> {
-        use crate::read::{NOTE_COLUMNS, row_to_note};
-
-        let conn = self.conn()?;
-
-        // Read the existing note.
-        let q = format!("MATCH (n:Note {{uid: $uid}}) RETURN {NOTE_COLUMNS}");
-        let mut stmt = conn
-            .prepare(&q)
-            .map_err(|e| StoreError::Query(format!("prepare: {e}")))?;
-        let mut result = conn
-            .execute(
-                &mut stmt,
-                vec![("uid", lbug::Value::String(uid.to_string()))],
-            )
-            .map_err(|e| StoreError::Query(format!("execute: {e}")))?;
-        let row = result.next().ok_or(StoreError::NotFound)?;
-        let mut note = row_to_note(&row)?;
-
-        // Set the embedding in memory.
-        note.embedding = Some(embedding.to_vec());
-
-        // Delete the existing node (DETACH removes all edges).
-        exec_params(
-            &conn,
-            "MATCH (n:Note {uid: $uid}) DETACH DELETE n",
-            vec![("uid", lbug::Value::String(uid.to_string()))],
-        )?;
-
-        // Re-insert with all fields preserved. insert_note does not store
-        // the embedding as a DB column (LadybugDB has no native float-array
-        // column), but the in-memory Note struct carries it so callers can
-        // use it immediately after the round-trip.
-        self.insert_note(&note)?;
-
-        Ok(())
+        self.add_embedding(uid, embedding.to_vec());
+        self.flush_embedding_index()
     }
 
-    /// Update the `embedding` field of a Heading node.
+    /// Persist a Heading embedding to the sidecar `EmbeddingIndex`.
     ///
-    /// LadybugDB does not support `SET`, so the heading is read, deleted with
-    /// DETACH DELETE, and re-inserted with the embedding set. This preserves
-    /// all other fields. The embedding is held only in the in-memory `Heading`
-    /// struct returned by `list_all_headings`; callers that need cross-session
-    /// persistence should use an `EmbeddingIndex` sidecar file.
+    /// The embedding is added to the in-memory index and immediately flushed
+    /// to disk. For batch operations, prefer `add_embedding` +
+    /// `flush_embedding_index` to avoid O(n^2) writes.
     pub fn update_heading_embedding(
         &self,
         uid: &str,
         embedding: &[f32],
     ) -> Result<(), StoreError> {
-        use crate::read::{HEADING_COLUMNS, row_to_heading};
-
-        let conn = self.conn()?;
-
-        // Read the existing heading.
-        let q = format!("MATCH (h:Heading {{uid: $uid}}) RETURN {HEADING_COLUMNS}");
-        let mut stmt = conn
-            .prepare(&q)
-            .map_err(|e| StoreError::Query(format!("prepare: {e}")))?;
-        let mut result = conn
-            .execute(
-                &mut stmt,
-                vec![("uid", lbug::Value::String(uid.to_string()))],
-            )
-            .map_err(|e| StoreError::Query(format!("execute: {e}")))?;
-        let row = result.next().ok_or(StoreError::NotFound)?;
-        let mut heading = row_to_heading(&row)?;
-
-        // Set the embedding in memory.
-        heading.embedding = Some(embedding.to_vec());
-
-        // Delete the existing node (DETACH removes all edges).
-        exec_params(
-            &conn,
-            "MATCH (h:Heading {uid: $uid}) DETACH DELETE h",
-            vec![("uid", lbug::Value::String(uid.to_string()))],
-        )?;
-
-        // Re-insert with all fields preserved. insert_heading does not store
-        // the embedding as a DB column (LadybugDB has no native float-array
-        // column), but the in-memory Heading struct carries it so callers can
-        // use it immediately after the round-trip.
-        self.insert_heading(&heading)?;
-
-        Ok(())
+        self.add_embedding(uid, embedding.to_vec());
+        self.flush_embedding_index()
     }
 
-    /// Update the `embedding` field of a Symbol node.
+    /// Persist a Symbol embedding to the sidecar `EmbeddingIndex`.
     ///
-    /// LadybugDB does not support `SET`, so the symbol is read, deleted with
-    /// DETACH DELETE, and re-inserted with the embedding set. This preserves
-    /// all other fields. The embedding is stored as a JSON-encoded string in
-    /// a separate sidecar structure; the Symbol node itself does not hold a
-    /// native float-array column — instead the embedding is stored in the
-    /// in-memory `Symbol.embedding` field, and callers that need persistence
-    /// across sessions should use an `EmbeddingIndex` sidecar file.
-    ///
-    /// This method updates the in-graph Symbol node so that `list_all_symbols`
-    /// can return embeddings without a separate sidecar.
+    /// The embedding is added to the in-memory index and immediately flushed
+    /// to disk. For batch operations, prefer `add_embedding` +
+    /// `flush_embedding_index` to avoid O(n^2) writes.
     pub fn update_symbol_embedding(&self, uid: &str, embedding: &[f32]) -> Result<(), StoreError> {
-        use crate::read::{SYMBOL_COLUMNS, row_to_symbol};
-
-        let conn = self.conn()?;
-
-        // Read the existing symbol.
-        let q = format!("MATCH (s:Symbol {{uid: $uid}}) RETURN {SYMBOL_COLUMNS}");
-        let mut stmt = conn
-            .prepare(&q)
-            .map_err(|e| StoreError::Query(format!("prepare: {e}")))?;
-        let mut result = conn
-            .execute(
-                &mut stmt,
-                vec![("uid", lbug::Value::String(uid.to_string()))],
-            )
-            .map_err(|e| StoreError::Query(format!("execute: {e}")))?;
-        let row = result.next().ok_or(StoreError::NotFound)?;
-        let mut sym = row_to_symbol(&row)?;
-
-        // Set the embedding in memory.
-        sym.embedding = Some(embedding.to_vec());
-
-        // Delete the existing node (DETACH removes all edges).
-        exec_params(
-            &conn,
-            "MATCH (s:Symbol {uid: $uid}) DETACH DELETE s",
-            vec![("uid", lbug::Value::String(uid.to_string()))],
-        )?;
-
-        // Re-insert with the embedding set. The Symbol struct carries
-        // `embedding` but the CREATE statement used by
-        // `insert_symbol_with_conn` does not include it (LadybugDB does
-        // not support arbitrary array columns). The embedding is therefore
-        // held only in the `Symbol` in-memory representation returned by
-        // `list_all_symbols`; the on-disk node is refreshed with all other
-        // fields preserved.
-        self.insert_symbol_with_conn(&conn, &sym)?;
-
-        Ok(())
+        self.add_embedding(uid, embedding.to_vec());
+        self.flush_embedding_index()
     }
 
     /// Bulk-delete all Symbol and File nodes belonging to `repo_uid` using two

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -2777,4 +2777,36 @@ impl GraphStore {
             discarded,
         })
     }
+
+    // ── DB-level metadata ───────────────────────────────────────────────────
+
+    /// Persist the embedding model ID and vector dimension as a singleton
+    /// `Meta` node in the database. lbug does not support MERGE or SET, so
+    /// we use the established delete-then-create upsert pattern. The node
+    /// is keyed by the fixed string `"embedding"` — only one such record
+    /// can exist at a time. Calling this again replaces any previous value.
+    pub fn set_embedding_metadata(&self, model_id: &str, dimension: u32) -> Result<(), StoreError> {
+        let conn = self.conn()?;
+
+        // Encode both fields into a single JSON string so we can use the
+        // two-column Meta table without widening it.
+        let value = format!(r#"{{"model_id":"{model_id}","dimension":{dimension}}}"#);
+
+        // Delete the existing singleton, if any. Best-effort: silently
+        // ignore errors from tables that were never created (old DBs).
+        let _ = exec_params(
+            &conn,
+            "MATCH (m:Meta {key: $k}) DETACH DELETE m",
+            vec![("k", lbug::Value::String("embedding".to_string()))],
+        );
+
+        exec_params(
+            &conn,
+            "CREATE (:Meta {key: $k, value: $v})",
+            vec![
+                ("k", lbug::Value::String("embedding".to_string())),
+                ("v", lbug::Value::String(value)),
+            ],
+        )
+    }
 }

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -2002,11 +2002,7 @@ impl GraphStore {
     /// The embedding is added to the in-memory index and immediately flushed
     /// to disk. For batch operations, prefer `add_embedding` +
     /// `flush_embedding_index` to avoid O(n^2) writes.
-    pub fn update_heading_embedding(
-        &self,
-        uid: &str,
-        embedding: &[f32],
-    ) -> Result<(), StoreError> {
+    pub fn update_heading_embedding(&self, uid: &str, embedding: &[f32]) -> Result<(), StoreError> {
         self.add_embedding(uid, embedding.to_vec());
         self.flush_embedding_index()
     }

--- a/crates/nestweaver-web/src/routes/context.rs
+++ b/crates/nestweaver-web/src/routes/context.rs
@@ -54,6 +54,7 @@ pub async fn brain_context(
         state.tantivy.as_deref(),
         &config,
         None,
+        None,
     )?;
     let json = serde_json::to_value(&result)?;
     Ok(Json(json).into_response())

--- a/crates/nestweaver-web/src/routes/llm.rs
+++ b/crates/nestweaver-web/src/routes/llm.rs
@@ -47,6 +47,7 @@ pub async fn query(
         state.tantivy.as_deref(),
         &config,
         None,
+        None,
     );
 
     let explanation = format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,10 +11,9 @@ use nestweaver_engine::{
     BrainContextResult, BrainWatcher, CodeWatcher, ContextResult, DeadCodeConfidence,
     FeatureContextResult, HubNode, HybridSearchConfig, LookupResult, Summary, SummaryLevel,
     affected_tests, analyze_blast_radius, attach_cluster_ids, attach_communities,
-    build_brain_context_hybrid_with_aliases,
-    build_context_with_intent, build_feature_context,
+    build_brain_context_hybrid_with_aliases, build_context_with_intent, build_feature_context,
     changed_files_from_git, compute_clusters, compute_cochanges, detect_implicit_projects,
-    discover_cross_domain_links, embedding::{generate_embedding, generate_embeddings_batch}, expand_query_with_aliases,
+    discover_cross_domain_links, embedding::generate_embeddings_batch, expand_query_with_aliases,
     export_cypher, export_graphml, export_in_memory_graph, export_mermaid, filter_by_target,
     find_bridge_nodes, find_hub_nodes, generate_agents_md_with_rules,
     generate_claude_md_with_rules, generate_cursor_rule_with_rules, generate_guide_with_rules,
@@ -1124,17 +1123,31 @@ enum Commands {
     Embed {
         #[arg(long, help = "Path to the database file [env: NESTWEAVER_DB]")]
         db: Option<PathBuf>,
-        #[arg(long, help = "Use the bundled local model (default when no --endpoint)")]
+        #[arg(
+            long,
+            help = "Use the bundled local model (default when no --endpoint)"
+        )]
         local: bool,
         #[arg(long, help = "OpenAI-compatible embedding API endpoint")]
         endpoint: Option<String>,
-        #[arg(long, help = "Model name for external API (e.g. text-embedding-3-small)")]
+        #[arg(
+            long,
+            help = "Model name for external API (e.g. text-embedding-3-small)"
+        )]
         model: Option<String>,
-        #[arg(long, default_value = "sentence-transformers/all-MiniLM-L6-v2", help = "HuggingFace model ID for local inference")]
+        #[arg(
+            long,
+            default_value = "sentence-transformers/all-MiniLM-L6-v2",
+            help = "HuggingFace model ID for local inference"
+        )]
         model_id: String,
         #[arg(long, default_value = "32", help = "Batch size")]
         batch_size: usize,
-        #[arg(long, default_value = "all", help = "What to embed: symbols, notes, headings, or all")]
+        #[arg(
+            long,
+            default_value = "all",
+            help = "What to embed: symbols, notes, headings, or all"
+        )]
         scope: String,
         #[arg(long, help = "Re-embed nodes that already have embeddings")]
         force: bool,
@@ -3195,9 +3208,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 return Ok((EXIT_SUCCESS, Some(stats)));
                             }
                             Err(e) => {
-                                eprintln!(
-                                    "Daemon RPC failed, falling back to local: {e}"
-                                );
+                                eprintln!("Daemon RPC failed, falling back to local: {e}");
                             }
                         }
                     }
@@ -10441,6 +10452,7 @@ fn print_project_context_json(
 }
 
 /// Generate embeddings for symbols, notes, and/or headings.
+#[allow(clippy::too_many_arguments)]
 fn run_embed(
     db: Option<&Path>,
     local: bool,
@@ -10468,27 +10480,39 @@ fn run_embed(
         if let Ok(pid) = pid_str.trim().parse::<i32>() {
             if unsafe { libc::kill(pid, 0) } == 0 {
                 eprintln!("Stopping daemon (PID {pid}) for exclusive DB access…");
-                unsafe { libc::kill(pid, libc::SIGTERM); }
+                unsafe {
+                    libc::kill(pid, libc::SIGTERM);
+                }
                 for _ in 0..50 {
                     std::thread::sleep(std::time::Duration::from_millis(100));
-                    if unsafe { libc::kill(pid, 0) } != 0 { break; }
+                    if unsafe { libc::kill(pid, 0) } != 0 {
+                        break;
+                    }
                 }
                 true
-            } else { false }
-        } else { false }
-    } else { false };
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    } else {
+        false
+    };
 
-    let store = nestweaver_store::GraphStore::open(path)
-        .map_err(|e| anyhow::anyhow!("failed to open database for writing at {}: {e}", path.display()))?;
+    let store = nestweaver_store::GraphStore::open(path).map_err(|e| {
+        anyhow::anyhow!(
+            "failed to open database for writing at {}: {e}",
+            path.display()
+        )
+    })?;
 
     let do_symbols = scope == "all" || scope == "symbols";
     let do_notes = scope == "all" || scope == "notes";
     let do_headings = scope == "all" || scope == "headings";
 
     if !do_symbols && !do_notes && !do_headings {
-        anyhow::bail!(
-            "unknown --scope '{scope}': expected one of: all, symbols, notes, headings"
-        );
+        anyhow::bail!("unknown --scope '{scope}': expected one of: all, symbols, notes, headings");
     }
 
     let mut success_count = 0usize;
@@ -10507,7 +10531,9 @@ fn run_embed(
             let to_embed: Vec<_> = if force {
                 all.iter().collect()
             } else {
-                all.iter().filter(|s| !store.has_embedding(&s.uid)).collect()
+                all.iter()
+                    .filter(|s| !store.has_embedding(&s.uid))
+                    .collect()
             };
             let total = to_embed.len();
             if total > 0 {
@@ -10515,13 +10541,20 @@ fn run_embed(
                 for (batch_idx, chunk) in to_embed.chunks(batch_size).enumerate() {
                     let done = batch_idx * batch_size + chunk.len();
                     eprint!("\rEmbedding symbols... {done}/{total}");
-                    let texts: Vec<String> = chunk.iter().map(|sym| {
-                        if sym.signature.is_empty() { sym.name.clone() } else { sym.signature.clone() }
-                    }).collect();
+                    let texts: Vec<String> = chunk
+                        .iter()
+                        .map(|sym| {
+                            if sym.signature.is_empty() {
+                                sym.name.clone()
+                            } else {
+                                sym.signature.clone()
+                            }
+                        })
+                        .collect();
                     let text_refs: Vec<&str> = texts.iter().map(|t| t.as_str()).collect();
                     match rt.block_on(generate_embeddings_batch(ep, api_model, &text_refs)) {
                         Ok(embeddings) => {
-                            for (sym, emb) in chunk.iter().zip(embeddings.into_iter()) {
+                            for (sym, emb) in chunk.iter().zip(embeddings) {
                                 store.add_embedding(&sym.uid, emb);
                                 success_count += 1;
                             }
@@ -10544,7 +10577,9 @@ fn run_embed(
             let to_embed: Vec<_> = if force {
                 all.iter().collect()
             } else {
-                all.iter().filter(|n| !store.has_embedding(&n.uid)).collect()
+                all.iter()
+                    .filter(|n| !store.has_embedding(&n.uid))
+                    .collect()
             };
             let total = to_embed.len();
             if total > 0 {
@@ -10556,7 +10591,7 @@ fn run_embed(
                     let text_refs: Vec<&str> = texts.iter().map(|t| t.as_str()).collect();
                     match rt.block_on(generate_embeddings_batch(ep, api_model, &text_refs)) {
                         Ok(embeddings) => {
-                            for (note, emb) in chunk.iter().zip(embeddings.into_iter()) {
+                            for (note, emb) in chunk.iter().zip(embeddings) {
                                 store.add_embedding(&note.uid, emb);
                                 success_count += 1;
                             }
@@ -10587,9 +10622,7 @@ fn run_embed(
             let total = to_embed.len();
             if total > 0 {
                 // Build note title lookup
-                let notes = store
-                    .list_notes(None)
-                    .map_err(|e| anyhow::anyhow!(e))?;
+                let notes = store.list_notes(None).map_err(|e| anyhow::anyhow!(e))?;
                 let note_titles: std::collections::HashMap<&str, &str> = notes
                     .iter()
                     .map(|n| (n.uid.as_str(), n.title.as_str()))
@@ -10599,21 +10632,22 @@ fn run_embed(
                 for (batch_idx, chunk) in to_embed.chunks(batch_size).enumerate() {
                     let done = batch_idx * batch_size + chunk.len();
                     eprint!("\rEmbedding headings... {done}/{total}");
-                    let texts: Vec<String> = chunk.iter().map(|h| {
-                        let note_title = note_titles
-                            .get(h.note_uid.as_str())
-                            .copied()
-                            .unwrap_or("");
-                        if note_title.is_empty() {
-                            h.text.clone()
-                        } else {
-                            format!("{note_title} > {}", h.text)
-                        }
-                    }).collect();
+                    let texts: Vec<String> = chunk
+                        .iter()
+                        .map(|h| {
+                            let note_title =
+                                note_titles.get(h.note_uid.as_str()).copied().unwrap_or("");
+                            if note_title.is_empty() {
+                                h.text.clone()
+                            } else {
+                                format!("{note_title} > {}", h.text)
+                            }
+                        })
+                        .collect();
                     let text_refs: Vec<&str> = texts.iter().map(|t| t.as_str()).collect();
                     match rt.block_on(generate_embeddings_batch(ep, api_model, &text_refs)) {
                         Ok(embeddings) => {
-                            for (h, emb) in chunk.iter().zip(embeddings.into_iter()) {
+                            for (h, emb) in chunk.iter().zip(embeddings) {
                                 store.add_embedding(&h.uid, emb);
                                 success_count += 1;
                             }
@@ -10646,7 +10680,9 @@ fn run_embed(
                 let to_embed: Vec<_> = if force {
                     all.iter().collect()
                 } else {
-                    all.iter().filter(|s| !store.has_embedding(&s.uid)).collect()
+                    all.iter()
+                        .filter(|s| !store.has_embedding(&s.uid))
+                        .collect()
                 };
                 let total = to_embed.len();
                 if total > 0 {
@@ -10664,8 +10700,7 @@ fn run_embed(
                                 )
                             })
                             .collect();
-                        let text_refs: Vec<&str> =
-                            texts.iter().map(|t| t.as_str()).collect();
+                        let text_refs: Vec<&str> = texts.iter().map(|t| t.as_str()).collect();
                         match embed_model.embed(&text_refs) {
                             Ok(embeddings) => {
                                 for (sym, emb) in batch.iter().zip(embeddings.iter()) {
@@ -10691,7 +10726,9 @@ fn run_embed(
                 let to_embed: Vec<_> = if force {
                     all.iter().collect()
                 } else {
-                    all.iter().filter(|n| !store.has_embedding(&n.uid)).collect()
+                    all.iter()
+                        .filter(|n| !store.has_embedding(&n.uid))
+                        .collect()
                 };
                 let total = to_embed.len();
                 if total > 0 {
@@ -10701,12 +10738,9 @@ fn run_embed(
                         eprint!("\rEmbedding notes... {done}/{total}");
                         let texts: Vec<String> = batch
                             .iter()
-                            .map(|n| {
-                                nestweaver_embed::preprocess::note_embed_text(&n.title, None)
-                            })
+                            .map(|n| nestweaver_embed::preprocess::note_embed_text(&n.title, None))
                             .collect();
-                        let text_refs: Vec<&str> =
-                            texts.iter().map(|t| t.as_str()).collect();
+                        let text_refs: Vec<&str> = texts.iter().map(|t| t.as_str()).collect();
                         match embed_model.embed(&text_refs) {
                             Ok(embeddings) => {
                                 for (note, emb) in batch.iter().zip(embeddings.iter()) {
@@ -10739,9 +10773,7 @@ fn run_embed(
                 };
                 let total = to_embed.len();
                 if total > 0 {
-                    let notes = store
-                        .list_notes(None)
-                        .map_err(|e| anyhow::anyhow!(e))?;
+                    let notes = store.list_notes(None).map_err(|e| anyhow::anyhow!(e))?;
                     let note_titles: std::collections::HashMap<&str, &str> = notes
                         .iter()
                         .map(|n| (n.uid.as_str(), n.title.as_str()))
@@ -10754,17 +10786,14 @@ fn run_embed(
                         let texts: Vec<String> = batch
                             .iter()
                             .map(|h| {
-                                let note_title = note_titles
-                                    .get(h.note_uid.as_str())
-                                    .copied()
-                                    .unwrap_or("");
+                                let note_title =
+                                    note_titles.get(h.note_uid.as_str()).copied().unwrap_or("");
                                 nestweaver_embed::preprocess::heading_embed_text(
                                     note_title, &h.text,
                                 )
                             })
                             .collect();
-                        let text_refs: Vec<&str> =
-                            texts.iter().map(|t| t.as_str()).collect();
+                        let text_refs: Vec<&str> = texts.iter().map(|t| t.as_str()).collect();
                         match embed_model.embed(&text_refs) {
                             Ok(embeddings) => {
                                 for (h, emb) in batch.iter().zip(embeddings.iter()) {
@@ -10793,10 +10822,10 @@ fn run_embed(
     }
 
     // Flush the embedding index to the sidecar file once at the end.
-    if success_count > 0 {
-        if let Err(e) = store.flush_embedding_index() {
-            eprintln!("Warning: failed to save embedding sidecar: {e}");
-        }
+    if success_count > 0
+        && let Err(e) = store.flush_embedding_index()
+    {
+        eprintln!("Warning: failed to save embedding sidecar: {e}");
     }
 
     if stats {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use nestweaver_engine::{
     BrainContextResult, BrainWatcher, CodeWatcher, ContextResult, DeadCodeConfidence,
     FeatureContextResult, HubNode, HybridSearchConfig, LookupResult, Summary, SummaryLevel,
     affected_tests, analyze_blast_radius, attach_cluster_ids, attach_communities,
-    build_brain_context_hybrid, build_brain_context_hybrid_with_aliases,
+    build_brain_context_hybrid_with_aliases,
     build_context_with_intent, build_feature_context,
     changed_files_from_git, compute_clusters, compute_cochanges, detect_implicit_projects,
     discover_cross_domain_links, embedding::generate_embedding, expand_query_with_aliases,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2492,7 +2492,6 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
     let t0 = std::time::Instant::now();
     let _ = &t0; // suppress unused warning for arms that don't use it
     let no_embed = cli.no_embed;
-    let _ = &no_embed; // suppress unused warning for arms that don't use it
     let use_daemon = if cli.no_daemon {
         if std::env::var("NESTWEAVER_NO_DAEMON").is_ok() {
             false

--- a/src/main.rs
+++ b/src/main.rs
@@ -10452,7 +10452,7 @@ fn print_project_context_json(
 }
 
 /// Generate embeddings for symbols, notes, and/or headings.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, unused_variables)]
 fn run_embed(
     db: Option<&Path>,
     local: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10551,7 +10551,7 @@ fn run_embed(
             let to_embed: Vec<_> = if force {
                 all.iter().collect()
             } else {
-                all.iter().filter(|s| s.embedding.is_none()).collect()
+                all.iter().filter(|s| !store.has_embedding(&s.uid)).collect()
             };
             let total = to_embed.len();
             if total > 0 {
@@ -10565,15 +10565,8 @@ fn run_embed(
                     };
                     match rt.block_on(generate_embedding(ep, api_model, &text)) {
                         Ok(embedding) => {
-                            if let Err(e) = store.update_symbol_embedding(&sym.uid, &embedding) {
-                                eprintln!(
-                                    "\n    Warning: failed to store embedding for {}: {e}",
-                                    sym.uid
-                                );
-                                error_count += 1;
-                            } else {
-                                success_count += 1;
-                            }
+                            store.add_embedding(&sym.uid, embedding);
+                            success_count += 1;
                         }
                         Err(e) => {
                             eprintln!("\n    Warning: embedding API error for {}: {e}", sym.uid);
@@ -10593,7 +10586,7 @@ fn run_embed(
             let to_embed: Vec<_> = if force {
                 all.iter().collect()
             } else {
-                all.iter().filter(|n| n.embedding.is_none()).collect()
+                all.iter().filter(|n| !store.has_embedding(&n.uid)).collect()
             };
             let total = to_embed.len();
             if total > 0 {
@@ -10603,15 +10596,8 @@ fn run_embed(
                     let text = note.title.clone();
                     match rt.block_on(generate_embedding(ep, api_model, &text)) {
                         Ok(embedding) => {
-                            if let Err(e) = store.update_note_embedding(&note.uid, &embedding) {
-                                eprintln!(
-                                    "\n    Warning: failed to store embedding for {}: {e}",
-                                    note.uid
-                                );
-                                error_count += 1;
-                            } else {
-                                success_count += 1;
-                            }
+                            store.add_embedding(&note.uid, embedding);
+                            success_count += 1;
                         }
                         Err(e) => {
                             eprintln!("\n    Warning: embedding API error for {}: {e}", note.uid);
@@ -10633,7 +10619,7 @@ fn run_embed(
             } else {
                 all_headings
                     .iter()
-                    .filter(|h| h.embedding.is_none())
+                    .filter(|h| !store.has_embedding(&h.uid))
                     .collect()
             };
             let total = to_embed.len();
@@ -10661,17 +10647,8 @@ fn run_embed(
                     };
                     match rt.block_on(generate_embedding(ep, api_model, &text)) {
                         Ok(embedding) => {
-                            if let Err(e) =
-                                store.update_heading_embedding(&h.uid, &embedding)
-                            {
-                                eprintln!(
-                                    "\n    Warning: failed to store embedding for {}: {e}",
-                                    h.uid
-                                );
-                                error_count += 1;
-                            } else {
-                                success_count += 1;
-                            }
+                            store.add_embedding(&h.uid, embedding);
+                            success_count += 1;
                         }
                         Err(e) => {
                             eprintln!("\n    Warning: embedding API error for {}: {e}", h.uid);
@@ -10701,7 +10678,7 @@ fn run_embed(
                 let to_embed: Vec<_> = if force {
                     all.iter().collect()
                 } else {
-                    all.iter().filter(|s| s.embedding.is_none()).collect()
+                    all.iter().filter(|s| !store.has_embedding(&s.uid)).collect()
                 };
                 let total = to_embed.len();
                 if total > 0 {
@@ -10724,17 +10701,8 @@ fn run_embed(
                         match embed_model.embed(&text_refs) {
                             Ok(embeddings) => {
                                 for (sym, emb) in batch.iter().zip(embeddings.iter()) {
-                                    if let Err(e) =
-                                        store.update_symbol_embedding(&sym.uid, emb)
-                                    {
-                                        eprintln!(
-                                            "\n    Warning: store error for {}: {e}",
-                                            sym.uid
-                                        );
-                                        error_count += 1;
-                                    } else {
-                                        success_count += 1;
-                                    }
+                                    store.add_embedding(&sym.uid, emb.clone());
+                                    success_count += 1;
                                 }
                             }
                             Err(e) => {
@@ -10755,7 +10723,7 @@ fn run_embed(
                 let to_embed: Vec<_> = if force {
                     all.iter().collect()
                 } else {
-                    all.iter().filter(|n| n.embedding.is_none()).collect()
+                    all.iter().filter(|n| !store.has_embedding(&n.uid)).collect()
                 };
                 let total = to_embed.len();
                 if total > 0 {
@@ -10774,17 +10742,8 @@ fn run_embed(
                         match embed_model.embed(&text_refs) {
                             Ok(embeddings) => {
                                 for (note, emb) in batch.iter().zip(embeddings.iter()) {
-                                    if let Err(e) =
-                                        store.update_note_embedding(&note.uid, emb)
-                                    {
-                                        eprintln!(
-                                            "\n    Warning: store error for {}: {e}",
-                                            note.uid
-                                        );
-                                        error_count += 1;
-                                    } else {
-                                        success_count += 1;
-                                    }
+                                    store.add_embedding(&note.uid, emb.clone());
+                                    success_count += 1;
                                 }
                             }
                             Err(e) => {
@@ -10807,7 +10766,7 @@ fn run_embed(
                 } else {
                     all_headings
                         .iter()
-                        .filter(|h| h.embedding.is_none())
+                        .filter(|h| !store.has_embedding(&h.uid))
                         .collect()
                 };
                 let total = to_embed.len();
@@ -10841,17 +10800,8 @@ fn run_embed(
                         match embed_model.embed(&text_refs) {
                             Ok(embeddings) => {
                                 for (h, emb) in batch.iter().zip(embeddings.iter()) {
-                                    if let Err(e) =
-                                        store.update_heading_embedding(&h.uid, emb)
-                                    {
-                                        eprintln!(
-                                            "\n    Warning: store error for {}: {e}",
-                                            h.uid
-                                        );
-                                        error_count += 1;
-                                    } else {
-                                        success_count += 1;
-                                    }
+                                    store.add_embedding(&h.uid, emb.clone());
+                                    success_count += 1;
                                 }
                             }
                             Err(e) => {
@@ -10871,6 +10821,13 @@ fn run_embed(
                 "local embedding requires the `embed` feature; \
                  rebuild with `--features embed` or pass --endpoint"
             );
+        }
+    }
+
+    // Flush the embedding index to the sidecar file once at the end.
+    if success_count > 0 {
+        if let Err(e) = store.flush_embedding_index() {
+            eprintln!("Warning: failed to save embedding sidecar: {e}");
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5888,6 +5888,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 &aliases,
                 Some(&db_path),
                 Some(nestweaver_store::QueryIntent::ProjectContext),
+                None,
             ) {
                 Ok(mut result) => {
                     // Surface the project's curated member notes into
@@ -6058,6 +6059,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 &query,
                 &scope,
                 Some(token_budget),
+                None,
             )?;
             if json {
                 println!("{}", serde_json::to_string_pretty(&result)?);
@@ -9269,6 +9271,7 @@ fn run_brain(
                 &aliases,
                 Some(&db_path),
                 parsed_intent,
+                None,
             ) {
                 Ok(mut result) => {
                     // Feature F6: apply per-path ranking priors (dampen/boost)

--- a/src/main.rs
+++ b/src/main.rs
@@ -3064,80 +3064,15 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             json,
             db,
         } => {
-            // ── daemon guard (typed GetContext RPC) ───────────────
-            // Route through the daemon when JSON output is requested and
-            // we're in normal seed-based mode (not --feature, which
-            // requires config-file processing the daemon doesn't handle
-            // for this legacy command).
-            if json && feature.is_none() && use_daemon {
-                let db_default = default_db_path();
-                let db_path = db.as_deref().unwrap_or(&db_default);
-                if let Ok(rt) = tokio::runtime::Runtime::new() {
-                    let connect = rt.block_on(nestweaver_client::DaemonClient::connect(
-                        db_path,
-                        config.as_deref(),
-                    ));
-                    if let Ok(mut client) = connect {
-                        let req = nestweaver_proto::BrainContextRequest {
-                            seeds: seeds.clone(),
-                            token_budget: token_budget.unwrap_or(0) as i32,
-                            response_format: String::new(),
-                            repos: vec![],
-                            vaults: vec![],
-                            kinds: vec![],
-                            path_prefix: String::new(),
-                            tags: vec![],
-                            exclude_tags: vec![],
-                            weight_ppr: 0.0,
-                            weight_bm25: 0.0,
-                            intent: intent.clone().unwrap_or_default(),
-                            include_seeds: true,
-                            include_bodies: false,
-                            root: String::new(),
-                            prf: false,
-                            rerank: false,
-                            weight_semantic: 0.0,
-                            since: String::new(),
-                            recency_weight: 0.0,
-                            recency_half_life_days: 0.0,
-                        };
-                        let rpc = rt.block_on(async {
-                            client
-                                .inner_mut()
-                                .get_context(req)
-                                .await
-                                .map(|r| r.into_inner())
-                        });
-                        if let Ok(resp) = rpc {
-                            let result: nestweaver_engine::BrainContextResult =
-                                serde_json::from_str(&resp.result_json)?;
-                            let cut = match token_budget {
-                                Some(budget) => token_budgeted_truncate(&result.connected, budget),
-                                None => limit.unwrap_or(30).min(result.connected.len()),
-                            };
-                            print_brain_context_json(&result, cut)?;
-                            let stats = format!(
-                                "{} seeds, {} connected nodes in {} (via daemon)",
-                                result.seeds.len(),
-                                cut,
-                                format_elapsed(t0.elapsed())
-                            );
-                            return Ok((EXIT_SUCCESS, Some(stats)));
-                        }
-                    }
-                }
-            }
-
-            let store = open_store(db.as_deref())?;
-
             let parsed_intent: Option<QueryIntent> = intent
                 .as_deref()
                 .map(|s| s.parse())
                 .transpose()
                 .map_err(|e| anyhow::anyhow!("invalid --intent value: {e}"))?;
 
+            // ── Feature-mode: always local (requires config processing) ──
             if let Some(feature_name) = &feature {
-                // Feature-mode: resolve via instance config.
+                let store = open_store(db.as_deref())?;
                 let config_path = config
                     .as_ref()
                     .ok_or_else(|| anyhow::anyhow!("--config is required when using --feature"))?;
@@ -3176,109 +3111,131 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         } else {
                             print_feature_context_text(&result);
                         }
-                        Ok((EXIT_SUCCESS, Some(stats)))
+                        return Ok((EXIT_SUCCESS, Some(stats)));
                     }
                     Err(e) => {
                         let msg = e.to_string();
                         if msg.contains("No symbols found") {
                             eprintln!("{msg}");
-                            Ok((EXIT_NOT_FOUND, None))
+                            return Ok((EXIT_NOT_FOUND, None));
                         } else {
                             eprintln!("Error: {msg}");
-                            Ok((EXIT_ERROR, None))
+                            return Ok((EXIT_ERROR, None));
                         }
                     }
                 }
-            } else {
-                // Normal seed-based context.
-                match build_context_with_intent(&store, &seeds, parsed_intent, limit) {
-                    Ok(mut result) => {
-                        if let Some(budget) = token_budget {
-                            let cut = context_token_budgeted_truncate(&result.connected, budget);
-                            result.connected.truncate(cut);
-                        }
-                        let stats = format!(
-                            "{} seeds, {} connected nodes in {}",
-                            result.seeds.len(),
-                            result.connected.len(),
-                            format_elapsed(t0.elapsed())
-                        );
-                        if json {
-                            println!("{}", serde_json::to_string_pretty(&result)?);
-                        } else {
-                            print_context_text(&result);
-                        }
-                        Ok((EXIT_SUCCESS, Some(stats)))
-                    }
-                    Err(e) => {
-                        let msg = e.to_string();
-                        if msg.contains("No matching symbols") {
-                            // Fall back to daemon-routed brain_context (has semantic leg)
-                            let db_path = db.clone().unwrap_or_else(default_db_path);
-                            let rt = tokio::runtime::Runtime::new()?;
-                            if let Ok(mut client) = rt.block_on(
-                                nestweaver_client::DaemonClient::connect(&db_path, None),
-                            ) {
-                                let req = nestweaver_proto::BrainContextRequest {
-                                    seeds: seeds.clone(),
-                                    token_budget: token_budget.unwrap_or(0) as i32,
-                                    response_format: String::new(),
-                                    repos: vec![],
-                                    vaults: vec![],
-                                    kinds: vec![],
-                                    path_prefix: String::new(),
-                                    tags: vec![],
-                                    exclude_tags: vec![],
-                                    weight_ppr: 0.0,
-                                    weight_bm25: 0.0,
-                                    intent: String::new(),
-                                    include_seeds: true,
-                                    include_bodies: false,
-                                    root: String::new(),
-                                    prf: false,
-                                    rerank: false,
-                                    weight_semantic: 0.0,
-                                    since: String::new(),
-                                    recency_weight: 0.0,
-                                    recency_half_life_days: 0.0,
-                                };
-                                let rpc = rt.block_on(async {
-                                    client
-                                        .inner_mut()
-                                        .get_context(req)
-                                        .await
-                                        .map(|r| r.into_inner())
-                                });
-                                if let Ok(resp) = rpc {
-                                    if let Ok(result) = serde_json::from_str::<nestweaver_engine::BrainContextResult>(&resp.result_json) {
-                                        if !result.seeds.is_empty() || !result.connected.is_empty() {
-                                            let stats = format!(
-                                                "{} seeds, {} connected in {} (semantic fallback)",
-                                                result.seeds.len(),
-                                                result.connected.len(),
-                                                format_elapsed(t0.elapsed())
-                                            );
-                                            if json {
-                                                println!("{}", serde_json::to_string_pretty(&result)?);
-                                            } else {
-                                                for node in result.seeds.iter().chain(result.connected.iter()) {
-                                                    println!("  {} — {}", node.uid, node.title);
-                                                }
-                                            }
-                                            return Ok((EXIT_SUCCESS, Some(stats)));
-                                        }
+            }
+
+            // ── Seed-based context: always try daemon first ──────────
+            // The daemon runs the full hybrid pipeline (PPR + BM25 +
+            // semantic) so we get better results and avoid the ~300ms
+            // double-RPC latency of the old name-resolution-then-fallback
+            // pattern.
+            let effective_limit = limit.unwrap_or(30);
+            if use_daemon {
+                let db_default = default_db_path();
+                let db_path = db.as_deref().unwrap_or(&db_default);
+                if let Ok(rt) = tokio::runtime::Runtime::new() {
+                    let connect = rt.block_on(nestweaver_client::DaemonClient::connect(
+                        db_path,
+                        config.as_deref(),
+                    ));
+                    if let Ok(mut client) = connect {
+                        let req = nestweaver_proto::BrainContextRequest {
+                            seeds: seeds.clone(),
+                            token_budget: token_budget.unwrap_or(0) as i32,
+                            response_format: String::new(),
+                            repos: vec![],
+                            vaults: vec![],
+                            kinds: vec![],
+                            path_prefix: String::new(),
+                            tags: vec![],
+                            exclude_tags: vec![],
+                            weight_ppr: 0.0,
+                            weight_bm25: 0.0,
+                            intent: intent.clone().unwrap_or_default(),
+                            include_seeds: true,
+                            include_bodies: false,
+                            root: String::new(),
+                            prf: false,
+                            rerank: false,
+                            weight_semantic: 0.0,
+                            since: String::new(),
+                            recency_weight: 0.0,
+                            recency_half_life_days: 0.0,
+                        };
+                        let rpc = rt.block_on(async {
+                            client
+                                .inner_mut()
+                                .get_context(req)
+                                .await
+                                .map(|r| r.into_inner())
+                        });
+                        match rpc {
+                            Ok(resp) => {
+                                let result: nestweaver_engine::BrainContextResult =
+                                    serde_json::from_str(&resp.result_json)?;
+                                let cut = match token_budget {
+                                    Some(budget) => {
+                                        token_budgeted_truncate(&result.connected, budget)
                                     }
+                                    None => effective_limit.min(result.connected.len()),
+                                };
+                                if json {
+                                    print_brain_context_json(&result, cut)?;
+                                } else {
+                                    print_brain_context_text(&result, cut, token_budget);
                                 }
+                                let stats = format!(
+                                    "{} seeds, {} connected nodes in {} (via daemon)",
+                                    result.seeds.len(),
+                                    cut,
+                                    format_elapsed(t0.elapsed())
+                                );
+                                return Ok((EXIT_SUCCESS, Some(stats)));
                             }
-                            eprintln!("{msg}");
-                            Ok((EXIT_NOT_FOUND, None))
-                        } else if msg.contains("Ambiguous") {
-                            eprintln!("{msg}");
-                            Ok((EXIT_AMBIGUOUS, None))
-                        } else {
-                            eprintln!("Error: {msg}");
-                            Ok((EXIT_ERROR, None))
+                            Err(e) => {
+                                eprintln!(
+                                    "Daemon RPC failed, falling back to local: {e}"
+                                );
+                            }
                         }
+                    }
+                }
+            }
+
+            // ── Local fallback (daemon unavailable) ──────────────────
+            let store = open_store(db.as_deref())?;
+            match build_context_with_intent(&store, &seeds, parsed_intent, limit) {
+                Ok(mut result) => {
+                    if let Some(budget) = token_budget {
+                        let cut = context_token_budgeted_truncate(&result.connected, budget);
+                        result.connected.truncate(cut);
+                    }
+                    let stats = format!(
+                        "{} seeds, {} connected nodes in {} (local fallback)",
+                        result.seeds.len(),
+                        result.connected.len(),
+                        format_elapsed(t0.elapsed())
+                    );
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&result)?);
+                    } else {
+                        print_context_text(&result);
+                    }
+                    Ok((EXIT_SUCCESS, Some(stats)))
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("No matching symbols") || msg.contains("No symbols found") {
+                        eprintln!("{msg}");
+                        Ok((EXIT_NOT_FOUND, None))
+                    } else if msg.contains("Ambiguous") {
+                        eprintln!("{msg}");
+                        Ok((EXIT_AMBIGUOUS, None))
+                    } else {
+                        eprintln!("Error: {msg}");
+                        Ok((EXIT_ERROR, None))
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,6 +169,10 @@ struct Cli {
     /// Requires NESTWEAVER_NO_DAEMON=1 environment variable.
     #[arg(long, global = true)]
     no_daemon: bool,
+
+    /// Disable semantic embedding for this invocation
+    #[arg(long, global = true)]
+    no_embed: bool,
 }
 
 // ── Output configuration ─────────────────────────────────────────────────────
@@ -1107,26 +1111,34 @@ enum Commands {
         db: Option<PathBuf>,
     },
 
-    /// Generate embeddings for all symbols in the database using an external API.
+    /// Generate embeddings for symbols, notes, and headings in the database.
     ///
-    /// Calls an OpenAI-compatible embedding endpoint for each symbol's signature
-    /// text and stores the result so hybrid retrieval can use the semantic signal.
-    /// Only symbols that do not yet have an embedding are processed (incremental).
+    /// By default uses the bundled local model (sentence-transformers/all-MiniLM-L6-v2).
+    /// Pass --endpoint to use an external OpenAI-compatible API instead.
+    /// Only nodes that do not yet have an embedding are processed (incremental);
+    /// use --force to re-embed everything.
     #[command(
-        after_help = "Examples:\n  nestweaver embed --endpoint https://api.openai.com --model text-embedding-3-small\n  nestweaver embed --endpoint http://localhost:11434 --model nomic-embed-text --batch-size 8"
+        after_help = "Examples:\n  nestweaver embed                           # local model, all node types\n  nestweaver embed --scope symbols           # only symbols\n  nestweaver embed --endpoint https://api.openai.com --model text-embedding-3-small\n  nestweaver embed --force --stats            # re-embed everything, print timing"
     )]
     Embed {
-        #[arg(
-            long,
-            help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
-        )]
+        #[arg(long, help = "Path to the database file [env: NESTWEAVER_DB]")]
         db: Option<PathBuf>,
-        #[arg(long, help = "Embedding API endpoint (OpenAI-compatible)")]
-        endpoint: String,
-        #[arg(long, help = "Model name (e.g. text-embedding-3-small, voyage-code-3)")]
-        model: String,
-        #[arg(long, default_value = "32", help = "Batch size for API calls")]
+        #[arg(long, help = "Use the bundled local model (default when no --endpoint)")]
+        local: bool,
+        #[arg(long, help = "OpenAI-compatible embedding API endpoint")]
+        endpoint: Option<String>,
+        #[arg(long, help = "Model name for external API (e.g. text-embedding-3-small)")]
+        model: Option<String>,
+        #[arg(long, default_value = "sentence-transformers/all-MiniLM-L6-v2", help = "HuggingFace model ID for local inference")]
+        model_id: String,
+        #[arg(long, default_value = "32", help = "Batch size")]
         batch_size: usize,
+        #[arg(long, default_value = "all", help = "What to embed: symbols, notes, headings, or all")]
+        scope: String,
+        #[arg(long, help = "Re-embed nodes that already have embeddings")]
+        force: bool,
+        #[arg(long, help = "Print timing and statistics")]
+        stats: bool,
     },
 
     /// Detect potentially dead code via entry point reachability
@@ -2478,6 +2490,8 @@ fn main() {
 fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
     let t0 = std::time::Instant::now();
     let _ = &t0; // suppress unused warning for arms that don't use it
+    let no_embed = cli.no_embed;
+    let _ = &no_embed; // suppress unused warning for arms that don't use it
     let use_daemon = if cli.no_daemon {
         if std::env::var("NESTWEAVER_NO_DAEMON").is_ok() {
             false
@@ -4133,16 +4147,32 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
 
         Commands::Snapshot { command } => run_snapshot(command, use_daemon).map(|c| (c, None)),
         Commands::Instance { command } => run_instance(command).map(|c| (c, None)),
-        Commands::Brain { command } => run_brain(*command, out, t0, use_daemon),
+        Commands::Brain { command } => run_brain(*command, out, t0, use_daemon, no_embed),
         Commands::Memory { command } => run_memory(*command, t0),
         Commands::Ranking { command } => run_ranking(command, t0),
         Commands::Eval { command } => run_eval_cmd(command).map(|c| (c, None)),
         Commands::Embed {
             db,
+            local,
             endpoint,
             model,
+            model_id,
             batch_size,
-        } => run_embed(db.as_deref(), &endpoint, &model, batch_size).map(|c| (c, None)),
+            scope,
+            force,
+            stats,
+        } => run_embed(
+            db.as_deref(),
+            local,
+            endpoint.as_deref(),
+            model.as_deref(),
+            &model_id,
+            batch_size,
+            &scope,
+            force,
+            stats,
+        )
+        .map(|c| (c, None)),
 
         Commands::DeadCode {
             min_confidence,
@@ -5879,12 +5909,20 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             ppr_seeds.extend(member_symbol_uids.iter().cloned());
 
             let defaults = HybridSearchConfig::default();
+            let search_config = if no_embed {
+                HybridSearchConfig {
+                    weight_semantic: 0.0,
+                    ..defaults
+                }
+            } else {
+                defaults
+            };
             let aliases = load_alias_sidecar(&db_path);
             match build_brain_context_hybrid_with_aliases(
                 &store,
                 &ppr_seeds,
                 tantivy.as_ref(),
-                &defaults,
+                &search_config,
                 &aliases,
                 Some(&db_path),
                 Some(nestweaver_store::QueryIntent::ProjectContext),
@@ -7510,6 +7548,7 @@ fn run_brain(
     out: &OutputConfig,
     t0: std::time::Instant,
     use_daemon: bool,
+    no_embed: bool,
 ) -> anyhow::Result<(i32, Option<String>)> {
     match command {
         BrainCommands::Add {
@@ -9172,7 +9211,11 @@ fn run_brain(
                             .to_string(),
                         prf,
                         rerank,
-                        weight_semantic: weight_semantic.unwrap_or(0.0),
+                        weight_semantic: if no_embed {
+                            0.0
+                        } else {
+                            weight_semantic.unwrap_or(0.0)
+                        },
                         since: since.as_deref().unwrap_or("").to_string(),
                         recency_weight,
                         recency_half_life_days,
@@ -9252,7 +9295,11 @@ fn run_brain(
             let config = HybridSearchConfig {
                 weight_ppr: weight_ppr.unwrap_or(defaults.weight_ppr),
                 weight_bm25: weight_bm25.unwrap_or(defaults.weight_bm25),
-                weight_semantic: weight_semantic.unwrap_or(defaults.weight_semantic),
+                weight_semantic: if no_embed {
+                    0.0
+                } else {
+                    weight_semantic.unwrap_or(defaults.weight_semantic)
+                },
                 prf: prf_enabled,
                 seed_resolution: configured_seed_resolution
                     .unwrap_or_else(|| defaults.seed_resolution.clone()),
@@ -10379,74 +10426,384 @@ fn print_project_context_json(
     Ok(())
 }
 
-/// Generate embeddings for all symbols that don't yet have one.
+/// Generate embeddings for symbols, notes, and/or headings.
 fn run_embed(
     db: Option<&Path>,
-    endpoint: &str,
-    model: &str,
+    local: bool,
+    endpoint: Option<&str>,
+    model: Option<&str>,
+    model_id: &str,
     batch_size: usize,
+    scope: &str,
+    force: bool,
+    stats: bool,
 ) -> anyhow::Result<i32> {
-    let store = open_store(db)?;
-
-    let all_symbols = store
-        .list_all_symbols()
-        .map_err(|e| anyhow::anyhow!(e))
-        .context("list_all_symbols")?;
-
-    let to_embed: Vec<_> = all_symbols
-        .iter()
-        .filter(|s| s.embedding.is_none())
-        .collect();
-
-    if to_embed.is_empty() {
-        eprintln!("All symbols already have embeddings. Nothing to do.");
-        return Ok(EXIT_SUCCESS);
+    // Validate flags
+    if local && endpoint.is_some() {
+        anyhow::bail!("--local and --endpoint are mutually exclusive");
     }
 
-    eprintln!(
-        "Generating embeddings for {} symbol(s) (skipping {} with existing embeddings) …",
-        to_embed.len(),
-        all_symbols.len() - to_embed.len()
-    );
+    let t0 = std::time::Instant::now();
+    let store = open_store(db)?;
 
-    let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
+    let do_symbols = scope == "all" || scope == "symbols";
+    let do_notes = scope == "all" || scope == "notes";
+    let do_headings = scope == "all" || scope == "headings";
+
+    if !do_symbols && !do_notes && !do_headings {
+        anyhow::bail!(
+            "unknown --scope '{scope}': expected one of: all, symbols, notes, headings"
+        );
+    }
 
     let mut success_count = 0usize;
     let mut error_count = 0usize;
 
-    for (batch_idx, batch) in to_embed.chunks(batch_size).enumerate() {
-        let batch_start = batch_idx * batch_size + 1;
-        let batch_end = (batch_start + batch.len() - 1).min(to_embed.len());
-        eprintln!("  Batch {batch_start}–{batch_end} / {}", to_embed.len());
+    if let Some(ep) = endpoint {
+        // ── External API path ────────────────────────────────────
+        let api_model = model.unwrap_or("text-embedding-3-small");
+        let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
 
-        for sym in batch {
-            let text = if sym.signature.is_empty() {
-                sym.name.clone()
+        if do_symbols {
+            let all = store
+                .list_all_symbols()
+                .map_err(|e| anyhow::anyhow!(e))
+                .context("list_all_symbols")?;
+            let to_embed: Vec<_> = if force {
+                all.iter().collect()
             } else {
-                sym.signature.clone()
+                all.iter().filter(|s| s.embedding.is_none()).collect()
             };
-
-            match rt.block_on(generate_embedding(endpoint, model, &text)) {
-                Ok(embedding) => {
-                    if let Err(e) = store.update_symbol_embedding(&sym.uid, &embedding) {
-                        eprintln!(
-                            "    Warning: failed to store embedding for {}: {e}",
-                            sym.uid
-                        );
-                        error_count += 1;
+            let total = to_embed.len();
+            if total > 0 {
+                eprintln!("Embedding {total} symbol(s) via API…");
+                for (i, sym) in to_embed.iter().enumerate() {
+                    eprint!("\rEmbedding symbols... {}/{total}", i + 1);
+                    let text = if sym.signature.is_empty() {
+                        sym.name.clone()
                     } else {
-                        success_count += 1;
+                        sym.signature.clone()
+                    };
+                    match rt.block_on(generate_embedding(ep, api_model, &text)) {
+                        Ok(embedding) => {
+                            if let Err(e) = store.update_symbol_embedding(&sym.uid, &embedding) {
+                                eprintln!(
+                                    "\n    Warning: failed to store embedding for {}: {e}",
+                                    sym.uid
+                                );
+                                error_count += 1;
+                            } else {
+                                success_count += 1;
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("\n    Warning: embedding API error for {}: {e}", sym.uid);
+                            error_count += 1;
+                        }
                     }
                 }
-                Err(e) => {
-                    eprintln!("    Warning: embedding API error for {}: {e}", sym.uid);
-                    error_count += 1;
+                eprintln!();
+            }
+        }
+
+        if do_notes {
+            let all = store
+                .list_notes(None)
+                .map_err(|e| anyhow::anyhow!(e))
+                .context("list_notes")?;
+            let to_embed: Vec<_> = if force {
+                all.iter().collect()
+            } else {
+                all.iter().filter(|n| n.embedding.is_none()).collect()
+            };
+            let total = to_embed.len();
+            if total > 0 {
+                eprintln!("Embedding {total} note(s) via API…");
+                for (i, note) in to_embed.iter().enumerate() {
+                    eprint!("\rEmbedding notes... {}/{total}", i + 1);
+                    let text = note.title.clone();
+                    match rt.block_on(generate_embedding(ep, api_model, &text)) {
+                        Ok(embedding) => {
+                            if let Err(e) = store.update_note_embedding(&note.uid, &embedding) {
+                                eprintln!(
+                                    "\n    Warning: failed to store embedding for {}: {e}",
+                                    note.uid
+                                );
+                                error_count += 1;
+                            } else {
+                                success_count += 1;
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("\n    Warning: embedding API error for {}: {e}", note.uid);
+                            error_count += 1;
+                        }
+                    }
+                }
+                eprintln!();
+            }
+        }
+
+        if do_headings {
+            let all_headings = store
+                .list_all_headings()
+                .map_err(|e| anyhow::anyhow!(e))
+                .context("list_all_headings")?;
+            let to_embed: Vec<_> = if force {
+                all_headings.iter().collect()
+            } else {
+                all_headings
+                    .iter()
+                    .filter(|h| h.embedding.is_none())
+                    .collect()
+            };
+            let total = to_embed.len();
+            if total > 0 {
+                // Build note title lookup
+                let notes = store
+                    .list_notes(None)
+                    .map_err(|e| anyhow::anyhow!(e))?;
+                let note_titles: std::collections::HashMap<&str, &str> = notes
+                    .iter()
+                    .map(|n| (n.uid.as_str(), n.title.as_str()))
+                    .collect();
+
+                eprintln!("Embedding {total} heading(s) via API…");
+                for (i, h) in to_embed.iter().enumerate() {
+                    eprint!("\rEmbedding headings... {}/{total}", i + 1);
+                    let note_title = note_titles
+                        .get(h.note_uid.as_str())
+                        .copied()
+                        .unwrap_or("");
+                    let text = if note_title.is_empty() {
+                        h.text.clone()
+                    } else {
+                        format!("{note_title} > {}", h.text)
+                    };
+                    match rt.block_on(generate_embedding(ep, api_model, &text)) {
+                        Ok(embedding) => {
+                            if let Err(e) =
+                                store.update_heading_embedding(&h.uid, &embedding)
+                            {
+                                eprintln!(
+                                    "\n    Warning: failed to store embedding for {}: {e}",
+                                    h.uid
+                                );
+                                error_count += 1;
+                            } else {
+                                success_count += 1;
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("\n    Warning: embedding API error for {}: {e}", h.uid);
+                            error_count += 1;
+                        }
+                    }
+                }
+                eprintln!();
+            }
+        }
+    } else {
+        // ── Local model path (default) ───────────────────────────
+        #[cfg(feature = "embed")]
+        {
+            let config = nestweaver_embed::EmbedConfig {
+                model_id: model_id.to_string(),
+                ..Default::default()
+            };
+            let embed_model = nestweaver_embed::EmbedModel::load(&config)
+                .context("failed to load local embedding model")?;
+
+            if do_symbols {
+                let all = store
+                    .list_all_symbols()
+                    .map_err(|e| anyhow::anyhow!(e))
+                    .context("list_all_symbols")?;
+                let to_embed: Vec<_> = if force {
+                    all.iter().collect()
+                } else {
+                    all.iter().filter(|s| s.embedding.is_none()).collect()
+                };
+                let total = to_embed.len();
+                if total > 0 {
+                    eprintln!("Embedding {total} symbol(s) with local model…");
+                    for (batch_idx, batch) in to_embed.chunks(batch_size).enumerate() {
+                        let done = batch_idx * batch_size + batch.len();
+                        eprint!("\rEmbedding symbols... {done}/{total}");
+                        let texts: Vec<String> = batch
+                            .iter()
+                            .map(|s| {
+                                nestweaver_embed::preprocess::symbol_embed_text(
+                                    &s.kind.to_string(),
+                                    &s.name,
+                                    None,
+                                )
+                            })
+                            .collect();
+                        let text_refs: Vec<&str> =
+                            texts.iter().map(|t| t.as_str()).collect();
+                        match embed_model.embed(&text_refs) {
+                            Ok(embeddings) => {
+                                for (sym, emb) in batch.iter().zip(embeddings.iter()) {
+                                    if let Err(e) =
+                                        store.update_symbol_embedding(&sym.uid, emb)
+                                    {
+                                        eprintln!(
+                                            "\n    Warning: store error for {}: {e}",
+                                            sym.uid
+                                        );
+                                        error_count += 1;
+                                    } else {
+                                        success_count += 1;
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                eprintln!("\n    Warning: local embed error: {e}");
+                                error_count += batch.len();
+                            }
+                        }
+                    }
+                    eprintln!();
+                }
+            }
+
+            if do_notes {
+                let all = store
+                    .list_notes(None)
+                    .map_err(|e| anyhow::anyhow!(e))
+                    .context("list_notes")?;
+                let to_embed: Vec<_> = if force {
+                    all.iter().collect()
+                } else {
+                    all.iter().filter(|n| n.embedding.is_none()).collect()
+                };
+                let total = to_embed.len();
+                if total > 0 {
+                    eprintln!("Embedding {total} note(s) with local model…");
+                    for (batch_idx, batch) in to_embed.chunks(batch_size).enumerate() {
+                        let done = batch_idx * batch_size + batch.len();
+                        eprint!("\rEmbedding notes... {done}/{total}");
+                        let texts: Vec<String> = batch
+                            .iter()
+                            .map(|n| {
+                                nestweaver_embed::preprocess::note_embed_text(&n.title, None)
+                            })
+                            .collect();
+                        let text_refs: Vec<&str> =
+                            texts.iter().map(|t| t.as_str()).collect();
+                        match embed_model.embed(&text_refs) {
+                            Ok(embeddings) => {
+                                for (note, emb) in batch.iter().zip(embeddings.iter()) {
+                                    if let Err(e) =
+                                        store.update_note_embedding(&note.uid, emb)
+                                    {
+                                        eprintln!(
+                                            "\n    Warning: store error for {}: {e}",
+                                            note.uid
+                                        );
+                                        error_count += 1;
+                                    } else {
+                                        success_count += 1;
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                eprintln!("\n    Warning: local embed error: {e}");
+                                error_count += batch.len();
+                            }
+                        }
+                    }
+                    eprintln!();
+                }
+            }
+
+            if do_headings {
+                let all_headings = store
+                    .list_all_headings()
+                    .map_err(|e| anyhow::anyhow!(e))
+                    .context("list_all_headings")?;
+                let to_embed: Vec<_> = if force {
+                    all_headings.iter().collect()
+                } else {
+                    all_headings
+                        .iter()
+                        .filter(|h| h.embedding.is_none())
+                        .collect()
+                };
+                let total = to_embed.len();
+                if total > 0 {
+                    let notes = store
+                        .list_notes(None)
+                        .map_err(|e| anyhow::anyhow!(e))?;
+                    let note_titles: std::collections::HashMap<&str, &str> = notes
+                        .iter()
+                        .map(|n| (n.uid.as_str(), n.title.as_str()))
+                        .collect();
+
+                    eprintln!("Embedding {total} heading(s) with local model…");
+                    for (batch_idx, batch) in to_embed.chunks(batch_size).enumerate() {
+                        let done = batch_idx * batch_size + batch.len();
+                        eprint!("\rEmbedding headings... {done}/{total}");
+                        let texts: Vec<String> = batch
+                            .iter()
+                            .map(|h| {
+                                let note_title = note_titles
+                                    .get(h.note_uid.as_str())
+                                    .copied()
+                                    .unwrap_or("");
+                                nestweaver_embed::preprocess::heading_embed_text(
+                                    note_title, &h.text,
+                                )
+                            })
+                            .collect();
+                        let text_refs: Vec<&str> =
+                            texts.iter().map(|t| t.as_str()).collect();
+                        match embed_model.embed(&text_refs) {
+                            Ok(embeddings) => {
+                                for (h, emb) in batch.iter().zip(embeddings.iter()) {
+                                    if let Err(e) =
+                                        store.update_heading_embedding(&h.uid, emb)
+                                    {
+                                        eprintln!(
+                                            "\n    Warning: store error for {}: {e}",
+                                            h.uid
+                                        );
+                                        error_count += 1;
+                                    } else {
+                                        success_count += 1;
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                eprintln!("\n    Warning: local embed error: {e}");
+                                error_count += batch.len();
+                            }
+                        }
+                    }
+                    eprintln!();
                 }
             }
         }
+
+        #[cfg(not(feature = "embed"))]
+        {
+            anyhow::bail!(
+                "local embedding requires the `embed` feature; \
+                 rebuild with `--features embed` or pass --endpoint"
+            );
+        }
     }
 
-    eprintln!("Done: {success_count} embedding(s) generated, {error_count} error(s).");
+    if stats {
+        let elapsed = t0.elapsed();
+        eprintln!(
+            "Embed stats: {success_count} succeeded, {error_count} failed, {:.2}s elapsed",
+            elapsed.as_secs_f64()
+        );
+    } else {
+        eprintln!("Done: {success_count} embedding(s) generated, {error_count} error(s).");
+    }
 
     if error_count > 0 {
         Ok(EXIT_ERROR)

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,8 @@ use nestweaver_engine::{
     BrainContextResult, BrainWatcher, CodeWatcher, ContextResult, DeadCodeConfidence,
     FeatureContextResult, HubNode, HybridSearchConfig, LookupResult, Summary, SummaryLevel,
     affected_tests, analyze_blast_radius, attach_cluster_ids, attach_communities,
-    build_brain_context_hybrid_with_aliases, build_context_with_intent, build_feature_context,
+    build_brain_context_hybrid, build_brain_context_hybrid_with_aliases,
+    build_context_with_intent, build_feature_context,
     changed_files_from_git, compute_clusters, compute_cochanges, detect_implicit_projects,
     discover_cross_domain_links, embedding::generate_embedding, expand_query_with_aliases,
     export_cypher, export_graphml, export_in_memory_graph, export_mermaid, filter_by_target,
@@ -3213,6 +3214,29 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     Err(e) => {
                         let msg = e.to_string();
                         if msg.contains("No matching symbols") {
+                            // Fall back to hybrid retrieval with semantic leg
+                            let hybrid_config = HybridSearchConfig::default();
+                            match build_brain_context_hybrid(
+                                &store, &seeds, None, &hybrid_config, parsed_intent, None,
+                            ) {
+                                Ok(result) if !result.seeds.is_empty() || !result.connected.is_empty() => {
+                                    let stats = format!(
+                                        "{} seeds, {} connected nodes in {} (semantic fallback)",
+                                        result.seeds.len(),
+                                        result.connected.len(),
+                                        format_elapsed(t0.elapsed())
+                                    );
+                                    if json {
+                                        println!("{}", serde_json::to_string_pretty(&result)?);
+                                    } else {
+                                        for node in result.seeds.iter().chain(result.connected.iter()) {
+                                            println!("  {} — {}", node.uid, node.title);
+                                        }
+                                    }
+                                    return Ok((EXIT_SUCCESS, Some(stats)));
+                                }
+                                _ => {}
+                            }
                             eprintln!("{msg}");
                             Ok((EXIT_NOT_FOUND, None))
                         } else if msg.contains("Ambiguous") {
@@ -10446,6 +10470,24 @@ fn run_embed(
     let t0 = std::time::Instant::now();
     let default = default_db_path();
     let path = db.unwrap_or(&default);
+
+    // Stop daemon if running — embed needs exclusive write access
+    let instance_id = nestweaver_daemon::instance_id_from_db_path(path);
+    let pidfile = nestweaver_daemon::pidfile_path(&instance_id);
+    let daemon_was_running = if let Ok(pid_str) = std::fs::read_to_string(&pidfile) {
+        if let Ok(pid) = pid_str.trim().parse::<i32>() {
+            if unsafe { libc::kill(pid, 0) } == 0 {
+                eprintln!("Stopping daemon (PID {pid}) for exclusive DB access…");
+                unsafe { libc::kill(pid, libc::SIGTERM); }
+                for _ in 0..50 {
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                    if unsafe { libc::kill(pid, 0) } != 0 { break; }
+                }
+                true
+            } else { false }
+        } else { false }
+    } else { false };
+
     let store = nestweaver_store::GraphStore::open(path)
         .map_err(|e| anyhow::anyhow!("failed to open database for writing at {}: {e}", path.display()))?;
 
@@ -10806,6 +10848,14 @@ fn run_embed(
         );
     } else {
         eprintln!("Done: {success_count} embedding(s) generated, {error_count} error(s).");
+    }
+
+    // Drop the store before restarting the daemon
+    drop(store);
+
+    if daemon_was_running {
+        eprintln!("Restarting daemon…");
+        let _ = nestweaver_client::autostart::ensure_daemon(path, None);
     }
 
     if error_count > 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3214,28 +3214,62 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     Err(e) => {
                         let msg = e.to_string();
                         if msg.contains("No matching symbols") {
-                            // Fall back to hybrid retrieval with semantic leg
-                            let hybrid_config = HybridSearchConfig::default();
-                            match build_brain_context_hybrid(
-                                &store, &seeds, None, &hybrid_config, parsed_intent, None,
+                            // Fall back to daemon-routed brain_context (has semantic leg)
+                            let db_path = db.clone().unwrap_or_else(default_db_path);
+                            let rt = tokio::runtime::Runtime::new()?;
+                            if let Ok(mut client) = rt.block_on(
+                                nestweaver_client::DaemonClient::connect(&db_path, None),
                             ) {
-                                Ok(result) if !result.seeds.is_empty() || !result.connected.is_empty() => {
-                                    let stats = format!(
-                                        "{} seeds, {} connected nodes in {} (semantic fallback)",
-                                        result.seeds.len(),
-                                        result.connected.len(),
-                                        format_elapsed(t0.elapsed())
-                                    );
-                                    if json {
-                                        println!("{}", serde_json::to_string_pretty(&result)?);
-                                    } else {
-                                        for node in result.seeds.iter().chain(result.connected.iter()) {
-                                            println!("  {} — {}", node.uid, node.title);
+                                let req = nestweaver_proto::BrainContextRequest {
+                                    seeds: seeds.clone(),
+                                    token_budget: token_budget.unwrap_or(0) as i32,
+                                    response_format: String::new(),
+                                    repos: vec![],
+                                    vaults: vec![],
+                                    kinds: vec![],
+                                    path_prefix: String::new(),
+                                    tags: vec![],
+                                    exclude_tags: vec![],
+                                    weight_ppr: 0.0,
+                                    weight_bm25: 0.0,
+                                    intent: String::new(),
+                                    include_seeds: true,
+                                    include_bodies: false,
+                                    root: String::new(),
+                                    prf: false,
+                                    rerank: false,
+                                    weight_semantic: 0.0,
+                                    since: String::new(),
+                                    recency_weight: 0.0,
+                                    recency_half_life_days: 0.0,
+                                };
+                                let rpc = rt.block_on(async {
+                                    client
+                                        .inner_mut()
+                                        .get_context(req)
+                                        .await
+                                        .map(|r| r.into_inner())
+                                });
+                                if let Ok(resp) = rpc {
+                                    if let Ok(result) = serde_json::from_str::<nestweaver_engine::BrainContextResult>(&resp.result_json) {
+                                        if !result.seeds.is_empty() || !result.connected.is_empty() {
+                                            let stats = format!(
+                                                "{} seeds, {} connected in {} (semantic fallback)",
+                                                result.seeds.len(),
+                                                result.connected.len(),
+                                                format_elapsed(t0.elapsed())
+                                            );
+                                            if json {
+                                                println!("{}", serde_json::to_string_pretty(&result)?);
+                                            } else {
+                                                for node in result.seeds.iter().chain(result.connected.iter()) {
+                                                    println!("  {} — {}", node.uid, node.title);
+                                                }
+                                            }
+                                            return Ok((EXIT_SUCCESS, Some(stats)));
                                         }
                                     }
-                                    return Ok((EXIT_SUCCESS, Some(stats)));
                                 }
-                                _ => {}
                             }
                             eprintln!("{msg}");
                             Ok((EXIT_NOT_FOUND, None))

--- a/src/main.rs
+++ b/src/main.rs
@@ -10444,7 +10444,10 @@ fn run_embed(
     }
 
     let t0 = std::time::Instant::now();
-    let store = open_store(db)?;
+    let default = default_db_path();
+    let path = db.unwrap_or(&default);
+    let store = nestweaver_store::GraphStore::open(path)
+        .map_err(|e| anyhow::anyhow!("failed to open database for writing at {}: {e}", path.display()))?;
 
     let do_symbols = scope == "all" || scope == "symbols";
     let do_notes = scope == "all" || scope == "notes";

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use nestweaver_engine::{
     build_brain_context_hybrid_with_aliases,
     build_context_with_intent, build_feature_context,
     changed_files_from_git, compute_clusters, compute_cochanges, detect_implicit_projects,
-    discover_cross_domain_links, embedding::generate_embedding, expand_query_with_aliases,
+    discover_cross_domain_links, embedding::{generate_embedding, generate_embeddings_batch}, expand_query_with_aliases,
     export_cypher, export_graphml, export_in_memory_graph, export_mermaid, filter_by_target,
     find_bridge_nodes, find_hub_nodes, generate_agents_md_with_rules,
     generate_claude_md_with_rules, generate_cursor_rule_with_rules, generate_guide_with_rules,
@@ -10554,22 +10554,24 @@ fn run_embed(
             };
             let total = to_embed.len();
             if total > 0 {
-                eprintln!("Embedding {total} symbol(s) via API…");
-                for (i, sym) in to_embed.iter().enumerate() {
-                    eprint!("\rEmbedding symbols... {}/{total}", i + 1);
-                    let text = if sym.signature.is_empty() {
-                        sym.name.clone()
-                    } else {
-                        sym.signature.clone()
-                    };
-                    match rt.block_on(generate_embedding(ep, api_model, &text)) {
-                        Ok(embedding) => {
-                            store.add_embedding(&sym.uid, embedding);
-                            success_count += 1;
+                eprintln!("Embedding {total} symbol(s) via API (batch size {batch_size})…");
+                for (batch_idx, chunk) in to_embed.chunks(batch_size).enumerate() {
+                    let done = batch_idx * batch_size + chunk.len();
+                    eprint!("\rEmbedding symbols... {done}/{total}");
+                    let texts: Vec<String> = chunk.iter().map(|sym| {
+                        if sym.signature.is_empty() { sym.name.clone() } else { sym.signature.clone() }
+                    }).collect();
+                    let text_refs: Vec<&str> = texts.iter().map(|t| t.as_str()).collect();
+                    match rt.block_on(generate_embeddings_batch(ep, api_model, &text_refs)) {
+                        Ok(embeddings) => {
+                            for (sym, emb) in chunk.iter().zip(embeddings.into_iter()) {
+                                store.add_embedding(&sym.uid, emb);
+                                success_count += 1;
+                            }
                         }
                         Err(e) => {
-                            eprintln!("\n    Warning: embedding API error for {}: {e}", sym.uid);
-                            error_count += 1;
+                            eprintln!("\n    Warning: batch embedding API error: {e}");
+                            error_count += chunk.len();
                         }
                     }
                 }
@@ -10589,18 +10591,22 @@ fn run_embed(
             };
             let total = to_embed.len();
             if total > 0 {
-                eprintln!("Embedding {total} note(s) via API…");
-                for (i, note) in to_embed.iter().enumerate() {
-                    eprint!("\rEmbedding notes... {}/{total}", i + 1);
-                    let text = note.title.clone();
-                    match rt.block_on(generate_embedding(ep, api_model, &text)) {
-                        Ok(embedding) => {
-                            store.add_embedding(&note.uid, embedding);
-                            success_count += 1;
+                eprintln!("Embedding {total} note(s) via API (batch size {batch_size})…");
+                for (batch_idx, chunk) in to_embed.chunks(batch_size).enumerate() {
+                    let done = batch_idx * batch_size + chunk.len();
+                    eprint!("\rEmbedding notes... {done}/{total}");
+                    let texts: Vec<String> = chunk.iter().map(|n| n.title.clone()).collect();
+                    let text_refs: Vec<&str> = texts.iter().map(|t| t.as_str()).collect();
+                    match rt.block_on(generate_embeddings_batch(ep, api_model, &text_refs)) {
+                        Ok(embeddings) => {
+                            for (note, emb) in chunk.iter().zip(embeddings.into_iter()) {
+                                store.add_embedding(&note.uid, emb);
+                                success_count += 1;
+                            }
                         }
                         Err(e) => {
-                            eprintln!("\n    Warning: embedding API error for {}: {e}", note.uid);
-                            error_count += 1;
+                            eprintln!("\n    Warning: batch embedding API error: {e}");
+                            error_count += chunk.len();
                         }
                     }
                 }
@@ -10632,26 +10638,32 @@ fn run_embed(
                     .map(|n| (n.uid.as_str(), n.title.as_str()))
                     .collect();
 
-                eprintln!("Embedding {total} heading(s) via API…");
-                for (i, h) in to_embed.iter().enumerate() {
-                    eprint!("\rEmbedding headings... {}/{total}", i + 1);
-                    let note_title = note_titles
-                        .get(h.note_uid.as_str())
-                        .copied()
-                        .unwrap_or("");
-                    let text = if note_title.is_empty() {
-                        h.text.clone()
-                    } else {
-                        format!("{note_title} > {}", h.text)
-                    };
-                    match rt.block_on(generate_embedding(ep, api_model, &text)) {
-                        Ok(embedding) => {
-                            store.add_embedding(&h.uid, embedding);
-                            success_count += 1;
+                eprintln!("Embedding {total} heading(s) via API (batch size {batch_size})…");
+                for (batch_idx, chunk) in to_embed.chunks(batch_size).enumerate() {
+                    let done = batch_idx * batch_size + chunk.len();
+                    eprint!("\rEmbedding headings... {done}/{total}");
+                    let texts: Vec<String> = chunk.iter().map(|h| {
+                        let note_title = note_titles
+                            .get(h.note_uid.as_str())
+                            .copied()
+                            .unwrap_or("");
+                        if note_title.is_empty() {
+                            h.text.clone()
+                        } else {
+                            format!("{note_title} > {}", h.text)
+                        }
+                    }).collect();
+                    let text_refs: Vec<&str> = texts.iter().map(|t| t.as_str()).collect();
+                    match rt.block_on(generate_embeddings_batch(ep, api_model, &text_refs)) {
+                        Ok(embeddings) => {
+                            for (h, emb) in chunk.iter().zip(embeddings.into_iter()) {
+                                store.add_embedding(&h.uid, emb);
+                                success_count += 1;
+                            }
                         }
                         Err(e) => {
-                            eprintln!("\n    Warning: embedding API error for {}: {e}", h.uid);
-                            error_count += 1;
+                            eprintln!("\n    Warning: batch embedding API error: {e}");
+                            error_count += chunk.len();
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Adds a local embedding model (candle-rs BERT, Metal-accelerated on Apple Silicon) that enables natural language queries against the code knowledge graph. The feature ships on by default with `--no-embed` as an escape hatch.

### What it does

- **Natural language queries work:** `nestweaver context "how does authentication work"` finds `authenticateRequest`, `isAuthenticated`, `AuthenticationService` — no need to know the exact symbol name
- **Seeds PPR from embeddings:** When name-based resolution fails, semantic search finds the closest symbols/notes/headings and feeds them as PPR seeds. The graph walk then surfaces structural connections
- **Three-signal fusion:** PPR (graph structure) + BM25 (text match) + semantic (embedding similarity) combined via Convex Combination with tanh normalization. Replaces the old RRF fusion
- **All node types embedded:** Symbols, notes, and headings are embedded. Identifier preprocessing splits camelCase/snake_case into natural words before embedding
- **Local + private:** No code leaves the machine. 22M-param MiniLM model (~80MB) downloads on first use, cached locally. Optional external API override with automatic fallback to local

### Performance

| Metric | Before | After |
|--------|--------|-------|
| Query latency (warm) | N/A (NL queries failed) | **0.28-0.41s** |
| Query latency (LRU hit) | N/A | **8-13ms** |
| Query embedding (Metal) | N/A | **9ms** |
| Query embedding (CPU) | N/A | **37ms** |
| Sidecar size (140K embeddings) | N/A | **213MB** (binary format) |
| PPR (Forward Push vs power iteration) | 44-390ms | **~5-10ms** |

### Architecture

- New `nestweaver-embed` crate: candle-rs BERT inference with Metal + CPU backends, HuggingFace Hub model download, external API client with fallback
- `EmbeddingIndex` sidecar: binary format (NWEM header + UID table + contiguous f32 vectors), loaded at daemon startup, searched via rayon-parallel cosine similarity
- Forward Push PPR: replaces 20-iteration power iteration with locality-aware push algorithm. Only visits relevant graph neighborhoods instead of scanning all 140K nodes
- PPR result LRU cache: 128-entry cache keyed on seeds + damping + scope + generation. Repeated queries return in <1ms
- Weighted Score Combination: replaces RRF with Convex Combination (tanh-normalized scores, configurable weights). Research-backed — CC outperforms RRF per ACM TOIS 2023

### New CLI

```
nestweaver embed [--local] [--endpoint URL] [--model-id HF_ID] [--scope all|symbols|notes|headings] [--force] [--stats]
nestweaver context "natural language query"          # semantic search enabled by default
nestweaver context --no-embed "exact symbol name"    # disable semantic for this query
```

### Configuration

```toml
[embedding]
model_id = "sentence-transformers/all-MiniLM-L6-v2"
weight_ppr = 0.40
weight_bm25 = 0.25
weight_semantic = 0.35
always_blend_semantic = true
semantic_seed_limit = 5
```

### Research basis

- Architecture validated by HippoRAG (ICLR 2025), GAAMA, GraphCoder
- CC fusion validated over RRF (ACM TOIS 2023)
- Forward Push PPR validated by FORA (ACM TODS 2019), SpeedPPR (SIGMOD 2021)
- Identifier preprocessing validated by code retrieval literature (no raw FQNs to NL models)
- Local/private embedding validated as enterprise differentiator (Sourcegraph, Tabnine patterns)

## Breaking changes

- `rrf_fuse` replaced with `weighted_score_fuse` — callers using the internal fusion function need to update
- `HybridSearchConfig` defaults changed: PPR 0.40 (was 0.70), BM25 0.25 (was 0.30), semantic 0.35 (was 0.00)
- `rrf_k` field removed from `HybridSearchConfig`
- `build_brain_context_hybrid_with_aliases` and `investigate` gain an `embed_model` parameter
- `context` CLI command now routes through daemon by default

## Release

This PR targets **v1.0.0** — the embedding seed layer is the flagship feature that establishes NestWeaver's competitive differentiator as the only tool combining local embedding + PPR graph walk + score fusion in a single binary.

## Test plan

- [x] All 30 existing tests pass (24 integration + 6 daemon)
- [x] 5 new Forward Push PPR tests
- [x] Semantic fusion integration test
- [x] Embedding latency benchmark (9ms Metal, 37ms CPU)
- [x] 10-query manual NL test suite
- [x] `--no-embed` flag verification
- [x] `--json` output validation
- [x] `--endpoint + --local` conflict error
- [x] Incremental embed (skips already-embedded nodes)
- [x] Binary sidecar persistence across restarts
- [x] Dimension mismatch detection
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo check --no-default-features` clean