### PR TITLE
fix(engine): resolve path-qualified wikilinks, and stop indexing external urls

### DIFF
--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -1570,14 +1570,35 @@ impl<'a> WikilinkLookup<'a> {
             return ResolveOutcome::Unresolved;
         }
 
-        // Priority 1: path match.
-        if key.contains('/')
-            && let Some(&uid) = self.by_path.get(&key)
-        {
-            return ResolveOutcome::Resolved(vec![ResolveCandidate {
-                note_uid: uid.to_string(),
-                confidence: 1.0,
-            }]);
+        // Priority 1: path match — vault-relative first, then relative to the
+        // SOURCE's folder.
+        //
+        // `by_path` is keyed on full vault-relative paths, so only the first
+        // form ever matched. But `[[plans/Phase B Execution Index]]` written in
+        // `Workspaces/Orbit/_Overview.md` is Obsidian's RELATIVE-path syntax and
+        // means `Workspaces/Orbit/plans/Phase B Execution Index.md`. Every
+        // path-qualified link in the vault therefore resolved to nothing — 45 of
+        // them, all reported at confidence 0.0 (nw-100).
+        //
+        // Both forms are exact, unambiguous single-key lookups, so both score
+        // 1.0 and priority ordering is preserved.
+        if key.contains('/') {
+            if let Some(&uid) = self.by_path.get(&key) {
+                return ResolveOutcome::Resolved(vec![ResolveCandidate {
+                    note_uid: uid.to_string(),
+                    confidence: 1.0,
+                }]);
+            }
+            if !source_folder.is_empty() {
+                // `by_path` keys are lowercased; `folder` is stored raw.
+                let scoped = format!("{}/{key}", source_folder.replace('\\', "/").to_lowercase());
+                if let Some(&uid) = self.by_path.get(&scoped) {
+                    return ResolveOutcome::Resolved(vec![ResolveCandidate {
+                        note_uid: uid.to_string(),
+                        confidence: 1.0,
+                    }]);
+                }
+            }
         }
 
         // Priority 2: unique title match.
@@ -2145,6 +2166,64 @@ sub b body
     }
 
     // ── Pass-2 wikilink/tag tests ─────────────────────────────────────────
+
+    /// nw-100: a path-qualified wikilink is Obsidian's RELATIVE-path syntax and
+    /// must resolve.
+    ///
+    /// `by_path` is keyed on full vault-relative paths, so priority 1 only ever
+    /// tried the bare target. `[[plans/Target]]` written in
+    /// `Workspaces/Orbit/_Overview.md` means
+    /// `Workspaces/Orbit/plans/Target.md`, which never matched — so every
+    /// path-qualified link in the vault resolved to nothing (45 of them, all
+    /// reported at confidence 0.0).
+    #[test]
+    fn resolves_a_path_relative_to_the_source_folder() {
+        let (_dir, root) = make_vault(&[
+            (
+                "Workspaces/Orbit/_Overview.md",
+                "# Overview\n\nSee [[plans/Phase B Execution Index]].\n",
+            ),
+            (
+                "Workspaces/Orbit/plans/Phase B Execution Index.md",
+                "# Phase B Execution Index\n\nbody\n",
+            ),
+        ]);
+        let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+        assert_eq!(
+            result.wikilinks_resolved, 1,
+            "a source-folder-relative path must resolve"
+        );
+        assert_eq!(result.wikilinks_unresolved, 0);
+    }
+
+    /// A full vault-relative path must keep working — that was the only form
+    /// priority 1 ever handled.
+    #[test]
+    fn resolves_a_full_vault_relative_path() {
+        let (_dir, root) = make_vault(&[
+            (
+                "notes/index.md",
+                "# Index\n\nSee [[Workspaces/Orbit/plans/Target]].\n",
+            ),
+            ("Workspaces/Orbit/plans/Target.md", "# Target\n\nbody\n"),
+        ]);
+        let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+        assert_eq!(result.wikilinks_resolved, 1);
+        assert_eq!(result.wikilinks_unresolved, 0);
+    }
+
+    /// A path-qualified link that matches nothing must still be unresolved —
+    /// the folder-relative attempt must not start inventing matches.
+    #[test]
+    fn a_path_qualified_link_to_nowhere_stays_unresolved() {
+        let (_dir, root) = make_vault(&[(
+            "Workspaces/Orbit/_Overview.md",
+            "# Overview\n\nSee [[plans/Does Not Exist]].\n",
+        )]);
+        let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+        assert_eq!(result.wikilinks_resolved, 0);
+        assert_eq!(result.wikilinks_unresolved, 1);
+    }
 
     #[test]
     fn resolves_unique_title_wikilink() {

--- a/crates/nestweaver-parser/src/markdown.rs
+++ b/crates/nestweaver-parser/src/markdown.rs
@@ -907,6 +907,15 @@ fn extract_md_links(body: &str, sections: &[RawSection]) -> Vec<RawWikilink> {
             if !path_part.ends_with(".md") {
                 continue;
             }
+            // ...and only to files IN THE VAULT. An external URL can end in
+            // `.md` too — `https://github.com/org/repo/blob/main/notes/x.md`
+            // passed this filter, became a wikilink target, and then resolved to
+            // nothing forever, so `broken-links` reported it as broken on every
+            // run with no possible fix (nw-100). A scheme means it is not a
+            // vault path.
+            if path_part.contains("://") || path_part.starts_with("//") {
+                continue;
+            }
             let target = path_part.to_string();
             let line = data.sourcepos.start.line as u32;
 
@@ -1518,6 +1527,28 @@ top 2 body
     }
 
     // ── Markdown link (.md) detection ────────────────────────────────────────
+
+    /// nw-100: an EXTERNAL url ending in `.md` is not a vault link.
+    ///
+    /// These passed the `.md` filter, became wikilink targets, and were then
+    /// reported broken on every run — permanently, since nothing in the vault
+    /// could ever satisfy them. Real example from the vault:
+    /// `https://github.com/Kehl-io/orbit/blob/main/docs/releases/v0.2.0-recovery.md`.
+    #[test]
+    fn external_urls_ending_in_md_are_not_wikilinks() {
+        let src = "# n\n\nSee [recovery](https://github.com/o/r/blob/main/docs/x.md) and \
+                   [local](notes/y.md).\n";
+        let note = parse_markdown("x.md", src).unwrap();
+        let targets: Vec<&str> = note.wikilinks.iter().map(|w| w.target.as_str()).collect();
+        assert!(
+            targets.contains(&"notes/y.md"),
+            "the in-vault link must still be captured: {targets:?}"
+        );
+        assert!(
+            !targets.iter().any(|t| t.contains("://")),
+            "an external url must not become a wikilink: {targets:?}"
+        );
+    }
 
     #[test]
     fn detects_md_link_as_wikilink() {


### PR DESCRIPTION
Two defects that both inflate the broken-link count with entries nobody can act on.

## 1. Path-qualified links never resolved (nw-100, defect 1)

`by_path` is keyed on **full vault-relative paths**, so priority 1 only ever tried the
bare target. But `[[plans/Phase B Execution Index]]` written in
`Workspaces/Orbit/_Overview.md` is Obsidian's **relative-path syntax** and means
`Workspaces/Orbit/plans/Phase B Execution Index.md` — which never matched.

**45 links in the vault**, all reported at confidence 0.0.

Priority 1 now tries the vault-relative key first, then the key relative to the
source's folder. Both are exact single-key lookups, so both score 1.0 and the
documented monotonic priority ordering holds. One detail that would have silently
broken it: `by_path` keys are lowercased while `folder` is stored raw.

## 2. External URLs became wikilinks (found while verifying, not reported)

`extract_md_links` filtered to targets ending in `.md` — which an external URL
satisfies:

```
https://github.com/Kehl-io/orbit/blob/main/docs/releases/v0.2.0-recovery.md
```

That became a wikilink target, resolved to nothing, and was reported broken **on
every run, permanently**, since nothing in the vault could ever satisfy it. Links
carrying a scheme are now skipped.

## Verified against the REAL Orbit notes

Synthetic tests prove the mechanism; the real paths prove the fix.

| | wikilinks | unresolved | path-qualified broken |
|---|---|---|---|
| released binary | 20 | **17** | 6 |
| after both fixes | 23 | **10** | **0** |

Zero external URLs left in the broken list.

## Tests

Includes the negative cases, which matter more than the positive ones here:

- a path-qualified link to a **nonexistent** target must **stay** unresolved — the new
  attempt must not start inventing matches
- an **in-vault** relative `.md` link is still captured while an external one is not

The path test was confirmed red first (0 resolved, expected 1).

968 engine + 476 parser tests pass; workspace clippy `-D warnings` and fmt clean.

## Not addressed

nw-100's **suggestion-quality** half: 95 of the 112 genuinely-broken links still get no
suggestion, because the heuristic is title-substring only and never considers filename
stems. nw-100 stays open for that.