### PR TITLE
fix: ensure frontend assets are embedded in release binaries

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -68,6 +68,14 @@ jobs:
           linker = "aarch64-linux-gnu-gcc"
           rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]
           EOF
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: crates/nestweaver-web/frontend/package-lock.json
+      - name: Build frontend
+        run: npm ci && npm run build
+        working-directory: crates/nestweaver-web/frontend
       - name: Build binary
         run: cargo build --release --target ${{ matrix.target }}
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,15 +56,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,7 +676,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core 0.5.6",
+ "axum-core",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -714,26 +705,6 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
@@ -749,20 +720,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-embed"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077959a7f8cf438676af90b483304528eb7e16eadadb7f44e9ada4f9dceb9e62"
-dependencies = [
- "axum-core 0.4.5",
- "chrono",
- "http 1.4.2",
- "mime_guess",
- "rust-embed",
- "tower-service",
 ]
 
 [[package]]
@@ -1155,19 +1112,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "chrono"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-link",
 ]
 
 [[package]]
@@ -2974,30 +2918,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3699,16 +3619,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3772,7 +3682,7 @@ checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "nestweaver"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3812,7 +3722,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-algorithms"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -3820,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-client"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -3836,7 +3746,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-daemon"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3862,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-embed"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -3881,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-engine"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "apollo-parser",
@@ -3921,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-mcp"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3944,7 +3854,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-parser"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "bumpalo",
  "comrak",
@@ -3992,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-proto"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "prost",
  "tonic",
@@ -4003,7 +3913,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-resolver"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "glob",
  "insta",
@@ -4020,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-schema"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "hex",
  "serde",
@@ -4031,7 +3941,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-storage"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4046,7 +3956,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-store"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -4070,7 +3980,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-wasm"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "js-sys",
  "nestweaver-algorithms",
@@ -4087,7 +3997,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
- "axum-embed",
  "futures",
  "nestweaver-algorithms",
  "nestweaver-engine",
@@ -7579,41 +7488,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ thiserror = "2"
 anyhow = "1"
 tracing = "0.1"
 axum = "0.8"
-axum-embed = "0.1"
 rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 tower-http = { version = "0.7", features = ["cors"] }
 tokio-stream = "0.1"

--- a/app/build.sh
+++ b/app/build.sh
@@ -7,43 +7,49 @@ APP_DIR="$REPO_ROOT/target/release/NestWeaver.app"
 
 echo "=== Building NestWeaver.app ==="
 
-# Step 1: Build Rust binary
-echo "[1/5] Building Rust binary..."
+# Step 1: Build frontend
+echo "[1/6] Building frontend..."
+cd "$REPO_ROOT/crates/nestweaver-web/frontend"
+npm install
+npm run build
 cd "$REPO_ROOT"
+
+# Step 2: Build Rust binary
+echo "[2/6] Building Rust binary..."
 cargo build --release --features embed,metal
 
-# Step 2: Generate icons if needed
+# Step 3: Generate icons if needed
 ICNS="$SCRIPT_DIR/icon/AppIcon.icns"
 MENU_ICON="$SCRIPT_DIR/icon/MenuIcon.png"
 if [ ! -f "$ICNS" ]; then
-    echo "[2/5] Generating app icon..."
+    echo "[3/6] Generating app icon..."
     "$SCRIPT_DIR/icon/generate-icns.sh"
 else
-    echo "[2/5] App icon already exists, skipping"
+    echo "[3/6] App icon already exists, skipping"
 fi
 
 # Generate menubar template icon (18x18, transparent bg)
 if [ ! -f "$MENU_ICON" ] && command -v rsvg-convert &>/dev/null; then
-    echo "[2b/5] Generating menubar icon..."
+    echo "[3b/6] Generating menubar icon..."
     rsvg-convert -w 36 -h 36 "$REPO_ROOT/assets/logo-icon-light.svg" -o "$MENU_ICON"
 elif [ ! -f "$MENU_ICON" ] && command -v sips &>/dev/null; then
-    echo "[2b/5] Generating menubar icon (sips)..."
+    echo "[3b/6] Generating menubar icon (sips)..."
     # Convert SVG to PNG via temporary — sips can't read SVG directly
     # Fall back: the Swift launcher will use AppIcon.icns with isTemplate=true
-    echo "[2b/5] Skipping menubar icon (no rsvg-convert), will use app icon as template"
+    echo "[3b/6] Skipping menubar icon (no rsvg-convert), will use app icon as template"
 else
-    echo "[2b/5] Menubar icon already exists"
+    echo "[3b/6] Menubar icon already exists"
 fi
 
-# Step 3: Compile Swift launcher
-echo "[3/5] Compiling Swift launcher..."
+# Step 4: Compile Swift launcher
+echo "[4/6] Compiling Swift launcher..."
 swiftc "$SCRIPT_DIR/Sources/main.swift" \
     -o "$REPO_ROOT/target/release/NestWeaverLauncher" \
     -framework AppKit \
     -O
 
-# Step 4: Assemble .app bundle
-echo "[4/5] Assembling app bundle..."
+# Step 5: Assemble .app bundle
+echo "[5/6] Assembling app bundle..."
 rm -rf "$APP_DIR"
 mkdir -p "$APP_DIR/Contents/MacOS"
 mkdir -p "$APP_DIR/Contents/Resources"

--- a/crates/nestweaver-web/Cargo.toml
+++ b/crates/nestweaver-web/Cargo.toml
@@ -10,7 +10,6 @@ nestweaver-store = { workspace = true }
 nestweaver-schema = { workspace = true }
 rmp-serde = "1"
 axum = { workspace = true }
-axum-embed = { workspace = true }
 rust-embed = { workspace = true }
 tower-http = { workspace = true }
 tokio = { version = "1", features = ["full"] }

--- a/crates/nestweaver-web/build.rs
+++ b/crates/nestweaver-web/build.rs
@@ -16,23 +16,31 @@ fn main() {
 
         match status {
             Ok(s) if s.success() => {}
-            _ => {
+            Ok(s) => {
                 println!(
-                    "cargo:warning=Frontend build failed or npm not found, using existing dist"
+                    "cargo:warning=Frontend build exited with status {s}, using existing dist"
                 );
-                ensure_dist_exists(&dist_dir, frontend_dir);
+            }
+            Err(e) => {
+                println!("cargo:warning=Frontend build failed ({e}), using existing dist");
             }
         }
-    } else {
-        ensure_dist_exists(&dist_dir, frontend_dir);
     }
-}
 
-fn ensure_dist_exists(dist_dir: &std::path::Path, frontend_dir: &std::path::Path) {
-    std::fs::create_dir_all(dist_dir).ok();
-    if !dist_dir.join("index.html").exists()
-        && let Ok(html) = std::fs::read_to_string(frontend_dir.join("index.html"))
-    {
+    if !dist_dir.join("assets").exists() || !dist_dir.join("index.html").exists() {
+        println!("cargo:warning=frontend/dist/assets/ is missing — the UI will not work.");
+        println!(
+            "cargo:warning=Run: cd crates/nestweaver-web/frontend && npm install && npm run build"
+        );
+
+        // Create a minimal dist so rust-embed doesn't fail compilation,
+        // but the UI will show a clear error instead of a blank screen.
+        std::fs::create_dir_all(dist_dir.join("assets")).ok();
+        let html = r#"<!DOCTYPE html>
+<html><head><title>NestWeaver</title></head>
+<body><h1>Frontend not built</h1>
+<p>Run <code>cd crates/nestweaver-web/frontend &amp;&amp; npm install &amp;&amp; npm run build</code> then rebuild.</p>
+</body></html>"#;
         std::fs::write(dist_dir.join("index.html"), html).ok();
     }
 }

--- a/crates/nestweaver-web/src/lib.rs
+++ b/crates/nestweaver-web/src/lib.rs
@@ -6,9 +6,11 @@ use std::sync::Arc;
 
 use axum::{
     Router,
+    extract::Request,
+    http::{self, StatusCode},
+    response::{IntoResponse, Response},
     routing::{get, post, put},
 };
-use axum_embed::{FallbackBehavior, ServeEmbed};
 use rust_embed::RustEmbed;
 use tower_http::cors::CorsLayer;
 
@@ -18,13 +20,61 @@ use crate::state::AppState;
 #[folder = "frontend/dist/"]
 struct FrontendAssets;
 
-pub fn create_router(state: Arc<AppState>) -> Router {
-    let static_handler = ServeEmbed::<FrontendAssets>::with_parameters(
-        Some("index.html".to_string()),
-        FallbackBehavior::Ok,
-        Some("index.html".to_string()),
-    );
+fn mime_for_path(path: &str) -> &'static str {
+    match path.rsplit('.').next() {
+        Some("js") | Some("mjs") => "application/javascript",
+        Some("css") => "text/css",
+        Some("wasm") => "application/wasm",
+        Some("html") => "text/html; charset=utf-8",
+        Some("svg") => "image/svg+xml",
+        Some("png") => "image/png",
+        Some("json") => "application/json",
+        Some("map") => "application/json",
+        Some("ico") => "image/x-icon",
+        Some("woff2") => "font/woff2",
+        Some("woff") => "font/woff",
+        Some("ttf") => "font/ttf",
+        _ => "application/octet-stream",
+    }
+}
 
+fn has_file_extension(path: &str) -> bool {
+    path.rsplit('/').next().is_some_and(|seg| seg.contains('.'))
+}
+
+async fn spa_fallback(request: Request) -> Response {
+    let path = request.uri().path();
+    let trimmed = path.trim_start_matches('/');
+
+    if !trimmed.is_empty()
+        && let Some(file) = FrontendAssets::get(trimmed)
+    {
+        return (
+            StatusCode::OK,
+            [(http::header::CONTENT_TYPE, mime_for_path(trimmed))],
+            file.data,
+        )
+            .into_response();
+    }
+
+    // Paths with file extensions that weren't found should 404
+    if has_file_extension(path) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+
+    // SPA fallback: serve index.html for navigation routes
+    match FrontendAssets::get("index.html") {
+        Some(file) => (
+            StatusCode::OK,
+            [(http::header::CONTENT_TYPE, "text/html; charset=utf-8")],
+            file.data,
+        )
+            .into_response(),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+pub fn create_router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/api/v1/health", get(routes::health::health))
         .route("/api/v1/version", get(routes::version::version))
@@ -131,7 +181,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         )
         // Events (SSE)
         .route("/api/v1/events", get(routes::events::events))
-        .fallback_service(static_handler)
+        .fallback(get(spa_fallback))
         .layer(CorsLayer::permissive())
         .with_state(state)
 }


### PR DESCRIPTION
## Summary

- Release binaries and the macOS `.app` were shipping without frontend JS/CSS/WASM assets — the build pipeline never ran `npm install && npm run build` before `cargo build`, so `rust-embed` only embedded a stub `index.html` that referenced non-existent hashed assets
- Users opening the UI from the menu bar got a blank screen with `Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html"` because `axum-embed`'s `FallbackBehavior::Ok` served `index.html` for missing asset requests
- Added frontend build steps to both `release-please.yml` and `app/build.sh`
- Replaced `axum-embed` with a custom SPA fallback handler that returns 404 for missing assets instead of silently serving HTML
- Updated `build.rs` to warn loudly and show a clear error page when assets are missing, instead of silently producing a broken binary

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test -p nestweaver-web` — all 30 tests pass
- [ ] CI passes on this PR
- [ ] Verify rebuilt `.app` bundle serves frontend correctly from menu bar