### PR TITLE
chore: remove remaining GitNexus references

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,31 +623,31 @@ Elasticsearch — 511K symbols, 43K files
 </table>
 
 <details>
-<summary>Benchmark results (NestWeaver vs Graphify vs GitNexus)</summary>
+<summary>Benchmark results (NestWeaver vs Graphify)</summary>
 
 **Query Speed (p50)**
 
-| Repository | Files | NestWeaver | Graphify | GitNexus |
-|---|---:|---:|---:|---:|
-| Tailwind CSS | 542 | **157ms** | 185ms | 700ms |
-| Deno | 14,136 | **82ms** | 1,355ms | 908ms |
-| Next.js | 29,402 | **71ms** | 2,440ms | 1,116ms |
-| Elasticsearch | 43,806 | **617ms** | crashed | 1,573ms |
+| Repository | Files | NestWeaver | Graphify |
+|---|---:|---:|---:|
+| Tailwind CSS | 542 | **157ms** | 185ms |
+| Deno | 14,136 | **82ms** | 1,355ms |
+| Next.js | 29,402 | **71ms** | 2,440ms |
+| Elasticsearch | 43,806 | **617ms** | crashed |
 
 **Indexing Speed**
 
-| Repository | NestWeaver | Graphify | GitNexus |
-|---|---:|---:|---:|
-| Tailwind CSS | 3.6s | 2.5s | 9.2s |
-| Deno | 51s | 33s | 84s |
-| Next.js | **33s** | 111s | 176s |
-| Elasticsearch | **3,462s** | crashed | 5,434s |
+| Repository | NestWeaver | Graphify |
+|---|---:|---:|
+| Tailwind CSS | 3.6s | 2.5s |
+| Deno | 51s | 33s |
+| Next.js | **33s** | 111s |
+| Elasticsearch | **3,462s** | crashed |
 
-**Incremental re-indexing** (NestWeaver only — competitors require full re-index): 632ms (Tailwind), 4.0s (Next.js), 73s (Elasticsearch).
+**Incremental re-indexing** (NestWeaver only — Graphify requires full re-index): 632ms (Tailwind), 4.0s (Next.js), 73s (Elasticsearch).
 
 **Graph depth**: NestWeaver extracts 142K symbols / 280K edges on Deno (vs Graphify's 76K / 177K). On Elasticsearch: 511K symbols, 14.8M edges.
 
-**Result quality**: NestWeaver returns ~30 connected symbols per query ranked by PageRank with full signatures. Graphify returns file-level nodes with 9-15% garbage stubs. GitNexus finds definitions but returns 0 callers and 0 callees.
+**Result quality**: NestWeaver returns ~30 connected symbols per query ranked by PageRank with full signatures. Graphify returns file-level nodes with 9-15% garbage stubs.
 
 *Benchmarked in daemon mode on M3 Pro (36 GB). See [benchmarks/](benchmarks/) to reproduce.*
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,6 @@
 # NestWeaver Benchmark Suite
 
-Competitive benchmark comparing NestWeaver against Graphify and GitNexus on indexing speed, query latency, and token savings.
+Competitive benchmark comparing NestWeaver against Graphify on indexing speed, query latency, and token savings.
 
 ## Quick Start
 
@@ -18,7 +18,7 @@ The suite is fully self-contained — nothing touches your global NestWeaver ins
 
 - **NestWeaver** is built from source into `/private/tmp/nestweaver-bench/local/` with Metal + embed features
 - **A dedicated daemon** starts per-repo with its own DB socket (your production daemon is untouched)
-- **GitNexus** is installed via npm into a local prefix under the bench root
+- **Graphify** is installed into a Python virtual environment under the bench root
 - **Python deps** (matplotlib, tiktoken) go into a venv at `venvs/bench/`
 - **All indexes, results, and reports** live under `/private/tmp/nestweaver-bench/`
 
@@ -50,7 +50,7 @@ Results land in `/private/tmp/nestweaver-bench/`:
 results/
   metadata.json               # Hardware, versions, repo SHAs
   <repo>-nestweaver.json      # Per-repo NestWeaver results
-  <repo>-gitnexus.json        # Per-repo competitor results
+  <repo>-graphify.json        # Per-repo competitor results
   token-savings.json           # Token comparison data
 report/
   benchmark-report.md          # Markdown report with tables

--- a/benchmarks/charts.py
+++ b/benchmarks/charts.py
@@ -72,16 +72,14 @@ apply_dark_theme()
 TOOL_COLORS = {
     "nestweaver": "#4F9CF7",
     "graphify": "#10B981",
-    "gitnexus": "#F59E0B",
 }
 
 TOOL_LABELS = {
     "nestweaver": "NestWeaver",
     "graphify": "Graphify",
-    "gitnexus": "GitNexus",
 }
 
-TOOL_ORDER = ["nestweaver", "graphify", "gitnexus"]
+TOOL_ORDER = ["nestweaver", "graphify"]
 
 REPO_ORDER = ["tailwindcss", "deno", "next.js", "elasticsearch"]
 
@@ -169,9 +167,6 @@ def compute_quality_stats(data: dict) -> dict:
                 total_nodes = sum(q.get("results", 0) for q in queries)
                 total_noise = sum(q.get("noise_nodes", 0) for q in queries)
                 t["noise_pct"] = (total_noise / total_nodes * 100) if total_nodes > 0 else 0.0
-
-            elif tool == "gitnexus":
-                t["avg_results"] = sum(q.get("results", 0) for q in queries) / len(queries)
 
             if t:
                 repo_stats[tool] = t
@@ -618,7 +613,7 @@ def generate_report(
         lines.append("## Incremental Indexing")
         lines.append("")
         lines.append("After a single file change, NestWeaver can re-index without "
-                      "rebuilding the entire graph. Competitors require a full re-index.")
+                     "rebuilding the entire graph. Graphify requires a full re-index.")
         lines.append("")
         if incremental_chart:
             lines.append("![Incremental Indexing](incremental-indexing.svg)")
@@ -666,7 +661,7 @@ def generate_report(
     if has_graph_stats:
         lines.append("## Graph Depth")
         lines.append("")
-        lines.append("NestWeaver extracts more symbols and cross-references than competitors,")
+        lines.append("NestWeaver extracts more symbols and cross-references than Graphify,")
         lines.append("building a richer knowledge graph that powers deeper query results.")
         lines.append("")
         if graph_depth_chart:
@@ -717,28 +712,25 @@ def generate_report(
         lines.append("Per-repo averages for structural / context queries:")
         lines.append("")
         lines.append("| Repository | NW Seeds | NW Connected | NW Unique Files "
-                     "| Graphify Nodes | Graphify Noise | GitNexus Results |")
-        lines.append("|---|---:|---:|---:|---:|---:|---:|")
+                     "| Graphify Nodes | Graphify Noise |")
+        lines.append("|---|---:|---:|---:|---:|---:|")
         for repo in repos:
             rs = quality_stats.get(repo, {})
             nw = rs.get("nestweaver", {})
             gf = rs.get("graphify", {})
-            gn = rs.get("gitnexus", {})
             seeds = f"{nw['avg_seeds']:.1f}" if "avg_seeds" in nw else "-"
             connected = f"{nw['avg_connected']:.1f}" if "avg_connected" in nw else "-"
             unique = f"{nw['avg_unique_files']:.1f}" if "avg_unique_files" in nw else "-"
             gf_nodes = f"{gf['avg_nodes']:.1f}" if "avg_nodes" in gf else "-"
             gf_noise = f"{gf['avg_noise']:.1f}" if "avg_noise" in gf else "-"
-            gn_results = f"{gn['avg_results']:.1f}" if "avg_results" in gn else "-"
             lines.append(f"| {REPO_LABELS.get(repo, repo)} | {seeds} | {connected} "
-                         f"| {unique} | {gf_nodes} | {gf_noise} | {gn_results} |")
+                         f"| {unique} | {gf_nodes} | {gf_noise} |")
         lines.append("")
 
     # Search Results table
     has_search = any(
         quality_stats.get(r, {}).get("nestweaver", {}).get("avg_search_results") is not None
         or quality_stats.get(r, {}).get("graphify", {}).get("avg_nodes") is not None
-        or quality_stats.get(r, {}).get("gitnexus", {}).get("avg_results") is not None
         for r in repos
     )
     if has_search:
@@ -762,8 +754,6 @@ def generate_report(
                     val = ts.get("avg_search_results")
                 elif tool == "graphify":
                     val = ts.get("avg_nodes")
-                elif tool == "gitnexus":
-                    val = ts.get("avg_results")
                 else:
                     val = None
                 row += f" {val:.1f} |" if val is not None else " - |"
@@ -779,12 +769,10 @@ def generate_report(
     nw_unique_files_vals = []
     gf_nodes_vals = []
     gf_noise_pcts = []
-    gn_results_vals = []
     for repo in repos:
         rs = quality_stats.get(repo, {})
         nw = rs.get("nestweaver", {})
         gf = rs.get("graphify", {})
-        gn = rs.get("gitnexus", {})
         if "avg_connected" in nw:
             nw_connected_vals.append(nw["avg_connected"])
         if "avg_unique_files" in nw:
@@ -793,8 +781,6 @@ def generate_report(
             gf_nodes_vals.append(gf["avg_nodes"])
         if "noise_pct" in gf:
             gf_noise_pcts.append(gf["noise_pct"])
-        if "avg_results" in gn:
-            gn_results_vals.append(gn["avg_results"])
 
     if nw_connected_vals and gf_nodes_vals:
         avg_nw_conn = sum(nw_connected_vals) / len(nw_connected_vals)
@@ -809,11 +795,6 @@ def generate_report(
         lines.append(f"- **Graphify noise**: {avg_noise:.0f}% of Graphify's returned nodes are "
                      f"framework stubs or vendored code without actionable source")
 
-    if gn_results_vals:
-        lines.append(f"- **GitNexus completeness**: GitNexus finds symbols but returns "
-                     f"0 callers and 0 callees — it locates definitions without showing "
-                     f"how they connect to the rest of the codebase")
-
     if nw_connected_vals and nw_unique_files_vals:
         avg_conn = sum(nw_connected_vals) / len(nw_connected_vals)
         avg_files = sum(nw_unique_files_vals) / len(nw_unique_files_vals)
@@ -824,8 +805,7 @@ def generate_report(
                 gf_noise_str = f" Graphify returns {sum(gf_nodes_vals) / len(gf_nodes_vals):.0f} nodes but {sum(gf_noise_pcts) / len(gf_noise_pcts):.0f}% are framework stubs without source code."
             lines.append("")
             lines.append(f"> NestWeaver returns **{avg_conn:.0f} connected symbols** per query with "
-                         f"**{file_pct:.0f}%** being from unique source files.{gf_noise_str} "
-                         f"GitNexus finds symbols but returns 0 callers and 0 callees.")
+                         f"**{file_pct:.0f}%** being from unique source files.{gf_noise_str}")
 
     lines.append("")
 

--- a/benchmarks/measure.sh
+++ b/benchmarks/measure.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # measure.sh -- benchmark measurement functions, sourced by run.sh
 # Requires: BENCH_NESTWEAVER, REPOS_DIR, INDEX_DIR, RESULTS_DIR, QUERIES,
-#           NUM_RUNS, GRAPHIFY_BIN, GITNEXUS_BIN, CBMCP_BIN
+#           NUM_RUNS, GRAPHIFY_BIN
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -399,7 +399,7 @@ benchmark_graphify() {
             if [[ $i -eq 1 ]] && [[ -n "$CAPTURED_OUTPUT" ]]; then
                 # Graphify outputs text -- NODE lines are actual results
                 results=$(echo "$CAPTURED_OUTPUT" | grep -c '^NODE ' || echo 0)
-                noise=$(echo "$CAPTURED_OUTPUT" | grep '^NODE' | grep 'src= ' | wc -l | tr -d ' ')
+                noise=$(echo "$CAPTURED_OUTPUT" | grep -c '^NODE.*src= ')
             fi
         done
 
@@ -446,113 +446,3 @@ with open('$result_file', 'w') as f:
     info "  [graphify] done -- index=${index_median}ms p50=${p50}ms p95=${p95}ms"
     set -e
 }
-
-# ---------------------------------------------------------------------------
-# benchmark_gitnexus REPO_NAME REPO_PATH
-# GitNexus stores its index inside the repo (.gitnexus/), so we operate
-# from within the repo directory.
-# ---------------------------------------------------------------------------
-benchmark_gitnexus() {
-    set +e
-    local name="$1" repo_path="$2"
-    local result_file="$RESULTS_DIR/${name}-gitnexus.json"
-
-    info "  [gitnexus] benchmarking $name..."
-
-    local index_times=()
-    for ((i = 1; i <= NUM_RUNS; i++)); do
-        rm -rf "$repo_path/.gitnexus"
-        local ms
-        ms=$(time_ms "$GITNEXUS_BIN" analyze "$repo_path")
-        index_times+=("$ms")
-        info "    index run $i: ${ms}ms"
-    done
-    local index_median
-    index_median=$(median "${index_times[@]}")
-
-    # --- Graph depth stats (re-run analyze to capture output) ---
-    local gn_stats
-    gn_stats=$("$GITNEXUS_BIN" analyze "$repo_path" --force 2>&1 || true)
-    local symbol_count edge_count
-    symbol_count=$(echo "$gn_stats" | grep -oE '[0-9,]+ nodes' | tr -d ',' | grep -oE '[0-9]+' || echo 0)
-    edge_count=$(echo "$gn_stats" | grep -oE '[0-9,]+ edges' | tr -d ',' | grep -oE '[0-9]+' || echo 0)
-    info "    graph: ${symbol_count} nodes, ${edge_count} edges"
-
-    # --- Index size on disk ---
-    local index_size_bytes
-    index_size_bytes=$(find "$repo_path/.gitnexus" -type f -exec stat -f%z {} + 2>/dev/null | awk '{s+=$1}END{print s+0}' || echo 0)
-
-    # Warm-up queries
-    for ((w = 0; w < 3; w++)); do
-        "$GITNEXUS_BIN" query "warmup" -r "$repo_path" >/dev/null 2>&1 || true
-    done
-
-    local all_latencies=()
-    local query_results=()
-
-    while IFS= read -r query; do
-        local latencies=()
-        local results=0
-
-        for ((i = 1; i <= NUM_RUNS; i++)); do
-            local ms
-            ms=$(time_ms_capture "$GITNEXUS_BIN" query "$query" -r "$repo_path")
-            latencies+=("$ms")
-
-            read_captured
-            if [[ $i -eq 1 ]] && [[ -n "$CAPTURED_OUTPUT" ]]; then
-                results=$(echo "$CAPTURED_OUTPUT" | python3 -c "
-import json, sys
-try:
-    d = json.load(sys.stdin)
-    procs = d.get('processes', [])
-    print(len(procs))
-except: print(0)
-" 2>/dev/null || echo 0)
-            fi
-        done
-
-        local lat_median
-        lat_median=$(median "${latencies[@]}")
-        all_latencies+=("${latencies[@]}")
-
-        local q_json runs_json
-        q_json=$(json_quote "$query")
-        runs_json=$(printf '%s,' "${latencies[@]}")
-        runs_json="[${runs_json%,}]"
-
-        query_results+=("{\"query\": $q_json, \"latency_median_ms\": $lat_median, \"results\": $results, \"runs\": $runs_json}")
-        info "    query '$query': ${lat_median}ms (results=$results)"
-    done < <(load_queries "$name" "search"; load_queries "$name" "context")
-
-    local p50 p95
-    p50=$(percentile 50 "${all_latencies[@]}")
-    p95=$(percentile 95 "${all_latencies[@]}")
-
-    local queries_json index_runs_json
-    queries_json=$(printf '%s,' "${query_results[@]}")
-    queries_json="[${queries_json%,}]"
-    index_runs_json=$(printf '%s,' "${index_times[@]}")
-    index_runs_json="[${index_runs_json%,}]"
-
-    python3 -c "
-import json
-result = {
-    'tool': 'gitnexus',
-    'repo': '$name',
-    'index_median_ms': $index_median,
-    'index_runs': $index_runs_json,
-    'index_size_bytes': $index_size_bytes,
-    'symbol_count': $symbol_count,
-    'edge_count': $edge_count,
-    'p50_ms': $p50,
-    'p95_ms': $p95,
-    'queries': $queries_json
-}
-with open('$result_file', 'w') as f:
-    json.dump(result, f, indent=2)
-"
-    info "  [gitnexus] done -- index=${index_median}ms p50=${p50}ms p95=${p95}ms"
-    set -e
-}
-

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # run.sh -- NestWeaver benchmark orchestrator
-# Fully isolated: builds NestWeaver to a local prefix, installs competitors
+# Fully isolated: builds NestWeaver to a local prefix, installs the competitor
 # locally, uses a dedicated daemon instance. Nothing touches your global
 # NestWeaver installation.
 set -euo pipefail
@@ -18,12 +18,11 @@ INDEX_DIR="$BENCH_ROOT/indexes"
 RESULTS_DIR="$BENCH_ROOT/results"
 REPORT_DIR="$BENCH_ROOT/report"
 VENVS_DIR="$BENCH_ROOT/venvs"
-NODE_DIR="$BENCH_ROOT/node"
 BIN_DIR="$BENCH_ROOT/bin"
 LOCAL_PREFIX="$BENCH_ROOT/local"
 
 mkdir -p "$REPOS_DIR" "$INDEX_DIR" "$RESULTS_DIR" "$REPORT_DIR" \
-         "$VENVS_DIR" "$NODE_DIR" "$BIN_DIR" "$LOCAL_PREFIX"
+         "$VENVS_DIR" "$BIN_DIR" "$LOCAL_PREFIX"
 
 NUM_RUNS="${NUM_RUNS:-3}"
 export NUM_RUNS REPOS_DIR INDEX_DIR RESULTS_DIR REPORT_DIR BIN_DIR BENCH_ROOT QUERIES REPO_ROOT
@@ -95,9 +94,9 @@ info "  nestweaver $NW_VERSION at $BENCH_NESTWEAVER"
 export BENCH_NESTWEAVER
 
 # ---------------------------------------------------------------------------
-# 4. Install competitors (all isolated under BENCH_ROOT)
+# 4. Install competitor (isolated under BENCH_ROOT)
 # ---------------------------------------------------------------------------
-info "Installing competitors..."
+info "Installing competitor..."
 
 # Python venv for benchmark scripts (charts, token_savings)
 BENCH_VENV="$VENVS_DIR/bench"
@@ -120,16 +119,7 @@ if [[ ! -f "$GRAPHIFY_VENV/bin/graphify" ]]; then
 fi
 GRAPHIFY_BIN="$GRAPHIFY_VENV/bin/graphify"
 
-# GitNexus -- local npm install
-GITNEXUS_DIR="$NODE_DIR/gitnexus"
-if [[ ! -f "$GITNEXUS_DIR/node_modules/.bin/gitnexus" ]]; then
-    mkdir -p "$GITNEXUS_DIR"
-    npm install --prefix "$GITNEXUS_DIR" gitnexus 2>/dev/null \
-        || warn "  gitnexus npm install failed"
-fi
-GITNEXUS_BIN="$GITNEXUS_DIR/node_modules/.bin/gitnexus"
-
-export GRAPHIFY_BIN GITNEXUS_BIN
+export GRAPHIFY_BIN
 
 # ---------------------------------------------------------------------------
 # 5. Record metadata
@@ -208,12 +198,6 @@ for name in $REPO_NAMES; do
         benchmark_graphify "$name" "$repo_path"
     else
         warn "  Skipping graphify (not installed)"
-    fi
-
-    if [[ -x "$GITNEXUS_BIN" ]]; then
-        benchmark_gitnexus "$name" "$repo_path"
-    else
-        warn "  Skipping gitnexus (not installed)"
     fi
 
     # codebase-memory-mcp removed -- unreliable install, dead upstream URL

--- a/scratch/rfc-implementation-plan/ADDENDUM-evidence-and-findings.md
+++ b/scratch/rfc-implementation-plan/ADDENDUM-evidence-and-findings.md
@@ -15,11 +15,9 @@ Across **every** Claude Code session under `~/.claude/projects/` on this machine
 | Signal | Count |
 |--------|-------|
 | NestWeaver MCP tool invocations | **0** |
-| GitNexus MCP tool invocations | **0** |
 | `Bash` tool calls | **39,668** |
 | Other MCP actually used | Claude-in-Chrome (183), Supabase (~38), Gmail/Drive (~11) |
 | Files *mentioning* "nestweaver" (as text/paths) | 665 |
-| Files *mentioning* "gitnexus" | 69 |
 
 In day-to-day captured usage, the agents orient via **Bash (grep/rg/git/find)**, not via NestWeaver. NestWeaver appears as *the thing being built*, not *a tool being used*.
 
@@ -41,7 +39,7 @@ of falling back to Bash* — F3/F4 (first-party regex/count so skills stop shell
 Prioritize them on that evidence, not taste.
 
 ### A.2 — Your own benchmark defines value as 7 code-graph journeys
-`_docs/benchmark/journeys.sh` measures these, by **latency + result count** (not retrieval quality), vs GitNexus/Graphify:
+`_docs/benchmark/journeys.sh` measures these, by **latency + result count** (not retrieval quality), vs Graphify:
 
 | # | Journey | CLI exercised | Features that serve it |
 |---|---------|---------------|------------------------|


### PR DESCRIPTION
## Summary

- remove GitNexus installation and execution from the competitive benchmark
- remove GitNexus-specific charting and report output
- remove remaining documentation references
- preserve published history and tags to avoid disrupting existing clones and releases

## Validation

- `bash -n benchmarks/run.sh benchmarks/measure.sh`
- `shellcheck -e SC1091 benchmarks/run.sh benchmarks/measure.sh`
- benchmark chart/report smoke test in an isolated Python virtual environment
- zero-reference sweep across the current worktree
- `git diff --check`
- NestWeaver changed-file risk check: low risk