### PR TITLE
fix(release): guard missing release PR output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,8 +33,9 @@ jobs:
       - name: Synchronize release lockfile
         if: steps.release.outputs.prs_created == 'true'
         env:
-          RELEASE_PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          RELEASE_PR: ${{ steps.release.outputs.pr }}
         run: |
+          RELEASE_PR_BRANCH="$(jq -er '.headBranchName' <<< "$RELEASE_PR")"
           cargo update --workspace
           if git diff --quiet -- Cargo.lock; then
             exit 0


### PR DESCRIPTION
## Summary

- stop evaluating `fromJSON` for an absent release PR output
- parse the PR payload only inside the PR-only lock synchronization step
- allow release-created runs to proceed to platform artifact builds

## Root cause

Release Please successfully created v2.5.1, but the subsequent lock synchronization step evaluated its `fromJSON` environment expression even though no release PR exists on the release-created path. That template error failed the job and skipped all artifact builds.

## Validation

- workflow YAML parses successfully
- PR payload branch extraction succeeds with `jq -er`
- `git diff --check` passes
- change is limited to the release workflow