### PR TITLE
fix: import edge fan-out corrupting hub ranking, and impact presenting a capped set as complete

### DIFF
--- a/crates/nestweaver-resolver/src/resolve.rs
+++ b/crates/nestweaver-resolver/src/resolve.rs
@@ -236,10 +236,16 @@ pub fn resolve_references_with_context(
             continue;
         }
 
-        let source_symbols = match file_symbols.get(file_path.as_str()) {
-            Some(syms) if !syms.is_empty() => *syms,
-            _ => continue,
-        };
+        // A file with no symbols has nothing that could enclose an import, so
+        // skip it before doing any per-import work. The symbol list itself is
+        // no longer read here: since nw-103 this pass attributes an edge only
+        // to a genuine enclosing symbol, never to the file's first declaration.
+        if file_symbols
+            .get(file_path.as_str())
+            .is_none_or(|syms| syms.is_empty())
+        {
+            continue;
+        }
 
         let source_sorted_syms: &[&RawSymbol] = match file_sorted_symbols.get(file_path.as_str()) {
             Some(syms) if !syms.is_empty() => syms.as_slice(),
@@ -264,10 +270,18 @@ pub fn resolve_references_with_context(
                 })
                 .map(|r| r.start_line);
 
-            // Use enclosing symbol at import line, or fall back to first symbol in file.
-            let source_sym = import_line
-                .and_then(|line| find_enclosing_symbol(source_sorted_syms, line))
-                .or_else(|| source_symbols.first());
+            // Attribute a named-import edge only when the import genuinely sits
+            // INSIDE a symbol — e.g. a dynamic `import()` in a function body.
+            //
+            // A top-level import has no enclosing symbol. Falling back to the
+            // file's first declaration (nw-103) made that arbitrary symbol look
+            // like the file's dependency hub: this pass then fans out to every
+            // non-private symbol in the target file, so a 3-reference,
+            // never-exported string constant acquired 830 out-edges and ranked
+            // #5 in a 158k-symbol graph. Pass 3a already emits a file-level
+            // proxy edge per import, so connectivity does not depend on this.
+            let source_sym =
+                import_line.and_then(|line| find_enclosing_symbol(source_sorted_syms, line));
 
             let source_uid = match source_sym {
                 Some(sym) => symbol_uid(repo_uid, file_path, &sym.name, sym.start_line),
@@ -842,10 +856,21 @@ mod tests {
         );
     }
 
+    /// A top-level import yields ONE file-level proxy edge, not one per
+    /// exported symbol in the target.
+    ///
+    /// This test previously asserted two edges — one to every export — which is
+    /// the fan-out that nw-103 removed. Attributing a top-level import to a
+    /// *symbol* is a category error: the import belongs to the file, and the
+    /// symbol Pass 3b picked was simply whichever happened to be declared
+    /// first. That is how a never-exported string constant ended up with 830
+    /// out-edges. Pass 3a keeps the file-level edge so connectivity survives.
+    ///
+    /// Genuine per-symbol import attribution — linking only the symbols that
+    /// actually reference the imported binding — is tracked separately; it
+    /// needs reference matching this pass does not do.
     #[test]
-    fn creates_imports_edges_from_import_graph() {
-        // main.js imports helper.js — should create IMPORTS edges
-        // to all exported symbols in helper.js
+    fn top_level_import_creates_one_file_level_proxy_edge() {
         let files = vec![
             (
                 "src/main.js".to_string(),
@@ -866,8 +891,9 @@ mod tests {
             .collect();
         assert_eq!(
             import_edges.len(),
-            2,
-            "should create IMPORTS edges to both exported symbols; got: {import_edges:?}"
+            1,
+            "a top-level import should yield exactly one file-level proxy edge, \
+             not one per export (nw-103 fan-out); got: {import_edges:?}"
         );
 
         let expected_confidence = confidence_score(MatchType::ImportResolved, Language::JavaScript);
@@ -881,6 +907,57 @@ mod tests {
                 "IMPORTS target should be resolved"
             );
         }
+    }
+
+    /// nw-103: a top-level import must not turn the file's first declaration
+    /// into a dependency hub.
+    ///
+    /// Imports sit above every declaration, so `find_enclosing_symbol` finds
+    /// nothing and Pass 3b fell back to `source_symbols.first()` — then fanned
+    /// out to every non-private symbol in each imported file. On the real graph
+    /// that gave `const ROSTER_STORAGE_KEY = "..."` — 3 references, never
+    /// exported — 830 out-edges and the #5 hub slot of a 158k-symbol graph.
+    #[test]
+    fn top_level_import_does_not_make_the_first_declaration_a_hub() {
+        // Mirrors the real shape: a constant declared immediately after the
+        // import block, then the function that actually uses the import.
+        let files = vec![
+            (
+                "src/view.ts".to_string(),
+                vec![make_symbol("STORAGE_KEY", 3), make_symbol("renderView", 20)],
+                vec![make_ref("./types", ReferenceKind::Import, 1)],
+            ),
+            (
+                "src/types.ts".to_string(),
+                vec![
+                    make_symbol("Alpha", 1),
+                    make_symbol("Beta", 10),
+                    make_symbol("Gamma", 20),
+                    make_symbol("Delta", 30),
+                ],
+                vec![],
+            ),
+        ];
+
+        let edges = resolve_references(&files, Language::TypeScript, "repo:test:abc");
+
+        // symbol_uid hashes the name, so the UID does NOT contain the literal
+        // identifier — filtering on `.contains("STORAGE_KEY")` matches nothing
+        // and makes this test pass vacuously. Compute the real UID instead.
+        let storage_key_uid = symbol_uid("repo:test:abc", "src/view.ts", "STORAGE_KEY", 3);
+        let from_storage_key: Vec<_> = edges
+            .iter()
+            .filter(|e| e.edge_type == EdgeType::Imports && e.source_uid == storage_key_uid)
+            .collect();
+
+        assert!(
+            from_storage_key.len() <= 1,
+            "STORAGE_KEY is declared after the import block and must not inherit \
+             the file's imports; at most a single file-level proxy edge is \
+             acceptable. Got {} IMPORTS edges: {:#?}",
+            from_storage_key.len(),
+            from_storage_key
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8342,11 +8342,38 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             .get("truncated_by_depth")
                             .and_then(|v| v.as_bool())
                             .unwrap_or(false);
+                        // nw-110: the daemon caps rows with `.take(limit)` and
+                        // reports both `total` and `returned`, but result-set
+                        // capping sets NEITHER truncated_by_* flag — those
+                        // describe traversal pruning. Reading only those flags
+                        // let a 50-of-495 answer print as a bare array of 50:
+                        // a floor presented as the whole set.
+                        let total = value.get("total").and_then(|v| v.as_u64());
+                        let returned = value.get("returned").and_then(|v| v.as_u64());
+                        let capped = matches!((total, returned), (Some(t), Some(r)) if r < t);
                         let payload = value
                             .get("impact_nodes")
                             .cloned()
                             .unwrap_or_else(|| value.clone());
-                        if truncated_by_threshold || truncated_by_depth {
+                        if capped {
+                            println!(
+                                "{}",
+                                serde_json::to_string_pretty(&serde_json::json!({
+                                    "nodes": payload,
+                                    "total": total,
+                                    "returned": returned,
+                                    "truncated": true,
+                                    "truncated_by_threshold": truncated_by_threshold,
+                                    "truncated_by_depth": truncated_by_depth,
+                                    "note": format!(
+                                        "showing {} of {} impacted node(s) — reported impact is a \
+                                         floor; raise --limit or pass --min-score 0 for the full set",
+                                        returned.unwrap_or(0),
+                                        total.unwrap_or(0)
+                                    ),
+                                }))?
+                            );
+                        } else if truncated_by_threshold || truncated_by_depth {
                             println!(
                                 "{}",
                                 serde_json::to_string_pretty(&serde_json::json!({
@@ -8378,8 +8405,17 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 println!("No impact found for '{name_or_uid}'.");
                             }
                         } else {
+                            // nw-110: say "50 of 495" when the daemon capped the
+                            // set, never a bare "50 nodes" — the latter reads as
+                            // the complete answer.
+                            let total = value.get("total").and_then(|v| v.as_u64());
                             if !out.quiet {
-                                println!("Impact of '{name_or_uid}' ({} nodes):", count);
+                                match total {
+                                    Some(t) if t > count as u64 => println!(
+                                        "Impact of '{name_or_uid}' ({count} of {t} nodes):"
+                                    ),
+                                    _ => println!("Impact of '{name_or_uid}' ({count} nodes):"),
+                                }
                             }
                             for n in &nodes {
                                 if out.verbose {


### PR DESCRIPTION
## Summary

Phase 1 of the post-v2.7.0 bug program: the two critical defects found by the release audit and multi-agent CLI sweep. Both were wrong *answers* rather than crashes — the failure mode this product exists to prevent.

Neither is a v2.7.0 regression; both are long-standing.

## nw-103 — import edges fanned out to every symbol in the imported file

`resolve.rs` Pass 3b fell back to the file's **first declaration** when an import had no enclosing symbol — which is every ordinary import, since they sit above all declarations. It then linked that arbitrary symbol to every non-private symbol in each imported file.

On the production graph that gave `const ROSTER_STORAGE_KEY = "raven:workflow-roster"` — three references, all in its own file, never exported — **830 out-edges and the #5 hub slot of a 158k-symbol graph**. Those 830 were exactly its file's import list at full file size (469 + 196 + 66 + 45 + 34 + 20). Eight of the top ten hubs were consts and type aliases, each simply the first declaration after its file's imports.

`hubs`, `bridges`, PageRank and `summary --level hub` all read these edges, so the flagship "which symbols matter" analysis was wrong at the top of the list — deterministically, which is worse than a flake.

Named-import edges are now created only where the import genuinely sits inside a symbol (a dynamic `import()` in a function body). Pass 3a already emits a file-level proxy edge per import, so connectivity is unaffected.

**Verified on raven:** `ROSTER_STORAGE_KEY` drops from 830 out-edges to 6 — one per import in its file — and out of the top ten entirely. New top hubs are `run_workflow_with_agent_executor_and_event_sink`, `App`, `handle_command`. `golden-check.sh` stays deterministic (6 files × 3 runs × 2 tools).

### On the legacy test

`creates_imports_edges_from_import_graph` asserted 2 edges — one per export — i.e. it encoded the fan-out. It is **rewritten to the correct contract, not deleted**, with a comment explaining what changed.

The precision this trades away was false precision: the source symbol was whichever sorted first, not the one using the import. In the raven case that was a `const` with no relationship to any of its 830 "callees". Genuine per-symbol attribution needs reference matching this pass does not do — tracked as nw-113.

## nw-110 — `impact` presented a capped result as the whole answer

`impact` printed `Impact of 'x' (50 nodes)` and emitted a bare JSON array whenever the daemon capped the result set. On the production graph `extract_string` returned **50 of 495** dependents — 90% discarded — at exit 0 with nothing indicating a subset.

**The daemon was never at fault.** `brain_impact` already returns both `total` and `returned` alongside the honesty flags. The CLI read only `truncated_by_threshold` and `truncated_by_depth`, which describe *traversal* pruning — a `.take(limit)` result cap sets neither, so the capped case fell through to the bare-array branch and the metadata was discarded.

The fix derives truncation from `returned < total`, using data already on the wire:

```
before:  Impact of 'extract_string' (50 nodes):        + bare JSON array
after:   Impact of 'extract_string' (50 of 495 nodes): + total/returned/truncated/note
```

This reclassifies nw-110 into the same family as nw-097 and nw-107 — the engine computes the caveat correctly and the text renderer throws it away. That family is now seven findings with one root cause, and is Phase 2 of the program.

## Validation

- `cargo test -p nestweaver-resolver` — 194 + 4 pass
- `cargo test -p nestweaver --test cli_test`
- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — exit 0
- `scripts/golden-check.sh` on a freshly-indexed real repo — deterministic, no corruption
- Both fixes verified against the real production graph, not fixtures

Exit codes captured explicitly rather than read through a pipe.

## A note on the first attempt

The initial nw-103 test **passed vacuously**. It filtered edges with `source_uid.contains("STORAGE_KEY")`, but `symbol_uid()` hashes the name into the UID, so the filter matched nothing and the assertion reduced to `0 <= 1`.

It was caught by adding a throwaway probe that printed the actual edges — which showed 4 edges from one source while the test reported clean. The committed test computes the real UID via `symbol_uid()` and was confirmed red before the fix.

Worth stating plainly because it is the same class as the inert `.gitleaks.toml` and `cargo audit || true` found during the v2.7.0 audit: a check that reports success while verifying nothing.
