### PR TITLE
fix(guide): generate-guide uses the live tool registry, emits raw markdown

### DIFF
--- a/crates/nestweaver-engine/src/agent_guide.rs
+++ b/crates/nestweaver-engine/src/agent_guide.rs
@@ -53,6 +53,22 @@ pub fn generate_guide_with_rules(
     config: Option<&InstanceConfig>,
     rules: Option<&[OwnedRule]>,
 ) -> Result<String, anyhow::Error> {
+    generate_guide_with_tools(store, config, rules, &[])
+}
+
+/// Like [`generate_guide_with_rules`] but accepts dynamic MCP tool metadata.
+///
+/// When `tool_docs` is non-empty the "Available MCP tools" section is rendered
+/// from the live registry (the full tool set); when empty it falls back to the
+/// curated legacy table for backward compatibility. Callers with access to the
+/// MCP registry (the CLI, the daemon's `brain_guide`) should always pass the
+/// live entries so the guide never drifts from the actual tool set.
+pub fn generate_guide_with_tools(
+    store: &GraphStore,
+    config: Option<&InstanceConfig>,
+    rules: Option<&[OwnedRule]>,
+    tool_docs: &[ToolDocEntry],
+) -> Result<String, anyhow::Error> {
     let mut out = String::new();
 
     // ── Frontmatter (carries the rules_version stamp) ─────────────────────
@@ -312,19 +328,26 @@ pub fn generate_guide_with_rules(
         }
     }
 
-    // Section 8: Available tools
-    out.push_str("## NestWeaver Tools\n\n");
-    out.push_str("This codebase is indexed by NestWeaver. Available MCP tools:\n\n");
-    out.push_str("| Tool | Use when |\n");
-    out.push_str("|------|----------|\n");
-    out.push_str("| `brain_context` | Exploring unfamiliar code — seeds from symbols, files, or note titles |\n");
-    out.push_str("| `brain_search` | Finding symbols or notes by keyword |\n");
-    out.push_str("| `note_get` | Reading a vault note's full content |\n");
-    out.push_str("| `backlinks` | Finding what links TO a note |\n");
-    out.push_str("| `brain_impact` | Checking blast radius before modifying a function |\n");
-    out.push_str("| `cross_repo_contracts` | Finding cross-service symbol relationships |\n");
-    out.push_str("| `brain_status` | Checking what's indexed |\n");
-    out.push('\n');
+    // Section 8: Available tools. Rendered from the live MCP registry when
+    // provided (the full tool set, grouped by category); otherwise a curated
+    // fallback for callers without registry access.
+    if !tool_docs.is_empty() {
+        out.push_str("This codebase is indexed by NestWeaver.\n\n");
+        render_dynamic_tool_tables(&mut out, tool_docs);
+    } else {
+        out.push_str("## NestWeaver Tools\n\n");
+        out.push_str("This codebase is indexed by NestWeaver. Available MCP tools:\n\n");
+        out.push_str("| Tool | Use when |\n");
+        out.push_str("|------|----------|\n");
+        out.push_str("| `brain_context` | Exploring unfamiliar code — seeds from symbols, files, or note titles |\n");
+        out.push_str("| `brain_search` | Finding symbols or notes by keyword |\n");
+        out.push_str("| `note_get` | Reading a vault note's full content |\n");
+        out.push_str("| `backlinks` | Finding what links TO a note |\n");
+        out.push_str("| `brain_impact` | Checking blast radius before modifying a function |\n");
+        out.push_str("| `cross_repo_contracts` | Finding cross-service symbol relationships |\n");
+        out.push_str("| `brain_status` | Checking what's indexed |\n");
+        out.push('\n');
+    }
 
     out.push_str("## When to Use MCP vs CLI vs Grep\n\n");
     out.push_str("NestWeaver provides three retrieval channels. Choose by context:\n\n");
@@ -973,6 +996,36 @@ mod tests {
         assert!(guide.contains("# Codebase Intelligence Guide"));
         assert!(guide.contains("## NestWeaver Tools"));
         assert!(guide.contains("brain_context"));
+    }
+
+    #[test]
+    fn guide_and_skill_render_dynamic_tool_registry_when_provided() {
+        // Regression guard: the tools section must come from the live registry
+        // passed by callers (CLI, daemon brain_guide), never a hand-curated
+        // subset. A probe tool that only exists here proves the dynamic path.
+        let store = nestweaver_store::GraphStore::in_memory().unwrap();
+        let tools = vec![ToolDocEntry {
+            name: "zzz_probe_tool".to_string(),
+            category: "Core retrieval".to_string(),
+            purpose: "A probe tool that only exists in this test.".to_string(),
+            key_params: vec!["seeds".to_string()],
+        }];
+
+        // With dynamic tool docs: categorized "Available MCP tools" table that
+        // includes the probe tool; the curated legacy heading is dropped.
+        let guide = generate_guide_with_tools(&store, None, None, &tools).unwrap();
+        assert!(guide.contains("## Available MCP tools"));
+        assert!(guide.contains("zzz_probe_tool"));
+        assert!(!guide.contains("## NestWeaver Tools"));
+
+        let skill = generate_skill_with_tools(&store, None, None, &tools).unwrap();
+        assert!(skill.contains("## Available MCP tools"));
+        assert!(skill.contains("zzz_probe_tool"));
+
+        // With no tool docs: both fall back to the curated legacy tables.
+        let guide_legacy = generate_guide_with_tools(&store, None, None, &[]).unwrap();
+        assert!(guide_legacy.contains("## NestWeaver Tools"));
+        assert!(!guide_legacy.contains("zzz_probe_tool"));
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -108,8 +108,8 @@ pub use affected_tests::{
 pub use agent_guide::{
     ToolDocEntry, generate_agents_md, generate_agents_md_with_rules, generate_claude_md,
     generate_claude_md_with_rules, generate_cursor_rule, generate_cursor_rule_with_rules,
-    generate_guide, generate_guide_with_rules, generate_skill, generate_skill_with_rules,
-    generate_skill_with_tools,
+    generate_guide, generate_guide_with_rules, generate_guide_with_tools, generate_skill,
+    generate_skill_with_rules, generate_skill_with_tools,
 };
 pub use backup::{
     BackupConfig, BackupManifest, BackupRepoInfo, BackupResult, BackupSizes, RestoreConfig,

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -14,14 +14,16 @@ use anyhow::{Context, anyhow};
 use nestweaver_engine::config::DEFAULT_RESULT_LIMIT;
 use nestweaver_engine::{
     BrainContextResult, DeadCodeConfidence, EmbedQueryFn, HybridSearchConfig, SummaryLevel,
-    affected_tests, analyze_blast_radius, attach_cluster_ids, attach_communities, broken_links,
-    build_brain_context_hybrid_with_aliases, compute_clusters, detect_changes_impact,
+    ToolDocEntry, affected_tests, analyze_blast_radius, attach_cluster_ids, attach_communities,
+    broken_links, build_brain_context_hybrid_with_aliases, compute_clusters, detect_changes_impact,
     detect_dead_code_cancellable, doc_stats, expand_query_with_aliases, filter_by_target,
-    find_bridge_nodes, find_hub_nodes, generate_guide, generate_summaries, get_all_properties,
-    get_last_indexed_at, investigate, investigate_expand, investigate_hydrate, load_alias_sidecar,
-    load_clusters, load_extensions, memory_consolidate, memory_lint, memory_related,
-    orphan_documents, parse_iso8601_to_epoch, populate_inline_bodies, query_by_property,
-    render_text, search_symbols, tag_graph, tag_graph_all, topic_clusters, truncate_to_budget,
+    find_bridge_nodes, find_hub_nodes, generate_agents_md_with_rules,
+    generate_claude_md_with_rules, generate_cursor_rule_with_rules, generate_guide_with_tools,
+    generate_skill_with_tools, generate_summaries, get_all_properties, get_last_indexed_at,
+    investigate, investigate_expand, investigate_hydrate, load_alias_sidecar, load_clusters,
+    load_extensions, memory_consolidate, memory_lint, memory_related, orphan_documents,
+    parse_iso8601_to_epoch, populate_inline_bodies, query_by_property, render_text, search_symbols,
+    tag_graph, tag_graph_all, topic_clusters, truncate_to_budget,
 };
 use nestweaver_schema::SymbolKind;
 use nestweaver_store::{GraphStore, TantivyIndex};
@@ -3872,18 +3874,48 @@ fn tool_brain_impact(
 fn tool_schema_brain_guide() -> Value {
     json!({
         "name": "brain_guide",
-        "description": "Generate a comprehensive orientation guide covering all indexed repos, vaults, cross-repo relationships, and available tools. No parameters required.\n\nGuidelines:\n- Call at session start for a read-once overview before issuing specific queries\n- Regenerated from current graph state on each call\n- Not a query tool — use brain_context or brain_search for specific lookups\n\nLimitations:\n- Can be expensive on large graphs; prefer brain_status for lightweight session initialization\n- Output size scales with number of indexed sources",
+        "description": "Generate a comprehensive orientation guide covering all indexed repos, vaults, cross-repo relationships, and available tools.\n\nGuidelines:\n- Call at session start for a read-once overview before issuing specific queries\n- Regenerated from current graph state on each call\n- The tools section is generated from the live MCP registry, so it never drifts from the actual tool set\n- Not a query tool — use brain_context or brain_search for specific lookups\n\nLimitations:\n- Can be expensive on large graphs; prefer brain_status for lightweight session initialization\n- Output size scales with number of indexed sources",
         "inputSchema": {
             "type": "object",
-            "properties": {}
+            "properties": {
+                "format": {
+                    "type": "string",
+                    "enum": ["markdown", "skill", "cursor-rule", "agents-md", "claude-md"],
+                    "default": "markdown",
+                    "description": "Output format. \"markdown\" (default) is the full orientation guide; \"skill\" emits a Claude skill; the others emit the matching agent-instruction file. All formats render the tool list from the live registry."
+                }
+            }
         }
     })
 }
 
-fn tool_brain_guide(store: &GraphStore, _args: Value) -> Result<Value, anyhow::Error> {
+fn tool_brain_guide(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error> {
+    let format = args
+        .get("format")
+        .and_then(|v| v.as_str())
+        .unwrap_or("markdown");
+
+    // Build tool docs from the live MCP registry so the tools section always
+    // reflects the real tool set rather than a hand-curated subset.
+    let tool_docs: Vec<ToolDocEntry> = tool_doc_entries()
+        .into_iter()
+        .map(|(name, category, purpose, key_params)| ToolDocEntry {
+            name,
+            category,
+            purpose,
+            key_params,
+        })
+        .collect();
+
     // The MCP server does not hold an InstanceConfig at runtime; cross-repo
     // edges from the graph are still included via the store query.
-    let guide = generate_guide(store, None)?;
+    let guide = match format {
+        "skill" => generate_skill_with_tools(store, None, None, &tool_docs)?,
+        "cursor-rule" => generate_cursor_rule_with_rules(store, None, None)?,
+        "agents-md" => generate_agents_md_with_rules(store, None, None, Some(tool_docs.len()))?,
+        "claude-md" => generate_claude_md_with_rules(store, None, None)?,
+        _ => generate_guide_with_tools(store, None, None, &tool_docs)?,
+    };
     Ok(json!({ "guide": guide }))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use nestweaver_engine::{
     discover_cross_domain_links, embedding::generate_embeddings_batch, expand_query_with_aliases,
     export_cypher, export_graphml, export_in_memory_graph, export_mermaid, filter_by_target,
     find_bridge_nodes, find_hub_nodes, generate_agents_md_with_rules,
-    generate_claude_md_with_rules, generate_cursor_rule_with_rules, generate_guide_with_rules,
+    generate_claude_md_with_rules, generate_cursor_rule_with_rules, generate_guide_with_tools,
     generate_repo_map, generate_summaries, get_last_indexed_at, incremental_index_with_name,
     index_directory_with_options, index_markdown_directory_since_with_ignore,
     index_markdown_directory_with_ignore, list_repos, list_services, load_alias_sidecar,
@@ -4019,8 +4019,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 if let Some(value) =
                     try_hybrid_json_rpc(true, &db_path, config.as_deref(), "brain_guide", args)
                 {
-                    // brain_guide returns the guide text as a JSON string.
-                    let text = if let Some(s) = value.as_str() {
+                    // brain_guide returns { "guide": "<markdown>" }. Extract the
+                    // raw markdown body — printing the JSON object would emit an
+                    // envelope with escaped newlines instead of a usable guide.
+                    let text = if let Some(s) = value.get("guide").and_then(|g| g.as_str()) {
+                        s.to_string()
+                    } else if let Some(s) = value.as_str() {
                         s.to_string()
                     } else {
                         serde_json::to_string_pretty(&value)?
@@ -4077,7 +4081,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     Some(tool_docs.len()),
                 )?,
                 "claude-md" => generate_claude_md_with_rules(&store, cfg_ref, rules_ref)?,
-                _ => generate_guide_with_rules(&store, cfg_ref, rules_ref)?,
+                _ => generate_guide_with_tools(&store, cfg_ref, rules_ref, &tool_docs)?,
             };
             match output {
                 Some(path) => {


### PR DESCRIPTION
## Problem
`generate-guide` routes through the daemon's `brain_guide` MCP tool whenever a daemon is running (the normal case). `brain_guide` ignored the `format` arg, called the tool-less `generate_guide`, and returned a JSON object. So `generate-guide --format skill` via the daemon:
- emitted a **JSON envelope** (the CLI's `value.as_str()` failed on the object → pretty-printed it) instead of raw markdown;
- rendered a **hand-curated 7-tool table** instead of the live **40-tool** registry;
- **ignored `--format`** entirely (returned a guide, not a skill).

The direct (`--no-daemon`) path already did the right thing — only the daemon proxy was lossy, so nobody noticed.

## Fix
- `generate_guide_with_tools` (mirrors `generate_skill_with_tools`): guide tools section renders from the live registry when provided, curated fallback when empty.
- `brain_guide` honors `format` and builds tool docs from `tool_doc_entries()`, dispatching to skill / cursor-rule / agents-md / claude-md / guide. Return shape `{"guide": …}` unchanged — backward-compatible for MCP agent callers (no args → default guide).
- CLI extracts the `guide` field from the daemon response → raw markdown, not an envelope.
- CLI default (markdown) guide now also passes the dynamic tool docs.
- Regression test locks in dynamic rendering vs the curated fallback.

## Verified at runtime (both paths)
- `--no-daemon generate-guide --format skill` → raw skill markdown, **40** tool rows.
- `--no-daemon generate-guide --format markdown` → "## Available MCP tools", **40** rows (was 7).
- Via a daemon running the rebuilt binary → raw markdown, skill frontmatter, 40 tools, **no JSON envelope**.
- Existing agent_guide tests pass (14), new regression test passes, clippy `-D warnings` clean.

**Squash-merge** (conventional `fix:` title).