### PR TITLE
fix(engine): repo-qualify the co-change sidecar instead of overwriting it

### DIFF
--- a/crates/nestweaver-engine/src/blast_radius.rs
+++ b/crates/nestweaver-engine/src/blast_radius.rs
@@ -950,8 +950,30 @@ pub fn analyze_blast_radius(
             Some(edges) => {
                 let changed_set: HashSet<&str> =
                     changed_files.iter().filter_map(|p| p.to_str()).collect();
+
+                // Qualify by repo. The sidecar now carries every indexed repo's
+                // pairs rather than only the last one written, and its paths are
+                // repo-RELATIVE — so without this a `CHANGELOG.md` in one repo
+                // would match a `CHANGELOG.md` in another and invent a coupling
+                // that does not exist (nw-062).
+                //
+                // `scope_uids` are the repos the changed symbols belong to;
+                // `Repo.root_path` is what the miner stamped on each pair. A repo
+                // with no root_path (server-side bare clone) contributes nothing
+                // here, and unattributed legacy rows match nothing — both cases
+                // fall through to the `cochange-no-coverage` disclosure below
+                // rather than guessing.
+                let scope_roots: HashSet<String> = scope_uids
+                    .iter()
+                    .filter_map(|uid| store.lookup_repo(uid).ok().flatten())
+                    .filter_map(|repo| repo.root_path)
+                    .collect();
                 let mut seen: HashSet<(String, String)> = HashSet::new();
                 for e in &edges {
+                    // Only pairs mined from a repo actually in scope.
+                    if !e.repo.is_empty() && !scope_roots.contains(&e.repo) {
+                        continue;
+                    }
                     let (coupled, changed) = if changed_set.contains(e.file_a.as_str())
                         && !changed_set.contains(e.file_b.as_str())
                     {
@@ -995,6 +1017,7 @@ pub fn analyze_blast_radius(
                 // "no history was mined for it".
                 let mined: HashSet<&str> = edges
                     .iter()
+                    .filter(|e| e.repo.is_empty() || scope_roots.contains(&e.repo))
                     .flat_map(|e| [e.file_a.as_str(), e.file_b.as_str()])
                     .collect();
                 let unmined: Vec<&str> = changed_set
@@ -2559,6 +2582,7 @@ mod tests {
         let db = dir.path().join("scratch.lbug");
         std::fs::write(&db, b"").expect("touch db");
         let edges = vec![CoChangeEdge {
+            repo: String::new(),
             file_a: "src/billing.rs".into(),
             file_b: "src/invoice_templates.sql".into(),
             cochange_count: 9,
@@ -2607,6 +2631,7 @@ mod tests {
 
         // History mined from a DIFFERENT repo than the file being analysed.
         let edges = vec![CoChangeEdge {
+            repo: String::new(),
             file_a: "crates/nestweaver-store/build.rs".into(),
             file_b: "crates/nestweaver-store/Cargo.toml".into(),
             cochange_count: 6,
@@ -2651,6 +2676,7 @@ mod tests {
         let db = dir.path().join("scratch.lbug");
         std::fs::write(&db, b"").expect("touch db");
         let edges = vec![CoChangeEdge {
+            repo: String::new(),
             file_a: "src/billing.rs".into(),
             file_b: "src/invoice_templates.sql".into(),
             cochange_count: 9,

--- a/crates/nestweaver-engine/src/cochange.rs
+++ b/crates/nestweaver-engine/src/cochange.rs
@@ -9,6 +9,19 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CoChangeEdge {
+    /// Absolute path of the repo this pair was mined from, matching
+    /// `Repo.root_path`.
+    ///
+    /// Without it the sidecar was a flat list with no owner, so each repo's
+    /// index BLIND-OVERWROTE the previous one's and a 34-repo database kept only
+    /// the last repo's couplings. The paths are repo-relative too, so even a
+    /// correctly merged file would have collided — `CHANGELOG.md` exists in most
+    /// repos (nw-062).
+    ///
+    /// `#[serde(default)]` so a legacy flat sidecar still loads; those entries
+    /// are unattributed and are treated as belonging to no repo in particular.
+    #[serde(default)]
+    pub repo: String,
     pub file_a: String,
     pub file_b: String,
     pub cochange_count: u32,
@@ -40,6 +53,13 @@ pub fn compute_cochanges(
     }
 
     let text = String::from_utf8_lossy(&output.stdout);
+    // Stamp every pair with the repo it came from. Canonicalised so it matches
+    // `Repo.root_path`, which is what the read side resolves a repo_uid to.
+    let repo_key = repo_path
+        .canonicalize()
+        .unwrap_or_else(|_| repo_path.to_path_buf())
+        .to_string_lossy()
+        .into_owned();
 
     // Parse: each commit is a hash line followed by file lines, then blank line
     let mut commits: Vec<Vec<String>> = Vec::new();
@@ -104,6 +124,7 @@ pub fn compute_cochanges(
                 return None;
             }
             Some(CoChangeEdge {
+                repo: repo_key.clone(),
                 file_a: a,
                 file_b: b,
                 cochange_count: count,
@@ -124,8 +145,29 @@ pub fn compute_cochanges(
 }
 
 /// Save co-change edges to a sidecar JSON file.
+/// Write `edges` into the sidecar, MERGING with what is already there.
+///
+/// Previously a plain overwrite, so indexing repo B destroyed repo A's pairs and
+/// a multi-repo database retained only whichever repo was indexed last — 33 of 34
+/// repos silently had no co-change data at all (nw-062).
+///
+/// Only the repos present in `edges` are replaced; every other repo's rows are
+/// preserved. Re-indexing one repo therefore refreshes exactly that repo.
+/// Unattributed legacy rows (empty `repo`) are dropped as soon as any repo is
+/// written, because they cannot be refreshed or trusted per-repo — the next index
+/// of each repo restores them, attributed.
 pub fn save_cochange_sidecar(edges: &[CoChangeEdge], path: &Path) -> Result<(), anyhow::Error> {
-    let json = serde_json::to_string_pretty(edges)?;
+    let incoming_repos: std::collections::HashSet<&str> =
+        edges.iter().map(|e| e.repo.as_str()).collect();
+
+    let mut merged: Vec<CoChangeEdge> = load_cochange_sidecar(path)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|e| !e.repo.is_empty() && !incoming_repos.contains(e.repo.as_str()))
+        .collect();
+    merged.extend_from_slice(edges);
+
+    let json = serde_json::to_string_pretty(&merged)?;
     std::fs::write(path, json)?;
     Ok(())
 }
@@ -145,6 +187,7 @@ mod tests {
         // If files A and B both change in 3 commits, A has 5 total, B has 4 total
         // Jaccard = 3 / (5 + 4 - 3) = 3/6 = 0.5
         let edge = CoChangeEdge {
+            repo: "/repos/demo".into(),
             file_a: "a.rs".into(),
             file_b: "b.rs".into(),
             cochange_count: 3,
@@ -155,9 +198,83 @@ mod tests {
         assert!((edge.confidence - 0.5).abs() < f32::EPSILON);
     }
 
+    fn edge(repo: &str, a: &str, b: &str) -> CoChangeEdge {
+        CoChangeEdge {
+            repo: repo.to_string(),
+            file_a: a.to_string(),
+            file_b: b.to_string(),
+            cochange_count: 5,
+            total_commits_a: 10,
+            total_commits_b: 8,
+            confidence: 0.385,
+        }
+    }
+
+    /// nw-062: writing one repo's pairs must NOT destroy another's.
+    ///
+    /// The sidecar was overwritten wholesale, so in a 34-repo database only the
+    /// last-indexed repo had any co-change data — 33 repos silently returned
+    /// empty. This is the conservation guarantee that was missing.
+    #[test]
+    fn writing_one_repo_preserves_every_other_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cochange.json");
+
+        save_cochange_sidecar(&[edge("/repos/alpha", "src/a.rs", "src/b.rs")], &path).unwrap();
+        save_cochange_sidecar(&[edge("/repos/beta", "lib/x.rs", "lib/y.rs")], &path).unwrap();
+
+        let loaded = load_cochange_sidecar(&path).unwrap();
+        let repos: std::collections::HashSet<&str> =
+            loaded.iter().map(|e| e.repo.as_str()).collect();
+        assert!(
+            repos.contains("/repos/alpha"),
+            "indexing beta destroyed alpha: {repos:?}"
+        );
+        assert!(repos.contains("/repos/beta"), "beta missing: {repos:?}");
+        assert_eq!(loaded.len(), 2);
+    }
+
+    /// Re-indexing a repo REPLACES its own rows rather than duplicating them.
+    #[test]
+    fn rewriting_the_same_repo_replaces_rather_than_appends() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cochange.json");
+
+        save_cochange_sidecar(&[edge("/repos/alpha", "src/a.rs", "src/b.rs")], &path).unwrap();
+        save_cochange_sidecar(&[edge("/repos/alpha", "src/c.rs", "src/d.rs")], &path).unwrap();
+
+        let loaded = load_cochange_sidecar(&path).unwrap();
+        assert_eq!(
+            loaded.len(),
+            1,
+            "should replace, not accumulate: {loaded:?}"
+        );
+        assert_eq!(loaded[0].file_a, "src/c.rs");
+    }
+
+    /// A legacy flat sidecar (no `repo` field) must still LOAD — the file on disk
+    /// predates this field, and failing to parse it would look like "no
+    /// co-change data" rather than "old format".
+    #[test]
+    fn a_legacy_sidecar_without_a_repo_field_still_loads() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cochange.json");
+        std::fs::write(
+            &path,
+            r#"[{"file_a":"src/a.rs","file_b":"src/b.rs","cochange_count":5,
+                 "total_commits_a":10,"total_commits_b":8,"confidence":0.385}]"#,
+        )
+        .unwrap();
+
+        let loaded = load_cochange_sidecar(&path).expect("legacy format must still parse");
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].repo, "", "legacy rows are unattributed");
+    }
+
     #[test]
     fn sidecar_roundtrip() {
         let edges = vec![CoChangeEdge {
+            repo: "/repos/demo".into(),
             file_a: "src/a.rs".into(),
             file_b: "src/b.rs".into(),
             cochange_count: 5,

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -11862,6 +11862,7 @@ mod blast_radius_visibility_tests {
         std::fs::write(&db_path, b"").unwrap();
         save_cochange_sidecar(
             &[CoChangeEdge {
+                repo: String::new(),
                 file_a: "src/api.rs".to_string(),
                 file_b: "hidden/private.sql".to_string(),
                 cochange_count: 8675309,


### PR DESCRIPTION
Completes **nw-062**. PR #201 fixed the *disclosure* half; this fixes the **data loss**.

## The defect

The sidecar was a flat JSON list with no owner, written per repo with a plain
overwrite. **Indexing repo B destroyed repo A's pairs**, so a 34-repo database kept only
whichever repo was indexed last — 33 of 34 repos silently had no co-change data.

Its paths are repo-*relative* too, so even a correctly merged file would have collided:
`CHANGELOG.md` exists in most repos.

## Write side

`compute_cochanges` already receives the repo path, so it stamps each pair with the
canonicalised path — the same value as `Repo.root_path`, which is what the read side can
resolve a `repo_uid` to. That shared key is what makes the fix possible.

`save_cochange_sidecar` now **merges**: only repos present in the incoming edges are
replaced; every other repo's rows survive. Re-indexing one repo refreshes exactly that
repo.

## Read side matters as much

**Qualifying storage alone would have made things worse.** Once the sidecar holds all 34
repos and its paths stay repo-relative, a `CHANGELOG.md` in one repo matches a
`CHANGELOG.md` in another and invents a coupling that doesn't exist — trading silent data
loss for silent false positives.

Matching now filters to repos actually in scope, resolved through the `scope_uids` the
coverage block already computes.

## Three degradations, none of them guesses

Each falls through to the existing `cochange-no-coverage` disclosure:

- a repo with no `root_path` (server-side bare clone) contributes nothing
- unattributed legacy rows match nothing
- **a legacy flat sidecar still parses** — failing to load it would have read as "no
  co-change data" rather than "old format"

Legacy rows are dropped once any repo is written, since they can't be refreshed or
trusted per-repo; the next index restores them attributed.

## Verification

Conservation test confirmed red by restoring the overwrite: **"indexing beta destroyed
alpha"**.

984 engine + 315 store + 132 mcp tests pass; workspace clippy `-D warnings` and fmt clean.