### PR TITLE
fix: normalize repo URLs and update docs for v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ cargo build --release
 | `setup` | Auto-detect and configure AI tools (16 supported). Use `--force` to regenerate customized files |
 | `generate-guide` | Generate tool-specific instruction files (skill, cursor-rule, agents-md, claude-md) |
 | `completions` | Generate shell completions (bash, zsh, fish, powershell) |
-| `embed` | Generate vector embeddings for indexed symbols |
+| `embed` | Generate vector embeddings for symbols, notes, and headings using a local model (Metal-accelerated) or external API |
 | `pull` | Pull a snapshot from a remote storage backend |
 | `instance` | Manage instance configuration |
 | `snapshot` | Manage graph snapshots (build, verify, push) |
@@ -256,6 +256,53 @@ nestweaver brain search "architecture"
 # Get unified context spanning code and notes
 nestweaver brain context "MyProject"
 ```
+
+</details>
+
+<details>
+<summary>Semantic Search (Embedding Seed Layer)</summary>
+
+Query with natural language — no need to know exact symbol names. NestWeaver embeds symbols, notes, and headings using a local BERT model (Metal-accelerated on Apple Silicon, CPU fallback elsewhere), then uses semantic similarity to find entry points for the graph walk.
+
+```sh
+# Embed all indexed content (one-time, incremental after)
+nestweaver embed --stats
+
+# Natural language queries just work
+nestweaver context "how does authentication work"
+nestweaver context "BLE bluetooth connection handling"
+nestweaver context "where does the upload pipeline start"
+```
+
+Three retrieval signals are fused via Convex Combination: PPR (graph structure), BM25 (text match), and semantic (embedding similarity). The embedding model downloads automatically on first use (~80MB).
+
+**Performance:** 7ms query embedding (Metal), 37ms (CPU). Forward Push PPR replaces power iteration for sub-10ms graph walks. LRU cache makes repeated queries instant (~8ms).
+
+Configure weights in `instance.toml`:
+```toml
+[embedding]
+model_id = "sentence-transformers/all-MiniLM-L6-v2"
+weight_ppr = 0.40
+weight_bm25 = 0.25
+weight_semantic = 0.35
+```
+
+</details>
+
+<details>
+<summary>macOS App</summary>
+
+NestWeaver includes a native macOS app with a menubar status icon. Double-click to start the daemon and open the web UI.
+
+```sh
+# Build the app bundle
+app/build.sh
+
+# Launch
+open target/release/NestWeaver.app
+```
+
+The app auto-detects your database, spawns the daemon with Metal GPU acceleration, opens the web UI at `http://127.0.0.1:9377`, and provides crash recovery. On macOS, the daemon runs via launchd for proper GPU access.
 
 </details>
 

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -360,7 +360,7 @@ fn index_into_store(
     } else {
         let repo = Repo {
             uid: r_uid.clone(),
-            url: repo_url.to_string(),
+            url: repo_url.trim_end_matches('/').to_string(),
             indexed_sha: indexed_sha.to_string(),
             staleness_commits_behind: 0,
             instance_id: instance_id.to_string(),

--- a/crates/nestweaver-engine/src/project.rs
+++ b/crates/nestweaver-engine/src/project.rs
@@ -138,7 +138,9 @@ pub fn materialize_projects(
                     .iter()
                     .filter(|r| {
                         repo_display_name(r) == *repo_name
-                            || cfg_url_for_name.is_some_and(|u| r.url == u)
+                            || cfg_url_for_name.is_some_and(|u| {
+                                r.url.trim_end_matches('/') == u.trim_end_matches('/')
+                            })
                             || r.url.contains(repo_name.as_str())
                     })
                     .collect();

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -3029,14 +3029,16 @@ fn tool_brain_remove_source(store: &GraphStore, args: Value) -> Result<Value, an
         String::new()
     };
 
+    let target_trimmed = target.trim_end_matches('/');
     let matched_repo: Vec<&nestweaver_schema::Repo> = repos
         .iter()
         .filter(|r| {
+            let r_url = r.url.trim_end_matches('/');
             r.uid == target
-                || r.name.as_deref() == Some(&target)
-                || r.url == url_target
-                || r.url == canonical_target
-                || r.url.ends_with(&format!("/{target}"))
+                || r.name.as_deref() == Some(target_trimmed)
+                || r_url == url_target.trim_end_matches('/')
+                || r_url == canonical_target.trim_end_matches('/')
+                || r_url.ends_with(&format!("/{target_trimmed}"))
         })
         .collect();
 

--- a/crates/nestweaver-schema/src/uid.rs
+++ b/crates/nestweaver-schema/src/uid.rs
@@ -10,7 +10,8 @@ pub fn truncated_hash(input: &str) -> String {
 
 /// "repo:{instance}:{url_hash}"
 pub fn repo_uid(instance: &str, url: &str) -> String {
-    format!("repo:{}:{}", instance, truncated_hash(url))
+    let normalized = url.trim_end_matches('/');
+    format!("repo:{}:{}", instance, truncated_hash(normalized))
 }
 
 /// "file:{repo_uid}:{path_hash}"

--- a/docs/guide/instance-config.md
+++ b/docs/guide/instance-config.md
@@ -90,6 +90,32 @@ embedding_model = "nomic-embed-text"
 summary_model = "qwen2.5-coder:7b"
 ```
 
+#### `[embedding]`
+
+Controls the local embedding model and hybrid retrieval weights. The embedding
+layer enables natural language queries by finding semantically similar symbols,
+notes, and headings as seeds for the graph walk.
+
+```toml
+[embedding]
+model_id = "sentence-transformers/all-MiniLM-L6-v2"  # any BERT-compatible HuggingFace model
+cache_dir = "~/.cache/nestweaver/models"
+
+# Optional: use an external API instead of the local model (falls back to local on failure)
+# external_endpoint = "https://api.openai.com"
+# external_model = "text-embedding-3-small"
+
+# Retrieval fusion weights (must sum to 1.0)
+weight_ppr = 0.40         # graph structure (Personalized PageRank)
+weight_bm25 = 0.25        # text match
+weight_semantic = 0.35    # embedding similarity
+
+# Seed selection
+always_blend_semantic = true   # add semantic matches to PPR seeds even when name resolution succeeds
+semantic_seed_limit = 5        # top-k semantic hits used as PPR seeds
+semantic_search_limit = 200    # top-k semantic hits fed into fusion
+```
+
 #### `[git]`
 
 How to authenticate git operations.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2596,14 +2596,15 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             };
 
             // Resolve target → repo UID.  Accept: UID, name, path, or URL.
-            let canonical_target = std::fs::canonicalize(&target)
+            let target_trimmed = target.trim_end_matches('/');
+            let canonical_target = std::fs::canonicalize(target_trimmed)
                 .map(|p| format!("file://{}", p.display()))
                 .unwrap_or_default();
 
-            let url_target = if target.starts_with("file://") {
-                target.clone()
-            } else if std::path::Path::new(&target).is_absolute() {
-                format!("file://{target}")
+            let url_target = if target_trimmed.starts_with("file://") {
+                target_trimmed.trim_end_matches('/').to_string()
+            } else if std::path::Path::new(target_trimmed).is_absolute() {
+                format!("file://{target_trimmed}")
             } else {
                 String::new()
             };
@@ -2611,11 +2612,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let matched: Vec<&nestweaver_schema::Repo> = repos
                 .iter()
                 .filter(|r| {
+                    let r_url = r.url.trim_end_matches('/');
                     r.uid == target
-                        || r.name.as_deref() == Some(&target)
-                        || r.url == url_target
-                        || r.url == canonical_target
-                        || r.url.ends_with(&format!("/{target}"))
+                        || r.name.as_deref() == Some(target_trimmed)
+                        || r_url == url_target
+                        || r_url == canonical_target
+                        || r_url.ends_with(&format!("/{target_trimmed}"))
                 })
                 .collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3016,13 +3016,14 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
 
             let repos = store.list_repos(None)?;
 
+            let repo_trimmed = repo.trim_end_matches('/');
             let sha_policy = if pinned {
                 let indexed_sha = repos
                     .iter()
                     .find(|r| {
-                        r.url == repo
+                        r.url.trim_end_matches('/') == repo_trimmed
                             || nestweaver_engine::repo_display_name(r)
-                                == nestweaver_engine::repo_name_from_url(&repo)
+                                == nestweaver_engine::repo_name_from_url(repo_trimmed)
                     })
                     .map(|r| r.indexed_sha.clone())
                     .unwrap_or_default();
@@ -3034,9 +3035,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let indexed_sha = repos
                 .iter()
                 .find(|r| {
-                    r.url == repo
+                    r.url.trim_end_matches('/') == repo_trimmed
                         || nestweaver_engine::repo_display_name(r)
-                            == nestweaver_engine::repo_name_from_url(&repo)
+                            == nestweaver_engine::repo_name_from_url(repo_trimmed)
                 })
                 .map(|r| r.indexed_sha.clone())
                 .unwrap_or_default();
@@ -6449,7 +6450,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
 
             let instance_id = instance.as_deref().unwrap_or("default");
 
-            let repo_url = format!("file://{}", repo_path.display());
+            let repo_url = format!("file://{}", repo_path.display())
+                .trim_end_matches('/')
+                .to_string();
 
             // Direct-write fallback for test/CI (NESTWEAVER_NO_DAEMON=1).
             out.status(&format!("Indexing {}", repo_path.display()));


### PR DESCRIPTION
## Summary

Fixes duplicate repo entries caused by trailing slashes and updates docs for v1.0/v1.1 features.

### Bug fix: trailing slash normalization

The same directory indexed with and without a trailing slash (e.g., `nestweaver` vs `nestweaver/`) created two separate repo entries with different UIDs. Fixed by normalizing URLs at every layer:

| Location | Fix |
|----------|-----|
| `repo_uid()` (schema) | Strip trailing `/` before hashing |
| `index.rs` (engine) | Normalize stored URL |
| `remove-repo` (CLI) | Normalize target when matching |
| `brain_remove_source` (MCP) | Normalize target when matching |
| `pull` (CLI) | Normalize when matching repos |
| `project.rs` (engine) | Normalize config URL comparisons |
| `index` (CLI) | Normalize `repo_url` construction |

### Docs updates

- **README.md**: Added "Semantic Search" and "macOS App" feature sections, updated `embed` command description
- **docs/guide/instance-config.md**: Added full `[embedding]` section documentation

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` zero errors
- [x] 30/30 tests pass
- [x] `cargo check --no-default-features` clean
- [x] Verified: same repo with/without trailing slash → single entry
- [x] Verified: `remove-repo testdata/js/` matches `testdata/js`
- [x] Full 25-point regression test pass