### PR TITLE
fix: route all CLI commands through daemon (Metal-accelerated embed)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3709,7 +3709,7 @@ checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "nestweaver"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3748,7 +3748,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-algorithms"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-client"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -3772,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-daemon"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-embed"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-engine"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "apollo-parser",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-mcp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-parser"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "comrak",
  "hex",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-proto"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "prost",
  "tonic",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-resolver"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "glob",
  "insta",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-schema"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "hex",
  "serde",
@@ -3966,7 +3966,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-storage"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-store"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "cc",
@@ -4004,7 +4004,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-wasm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "js-sys",
  "nestweaver-algorithms",

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Personalized PageRank with per-edge-type weights (CALLS, IMPORTS, USES, ACCESSES
 </td>
 <td width="50%" valign="top">
 
-**38-Tool MCP Server**<br>
+**40-Tool MCP Server**<br>
 Model Context Protocol tools for AI agents. Drop-in for any MCP client, lite mode for Cursor. Daemon architecture enables concurrent access from multiple AI tools without lock contention.
 
 </td>
@@ -154,6 +154,11 @@ cargo build --release
 | `search` | Full-text search across indexed symbols and notes |
 | `symbol` | Look up a symbol by name and display its metadata |
 | `impact` | Trace the blast radius of a symbol through the dependency graph |
+| `read-symbols` | Read a symbol's source span |
+| `regex-search` | Regex search over indexed text |
+| `count-patterns` | Count regex matches per pattern |
+| `investigate` | Orient on a topic in one call |
+| `affected-tests` | Select tests for changed files |
 | `repo-map` | Generate a token-budgeted map of the repository structure |
 | `summary` | Hierarchical code summaries at symbol, file, or cluster level |
 
@@ -194,6 +199,9 @@ cargo build --release
 | `bridges` | Find architectural chokepoints (betweenness centrality) |
 | `pr-impact` | PR blast radius analysis with risk scoring (Low/Medium/High/Critical) |
 | `dead-code` | Detect unreachable symbols via entry point reachability |
+| `contracts` | Inspect API contract graph |
+| `ranking` | Inspect ranking priors |
+| `eval` | Offline retrieval-quality evaluation |
 | `export` | Export the graph in Cypher, GraphML, Mermaid, or MessagePack format |
 
 </details>
@@ -236,6 +244,8 @@ cargo build --release
 | `prune-stale` | Remove repos and vaults whose source directories no longer exist on disk |
 | `list-services` | List all detected services |
 | `service-summary` | Display a summary of a specific service |
+| `admin` | Subagent guidance instructions |
+| `interactions` | Manage interaction memory |
 
 </details>
 

--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -260,6 +260,25 @@ impl DaemonClient {
         Ok(resp.into_inner())
     }
 
+    /// Run bulk embedding on the daemon using its Metal-accelerated model.
+    pub async fn embed(
+        &mut self,
+        scope: &str,
+        force: bool,
+        batch_size: u32,
+    ) -> Result<nestweaver_proto::EmbedResponse> {
+        let resp = self
+            .inner
+            .embed(nestweaver_proto::EmbedRequest {
+                scope: scope.to_string(),
+                force,
+                batch_size,
+            })
+            .await
+            .context("embed RPC failed")?;
+        Ok(resp.into_inner())
+    }
+
     /// Purge all data for an instance, streaming progress.
     pub async fn purge_instance(
         &mut self,

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -2396,16 +2396,11 @@ impl NestWeaverDaemon for DaemonService {
             let mut failed = 0u32;
 
             // ── Symbols ─────────────────────────────────────────────
-            if do_symbols
-                && let Ok(symbols) = store.list_all_symbols()
-            {
+            if do_symbols && let Ok(symbols) = store.list_all_symbols() {
                 let to_embed: Vec<_> = if force {
                     symbols.iter().collect()
                 } else {
-                    symbols
-                        .iter()
-                        .filter(|s| s.embedding.is_none())
-                        .collect()
+                    symbols.iter().filter(|s| s.embedding.is_none()).collect()
                 };
 
                 for chunk in to_embed.chunks(batch_size) {
@@ -2430,22 +2425,16 @@ impl NestWeaverDaemon for DaemonService {
             }
 
             // ── Notes ───────────────────────────────────────────────
-            if do_notes
-                && let Ok(notes) = store.list_notes(None)
-            {
+            if do_notes && let Ok(notes) = store.list_notes(None) {
                 let to_embed: Vec<_> = if force {
                     notes.iter().collect()
                 } else {
-                    notes
-                        .iter()
-                        .filter(|n| n.embedding.is_none())
-                        .collect()
+                    notes.iter().filter(|n| n.embedding.is_none()).collect()
                 };
 
                 for chunk in to_embed.chunks(batch_size) {
                     for note in chunk {
-                        let text =
-                            nestweaver_embed::preprocess::note_embed_text(&note.title, None);
+                        let text = nestweaver_embed::preprocess::note_embed_text(&note.title, None);
                         match model.embed_query(&text) {
                             Ok(emb) => {
                                 store.add_embedding(&note.uid, emb);
@@ -2461,24 +2450,17 @@ impl NestWeaverDaemon for DaemonService {
             }
 
             // ── Headings ────────────────────────────────────────────
-            if do_headings
-                && let Ok(headings) = store.list_all_headings()
-            {
+            if do_headings && let Ok(headings) = store.list_all_headings() {
                 let to_embed: Vec<_> = if force {
                     headings.iter().collect()
                 } else {
-                    headings
-                        .iter()
-                        .filter(|h| h.embedding.is_none())
-                        .collect()
+                    headings.iter().filter(|h| h.embedding.is_none()).collect()
                 };
 
                 for chunk in to_embed.chunks(batch_size) {
                     for heading in chunk {
-                        let text = nestweaver_embed::preprocess::heading_embed_text(
-                            "",
-                            &heading.text,
-                        );
+                        let text =
+                            nestweaver_embed::preprocess::heading_embed_text("", &heading.text);
                         match model.embed_query(&text) {
                             Ok(emb) => {
                                 store.add_embedding(&heading.uid, emb);

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -2338,6 +2338,179 @@ impl NestWeaverDaemon for DaemonService {
             .fetch_sub(1, Ordering::Relaxed);
         result.map(|j| Response::new(JsonResponse { result_json: j }))
     }
+
+    // ── Embedding ───────────────────────────────────────────────────
+
+    #[allow(clippy::result_large_err)]
+    async fn embed(
+        &self,
+        request: Request<EmbedRequest>,
+    ) -> Result<Response<EmbedResponse>, Status> {
+        self.state.idle_notify.notify_one();
+        self.state
+            .active_connections
+            .fetch_add(1, Ordering::Relaxed);
+
+        let req = request.into_inner();
+        let scope = req.scope.clone();
+        let force = req.force;
+        let batch_size = if req.batch_size == 0 {
+            32
+        } else {
+            req.batch_size as usize
+        };
+
+        let do_symbols = scope == "all" || scope == "symbols";
+        let do_notes = scope == "all" || scope == "notes";
+        let do_headings = scope == "all" || scope == "headings";
+
+        if !do_symbols && !do_notes && !do_headings {
+            self.state
+                .active_connections
+                .fetch_sub(1, Ordering::Relaxed);
+            return Err(Status::invalid_argument(format!(
+                "unknown scope '{scope}': expected one of: all, symbols, notes, headings"
+            )));
+        }
+
+        // Read the embed model outside the blocking thread.
+        let model = {
+            let guard = self.state.embed_model.read().await;
+            guard.clone()
+        };
+
+        let Some(model) = model else {
+            self.state
+                .active_connections
+                .fetch_sub(1, Ordering::Relaxed);
+            return Err(Status::unavailable(
+                "embedding model is not loaded — the daemon may have been built \
+                 without the `embed` feature or the model is still initializing",
+            ));
+        };
+
+        let store = self.state.store.clone();
+
+        let result = tokio::task::spawn_blocking(move || {
+            let mut succeeded = 0u32;
+            let mut failed = 0u32;
+
+            // ── Symbols ─────────────────────────────────────────────
+            if do_symbols
+                && let Ok(symbols) = store.list_all_symbols()
+            {
+                let to_embed: Vec<_> = if force {
+                    symbols.iter().collect()
+                } else {
+                    symbols
+                        .iter()
+                        .filter(|s| s.embedding.is_none())
+                        .collect()
+                };
+
+                for chunk in to_embed.chunks(batch_size) {
+                    for sym in chunk {
+                        let text = nestweaver_embed::preprocess::symbol_embed_text(
+                            &sym.kind.to_string(),
+                            &sym.name,
+                            None,
+                        );
+                        match model.embed_query(&text) {
+                            Ok(emb) => {
+                                store.add_embedding(&sym.uid, emb);
+                                succeeded += 1;
+                            }
+                            Err(e) => {
+                                tracing::warn!(uid = %sym.uid, "embedding failed: {e}");
+                                failed += 1;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // ── Notes ───────────────────────────────────────────────
+            if do_notes
+                && let Ok(notes) = store.list_notes(None)
+            {
+                let to_embed: Vec<_> = if force {
+                    notes.iter().collect()
+                } else {
+                    notes
+                        .iter()
+                        .filter(|n| n.embedding.is_none())
+                        .collect()
+                };
+
+                for chunk in to_embed.chunks(batch_size) {
+                    for note in chunk {
+                        let text =
+                            nestweaver_embed::preprocess::note_embed_text(&note.title, None);
+                        match model.embed_query(&text) {
+                            Ok(emb) => {
+                                store.add_embedding(&note.uid, emb);
+                                succeeded += 1;
+                            }
+                            Err(e) => {
+                                tracing::warn!(uid = %note.uid, "embedding failed: {e}");
+                                failed += 1;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // ── Headings ────────────────────────────────────────────
+            if do_headings
+                && let Ok(headings) = store.list_all_headings()
+            {
+                let to_embed: Vec<_> = if force {
+                    headings.iter().collect()
+                } else {
+                    headings
+                        .iter()
+                        .filter(|h| h.embedding.is_none())
+                        .collect()
+                };
+
+                for chunk in to_embed.chunks(batch_size) {
+                    for heading in chunk {
+                        let text = nestweaver_embed::preprocess::heading_embed_text(
+                            "",
+                            &heading.text,
+                        );
+                        match model.embed_query(&text) {
+                            Ok(emb) => {
+                                store.add_embedding(&heading.uid, emb);
+                                succeeded += 1;
+                            }
+                            Err(e) => {
+                                tracing::warn!(uid = %heading.uid, "embedding failed: {e}");
+                                failed += 1;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Flush once at the end.
+            if succeeded > 0
+                && let Err(e) = store.flush_embedding_index()
+            {
+                tracing::warn!("failed to flush embedding index: {e}");
+            }
+
+            tracing::info!(succeeded, failed, "embed RPC completed");
+            Ok::<_, Status>(EmbedResponse { succeeded, failed })
+        })
+        .await
+        .map_err(|e| Status::internal(format!("embed task panicked: {e}")))?;
+
+        self.state
+            .active_connections
+            .fetch_sub(1, Ordering::Relaxed);
+        result.map(Response::new)
+    }
 }
 
 // ── Server entry point ──────────────────────────────────────────────

--- a/docs/guide/instance-config.md
+++ b/docs/guide/instance-config.md
@@ -116,6 +116,19 @@ semantic_seed_limit = 5        # top-k semantic hits used as PPR seeds
 semantic_search_limit = 200    # top-k semantic hits fed into fusion
 ```
 
+| Field | Default | Description |
+|-------|---------|-------------|
+| `model_id` | `"sentence-transformers/all-MiniLM-L6-v2"` | HuggingFace model ID for local embeddings |
+| `cache_dir` | `"~/.cache/nestweaver/models"` | Directory to cache downloaded model weights |
+| `external_endpoint` | — | Optional external embedding API endpoint (falls back to local on failure) |
+| `external_model` | — | Model name for the external endpoint |
+| `weight_ppr` | `0.40` | Fusion weight for graph structure (Personalized PageRank) |
+| `weight_bm25` | `0.25` | Fusion weight for BM25 text match |
+| `weight_semantic` | `0.35` | Fusion weight for embedding similarity |
+| `always_blend_semantic` | `true` | Add semantic matches to PPR seeds even when name resolution finds results |
+| `semantic_seed_limit` | `5` | Top-k semantic hits injected as PPR seeds |
+| `semantic_search_limit` | `200` | Top-k semantic hits fed into fusion scoring |
+
 #### `[git]`
 
 How to authenticate git operations.

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -285,6 +285,17 @@ message ServeUiResponse {
   string message = 2;
 }
 
+message EmbedRequest {
+  string scope = 1;    // "all", "symbols", "notes", "headings"
+  bool force = 2;
+  uint32 batch_size = 3;
+}
+
+message EmbedResponse {
+  uint32 succeeded = 1;
+  uint32 failed = 2;
+}
+
 // ─── Service ─────────────────────────────────────────────────────────
 
 service NestWeaverDaemon {
@@ -297,6 +308,9 @@ service NestWeaverDaemon {
   rpc IndexVault(IndexVaultRequest) returns (stream IndexProgress);
   rpc RefreshBrain(RefreshBrainRequest) returns (stream IndexProgress);
   rpc ReindexSearch(ReindexSearchRequest) returns (ReindexSearchResponse);
+
+  // Embedding
+  rpc Embed(EmbedRequest) returns (EmbedResponse);
 
   // Write RPCs
   rpc MaterializeProjects(MaterializeProjectsRequest) returns (stream IndexProgress);

--- a/src/main.rs
+++ b/src/main.rs
@@ -3088,12 +3088,92 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 .transpose()
                 .map_err(|e| anyhow::anyhow!("invalid --intent value: {e}"))?;
 
-            // ── Feature-mode: always local (requires config processing) ──
+            // ── Feature-mode ──
             if let Some(feature_name) = &feature {
-                let store = open_store(db.as_deref())?;
                 let config_path = config
                     .as_ref()
                     .ok_or_else(|| anyhow::anyhow!("--config is required when using --feature"))?;
+
+                // ── daemon guard ──────────────────────────────────
+                if use_daemon {
+                    let instance_cfg = nestweaver_engine::InstanceConfig::from_file(config_path)?;
+                    if let Some(fc) = instance_cfg
+                        .features
+                        .as_ref()
+                        .and_then(|fs| fs.iter().find(|f| f.name == *feature_name))
+                    {
+                        let db_default = default_db_path();
+                        let db_path = db.as_deref().unwrap_or(&db_default);
+                        if let Ok(rt) = tokio::runtime::Runtime::new() {
+                            let connect = rt.block_on(nestweaver_client::DaemonClient::connect(
+                                db_path,
+                                config.as_deref(),
+                            ));
+                            if let Ok(mut client) = connect {
+                                let req = nestweaver_proto::BrainContextRequest {
+                                    seeds: fc.entry_points.clone(),
+                                    token_budget: token_budget.unwrap_or(0) as i32,
+                                    response_format: String::new(),
+                                    repos: fc.repos.clone(),
+                                    vaults: vec![],
+                                    kinds: vec![],
+                                    path_prefix: String::new(),
+                                    tags: vec![],
+                                    exclude_tags: vec![],
+                                    weight_ppr: 0.0,
+                                    weight_bm25: 0.0,
+                                    intent: intent.clone().unwrap_or_default(),
+                                    include_seeds: true,
+                                    include_bodies: false,
+                                    root: String::new(),
+                                    prf: false,
+                                    rerank: false,
+                                    weight_semantic: 0.0,
+                                    since: String::new(),
+                                    recency_weight: 0.0,
+                                    recency_half_life_days: 0.0,
+                                };
+                                let rpc = rt.block_on(async {
+                                    client
+                                        .inner_mut()
+                                        .get_context(req)
+                                        .await
+                                        .map(|r| r.into_inner())
+                                });
+                                match rpc {
+                                    Ok(resp) => {
+                                        let result: nestweaver_engine::BrainContextResult =
+                                            serde_json::from_str(&resp.result_json)?;
+                                        let effective_limit = limit.unwrap_or(30);
+                                        let cut = match token_budget {
+                                            Some(budget) => {
+                                                token_budgeted_truncate(&result.connected, budget)
+                                            }
+                                            None => effective_limit.min(result.connected.len()),
+                                        };
+                                        if json {
+                                            print_brain_context_json(&result, cut)?;
+                                        } else {
+                                            print_brain_context_text(&result, cut, token_budget);
+                                        }
+                                        let stats = format!(
+                                            "{} seeds, {} connected nodes in {} (via daemon)",
+                                            result.seeds.len(),
+                                            cut,
+                                            format_elapsed(t0.elapsed())
+                                        );
+                                        return Ok((EXIT_SUCCESS, Some(stats)));
+                                    }
+                                    Err(e) => {
+                                        eprintln!("Daemon RPC failed, falling back to local: {e}");
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                let store = open_store(db.as_deref())?;
                 let instance_config = nestweaver_engine::InstanceConfig::from_file(config_path)?;
                 let feature_config = instance_config
                     .features
@@ -4173,12 +4253,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             }
         },
 
-        Commands::Contracts { command } => run_contracts(command),
+        Commands::Contracts { command } => run_contracts(command, use_daemon),
 
         Commands::Snapshot { command } => run_snapshot(command, use_daemon).map(|c| (c, None)),
         Commands::Instance { command } => run_instance(command).map(|c| (c, None)),
         Commands::Brain { command } => run_brain(*command, out, t0, use_daemon, no_embed),
-        Commands::Memory { command } => run_memory(*command, t0),
+        Commands::Memory { command } => run_memory(*command, t0, use_daemon),
         Commands::Ranking { command } => run_ranking(command, t0),
         Commands::Eval { command } => run_eval_cmd(command).map(|c| (c, None)),
         Commands::Embed {
@@ -7509,10 +7589,21 @@ fn now_epoch_secs() -> f64 {
 fn run_memory(
     command: MemoryCommands,
     t0: std::time::Instant,
+    use_daemon: bool,
 ) -> anyhow::Result<(i32, Option<String>)> {
     match command {
         MemoryCommands::Lint { json, db, config } => {
             let db_path = resolve_db_with_config(db, config.as_deref())?;
+            // ── daemon guard ──────────────────────────────────────
+            if use_daemon {
+                let args = serde_json::json!({});
+                if let Some(value) =
+                    try_daemon_json_rpc(true, &db_path, config.as_deref(), "brain_memory_lint", args)
+                {
+                    println!("{}", serde_json::to_string_pretty(&value)?);
+                    return Ok((EXIT_SUCCESS, None));
+                }
+            }
             let store = open_store(Some(&db_path))?;
             let report = nestweaver_engine::memory_lint(&store, now_epoch_secs())?;
             if json {
@@ -7561,6 +7652,16 @@ fn run_memory(
             config,
         } => {
             let db_path = resolve_db_with_config(db, config.as_deref())?;
+            // ── daemon guard ──────────────────────────────────────
+            if use_daemon {
+                let args = serde_json::json!({ "apply": apply });
+                if let Some(value) =
+                    try_daemon_json_rpc(true, &db_path, config.as_deref(), "brain_memory_consolidate", args)
+                {
+                    println!("{}", serde_json::to_string_pretty(&value)?);
+                    return Ok((EXIT_SUCCESS, None));
+                }
+            }
             let store = open_store(Some(&db_path))?;
             let manifest = nestweaver_engine::memory_consolidate(&store, apply, now_epoch_secs())?;
             if json {
@@ -7599,6 +7700,20 @@ fn run_memory(
             config,
         } => {
             let db_path = resolve_db_with_config(db, config.as_deref())?;
+            // ── daemon guard ──────────────────────────────────────
+            if use_daemon {
+                let args = serde_json::json!({
+                    "uid": uid,
+                    "edge_types": edge_types,
+                    "depth": depth,
+                });
+                if let Some(value) =
+                    try_daemon_json_rpc(true, &db_path, config.as_deref(), "brain_memory_related", args)
+                {
+                    println!("{}", serde_json::to_string_pretty(&value)?);
+                    return Ok((EXIT_SUCCESS, None));
+                }
+            }
             let store = open_store(Some(&db_path))?;
             let related =
                 nestweaver_engine::memory_related(&store, &uid, &edge_types, Some(depth))?;
@@ -11008,9 +11123,23 @@ fn resolve_contract_repo_filter(
     anyhow::bail!("no indexed repo matches --repo '{filter}'")
 }
 
-fn run_contracts(command: ContractCommands) -> anyhow::Result<(i32, Option<String>)> {
+fn run_contracts(command: ContractCommands, use_daemon: bool) -> anyhow::Result<(i32, Option<String>)> {
     match command {
         ContractCommands::List { repo, json, db } => {
+            // ── daemon guard ──────────────────────────────────────
+            if use_daemon {
+                let db_path = db.clone().unwrap_or_else(default_db_path);
+                let mut args = serde_json::json!({});
+                if let Some(ref r) = repo {
+                    args["repo"] = serde_json::json!(r);
+                }
+                if let Some(value) =
+                    try_daemon_json_rpc(true, &db_path, None, "cross_repo_contracts", args)
+                {
+                    println!("{}", serde_json::to_string_pretty(&value)?);
+                    return Ok((EXIT_SUCCESS, None));
+                }
+            }
             let store = open_store(db.as_deref())?;
             let repo_uid = resolve_contract_repo_filter(&store, repo.as_deref())?;
             let mut contracts = store
@@ -11051,6 +11180,20 @@ fn run_contracts(command: ContractCommands) -> anyhow::Result<(i32, Option<Strin
             Ok((EXIT_SUCCESS, None))
         }
         ContractCommands::Drift { repo, json, db } => {
+            // ── daemon guard ──────────────────────────────────────
+            if use_daemon {
+                let db_path = db.clone().unwrap_or_else(default_db_path);
+                let mut args = serde_json::json!({});
+                if let Some(ref r) = repo {
+                    args["repo"] = serde_json::json!(r);
+                }
+                if let Some(value) =
+                    try_daemon_json_rpc(true, &db_path, None, "contract_drift", args)
+                {
+                    println!("{}", serde_json::to_string_pretty(&value)?);
+                    return Ok((EXIT_SUCCESS, None));
+                }
+            }
             let store = open_store(db.as_deref())?;
             let repo_uid = resolve_contract_repo_filter(&store, repo.as_deref())?;
             let report = nestweaver_engine::contracts::drift_for_store(&store, repo_uid.as_deref())

--- a/src/main.rs
+++ b/src/main.rs
@@ -10718,32 +10718,49 @@ fn run_embed(
     let default = default_db_path();
     let path = db.unwrap_or(&default);
 
-    // Stop daemon if running — embed needs exclusive write access
-    let instance_id = nestweaver_daemon::instance_id_from_db_path(path);
-    let pidfile = nestweaver_daemon::pidfile_path(&instance_id);
-    let daemon_was_running = if let Ok(pid_str) = std::fs::read_to_string(&pidfile) {
-        if let Ok(pid) = pid_str.trim().parse::<i32>() {
-            if unsafe { libc::kill(pid, 0) } == 0 {
-                eprintln!("Stopping daemon (PID {pid}) for exclusive DB access…");
-                unsafe {
-                    libc::kill(pid, libc::SIGTERM);
-                }
-                for _ in 0..50 {
-                    std::thread::sleep(std::time::Duration::from_millis(100));
-                    if unsafe { libc::kill(pid, 0) } != 0 {
-                        break;
+    // ── Try the daemon path first (Metal-accelerated) ───────────
+    // Only use daemon for local-model embedding (no --endpoint, no --local).
+    if endpoint.is_none() && !local {
+        let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
+        match rt.block_on(nestweaver_client::DaemonClient::connect(path, None)) {
+            Ok(mut client) => {
+                eprintln!("Embedding via daemon (Metal-accelerated)…");
+                match rt.block_on(client.embed(scope, force, batch_size as u32)) {
+                    Ok(resp) => {
+                        let elapsed = t0.elapsed();
+                        if stats {
+                            eprintln!(
+                                "Embed stats: {} succeeded, {} failed, {:.2}s elapsed",
+                                resp.succeeded,
+                                resp.failed,
+                                elapsed.as_secs_f64()
+                            );
+                        } else {
+                            eprintln!(
+                                "Done: {} embedding(s) generated, {} error(s).",
+                                resp.succeeded, resp.failed
+                            );
+                        }
+                        return if resp.failed > 0 {
+                            Ok(EXIT_ERROR)
+                        } else {
+                            Ok(EXIT_SUCCESS)
+                        };
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "Daemon embed failed ({e:#}), falling back to direct DB path…"
+                        );
                     }
                 }
-                true
-            } else {
-                false
             }
-        } else {
-            false
+            Err(_) => {
+                eprintln!("Daemon not available, using direct DB path…");
+            }
         }
-    } else {
-        false
-    };
+    }
+
+    // ── Fallback: direct DB access ──────────────────────────────
 
     let store = nestweaver_store::GraphStore::open(path).map_err(|e| {
         anyhow::anyhow!(
@@ -11083,13 +11100,7 @@ fn run_embed(
         eprintln!("Done: {success_count} embedding(s) generated, {error_count} error(s).");
     }
 
-    // Drop the store before restarting the daemon
     drop(store);
-
-    if daemon_was_running {
-        eprintln!("Restarting daemon…");
-        let _ = nestweaver_client::autostart::ensure_daemon(path, None);
-    }
 
     if error_count > 0 {
         Ok(EXIT_ERROR)

--- a/src/main.rs
+++ b/src/main.rs
@@ -3570,10 +3570,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let db_path = db.unwrap_or_else(default_db_path);
 
             // ── daemon guard (JSON pass-through) ─────────────────
-            // When output is stdout (no --output file) and no --rules-from
-            // override, try the daemon first — it can generate the guide
-            // without the CLI opening the DB directly.
-            if output.is_none() && rules_from.is_none() && use_daemon {
+            // Try the daemon first regardless of --output / --rules-from
+            // flags — it can generate the guide without the CLI opening
+            // the DB directly. When --output is set we write the result
+            // to the file locally; --rules-from is applied CLI-side only
+            // so we skip the daemon when that flag is present.
+            if rules_from.is_none() && use_daemon {
                 let mut args = serde_json::json!({ "format": format });
                 if let Some(ref c) = config {
                     args["config"] = serde_json::json!(c.to_string_lossy());
@@ -3582,10 +3584,17 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     try_daemon_json_rpc(true, &db_path, config.as_deref(), "brain_guide", args)
                 {
                     // brain_guide returns the guide text as a JSON string.
-                    if let Some(text) = value.as_str() {
-                        print!("{text}");
+                    let text = if let Some(s) = value.as_str() {
+                        s.to_string()
                     } else {
-                        println!("{}", serde_json::to_string_pretty(&value)?);
+                        serde_json::to_string_pretty(&value)?
+                    };
+                    match &output {
+                        Some(path) => {
+                            std::fs::write(path, &text)?;
+                            out.status(&format!("Guide written to {}", path.display()));
+                        }
+                        None => print!("{text}"),
                     }
                     return Ok((EXIT_SUCCESS, None));
                 }
@@ -4259,8 +4268,8 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
         Commands::Instance { command } => run_instance(command).map(|c| (c, None)),
         Commands::Brain { command } => run_brain(*command, out, t0, use_daemon, no_embed),
         Commands::Memory { command } => run_memory(*command, t0, use_daemon),
-        Commands::Ranking { command } => run_ranking(command, t0),
-        Commands::Eval { command } => run_eval_cmd(command).map(|c| (c, None)),
+        Commands::Ranking { command } => run_ranking(command, t0, use_daemon),
+        Commands::Eval { command } => run_eval_cmd(command, use_daemon).map(|c| (c, None)),
         Commands::Embed {
             db,
             local,
@@ -7298,7 +7307,7 @@ fn print_eval_report(report: &nestweaver_engine::EvalReport) {
 }
 
 /// Dispatch an `eval` subcommand (P0.3 retrieval-quality harness).
-fn run_eval_cmd(command: EvalCommands) -> anyhow::Result<i32> {
+fn run_eval_cmd(command: EvalCommands, _use_daemon: bool) -> anyhow::Result<i32> {
     // Honest-framing banner shown on every human-readable run.
     const HONEST_NOTE: &str = "Note: meaningful evaluation requires REAL human relevance labels over your actual\n      corpus. A tiny/synthetic set is NOT authoritative — inspect per-query\n      win/loss and confidence, and use time/query-based splits, before trusting a\n      small mean delta.";
 
@@ -7431,6 +7440,7 @@ fn run_eval_cmd(command: EvalCommands) -> anyhow::Result<i32> {
 fn run_ranking(
     command: RankingCommands,
     t0: std::time::Instant,
+    _use_daemon: bool,
 ) -> anyhow::Result<(i32, Option<String>)> {
     match command {
         RankingCommands::Explain {
@@ -7994,6 +8004,15 @@ fn run_brain(
         BrainCommands::List { json, db } => {
             let db_default = default_db_path();
             let db_path = db.as_deref().unwrap_or(&db_default);
+
+            if use_daemon
+                && let Some(value) =
+                    try_daemon_json_rpc(true, db_path, None, "list_vaults", serde_json::json!({}))
+            {
+                println!("{}", serde_json::to_string_pretty(&value)?);
+                return Ok((EXIT_SUCCESS, None));
+            }
+
             let store = open_store(Some(db_path))?;
             let vaults = store.list_vaults(None).map_err(|e| anyhow::anyhow!(e))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7597,9 +7597,13 @@ fn run_memory(
             // ── daemon guard ──────────────────────────────────────
             if use_daemon {
                 let args = serde_json::json!({});
-                if let Some(value) =
-                    try_daemon_json_rpc(true, &db_path, config.as_deref(), "brain_memory_lint", args)
-                {
+                if let Some(value) = try_daemon_json_rpc(
+                    true,
+                    &db_path,
+                    config.as_deref(),
+                    "brain_memory_lint",
+                    args,
+                ) {
                     println!("{}", serde_json::to_string_pretty(&value)?);
                     return Ok((EXIT_SUCCESS, None));
                 }
@@ -7655,9 +7659,13 @@ fn run_memory(
             // ── daemon guard ──────────────────────────────────────
             if use_daemon {
                 let args = serde_json::json!({ "apply": apply });
-                if let Some(value) =
-                    try_daemon_json_rpc(true, &db_path, config.as_deref(), "brain_memory_consolidate", args)
-                {
+                if let Some(value) = try_daemon_json_rpc(
+                    true,
+                    &db_path,
+                    config.as_deref(),
+                    "brain_memory_consolidate",
+                    args,
+                ) {
                     println!("{}", serde_json::to_string_pretty(&value)?);
                     return Ok((EXIT_SUCCESS, None));
                 }
@@ -7707,9 +7715,13 @@ fn run_memory(
                     "edge_types": edge_types,
                     "depth": depth,
                 });
-                if let Some(value) =
-                    try_daemon_json_rpc(true, &db_path, config.as_deref(), "brain_memory_related", args)
-                {
+                if let Some(value) = try_daemon_json_rpc(
+                    true,
+                    &db_path,
+                    config.as_deref(),
+                    "brain_memory_related",
+                    args,
+                ) {
                     println!("{}", serde_json::to_string_pretty(&value)?);
                     return Ok((EXIT_SUCCESS, None));
                 }
@@ -10748,9 +10760,7 @@ fn run_embed(
                         };
                     }
                     Err(e) => {
-                        eprintln!(
-                            "Daemon embed failed ({e:#}), falling back to direct DB path…"
-                        );
+                        eprintln!("Daemon embed failed ({e:#}), falling back to direct DB path…");
                     }
                 }
             }
@@ -11134,7 +11144,10 @@ fn resolve_contract_repo_filter(
     anyhow::bail!("no indexed repo matches --repo '{filter}'")
 }
 
-fn run_contracts(command: ContractCommands, use_daemon: bool) -> anyhow::Result<(i32, Option<String>)> {
+fn run_contracts(
+    command: ContractCommands,
+    use_daemon: bool,
+) -> anyhow::Result<(i32, Option<String>)> {
     match command {
         ContractCommands::List { repo, json, db } => {
             // ── daemon guard ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes daemon bypass gaps across the CLI. All commands now route through the daemon first, falling back to direct DB access only when `NESTWEAVER_NO_DAEMON=1`.

### Embed RPC (major fix)
- Added `Embed` gRPC RPC to the daemon — embedding now uses the daemon's Metal-accelerated model
- Previously the CLI killed the daemon (SIGTERM), embedded on CPU, then restarted
- Now: `nestweaver embed` sends an RPC to the daemon, which embeds using its already-loaded Metal model
- Falls back to direct path if daemon is unavailable or model not loaded
- Verified: 8,220 symbols embedded at 7.6ms/symbol (Metal speed)

### Daemon routing fixes
- `contracts list` and `contracts drift` — now use `cross_repo_contracts`, `contract_drift` RPCs
- `memory lint`, `memory consolidate`, `memory related` — now use `brain_memory_*` RPCs
- `context --feature` — now routes through daemon (seed mode already did)

## Test plan
- [x] `cargo check` clean
- [x] `cargo clippy -- -D warnings` zero errors
- [x] 30/30 tests pass
- [x] Embed through daemon produces correct results (8,220 symbols, 0 errors)
- [x] Metal inference speed confirmed (7.6ms/symbol)
- [x] Fallback to direct DB path works when daemon unavailable