### PR TITLE
chore: remove GitNexus integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,7 +28,6 @@ graphify-out/
 .claude/
 .agents/
 .codex/
-.gitnexus/
 .playwright-cli/
 .superpowers/
 .devcontainer/

--- a/.gitignore
+++ b/.gitignore
@@ -57,9 +57,6 @@ GEMINI.md
 .clinerules
 .windsurfrules
 
-# Competitor skills (not part of this project)
-.claude/skills/gitnexus/
-
 # Sidecar files (generated at runtime)
 *.pagerank.json
 *.manifests.json


### PR DESCRIPTION
## Summary

- remove GitNexus-specific repository ignore entries
- remove the local GitNexus index and unregister the repository
- remove generated GitNexus agent skills and instructions
- preserve intentional benchmark comparisons against GitNexus

## Verification

- `gitnexus status`: repository not indexed
- `gitnexus list`: no indexed repositories
- full integration-path/reference sweep is empty
- `git diff --check` passes