### PR TITLE
fix(release): use portable lipo syntax

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           CLANG_RT="$(clang --print-resource-dir)/lib/darwin/libclang_rt.osx.a"
           test -f "$CLANG_RT"
-          lipo -verify_arch x86_64 "$CLANG_RT"
+          lipo "$CLANG_RT" -verify_arch x86_64
           nm -arch x86_64 "$CLANG_RT" | grep '___cpu_model'
           echo "CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS=-Clink-arg=$CLANG_RT" >> "$GITHUB_ENV"
       - name: Build binary


### PR DESCRIPTION
## Summary
- pass the compiler-runtime archive to `lipo` before `-verify_arch`, as required by Xcode 16
- retain the x86_64 slice and `___cpu_model` symbol preflight before the Intel release build

## Validation
- corrected command succeeds against the local Xcode compiler-runtime archive
- x86_64 `___cpu_model` symbol is present
- release workflow YAML parses successfully
- all 15 workflow shell blocks pass ShellCheck
- `git diff --check` passes
