### PR TITLE
fix(release): avoid stale native build cache

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,6 +70,7 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
         with:
+          cache-targets: false
           cache-on-failure: true
       - name: Install build dependencies (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary

- keep Cargo registry caching for release builds
- stop restoring compiled target directories in the release matrix
- guarantee native dependencies are configured from a fresh build tree

## Root cause

The v2.5.4 ARM64 OpenSSL preflight passed, but LadybugDB reused a `CMakeCache.txt` restored by `Swatinem/rust-cache`. The `cmake` crate skips configuration when that file exists, so the new toolchain was logged as unused and the stale host include path remained.

`cache-targets: false` is the cache action's supported mechanism for caching only Cargo registry data. It avoids stale CMake state without deleting runner files or disabling dependency-download caching.

## Validation

- confirmed the failed run passed the ARM64 OpenSSL preflight
- confirmed the failed build logged `CMake project was already configured` / unused toolchain behavior
- verified `cache-targets` against the action's current `action.yml`
- YAML parse
- workflow assertions
- `git diff --check`