### PR TITLE
fix(ci): repair release builds (pin tree-sitter-kotlin) and speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - run: cargo fmt --all -- --check
 
   build-and-check:
-    name: Build, Clippy & Tests
+    name: Build & Tests
     needs: changes
     if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
@@ -69,18 +69,36 @@ jobs:
           cache-on-failure: true
           shared-key: build
       - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler
+        run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
       - name: Configure linker for lbug+tantivy zstd coexistence
         run: |
           mkdir -p .cargo
-          printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]\n' > .cargo/config.toml
-      - name: Build (triggers lbug prebuilt download on first run)
+          printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' > .cargo/config.toml
+      - name: Compute native dependency cache key
+        id: nativekey
         run: |
-          cargo build -p nestweaver-store 2>/dev/null || true
+          LBUG_VER=$(awk '/^name = "lbug"$/{getline; print $3}' Cargo.lock | tr -d '"')
+          OSSL_VER=$(awk '/^name = "openssl-sys"$/{getline; print $3}' Cargo.lock | tr -d '"')
+          RUSTC_VER=$(rustc --version | awk '{print $2}')
+          echo "key=${LBUG_VER}-${OSSL_VER}-rustc${RUSTC_VER}" >> "$GITHUB_OUTPUT"
+      - name: Cache native build outputs (lbug C++, OpenSSL)
+        # lbug (C++ graph DB, built from source) and vendored OpenSSL dominate
+        # cold-build time. Keyed on their package versions (not Cargo.lock as a
+        # whole) so they survive release-please lockfile churn.
+        uses: actions/cache@v4
+        with:
+          path: |
+            target/**/build/lbug-*/out
+            target/**/build/openssl-sys-*/out
+          key: native-${{ runner.os }}-${{ runner.arch }}-${{ steps.nativekey.outputs.key }}
+          restore-keys: native-${{ runner.os }}-${{ runner.arch }}-
+      - name: Build (triggers lbug prebuilt download on first run)
+        # --locked: fail the PR (not the release build) when Cargo.lock drifts
+        # out of sync with the manifests.
+        run: |
+          cargo build --locked -p nestweaver-store 2>/dev/null || true
           sleep 2
-          cargo build --tests
-      - name: Clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+          cargo build --locked --tests
       - name: Tests
         # --workspace is REQUIRED: the root manifest is both [package] and
         # [workspace], so `cargo test` without it runs ONLY the root package's
@@ -89,6 +107,50 @@ jobs:
         run: cargo test --workspace --no-fail-fast -- --skip daemon_
         env:
           NESTWEAVER_NO_DAEMON: "1"
+
+  clippy:
+    name: Clippy
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
+          sudo apt-get clean
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: build
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
+      - name: Configure linker for lbug+tantivy zstd coexistence
+        run: |
+          mkdir -p .cargo
+          printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' > .cargo/config.toml
+      - name: Compute native dependency cache key
+        id: nativekey
+        run: |
+          LBUG_VER=$(awk '/^name = "lbug"$/{getline; print $3}' Cargo.lock | tr -d '"')
+          OSSL_VER=$(awk '/^name = "openssl-sys"$/{getline; print $3}' Cargo.lock | tr -d '"')
+          RUSTC_VER=$(rustc --version | awk '{print $2}')
+          echo "key=${LBUG_VER}-${OSSL_VER}-rustc${RUSTC_VER}" >> "$GITHUB_OUTPUT"
+      - name: Cache native build outputs (lbug C++, OpenSSL)
+        uses: actions/cache@v4
+        with:
+          path: |
+            target/**/build/lbug-*/out
+            target/**/build/openssl-sys-*/out
+          key: native-${{ runner.os }}-${{ runner.arch }}-${{ steps.nativekey.outputs.key }}
+          restore-keys: native-${{ runner.os }}-${{ runner.arch }}-
+      # Parallel with Build & Tests: when the shared rust cache is warm this
+      # finishes in minutes instead of adding ~20 min serial to the build job.
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
   daemon-tests:
     name: Daemon Integration Tests
@@ -111,16 +173,36 @@ jobs:
           cache-on-failure: true
           shared-key: build
       - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler
+        run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
       - name: Configure linker for lbug+tantivy zstd coexistence
         run: |
           mkdir -p .cargo
-          printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]\n' > .cargo/config.toml
-      - name: Build (triggers lbug prebuilt download on first run)
+          printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' > .cargo/config.toml
+      - name: Compute native dependency cache key
+        id: nativekey
         run: |
-          cargo build -p nestweaver-store 2>/dev/null || true
+          LBUG_VER=$(awk '/^name = "lbug"$/{getline; print $3}' Cargo.lock | tr -d '"')
+          OSSL_VER=$(awk '/^name = "openssl-sys"$/{getline; print $3}' Cargo.lock | tr -d '"')
+          RUSTC_VER=$(rustc --version | awk '{print $2}')
+          echo "key=${LBUG_VER}-${OSSL_VER}-rustc${RUSTC_VER}" >> "$GITHUB_OUTPUT"
+      - name: Cache native build outputs (lbug C++, OpenSSL)
+        # lbug (C++ graph DB, built from source) and vendored OpenSSL dominate
+        # cold-build time. Keyed on their package versions (not Cargo.lock as a
+        # whole) so they survive release-please lockfile churn.
+        uses: actions/cache@v4
+        with:
+          path: |
+            target/**/build/lbug-*/out
+            target/**/build/openssl-sys-*/out
+          key: native-${{ runner.os }}-${{ runner.arch }}-${{ steps.nativekey.outputs.key }}
+          restore-keys: native-${{ runner.os }}-${{ runner.arch }}-
+      - name: Build (triggers lbug prebuilt download on first run)
+        # --locked: fail the PR (not the release build) when Cargo.lock drifts
+        # out of sync with the manifests.
+        run: |
+          cargo build --locked -p nestweaver-store 2>/dev/null || true
           sleep 2
-          cargo build --tests
+          cargo build --locked --tests
       - name: Daemon-named tests (skipped in the main job)
         # The main job's `--skip daemon_` keeps these out of the flaky-prone
         # parallel run; they run here instead so daemon integration coverage
@@ -157,16 +239,36 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler
+        run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
       - name: Configure linker for lbug+tantivy zstd coexistence
         run: |
           mkdir -p .cargo
-          printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]\n' > .cargo/config.toml
-      - name: Build (triggers lbug prebuilt download on first run)
+          printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' > .cargo/config.toml
+      - name: Compute native dependency cache key
+        id: nativekey
         run: |
-          cargo build -p nestweaver-store 2>/dev/null || true
+          LBUG_VER=$(awk '/^name = "lbug"$/{getline; print $3}' Cargo.lock | tr -d '"')
+          OSSL_VER=$(awk '/^name = "openssl-sys"$/{getline; print $3}' Cargo.lock | tr -d '"')
+          RUSTC_VER=$(rustc --version | awk '{print $2}')
+          echo "key=${LBUG_VER}-${OSSL_VER}-rustc${RUSTC_VER}" >> "$GITHUB_OUTPUT"
+      - name: Cache native build outputs (lbug C++, OpenSSL)
+        # lbug (C++ graph DB, built from source) and vendored OpenSSL dominate
+        # cold-build time. Keyed on their package versions (not Cargo.lock as a
+        # whole) so they survive release-please lockfile churn.
+        uses: actions/cache@v4
+        with:
+          path: |
+            target/**/build/lbug-*/out
+            target/**/build/openssl-sys-*/out
+          key: native-${{ runner.os }}-${{ runner.arch }}-${{ steps.nativekey.outputs.key }}
+          restore-keys: native-${{ runner.os }}-${{ runner.arch }}-
+      - name: Build (triggers lbug prebuilt download on first run)
+        # --locked: fail the PR (not the release build) when Cargo.lock drifts
+        # out of sync with the manifests.
+        run: |
+          cargo build --locked -p nestweaver-store 2>/dev/null || true
           sleep 2
-          cargo build --tests
+          cargo build --locked --tests
       - name: Generate coverage
         # --workspace so coverage reflects the whole codebase, not just the root
         # package (see the Tests step note on the [package]+[workspace] manifest).
@@ -221,14 +323,32 @@ jobs:
           cache: "npm"
           cache-dependency-path: crates/nestweaver-web/frontend/package-lock.json
       - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler
+        run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
       - name: Configure linker for lbug+tantivy zstd coexistence
         run: |
           mkdir -p .cargo
-          printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]\n' > .cargo/config.toml
+          printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' > .cargo/config.toml
       - name: Install frontend dependencies
         working-directory: crates/nestweaver-web/frontend
         run: npm ci
+      - name: Compute native dependency cache key
+        id: nativekey
+        run: |
+          LBUG_VER=$(awk '/^name = "lbug"$/{getline; print $3}' Cargo.lock | tr -d '"')
+          OSSL_VER=$(awk '/^name = "openssl-sys"$/{getline; print $3}' Cargo.lock | tr -d '"')
+          RUSTC_VER=$(rustc --version | awk '{print $2}')
+          echo "key=${LBUG_VER}-${OSSL_VER}-rustc${RUSTC_VER}" >> "$GITHUB_OUTPUT"
+      - name: Cache native build outputs (lbug C++, OpenSSL)
+        # lbug (C++ graph DB, built from source) and vendored OpenSSL dominate
+        # cold-build time. Keyed on their package versions (not Cargo.lock as a
+        # whole) so they survive release-please lockfile churn.
+        uses: actions/cache@v4
+        with:
+          path: |
+            target/**/build/lbug-*/out
+            target/**/build/openssl-sys-*/out
+          key: native-${{ runner.os }}-${{ runner.arch }}-${{ steps.nativekey.outputs.key }}
+          restore-keys: native-${{ runner.os }}-${{ runner.arch }}-
       - name: Build (triggers lbug prebuilt download on first run)
         run: |
           cargo build -p nestweaver-store 2>/dev/null || true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -93,7 +93,7 @@ jobs:
           cache-on-failure: true
       - name: Install build dependencies (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler
+        run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
       - name: Install build dependencies (macOS)
         if: runner.os == 'macOS'
         run: brew install protobuf
@@ -116,10 +116,10 @@ jobs:
           mkdir -p .cargo
           cat > .cargo/config.toml << 'EOF'
           [target.x86_64-unknown-linux-gnu]
-          rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]
+          rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]
 
           [target.aarch64-unknown-linux-gnu]
-          rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]
+          rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]
           EOF
       - uses: actions/setup-node@v7
         with:
@@ -129,6 +129,25 @@ jobs:
       - name: Build frontend
         run: npm ci && npm run build
         working-directory: crates/nestweaver-web/frontend
+      - name: Compute native dependency cache key
+        id: nativekey
+        shell: bash
+        run: |
+          LBUG_VER=$(awk '/^name = "lbug"$/{getline; print $3}' Cargo.lock | tr -d '"')
+          OSSL_VER=$(awk '/^name = "openssl-sys"$/{getline; print $3}' Cargo.lock | tr -d '"')
+          RUSTC_VER=$(rustc --version | awk '{print $2}')
+          echo "key=${LBUG_VER}-${OSSL_VER}-rustc${RUSTC_VER}" >> "$GITHUB_OUTPUT"
+      - name: Cache native build outputs (lbug C++, OpenSSL)
+        # Keyed on package versions (not Cargo.lock) so the cache survives
+        # release lockfile churn; per-target since the build matrix crosses
+        # os/arch.
+        uses: actions/cache@v4
+        with:
+          path: |
+            target/**/build/lbug-*/out
+            target/**/build/openssl-sys-*/out
+          key: native-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-${{ steps.nativekey.outputs.key }}
+          restore-keys: native-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-
       - name: Build target OpenSSL
         shell: bash
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4069,7 +4069,7 @@ checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "nestweaver"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-algorithms"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -4119,7 +4119,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-client"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-daemon"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-embed"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-engine"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "anyhow",
  "apollo-parser",
@@ -4252,7 +4252,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-federation"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-mcp"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-parser"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "bumpalo",
  "comrak",
@@ -4349,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-proto"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "prost",
  "tokio-stream",
@@ -4361,7 +4361,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-resolver"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "glob",
  "insta",
@@ -4378,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-schema"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "hex",
  "serde",
@@ -4389,7 +4389,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-storage"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4404,7 +4404,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-store"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "anyhow",
  "cc",
@@ -4430,7 +4430,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-wasm"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "js-sys",
  "nestweaver-algorithms",
@@ -4443,7 +4443,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-web"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -7679,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-kotlin"
 version = "0.4.0"
-source = "git+https://github.com/fwcd/tree-sitter-kotlin?branch=main#c8ac3d2627240160b999a2c100de3babbdb8f419"
+source = "git+https://github.com/fwcd/tree-sitter-kotlin?rev=c8ac3d2627240160b999a2c100de3babbdb8f419#c8ac3d2627240160b999a2c100de3babbdb8f419"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/nestweaver-parser/Cargo.toml
+++ b/crates/nestweaver-parser/Cargo.toml
@@ -18,7 +18,10 @@ tree-sitter-cpp = "0.23"
 tree-sitter-rust = "0.24"
 tree-sitter-c = "0.24"
 tree-sitter-c-sharp = "0.23"
-tree-sitter-kotlin = { git = "https://github.com/fwcd/tree-sitter-kotlin", branch = "main" }
+# Pinned to an exact rev: branch-pinned git deps drift and break `cargo build
+# --locked` in the release workflow on fresh runners (cargo refuses to update
+# the lock). Bump deliberately when a grammar update is needed.
+tree-sitter-kotlin = { git = "https://github.com/fwcd/tree-sitter-kotlin", rev = "c8ac3d2627240160b999a2c100de3babbdb8f419" }
 tree-sitter-php = "0.24"
 tree-sitter-ruby = "0.23"
 tree-sitter-swift = "0.7"


### PR DESCRIPTION
## Why all four v2.6.1 release binaries failed

`nestweaver-parser` depended on `fwcd/tree-sitter-kotlin` via `branch = "main"`. Regular CI builds don't pass `--locked`, so they silently re-resolve when the branch moves; the **release** workflow builds with `cargo build --locked`, and on a fresh runner cargo fetches the repo, sees `main` advanced past the locked rev, and fails: `cannot update the lock file … because --locked was passed`. The lock was last synced in May — any upstream push since broke release builds. (Failed run: https://github.com/Kehl-io/nestweaver/actions/runs/30142776954)

**Fix:** pin the currently-locked rev (`c8ac3d26…` — the same code 2.6.x shipped with). It was the only branch-pinned git dep in the workspace. Also added `--locked` to PR-time CI builds so this failure class is caught on PRs, not at release time.

## Build speed (measured on the failed run: 48m build + 22m clippy + 34m test-compile)

- **Native dependency cache**: `lbug` (C++ graph DB, forced to build from source for the zstd/whole-archive issues — see `67683746`) and vendored OpenSSL outputs are cached via `actions/cache`, keyed on **package version + rustc + os/arch** rather than Cargo.lock — so the cache survives release-please lockfile churn, which is what kept busting the rust cache. Cold builds skip the C++ compiles entirely (est. 15-25 min).
- **mold** linker on all Linux jobs (faster linking of the large test binaries).
- **Clippy → its own parallel job** sharing the rust cache: ~20 min off the build job's serial critical path when warm (it was effectively a second full compile).

## Verification

- `cargo build --locked -p nestweaver-parser` passes locally with the pinned rev; `cargo tree --locked` resolves
- Both workflow files parse clean (YAML)
- This PR's own CI validates the ci.yml changes (new clippy job, `--locked` step, native cache, mold). **Note:** the release-please.yml build job only runs on release events, so its changes are exercised on the next release cut — the lbug/openssl cache and mold edits there mirror the ci.yml ones exactly.

Not included (deliberately): sccache (overlaps operationally with rust-cache; evaluate after seeing post-cache timings), larger runners (cost decision, not code).