### PR TITLE
fix(engine): disclose when the co-change sidecar does not cover a changed file

### DIFF
--- a/crates/nestweaver-engine/src/blast_radius.rs
+++ b/crates/nestweaver-engine/src/blast_radius.rs
@@ -984,6 +984,38 @@ pub fn analyze_blast_radius(
                         .unwrap_or(std::cmp::Ordering::Equal)
                         .then_with(|| a.file.cmp(&b.file))
                 });
+
+                // A loaded sidecar is not the same as a sidecar that covers
+                // THESE files (nw-062). It is written per indexed repo and
+                // blind-overwritten, so in a multi-repo database it holds one
+                // repo's history — every other repo takes this branch, matches
+                // nothing, and would otherwise return an empty list with no
+                // disclosure at all. An empty result must not be readable as
+                // "this file has no historical coupling" when the truth is
+                // "no history was mined for it".
+                let mined: HashSet<&str> = edges
+                    .iter()
+                    .flat_map(|e| [e.file_a.as_str(), e.file_b.as_str()])
+                    .collect();
+                let unmined: Vec<&str> = changed_set
+                    .iter()
+                    .copied()
+                    .filter(|path| !mined.contains(path))
+                    .collect();
+                if !unmined.is_empty() {
+                    notifications.push(Notification {
+                        level: NotificationLevel::Note,
+                        message: format!(
+                            "{} of {} changed file(s) do not appear in the co-change sidecar, so \
+                             an empty co-change result for them cannot be distinguished from \
+                             unmined history — the sidecar covers the most recently indexed repo \
+                             only, so files from other repos in this database are not represented",
+                            unmined.len(),
+                            changed_set.len()
+                        ),
+                        descriptor: "cochange-no-coverage".to_string(),
+                    });
+                }
             }
             None => {
                 notifications.push(Notification {
@@ -2553,6 +2585,100 @@ mod tests {
         assert_eq!(c.cochange_count, 9);
         assert!((c.confidence - 0.69).abs() < 1e-6);
         assert!(c.note.contains("no static edge"));
+    }
+
+    /// nw-062: the sidecar exists but holds another repo's history. This is the
+    /// 33-of-34 case on the real multi-repo database — the run took the "loaded"
+    /// branch, matched nothing, and disclosed nothing, so a caller could not
+    /// tell "no coupling" from "no data".
+    #[test]
+    fn a_sidecar_that_does_not_cover_the_changed_file_is_disclosed() {
+        use crate::cochange::{CoChangeEdge, save_cochange_sidecar};
+        let store = GraphStore::in_memory().expect("store");
+        insert_minimal_symbol(
+            &store,
+            "sym:view",
+            "WorkflowsView",
+            "src/app/WorkflowsView.tsx",
+        );
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("scratch.lbug");
+        std::fs::write(&db, b"").expect("touch db");
+
+        // History mined from a DIFFERENT repo than the file being analysed.
+        let edges = vec![CoChangeEdge {
+            file_a: "crates/nestweaver-store/build.rs".into(),
+            file_b: "crates/nestweaver-store/Cargo.toml".into(),
+            cochange_count: 6,
+            total_commits_a: 10,
+            total_commits_b: 10,
+            confidence: 0.60,
+        }];
+        save_cochange_sidecar(&edges, &crate::sidecar_path(&db, ".cochange.json"))
+            .expect("save sidecar");
+
+        let result = analyze_blast_radius(
+            &store,
+            &[PathBuf::from("src/app/WorkflowsView.tsx")],
+            &BlastRadiusOptions::default(),
+            None,
+            Some(&db),
+        )
+        .expect("analyze");
+
+        assert!(result.cochanged_files.is_empty());
+        assert!(
+            result
+                .notifications
+                .iter()
+                .any(|n| n.descriptor == "cochange-no-coverage"),
+            "a sidecar with no history for this file must be disclosed: {:?}",
+            result.notifications
+        );
+        // Advisory tier: absence never degrades the run.
+        assert_eq!(result.status, AnalysisStatus::Complete);
+    }
+
+    /// The complement: when the sidecar DOES cover the changed file, an empty or
+    /// populated result is trustworthy and must not carry the caveat — a note
+    /// that always fires teaches callers to ignore it.
+    #[test]
+    fn a_covered_file_does_not_carry_the_no_coverage_caveat() {
+        use crate::cochange::{CoChangeEdge, save_cochange_sidecar};
+        let store = GraphStore::in_memory().expect("store");
+        insert_minimal_symbol(&store, "sym:bill", "compute_total", "src/billing.rs");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("scratch.lbug");
+        std::fs::write(&db, b"").expect("touch db");
+        let edges = vec![CoChangeEdge {
+            file_a: "src/billing.rs".into(),
+            file_b: "src/invoice_templates.sql".into(),
+            cochange_count: 9,
+            total_commits_a: 12,
+            total_commits_b: 10,
+            confidence: 0.69,
+        }];
+        save_cochange_sidecar(&edges, &crate::sidecar_path(&db, ".cochange.json"))
+            .expect("save sidecar");
+
+        let result = analyze_blast_radius(
+            &store,
+            &[PathBuf::from("src/billing.rs")],
+            &BlastRadiusOptions::default(),
+            None,
+            Some(&db),
+        )
+        .expect("analyze");
+
+        assert_eq!(result.cochanged_files.len(), 1);
+        assert!(
+            !result
+                .notifications
+                .iter()
+                .any(|n| n.descriptor == "cochange-no-coverage"),
+            "a covered file must not be told its history is missing: {:?}",
+            result.notifications
+        );
     }
 
     #[test]


### PR DESCRIPTION
The **disclosure half of nw-062** — which the backlog retest calls "arguably
worse than the overwrite itself".

## The defect

Only a fully **absent** sidecar was disclosed (`cochange-unavailable`). A sidecar
that loads but contains no history for the changed file took the success branch,
matched nothing, and returned `cochanged_files: []` alongside
`notifications: []`.

Because the sidecar is written per indexed repo and blind-overwritten, in a
multi-repo database it holds exactly one repo's history — so **33 of 34 repos hit
this path**. Measured on the real database: `blast_radius` on a nestweaver file
returns populated `cochanged_files`; the same query against a raven file returns
an empty list and an empty notification array.

A caller cannot distinguish *"this file has no historical coupling"* from *"no
history was mined for it"*, and the first reading is the dangerous one —
co-change exists specifically to catch coupling the static graph cannot see.

## The fix

Changed files with no representation anywhere in the sidecar now raise a
`cochange-no-coverage` note stating how many of the changed files are unmined and
why. Files the sidecar **does** cover do not carry the caveat — a note that always
fires is a note callers learn to ignore, so that complement is tested too.

Advisory tier semantics are unchanged: this never degrades `status` or the gate.

Confirmed red by suppressing the emission — the disclosure test fails with
`notifications: []`, reproducing the reported behaviour exactly.

## What this does NOT fix

The underlying **blind overwrite**. The sidecar is a flat JSON list with no `repo`
field, and paths are unqualified repo-relative, so `CHANGELOG.md` would collide
across repos even if the file were merged correctly. Fixing that needs a sidecar
format migration (repo-qualified entries + merge-on-write instead of overwrite)
across the engine, daemon and CLI write paths, and is deliberately left for a
separate change. nw-062 stays open.