### PR TITLE
fix(release): synchronize Cargo lockfile in release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,6 +22,29 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+      - name: Check out release PR
+        if: steps.release.outputs.prs_created == 'true'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+      - name: Install Rust toolchain
+        if: steps.release.outputs.prs_created == 'true'
+        uses: dtolnay/rust-toolchain@stable
+      - name: Synchronize release lockfile
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          RELEASE_PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+        run: |
+          cargo update --workspace
+          if git diff --quiet -- Cargo.lock; then
+            exit 0
+          fi
+
+          git add Cargo.lock
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore: synchronize Cargo.lock for release"
+          git push origin "HEAD:$RELEASE_PR_BRANCH"
 
   build:
     name: Build ${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3969,7 +3969,7 @@ checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "nestweaver"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4011,7 +4011,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-algorithms"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -4019,7 +4019,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-client"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -4043,7 +4043,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-daemon"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-embed"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-engine"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "apollo-parser",
@@ -4151,7 +4151,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-federation"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4169,7 +4169,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-mcp"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-parser"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "bumpalo",
  "comrak",
@@ -4247,7 +4247,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-proto"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "prost",
  "tokio-stream",
@@ -4259,7 +4259,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-resolver"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "glob",
  "insta",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-schema"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "hex",
  "serde",
@@ -4287,7 +4287,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-storage"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4302,7 +4302,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-store"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -4328,7 +4328,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-wasm"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "js-sys",
  "nestweaver-algorithms",
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-web"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "axum",


### PR DESCRIPTION
## Summary

- synchronize the 2.5.0 workspace package versions in `Cargo.lock`
- post-process Release Please PRs with `cargo update --workspace`
- commit only the generated lockfile correction back to the release branch

## Root cause

Release Please updates `[workspace.package].version` through the simple releaser, but does not update the corresponding workspace package entries in `Cargo.lock`. The strict release build therefore failed immediately under `--locked` on all four target platforms.

## Verification

- reproduced the failure with `cargo build --locked --release --target aarch64-apple-darwin -p openssl-sys`
- synchronized the lockfile and reran the same command successfully
- `cargo metadata --locked --format-version 1`
- workflow YAML parse
- `git diff --check`
- NestWeaver change impact: low risk, no runtime symbols or flows affected