### PR TITLE
ci: skip Rust jobs on frontend-only PRs, defer coverage to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,35 @@ env:
   CFLAGS: "-DZSTD_DISABLE_ASM"
 
 jobs:
+  # Detect what actually changed so we don't recompile the entire Rust
+  # workspace (~50 min) for a frontend-only PR, or run the frontend/e2e
+  # stack for a pure-Rust change. There are no branch-protection required
+  # checks, so skipped jobs are safe — they don't deadlock merges.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - '.cargo/**'
+              - '.github/workflows/ci.yml'
+            frontend:
+              - 'crates/nestweaver-web/frontend/**'
+
   fmt:
     name: Rustfmt
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -25,6 +52,8 @@ jobs:
 
   build-and-check:
     name: Build, Clippy & Tests
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Free disk space
@@ -63,6 +92,12 @@ jobs:
 
   coverage:
     name: Coverage
+    needs: changes
+    # Coverage is informational (uploads an lcov artifact; nothing gates on it)
+    # and is the single slowest job — a full *instrumented* recompile that can't
+    # reuse the build job's cache. Run it only when landing on main, not on
+    # every PR, so it's off the PR critical path.
+    if: github.event_name == 'push' && needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Free disk space
@@ -104,17 +139,25 @@ jobs:
 
   audit:
     name: Security Audit
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+      # Prebuilt binary via install-action instead of `cargo install cargo-audit`
+      # (which compiles it from source on every run, ~3 min).
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        uses: taiki-e/install-action@cargo-audit
       - name: Run audit
         run: cargo audit || true
 
   e2e:
     name: E2E Tests
+    needs: changes
+    # E2E drives the real backend API + the frontend, so run it whenever either
+    # side changes.
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     env:
       NESTWEAVER_NO_DAEMON: "1"


### PR DESCRIPTION
## Why

CI wall-clock is gated by two structural costs, neither of which needs to run on every PR. Measured from recent runs:

| Job | Duration |
|---|---|
| Coverage | up to **73 min** (cold), ~15 min (warm) — **wall-clock ceiling** |
| Build, Clippy & Tests | ~50–53 min |
| E2E | ~7 min |
| Security Audit | ~3 min |
| Rustfmt | ~17 s |

Two problems:
1. **Frontend-only PRs recompiled the entire Rust workspace 3× in parallel** (build-and-check, coverage, e2e each `cargo build`). ~53–73 min to validate a TypeScript/bundle change.
2. **Coverage is the slowest job and is purely informational** — it uploads an lcov artifact on its own cache key (never reuses the build job's work) and does a full *instrumented* recompile. Nothing gates on it.

Note: `lbug` must compile from source on Linux (the prebuilt double-frees on glibc — see `crates/nestweaver-store/build.rs`), so the C++ compile cost is unavoidable per cold build. The fix is to stop paying it when it isn't needed.

## What

- Add a `changes` job (`dorny/paths-filter`) that detects Rust vs frontend changes.
- Gate Rust jobs (`fmt`, `build-and-check`, `audit`) on `rust` changes; run `e2e` when **either** Rust or frontend changes (it drives the real backend API + frontend).
- Run `coverage` **only on push to `main`**, not on PRs — off the PR critical path.
- Install `cargo-audit` via `taiki-e/install-action` (prebuilt) instead of `cargo install` (source build, ~3 min).

Safe to skip jobs: there are **no branch-protection required status checks**, so a skipped job does not deadlock merges.

## Expected impact

- **Frontend-only PRs:** ~53–73 min → **~7 min** (e2e only).
- **Rust PRs:** ceiling drops ~73 min → **~53 min** (no per-PR coverage).
- Coverage still runs on every merge to `main`.

Follow-up (not in this PR): `sccache` to cache the `lbug` C++ + Rust compilation across the Cargo.lock cache-invalidations that version bumps cause — the structural fix for "why is build ~50 min even warm." Worth measuring separately.