### PR TITLE
fix(ci): gate releases on lockfile synchronization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,12 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
+    env:
+      # Test binaries with full debug info exhaust the GitHub-hosted runner's
+      # disk once the entire workspace is compiled. Backtraces still retain
+      # symbol names while keeping target/ small enough for the full suite.
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
     steps:
       - name: Free disk space
         run: |
@@ -92,19 +98,17 @@ jobs:
             target/**/build/openssl-sys-*/out
           key: native-${{ runner.os }}-${{ runner.arch }}-${{ steps.nativekey.outputs.key }}
           restore-keys: native-${{ runner.os }}-${{ runner.arch }}-
-      - name: Build (triggers lbug prebuilt download on first run)
-        # --locked: fail the PR (not the release build) when Cargo.lock drifts
-        # out of sync with the manifests.
+      - name: Validate lockfile and warm native dependencies
         run: |
+          cargo metadata --locked --no-deps --format-version 1 >/dev/null
           cargo build --locked -p nestweaver-store 2>/dev/null || true
           sleep 2
-          cargo build --locked --tests
       - name: Tests
         # --workspace is REQUIRED: the root manifest is both [package] and
         # [workspace], so `cargo test` without it runs ONLY the root package's
         # tests and silently skips every sub-crate's unit tests (engine, store,
         # federation, mcp, …) — where most of the logic lives.
-        run: cargo test --workspace --no-fail-fast -- --skip daemon_
+        run: cargo test --locked --workspace --no-fail-fast -- --skip daemon_
         env:
           NESTWEAVER_NO_DAEMON: "1"
 
@@ -161,6 +165,8 @@ jobs:
       # Shared CI runners are slower than a dev box; give the test server
       # startup deadline (tests/helpers/server_guard.rs) extra headroom.
       NESTWEAVER_TEST_SERVER_TIMEOUT_SECS: "60"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
     steps:
       - name: Free disk space
         run: |
@@ -196,23 +202,21 @@ jobs:
             target/**/build/openssl-sys-*/out
           key: native-${{ runner.os }}-${{ runner.arch }}-${{ steps.nativekey.outputs.key }}
           restore-keys: native-${{ runner.os }}-${{ runner.arch }}-
-      - name: Build (triggers lbug prebuilt download on first run)
-        # --locked: fail the PR (not the release build) when Cargo.lock drifts
-        # out of sync with the manifests.
+      - name: Validate lockfile and warm native dependencies
         run: |
+          cargo metadata --locked --no-deps --format-version 1 >/dev/null
           cargo build --locked -p nestweaver-store 2>/dev/null || true
           sleep 2
-          cargo build --locked --tests
       - name: Daemon-named tests (skipped in the main job)
         # The main job's `--skip daemon_` keeps these out of the flaky-prone
         # parallel run; they run here instead so daemon integration coverage
         # (authz boundary, migration self-heal, daemon proxy, …) is not lost.
         # The `daemon_` filter is the exact complement of the main job's skip.
-        run: cargo test --workspace --no-fail-fast -- daemon_
+        run: cargo test --locked --workspace --no-fail-fast -- daemon_
       - name: MCP daemon-feature tests
         # `cargo test --workspace` builds nestweaver-mcp without its optional
         # `daemon` feature, so these tests never run in the main job.
-        run: cargo test -p nestweaver-mcp --features daemon --no-fail-fast
+        run: cargo test --locked -p nestweaver-mcp --features daemon --no-fail-fast
 
   coverage:
     name: Coverage

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,19 +33,26 @@ jobs:
       - name: Synchronize release lockfile
         if: steps.release.outputs.prs_created == 'true'
         env:
+          GH_TOKEN: ${{ github.token }}
           RELEASE_PR: ${{ steps.release.outputs.pr }}
         run: |
+          set -euo pipefail
+
+          RELEASE_PR_NUMBER="$(jq -er '.number' <<< "$RELEASE_PR")"
           RELEASE_PR_BRANCH="$(jq -er '.headBranchName' <<< "$RELEASE_PR")"
           cargo update --workspace
-          if git diff --quiet -- Cargo.lock; then
-            exit 0
+
+          if ! git diff --quiet -- Cargo.lock; then
+            git add Cargo.lock
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -m "chore: synchronize Cargo.lock for release"
+            git push origin "HEAD:$RELEASE_PR_BRANCH"
           fi
 
-          git add Cargo.lock
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "chore: synchronize Cargo.lock for release"
-          git push origin "HEAD:$RELEASE_PR_BRANCH"
+          if [ "$(gh pr view "$RELEASE_PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')" = "true" ]; then
+            gh pr ready "$RELEASE_PR_NUMBER" --repo "$GITHUB_REPOSITORY"
+          fi
 
   build:
     name: Build ${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4069,7 +4069,7 @@ checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "nestweaver"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-algorithms"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -4119,7 +4119,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-client"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-daemon"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-embed"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-engine"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "anyhow",
  "apollo-parser",
@@ -4252,7 +4252,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-federation"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-mcp"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-parser"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "bumpalo",
  "comrak",
@@ -4349,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-proto"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "prost",
  "tokio-stream",
@@ -4361,7 +4361,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-resolver"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "glob",
  "insta",
@@ -4378,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-schema"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "hex",
  "serde",
@@ -4389,7 +4389,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-storage"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4404,7 +4404,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-store"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "anyhow",
  "cc",
@@ -4430,7 +4430,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-wasm"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "js-sys",
  "nestweaver-algorithms",
@@ -4443,7 +4443,7 @@ dependencies = [
 
 [[package]]
 name = "nestweaver-web"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "packages": {
     ".": {
       "release-type": "simple",
+      "draft-pull-request": true,
       "component": "nestweaver",
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,


### PR DESCRIPTION
## Summary

- synchronize the checked-in lockfile with workspace version 2.6.2
- create Release Please PRs as drafts
- mark a release PR ready only after Cargo.lock is synchronized and pushed

## Root cause

Release PR #176 was merged while the Release Please workflow was still updating Cargo.lock. Main therefore contained Cargo.toml at 2.6.2 and Cargo.lock workspace packages at 2.6.1, so every strict cargo --locked build exited before compilation.

## Verification

- jq empty release-please-config.json
- actionlint on release-please.yml
- cargo metadata --locked --offline --no-deps --format-version 1
- cargo build --locked --offline --release -p openssl-sys
- git diff --check
