### PR TITLE
fix(daemon): log boot timing so a stalled start is diagnosable

### DIFF
--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -6944,6 +6944,14 @@ pub async fn run_server(
 
     // Open the graph store: read-only for a snapshot replica, read-write
     // otherwise (the daemon is the sole DB owner).
+    // Time the pre-bind phases. A client gives the daemon a bounded window to
+    // bind its socket, and when that expired the only evidence was a single
+    // "[daemon] starting" line — nothing said WHERE the time went, so the cause
+    // had to be guessed at. It is not the embedding model: that loads long after
+    // the socket is serving (see `load_embedding_model` below). Opening the
+    // database is the dominant pre-bind cost, so measure it (nw-114).
+    let boot_started = std::time::Instant::now();
+
     let store = if read_only {
         GraphStore::open_read_only(&db_path).with_context(|| {
             format!("failed to open snapshot read-only at {}", db_path.display())
@@ -6962,6 +6970,7 @@ pub async fn run_server(
             }
         }
     };
+    let store_open_ms = boot_started.elapsed().as_millis() as u64;
 
     // Load sidecars (PageRank, interaction scores).
     nestweaver_engine::migrate_sidecar(&db_path, "pagerank.json", ".pagerank.json");
@@ -7305,6 +7314,14 @@ pub async fn run_server(
 
     let uds = tokio::net::UnixListener::bind(&sock_path)
         .with_context(|| format!("bind UDS: {}", sock_path.display()))?;
+    // The line a stalled-boot investigation actually needs: how long the client
+    // had to wait, and how much of it was the database open.
+    tracing::info!(
+        boot_ms = boot_started.elapsed().as_millis() as u64,
+        store_open_ms = store_open_ms,
+        socket = %sock_path.display(),
+        "socket bound and accepting connections"
+    );
     let uds_stream = tokio_stream::wrappers::UnixListenerStream::new(uds);
 
     // Create scheduler command channel. The sender goes into AdminState


### PR DESCRIPTION
Closes **nw-114** — but not the way the entry, nw-014's note, or my own recommendation
said.

## The premise was wrong

nw-014 proposed binding the socket **before** loading the embed model, and both nw-114
and my recommendation to Kory carried that forward as the outstanding root fix.

**It is already implemented, and has been.** The UDS socket binds and the serve task is
spawned; `load_embedding_model` runs afterwards; the serve task is awaited later still.
The comment at the bind site says it outright:

> the socket must not wait on a cold-cache model download

The daemon has always been serving before the model loads. **The embed model was never
what delayed the bind.** I verified this by reading the ordering rather than trusting the
note — the same stale-premise trap I'd caught three times in the backlog today, made by
me this time.

## What actually occupies the window

Everything between process start and the bind, dominated by
`GraphStore::open_or_create` — and there was **no timing log in it at all**. That's
precisely why the CI evidence artifact for the Cold Metal flake contained a single
`[daemon] starting` line and the cause had to be inferred.

`boot_ms` and `store_open_ms` are now logged at the moment the socket binds, so the next
occurrence reports where the time went. **No behaviour changes** — this is observability
for a window that had none.

## Consequence

The 30s ceiling with liveness detection from #210 is **not a stopgap awaiting a root
fix — it is the fix**. The backlog entry claiming otherwise is corrected and nw-114 is
closed.

193 daemon unit + 42 daemon integration tests pass; workspace clippy `-D warnings` and
fmt clean.