### PR TITLE
fix: user-reported 2.5.10 bugs — affected_tests crash/hang, top-level stale-check, trust-contract casing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ cargo build --release
 | `brain watch` | Watch vaults for changes and re-index automatically |
 | `brain refresh` | Force re-index of all registered vaults |
 | `brain remove` | Remove a vault from the brain (cascade-deletes nodes; does not touch files on disk) |
-| `brain stale-check` | Check if the indexed graph is stale by comparing each repo's indexed SHA against git HEAD |
+| `brain stale-check` | Check if the indexed graph is stale by comparing each repo's indexed SHA against git HEAD (also available top-level as `stale-check`) |
 | `brain reindex-search` | Rebuild the Tantivy BM25 search index from current graph state |
 | `brain broken-links` | List wikilinks with ambiguous or low-confidence targets, with suggested fixes |
 | `brain orphans` | List notes with zero inbound and zero outbound wikilinks |

--- a/crates/nestweaver-engine/src/affected_tests.rs
+++ b/crates/nestweaver-engine/src/affected_tests.rs
@@ -30,7 +30,6 @@ use nestweaver_parser::is_test_file;
 use nestweaver_store::GraphStore;
 
 use crate::blast_radius::{AnalysisStatus, Notification, NotificationLevel};
-use crate::process::detect_changes_impact;
 
 /// Maximum reverse-traversal depth for finding dependent tests.
 const MAX_TEST_DEPTH: u32 = 3;
@@ -113,7 +112,7 @@ provably-safe subset. Misses reflection, DI, codegen, and data-driven/integratio
 /// Compute the affected tests for a set of changed files.
 ///
 /// Pipeline:
-///   1. changed_files → changed_symbols (via `detect_changes_impact`).
+///   1. changed_files → changed_symbols (direct `symbols_in_file` lookup).
 ///   2. for each changed symbol, reverse-traverse CALLS/IMPORTS to depth 3.
 ///   3. keep reached symbols whose file is a test file (`is_test_file`).
 ///   4. bucket by traversal depth (tier_1 = depth 1, etc.), ordering within a
@@ -124,28 +123,38 @@ pub fn affected_tests(store: &GraphStore, changed_files: &[String]) -> Result<Af
     let mut status = AnalysisStatus::Complete;
     let mut notifications: Vec<Notification> = Vec::new();
 
-    // Step 1: changed files → changed symbols.
-    let changed_symbols: Vec<ChangedSymbolRef> =
-        match detect_changes_impact(store, changed_files, MAX_TEST_DEPTH) {
-            Ok(impact) => impact
-                .affected_symbols
-                .iter()
-                .map(|s| ChangedSymbolRef {
-                    uid: s.uid.clone(),
-                    name: s.name.clone(),
-                    file_path: s.file_path.clone(),
-                })
-                .collect(),
+    // Step 1: changed files → changed symbols, via direct per-file lookup.
+    //
+    // Deliberately NOT `detect_changes_impact`: that helper also runs
+    // `trace_processes` — a BFS from every entry-point-ish symbol across the
+    // ENTIRE store — whose process output this analysis never used. On large
+    // multi-repo stores that traversal hangs or crashes the native store
+    // layer (the 2.5.10 affected_tests daemon-crash/segfault report).
+    let mut changed_symbols: Vec<ChangedSymbolRef> = Vec::new();
+    let mut changed_uids: HashSet<String> = HashSet::new();
+    for file_path in changed_files {
+        match store.symbols_in_file(file_path) {
+            Ok(syms) => {
+                for s in syms {
+                    if changed_uids.insert(s.uid.clone()) {
+                        changed_symbols.push(ChangedSymbolRef {
+                            uid: s.uid,
+                            name: s.name,
+                            file_path: s.file_path,
+                        });
+                    }
+                }
+            }
             Err(e) => {
                 notifications.push(Notification {
                     level: NotificationLevel::Error,
-                    message: format!("mapping changed files to symbols failed: {e}"),
-                    descriptor: "store.detect-changes-failed".to_string(),
+                    message: format!("mapping changed file {file_path} to symbols failed: {e}"),
+                    descriptor: "store.symbols-in-file-failed".to_string(),
                 });
                 status = status.max(AnalysisStatus::Degraded);
-                Vec::new()
             }
-        };
+        }
+    }
 
     // Step 2 + 3: reverse-traverse from each changed symbol and keep tests.
     //
@@ -477,6 +486,30 @@ mod tests {
                 .collect::<Vec<_>>(),
             result.summary
         );
+    }
+
+    #[test]
+    fn duplicate_changed_files_do_not_duplicate_changed_symbols() {
+        let store = GraphStore::in_memory().expect("store");
+        let changed = sym("sym:changed", "computeTotal", "src/billing.rs");
+        store.insert_symbol(&changed).expect("insert");
+
+        let result = affected_tests(
+            &store,
+            &["src/billing.rs".to_string(), "src/billing.rs".to_string()],
+        )
+        .expect("ok");
+
+        assert_eq!(
+            result
+                .changed_symbols
+                .iter()
+                .filter(|c| c.uid == "sym:changed")
+                .count(),
+            1,
+            "changed symbol must be deduplicated across duplicate changed_files entries"
+        );
+        assert_eq!(result.status, AnalysisStatus::Complete);
     }
 
     #[test]

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -273,6 +273,32 @@ The SARIF carries the full trust contract, so reviewers see it inline:
   results carry `severitySource: contract-verified` (a real signature diff),
   distinct from the reach-based cross-repo hints (`severitySource: reach-only`).
 
+### Field naming: MCP JSON vs SARIF
+
+The trust contract is one contract serialized on two surfaces with different
+casing conventions — this is deliberate, not drift. MCP/JSON tool output uses
+`snake_case` (Rust serde defaults); the SARIF *property-bag keys* follow the
+SARIF ecosystem's `camelCase` convention, namespaced under `nestweaver/`.
+Integrators parsing both surfaces should map:
+
+| MCP / JSON (snake_case) | SARIF property bag (camelCase key)                |
+| ----------------------- | ------------------------------------------------- |
+| `gate_state`            | `run.properties["nestweaver/gateState"]`          |
+| `status`                | `run.properties["nestweaver/status"]`             |
+| `risk_level`            | `run.properties["nestweaver/riskLevel"]`          |
+| `blind_spots`           | `run.properties["nestweaver/blindSpots"]`         |
+| `analysis_direction`    | `run.properties["nestweaver/analysisDirection"]`  |
+| `coverage`              | `run.properties["nestweaver/coverage"]`           |
+| (per-result severity provenance) | `result.properties["nestweaver/severitySource"]` |
+
+Two things do **not** change casing across surfaces:
+
+- **Enum values** are identical everywhere (e.g. `degraded-unknown`,
+  `dynamic-dispatch`, `contract-verified`).
+- **The `coverage` object's inner keys** stay `snake_case` inside the SARIF
+  property bag too (`stale_repos`, etc.) — the object is embedded verbatim;
+  only the top-level property-bag *keys* are camelCase.
+
 This is advisory: the workflow never fails the build. To gate, add a separate
 step that inspects `gateState`/`nw/contract-break` and exits non-zero, or use
 `pr-impact --base "$base" --strict`. By default `--strict` exits non-zero **only

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,6 +317,17 @@ enum Commands {
         )]
         db: Option<PathBuf>,
     },
+    /// Check if the indexed graph is stale by comparing each repo's
+    /// indexed SHA against git HEAD. (Same as `brain stale-check`.)
+    StaleCheck {
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+        #[arg(
+            long,
+            help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
+        )]
+        db: Option<PathBuf>,
+    },
     /// List all services/modules in the graph
     ListServices {
         #[arg(long, help = "Filter by instance ID")]
@@ -5167,6 +5178,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
         Commands::Backup { command } => run_backup(command).map(|c| (c, None)),
         Commands::Instance { command } => run_instance(command).map(|c| (c, None)),
         Commands::Brain { command } => run_brain(*command, out, t0, use_daemon, no_embed),
+        Commands::StaleCheck { json, db } => run_brain(
+            BrainCommands::StaleCheck { json, db },
+            out,
+            t0,
+            use_daemon,
+            no_embed,
+        ),
         Commands::Memory { command } => run_memory(*command, t0, use_daemon),
         Commands::Ranking { command } => run_ranking(command, t0, use_daemon),
         Commands::Eval { command } => run_eval_cmd(command, use_daemon).map(|c| (c, None)),
@@ -15765,5 +15783,30 @@ mod daemon_index_phase_tests {
                     .is_err()
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod stale_check_cli_tests {
+    use super::*;
+
+    #[test]
+    fn top_level_stale_check_parses() {
+        // Parsing the full Cli overflows the default 2 MiB test-thread stack
+        // in debug builds (the Commands enum is large); use a bigger stack.
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                let cli = Cli::try_parse_from(["nestweaver", "stale-check", "--json"]).expect(
+                    "top-level stale-check must parse (regression: dropped in the CLI reorg)",
+                );
+                assert!(matches!(
+                    cli.command,
+                    Commands::StaleCheck { json: true, .. }
+                ));
+            })
+            .expect("spawn")
+            .join()
+            .expect("join");
     }
 }


### PR DESCRIPTION
Fixes the three user-reported 2.5.10 bugs (backlog nw-055, nw-056, nw-057).

## P1 — affected_tests crashed the daemon / segfaulted the CLI (nw-055)
`affected_tests` called `detect_changes_impact` only to map changed files to
symbols, but that helper also runs `trace_processes`: a BFS from every
entry-point-ish symbol across the ENTIRE store (3 native lbug queries per
visited node) whose process output F13 discarded. On large multi-repo stores
this hung (reproduced locally; `sample` stack pinned in
`trace_processes → callees_of → lbug TaskScheduler`) or crashed inside the
native store layer — CLI exit 139, daemon death + respawn via MCP.

Fix: map changed files directly with `symbols_in_file`, degrading per-file on
store errors (previously swallowed by `unwrap_or_default`).

Manual verification on the 32-repo brain DB: the exact pre-fix hang repro
(`affected-tests --files src/App.js` in an indexed JS repo, >120 s timeout)
now returns complete JSON in 2.9 s; second reported shape (TS config file,
also hung) returns in 0.7 s; unknown-file input still exits 0 with empty
tiers. Engine suite green (842 tests), incl. two new behavior-contract tests
(changed-symbol dedup across duplicate inputs; status stays Complete).

Out of scope (tracked in backlog): the `detect_changes` MCP tool still uses
the full-store `trace_processes` legitimately and remains pathological on
very large stores.

## P2 — top-level `stale-check` dropped (nw-056)
The v0.19.0 top-level `stale-check` was silently lost when the command moved
under `brain` in a CLI reorg. Restored as a thin forwarder to
`BrainCommands::StaleCheck`; `--json` output verified byte-identical between
both spellings against the live DB. `brain stale-check`, the `stale_check`
MCP tool, and `brain status` staleness warnings are unchanged. Adds a clap
parse regression test.

## P3 — trust-contract field casing (nw-057)
MCP/JSON emits snake_case (`gate_state`, `blind_spots`) while the SARIF
property bag follows the SARIF camelCase convention
(`nestweaver/gateState`, `nestweaver/blindSpots`, `nestweaver/severitySource`).
Deliberate, but undocumented — added the mapping table to
`docs/ci-integration.md`, including the two things that do NOT change casing
(enum values; the `coverage` object's inner keys, embedded verbatim). No
shipped field renamed.

## CI parity (run locally)
- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace --no-fail-fast -- --skip daemon_` — 2461 passed, 0 failed