### PR TITLE
feat(daemon): add embedding preflight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4104,6 +4104,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tonic",
+ "tonic-prost",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ criterion = { version = "0.8", default-features = false }
 nestweaver-daemon = { workspace = true }
 nestweaver-proto = { workspace = true }
 tonic = { workspace = true }
+tonic-prost = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 libc = "0.2"
 blake3 = { workspace = true }

--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -419,6 +419,24 @@ impl DaemonClient {
         Ok(resp.into_inner())
     }
 
+    /// Return the authoritative embedding eligibility snapshot for a scope.
+    pub async fn plan_embed(
+        &mut self,
+        scope: &str,
+        force: bool,
+    ) -> Result<nestweaver_proto::EmbedResponse> {
+        let resp = self
+            .inner
+            .plan_embed(nestweaver_proto::EmbedRequest {
+                scope: scope.to_string(),
+                force,
+                batch_size: 0,
+            })
+            .await
+            .context("plan_embed RPC failed")?;
+        Ok(resp.into_inner())
+    }
+
     /// Run bulk embedding on the daemon using its configured embedding backend.
     pub async fn embed(
         &mut self,

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -2526,6 +2526,80 @@ fn run_remove_vault_with_projection(
     )
 }
 
+#[derive(Clone, Copy)]
+struct EmbeddingScopes {
+    symbols: bool,
+    notes: bool,
+    headings: bool,
+}
+
+fn embedding_scopes(scope: &str) -> Result<EmbeddingScopes, Status> {
+    let scopes = EmbeddingScopes {
+        symbols: scope == "all" || scope == "symbols",
+        notes: scope == "all" || scope == "notes",
+        headings: scope == "all" || scope == "headings",
+    };
+    if !scopes.symbols && !scopes.notes && !scopes.headings {
+        return Err(Status::invalid_argument(format!(
+            "unknown scope '{scope}': expected one of: all, symbols, notes, headings"
+        )));
+    }
+    Ok(scopes)
+}
+
+fn embedding_is_eligible(store: &GraphStore, uid: &str, force: bool) -> bool {
+    force || !store.has_embedding(uid)
+}
+
+fn embedding_store_status(operation: &str, error: anyhow::Error) -> Status {
+    tracing::error!(operation, "embedding eligibility query failed: {error:#}");
+    Status::internal(format!("failed to inspect embedding {operation}"))
+}
+
+fn plan_embeddings(store: &GraphStore, scope: &str, force: bool) -> Result<EmbedResponse, Status> {
+    let scopes = embedding_scopes(scope)?;
+    let mut scoped = 0u64;
+    let mut eligible = 0u64;
+
+    if scopes.symbols {
+        let symbols = store
+            .list_all_symbols()
+            .map_err(|error| embedding_store_status("symbols", error.into()))?;
+        scoped += symbols.len() as u64;
+        eligible += symbols
+            .iter()
+            .filter(|symbol| embedding_is_eligible(store, &symbol.uid, force))
+            .count() as u64;
+    }
+    if scopes.notes {
+        let notes = store
+            .list_notes(None)
+            .map_err(|error| embedding_store_status("notes", error.into()))?;
+        scoped += notes.len() as u64;
+        eligible += notes
+            .iter()
+            .filter(|note| embedding_is_eligible(store, &note.uid, force))
+            .count() as u64;
+    }
+    if scopes.headings {
+        let headings = store
+            .list_all_headings()
+            .map_err(|error| embedding_store_status("headings", error.into()))?;
+        scoped += headings.len() as u64;
+        eligible += headings
+            .iter()
+            .filter(|heading| embedding_is_eligible(store, &heading.uid, force))
+            .count() as u64;
+    }
+
+    Ok(EmbedResponse {
+        scoped,
+        eligible,
+        skipped: scoped.saturating_sub(eligible),
+        ..EmbedResponse::default()
+    })
+}
+
 #[tonic::async_trait]
 impl NestWeaverDaemon for DaemonService {
     // ── Lifecycle ───────────────────────────────────────────────────
@@ -5329,6 +5403,23 @@ impl NestWeaverDaemon for DaemonService {
     // ── Embedding ───────────────────────────────────────────────────
 
     #[allow(clippy::result_large_err)]
+    async fn plan_embed(
+        &self,
+        request: Request<EmbedRequest>,
+    ) -> Result<Response<EmbedResponse>, Status> {
+        let _write_lock = self.state.write_mutex.lock().await;
+        let _guard = ConnectionGuard::read(&self.state);
+        let request = request.into_inner();
+        let store = self.state.store.clone();
+        let response = tokio::task::spawn_blocking(move || {
+            plan_embeddings(&store, &request.scope, request.force)
+        })
+        .await
+        .map_err(|error| Status::internal(format!("embed plan task panicked: {error}")))??;
+        Ok(Response::new(response))
+    }
+
+    #[allow(clippy::result_large_err)]
     async fn embed(
         &self,
         request: Request<EmbedRequest>,
@@ -5360,15 +5451,10 @@ impl NestWeaverDaemon for DaemonService {
                 req.batch_size as usize
             };
 
-            let do_symbols = scope == "all" || scope == "symbols";
-            let do_notes = scope == "all" || scope == "notes";
-            let do_headings = scope == "all" || scope == "headings";
-
-            if !do_symbols && !do_notes && !do_headings {
-                return Err(Status::invalid_argument(format!(
-                    "unknown scope '{scope}': expected one of: all, symbols, notes, headings"
-                )));
-            }
+            let scopes = embedding_scopes(&scope)?;
+            let do_symbols = scopes.symbols;
+            let do_notes = scopes.notes;
+            let do_headings = scopes.headings;
 
             let (status, model) = self.state.embedding_runtime.snapshot();
             let Some(model) = model else {
@@ -5388,20 +5474,23 @@ impl NestWeaverDaemon for DaemonService {
                 let mut succeeded = 0u32;
                 let mut failed = 0u32;
                 let mut rejected = 0u32;
+                let mut scoped = 0u64;
+                let mut eligible = 0u64;
 
                 // Each embed run may legitimately force-switch the model once;
                 // re-arm the once-per-run clear guard on this long-lived index.
                 store.reset_embedding_force_guard();
 
-                if do_symbols && let Ok(symbols) = store.list_all_symbols() {
-                    let to_embed: Vec<_> = if force {
-                        symbols.iter().collect()
-                    } else {
-                        symbols
-                            .iter()
-                            .filter(|s| !store.has_embedding(&s.uid))
-                            .collect()
-                    };
+                if do_symbols {
+                    let symbols = store
+                        .list_all_symbols()
+                        .map_err(|error| embedding_store_status("symbols", error.into()))?;
+                    scoped += symbols.len() as u64;
+                    let to_embed: Vec<_> = symbols
+                        .iter()
+                        .filter(|symbol| embedding_is_eligible(&store, &symbol.uid, force))
+                        .collect();
+                    eligible += to_embed.len() as u64;
                     for chunk in to_embed.chunks(batch_size) {
                         for sym in chunk {
                             let text = nestweaver_embed::preprocess::symbol_embed_text(
@@ -5426,15 +5515,16 @@ impl NestWeaverDaemon for DaemonService {
                     }
                 }
 
-                if do_notes && let Ok(notes) = store.list_notes(None) {
-                    let to_embed: Vec<_> = if force {
-                        notes.iter().collect()
-                    } else {
-                        notes
-                            .iter()
-                            .filter(|n| !store.has_embedding(&n.uid))
-                            .collect()
-                    };
+                if do_notes {
+                    let notes = store
+                        .list_notes(None)
+                        .map_err(|error| embedding_store_status("notes", error.into()))?;
+                    scoped += notes.len() as u64;
+                    let to_embed: Vec<_> = notes
+                        .iter()
+                        .filter(|note| embedding_is_eligible(&store, &note.uid, force))
+                        .collect();
+                    eligible += to_embed.len() as u64;
                     for chunk in to_embed.chunks(batch_size) {
                         for note in chunk {
                             let text =
@@ -5456,15 +5546,16 @@ impl NestWeaverDaemon for DaemonService {
                     }
                 }
 
-                if do_headings && let Ok(headings) = store.list_all_headings() {
-                    let to_embed: Vec<_> = if force {
-                        headings.iter().collect()
-                    } else {
-                        headings
-                            .iter()
-                            .filter(|h| !store.has_embedding(&h.uid))
-                            .collect()
-                    };
+                if do_headings {
+                    let headings = store
+                        .list_all_headings()
+                        .map_err(|error| embedding_store_status("headings", error.into()))?;
+                    scoped += headings.len() as u64;
+                    let to_embed: Vec<_> = headings
+                        .iter()
+                        .filter(|heading| embedding_is_eligible(&store, &heading.uid, force))
+                        .collect();
+                    eligible += to_embed.len() as u64;
                     for chunk in to_embed.chunks(batch_size) {
                         for heading in chunk {
                             let text =
@@ -5497,6 +5588,9 @@ impl NestWeaverDaemon for DaemonService {
                     succeeded,
                     failed,
                     rejected,
+                    scoped,
+                    eligible,
+                    skipped: scoped.saturating_sub(eligible),
                 })
             })
             .await
@@ -5763,6 +5857,7 @@ const READ_ONLY_ALLOWED_METHODS: &[&str] = &[
     "ListReposJson",
     "ListServicesJson",
     "ListVaultsJson",
+    "PlanEmbed",
     "PrImpactJson",
     "QueryExtensions",
     "ReadSymbols",
@@ -13386,6 +13481,96 @@ mod startup_helper_tests {
     }
 
     #[cfg(feature = "embed")]
+    #[tokio::test]
+    async fn embed_plan_reports_all_missing_nodes_as_eligible() {
+        let state = test_state_with_writer();
+        insert_unembedded_nodes_for_every_scope(&state.store, "plan-missing");
+        let service = DaemonService::new(state);
+
+        let response = service
+            .plan_embed(Request::new(EmbedRequest {
+                scope: "all".to_string(),
+                force: false,
+                batch_size: 0,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.scoped, 3);
+        assert_eq!(response.eligible, 3);
+        assert_eq!(response.skipped, 0);
+    }
+
+    #[cfg(feature = "embed")]
+    #[tokio::test]
+    async fn embed_plan_skips_nodes_present_in_the_sidecar() {
+        let state = test_state_with_writer();
+        let uids = insert_unembedded_nodes_for_every_scope(&state.store, "plan-sidecar");
+        for uid in &uids {
+            assert!(state.store.add_embedding(uid, vec![0.1, 0.2, 0.3]));
+        }
+        let service = DaemonService::new(state);
+
+        let response = service
+            .plan_embed(Request::new(EmbedRequest {
+                scope: "all".to_string(),
+                force: false,
+                batch_size: 0,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.scoped, 3);
+        assert_eq!(response.eligible, 0);
+        assert_eq!(response.skipped, 3);
+    }
+
+    #[cfg(feature = "embed")]
+    #[tokio::test]
+    async fn forced_embed_plan_keeps_sidecar_nodes_eligible() {
+        let state = test_state_with_writer();
+        let uids = insert_unembedded_nodes_for_every_scope(&state.store, "plan-force");
+        for uid in &uids {
+            assert!(state.store.add_embedding(uid, vec![0.1, 0.2, 0.3]));
+        }
+        let service = DaemonService::new(state);
+
+        let response = service
+            .plan_embed(Request::new(EmbedRequest {
+                scope: "all".to_string(),
+                force: true,
+                batch_size: 0,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.scoped, 3);
+        assert_eq!(response.eligible, 3);
+        assert_eq!(response.skipped, 0);
+    }
+
+    #[cfg(feature = "embed")]
+    #[tokio::test]
+    async fn embed_plan_rejects_an_unknown_scope() {
+        let service = DaemonService::new(test_state_with_writer());
+
+        let status = service
+            .plan_embed(Request::new(EmbedRequest {
+                scope: "unknown".to_string(),
+                force: false,
+                batch_size: 0,
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(status.message().contains("unknown scope 'unknown'"));
+    }
+
+    #[cfg(feature = "embed")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn incremental_embed_rpc_skips_sidecar_embeddings_for_every_scope() {
         let mut state = test_state_with_writer();
@@ -13419,6 +13604,9 @@ mod startup_helper_tests {
         assert_eq!(response.succeeded, 0);
         assert_eq!(response.failed, 0);
         assert_eq!(response.rejected, 0);
+        assert_eq!(response.scoped, 3);
+        assert_eq!(response.eligible, 0);
+        assert_eq!(response.skipped, 3);
         assert_eq!(
             calls.load(Ordering::Relaxed),
             0,
@@ -14075,6 +14263,7 @@ external_model = "unavailable-test-model"
             "ListVaultsJson",
             "MaterializeProjects",
             "MergeInstance",
+            "PlanEmbed",
             "PrImpactJson",
             "PruneStale",
             "PurgeInstance",

--- a/docs/guide/instance-config.md
+++ b/docs/guide/instance-config.md
@@ -156,6 +156,24 @@ local backend after an external load, readiness, or request failure. Fix the
 endpoint, or follow the forced re-embedding procedure below to switch to a local
 backend.
 
+#### Daemon embedding preflight
+
+For the normal daemon route, `nestweaver embed --db <path>` first reports an
+embedding plan: the number of nodes in scope, the number eligible to embed, and
+the number already present in the authoritative embedding sidecar. With the
+default incremental behavior, sidecar entries are skipped; `--force` makes every
+scoped node eligible. If the plan has no eligible nodes, the command succeeds
+without loading the embedding model.
+
+The plan is a point-in-time observation. Files indexed after the plan are
+handled by a later embed or the daemon's incremental watcher. If the command
+reports that the daemon does not support preflight after installing an updated
+binary, restart that daemon for the same database:
+
+```sh
+nestweaver daemon --db <path> restart
+```
+
 Daemon startup is cache-only. It does not contact Hugging Face or download
 missing model files. To populate a new cache, stop the daemon (which owns the DB
 write lock) and run the direct local command. Its required form is

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -410,6 +410,12 @@ message EmbedResponse {
   // Embeddings rejected by the dimension guard (model mismatch), as opposed
   // to `failed` (the model errored). Zero from pre-2.2.1 daemons.
   uint32 rejected = 3;
+  // Nodes present in the requested scope when eligibility was evaluated.
+  uint64 scoped = 4;
+  // Nodes selected for embedding after applying `force` and sidecar state.
+  uint64 eligible = 5;
+  // Scoped nodes omitted because their authoritative sidecar embedding exists.
+  uint64 skipped = 6;
 }
 
 // ─── Impact Analysis (Phase 4) ──────────────────────────────────────
@@ -542,6 +548,7 @@ service NestWeaverDaemon {
   rpc ReindexSearch(ReindexSearchRequest) returns (ReindexSearchResponse);
 
   // Embedding
+  rpc PlanEmbed(EmbedRequest) returns (EmbedResponse);
   rpc Embed(EmbedRequest) returns (EmbedResponse);
 
   // Write RPCs

--- a/src/main.rs
+++ b/src/main.rs
@@ -14673,11 +14673,11 @@ fn run_embed(
     let path = db.unwrap_or(&default);
     let local_model_id = local_embedding_model_id(model_id);
 
-    // ── Try the daemon path first (configured embedding backend) ───────────
+    // ── Daemon path (configured embedding backend) ─────────────────────────
     // Only use daemon for local-model embedding (no --endpoint, no --local) AND
     // when the daemon is enabled. Under --no-daemon / NESTWEAVER_NO_DAEMON=1 we must
     // NOT touch the daemon: connecting auto-starts one, whose held DB lock then
-    // breaks the direct fallback with a confusing "could not set lock" error (and
+    // breaks the direct path with a confusing "could not set lock" error (and
     // leaks the daemon). Skip straight to the in-process path instead.
     if use_daemon && endpoint.is_none() && !local {
         // The daemon embeds with the model recorded in the database (or the
@@ -14709,6 +14709,35 @@ fn run_embed(
         let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
         match rt.block_on(nestweaver_client::DaemonClient::connect(path, None)) {
             Ok(mut client) => {
+                match rt.block_on(client.plan_embed(scope, force)) {
+                    Ok(plan) => {
+                        eprintln!(
+                            "Embedding plan: {} eligible, {} already embedded, {} scoped node(s).",
+                            plan.eligible, plan.skipped, plan.scoped
+                        );
+                        if plan.eligible == 0 {
+                            eprintln!(
+                                "No embedding work required; every scoped node already has an authoritative sidecar embedding."
+                            );
+                            return Ok(EXIT_SUCCESS);
+                        }
+                    }
+                    Err(error) => {
+                        // A same-version daemon from before PlanEmbed can survive a binary
+                        // upgrade. Keep the legacy route usable, but make the lost preflight
+                        // visible and tell the operator how to enable it.
+                        if daemon_lacks_embedding_preflight(&error) {
+                            eprintln!(
+                                "Daemon does not support embedding preflight; restart it with \
+                                 `nestweaver daemon --db {} restart` to enable eligibility reporting.",
+                                path.display()
+                            );
+                        } else {
+                            return Err(error).context("daemon embedding preflight failed");
+                        }
+                    }
+                }
+
                 eprintln!("Embedding via daemon (configured backend)…");
                 match rt.block_on(client.embed(scope, force, batch_size as u32)) {
                     Ok(resp) => {
@@ -14723,16 +14752,21 @@ fn run_embed(
                         if stats {
                             eprintln!(
                                 "Embed stats: {} succeeded, {} failed, \
-                                 {} rejected (dim mismatch), {:.2}s elapsed",
+                                 {} rejected (dim mismatch), {} eligible, \
+                                 {} already embedded, {} scoped node(s), {:.2}s elapsed",
                                 resp.succeeded,
                                 resp.failed,
                                 resp.rejected,
+                                resp.eligible,
+                                resp.skipped,
+                                resp.scoped,
                                 elapsed.as_secs_f64()
                             );
                         } else {
                             eprintln!(
-                                "Done: {} embedding(s) generated, {} error(s).",
-                                resp.succeeded, resp.failed
+                                "Done: {} embedding(s) generated, {} error(s); \
+                                 {} already embedded out of {} scoped node(s).",
+                                resp.succeeded, resp.failed, resp.skipped, resp.scoped
                             );
                         }
                         return if resp.failed > 0 || resp.rejected > 0 {
@@ -14742,18 +14776,26 @@ fn run_embed(
                         };
                     }
                     Err(e) => {
-                        eprintln!("Daemon embed failed ({e:#}), falling back to direct DB path…");
+                        return Err(e).context("daemon embed failed");
                     }
                 }
             }
-            Err(_) => {
-                eprintln!("Daemon not available, using direct DB path…");
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "failed to connect to daemon for {}; start it with \
+                         'nestweaver daemon --db {} start' or use --no-daemon \
+                         (requires NESTWEAVER_NO_DAEMON=1)",
+                        path.display(),
+                        path.display()
+                    )
+                });
             }
         }
     }
 
-    // ── Fallback: direct DB access ──────────────────────────────
-    // Only allowed when the daemon path was not attempted (--local or --endpoint)
+    // ── Direct DB access ──────────────────────────────────────────
+    // Only allowed when the daemon path was not selected (--local or --endpoint)
     // or when the daemon is explicitly disabled (--no-daemon / NESTWEAVER_NO_DAEMON=1).
     if use_daemon && endpoint.is_none() && !local {
         anyhow::bail!(
@@ -15170,6 +15212,12 @@ fn run_embed(
     } else {
         Ok(EXIT_SUCCESS)
     }
+}
+
+fn daemon_lacks_embedding_preflight(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<tonic::Status>()
+        .is_some_and(|status| status.code() == tonic::Code::Unimplemented)
 }
 
 /// Resolve a `--repo` filter (display name or literal UID) to a repo UID.
@@ -18609,6 +18657,22 @@ mod cli_bounds_tests {
 #[cfg(all(test, feature = "embed"))]
 mod embed_accelerator_cli_tests {
     use super::*;
+
+    #[test]
+    fn preflight_unimplemented_status_is_recognized_through_context() {
+        let error = anyhow::Error::new(tonic::Status::unimplemented("PlanEmbed"))
+            .context("plan_embed RPC failed");
+
+        assert!(daemon_lacks_embedding_preflight(&error));
+    }
+
+    #[test]
+    fn preflight_other_statuses_are_not_treated_as_legacy_daemons() {
+        let error = anyhow::Error::new(tonic::Status::failed_precondition("model unavailable"))
+            .context("plan_embed RPC failed");
+
+        assert!(!daemon_lacks_embedding_preflight(&error));
+    }
 
     #[test]
     fn daemon_route_ignores_external_metadata_without_local_model_override() {

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -354,7 +354,15 @@ fn cli_embed_reports_a_noop_plan_without_loading_the_embedding_runtime() {
     drop(store);
 
     let _guard = helpers::server_guard::ServerGuard::start(&db_path);
+    // The preflight is a daemon RPC, so this must exercise the daemon route.
+    // CI exports NESTWEAVER_NO_DAEMON=1 for the whole test job, which
+    // `resolve_use_daemon` honors under GITHUB_ACTIONS — the CLI would then take
+    // the direct path and collide with the write lock the guard's daemon holds.
+    // Clear the bypass for this child so the route is the same everywhere
+    // (same idiom as `daemon_cmd` in tests/parity_test.rs).
     let output = StdCommand::new(env!("CARGO_BIN_EXE_nestweaver"))
+        .env_remove("NESTWEAVER_NO_DAEMON")
+        .env_remove("NESTWEAVER_ALLOW_NO_DAEMON")
         .args(["embed", "--db", &db_path.display().to_string()])
         .output()
         .unwrap();

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -16,10 +16,12 @@ use nestweaver_client::hybrid::{
 use nestweaver_client::upstream::UpstreamHandle;
 use nestweaver_proto::nest_weaver_daemon_client::NestWeaverDaemonClient;
 use nestweaver_proto::{
-    BackupRequest, BrainSearchRequest, BrainStatusRequest, JsonRequest, RepoStatesRequest,
+    BackupRequest, BrainSearchRequest, BrainStatusRequest, EmbedRequest, EmbedResponse,
+    JsonRequest, RepoStatesRequest,
 };
 use serde_json::{Value, json};
 use sha2::Sha256;
+use tonic::codegen::http::uri::PathAndQuery;
 use tonic::transport::{Certificate, ClientTlsConfig};
 
 /// Create a minimal git repo with a JS file for indexing.
@@ -256,6 +258,124 @@ async fn server_tcp_brain_status() {
         status.repo_count >= 1,
         "expected at least 1 repo, got {}",
         status.repo_count
+    );
+}
+
+#[tokio::test]
+async fn server_exposes_read_only_embed_plan_rpc() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.lbug");
+    let repo_dir = dir.path().join("repo");
+    write_test_repo(&repo_dir);
+
+    let output = StdCommand::new(env!("CARGO_BIN_EXE_nestweaver"))
+        .env("NESTWEAVER_NO_DAEMON", "1")
+        .env("NESTWEAVER_ALLOW_NO_DAEMON", "1")
+        .args([
+            "index",
+            "--repo",
+            &repo_dir.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "index failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let guard = helpers::server_guard::ServerGuard::start(&db_path);
+    let channel = tonic::transport::Channel::from_shared(guard.grpc_addr())
+        .unwrap()
+        .connect()
+        .await
+        .expect("failed to connect to TCP gRPC server");
+    let mut grpc = tonic::client::Grpc::new(channel);
+    grpc.ready().await.expect("gRPC channel must be ready");
+    let response: Result<tonic::Response<EmbedResponse>, tonic::Status> = grpc
+        .unary(
+            tonic::Request::new(EmbedRequest {
+                scope: "all".to_string(),
+                force: false,
+                batch_size: 0,
+            }),
+            PathAndQuery::from_static("/nestweaver.daemon.v1.NestWeaverDaemon/PlanEmbed"),
+            tonic_prost::ProstCodec::default(),
+        )
+        .await;
+
+    assert!(
+        response.is_ok(),
+        "PlanEmbed must be available before committing to a long embed run: {response:?}"
+    );
+}
+
+#[test]
+fn cli_embed_reports_a_noop_plan_without_loading_the_embedding_runtime() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.lbug");
+    let repo_dir = dir.path().join("repo");
+    write_test_repo(&repo_dir);
+    index_repo(&repo_dir, &db_path);
+
+    // Seed every indexed node in the authoritative sidecar before the daemon
+    // starts. A no-op plan must return without requiring a ready model.
+    let store = nestweaver_store::GraphStore::open(&db_path).unwrap();
+    let mut uids: Vec<_> = store
+        .list_all_symbols()
+        .unwrap()
+        .into_iter()
+        .map(|symbol| symbol.uid)
+        .collect();
+    uids.extend(
+        store
+            .list_notes(None)
+            .unwrap()
+            .into_iter()
+            .map(|note| note.uid),
+    );
+    uids.extend(
+        store
+            .list_all_headings()
+            .unwrap()
+            .into_iter()
+            .map(|heading| heading.uid),
+    );
+    assert!(
+        !uids.is_empty(),
+        "fixture must index at least one embeddable node"
+    );
+    for uid in uids {
+        assert!(store.add_embedding(&uid, vec![0.1, 0.2, 0.3]));
+    }
+    store.flush_embedding_index().unwrap();
+    drop(store);
+
+    let _guard = helpers::server_guard::ServerGuard::start(&db_path);
+    let output = StdCommand::new(env!("CARGO_BIN_EXE_nestweaver"))
+        .args(["embed", "--db", &db_path.display().to_string()])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "embed no-op failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Embedding plan: 0 eligible,"),
+        "missing preflight counts: {stderr}"
+    );
+    assert!(
+        stderr.contains("No embedding work required; every scoped node already has an authoritative sidecar embedding."),
+        "missing no-op outcome: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Embedding via daemon"),
+        "a no-op plan must not load the embedding runtime: {stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary

- add an additive `PlanEmbed` RPC that reports scoped, eligible, and sidecar-skipped nodes before an embedding run
- show the plan in the daemon-backed CLI path; a zero-eligible plan exits successfully without loading the embedding runtime
- retain compatibility with an older daemon through a clear restart instruction and its legacy embed route
- return real daemon failures instead of claiming a direct-path fallback that did not occur
- document preflight, no-op behavior, and daemon restart after an in-place binary update

## Root cause

The daemon had no authoritative eligibility query before a long embed run. Operators could not see whether sidecar-backed incremental embedding had any work, and failure messaging suggested a local fallback that the CLI did not actually perform. The new plan and execution accounting use `GraphStore::has_embedding`, the persisted sidecar source of truth.

## Validation

- focused plan, idempotency, raw gRPC, CLI no-op, and legacy-daemon tests
- CI-equivalent Rust, daemon, and MCP-daemon test lanes
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --locked --release --features metal`
- release-mode cached-daemon embedding-startup test
- warm `npx playwright test` (exit 0; two retry-only UI flakes recorded)
- `git diff --check`

## Compatibility and impact

The protobuf change is additive. A new CLI detects an older daemon that lacks `PlanEmbed`, gives an exact restart command, and continues through the legacy RPC. The public RPC/CLI boundary makes this a high-surface-area change in impact analysis, so the PR includes protocol, daemon, client, CLI, and end-to-end no-op coverage.