### PR TITLE
refactor: replace mtime stale-detection with version-check + drain shutdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,11 @@ cargo fmt --all                                             # format in place
 All CLI commands and MCP tool calls route through a background daemon process
 that owns the LadybugDB write lock. The daemon auto-starts on the first CLI
 invocation and self-terminates after an idle timeout. The client auto-restarts
-the daemon on version mismatch or when it detects the database has been rebuilt
-(DB mtime check).
+the daemon on version mismatch. Shutdown is graceful: the daemon drains active
+write RPCs before exiting (up to `NESTWEAVER_DRAIN_TIMEOUT_SECS`, default 660s).
 
-**Never bypass the daemon in normal use.** The `--no-daemon` flag and
+**The daemon is the sole writer to the DB file.** Never run `sqlite3` or other
+tools against the DB while the daemon is running. The `--no-daemon` flag and
 `NESTWEAVER_NO_DAEMON=1` env var exist only for CI/testing. Bypassing the
 daemon risks WAL corruption from concurrent access. If you see "database
 locked" errors, stop the daemon (`nestweaver daemon stop`) rather than using

--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -25,8 +25,8 @@ impl DaemonClient {
     /// Connect to the daemon for the given database, auto-starting if needed.
     ///
     /// After connecting, performs a version check. If the running daemon's
-    /// version doesn't match this binary's version, it stops the old daemon
-    /// and restarts with the current binary.
+    /// version doesn't match this binary's version, it asks the daemon to
+    /// gracefully drain active writes and shut down, then restarts.
     pub async fn connect(db_path: &Path, config_path: Option<&Path>) -> Result<Self> {
         let sock_path = autostart::ensure_daemon(db_path, config_path)?;
         let mut client = Self::connect_to_socket(&sock_path).await?;
@@ -40,38 +40,21 @@ impl DaemonClient {
             .into_inner();
 
         let our_version = env!("CARGO_PKG_VERSION");
-        let needs_restart = if resp.version != our_version {
+        if resp.version != our_version {
             warn!(
                 daemon_version = %resp.version,
                 client_version = %our_version,
-                "version mismatch — restarting daemon"
+                "version mismatch — requesting graceful daemon restart"
             );
-            true
-        } else if resp.db_opened_at > 0 {
-            // Check if the DB file has been replaced since the daemon opened it.
-            let current_mtime = std::fs::metadata(db_path)
-                .and_then(|m| m.modified())
-                .ok()
-                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|d| d.as_secs())
-                .unwrap_or(0);
-            if current_mtime > resp.db_opened_at {
-                warn!(
-                    daemon_db_mtime = resp.db_opened_at,
-                    current_db_mtime = current_mtime,
-                    "database rebuilt since daemon started — restarting daemon"
-                );
-                true
-            } else {
-                false
-            }
-        } else {
-            false
-        };
 
-        if needs_restart {
-            // Stop the old daemon.
-            Self::stop_old_daemon(db_path)?;
+            // Ask the daemon to drain active writes and shut down.
+            let _ = client
+                .inner
+                .shutdown(nestweaver_proto::ShutdownRequest {})
+                .await;
+
+            // Wait for the daemon process to exit.
+            Self::wait_for_exit(db_path)?;
 
             // Re-start and reconnect.
             let sock_path = autostart::ensure_daemon(db_path, config_path)?;
@@ -106,34 +89,39 @@ impl DaemonClient {
         })
     }
 
-    /// Stop an old daemon by sending SIGTERM to its PID.
-    fn stop_old_daemon(db_path: &Path) -> Result<()> {
+    /// Wait for the daemon to exit after a Shutdown RPC was sent.
+    /// Falls back to SIGKILL after the drain ceiling + buffer.
+    fn wait_for_exit(db_path: &Path) -> Result<()> {
         let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
         let pidfile = nestweaver_daemon::lifecycle::pidfile_path(&instance_id);
 
-        if let Some(pid) = autostart::read_pid(&pidfile)
-            && autostart::is_process_alive(pid)
-        {
-            info!(pid, "sending SIGTERM to old daemon");
-            unsafe { libc::kill(pid, libc::SIGTERM) };
+        let ceiling = std::env::var("NESTWEAVER_DRAIN_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(660);
 
-            // Poll for exit with 5s timeout, then SIGKILL.
-            let start = std::time::Instant::now();
-            while start.elapsed() < std::time::Duration::from_secs(5) {
-                if !autostart::is_process_alive(pid) {
-                    break;
+        let start = std::time::Instant::now();
+        let timeout = std::time::Duration::from_secs(ceiling + 5);
+
+        while start.elapsed() < timeout {
+            match autostart::read_pid(&pidfile) {
+                Some(pid) if autostart::is_process_alive(pid) => {
+                    std::thread::sleep(std::time::Duration::from_millis(200));
                 }
-                std::thread::sleep(std::time::Duration::from_millis(100));
+                _ => break,
             }
+        }
 
+        // If still alive after ceiling + buffer, force kill.
+        if let Some(pid) = autostart::read_pid(&pidfile) {
             if autostart::is_process_alive(pid) {
-                warn!(pid, "daemon did not exit after SIGTERM, sending SIGKILL");
+                warn!(pid, ceiling, "daemon did not exit after drain timeout — sending SIGKILL");
                 unsafe { libc::kill(pid, libc::SIGKILL) };
                 std::thread::sleep(std::time::Duration::from_millis(500));
             }
         }
 
-        // Clean up stale socket.
+        // Clean up socket.
         let sock = nestweaver_daemon::lifecycle::socket_path(&instance_id);
         if sock.exists() {
             let _ = std::fs::remove_file(&sock);

--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -113,12 +113,15 @@ impl DaemonClient {
         }
 
         // If still alive after ceiling + buffer, force kill.
-        if let Some(pid) = autostart::read_pid(&pidfile) {
-            if autostart::is_process_alive(pid) {
-                warn!(pid, ceiling, "daemon did not exit after drain timeout — sending SIGKILL");
-                unsafe { libc::kill(pid, libc::SIGKILL) };
-                std::thread::sleep(std::time::Duration::from_millis(500));
-            }
+        if let Some(pid) = autostart::read_pid(&pidfile)
+            && autostart::is_process_alive(pid)
+        {
+            warn!(
+                pid,
+                ceiling, "daemon did not exit after drain timeout — sending SIGKILL"
+            );
+            unsafe { libc::kill(pid, libc::SIGKILL) };
+            std::thread::sleep(std::time::Duration::from_millis(500));
         }
 
         // Clean up socket.

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -363,6 +363,7 @@ impl NestWeaverDaemon for DaemonService {
             db_path: self.state.db_path.display().to_string(),
             uptime_seconds: uptime,
             active_connections: active,
+            db_opened_at: 0,
         }))
     }
 
@@ -370,9 +371,8 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         _request: Request<ShutdownRequest>,
     ) -> Result<Response<ShutdownResponse>, Status> {
-        tracing::info!("shutdown requested via gRPC");
+        tracing::info!("shutdown requested via gRPC — draining active writes");
 
-        // Stop the file watcher if one is running.
         if let Ok(mut guard) = self.state.watcher_stop.lock()
             && let Some(handle) = guard.take()
         {
@@ -380,11 +380,51 @@ impl NestWeaverDaemon for DaemonService {
             handle.stop();
         }
 
-        let tx = self.state.shutdown_tx.clone();
+        let state = self.state.clone();
         tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            let _ = tx.send(true);
+            let ceiling = std::env::var("NESTWEAVER_DRAIN_TIMEOUT_SECS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(660);
+
+            let timeout = std::time::Duration::from_secs(ceiling);
+            let half = std::time::Duration::from_secs(ceiling / 2);
+            let ninety = std::time::Duration::from_secs(ceiling * 9 / 10);
+            let start = tokio::time::Instant::now();
+            let mut warned_half = false;
+            let mut warned_ninety = false;
+
+            loop {
+                let writes = state.active_writes.load(Ordering::Relaxed);
+                if writes == 0 {
+                    tracing::info!("no active writes — shutting down");
+                    break;
+                }
+
+                let elapsed = start.elapsed();
+                if elapsed >= timeout {
+                    tracing::warn!(
+                        active_writes = writes,
+                        "drain timeout ({ceiling}s) reached — forcing shutdown"
+                    );
+                    break;
+                }
+
+                if !warned_half && elapsed >= half {
+                    tracing::warn!(active_writes = writes, "drain at 50% of timeout ({ceiling}s)");
+                    warned_half = true;
+                }
+                if !warned_ninety && elapsed >= ninety {
+                    tracing::warn!(active_writes = writes, "drain at 90% of timeout ({ceiling}s)");
+                    warned_ninety = true;
+                }
+
+                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            }
+
+            let _ = state.shutdown_tx.send(true);
         });
+
         Ok(Response::new(ShutdownResponse { ok: true }))
     }
 

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -31,13 +31,17 @@ impl ConnectionGuard {
     fn read(state: &DaemonState) -> Self {
         state.active_reads.fetch_add(1, Ordering::Relaxed);
         state.idle_notify.notify_one();
-        Self { counter: Arc::clone(&state.active_reads) }
+        Self {
+            counter: Arc::clone(&state.active_reads),
+        }
     }
 
     fn write(state: &DaemonState) -> Self {
         state.active_writes.fetch_add(1, Ordering::Relaxed);
         state.idle_notify.notify_one();
-        Self { counter: Arc::clone(&state.active_writes) }
+        Self {
+            counter: Arc::clone(&state.active_writes),
+        }
     }
 }
 
@@ -363,7 +367,6 @@ impl NestWeaverDaemon for DaemonService {
             db_path: self.state.db_path.display().to_string(),
             uptime_seconds: uptime,
             active_connections: active,
-            db_opened_at: 0,
         }))
     }
 
@@ -411,11 +414,17 @@ impl NestWeaverDaemon for DaemonService {
                 }
 
                 if !warned_half && elapsed >= half {
-                    tracing::warn!(active_writes = writes, "drain at 50% of timeout ({ceiling}s)");
+                    tracing::warn!(
+                        active_writes = writes,
+                        "drain at 50% of timeout ({ceiling}s)"
+                    );
                     warned_half = true;
                 }
                 if !warned_ninety && elapsed >= ninety {
-                    tracing::warn!(active_writes = writes, "drain at 90% of timeout ({ceiling}s)");
+                    tracing::warn!(
+                        active_writes = writes,
+                        "drain at 90% of timeout ({ceiling}s)"
+                    );
                     warned_ninety = true;
                 }
 
@@ -950,7 +959,6 @@ impl NestWeaverDaemon for DaemonService {
                     }));
                 }
             }
-
         });
 
         Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
@@ -1050,7 +1058,6 @@ impl NestWeaverDaemon for DaemonService {
                     }));
                 }
             }
-
         });
 
         Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
@@ -1458,7 +1465,6 @@ impl NestWeaverDaemon for DaemonService {
                     }));
                 }
             }
-
         });
 
         Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -89,10 +89,7 @@ impl DaemonService {
         args_json: &str,
     ) -> Result<Response<JsonResponse>, Status> {
         let t0 = std::time::Instant::now();
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::read(&self.state);
 
         let state = self.state.clone();
         let tool_name = tool_name.to_string();
@@ -157,10 +154,6 @@ impl DaemonService {
         .await
         .map_err(|e| Status::internal(format!("dispatch task panicked: {e}")))?;
 
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
-
         tracing::debug!(
             tool = %tool_name_for_log,
             elapsed_ms = t0.elapsed().as_millis(),
@@ -179,10 +172,7 @@ impl DaemonService {
         args: serde_json::Value,
     ) -> Result<serde_json::Value, Status> {
         let t0 = std::time::Instant::now();
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::read(&self.state);
 
         let state = self.state.clone();
         let tool_name = tool_name.to_string();
@@ -228,10 +218,6 @@ impl DaemonService {
             elapsed_ms = t0.elapsed().as_millis(),
             "dispatch_tool_json total completed"
         );
-
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
 
         result
     }
@@ -408,8 +394,6 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         request: Request<WatchVaultRequest>,
     ) -> Result<Response<WatchVaultResponse>, Status> {
-        self.state.idle_notify.notify_one();
-
         let req = request.into_inner();
         let vault_path = PathBuf::from(&req.vault_path);
         let vault_name = req.vault_name.clone();
@@ -469,16 +453,14 @@ impl NestWeaverDaemon for DaemonService {
             *guard = Some(shutdown_handle);
         }
 
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
-
+        let guard = ConnectionGuard::write(&self.state);
         let state = self.state.clone();
         let store = self.state.store.clone();
         let on_change =
             Self::make_embed_on_change(self.state.embed_model.clone(), self.state.store.clone());
 
         tokio::task::spawn_blocking(move || {
+            let _guard = guard;
             tracing::info!(vault = %vault_path.display(), "watcher thread started");
 
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -491,8 +473,6 @@ impl NestWeaverDaemon for DaemonService {
                 Err(_) => tracing::error!("watcher thread panicked"),
             }
 
-            refresh_db_opened_at(&state);
-            state.active_connections.fetch_sub(1, Ordering::Relaxed);
             if let Ok(mut guard) = state.watcher_stop.lock() {
                 *guard = None;
             }
@@ -511,8 +491,6 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         request: Request<WatchCodeRequest>,
     ) -> Result<Response<WatchCodeResponse>, Status> {
-        self.state.idle_notify.notify_one();
-
         let req = request.into_inner();
         let repo_path = PathBuf::from(&req.repo_path);
         let instance_id = if req.instance_id.is_empty() {
@@ -550,16 +528,14 @@ impl NestWeaverDaemon for DaemonService {
             *guard = Some(shutdown_handle);
         }
 
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
-
+        let guard = ConnectionGuard::write(&self.state);
         let state = self.state.clone();
         let store = self.state.store.clone();
         let on_change =
             Self::make_embed_on_change(self.state.embed_model.clone(), self.state.store.clone());
 
         tokio::task::spawn_blocking(move || {
+            let _guard = guard;
             tracing::info!(repo = %repo_path.display(), "code watcher thread started");
 
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -572,8 +548,6 @@ impl NestWeaverDaemon for DaemonService {
                 Err(_) => tracing::error!("code watcher thread panicked"),
             }
 
-            refresh_db_opened_at(&state);
-            state.active_connections.fetch_sub(1, Ordering::Relaxed);
             if let Ok(mut guard) = state.watcher_stop.lock() {
                 *guard = None;
             }
@@ -611,10 +585,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<JsonRequest>,
     ) -> Result<Response<JsonResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::read(&self.state);
         let state = self.state.clone();
         let args: serde_json::Value =
             serde_json::from_str(&r.into_inner().args_json).unwrap_or(serde_json::Value::Null);
@@ -705,9 +676,6 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking panicked: {e}")))?;
 
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
         result.map(|j| Response::new(JsonResponse { result_json: j }))
     }
 
@@ -717,8 +685,6 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         request: Request<ServeUiRequest>,
     ) -> Result<Response<ServeUiResponse>, Status> {
-        self.state.idle_notify.notify_one();
-
         let req = request.into_inner();
         let state = self.state.clone();
 
@@ -772,8 +738,6 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         request: Request<IndexRepoRequest>,
     ) -> Result<Response<Self::IndexRepoStream>, Status> {
-        self.state.idle_notify.notify_one();
-
         let req = request.into_inner();
         let repo_path = PathBuf::from(&req.repo_path);
         let state = self.state.clone();
@@ -788,7 +752,9 @@ impl NestWeaverDaemon for DaemonService {
 
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<IndexProgress, Status>>(16);
 
+        let guard = ConnectionGuard::write(&self.state);
         tokio::task::spawn_blocking(move || {
+            let _guard = guard;
             let repo_url = format!("file://{}", repo_path.display());
 
             let indexed_sha = std::process::Command::new("git")
@@ -945,7 +911,6 @@ impl NestWeaverDaemon for DaemonService {
                 }
             }
 
-            refresh_db_opened_at(&state);
         });
 
         Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
@@ -959,8 +924,6 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         request: Request<IndexVaultRequest>,
     ) -> Result<Response<Self::IndexVaultStream>, Status> {
-        self.state.idle_notify.notify_one();
-
         let req = request.into_inner();
         let vault_path = PathBuf::from(&req.vault_path);
         let vault_name = req.vault_name.clone();
@@ -974,7 +937,9 @@ impl NestWeaverDaemon for DaemonService {
 
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<IndexProgress, Status>>(16);
 
+        let guard = ConnectionGuard::write(&self.state);
         tokio::task::spawn_blocking(move || {
+            let _guard = guard;
             let _ = tx.blocking_send(Ok(IndexProgress {
                 phase: Phase::Discovering as i32,
                 message: format!("Scanning vault {}", vault_path.display()),
@@ -1046,7 +1011,6 @@ impl NestWeaverDaemon for DaemonService {
                 }
             }
 
-            refresh_db_opened_at(&state);
         });
 
         Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
@@ -1060,11 +1024,6 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         request: Request<MaterializeProjectsRequest>,
     ) -> Result<Response<Self::MaterializeProjectsStream>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
-
         let req = request.into_inner();
         let config_path = PathBuf::from(&req.config_path);
         let instance_id = if req.instance_id.is_empty() {
@@ -1076,7 +1035,9 @@ impl NestWeaverDaemon for DaemonService {
 
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<IndexProgress, Status>>(16);
 
+        let guard = ConnectionGuard::write(&self.state);
         tokio::task::spawn_blocking(move || {
+            let _guard = guard;
             let _ = tx.blocking_send(Ok(IndexProgress {
                 phase: Phase::Discovering as i32,
                 message: format!("Loading instance config from {}", config_path.display()),
@@ -1095,7 +1056,6 @@ impl NestWeaverDaemon for DaemonService {
                         files_total: 0,
                         symbols_found: 0,
                     }));
-                    state.active_connections.fetch_sub(1, Ordering::Relaxed);
                     return;
                 }
             };
@@ -1139,9 +1099,6 @@ impl NestWeaverDaemon for DaemonService {
                     }));
                 }
             }
-
-            refresh_db_opened_at(&state);
-            state.active_connections.fetch_sub(1, Ordering::Relaxed);
         });
 
         Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
@@ -1153,10 +1110,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         request: Request<RemoveVaultRequest>,
     ) -> Result<Response<RemoveVaultResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::write(&self.state);
 
         let req = request.into_inner();
         let state = self.state.clone();
@@ -1186,10 +1140,6 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
 
-        refresh_db_opened_at(&self.state);
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
         result.map(Response::new)
     }
 
@@ -1197,10 +1147,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         request: Request<RemoveRepoRequest>,
     ) -> Result<Response<RemoveRepoResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::write(&self.state);
 
         let req = request.into_inner();
         let state = self.state.clone();
@@ -1243,10 +1190,6 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
 
-        refresh_db_opened_at(&self.state);
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
         result.map(Response::new)
     }
 
@@ -1254,10 +1197,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         request: Request<RemoveProjectRequest>,
     ) -> Result<Response<RemoveProjectResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::write(&self.state);
 
         let req = request.into_inner();
         let state = self.state.clone();
@@ -1290,10 +1230,6 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
 
-        refresh_db_opened_at(&self.state);
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
         result.map(Response::new)
     }
 
@@ -1301,10 +1237,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         request: Request<PruneStaleRequest>,
     ) -> Result<Response<PruneStaleResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::write(&self.state);
 
         let _req = request.into_inner();
         let state = self.state.clone();
@@ -1381,10 +1314,6 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
 
-        refresh_db_opened_at(&self.state);
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
         result.map(Response::new)
     }
 
@@ -1392,10 +1321,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         request: Request<MergeInstanceRequest>,
     ) -> Result<Response<MergeInstanceResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::write(&self.state);
 
         let req = request.into_inner();
         let state = self.state.clone();
@@ -1423,10 +1349,6 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
 
-        refresh_db_opened_at(&self.state);
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
         result.map(Response::new)
     }
 
@@ -1436,18 +1358,15 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         request: Request<PurgeInstanceRequest>,
     ) -> Result<Response<Self::PurgeInstanceStream>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
-
         let req = request.into_inner();
         let instance_id = req.instance_id.clone();
         let state = self.state.clone();
 
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<IndexProgress, Status>>(16);
 
+        let guard = ConnectionGuard::write(&self.state);
         tokio::task::spawn_blocking(move || {
+            let _guard = guard;
             let _ = tx.blocking_send(Ok(IndexProgress {
                 phase: Phase::Writing as i32,
                 message: format!("Purging instance {instance_id}"),
@@ -1500,8 +1419,6 @@ impl NestWeaverDaemon for DaemonService {
                 }
             }
 
-            refresh_db_opened_at(&state);
-            state.active_connections.fetch_sub(1, Ordering::Relaxed);
         });
 
         Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
@@ -2063,10 +1980,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<JsonRequest>,
     ) -> Result<Response<JsonResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::read(&self.state);
         let state = self.state.clone();
         let args: serde_json::Value =
             serde_json::from_str(&r.into_inner().args_json).unwrap_or(serde_json::Value::Null);
@@ -2083,9 +1997,6 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking panicked: {e}")))?;
 
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
         result.map(|j| Response::new(JsonResponse { result_json: j }))
     }
 
@@ -2094,10 +2005,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<JsonRequest>,
     ) -> Result<Response<JsonResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::read(&self.state);
         let state = self.state.clone();
         let args: serde_json::Value =
             serde_json::from_str(&r.into_inner().args_json).unwrap_or(serde_json::Value::Null);
@@ -2114,9 +2022,6 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking panicked: {e}")))?;
 
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
         result.map(|j| Response::new(JsonResponse { result_json: j }))
     }
 
@@ -2125,10 +2030,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<JsonRequest>,
     ) -> Result<Response<JsonResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::read(&self.state);
         let state = self.state.clone();
         let _args: serde_json::Value =
             serde_json::from_str(&r.into_inner().args_json).unwrap_or(serde_json::Value::Null);
@@ -2144,9 +2046,6 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking panicked: {e}")))?;
 
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
         result.map(|j| Response::new(JsonResponse { result_json: j }))
     }
 
@@ -2155,10 +2054,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<JsonRequest>,
     ) -> Result<Response<JsonResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::read(&self.state);
         let state = self.state.clone();
         let args: serde_json::Value =
             serde_json::from_str(&r.into_inner().args_json).unwrap_or(serde_json::Value::Null);
@@ -2175,9 +2071,6 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking panicked: {e}")))?;
 
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
         result.map(|j| Response::new(JsonResponse { result_json: j }))
     }
 
@@ -2186,10 +2079,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<JsonRequest>,
     ) -> Result<Response<JsonResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::read(&self.state);
         let state = self.state.clone();
         let args: serde_json::Value =
             serde_json::from_str(&r.into_inner().args_json).unwrap_or(serde_json::Value::Null);
@@ -2211,9 +2101,6 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking panicked: {e}")))?;
 
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
         result.map(|j| Response::new(JsonResponse { result_json: j }))
     }
 
@@ -2222,10 +2109,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<JsonRequest>,
     ) -> Result<Response<JsonResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::read(&self.state);
         let state = self.state.clone();
         let _args: serde_json::Value =
             serde_json::from_str(&r.into_inner().args_json).unwrap_or(serde_json::Value::Null);
@@ -2241,9 +2125,6 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking panicked: {e}")))?;
 
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
         result.map(|j| Response::new(JsonResponse { result_json: j }))
     }
 
@@ -2252,10 +2133,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<JsonRequest>,
     ) -> Result<Response<JsonResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::read(&self.state);
         let state = self.state.clone();
         let args: serde_json::Value =
             serde_json::from_str(&r.into_inner().args_json).unwrap_or(serde_json::Value::Null);
@@ -2271,9 +2149,6 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking panicked: {e}")))?;
 
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
         result.map(|j| Response::new(JsonResponse { result_json: j }))
     }
 
@@ -2282,10 +2157,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<JsonRequest>,
     ) -> Result<Response<JsonResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::read(&self.state);
         let state = self.state.clone();
         let args: serde_json::Value =
             serde_json::from_str(&r.into_inner().args_json).unwrap_or(serde_json::Value::Null);
@@ -2315,9 +2187,6 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking panicked: {e}")))?;
 
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
         result.map(|j| Response::new(JsonResponse { result_json: j }))
     }
 
@@ -2328,10 +2197,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<JsonRequest>,
     ) -> Result<Response<JsonResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::read(&self.state);
         let state = self.state.clone();
         let args: serde_json::Value =
             serde_json::from_str(&r.into_inner().args_json).unwrap_or(serde_json::Value::Null);
@@ -2353,9 +2219,6 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking panicked: {e}")))?;
 
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
         result.map(|j| Response::new(JsonResponse { result_json: j }))
     }
 
@@ -2364,10 +2227,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<JsonRequest>,
     ) -> Result<Response<JsonResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::read(&self.state);
         let state = self.state.clone();
         let _args: serde_json::Value =
             serde_json::from_str(&r.into_inner().args_json).unwrap_or(serde_json::Value::Null);
@@ -2383,9 +2243,6 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking panicked: {e}")))?;
 
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
         result.map(|j| Response::new(JsonResponse { result_json: j }))
     }
 
@@ -2394,10 +2251,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<JsonRequest>,
     ) -> Result<Response<JsonResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::read(&self.state);
         let state = self.state.clone();
         let args: serde_json::Value =
             serde_json::from_str(&r.into_inner().args_json).unwrap_or(serde_json::Value::Null);
@@ -2424,9 +2278,6 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking panicked: {e}")))?;
 
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
         result.map(|j| Response::new(JsonResponse { result_json: j }))
     }
 
@@ -2435,10 +2286,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<JsonRequest>,
     ) -> Result<Response<JsonResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::read(&self.state);
         let state = self.state.clone();
         let args: serde_json::Value =
             serde_json::from_str(&r.into_inner().args_json).unwrap_or(serde_json::Value::Null);
@@ -2472,9 +2320,6 @@ impl NestWeaverDaemon for DaemonService {
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking panicked: {e}")))?;
 
-        self.state
-            .active_connections
-            .fetch_sub(1, Ordering::Relaxed);
         result.map(|j| Response::new(JsonResponse { result_json: j }))
     }
 
@@ -2485,16 +2330,10 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         request: Request<EmbedRequest>,
     ) -> Result<Response<EmbedResponse>, Status> {
-        self.state.idle_notify.notify_one();
-        self.state
-            .active_connections
-            .fetch_add(1, Ordering::Relaxed);
+        let _guard = ConnectionGuard::write(&self.state);
 
         #[cfg(not(feature = "embed"))]
         {
-            self.state
-                .active_connections
-                .fetch_sub(1, Ordering::Relaxed);
             let _ = request;
             return Err(Status::unavailable(
                 "embedding is not available — the daemon was built without the `embed` feature",
@@ -2517,9 +2356,6 @@ impl NestWeaverDaemon for DaemonService {
             let do_headings = scope == "all" || scope == "headings";
 
             if !do_symbols && !do_notes && !do_headings {
-                self.state
-                    .active_connections
-                    .fetch_sub(1, Ordering::Relaxed);
                 return Err(Status::invalid_argument(format!(
                     "unknown scope '{scope}': expected one of: all, symbols, notes, headings"
                 )));
@@ -2531,9 +2367,6 @@ impl NestWeaverDaemon for DaemonService {
             };
 
             let Some(model) = model else {
-                self.state
-                    .active_connections
-                    .fetch_sub(1, Ordering::Relaxed);
                 return Err(Status::unavailable(
                     "embedding model is not loaded — it may still be initializing",
                 ));
@@ -2632,10 +2465,6 @@ impl NestWeaverDaemon for DaemonService {
             .await
             .map_err(|e| Status::internal(format!("embed task panicked: {e}")))?;
 
-            refresh_db_opened_at(&self.state);
-            self.state
-                .active_connections
-                .fetch_sub(1, Ordering::Relaxed);
             result.map(Response::new)
         }
     }

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -6,7 +6,7 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{Duration, Instant};
 
 use anyhow::Context;
@@ -20,21 +20,31 @@ use crate::lifecycle;
 
 // ── State ───────────────────────────────────────────────────────────
 
-/// Re-read the DB file's mtime and store it in `state.db_opened_at`.
-/// Called after any write RPC so the next `DaemonClient::connect()` health
-/// check sees the current mtime and doesn't falsely conclude the DB was
-/// rebuilt externally.
-fn refresh_db_opened_at(state: &DaemonState) {
-    let mtime = std::fs::metadata(&state.db_path)
-        .and_then(|m| m.modified())
-        .ok()
-        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_secs())
-        .unwrap_or_else(|| {
-            tracing::warn!(path = %state.db_path.display(), "failed to stat DB — stale-detection disabled until next write");
-            0
-        });
-    state.db_opened_at.store(mtime, Ordering::Relaxed);
+/// RAII guard that decrements a connection counter on drop.
+/// Fixes cancellation-safety: if a client disconnects mid-RPC or
+/// the async task is cancelled, the counter is still decremented.
+struct ConnectionGuard {
+    counter: Arc<AtomicU32>,
+}
+
+impl ConnectionGuard {
+    fn read(state: &DaemonState) -> Self {
+        state.active_reads.fetch_add(1, Ordering::Relaxed);
+        state.idle_notify.notify_one();
+        Self { counter: Arc::clone(&state.active_reads) }
+    }
+
+    fn write(state: &DaemonState) -> Self {
+        state.active_writes.fetch_add(1, Ordering::Relaxed);
+        state.idle_notify.notify_one();
+        Self { counter: Arc::clone(&state.active_writes) }
+    }
+}
+
+impl Drop for ConnectionGuard {
+    fn drop(&mut self) {
+        self.counter.fetch_sub(1, Ordering::Relaxed);
+    }
 }
 
 /// Shared state held by the daemon process.
@@ -45,8 +55,8 @@ pub struct DaemonState {
     pub db_path: PathBuf,
     pub instance_id: String,
     pub start_time: Instant,
-    pub db_opened_at: AtomicU64,
-    pub active_connections: AtomicU32,
+    pub active_reads: Arc<AtomicU32>,
+    pub active_writes: Arc<AtomicU32>,
     pub idle_notify: Arc<Notify>,
     pub shutdown_tx: tokio::sync::watch::Sender<bool>,
     pub watcher_stop: std::sync::Mutex<Option<nestweaver_engine::ShutdownHandle>>,
@@ -359,14 +369,14 @@ impl NestWeaverDaemon for DaemonService {
         _request: Request<HealthCheckRequest>,
     ) -> Result<Response<HealthCheckResponse>, Status> {
         let uptime = self.state.start_time.elapsed().as_secs();
-        let active = self.state.active_connections.load(Ordering::Relaxed);
+        let active = self.state.active_reads.load(Ordering::Relaxed)
+            + self.state.active_writes.load(Ordering::Relaxed);
         Ok(Response::new(HealthCheckResponse {
             version: env!("CARGO_PKG_VERSION").to_string(),
             instance_id: self.state.instance_id.clone(),
             db_path: self.state.db_path.display().to_string(),
             uptime_seconds: uptime,
             active_connections: active,
-            db_opened_at: self.state.db_opened_at.load(Ordering::Relaxed),
         }))
     }
 
@@ -2767,13 +2777,6 @@ pub async fn run_server(
             }
         });
 
-    let db_opened_at = std::fs::metadata(&db_path)
-        .and_then(|m| m.modified())
-        .ok()
-        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-
     let state = Arc::new(DaemonState {
         store: Arc::new(store),
         store_read: Arc::new(store_read),
@@ -2781,8 +2784,8 @@ pub async fn run_server(
         db_path: db_path.clone(),
         instance_id: instance_id.clone(),
         start_time: Instant::now(),
-        db_opened_at: AtomicU64::new(db_opened_at),
-        active_connections: AtomicU32::new(0),
+        active_reads: Arc::new(AtomicU32::new(0)),
+        active_writes: Arc::new(AtomicU32::new(0)),
         idle_notify: idle_notify.clone(),
         shutdown_tx: shutdown_tx.clone(),
         watcher_stop: std::sync::Mutex::new(None),
@@ -2918,7 +2921,7 @@ pub async fn run_server(
                 tokio::select! {
                     _ = notify.notified() => continue,
                     _ = tokio::time::sleep(timeout) => {
-                        if active.active_connections.load(Ordering::Relaxed) == 0 {
+                        if active.active_reads.load(Ordering::Relaxed) + active.active_writes.load(Ordering::Relaxed) == 0 {
                             tracing::info!(
                                 timeout_secs = timeout.as_secs(),
                                 "idle timeout reached — shutting down"

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -12,9 +12,8 @@ message HealthCheckResponse {
   string db_path = 3;
   uint64 uptime_seconds = 4;
   uint32 active_connections = 5;
-  // Unix timestamp (seconds) of the DB file when the daemon opened it.
-  // Clients compare against the current file mtime to detect stale daemons.
-  uint64 db_opened_at = 6;
+  reserved 6;
+  reserved "db_opened_at";
 }
 
 message ShutdownRequest {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4311,6 +4311,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             &scope,
             force,
             stats,
+            use_daemon,
         )
         .map(|c| (c, None)),
 
@@ -5110,39 +5111,15 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 let tantivy_path = tantivy_sidecar_path_for(&db_path);
                 let tantivy = TantivyIndex::open_reader_only(&tantivy_path).ok();
 
-                let state = if watch {
-                    let store =
-                        std::sync::Arc::new(GraphStore::open_or_create(&db_path).with_context(
-                            || format!("failed to open database at {}", db_path.display()),
-                        )?);
-                    nestweaver_web::state::AppState::new_with_store(store, tantivy, db_path.clone())
-                } else {
+                if watch {
+                    tracing::warn!(
+                        "daemon unavailable — serving UI without live-watch (read-only)"
+                    );
+                }
+                let state = {
                     let store = open_store(Some(&db_path))?;
                     nestweaver_web::state::AppState::new(store, tantivy, db_path.clone())
                 };
-
-                if watch {
-                    let repo_root = detect_repo_root();
-                    let code_store = state.store.clone();
-                    let code_tx = state.event_tx.clone();
-                    let code_db = db_path.clone();
-                    let code_instance = "default".to_string();
-
-                    std::thread::spawn(move || {
-                        let watcher = CodeWatcher::new(&code_db, &repo_root, &code_instance);
-                        let store_for_cb = code_store.clone();
-                        let on_change = Box::new(move || {
-                            let generation = store_for_cb.graph_generation();
-                            let _ = code_tx.send(nestweaver_web::state::GraphEvent {
-                                event_type: "graph:updated".to_string(),
-                                payload: serde_json::json!({"source": "code_watcher", "generation": generation}),
-                            });
-                        });
-                        if let Err(e) = watcher.run_with_store(code_store, Some(on_change)) {
-                            tracing::error!("CodeWatcher failed: {e}");
-                        }
-                    });
-                }
 
                 let rt =
                     tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
@@ -10829,6 +10806,7 @@ fn run_embed(
     scope: &str,
     force: bool,
     stats: bool,
+    use_daemon: bool,
 ) -> anyhow::Result<i32> {
     // Validate flags
     if local && endpoint.is_some() {
@@ -10880,6 +10858,15 @@ fn run_embed(
     }
 
     // ── Fallback: direct DB access ──────────────────────────────
+    // Only allowed when the daemon path was not attempted (--local or --endpoint)
+    // or when the daemon is explicitly disabled (--no-daemon / NESTWEAVER_NO_DAEMON=1).
+    if use_daemon && endpoint.is_none() && !local {
+        anyhow::bail!(
+            "daemon is not running. Start it with 'nestweaver daemon --db {} start' \
+             or use --no-daemon (requires NESTWEAVER_NO_DAEMON=1)",
+            path.display()
+        );
+    }
 
     let store = nestweaver_store::GraphStore::open(path).map_err(|e| {
         anyhow::anyhow!(

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -591,8 +591,10 @@ repos = ["repo"]
         daemon_cmd()
             .args([
                 "materialize-projects",
-                "--config", &config_str,
-                "--db", &db_str,
+                "--config",
+                &config_str,
+                "--db",
+                &db_str,
             ])
             .assert()
             .success();
@@ -603,15 +605,13 @@ repos = ["repo"]
 
     // Concurrent read — should NOT trigger a daemon restart.
     daemon_cmd()
-        .args([
-            "list-repos",
-            "--db",
-            &db_path.display().to_string(),
-        ])
+        .args(["list-repos", "--db", &db_path.display().to_string()])
         .assert()
         .success();
 
-    materialize_handle.join().expect("materialize thread panicked");
+    materialize_handle
+        .join()
+        .expect("materialize thread panicked");
 }
 
 #[test]
@@ -624,21 +624,15 @@ fn daemon_shutdown_rpc_exits_cleanly() {
     create_db(&repo_dir, &db_path);
 
     // Start the daemon.
-    daemon_action_cmd(&db_path, "start")
-        .assert()
-        .success();
+    daemon_action_cmd(&db_path, "start").assert().success();
 
     std::thread::sleep(Duration::from_secs(1));
 
     // Verify daemon is running.
-    daemon_action_cmd(&db_path, "status")
-        .assert()
-        .success();
+    daemon_action_cmd(&db_path, "status").assert().success();
 
     // Stop via the CLI (which uses the Shutdown RPC).
-    daemon_action_cmd(&db_path, "stop")
-        .assert()
-        .success();
+    daemon_action_cmd(&db_path, "stop").assert().success();
 
     std::thread::sleep(Duration::from_secs(2));
 

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -528,3 +528,123 @@ repos = ["repo"]
         .assert()
         .success();
 }
+
+#[test]
+fn daemon_concurrent_client_during_write() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_dir = dir.path().join("repo");
+    let vault_dir = dir.path().join("vault");
+    let db_path = dir.path().join("test.lbug");
+
+    write_test_repo(&repo_dir);
+    write_test_vault(&vault_dir);
+    create_db(&repo_dir, &db_path);
+
+    let config_path = dir.path().join("instance.toml");
+    let repo_url = format!("file://{}", repo_dir.display());
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"
+instance_id = "test-instance"
+
+[snapshot_storage]
+backend = "local"
+path = "{storage}"
+
+[workspace]
+backend = "local"
+path = "{workspace}"
+
+[inference]
+endpoint = "http://localhost:11434"
+embedding_model = "nomic-embed-text"
+summary_model = "qwen2.5-coder:7b"
+
+[git]
+credential_method = "gh"
+
+[[repos]]
+url = "{repo_url}"
+name = "repo"
+
+[[projects]]
+name = "test-project"
+description = "A test project"
+repos = ["repo"]
+"#,
+            storage = dir.path().join("storage").display(),
+            workspace = dir.path().join("workspace").display(),
+            repo_url = repo_url,
+        ),
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.path().join("storage")).unwrap();
+    std::fs::create_dir_all(dir.path().join("workspace")).unwrap();
+
+    let _guard = DaemonGuard::new(&db_path);
+
+    // Start materialize in background thread.
+    let db_str = db_path.display().to_string();
+    let config_str = config_path.display().to_string();
+    let materialize_handle = std::thread::spawn(move || {
+        daemon_cmd()
+            .args([
+                "materialize-projects",
+                "--config", &config_str,
+                "--db", &db_str,
+            ])
+            .assert()
+            .success();
+    });
+
+    // Brief pause to let materialize start.
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Concurrent read — should NOT trigger a daemon restart.
+    daemon_cmd()
+        .args([
+            "list-repos",
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .assert()
+        .success();
+
+    materialize_handle.join().expect("materialize thread panicked");
+}
+
+#[test]
+fn daemon_shutdown_rpc_exits_cleanly() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_dir = dir.path().join("repo");
+    let db_path = dir.path().join("test.lbug");
+
+    write_test_repo(&repo_dir);
+    create_db(&repo_dir, &db_path);
+
+    // Start the daemon.
+    daemon_action_cmd(&db_path, "start")
+        .assert()
+        .success();
+
+    std::thread::sleep(Duration::from_secs(1));
+
+    // Verify daemon is running.
+    daemon_action_cmd(&db_path, "status")
+        .assert()
+        .success();
+
+    // Stop via the CLI (which uses the Shutdown RPC).
+    daemon_action_cmd(&db_path, "stop")
+        .assert()
+        .success();
+
+    std::thread::sleep(Duration::from_secs(2));
+
+    // Verify daemon is no longer running.
+    daemon_action_cmd(&db_path, "status")
+        .assert()
+        .success()
+        .stdout(contains("not running"));
+}


### PR DESCRIPTION
## Summary

Replaces the mtime-based daemon stale-detection (which caused h2 broken-pipe errors when concurrent clients connected during long-running writes) with a cleaner architecture:

- **Remove mtime detection entirely** — the daemon is the sole DB writer, so file mtime changes are always self-inflicted. The `db_opened_at` field, `AtomicU64`, `refresh_db_opened_at()`, and all 13 call sites are removed.
- **Version-check is the sole restart trigger** — if client and daemon versions match, the daemon is correct. No file-level heuristics needed.
- **Graceful drain shutdown** — on version mismatch, the client sends a `Shutdown` RPC. The daemon waits for active write RPCs to finish (up to 660s configurable ceiling via `NESTWEAVER_DRAIN_TIMEOUT_SECS`) before exiting. Replaces the blunt 5s SIGTERM+SIGKILL.
- **RAII ConnectionGuard** — replaces manual `fetch_add`/`fetch_sub` with drop guards, fixing a cancellation-safety bug where client disconnect leaked the counter. Splits `active_connections` into `active_reads` + `active_writes` so read RPCs don't block version-mismatch restarts.
- **Sole-writer enforcement** — `run_embed` now errors when daemon is unavailable (instead of silently opening DB read-write). `ui --watch` falls back to read-only mode.

Validated by research into production patterns: Redis `replid`, Litestream generation IDs, nginx/HAProxy/Envoy drain timeouts, protobuf field reservation best practices.

## Test plan

- [x] `cargo test --test cli_test` — 25/25 pass
- [x] `cargo test --test daemon_test -- --test-threads=1` — 9/9 pass
  - `daemon_materialize_twice_no_broken_pipe` (existing, still passes)
  - `daemon_concurrent_client_during_write` (new — read during streaming write)
  - `daemon_shutdown_rpc_exits_cleanly` (new — graceful drain)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean