### PR TITLE
fix(cli): surface honesty fields the text renderers were dropping, and enforce parity

### DIFF
--- a/crates/nestweaver-engine/src/blast_radius.rs
+++ b/crates/nestweaver-engine/src/blast_radius.rs
@@ -117,7 +117,10 @@ pub enum AnalysisStatus {
 
 impl AnalysisStatus {
     /// Lowercase label for embedding in the human summary string.
-    fn label(self) -> &'static str {
+    ///
+    /// Public so CLI text renderers can surface the status verbatim rather than
+    /// re-deriving the mapping (nw-107).
+    pub fn label(self) -> &'static str {
         match self {
             AnalysisStatus::Complete => "complete",
             AnalysisStatus::Partial => "partial",

--- a/src/main.rs
+++ b/src/main.rs
@@ -3322,7 +3322,10 @@ fn print_pr_impact_hook(result: &BlastRadiusResult, breaking: &[BreakingChange])
 
     // Coverage caveat: reported impact is a floor when the walk was cut short or
     // a referenced repo isn't indexed.
-    if result.coverage.traversal_truncated || !result.coverage.repos_not_indexed.is_empty() {
+    if result.coverage.traversal_truncated
+        || !result.coverage.repos_not_indexed.is_empty()
+        || !result.blind_spots.is_empty()
+    {
         let mut notes = Vec::new();
         if result.coverage.traversal_truncated {
             notes.push("traversal truncated".to_string());
@@ -3332,6 +3335,21 @@ fn print_pr_impact_hook(result: &BlastRadiusResult, breaking: &[BreakingChange])
                 "{} repo(s) not indexed",
                 result.coverage.repos_not_indexed.len()
             ));
+        }
+        // The JSON carries `coverage.blind_spots` — categories of edge the
+        // static walk cannot see at all (dynamic dispatch, reflection, ...).
+        // Text omitted them, so a reviewer had no way to know which whole
+        // classes of dependency were never considered.
+        if !result.blind_spots.is_empty() {
+            // BlindSpot serializes kebab-case; render it the same way so text
+            // and --json name the same categories.
+            let spots: Vec<String> = result
+                .blind_spots
+                .iter()
+                .filter_map(|s| serde_json::to_value(s).ok())
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect();
+            notes.push(format!("blind spots: {}", spots.join(", ")));
         }
         println!("  note: {} — reported impact is a floor", notes.join(", "));
     }
@@ -7389,7 +7407,24 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     if json {
                         println!("{}", serde_json::to_string_pretty(&res)?);
                     } else if res.results.is_empty() {
-                        println!("No matches for '{pattern}'.");
+                        // nw-097/nw-111: the caveat notes below live in the
+                        // non-empty branch, so the ONE case where truncation matters
+                        // most — zero results because the budget ran out — printed a
+                        // flat "No matches", an actively false claim. On the real
+                        // 5.6 GB brain DB `regex-search NestWeaver --max-millis 5`
+                        // returns nothing while thousands of matches exist.
+                        if res.truncated {
+                            println!(
+                                "No matches for '{pattern}' WITHIN THE SEARCH BUDGET — the scan was cut \
+                         short, so matches may exist beyond the scanned range. Raise \
+                         --max-millis, or run `index --with-trigrams` to make this fast."
+                            );
+                        } else {
+                            println!("No matches for '{pattern}'.");
+                        }
+                        if res.stale_index {
+                            print_stale_index_note();
+                        }
                     } else {
                         println!("Found {} match(es) for '{pattern}':", res.results.len());
                         for m in &res.results {
@@ -7423,7 +7458,24 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             if json {
                 println!("{}", serde_json::to_string_pretty(&res)?);
             } else if res.results.is_empty() {
-                println!("No matches for '{pattern}'.");
+                // nw-097/nw-111: the caveat notes below live in the
+                // non-empty branch, so the ONE case where truncation matters
+                // most — zero results because the budget ran out — printed a
+                // flat "No matches", an actively false claim. On the real
+                // 5.6 GB brain DB `regex-search NestWeaver --max-millis 5`
+                // returns nothing while thousands of matches exist.
+                if res.truncated {
+                    println!(
+                        "No matches for '{pattern}' WITHIN THE SEARCH BUDGET — the scan was cut \
+                         short, so matches may exist beyond the scanned range. Raise \
+                         --max-millis, or run `index --with-trigrams` to make this fast."
+                    );
+                } else {
+                    println!("No matches for '{pattern}'.");
+                }
+                if res.stale_index {
+                    print_stale_index_note();
+                }
             } else {
                 println!("Found {} match(es) for '{pattern}':", res.results.len());
                 for m in &res.results {
@@ -13688,7 +13740,17 @@ fn run_brain(
                     if links.is_empty() {
                         println!("No broken or ambiguous wikilinks found.");
                     } else {
-                        println!("Broken / ambiguous wikilinks ({}):", links.len());
+                        // nw-097 class: the daemon reports `total`; this path
+                        // printed only how many it chose to show, so 50 of 778
+                        // read as "778 does not exist". The direct path below
+                        // already renders "N of total" — match it.
+                        let total = value.get("total").and_then(|v| v.as_u64());
+                        match total {
+                            Some(tot) if tot > links.len() as u64 => {
+                                println!("Broken / ambiguous wikilinks ({} of {tot}):", links.len())
+                            }
+                            _ => println!("Broken / ambiguous wikilinks ({}):", links.len()),
+                        }
                         for l in &links {
                             println!(
                                 "  [[{}]] in {} (confidence {:.2})",
@@ -13781,7 +13843,15 @@ fn run_brain(
                         if orphans.is_empty() {
                             println!("No orphan documents found.");
                         } else {
-                            println!("Orphan documents ({}):", orphans.len());
+                            // nw-097 class: daemon carries `total`; printing
+                            // only the shown count hid 607 orphans behind 50.
+                            let total = value.get("total").and_then(|v| v.as_u64());
+                            match total {
+                                Some(tot) if tot > orphans.len() as u64 => {
+                                    println!("Orphan documents ({} of {tot}):", orphans.len())
+                                }
+                                _ => println!("Orphan documents ({}):", orphans.len()),
+                            }
                             for o in &orphans {
                                 println!("  {} — {}", o.title, o.file_path);
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6865,6 +6865,26 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 print_tier("Tier 1 (direct)", &result.tier_1);
                 print_tier("Tier 2 (caller's tests)", &result.tier_2);
                 print_tier("Tier 3 (transitive)", &result.tier_3);
+
+                // nw-107: the JSON path reports `status`, `notifications` and
+                // `recommendation`; text printed only the generic disclaimer.
+                // A developer saw a clean "0 tests affected" with no sign the
+                // selection was degraded and that the tool ITSELF recommends a
+                // full suite — the exact "no tests found is NOT safe-to-skip"
+                // failure the disclaimer exists to prevent.
+                let status_label = result.status.label();
+                if status_label != "complete" {
+                    println!("Status: {status_label} — selection is incomplete.");
+                }
+                for n in &result.notifications {
+                    println!("Warning: {}", n.message);
+                }
+                if result.recommendation == "run-full-suite" {
+                    println!(
+                        "Recommendation: RUN THE FULL SUITE — this selection is not safe to rely on."
+                    );
+                }
+
                 println!("Note: {}", result.disclaimer);
             }
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -3394,3 +3394,151 @@ fn every_cli_invocation_pins_its_daemon_routing() {
          .env_remove(\"NESTWEAVER_NO_DAEMON\") for the daemon path: {unpinned:?}"
     );
 }
+
+// ── text/JSON honesty parity ─────────────────────────────────────────────
+//
+// The engine computes caveats correctly; the failures this guards against are
+// text renderers that DROP them. Six separate findings in the v2.7.0 CLI sweep
+// were this one defect (nw-097, nw-107, nw-110, nw-111), so the class needs an
+// enforced contract rather than six point fixes.
+//
+// The rule: if --json reports a caveat, the human output must say so too.
+// A caller reading a terminal must not be told less than a caller parsing JSON.
+
+/// Build a throwaway indexed repo and return (tempdir, db path).
+fn honesty_fixture() -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().join("repo");
+    std::fs::create_dir_all(repo.join("src")).unwrap();
+    std::fs::write(
+        repo.join("src/lib.js"),
+        "export function alpha() { return beta(); }\nexport function beta() { return 1; }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        repo.join("src/lib.test.js"),
+        "import { alpha } from './lib';\ntest('alpha', () => { alpha(); });\n",
+    )
+    .unwrap();
+
+    let db = dir.path().join("honesty.lbug").display().to_string();
+    nestweaver_cmd()
+        .args(["index", "--repo", &repo.display().to_string(), "--db", &db])
+        .assert()
+        .success();
+    (dir, db)
+}
+
+/// `affected-tests` must not print a clean zero while privately recommending a
+/// full suite (nw-107).
+#[test]
+fn affected_tests_text_surfaces_status_warning_and_recommendation() {
+    let (_dir, db) = honesty_fixture();
+
+    // A path that resolves to no indexed symbols — the analysis is degraded,
+    // and the JSON path says so.
+    let args = ["affected-tests", "--files", "zzz/not/real.js", "--db", &db];
+
+    let json_out = nestweaver_cmd().args(args).arg("--json").output().unwrap();
+    let json: serde_json::Value =
+        serde_json::from_slice(&json_out.stdout).expect("affected-tests --json must be valid JSON");
+
+    // Only assert parity when the JSON actually reports a caveat; if the
+    // analysis came back complete there is nothing for text to surface, and a
+    // test that asserted otherwise would be testing the fixture, not the code.
+    let status = json.get("status").and_then(|v| v.as_str()).unwrap_or("");
+    if status == "complete" {
+        return;
+    }
+
+    let text_out = nestweaver_cmd().args(args).output().unwrap();
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&text_out.stdout),
+        String::from_utf8_lossy(&text_out.stderr)
+    )
+    .to_lowercase();
+
+    assert!(
+        text.contains(status),
+        "--json reported status {status:?} but the text output never mentions it. \
+         A developer sees a clean result while the tool privately knows the \
+         selection is incomplete.\n\n{text}"
+    );
+
+    if let Some(rec) = json.get("recommendation").and_then(|v| v.as_str())
+        && rec == "run-full-suite"
+    {
+        assert!(
+            text.contains("full suite"),
+            "--json recommends running the full suite; the text output must say so — \
+             this is the command where the cost of silence is skipped tests.\n\n{text}"
+        );
+    }
+
+    if let Some(notes) = json.get("notifications").and_then(|v| v.as_array())
+        && !notes.is_empty()
+    {
+        assert!(
+            text.contains("warning") || text.contains("not assessed"),
+            "--json carries {} notification(s) that text never shows.\n\n{text}",
+            notes.len()
+        );
+    }
+}
+
+/// `regex-search` must not report "No matches" when it merely ran out of budget
+/// (nw-097, nw-111). A genuine empty result must still read cleanly.
+#[test]
+fn regex_search_text_distinguishes_no_matches_from_budget_exhaustion() {
+    let (_dir, db) = honesty_fixture();
+
+    // Genuine miss: a pattern that truly is not present.
+    let miss = nestweaver_cmd()
+        .args([
+            "regex-search",
+            "zzqq_definitely_absent_pattern_41",
+            "--db",
+            &db,
+            "--max-millis",
+            "60000",
+        ])
+        .output()
+        .unwrap();
+    let miss_text = String::from_utf8_lossy(&miss.stdout).to_lowercase();
+    assert!(
+        miss_text.contains("no matches"),
+        "a genuine miss should still read as a plain no-match: {miss_text}"
+    );
+    assert!(
+        !miss_text.contains("budget"),
+        "a genuine miss must NOT warn about the budget — crying wolf on every \
+         empty result is how a real truncation warning gets ignored: {miss_text}"
+    );
+
+    // Budget exhaustion: assert parity only if the engine actually reports it,
+    // since a tiny fixture may complete within any budget.
+    let args = ["regex-search", "alpha", "--db", &db, "--max-millis", "1"];
+    let json_out = nestweaver_cmd().args(args).arg("--json").output().unwrap();
+    let json: serde_json::Value =
+        serde_json::from_slice(&json_out.stdout).expect("regex-search --json must be valid JSON");
+    let truncated = json
+        .get("truncated")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let empty = json
+        .get("results")
+        .and_then(|v| v.as_array())
+        .is_some_and(|a| a.is_empty());
+    if !(truncated && empty) {
+        return;
+    }
+
+    let text_out = nestweaver_cmd().args(args).output().unwrap();
+    let text = String::from_utf8_lossy(&text_out.stdout).to_lowercase();
+    assert!(
+        text.contains("budget") || text.contains("cut short") || text.contains("truncat"),
+        "--json reported truncated:true with zero results, but text printed a bare \
+         no-match — an actively false claim that matches do not exist.\n\n{text}"
+    );
+}


### PR DESCRIPTION
## Summary

Phase 2 of the post-v2.7.0 bug program: the defect family where the engine computes a caveat correctly and the **text renderer throws it away**. Six separate findings (nw-097, nw-107, nw-110, nw-111) were this one bug.

## Method: survey first, then fix

Rather than fixing the five known findings, I wrote a parity survey that runs 17 commands in both modes against the **real 5.6 GB brain DB, 961 notes and 34 indexed repos**, and reports every honesty key present in JSON but absent from text.

That found **9 gaps, not 5** — and caught nuance a per-command audit would have missed: `regex-search` surfaces its caveats fine at a large budget; only the *exhausted* path drops them, which is exactly where silence misleads.

## Fixed

| command | before | after |
| --- | --- | --- |
| `affected-tests` | "0 tests affected" + generic note | `Status: partial`, the specific warning, **RUN THE FULL SUITE** |
| `regex-search` (budget) | flat "No matches" — an actively false claim | "No matches **WITHIN THE SEARCH BUDGET**" + remedy |
| `brain broken-links` | "wikilinks (50):" | "wikilinks (**50 of 778**):" |
| `brain orphans` | "Orphan documents (50):" | "(**50 of 607**):" |
| `pr-impact` | truncation note only | + "blind spots: dynamic-dispatch, reflection, config-wiring, codegen" |

`broken-links` and `orphans` each had **two** render paths — the direct path already showed "N of total"; only the daemon path dropped it, though the daemon response carried `total` all along.

The `regex-search` fix preserves an important distinction: a **genuine** no-match still prints cleanly. Only a truncated one warns.

## Enforcement

Two tests assert the contract so the class cannot regrow. Both verified red by reverting the fixes.

That verification needed `touch src/main.rs` first: a plain `git stash` does not invalidate cargo's mtime cache, so the first revert run silently exercised the already-fixed binary and reported a false pass. I briefly concluded the tests were vacuous before catching it — recorded in the commit, because a proof that a test is meaningful is itself worthless if it ran stale code.

## Validation

- `cargo test -p nestweaver --test cli_test` — 85 passed
- `cargo fmt --all -- --check`, `cargo clippy -D warnings` — exit 0
- Survey re-run after the fixes: 9 gaps → 0 real
- All verified against the real vault and repos, not fixtures

Three apparent gaps turned out to be **my tooling, not the product** — a `--limit` flag `clusters` does not have, a matcher looking for literal `run-full-suite` where text says "RUN THE FULL SUITE", and a `pr-impact` case using a release merge with no source changes. Fixed in the survey rather than filed as bugs.