### PR TITLE
Cascade orphaned note fragments during deletion

### DIFF
--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -1040,6 +1040,150 @@ mod tests {
     }
 
     #[test]
+    fn delete_note_cascade_removes_fragments_from_either_ownership_signal() {
+        use nestweaver_schema::{Heading, Note, NoteKind, Section, Vault};
+        let store = test_store();
+
+        store
+            .insert_vault(&Vault {
+                uid: "vlt:partial-note".to_string(),
+                name: "partial-note".to_string(),
+                root_path: "/partial-note".to_string(),
+                instance_id: "default".to_string(),
+            })
+            .unwrap();
+        store
+            .insert_note(&Note {
+                uid: "note:partial-note".to_string(),
+                vault_uid: "vlt:partial-note".to_string(),
+                file_path: "partial.md".to_string(),
+                title: "Partial".to_string(),
+                note_kind: NoteKind::General,
+                word_count: 1,
+                content_hash: "note-hash".to_string(),
+                frontmatter: None,
+                created_at: None,
+                modified_at: None,
+                pagerank_score: None,
+                embedding: None,
+            })
+            .unwrap();
+        store
+            .insert_note(&Note {
+                uid: "note:unrelated".to_string(),
+                vault_uid: "vlt:partial-note".to_string(),
+                file_path: "unrelated.md".to_string(),
+                title: "Unrelated".to_string(),
+                note_kind: NoteKind::General,
+                word_count: 1,
+                content_hash: "unrelated-note-hash".to_string(),
+                frontmatter: None,
+                created_at: None,
+                modified_at: None,
+                pagerank_score: None,
+                embedding: None,
+            })
+            .unwrap();
+        store
+            .insert_heading(&Heading {
+                uid: "head:partial-note".to_string(),
+                note_uid: "note:partial-note".to_string(),
+                level: 1,
+                text: "Partial".to_string(),
+                slug: "partial".to_string(),
+                start_line: 1,
+                end_line: 1,
+                content_hash: "heading-hash".to_string(),
+                embedding: None,
+            })
+            .unwrap();
+        store
+            .insert_heading(&Heading {
+                uid: "head:edge-owned-note".to_string(),
+                note_uid: "note:wrong-owner".to_string(),
+                level: 1,
+                text: "Edge owned".to_string(),
+                slug: "edge-owned".to_string(),
+                start_line: 3,
+                end_line: 3,
+                content_hash: "edge-heading-hash".to_string(),
+                embedding: None,
+            })
+            .unwrap();
+        store
+            .insert_heading(&Heading {
+                uid: "head:unrelated".to_string(),
+                note_uid: "note:unrelated".to_string(),
+                level: 1,
+                text: "Unrelated".to_string(),
+                slug: "unrelated".to_string(),
+                start_line: 1,
+                end_line: 1,
+                content_hash: "unrelated-heading-hash".to_string(),
+                embedding: None,
+            })
+            .unwrap();
+        store
+            .insert_section(&Section {
+                uid: "sec:partial-note".to_string(),
+                note_uid: "note:partial-note".to_string(),
+                heading_uid: Some("head:partial-note".to_string()),
+                start_line: 2,
+                end_line: 2,
+                text_hash: "section-hash".to_string(),
+                text_content: "partial body".to_string(),
+                word_count: 2,
+                pagerank_score: None,
+            })
+            .unwrap();
+        store
+            .insert_section(&Section {
+                uid: "sec:edge-owned-note".to_string(),
+                note_uid: "note:wrong-owner".to_string(),
+                heading_uid: Some("head:edge-owned-note".to_string()),
+                start_line: 4,
+                end_line: 4,
+                text_hash: "edge-section-hash".to_string(),
+                text_content: "edge-owned body".to_string(),
+                word_count: 2,
+                pagerank_score: None,
+            })
+            .unwrap();
+        store
+            .insert_section(&Section {
+                uid: "sec:unrelated".to_string(),
+                note_uid: "note:unrelated".to_string(),
+                heading_uid: Some("head:unrelated".to_string()),
+                start_line: 2,
+                end_line: 2,
+                text_hash: "unrelated-section-hash".to_string(),
+                text_content: "unrelated body".to_string(),
+                word_count: 2,
+                pagerank_score: None,
+            })
+            .unwrap();
+        store
+            .batch_insert_note_heading_edges(&[
+                ("note:partial-note", "head:edge-owned-note"),
+                ("note:unrelated", "head:unrelated"),
+            ])
+            .unwrap();
+        store
+            .batch_insert_note_section_edges(&[
+                ("note:partial-note", "sec:edge-owned-note"),
+                ("note:unrelated", "sec:unrelated"),
+            ])
+            .unwrap();
+
+        store.delete_note_cascade("note:partial-note").unwrap();
+
+        assert_eq!(store.count_notes().unwrap(), 1);
+        assert_eq!(store.count_headings().unwrap(), 1);
+        assert_eq!(store.count_sections().unwrap(), 1);
+        assert_eq!(store.list_vaults(None).unwrap().len(), 1);
+    }
+
+    #[test]
     fn delete_note_cascade_is_a_noop_for_missing_uid() {
         let store = test_store();
         store.delete_note_cascade("note:does:not:exist").unwrap();
@@ -1837,6 +1981,161 @@ mod tests {
         assert_eq!(store.count_tags().unwrap(), 0);
         // Vault node itself should be gone — list_vaults returns nothing.
         assert_eq!(store.list_vaults(None).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn delete_vault_cascade_removes_fragments_from_either_ownership_signal() {
+        use nestweaver_schema::{Heading, Note, NoteKind, Section, Vault};
+        let store = test_store();
+
+        store
+            .insert_vault(&Vault {
+                uid: "vlt:partial-vault".to_string(),
+                name: "partial-vault".to_string(),
+                root_path: "/partial-vault".to_string(),
+                instance_id: "default".to_string(),
+            })
+            .unwrap();
+        store
+            .insert_vault(&Vault {
+                uid: "vlt:unrelated-vault".to_string(),
+                name: "unrelated-vault".to_string(),
+                root_path: "/unrelated-vault".to_string(),
+                instance_id: "default".to_string(),
+            })
+            .unwrap();
+        store
+            .insert_note(&Note {
+                uid: "note:partial-vault".to_string(),
+                vault_uid: "vlt:partial-vault".to_string(),
+                file_path: "partial.md".to_string(),
+                title: "Partial".to_string(),
+                note_kind: NoteKind::General,
+                word_count: 1,
+                content_hash: "note-hash".to_string(),
+                frontmatter: None,
+                created_at: None,
+                modified_at: None,
+                pagerank_score: None,
+                embedding: None,
+            })
+            .unwrap();
+        store
+            .insert_note(&Note {
+                uid: "note:unrelated-vault".to_string(),
+                vault_uid: "vlt:unrelated-vault".to_string(),
+                file_path: "unrelated.md".to_string(),
+                title: "Unrelated".to_string(),
+                note_kind: NoteKind::General,
+                word_count: 1,
+                content_hash: "unrelated-note-hash".to_string(),
+                frontmatter: None,
+                created_at: None,
+                modified_at: None,
+                pagerank_score: None,
+                embedding: None,
+            })
+            .unwrap();
+        store
+            .insert_heading(&Heading {
+                uid: "head:partial-vault".to_string(),
+                note_uid: "note:partial-vault".to_string(),
+                level: 1,
+                text: "Partial".to_string(),
+                slug: "partial".to_string(),
+                start_line: 1,
+                end_line: 1,
+                content_hash: "heading-hash".to_string(),
+                embedding: None,
+            })
+            .unwrap();
+        store
+            .insert_heading(&Heading {
+                uid: "head:edge-owned-vault".to_string(),
+                note_uid: "note:wrong-owner".to_string(),
+                level: 1,
+                text: "Edge owned".to_string(),
+                slug: "edge-owned".to_string(),
+                start_line: 3,
+                end_line: 3,
+                content_hash: "edge-heading-hash".to_string(),
+                embedding: None,
+            })
+            .unwrap();
+        store
+            .insert_heading(&Heading {
+                uid: "head:unrelated-vault".to_string(),
+                note_uid: "note:unrelated-vault".to_string(),
+                level: 1,
+                text: "Unrelated".to_string(),
+                slug: "unrelated".to_string(),
+                start_line: 1,
+                end_line: 1,
+                content_hash: "unrelated-heading-hash".to_string(),
+                embedding: None,
+            })
+            .unwrap();
+        store
+            .insert_section(&Section {
+                uid: "sec:partial-vault".to_string(),
+                note_uid: "note:partial-vault".to_string(),
+                heading_uid: Some("head:partial-vault".to_string()),
+                start_line: 2,
+                end_line: 2,
+                text_hash: "section-hash".to_string(),
+                text_content: "partial body".to_string(),
+                word_count: 2,
+                pagerank_score: None,
+            })
+            .unwrap();
+        store
+            .insert_section(&Section {
+                uid: "sec:edge-owned-vault".to_string(),
+                note_uid: "note:wrong-owner".to_string(),
+                heading_uid: Some("head:edge-owned-vault".to_string()),
+                start_line: 4,
+                end_line: 4,
+                text_hash: "edge-section-hash".to_string(),
+                text_content: "edge-owned body".to_string(),
+                word_count: 2,
+                pagerank_score: None,
+            })
+            .unwrap();
+        store
+            .insert_section(&Section {
+                uid: "sec:unrelated-vault".to_string(),
+                note_uid: "note:unrelated-vault".to_string(),
+                heading_uid: Some("head:unrelated-vault".to_string()),
+                start_line: 2,
+                end_line: 2,
+                text_hash: "unrelated-section-hash".to_string(),
+                text_content: "unrelated body".to_string(),
+                word_count: 2,
+                pagerank_score: None,
+            })
+            .unwrap();
+        store
+            .batch_insert_note_heading_edges(&[
+                ("note:partial-vault", "head:edge-owned-vault"),
+                ("note:unrelated-vault", "head:unrelated-vault"),
+            ])
+            .unwrap();
+        store
+            .batch_insert_note_section_edges(&[
+                ("note:partial-vault", "sec:edge-owned-vault"),
+                ("note:unrelated-vault", "sec:unrelated-vault"),
+            ])
+            .unwrap();
+
+        let deleted = store.delete_vault_cascade("vlt:partial-vault").unwrap();
+
+        assert_eq!(deleted, 1);
+        assert_eq!(store.count_notes().unwrap(), 1);
+        assert_eq!(store.count_headings().unwrap(), 1);
+        assert_eq!(store.count_sections().unwrap(), 1);
+        let vaults = store.list_vaults(None).unwrap();
+        assert_eq!(vaults.len(), 1);
+        assert_eq!(vaults[0].uid, "vlt:unrelated-vault");
     }
 
     #[test]

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -2326,26 +2326,48 @@ impl GraphStore {
     pub fn delete_note_cascade(&self, note_uid: &str) -> Result<(), StoreError> {
         let conn = self.conn()?;
 
-        // 1. Drop every Section under this note. DETACH removes the
+        // 1. Drop every Section whose ownership property references this
+        //    note, including fragments whose NOTE_HAS_SECTION edge is missing.
+        //    DETACH removes the
         //    NOTE_HAS_SECTION, HEADING_HAS_SECTION, WIKILINK_TO_NOTE
         //    (incoming) and SECTION_TAGGED_WITH edges along with it.
+        exec_params(
+            &conn,
+            "MATCH (s:Section) WHERE s.note_uid = $uid DETACH DELETE s",
+            vec![("uid", lbug::Value::String(note_uid.to_string()))],
+        )?;
+
+        // 2. Drop Sections whose ownership edge references this note. This
+        //    independent pass also handles a missing or corrupt note_uid
+        //    property.
         exec_params(
             &conn,
             "MATCH (n:Note {uid: $uid})-[:NOTE_HAS_SECTION]->(s:Section) DETACH DELETE s",
             vec![("uid", lbug::Value::String(note_uid.to_string()))],
         )?;
 
-        // 2. Drop every Heading under this note. DETACH removes
+        // 3. Drop every Heading whose ownership property references this
+        //    note, including fragments whose NOTE_HAS_HEADING edge is missing.
+        //    DETACH removes
         //    NOTE_HAS_HEADING, HEADING_HAS_SECTION (already gone if its
         //    section was dropped above), HEADING_PARENT (both directions),
         //    and WIKILINK_TO_HEADING (incoming).
+        exec_params(
+            &conn,
+            "MATCH (h:Heading) WHERE h.note_uid = $uid DETACH DELETE h",
+            vec![("uid", lbug::Value::String(note_uid.to_string()))],
+        )?;
+
+        // 4. Drop Headings whose ownership edge references this note. This
+        //    independent pass also handles a missing or corrupt note_uid
+        //    property.
         exec_params(
             &conn,
             "MATCH (n:Note {uid: $uid})-[:NOTE_HAS_HEADING]->(h:Heading) DETACH DELETE h",
             vec![("uid", lbug::Value::String(note_uid.to_string()))],
         )?;
 
-        // 3. Drop the Note itself. DETACH removes VAULT_HAS_NOTE,
+        // 5. Drop the Note itself. DETACH removes VAULT_HAS_NOTE,
         //    NOTE_TAGGED_WITH, PROJECT_INCLUDES_NOTE, and any incoming
         //    WIKILINK_TO_NOTE edges from other notes' sections.
         exec_params(
@@ -2354,7 +2376,7 @@ impl GraphStore {
             vec![("uid", lbug::Value::String(note_uid.to_string()))],
         )?;
 
-        // 4. Drop any recorded unresolved-wikilink rows for this note so they
+        // 6. Drop any recorded unresolved-wikilink rows for this note so they
         //    do not linger after re-index (e.g. once the target note appears).
         self.delete_unresolved_wikilinks_for_note(note_uid)?;
 
@@ -2367,8 +2389,8 @@ impl GraphStore {
     ///
     /// Order of operations (within a single transaction):
     ///   1. Count notes (before deleting, so we can return the count).
-    ///   2. Delete Sections via edge traversal (NOTE_HAS_SECTION).
-    ///   3. Delete Headings via edge traversal (NOTE_HAS_HEADING).
+    ///   2. Delete Sections by note_uid property and NOTE_HAS_SECTION edge.
+    ///   3. Delete Headings by note_uid property and NOTE_HAS_HEADING edge.
     ///   4. Delete UnresolvedWikilinks via cross-node join on source_note_uid.
     ///   5. Delete all Note nodes (vault_uid property; DETACH removes
     ///      VAULT_HAS_NOTE, NOTE_TAGGED_WITH, PROJECT_INCLUDES_NOTE, and
@@ -2733,21 +2755,47 @@ impl GraphStore {
             ));
         }
 
-        // 1. Delete all Sections under notes in this vault.
+        // 1. Delete all Sections whose ownership property references notes in
+        //    this vault, including fragments whose NOTE_HAS_SECTION edge is
+        //    missing.
+        exec_params(
+            conn,
+            "MATCH (n:Note), (s:Section) \
+             WHERE n.vault_uid = $vid AND s.note_uid = n.uid \
+             DETACH DELETE s",
+            vec![("vid", lbug::Value::String(vault_uid.to_string()))],
+        )?;
+
+        // 2. Delete Sections whose ownership edge references notes in this
+        //    vault. This independent pass also handles a missing or corrupt
+        //    note_uid property.
         exec_params(
             conn,
             "MATCH (n:Note {vault_uid: $vid})-[:NOTE_HAS_SECTION]->(s:Section) DETACH DELETE s",
             vec![("vid", lbug::Value::String(vault_uid.to_string()))],
         )?;
 
-        // 2. Delete all Headings under notes in this vault.
+        // 3. Delete all Headings whose ownership property references notes in
+        //    this vault, including fragments whose NOTE_HAS_HEADING edge is
+        //    missing.
+        exec_params(
+            conn,
+            "MATCH (n:Note), (h:Heading) \
+             WHERE n.vault_uid = $vid AND h.note_uid = n.uid \
+             DETACH DELETE h",
+            vec![("vid", lbug::Value::String(vault_uid.to_string()))],
+        )?;
+
+        // 4. Delete Headings whose ownership edge references notes in this
+        //    vault. This independent pass also handles a missing or corrupt
+        //    note_uid property.
         exec_params(
             conn,
             "MATCH (n:Note {vault_uid: $vid})-[:NOTE_HAS_HEADING]->(h:Heading) DETACH DELETE h",
             vec![("vid", lbug::Value::String(vault_uid.to_string()))],
         )?;
 
-        // 3. Delete UnresolvedWikilinks whose source note belongs to this vault.
+        // 5. Delete UnresolvedWikilinks whose source note belongs to this vault.
         //    Uses a cross-node join: LadybugDB supports `MATCH (a), (b) WHERE a.prop = b.prop`.
         //    Best-effort: silently skip if the table does not exist on older DBs.
         {
@@ -2771,7 +2819,7 @@ impl GraphStore {
             }
         }
 
-        // 4. Delete all Note nodes (DETACH removes VAULT_HAS_NOTE, NOTE_TAGGED_WITH,
+        // 6. Delete all Note nodes (DETACH removes VAULT_HAS_NOTE, NOTE_TAGGED_WITH,
         //    PROJECT_INCLUDES_NOTE, and any incoming/outgoing wikilink edges).
         exec_params(
             conn,
@@ -2779,14 +2827,14 @@ impl GraphStore {
             vec![("vid", lbug::Value::String(vault_uid.to_string()))],
         )?;
 
-        // 5. Delete Tag nodes belonging to this vault.
+        // 7. Delete Tag nodes belonging to this vault.
         exec_params(
             conn,
             "MATCH (t:Tag {vault_uid: $vid}) DETACH DELETE t",
             vec![("vid", lbug::Value::String(vault_uid.to_string()))],
         )?;
 
-        // 6. Delete the Vault node itself.
+        // 8. Delete the Vault node itself.
         exec_params(
             conn,
             "MATCH (v:Vault {uid: $vid}) DETACH DELETE v",


### PR DESCRIPTION
## Summary

- delete note fragments referenced by either ownership property or ownership edge
- apply the same union-of-signals rule to transactional vault cascades
- preserve unrelated note and vault ownership trees
- retain linear bulk behavior by using Ladybug hash joins for property-owned fragments
- add corruption regressions for missing edges and mismatched ownership properties

## Root cause

`Heading` and `Section` ownership is represented redundantly: each fragment stores `note_uid`, and the graph also stores `NOTE_HAS_HEADING` or `NOTE_HAS_SECTION`. The previous cascade followed only the ownership edge. If indexing was interrupted after a fragment row was written but before its edge was published, the fragment survived note or vault deletion. Conversely, relying only on `note_uid` would miss rows whose property was corrupt while their edge remained correct.

The cascade now treats the two representations as independent ownership evidence and deletes the union. Property-owned fragments are removed first, then edge-owned fragments, before the parent note rows. This leaves no dangling ownership reference while preserving unrelated trees.

## Validation

- `cargo test --workspace --locked -- --test-threads=1`: passed
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`: passed
- `cargo fmt --all -- --check`: passed
- complete `nestweaver-store` suite: 295 unit tests, 14 build-selection tests, and the 4,113-row Ladybug regression passed
- targeted corruption tests cover missing ownership edges, mismatched `note_uid` values, and unrelated-tree preservation
- existing single-note and bulk-vault cascade regressions passed
- Ladybug `EXPLAIN` confirmed the vault property join uses hash build/probe operators rather than a nested-loop plan
- pinned Ladybug filtered-scan regression remains green
- `git diff --check`: passed

## Documentation

No user-facing configuration or installation behavior changes in this deliverable. The cascade contract and operation ordering are documented inline. Existing installation guidance for the temporary Ladybug pin remains unchanged.

NestWeaver reports a high static blast radius because these methods sit in the core store; the full workspace test and all-features lint gates were run accordingly.

This PR targets the persistent `staging` integration branch. It must be reviewed and have all required checks green before merge. The final `staging` to `main` PR will be opened only after every planned deliverable is integrated and the combined branch passes final validation.