### PR TITLE
fix(release): build Intel macOS natively

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -53,6 +53,7 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
@@ -60,10 +61,22 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-15-intel
           - target: aarch64-apple-darwin
             os: macos-latest
     steps:
+      - name: Verify native runner architecture
+        shell: bash
+        run: |
+          TARGET="${{ matrix.target }}"
+          HOST_ARCH="$(uname -m)"
+          case "$TARGET:$HOST_ARCH" in
+            x86_64-*:x86_64|aarch64-unknown-linux-gnu:aarch64|aarch64-apple-darwin:arm64) ;;
+            *)
+              echo "Runner architecture $HOST_ARCH does not match target $TARGET" >&2
+              exit 1
+              ;;
+          esac
       - name: Free disk space (Linux)
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
## Summary

- run the x86_64 macOS release build on GitHub's native `macos-15-intel` runner
- assert every release runner's host architecture matches its target
- disable matrix fail-fast so one target cannot cancel diagnostics for the others

## Root cause

The v2.5.6 Linux ARM64 job completed successfully on the native ARM runner. The remaining failure was Intel macOS cross-compilation on Apple Silicon: LadybugDB built x86_64 objects but its shared-library link had unresolved OpenSSL symbols.

Building Intel macOS on `macos-15-intel` removes the last cross-architecture native dependency build.

## Validation

- YAML parse
- ShellCheck for every release build shell block
- native runner matrix assertions
- `git diff --check`

NestWeaver change detection was attempted but the local daemon socket is unavailable.