### PR TITLE
fix(cli): make search limit honest and enforce float/enum flag contracts

### DIFF
--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -3372,7 +3372,7 @@ fn tool_schema_brain_search() -> Value {
                 },
                 "limit": {
                     "type": "integer",
-                    "description": "Maximum results to return. Default 20. Set lower for focused lookups, higher for broad discovery.",
+                    "description": "Maximum results PER KIND, not in total. Default 20. Notes and code symbols are capped separately, so a query matching both can return up to 2x this value — budget accordingly and read returned_matches for the true count. Set lower for focused lookups, higher for broad discovery.",
                     "default": 20,
                     "minimum": 1,
                     "maximum": 1000
@@ -4590,6 +4590,25 @@ mod brain_search_total_contract_tests {
         let description = schema["description"].as_str().unwrap();
         assert!(description.contains("total_matches_relation"));
         assert!(description.contains("returned_matches"));
+
+        // nw-101: the `limit` property itself must disclose that the cap is
+        // per-kind. The tool description said so while this said "Maximum
+        // results to return", and a caller reading the field they are actually
+        // setting was told a total cap that does not exist — `--limit 3` on a
+        // mixed query returns 6. The per-kind cap is deliberate (symbols carry
+        // a fixed 0.5 score against BM25 notes scoring 15+, so a merged cap
+        // would evict every symbol), so the contract is what needs correcting.
+        let limit_doc = schema["inputSchema"]["properties"]["limit"]["description"]
+            .as_str()
+            .unwrap();
+        assert!(
+            limit_doc.contains("PER KIND"),
+            "the limit field must state it is per-kind, not a total: {limit_doc}"
+        );
+        assert!(
+            limit_doc.contains("2x"),
+            "it must state the consequence — up to 2x limit rows: {limit_doc}"
+        );
         assert!(
             schema["inputSchema"]["properties"]["response_format"]["description"]
                 .as_str()

--- a/src/main.rs
+++ b/src/main.rs
@@ -592,6 +592,45 @@ fn scan_crash_reports_in(directories: &[PathBuf], supported: bool) -> CrashRecur
     scan
 }
 
+/// The closed set of node kinds accepted by `--kinds`.
+const NODE_KINDS: [&str; 3] = ["Section", "Note", "Symbol"];
+
+/// Parse and validate a `--kinds` token against [`NODE_KINDS`].
+///
+/// Matching stays case-insensitive, but an unknown token is now rejected
+/// instead of silently dropped. `--kinds Bogus` used to return zero matches at
+/// exit 0, so a typo was indistinguishable from a real empty result (nw-108).
+fn parse_node_kind(value: &str) -> Result<String, String> {
+    NODE_KINDS
+        .iter()
+        .find(|k| k.eq_ignore_ascii_case(value))
+        .map(|k| (*k).to_string())
+        .ok_or_else(|| format!("must be one of {}", NODE_KINDS.join(", ")))
+}
+
+/// Parse a float documented as `[0.0-1.0]` and enforce that range.
+///
+/// Every INTEGER range in the CLI is enforced by clap, but the floats were
+/// unguarded: `--confidence 5.0` was accepted at exit 0 and returned an empty
+/// result with no explanation, which reads exactly like "nothing depends on
+/// this symbol" (nw-108).
+fn parse_unit_interval_f32(value: &str) -> Result<f32, String> {
+    let parsed: f32 = value.parse().map_err(|_| "must be a number".to_string())?;
+    if !parsed.is_finite() || !(0.0..=1.0).contains(&parsed) {
+        return Err("must be in 0.0..=1.0".to_string());
+    }
+    Ok(parsed)
+}
+
+/// `f64` counterpart of [`parse_unit_interval_f32`].
+fn parse_unit_interval_f64(value: &str) -> Result<f64, String> {
+    let parsed: f64 = value.parse().map_err(|_| "must be a number".to_string())?;
+    if !parsed.is_finite() || !(0.0..=1.0).contains(&parsed) {
+        return Err("must be in 0.0..=1.0".to_string());
+    }
+    Ok(parsed)
+}
+
 fn capability_diagnostics_value(
     embedding_compiled: bool,
     metal_compiled: bool,
@@ -887,6 +926,7 @@ enum Commands {
         #[arg(
             long,
             value_delimiter = ',',
+            value_parser = parse_node_kind,
             help = "Restrict to node kinds (comma-separated): Section,Note,Symbol"
         )]
         kinds: Option<Vec<String>>,
@@ -928,6 +968,7 @@ enum Commands {
         #[arg(
             long,
             value_delimiter = ',',
+            value_parser = parse_node_kind,
             help = "Restrict to node kinds (comma-separated): Section,Note,Symbol"
         )]
         kinds: Option<Vec<String>>,
@@ -961,11 +1002,13 @@ enum Commands {
         #[arg(
             long,
             default_value = "0.0",
+            value_parser = parse_unit_interval_f32,
             help = "Minimum edge confidence [0.0-1.0]"
         )]
         confidence: f32,
         #[arg(
             long,
+            value_parser = parse_unit_interval_f64,
             help = "Minimum impact score for including a dependent [0.0-1.0] (default: 0.10; pass 0 to disable score pruning and get the full traversal)"
         )]
         min_score: Option<f64>,
@@ -2605,7 +2648,7 @@ enum BrainCommands {
         #[arg(
             long,
             value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=1000),
-            help = "Maximum results (1-1000; default: 20, or [limits].default_result_limit from config; matches the MCP brain_search schema)"
+            help = "Maximum results PER KIND (1-1000; default: 20, or [limits].default_result_limit from config; matches the MCP brain_search schema). Notes and code symbols are capped separately, so a query matching both can return up to 2x this value; `returned_matches` always reports the true total"
         )]
         limit: Option<usize>,
         #[arg(long, help = "Output as JSON")]
@@ -19301,6 +19344,21 @@ mod cli_bounds_tests {
                         &["0"],
                         &["1", "20"],
                     ),
+                    // nw-108: the FLOAT ranges were the gap. Every integer
+                    // range above was already enforced by clap, but
+                    // `--confidence 5.0` and `--min-score 9.9` parsed happily
+                    // and returned an empty result at exit 0 — indistinguishable
+                    // from "nothing depends on this symbol".
+                    (
+                        &["nestweaver", "impact", "sym", "--confidence"],
+                        &["-0.1", "1.1", "5.0", "nan", "abc"],
+                        &["0", "0.0", "0.5", "1", "1.0"],
+                    ),
+                    (
+                        &["nestweaver", "impact", "sym", "--min-score"],
+                        &["-0.1", "1.1", "9.9", "inf", "abc"],
+                        &["0", "0.0", "0.1", "1", "1.0"],
+                    ),
                 ];
                 for (prefix, bad, good) in cases {
                     for v in *bad {
@@ -19315,6 +19373,42 @@ mod cli_bounds_tests {
                         let mut argv = prefix.to_vec();
                         argv.push(v);
                         assert!(Cli::try_parse_from(&argv).is_ok(), "{argv:?} must parse");
+                    }
+                }
+            })
+            .expect("spawn")
+            .join()
+            .expect("join");
+    }
+
+    /// nw-108: `--kinds` documents a closed set but silently dropped unknown
+    /// tokens, so `--kinds Bogus` returned zero matches at exit 0 and a typo
+    /// looked exactly like a real empty result. Case-insensitive matching is
+    /// preserved — only unknown values are now rejected.
+    #[test]
+    fn kinds_flag_rejects_values_outside_the_documented_set() {
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                for prefix in [
+                    ["nestweaver", "count-patterns", "pat", "--kinds"],
+                    ["nestweaver", "regex-search", "pat", "--kinds"],
+                ] {
+                    for bad in ["Bogus", "Sections", "note,Bogus", ""] {
+                        let mut argv = prefix.to_vec();
+                        argv.push(bad);
+                        assert!(
+                            Cli::try_parse_from(&argv).is_err(),
+                            "{argv:?} must be rejected — a typo must not read as an empty result"
+                        );
+                    }
+                    for good in ["Section", "note", "SYMBOL", "Note,Symbol"] {
+                        let mut argv = prefix.to_vec();
+                        argv.push(good);
+                        assert!(
+                            Cli::try_parse_from(&argv).is_ok(),
+                            "{argv:?} must parse — matching stays case-insensitive"
+                        );
                     }
                 }
             })


### PR DESCRIPTION
Three CLI contract gaps — **nw-101** plus **nw-108 (2)** and **(3)**. The handover
grouped these as papercuts to batch; that grouping holds (nw-104 does not — see below).

## nw-101 — `--limit` is per-kind, not a total

`brain search useState --limit 3` returns **6** rows (3 notes + 3 symbols);
`--limit 6` returns **9**.

The report proposed capping the merged result set. **That would have caused a
regression** — the code documents why:

> A merged cap would evict every symbol whenever ≥ `limit` notes match because
> symbols carry a fixed 0.5 score while BM25 notes score 15+.

So the per-kind cap is deliberate and correct; the **documented contract** is what's
wrong. The MCP tool description already said "limit is applied per-kind", while the
`limit` property a caller actually sets said "Maximum results to return", and the CLI
help said "Maximum results" unqualified. Both now state the per-kind semantics, the
up-to-2x consequence, and point at `returned_matches`.

The deeper root cause — scores aren't comparable across kinds — is what makes a merged
cap impossible today. Worth its own item; not attempted here.

## nw-108 (2) — float ranges unenforced

`--confidence` and `--min-score` are documented `[0.0-1.0]`. `5.0` and `9.9` parsed
happily and returned an empty result at **exit 0** — indistinguishable from "nothing
depends on this symbol". All 9 integer ranges were already enforced by clap; only the
floats were unguarded.

## nw-108 (3) — `--kinds` enum unvalidated

`--kinds Bogus` returned 0 matches at exit 0, so a typo looked like a real empty
result. Now rejected; case-insensitive matching preserved.

## Verification

The float cases extend the existing `numeric_flags_enforce_mcp_schema_bounds` table —
which covered 9 integer ranges and was blind to floats, exactly the gap reported.
Both new tests were observed failing against a checkout without the validators and
passing with them.

Against the real database:

```
--confidence 5.0  -> exit 2  must be in 0.0..=1.0
--min-score 9.9   -> exit 2  must be in 0.0..=1.0
--confidence 0.8  -> exit 0  Impact of 'analyze_blast_radius' (37 nodes)
--kinds Bogus     -> exit 2  must be one of Section, Note, Symbol
--kinds note,SYMBOL -> exit 0
```

98 bin + 132 MCP tests pass; clippy `-D warnings` and fmt clean.

## Not addressed

- **nw-108 (1)** `--json` is a no-op on `dead-code` / `investigate` (always JSON)
- **nw-108 (4)** error quality splits across ~12 commands on a missing DB

nw-108 stays open.