### PR TITLE
release: hub ranking, impact truncation, and CLI honesty fixes

### DIFF
--- a/crates/nestweaver-engine/src/blast_radius.rs
+++ b/crates/nestweaver-engine/src/blast_radius.rs
@@ -808,6 +808,23 @@ pub fn analyze_blast_radius(
 
     let risk_level = compute_risk_level(total_affected, clusters_touched, high_centrality);
 
+    // nw-105: a truncated traversal must not report as Complete.
+    //
+    // The truncation flags are accumulated at :598, long before this point, but
+    // `status` was left at Complete — so `derive_gate_state` below returned Ok
+    // for a run that simultaneously reported coverage.traversal_truncated and a
+    // depth-truncated blind spot. A merge gate consuming gate_state read "ok"
+    // for an analysis that never finished.
+    //
+    // Fixed here rather than inside derive_gate_state: that function's rule is
+    // already correct and stating it twice would let the two copies drift, and
+    // more importantly `status` itself is consumed by the summary line, the MCP
+    // envelope and pr-impact. Downgrading only from Complete so a run already
+    // Degraded or Failed is never upgraded.
+    if (truncated_by_threshold || truncated_by_depth) && status == AnalysisStatus::Complete {
+        status = AnalysisStatus::Partial;
+    }
+
     let summary = render_blast_summary(
         changed_symbols.len(),
         changed_files.len(),
@@ -2223,6 +2240,25 @@ mod tests {
             result.blind_spots.contains(&BlindSpot::DepthTruncated),
             "a depth-capped traversal must flag DepthTruncated, got: {:?}",
             result.blind_spots
+        );
+
+        // nw-105: the same run must not simultaneously claim it completed.
+        // Before the fix, coverage.traversal_truncated and the DepthTruncated
+        // blind spot were both set while status stayed Complete, so
+        // derive_gate_state returned Ok — a merge gate read "safe" for an
+        // analysis that never finished.
+        assert_ne!(
+            result.status,
+            AnalysisStatus::Complete,
+            "a truncated traversal must not report status Complete — it did not complete"
+        );
+        assert_eq!(
+            result.gate_state,
+            GateState::DegradedUnknown,
+            "a truncated traversal must gate as degraded-unknown, never ok; \
+             got status {:?} / gate {:?}",
+            result.status,
+            result.gate_state
         );
         assert!(
             !result

--- a/crates/nestweaver-engine/src/blast_radius.rs
+++ b/crates/nestweaver-engine/src/blast_radius.rs
@@ -117,7 +117,10 @@ pub enum AnalysisStatus {
 
 impl AnalysisStatus {
     /// Lowercase label for embedding in the human summary string.
-    fn label(self) -> &'static str {
+    ///
+    /// Public so CLI text renderers can surface the status verbatim rather than
+    /// re-deriving the mapping (nw-107).
+    pub fn label(self) -> &'static str {
         match self {
             AnalysisStatus::Complete => "complete",
             AnalysisStatus::Partial => "partial",

--- a/crates/nestweaver-resolver/src/resolve.rs
+++ b/crates/nestweaver-resolver/src/resolve.rs
@@ -236,10 +236,16 @@ pub fn resolve_references_with_context(
             continue;
         }
 
-        let source_symbols = match file_symbols.get(file_path.as_str()) {
-            Some(syms) if !syms.is_empty() => *syms,
-            _ => continue,
-        };
+        // A file with no symbols has nothing that could enclose an import, so
+        // skip it before doing any per-import work. The symbol list itself is
+        // no longer read here: since nw-103 this pass attributes an edge only
+        // to a genuine enclosing symbol, never to the file's first declaration.
+        if file_symbols
+            .get(file_path.as_str())
+            .is_none_or(|syms| syms.is_empty())
+        {
+            continue;
+        }
 
         let source_sorted_syms: &[&RawSymbol] = match file_sorted_symbols.get(file_path.as_str()) {
             Some(syms) if !syms.is_empty() => syms.as_slice(),
@@ -264,10 +270,18 @@ pub fn resolve_references_with_context(
                 })
                 .map(|r| r.start_line);
 
-            // Use enclosing symbol at import line, or fall back to first symbol in file.
-            let source_sym = import_line
-                .and_then(|line| find_enclosing_symbol(source_sorted_syms, line))
-                .or_else(|| source_symbols.first());
+            // Attribute a named-import edge only when the import genuinely sits
+            // INSIDE a symbol — e.g. a dynamic `import()` in a function body.
+            //
+            // A top-level import has no enclosing symbol. Falling back to the
+            // file's first declaration (nw-103) made that arbitrary symbol look
+            // like the file's dependency hub: this pass then fans out to every
+            // non-private symbol in the target file, so a 3-reference,
+            // never-exported string constant acquired 830 out-edges and ranked
+            // #5 in a 158k-symbol graph. Pass 3a already emits a file-level
+            // proxy edge per import, so connectivity does not depend on this.
+            let source_sym =
+                import_line.and_then(|line| find_enclosing_symbol(source_sorted_syms, line));
 
             let source_uid = match source_sym {
                 Some(sym) => symbol_uid(repo_uid, file_path, &sym.name, sym.start_line),
@@ -842,10 +856,21 @@ mod tests {
         );
     }
 
+    /// A top-level import yields ONE file-level proxy edge, not one per
+    /// exported symbol in the target.
+    ///
+    /// This test previously asserted two edges — one to every export — which is
+    /// the fan-out that nw-103 removed. Attributing a top-level import to a
+    /// *symbol* is a category error: the import belongs to the file, and the
+    /// symbol Pass 3b picked was simply whichever happened to be declared
+    /// first. That is how a never-exported string constant ended up with 830
+    /// out-edges. Pass 3a keeps the file-level edge so connectivity survives.
+    ///
+    /// Genuine per-symbol import attribution — linking only the symbols that
+    /// actually reference the imported binding — is tracked separately; it
+    /// needs reference matching this pass does not do.
     #[test]
-    fn creates_imports_edges_from_import_graph() {
-        // main.js imports helper.js — should create IMPORTS edges
-        // to all exported symbols in helper.js
+    fn top_level_import_creates_one_file_level_proxy_edge() {
         let files = vec![
             (
                 "src/main.js".to_string(),
@@ -866,8 +891,9 @@ mod tests {
             .collect();
         assert_eq!(
             import_edges.len(),
-            2,
-            "should create IMPORTS edges to both exported symbols; got: {import_edges:?}"
+            1,
+            "a top-level import should yield exactly one file-level proxy edge, \
+             not one per export (nw-103 fan-out); got: {import_edges:?}"
         );
 
         let expected_confidence = confidence_score(MatchType::ImportResolved, Language::JavaScript);
@@ -881,6 +907,57 @@ mod tests {
                 "IMPORTS target should be resolved"
             );
         }
+    }
+
+    /// nw-103: a top-level import must not turn the file's first declaration
+    /// into a dependency hub.
+    ///
+    /// Imports sit above every declaration, so `find_enclosing_symbol` finds
+    /// nothing and Pass 3b fell back to `source_symbols.first()` — then fanned
+    /// out to every non-private symbol in each imported file. On the real graph
+    /// that gave `const ROSTER_STORAGE_KEY = "..."` — 3 references, never
+    /// exported — 830 out-edges and the #5 hub slot of a 158k-symbol graph.
+    #[test]
+    fn top_level_import_does_not_make_the_first_declaration_a_hub() {
+        // Mirrors the real shape: a constant declared immediately after the
+        // import block, then the function that actually uses the import.
+        let files = vec![
+            (
+                "src/view.ts".to_string(),
+                vec![make_symbol("STORAGE_KEY", 3), make_symbol("renderView", 20)],
+                vec![make_ref("./types", ReferenceKind::Import, 1)],
+            ),
+            (
+                "src/types.ts".to_string(),
+                vec![
+                    make_symbol("Alpha", 1),
+                    make_symbol("Beta", 10),
+                    make_symbol("Gamma", 20),
+                    make_symbol("Delta", 30),
+                ],
+                vec![],
+            ),
+        ];
+
+        let edges = resolve_references(&files, Language::TypeScript, "repo:test:abc");
+
+        // symbol_uid hashes the name, so the UID does NOT contain the literal
+        // identifier — filtering on `.contains("STORAGE_KEY")` matches nothing
+        // and makes this test pass vacuously. Compute the real UID instead.
+        let storage_key_uid = symbol_uid("repo:test:abc", "src/view.ts", "STORAGE_KEY", 3);
+        let from_storage_key: Vec<_> = edges
+            .iter()
+            .filter(|e| e.edge_type == EdgeType::Imports && e.source_uid == storage_key_uid)
+            .collect();
+
+        assert!(
+            from_storage_key.len() <= 1,
+            "STORAGE_KEY is declared after the import block and must not inherit \
+             the file's imports; at most a single file-level proxy edge is \
+             acceptable. Got {} IMPORTS edges: {:#?}",
+            from_storage_key.len(),
+            from_storage_key
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8697,9 +8697,19 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
         }
 
         Commands::ListProjects { json, db, config } => {
+            // nw-106: read-only command — fail `db_not_found` on a missing --db
+            // before any daemon/store connect. Without this the daemon path
+            // swallowed the open error and returned an empty list at exit 0, so
+            // a missing database was indistinguishable from "no projects
+            // defined" — and the text path suggested adding [[projects]] to a
+            // config, an actively wrong remedy. 17 of 18 comparable commands
+            // already exit 1 here; this was the outlier.
+            let resolved_db = db.clone().unwrap_or_else(default_db_path);
+            require_existing_db(&resolved_db)?;
+
             // ── daemon guard ──────────────────────────────────────
             let materialized: Vec<nestweaver_schema::Project> = if use_daemon {
-                let db_path = db.clone().unwrap_or_else(default_db_path);
+                let db_path = resolved_db.clone();
                 let args = serde_json::json!({});
                 try_hybrid_json_rpc(true, &db_path, None, "list_projects", args)
                     .and_then(|v| serde_json::from_value(unwrap_hybrid_payload(v)).ok())

--- a/src/main.rs
+++ b/src/main.rs
@@ -8342,11 +8342,38 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             .get("truncated_by_depth")
                             .and_then(|v| v.as_bool())
                             .unwrap_or(false);
+                        // nw-110: the daemon caps rows with `.take(limit)` and
+                        // reports both `total` and `returned`, but result-set
+                        // capping sets NEITHER truncated_by_* flag — those
+                        // describe traversal pruning. Reading only those flags
+                        // let a 50-of-495 answer print as a bare array of 50:
+                        // a floor presented as the whole set.
+                        let total = value.get("total").and_then(|v| v.as_u64());
+                        let returned = value.get("returned").and_then(|v| v.as_u64());
+                        let capped = matches!((total, returned), (Some(t), Some(r)) if r < t);
                         let payload = value
                             .get("impact_nodes")
                             .cloned()
                             .unwrap_or_else(|| value.clone());
-                        if truncated_by_threshold || truncated_by_depth {
+                        if capped {
+                            println!(
+                                "{}",
+                                serde_json::to_string_pretty(&serde_json::json!({
+                                    "nodes": payload,
+                                    "total": total,
+                                    "returned": returned,
+                                    "truncated": true,
+                                    "truncated_by_threshold": truncated_by_threshold,
+                                    "truncated_by_depth": truncated_by_depth,
+                                    "note": format!(
+                                        "showing {} of {} impacted node(s) — reported impact is a \
+                                         floor; raise --limit or pass --min-score 0 for the full set",
+                                        returned.unwrap_or(0),
+                                        total.unwrap_or(0)
+                                    ),
+                                }))?
+                            );
+                        } else if truncated_by_threshold || truncated_by_depth {
                             println!(
                                 "{}",
                                 serde_json::to_string_pretty(&serde_json::json!({
@@ -8378,8 +8405,17 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 println!("No impact found for '{name_or_uid}'.");
                             }
                         } else {
+                            // nw-110: say "50 of 495" when the daemon capped the
+                            // set, never a bare "50 nodes" — the latter reads as
+                            // the complete answer.
+                            let total = value.get("total").and_then(|v| v.as_u64());
                             if !out.quiet {
-                                println!("Impact of '{name_or_uid}' ({} nodes):", count);
+                                match total {
+                                    Some(t) if t > count as u64 => println!(
+                                        "Impact of '{name_or_uid}' ({count} of {t} nodes):"
+                                    ),
+                                    _ => println!("Impact of '{name_or_uid}' ({count} nodes):"),
+                                }
                             }
                             for n in &nodes {
                                 if out.verbose {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3322,7 +3322,10 @@ fn print_pr_impact_hook(result: &BlastRadiusResult, breaking: &[BreakingChange])
 
     // Coverage caveat: reported impact is a floor when the walk was cut short or
     // a referenced repo isn't indexed.
-    if result.coverage.traversal_truncated || !result.coverage.repos_not_indexed.is_empty() {
+    if result.coverage.traversal_truncated
+        || !result.coverage.repos_not_indexed.is_empty()
+        || !result.blind_spots.is_empty()
+    {
         let mut notes = Vec::new();
         if result.coverage.traversal_truncated {
             notes.push("traversal truncated".to_string());
@@ -3332,6 +3335,21 @@ fn print_pr_impact_hook(result: &BlastRadiusResult, breaking: &[BreakingChange])
                 "{} repo(s) not indexed",
                 result.coverage.repos_not_indexed.len()
             ));
+        }
+        // The JSON carries `coverage.blind_spots` — categories of edge the
+        // static walk cannot see at all (dynamic dispatch, reflection, ...).
+        // Text omitted them, so a reviewer had no way to know which whole
+        // classes of dependency were never considered.
+        if !result.blind_spots.is_empty() {
+            // BlindSpot serializes kebab-case; render it the same way so text
+            // and --json name the same categories.
+            let spots: Vec<String> = result
+                .blind_spots
+                .iter()
+                .filter_map(|s| serde_json::to_value(s).ok())
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect();
+            notes.push(format!("blind spots: {}", spots.join(", ")));
         }
         println!("  note: {} — reported impact is a floor", notes.join(", "));
     }
@@ -6865,6 +6883,26 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 print_tier("Tier 1 (direct)", &result.tier_1);
                 print_tier("Tier 2 (caller's tests)", &result.tier_2);
                 print_tier("Tier 3 (transitive)", &result.tier_3);
+
+                // nw-107: the JSON path reports `status`, `notifications` and
+                // `recommendation`; text printed only the generic disclaimer.
+                // A developer saw a clean "0 tests affected" with no sign the
+                // selection was degraded and that the tool ITSELF recommends a
+                // full suite — the exact "no tests found is NOT safe-to-skip"
+                // failure the disclaimer exists to prevent.
+                let status_label = result.status.label();
+                if status_label != "complete" {
+                    println!("Status: {status_label} — selection is incomplete.");
+                }
+                for n in &result.notifications {
+                    println!("Warning: {}", n.message);
+                }
+                if result.recommendation == "run-full-suite" {
+                    println!(
+                        "Recommendation: RUN THE FULL SUITE — this selection is not safe to rely on."
+                    );
+                }
+
                 println!("Note: {}", result.disclaimer);
             }
 
@@ -7369,7 +7407,24 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     if json {
                         println!("{}", serde_json::to_string_pretty(&res)?);
                     } else if res.results.is_empty() {
-                        println!("No matches for '{pattern}'.");
+                        // nw-097/nw-111: the caveat notes below live in the
+                        // non-empty branch, so the ONE case where truncation matters
+                        // most — zero results because the budget ran out — printed a
+                        // flat "No matches", an actively false claim. On the real
+                        // 5.6 GB brain DB `regex-search NestWeaver --max-millis 5`
+                        // returns nothing while thousands of matches exist.
+                        if res.truncated {
+                            println!(
+                                "No matches for '{pattern}' WITHIN THE SEARCH BUDGET — the scan was cut \
+                         short, so matches may exist beyond the scanned range. Raise \
+                         --max-millis, or run `index --with-trigrams` to make this fast."
+                            );
+                        } else {
+                            println!("No matches for '{pattern}'.");
+                        }
+                        if res.stale_index {
+                            print_stale_index_note();
+                        }
                     } else {
                         println!("Found {} match(es) for '{pattern}':", res.results.len());
                         for m in &res.results {
@@ -7403,7 +7458,24 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             if json {
                 println!("{}", serde_json::to_string_pretty(&res)?);
             } else if res.results.is_empty() {
-                println!("No matches for '{pattern}'.");
+                // nw-097/nw-111: the caveat notes below live in the
+                // non-empty branch, so the ONE case where truncation matters
+                // most — zero results because the budget ran out — printed a
+                // flat "No matches", an actively false claim. On the real
+                // 5.6 GB brain DB `regex-search NestWeaver --max-millis 5`
+                // returns nothing while thousands of matches exist.
+                if res.truncated {
+                    println!(
+                        "No matches for '{pattern}' WITHIN THE SEARCH BUDGET — the scan was cut \
+                         short, so matches may exist beyond the scanned range. Raise \
+                         --max-millis, or run `index --with-trigrams` to make this fast."
+                    );
+                } else {
+                    println!("No matches for '{pattern}'.");
+                }
+                if res.stale_index {
+                    print_stale_index_note();
+                }
             } else {
                 println!("Found {} match(es) for '{pattern}':", res.results.len());
                 for m in &res.results {
@@ -13668,7 +13740,17 @@ fn run_brain(
                     if links.is_empty() {
                         println!("No broken or ambiguous wikilinks found.");
                     } else {
-                        println!("Broken / ambiguous wikilinks ({}):", links.len());
+                        // nw-097 class: the daemon reports `total`; this path
+                        // printed only how many it chose to show, so 50 of 778
+                        // read as "778 does not exist". The direct path below
+                        // already renders "N of total" — match it.
+                        let total = value.get("total").and_then(|v| v.as_u64());
+                        match total {
+                            Some(tot) if tot > links.len() as u64 => {
+                                println!("Broken / ambiguous wikilinks ({} of {tot}):", links.len())
+                            }
+                            _ => println!("Broken / ambiguous wikilinks ({}):", links.len()),
+                        }
                         for l in &links {
                             println!(
                                 "  [[{}]] in {} (confidence {:.2})",
@@ -13761,7 +13843,15 @@ fn run_brain(
                         if orphans.is_empty() {
                             println!("No orphan documents found.");
                         } else {
-                            println!("Orphan documents ({}):", orphans.len());
+                            // nw-097 class: daemon carries `total`; printing
+                            // only the shown count hid 607 orphans behind 50.
+                            let total = value.get("total").and_then(|v| v.as_u64());
+                            match total {
+                                Some(tot) if tot > orphans.len() as u64 => {
+                                    println!("Orphan documents ({} of {tot}):", orphans.len())
+                                }
+                                _ => println!("Orphan documents ({}):", orphans.len()),
+                            }
                             for o in &orphans {
                                 println!("  {} — {}", o.title, o.file_path);
                             }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -3394,3 +3394,151 @@ fn every_cli_invocation_pins_its_daemon_routing() {
          .env_remove(\"NESTWEAVER_NO_DAEMON\") for the daemon path: {unpinned:?}"
     );
 }
+
+// ── text/JSON honesty parity ─────────────────────────────────────────────
+//
+// The engine computes caveats correctly; the failures this guards against are
+// text renderers that DROP them. Six separate findings in the v2.7.0 CLI sweep
+// were this one defect (nw-097, nw-107, nw-110, nw-111), so the class needs an
+// enforced contract rather than six point fixes.
+//
+// The rule: if --json reports a caveat, the human output must say so too.
+// A caller reading a terminal must not be told less than a caller parsing JSON.
+
+/// Build a throwaway indexed repo and return (tempdir, db path).
+fn honesty_fixture() -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().join("repo");
+    std::fs::create_dir_all(repo.join("src")).unwrap();
+    std::fs::write(
+        repo.join("src/lib.js"),
+        "export function alpha() { return beta(); }\nexport function beta() { return 1; }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        repo.join("src/lib.test.js"),
+        "import { alpha } from './lib';\ntest('alpha', () => { alpha(); });\n",
+    )
+    .unwrap();
+
+    let db = dir.path().join("honesty.lbug").display().to_string();
+    nestweaver_cmd()
+        .args(["index", "--repo", &repo.display().to_string(), "--db", &db])
+        .assert()
+        .success();
+    (dir, db)
+}
+
+/// `affected-tests` must not print a clean zero while privately recommending a
+/// full suite (nw-107).
+#[test]
+fn affected_tests_text_surfaces_status_warning_and_recommendation() {
+    let (_dir, db) = honesty_fixture();
+
+    // A path that resolves to no indexed symbols — the analysis is degraded,
+    // and the JSON path says so.
+    let args = ["affected-tests", "--files", "zzz/not/real.js", "--db", &db];
+
+    let json_out = nestweaver_cmd().args(args).arg("--json").output().unwrap();
+    let json: serde_json::Value =
+        serde_json::from_slice(&json_out.stdout).expect("affected-tests --json must be valid JSON");
+
+    // Only assert parity when the JSON actually reports a caveat; if the
+    // analysis came back complete there is nothing for text to surface, and a
+    // test that asserted otherwise would be testing the fixture, not the code.
+    let status = json.get("status").and_then(|v| v.as_str()).unwrap_or("");
+    if status == "complete" {
+        return;
+    }
+
+    let text_out = nestweaver_cmd().args(args).output().unwrap();
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&text_out.stdout),
+        String::from_utf8_lossy(&text_out.stderr)
+    )
+    .to_lowercase();
+
+    assert!(
+        text.contains(status),
+        "--json reported status {status:?} but the text output never mentions it. \
+         A developer sees a clean result while the tool privately knows the \
+         selection is incomplete.\n\n{text}"
+    );
+
+    if let Some(rec) = json.get("recommendation").and_then(|v| v.as_str())
+        && rec == "run-full-suite"
+    {
+        assert!(
+            text.contains("full suite"),
+            "--json recommends running the full suite; the text output must say so — \
+             this is the command where the cost of silence is skipped tests.\n\n{text}"
+        );
+    }
+
+    if let Some(notes) = json.get("notifications").and_then(|v| v.as_array())
+        && !notes.is_empty()
+    {
+        assert!(
+            text.contains("warning") || text.contains("not assessed"),
+            "--json carries {} notification(s) that text never shows.\n\n{text}",
+            notes.len()
+        );
+    }
+}
+
+/// `regex-search` must not report "No matches" when it merely ran out of budget
+/// (nw-097, nw-111). A genuine empty result must still read cleanly.
+#[test]
+fn regex_search_text_distinguishes_no_matches_from_budget_exhaustion() {
+    let (_dir, db) = honesty_fixture();
+
+    // Genuine miss: a pattern that truly is not present.
+    let miss = nestweaver_cmd()
+        .args([
+            "regex-search",
+            "zzqq_definitely_absent_pattern_41",
+            "--db",
+            &db,
+            "--max-millis",
+            "60000",
+        ])
+        .output()
+        .unwrap();
+    let miss_text = String::from_utf8_lossy(&miss.stdout).to_lowercase();
+    assert!(
+        miss_text.contains("no matches"),
+        "a genuine miss should still read as a plain no-match: {miss_text}"
+    );
+    assert!(
+        !miss_text.contains("budget"),
+        "a genuine miss must NOT warn about the budget — crying wolf on every \
+         empty result is how a real truncation warning gets ignored: {miss_text}"
+    );
+
+    // Budget exhaustion: assert parity only if the engine actually reports it,
+    // since a tiny fixture may complete within any budget.
+    let args = ["regex-search", "alpha", "--db", &db, "--max-millis", "1"];
+    let json_out = nestweaver_cmd().args(args).arg("--json").output().unwrap();
+    let json: serde_json::Value =
+        serde_json::from_slice(&json_out.stdout).expect("regex-search --json must be valid JSON");
+    let truncated = json
+        .get("truncated")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let empty = json
+        .get("results")
+        .and_then(|v| v.as_array())
+        .is_some_and(|a| a.is_empty());
+    if !(truncated && empty) {
+        return;
+    }
+
+    let text_out = nestweaver_cmd().args(args).output().unwrap();
+    let text = String::from_utf8_lossy(&text_out.stdout).to_lowercase();
+    assert!(
+        text.contains("budget") || text.contains("cut short") || text.contains("truncat"),
+        "--json reported truncated:true with zero results, but text printed a bare \
+         no-match — an actively false claim that matches do not exist.\n\n{text}"
+    );
+}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -3542,3 +3542,40 @@ fn regex_search_text_distinguishes_no_matches_from_budget_exhaustion() {
          no-match — an actively false claim that matches do not exist.\n\n{text}"
     );
 }
+
+/// A read-only command must never report success for a database that isn't there.
+///
+/// nw-106: `list-projects` swallowed the store-open error on the daemon path and
+/// returned `{"materialized": []}` at exit 0, so a missing database was
+/// indistinguishable from "no projects defined" — and text mode suggested adding
+/// `[[projects]]` to a config, an actively wrong remedy. A CI gate or agent reads
+/// "zero projects" and proceeds on a false premise.
+#[test]
+fn list_projects_fails_on_a_missing_database() {
+    let missing = "/nonexistent/dir/definitely-not-here.lbug";
+
+    for extra in [vec![], vec!["--json"]] {
+        let output = nestweaver_cmd()
+            .args(["list-projects", "--db", missing])
+            .args(&extra)
+            .output()
+            .unwrap();
+
+        assert!(
+            !output.status.success(),
+            "list-projects must exit non-zero for a missing --db (mode {extra:?}); \
+             17 of 18 comparable commands already do"
+        );
+
+        let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+        assert!(
+            stderr.contains("not found") || stderr.contains("db_not_found"),
+            "the error must name the real problem — a missing database — rather than \
+             leaking a raw store error or suggesting a config change: {stderr}"
+        );
+        assert!(
+            !String::from_utf8_lossy(&output.stdout).contains("materialized"),
+            "no result payload should be emitted for a database that does not exist"
+        );
+    }
+}


### PR DESCRIPTION
Patch release on top of v2.7.0. Four user-visible correctness fixes, all already
CI-green on their own PRs (#195, #196, #197, #198).

## Critical

- **nw-103 — import edge fan-out corrupting hub ranking** (#195). Import edges were
  fanned out to every symbol in the imported file, inflating in-degree and putting
  the wrong symbols at the top of hub rankings.
- **nw-110 — `impact` presenting a capped set as complete** (#195). Results were
  silently capped at 50 nodes with no truncation notice, discarding up to 90% of
  results while reporting the run as complete.

## High

- **nw-105 — truncated traversal reported as Complete** (#198). `blast_radius`
  returned `gate_state: ok` / `status: complete` on a run it had simultaneously
  flagged as truncated, waving a change through a merge gate whose impact was
  never assessed.
- **nw-106 — `list-projects` exit code** (#197). A missing database returned exit 0
  and an empty list, indistinguishable from "no projects defined", with an actively
  wrong remedy in the text output.
- **Text/JSON honesty parity** (#196). A parity survey over 17 commands found 9
  honesty values present in `--json` and absent from text — most notably
  `regex-search` printing a flat "No matches" when the budget was exhausted. Closed
  across 5 commands with an enforcement test.

Merge with a merge commit so release-please cuts 2.7.1.