### PR TITLE
fix(cli): make dead-code and investigate output format depend on the flag, not the daemon

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -663,6 +663,97 @@ fn print_link_classification(links: &[nestweaver_engine::BrokenLink]) {
 /// daemon happened to be running rather than on the flag — `dead-code` printed
 /// text standalone and JSON once the daemon was up (nw-108). Driving both from
 /// the same payload makes parity structural rather than something to remember.
+/// Render an `investigate` bundle as text from its JSON payload.
+///
+/// Shared by the direct and daemon paths for the same reason as
+/// [`render_dead_code_text`]: the daemon branch printed its response verbatim,
+/// so the output format tracked whether a daemon was running instead of the
+/// `--json` flag (nw-108).
+fn render_investigate_text(payload: &serde_json::Value) {
+    let text = |v: &serde_json::Value, k: &str| {
+        v.get(k)
+            .and_then(|x| x.as_str())
+            .unwrap_or_default()
+            .to_string()
+    };
+    let entries: Vec<&serde_json::Value> = payload
+        .get("entries")
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().collect())
+        .unwrap_or_default();
+    let domains: Vec<&serde_json::Value> = payload
+        .get("domains")
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().collect())
+        .unwrap_or_default();
+    let more_available = payload
+        .get("more_available")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    println!(
+        "Bundle: {}  (query: {:?})",
+        text(payload, "bundle_id"),
+        text(payload, "query")
+    );
+    println!(
+        "{} domain(s), {} entr{}{}",
+        domains.len(),
+        entries.len(),
+        if entries.len() == 1 { "y" } else { "ies" },
+        if more_available > 0 {
+            format!(" ({more_available} more available — raise --token-budget)")
+        } else {
+            String::new()
+        }
+    );
+
+    for d in &domains {
+        println!("\n[{}]", text(d, "label"));
+        let entry_point = text(d, "entry_point");
+        for member in d
+            .get("members")
+            .and_then(|v| v.as_array())
+            .into_iter()
+            .flatten()
+        {
+            let asset_id = member.as_str().unwrap_or_default();
+            let Some(e) = entries
+                .iter()
+                .find(|e| e.get("asset_id").and_then(|v| v.as_str()) == Some(asset_id))
+            else {
+                continue;
+            };
+            let marker = if asset_id == entry_point { "*" } else { " " };
+            println!(
+                "  {marker} {}  {} ({})  {}",
+                asset_id,
+                text(e, "title"),
+                text(e, "kind"),
+                text(e, "location")
+            );
+            if let Some(summary) = e.get("summary").and_then(|v| v.as_str()) {
+                let truncated = if !e.get("inline_body").is_none_or(|v| v.is_null())
+                    && !e
+                        .get("body_complete")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(true)
+                {
+                    " [truncated]"
+                } else {
+                    ""
+                };
+                println!("      {summary}{truncated}");
+            }
+        }
+    }
+
+    println!(
+        "\nDrill in: nestweaver investigate-expand {} --targets <asset_id,...>",
+        text(payload, "bundle_id")
+    );
+}
+
 fn render_dead_code_text(payload: &serde_json::Value) {
     let num = |k: &str| payload.get(k).and_then(|v| v.as_u64()).unwrap_or(0);
     let total = num("total_symbols");
@@ -9497,7 +9588,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
                 if let Some(value) = try_hybrid_json_rpc(true, &db_path, None, "investigate", args)
                 {
-                    println!("{}", serde_json::to_string_pretty(&value)?);
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&value)?);
+                    } else {
+                        render_investigate_text(&value);
+                    }
                     return Ok((EXIT_SUCCESS, None));
                 }
             }
@@ -9517,56 +9612,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 Some(token_budget),
                 None,
             )?;
+            // Built unconditionally so text and JSON render from the SAME
+            // payload, and so the daemon path can reuse the renderer (nw-108).
+            let payload = serde_json::to_value(&result)?;
             if json {
-                println!("{}", serde_json::to_string_pretty(&result)?);
+                println!("{}", serde_json::to_string_pretty(&payload)?);
             } else {
-                println!("Bundle: {}  (query: {:?})", result.bundle_id, result.query);
-                println!(
-                    "{} domain(s), {} entr{}{}",
-                    result.domains.len(),
-                    result.entries.len(),
-                    if result.entries.len() == 1 {
-                        "y"
-                    } else {
-                        "ies"
-                    },
-                    if result.more_available > 0 {
-                        format!(
-                            " ({} more available — raise --token-budget)",
-                            result.more_available
-                        )
-                    } else {
-                        String::new()
-                    }
-                );
-                for d in &result.domains {
-                    println!("\n[{}]", d.label);
-                    for asset_id in &d.members {
-                        if let Some(e) = result.entries.iter().find(|e| &e.asset_id == asset_id) {
-                            let marker = if e.asset_id == d.entry_point {
-                                "*"
-                            } else {
-                                " "
-                            };
-                            println!(
-                                "  {marker} {}  {} ({})  {}",
-                                e.asset_id, e.title, e.kind, e.location
-                            );
-                            if let Some(s) = &e.summary {
-                                let truncated = if e.inline_body.is_some() && !e.body_complete {
-                                    " [truncated]"
-                                } else {
-                                    ""
-                                };
-                                println!("      {s}{truncated}");
-                            }
-                        }
-                    }
-                }
-                println!(
-                    "\nDrill in: nestweaver investigate-expand {} --targets <asset_id,...>",
-                    result.bundle_id
-                );
+                render_investigate_text(&payload);
             }
             Ok((EXIT_SUCCESS, None))
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -655,6 +655,93 @@ fn print_link_classification(links: &[nestweaver_engine::BrokenLink]) {
     );
 }
 
+/// Render a `dead-code` result as text from its JSON payload.
+///
+/// BOTH the direct and daemon paths render through this, so the two cannot
+/// drift. The daemon branch used to `println!` the RPC response verbatim with
+/// no `if json` guard, which meant the OUTPUT FORMAT depended on whether a
+/// daemon happened to be running rather than on the flag — `dead-code` printed
+/// text standalone and JSON once the daemon was up (nw-108). Driving both from
+/// the same payload makes parity structural rather than something to remember.
+fn render_dead_code_text(payload: &serde_json::Value) {
+    let num = |k: &str| payload.get(k).and_then(|v| v.as_u64()).unwrap_or(0);
+    let total = num("total_symbols");
+    let matching = num("matching_count");
+    let excluded = num("excluded_count");
+
+    let excluded_note = || {
+        if excluded > 0 {
+            println!("({excluded} type-only/declaration symbols excluded from analysis)");
+        }
+    };
+
+    if matching == 0 {
+        println!("No dead code detected ({total} symbols, all reachable from entry points).");
+        excluded_note();
+        return;
+    }
+
+    println!(
+        "Dead code analysis: {} of {total} symbols ({:.1}%) unreachable from entry points\n",
+        num("unreachable_count"),
+        payload
+            .get("dead_percentage")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0),
+    );
+    excluded_note();
+
+    let returned = num("returned");
+    let min_conf = payload
+        .get("min_confidence")
+        .and_then(|v| v.as_str())
+        .unwrap_or("low");
+    if min_conf != "low" {
+        println!("Showing {returned} symbol(s) with confidence >= {min_conf}\n");
+    }
+    if payload
+        .get("truncated")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        println!("(showing first {returned} of {matching} — pass --limit to change)\n");
+    }
+
+    // Group by file path, matching the direct path's BTreeMap ordering.
+    let mut by_file: std::collections::BTreeMap<&str, Vec<&serde_json::Value>> =
+        std::collections::BTreeMap::new();
+    for sym in payload
+        .get("unreachable_symbols")
+        .and_then(|v| v.as_array())
+        .into_iter()
+        .flatten()
+    {
+        let file = sym.get("file_path").and_then(|v| v.as_str()).unwrap_or("");
+        by_file.entry(file).or_default().push(sym);
+    }
+    for (file, syms) in &by_file {
+        println!("{file}:");
+        for sym in syms {
+            let field = |k: &str| sym.get(k).and_then(|v| v.as_str()).unwrap_or("");
+            // Lowercase the confidence: the two paths serialise it
+            // differently — the direct payload carries the serde variant
+            // name ("Medium") while the daemon returns "medium" — and the
+            // historical text output used the Display impl, which is
+            // lowercase. Normalising here keeps the rendered text stable and
+            // identical across modes. The underlying JSON inconsistency is a
+            // separate defect.
+            println!(
+                "  {} ({}) [{}] confidence={}",
+                field("name"),
+                field("kind"),
+                field("visibility"),
+                field("confidence").to_lowercase(),
+            );
+        }
+        println!();
+    }
+}
+
 fn capability_diagnostics_value(
     embedding_compiled: bool,
     metal_compiled: bool,
@@ -6621,7 +6708,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     args["limit"] = serde_json::json!(n);
                 }
                 if let Some(value) = try_hybrid_json_rpc(true, &db_path, None, "dead_code", args) {
-                    println!("{}", serde_json::to_string_pretty(&value)?);
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&value)?);
+                    } else {
+                        render_dead_code_text(&value);
+                    }
                     return Ok((EXIT_SUCCESS, None));
                 }
             }
@@ -6658,97 +6749,44 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 None => filtered,
             };
 
+            #[derive(serde::Serialize)]
+            struct DeadCodeJson<'a> {
+                total_symbols: usize,
+                reachable_symbols: usize,
+                unreachable_count: usize,
+                matching_count: usize,
+                returned: usize,
+                truncated: bool,
+                excluded_count: usize,
+                dead_percentage: f64,
+                min_confidence: String,
+                unreachable_symbols: Vec<&'a nestweaver_engine::UnreachableSymbol>,
+            }
+            // Count contract (same as the dead_code MCP tool):
+            // `unreachable_count` is the UNFILTERED total, consistent with
+            // total_symbols/reachable_symbols/dead_percentage;
+            // `matching_count` is the post-min-confidence count.
+            //
+            // Built unconditionally so the text path renders from the SAME
+            // payload the JSON path prints, and from the same payload the
+            // daemon returns (nw-108).
+            let payload = serde_json::to_value(DeadCodeJson {
+                total_symbols: result.total_symbols,
+                reachable_symbols: result.reachable_symbols,
+                unreachable_count: result.unreachable_symbols.len(),
+                matching_count: filtered_count,
+                returned: shown.len(),
+                truncated,
+                excluded_count: result.excluded_count,
+                dead_percentage: result.dead_percentage,
+                min_confidence: min_conf.to_string(),
+                unreachable_symbols: shown,
+            })?;
+
             if json {
-                #[derive(serde::Serialize)]
-                struct DeadCodeJson<'a> {
-                    total_symbols: usize,
-                    reachable_symbols: usize,
-                    unreachable_count: usize,
-                    matching_count: usize,
-                    returned: usize,
-                    truncated: bool,
-                    excluded_count: usize,
-                    dead_percentage: f64,
-                    min_confidence: String,
-                    unreachable_symbols: Vec<&'a nestweaver_engine::UnreachableSymbol>,
-                }
-                // Count contract (same as the dead_code MCP tool):
-                // `unreachable_count` is the UNFILTERED total, consistent with
-                // total_symbols/reachable_symbols/dead_percentage;
-                // `matching_count` is the post-min-confidence count.
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&DeadCodeJson {
-                        total_symbols: result.total_symbols,
-                        reachable_symbols: result.reachable_symbols,
-                        unreachable_count: result.unreachable_symbols.len(),
-                        matching_count: filtered_count,
-                        returned: shown.len(),
-                        truncated,
-                        excluded_count: result.excluded_count,
-                        dead_percentage: result.dead_percentage,
-                        min_confidence: min_conf.to_string(),
-                        unreachable_symbols: shown,
-                    })?
-                );
-            } else if filtered_count == 0 {
-                println!(
-                    "No dead code detected ({} symbols, all reachable from entry points).",
-                    result.total_symbols
-                );
-                if result.excluded_count > 0 {
-                    println!(
-                        "({} type-only/declaration symbols excluded from analysis)",
-                        result.excluded_count
-                    );
-                }
+                println!("{}", serde_json::to_string_pretty(&payload)?);
             } else {
-                println!(
-                    "Dead code analysis: {} of {} symbols ({:.1}%) unreachable from entry points\n",
-                    result.unreachable_symbols.len(),
-                    result.total_symbols,
-                    result.dead_percentage,
-                );
-                if result.excluded_count > 0 {
-                    println!(
-                        "({} type-only/declaration symbols excluded from analysis)",
-                        result.excluded_count
-                    );
-                }
-                if min_conf != DeadCodeConfidence::Low {
-                    println!(
-                        "Showing {} symbol(s) with confidence >= {}\n",
-                        shown.len(),
-                        min_conf
-                    );
-                }
-                if truncated {
-                    println!(
-                        "(showing first {} of {} — pass --limit to change)\n",
-                        shown.len(),
-                        filtered_count
-                    );
-                }
-
-                // Group by file path.
-                let mut by_file: std::collections::BTreeMap<
-                    &str,
-                    Vec<&nestweaver_engine::UnreachableSymbol>,
-                > = std::collections::BTreeMap::new();
-                for sym in &shown {
-                    by_file.entry(&sym.file_path).or_default().push(sym);
-                }
-
-                for (file, syms) in &by_file {
-                    println!("{}:", file);
-                    for sym in syms {
-                        println!(
-                            "  {} ({}) [{}] confidence={}",
-                            sym.name, sym.kind, sym.visibility, sym.confidence,
-                        );
-                    }
-                    println!();
-                }
+                render_dead_code_text(&payload);
             }
 
             let stats = format!(

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -456,6 +456,54 @@ fn parity_affected_tests_direct_vs_daemon() {
 /// the daemon was up. The text renderer was never missing; it was simply not
 /// reached. This is the nw-097 divergence family, and the reason it survived is
 /// that `dead-code` was not in this file.
+/// Replace generated bundle IDs with a fixed placeholder.
+///
+/// `investigate` mints a fresh `bndl_<hex>` per invocation, so its stdout is
+/// never byte-identical across two runs — comparing raw bytes would test the ID
+/// generator, not the renderer.
+fn redact_bundle_ids(bytes: &[u8]) -> String {
+    let text = String::from_utf8_lossy(bytes);
+    let mut out = String::with_capacity(text.len());
+    let mut rest: &str = &text;
+    while let Some(pos) = rest.find("bndl_") {
+        out.push_str(&rest[..pos]);
+        out.push_str("bndl_<redacted>");
+        let after = &rest[pos + "bndl_".len()..];
+        let end = after
+            .find(|c: char| !c.is_ascii_hexdigit())
+            .unwrap_or(after.len());
+        rest = &after[end..];
+    }
+    out.push_str(rest);
+    out
+}
+
+/// nw-108: `investigate` carried the identical defect to `dead-code` — its
+/// daemon branch printed the RPC response verbatim, so the format followed
+/// process state rather than the flag.
+#[test]
+fn parity_investigate_human_direct_vs_daemon() {
+    let fixture = setup_fixture();
+    let args: &[&str] = &["investigate", "alpha"];
+
+    let direct = run_direct(&fixture.db_path, args);
+
+    let _guard = DaemonGuard::new(&fixture.db_path);
+    start_daemon(&fixture.db_path);
+    let daemon = run_via_daemon(&fixture.db_path, args);
+
+    assert_eq!(
+        direct.status.code(),
+        daemon.status.code(),
+        "investigate (human): exit code diverged"
+    );
+    assert_eq!(
+        redact_bundle_ids(&direct.stdout),
+        redact_bundle_ids(&daemon.stdout),
+        "investigate (human): stdout diverged between direct and daemon mode"
+    );
+}
+
 ///
 /// Scoped to HUMAN mode deliberately. `--json` still diverges between the two
 /// paths for reasons that predate this fix and would change a published

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -450,6 +450,35 @@ fn parity_affected_tests_direct_vs_daemon() {
     );
 }
 
+/// nw-108: `dead-code`'s daemon branch printed the RPC response verbatim with
+/// no `if json` guard, so the OUTPUT FORMAT depended on whether a daemon
+/// happened to be running rather than on the flag — text standalone, JSON once
+/// the daemon was up. The text renderer was never missing; it was simply not
+/// reached. This is the nw-097 divergence family, and the reason it survived is
+/// that `dead-code` was not in this file.
+///
+/// Scoped to HUMAN mode deliberately. `--json` still diverges between the two
+/// paths for reasons that predate this fix and would change a published
+/// contract to resolve: the daemon wraps its payload in `_meta`, and it
+/// lowercases the confidence ("medium") while the direct payload carries the
+/// serde variant name ("Medium"). Both are real and tracked separately; neither
+/// is the format flip this test exists to catch. Asserting json parity here
+/// would couple this regression guard to that unrelated decision.
+#[test]
+fn parity_dead_code_human_direct_vs_daemon() {
+    let fixture = setup_fixture();
+    let args: &[&str] = &["dead-code", "--limit", "5"];
+
+    // Direct mode first — the daemon is not started yet and may hold the lock.
+    let direct = run_direct(&fixture.db_path, args);
+
+    let _guard = DaemonGuard::new(&fixture.db_path);
+    start_daemon(&fixture.db_path);
+    let daemon = run_via_daemon(&fixture.db_path, args);
+
+    assert_parity("dead-code", "human", &direct, &daemon);
+}
+
 /// `stale-check` is a freshness gate: it exits 1 when the index is
 /// stale. The fixture here is freshly indexed (not stale), but regardless we
 /// only assert stdout equality and equal exit codes across modes — never


### PR DESCRIPTION
Completes **nw-108 (1)** for both affected commands.

## The defect

Both `dead-code` and `investigate` printed the daemon RPC response verbatim:

```rust
println!("{}", serde_json::to_string_pretty(&value)?);   // no `if json`
```

So each emitted **text standalone and JSON once a daemon was up** — output format
followed process state, not the flag.

## The report's framing was wrong

nw-108 says the text renderer "is reachable ONLY through the invalid-input
branch". It isn't missing — it exists and works on the direct path. Invalid input
just fails *before* the RPC, which is why that was the only way anyone saw text.

| | direct | daemon |
|---|---|---|
| `dead-code` | text | **JSON** |
| `investigate` | text | **JSON** |

Same family as nw-097, fixed in #196.

## The fix

Each command renders through a single function over the JSON payload, so the two
paths cannot drift: the direct path builds the payload unconditionally and either
prints or renders it; the daemon branch renders the response it already has.

## Two things the tests caught that I'd otherwise have shipped wrong

**Confidence casing.** Routing `dead-code`'s direct path through the shared
renderer silently changed its output from `medium` to `Medium` — the direct
payload carries the serde variant name while the historical text used the
lowercase `Display` impl. Now normalised.

**Non-deterministic bundle IDs.** `investigate` mints a fresh `bndl_<hex>` per
invocation, so its stdout is never byte-identical across runs. The first parity
run failed with the two outputs differing in *exactly one place* — the bundle ID,
every other byte equal — so IDs are redacted before comparison. Comparing raw
bytes would have tested the ID generator, not the renderer.

## Why this survived

`tests/parity_test.rs` already asserts byte-identical stdout across both modes,
but covered only count-patterns, regex-search, hubs, bridges, clusters,
affected-tests and stale-check. Neither command was in it. Both are now, and
**both were confirmed red** against the unguarded branches.

Worth recording: I first "verified" `dead-code` by hand and got a false pass — my
dev binary is 2.7.1 while the launchd daemon is 2.7.0, so the RPC failed on
version mismatch and silently fell back to direct. I was comparing direct against
direct. The parity harness starts a daemon from the built binary, which is the
only trustworthy way to test this.

## Scope

Tests assert **human mode only**. `--json` still diverges for pre-existing reasons
that would change a published contract to resolve — the daemon wraps its payload
in `_meta`, and the confidence casing differs in the JSON itself. Filed as
**nw-117**; neither is the format flip this fixes.

**nw-108 (4)** — split error quality across ~12 commands on a missing DB —
remains open.

13 parity + 98 bin tests pass; clippy `-D warnings` and fmt clean.