### PR TITLE
fix(store): label the edge type flow_trace followed to each callee

### DIFF
--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -6095,7 +6095,7 @@ fn tool_brain_guide(store: &GraphStore, args: Value) -> Result<Value, anyhow::Er
 fn tool_schema_flow_trace() -> Value {
     json!({
         "name": "flow_trace",
-        "description": "Trace forward execution flow from a symbol: what it calls, what those call, and so on. Returns a tree of callees.\n\nGuidelines:\n- Best for tracing from entry points (main, request handlers) to understand execution paths\n- Cycles are detected and pruned; use max_depth to control tree depth (default 10)\n- Classes are auto-expanded to their methods since classes have no direct CALLS edges\n\nLimitations:\n- For reverse dependencies ('what calls this?') use brain_impact instead\n- For general structural context use brain_context",
+        "description": "Trace forward execution flow from a symbol: what it calls, what those call, and so on. Returns a tree of callees.\n\nGuidelines:\n- Best for tracing from entry points (main, request handlers) to understand execution paths\n- Every child carries `edge_type`: CALLS and IMPORTS are observed in code, CROSS_REPO_LINK is an INFERRED cross-repo link. A CROSS_REPO_LINK child is NOT an observed call — filter it out when you need a real execution path\n- Cycles are detected and pruned; use max_depth to control tree depth (default 10)\n- Classes are auto-expanded to their methods since classes have no direct CALLS edges\n\nLimitations:\n- For reverse dependencies ('what calls this?') use brain_impact instead\n- For general structural context use brain_context",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -6274,14 +6274,14 @@ fn build_flow_tree(
     let mut children = Vec::new();
 
     if depth < opts.max_depth
-        && let Ok(callees) = store.callees_of(uid)
+        && let Ok(callees) = store.callees_with_edge_types_of(uid)
     {
-        for callee in &callees {
+        for (callee, edge_type) in &callees {
             if visited.contains(&callee.uid) {
                 continue;
             }
             visited.insert(callee.uid.clone());
-            let child = build_flow_tree(
+            let mut child = build_flow_tree(
                 store,
                 &callee.uid,
                 &callee.name,
@@ -6290,11 +6290,25 @@ fn build_flow_tree(
                 visited,
                 opts,
             )?;
+            // Label the edge that reached this node. The traversal spans CALLS,
+            // IMPORTS and CROSS_REPO_LINK, and the last is an INFERRED link
+            // between repos — following it as a call produced fabricated
+            // execution paths (a Rust function appearing to call JavaScript
+            // symbols in unrelated repos). Without this field they were
+            // indistinguishable from real calls, on the flagship "what does this
+            // call" surface. `impact` has always labelled its edges; this brings
+            // flow_trace to parity (nw-111).
+            if let Some(obj) = child.as_object_mut() {
+                obj.insert("edge_type".to_string(), json!(edge_type));
+            }
             children.push(child);
         }
     }
 
     if opts.concise {
+        // The label ships in concise mode too: a caller scanning a compact tree
+        // is exactly the one who cannot afford to mistake a cross-repo guess for
+        // a call.
         Ok(json!({
             "name": name,
             "children": children,

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -1798,11 +1798,42 @@ impl GraphStore {
     /// Follows CALLS, IMPORTS, and CROSS_REPO_LINK edges so that
     /// `flow_trace` can traverse function calls, import relationships,
     /// and cross-repo boundaries.
+    ///
+    /// Prefer [`callees_with_edge_types_of`](Self::callees_with_edge_types_of)
+    /// for anything user-facing: this drops the edge type, and a CROSS_REPO_LINK
+    /// is a cross-repo HYPOTHESIS, not an observed call.
     pub fn callees_of(&self, uid: &str) -> Result<Vec<Symbol>, StoreError> {
+        Ok(self
+            .callees_with_edge_types_of(uid)?
+            .into_iter()
+            .map(|(sym, _)| sym)
+            .collect())
+    }
+
+    /// As [`callees_of`](Self::callees_of), but keeps the edge type that reached
+    /// each callee.
+    ///
+    /// The traversal spans three very different relationships, and collapsing
+    /// them was the defect: a CROSS_REPO_LINK is an INFERRED link between repos,
+    /// so following it as though it were a call produced fabricated execution
+    /// paths — tracing a Rust function returned JavaScript symbols from unrelated
+    /// repos as its callees. Because the edge type was discarded here,
+    /// `flow_trace` could not label them and a consumer had no way to tell a real
+    /// call from a cross-repo guess. `impact` already returns the edge type for
+    /// exactly this reason (nw-111).
+    ///
+    /// Returned in edge-type priority order, and de-duplicated by symbol, so a
+    /// callee reachable by both CALLS and CROSS_REPO_LINK is reported as the
+    /// stronger CALLS.
+    pub fn callees_with_edge_types_of(
+        &self,
+        uid: &str,
+    ) -> Result<Vec<(Symbol, String)>, StoreError> {
         let conn = self.conn()?;
         let cols = SYMBOL_COLUMNS.replace("s.", "t.");
+        // Order matters: strongest evidence first, so the de-dup below keeps it.
         let edge_types = ["CALLS", "IMPORTS", "CROSS_REPO_LINK"];
-        let mut all: Vec<Symbol> = Vec::new();
+        let mut all: Vec<(Symbol, String)> = Vec::new();
         let mut seen = std::collections::HashSet::new();
         for et in &edge_types {
             let q = format!("MATCH (s:Symbol {{uid: $uid}})-[:{et}]->(t:Symbol) RETURN {cols}");
@@ -1815,7 +1846,7 @@ impl GraphStore {
             for row in result {
                 let sym = row_to_symbol(&row)?;
                 if seen.insert(sym.uid.clone()) {
-                    all.push(sym);
+                    all.push((sym, (*et).to_string()));
                 }
             }
         }

--- a/crates/nestweaver-store/src/traverse.rs
+++ b/crates/nestweaver-store/src/traverse.rs
@@ -1495,6 +1495,109 @@ mod tests {
         }
     }
 
+    /// nw-111: the callee traversal must REPORT which edge reached each callee.
+    ///
+    /// It spans CALLS, IMPORTS and CROSS_REPO_LINK, and the last is an inferred
+    /// link between repos rather than an observed call. Collapsing them to a bare
+    /// symbol list meant `flow_trace` presented fabricated cross-language
+    /// execution paths as real ones — tracing a Rust function returned JavaScript
+    /// symbols from unrelated repos as its callees, with nothing in the payload
+    /// to tell them apart. `impact` has always returned the edge type; this is the
+    /// callee-side parity.
+    #[test]
+    fn callee_traversal_reports_the_edge_type_that_reached_each_callee() {
+        use nestweaver_schema::{CrossRepoLinkType, EdgeType, ResolvedEdge};
+
+        let store = GraphStore::in_memory().unwrap();
+        for uid in ["root", "real_callee", "remote_guess"] {
+            store.insert_symbol(&make_symbol(uid, uid)).unwrap();
+        }
+
+        // An observed call...
+        store
+            .insert_edge(&ResolvedEdge {
+                source_uid: "root".to_string(),
+                target_uid: "real_callee".to_string(),
+                edge_type: EdgeType::Calls,
+                confidence: 1.0,
+                link_type: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
+        // ...and an INFERRED cross-repo link, which is not a call at all.
+        store
+            .insert_edge(&ResolvedEdge {
+                source_uid: "root".to_string(),
+                target_uid: "remote_guess".to_string(),
+                edge_type: EdgeType::CrossRepoLink,
+                confidence: 0.9,
+                link_type: Some(CrossRepoLinkType::SharedImport),
+                evidence: Vec::new(),
+            })
+            .unwrap();
+
+        let callees = store.callees_with_edge_types_of("root").unwrap();
+        let by_uid: std::collections::HashMap<&str, &str> = callees
+            .iter()
+            .map(|(sym, et)| (sym.uid.as_str(), et.as_str()))
+            .collect();
+
+        assert_eq!(
+            by_uid.get("real_callee"),
+            Some(&"CALLS"),
+            "an observed call must be labelled CALLS; got {by_uid:?}"
+        );
+        assert_eq!(
+            by_uid.get("remote_guess"),
+            Some(&"CROSS_REPO_LINK"),
+            "a cross-repo hypothesis must be labelled, not presented as a call; got {by_uid:?}"
+        );
+
+        // The unlabelled helper still returns both, so existing callers are
+        // unaffected — this adds information rather than removing any.
+        let plain = store.callees_of("root").unwrap();
+        assert_eq!(plain.len(), 2, "callees_of must be unchanged in coverage");
+    }
+
+    /// A callee reachable by BOTH a real call and a cross-repo link must be
+    /// reported as the stronger CALLS, not downgraded to a guess.
+    #[test]
+    fn a_callee_reachable_two_ways_reports_the_strongest_edge() {
+        use nestweaver_schema::{CrossRepoLinkType, EdgeType, ResolvedEdge};
+
+        let store = GraphStore::in_memory().unwrap();
+        for uid in ["root", "shared"] {
+            store.insert_symbol(&make_symbol(uid, uid)).unwrap();
+        }
+        store
+            .insert_edge(&ResolvedEdge {
+                source_uid: "root".to_string(),
+                target_uid: "shared".to_string(),
+                edge_type: EdgeType::CrossRepoLink,
+                confidence: 0.9,
+                link_type: Some(CrossRepoLinkType::SharedImport),
+                evidence: Vec::new(),
+            })
+            .unwrap();
+        store
+            .insert_edge(&ResolvedEdge {
+                source_uid: "root".to_string(),
+                target_uid: "shared".to_string(),
+                edge_type: EdgeType::Calls,
+                confidence: 1.0,
+                link_type: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
+
+        let callees = store.callees_with_edge_types_of("root").unwrap();
+        assert_eq!(callees.len(), 1, "de-duplicated by symbol: {callees:?}");
+        assert_eq!(
+            callees[0].1, "CALLS",
+            "strongest evidence wins: {callees:?}"
+        );
+    }
+
     /// Impact analysis must follow CROSS_REPO_LINK edges so that callers in
     /// other repos (modeled as cross-repo links in a unified multi-repo graph)
     /// are reported. Regression guard for cross-boundary intelligence: without


### PR DESCRIPTION
Addresses **nw-111 (1)** — the severe item in that batch.

## The defect

`flow_trace` presented **fabricated cross-language execution paths as real ones**.
Tracing the Rust `analyze_blast_radius` returned JavaScript symbols from unrelated
repos as its callees — a `cancelled` in a Shot-Insights test, a `clone` in a Coyote
service — which are actually a local Rust closure and `.clone()`.

This is the flagship *"what does this function call"* surface.

## Root cause

```rust
// read.rs  callees_of
let edge_types = ["CALLS", "IMPORTS", "CROSS_REPO_LINK"];
```

It queries all three, then returns `Vec<Symbol>` — **discarding which edge reached
each callee**. `CROSS_REPO_LINK` is an *inferred* link between repos, not an observed
call, and `flow_trace` could not label one even in principle because the store had
already thrown the information away.

`impact` has always returned the edge type and its MCP payload emits it, so consumers
there can filter. The callee side couldn't. This closes that asymmetry.

## The fix preserves information rather than removing edges

`callees_with_edge_types_of` returns `(Symbol, edge_type)`, and `flow_trace` labels
every child with `edge_type` in **both concise and detailed** mode. Concise matters
most — a caller scanning a compact tree is exactly the one who can't afford to mistake
a cross-repo guess for a call.

**Cross-repo links are deliberately still followed.** Dropping them would silently lose
real cross-boundary reach, which is precisely what
`impact_includes_cross_repo_link_callers` exists to prevent. The problem was never that
the edge was traversed — it's that the result didn't say so.

Edges are queried strongest-evidence-first and de-duplicated by symbol, so a callee
reachable by *both* a real call and a cross-repo link reports `CALLS` rather than being
downgraded to a guess. **That ordering is load-bearing and confirmed red by inverting
it.**

`callees_of` is kept and delegates, so no existing caller changes behaviour — the
pre-existing `callees_of_includes_cross_repo_link` test still passes, showing this adds
information without altering coverage.

The tool schema now documents the distinction; a field consumers can't discover isn't
much better than no field.

## On the rest of nw-111

**(2) needed no work.** The `regex-search` text now reads *"No matches … WITHIN THE
SEARCH BUDGET — the scan was cut short"*, matching `truncated: true`. Already fixed by
the #196 honesty batch — I verified before touching it rather than re-fixing a closed
bug.

Untouched: **(3)** `read-symbols --token-budget` unenforced (a contained bug),
**(4)** `impact --json` emitting three incompatible schemas, **(5)** `blast-radius` /
`flow-trace` absent as CLI subcommands. (4) and (5) are contract and product decisions
rather than defects — the entry itself says (5) is "worth deciding whether that is
intentional."

315 store + 132 mcp tests pass; workspace clippy `-D warnings` and fmt clean.