### PR TITLE
fix(engine): link declared gRPC contracts to their Rust/tonic implementations

### DIFF
--- a/crates/nestweaver-engine/src/contracts.rs
+++ b/crates/nestweaver-engine/src/contracts.rs
@@ -191,6 +191,231 @@ fn openapi_contracts(spec: &openapiv3::OpenAPI) -> Vec<SpecContract> {
     out
 }
 
+/// Convert a protobuf RPC name to the Rust method identifier tonic generates.
+///
+/// tonic derives server-trait method names through `prost_build::ident::to_snake`,
+/// which delegates to `heck`'s snake_case and then sanitizes Rust keywords. Both
+/// steps matter, and a hand-rolled "insert `_` before each capital" does NOT
+/// reproduce either:
+///
+/// heck's documented word boundary is "if an uppercase character is followed by
+/// lowercase letters, a boundary is just prior to it; consecutive uppercase
+/// characters are one word, except the last joins the next word when followed by
+/// lowercase". So `XMLHttpRequest` segments `XML|Http|Request` ->
+/// `xml_http_request`, where the naive rule yields `x_m_l_http_request`.
+/// prost's own test suite asserts exactly this case.
+///
+/// Keyword collisions are then sanitized: most become `r#ident` (`Type` ->
+/// `r#type`), while `_`, `super`, `self`, `Self`, `extern` and `crate` get a
+/// trailing underscore. [`grpc_rpc_rust_idents`] returns every acceptable form.
+pub(crate) fn grpc_rpc_to_rust_method(rpc_name: &str) -> String {
+    let chars: Vec<char> = rpc_name.chars().collect();
+    let mut out = String::with_capacity(rpc_name.len() + 4);
+    for (i, &ch) in chars.iter().enumerate() {
+        if ch.is_uppercase() && i > 0 {
+            let prev_is_lower_or_digit = chars[i - 1].is_lowercase() || chars[i - 1].is_numeric();
+            let next_is_lower = chars.get(i + 1).is_some_and(|c| c.is_lowercase());
+            if prev_is_lower_or_digit || next_is_lower {
+                out.push('_');
+            }
+        }
+        out.extend(ch.to_lowercase());
+    }
+    out
+}
+
+/// A gRPC RPC implemented in Rust: the declared contract UID plus the symbol
+/// implementing it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GrpcImplMatch {
+    /// UID of the contract DECLARED by the proto, adopted verbatim.
+    pub contract_uid: String,
+    /// UID of the implementing symbol.
+    pub symbol_uid: String,
+}
+
+/// Link declared gRPC contracts to their Rust/tonic implementations.
+///
+/// Deliberately matches implementations AGAINST declared contracts rather than
+/// minting contract UIDs from Rust source. The proto package
+/// (`nestweaver.daemon.v1`) appears nowhere in the Rust file, so any UID built
+/// from the implementation would be a guess that has to coincide with what
+/// `parse_proto` produced. Adopting the declared UID makes the edge point at a
+/// contract that provably exists — which is the acceptance criterion for this
+/// bug: confirm the edge appears, not merely that a drift count dropped.
+///
+/// This mirrors the approach published for microservice endpoint coverage:
+/// extract implemented endpoints statically, then compare against the declared
+/// set (arXiv 2308.09257).
+///
+/// The match key is a documented tonic guarantee: a `service Greeter` generates
+/// a trait named `Greeter`, implemented as `impl Greeter for MyService`, with
+/// methods snake_cased by prost. So an `impl <Service> for _` block whose method
+/// names convert back to the service's RPC names is that service's server
+/// implementation.
+///
+/// `declared` maps a contract UID to its `<package>.<Service>/<Rpc>` operation.
+/// `symbols` are `(symbol_uid, name, start_line)` for one file.
+pub fn detect_grpc_impls(
+    source: &str,
+    declared: &[(String, String)],
+    symbols: &[(String, String, u32)],
+) -> Vec<GrpcImplMatch> {
+    if declared.is_empty() || symbols.is_empty() {
+        return Vec::new();
+    }
+
+    // Which trait does each line fall inside? Only `impl <Trait> for <Type>`
+    // blocks matter, and tonic's is always a trait impl.
+    let impl_blocks = rust_trait_impl_blocks(source);
+    if impl_blocks.is_empty() {
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+    for (contract_uid, operation) in declared {
+        // "<package>.<Service>/<Rpc>" — the service is the last dot-segment
+        // before the slash.
+        let Some((qualified_service, rpc)) = operation.rsplit_once('/') else {
+            continue;
+        };
+        let service = qualified_service
+            .rsplit_once('.')
+            .map_or(qualified_service, |(_, s)| s);
+        if service.is_empty() || rpc.is_empty() {
+            continue;
+        }
+        let accepted = grpc_rpc_rust_idents(rpc);
+
+        for (symbol_uid, name, line) in symbols {
+            if !accepted.iter().any(|candidate| candidate == name) {
+                continue;
+            }
+            // The method must sit inside `impl <Service> for _`. Without this a
+            // free function that merely shares a name would be linked.
+            let inside = impl_blocks.iter().any(|(trait_name, start, end)| {
+                trait_name == service && *line >= *start && *line <= *end
+            });
+            if inside {
+                out.push(GrpcImplMatch {
+                    contract_uid: contract_uid.clone(),
+                    symbol_uid: symbol_uid.clone(),
+                });
+                break;
+            }
+        }
+    }
+    out
+}
+
+/// Locate `impl <Trait> for <Type>` blocks as `(trait_name, start_line,
+/// end_line)`, 1-based inclusive.
+///
+/// Brace-depth scanning rather than a parser: the engine has the file as text
+/// here, and `detect_handlers` already recovers class-level context the same way.
+/// Inherent impls (`impl Foo {`) are skipped — a tonic server implementation is
+/// always a trait impl.
+fn rust_trait_impl_blocks(source: &str) -> Vec<(String, u32, u32)> {
+    let mut out = Vec::new();
+    let mut open: Option<(String, u32, i32)> = None;
+
+    for (idx, raw) in source.lines().enumerate() {
+        let line_no = idx as u32 + 1;
+        let line = raw.split("//").next().unwrap_or(raw);
+
+        if open.is_none()
+            && let Some(trait_name) = parse_trait_impl_header(line)
+        {
+            let depth = brace_delta(line);
+            open = Some((trait_name, line_no, depth.max(0)));
+            // A single-line `impl T for U {}` closes immediately.
+            if depth <= 0
+                && let Some((name, start, _)) = open.take()
+            {
+                out.push((name, start, line_no));
+            }
+            continue;
+        }
+
+        if let Some((_, _, depth)) = open.as_mut() {
+            *depth += brace_delta(line);
+            if *depth <= 0
+                && let Some((name, start, _)) = open.take()
+            {
+                out.push((name, start, line_no));
+            }
+        }
+    }
+
+    // Unterminated block (truncated file): treat it as running to the end.
+    if let Some((name, start, _)) = open {
+        out.push((name, start, source.lines().count() as u32));
+    }
+    out
+}
+
+/// Extract the trait name from an `impl [<generics>] <Trait> for <Type>` header.
+fn parse_trait_impl_header(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    let rest = trimmed.strip_prefix("impl")?;
+    // Require a boundary so `implementation_note` is not read as `impl`.
+    if !rest.starts_with([' ', '<']) {
+        return None;
+    }
+    let (before_for, _after) = rest.split_once(" for ")?;
+    // Drop any generic parameter list directly after `impl`.
+    let mut candidate = before_for.trim();
+    if candidate.starts_with('<')
+        && let Some(close) = matching_angle(candidate)
+    {
+        candidate = candidate[close + 1..].trim();
+    }
+    // Strip the trait's own generic arguments and any path qualification.
+    let candidate = candidate.split('<').next().unwrap_or(candidate).trim();
+    let candidate = candidate.rsplit("::").next().unwrap_or(candidate).trim();
+    if candidate.is_empty() || !candidate.chars().all(|c| c.is_alphanumeric() || c == '_') {
+        return None;
+    }
+    Some(candidate.to_string())
+}
+
+/// Index of the `>` closing a generic list that starts at index 0.
+fn matching_angle(s: &str) -> Option<usize> {
+    let mut depth = 0i32;
+    for (i, ch) in s.char_indices() {
+        match ch {
+            '<' => depth += 1,
+            '>' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn brace_delta(line: &str) -> i32 {
+    line.chars().fold(0, |acc, c| match c {
+        '{' => acc + 1,
+        '}' => acc - 1,
+        _ => acc,
+    })
+}
+
+/// Every Rust identifier tonic could plausibly generate for `rpc_name`.
+///
+/// Comparing against a small candidate set is simpler and safer than trying to
+/// invert prost's sanitization: a parsed `foo_` is genuinely ambiguous between
+/// "sanitized keyword" and "a method actually named foo_", and accepting both
+/// costs nothing because the service and RPC still have to match.
+pub(crate) fn grpc_rpc_rust_idents(rpc_name: &str) -> Vec<String> {
+    let base = grpc_rpc_to_rust_method(rpc_name);
+    vec![format!("r#{base}"), format!("{base}_"), base]
+}
+
 fn parse_proto(path: &str, source: &str) -> Vec<SpecContract> {
     let fd = match protox_parse::parse(path, source) {
         Ok(fd) => fd,
@@ -1414,6 +1639,170 @@ paths:
             uids.contains(&"contract:http:GET:/v1/users/{}".to_string()),
             "param slot must normalize; uids: {uids:?}"
         );
+    }
+
+    const TONIC_SOURCE: &str = r#"
+use crate::proto::nest_weaver_daemon_server::NestWeaverDaemon;
+
+fn health_check() {}
+
+#[tonic::async_trait]
+impl NestWeaverDaemon for DaemonService {
+    async fn health_check(&self, req: Request<()>) -> Result<Response<()>, Status> {
+        Ok(Response::new(()))
+    }
+
+    async fn index_repo(&self, req: Request<()>) -> Result<Response<()>, Status> {
+        Ok(Response::new(()))
+    }
+}
+
+impl SomethingElse for DaemonService {
+    async fn shutdown(&self) {}
+}
+"#;
+
+    fn decl(uid: &str, op: &str) -> (String, String) {
+        (uid.to_string(), op.to_string())
+    }
+
+    /// The core linkage: a declared RPC whose snake_case method sits inside
+    /// `impl <Service> for _` is that contract's implementation, and the edge
+    /// adopts the DECLARED uid rather than minting one from Rust.
+    #[test]
+    fn links_declared_grpc_contracts_to_their_tonic_impl() {
+        let declared = vec![
+            decl(
+                "contract:grpc:nestweaver.daemon.v1.NestWeaverDaemon/HealthCheck",
+                "nestweaver.daemon.v1.NestWeaverDaemon/HealthCheck",
+            ),
+            decl(
+                "contract:grpc:nestweaver.daemon.v1.NestWeaverDaemon/IndexRepo",
+                "nestweaver.daemon.v1.NestWeaverDaemon/IndexRepo",
+            ),
+        ];
+        // (uid, name, line) — the free fn at line 4 shares a name with the RPC.
+        let symbols = vec![
+            ("sym:free".to_string(), "health_check".to_string(), 4),
+            ("sym:hc".to_string(), "health_check".to_string(), 8),
+            ("sym:ir".to_string(), "index_repo".to_string(), 12),
+        ];
+
+        let got = detect_grpc_impls(TONIC_SOURCE, &declared, &symbols);
+
+        assert_eq!(got.len(), 2, "both declared RPCs must link: {got:?}");
+        let hc = got
+            .iter()
+            .find(|m| m.contract_uid.ends_with("/HealthCheck"))
+            .expect("HealthCheck must link");
+        assert_eq!(
+            hc.symbol_uid, "sym:hc",
+            "must pick the method INSIDE the trait impl, not the free fn"
+        );
+    }
+
+    /// A declared RPC with no implementation must stay unlinked, or the fix would
+    /// suppress the real drift it exists to report.
+    #[test]
+    fn a_declared_rpc_with_no_impl_is_not_linked() {
+        let declared = vec![decl(
+            "contract:grpc:nestweaver.daemon.v1.NestWeaverDaemon/NotImplemented",
+            "nestweaver.daemon.v1.NestWeaverDaemon/NotImplemented",
+        )];
+        let symbols = vec![("sym:hc".to_string(), "health_check".to_string(), 8)];
+        assert!(detect_grpc_impls(TONIC_SOURCE, &declared, &symbols).is_empty());
+    }
+
+    /// A method in a DIFFERENT trait must not satisfy the contract, even when the
+    /// name converts correctly.
+    #[test]
+    fn a_method_in_another_trait_does_not_satisfy_the_contract() {
+        let declared = vec![decl(
+            "contract:grpc:nestweaver.daemon.v1.NestWeaverDaemon/Shutdown",
+            "nestweaver.daemon.v1.NestWeaverDaemon/Shutdown",
+        )];
+        // `shutdown` exists, but inside `impl SomethingElse for DaemonService`.
+        let symbols = vec![("sym:sd".to_string(), "shutdown".to_string(), 17)];
+        assert!(
+            detect_grpc_impls(TONIC_SOURCE, &declared, &symbols).is_empty(),
+            "wrong trait must not link"
+        );
+    }
+
+    #[test]
+    fn trait_impl_blocks_are_located_with_their_line_ranges() {
+        let blocks = rust_trait_impl_blocks(TONIC_SOURCE);
+        let names: Vec<&str> = blocks.iter().map(|(n, _, _)| n.as_str()).collect();
+        assert!(names.contains(&"NestWeaverDaemon"), "{blocks:?}");
+        assert!(names.contains(&"SomethingElse"), "{blocks:?}");
+    }
+
+    /// Header parsing must survive generics and path qualification, and must not
+    /// mistake an inherent impl for a trait impl.
+    #[test]
+    fn trait_impl_header_parsing_handles_generics_and_paths() {
+        assert_eq!(
+            parse_trait_impl_header("impl NestWeaverDaemon for DaemonService {").as_deref(),
+            Some("NestWeaverDaemon")
+        );
+        assert_eq!(
+            parse_trait_impl_header("impl<T: Send> proto::Greeter<T> for MyService {").as_deref(),
+            Some("Greeter")
+        );
+        // Inherent impl — no trait, nothing to link.
+        assert_eq!(parse_trait_impl_header("impl DaemonService {"), None);
+        // Must not read `implementation` as `impl`.
+        assert_eq!(parse_trait_impl_header("implementation_note for x {"), None);
+    }
+
+    /// The acronym cases are the whole reason this is not a hand-rolled
+    /// "insert `_` before each capital".
+    ///
+    /// prost's `to_snake` delegates to heck, whose documented boundary treats a
+    /// run of capitals as ONE word except that the last joins the next word when
+    /// followed by lowercase. prost's own suite asserts
+    /// `to_snake("XMLHttpRequest") == "xml_http_request"`; the naive rule yields
+    /// `x_m_l_http_request` and would silently fail to match every acronym-bearing
+    /// RPC. This repo's own 75 RPCs contain no acronyms, so it cannot catch the
+    /// difference — hence these cases.
+    #[test]
+    fn rpc_names_convert_the_way_prost_and_heck_do() {
+        let cases = [
+            ("HealthCheck", "health_check"),
+            ("Shutdown", "shutdown"),
+            ("IndexRepo", "index_repo"),
+            // Acronyms: a run of capitals is one word.
+            ("XMLHttpRequest", "xml_http_request"),
+            ("GetHTTPStatus", "get_http_status"),
+            ("ExportSARIF", "export_sarif"),
+            ("GetURL", "get_url"),
+            // Digits do not start a new word on their own.
+            ("IndexV2", "index_v2"),
+            ("BlastRadiusV10", "blast_radius_v10"),
+            // Already-lowercase and single words survive unchanged.
+            ("backup", "backup"),
+        ];
+        for (rpc, expected) in cases {
+            assert_eq!(
+                grpc_rpc_to_rust_method(rpc),
+                expected,
+                "{rpc} must convert like heck does"
+            );
+        }
+    }
+
+    /// prost sanitizes keyword collisions, so the matcher accepts every form it
+    /// could emit. None of this repo's RPCs collide, which is exactly why this
+    /// needs a test rather than a happy-path check.
+    #[test]
+    fn keyword_rpcs_accept_prosts_sanitized_forms() {
+        let idents = grpc_rpc_rust_idents("Type");
+        assert!(idents.contains(&"r#type".to_string()), "{idents:?}");
+        assert!(idents.contains(&"type".to_string()), "{idents:?}");
+        assert!(idents.contains(&"type_".to_string()), "{idents:?}");
+
+        // A non-keyword still yields its plain form.
+        assert!(grpc_rpc_rust_idents("HealthCheck").contains(&"health_check".to_string()));
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -2715,7 +2715,14 @@ where
         // Best-effort: a malformed spec or unexpected store error here must not
         // fail the whole index. Contracts are hypotheses layered on top of the
         // code graph.
-        if let Err(e) = derive_contracts(store, reader, &r_uid, &spec_files, &handler_files) {
+        if let Err(e) = derive_contracts(
+            store,
+            reader,
+            &r_uid,
+            &spec_files,
+            &handler_files,
+            &all_symbols,
+        ) {
             tracing::warn!("contract derivation failed (non-fatal): {e}");
         }
         tracing::info!(
@@ -2865,6 +2872,7 @@ fn derive_contracts(
     r_uid: &str,
     spec_files: &[PathBuf],
     handler_files: &[HandlerFileData],
+    all_symbols: &[nestweaver_schema::Symbol],
 ) -> Result<(), anyhow::Error> {
     use nestweaver_schema::{EdgeType, ResolvedEdge};
     use std::collections::HashSet;
@@ -2875,6 +2883,8 @@ fn derive_contracts(
     // 1. Declared contracts from specs.
     let mut all_contracts: Vec<nestweaver_schema::Contract> = Vec::new();
     let mut declared_uids: HashSet<String> = HashSet::new();
+    // (contract_uid, "<package>.<Service>/<Rpc>") for every declared gRPC method.
+    let mut declared_grpc: Vec<(String, String)> = Vec::new();
     let repo_path = reader.root();
     for spec_path in spec_files {
         let rel = spec_path
@@ -2890,7 +2900,15 @@ fn derive_contracts(
             }
         };
         for sc in crate::contracts::parse_spec_file(&rel, &source) {
+            // Keep gRPC operations so implementations can be matched against the
+            // DECLARED contract rather than minting a UID from source (nw-104).
+            let grpc_operation = (sc.kind == "grpc")
+                .then(|| sc.operation_id.clone())
+                .flatten();
             let contract = sc.into_contract(r_uid, &rel, 1.0);
+            if let Some(operation) = grpc_operation {
+                declared_grpc.push((contract.uid.clone(), operation));
+            }
             declared_uids.insert(contract.uid.clone());
             all_contracts.push(contract);
         }
@@ -2929,6 +2947,60 @@ fn derive_contracts(
                     evidence: Vec::new(),
                 });
             }
+        }
+    }
+
+    // 3b. gRPC: link declared contracts to their Rust/tonic implementations
+    //     (nw-104).
+    //
+    // This does NOT go through `detect_handlers`. That path needs a framework
+    // hint, which `detect_frameworks` never produces for Rust, which in turn
+    // means no `HandlerFileData` is built — three gates that all had to be
+    // opened to reach a detector that also did not exist. Matching declared
+    // contracts against symbols here needs none of them, and the edge adopts the
+    // DECLARED uid so it provably points at a real contract.
+    if !declared_grpc.is_empty() {
+        // Group symbols by file so each candidate file is read once.
+        let mut by_file: std::collections::BTreeMap<&str, Vec<(String, String, u32)>> =
+            std::collections::BTreeMap::new();
+        for sym in all_symbols {
+            by_file.entry(sym.file_path.as_str()).or_default().push((
+                sym.uid.clone(),
+                sym.name.clone(),
+                sym.start_line,
+            ));
+        }
+
+        let mut linked = 0usize;
+        for (rel_path, symbols) in by_file {
+            // Cheap pre-filter: a tonic server implementation is a trait impl, so
+            // a file with no `impl ` at all cannot contain one. Avoids reading
+            // every source file in the repo.
+            let Ok(source) = reader.read_file(Path::new(rel_path)) else {
+                continue;
+            };
+            if !source.contains("impl ") {
+                continue;
+            }
+            for m in crate::contracts::detect_grpc_impls(&source, &declared_grpc, &symbols) {
+                edges.push(ResolvedEdge {
+                    source_uid: m.symbol_uid,
+                    target_uid: m.contract_uid,
+                    edge_type: EdgeType::ImplementsContract,
+                    // Exact service AND method match against a declared contract.
+                    confidence: 1.0,
+                    link_type: None,
+                    evidence: Vec::new(),
+                });
+                linked += 1;
+            }
+        }
+        if linked > 0 {
+            tracing::debug!(
+                linked,
+                declared = declared_grpc.len(),
+                "linked gRPC contracts to tonic implementations"
+            );
         }
     }
 
@@ -4989,6 +5061,69 @@ function hello(name) { return "Hello " + name; }
         assert!(
             implemented.contains(&"contract:http:POST:/v1/approvals".to_string()),
             "expected IMPLEMENTS_CONTRACT edge; implemented: {implemented:?}"
+        );
+    }
+
+    /// nw-104: a declared gRPC contract must link to its Rust/tonic
+    /// implementation.
+    ///
+    /// `contracts drift` reported 75 declared RPCs as unimplemented on this very
+    /// repo while every one of them was implemented, because nothing ever emitted
+    /// an IMPLEMENTS_CONTRACT edge for gRPC. The acceptance criterion for the bug
+    /// is that the EDGE appears — not merely that a drift count fell — so this
+    /// asserts the edge and that unimplemented RPCs still show as drift.
+    #[test]
+    fn grpc_proto_links_to_its_tonic_implementation() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("repo");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(
+            src.join("service.proto"),
+            "syntax = \"proto3\";\n\
+             package demo.v1;\n\
+             service Greeter {\n  \
+             rpc SayHello (Empty) returns (Empty);\n  \
+             rpc GetHTTPStatus (Empty) returns (Empty);\n  \
+             rpc NeverBuilt (Empty) returns (Empty);\n\
+             }\n\
+             message Empty {}\n",
+        )
+        .unwrap();
+        fs::write(
+            src.join("server.rs"),
+            "#[tonic::async_trait]\n\
+             impl Greeter for MyService {\n    \
+             async fn say_hello(&self) {}\n    \
+             async fn get_http_status(&self) {}\n\
+             }\n",
+        )
+        .unwrap();
+
+        let (_result, store) =
+            index_directory_in_memory(&src, "test", "https://example.com/repo", "abc123").unwrap();
+
+        let contracts = store.list_contracts(None).unwrap();
+        let uids: Vec<&String> = contracts.iter().map(|c| &c.uid).collect();
+        assert!(
+            uids.iter()
+                .any(|u| u.as_str() == "contract:grpc:demo.v1.Greeter/SayHello"),
+            "expected the declared gRPC contract; got {uids:?}"
+        );
+
+        let implemented = store.list_implemented_contract_uids().unwrap();
+        assert!(
+            implemented.contains(&"contract:grpc:demo.v1.Greeter/SayHello".to_string()),
+            "expected IMPLEMENTS_CONTRACT edge for SayHello; implemented: {implemented:?}"
+        );
+        // The acronym case, which a naive snake_case would have missed.
+        assert!(
+            implemented.contains(&"contract:grpc:demo.v1.Greeter/GetHTTPStatus".to_string()),
+            "GetHTTPStatus -> get_http_status must link; implemented: {implemented:?}"
+        );
+        // A declared RPC with no impl must STILL be drift.
+        assert!(
+            !implemented.contains(&"contract:grpc:demo.v1.Greeter/NeverBuilt".to_string()),
+            "an unimplemented RPC must remain drift; implemented: {implemented:?}"
         );
     }
 


### PR DESCRIPTION
Fixes **nw-104** — the last defect in the release gate.

## The defect

`contracts drift` reported **75 of 75** declared gRPC contracts as unimplemented on
this repo, while every one is implemented (`HealthCheck` as `async fn health_check`).
Nothing ever emitted an `IMPLEMENTS_CONTRACT` edge for gRPC, so `compute_drift` was
reporting correctly on the data it had.

## The report's diagnosis was wrong

Both the entry and the handover describe a PascalCase/snake_case mismatch in
*"whatever resolves `health_check` to the `HealthCheck` UID"*. **No such resolver
exists.** Three gates stood between here and one:

1. `detect_frameworks` has no Rust arm → no framework hint
2. without a hint, `index.rs` builds no `HandlerFileData`
3. `detect_handlers` is a two-arm match on `spring` / `nestjs`

The defect is **absent capability**, not a faulty comparison.

## This opens none of them

`derive_contracts` already holds every contract parsed from the protos, and
`all_symbols` is in scope at the call site. Declared contracts are matched against
symbols directly, and the edge **adopts the declared UID**.

Contract UIDs are never minted from Rust: the proto package `nestweaver.daemon.v1`
appears nowhere in the Rust source, so any UID built from the implementation would be
a guess that has to coincide with what `parse_proto` produced. Adopting the declared
UID makes the edge provably point at a real contract — this bug's stated acceptance
criterion ("confirm the edge appears, don't just watch the drift count drop").

Match key is a documented tonic guarantee: `service Greeter` → trait `Greeter` →
`impl Greeter for MyService`, methods snake_cased by prost.

## The naming rule is researched, not hand-rolled — and this repo can't test it

prost's [`to_snake`](https://raw.githubusercontent.com/tokio-rs/prost/master/prost-build/src/ident.rs)
delegates to heck, whose [documented boundary](https://docs.rs/heck/latest/heck/) treats
a run of capitals as one word except that the last joins the next when followed by
lowercase — `XMLHttpRequest` → `xml_http_request`, asserted by prost's own test suite.

A naive "underscore before each capital" yields `x_m_l_http_request`.

**This repo's 75 RPC names contain no acronyms, so both rules score 75/75 here.** The
difference is invisible to any test written against this codebase, which is why the
acronym cases are pinned explicitly. prost also sanitizes keyword collisions
(`Type` → `r#type`) — nothing here collides, so likewise test-only coverage.

## Prior art

Architecture matches the published approach for microservice endpoint coverage:
extract implemented endpoints statically, compare against the declared set
([arXiv 2308.09257](https://arxiv.org/pdf/2308.09257)). The underlying gap is
acknowledged upstream — [grpc-go #3669](https://github.com/grpc/grpc-go/issues/3669)
notes that embedding `Unimplemented` means missing methods aren't known until runtime.

## Verification

On this repo: **75 contracts declared, drift now empty** — so all 75 carry edges. I
checked that contracts were actually *parsed* rather than absent, since an empty drift
list looks identical either way. Confirmed red by disabling the pass: `implemented: []`,
the exact reported symptom.

Negative cases: a free function sharing a method name isn't linked; a method in a
**different** trait doesn't satisfy the contract; a declared RPC with no implementation
still reports as drift.

## Scope

Rust/tonic servers. A Go or Python gRPC server would still show false drift — an honest
limitation, not a general fix.

979 engine tests pass; workspace clippy `-D warnings` and fmt clean.