### PR TITLE
chore: release hygiene — enforce secret scanning, close no-op gates, document shipped contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,6 +547,53 @@ jobs:
       - name: Run audit
         run: cargo audit || true
 
+  secret-scan:
+    name: Secret Scan
+    # Deliberately NOT gated on needs.changes: a credential can be committed in
+    # any file type, including ones no language filter matches.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Full history. This repo is public, so a secret that was committed and
+          # later removed is still disclosed and still needs rotating — scanning
+          # only the tip would miss exactly the case that matters most.
+          fetch-depth: 0
+      # Install the binary directly rather than gitleaks-action: the marketplace
+      # action requires a GITLEAKS_LICENSE for organization-owned repos, which
+      # would make this gate fail for reasons unrelated to the code.
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          VERSION=8.30.1
+          curl -sSfL -o /tmp/gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz"
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          sudo install /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+      - name: Verify the config actually loads rules
+        # A gitleaks config with no [extend] block and only an [allowlist]
+        # silently loads zero detectors and reports "no leaks found" on
+        # everything — this repo shipped exactly that config, unused, for
+        # months. Prove the scanner is live before trusting a clean result.
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/gl-probe
+          # Assemble the probe token at runtime. Writing it as a literal would
+          # commit a credential-shaped string into the repo, which this very
+          # scanner then flags on every subsequent run. Split, neither half
+          # matches a rule.
+          PROBE_PREFIX='ghp_'
+          PROBE_BODY='016C7B1D2E3F4a5b6c7d8e9f0A1B2C3D4E5F'
+          printf 'token = "%s%s"\n' "$PROBE_PREFIX" "$PROBE_BODY" > /tmp/gl-probe/probe.txt
+          if gitleaks detect --source /tmp/gl-probe --config .gitleaks.toml --no-git --redact; then
+            echo "::error::gitleaks did not detect a planted credential — the config is not loading rules"
+            exit 1
+          fi
+          echo "config verified: planted credential was detected"
+      - name: Scan repository history
+        run: gitleaks detect --source . --config .gitleaks.toml --redact --verbose
+
   e2e:
     name: E2E Tests
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,8 +544,18 @@ jobs:
       # (which compiles it from source on every run, ~3 min).
       - name: Install cargo-audit
         uses: taiki-e/install-action@cargo-audit
+      # No `|| true`. This check is displayed as "Security Audit" on every pull
+      # request in a public repo, which reads as an enforced supply-chain gate —
+      # suppressing the exit code made that a false claim. Verified clean on
+      # 2026-07-27: 834 dependencies, 0 vulnerabilities, 2 allowed warnings
+      # (RUSTSEC-2024-0436 paste unmaintained, RUSTSEC-2026-0202 cxx unsound),
+      # neither of which fails cargo-audit's default policy.
+      #
+      # When this does fail: triage the advisory, and if it must be accepted,
+      # record it in audit.toml with a justification and a review date rather
+      # than restoring a blanket suppression.
       - name: Run audit
-        run: cargo audit || true
+        run: cargo audit
 
   secret-scan:
     name: Secret Scan

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,6 +1,27 @@
+# Gitleaks configuration.
+#
+# IMPORTANT: the `[extend]` block is load-bearing. A config with only an
+# `[allowlist]` section and no rules loads zero detectors and reports
+# "no leaks found" for any input — which is exactly what this file did for as
+# long as it existed before 2026-07-27. Never remove it.
+#
+# Verify after any edit by planting a detectable secret and confirming a
+# non-zero exit:
+# Assemble the token from parts — writing a credential-shaped literal here
+# would commit a finding that this scanner then reports forever:
+#   printf 'token = "%s%s"\n' 'ghp_' '016C7B1D2E3F4a5b6c7d8e9f0A1B2C3D4E5F' > ./probe.txt
+#   gitleaks detect --source . --config .gitleaks.toml --no-git --redact; echo $?
+#   rm ./probe.txt
+#
+# Do NOT probe with `AKIAIOSFODNN7EXAMPLE` — the default ruleset allowlists it
+# as AWS's published example value, so it returns "no leaks found" even when
+# the config is working perfectly, and reads as a broken scanner.
+[extend]
+useDefault = true
+
 [allowlist]
 description = "Global allowlist"
 paths = [
     '''target/''',
-    '''.git/''',
+    '''\.git/''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -6,9 +6,9 @@
 # long as it existed before 2026-07-27. Never remove it.
 #
 # Verify after any edit by planting a detectable secret and confirming a
-# non-zero exit:
-# Assemble the token from parts — writing a credential-shaped literal here
-# would commit a finding that this scanner then reports forever:
+# non-zero exit. Assemble the token from parts — a credential-shaped literal
+# committed here becomes a finding this scanner then reports on every run,
+# forever. That happened once already; do not write it as one string:
 #   printf 'token = "%s%s"\n' 'ghp_' '016C7B1D2E3F4a5b6c7d8e9f0A1B2C3D4E5F' > ./probe.txt
 #   gitleaks detect --source . --config .gitleaks.toml --no-git --redact; echo $?
 #   rm ./probe.txt

--- a/README.md
+++ b/README.md
@@ -327,9 +327,11 @@ containing it is available, use this source-build path.
 | `setup` | Auto-detect and configure AI tools (16 supported). Use `--force` to regenerate customized files |
 | `generate-guide` | Generate tool-specific instruction files (skill, cursor-rule, agents-md, claude-md) |
 | `completions` | Generate shell completions (bash, zsh, fish, powershell) |
-| `embed` | Generate vector embeddings for symbols, notes, and headings using a local model (Metal-accelerated) or external API |
+| `embed` | Generate vector embeddings for symbols, notes, and headings using a local model (Metal-accelerated) or external API. Reports an eligibility plan before embedding and exits successfully without loading the model when nothing is eligible; `--force` re-embeds everything |
 | `pull` | Pull a snapshot from a remote storage backend |
-| `instance` | Manage instance configuration |
+| `config validate` | Validate an instance config without creating files or contacting services (`--json` for a machine-readable result) |
+| `diagnostics capabilities` | Report embedding and Metal compile/runtime capabilities, including whether Metal was selected or fell back (`--json`) |
+| `instance` | Manage instance configuration. `abort-migration` clears a wedged migration journal so the daemon can boot |
 | `snapshot` | Manage graph snapshots (build, verify, push) |
 | `backup` | Backup and restore the NestWeaver database |
 | `list-repos` | List all indexed repositories |

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -5353,7 +5353,7 @@ fn tool_brain_add_source(store: &GraphStore, args: Value) -> Result<Value, anyho
 fn tool_schema_brain_remove_source() -> Value {
     json!({
         "name": "brain_remove_source",
-        "description": "Remove an indexed code repository or markdown vault from the brain graph permanently.\n\nGuidelines:\n- Accepts repo name, vault name, filesystem path, file:// URL, or UID\n- Auto-detects whether the target is a repo or vault\n- To re-index (not remove), use brain_add_source instead\n\nLimitations:\n- Removal is permanent — the source must be re-indexed with brain_add_source to restore\n- Ambiguous targets (matching multiple sources) require a UID to disambiguate",
+        "description": "Remove an indexed code repository or markdown vault from the brain graph permanently.\n\nGuidelines:\n- Accepts repo name, vault name, filesystem path, file:// URL, or UID\n- Auto-detects whether the target is a repo or vault\n- To re-index (not remove), use brain_add_source instead\n\nReading the response:\n- `committed: true` means the removal HAPPENED and is durable. If `reconciliation_warnings` is also non-empty, some post-commit bookkeeping step failed — the removal still succeeded. Do NOT retry as though nothing happened, and do not take corrective action against the removed data; re-run only to retry the bookkeeping.\n- `committed: false` means nothing was removed.\n\nLimitations:\n- Removal is permanent — the source must be re-indexed with brain_add_source to restore\n- Ambiguous targets (matching multiple sources) require a UID to disambiguate",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -5535,7 +5535,7 @@ fn tool_brain_remove_source(store: &GraphStore, args: Value) -> Result<Value, an
 fn tool_schema_prune_stale() -> Value {
     json!({
         "name": "prune_stale",
-        "description": "Remove all indexed repos and vaults whose source directories no longer exist on disk. No parameters required.\n\nGuidelines:\n- Use after moving, renaming, or deleting project directories\n- Returns the list of removed repos and vaults\n\nLimitations:\n- Only checks filesystem existence, not content staleness (use stale_check for that)\n- Cannot undo — removed sources must be re-indexed with brain_add_source",
+        "description": "Remove all indexed repos and vaults whose source directories no longer exist on disk. No parameters required.\n\nGuidelines:\n- Use after moving, renaming, or deleting project directories\n- Returns the list of removed repos and vaults\n\nReading the response:\n- `committed: true` means the prune HAPPENED and is durable. If `reconciliation_warnings` is also non-empty, some post-commit bookkeeping step failed — the prune still succeeded. Do NOT retry as though nothing happened; re-run only to retry the bookkeeping.\n- `committed: false` means nothing was pruned.\n\nLimitations:\n- Only checks filesystem existence, not content staleness (use stale_check for that)\n- Cannot undo — removed sources must be re-indexed with brain_add_source",
         "inputSchema": {
             "type": "object",
             "properties": {},
@@ -12262,5 +12262,45 @@ mod stale_check_tool_tests {
         let result = tool_stale_check(&store).expect("stale check");
         assert_eq!(result["any_stale"], false, "{result}");
         assert_eq!(result["repos"][0]["status"], "ok", "{result}");
+    }
+}
+
+#[cfg(test)]
+mod destructive_tool_contract_tests {
+    use super::*;
+
+    /// Destructive tools must document the committed/warnings contract.
+    ///
+    /// nw-091: these mutations commit first and then run fallible post-commit
+    /// reconciliation, so a response can carry `committed: true` alongside
+    /// warnings. The whole point of that contract is that a caller can tell
+    /// "it happened, with bookkeeping warnings" from "nothing happened" — an
+    /// agent that only reads the tool description would otherwise see warnings,
+    /// conclude the operation failed, and take corrective action against data
+    /// that is already gone. That is the exact incident nw-091 came from, so
+    /// the description carries the same weight as the response field.
+    #[test]
+    fn destructive_tools_document_the_committed_contract() {
+        const DESTRUCTIVE: &[&str] = &["brain_remove_source", "prune_stale"];
+
+        let schemas = all_tool_schemas();
+        for name in DESTRUCTIVE {
+            let schema = schemas
+                .iter()
+                .find(|s| s["name"] == *name)
+                .unwrap_or_else(|| panic!("tool `{name}` is missing from all_tool_schemas()"));
+            let description = schema["description"]
+                .as_str()
+                .unwrap_or_else(|| panic!("tool `{name}` has no description"));
+
+            for required in ["committed", "reconciliation_warnings"] {
+                assert!(
+                    description.contains(required),
+                    "`{name}` description does not explain `{required}`. A caller that cannot \
+                     distinguish a committed-with-warnings result from a no-op will take \
+                     corrective action against data that is already gone (nw-091).\n\n{description}"
+                );
+            }
+        }
     }
 }

--- a/docs/guide/instance-config.md
+++ b/docs/guide/instance-config.md
@@ -517,6 +517,37 @@ nestweaver list-links --config ./nestweaver-instance.toml
 nestweaver list-features --config ./nestweaver-instance.toml
 ```
 
+## Storage engine tuning (advanced)
+
+Write-capable database opens use a hardened engine configuration. The defaults
+are chosen for safety, not throughput, and **the thread bound is a correctness
+setting, not a performance one**.
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `NESTWEAVER_LBUG_MAX_THREADS` | `1` | Engine thread-pool size (`0` = library auto). |
+| `NESTWEAVER_LBUG_BUFFER_POOL_BYTES` | auto | Buffer pool size in bytes. A larger pool avoids eviction when the working set fits. |
+| `NESTWEAVER_LBUG_AUTO_CHECKPOINT` | on | Set `0`/`false`/`off` to defer automatic checkpoints. |
+
+> **Raising `NESTWEAVER_LBUG_MAX_THREADS` re-opens a known crash window.**
+> The storage engine's optimistic page read has no reader pinning on native
+> builds, so an eviction racing a concurrent read is an unguarded SIGSEGV. The
+> race requires concurrency inside the engine; capping the pool at `1` is what
+> removes it, and `1` is the only value that fully eliminates it. This crash is
+> what began a reported incident in which a vault went from 752 notes to 1 —
+> recovered only because the write-ahead log had not yet checkpointed.
+>
+> Read-only opens keep full parallelism and are unaffected. The measured cost
+> of the cap on the write path was negligible (index throughput 55 s vs 58 s;
+> bulk load is already single-threaded), so raise it only if you have measured
+> a real query-latency cost on your own workload, and accept the crash risk
+> knowingly.
+
+Deferring auto-checkpoints reduces exposure to a separate upstream defect: the
+string-corruption trigger needs several checkpoint-separated segments, so
+deferring during a bulk load makes it less likely. Corruption is detected and
+reported rather than silently returned in either case.
+
 ## Daemon, watcher, and MCP server coexistence
 
 All write operations route through the daemon process, which holds the single

--- a/src/main.rs
+++ b/src/main.rs
@@ -14359,6 +14359,113 @@ fn render_brain_search_response(
 }
 
 #[cfg(test)]
+mod cli_help_contract_tests {
+    use super::*;
+
+    /// Stack size for the CLI-tree tests.
+    ///
+    /// `Cli::command()` alone overflows a test thread's default 2 MiB stack:
+    /// the derive-generated builder nests one frame per command/arg and this
+    /// CLI's definition is very large. The binary itself is fine (the main
+    /// thread gets 8 MiB), so this is a test-harness constraint, not a runtime
+    /// bug. Run the tree work on an explicitly-sized thread rather than relying
+    /// on a `RUST_MIN_STACK` that CI would have to remember to set.
+    const CLI_TREE_STACK_BYTES: usize = 32 * 1024 * 1024;
+
+    fn on_big_stack<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
+        std::thread::Builder::new()
+            .stack_size(CLI_TREE_STACK_BYTES)
+            .spawn(f)
+            .expect("spawn CLI-tree thread")
+            .join()
+            .expect("CLI-tree thread panicked")
+    }
+
+    /// Walk the whole clap tree, returning (help gaps, commands seen, args seen).
+    ///
+    /// Iterative rather than recursive so tree depth does not compound the
+    /// already-tight stack budget.
+    fn walk_cli(root: &clap::Command) -> (Vec<String>, usize, usize) {
+        let mut gaps = Vec::new();
+        let mut commands = 0usize;
+        let mut args = 0usize;
+        let mut queue: Vec<(&clap::Command, String)> = vec![(root, String::new())];
+
+        while let Some((cmd, path)) = queue.pop() {
+            commands += 1;
+            let here = if path.is_empty() {
+                cmd.get_name().to_string()
+            } else {
+                format!("{path} {}", cmd.get_name())
+            };
+
+            if cmd.get_about().is_none() && cmd.get_long_about().is_none() {
+                gaps.push(format!("command `{here}` has no about text"));
+            }
+
+            for arg in cmd.get_arguments() {
+                // Hidden args are deliberately absent from --help (e.g. the
+                // daemon's internal --idle-exit-seconds), so they carry no
+                // documentation debt.
+                if arg.is_hide_set() {
+                    continue;
+                }
+                args += 1;
+                if arg.get_help().is_none() && arg.get_long_help().is_none() {
+                    gaps.push(format!("`{here}` arg `{}` has no help", arg.get_id()));
+                }
+            }
+
+            for sub in cmd.get_subcommands() {
+                queue.push((sub, here.clone()));
+            }
+        }
+
+        gaps.sort();
+        (gaps, commands, args)
+    }
+
+    /// Every command and every visible argument must carry help text.
+    ///
+    /// `--help` is the only documentation most users ever read. A subcommand or
+    /// flag that ships without an `about`/`help` string is invisible there, and
+    /// the gap is silent — nothing else in the build complains. This walks the
+    /// entire tree so the guard cannot be outgrown by new commands.
+    #[test]
+    fn every_command_and_arg_has_help_text() {
+        let (gaps, commands, args) = on_big_stack(|| {
+            let cmd = Cli::command();
+            walk_cli(&cmd)
+        });
+
+        // A walk that silently visited nothing would report zero gaps and read
+        // exactly like a clean bill of health. Floors well below the real
+        // counts, so they catch a broken walk without churning on every new
+        // command.
+        assert!(
+            commands >= 30 && args >= 100,
+            "CLI walk looks vacuous — only {commands} command(s) and {args} arg(s) visited; \
+             the guard is not actually inspecting the tree"
+        );
+
+        assert!(
+            gaps.is_empty(),
+            "{} command(s)/arg(s) ship without help text:\n{}",
+            gaps.len(),
+            gaps.join("\n")
+        );
+    }
+
+    /// clap's own internal consistency check (duplicate names, conflicting
+    /// short flags, invalid defaults). It panics on a malformed definition,
+    /// which is otherwise only discovered at runtime by whoever runs the command.
+    #[test]
+    fn cli_definition_is_internally_consistent() {
+        on_big_stack(|| Cli::command().debug_assert());
+    }
+}
+
+#[cfg(test)]
 mod brain_search_renderer_tests {
     use super::*;
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -3289,3 +3289,108 @@ fn cli_abort_migration_corrupt_journal_force_discards() {
         "--force must remove the corrupt journal"
     );
 }
+
+// ── release help-text contract ───────────────────────────────────────────
+// The unit guard in src/main.rs proves every command and visible arg carries
+// *some* help string. These assert that the specific commands shipped in this
+// release describe what they actually do, which a presence check cannot.
+
+#[test]
+fn cli_help_documents_the_commands_shipped_in_this_release() {
+    // (argv, substring the help must contain)
+    let cases: &[(&[&str], &str)] = &[
+        (&["config", "validate", "--help"], "without creating files"),
+        (&["diagnostics", "capabilities", "--help"], "metal"),
+        (&["instance", "abort-migration", "--help"], "journal"),
+        (&["embed", "--help"], "--force"),
+    ];
+
+    for (args, expected) in cases {
+        let output = nestweaver_cmd()
+            .args(*args)
+            .output()
+            .unwrap_or_else(|e| panic!("failed to run `{}`: {e}", args.join(" ")));
+        assert!(
+            output.status.success(),
+            "`nestweaver {}` exited {:?}: {}",
+            args.join(" "),
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let help = String::from_utf8_lossy(&output.stdout).to_lowercase();
+        assert!(
+            help.contains(&expected.to_lowercase()),
+            "`nestweaver {}` help does not mention {expected:?}. Full help:\n{help}",
+            args.join(" ")
+        );
+    }
+}
+
+/// Every direct CLI invocation in the test suite must pin its daemon routing.
+///
+/// CI exports `NESTWEAVER_NO_DAEMON=1` for the whole job while local runs do
+/// not, so an invocation that neither sets nor clears it takes a different code
+/// path on each — which is how the embed-preflight test passed locally and
+/// failed only on CI.
+///
+/// This checks each binary-invocation chain individually, not merely whether
+/// the file mentions the variable somewhere: the file that carried the bug
+/// already pinned routing on 28 other invocations.
+///
+/// Scoped to invocations that pass `--db`, since daemon routing is only
+/// selected for local-database commands — a `server status --url ...` call
+/// talks to a remote server over HTTP and has no routing to pin.
+#[test]
+fn every_cli_invocation_pins_its_daemon_routing() {
+    let suite_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let mut unpinned = Vec::new();
+
+    for entry in std::fs::read_dir(&suite_dir).expect("read tests/") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        let src = std::fs::read_to_string(&path).expect("read test source");
+
+        // Build the constructor token at runtime so this scanner does not
+        // match its own source when it scans tests/cli_test.rs.
+        let needle = format!("CARGO_BIN_EXE_{}", "nestweaver");
+        for (idx, _) in src.match_indices(needle.as_str()) {
+            // Skip mentions inside comments (docs, not invocations).
+            let line_start = src[..idx].rfind('\n').map_or(0, |i| i + 1);
+            if src[line_start..idx].trim_start().starts_with("//") {
+                continue;
+            }
+            // The builder chain runs from the constructor to whichever
+            // terminal call executes it.
+            let rest = &src[idx..];
+            let end = [
+                "\n        .output()",
+                "\n        .status()",
+                "\n        .assert()",
+            ]
+            .iter()
+            .filter_map(|t| rest.find(t))
+            .min()
+            .unwrap_or_else(|| rest.len().min(1200));
+            let chain = &rest[..end];
+            // Only local-database commands select a daemon route.
+            if !chain.contains("\"--db\"") {
+                continue;
+            }
+            if !chain.contains("NESTWEAVER_NO_DAEMON") {
+                let line = src[..idx].matches('\n').count() + 1;
+                unpinned.push(format!("{name}:{line}"));
+            }
+        }
+    }
+
+    unpinned.sort();
+    assert!(
+        unpinned.is_empty(),
+        "these CLI invocations do not pin daemon routing — set \
+         .env(\"NESTWEAVER_NO_DAEMON\", \"1\") for the direct path, or \
+         .env_remove(\"NESTWEAVER_NO_DAEMON\") for the daemon path: {unpinned:?}"
+    );
+}

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -429,7 +429,12 @@ async fn server_transport_parity() {
         .into_inner();
 
     // ── UDS query via CLI (daemon is running, CLI routes through UDS) ─
+    // Clear the bypass: CI exports NESTWEAVER_NO_DAEMON=1 job-wide, which would
+    // send this down the direct path and quietly stop exercising UDS routing —
+    // the assertion would still pass, testing the wrong thing.
     let cli_output = StdCommand::new(env!("CARGO_BIN_EXE_nestweaver"))
+        .env_remove("NESTWEAVER_NO_DAEMON")
+        .env_remove("NESTWEAVER_ALLOW_NO_DAEMON")
         .args([
             "brain",
             "status",


### PR DESCRIPTION
## Summary

Release-hygiene pass ahead of the `staging` → `main` production release. Five commits: two close gates that were reporting success without checking anything, two document contracts that shipped undocumented, one fixes a latent test-routing bug.

## The theme

Each of these is the same failure mode the store-integrity and data-loss work exists to prevent — *silently wrong, reads as safe* — but sitting in the verification layer rather than the query layer. A release is only as trustworthy as the checks gating it.

## What changed

**`.gitleaks.toml` was decorative** (`2e4c08e9`). It was referenced by no workflow, script, or hook, and contained an `[allowlist]` with no rules — which makes gitleaks load zero detectors and report "no leaks found" for any input. Proven by planting an AWS key pair and a GitHub PAT and getting a clean exit 0.

Now extends the default ruleset and runs as a `Secret Scan` job over full history, ungated by the changed-paths filter (a credential can land in any file type). The job **plants a known-detectable credential and asserts gitleaks reports it before scanning for real** — without that step an inert config is indistinguishable from a clean repository, which is exactly how this went unnoticed.

Scans performed: working tree clean; **full history clean across 1,474 commits**, so no credential was ever committed and no rotation is required.

**`cargo audit || true`** (`ba7a72f8`). The "Security Audit" status is displayed on every PR in a public repo and reads as an enforced supply-chain gate; suppressing the exit code made that a false claim. Verified clean before removing the suppression rather than assuming: 834 dependencies, 0 vulnerabilities, 2 allowed warnings (`RUSTSEC-2024-0436` paste unmaintained, `RUSTSEC-2026-0202` cxx unsound).

**Help-text and daemon-routing guards** (`35e38948`). Only four `--help` assertions existed across the whole suite. A unit guard now walks the entire clap tree — **127 commands, 467 visible args, all already documented** — and names the exact command or arg on failure. It runs on an explicitly-sized thread because `Cli::command()` alone overflows a test thread's default 2 MiB stack, and it asserts a floor on what it visited so a walk that silently inspected nothing cannot read as clean.

The routing guard checks each `--db` invocation chain individually rather than whether the file mentions `NESTWEAVER_NO_DAEMON` somewhere — the file that carried the CI failure in #189 already pinned routing on 28 other invocations, so a file-level check would have missed it. **It immediately found a second latent case:** the UDS-routing assertion in `server_test.rs` took the direct path under CI, passing while no longer testing what its comment claimed.

**MCP destructive-tool contract** (`0bf3bfe4`). nw-091 added `committed` and `reconciliation_warnings` so a caller could distinguish "it happened, with post-commit bookkeeping warnings" from "nothing happened" — but `brain_remove_source` and `prune_stale` never said so in their descriptions. Against an agent caller that reproduces the original incident exactly: read warnings, conclude failure, take corrective action against data already gone.

**Docs currency** (`996897e5`). README gains `config validate`, `diagnostics capabilities`, `instance abort-migration`, and the embed preflight semantics, with descriptions copied from actual `--help` output. The instance-config guide gains the storage-engine tuning variables, stating plainly that `NESTWEAVER_LBUG_MAX_THREADS` is a **correctness** setting — raising it re-opens the unguarded-SIGSEGV window that began the 752-notes-to-1 incident.

## Audits, all clean

| Check | Result |
| --- | --- |
| Secrets, working tree | clean |
| Secrets, full history | clean, 1,474 commits — **no rotation needed** |
| `/Users/...` personal paths, tree and history | 0 |
| Tracked databases / archives / keys / crash reports | 0 |
| Emails | placeholders only; one real address, the security contact in `SECURITY.md` |
| 42 private repo/org names vs tree and history | no leaks (every hit a generic word; `orbit` resolved to `OrbitControls` from `@react-three/drei`) |
| MCP surface | 40 tools all described, lite mode 6 — matches README, CLAUDE.md, integration guides |

## Validation

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and the full workspace suite, each with exit codes captured explicitly. gitleaks verified red on a planted credential and green on the clean tree; the help guard verified red on a stripped help string; the routing guard verified red on the unpinned invocation.

## Follow-ups filed, not fixed here

- `nw-095` — six pre-existing top-level commands absent from the README table. A blanket "every command must be in the README" test was deliberately not added: it would force documenting internal plumbing to go green.
- The `cxx` unsoundness advisory sits in the C++ binding layer under the same storage engine whose `optimisticRead` use-after-free is mitigated but not fixed (`nw-073`). Worth tracking together.

## The scanner's first catch was this PR

The first CI run of the new `Secret Scan` job **failed — on a credential I had just committed in the job itself.** The self-verification step wrote its probe token as a literal (`ci.yml:582`), so gitleaks correctly reported a `github-pat` finding on every subsequent run. My earlier local history scan had been clean only because it ran before that commit existed.

Fixed by assembling the probe from two halves at runtime, so neither part matches a rule and no credential-shaped string is committed. The branch was then rewritten (`git push --force-with-lease`) rather than adding an allowlist entry: the finding was self-inflicted and unmerged, and a permanent exception for it would have been the first crack in a gate whose whole value is that it has no exceptions.

Re-verified after the rewrite: **1,478 commits, no leaks, exit 0**, and the probe is still detected (exit 1) so the self-check retains its teeth.

The literal was a fake probe value, never a real credential, so no rotation applies.
