### PR TITLE
fix: embedding model-switch, MCP crash recovery, wikilink resolution, and schema consistency

### DIFF
--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -3230,8 +3230,11 @@ impl NestWeaverDaemon for DaemonService {
                             );
                             match model.embed_query(&text) {
                                 Ok(emb) => {
-                                    store.add_embedding(&sym.uid, emb);
-                                    succeeded += 1;
+                                    if store.add_embedding_with_force(&sym.uid, emb, force) {
+                                        succeeded += 1;
+                                    } else {
+                                        failed += 1;
+                                    }
                                 }
                                 Err(e) => {
                                     tracing::warn!(uid = %sym.uid, "embedding failed: {e}");
@@ -3254,8 +3257,11 @@ impl NestWeaverDaemon for DaemonService {
                                 nestweaver_embed::preprocess::note_embed_text(&note.title, None);
                             match model.embed_query(&text) {
                                 Ok(emb) => {
-                                    store.add_embedding(&note.uid, emb);
-                                    succeeded += 1;
+                                    if store.add_embedding_with_force(&note.uid, emb, force) {
+                                        succeeded += 1;
+                                    } else {
+                                        failed += 1;
+                                    }
                                 }
                                 Err(e) => {
                                     tracing::warn!(uid = %note.uid, "embedding failed: {e}");
@@ -3278,8 +3284,11 @@ impl NestWeaverDaemon for DaemonService {
                                 nestweaver_embed::preprocess::heading_embed_text("", &heading.text);
                             match model.embed_query(&text) {
                                 Ok(emb) => {
-                                    store.add_embedding(&heading.uid, emb);
-                                    succeeded += 1;
+                                    if store.add_embedding_with_force(&heading.uid, emb, force) {
+                                        succeeded += 1;
+                                    } else {
+                                        failed += 1;
+                                    }
                                 }
                                 Err(e) => {
                                     tracing::warn!(uid = %heading.uid, "embedding failed: {e}");

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -511,8 +511,11 @@ impl DaemonService {
                     );
                     match model.embed_query(&text) {
                         Ok(emb) => {
-                            store.add_embedding(&sym.uid, emb);
-                            embedded += 1;
+                            // Dimension-guard rejections must not count as
+                            // embedded (add_embedding logs them).
+                            if store.add_embedding(&sym.uid, emb) {
+                                embedded += 1;
+                            }
                         }
                         Err(e) => {
                             tracing::warn!(uid = %sym.uid, "embedding failed: {e}");
@@ -535,8 +538,9 @@ impl DaemonService {
                     let text = nestweaver_embed::preprocess::note_embed_text(&note.title, None);
                     match model.embed_query(&text) {
                         Ok(emb) => {
-                            store.add_embedding(&note.uid, emb);
-                            embedded += 1;
+                            if store.add_embedding(&note.uid, emb) {
+                                embedded += 1;
+                            }
                         }
                         Err(e) => {
                             tracing::warn!(uid = %note.uid, "embedding failed: {e}");
@@ -559,8 +563,9 @@ impl DaemonService {
                     let text = nestweaver_embed::preprocess::heading_embed_text("", &heading.text);
                     match model.embed_query(&text) {
                         Ok(emb) => {
-                            store.add_embedding(&heading.uid, emb);
-                            embedded += 1;
+                            if store.add_embedding(&heading.uid, emb) {
+                                embedded += 1;
+                            }
                         }
                         Err(e) => {
                             tracing::warn!(uid = %heading.uid, "embedding failed: {e}");

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -3214,6 +3214,11 @@ impl NestWeaverDaemon for DaemonService {
             let result = tokio::task::spawn_blocking(move || {
                 let mut succeeded = 0u32;
                 let mut failed = 0u32;
+                let mut rejected = 0u32;
+
+                // Each embed run may legitimately force-switch the model once;
+                // re-arm the once-per-run clear guard on this long-lived index.
+                store.reset_embedding_force_guard();
 
                 if do_symbols && let Ok(symbols) = store.list_all_symbols() {
                     let to_embed: Vec<_> = if force {
@@ -3233,7 +3238,7 @@ impl NestWeaverDaemon for DaemonService {
                                     if store.add_embedding_with_force(&sym.uid, emb, force) {
                                         succeeded += 1;
                                     } else {
-                                        failed += 1;
+                                        rejected += 1;
                                     }
                                 }
                                 Err(e) => {
@@ -3260,7 +3265,7 @@ impl NestWeaverDaemon for DaemonService {
                                     if store.add_embedding_with_force(&note.uid, emb, force) {
                                         succeeded += 1;
                                     } else {
-                                        failed += 1;
+                                        rejected += 1;
                                     }
                                 }
                                 Err(e) => {
@@ -3287,7 +3292,7 @@ impl NestWeaverDaemon for DaemonService {
                                     if store.add_embedding_with_force(&heading.uid, emb, force) {
                                         succeeded += 1;
                                     } else {
-                                        failed += 1;
+                                        rejected += 1;
                                     }
                                 }
                                 Err(e) => {
@@ -3305,8 +3310,12 @@ impl NestWeaverDaemon for DaemonService {
                     tracing::warn!("failed to flush embedding index: {e}");
                 }
 
-                tracing::info!(succeeded, failed, "embed RPC completed");
-                Ok::<_, Status>(EmbedResponse { succeeded, failed })
+                tracing::info!(succeeded, failed, rejected, "embed RPC completed");
+                Ok::<_, Status>(EmbedResponse {
+                    succeeded,
+                    failed,
+                    rejected,
+                })
             })
             .await
             .map_err(|e| Status::internal(format!("embed task panicked: {e}")))?;

--- a/crates/nestweaver-embed/src/lib.rs
+++ b/crates/nestweaver-embed/src/lib.rs
@@ -38,6 +38,9 @@ pub struct EmbedConfig {
 impl Default for EmbedConfig {
     fn default() -> Self {
         Self {
+            // Keep in sync with nestweaver_engine::config::DEFAULT_EMBEDDING_MODEL_ID
+            // (the canonical constant; this crate sits below nestweaver-engine in
+            // the dependency graph, so it cannot reference it directly).
             model_id: "sentence-transformers/all-MiniLM-L6-v2".to_string(),
             cache_dir: default_cache_dir(),
             external_endpoint: None,

--- a/crates/nestweaver-engine/src/cluster_dispatch.rs
+++ b/crates/nestweaver-engine/src/cluster_dispatch.rs
@@ -190,11 +190,22 @@ pub fn sidecar_path(db_path: &Path) -> PathBuf {
 }
 
 /// Persist clustering output to the sidecar file.
+///
+/// Writes to a process-unique temp file and renames into place, so a
+/// concurrent `load_clusters` (e.g. `hub_nodes` racing a `clusters` call)
+/// never observes a partially-written file. Concurrent writers resolve to
+/// last-writer-wins — acceptable because the output is deterministic for a
+/// given graph state.
 pub fn save_clusters(db_path: &Path, output: &ClusteringOutput) -> Result<()> {
     let path = sidecar_path(db_path);
     let json =
         serde_json::to_string_pretty(output).context("failed to serialize clustering output")?;
-    fs::write(&path, json).with_context(|| format!("failed to write {}", path.display()))?;
+    let tmp = path.with_extension(format!("json.tmp.{}", std::process::id()));
+    fs::write(&tmp, json).with_context(|| format!("failed to write {}", tmp.display()))?;
+    if let Err(e) = fs::rename(&tmp, &path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e).with_context(|| format!("failed to move {} into place", path.display()));
+    }
     Ok(())
 }
 

--- a/crates/nestweaver-engine/src/config.rs
+++ b/crates/nestweaver-engine/src/config.rs
@@ -275,13 +275,22 @@ pub struct EmbeddingConfig {
     pub semantic_search_limit: usize,
 }
 
+/// The default local embedding model, canonical for the whole workspace.
+///
+/// all-MiniLM-L6-v2: 384-dim, ~22MB, mean-pooled, no prefix — fast and light, the best
+/// general default for most users (many run CPU-only servers). A DB embedded with a
+/// different model records it (set_embedding_metadata) and the daemon loads that instead,
+/// so this default only applies to fresh/un-embedded instances. Override per-instance via
+/// `[embedding] model_id` (e.g. thenlper/gte-base for higher-quality 768-dim retrieval).
+///
+/// The CLI's `--model-id` default and the daemon-routing guard in `run_embed`
+/// reference this constant. `nestweaver-embed` keeps an internal copy in its
+/// `Default` impl (it cannot depend on this crate — the dependency runs the
+/// other way); keep the two in sync.
+pub const DEFAULT_EMBEDDING_MODEL_ID: &str = "sentence-transformers/all-MiniLM-L6-v2";
+
 fn default_model_id() -> String {
-    // all-MiniLM-L6-v2: 384-dim, ~22MB, mean-pooled, no prefix — fast and light, the best
-    // general default for most users (many run CPU-only servers). A DB embedded with a
-    // different model records it (set_embedding_metadata) and the daemon loads that instead,
-    // so this default only applies to fresh/un-embedded instances. Override per-instance via
-    // `[embedding] model_id` (e.g. thenlper/gte-base for higher-quality 768-dim retrieval).
-    "sentence-transformers/all-MiniLM-L6-v2".to_string()
+    DEFAULT_EMBEDDING_MODEL_ID.to_string()
 }
 fn default_embedding_cache_dir() -> String {
     "~/.cache/nestweaver/models".to_string()

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -1526,14 +1526,21 @@ impl<'a> WikilinkLookup<'a> {
         }
     }
 
-    /// Apply the 5-priority resolution scheme to `target`.
+    /// Apply the priority resolution scheme to `target`. Confidence decreases
+    /// monotonically down the chain — an earlier (more authoritative) tier
+    /// must never score below a later one, so downstream consumers can
+    /// threshold on confidence without inverting the resolver's own ordering.
     ///
-    /// 1. Path match: target contains `/` and matches a known path (lowercased,
-    ///    with/without `.md`) → confidence 1.0.
-    /// 2. Unique title match → confidence 1.0.
-    /// 3. Alias match → confidence 0.7.
-    /// 4. Same-folder match (title scoped to source's folder) → confidence 0.5.
-    /// 5. Ambiguous (multiple title/alias matches) → split confidence 1/N.
+    /// - Priority 1: path match — target contains `/` and matches a known
+    ///   path (lowercased, with/without `.md`) → confidence 1.0.
+    /// - Priority 2: unique title match → confidence 1.0.
+    /// - Priority 3: same-folder match (filename stem or title scoped to the
+    ///   source's folder) → confidence 0.95.
+    /// - Priority 3b: unique global filename-stem match (Obsidian
+    ///   shortest-path) → confidence 0.9.
+    /// - Priority 4: alias match → unique 0.7, ambiguous split.
+    /// - Priority 5: ambiguous title match → same-folder narrowing 0.5,
+    ///   otherwise split across all candidates.
     fn resolve(&self, target: &str, source_folder: &str) -> ResolveOutcome {
         let key = target.trim().replace('\\', "/").to_lowercase();
         if key.is_empty() {
@@ -1574,7 +1581,9 @@ impl<'a> WikilinkLookup<'a> {
         {
             return ResolveOutcome::Resolved(vec![ResolveCandidate {
                 note_uid: uids[0].to_string(),
-                confidence: 0.5,
+                // Must stay above priority 3b's 0.9: this tier outranks the
+                // global-stem match, and confidence must not invert priority.
+                confidence: 0.95,
             }]);
         }
 
@@ -2154,6 +2163,67 @@ sub b body
         ]);
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
         assert_eq!(result.wikilinks_resolved, 1);
+    }
+
+    #[test]
+    fn global_stem_match_resolves_cross_folder_wikilink() {
+        // Obsidian shortest-path: [[Boost Billing]] from another folder must
+        // resolve to projects/Boost Billing.md by filename stem, even though
+        // the note's title differs and it declares no alias. This was the
+        // ~25%-resolution-rate bug: only title/alias/same-folder matched.
+        let (_dir, root) = make_vault(&[
+            ("projects/Boost Billing.md", "# Billing PRD\n\nbody\n"),
+            ("logs/daily.md", "# Daily\n\nShipped [[Boost Billing]].\n"),
+        ]);
+        let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+        assert_eq!(result.wikilinks_resolved, 1);
+        assert_eq!(result.wikilinks_unresolved, 0);
+    }
+
+    #[test]
+    fn same_folder_match_outranks_global_stem() {
+        // Two notes share the stem `target`; the source sits next to one of
+        // them. Same-folder (priority 3) must win over the global-stem tier
+        // and pick the sibling, not leave the link ambiguous.
+        let (_dir, root) = make_vault(&[
+            ("f/x.md", "# X\n\nSee [[target]].\n"),
+            ("f/target.md", "# Alpha\n\nbody\n"),
+            ("g/target.md", "# Beta\n\nbody\n"),
+        ]);
+        let (result, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+        assert_eq!(result.wikilinks_resolved, 1);
+
+        let notes = store.list_notes(None).unwrap();
+        let uid_of = |path_frag: &str| {
+            notes
+                .iter()
+                .find(|n| n.file_path.contains(path_frag))
+                .map(|n| n.uid.clone())
+                .unwrap()
+        };
+        let edges = store.note_wikilink_edges().unwrap();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].0, uid_of("f/x.md"));
+        assert_eq!(
+            edges[0].1,
+            uid_of("f/target.md"),
+            "same-folder sibling must beat the cross-folder stem match"
+        );
+    }
+
+    #[test]
+    fn ambiguous_global_stem_stays_unresolved() {
+        // Two notes share the stem and the source is in a third folder: no
+        // tier can break the tie, so the link must count as unresolved rather
+        // than guess.
+        let (_dir, root) = make_vault(&[
+            ("logs/daily.md", "# Daily\n\nSee [[target]].\n"),
+            ("f/target.md", "# Alpha\n\nbody\n"),
+            ("g/target.md", "# Beta\n\nbody\n"),
+        ]);
+        let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+        assert_eq!(result.wikilinks_resolved, 0);
+        assert_eq!(result.wikilinks_unresolved, 1);
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -1431,6 +1431,9 @@ struct WikilinkLookup<'a> {
     by_title: HashMap<String, Vec<&'a str>>,
     /// Lowercased alias → list of note_uids that declare that alias.
     by_alias: HashMap<String, Vec<&'a str>>,
+    /// Lowercased filename stem → list of note_uids. Global lookup that
+    /// mirrors Obsidian's shortest-path resolution.
+    by_stem: HashMap<String, Vec<&'a str>>,
     /// note_uid → folder (relative, forward-slash). For same-folder priority.
     folder_by_note: HashMap<&'a str, &'a str>,
     /// note_uid → heading slug → heading_uid. For anchor resolution.
@@ -1449,6 +1452,7 @@ impl<'a> WikilinkLookup<'a> {
         let mut by_path: HashMap<String, &'a str> = HashMap::new();
         let mut by_title: HashMap<String, Vec<&'a str>> = HashMap::new();
         let mut by_alias: HashMap<String, Vec<&'a str>> = HashMap::new();
+        let mut by_stem: HashMap<String, Vec<&'a str>> = HashMap::new();
         let mut folder_by_note: HashMap<&'a str, &'a str> = HashMap::new();
         let mut headings_by_note: HashMap<&'a str, HashMap<&'a str, &'a str>> = HashMap::new();
         let mut by_folder_name: HashMap<(String, String), Vec<&'a str>> = HashMap::new();
@@ -1494,7 +1498,11 @@ impl<'a> WikilinkLookup<'a> {
             {
                 let stem_lc = stem.to_lowercase();
                 by_folder_name
-                    .entry((folder, stem_lc))
+                    .entry((folder, stem_lc.clone()))
+                    .or_default()
+                    .push(note.note_uid.as_str());
+                by_stem
+                    .entry(stem_lc)
                     .or_default()
                     .push(note.note_uid.as_str());
             }
@@ -1510,6 +1518,7 @@ impl<'a> WikilinkLookup<'a> {
             by_path,
             by_title,
             by_alias,
+            by_stem,
             folder_by_note,
             headings_by_note,
             by_folder_name,
@@ -1566,6 +1575,16 @@ impl<'a> WikilinkLookup<'a> {
             return ResolveOutcome::Resolved(vec![ResolveCandidate {
                 note_uid: uids[0].to_string(),
                 confidence: 0.5,
+            }]);
+        }
+
+        // Priority 3b: global filename-stem match (Obsidian shortest-path).
+        if let Some(uids) = self.by_stem.get(&key)
+            && uids.len() == 1
+        {
+            return ResolveOutcome::Resolved(vec![ResolveCandidate {
+                note_uid: uids[0].to_string(),
+                confidence: 0.9,
             }]);
         }
 

--- a/crates/nestweaver-federation/src/dispatch.rs
+++ b/crates/nestweaver-federation/src/dispatch.rs
@@ -418,7 +418,13 @@ async fn dispatch_typed_hub_nodes(
     auth_token: Option<&str>,
 ) -> Result<Value> {
     let req = nestweaver_proto::HubNodesRequest {
-        top_n: params.get("top_n").and_then(|v| v.as_i64()).unwrap_or(10) as i32,
+        // The MCP schema advertises 'limit'; 'top_n' kept as a backward-compat
+        // alias (and it is the proto field name).
+        top_n: params
+            .get("limit")
+            .or_else(|| params.get("top_n"))
+            .and_then(|v| v.as_i64())
+            .unwrap_or(10) as i32,
         response_format: params
             .get("response_format")
             .and_then(|v| v.as_str())

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -2605,7 +2605,7 @@ fn group_search_hits_by_note(
 fn tool_schema_note_get() -> Value {
     json!({
         "name": "note_get",
-        "description": "Fetch a vault note's full markdown body or specific sections, plus structural metadata (frontmatter, heading outline, tags).\n\nGuidelines:\n- Use after brain_search or brain_context identifies a relevant note\n- Pass uid for unambiguous lookup, or title for case-insensitive first-match\n- Use sections parameter to retrieve only specific heading sections — much more token-efficient for large notes\n\nLimitations:\n- Markdown notes only — for code symbols use read_symbols\n- Not a discovery tool — use brain_search or brain_context to find notes first",
+        "description": "Fetch a vault note's full markdown body or specific sections, plus structural metadata (frontmatter, heading outline, tags).\n\nRequires either 'uid' or 'title' (at least one must be provided).\n\nGuidelines:\n- Use after brain_search or brain_context identifies a relevant note\n- Pass uid for unambiguous lookup, or title for case-insensitive first-match\n- Use sections parameter to retrieve only specific heading sections — much more token-efficient for large notes\n\nLimitations:\n- Markdown notes only — for code symbols use read_symbols\n- Not a discovery tool — use brain_search or brain_context to find notes first",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -2777,7 +2777,7 @@ fn tool_note_get(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error
 fn tool_schema_backlinks() -> Value {
     json!({
         "name": "backlinks",
-        "description": "Find every note that wiki-links TO a specific target note, revealing the reverse link graph.\n\nGuidelines:\n- Pass uid or title (case-insensitive, first match) to identify the target\n- Returns source note paths, linking sections, confidence scores, and display text\n- For forward links (what a note links to), read the note body with note_get instead\n\nLimitations:\n- Only considers vault wikilinks, not code symbol dependencies (use brain_impact for those)\n- Confidence reflects link resolution quality, not semantic relevance",
+        "description": "Find every note that wiki-links TO a specific target note, revealing the reverse link graph.\n\nRequires either 'uid' or 'title' (at least one must be provided).\n\nGuidelines:\n- Pass uid or title (case-insensitive, first match) to identify the target\n- Returns source note paths, linking sections, confidence scores, and display text\n- For forward links (what a note links to), read the note body with note_get instead\n\nLimitations:\n- Only considers vault wikilinks, not code symbol dependencies (use brain_impact for those)\n- Confidence reflects link resolution quality, not semantic relevance",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -3615,7 +3615,7 @@ fn inline_ensure_daemon(db_path: &std::path::Path) -> anyhow::Result<std::path::
 fn tool_schema_cross_repo_contracts() -> Value {
     json!({
         "name": "cross_repo_contracts",
-        "description": "Find cross-repository references to a symbol — other repos that import, re-export, or implement the same symbol name.\n\nGuidelines:\n- Use when modifying a shared symbol to understand cross-repo blast radius\n- Pass uid or name; returns other repos with confidence scores and link types\n- Only useful when multiple repos are indexed in the same brain\n\nLimitations:\n- For single-repo impact use brain_impact; for general search use brain_search\n- Contract links are hypotheses — check confidence scores before acting\n\nIn server mode, the server has the full org-wide view of cross-repo contracts. Through the hybrid client, results include _meta.sources indicating which data sources contributed; a raw single-daemon connection returns local results only.",
+        "description": "Find cross-repository references to a symbol — other repos that import, re-export, or implement the same symbol name.\n\nRequires either 'uid' or 'name' (at least one must be provided).\n\nGuidelines:\n- Use when modifying a shared symbol to understand cross-repo blast radius\n- Pass uid or name; returns other repos with confidence scores and link types\n- Only useful when multiple repos are indexed in the same brain\n\nLimitations:\n- For single-repo impact use brain_impact; for general search use brain_search\n- Contract links are hypotheses — check confidence scores before acting\n\nIn server mode, the server has the full org-wide view of cross-repo contracts. Through the hybrid client, results include _meta.sources indicating which data sources contributed; a raw single-daemon connection returns local results only.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -4129,22 +4129,23 @@ fn tool_schema_detect_changes() -> Value {
         "inputSchema": {
             "type": "object",
             "properties": {
-                "files": {
+                "changed_files": {
                     "type": "array",
                     "items": { "type": "string" },
                     "description": "List of changed file paths (repo-relative). Example: [\"src/auth/login.ts\", \"src/utils/validate.ts\"]."
                 }
             },
-            "required": ["files"]
+            "required": ["changed_files"]
         }
     })
 }
 
 fn tool_detect_changes(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error> {
     let files: Vec<String> = args
-        .get("files")
+        .get("changed_files")
+        .or_else(|| args.get("files"))
         .and_then(|v| v.as_array())
-        .ok_or_else(|| anyhow!("'files' must be an array of strings"))?
+        .ok_or_else(|| anyhow!("'changed_files' must be an array of strings"))?
         .iter()
         .filter_map(|v| v.as_str().map(String::from))
         .collect();
@@ -4202,7 +4203,7 @@ fn tool_detect_changes(store: &GraphStore, args: Value) -> Result<Value, anyhow:
 fn tool_schema_affected_tests() -> Value {
     json!({
         "name": "affected_tests",
-        "description": "Prioritize which test files a PR should run by mapping changed files through the call/import graph to test files. Results bucketed into priority tiers.\n\nGuidelines:\n- Provide changed_files (repo-relative) or base_ref (git ref like 'main') to diff against\n- tier_1 = directly references changed symbol, tier_2 = direct caller, tier_3 = transitive\n- For symbol-level blast radius use brain_impact; for risk scoring use detect_changes\n\nLimitations:\n- Static call-graph regression test selection — misses reflection, DI, codegen, and integration/e2e tests\n- 'No tests found' does NOT mean safe to skip testing. IMPORTANT: keep periodic full test runs in CI\n\nWhen queried through the hybrid client (a local daemon connected to an upstream server), returns two-tier results (local_impact + org_wide_impact) with _meta.sources indicating provenance; a raw MCP connection to a single daemon returns single-tier local results.",
+        "description": "Prioritize which test files a PR should run by mapping changed files through the call/import graph to test files. Results bucketed into priority tiers.\n\nRequires either 'changed_files' or 'base_ref' (at least one must be provided).\n\nGuidelines:\n- Provide changed_files (repo-relative) or base_ref (git ref like 'main') to diff against\n- tier_1 = directly references changed symbol, tier_2 = direct caller, tier_3 = transitive\n- For symbol-level blast radius use brain_impact; for risk scoring use detect_changes\n\nLimitations:\n- Static call-graph regression test selection — misses reflection, DI, codegen, and integration/e2e tests\n- 'No tests found' does NOT mean safe to skip testing. IMPORTANT: keep periodic full test runs in CI\n\nWhen queried through the hybrid client (a local daemon connected to an upstream server), returns two-tier results (local_impact + org_wide_impact) with _meta.sources indicating provenance; a raw MCP connection to a single daemon returns single-tier local results.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -4295,6 +4296,12 @@ fn tool_clusters(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error
     });
 
     let output = compute_clusters(store, resolution).context("compute_clusters")?;
+
+    if let Ok(db_path) = current_db_path(store) {
+        if let Err(e) = nestweaver_engine::save_clusters(&db_path, &output) {
+            tracing::warn!("failed to persist clusters sidecar: {e}");
+        }
+    }
 
     let clusters_json: Vec<Value> = output
         .communities
@@ -4556,7 +4563,7 @@ fn dispatch_set_extension_via_daemon(
 fn tool_schema_query_extensions() -> Value {
     json!({
         "name": "query_extensions",
-        "description": "Query custom metadata set via set_extension. Two modes: by uid (all properties for a node) or by key+value (find all nodes matching a property).\n\nGuidelines:\n- Pass uid alone to inspect a node's custom properties\n- Pass key + value to find all nodes matching that property (exact match only)\n- For core graph queries use brain_search or brain_context, not this tool\n\nLimitations:\n- Exact match only — no partial matching, ranges, or regex on values\n- Only queries the extension sidecar, not core graph properties",
+        "description": "Query custom metadata set via set_extension. Two modes: by uid (all properties for a node) or by key+value (find all nodes matching a property).\n\nRequires either 'uid' or both 'key' and 'value' (at least one mode must be specified).\n\nGuidelines:\n- Pass uid alone to inspect a node's custom properties\n- Pass key + value to find all nodes matching that property (exact match only)\n- For core graph queries use brain_search or brain_context, not this tool\n\nLimitations:\n- Exact match only — no partial matching, ranges, or regex on values\n- Only queries the extension sidecar, not core graph properties",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -5467,7 +5474,7 @@ fn tool_schema_hub_nodes() -> Value {
         "inputSchema": {
             "type": "object",
             "properties": {
-                "top_n": {
+                "limit": {
                     "type": "integer",
                     "description": "Number of top hubs to return. Default 10.",
                     "default": 10
@@ -5485,7 +5492,8 @@ fn tool_schema_hub_nodes() -> Value {
 
 fn tool_hub_nodes(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error> {
     let top_n = args
-        .get("top_n")
+        .get("limit")
+        .or_else(|| args.get("top_n"))
         .and_then(|v| v.as_u64())
         .map(|n| n as usize)
         .unwrap_or(10);
@@ -5549,7 +5557,7 @@ fn tool_schema_bridge_nodes() -> Value {
         "inputSchema": {
             "type": "object",
             "properties": {
-                "top_n": {
+                "limit": {
                     "type": "integer",
                     "description": "Number of top bridges to return. Default 10.",
                     "default": 10
@@ -5567,7 +5575,8 @@ fn tool_schema_bridge_nodes() -> Value {
 
 fn tool_bridge_nodes(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error> {
     let top_n = args
-        .get("top_n")
+        .get("limit")
+        .or_else(|| args.get("top_n"))
         .and_then(|v| v.as_u64())
         .map(|n| n as usize)
         .unwrap_or(10);

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -4297,10 +4297,10 @@ fn tool_clusters(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error
 
     let output = compute_clusters(store, resolution).context("compute_clusters")?;
 
-    if let Ok(db_path) = current_db_path(store) {
-        if let Err(e) = nestweaver_engine::save_clusters(&db_path, &output) {
-            tracing::warn!("failed to persist clusters sidecar: {e}");
-        }
+    if let Ok(db_path) = current_db_path(store)
+        && let Err(e) = nestweaver_engine::save_clusters(&db_path, &output)
+    {
+        tracing::warn!("failed to persist clusters sidecar: {e}");
     }
 
     let clusters_json: Vec<Value> = output

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -4297,6 +4297,11 @@ fn tool_clusters(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error
 
     let output = compute_clusters(store, resolution).context("compute_clusters")?;
 
+    // Persist so hub_nodes/bridge_nodes can read the sidecar afterwards.
+    // Deliberate exception to "reads don't write": `clusters` is not in
+    // MUTATING_TOOLS, so this runs under the daemon's read guard — but it
+    // only writes derived cache data to a fixed sidecar path, never graph
+    // state, and degrades to warn-only (e.g. on a read-only filesystem).
     if let Ok(db_path) = current_db_path(store)
         && let Err(e) = nestweaver_engine::save_clusters(&db_path, &output)
     {
@@ -6263,7 +6268,13 @@ pub fn dispatch_via_daemon(
             "hub_nodes" => {
                 use nestweaver_proto::HubNodesRequest;
                 let req = tonic::Request::new(HubNodesRequest {
-                    top_n: i32_field("top_n"),
+                    // The schema advertises 'limit'; 'top_n' kept as a
+                    // backward-compat alias (and it is the proto field name).
+                    top_n: args
+                        .get("limit")
+                        .or_else(|| args.get("top_n"))
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0) as i32,
                     response_format: str_field("response_format"),
                 });
                 let resp = client
@@ -7239,5 +7250,45 @@ mod tool_doc_tests {
         for (name, cat, _, _) in &entries {
             assert_ne!(cat, "Other", "tool {name} is missing a category assignment");
         }
+    }
+}
+
+// The v2.2.1 schema renames (top_n → limit, files → changed_files) keep the
+// old names as runtime aliases. These tests pin both spellings on the
+// store-direct handlers; the daemon dispatch mappings (dispatch_via_daemon,
+// nestweaver-federation) forward 'limit' into the proto's top_n field.
+#[cfg(test)]
+mod arg_alias_tests {
+    use super::*;
+
+    #[test]
+    fn hub_nodes_accepts_limit_and_top_n_alias() {
+        let store = GraphStore::in_memory().unwrap();
+        let via_limit = tool_hub_nodes(&store, json!({ "limit": 5 })).unwrap();
+        assert_eq!(via_limit["top_n"], json!(5));
+        let via_alias = tool_hub_nodes(&store, json!({ "top_n": 7 })).unwrap();
+        assert_eq!(via_alias["top_n"], json!(7));
+        let default = tool_hub_nodes(&store, json!({})).unwrap();
+        assert_eq!(default["top_n"], json!(10));
+    }
+
+    #[test]
+    fn bridge_nodes_accepts_limit_and_top_n_alias() {
+        let store = GraphStore::in_memory().unwrap();
+        let via_limit = tool_bridge_nodes(&store, json!({ "limit": 5 })).unwrap();
+        assert_eq!(via_limit["top_n"], json!(5));
+        let via_alias = tool_bridge_nodes(&store, json!({ "top_n": 7 })).unwrap();
+        assert_eq!(via_alias["top_n"], json!(7));
+    }
+
+    #[test]
+    fn detect_changes_accepts_changed_files_and_files_alias() {
+        let store = GraphStore::in_memory().unwrap();
+        let via_new =
+            tool_detect_changes(&store, json!({ "changed_files": ["src/a.rs"] })).unwrap();
+        assert_eq!(via_new["files"], json!(["src/a.rs"]));
+        let via_alias = tool_detect_changes(&store, json!({ "files": ["src/b.rs"] })).unwrap();
+        assert_eq!(via_alias["files"], json!(["src/b.rs"]));
+        assert!(tool_detect_changes(&store, json!({})).is_err());
     }
 }

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -462,6 +462,17 @@ impl GraphStore {
         idx.add(uid, embedding, force)
     }
 
+    /// Re-arm the embedding index's once-per-run force-clear guard. Call at
+    /// the start of an embed run — matters for long-lived stores (the daemon)
+    /// where the index outlives individual embed runs.
+    pub fn reset_embedding_force_guard(&self) {
+        let mut idx = self
+            .embedding_index
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        idx.reset_force_guard();
+    }
+
     /// Check whether the embedding index already has an entry for `uid`.
     pub fn has_embedding(&self, uid: &str) -> bool {
         let idx = self

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -450,10 +450,15 @@ impl GraphStore {
 
     /// Add an embedding to the in-memory index without saving to disk.
     /// Use `flush_embedding_index` after a batch of additions to persist.
+    ///
+    /// Returns `false` when the dimension guard rejects the vector — callers
+    /// must not count a rejected embedding as stored.
+    #[must_use = "a false return means the dimension guard rejected the embedding"]
     pub fn add_embedding(&self, uid: &str, embedding: Vec<f32>) -> bool {
         self.add_embedding_with_force(uid, embedding, false)
     }
 
+    #[must_use = "a false return means the dimension guard rejected the embedding"]
     pub fn add_embedding_with_force(&self, uid: &str, embedding: Vec<f32>, force: bool) -> bool {
         let mut idx = self
             .embedding_index

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -450,12 +450,16 @@ impl GraphStore {
 
     /// Add an embedding to the in-memory index without saving to disk.
     /// Use `flush_embedding_index` after a batch of additions to persist.
-    pub fn add_embedding(&self, uid: &str, embedding: Vec<f32>) {
+    pub fn add_embedding(&self, uid: &str, embedding: Vec<f32>) -> bool {
+        self.add_embedding_with_force(uid, embedding, false)
+    }
+
+    pub fn add_embedding_with_force(&self, uid: &str, embedding: Vec<f32>, force: bool) -> bool {
         let mut idx = self
             .embedding_index
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        idx.add(uid, embedding);
+        idx.add(uid, embedding, force)
     }
 
     /// Check whether the embedding index already has an entry for `uid`.

--- a/crates/nestweaver-store/src/search.rs
+++ b/crates/nestweaver-store/src/search.rs
@@ -62,6 +62,7 @@ impl EmbeddingIndex {
     /// already stored, the entire index is cleared on the first mismatch so
     /// the new dimension becomes authoritative — this is the model-switch path.
     /// The clear happens at most once per run (see `force_cleared`).
+    #[must_use = "a false return means the dimension guard rejected the embedding"]
     pub fn add(&mut self, uid: &str, embedding: Vec<f32>, force: bool) -> bool {
         if let Some(existing) = self.embeddings.values().next()
             && embedding.len() != existing.len()
@@ -535,8 +536,8 @@ mod tests {
     #[test]
     fn add_force_clears_index_on_dimension_change() {
         let mut idx = EmbeddingIndex::new();
-        idx.add("sym:a", vec![1.0_f32, 0.0, 0.0], false);
-        idx.add("sym:b", vec![0.0_f32, 1.0, 0.0], false);
+        assert!(idx.add("sym:a", vec![1.0_f32, 0.0, 0.0], false));
+        assert!(idx.add("sym:b", vec![0.0_f32, 1.0, 0.0], false));
         assert_eq!(idx.len(), 2);
         assert_eq!(idx.dimension(), Some(3));
 
@@ -561,7 +562,7 @@ mod tests {
         // the same run means the source is emitting mixed dimensions and its
         // vectors must be rejected, not honored with another clear.
         let mut idx = EmbeddingIndex::new();
-        idx.add("sym:a", vec![1.0_f32, 0.0, 0.0], false); // dim 3
+        assert!(idx.add("sym:a", vec![1.0_f32, 0.0, 0.0], false)); // dim 3
         assert!(idx.add("sym:b", vec![1.0_f32, 0.0], true)); // dim 2: first clear
         assert!(idx.add("sym:c", vec![0.0_f32, 1.0], true)); // dim 2: normal add
         assert_eq!(idx.len(), 2);
@@ -577,7 +578,7 @@ mod tests {
         // The daemon's index outlives embed runs; a fresh run re-arms the
         // guard so a second deliberate model switch works.
         let mut idx = EmbeddingIndex::new();
-        idx.add("sym:a", vec![1.0_f32, 0.0, 0.0], false); // dim 3
+        assert!(idx.add("sym:a", vec![1.0_f32, 0.0, 0.0], false)); // dim 3
         assert!(idx.add("sym:b", vec![1.0_f32, 0.0], true)); // switch to dim 2
 
         idx.reset_force_guard();
@@ -593,7 +594,7 @@ mod tests {
         // guard). Before the query guard, `.zip()` truncated and returned a
         // plausible-but-wrong score.
         let mut idx = EmbeddingIndex::new();
-        idx.add("sym:right", vec![1.0_f32, 0.0, 0.0], false);
+        assert!(idx.add("sym:right", vec![1.0_f32, 0.0, 0.0], false));
         idx.embeddings
             .insert("sym:wrongdim".to_string(), vec![1.0_f32, 0.0]);
         let query = vec![1.0_f32, 0.0, 0.0];
@@ -621,9 +622,9 @@ mod tests {
     #[test]
     fn vector_search_cancellable_uncancelled_returns_results() {
         let mut idx = EmbeddingIndex::new();
-        idx.add("a", vec![1.0, 0.0, 0.0], false);
-        idx.add("b", vec![0.9, 0.1, 0.0], false);
-        idx.add("c", vec![0.0, 0.0, 1.0], false);
+        assert!(idx.add("a", vec![1.0, 0.0, 0.0], false));
+        assert!(idx.add("b", vec![0.9, 0.1, 0.0], false));
+        assert!(idx.add("c", vec![0.0, 0.0, 1.0], false));
 
         // Not cancelled → normal results.
         let live = idx
@@ -638,9 +639,9 @@ mod tests {
     #[test]
     fn vector_search_cancellable_returns_err_not_empty_on_cancel() {
         let mut idx = EmbeddingIndex::new();
-        idx.add("a", vec![1.0, 0.0, 0.0], false);
-        idx.add("b", vec![0.9, 0.1, 0.0], false);
-        idx.add("c", vec![0.0, 0.0, 1.0], false);
+        assert!(idx.add("a", vec![1.0, 0.0, 0.0], false));
+        assert!(idx.add("b", vec![0.9, 0.1, 0.0], false));
+        assert!(idx.add("c", vec![0.0, 0.0, 1.0], false));
 
         // Pre-cancelled over a NON-empty candidate set: a cancelled computation
         // is incomplete, not empty — it must surface as a distinct error so no
@@ -656,9 +657,9 @@ mod tests {
     #[test]
     fn vector_search_returns_most_similar() {
         let mut idx = EmbeddingIndex::new();
-        idx.add("a", vec![1.0, 0.0, 0.0], false);
-        idx.add("b", vec![0.9, 0.1, 0.0], false);
-        idx.add("c", vec![0.0, 0.0, 1.0], false);
+        assert!(idx.add("a", vec![1.0, 0.0, 0.0], false));
+        assert!(idx.add("b", vec![0.9, 0.1, 0.0], false));
+        assert!(idx.add("c", vec![0.0, 0.0, 1.0], false));
 
         let results = idx.vector_search(&[1.0, 0.0, 0.0], 2);
         assert_eq!(results.len(), 2);
@@ -670,7 +671,7 @@ mod tests {
     fn vector_search_limit_respected() {
         let mut idx = EmbeddingIndex::new();
         for i in 0..10 {
-            idx.add(&format!("sym:{i}"), vec![i as f32, 0.0], false);
+            assert!(idx.add(&format!("sym:{i}"), vec![i as f32, 0.0], false));
         }
         let results = idx.vector_search(&[1.0, 0.0], 3);
         assert_eq!(results.len(), 3);
@@ -684,7 +685,7 @@ mod tests {
         // Use an L2-normalized vector (vector_search assumes pre-normalized embeddings)
         let norm = (0.1_f32 * 0.1 + 0.2 * 0.2 + 0.3 * 0.3).sqrt();
         let v = vec![0.1 / norm, 0.2 / norm, 0.3 / norm];
-        idx.add("sym:test", v.clone(), false);
+        assert!(idx.add("sym:test", v.clone(), false));
         idx.save(&path).unwrap();
 
         let loaded = EmbeddingIndex::load(&path).unwrap();
@@ -760,9 +761,9 @@ mod tests {
         let path = dir.path().join("embeddings.bin");
 
         let mut idx = EmbeddingIndex::new();
-        idx.add("sym:alpha", vec![0.1, 0.2, 0.3], false);
-        idx.add("sym:beta", vec![0.4, 0.5, 0.6], false);
-        idx.add("sym:gamma", vec![0.7, 0.8, 0.9], false);
+        assert!(idx.add("sym:alpha", vec![0.1, 0.2, 0.3], false));
+        assert!(idx.add("sym:beta", vec![0.4, 0.5, 0.6], false));
+        assert!(idx.add("sym:gamma", vec![0.7, 0.8, 0.9], false));
         idx.save_binary(&path).unwrap();
 
         let loaded = EmbeddingIndex::load_binary(&path).unwrap();
@@ -825,8 +826,8 @@ mod tests {
 
         let mut idx = EmbeddingIndex::new();
         // farewell gets a perfect embedding match; greet gets a distant one
-        idx.add("sym:farewell", vec![1.0, 0.0, 0.0], false);
-        idx.add("sym:greet", vec![0.0, 1.0, 0.0], false);
+        assert!(idx.add("sym:farewell", vec![1.0, 0.0, 0.0], false));
+        assert!(idx.add("sym:greet", vec![0.0, 1.0, 0.0], false));
 
         let query_vec = [1.0_f32, 0.0, 0.0];
         let results = store

--- a/crates/nestweaver-store/src/search.rs
+++ b/crates/nestweaver-store/src/search.rs
@@ -51,24 +51,24 @@ impl EmbeddingIndex {
     /// already stored, the entire index is cleared on the first mismatch so
     /// the new dimension becomes authoritative — this is the model-switch path.
     pub fn add(&mut self, uid: &str, embedding: Vec<f32>, force: bool) -> bool {
-        if let Some(existing) = self.embeddings.values().next() {
-            if embedding.len() != existing.len() {
-                if force {
-                    tracing::info!(
-                        old_dim = existing.len(),
-                        new_dim = embedding.len(),
-                        "dimension change detected with --force; clearing index for model switch"
-                    );
-                    self.embeddings.clear();
-                } else {
-                    tracing::warn!(
-                        uid,
-                        got = embedding.len(),
-                        expected = existing.len(),
-                        "skipping embedding with mismatched dimension (re-embed with --force to switch models)"
-                    );
-                    return false;
-                }
+        if let Some(existing) = self.embeddings.values().next()
+            && embedding.len() != existing.len()
+        {
+            if force {
+                tracing::info!(
+                    old_dim = existing.len(),
+                    new_dim = embedding.len(),
+                    "dimension change detected with --force; clearing index for model switch"
+                );
+                self.embeddings.clear();
+            } else {
+                tracing::warn!(
+                    uid,
+                    got = embedding.len(),
+                    expected = existing.len(),
+                    "skipping embedding with mismatched dimension (re-embed with --force to switch models)"
+                );
+                return false;
             }
         }
         self.embeddings.insert(uid.to_string(), embedding);
@@ -508,7 +508,11 @@ mod tests {
         // Force with new dimension clears existing entries
         assert!(idx.add("sym:c", vec![1.0_f32, 0.0], true));
         assert_eq!(idx.len(), 1, "force should clear old entries");
-        assert_eq!(idx.dimension(), Some(2), "dimension should switch to new model's");
+        assert_eq!(
+            idx.dimension(),
+            Some(2),
+            "dimension should switch to new model's"
+        );
 
         // Subsequent adds with matching dimension work normally
         assert!(idx.add("sym:d", vec![0.0_f32, 1.0], false));

--- a/crates/nestweaver-store/src/search.rs
+++ b/crates/nestweaver-store/src/search.rs
@@ -44,27 +44,35 @@ impl EmbeddingIndex {
         }
     }
 
-    pub fn add(&mut self, uid: &str, embedding: Vec<f32>) {
-        // Keep the index homogeneous. A mixed-dimension index breaks the binary
-        // sidecar (`save_binary` writes one header dim but per-vector bytes;
-        // `load_binary` reads a fixed stride) → misaligned garbage or a load
-        // failure that silently kills semantic search. A dimension mismatch here
-        // means a vector from a different model — e.g. the daemon's local-fallback
-        // (384) leaking into a remote-embedded (768/1536) index on a transient
-        // remote outage, or a model switch without `--force`. Reject it rather
-        // than corrupt the index; the caller should re-embed with `--force`.
-        if let Some(existing) = self.embeddings.values().next()
-            && embedding.len() != existing.len()
-        {
-            tracing::warn!(
-                uid,
-                got = embedding.len(),
-                expected = existing.len(),
-                "skipping embedding with mismatched dimension (re-embed with --force to switch models)"
-            );
-            return;
+    /// Insert an embedding. Returns `true` if accepted, `false` if rejected
+    /// due to a dimension mismatch (when `force` is false).
+    ///
+    /// When `force` is true and the incoming dimension differs from what's
+    /// already stored, the entire index is cleared on the first mismatch so
+    /// the new dimension becomes authoritative — this is the model-switch path.
+    pub fn add(&mut self, uid: &str, embedding: Vec<f32>, force: bool) -> bool {
+        if let Some(existing) = self.embeddings.values().next() {
+            if embedding.len() != existing.len() {
+                if force {
+                    tracing::info!(
+                        old_dim = existing.len(),
+                        new_dim = embedding.len(),
+                        "dimension change detected with --force; clearing index for model switch"
+                    );
+                    self.embeddings.clear();
+                } else {
+                    tracing::warn!(
+                        uid,
+                        got = embedding.len(),
+                        expected = existing.len(),
+                        "skipping embedding with mismatched dimension (re-embed with --force to switch models)"
+                    );
+                    return false;
+                }
+            }
         }
         self.embeddings.insert(uid.to_string(), embedding);
+        true
     }
 
     pub fn save(&self, path: &Path) -> Result<(), anyhow::Error> {
@@ -483,10 +491,28 @@ mod tests {
     fn add_rejects_dimension_mismatched_vector() {
         // The index must stay homogeneous so the binary sidecar can't misalign.
         let mut idx = EmbeddingIndex::new();
-        idx.add("sym:a", vec![1.0_f32, 0.0, 0.0]); // establishes dim 3
-        idx.add("sym:b", vec![1.0_f32, 0.0]); // dim 2 — must be rejected
+        assert!(idx.add("sym:a", vec![1.0_f32, 0.0, 0.0], false)); // establishes dim 3
+        assert!(!idx.add("sym:b", vec![1.0_f32, 0.0], false)); // dim 2 — must be rejected
         assert_eq!(idx.len(), 1, "mismatched-dim vector must not be added");
         assert_eq!(idx.dimension(), Some(3));
+    }
+
+    #[test]
+    fn add_force_clears_index_on_dimension_change() {
+        let mut idx = EmbeddingIndex::new();
+        idx.add("sym:a", vec![1.0_f32, 0.0, 0.0], false);
+        idx.add("sym:b", vec![0.0_f32, 1.0, 0.0], false);
+        assert_eq!(idx.len(), 2);
+        assert_eq!(idx.dimension(), Some(3));
+
+        // Force with new dimension clears existing entries
+        assert!(idx.add("sym:c", vec![1.0_f32, 0.0], true));
+        assert_eq!(idx.len(), 1, "force should clear old entries");
+        assert_eq!(idx.dimension(), Some(2), "dimension should switch to new model's");
+
+        // Subsequent adds with matching dimension work normally
+        assert!(idx.add("sym:d", vec![0.0_f32, 1.0], false));
+        assert_eq!(idx.len(), 2);
     }
 
     #[test]
@@ -496,7 +522,7 @@ mod tests {
         // guard). Before the query guard, `.zip()` truncated and returned a
         // plausible-but-wrong score.
         let mut idx = EmbeddingIndex::new();
-        idx.add("sym:right", vec![1.0_f32, 0.0, 0.0]);
+        idx.add("sym:right", vec![1.0_f32, 0.0, 0.0], false);
         idx.embeddings
             .insert("sym:wrongdim".to_string(), vec![1.0_f32, 0.0]);
         let query = vec![1.0_f32, 0.0, 0.0];
@@ -524,9 +550,9 @@ mod tests {
     #[test]
     fn vector_search_cancellable_uncancelled_returns_results() {
         let mut idx = EmbeddingIndex::new();
-        idx.add("a", vec![1.0, 0.0, 0.0]);
-        idx.add("b", vec![0.9, 0.1, 0.0]);
-        idx.add("c", vec![0.0, 0.0, 1.0]);
+        idx.add("a", vec![1.0, 0.0, 0.0], false);
+        idx.add("b", vec![0.9, 0.1, 0.0], false);
+        idx.add("c", vec![0.0, 0.0, 1.0], false);
 
         // Not cancelled → normal results.
         let live = idx
@@ -541,9 +567,9 @@ mod tests {
     #[test]
     fn vector_search_cancellable_returns_err_not_empty_on_cancel() {
         let mut idx = EmbeddingIndex::new();
-        idx.add("a", vec![1.0, 0.0, 0.0]);
-        idx.add("b", vec![0.9, 0.1, 0.0]);
-        idx.add("c", vec![0.0, 0.0, 1.0]);
+        idx.add("a", vec![1.0, 0.0, 0.0], false);
+        idx.add("b", vec![0.9, 0.1, 0.0], false);
+        idx.add("c", vec![0.0, 0.0, 1.0], false);
 
         // Pre-cancelled over a NON-empty candidate set: a cancelled computation
         // is incomplete, not empty — it must surface as a distinct error so no
@@ -559,9 +585,9 @@ mod tests {
     #[test]
     fn vector_search_returns_most_similar() {
         let mut idx = EmbeddingIndex::new();
-        idx.add("a", vec![1.0, 0.0, 0.0]);
-        idx.add("b", vec![0.9, 0.1, 0.0]);
-        idx.add("c", vec![0.0, 0.0, 1.0]);
+        idx.add("a", vec![1.0, 0.0, 0.0], false);
+        idx.add("b", vec![0.9, 0.1, 0.0], false);
+        idx.add("c", vec![0.0, 0.0, 1.0], false);
 
         let results = idx.vector_search(&[1.0, 0.0, 0.0], 2);
         assert_eq!(results.len(), 2);
@@ -573,7 +599,7 @@ mod tests {
     fn vector_search_limit_respected() {
         let mut idx = EmbeddingIndex::new();
         for i in 0..10 {
-            idx.add(&format!("sym:{i}"), vec![i as f32, 0.0]);
+            idx.add(&format!("sym:{i}"), vec![i as f32, 0.0], false);
         }
         let results = idx.vector_search(&[1.0, 0.0], 3);
         assert_eq!(results.len(), 3);
@@ -587,7 +613,7 @@ mod tests {
         // Use an L2-normalized vector (vector_search assumes pre-normalized embeddings)
         let norm = (0.1_f32 * 0.1 + 0.2 * 0.2 + 0.3 * 0.3).sqrt();
         let v = vec![0.1 / norm, 0.2 / norm, 0.3 / norm];
-        idx.add("sym:test", v.clone());
+        idx.add("sym:test", v.clone(), false);
         idx.save(&path).unwrap();
 
         let loaded = EmbeddingIndex::load(&path).unwrap();
@@ -663,9 +689,9 @@ mod tests {
         let path = dir.path().join("embeddings.bin");
 
         let mut idx = EmbeddingIndex::new();
-        idx.add("sym:alpha", vec![0.1, 0.2, 0.3]);
-        idx.add("sym:beta", vec![0.4, 0.5, 0.6]);
-        idx.add("sym:gamma", vec![0.7, 0.8, 0.9]);
+        idx.add("sym:alpha", vec![0.1, 0.2, 0.3], false);
+        idx.add("sym:beta", vec![0.4, 0.5, 0.6], false);
+        idx.add("sym:gamma", vec![0.7, 0.8, 0.9], false);
         idx.save_binary(&path).unwrap();
 
         let loaded = EmbeddingIndex::load_binary(&path).unwrap();
@@ -728,8 +754,8 @@ mod tests {
 
         let mut idx = EmbeddingIndex::new();
         // farewell gets a perfect embedding match; greet gets a distant one
-        idx.add("sym:farewell", vec![1.0, 0.0, 0.0]);
-        idx.add("sym:greet", vec![0.0, 1.0, 0.0]);
+        idx.add("sym:farewell", vec![1.0, 0.0, 0.0], false);
+        idx.add("sym:greet", vec![0.0, 1.0, 0.0], false);
 
         let query_vec = [1.0_f32, 0.0, 0.0];
         let results = store

--- a/crates/nestweaver-store/src/search.rs
+++ b/crates/nestweaver-store/src/search.rs
@@ -29,6 +29,15 @@ use crate::ranking::SeedResolutionConfig;
 /// ```
 pub struct EmbeddingIndex {
     embeddings: HashMap<String, Vec<f32>>, // uid -> embedding vector
+    /// Whether a `force` add has already cleared this index for a dimension
+    /// switch. A model switch flips the dimension exactly once; a second flip
+    /// in the same run means the embedding source is emitting mixed dimensions
+    /// (e.g. a mid-run fallback to a different model) — clearing again would
+    /// wipe everything embedded so far, so those vectors are rejected instead.
+    /// Reset via [`reset_force_guard`] at the start of each embed run.
+    ///
+    /// [`reset_force_guard`]: EmbeddingIndex::reset_force_guard
+    force_cleared: bool,
 }
 
 impl Default for EmbeddingIndex {
@@ -41,26 +50,39 @@ impl EmbeddingIndex {
     pub fn new() -> Self {
         Self {
             embeddings: HashMap::new(),
+            force_cleared: false,
         }
     }
 
     /// Insert an embedding. Returns `true` if accepted, `false` if rejected
-    /// due to a dimension mismatch (when `force` is false).
+    /// due to a dimension mismatch (when `force` is false, or when `force`
+    /// already cleared the index once this run).
     ///
     /// When `force` is true and the incoming dimension differs from what's
     /// already stored, the entire index is cleared on the first mismatch so
     /// the new dimension becomes authoritative — this is the model-switch path.
+    /// The clear happens at most once per run (see `force_cleared`).
     pub fn add(&mut self, uid: &str, embedding: Vec<f32>, force: bool) -> bool {
         if let Some(existing) = self.embeddings.values().next()
             && embedding.len() != existing.len()
         {
-            if force {
+            if force && !self.force_cleared {
                 tracing::info!(
                     old_dim = existing.len(),
                     new_dim = embedding.len(),
                     "dimension change detected with --force; clearing index for model switch"
                 );
                 self.embeddings.clear();
+                self.force_cleared = true;
+            } else if force {
+                tracing::warn!(
+                    uid,
+                    got = embedding.len(),
+                    expected = existing.len(),
+                    "rejecting embedding: index was already force-cleared once this run; \
+                     the embedding source is emitting mixed dimensions"
+                );
+                return false;
             } else {
                 tracing::warn!(
                     uid,
@@ -75,6 +97,13 @@ impl EmbeddingIndex {
         true
     }
 
+    /// Re-arm the force-clear guard. Call at the start of an embed run so a
+    /// long-lived index (the daemon's) can honor a later, separate model
+    /// switch while still refusing mixed dimensions within one run.
+    pub fn reset_force_guard(&mut self) {
+        self.force_cleared = false;
+    }
+
     pub fn save(&self, path: &Path) -> Result<(), anyhow::Error> {
         let json = serde_json::to_string(&self.embeddings)?;
         std::fs::write(path, json)?;
@@ -84,7 +113,10 @@ impl EmbeddingIndex {
     pub fn load(path: &Path) -> Result<Self, anyhow::Error> {
         let json = std::fs::read_to_string(path)?;
         let embeddings: HashMap<String, Vec<f32>> = serde_json::from_str(&json)?;
-        Ok(Self { embeddings })
+        Ok(Self {
+            embeddings,
+            force_cleared: false,
+        })
     }
 
     // -- Binary persistence -------------------------------------------------
@@ -176,7 +208,10 @@ impl EmbeddingIndex {
             embeddings.insert(uid, vec);
         }
 
-        Ok(Self { embeddings })
+        Ok(Self {
+            embeddings,
+            force_cleared: false,
+        })
     }
 
     /// Return the top-`limit` (uid, similarity) pairs sorted descending.
@@ -517,6 +552,38 @@ mod tests {
         // Subsequent adds with matching dimension work normally
         assert!(idx.add("sym:d", vec![0.0_f32, 1.0], false));
         assert_eq!(idx.len(), 2);
+    }
+
+    #[test]
+    fn add_force_clears_at_most_once_per_run() {
+        // A mixed-dimension source under --force must not ping-pong-wipe the
+        // index: the first flip is a legitimate model switch, a second flip in
+        // the same run means the source is emitting mixed dimensions and its
+        // vectors must be rejected, not honored with another clear.
+        let mut idx = EmbeddingIndex::new();
+        idx.add("sym:a", vec![1.0_f32, 0.0, 0.0], false); // dim 3
+        assert!(idx.add("sym:b", vec![1.0_f32, 0.0], true)); // dim 2: first clear
+        assert!(idx.add("sym:c", vec![0.0_f32, 1.0], true)); // dim 2: normal add
+        assert_eq!(idx.len(), 2);
+
+        // dim-3 straggler (e.g. a mid-run fallback model) — rejected, no wipe
+        assert!(!idx.add("sym:d", vec![1.0_f32, 0.0, 0.0], true));
+        assert_eq!(idx.len(), 2, "second flip must not clear again");
+        assert_eq!(idx.dimension(), Some(2));
+    }
+
+    #[test]
+    fn reset_force_guard_allows_a_later_model_switch() {
+        // The daemon's index outlives embed runs; a fresh run re-arms the
+        // guard so a second deliberate model switch works.
+        let mut idx = EmbeddingIndex::new();
+        idx.add("sym:a", vec![1.0_f32, 0.0, 0.0], false); // dim 3
+        assert!(idx.add("sym:b", vec![1.0_f32, 0.0], true)); // switch to dim 2
+
+        idx.reset_force_guard();
+        assert!(idx.add("sym:c", vec![1.0_f32, 0.0, 0.0], true)); // switch back to dim 3
+        assert_eq!(idx.len(), 1);
+        assert_eq!(idx.dimension(), Some(3));
     }
 
     #[test]

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -2510,8 +2510,12 @@ impl GraphStore {
     /// to disk. For batch operations, prefer `add_embedding` +
     /// `flush_embedding_index` to avoid O(n^2) writes.
     pub fn update_note_embedding(&self, uid: &str, embedding: &[f32]) -> Result<(), StoreError> {
-        self.add_embedding(uid, embedding.to_vec());
-        self.flush_embedding_index()
+        // A dimension-guard rejection is logged by the index; nothing was
+        // inserted, so skip the flush.
+        if self.add_embedding(uid, embedding.to_vec()) {
+            self.flush_embedding_index()?;
+        }
+        Ok(())
     }
 
     /// Persist a Heading embedding to the sidecar `EmbeddingIndex`.
@@ -2520,8 +2524,10 @@ impl GraphStore {
     /// to disk. For batch operations, prefer `add_embedding` +
     /// `flush_embedding_index` to avoid O(n^2) writes.
     pub fn update_heading_embedding(&self, uid: &str, embedding: &[f32]) -> Result<(), StoreError> {
-        self.add_embedding(uid, embedding.to_vec());
-        self.flush_embedding_index()
+        if self.add_embedding(uid, embedding.to_vec()) {
+            self.flush_embedding_index()?;
+        }
+        Ok(())
     }
 
     /// Persist a Symbol embedding to the sidecar `EmbeddingIndex`.
@@ -2530,8 +2536,10 @@ impl GraphStore {
     /// to disk. For batch operations, prefer `add_embedding` +
     /// `flush_embedding_index` to avoid O(n^2) writes.
     pub fn update_symbol_embedding(&self, uid: &str, embedding: &[f32]) -> Result<(), StoreError> {
-        self.add_embedding(uid, embedding.to_vec());
-        self.flush_embedding_index()
+        if self.add_embedding(uid, embedding.to_vec()) {
+            self.flush_embedding_index()?;
+        }
+        Ok(())
     }
 
     /// Bulk-delete all Symbol and File nodes belonging to `repo_uid` using two

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -323,6 +323,9 @@ message EmbedRequest {
 message EmbedResponse {
   uint32 succeeded = 1;
   uint32 failed = 2;
+  // Embeddings rejected by the dimension guard (model mismatch), as opposed
+  // to `failed` (the model errored). Zero from pre-2.2.1 daemons.
+  uint32 rejected = 3;
 }
 
 // ─── Impact Analysis (Phase 4) ──────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -12294,7 +12294,7 @@ fn print_project_context_json(
 }
 
 /// Generate embeddings for symbols, notes, and/or headings.
-#[allow(clippy::too_many_arguments, unused_variables)]
+#[allow(clippy::too_many_arguments)]
 fn run_embed(
     db: Option<&Path>,
     local: bool,
@@ -12322,7 +12322,15 @@ fn run_embed(
     // NOT touch the daemon: connecting auto-starts one, whose held DB lock then
     // breaks the direct fallback with a confusing "could not set lock" error (and
     // leaks the daemon). Skip straight to the in-process path instead.
+    const DEFAULT_MODEL_ID: &str = "sentence-transformers/all-MiniLM-L6-v2";
     if use_daemon && endpoint.is_none() && !local {
+        if model_id != DEFAULT_MODEL_ID {
+            anyhow::bail!(
+                "--model-id '{model_id}' cannot be honored through the daemon; \
+                 the daemon uses the model recorded in the database. \
+                 Use --local --model-id '{model_id}' --force to switch models."
+            );
+        }
         let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
         match rt.block_on(nestweaver_client::DaemonClient::connect(path, None)) {
             Ok(mut client) => {
@@ -12388,6 +12396,7 @@ fn run_embed(
 
     let mut success_count = 0usize;
     let mut error_count = 0usize;
+    let mut rejected_count = 0usize;
 
     if let Some(ep) = endpoint {
         // ── External API path ────────────────────────────────────
@@ -12426,8 +12435,11 @@ fn run_embed(
                     match rt.block_on(generate_embeddings_batch(ep, api_model, &text_refs)) {
                         Ok(embeddings) => {
                             for (sym, emb) in chunk.iter().zip(embeddings) {
-                                store.add_embedding(&sym.uid, emb);
-                                success_count += 1;
+                                if store.add_embedding_with_force(&sym.uid, emb, force) {
+                                    success_count += 1;
+                                } else {
+                                    rejected_count += 1;
+                                }
                             }
                         }
                         Err(e) => {
@@ -12463,8 +12475,11 @@ fn run_embed(
                     match rt.block_on(generate_embeddings_batch(ep, api_model, &text_refs)) {
                         Ok(embeddings) => {
                             for (note, emb) in chunk.iter().zip(embeddings) {
-                                store.add_embedding(&note.uid, emb);
-                                success_count += 1;
+                                if store.add_embedding_with_force(&note.uid, emb, force) {
+                                    success_count += 1;
+                                } else {
+                                    rejected_count += 1;
+                                }
                             }
                         }
                         Err(e) => {
@@ -12519,8 +12534,11 @@ fn run_embed(
                     match rt.block_on(generate_embeddings_batch(ep, api_model, &text_refs)) {
                         Ok(embeddings) => {
                             for (h, emb) in chunk.iter().zip(embeddings) {
-                                store.add_embedding(&h.uid, emb);
-                                success_count += 1;
+                                if store.add_embedding_with_force(&h.uid, emb, force) {
+                                    success_count += 1;
+                                } else {
+                                    rejected_count += 1;
+                                }
                             }
                         }
                         Err(e) => {
@@ -12575,8 +12593,11 @@ fn run_embed(
                         match embed_model.embed(&text_refs) {
                             Ok(embeddings) => {
                                 for (sym, emb) in batch.iter().zip(embeddings.iter()) {
-                                    store.add_embedding(&sym.uid, emb.clone());
-                                    success_count += 1;
+                                    if store.add_embedding_with_force(&sym.uid, emb.clone(), force) {
+                                        success_count += 1;
+                                    } else {
+                                        rejected_count += 1;
+                                    }
                                 }
                             }
                             Err(e) => {
@@ -12615,8 +12636,11 @@ fn run_embed(
                         match embed_model.embed(&text_refs) {
                             Ok(embeddings) => {
                                 for (note, emb) in batch.iter().zip(embeddings.iter()) {
-                                    store.add_embedding(&note.uid, emb.clone());
-                                    success_count += 1;
+                                    if store.add_embedding_with_force(&note.uid, emb.clone(), force) {
+                                        success_count += 1;
+                                    } else {
+                                        rejected_count += 1;
+                                    }
                                 }
                             }
                             Err(e) => {
@@ -12668,8 +12692,11 @@ fn run_embed(
                         match embed_model.embed(&text_refs) {
                             Ok(embeddings) => {
                                 for (h, emb) in batch.iter().zip(embeddings.iter()) {
-                                    store.add_embedding(&h.uid, emb.clone());
-                                    success_count += 1;
+                                    if store.add_embedding_with_force(&h.uid, emb.clone(), force) {
+                                        success_count += 1;
+                                    } else {
+                                        rejected_count += 1;
+                                    }
                                 }
                             }
                             Err(e) => {
@@ -12716,10 +12743,18 @@ fn run_embed(
         }
     }
 
+    if rejected_count > 0 {
+        eprintln!(
+            "Error: {rejected_count} embedding(s) rejected due to dimension mismatch. \
+             Use --force to switch models (clears existing embeddings)."
+        );
+    }
+
     if stats {
         let elapsed = t0.elapsed();
         eprintln!(
-            "Embed stats: {success_count} succeeded, {error_count} failed, {:.2}s elapsed",
+            "Embed stats: {success_count} succeeded, {error_count} failed, \
+             {rejected_count} rejected (dim mismatch), {:.2}s elapsed",
             elapsed.as_secs_f64()
         );
     } else {
@@ -12728,7 +12763,7 @@ fn run_embed(
 
     drop(store);
 
-    if error_count > 0 {
+    if error_count > 0 || rejected_count > 0 {
         Ok(EXIT_ERROR)
     } else {
         Ok(EXIT_SUCCESS)
@@ -13594,39 +13629,59 @@ fn run_mcp_hybrid(
                 } else if write_tools.contains(name) {
                     // Write operations go through standard gRPC dispatch.
                     let grpc = hybrid.inner_mut();
-                    match nestweaver_mcp::tools::dispatch_via_daemon(
-                        grpc,
-                        &rt,
-                        name,
-                        arguments.clone(),
-                    ) {
-                        Ok(result) => {
+                    let dispatched = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        nestweaver_mcp::tools::dispatch_via_daemon(
+                            grpc,
+                            &rt,
+                            name,
+                            arguments.clone(),
+                        )
+                    }));
+                    match dispatched {
+                        Ok(Ok(result)) => {
                             serde_json::json!({
                                 "jsonrpc": "2.0",
                                 "id": id,
                                 "result": nestweaver_mcp::tools::wrap_tool_result(result),
                             })
                         }
-                        Err(e) => serde_json::json!({
+                        Ok(Err(e)) => serde_json::json!({
                             "jsonrpc": "2.0",
                             "id": id,
                             "result": nestweaver_mcp::tools::wrap_tool_error(&e.to_string()),
                         }),
+                        Err(_) => serde_json::json!({
+                            "jsonrpc": "2.0",
+                            "id": id,
+                            "result": nestweaver_mcp::tools::wrap_tool_error(
+                                &format!("tool '{name}' panicked")
+                            ),
+                        }),
                     }
                 } else {
                     // Read queries go through HybridClient for routing.
-                    match rt.block_on(hybrid.query(name, &arguments)) {
-                        Ok(result) => {
+                    let dispatched = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        rt.block_on(hybrid.query(name, &arguments))
+                    }));
+                    match dispatched {
+                        Ok(Ok(result)) => {
                             serde_json::json!({
                                 "jsonrpc": "2.0",
                                 "id": id,
                                 "result": nestweaver_mcp::tools::wrap_tool_result(result),
                             })
                         }
-                        Err(e) => serde_json::json!({
+                        Ok(Err(e)) => serde_json::json!({
                             "jsonrpc": "2.0",
                             "id": id,
                             "result": nestweaver_mcp::tools::wrap_tool_error(&e.to_string()),
+                        }),
+                        Err(_) => serde_json::json!({
+                            "jsonrpc": "2.0",
+                            "id": id,
+                            "result": nestweaver_mcp::tools::wrap_tool_error(
+                                &format!("tool '{name}' panicked")
+                            ),
                         }),
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12327,11 +12327,23 @@ fn run_embed(
         // compiled-in default for a fresh DB) — it cannot honor a different
         // --model-id, so bail early instead of silently embedding with the
         // wrong model. Read the recorded model through a read-only open: the
-        // daemon may hold the write lock, and a missing/locked DB just falls
-        // back to the default (matching what the daemon would load).
-        let daemon_model = nestweaver_store::GraphStore::open_read_only(path)
-            .ok()
-            .and_then(|s| s.get_embedding_metadata().ok().flatten())
+        // daemon may hold the write lock. A missing DB legitimately falls back
+        // to the default (that is what the daemon would load); a DB that
+        // exists but cannot be read gets a warning, because comparing against
+        // the default could then produce a spurious "cannot honor" error.
+        let recorded_model = match nestweaver_store::GraphStore::open_read_only(path) {
+            Ok(store) => store.get_embedding_metadata().ok().flatten(),
+            Err(e) => {
+                if path.exists() {
+                    eprintln!(
+                        "Warning: could not read the recorded embedding model ({e:#}); \
+                         assuming the default model"
+                    );
+                }
+                None
+            }
+        };
+        let daemon_model = recorded_model
             .map(|(recorded_model, _dim)| recorded_model)
             .unwrap_or_else(|| nestweaver_engine::config::DEFAULT_EMBEDDING_MODEL_ID.to_string());
         if model_id != daemon_model {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1256,7 +1256,7 @@ enum Commands {
         model: Option<String>,
         #[arg(
             long,
-            default_value = "sentence-transformers/all-MiniLM-L6-v2",
+            default_value = nestweaver_engine::config::DEFAULT_EMBEDDING_MODEL_ID,
             help = "HuggingFace model ID for local inference"
         )]
         model_id: String,
@@ -12322,12 +12322,22 @@ fn run_embed(
     // NOT touch the daemon: connecting auto-starts one, whose held DB lock then
     // breaks the direct fallback with a confusing "could not set lock" error (and
     // leaks the daemon). Skip straight to the in-process path instead.
-    const DEFAULT_MODEL_ID: &str = "sentence-transformers/all-MiniLM-L6-v2";
     if use_daemon && endpoint.is_none() && !local {
-        if model_id != DEFAULT_MODEL_ID {
+        // The daemon embeds with the model recorded in the database (or the
+        // compiled-in default for a fresh DB) — it cannot honor a different
+        // --model-id, so bail early instead of silently embedding with the
+        // wrong model. Read the recorded model through a read-only open: the
+        // daemon may hold the write lock, and a missing/locked DB just falls
+        // back to the default (matching what the daemon would load).
+        let daemon_model = nestweaver_store::GraphStore::open_read_only(path)
+            .ok()
+            .and_then(|s| s.get_embedding_metadata().ok().flatten())
+            .map(|(recorded_model, _dim)| recorded_model)
+            .unwrap_or_else(|| nestweaver_engine::config::DEFAULT_EMBEDDING_MODEL_ID.to_string());
+        if model_id != daemon_model {
             anyhow::bail!(
                 "--model-id '{model_id}' cannot be honored through the daemon; \
-                 the daemon uses the model recorded in the database. \
+                 the daemon uses the model recorded in the database ('{daemon_model}'). \
                  Use --local --model-id '{model_id}' --force to switch models."
             );
         }
@@ -12338,11 +12348,20 @@ fn run_embed(
                 match rt.block_on(client.embed(scope, force, batch_size as u32)) {
                     Ok(resp) => {
                         let elapsed = t0.elapsed();
+                        if resp.rejected > 0 {
+                            eprintln!(
+                                "Error: {} embedding(s) rejected due to dimension mismatch. \
+                                 Use --force to switch models (clears existing embeddings).",
+                                resp.rejected
+                            );
+                        }
                         if stats {
                             eprintln!(
-                                "Embed stats: {} succeeded, {} failed, {:.2}s elapsed",
+                                "Embed stats: {} succeeded, {} failed, \
+                                 {} rejected (dim mismatch), {:.2}s elapsed",
                                 resp.succeeded,
                                 resp.failed,
+                                resp.rejected,
                                 elapsed.as_secs_f64()
                             );
                         } else {
@@ -12351,7 +12370,7 @@ fn run_embed(
                                 resp.succeeded, resp.failed
                             );
                         }
-                        return if resp.failed > 0 {
+                        return if resp.failed > 0 || resp.rejected > 0 {
                             Ok(EXIT_ERROR)
                         } else {
                             Ok(EXIT_SUCCESS)

--- a/src/main.rs
+++ b/src/main.rs
@@ -12593,7 +12593,8 @@ fn run_embed(
                         match embed_model.embed(&text_refs) {
                             Ok(embeddings) => {
                                 for (sym, emb) in batch.iter().zip(embeddings.iter()) {
-                                    if store.add_embedding_with_force(&sym.uid, emb.clone(), force) {
+                                    if store.add_embedding_with_force(&sym.uid, emb.clone(), force)
+                                    {
                                         success_count += 1;
                                     } else {
                                         rejected_count += 1;
@@ -12636,7 +12637,8 @@ fn run_embed(
                         match embed_model.embed(&text_refs) {
                             Ok(embeddings) => {
                                 for (note, emb) in batch.iter().zip(embeddings.iter()) {
-                                    if store.add_embedding_with_force(&note.uid, emb.clone(), force) {
+                                    if store.add_embedding_with_force(&note.uid, emb.clone(), force)
+                                    {
                                         success_count += 1;
                                     } else {
                                         rejected_count += 1;


### PR DESCRIPTION
## Summary

Fixes 6 bugs from user feedback on the v2.2.0 release:

- **`--force` doesn't bypass embedding dimension guard (critical)** — `EmbeddingIndex::add()` now accepts a `force` param that clears the index on dimension mismatch instead of silently rejecting every vector. Returns `bool` so callers track accepted vs rejected. CLI reports rejected embeddings as errors instead of false successes.
- **`--model-id` silently ignored when daemon is running** — CLI now errors early when `--model-id` differs from the default and the embed would route through the daemon, directing users to `--local --model-id X --force`.
- **MCP server crash in hybrid mode** — `run_mcp_hybrid` lacked `catch_unwind` around tool dispatch (both write-tool and hybrid-query paths), unlike the other two server modes. A panic in the federation dispatch chain killed the MCP stdio pipe while the daemon stayed alive.
- **Wikilinks: low resolution rate (~25%)** — `WikilinkLookup` only matched filename stems within the same folder. Added global `by_stem` lookup (priority 3b, confidence 0.9) mirroring Obsidian's shortest-path resolution.
- **`hub_nodes` says "clustering not computed" after running `clusters`** — `tool_clusters` (MCP/daemon path) never called `save_clusters()`, so the sidecar wasn't written when clusters were computed via the daemon.
- **MCP tool schema inconsistencies** — Normalized `top_n` → `limit` on hub/bridge_nodes, `files` → `changed_files` on detect_changes (backward-compat aliases preserved), added "Requires either X or Y" to 5 tool descriptions where runtime enforces constraints not expressed in JSON schema.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace --no-fail-fast -- --skip daemon_` — 2,080 tests pass, 0 failures
- [x] Manual: `embed --model-id thenlper/gte-base --force` errors with clear message when daemon would be used
- [x] Manual: `embed --model-id thenlper/gte-base --force` (local mode) switches 384→768 dim successfully
- [x] Manual: re-embed with default model + `--force` over 768-dim index clears and re-embeds correctly
- [x] Manual: `clusters` writes `.clusters.json` sidecar on CLI-direct path
- [x] Manual: `detect_changes` accepts both `changed_files` (new) and `files` (backward compat)
- [x] New test: `add_force_clears_index_on_dimension_change` covers the force+dimension-switch path

## Behavior notes (for release notes)

- **Wikilink confidence values changed.** Same-folder matches now carry confidence **0.95** (was 0.5), and the new global-stem tier carries 0.9, so confidence decreases monotonically down the resolver's priority chain. Any consumer holding a numeric threshold on wikilink confidence will see more edges pass; in-repo, the affected consumers are PPR edge weighting (same-folder links now contribute more strongly) and the confidence values surfaced by `backlinks`/the web UI — no in-repo code thresholds on these values.
- **`nestweaver embed` exits non-zero when embeddings are rejected** by the dimension guard (previously reported success), on both the direct and daemon paths. The daemon's `EmbedResponse` gained a backward-compatible `rejected` field (zero from older daemons).
- **`--endpoint` mode bypasses the daemon `--model-id` guard by design** (no local model is loaded). A mismatched-dimension endpoint model is still rejected per-vector by the index guard and now surfaces as a non-zero exit with a `--force` hint.
