### PR TITLE
fix(blast-radius): a truncated traversal must not report status Complete (nw-105)

### DIFF
--- a/crates/nestweaver-engine/src/blast_radius.rs
+++ b/crates/nestweaver-engine/src/blast_radius.rs
@@ -808,6 +808,23 @@ pub fn analyze_blast_radius(
 
     let risk_level = compute_risk_level(total_affected, clusters_touched, high_centrality);
 
+    // nw-105: a truncated traversal must not report as Complete.
+    //
+    // The truncation flags are accumulated at :598, long before this point, but
+    // `status` was left at Complete — so `derive_gate_state` below returned Ok
+    // for a run that simultaneously reported coverage.traversal_truncated and a
+    // depth-truncated blind spot. A merge gate consuming gate_state read "ok"
+    // for an analysis that never finished.
+    //
+    // Fixed here rather than inside derive_gate_state: that function's rule is
+    // already correct and stating it twice would let the two copies drift, and
+    // more importantly `status` itself is consumed by the summary line, the MCP
+    // envelope and pr-impact. Downgrading only from Complete so a run already
+    // Degraded or Failed is never upgraded.
+    if (truncated_by_threshold || truncated_by_depth) && status == AnalysisStatus::Complete {
+        status = AnalysisStatus::Partial;
+    }
+
     let summary = render_blast_summary(
         changed_symbols.len(),
         changed_files.len(),
@@ -2223,6 +2240,25 @@ mod tests {
             result.blind_spots.contains(&BlindSpot::DepthTruncated),
             "a depth-capped traversal must flag DepthTruncated, got: {:?}",
             result.blind_spots
+        );
+
+        // nw-105: the same run must not simultaneously claim it completed.
+        // Before the fix, coverage.traversal_truncated and the DepthTruncated
+        // blind spot were both set while status stayed Complete, so
+        // derive_gate_state returned Ok — a merge gate read "safe" for an
+        // analysis that never finished.
+        assert_ne!(
+            result.status,
+            AnalysisStatus::Complete,
+            "a truncated traversal must not report status Complete — it did not complete"
+        );
+        assert_eq!(
+            result.gate_state,
+            GateState::DegradedUnknown,
+            "a truncated traversal must gate as degraded-unknown, never ok; \
+             got status {:?} / gate {:?}",
+            result.status,
+            result.gate_state
         );
         assert!(
             !result


### PR DESCRIPTION
## Summary

A merge gate was returning `ok` for an analysis that never finished.

`analyze_blast_radius` initialized `status` to `Complete` and never reconciled it with the truncation flags — even though those are accumulated much earlier in the same function. `derive_gate_state` was then called with a Complete status and returned `Ok`, for a run that *simultaneously* reported `coverage.traversal_truncated: true` and a `DepthTruncated` blind spot.

Observed on the production graph: `blast_radius` on a 1,556-line React view containing 202 symbols returned `gate_state: "ok"`, `status: "complete"` and `affected_symbol_count: 0`, while flagging the traversal as truncated. A CI gate consuming `gate_state` waves through a change whose impact was never assessed.

## Why the fix isn't in `derive_gate_state`

That was the obvious place, and it would have been wrong.

`derive_gate_state` is already correct — its doc comment states the rule as **non-negotiable**: a run that did not complete is never `RiskFlagged`, it is `DegradedUnknown`. It simply gets called before the truncation facts are folded into `status`. It's an ordering bug, not a logic bug.

Special-casing truncation inside `derive_gate_state` would have:
- restated the rule in two places, free to drift
- left `status` itself still claiming Complete to **every other consumer** — the summary line, the MCP envelope, `pr-impact`

So `status` is downgraded at the source, before the summary and gate are derived. Only `Complete` is downgraded, so a run already `Degraded` or `Failed` is never upgraded.

## Test

Asserted in the **existing** depth-truncation test, which already constructed exactly this condition and checked only the coverage flag — the setup was there, the assertion was missing.

Verified red by removing the fix:

```
assertion `left != right` failed: a truncated traversal must not report status
Complete — it did not complete
```

## Validation

- `cargo test -p nestweaver-engine --lib` — 961 passed
- `cargo fmt --all -- --check` — exit 0
- Rebased onto `staging` after #197 merged