### PR TITLE
fix(store): conserve the wikilink graph across an instance merge

### DIFF
--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -251,6 +251,10 @@ impl RepoDeletionSnapshot {
     }
 }
 
+/// One recorded unresolved wikilink:
+/// `(uid, source_note_uid, source_path, source_title, wikilink_text)`.
+pub type UnresolvedWikilinkRecord = (String, String, String, String, String);
+
 /// A vault whose notes were discarded during a collision in instance merge.
 /// When two instances have vaults at the same root_path, the vault with
 /// fewer notes loses and its notes are cascade-deleted.
@@ -1969,7 +1973,7 @@ impl GraphStore {
     /// `(uid, source_note_uid, source_path, source_title, wikilink_text)`.
     pub fn batch_insert_unresolved_wikilinks(
         &self,
-        records: &[(String, String, String, String, String)],
+        records: &[UnresolvedWikilinkRecord],
     ) -> Result<(), StoreError> {
         if records.is_empty() {
             return Ok(());
@@ -1978,6 +1982,20 @@ impl GraphStore {
         // per statement otherwise, which is what made the per-row insert take
         // ~ms/link. Prepared statements are reused across the batch.
         let conn = self.begin_transaction()?;
+        Self::batch_insert_unresolved_wikilinks_on(&conn, records)?;
+        self.commit_transaction(&conn)?;
+        Ok(())
+    }
+
+    /// Insert unresolved wikilinks on a caller-provided connection, so a larger
+    /// transaction (e.g. `reparent_vault`) can batch them with its other work.
+    pub fn batch_insert_unresolved_wikilinks_on(
+        conn: &lbug::Connection<'_>,
+        records: &[UnresolvedWikilinkRecord],
+    ) -> Result<(), StoreError> {
+        if records.is_empty() {
+            return Ok(());
+        }
         let mut del = conn
             .prepare("MATCH (u:UnresolvedWikilink {uid: $uid}) DETACH DELETE u")
             .map_err(|e| StoreError::Query(format!("prepare delete unresolved: {e}")))?;
@@ -2002,7 +2020,6 @@ impl GraphStore {
             )
             .map_err(|e| StoreError::Query(format!("create unresolved: {e}")))?;
         }
-        self.commit_transaction(&conn)?;
         Ok(())
     }
 
@@ -4949,6 +4966,86 @@ impl GraphStore {
     ///
     /// Uses the LadybugDB-compatible DETACH DELETE + re-CREATE pattern
     /// since SET is not supported for property updates.
+    /// Read wikilink edges that ORIGINATE in `vault_uid`, as
+    /// `(section_uid, target_uid, confidence, display)`.
+    ///
+    /// `rel` is the relationship name and `dst` the destination pattern, so one
+    /// helper serves both WIKILINK_TO_NOTE and WIKILINK_TO_HEADING. Best-effort:
+    /// a missing table yields an empty vec rather than an error, matching how
+    /// the cascade treats these tables.
+    fn wikilink_edges_for_vault(
+        &self,
+        vault_uid: &str,
+        rel: &str,
+        dst: &str,
+    ) -> Result<Vec<(String, String, f32, String)>, StoreError> {
+        let conn = self.conn()?;
+        let q = format!(
+            "MATCH (n:Note {{vault_uid: $vid}})-[:NOTE_HAS_SECTION]->(s:Section)-[r:{rel}]->({dst}) \
+             RETURN s.uid, dst.uid, r.confidence, r.display"
+        );
+        let mut stmt = match conn.prepare(&q) {
+            Ok(stmt) => stmt,
+            Err(e) => {
+                tracing::trace!("wikilink_edges_for_vault: prepare {rel} skipped: {e}");
+                return Ok(Vec::new());
+            }
+        };
+        let result = match conn.execute(
+            &mut stmt,
+            vec![("vid", lbug::Value::String(vault_uid.to_string()))],
+        ) {
+            Ok(result) => result,
+            Err(e) => {
+                tracing::trace!("wikilink_edges_for_vault: execute {rel} skipped: {e}");
+                return Ok(Vec::new());
+            }
+        };
+        Ok(result
+            .filter_map(|row| {
+                Some((
+                    crate::read::extract_string(&row, 0).ok()?,
+                    crate::read::extract_string(&row, 1).ok()?,
+                    row.get(2)
+                        .and_then(|v| match v {
+                            lbug::Value::Double(d) => Some(*d as f32),
+                            lbug::Value::Float(f) => Some(*f),
+                            _ => None,
+                        })
+                        .unwrap_or(0.0),
+                    crate::read::extract_string(&row, 3).unwrap_or_default(),
+                ))
+            })
+            .collect())
+    }
+
+    /// Read every UnresolvedWikilink row as
+    /// `(uid, source_note_uid, source_path, source_title, wikilink_text)`.
+    /// Callers filter by source note. Best-effort on a missing table.
+    fn all_unresolved_wikilinks(&self) -> Result<Vec<UnresolvedWikilinkRecord>, StoreError> {
+        let conn = self.conn()?;
+        let q = "MATCH (u:UnresolvedWikilink) \
+                 RETURN u.uid, u.source_note_uid, u.source_path, u.source_title, u.wikilink_text";
+        let result = match conn.query(q) {
+            Ok(result) => result,
+            Err(e) => {
+                tracing::trace!("all_unresolved_wikilinks skipped: {e}");
+                return Ok(Vec::new());
+            }
+        };
+        Ok(result
+            .filter_map(|row| {
+                Some((
+                    crate::read::extract_string(&row, 0).ok()?,
+                    crate::read::extract_string(&row, 1).ok()?,
+                    crate::read::extract_string(&row, 2).unwrap_or_default(),
+                    crate::read::extract_string(&row, 3).unwrap_or_default(),
+                    crate::read::extract_string(&row, 4).unwrap_or_default(),
+                ))
+            })
+            .collect())
+    }
+
     pub fn reparent_vault(
         &self,
         old_vault_uid: &str,
@@ -5051,6 +5148,36 @@ impl GraphStore {
                     .map(|huid| (huid.as_str(), s.uid.as_str()))
             })
             .collect();
+        // Capture the wikilink graph before the cascade destroys it (nw-112).
+        //
+        // Every other child and edge above is captured and re-inserted, but
+        // wikilinks were not — so `instance merge` reparented a vault and
+        // silently wiped the note-to-note link graph, 2,067 edges to 0 on the
+        // real brain, while reporting success. Backlinks, broken-link detection
+        // and the graph view all went empty with no warning.
+        //
+        // Edges are keyed on section/note/heading UIDs, none of which change
+        // here, so restoring them verbatim is sufficient. A link whose TARGET
+        // lives in another vault is preserved too: that node is untouched by
+        // this cascade.
+        let wikilink_to_note: Vec<(String, String, f32, String)> =
+            self.wikilink_edges_for_vault(old_vault_uid, "WIKILINK_TO_NOTE", "dst:Note")?;
+        let wikilink_to_heading: Vec<(String, String, f32, String)> =
+            self.wikilink_edges_for_vault(old_vault_uid, "WIKILINK_TO_HEADING", "dst:Heading")?;
+
+        // `delete_vault_cascade` removes UnresolvedWikilink rows whose source
+        // note belongs to this vault (its step 5), so they need restoring as
+        // well or `broken-links` comes back empty after a merge.
+        // UIDs are unchanged by reparenting (only vault_uid moves), so the
+        // reparented list identifies the same notes.
+        let note_uid_set: std::collections::HashSet<&str> =
+            reparented_notes.iter().map(|n| n.uid.as_str()).collect();
+        let unresolved: Vec<UnresolvedWikilinkRecord> = self
+            .all_unresolved_wikilinks()?
+            .into_iter()
+            .filter(|(_, source_note_uid, _, _, _)| note_uid_set.contains(source_note_uid.as_str()))
+            .collect();
+
         let reparented_tags: Vec<Tag> = tags
             .into_iter()
             .map(|t| Tag {
@@ -5107,6 +5234,28 @@ impl GraphStore {
         if !st_edges.is_empty() {
             Self::batch_insert_section_tag_edges_on(conn, &st_edges)?;
         }
+
+        // 9. Restore the wikilink graph. Runs last: the edges reference
+        //    sections, notes and headings, all of which are back in place by
+        //    now (nw-112).
+        let wl_note: Vec<(&str, &str, f32, &str)> = wikilink_to_note
+            .iter()
+            .map(|(src, dst, conf, disp)| (src.as_str(), dst.as_str(), *conf, disp.as_str()))
+            .collect();
+        if !wl_note.is_empty() {
+            Self::batch_insert_wikilink_to_note_edges_on(conn, &wl_note)?;
+        }
+        let wl_heading: Vec<(&str, &str, f32, &str)> = wikilink_to_heading
+            .iter()
+            .map(|(src, dst, conf, disp)| (src.as_str(), dst.as_str(), *conf, disp.as_str()))
+            .collect();
+        if !wl_heading.is_empty() {
+            Self::batch_insert_wikilink_to_heading_edges_on(conn, &wl_heading)?;
+        }
+        if !unresolved.is_empty() {
+            Self::batch_insert_unresolved_wikilinks_on(conn, &unresolved)?;
+        }
+
         self.commit_transaction(&txn)?;
 
         Ok(result)
@@ -6402,6 +6551,92 @@ mod tests {
                 name: "one".to_string(),
             })
             .unwrap();
+    }
+
+    /// nw-112: a merge must CONSERVE the wikilink graph.
+    ///
+    /// `reparent_vault` captures notes, headings, sections, tags and their edges
+    /// before the cascade delete, then re-inserts them — but it never captured
+    /// wikilink edges, so the cascade destroyed them and nothing put them back.
+    /// On the real brain this took wikilinks 2,067 -> 0 while the command
+    /// printed success and exited 0: backlinks, broken-link detection and the
+    /// graph view all went silently empty.
+    #[test]
+    fn merge_conserves_the_wikilink_graph() {
+        let store = GraphStore::in_memory().expect("store");
+
+        let vault_uid = "vlt:old:aaaa";
+        store
+            .insert_vault(&Vault {
+                uid: vault_uid.to_string(),
+                name: "brain".to_string(),
+                root_path: "/brain".to_string(),
+                instance_id: "old".to_string(),
+            })
+            .unwrap();
+
+        // Two notes, each with one section, and a wikilink from A's section to B.
+        for (n, title) in [("a", "Alpha"), ("b", "Beta")] {
+            store
+                .insert_note(&Note {
+                    uid: format!("note:{vault_uid}:{n}"),
+                    vault_uid: vault_uid.to_string(),
+                    file_path: format!("{n}.md"),
+                    title: title.to_string(),
+                    note_kind: nestweaver_schema::NoteKind::General,
+                    word_count: 1,
+                    content_hash: n.to_string(),
+                    frontmatter: None,
+                    created_at: None,
+                    modified_at: None,
+                    pagerank_score: None,
+                    embedding: None,
+                })
+                .unwrap();
+            store
+                .insert_section(&Section {
+                    uid: format!("sec:{vault_uid}:{n}"),
+                    note_uid: format!("note:{vault_uid}:{n}"),
+                    heading_uid: None,
+                    start_line: 1,
+                    end_line: 2,
+                    text_hash: n.to_string(),
+                    text_content: format!("body {n}"),
+                    word_count: 2,
+                    pagerank_score: None,
+                })
+                .unwrap();
+            let note_uid = format!("note:{vault_uid}:{n}");
+            let sec_uid = format!("sec:{vault_uid}:{n}");
+            store
+                .batch_insert_note_section_edges(&[(note_uid.as_str(), sec_uid.as_str())])
+                .unwrap();
+            store
+                .batch_insert_vault_note_edges(&[(vault_uid, note_uid.as_str())])
+                .unwrap();
+        }
+
+        let src_sec = format!("sec:{vault_uid}:a");
+        let dst_note = format!("note:{vault_uid}:b");
+        store
+            .batch_insert_wikilink_to_note_edges(&[(
+                src_sec.as_str(),
+                dst_note.as_str(),
+                1.0f32,
+                "Beta",
+            )])
+            .unwrap();
+
+        let before = store.count_wikilink_edges().unwrap();
+        assert_eq!(before, 1, "fixture must start with a wikilink");
+
+        store.merge_instance_ids("old", "new").unwrap();
+
+        let after = store.count_wikilink_edges().unwrap();
+        assert_eq!(
+            after, before,
+            "merge destroyed the wikilink graph: {before} -> {after}"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16345,8 +16345,11 @@ fn run_instance(command: InstanceCommands) -> anyhow::Result<i32> {
                     "Merged '{from}' -> '{to}': {} vault(s), {} repo(s), {} project(s)",
                     result.vaults_reparented, result.repos_reparented, result.projects_reparented
                 );
-                for d in &result.discarded_vaults {
-                    eprintln!("Note: {d}");
+                if !result.discarded_vaults.is_empty() {
+                    eprintln!(
+                        "{}",
+                        merge_discarded_vault_guidance(&result.discarded_vaults, &to)
+                    );
                 }
                 if !result.repos_needing_reindex.is_empty() {
                     eprintln!("{}", merge_reindex_guidance(&result.repos_needing_reindex));
@@ -16387,6 +16390,30 @@ fn run_instance(command: InstanceCommands) -> anyhow::Result<i32> {
     }
 }
 
+/// Guidance for vaults whose notes were discarded by a merge collision.
+///
+/// When two instances hold a vault at the same root, the one with fewer notes
+/// loses and its notes are dropped. That was reported as a bare
+/// `Note: <root> (N notes discarded)` with no remedy — a line that states data
+/// loss and stops. Notes are re-derivable from the files on disk, so say how
+/// (nw-112).
+fn merge_discarded_vault_guidance(discarded: &[String], to_instance: &str) -> String {
+    let mut guidance = String::from(
+        "\nNOTE: a vault collision discarded notes from the losing vault.\n\
+         Those notes are re-derivable from the files on disk — re-index each root \
+         below under the target instance to restore them:\n",
+    );
+    for entry in discarded {
+        guidance.push_str("  ");
+        guidance.push_str(entry);
+        guidance.push('\n');
+    }
+    guidance.push_str(&format!(
+        "  nestweaver brain refresh <root> --instance {to_instance}"
+    ));
+    guidance
+}
+
 fn merge_reindex_guidance(repos: &[String]) -> String {
     let mut guidance = String::from(
         "\nNOTE: source repo graph rows were removed during merge.\n\
@@ -16405,6 +16432,26 @@ fn merge_reindex_guidance(repos: &[String]) -> String {
 #[cfg(test)]
 mod merge_instance_guidance_tests {
     use super::*;
+
+    /// nw-112: a discarded-vault line must carry a remedy, not just announce
+    /// data loss. The notes are re-derivable from disk, so the guidance names
+    /// the refresh command and the target instance.
+    #[test]
+    fn discarded_vault_guidance_names_the_refresh_and_target_instance() {
+        let guidance = merge_discarded_vault_guidance(
+            &["/Users/me/brain (945 notes discarded)".to_string()],
+            "kory-brain",
+        );
+        assert!(guidance.contains("945 notes discarded"));
+        assert!(
+            guidance.contains("brain refresh"),
+            "must name the remedy: {guidance}"
+        );
+        assert!(
+            guidance.contains("--instance kory-brain"),
+            "must name the target instance so the refresh does not create a second vault: {guidance}"
+        );
+    }
 
     #[test]
     fn reindex_guidance_describes_removed_then_recreated_graph_rows() {


### PR DESCRIPTION
Fixes **nw-112** — the only open critical.

## The defect

`instance merge` reparented a vault and silently wiped the note-to-note link graph
— **2,067 edges to 0** on the real brain — while printing success and exiting 0.
Backlinks, broken-link detection and the Obsidian graph view all went empty with no
warning.

It's also the operation **`brain status` recommends** when it detects duplicate vault
roots. Following the product's own remediation advice destroyed the link graph.

## Root cause — not the one the report proposed

`reparent_vault` captures notes, headings, sections, tags and their edges before its
cascade delete, then re-inserts them. It **never captured wikilink edges at all**, so
the cascade destroyed them and nothing put them back.

The backlog entry blamed stale child UIDs as "the likely mechanism". They aren't:
notes, headings and sections all survive keyed on those *same unchanged UIDs*, which
is precisely why restoring the edges verbatim works. Rewriting UIDs would not have
recovered a single wikilink. It stays a cosmetic inconsistency — tracked, not fixed
here.

## Restores three things, not one

Determined by reading the cascade rather than assuming:

- `WIKILINK_TO_NOTE` edges
- `WIKILINK_TO_HEADING` edges
- **`UnresolvedWikilink` nodes** — the cascade deletes these too (its own step 5).
  Without them `broken-links` comes back empty after a merge even with the edges
  restored.

Cross-vault links survive as a side effect: the far node is untouched by this cascade.
Needed `batch_insert_unresolved_wikilinks_on` extracted so the restore joins the
existing transaction rather than opening its own inside it.

Adds the conservation test the entry asked for: **1 → 0 before, 1 → 1 after**.

## Also: a data-loss line with no remedy

A vault collision printed `Note: <root> (945 notes discarded)` and stopped. It now
names `brain refresh <root> --instance <to>`.

The `--instance` is spelled out deliberately — omitting it is **nw-098**, which forks
the vault. A remedy that triggers another known bug isn't a remedy.

## Verification

313 store + 100 bin + 42 daemon tests pass; workspace clippy `-D warnings` and fmt
clean.