### PR TITLE
fix: snapshot stamp.json bugs + materialize broken-pipe + release checksums

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
+  attestations: write
 
 jobs:
   release-please:
@@ -77,8 +79,16 @@ jobs:
           ARCHIVE="nestweaver-${{ needs.release-please.outputs.tag_name }}-${{ matrix.target }}.tar.gz"
           tar czf "$ARCHIVE" -C "target/${{ matrix.target }}/release" nestweaver
           echo "ARCHIVE=$ARCHIVE" >> $GITHUB_ENV
+      - name: Generate SHA-256 checksum
+        run: shasum -a 256 "$ARCHIVE" > "$ARCHIVE.sha256"
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ env.ARCHIVE }}
       - name: Upload release artifact
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
-          files: ${{ env.ARCHIVE }}
+          files: |
+            ${{ env.ARCHIVE }}
+            ${{ env.ARCHIVE }}.sha256

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -6,7 +6,7 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use anyhow::Context;
@@ -20,6 +20,20 @@ use crate::lifecycle;
 
 // ── State ───────────────────────────────────────────────────────────
 
+/// Re-read the DB file's mtime and store it in `state.db_opened_at`.
+/// Called after any write RPC so the next `DaemonClient::connect()` health
+/// check sees the current mtime and doesn't falsely conclude the DB was
+/// rebuilt externally.
+fn refresh_db_opened_at(state: &DaemonState) {
+    let mtime = std::fs::metadata(&state.db_path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    state.db_opened_at.store(mtime, Ordering::Relaxed);
+}
+
 /// Shared state held by the daemon process.
 pub struct DaemonState {
     pub store: Arc<GraphStore>,      // Read-write (for write RPCs only)
@@ -28,7 +42,7 @@ pub struct DaemonState {
     pub db_path: PathBuf,
     pub instance_id: String,
     pub start_time: Instant,
-    pub db_opened_at: u64,
+    pub db_opened_at: AtomicU64,
     pub active_connections: AtomicU32,
     pub idle_notify: Arc<Notify>,
     pub shutdown_tx: tokio::sync::watch::Sender<bool>,
@@ -349,7 +363,7 @@ impl NestWeaverDaemon for DaemonService {
             db_path: self.state.db_path.display().to_string(),
             uptime_seconds: uptime,
             active_connections: active,
-            db_opened_at: self.state.db_opened_at,
+            db_opened_at: self.state.db_opened_at.load(Ordering::Relaxed),
         }))
     }
 
@@ -2750,7 +2764,7 @@ pub async fn run_server(
         db_path: db_path.clone(),
         instance_id: instance_id.clone(),
         start_time: Instant::now(),
-        db_opened_at,
+        db_opened_at: AtomicU64::new(db_opened_at),
         active_connections: AtomicU32::new(0),
         idle_notify: idle_notify.clone(),
         shutdown_tx: shutdown_tx.clone(),

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -2622,6 +2622,7 @@ impl NestWeaverDaemon for DaemonService {
             .await
             .map_err(|e| Status::internal(format!("embed task panicked: {e}")))?;
 
+            refresh_db_opened_at(&self.state);
             self.state
                 .active_connections
                 .fetch_sub(1, Ordering::Relaxed);

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -30,7 +30,10 @@ fn refresh_db_opened_at(state: &DaemonState) {
         .ok()
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
         .map(|d| d.as_secs())
-        .unwrap_or(0);
+        .unwrap_or_else(|| {
+            tracing::warn!(path = %state.db_path.display(), "failed to stat DB — stale-detection disabled until next write");
+            0
+        });
     state.db_opened_at.store(mtime, Ordering::Relaxed);
 }
 

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -478,6 +478,7 @@ impl NestWeaverDaemon for DaemonService {
                 Err(_) => tracing::error!("watcher thread panicked"),
             }
 
+            refresh_db_opened_at(&state);
             state.active_connections.fetch_sub(1, Ordering::Relaxed);
             if let Ok(mut guard) = state.watcher_stop.lock() {
                 *guard = None;
@@ -558,6 +559,7 @@ impl NestWeaverDaemon for DaemonService {
                 Err(_) => tracing::error!("code watcher thread panicked"),
             }
 
+            refresh_db_opened_at(&state);
             state.active_connections.fetch_sub(1, Ordering::Relaxed);
             if let Ok(mut guard) = state.watcher_stop.lock() {
                 *guard = None;
@@ -929,6 +931,8 @@ impl NestWeaverDaemon for DaemonService {
                     }));
                 }
             }
+
+            refresh_db_opened_at(&state);
         });
 
         Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
@@ -1028,6 +1032,8 @@ impl NestWeaverDaemon for DaemonService {
                     }));
                 }
             }
+
+            refresh_db_opened_at(&state);
         });
 
         Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
@@ -1121,6 +1127,7 @@ impl NestWeaverDaemon for DaemonService {
                 }
             }
 
+            refresh_db_opened_at(&state);
             state.active_connections.fetch_sub(1, Ordering::Relaxed);
         });
 
@@ -1166,6 +1173,7 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
 
+        refresh_db_opened_at(&self.state);
         self.state
             .active_connections
             .fetch_sub(1, Ordering::Relaxed);
@@ -1222,6 +1230,7 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
 
+        refresh_db_opened_at(&self.state);
         self.state
             .active_connections
             .fetch_sub(1, Ordering::Relaxed);
@@ -1268,6 +1277,7 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
 
+        refresh_db_opened_at(&self.state);
         self.state
             .active_connections
             .fetch_sub(1, Ordering::Relaxed);
@@ -1358,6 +1368,7 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
 
+        refresh_db_opened_at(&self.state);
         self.state
             .active_connections
             .fetch_sub(1, Ordering::Relaxed);
@@ -1399,6 +1410,7 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
 
+        refresh_db_opened_at(&self.state);
         self.state
             .active_connections
             .fetch_sub(1, Ordering::Relaxed);
@@ -1475,6 +1487,7 @@ impl NestWeaverDaemon for DaemonService {
                 }
             }
 
+            refresh_db_opened_at(&state);
             state.active_connections.fetch_sub(1, Ordering::Relaxed);
         });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11528,9 +11528,12 @@ fn run_snapshot(command: SnapshotCommands, use_daemon: bool) -> anyhow::Result<i
                     serde_json::from_value(value)
                         .context("failed to deserialize repos from daemon response")?
                 } else {
+                    // No daemon: read directly from the store. The CLI `index` command
+                    // stores repos with instance_id = "default", not the hash-based id
+                    // used by the daemon, so pass None to return all repos.
                     let store = GraphStore::open_read_only(&db_path)
                         .map_err(|e| anyhow::anyhow!("failed to open database: {e}"))?;
-                    nestweaver_engine::list_repos(&store, Some(&instance_id))?
+                    nestweaver_engine::list_repos(&store, None)?
                 }
             };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11512,10 +11512,11 @@ fn run_snapshot(command: SnapshotCommands, use_daemon: bool) -> anyhow::Result<i
             // Load instance config if provided
             let cfg = load_instance_config_opt(config.as_deref());
 
-            // Resolve instance ID
-            let instance_id = instance
-                .or_else(|| cfg.as_ref().map(|c| c.instance_id.clone()))
-                .unwrap_or_else(|| "standalone".to_string());
+            // Resolve instance ID using the same hash-based algorithm the daemon uses,
+            // so the filter matches how repos are actually stored.
+            let instance_id = instance.unwrap_or_else(|| {
+                nestweaver_daemon::lifecycle::instance_id_from_db_path(&db_path)
+            });
 
             // Fetch repos via daemon RPC (preferred) or direct store open (fallback).
             let repos: Vec<nestweaver_schema::Repo> = {
@@ -11524,7 +11525,8 @@ fn run_snapshot(command: SnapshotCommands, use_daemon: bool) -> anyhow::Result<i
                 if let Some(value) =
                     try_daemon_json_rpc(use_daemon, &db_path, config.as_deref(), "list_repos", args)
                 {
-                    serde_json::from_value(value).unwrap_or_default()
+                    serde_json::from_value(value)
+                        .context("failed to deserialize repos from daemon response")?
                 } else {
                     let store = GraphStore::open_read_only(&db_path)
                         .map_err(|e| anyhow::anyhow!("failed to open database: {e}"))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11579,10 +11579,11 @@ fn run_snapshot(command: SnapshotCommands, use_daemon: bool) -> anyhow::Result<i
             };
             let effective_hash = nestweaver_schema::effective_schema_hash(&core_hash, &ext_hash);
 
-            // Embedding info
+            // Embedding info — use [embedding].model_id (local sentence-transformer),
+            // not [inference].embedding_model (remote Ollama model name).
             let embedding_model_id = cfg
                 .as_ref()
-                .map(|c| c.inference.embedding_model.clone())
+                .map(|c| c.embedding.model_id.clone())
                 .unwrap_or_else(|| "unknown".to_string());
 
             // Timestamp (RFC3339 UTC)

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -883,3 +883,140 @@ fn daemon_status_accepts_db_after_subcommand() {
         "daemon status should accept --db after subcommand, got: {stderr}"
     );
 }
+
+#[test]
+fn cli_snapshot_stamp_has_repos_and_correct_embedding_model() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_dir = dir.path().join("repo");
+    let db_path = dir.path().join("test.lbug");
+    let snapshot_dir = dir.path().join("snapshot-out");
+    std::fs::create_dir_all(&repo_dir).unwrap();
+
+    // Create a minimal git repo
+    StdCommand::new("git")
+        .args(["init"])
+        .current_dir(&repo_dir)
+        .output()
+        .unwrap();
+    StdCommand::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(&repo_dir)
+        .output()
+        .unwrap();
+    StdCommand::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(&repo_dir)
+        .output()
+        .unwrap();
+    std::fs::write(
+        repo_dir.join("main.js"),
+        "function greet(name) { return name; }",
+    )
+    .unwrap();
+    StdCommand::new("git")
+        .args(["add", "."])
+        .current_dir(&repo_dir)
+        .output()
+        .unwrap();
+    StdCommand::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(&repo_dir)
+        .output()
+        .unwrap();
+
+    // Index
+    nestweaver_cmd()
+        .args([
+            "index",
+            "--repo",
+            &repo_dir.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .assert()
+        .success();
+
+    // Write a config file with a known embedding model_id
+    let config_path = dir.path().join("instance.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"
+instance_id = "test-instance"
+repos = []
+
+[snapshot_storage]
+backend = "local"
+path = "{storage}"
+
+[workspace]
+backend = "local"
+path = "{workspace}"
+
+[inference]
+endpoint = "http://localhost:11434"
+embedding_model = "nomic-embed-text"
+summary_model = "qwen2.5-coder:7b"
+
+[git]
+credential_method = "gh"
+
+[embedding]
+model_id = "sentence-transformers/all-MiniLM-L6-v2"
+"#,
+            storage = dir.path().join("storage").display(),
+            workspace = dir.path().join("workspace").display(),
+        ),
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.path().join("storage")).unwrap();
+    std::fs::create_dir_all(dir.path().join("workspace")).unwrap();
+
+    // Build snapshot with --config so embedding_model_id is populated
+    nestweaver_cmd()
+        .args([
+            "snapshot",
+            "build",
+            "--db",
+            &db_path.display().to_string(),
+            "--config",
+            &config_path.display().to_string(),
+            "--output",
+            &snapshot_dir.display().to_string(),
+        ])
+        .assert()
+        .success();
+
+    // Parse stamp.json and verify
+    let stamp_json = std::fs::read_to_string(snapshot_dir.join("stamp.json"))
+        .expect("stamp.json should exist");
+    let stamp: serde_json::Value =
+        serde_json::from_str(&stamp_json).expect("stamp.json should be valid JSON");
+
+    // Bug 1a: repos should NOT be empty — we indexed one repo
+    let repos = stamp["repos"].as_array().expect("repos should be an array");
+    assert!(
+        !repos.is_empty(),
+        "stamp.json repos should not be empty after indexing a repo"
+    );
+
+    // The repo URL should match the repo we indexed
+    let repo_url = repos[0]["url"].as_str().unwrap();
+    assert!(
+        repo_url.contains("repo"),
+        "repo URL '{repo_url}' should reference the indexed repo"
+    );
+
+    // Bug 1b: embedding_model_id should come from [embedding], not [inference]
+    let model_id = stamp["embedding_model_id"]
+        .as_str()
+        .expect("embedding_model_id should be a string");
+    assert_eq!(
+        model_id, "sentence-transformers/all-MiniLM-L6-v2",
+        "embedding_model_id should come from [embedding].model_id, not [inference].embedding_model"
+    );
+    assert_ne!(
+        model_id, "nomic-embed-text",
+        "embedding_model_id should NOT be the inference model"
+    );
+}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -988,8 +988,8 @@ model_id = "sentence-transformers/all-MiniLM-L6-v2"
         .success();
 
     // Parse stamp.json and verify
-    let stamp_json = std::fs::read_to_string(snapshot_dir.join("stamp.json"))
-        .expect("stamp.json should exist");
+    let stamp_json =
+        std::fs::read_to_string(snapshot_dir.join("stamp.json")).expect("stamp.json should exist");
     let stamp: serde_json::Value =
         serde_json::from_str(&stamp_json).expect("stamp.json should be valid JSON");
 

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -442,3 +442,89 @@ fn daemon_mcp_brain_add_source() {
         "brain_status should show indexed notes after brain_add_source; got: {result_str}"
     );
 }
+
+#[test]
+fn daemon_materialize_twice_no_broken_pipe() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_dir = dir.path().join("repo");
+    let vault_dir = dir.path().join("vault");
+    let db_path = dir.path().join("test.lbug");
+
+    write_test_repo(&repo_dir);
+    write_test_vault(&vault_dir);
+
+    // Index repo to create the DB (no-daemon path).
+    create_db(&repo_dir, &db_path);
+
+    // Write a minimal instance config with a project.
+    let config_path = dir.path().join("instance.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"
+instance_id = "test-instance"
+
+[snapshot_storage]
+backend = "local"
+path = "{storage}"
+
+[workspace]
+backend = "local"
+path = "{workspace}"
+
+[inference]
+endpoint = "http://localhost:11434"
+embedding_model = "nomic-embed-text"
+summary_model = "qwen2.5-coder:7b"
+
+[git]
+credential_method = "gh"
+
+[[repos]]
+url = "file://{repo}"
+name = "repo"
+
+[[projects]]
+name = "test-project"
+description = "A test project"
+repos = ["repo"]
+"#,
+            storage = dir.path().join("storage").display(),
+            workspace = dir.path().join("workspace").display(),
+            repo = repo_dir.display(),
+        ),
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.path().join("storage")).unwrap();
+    std::fs::create_dir_all(dir.path().join("workspace")).unwrap();
+
+    let _guard = DaemonGuard::new(&db_path);
+
+    // First materialize — should succeed and start the daemon.
+    daemon_cmd()
+        .args([
+            "materialize-projects",
+            "--config",
+            &config_path.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .assert()
+        .success();
+
+    // Brief pause to let the file mtime settle (filesystem resolution).
+    std::thread::sleep(Duration::from_millis(200));
+
+    // Second materialize — previously triggered h2 broken-pipe because
+    // the daemon's db_opened_at was stale after the first write.
+    daemon_cmd()
+        .args([
+            "materialize-projects",
+            "--config",
+            &config_path.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .assert()
+        .success();
+}


### PR DESCRIPTION
## Summary

- **Snapshot `repos: []`** — the snapshot builder filtered repos by the config's `instance_id` (e.g. `"kory-brain"`), but the daemon stores repos under a hash-based id (e.g. `"051a9ff9"`). Now uses `instance_id_from_db_path()` to match. Also passes `None` in the no-daemon fallback to avoid the same mismatch.
- **Snapshot `embedding_model_id` wrong** — read from `[inference].embedding_model` (remote Ollama model) instead of `[embedding].model_id` (local sentence-transformer). One-line fix.
- **h2 broken-pipe on double `materialize-projects`** — `db_opened_at` was a plain `u64` set once at daemon startup. After any write RPC bumped the DB file mtime, the next client connection falsely detected a "rebuilt DB" and killed the daemon. Now an `AtomicU64` refreshed after every write RPC.
- **Release checksums + attestations** — each release artifact now ships with a `.sha256` sidecar and a signed SLSA provenance statement via `actions/attest-build-provenance`.

## Test plan

- [x] `cargo test --test cli_test` — 25/25 pass (includes new `cli_snapshot_stamp_has_repos_and_correct_embedding_model`)
- [x] `cargo test --test daemon_test -- --test-threads=1` — 7/7 pass (includes new `daemon_materialize_twice_no_broken_pipe`)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Manual smoke test: `snapshot build` against real 68-repo brain DB → repos=68, embedding_model_id=`sentence-transformers/all-MiniLM-L6-v2`