### PR TITLE
Pin the reviewed Ladybug filtered-scan correction

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[env]
+# The temporary lbug wrapper pin contains the reviewed Ladybug source as an
+# immutable submodule. Always compile that source so Cargo cannot substitute an
+# unrelated prebuilt archive while the upstream release is pending.
+LBUG_BUILD_FROM_SOURCE = { value = "1", force = true }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,8 +325,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
       - name: Configure linker for lbug+tantivy zstd coexistence
         run: |
-          mkdir -p .cargo
-          printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' > .cargo/config.toml
+          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
       - name: Compute native dependency cache key
         id: nativekey
         run: |
@@ -385,8 +384,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
       - name: Configure linker for lbug+tantivy zstd coexistence
         run: |
-          mkdir -p .cargo
-          printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' > .cargo/config.toml
+          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
       - name: Compute native dependency cache key
         id: nativekey
         run: |
@@ -433,8 +431,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
       - name: Configure linker for lbug+tantivy zstd coexistence
         run: |
-          mkdir -p .cargo
-          printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' > .cargo/config.toml
+          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
       - name: Compute native dependency cache key
         id: nativekey
         run: |
@@ -497,8 +494,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
       - name: Configure linker for lbug+tantivy zstd coexistence
         run: |
-          mkdir -p .cargo
-          printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' > .cargo/config.toml
+          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
       - name: Compute native dependency cache key
         id: nativekey
         run: |
@@ -581,8 +577,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
       - name: Configure linker for lbug+tantivy zstd coexistence
         run: |
-          mkdir -p .cargo
-          printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' > .cargo/config.toml
+          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
       - name: Install frontend dependencies
         working-directory: crates/nestweaver-web/frontend
         run: npm ci

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -124,8 +124,8 @@ jobs:
       - name: Configure linker (Linux)
         if: runner.os == 'Linux'
         run: |
-          mkdir -p .cargo
-          cat > .cargo/config.toml << 'EOF'
+          cat >> .cargo/config.toml << 'EOF'
+
           [target.x86_64-unknown-linux-gnu]
           rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ docs(cli): improve --help text for impact command
 ### Setup
 
 ```sh
-# Clone and build
+# Clone and install native build prerequisites (see INSTALL.md for each OS)
 git clone https://github.com/Kehl-io/nestweaver.git
 cd nestweaver
 cargo build
@@ -86,6 +86,11 @@ cargo build
 pre-commit install
 pre-commit install --hook-type commit-msg
 ```
+
+Keep `.cargo/config.toml` in place. It forces the reviewed Ladybug dependency
+to build from its immutable source pin; the initial native build can take
+several minutes. See [INSTALL.md](INSTALL.md#build-from-source) for CMake, C++,
+OpenSSL, zstd, `pkg-config`, and Protocol Buffers prerequisites.
 
 ### Check suite
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3650,8 +3650,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lbug"
 version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf427c75bcdc5768ba41933235e14dbfbf7fe9b14e6ad079d8174d6a2bd7d77c"
+source = "git+https://github.com/kory-io/ladybug-rust.git?rev=8992183ff8de526e8a852be8a97ad04b412f56ed#8992183ff8de526e8a852be8a97ad04b412f56ed"
 dependencies = [
  "cmake",
  "cxx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,3 +159,9 @@ test = false
 name = "index_benchmarks"
 harness = false
 test = false
+
+# Temporary source override for the filtered multi-segment string-scan fix.
+# Remove this patch after the upstream fix is released in an lbug version that
+# passes NestWeaver's storage regression suite.
+[patch.crates-io]
+lbug = { git = "https://github.com/kory-io/ladybug-rust.git", rev = "8992183ff8de526e8a852be8a97ad04b412f56ed" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Build stage
 FROM rust:1.96-trixie AS builder
 WORKDIR /build
-RUN apt-get update && apt-get install -y libssl-dev pkg-config protobuf-compiler && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler && rm -rf /var/lib/apt/lists/*
 COPY . .
-RUN RUSTFLAGS="-C link-arg=-Wl,--allow-multiple-definition" cargo build --release --bin nestweaver
+RUN RUSTFLAGS="-C link-arg=-Wl,--allow-multiple-definition" cargo build --locked --release --bin nestweaver
 
 # Runtime stage
 FROM debian:trixie-slim

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,7 +42,17 @@ accelerator = "cpu"
 
 ## Build from source
 
-Building from source requires Rust 1.85+.
+Building from source requires Rust 1.85+, CMake, a C++20 compiler, OpenSSL and
+zstd development files, `pkg-config`, and Protocol Buffers:
+
+```sh
+# macOS with Homebrew (also install the Xcode Command Line Tools)
+brew install cmake openssl@3 pkg-config protobuf zstd
+
+# Debian/Ubuntu
+sudo apt-get update
+sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler
+```
 
 ```sh
 git clone https://github.com/Kehl-io/nestweaver.git
@@ -51,12 +61,44 @@ cargo install --locked --path .
 nestweaver --version
 ```
 
+The first source build compiles LadybugDB and can take several minutes. Keep
+the checkout's `.cargo/config.toml`: it forces `LBUG_BUILD_FROM_SOURCE=1` so
+the build uses the reviewed source pinned by `Cargo.lock`, rather than an
+unrelated prebuilt archive. Cargo fetches the pinned Ladybug submodule
+automatically.
+
+If OpenSSL is installed in a non-default location and the linker cannot find
+`ssl` or `crypto`, expose that installation while building:
+
+```sh
+# macOS with Homebrew
+LIBRARY_PATH="$(brew --prefix openssl@3)/lib" cargo install --locked --path .
+```
+
 Semantic embeddings are included by default. On macOS, build with Metal when
 you want GPU-accelerated embeddings:
 
 ```sh
 cargo install --locked --path . --features metal
 ```
+
+### Temporary Ladybug source pin
+
+This revision temporarily patches `lbug` 0.18.2 to wrapper commit
+`8992183ff8de526e8a852be8a97ad04b412f56ed`, whose `lbug-src` submodule is
+pinned to Ladybug commit
+`9e221866e08371d380c8bd91f7bc98d101ebf723`. That commit backports the filtered
+multi-segment string-scan correction proposed in
+[LadybugDB/ladybug#737](https://github.com/LadybugDB/ladybug/pull/737).
+
+Do not remove the workspace `[patch.crates-io]` entry, delete
+`.cargo/config.toml`, or point `LBUG_LIBRARY_DIR`/`LBUG_INCLUDE_DIR` at a
+different Ladybug build when validating this fix. The temporary patch can be
+removed after upstream publishes an `lbug` release containing the correction
+and NestWeaver's storage regression suite passes against that release.
+
+Until a NestWeaver release containing this change is published, build this
+revision from source when you specifically need the filtered-scan correction.
 
 ## macOS app
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,13 @@ support select CPU for `auto`.
 cargo install --locked --path .
 ```
 
+Source builds also require CMake, a C++20 compiler, OpenSSL and zstd
+development files, `pkg-config`, and Protocol Buffers. The checkout currently
+compiles an immutable LadybugDB source pin to include the filtered multi-segment
+string-scan correction; keep `.cargo/config.toml` intact. See
+[the source-build prerequisites and pin provenance](INSTALL.md#build-from-source)
+before building.
+
 <details>
 <summary>Pre-built binaries</summary>
 
@@ -214,6 +221,10 @@ cargo install --locked --path .
 # On macOS with Metal embeddings:
 # cargo install --locked --path . --features metal
 ```
+
+The first build compiles the pinned LadybugDB source and may take several
+minutes. If you need the filtered-scan correction before a NestWeaver release
+containing it is available, use this source-build path.
 
 </details>
 

--- a/crates/nestweaver-store/tests/ladybug_filtered_string_scan.rs
+++ b/crates/nestweaver-store/tests/ladybug_filtered_string_scan.rs
@@ -1,0 +1,65 @@
+use nestweaver_schema::{Note, NoteKind};
+use nestweaver_store::GraphStore;
+
+// Ladybug's default value-vector capacity is 2,048 rows. Crossing two complete
+// vectors makes this an end-to-end guard for filtered string reads that span
+// multiple scan batches instead of a single-vector happy path.
+const NOTE_COUNT: usize = 4_113;
+const SELECTED_VAULT: &str = "vlt:selected";
+
+#[test]
+fn filtered_string_scan_preserves_every_selected_value_across_batches() {
+    let store = GraphStore::in_memory().unwrap();
+    let notes = (0..NOTE_COUNT)
+        .map(|index| {
+            let selected = index % 3 == 1;
+            Note {
+                uid: format!("note:scan:{index:05}"),
+                vault_uid: if selected {
+                    SELECTED_VAULT.to_string()
+                } else {
+                    "vlt:other".to_string()
+                },
+                file_path: format!("notes/scan-{index:05}.md"),
+                title: format!("SCAN_TITLE_{index:05}"),
+                note_kind: NoteKind::General,
+                word_count: index as u32,
+                content_hash: format!("hash-{index:05}"),
+                frontmatter: None,
+                created_at: None,
+                modified_at: None,
+                pagerank_score: None,
+                embedding: None,
+            }
+        })
+        .collect::<Vec<_>>();
+    store.batch_insert_notes(&notes).unwrap();
+
+    let expected = notes
+        .iter()
+        .filter(|note| note.vault_uid == SELECTED_VAULT)
+        .map(|note| {
+            (
+                note.uid.clone(),
+                note.file_path.clone(),
+                note.title.clone(),
+                note.content_hash.clone(),
+            )
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+
+    // Repeat the same filtered read to guard both exact values and determinism.
+    for run in 0..3 {
+        let actual = store
+            .list_notes(Some(SELECTED_VAULT))
+            .unwrap_or_else(|error| panic!("filtered scan run {run} failed: {error}"))
+            .into_iter()
+            .map(|note| (note.uid, note.file_path, note.title, note.content_hash))
+            .collect::<std::collections::BTreeSet<_>>();
+
+        assert_eq!(
+            actual, expected,
+            "filtered scan run {run} returned missing or corrupted string values"
+        );
+    }
+}

--- a/npm/README.md
+++ b/npm/README.md
@@ -6,7 +6,9 @@ channel.
 
 Install NestWeaver from a verified
 [GitHub Release archive](../INSTALL.md#pre-built-cli-recommended), including
-its matching SHA-256 file, or build from a source checkout with Rust 1.85+:
+its matching SHA-256 file, or build from a source checkout with Rust 1.85+ and
+the native prerequisites listed in
+[INSTALL.md](../INSTALL.md#build-from-source):
 
 ```sh
 git clone https://github.com/Kehl-io/nestweaver.git

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -219,6 +219,86 @@ fn installation_docs_only_claim_live_channels() {
 }
 
 #[test]
+fn ladybug_hotfix_dependency_is_immutable_and_built_from_source() {
+    const LBUG_RUST_FORK: &str = "https://github.com/kory-io/ladybug-rust.git";
+    const LBUG_RUST_REV: &str = "8992183ff8de526e8a852be8a97ad04b412f56ed";
+
+    let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let manifest = std::fs::read_to_string(repo_root.join("Cargo.toml")).unwrap();
+    let lockfile = std::fs::read_to_string(repo_root.join("Cargo.lock")).unwrap();
+    let cargo_config = std::fs::read_to_string(repo_root.join(".cargo/config.toml")).unwrap();
+    let installation = std::fs::read_to_string(repo_root.join("INSTALL.md")).unwrap();
+    let ci_workflow = std::fs::read_to_string(repo_root.join(".github/workflows/ci.yml")).unwrap();
+    let release_workflow =
+        std::fs::read_to_string(repo_root.join(".github/workflows/release-please.yml")).unwrap();
+    let dockerfile = std::fs::read_to_string(repo_root.join("Dockerfile")).unwrap();
+    let dockerignore = std::fs::read_to_string(repo_root.join(".dockerignore")).unwrap();
+
+    assert!(
+        manifest.contains("[patch.crates-io]"),
+        "the temporary lbug fork must be a workspace-level crates.io patch"
+    );
+    assert!(
+        manifest.contains(&format!(
+            "lbug = {{ git = \"{LBUG_RUST_FORK}\", rev = \"{LBUG_RUST_REV}\" }}"
+        )),
+        "Cargo.toml must pin the reviewed lbug wrapper commit"
+    );
+    assert!(
+        lockfile.contains(&format!(
+            "source = \"git+{LBUG_RUST_FORK}?rev={LBUG_RUST_REV}#{LBUG_RUST_REV}\""
+        )),
+        "Cargo.lock must resolve lbug to the exact reviewed wrapper commit"
+    );
+    assert!(
+        cargo_config.contains("LBUG_BUILD_FROM_SOURCE = { value = \"1\", force = true }"),
+        "workspace builds must compile the pinned Ladybug submodule instead of downloading a prebuilt archive"
+    );
+    for (workflow_name, workflow) in [
+        ("ci.yml", ci_workflow.as_str()),
+        ("release-please.yml", release_workflow.as_str()),
+    ] {
+        assert!(
+            !workflow.contains(" > .cargo/config.toml"),
+            "{workflow_name} must not overwrite the workspace source-build configuration"
+        );
+    }
+    for native_dependency in [
+        "cmake",
+        "g++",
+        "libssl-dev",
+        "libzstd-dev",
+        "pkg-config",
+        "protobuf-compiler",
+    ] {
+        assert!(
+            dockerfile.contains(native_dependency),
+            "Dockerfile must install Ladybug source-build dependency `{native_dependency}`"
+        );
+    }
+    assert!(
+        !dockerignore.lines().any(|line| line.trim() == ".cargo/"),
+        "the Docker build context must include the workspace source-build configuration"
+    );
+    assert!(
+        dockerfile.contains("cargo build --locked --release --bin nestweaver"),
+        "the Docker image must resolve the reviewed dependency lockfile without updating it"
+    );
+    for required_provenance in [
+        LBUG_RUST_REV,
+        "9e221866e08371d380c8bd91f7bc98d101ebf723",
+        "https://github.com/LadybugDB/ladybug/pull/737",
+        ".cargo/config.toml",
+        "LBUG_BUILD_FROM_SOURCE=1",
+    ] {
+        assert!(
+            installation.contains(required_provenance),
+            "INSTALL.md must document Ladybug provenance and source-build requirement `{required_provenance}`"
+        );
+    }
+}
+
+#[test]
 fn embedding_docs_match_runtime_contract() {
     let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let documentation = [


### PR DESCRIPTION
## Summary

- patch `lbug` to an immutable reviewed wrapper commit backed by the exact Ladybug source correction
- force source builds so prebuilt archives cannot bypass the correction
- preserve the tracked Cargo configuration across CI and release linker setup
- add the missing native prerequisites to Docker and installation documentation
- add an end-to-end regression for filtered string scans across multiple Ladybug value-vector batches
- document exact provenance and the upstream-release removal condition

## Root cause

Ladybug 0.18.2 can use the filtered selection index as though it were a segment-local position while scanning multi-segment string columns. That can return missing or corrupted strings once a filtered scan crosses value-vector boundaries. NestWeaver also allowed the Rust wrapper to select a prebuilt archive, so updating source alone would not guarantee that builds exercised the correction.

This change pins wrapper commit `8992183ff8de526e8a852be8a97ad04b412f56ed`, whose `lbug-src` submodule pins Ladybug commit `9e221866e08371d380c8bd91f7bc98d101ebf723`. The C++ correction is proposed upstream in LadybugDB/ladybug#737.

## Validation

- `cargo test --locked --workspace`: passed
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`: passed
- `cargo fmt --all -- --check`: passed
- `actionlint` for CI and release workflows: passed
- 4,113-row filtered string regression across multiple scan batches: passed repeatedly
- installed-binary fresh full-repository index, search, and symbol read: passed
- golden corruption/determinism harness: 6 files x 3 runs x 2 tools, passed
- offline Metal inference selected Metal and produced a finite normalized vector: passed
- Metal failure/panic policy tests verified no CPU fallback: 6 passed
- clean Linux ARM64 Docker source build and final runtime-image smoke: passed
- graph PR impact: complete, Low risk, no breaking changes or affected symbols
- staged credential, private-key, personal-path, and personal-identity scan: clean

## Temporary pin removal

Remove the workspace patch and forced source-build configuration only after an upstream `lbug` release contains the correction and NestWeaver storage, installed-binary, Docker, and Metal validation pass against that release.

This PR targets the persistent `staging` integration branch. It must be reviewed and have all required checks green before merge. The final `staging` to `main` PR will be opened only after every planned deliverable is integrated and the combined branch passes final validation.