### PR TITLE
fix(release): require macOS 13.3

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -101,9 +101,9 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
+          # LadybugDB uses floating-point std::format, available since macOS 13.3.
           case "${{ matrix.target }}" in
-            x86_64-apple-darwin) DEPLOYMENT_TARGET=10.12 ;;
-            aarch64-apple-darwin) DEPLOYMENT_TARGET=11.0 ;;
+            x86_64-apple-darwin|aarch64-apple-darwin) DEPLOYMENT_TARGET=13.3 ;;
             *)
               echo "Unsupported macOS target: ${{ matrix.target }}" >&2
               exit 1

--- a/app/Info.plist
+++ b/app/Info.plist
@@ -22,7 +22,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>LSMinimumSystemVersion</key>
-    <string>13.0</string>
+    <string>13.3</string>
     <key>LSUIElement</key>
     <true/>
     <key>NSHighResolutionCapable</key>

--- a/app/build.sh
+++ b/app/build.sh
@@ -4,6 +4,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 APP_DIR="$REPO_ROOT/target/release/NestWeaver.app"
+# LadybugDB uses floating-point std::format, available since macOS 13.3.
+export MACOSX_DEPLOYMENT_TARGET=13.3
+APP_ARCH="$(uname -m)"
+case "$APP_ARCH" in
+    arm64|x86_64) SWIFT_TARGET="$APP_ARCH-apple-macosx$MACOSX_DEPLOYMENT_TARGET" ;;
+    *)
+        echo "Unsupported macOS architecture: $APP_ARCH" >&2
+        exit 1
+        ;;
+esac
 
 echo "=== Building NestWeaver.app ==="
 
@@ -45,6 +55,7 @@ fi
 echo "[4/6] Compiling Swift launcher..."
 swiftc "$SCRIPT_DIR/Sources/main.swift" \
     -o "$REPO_ROOT/target/release/NestWeaverLauncher" \
+    -target "$SWIFT_TARGET" \
     -framework AppKit \
     -O
 


### PR DESCRIPTION
## Summary

- require macOS 13.3 for both native release targets because LadybugDB uses floating-point `std::format`
- align the native app bundle minimum with the CLI runtime requirement
- pass an explicit Swift target so the launcher does not inherit the runner OS version

## Root cause

Xcode libc++ exposes the floating-point `std::to_chars` used by `std::format` starting in macOS 13.3. The previous 10.12/11.0 release targets failed while compiling LadybugDB from source. Swift also ignored `MACOSX_DEPLOYMENT_TARGET` and stamped the launcher with the build host version unless `-target` was provided.

## Validation

- 13.0 compiler probe fails with the release error; 13.3 succeeds
- full `aarch64-apple-darwin` release build from LadybugDB source succeeds
- release binary is arm64, runs `nestweaver 2.5.9`, has Mach-O minimum 13.3, and has no dynamic OpenSSL dependency
- complete `NestWeaver.app` build succeeds; plist, Swift launcher, and CLI all report minimum macOS 13.3
- plist, Bash syntax, app ShellCheck, workflow YAML, and all 15 workflow shell blocks pass validation
