### PR TITLE
fix(list-projects): fail on a missing database instead of reporting zero projects

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8697,9 +8697,19 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
         }
 
         Commands::ListProjects { json, db, config } => {
+            // nw-106: read-only command — fail `db_not_found` on a missing --db
+            // before any daemon/store connect. Without this the daemon path
+            // swallowed the open error and returned an empty list at exit 0, so
+            // a missing database was indistinguishable from "no projects
+            // defined" — and the text path suggested adding [[projects]] to a
+            // config, an actively wrong remedy. 17 of 18 comparable commands
+            // already exit 1 here; this was the outlier.
+            let resolved_db = db.clone().unwrap_or_else(default_db_path);
+            require_existing_db(&resolved_db)?;
+
             // ── daemon guard ──────────────────────────────────────
             let materialized: Vec<nestweaver_schema::Project> = if use_daemon {
-                let db_path = db.clone().unwrap_or_else(default_db_path);
+                let db_path = resolved_db.clone();
                 let args = serde_json::json!({});
                 try_hybrid_json_rpc(true, &db_path, None, "list_projects", args)
                     .and_then(|v| serde_json::from_value(unwrap_hybrid_payload(v)).ok())

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -3542,3 +3542,40 @@ fn regex_search_text_distinguishes_no_matches_from_budget_exhaustion() {
          no-match — an actively false claim that matches do not exist.\n\n{text}"
     );
 }
+
+/// A read-only command must never report success for a database that isn't there.
+///
+/// nw-106: `list-projects` swallowed the store-open error on the daemon path and
+/// returned `{"materialized": []}` at exit 0, so a missing database was
+/// indistinguishable from "no projects defined" — and text mode suggested adding
+/// `[[projects]]` to a config, an actively wrong remedy. A CI gate or agent reads
+/// "zero projects" and proceeds on a false premise.
+#[test]
+fn list_projects_fails_on_a_missing_database() {
+    let missing = "/nonexistent/dir/definitely-not-here.lbug";
+
+    for extra in [vec![], vec!["--json"]] {
+        let output = nestweaver_cmd()
+            .args(["list-projects", "--db", missing])
+            .args(&extra)
+            .output()
+            .unwrap();
+
+        assert!(
+            !output.status.success(),
+            "list-projects must exit non-zero for a missing --db (mode {extra:?}); \
+             17 of 18 comparable commands already do"
+        );
+
+        let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+        assert!(
+            stderr.contains("not found") || stderr.contains("db_not_found"),
+            "the error must name the real problem — a missing database — rather than \
+             leaking a raw store error or suggesting a config change: {stderr}"
+        );
+        assert!(
+            !String::from_utf8_lossy(&output.stdout).contains("materialized"),
+            "no result payload should be emitted for a database that does not exist"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

First fix of Phase 3 (contract and validation gaps). Scoped to one item so it can land independently — the rest of Phase 3 continues separately.

## nw-106

`list-projects` swallowed the store-open error on the daemon path and returned `{"materialized": []}` at exit 0, demoting the real failure to a stderr warning. A missing database was indistinguishable from "no projects defined".

Text mode was worse: it printed "No projects found. Use an instance config with [[projects]] to define them" — an actively wrong remedy for a database that isn't there. A CI gate or agent reads "zero projects" and proceeds on a false premise.

17 of the 18 comparable commands already exit 1 on this fault, so it was an oversight, not a design choice. Now uses the `require_existing_db` guard `list-repos` has carried since nw-087.

## Verified on the real environment

```
missing --db, text  -> exit 1, nestweaver::db_not_found + help line
missing --db, --json -> exit 1, no result payload emitted
production --db      -> exit 0, lists normally
```

## Test

The regression test was confirmed red by removing the guard — with an explicit `touch src/main.rs`, because cargo's mtime cache otherwise re-runs the already-fixed binary and reports a false pass. That bit me earlier in this program and is now called out in the commit.

- `cargo test -p nestweaver --test cli_test` — 86 passed
- `cargo fmt --all -- --check`, `cargo clippy -D warnings` — exit 0

## Also in this phase, not in this PR

**nw-104 was narrowed, not fixed.** `compute_drift` matches on contract UIDs, not names, so the PascalCase/snake_case mismatch is upstream in whatever resolves `async fn health_check` to the proto-declared `HealthCheck` UID. Adding case conversion inside `compute_drift` would be the wrong layer and would paper over a missing `IMPLEMENTS_CONTRACT` edge — the edge should exist so blast radius and `contracts list` benefit too. Recorded in the backlog with that acceptance criterion.