### PR TITLE
perf(store): bulk-load impact snapshot endpoints

### DIFF
--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -1828,6 +1828,52 @@ mod tests {
     }
 
     #[test]
+    fn exact_batch_lookup_rejects_a_missing_uid() {
+        let store = test_store();
+        store
+            .insert_symbol(&make_symbol(
+                "sym:exact-present",
+                "present_fn",
+                "repo-1",
+                "a.rs",
+            ))
+            .unwrap();
+
+        let error = store
+            .batch_lookup_symbols_exact(&["sym:exact-present", "sym:exact-ghost"])
+            .expect_err("an exact lookup must not silently omit a requested symbol");
+
+        assert!(
+            error
+                .to_string()
+                .contains("missing symbol UID sym:exact-ghost"),
+            "the error must identify the missing primary key, got: {error}"
+        );
+    }
+
+    #[test]
+    fn exact_batch_lookup_rejects_duplicate_requested_uids() {
+        let store = test_store();
+        store
+            .insert_symbol(&make_symbol(
+                "sym:exact-duplicate",
+                "duplicate_fn",
+                "repo-1",
+                "a.rs",
+            ))
+            .unwrap();
+
+        let error = store
+            .batch_lookup_symbols_exact(&["sym:exact-duplicate", "sym:exact-duplicate"])
+            .expect_err("an exact lookup must reject duplicate requested primary keys");
+
+        assert!(
+            error.to_string().contains("duplicate requested UID"),
+            "the error must identify the duplicate request, got: {error}"
+        );
+    }
+
+    #[test]
     fn batch_lookup_symbols_empty_input_returns_empty_map() {
         let store = test_store();
         let map = store.batch_lookup_symbols(&[]).unwrap();

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -380,16 +380,49 @@ impl GraphStore {
 
     /// Fetch multiple symbols in a single query, keyed by UID.
     ///
-    /// Builds one `WHERE s.uid IN [...]` query instead of N individual lookups.
+    /// Drives primary-key probes through one `UNWIND` query instead of N
+    /// individual lookups.
     /// UIDs not found in the graph are simply absent from the returned map.
     /// Returns an empty map when `uids` is empty.
     pub fn batch_lookup_symbols(
         &self,
         uids: &[&str],
     ) -> Result<std::collections::HashMap<String, Symbol>, StoreError> {
+        self.batch_lookup_symbols_impl(uids, false)
+    }
+
+    /// Exact variant for trust-sensitive snapshots.
+    ///
+    /// In addition to using primary-key probes, this rejects duplicate
+    /// requests, missing rows, unexpected rows, and duplicate result rows.
+    pub(crate) fn batch_lookup_symbols_exact(
+        &self,
+        uids: &[&str],
+    ) -> Result<std::collections::HashMap<String, Symbol>, StoreError> {
+        self.batch_lookup_symbols_impl(uids, true)
+    }
+
+    fn batch_lookup_symbols_impl(
+        &self,
+        uids: &[&str],
+        require_exact: bool,
+    ) -> Result<std::collections::HashMap<String, Symbol>, StoreError> {
         if uids.is_empty() {
             return Ok(std::collections::HashMap::new());
         }
+        let expected = if require_exact {
+            let mut expected = std::collections::HashSet::with_capacity(uids.len());
+            for uid in uids {
+                if !expected.insert(*uid) {
+                    return Err(StoreError::Query(format!(
+                        "batch_lookup_symbols_exact: duplicate requested UID {uid}"
+                    )));
+                }
+            }
+            Some(expected)
+        } else {
+            None
+        };
         let conn = self.conn()?;
         // Drive PRIMARY-KEY point lookups via UNWIND rather than a
         // `WHERE s.uid IN [...]` scan-with-filter. Two reasons:
@@ -398,9 +431,8 @@ impl GraphStore {
         //      delete+checkpoint cycles (re-indexing), while primary-key point
         //      lookups return correct values for the same rows. Driving the
         //      lookup through the PK index is what keeps names/paths intact.
-        //   2. Speed: N index probes instead of a filtered scan, and one
-        //      parameterized statement instead of a fresh query string (which
-        //      would force a re-plan) per distinct key set.
+        //   2. Speed: N index probes inside one query plan instead of a
+        //      filtered scan or a separately planned query per UID.
         let in_list: String = uids
             .iter()
             .map(|u| format!("'{}'", u.replace('\'', "''")))
@@ -414,10 +446,32 @@ impl GraphStore {
         let result = conn
             .query(&q)
             .map_err(|e| StoreError::Query(format!("batch_lookup_symbols: {e}")))?;
-        let mut map = std::collections::HashMap::new();
+        let mut map = std::collections::HashMap::with_capacity(uids.len());
         for row in result {
             let sym = row_to_symbol(&row)?;
-            map.insert(sym.uid.clone(), sym);
+            if let Some(expected) = &expected
+                && !expected.contains(sym.uid.as_str())
+            {
+                return Err(StoreError::Query(format!(
+                    "batch_lookup_symbols_exact: unexpected symbol UID {}",
+                    sym.uid
+                )));
+            }
+            let uid = sym.uid.clone();
+            if map.insert(uid.clone(), sym).is_some() && require_exact {
+                return Err(StoreError::Query(format!(
+                    "batch_lookup_symbols_exact: duplicate result row for {uid}"
+                )));
+            }
+        }
+        if expected.is_some() {
+            for uid in uids {
+                if !map.contains_key(*uid) {
+                    return Err(StoreError::Query(format!(
+                        "batch_lookup_symbols_exact: missing symbol UID {uid}"
+                    )));
+                }
+            }
         }
         Ok(map)
     }

--- a/crates/nestweaver-store/src/traverse.rs
+++ b/crates/nestweaver-store/src/traverse.rs
@@ -432,21 +432,22 @@ impl GraphStore {
     ///
     /// Strict scans of the impact edge tables supply the distinct endpoint
     /// primary keys. Every participating symbol is then re-read through an
-    /// individual primary-key point lookup before any of its display fields
-    /// can enter the snapshot. This intentionally avoids the engine's
-    /// `UNWIND`/filtered-scan path: a prior optimization could align a valid
-    /// edge with the wrong scanned symbol row. Any edge-table query failure,
-    /// missing point lookup, duplicate key, dangling symbol edge, or non-
-    /// finite/out-of-range confidence fails the entire build rather than
-    /// producing a deceptively incomplete impact graph. Symbols with no impact
-    /// edges are omitted because they cannot appear in an impact result.
+    /// exact `UNWIND`-driven batch of primary-key probes before any display
+    /// fields can enter the snapshot. This intentionally avoids a filtered
+    /// `Symbol` scan: a prior optimization could align a valid edge with the
+    /// wrong scanned symbol row. The expected key set is reconciled against
+    /// every result row. Any edge-table query failure, missing or unexpected
+    /// symbol, duplicate key, dangling symbol edge, or non-finite/out-of-range
+    /// confidence fails the entire build rather than producing a deceptively
+    /// incomplete impact graph. Symbols with no impact edges are omitted
+    /// because they cannot appear in an impact result.
     ///
     /// # Performance
     ///
-    /// This correctness-first candidate performs one primary-key lookup per
-    /// distinct impact-edge endpoint and can be expensive on large graphs. It
-    /// must remain off hot paths until a safe bulk loader passes the real-graph
-    /// golden-output and latency gates.
+    /// Snapshot construction still scales with the full impact-edge endpoint
+    /// set and can be expensive on large graphs. It must remain off hot paths
+    /// until a generation-keyed cache passes the real-graph golden-output and
+    /// latency gates.
     pub fn load_impact_snapshot(&self) -> Result<ImpactSnapshot, StoreError> {
         let conn = self.conn()?;
         let mut snapshot_edges = Vec::new();
@@ -494,55 +495,17 @@ impl GraphStore {
             }
         }
 
-        let point_query = format!(
-            "MATCH (s:Symbol {{uid: $uid}}) RETURN {}",
-            crate::read::SYMBOL_COLUMNS
-        );
-        let mut point_stmt = conn.prepare(&point_query).map_err(|error| {
-            StoreError::Query(format!(
-                "impact snapshot failed to prepare primary-key lookup: {error}"
-            ))
-        })?;
         let mut required_uids: Vec<String> = required_uids.into_iter().collect();
         required_uids.sort();
-        let mut symbols_by_uid = HashMap::with_capacity(required_uids.len());
-        for uid in required_uids {
-            let trusted = {
-                let mut rows = conn
-                    .execute(
-                        &mut point_stmt,
-                        vec![("uid", lbug::Value::String(uid.clone()))],
-                    )
-                    .map_err(|error| {
-                        StoreError::Query(format!(
-                            "impact snapshot primary-key lookup failed for {uid}: {error}"
-                        ))
-                    })?;
-                let row = rows.next().ok_or_else(|| {
-                    StoreError::Query(format!(
-                        "impact snapshot primary-key lookup returned no row for {uid}"
-                    ))
-                })?;
-                let trusted = crate::read::row_to_symbol(&row)?;
-                if rows.next().is_some() {
-                    return Err(StoreError::Query(format!(
-                        "impact snapshot primary-key lookup returned duplicate rows for {uid}"
-                    )));
-                }
-                trusted
-            };
-            if trusted.uid != uid {
-                return Err(StoreError::Query(format!(
-                    "impact snapshot primary-key mismatch: requested {uid}, received {}",
-                    trusted.uid
-                )));
-            }
-            if symbols_by_uid.insert(uid.clone(), trusted).is_some() {
-                return Err(StoreError::Query(format!(
-                    "impact snapshot duplicate symbol primary key: {uid}"
-                )));
-            }
-        }
+        let required_uid_refs: Vec<&str> = required_uids.iter().map(String::as_str).collect();
+        drop(conn);
+        let symbols_by_uid = self
+            .batch_lookup_symbols_exact(&required_uid_refs)
+            .map_err(|error| {
+                StoreError::Query(format!(
+                    "impact snapshot exact bulk symbol lookup failed: {error}"
+                ))
+            })?;
 
         let mut callers_by_target: HashMap<String, HashMap<String, Vec<SnapshotCaller>>> =
             HashMap::new();
@@ -2492,6 +2455,48 @@ mod tests {
             as_bytes(&from_snapshot),
             as_bytes(&live),
             "the snapshot traversal must be byte-equivalent before it can replace the live path"
+        );
+    }
+
+    #[test]
+    fn impact_snapshot_bulk_loads_thousands_of_endpoints_within_two_seconds() {
+        use std::time::{Duration, Instant};
+
+        use nestweaver_schema::{EdgeType, ResolvedEdge};
+
+        const SYMBOL_COUNT: usize = 2_048;
+
+        let store = GraphStore::in_memory().unwrap();
+        let symbols: Vec<_> = (0..SYMBOL_COUNT)
+            .map(|index| {
+                let uid = format!("bulk-endpoint-{index:04}");
+                make_symbol(&uid, &uid)
+            })
+            .collect();
+        store.batch_insert_symbols(&symbols).unwrap();
+
+        let edges: Vec<_> = symbols
+            .windows(2)
+            .map(|pair| ResolvedEdge {
+                source_uid: pair[0].uid.clone(),
+                target_uid: pair[1].uid.clone(),
+                edge_type: EdgeType::Calls,
+                confidence: 0.95,
+                link_type: None,
+                evidence: Vec::new(),
+            })
+            .collect();
+        store.batch_insert_edges(&edges).unwrap();
+
+        let started = Instant::now();
+        let snapshot = store.load_impact_snapshot().unwrap();
+        let elapsed = started.elapsed();
+
+        assert_eq!(snapshot.symbols_by_uid.len(), SYMBOL_COUNT);
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "loading {SYMBOL_COUNT} endpoint symbols took {elapsed:?}; \
+             the snapshot must not issue one query per UID"
         );
     }
 


### PR DESCRIPTION
## Summary

- replace one Ladybug query per impact endpoint with one `UNWIND`-driven batch of primary-key probes
- add an exact bulk lookup path that rejects duplicate requests, missing or unexpected rows, duplicate results, and dangling endpoints
- preserve the existing public batch lookup behavior and keep the snapshot candidate non-default
- add strict correctness regressions and a 2,048-endpoint performance contract
- update API documentation to describe the safe bulk loader and the remaining generation-keyed cache gate

## Trust and compatibility

The edge tables are still scanned strictly and every distinct endpoint is reconciled before a snapshot can be returned. Any incomplete, duplicate, corrupt, or mismatched data fails the entire build rather than degrading silently. The existing live traversal remains the default, and the public non-strict batch lookup continues to omit missing UIDs as documented.

This internal loader change does not alter installation steps, configuration keys, file formats, or user-facing defaults, so no installation/configuration migration is required.

## Performance and equivalence

- TDD red: the legacy per-UID loader took 2.674 seconds for 2,048 endpoints and failed the two-second contract
- current production graph: strict snapshot construction completed in 11.537–20.142 seconds across three runs
- representative highest-fan-in symbol: `collect` (410 incoming edges, 432 total)
- live Ladybug traversal: 183.777 seconds and 1,454 nodes
- snapshot traversal: 9.241–9.485 milliseconds across ten runs
- exact real-graph equivalence passed for node ordering, identity/display fields, edge types, confidence bits, depth, impact-score bits, and honesty flags

The traversal gate is now satisfied by a wide margin. Construction is still too expensive for a hot path, so a generation-keyed snapshot cache remains the next deliverable before selection can change.

## Validation

- `cargo test --workspace --all-features`
- `cargo test -p nestweaver-store` (302 unit tests, 14 build-selection tests, Ladybug filtered-string regression)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- mutation checks proved both new exactness tests fail when strict reconciliation is disabled
- added-line scan found no credentials, tokens, private keys, personal paths, attribution, or sensitive data
- Metal-enabled embedding dependencies compiled under both workspace tests and Clippy without fallback-related build errors

## Type

- [x] Enhancement
- [x] Refactoring
- [x] Documentation

## Checklist

- [x] Tests pass
- [x] Clippy is clean with warnings denied
- [x] Formatting passes
- [x] Commit follows conventional commits
- [x] Added tests for strict reconciliation and bulk-load performance

## Workflow

This deliverable branches from `staging` and targets `staging`. It should merge only after review and all required checks pass. The final integration PR will be opened from `staging` to `main` after the remaining deliverables are complete.