### PR TITLE
fix(dist): repair npm install path and stamp app bundle version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -100,3 +100,30 @@ jobs:
           files: |
             ${{ env.ARCHIVE }}
             ${{ env.ARCHIVE }}.sha256
+
+  publish-npm:
+    name: Publish npm wrapper
+    needs: [release-please, build]
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+      # The wrapper's postinstall downloads the matching release binary, so it
+      # must publish only after the `build` job has uploaded the assets for
+      # this tag. No-ops with a clear message until NPM_TOKEN is configured,
+      # so releases stay green before the secret exists.
+      - name: Publish to npm
+        working-directory: npm
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "NPM_TOKEN not set — skipping npm publish."
+            echo "Add the NPM_TOKEN repo secret to enable automatic publishing."
+            exit 0
+          fi
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3818,7 +3818,7 @@ checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "nestweaver"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3860,7 +3860,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-algorithms"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-client"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-daemon"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-embed"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -3953,7 +3953,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-engine"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "apollo-parser",
@@ -4001,7 +4001,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-federation"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4019,7 +4019,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-mcp"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-parser"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "bumpalo",
  "comrak",
@@ -4097,7 +4097,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-proto"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "prost",
  "tonic",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-resolver"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "glob",
  "insta",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-schema"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "hex",
  "serde",
@@ -4136,7 +4136,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-storage"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4151,7 +4151,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-store"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -4175,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-wasm"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "js-sys",
  "nestweaver-algorithms",
@@ -4188,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-web"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,8 +12,13 @@ nestweaver --version
 
 ## Option 2: Cargo (Rust users)
 
+Build and install from a local checkout (crates.io publishing is not yet
+automated, so `cargo install nestweaver` from the registry may lag the latest
+release — build from source to guarantee the current version):
+
 ```bash
-cargo install nestweaver
+git clone https://github.com/Kehl-io/nestweaver && cd nestweaver
+cargo install --path .
 nestweaver --version
 # Expected: nestweaver X.Y.Z
 ```
@@ -22,7 +27,7 @@ Semantic embeddings are included by default (`embed` feature). On **macOS**, add
 `--features metal` for GPU-accelerated embeddings from the CLI:
 
 ```bash
-cargo install nestweaver --features metal   # macOS: Metal GPU embeddings
+cargo install --path . --features metal   # macOS: Metal GPU embeddings
 ```
 
 > The macOS `.app` bundle (below) is already built with Metal and is the

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ See [Server Mode Guide](docs/server-mode.md) for full documentation.
 
 ### macOS (recommended: native app)
 
-Download **NestWeaver.app** from [GitHub Releases](https://github.com/Kehl-io/nestweaver/releases) — or build from source:
+Build the native **NestWeaver.app** from source (it bundles Metal-accelerated embeddings and the web UI):
 
 ```sh
 cd app && bash build.sh
@@ -379,8 +379,6 @@ NestWeaver includes a native macOS `.app` bundle — the recommended way to run 
 # Build from source (requires Xcode Command Line Tools)
 cd app && bash build.sh
 open target/release/NestWeaver.app
-
-# Or download NestWeaver.app from GitHub Releases
 ```
 
 The app is menubar-only (no Dock icon). Click the NestWeaver icon in the menubar to open the web UI or quit. Database is auto-detected from `NESTWEAVER_DB`, `~/.nestweaver/instance.toml`, or `~/.local/share/nestweaver/*/brain.lbug`.

--- a/app/Info.plist
+++ b/app/Info.plist
@@ -8,10 +8,13 @@
     <string>NestWeaver</string>
     <key>CFBundleIdentifier</key>
     <string>io.kehl.nestweaver</string>
+    <!-- Version is injected from version.txt by app/build.sh at build time,
+         so the bundle always matches the nestweaver binary it wraps. This
+         placeholder is only used if the bundle is assembled by hand. -->
     <key>CFBundleVersion</key>
-    <string>1.0.1</string>
+    <string>0.0.0</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0.1</string>
+    <string>0.0.0</string>
     <key>CFBundleExecutable</key>
     <string>NestWeaver</string>
     <key>CFBundleIconFile</key>

--- a/app/build.sh
+++ b/app/build.sh
@@ -55,6 +55,12 @@ mkdir -p "$APP_DIR/Contents/MacOS"
 mkdir -p "$APP_DIR/Contents/Resources"
 
 cp "$SCRIPT_DIR/Info.plist" "$APP_DIR/Contents/"
+# Stamp the bundle version from version.txt (release-please keeps it current)
+# so Finder/About match the nestweaver binary the bundle wraps.
+VERSION="$(tr -d '[:space:]' < "$REPO_ROOT/version.txt")"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$APP_DIR/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $VERSION" "$APP_DIR/Contents/Info.plist"
+echo "      Stamped app bundle version: $VERSION"
 cp "$REPO_ROOT/target/release/NestWeaverLauncher" "$APP_DIR/Contents/MacOS/NestWeaver"
 cp "$REPO_ROOT/target/release/nestweaver" "$APP_DIR/Contents/MacOS/nestweaver-cli"
 cp "$ICNS" "$APP_DIR/Contents/Resources/AppIcon.icns"

--- a/npm/install.js
+++ b/npm/install.js
@@ -23,23 +23,53 @@ if (!target) {
 
 const version = require("./package.json").version;
 const repo = "Kehl-io/nestweaver";
-const tag = `nestweaver-v${version}`;
+// Release tags are `v<version>` (release-please config: include-component-in-tag
+// false) and assets are `nestweaver-v<version>-<target>.tar.gz` (see the
+// `build` job in .github/workflows/release-please.yml). Keep these in sync.
+const tag = `v${version}`;
 const archive = `nestweaver-${tag}-${target}.tar.gz`;
-const url = `https://github.com/${repo}/releases/download/${tag}/${archive}`;
+const base = `https://github.com/${repo}/releases/download/${tag}`;
+const url = `${base}/${archive}`;
 
 const binDir = path.join(__dirname, ".nestweaver-bin");
 fs.mkdirSync(binDir, { recursive: true });
+const archivePath = path.join(binDir, archive);
 
 console.log(`Downloading NestWeaver v${version} for ${target}...`);
 
 try {
-  execSync(`curl -fsSL "${url}" | tar xz -C "${binDir}"`, {
-    stdio: "inherit",
-  });
+  execSync(`curl -fsSL "${url}" -o "${archivePath}"`, { stdio: "inherit" });
+
+  // Verify the SHA-256 the release ships alongside the archive — a mismatch
+  // means a corrupted or tampered download, which must fail loudly.
+  try {
+    const expected = execSync(`curl -fsSL "${url}.sha256"`)
+      .toString()
+      .trim()
+      .split(/\s+/)[0];
+    const actual = execSync(`shasum -a 256 "${archivePath}"`)
+      .toString()
+      .trim()
+      .split(/\s+/)[0];
+    if (expected && actual && expected !== actual) {
+      throw new Error(
+        `checksum mismatch: expected ${expected}, got ${actual}`,
+      );
+    }
+  } catch (checksumErr) {
+    if (String(checksumErr.message || "").includes("checksum mismatch")) {
+      throw checksumErr; // integrity failure — do not install
+    }
+    // Missing/unreadable .sha256 is not fatal; proceed with the download.
+  }
+
+  execSync(`tar xz -C "${binDir}" -f "${archivePath}"`, { stdio: "inherit" });
+  fs.rmSync(archivePath, { force: true });
   fs.chmodSync(path.join(binDir, "nestweaver"), 0o755);
   console.log("NestWeaver installed successfully.");
 } catch (err) {
-  console.warn(`Failed to download binary from ${url}`);
-  console.warn("Install from source instead: cargo install nestweaver");
-  process.exit(0); // Don't break npm install
+  console.warn(`Failed to install NestWeaver binary: ${err.message}`);
+  console.warn(`  URL: ${url}`);
+  console.warn("Build from source instead: cargo install --path . (from a checkout)");
+  process.exit(0); // Don't break npm install on transient/network failures
 }

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kehl-io/nestweaver",
-  "version": "0.1.0",
+  "version": "2.3.0",
   "description": "Code knowledge graph for AI agents — 40 MCP tools, 15 languages, graph visualization",
   "bin": {
     "nestweaver": "bin/nestweaver"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,11 @@
           "type": "toml",
           "path": "Cargo.toml",
           "jsonpath": "$.workspace.package.version"
+        },
+        {
+          "type": "json",
+          "path": "npm/package.json",
+          "jsonpath": "$.version"
         }
       ]
     }


### PR DESCRIPTION
Fixes the distribution-pipeline gaps found while installing 2.3.0.

## Problems
- `npm install -g @kehl-io/nestweaver` could **never** fetch a release: `npm/install.js` built the URL as tag `nestweaver-v<version>` with a doubled archive name, but releases are tagged `v<version>` with `nestweaver-v<version>-<target>.tar.gz`. (npm registry also had nothing published.)
- The macOS `.app` reported version **1.0.1** regardless of the real version — `app/Info.plist` was hardcoded and never stamped.
- **Cargo.lock drift**: release-please bumped `Cargo.toml` to 2.3.0 but not the lockfile's per-crate version entries, so `Cargo.lock` lagged at 2.2.1.
- INSTALL.md/README promised `cargo install nestweaver` (crates.io) and `.app` downloads from Releases, neither of which is automated.

## Fixes
- **npm URL** — correct tag/archive construction + SHA-256 verification (fails loudly on mismatch, soft-fails on network errors).
- **version sync** — `npm/package.json` added to release-please `extra-files`; bootstrapped to 2.3.0.
- **npm publish** — new `publish-npm` job (`needs: [release-please, build]`); no-ops until the `NPM_TOKEN` repo secret is added, so releases stay green.
- **app version** — `build.sh` stamps `CFBundleShortVersionString`/`CFBundleVersion` from `version.txt` via PlistBuddy.
- **Cargo.lock** — regenerated with `cargo update --workspace` (workspace crates → 2.3.0; external deps untouched); verified in sync via `cargo metadata --locked`.
- **docs** — reconciled to reality (build-from-source for cargo + `.app`).

## Verified at runtime
- `node npm/install.js` downloads + checksum-verifies the live `v2.3.0` arm64 asset → installed binary reports `nestweaver 2.3.0`.
- PlistBuddy injection stamps 2.3.0; `cargo metadata --locked` passes; release-please config + workflow parse clean.

## Follow-ups (not in this PR)
- **Add the `NPM_TOKEN` secret** to activate auto-publish.
- **Prevent Cargo.lock drift recurring**: the lockfile is correct now, but release-please will drift it again next release. A safe fix (a lockfile-sync step on the release PR) needs a real release to validate, so it's deferred rather than committed untested — a misconfigured release workflow is worse than the benign, auto-correcting drift.
- Signed+notarized `.app` in Releases and crates.io publishing remain deferred.

**Squash-merge** (conventional `fix:` title → release-please will cut a patch release).