### PR TITLE
fix: v2.7.2 regression hardening — 16 defects fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 ## Unreleased
 
 
+### Upgrade Notes
+
+* **Re-index your repositories after upgrading.** The import-edge fan-out fix
+  (nw-103) changed how edges are *written*, not how they are read, so it runs at
+  index time and cannot repair edges already in your database. Until a repo is
+  re-indexed, `hubs`, `bridges`, `summary --level hub` and PageRank keep
+  returning the pre-fix ranking for it — on a real 34-repo graph the upgraded
+  binary still reported the exact corrupted ranking from the bug report, and
+  re-indexing a single repo removed all of its artefacts from the top 10.
+
+  ```sh
+  nestweaver index --repo /path/to/each/repo
+  ```
+
+  You do not have to guess whether this affects you: `hubs` and `bridges` now
+  report on stderr when a database contains repos indexed by an older resolver,
+  and stay quiet once everything is current. Vault (`brain refresh`) data is
+  unaffected — this applies to code repositories only.
+
 ### Bug Fixes
 
 * **search:** `regex-search`/`count-patterns` — fix trigram pre-filter correctness for alternation patterns; detect a stale trigram index and fall back to a full scan (`stale_index: true` in JSON, note in text output; remedy: re-run `index --with-trigrams`); bound `--limit` to 1–10000 and `--max-millis` to 1–600000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,29 @@ daemon risks WAL corruption from concurrent access. If you see "database
 locked" errors, stop the daemon (`nestweaver daemon stop`) rather than using
 `--no-daemon`.
 
+## Environment variables (operator-facing)
+
+Timeouts and tuning an operator may actually need. Every one of these is named
+by an error message the tool can print, so they belong somewhere findable.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NESTWEAVER_DAEMON_BOOT_TIMEOUT_SECS` | 30 | How long a client waits for the daemon to bind its socket. Raise it on a slow cold start; the boot-failure message names it. Boot phase timings (`boot_ms`, `store_open_ms`, `extension_reconcile_ms`, `unattributed_ms`) are logged at bind so a slow boot is diagnosable rather than guessed at. |
+| `NESTWEAVER_INDEX_TIMEOUT_SECS` | 1800 | Overall ceiling for one index. On expiry the daemon requests cancellation and reports a terminal error naming this variable. Cancellation is COOPERATIVE and only observed at the next pre-write boundary, so the index may still be finishing — check the daemon log before assuming it stopped. |
+| `NESTWEAVER_DRAIN_TIMEOUT_SECS` | 660 | How long a shutting-down daemon drains active write RPCs. |
+| `NESTWEAVER_STOP_GRACE_SECS` | — | Grace period before a stopping daemon is escalated. |
+| `NESTWEAVER_INDEX_CPU_PERCENT` | 50 | Index CPU duty cycle, percent of one core (1–99; `0` or `>=100` disables). Also see the launchd note below. |
+| `NESTWEAVER_ALLOW_NO_DAEMON` | unset | Opt-in required to honour `--no-daemon` / `NESTWEAVER_NO_DAEMON` outside CI. Without it the bypass is REFUSED, because it circumvents the single-writer lock. Not for normal use. |
+| `NESTWEAVER_LBUG_MAX_THREADS` | 1 | Engine thread-pool size. `1` closes the nw-073 eviction-vs-read race; raise only if you measure a query-latency cost. |
+| `NESTWEAVER_LBUG_BUFFER_POOL_BYTES` | auto | Buffer pool size. A larger pool avoids eviction when the working set fits. |
+| `NESTWEAVER_LBUG_AUTO_CHECKPOINT` | on | `0`/`false` defers auto-checkpoints; reduces the #678 corruption trigger during bulk load. |
+| `NESTWEAVER_CRASH_REPORT_DIRS` | platform | Extra directories scanned by `diagnostics capabilities` for nw-073 crash recurrence. |
+| `NESTWEAVER_GIT_CLONE_TIMEOUT_SECS` / `NESTWEAVER_GIT_NET_TIMEOUT_SECS` | — | Bounds on git clone / network operations during pull. |
+
+Server mode additionally reads `NESTWEAVER_BIND`, `NESTWEAVER_TOKEN`,
+`NESTWEAVER_ADMIN_TOKEN`, `NESTWEAVER_UPSTREAM`, and
+`NESTWEAVER_WEBHOOK_SECRET` / `NESTWEAVER_WEBHOOK_SECRET_OLD` (rotation).
+
 ## macOS App (preferred on Mac)
 
 On macOS, prefer the native `.app` bundle over the CLI daemon. It provides:
@@ -186,6 +209,7 @@ Sidecar files written alongside the database:
 - `<db>.cache` — MCP response cache (binary: MessagePack + ZSTD; falls back to legacy JSON on read)
 - `<db>.parsed_cache.bin` — Cached parse results (symbols, references, type bindings) keyed by content hash, for skipping re-parsing unchanged files
 - `<db>.resolution_deps.bin` — Per-file resolution dependency tracker for incremental cross-file resolution
+- `<db>.resolver_generation.json` — per-repo record of which resolver generation built that repo's edges. A repo with no entry predates the record and is reported as stale by `hubs`/`bridges`, because a resolver fix that changes edge SHAPE (nw-103's import fan-out) cannot repair edges already written — only re-indexing can
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -241,10 +241,14 @@ containing it is available, use this source-build path.
 | `search` | Full-text search across indexed symbols and notes |
 | `symbol` | Look up a symbol by name and display its metadata |
 | `impact` | Trace the blast radius of a symbol through the dependency graph (fails closed on unknown/foreign UIDs, exit 2; `--depth` 1–15; pruning by impact-score threshold or depth is disclosed, `--min-score 0` opts out) |
+| `blast-radius` | Assess blast radius for a set of changed files; reports `gate_state`/`status` and blind spots, and never reports `ok` for a truncated traversal |
+| `flow-trace` | Trace forward execution flow from a symbol — what it calls, and what those call |
 | `read-symbols` | Read a symbol's source span |
 | `regex-search` | Regex search over indexed text (trigram pre-filter; falls back to a full scan with `stale_index: true` when the trigram index is stale — re-run `index --with-trigrams`) |
 | `count-patterns` | Count regex matches per pattern |
 | `investigate` | Orient on a topic in one call |
+| `investigate-expand` | Drill into investigate bundle entries — full body plus immediate neighbours |
+| `investigate-hydrate` | Fill in bodies/summaries for all un-hydrated entries of a bundle |
 | `affected-tests` | Select tests for changed files (tiered; carries a `recommendation` CI directive — `run-full-suite` on any degraded run or when changed files have unrecognized extensions like Makefile/CI YAML/`.sql`) |
 | `repo-map` | Generate a token-budgeted map of the repository structure |
 | `summary` | Hierarchical code summaries at symbol, file, or cluster level |
@@ -288,6 +292,8 @@ containing it is available, use this source-build path.
 | `rts-eval record-truth` | Report a full-suite outcome from CI so selection quality can be measured |
 | `rts-eval report` | Measured file-recall / change-recall / selection-breadth of past selections (refuses percentages below 10 joined runs) |
 | `dead-code` | Detect unreachable symbols via entry point reachability (`unreachable_count` is the unfiltered total; `matching_count` reflects `--min-confidence`; Rust `pub mod` Modules are never flagged; visibility isn't persisted, so all confidence scores are inferred/Medium) |
+| `rerank` | Lightweight result reranker (off-by-default heuristic) |
+| `info` | Show hardware and configuration information |
 | `contracts list` | List API contracts derived from spec files + framework handlers |
 | `contracts drift` | Routes declared in a spec but not implemented, and vice versa (presence-level) |
 | `contracts diff` | Field/type-level OpenAPI breaking-change diff between two spec versions (`--base`/`--head`, `--fail-on-breaking` for CI) |
@@ -343,6 +349,8 @@ containing it is available, use this source-build path.
 | `admin` | Subagent guidance instructions |
 | `interactions` | Manage interaction memory |
 | `hooks` | Install/remove the local pre-push blast-radius check (`--install`, `--strict`, `--uninstall`) |
+| `pre-push-impact` | Analyse local changes against the org-wide graph — what `hooks` runs, and runnable directly (alias `ppi`) |
+| `format-comment` | Format impact analysis results as a PR/MR comment, for CI to post |
 
 </details>
 

--- a/crates/nestweaver-client/src/autostart.rs
+++ b/crates/nestweaver-client/src/autostart.rs
@@ -355,13 +355,20 @@ fn wait_for_socket_watching(
         return Ok(());
     }
 
+    // Do NOT offer `--no-daemon` here. It is a CI-only escape hatch that
+    // bypasses the single-writer lock, and `resolve_use_daemon` refuses it
+    // outside CI anyway — so the suggestion was both unusable and, if forced,
+    // exactly the WAL-corruption risk the daemon exists to prevent (nw-125).
+    // A slow boot is the common cause, so name the knob that actually helps.
     bail!(
         "daemon socket at {} did not accept connections within {:.1}s.\n\
          Check the daemon logs for errors: {}\n\
-         If another process holds the database lock, stop it or use --no-daemon.",
+         If it is simply slow to boot, raise {}; if another process holds the \
+         database lock, stop that process.",
         sock.display(),
         timeout.as_secs_f64(),
-        log_hint_for_socket(sock)
+        log_hint_for_socket(sock),
+        DAEMON_BOOT_TIMEOUT_ENV
     );
 }
 

--- a/crates/nestweaver-client/src/autostart.rs
+++ b/crates/nestweaver-client/src/autostart.rs
@@ -302,6 +302,19 @@ fn wait_for_socket(sock: &Path) -> Result<()> {
 /// aborts the very restart we just requested — which is exactly what broke
 /// `daemon_crash_recovery`. A pidfile that cannot be read yet is likewise not
 /// treated as death: a freshly spawned daemon writes it asynchronously.
+/// Where to send an operator whose daemon failed to bind `sock`.
+///
+/// The instance id is recovered from the socket's parent directory name, which
+/// is the only identifier available at this point in the failure path.
+fn log_hint_for_socket(sock: &Path) -> String {
+    let instance_id = sock
+        .parent()
+        .and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().replace("nestweaver-", ""))
+        .unwrap_or_else(|| "default".to_string());
+    nestweaver_daemon::lifecycle::log_hint(&instance_id)
+}
+
 fn wait_for_socket_watching(
     sock: &Path,
     pidfile: Option<&Path>,
@@ -328,16 +341,9 @@ fn wait_for_socket_watching(
             }
             bail!(
                 "daemon process {pid} exited before binding {}.\n\
-                 Check the daemon log for errors: {}",
+                 Check the daemon logs for errors: {}",
                 sock.display(),
-                nestweaver_daemon::lifecycle::log_path(
-                    &sock
-                        .parent()
-                        .and_then(|p| p.file_name())
-                        .map(|n| n.to_string_lossy().replace("nestweaver-", ""))
-                        .unwrap_or_else(|| "default".to_string())
-                )
-                .display()
+                log_hint_for_socket(sock)
             );
         }
         std::thread::sleep(delay);
@@ -351,18 +357,11 @@ fn wait_for_socket_watching(
 
     bail!(
         "daemon socket at {} did not accept connections within {:.1}s.\n\
-         Check the daemon log for errors: {}\n\
+         Check the daemon logs for errors: {}\n\
          If another process holds the database lock, stop it or use --no-daemon.",
         sock.display(),
         timeout.as_secs_f64(),
-        nestweaver_daemon::lifecycle::log_path(
-            &sock
-                .parent()
-                .and_then(|p| p.file_name())
-                .map(|n| n.to_string_lossy().replace("nestweaver-", ""))
-                .unwrap_or_else(|| "default".to_string())
-        )
-        .display()
+        log_hint_for_socket(sock)
     );
 }
 

--- a/crates/nestweaver-daemon/src/lifecycle.rs
+++ b/crates/nestweaver-daemon/src/lifecycle.rs
@@ -204,6 +204,25 @@ pub fn log_path(instance_id: &str) -> PathBuf {
     log_dir(instance_id).join("daemon.log")
 }
 
+/// Operator-facing pointer to where daemon diagnostics actually live.
+///
+/// Two writers put daemon output in [`log_dir`], and they do NOT overlap:
+/// launchd redirects the process's stderr to the undated `daemon.log`, while
+/// the tracing subscriber uses a daily rolling appender that writes structured
+/// records to `daemon.log.<YYYY-MM-DD>`. Boot timing, and every
+/// `tracing::error!` emitted by a failing startup, land only in the dated file.
+///
+/// Pointing a stuck operator at `log_path` alone therefore names the one file
+/// guaranteed not to hold the tracing error they are looking for, which is the
+/// dead end this hint exists to avoid.
+pub fn log_hint(instance_id: &str) -> String {
+    format!(
+        "{} — `daemon.log` is stderr; `daemon.log.<date>` has the structured \
+         boot timing and errors",
+        log_dir(instance_id).display()
+    )
+}
+
 /// Launchd service label for the given instance.
 pub fn launchd_label(instance_id: &str) -> String {
     format!("io.kehl.nestweaver.{instance_id}")
@@ -542,5 +561,22 @@ mod tests {
     fn log_path_ends_with_daemon_log() {
         let lp = log_path("test1234");
         assert!(lp.ends_with("daemon.log"));
+    }
+
+    /// The boot-failure messages used to hand operators `log_path` alone. That
+    /// is the launchd stderr file; the tracing subscriber's daily rolling
+    /// appender writes boot timing and startup errors to `daemon.log.<date>`
+    /// instead, so the named file never contained the error being hunted.
+    #[test]
+    fn log_hint_names_the_dated_tracing_file_not_just_stderr() {
+        let hint = log_hint("test1234");
+        assert!(
+            hint.contains("daemon.log.<date>"),
+            "hint must point at the dated tracing file: {hint}"
+        );
+        assert!(
+            hint.contains(&log_dir("test1234").display().to_string()),
+            "hint must name the directory holding both files: {hint}"
+        );
     }
 }

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -7198,6 +7198,15 @@ pub async fn run_server(
         ui_server: std::sync::Mutex::new(None),
     });
 
+    // nw-119: two instrumentation passes narrowed the unattributed boot time to
+    // the span between the Tantivy open and the bind — 253s of a 268s boot,
+    // with no log output in it at all. Config load, permission source and the
+    // embedding probe measured 0-210ms, so the cost is here: these reconcile
+    // passes walk extension state against a 5.6 GB graph, synchronously, before
+    // the socket is allowed to bind. Measure rather than assume — the previous
+    // two hypotheses (store open, then the 13 MB pagerank sidecar) were both
+    // wrong.
+    let reconcile_started = std::time::Instant::now();
     if !read_only {
         recover_pending_instance_extension_migration(&state).with_context(|| {
             format!(
@@ -7220,6 +7229,8 @@ pub async fn run_server(
                 )
             })?;
     }
+
+    let extension_reconcile_ms = reconcile_started.elapsed().as_millis() as u64;
 
     // Pre-warm PPR adjacency cache so the first PPR query after startup
     // hits the cache instead of spending ~350ms rebuilding from the DB.
@@ -7359,6 +7370,7 @@ pub async fn run_server(
         tantivy_open_ms = tantivy_open_ms,
         permission_source_ms = permission_source_ms,
         embedding_probe_ms = embedding_probe_ms,
+        extension_reconcile_ms = extension_reconcile_ms,
         unattributed_ms = boot_ms.saturating_sub(
             store_open_ms
                 + pagerank_load_ms
@@ -7366,6 +7378,7 @@ pub async fn run_server(
                 + tantivy_open_ms
                 + permission_source_ms
                 + embedding_probe_ms
+                + extension_reconcile_ms
         ),
         socket = %sock_path.display(),
         "socket bound and accepting connections"

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -6973,13 +6973,26 @@ pub async fn run_server(
     let store_open_ms = boot_started.elapsed().as_millis() as u64;
 
     // Load sidecars (PageRank, interaction scores).
+    //
+    // nw-119: nw-114 attributed daemon boot cost to opening the store, and the
+    // instrumentation it added disproved that — `boot_ms=6712` against
+    // `store_open_ms=876` on a warm cache, and a later boot measured 36,474ms
+    // against 10,041ms. So the majority of pre-bind time was somewhere in here
+    // and nobody could say where. Guessing once was already wrong; time each
+    // phase instead. These sidecars are not small (the production
+    // `.pagerank.json` is 13 MB of JSON), which is a candidate but not yet a
+    // conclusion.
+    let sidecar_started = std::time::Instant::now();
     nestweaver_engine::migrate_sidecar(&db_path, "pagerank.json", ".pagerank.json");
     let pr_path = nestweaver_engine::sidecar_path(&db_path, ".pagerank.json");
     let _ = store.load_pagerank_cache(&pr_path);
+    let pagerank_load_ms = sidecar_started.elapsed().as_millis() as u64;
 
+    let interactions_started = std::time::Instant::now();
     if let Some(scores) = nestweaver_engine::load_interaction_scores(&db_path) {
         store.load_interaction_cache(scores);
     }
+    let interactions_load_ms = interactions_started.elapsed().as_millis() as u64;
 
     // Open the Tantivy index. A read-only snapshot replica intentionally
     // disables search reconciliation and uses a reader when one is available.
@@ -6990,7 +7003,9 @@ pub async fn run_server(
     // opens, queries use substring fallback and indexed mutations still surface
     // the configured-index failure.
     let tantivy_path = nestweaver_mcp::tantivy_sidecar_path(&db_path);
+    let tantivy_started = std::time::Instant::now();
     let (tantivy, search_reconciliation) = open_search_index(&tantivy_path, read_only);
+    let tantivy_open_ms = tantivy_started.elapsed().as_millis() as u64;
 
     let idle_notify = Arc::new(Notify::new());
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
@@ -7122,7 +7137,18 @@ pub async fn run_server(
     )?;
 
     // Build the per-repo authz policy ONCE, before the state is assembled.
+    // nw-119: the first instrumentation pass narrowed the gap but did not close
+    // it — store open, pagerank and tantivy together accounted for well under a
+    // third of boot, leaving ~52s unattributed on a 66s boot. The 13 MB
+    // `.pagerank.json` was the leading suspect and measured 448ms, so that
+    // hypothesis is dead too. Everything between the tantivy open and the bind
+    // is the remaining candidate; `get_embedding_metadata` is a store query
+    // against a 5.6 GB database, which is the next thing worth timing rather
+    // than assuming.
+    let permission_started = std::time::Instant::now();
     let permission_source = build_daemon_permission_source(instance_cfg.as_ref());
+    let permission_source_ms = permission_started.elapsed().as_millis() as u64;
+    let embedding_probe_started = std::time::Instant::now();
     let embedding_cfg = instance_cfg
         .as_ref()
         .map(|config| config.embedding.clone())
@@ -7138,6 +7164,7 @@ pub async fn run_server(
         cfg!(feature = "embed"),
         daemon_metal_compiled(),
     );
+    let embedding_probe_ms = embedding_probe_started.elapsed().as_millis() as u64;
     let state = Arc::new(DaemonState {
         store: Arc::new(store),
 
@@ -7315,10 +7342,31 @@ pub async fn run_server(
     let uds = tokio::net::UnixListener::bind(&sock_path)
         .with_context(|| format!("bind UDS: {}", sock_path.display()))?;
     // The line a stalled-boot investigation actually needs: how long the client
-    // had to wait, and how much of it was the database open.
+    // had to wait, and where it went.
+    //
+    // nw-119: `boot_ms` and `store_open_ms` alone showed the store was a small
+    // fraction of boot without saying what the rest was, so the phases are
+    // broken out. `unattributed_ms` is deliberately reported rather than left
+    // for the reader to subtract — if it stays large, the next phase to
+    // instrument is still missing, and that should be visible instead of
+    // requiring arithmetic nobody performs.
+    let boot_ms = boot_started.elapsed().as_millis() as u64;
     tracing::info!(
-        boot_ms = boot_started.elapsed().as_millis() as u64,
+        boot_ms = boot_ms,
         store_open_ms = store_open_ms,
+        pagerank_load_ms = pagerank_load_ms,
+        interactions_load_ms = interactions_load_ms,
+        tantivy_open_ms = tantivy_open_ms,
+        permission_source_ms = permission_source_ms,
+        embedding_probe_ms = embedding_probe_ms,
+        unattributed_ms = boot_ms.saturating_sub(
+            store_open_ms
+                + pagerank_load_ms
+                + interactions_load_ms
+                + tantivy_open_ms
+                + permission_source_ms
+                + embedding_probe_ms
+        ),
         socket = %sock_path.display(),
         "socket bound and accepting connections"
     );

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -3360,6 +3360,32 @@ impl NestWeaverDaemon for DaemonService {
                     _ = tokio::time::sleep(index_timeout) => {
                         tracing::warn!(?index_timeout, "index exceeded timeout; cancelling");
                         cancel.store(true, std::sync::atomic::Ordering::Relaxed);
+                        // nw-127: previously the watchdog set the flag and said
+                        // nothing, so the client's stream simply ended and it
+                        // reported "index progress stream ended before
+                        // completion" — indistinguishable from a crash, and
+                        // reported as a FAILURE for an index that (because
+                        // cancellation is cooperative and only observed at the
+                        // pre-write boundary) may still be running and may still
+                        // succeed. Send a terminal Error event so the caller
+                        // learns what actually happened, names the knob, and is
+                        // warned not to assume the work stopped.
+                        let _ = watch_tx
+                            .send(Ok(IndexProgress {
+                                phase: Phase::Error as i32,
+                                message: format!(
+                                    "index exceeded the {}s timeout and cancellation was requested \
+                                     (raise NESTWEAVER_INDEX_TIMEOUT_SECS). Cancellation is \
+                                     cooperative and is only observed at the next pre-write \
+                                     boundary, so the daemon may still be finishing this index — \
+                                     check the daemon log before assuming it stopped or retrying.",
+                                    index_timeout.as_secs()
+                                ),
+                                files_processed: 0,
+                                files_total: 0,
+                                symbols_found: 0,
+                            }))
+                            .await;
                     }
                     _ = watch_tx.closed() => {
                         // Client dropped the progress stream — stop wasting CPU.

--- a/crates/nestweaver-engine/src/agent_guide.rs
+++ b/crates/nestweaver-engine/src/agent_guide.rs
@@ -906,8 +906,34 @@ pub fn generate_claude_md_with_rules(
     out.push_str("- `brain_context` — PPR-ranked structural context from symbol seeds\n");
     out.push_str("- `brain_impact` — blast radius before modifying code\n");
     out.push_str("- `brain_search` — full-text search across code and notes\n");
+    out.push_str("- `blast_radius` — assess a set of CHANGED FILES, with a trust contract\n");
+    out.push_str("- `flow_trace` — trace forward execution flow from a symbol\n");
     out.push_str("- `project_context` — project-scoped notes and symbols\n");
     out.push_str("- `detect_changes` — assess risk after changes\n");
+
+    // These tools report how much they actually established. An agent that
+    // ignores those fields will present a partial or unanchored answer as a
+    // complete one, which is the failure mode the fields exist to prevent —
+    // so the guide has to say so explicitly rather than assume it is read.
+    out.push_str("\n### Read the trust fields before trusting a result\n\n");
+    out.push_str(
+        "- `status` / `gate_state` — a run that did not complete is `partial` / \
+         `degraded-unknown`, never `ok`. Do not report it as a clean result.\n",
+    );
+    out.push_str(
+        "- `truncated` (with `truncated_by_depth` / `truncated_by_threshold`) — an \
+         empty or short result may be a budget limit, not an absence. `total` is \
+         `null` when genuinely unknown; it is not zero.\n",
+    );
+    out.push_str(
+        "- `semantic_applied` / `degraded_components` — retrieval that fell back to \
+         lexical ranking orders results differently. Say so rather than implying \
+         relevance you did not get.\n",
+    );
+    out.push_str(
+        "- `notifications` / `note` — read them. A caveat like `cochange-no-coverage` \
+         means an empty list is unmined history, not evidence of no coupling.\n",
+    );
 
     Ok(out)
 }
@@ -1200,6 +1226,18 @@ mod tests {
         assert!(output.contains("brain_search"));
         assert!(output.contains("project_context"));
         assert!(output.contains("detect_changes"));
+        // The flagship analysis tools and the trust contract must reach every
+        // generated guide — an agent that never learns to read `gate_state`
+        // will present a degraded result as a clean one.
+        assert!(
+            output.contains("blast_radius"),
+            "guide must list blast_radius"
+        );
+        assert!(output.contains("flow_trace"), "guide must list flow_trace");
+        assert!(
+            output.contains("gate_state"),
+            "guide must tell agents to read the trust fields"
+        );
     }
 
     fn make_symbol(uid: &str, name: &str, file_path: &str) -> nestweaver_schema::Symbol {

--- a/crates/nestweaver-engine/src/extensions.rs
+++ b/crates/nestweaver-engine/src/extensions.rs
@@ -1996,7 +1996,9 @@ pub fn reconcile_extension_liveness(
     // result is identical to doing nothing, and skipping the walk is an
     // equivalence rather than an approximation. Falls through to the same
     // durable directory sync the `removed == 0` path performs.
-    let needs_liveness_scan = extensions.keys().any(|uid| is_shared_finalizer_graph_uid(uid));
+    let needs_liveness_scan = extensions
+        .keys()
+        .any(|uid| is_shared_finalizer_graph_uid(uid));
     let (live, protected) = if needs_liveness_scan {
         (
             graph.live_graph_node_uids()?,
@@ -2187,7 +2189,11 @@ pub fn query_by_property<'a>(
 ) -> Vec<&'a str> {
     store
         .iter()
-        .filter(|(_, props)| props.get(key).is_some_and(|stored| property_matches(stored, value)))
+        .filter(|(_, props)| {
+            props
+                .get(key)
+                .is_some_and(|stored| property_matches(stored, value))
+        })
         .map(|(uid, _)| uid.as_str())
         .collect()
 }
@@ -2198,12 +2204,12 @@ pub fn query_by_property<'a>(
 /// query is a scalar.
 ///
 /// nw-109: exact equality alone made key+value mode useless against real data.
-/// Properties in a live sidecar are array-valued (`aliases: ["Raven","raven"]`),
+/// Properties in a live sidecar are array-valued (`aliases: ["Widget","widget"]`),
 /// so the only query that could ever match was one reproducing the entire array
 /// verbatim, in order — meaning the obvious question, "which nodes have alias
-/// Raven", had no expressible form. Membership makes the mode usable without
+/// Widget", had no expressible form. Membership makes the mode usable without
 /// weakening exact matching: an array query still compares whole-array, so
-/// `["Raven","raven"]` matches only that exact array.
+/// `["Widget","widget"]` matches only that exact array.
 fn property_matches(stored: &serde_json::Value, query: &serde_json::Value) -> bool {
     if stored == query {
         return true;
@@ -2289,23 +2295,23 @@ mod tests {
 
     /// nw-109: with every property in a real sidecar array-valued, exact-only
     /// matching meant key+value mode returned 0 results for 100% of live data —
-    /// the obvious question ("which nodes carry alias Raven") had no expressible
-    /// form. Membership makes it answerable.
+    /// the obvious question ("which nodes carry alias Widget") had no
+    /// expressible form. Membership makes it answerable.
     #[test]
     fn scalar_query_matches_a_member_of_an_array_valued_property() {
         let mut store: ExtensionStore = Default::default();
         store.insert(
-            "repo:raven".to_string(),
+            "repo:widget".to_string(),
             [(
                 "aliases".to_string(),
-                serde_json::json!(["Raven", "raven"]),
+                serde_json::json!(["Widget", "widget"]),
             )]
             .into_iter()
             .collect(),
         );
         assert_eq!(
-            query_by_property(&store, "aliases", &serde_json::json!("Raven")),
-            vec!["repo:raven"]
+            query_by_property(&store, "aliases", &serde_json::json!("Widget")),
+            vec!["repo:widget"]
         );
         assert!(query_by_property(&store, "aliases", &serde_json::json!("nope")).is_empty());
     }
@@ -2336,9 +2342,14 @@ mod tests {
         let mut store: ExtensionStore = Default::default();
         store.insert(
             "a".to_string(),
-            [("n".to_string(), serde_json::json!(7))].into_iter().collect(),
+            [("n".to_string(), serde_json::json!(7))]
+                .into_iter()
+                .collect(),
         );
-        assert_eq!(query_by_property(&store, "n", &serde_json::json!(7)), vec!["a"]);
+        assert_eq!(
+            query_by_property(&store, "n", &serde_json::json!(7)),
+            vec!["a"]
+        );
         assert!(query_by_property(&store, "n", &serde_json::json!(8)).is_empty());
     }
 
@@ -2383,9 +2394,7 @@ mod tests {
         let protected: std::collections::BTreeSet<String> = Default::default();
         let before = extensions.len();
         extensions.retain(|uid, _| {
-            !is_shared_finalizer_graph_uid(uid)
-                || live.contains(uid)
-                || protected.contains(uid)
+            !is_shared_finalizer_graph_uid(uid) || live.contains(uid) || protected.contains(uid)
         });
         assert_eq!(
             extensions.len(),

--- a/crates/nestweaver-engine/src/extensions.rs
+++ b/crates/nestweaver-engine/src/extensions.rs
@@ -1981,8 +1981,31 @@ pub fn reconcile_extension_liveness(
     let Some(mut extensions) = load_extensions_strict(&path)? else {
         return Ok(0);
     };
-    let live = graph.live_graph_node_uids()?;
-    let protected = protected_migration_source_uids(db_path)?;
+
+    // nw-119: `live_graph_node_uids` enumerates every node in the graph, and it
+    // runs synchronously before the daemon binds its socket. Measured on a
+    // 5.6 GB production graph it cost 41.6s of a 53.9s boot — 77% of the time a
+    // client spends waiting, and the reason boot repeatedly blew past the
+    // timeout raised by nw-114. The existing early-out only fires when the
+    // sidecar is ABSENT, so a 2 KB extensions file was paying for a full-graph
+    // scan on every start.
+    //
+    // The scan is only ever consulted for keys where
+    // `is_shared_finalizer_graph_uid` holds: the retain below keeps every other
+    // key unconditionally via its first clause. So when no key qualifies, the
+    // result is identical to doing nothing, and skipping the walk is an
+    // equivalence rather than an approximation. Falls through to the same
+    // durable directory sync the `removed == 0` path performs.
+    let needs_liveness_scan = extensions.keys().any(|uid| is_shared_finalizer_graph_uid(uid));
+    let (live, protected) = if needs_liveness_scan {
+        (
+            graph.live_graph_node_uids()?,
+            protected_migration_source_uids(db_path)?,
+        )
+    } else {
+        (Default::default(), Default::default())
+    };
+
     let before = extensions.len();
     extensions.retain(|uid, _| {
         !is_shared_finalizer_graph_uid(uid) || live.contains(uid) || protected.contains(uid)
@@ -2238,6 +2261,58 @@ fn sidecar_path(db_path: &Path) -> std::path::PathBuf {
 mod tests {
     use super::*;
     use tempfile::NamedTempFile;
+
+    /// nw-119: the boot-time liveness reconcile skips the full-graph walk when
+    /// no extension key is a shared-finalizer UID. That skip must be an
+    /// EQUIVALENCE, not an approximation — the retain clause keeps every
+    /// non-shared key unconditionally, so a scan could not have removed them.
+    ///
+    /// Guarding the predicate directly: if this ever starts reporting true for
+    /// ordinary application keys, the optimisation would begin skipping a scan
+    /// that matters.
+    #[test]
+    fn only_shared_finalizer_uids_can_ever_be_removed_by_a_liveness_scan() {
+        // Opaque application metadata — must survive a restart even with no
+        // matching graph node, so a liveness scan is irrelevant to it.
+        assert!(!is_shared_finalizer_graph_uid("proj:anything"));
+        assert!(!is_shared_finalizer_graph_uid("note:vlt:unrelated:abc:def"));
+        assert!(!is_shared_finalizer_graph_uid("not-a-uid"));
+        assert!(!is_shared_finalizer_graph_uid(""));
+    }
+
+    /// The skip is decided purely by the sidecar's own keys, so a database with
+    /// only opaque keys never pays for the graph walk that cost 41.6s of a
+    /// 53.9s daemon boot on the production graph.
+    #[test]
+    fn liveness_scan_is_skipped_when_no_key_is_a_shared_finalizer_uid() {
+        let mut extensions: ExtensionStore = Default::default();
+        extensions.insert("proj:alpha".to_string(), Default::default());
+        extensions.insert("note:vlt:other:aaa:bbb".to_string(), Default::default());
+
+        let needs = extensions
+            .keys()
+            .any(|uid| is_shared_finalizer_graph_uid(uid));
+        assert!(
+            !needs,
+            "a sidecar of purely opaque keys must not trigger a full-graph walk"
+        );
+
+        // And every one of them is retained regardless of liveness, which is
+        // why skipping the walk cannot change the outcome.
+        let live: std::collections::BTreeSet<String> = Default::default();
+        let protected: std::collections::BTreeSet<String> = Default::default();
+        let before = extensions.len();
+        extensions.retain(|uid, _| {
+            !is_shared_finalizer_graph_uid(uid)
+                || live.contains(uid)
+                || protected.contains(uid)
+        });
+        assert_eq!(
+            extensions.len(),
+            before,
+            "no key may be dropped when the scan is skipped"
+        );
+    }
 
     fn test_pending_handoff(operation_id: &str, source_uid: &str) -> PendingExtensionHandoff {
         PendingExtensionHandoff {

--- a/crates/nestweaver-engine/src/extensions.rs
+++ b/crates/nestweaver-engine/src/extensions.rs
@@ -2187,9 +2187,34 @@ pub fn query_by_property<'a>(
 ) -> Vec<&'a str> {
     store
         .iter()
-        .filter(|(_, props)| props.get(key) == Some(value))
+        .filter(|(_, props)| props.get(key).is_some_and(|stored| property_matches(stored, value)))
         .map(|(uid, _)| uid.as_str())
         .collect()
+}
+
+/// Whether a stored property value satisfies a query value.
+///
+/// Exact equality, PLUS membership when the stored value is an array and the
+/// query is a scalar.
+///
+/// nw-109: exact equality alone made key+value mode useless against real data.
+/// Properties in a live sidecar are array-valued (`aliases: ["Raven","raven"]`),
+/// so the only query that could ever match was one reproducing the entire array
+/// verbatim, in order — meaning the obvious question, "which nodes have alias
+/// Raven", had no expressible form. Membership makes the mode usable without
+/// weakening exact matching: an array query still compares whole-array, so
+/// `["Raven","raven"]` matches only that exact array.
+fn property_matches(stored: &serde_json::Value, query: &serde_json::Value) -> bool {
+    if stored == query {
+        return true;
+    }
+    match (stored, query) {
+        // Scalar-in-array membership. A query that is itself an array is NOT
+        // treated as a set of alternatives — that would silently turn an exact
+        // array comparison into an any-of, which is a different question.
+        (serde_json::Value::Array(items), q) if !q.is_array() => items.iter().any(|i| i == q),
+        _ => false,
+    }
 }
 
 /// Return all properties stored for a node, or an empty map.
@@ -2261,6 +2286,61 @@ fn sidecar_path(db_path: &Path) -> std::path::PathBuf {
 mod tests {
     use super::*;
     use tempfile::NamedTempFile;
+
+    /// nw-109: with every property in a real sidecar array-valued, exact-only
+    /// matching meant key+value mode returned 0 results for 100% of live data —
+    /// the obvious question ("which nodes carry alias Raven") had no expressible
+    /// form. Membership makes it answerable.
+    #[test]
+    fn scalar_query_matches_a_member_of_an_array_valued_property() {
+        let mut store: ExtensionStore = Default::default();
+        store.insert(
+            "repo:raven".to_string(),
+            [(
+                "aliases".to_string(),
+                serde_json::json!(["Raven", "raven"]),
+            )]
+            .into_iter()
+            .collect(),
+        );
+        assert_eq!(
+            query_by_property(&store, "aliases", &serde_json::json!("Raven")),
+            vec!["repo:raven"]
+        );
+        assert!(query_by_property(&store, "aliases", &serde_json::json!("nope")).is_empty());
+    }
+
+    /// Exact array equality must keep working, and must stay EXACT — an array
+    /// query is one value, not a set of alternatives.
+    #[test]
+    fn array_query_still_compares_whole_array_not_any_of() {
+        let mut store: ExtensionStore = Default::default();
+        store.insert(
+            "a".to_string(),
+            [("t".to_string(), serde_json::json!(["x", "y"]))]
+                .into_iter()
+                .collect(),
+        );
+        assert_eq!(
+            query_by_property(&store, "t", &serde_json::json!(["x", "y"])),
+            vec!["a"]
+        );
+        // A subset array must NOT match: that would silently reinterpret the
+        // query as any-of, which is a different question than the caller asked.
+        assert!(query_by_property(&store, "t", &serde_json::json!(["x"])).is_empty());
+    }
+
+    /// Scalar properties are unaffected.
+    #[test]
+    fn scalar_property_still_requires_exact_equality() {
+        let mut store: ExtensionStore = Default::default();
+        store.insert(
+            "a".to_string(),
+            [("n".to_string(), serde_json::json!(7))].into_iter().collect(),
+        );
+        assert_eq!(query_by_property(&store, "n", &serde_json::json!(7)), vec!["a"]);
+        assert!(query_by_property(&store, "n", &serde_json::json!(8)).is_empty());
+    }
 
     /// nw-119: the boot-time liveness reconcile skips the full-graph walk when
     /// no extension key is a shared-finalizer UID. That skip must be an

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -1542,6 +1542,9 @@ fn infer_cross_repo_call_edges(
         .collect();
     let mut edges = Vec::new();
     let mut seen = std::collections::HashSet::new();
+    // name -> store hits, memoised for this call (nw-127).
+    let mut name_lookup_cache: std::collections::HashMap<String, Vec<nestweaver_schema::Symbol>> =
+        std::collections::HashMap::new();
     for (rel_path, symbols, references, _) in parsed_files {
         // Names this file imports — corroborates a same-named cross-repo call.
         let imported_names: std::collections::HashSet<&str> = references
@@ -1570,15 +1573,31 @@ fn infer_cross_repo_call_edges(
             );
 
             // Collect eligible cross-repo candidates, then apply the ubiquity cap.
-            let candidates: Vec<_> = store
-                .lookup_symbols_by_name(&reference.name)
-                .map_err(|e| anyhow::anyhow!(e))?
-                .into_iter()
+            //
+            // nw-127: this is one store round-trip PER CALL SITE, and call names
+            // repeat heavily across a repo, so the same name was looked up
+            // thousands of times per run. The store is not mutated inside this
+            // loop (symbol writes happen earlier in the phase), so memoising the
+            // lookup for the duration of the call is a pure win.
+            let by_name = match name_lookup_cache.get(reference.name.as_str()) {
+                Some(hits) => hits,
+                None => {
+                    let hits = store
+                        .lookup_symbols_by_name(&reference.name)
+                        .map_err(|e| anyhow::anyhow!(e))?;
+                    name_lookup_cache
+                        .entry(reference.name.clone())
+                        .or_insert(hits)
+                }
+            };
+            let candidates: Vec<_> = by_name
+                .iter()
                 .filter(|t| {
                     t.repo_uid != current_repo_uid
                         && t.uid != source_uid
                         && t.visibility != Visibility::Private
                 })
+                .cloned()
                 .collect();
             if candidates.is_empty() || candidates.len() > MAX_CROSS_REPO_NAME_CANDIDATES {
                 continue;
@@ -2604,8 +2623,23 @@ where
             .batch_insert_edges(&insertable_edges)
             .context("batch_insert_edges (resolved)")?;
 
-        let inferred_cross_repo_edges =
-            infer_cross_repo_call_edges(store, &r_uid, &parsed_files_for_resolver)?;
+        // nw-127: this walks EVERY parsed file — including unchanged ones, which
+        // are deliberately fed to the resolver — and issues a store lookup per
+        // call site. It ran unconditionally, so an index with zero changed files
+        // still paid for it: 57 minutes on a 755-file repo against a 130k-symbol
+        // graph, which is what pushed large repos past the 1800s ceiling and made
+        // them report failure for work that had actually succeeded.
+        //
+        // When nothing changed, this repo's call sites are identical to the last
+        // run and the edges it would infer are already in the database, so the
+        // whole pass is recomputing a known answer. Skipping matches what
+        // `skip_resolution` already does for ordinary resolution one block above,
+        // and for the same reason.
+        let inferred_cross_repo_edges = if skip_resolution {
+            Vec::new()
+        } else {
+            infer_cross_repo_call_edges(store, &r_uid, &parsed_files_for_resolver)?
+        };
         if !inferred_cross_repo_edges.is_empty() {
             edges_count += inferred_cross_repo_edges.len();
             store

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -2840,7 +2840,26 @@ where
         bump_generation_after_write,
     );
     match (graph_result, finalization) {
-        (Ok(result), Ok(())) => Ok(result),
+        (Ok(result), Ok(())) => {
+            // nw-124: stamp WHICH resolver produced this repo's edges. Some
+            // resolver fixes change edge shape rather than query behaviour
+            // (nw-103's import fan-out), so upgrading the binary leaves already
+            // indexed repos wrong and nothing said so. Recorded only on a fully
+            // successful, finalized index — a failed run must not claim the
+            // repo is current. Best-effort: a sidecar write failure must never
+            // fail an index that already committed.
+            if let Some(db_path) = store.db_path()
+                && let Err(e) = crate::resolver_generation::record(db_path, &r_uid)
+            {
+                tracing::warn!(
+                    repo = %r_uid,
+                    error = %e,
+                    "indexed successfully but could not record the resolver generation; \
+                     ranking staleness for this repo will be over-reported"
+                );
+            }
+            Ok(result)
+        }
         (Ok(_), Err(finalization)) => Err(finalization.into()),
         (Err(primary), Ok(())) => Err(primary),
         (Err(primary), Err(finalization)) => {

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -1583,11 +1583,11 @@ impl<'a> WikilinkLookup<'a> {
         // SOURCE's folder.
         //
         // `by_path` is keyed on full vault-relative paths, so only the first
-        // form ever matched. But `[[plans/Phase B Execution Index]]` written in
-        // `Workspaces/Orbit/_Overview.md` is Obsidian's RELATIVE-path syntax and
-        // means `Workspaces/Orbit/plans/Phase B Execution Index.md`. Every
-        // path-qualified link in the vault therefore resolved to nothing — 45 of
-        // them, all reported at confidence 0.0 (nw-100).
+        // form ever matched. But `[[plans/Rollout Plan]]` written in
+        // `Workspaces/ExampleProject/_Overview.md` is Obsidian's RELATIVE-path
+        // syntax and means `Workspaces/ExampleProject/plans/Rollout Plan.md`.
+        // Every path-qualified link in the vault therefore resolved to nothing —
+        // 45 of them, all reported at confidence 0.0 (nw-100).
         //
         // Both forms are exact, unambiguous single-key lookups, so both score
         // 1.0 and priority ordering is preserved.
@@ -2181,20 +2181,20 @@ sub b body
     ///
     /// `by_path` is keyed on full vault-relative paths, so priority 1 only ever
     /// tried the bare target. `[[plans/Target]]` written in
-    /// `Workspaces/Orbit/_Overview.md` means
-    /// `Workspaces/Orbit/plans/Target.md`, which never matched — so every
-    /// path-qualified link in the vault resolved to nothing (45 of them, all
-    /// reported at confidence 0.0).
+    /// `Workspaces/ExampleProject/_Overview.md` means
+    /// `Workspaces/ExampleProject/plans/Target.md`, which never matched — so
+    /// every path-qualified link in the vault resolved to nothing (45 of them,
+    /// all reported at confidence 0.0).
     #[test]
     fn resolves_a_path_relative_to_the_source_folder() {
         let (_dir, root) = make_vault(&[
             (
-                "Workspaces/Orbit/_Overview.md",
-                "# Overview\n\nSee [[plans/Phase B Execution Index]].\n",
+                "Workspaces/ExampleProject/_Overview.md",
+                "# Overview\n\nSee [[plans/Rollout Plan]].\n",
             ),
             (
-                "Workspaces/Orbit/plans/Phase B Execution Index.md",
-                "# Phase B Execution Index\n\nbody\n",
+                "Workspaces/ExampleProject/plans/Rollout Plan.md",
+                "# Rollout Plan\n\nbody\n",
             ),
         ]);
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
@@ -2212,9 +2212,12 @@ sub b body
         let (_dir, root) = make_vault(&[
             (
                 "notes/index.md",
-                "# Index\n\nSee [[Workspaces/Orbit/plans/Target]].\n",
+                "# Index\n\nSee [[Workspaces/ExampleProject/plans/Target]].\n",
             ),
-            ("Workspaces/Orbit/plans/Target.md", "# Target\n\nbody\n"),
+            (
+                "Workspaces/ExampleProject/plans/Target.md",
+                "# Target\n\nbody\n",
+            ),
         ]);
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
         assert_eq!(result.wikilinks_resolved, 1);
@@ -2226,7 +2229,7 @@ sub b body
     #[test]
     fn a_path_qualified_link_to_nowhere_stays_unresolved() {
         let (_dir, root) = make_vault(&[(
-            "Workspaces/Orbit/_Overview.md",
+            "Workspaces/ExampleProject/_Overview.md",
             "# Overview\n\nSee [[plans/Does Not Exist]].\n",
         )]);
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -665,8 +665,12 @@ fn reinsert_single_note(
         }
         map
     };
-    let mut wl_note_edges: Vec<(String, String, f32, String)> = Vec::new();
-    let mut wl_head_edges: Vec<(String, String, f32, String)> = Vec::new();
+    // nw-122: carry BOTH the visible text and the link target. Backlinks want
+    // the alias a reader sees; broken-links wants the target resolution acted
+    // on. Reporting the alias there rendered `[[workspace]]` for
+    // `[[Home|workspace]]` — a link that appears nowhere in the vault.
+    let mut wl_note_edges: Vec<(String, String, f32, String, String)> = Vec::new();
+    let mut wl_head_edges: Vec<(String, String, f32, String, String)> = Vec::new();
     // Unresolved links collected for a single batched insert — a per-row insert
     // here made a single note with many missing-target links hang the watcher.
     let mut unresolved: Vec<(String, String, String, String, String)> = Vec::new();
@@ -707,6 +711,7 @@ fn reinsert_single_note(
                         h.uid.clone(),
                         conf,
                         display.clone(),
+                        wl.target.clone(),
                     ));
                     continue;
                 }
@@ -716,6 +721,7 @@ fn reinsert_single_note(
                 target.clone(),
                 conf,
                 display.clone(),
+                wl.target.clone(),
             ));
         }
     }
@@ -727,16 +733,16 @@ fn reinsert_single_note(
             tracing::warn!("failed to record unresolved wikilinks: {e}");
         }
     }
-    let wl_note_refs: Vec<(&str, &str, f32, &str)> = wl_note_edges
+    let wl_note_refs: Vec<(&str, &str, f32, &str, &str)> = wl_note_edges
         .iter()
-        .map(|(s, n, c, d)| (s.as_str(), n.as_str(), *c, d.as_str()))
+        .map(|(s, n, c, d, t)| (s.as_str(), n.as_str(), *c, d.as_str(), t.as_str()))
         .collect();
     store
         .batch_insert_wikilink_to_note_edges(&wl_note_refs)
         .context("batch_insert_wikilink_to_note_edges")?;
-    let wl_head_refs: Vec<(&str, &str, f32, &str)> = wl_head_edges
+    let wl_head_refs: Vec<(&str, &str, f32, &str, &str)> = wl_head_edges
         .iter()
-        .map(|(s, h, c, d)| (s.as_str(), h.as_str(), *c, d.as_str()))
+        .map(|(s, h, c, d, t)| (s.as_str(), h.as_str(), *c, d.as_str(), t.as_str()))
         .collect();
     store
         .batch_insert_wikilink_to_heading_edges(&wl_head_refs)
@@ -1199,8 +1205,9 @@ where
     // Wikilink resolution: build lookup indices once, then 5-priority match.
     let lookup = WikilinkLookup::build(&note_contexts);
 
-    let mut wikilink_to_note: Vec<(String, String, f32, String)> = Vec::new();
-    let mut wikilink_to_heading: Vec<(String, String, f32, String)> = Vec::new();
+    // nw-122: (section, target_node, confidence, display_text, link_target).
+    let mut wikilink_to_note: Vec<(String, String, f32, String, String)> = Vec::new();
+    let mut wikilink_to_heading: Vec<(String, String, f32, String, String)> = Vec::new();
     let mut wikilinks_unresolved: usize = 0;
     // (uid, source_note_uid, source_path, source_title, wikilink_text)
     let mut unresolved_records: Vec<(String, String, String, String, String)> = Vec::new();
@@ -1229,6 +1236,7 @@ where
                                     h_uid,
                                     conf_per,
                                     display.clone(),
+                                    wl.target.clone(),
                                 ));
                                 continue;
                             }
@@ -1239,6 +1247,7 @@ where
                             cand.note_uid.clone(),
                             conf_per,
                             display.clone(),
+                            wl.target.clone(),
                         ));
                     }
                 }
@@ -1302,13 +1311,13 @@ where
             .iter()
             .map(|(s, t)| (s.as_str(), t.as_str()))
             .collect();
-        let wl_note_refs: Vec<(&str, &str, f32, &str)> = wikilink_to_note
+        let wl_note_refs: Vec<(&str, &str, f32, &str, &str)> = wikilink_to_note
             .iter()
-            .map(|(s, n, c, d)| (s.as_str(), n.as_str(), *c, d.as_str()))
+            .map(|(s, n, c, d, t)| (s.as_str(), n.as_str(), *c, d.as_str(), t.as_str()))
             .collect();
-        let wl_head_refs: Vec<(&str, &str, f32, &str)> = wikilink_to_heading
+        let wl_head_refs: Vec<(&str, &str, f32, &str, &str)> = wikilink_to_heading
             .iter()
-            .map(|(s, h, c, d)| (s.as_str(), h.as_str(), *c, d.as_str()))
+            .map(|(s, h, c, d, t)| (s.as_str(), h.as_str(), *c, d.as_str(), t.as_str()))
             .collect();
 
         store

--- a/crates/nestweaver-engine/src/investigate.rs
+++ b/crates/nestweaver-engine/src/investigate.rs
@@ -144,6 +144,21 @@ pub struct InvestigateResult {
     /// Number of additional connected nodes dropped due to the token budget.
     #[serde(default, skip_serializing_if = "is_zero")]
     pub more_available: usize,
+    /// Whether semantic retrieval contributed to this map.
+    ///
+    /// nw-120: the daemon passes its warm embedding model here while the CLI's
+    /// direct path hardcodes `None`, so the two return materially different
+    /// RANKINGS for the same query — daemon topped "daemon boot" with
+    /// `wait_for_daemon_boot`, direct with a lexical `BootstrapErrorScreen`.
+    /// The tradeoff is defensible (a per-invocation BERT load is expensive and
+    /// the daemon is the supported path); reporting nothing about it was not,
+    /// because the caller had no way to know the ranking was BM25-only.
+    #[serde(default)]
+    pub semantic_applied: bool,
+    /// Retrieval components that were requested but unavailable, matching
+    /// `brain_context` / `brain_search`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub degraded_components: Vec<String>,
 }
 
 /// The result of `investigate_expand`: the expanded entries plus their
@@ -573,6 +588,7 @@ pub fn investigate(
         })?;
     }
 
+    let semantic_applied = embed_model.is_some();
     Ok(InvestigateResult {
         bundle_id,
         query: query.to_string(),
@@ -580,6 +596,12 @@ pub fn investigate(
         domains,
         entries,
         more_available,
+        semantic_applied,
+        degraded_components: if semantic_applied {
+            Vec::new()
+        } else {
+            vec!["semantic".to_string()]
+        },
     })
 }
 

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -95,6 +95,7 @@ pub mod recency;
 pub mod registry;
 pub mod rerank;
 pub mod resolution_cache;
+pub mod resolver_generation;
 pub mod rts_eval;
 pub mod scheduler;
 pub mod signature_diff;

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -640,6 +640,7 @@ mod promote_tests {
             unresolved_seeds: vec![],
             expansion_terms: vec![],
             semantic_applied: false,
+            semantic_seed_count: 0,
             degraded_components: vec![],
         };
         let members: HashSet<String> = ["note:prd".to_string(), "note:status".to_string()]
@@ -669,6 +670,7 @@ mod promote_tests {
             unresolved_seeds: vec![],
             expansion_terms: vec![],
             semantic_applied: false,
+            semantic_seed_count: 0,
             degraded_components: vec![],
         };
         let members: HashSet<String> = ["note:prd".to_string()].into_iter().collect();
@@ -707,6 +709,7 @@ mod promote_tests {
             unresolved_seeds: vec![],
             expansion_terms: vec![],
             semantic_applied: false,
+            semantic_seed_count: 0,
             degraded_components: vec![],
         };
         let members: HashSet<String> = ["sym:foo".to_string(), "sym:bar".to_string()]
@@ -738,6 +741,7 @@ mod promote_tests {
             unresolved_seeds: vec![],
             expansion_terms: vec![],
             semantic_applied: false,
+            semantic_seed_count: 0,
             degraded_components: vec![],
         };
         let members: HashSet<String> = ["sym:foo".to_string()].into_iter().collect();
@@ -1080,6 +1084,10 @@ pub(crate) fn truncate_body_to_chars(body: String, max_chars: usize) -> (String,
     (truncated, false)
 }
 
+fn is_zero_usize(n: &usize) -> bool {
+    *n == 0
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BrainContextResult {
     /// Resolved seed nodes. The MCP `brain_context` tool omits this field
@@ -1103,6 +1111,18 @@ pub struct BrainContextResult {
     /// vector search successfully.
     #[serde(default)]
     pub semantic_applied: bool,
+    /// How many entries in `seeds` were injected by the semantic leg rather
+    /// than resolved from the query text.
+    ///
+    /// nw-102: vector KNN always returns its k nearest neighbours regardless of
+    /// how far away they are, and those hits were pushed into `seeds`
+    /// unconditionally — the similarity score was discarded at the call site.
+    /// So a nonsense query reported "Seeds (5 resolved)" listing unrelated
+    /// symbols WHILE also listing the same query under `unresolved_seeds`,
+    /// contradicting itself. Recording the provenance lets a renderer say which
+    /// seeds were actually matched and which are nearest-neighbour guesses.
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    pub semantic_seed_count: usize,
     /// Retrieval components that were requested but unavailable. The graph,
     /// PPR, and BM25 legs remain usable when semantic retrieval degrades.
     #[serde(default)]
@@ -1535,6 +1555,7 @@ pub fn build_brain_context_hybrid_with_aliases(
     // hit list is passed to weighted_score_fuse as the semantic signal.
     let semantic_requested = config.weight_semantic > 0.0;
     let mut semantic_applied = false;
+    let mut semantic_seed_count: usize = 0;
     let mut semantic_hits: Vec<(String, f64)> = Vec::new();
     if let Some(model) = embed_model
         && config.weight_semantic > 0.0
@@ -1564,6 +1585,9 @@ pub fn build_brain_context_hybrid_with_aliases(
                         for (uid, _score) in hits.iter().take(config.semantic_seed_limit) {
                             if !seed_uids.contains(uid) {
                                 seed_uids.push(uid.clone());
+                                // nw-102: remember these are nearest-neighbour
+                                // guesses, not resolutions of the query text.
+                                semantic_seed_count += 1;
                             }
                         }
                     }
@@ -1658,6 +1682,7 @@ pub fn build_brain_context_hybrid_with_aliases(
         unresolved_seeds: unresolved,
         expansion_terms,
         semantic_applied,
+        semantic_seed_count,
         degraded_components: if semantic_requested && !semantic_applied {
             vec!["semantic".to_string()]
         } else {
@@ -2996,6 +3021,7 @@ mod dedup_heading_section_tests {
             unresolved_seeds: vec![],
             expansion_terms: vec![],
             semantic_applied: false,
+            semantic_seed_count: 0,
             degraded_components: vec![],
         }
     }

--- a/crates/nestweaver-engine/src/resolver_generation.rs
+++ b/crates/nestweaver-engine/src/resolver_generation.rs
@@ -1,0 +1,160 @@
+//! Per-repo record of which resolver built a repo's edges.
+//!
+//! nw-124. Some resolver fixes change the SHAPE of the graph rather than the
+//! query that reads it, so upgrading the binary does not correct data already
+//! on disk. nw-103 is the motivating case: import edges used to be fanned out
+//! to every symbol in the imported file, which put never-exported string
+//! constants at the top of `hubs` with 800+ out-edges. The fix landed in
+//! `resolve_references`, but that runs at INDEX time — so a user who upgrades
+//! keeps the corrupted hub, bridge and PageRank rankings until each repo is
+//! re-indexed, with nothing telling them the numbers are stale.
+//!
+//! Measured on the production graph: with the FIXED binary, `hubs` still
+//! returned the exact ranking from the bug report. Re-indexing one repo removed
+//! every one of its artefacts from the top 10.
+//!
+//! This sidecar makes that staleness visible instead of silent. It is
+//! deliberately a sidecar and not a node property: adding a column to `Repo`
+//! would need a graph-schema migration, and a repo indexed before this file
+//! existed has no entry — which is exactly the "predates the fix" answer we
+//! want, at zero migration cost.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Current resolver generation.
+///
+/// Bump this whenever a resolver change alters persisted edge shape such that
+/// previously-indexed repos would yield different (wrong) analysis results.
+/// Bumping it makes every not-yet-re-indexed repo report as stale.
+///
+/// 1 — nw-103: import edges attributed to the importing file instead of being
+///     fanned out to every symbol in the imported file.
+pub const RESOLVER_GENERATION: u32 = 1;
+
+/// An unrecorded repo reads as generation 0, so the current generation must
+/// stay above it — otherwise the pre-fix data this module exists to flag would
+/// report as current.
+const _: () = assert!(RESOLVER_GENERATION > 0);
+
+/// Sidecar filename suffix, alongside the other `<db>.*` sidecars.
+pub const RESOLVER_GENERATION_SIDECAR: &str = ".resolver_generation.json";
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct ResolverGenerations {
+    /// repo uid -> generation that produced its edges.
+    #[serde(default)]
+    pub repos: BTreeMap<String, u32>,
+}
+
+impl ResolverGenerations {
+    /// Generation recorded for `repo_uid`. A repo with no entry was indexed
+    /// before this record existed, which is generation 0 by definition.
+    pub fn generation_for(&self, repo_uid: &str) -> u32 {
+        self.repos.get(repo_uid).copied().unwrap_or(0)
+    }
+
+    /// Repo uids whose edges predate [`RESOLVER_GENERATION`].
+    pub fn stale_repos<'a, I: IntoIterator<Item = &'a str>>(&self, known: I) -> Vec<String> {
+        known
+            .into_iter()
+            .filter(|uid| self.generation_for(uid) < RESOLVER_GENERATION)
+            .map(|uid| uid.to_string())
+            .collect()
+    }
+}
+
+/// Load the sidecar, or an empty record when absent/unreadable.
+///
+/// Absent is not an error: it means every repo predates the record, which is
+/// the correct reading for any database indexed before this shipped.
+pub fn load(db_path: &Path) -> ResolverGenerations {
+    let path = crate::sidecar_path(db_path, RESOLVER_GENERATION_SIDECAR);
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+/// Record that `repo_uid` was just indexed by the current resolver.
+///
+/// Merges into the existing file so re-indexing one repo never claims the
+/// others were refreshed too — the whole point is per-repo truth.
+pub fn record(db_path: &Path, repo_uid: &str) -> Result<(), anyhow::Error> {
+    let path = crate::sidecar_path(db_path, RESOLVER_GENERATION_SIDECAR);
+    let mut current = load(db_path);
+    current
+        .repos
+        .insert(repo_uid.to_string(), RESOLVER_GENERATION);
+    std::fs::write(&path, serde_json::to_string_pretty(&current)?)?;
+    Ok(())
+}
+
+/// Operator-facing caveat for ranking output, or `None` when every repo is
+/// current.
+///
+/// Ranking commands (`hubs`, `bridges`, and anything built on PageRank) are
+/// the surfaces nw-103 corrupted, so they are where the disclosure belongs.
+pub fn staleness_note(db_path: &Path, repo_uids: &[String]) -> Option<String> {
+    let gens = load(db_path);
+    let stale = gens.stale_repos(repo_uids.iter().map(|s| s.as_str()));
+    if stale.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "{} of {} repo(s) were indexed by an older resolver, so their edges predate \
+         the nw-103 import-fan-out fix — hub, bridge and PageRank rankings for those \
+         repos are NOT corrected by upgrading alone. Re-index them \
+         (`nestweaver index --repo <path>`) to get accurate rankings.",
+        stale.len(),
+        repo_uids.len()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_entry_reads_as_generation_zero() {
+        let g = ResolverGenerations::default();
+        assert_eq!(g.generation_for("repo:whatever"), 0);
+    }
+
+    #[test]
+    fn only_repos_below_the_current_generation_are_stale() {
+        let mut g = ResolverGenerations::default();
+        g.repos.insert("fresh".into(), RESOLVER_GENERATION);
+        g.repos.insert("ancient".into(), 0);
+        let stale = g.stale_repos(vec!["fresh", "ancient", "unrecorded"]);
+        assert_eq!(stale, vec!["ancient".to_string(), "unrecorded".to_string()]);
+    }
+
+    #[test]
+    fn recording_one_repo_does_not_mark_the_others_refreshed() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("g.lbug");
+        record(&db, "repo:a").unwrap();
+        record(&db, "repo:b").unwrap();
+
+        let g = load(&db);
+        assert_eq!(g.generation_for("repo:a"), RESOLVER_GENERATION);
+        assert_eq!(g.generation_for("repo:b"), RESOLVER_GENERATION);
+        assert_eq!(g.generation_for("repo:never-indexed"), 0);
+    }
+
+    #[test]
+    fn note_is_absent_when_everything_is_current_and_counts_when_not() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("g.lbug");
+        record(&db, "repo:a").unwrap();
+
+        assert!(staleness_note(&db, &["repo:a".to_string()]).is_none());
+
+        let note = staleness_note(&db, &["repo:a".to_string(), "repo:b".to_string()])
+            .expect("a stale repo must produce a caveat");
+        assert!(note.contains("1 of 2"), "{note}");
+        assert!(note.contains("nw-103"), "{note}");
+    }
+}

--- a/crates/nestweaver-engine/src/watcher.rs
+++ b/crates/nestweaver-engine/src/watcher.rs
@@ -988,8 +988,9 @@ fn reinsert_note(
 
     // ── Wikilinks (per-file: resolve against the pre-built title lookup) ─
     let mut wl_resolved = 0usize;
-    let mut wl_note_edges: Vec<(String, String, f32, String)> = Vec::new();
-    let mut wl_head_edges: Vec<(String, String, f32, String)> = Vec::new();
+    // nw-122: carry the link target alongside the display alias.
+    let mut wl_note_edges: Vec<(String, String, f32, String, String)> = Vec::new();
+    let mut wl_head_edges: Vec<(String, String, f32, String, String)> = Vec::new();
 
     for wl in &parsed.wikilinks {
         if wl.section_idx >= section_uids.len() {
@@ -1014,6 +1015,7 @@ fn reinsert_note(
                         h.uid.clone(),
                         conf,
                         display.clone(),
+                        wl.target.clone(),
                     ));
                     wl_resolved += 1;
                     continue;
@@ -1024,19 +1026,20 @@ fn reinsert_note(
                 target.clone(),
                 conf,
                 display.clone(),
+                wl.target.clone(),
             ));
             wl_resolved += 1;
         }
     }
 
-    let wl_note_refs: Vec<(&str, &str, f32, &str)> = wl_note_edges
+    let wl_note_refs: Vec<(&str, &str, f32, &str, &str)> = wl_note_edges
         .iter()
-        .map(|(s, n, c, d)| (s.as_str(), n.as_str(), *c, d.as_str()))
+        .map(|(s, n, c, d, t)| (s.as_str(), n.as_str(), *c, d.as_str(), t.as_str()))
         .collect();
     store.batch_insert_wikilink_to_note_edges(&wl_note_refs)?;
-    let wl_head_refs: Vec<(&str, &str, f32, &str)> = wl_head_edges
+    let wl_head_refs: Vec<(&str, &str, f32, &str, &str)> = wl_head_edges
         .iter()
-        .map(|(s, h, c, d)| (s.as_str(), h.as_str(), *c, d.as_str()))
+        .map(|(s, h, c, d, t)| (s.as_str(), h.as_str(), *c, d.as_str(), t.as_str()))
         .collect();
     store.batch_insert_wikilink_to_heading_edges(&wl_head_refs)?;
 

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -2167,21 +2167,10 @@ fn tool_regex_search(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
     let res = store
         .regex_search(pattern, path_prefix, kinds.as_deref(), limit, max_millis)
         .map_err(|e| anyhow!("regex_search: {e}"))?;
-    let mut resp = serde_json::to_value(res)?;
-    if resp
-        .get("results")
-        .and_then(|r| r.as_array())
-        .is_some_and(|a| a.is_empty())
-        && resp
-            .get("truncated")
-            .and_then(|t| t.as_bool())
-            .unwrap_or(false)
-    {
-        resp["note"] = json!(
-            "Pattern matched no candidates within the scan budget. Results may exist beyond the scanned range."
-        );
-    }
-    Ok(resp)
+    // nw-097: the note now rides on RegexSearchResult itself, attached by the
+    // store, so the CLI and daemon paths carry it too. This tool used to bolt it
+    // on here, which is exactly why only MCP had it.
+    Ok(serde_json::to_value(res)?)
 }
 
 fn tool_schema_regex_search() -> Value {
@@ -6970,7 +6959,7 @@ fn tool_schema_query_extensions() -> Value {
                     "description": "Property name to filter by (e.g. \"team_owner\", \"deprecated\"). Required when not using uid mode."
                 },
                 "value": {
-                    "description": "Value to match — any JSON value. Required when key is provided. Exact match only."
+                    "description": "Value to match — any JSON value. Required when key is provided. Exact match, plus membership: a SCALAR query matches when the stored property is an array containing it (so key=\"aliases\", value=\"Raven\" matches [\"Raven\",\"raven\"]). An ARRAY query stays an exact whole-array comparison, not any-of. Pass a real JSON value, not a stringified one."
                 },
                 "uid": {
                     "type": "string",

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -3210,6 +3210,14 @@ fn tool_brain_context(
         resp["unresolved_seeds"] = json!(result.unresolved_seeds);
     }
 
+    // nw-102: how many of `seeds` are semantic nearest-neighbour guesses rather
+    // than resolutions of the query. Without this the daemon path could not
+    // distinguish them and reported every guess as "resolved" — the same
+    // response then claimed a seed both resolved AND unresolved.
+    if result.semantic_seed_count > 0 {
+        resp["semantic_seed_count"] = json!(result.semantic_seed_count);
+    }
+
     // Feature F7: surface the PRF-mined expansion terms for auditing. Only
     // present when PRF was enabled and mined at least one term.
     if !result.expansion_terms.is_empty() {

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -6967,7 +6967,7 @@ fn tool_schema_query_extensions() -> Value {
                     "description": "Property name to filter by (e.g. \"team_owner\", \"deprecated\"). Required when not using uid mode."
                 },
                 "value": {
-                    "description": "Value to match — any JSON value. Required when key is provided. Exact match, plus membership: a SCALAR query matches when the stored property is an array containing it (so key=\"aliases\", value=\"Raven\" matches [\"Raven\",\"raven\"]). An ARRAY query stays an exact whole-array comparison, not any-of. Pass a real JSON value, not a stringified one."
+                    "description": "Value to match — any JSON value. Required when key is provided. Exact match, plus membership: a SCALAR query matches when the stored property is an array containing it (so key=\"aliases\", value=\"Widget\" matches [\"Widget\",\"widget\"]). An ARRAY query stays an exact whole-array comparison, not any-of. Pass a real JSON value, not a stringified one."
                 },
                 "uid": {
                     "type": "string",

--- a/crates/nestweaver-parser/src/markdown.rs
+++ b/crates/nestweaver-parser/src/markdown.rs
@@ -1532,8 +1532,9 @@ top 2 body
     ///
     /// These passed the `.md` filter, became wikilink targets, and were then
     /// reported broken on every run — permanently, since nothing in the vault
-    /// could ever satisfy them. Real example from the vault:
-    /// `https://github.com/Kehl-io/orbit/blob/main/docs/releases/v0.2.0-recovery.md`.
+    /// could ever satisfy them. The shape that triggered it is a plain link to
+    /// a file in a git forge, e.g.
+    /// `https://github.com/<org>/<repo>/blob/main/docs/releases/v0.2.0.md`.
     #[test]
     fn external_urls_ending_in_md_are_not_wikilinks() {
         let src = "# n\n\nSee [recovery](https://github.com/o/r/blob/main/docs/x.md) and \

--- a/crates/nestweaver-proto/src/lib.rs
+++ b/crates/nestweaver-proto/src/lib.rs
@@ -292,7 +292,10 @@ mod index_progress_tracker_tests {
             .observe(&progress(Phase::Writing, "still writing"))
             .unwrap();
         assert!(
-            matches!(silent.finish().unwrap_err(), IndexProgressError::Truncated { .. }),
+            matches!(
+                silent.finish().unwrap_err(),
+                IndexProgressError::Truncated { .. }
+            ),
             "without the terminal event the caller can only report a truncated stream"
         );
     }

--- a/crates/nestweaver-proto/src/lib.rs
+++ b/crates/nestweaver-proto/src/lib.rs
@@ -257,6 +257,46 @@ mod index_progress_tracker_tests {
         ));
     }
 
+    /// nw-127: a timeout must reach the caller as a REPORTED error naming the
+    /// cause, not as a truncated stream.
+    ///
+    /// The daemon's watchdog used to set its cancel flag and say nothing, so the
+    /// client saw the stream simply end and rendered "index progress stream
+    /// ended before completion" — indistinguishable from a crash, and shown as a
+    /// failure for an index that was still running and went on to SUCCEED.
+    /// Emitting a terminal `Phase::Error` is what turns that into an explanation.
+    #[test]
+    fn a_timeout_reported_in_band_beats_a_truncated_stream() {
+        // What the watchdog does now.
+        let mut reported = IndexProgressTracker::default();
+        reported
+            .observe(&progress(Phase::Writing, "still writing"))
+            .unwrap();
+        reported
+            .observe(&progress(
+                Phase::Error,
+                "index exceeded the 1800s timeout and cancellation was requested",
+            ))
+            .unwrap();
+        let err = reported.finish().unwrap_err();
+        match err {
+            IndexProgressError::Reported { message } => {
+                assert!(message.contains("timeout"), "{message}");
+            }
+            other => panic!("expected a reported error naming the timeout, got {other:?}"),
+        }
+
+        // What it did before: the same run, with the terminal event missing.
+        let mut silent = IndexProgressTracker::default();
+        silent
+            .observe(&progress(Phase::Writing, "still writing"))
+            .unwrap();
+        assert!(
+            matches!(silent.finish().unwrap_err(), IndexProgressError::Truncated { .. }),
+            "without the terminal event the caller can only report a truncated stream"
+        );
+    }
+
     #[test]
     fn any_event_after_a_terminal_event_is_rejected() {
         for terminal in [Phase::Done, Phase::Error] {

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -1659,15 +1659,25 @@ impl GraphStore {
         // target kind (Note vs Heading).
         conn.query(
             "CREATE REL TABLE IF NOT EXISTS WIKILINK_TO_NOTE(\
-                FROM Section TO Note, confidence FLOAT, display STRING)",
+                FROM Section TO Note, confidence FLOAT, display STRING, target STRING)",
         )
         .map_err(|e| StoreError::Query(e.to_string()))?;
 
         conn.query(
             "CREATE REL TABLE IF NOT EXISTS WIKILINK_TO_HEADING(\
-                FROM Section TO Heading, confidence FLOAT, display STRING)",
+                FROM Section TO Heading, confidence FLOAT, display STRING, target STRING)",
         )
         .map_err(|e| StoreError::Query(e.to_string()))?;
+
+        // Migration: `display` alone cannot answer both questions a wikilink is
+        // asked. For a piped link `[[Home|workspace]]` the BACKLINKS view wants
+        // the visible text ("workspace") while BROKEN-LINKS wants the link
+        // target ("Home") — reporting the alias there rendered `[[workspace]]`,
+        // a string that appears nowhere in the vault (nw-122). Carry both.
+        // Empty string means "written before this column existed"; readers fall
+        // back to `display`, which is what those rows have always held.
+        let _ = conn.query("ALTER TABLE WIKILINK_TO_NOTE ADD target STRING DEFAULT ''");
+        let _ = conn.query("ALTER TABLE WIKILINK_TO_HEADING ADD target STRING DEFAULT ''");
 
         // ── F11 memory-bank: typed Note→Note relationships ─────────────────
         // Explicit, semantically-typed knowledge edges derived from frontmatter

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -384,7 +384,9 @@ fn quarantine_orphaned_wal(path: &Path) -> Option<PathBuf> {
         .map(|d| d.as_secs())
         .unwrap_or(0);
     let quarantined = PathBuf::from(format!("{}.wal.orphaned-{stamp}", path.display()));
-    std::fs::rename(&wal, &quarantined).ok().map(|()| quarantined)
+    std::fs::rename(&wal, &quarantined)
+        .ok()
+        .map(|()| quarantined)
 }
 
 /// Open an lbug database, auto-recovering once from crash debris that would
@@ -494,7 +496,9 @@ impl GraphStore {
     /// Open an existing database in read-only mode. Allows concurrent access
     /// while another process (e.g. the web UI) holds the write lock.
     pub fn open_read_only(path: &Path) -> Result<Self, StoreError> {
-        let db = open_lbug_with_recovery(path, false, || lbug::SystemConfig::default().read_only(true))?;
+        let db = open_lbug_with_recovery(path, false, || {
+            lbug::SystemConfig::default().read_only(true)
+        })?;
         let store = GraphStore {
             db,
             pagerank_cache: Mutex::new(None),
@@ -1879,7 +1883,10 @@ mod tests {
 
         let moved = quarantine_orphaned_wal(&db).expect("orphaned wal must be quarantined");
 
-        assert!(!dir.path().join("brain.lbug.wal").exists(), "wal moved aside");
+        assert!(
+            !dir.path().join("brain.lbug.wal").exists(),
+            "wal moved aside"
+        );
         assert!(moved.exists(), "quarantined copy must still exist");
         assert_eq!(
             std::fs::read(&moved).unwrap(),

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -351,23 +351,81 @@ fn hardened_system_config() -> lbug::SystemConfig {
     cfg
 }
 
+/// A `SIGKILL`ed daemon can leave `<db>.wal` behind with NO `<db>.shadow`
+/// alongside it. lbug's read-write open then fails with an IO exception naming
+/// the absent shadow file, and because that text ends in "No such file or
+/// directory" the CLI's diagnostic heuristic read it as a MISSING DATABASE and
+/// told the user to create one over the top of their data (nw-126).
+///
+/// This is a different shape from [`is_stale_checkpoint_error`], which matches
+/// a checkpoint mismatch rather than an orphaned log, so the existing recovery
+/// arm never fired.
+fn is_orphaned_wal_error(msg: &str) -> bool {
+    msg.contains(".shadow") && msg.to_lowercase().contains("no such file")
+}
+
+/// Move an orphaned `<db>.wal` aside so the next open can proceed.
+///
+/// Deliberately a RENAME, never a delete: a WAL can in principle hold committed
+/// work, and destroying it to fix an outage would trade one data-loss story for
+/// another. Quarantining is reversible and leaves the evidence in place.
+///
+/// Only acts on the exact orphan signature — `.wal` present AND `.shadow`
+/// absent. A `.wal` with its `.shadow` intact is a normal recoverable log and
+/// must be left for the engine to replay.
+fn quarantine_orphaned_wal(path: &Path) -> Option<PathBuf> {
+    let wal = PathBuf::from(format!("{}.wal", path.display()));
+    let shadow = PathBuf::from(format!("{}.shadow", path.display()));
+    if !wal.exists() || shadow.exists() {
+        return None;
+    }
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let quarantined = PathBuf::from(format!("{}.wal.orphaned-{stamp}", path.display()));
+    std::fs::rename(&wal, &quarantined).ok().map(|()| quarantined)
+}
+
+/// Open an lbug database, auto-recovering once from crash debris that would
+/// otherwise make it permanently unopenable.
+///
+/// `read_write` gates the orphaned-WAL arm. Replay is inherently a write
+/// operation, so a read-only open must report the condition rather than mutate
+/// the directory to clear it — and a read-only caller quarantining a log out
+/// from under a live writer would be a genuine hazard.
 fn open_lbug_with_recovery(
     path: &Path,
+    read_write: bool,
     make_config: impl Fn() -> lbug::SystemConfig,
 ) -> Result<lbug::Database, StoreError> {
     match lbug::Database::new(path, make_config()) {
         Ok(db) => Ok(db),
         Err(e) => {
-            if is_stale_checkpoint_error(&e.to_string()) && remove_stale_checkpoint_sidecars(path) {
+            let msg = e.to_string();
+            if is_stale_checkpoint_error(&msg) && remove_stale_checkpoint_sidecars(path) {
                 tracing::warn!(
                     "recovered a stale WAL checkpoint for {} (a prior crash left \
                      .wal.checkpoint/.shadow that made the DB unopenable); retrying open",
                     path.display()
                 );
-                Ok(lbug::Database::new(path, make_config())?)
-            } else {
-                Err(e.into())
+                return Ok(lbug::Database::new(path, make_config())?);
             }
+            if read_write
+                && is_orphaned_wal_error(&msg)
+                && let Some(quarantined) = quarantine_orphaned_wal(path)
+            {
+                tracing::warn!(
+                    "recovered {} from an orphaned write-ahead log left by a prior \
+                     crash (.wal present with no .shadow, which made the database \
+                     unopenable on every path); moved it to {} and retried — it was \
+                     NOT deleted",
+                    path.display(),
+                    quarantined.display()
+                );
+                return Ok(lbug::Database::new(path, make_config())?);
+            }
+            Err(e.into())
         }
     }
 }
@@ -375,7 +433,7 @@ fn open_lbug_with_recovery(
 impl GraphStore {
     /// Create a new persistent database at `path`, initialising schema tables.
     pub fn create(path: &Path) -> Result<Self, StoreError> {
-        let db = open_lbug_with_recovery(path, hardened_system_config)?;
+        let db = open_lbug_with_recovery(path, true, hardened_system_config)?;
         let store = GraphStore {
             db,
             pagerank_cache: Mutex::new(None),
@@ -406,7 +464,7 @@ impl GraphStore {
     /// Runs schema migrations to ensure any new tables/columns from newer
     /// versions are present (all statements are idempotent).
     pub fn open(path: &Path) -> Result<Self, StoreError> {
-        let db = open_lbug_with_recovery(path, hardened_system_config)?;
+        let db = open_lbug_with_recovery(path, true, hardened_system_config)?;
         let store = GraphStore {
             db,
             pagerank_cache: Mutex::new(None),
@@ -436,7 +494,7 @@ impl GraphStore {
     /// Open an existing database in read-only mode. Allows concurrent access
     /// while another process (e.g. the web UI) holds the write lock.
     pub fn open_read_only(path: &Path) -> Result<Self, StoreError> {
-        let db = open_lbug_with_recovery(path, || lbug::SystemConfig::default().read_only(true))?;
+        let db = open_lbug_with_recovery(path, false, || lbug::SystemConfig::default().read_only(true))?;
         let store = GraphStore {
             db,
             pagerank_cache: Mutex::new(None),
@@ -1776,6 +1834,75 @@ mod tests {
     fn index_publication_lease_is_send_without_a_held_mutex_guard() {
         fn assert_send<T: Send>() {}
         assert_send::<IndexPublicationLease<'static>>();
+    }
+
+    /// nw-126: the signature observed on the production database after a
+    /// SIGKILLed daemon — `.wal` present, `.shadow` absent. lbug reports
+    /// "IO exception: Cannot open file <db>.shadow: No such file or directory",
+    /// which the stale-CHECKPOINT matcher cannot recognise, so nothing
+    /// recovered and every open failed.
+    #[test]
+    fn orphaned_wal_error_is_distinguished_from_a_stale_checkpoint() {
+        let orphan = "database error: IO exception: Cannot open file \
+                      /x/brain.lbug.shadow: No such file or directory";
+        assert!(is_orphaned_wal_error(orphan));
+        assert!(
+            !is_stale_checkpoint_error(orphan),
+            "the existing checkpoint matcher must NOT claim this case — that it \
+             does not is exactly why the database stayed unopenable"
+        );
+
+        let checkpoint = "wal.checkpoint header does not match";
+        assert!(is_stale_checkpoint_error(checkpoint));
+        assert!(!is_orphaned_wal_error(checkpoint));
+    }
+
+    /// The orphan is quarantined by RENAME, never deleted: a WAL can hold
+    /// committed work, and destroying it to clear an outage would swap one
+    /// data-loss story for another.
+    #[test]
+    fn orphaned_wal_is_quarantined_not_deleted() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        std::fs::write(&db, b"db").unwrap();
+        std::fs::write(dir.path().join("brain.lbug.wal"), b"orphan-contents").unwrap();
+
+        let moved = quarantine_orphaned_wal(&db).expect("orphaned wal must be quarantined");
+
+        assert!(!dir.path().join("brain.lbug.wal").exists(), "wal moved aside");
+        assert!(moved.exists(), "quarantined copy must still exist");
+        assert_eq!(
+            std::fs::read(&moved).unwrap(),
+            b"orphan-contents",
+            "contents must be preserved verbatim — quarantine, not deletion"
+        );
+        assert!(db.exists(), "the database itself is untouched");
+    }
+
+    /// A `.wal` WITH its `.shadow` is a normal replayable log. Quarantining it
+    /// would discard recoverable committed work, so the guard must decline.
+    #[test]
+    fn wal_with_its_shadow_is_left_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        std::fs::write(&db, b"db").unwrap();
+        std::fs::write(dir.path().join("brain.lbug.wal"), b"live").unwrap();
+        std::fs::write(dir.path().join("brain.lbug.shadow"), b"shadow").unwrap();
+
+        assert!(
+            quarantine_orphaned_wal(&db).is_none(),
+            "a wal accompanied by its shadow must never be moved"
+        );
+        assert!(dir.path().join("brain.lbug.wal").exists());
+    }
+
+    /// No `.wal` at all is not an orphan case.
+    #[test]
+    fn absent_wal_is_not_quarantined() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        std::fs::write(&db, b"db").unwrap();
+        assert!(quarantine_orphaned_wal(&db).is_none());
     }
 
     #[test]

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -516,6 +516,85 @@ mod tests {
         assert_eq!(found.name, "fn_3");
     }
 
+    /// nw-122: `broken_wikilinks` must report the link TARGET, not the visible
+    /// alias. For `[[Home|workspace]]` it used to report "workspace" — a string
+    /// that appears nowhere in the vault, so grepping for the reported link
+    /// found nothing.
+    ///
+    /// Rows written before the `target` column existed have an empty target and
+    /// MUST fall back to `display`, which is exactly what they have always held.
+    /// Without that fallback an upgrade would blank the text on every
+    /// pre-existing broken link.
+    #[test]
+    fn broken_wikilinks_reports_target_and_falls_back_to_display_pre_migration() {
+        let store = GraphStore::in_memory().unwrap();
+        let vault = Vault {
+            uid: "vlt:t:1".into(),
+            name: "t".into(),
+            root_path: "/t".into(),
+            instance_id: "t".into(),
+        };
+        store.insert_vault(&vault).unwrap();
+
+        let mk_note = |uid: &str, title: &str| nestweaver_schema::Note {
+            uid: uid.to_string(),
+            vault_uid: vault.uid.clone(),
+            file_path: format!("{title}.md"),
+            title: title.to_string(),
+            note_kind: nestweaver_schema::NoteKind::General,
+            word_count: 1,
+            content_hash: String::new(),
+            frontmatter: None,
+            created_at: None,
+            modified_at: None,
+            pagerank_score: None,
+            embedding: None,
+        };
+        let src = mk_note("note:src", "Source");
+        let dst = mk_note("note:dst", "Home");
+        store.insert_note(&src).unwrap();
+        store.insert_note(&dst).unwrap();
+
+        let sec = nestweaver_schema::Section {
+            uid: "sec:src:1".into(),
+            note_uid: src.uid.clone(),
+            heading_uid: None,
+            start_line: 1,
+            end_line: 2,
+            text_hash: String::new(),
+            text_content: "x".into(),
+            word_count: 1,
+            pagerank_score: None,
+        };
+        store.insert_section(&sec).unwrap();
+        store
+            .batch_insert_note_section_edges(&[(src.uid.as_str(), sec.uid.as_str())])
+            .unwrap();
+
+        // A piped link: visible text "workspace", target "Home". Confidence < 1
+        // so it lands in the broken/low-confidence report.
+        store
+            .batch_insert_wikilink_to_note_edges(&[(
+                sec.uid.as_str(),
+                dst.uid.as_str(),
+                0.9,
+                "workspace",
+                "Home",
+            )])
+            .unwrap();
+
+        let rows = store.broken_wikilinks().unwrap();
+        let texts: Vec<&str> = rows.iter().map(|r| r.wikilink_text.as_str()).collect();
+        assert!(
+            texts.contains(&"Home"),
+            "must report the link target, got {texts:?}"
+        );
+        assert!(
+            !texts.contains(&"workspace"),
+            "must not report the display alias as the link: {texts:?}"
+        );
+    }
+
     #[test]
     fn insert_repo_file_and_symbol_edges() {
         let store = test_store();
@@ -1756,8 +1835,8 @@ mod tests {
         let note_section_edges: Vec<(&str, &str)> = vec![("note:bvw:n1", "sec:bvw:s1")];
         let heading_section_edges: Vec<(&str, &str)> = vec![("hdg:bvw:h1", "sec:bvw:s1")];
         let note_tag_edges: Vec<(&str, &str)> = vec![("note:bvw:n1", "tag:bvw:rust")];
-        let wikilink_to_note_edges: Vec<(&str, &str, f32, &str)> =
-            vec![("sec:bvw:s1", "note:bvw:n2", 1.0, "Note Two")];
+        let wikilink_to_note_edges: Vec<(&str, &str, f32, &str, &str)> =
+            vec![("sec:bvw:s1", "note:bvw:n2", 1.0, "Note Two", "Note Two")];
 
         store
             .bulk_vault_write(

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -1531,6 +1531,78 @@ mod tests {
         );
     }
 
+    /// nw-061, corrected: a 2-node graph scoring 0.5/0.5 is NOT edge-blindness.
+    ///
+    /// The item reported `{a: 0.5, b: 0.5}` for a single `b -> a` edge and
+    /// concluded "the ranking loader's edge queries see no rows". Measured, the
+    /// loader returns `incoming=[[(1, 1.0)], [(0, 0.3)]]` with
+    /// `out_weight=[0.3, 1.0]` — the forward CALLS edge at 1.0 AND a reverse
+    /// edge at 0.3. Both are present.
+    ///
+    /// PageRank normalises each contribution by the source's total out-weight,
+    /// so `a`'s single 0.3 out-edge divided by `out_weight[a]` of 0.3 is 1.0 —
+    /// exactly what `b`'s 1.0/1.0 gives. On a TWO-node graph that makes the
+    /// system perfectly symmetric, and 0.5/0.5 is the correct fixed point. The
+    /// asymmetry only survives when a node's out-weight differs from the weight
+    /// of the edge being followed, which needs a third node.
+    #[test]
+    fn two_node_graph_is_symmetric_after_out_degree_normalisation() {
+        let store = test_store();
+        store.insert_symbol(&make_symbol("a", "fn_a")).unwrap();
+        store.insert_symbol(&make_symbol("b", "fn_b")).unwrap();
+        store.insert_edge(&make_calls_edge("b", "a")).unwrap();
+
+        let (uids, _idx, incoming, out_weight) = store
+            .load_ppr_graph(&GraphScope::code_only(), None)
+            .unwrap();
+        assert_eq!(uids.len(), 2);
+        assert!(
+            incoming.iter().all(|v| !v.is_empty()),
+            "both directions must be loaded — an empty side WOULD be the \
+             edge-blindness nw-061 suspected: {incoming:?}"
+        );
+        assert!(
+            out_weight.iter().all(|&w| w > 0.0),
+            "neither node is dangling once the reverse edge exists: {out_weight:?}"
+        );
+    }
+
+    /// The real guard against edge-blindness, and the one nw-061 asked for.
+    ///
+    /// If the ranking loader ever stopped seeing edges, every node would be
+    /// dangling, scores would go uniform, and this assertion fails. It needs
+    /// three or more nodes precisely because of the two-node symmetry above.
+    #[test]
+    fn pagerank_is_edge_sensitive_hub_outranks_leaf() {
+        let store = test_store();
+        for uid in ["hub", "leaf", "x", "y"] {
+            store
+                .insert_symbol(&make_symbol(uid, &format!("fn_{uid}")))
+                .unwrap();
+        }
+        store.insert_edge(&make_calls_edge("x", "hub")).unwrap();
+        store.insert_edge(&make_calls_edge("y", "hub")).unwrap();
+        store.insert_edge(&make_calls_edge("leaf", "hub")).unwrap();
+
+        store
+            .compute_pagerank(0.85, 20, &GraphScope::code_only())
+            .unwrap();
+        let ranked = store.symbols_by_pagerank(None).unwrap();
+        let score_of = |uid: &str| -> f64 {
+            ranked
+                .iter()
+                .find(|s| s.uid == uid)
+                .and_then(|s| s.pagerank_score)
+                .unwrap_or(0.0)
+        };
+        let (hub, leaf) = (score_of("hub"), score_of("leaf"));
+        assert!(
+            hub > leaf,
+            "a node with three inbound calls must outrank one with none; \
+             equal scores mean ranking has gone edge-blind (hub={hub:.4} leaf={leaf:.4})"
+        );
+    }
+
     #[test]
     fn highly_called_symbol_ranks_higher() {
         // A->C, B->C, D->C — C has three incoming, should rank highest.

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -1801,8 +1801,8 @@ mod tests {
         // Wikilinks: A→B and C→B. B is the hub.
         store
             .batch_insert_wikilink_to_note_edges(&[
-                ("sec:note:a", "note:b", 1.0, "B"),
-                ("sec:note:c", "note:b", 1.0, "B"),
+                ("sec:note:a", "note:b", 1.0, "B", "B"),
+                ("sec:note:c", "note:b", 1.0, "B", "B"),
             ])
             .unwrap();
 
@@ -2534,8 +2534,8 @@ mod tests {
             // Wikilink from filler section -> popular_x and popular_y
             store
                 .batch_insert_wikilink_to_note_edges(&[
-                    (&sec_uid, "note:popular_x", 1.0, "Popular X"),
-                    (&sec_uid, "note:popular_y", 1.0, "Popular Y"),
+                    (&sec_uid, "note:popular_x", 1.0, "Popular X", "Popular X"),
+                    (&sec_uid, "note:popular_y", 1.0, "Popular Y", "Popular Y"),
                 ])
                 .unwrap();
         }

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -2416,7 +2416,9 @@ impl GraphStore {
         // 1. Low-confidence / ambiguous resolved links.
         let q = "MATCH (src:Note)-[:NOTE_HAS_SECTION]->(:Section)-[r:WIKILINK_TO_NOTE]->(dst:Note) \
                  WHERE r.confidence < 1.0 \
-                 RETURN src.uid, src.file_path, src.title, r.display, r.confidence, dst.uid";
+                 RETURN src.uid, src.file_path, src.title, \
+                 CASE WHEN r.target = '' THEN r.display ELSE r.target END, \
+                 r.confidence, dst.uid";
         match conn.query(q) {
             Ok(result) => {
                 for row in result {

--- a/crates/nestweaver-store/src/regex.rs
+++ b/crates/nestweaver-store/src/regex.rs
@@ -130,8 +130,7 @@ pub struct RegexSearchResult {
 ///
 /// A search that ran out of scan budget before matching anything has NOT
 /// established that no matches exist, and must not be presented as if it had.
-pub const SCAN_BUDGET_NOTE: &str =
-    "Pattern matched no candidates within the scan budget. Results may exist beyond \
+pub const SCAN_BUDGET_NOTE: &str = "Pattern matched no candidates within the scan budget. Results may exist beyond \
      the scanned range.";
 
 impl RegexSearchResult {

--- a/crates/nestweaver-store/src/regex.rs
+++ b/crates/nestweaver-store/src/regex.rs
@@ -113,6 +113,36 @@ pub struct RegexSearchResult {
     /// pattern has usable literals; always false when no index was ever built.
     #[serde(default)]
     pub stale_index: bool,
+    /// Human-readable explanation when an empty result is NOT a definitive
+    /// "no matches exist".
+    ///
+    /// nw-097: the MCP tool attached this note itself, so a CLI caller saw
+    /// `{"results": [], "truncated": true}` with nothing explaining it and
+    /// reasonably read it as "the pattern matches nothing". `truncated` alone
+    /// does not carry that meaning to a human. Living on the shared result
+    /// means every surface — CLI, MCP, daemon — reports it identically rather
+    /// than each remembering to bolt it on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+/// The note attached to an empty-but-truncated regex search.
+///
+/// A search that ran out of scan budget before matching anything has NOT
+/// established that no matches exist, and must not be presented as if it had.
+pub const SCAN_BUDGET_NOTE: &str =
+    "Pattern matched no candidates within the scan budget. Results may exist beyond \
+     the scanned range.";
+
+impl RegexSearchResult {
+    /// Attach [`SCAN_BUDGET_NOTE`] when this result is empty only because the
+    /// scan was cut short. Idempotent, and never overwrites an existing note.
+    pub fn with_scan_budget_note(mut self) -> Self {
+        if self.results.is_empty() && self.truncated && self.note.is_none() {
+            self.note = Some(SCAN_BUDGET_NOTE.to_string());
+        }
+        self
+    }
 }
 
 /// Per-file aggregate count for `count_patterns`.
@@ -662,12 +692,15 @@ impl GraphStore {
             }
         }
 
+        // nw-097: attach the note at the source so no caller has to remember.
         Ok(RegexSearchResult {
             results,
             truncated,
             scanned_fallback,
             stale_index,
-        })
+            note: None,
+        }
+        .with_scan_budget_note())
     }
 
     /// Counts-only companion to `regex_search`. For each pattern, returns total
@@ -750,6 +783,62 @@ fn line_and_snippet(text: &str, match_start: usize) -> (u32, String) {
 
 #[cfg(test)]
 mod tests {
+    /// nw-097: an empty result that is empty only because the scan budget ran
+    /// out must SAY so. Previously the MCP tool attached this note itself, so a
+    /// CLI `--json` caller received `{"results": [], "truncated": true}` with
+    /// nothing explaining it and would reasonably read it as "no matches exist".
+    /// Attaching it on the shared result is what makes every surface agree.
+    #[test]
+    fn empty_and_truncated_carries_the_scan_budget_note() {
+        let r = RegexSearchResult {
+            results: vec![],
+            truncated: true,
+            scanned_fallback: false,
+            stale_index: false,
+            note: None,
+        }
+        .with_scan_budget_note();
+        assert_eq!(r.note.as_deref(), Some(SCAN_BUDGET_NOTE));
+    }
+
+    /// A genuinely exhaustive empty search HAS established that nothing matches,
+    /// so it must not be hedged — the note would be a false caveat.
+    #[test]
+    fn empty_but_complete_search_gets_no_note() {
+        let r = RegexSearchResult {
+            results: vec![],
+            truncated: false,
+            scanned_fallback: false,
+            stale_index: false,
+            note: None,
+        }
+        .with_scan_budget_note();
+        assert!(r.note.is_none(), "a complete empty scan must not be hedged");
+    }
+
+    /// Results present means the caller has something concrete; the budget note
+    /// is about an EMPTY result being misread.
+    #[test]
+    fn truncated_with_results_gets_no_scan_budget_note() {
+        let hit = RegexMatch {
+            uid: "sym:x".into(),
+            kind: "Symbol".into(),
+            title: "x".into(),
+            location: "a.rs".into(),
+            line: Some(1),
+            snippet: "x".into(),
+        };
+        let r = RegexSearchResult {
+            results: vec![hit],
+            truncated: true,
+            scanned_fallback: false,
+            stale_index: false,
+            note: None,
+        }
+        .with_scan_budget_note();
+        assert!(r.note.is_none());
+    }
+
     use super::*;
     use nestweaver_schema::{Note, NoteKind, Section, Symbol, SymbolKind, Visibility};
 

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -5254,7 +5254,13 @@ impl GraphStore {
         let wl_note: Vec<(&str, &str, f32, &str, &str)> = wikilink_to_note
             .iter()
             .map(|(src, dst, conf, disp, tgt)| {
-                (src.as_str(), dst.as_str(), *conf, disp.as_str(), tgt.as_str())
+                (
+                    src.as_str(),
+                    dst.as_str(),
+                    *conf,
+                    disp.as_str(),
+                    tgt.as_str(),
+                )
             })
             .collect();
         if !wl_note.is_empty() {
@@ -5263,7 +5269,13 @@ impl GraphStore {
         let wl_heading: Vec<(&str, &str, f32, &str, &str)> = wikilink_to_heading
             .iter()
             .map(|(src, dst, conf, disp, tgt)| {
-                (src.as_str(), dst.as_str(), *conf, disp.as_str(), tgt.as_str())
+                (
+                    src.as_str(),
+                    dst.as_str(),
+                    *conf,
+                    disp.as_str(),
+                    tgt.as_str(),
+                )
             })
             .collect();
         if !wl_heading.is_empty() {

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -255,6 +255,13 @@ impl RepoDeletionSnapshot {
 /// `(uid, source_note_uid, source_path, source_title, wikilink_text)`.
 pub type UnresolvedWikilinkRecord = (String, String, String, String, String);
 
+/// One captured wikilink edge: `(source_section_uid, target_node_uid,
+/// confidence, display_text, link_target)`.
+///
+/// `display_text` is what a reader sees, `link_target` is what resolution acted
+/// on; for `[[Home|workspace]]` those are "workspace" and "Home" (nw-122).
+pub type WikilinkEdgeRecord = (String, String, f32, String, String);
+
 /// A vault whose notes were discarded during a collision in instance merge.
 /// When two instances have vaults at the same root_path, the vault with
 /// fewer notes loses and its notes are cascade-deleted.
@@ -1193,8 +1200,8 @@ impl GraphStore {
         tags: &[Tag],
         note_tag_edges: &[(&str, &str)],
         section_tag_edges: &[(&str, &str)],
-        wikilink_to_note_edges: &[(&str, &str, f32, &str)],
-        wikilink_to_heading_edges: &[(&str, &str, f32, &str)],
+        wikilink_to_note_edges: &[(&str, &str, f32, &str, &str)],
+        wikilink_to_heading_edges: &[(&str, &str, f32, &str, &str)],
     ) -> Result<(), StoreError> {
         let conn = self.begin_transaction()?;
         Self::bulk_vault_write_on(
@@ -1236,8 +1243,8 @@ impl GraphStore {
         tags: &[Tag],
         note_tag_edges: &[(&str, &str)],
         section_tag_edges: &[(&str, &str)],
-        wikilink_to_note_edges: &[(&str, &str, f32, &str)],
-        wikilink_to_heading_edges: &[(&str, &str, f32, &str)],
+        wikilink_to_note_edges: &[(&str, &str, f32, &str, &str)],
+        wikilink_to_heading_edges: &[(&str, &str, f32, &str, &str)],
     ) -> Result<(), StoreError> {
         // Insert node tables first so edge MATCH clauses find their endpoints.
         Self::batch_insert_notes_on(conn, notes)?;
@@ -1293,8 +1300,8 @@ impl GraphStore {
         tags: &[Tag],
         note_tag_edges: &[(&str, &str)],
         section_tag_edges: &[(&str, &str)],
-        wikilink_to_note_edges: &[(&str, &str, f32, &str)],
-        wikilink_to_heading_edges: &[(&str, &str, f32, &str)],
+        wikilink_to_note_edges: &[(&str, &str, f32, &str, &str)],
+        wikilink_to_heading_edges: &[(&str, &str, f32, &str, &str)],
     ) -> Result<usize, StoreError> {
         let conn = self.begin_transaction()?;
 
@@ -2104,7 +2111,7 @@ impl GraphStore {
 
     pub fn batch_insert_wikilink_to_note_edges(
         &self,
-        edges: &[(&str, &str, f32, &str)],
+        edges: &[(&str, &str, f32, &str, &str)],
     ) -> Result<(), StoreError> {
         let conn = self.conn()?;
         Self::batch_insert_wikilink_to_note_edges_on(&conn, edges)
@@ -2113,15 +2120,15 @@ impl GraphStore {
     /// Insert wikilink-to-note edges using an externally-provided connection (for transaction batching).
     pub fn batch_insert_wikilink_to_note_edges_on(
         conn: &lbug::Connection<'_>,
-        edges: &[(&str, &str, f32, &str)],
+        edges: &[(&str, &str, f32, &str, &str)],
     ) -> Result<(), StoreError> {
         let mut stmt = conn
             .prepare(
                 "MATCH (s:Section {uid: $sid}), (n:Note {uid: $nid}) \
-                 CREATE (s)-[:WIKILINK_TO_NOTE {confidence: $conf, display: $disp}]->(n)",
+                 CREATE (s)-[:WIKILINK_TO_NOTE {confidence: $conf, display: $disp, target: $tgt}]->(n)",
             )
             .map_err(|e| StoreError::Query(format!("prepare: {e}")))?;
-        for (sec_uid, note_uid, conf, display) in edges {
+        for (sec_uid, note_uid, conf, display, target) in edges {
             conn.execute(
                 &mut stmt,
                 vec![
@@ -2129,6 +2136,7 @@ impl GraphStore {
                     ("nid", lbug::Value::String(note_uid.to_string())),
                     ("conf", lbug::Value::Double(*conf as f64)),
                     ("disp", lbug::Value::String(display.to_string())),
+                    ("tgt", lbug::Value::String(target.to_string())),
                 ],
             )
             .map_err(|e| StoreError::Query(format!("execute: {e}")))?;
@@ -2138,7 +2146,7 @@ impl GraphStore {
 
     pub fn batch_insert_wikilink_to_heading_edges(
         &self,
-        edges: &[(&str, &str, f32, &str)],
+        edges: &[(&str, &str, f32, &str, &str)],
     ) -> Result<(), StoreError> {
         let conn = self.conn()?;
         Self::batch_insert_wikilink_to_heading_edges_on(&conn, edges)
@@ -2147,15 +2155,15 @@ impl GraphStore {
     /// Insert wikilink-to-heading edges using an externally-provided connection (for transaction batching).
     pub fn batch_insert_wikilink_to_heading_edges_on(
         conn: &lbug::Connection<'_>,
-        edges: &[(&str, &str, f32, &str)],
+        edges: &[(&str, &str, f32, &str, &str)],
     ) -> Result<(), StoreError> {
         let mut stmt = conn
             .prepare(
                 "MATCH (s:Section {uid: $sid}), (h:Heading {uid: $hid}) \
-                 CREATE (s)-[:WIKILINK_TO_HEADING {confidence: $conf, display: $disp}]->(h)",
+                 CREATE (s)-[:WIKILINK_TO_HEADING {confidence: $conf, display: $disp, target: $tgt}]->(h)",
             )
             .map_err(|e| StoreError::Query(format!("prepare: {e}")))?;
-        for (sec_uid, head_uid, conf, display) in edges {
+        for (sec_uid, head_uid, conf, display, target) in edges {
             conn.execute(
                 &mut stmt,
                 vec![
@@ -2163,6 +2171,7 @@ impl GraphStore {
                     ("hid", lbug::Value::String(head_uid.to_string())),
                     ("conf", lbug::Value::Double(*conf as f64)),
                     ("disp", lbug::Value::String(display.to_string())),
+                    ("tgt", lbug::Value::String(target.to_string())),
                 ],
             )
             .map_err(|e| StoreError::Query(format!("execute: {e}")))?;
@@ -4978,11 +4987,11 @@ impl GraphStore {
         vault_uid: &str,
         rel: &str,
         dst: &str,
-    ) -> Result<Vec<(String, String, f32, String)>, StoreError> {
+    ) -> Result<Vec<WikilinkEdgeRecord>, StoreError> {
         let conn = self.conn()?;
         let q = format!(
             "MATCH (n:Note {{vault_uid: $vid}})-[:NOTE_HAS_SECTION]->(s:Section)-[r:{rel}]->({dst}) \
-             RETURN s.uid, dst.uid, r.confidence, r.display"
+             RETURN s.uid, dst.uid, r.confidence, r.display, r.target"
         );
         let mut stmt = match conn.prepare(&q) {
             Ok(stmt) => stmt,
@@ -5014,6 +5023,10 @@ impl GraphStore {
                         })
                         .unwrap_or(0.0),
                     crate::read::extract_string(&row, 3).unwrap_or_default(),
+                    // nw-122: `target` is empty on rows written before the
+                    // column existed; readers fall back to `display`, which is
+                    // exactly what those rows have always carried.
+                    crate::read::extract_string(&row, 4).unwrap_or_default(),
                 ))
             })
             .collect())
@@ -5160,9 +5173,9 @@ impl GraphStore {
         // here, so restoring them verbatim is sufficient. A link whose TARGET
         // lives in another vault is preserved too: that node is untouched by
         // this cascade.
-        let wikilink_to_note: Vec<(String, String, f32, String)> =
+        let wikilink_to_note: Vec<WikilinkEdgeRecord> =
             self.wikilink_edges_for_vault(old_vault_uid, "WIKILINK_TO_NOTE", "dst:Note")?;
-        let wikilink_to_heading: Vec<(String, String, f32, String)> =
+        let wikilink_to_heading: Vec<WikilinkEdgeRecord> =
             self.wikilink_edges_for_vault(old_vault_uid, "WIKILINK_TO_HEADING", "dst:Heading")?;
 
         // `delete_vault_cascade` removes UnresolvedWikilink rows whose source
@@ -5238,16 +5251,20 @@ impl GraphStore {
         // 9. Restore the wikilink graph. Runs last: the edges reference
         //    sections, notes and headings, all of which are back in place by
         //    now (nw-112).
-        let wl_note: Vec<(&str, &str, f32, &str)> = wikilink_to_note
+        let wl_note: Vec<(&str, &str, f32, &str, &str)> = wikilink_to_note
             .iter()
-            .map(|(src, dst, conf, disp)| (src.as_str(), dst.as_str(), *conf, disp.as_str()))
+            .map(|(src, dst, conf, disp, tgt)| {
+                (src.as_str(), dst.as_str(), *conf, disp.as_str(), tgt.as_str())
+            })
             .collect();
         if !wl_note.is_empty() {
             Self::batch_insert_wikilink_to_note_edges_on(conn, &wl_note)?;
         }
-        let wl_heading: Vec<(&str, &str, f32, &str)> = wikilink_to_heading
+        let wl_heading: Vec<(&str, &str, f32, &str, &str)> = wikilink_to_heading
             .iter()
-            .map(|(src, dst, conf, disp)| (src.as_str(), dst.as_str(), *conf, disp.as_str()))
+            .map(|(src, dst, conf, disp, tgt)| {
+                (src.as_str(), dst.as_str(), *conf, disp.as_str(), tgt.as_str())
+            })
             .collect();
         if !wl_heading.is_empty() {
             Self::batch_insert_wikilink_to_heading_edges_on(conn, &wl_heading)?;
@@ -6623,6 +6640,7 @@ mod tests {
                 src_sec.as_str(),
                 dst_note.as_str(),
                 1.0f32,
+                "Beta",
                 "Beta",
             )])
             .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -15561,13 +15561,41 @@ fn print_clusters_output(
     Ok(())
 }
 
+/// Header line for `brain context` seeds.
+///
+/// nw-102: `seeds` mixes nodes resolved from the query text with nearest
+/// neighbours injected by the semantic leg, and counting both as "resolved"
+/// made the output contradict itself — a nonsense query printed
+/// `Seeds (5 resolved)` while the same response listed that query under
+/// `Unresolved seeds (1)`. Reports PROVENANCE, not quality: a phrase like
+/// "blast radius" fails a direct lookup against the symbol `blast_radius` yet
+/// its semantic hits are excellent, so labelling them guesses would understate
+/// them exactly as counting them as direct matches overstated them.
+fn seed_header(total_seeds: usize, semantic_seeds: usize) -> String {
+    let matched = total_seeds.saturating_sub(semantic_seeds);
+    if semantic_seeds > 0 {
+        format!("Seeds ({matched} matched directly, {semantic_seeds} via semantic search):")
+    } else {
+        format!("Seeds ({matched} resolved):")
+    }
+}
+
 fn print_brain_context_text(result: &BrainContextResult, cut: usize, token_budget: Option<usize>) {
     // Feature F7: show PRF-mined expansion terms for auditing.
     if !result.expansion_terms.is_empty() {
         println!("PRF expansion terms: {}", result.expansion_terms.join(", "));
         println!();
     }
-    println!("Seeds ({} resolved):", result.seeds.len());
+    // nw-102: `seeds` mixes two different things — nodes actually resolved from
+    // the query, and nearest-neighbour guesses injected by the semantic leg,
+    // which vector KNN returns regardless of how distant they are. Counting
+    // both as "resolved" made the output contradict itself: a nonsense query
+    // printed `Seeds (5 resolved)` while ALSO listing that same query under
+    // `Unresolved seeds (1)`. Report the two separately.
+    println!(
+        "{}",
+        seed_header(result.seeds.len(), result.semantic_seed_count)
+    );
     for n in &result.seeds {
         if n.location.is_empty() {
             println!("  {}  [{}]", n.title, n.kind);
@@ -15581,6 +15609,17 @@ fn print_brain_context_text(result: &BrainContextResult, cut: usize, token_budge
         println!("Unresolved seeds ({}):", result.unresolved_seeds.len());
         for s in &result.unresolved_seeds {
             println!("  {s}");
+        }
+        if result.seeds.len() == result.semantic_seed_count && result.semantic_seed_count > 0 {
+            // State HOW the seeds were found, not how good they are. A phrase
+            // like "blast radius" fails a direct lookup against the symbol
+            // `blast_radius` yet its semantic hits are excellent, so calling
+            // them guesses would understate them just as counting them as
+            // direct matches overstated them.
+            println!(
+                "  note: no seed matched the query text directly; the seeds above \
+                 came from semantic similarity."
+            );
         }
     }
 
@@ -18930,6 +18969,36 @@ mod hybrid_cli_tests {
         let present = dir.path().join("present.lbug");
         std::fs::write(&present, b"").unwrap();
         assert!(require_existing_db(&present).is_ok());
+    }
+
+    /// nw-102: a seed injected by the semantic leg must never be counted as
+    /// "resolved". Counting them together let one response claim a query both
+    /// resolved AND unresolved at the same time.
+    #[test]
+    fn seed_header_never_counts_semantic_hits_as_resolved() {
+        // The reported case: nothing matched, five nearest neighbours injected.
+        let h = seed_header(5, 5);
+        assert!(h.contains("0 matched directly"), "{h}");
+        assert!(h.contains("5 via semantic search"), "{h}");
+        assert!(
+            !h.contains("5 resolved"),
+            "must not report semantic guesses as resolved: {h}"
+        );
+
+        // Genuine direct matches, no semantic leg.
+        assert_eq!(seed_header(3, 0), "Seeds (3 resolved):");
+
+        // Mixed: two direct, three semantic.
+        let m = seed_header(5, 3);
+        assert!(m.contains("2 matched directly") && m.contains("3 via semantic search"), "{m}");
+    }
+
+    /// Defensive: the counts arrive from a daemon response, so a malformed or
+    /// older payload must not underflow the subtraction.
+    #[test]
+    fn seed_header_does_not_underflow_on_inconsistent_counts() {
+        let h = seed_header(2, 9);
+        assert!(h.contains("0 matched directly"), "{h}");
     }
 
     /// nw-123: the impact envelope's key set must not depend on which

--- a/src/main.rs
+++ b/src/main.rs
@@ -949,6 +949,20 @@ fn render_investigate_text(payload: &serde_json::Value) {
             String::new()
         }
     );
+    // nw-120: the daemon ranks with its warm embedding model; the direct path
+    // has none, so the SAME query returns a different ordering. Say which one
+    // produced this map rather than letting the ranking imply a quality it did
+    // not have.
+    if payload
+        .get("semantic_applied")
+        .and_then(|v| v.as_bool())
+        .is_some_and(|applied| !applied)
+    {
+        println!(
+            "  note: semantic retrieval unavailable — ranking is lexical (BM25) only, \
+             so ordering differs from a daemon-served run."
+        );
+    }
 
     for d in &domains {
         println!("\n[{}]", text(d, "label"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,6 +161,41 @@ enum CliDiagnostic {
     )]
     EmptyDatabase,
 
+    /// The database file is present but could not be opened. NEVER conflate
+    /// this with `db_not_found`: suggesting `index --repo` at a path that
+    /// already holds a database invites the user to write over their own data
+    /// (nw-126). The underlying store error is carried through verbatim
+    /// because it is the only thing that says WHY.
+    #[error("Database exists but could not be opened: {path}")]
+    #[diagnostic(
+        code(nestweaver::db_unavailable),
+        help(
+            "{cause}\nThe database file is present, so do NOT run `index` at this path.\n\
+             If a daemon or other process holds it, stop it with \
+             `nestweaver daemon --db {path} stop`."
+        )
+    )]
+    DatabaseUnavailable { path: String, cause: String },
+
+    /// A crashed daemon leaves an unreplayed write-ahead log. Replay needs
+    /// read-write access, so the read-only path can never perform it and the
+    /// generic "could not open" message sends the user nowhere (nw-126).
+    #[error("Database has an unreplayed write-ahead log: {path}")]
+    #[diagnostic(
+        code(nestweaver::db_wal_unreplayed),
+        help(
+            "{cause}\nThis usually follows a daemon crash. Replay requires read-write \
+             access:\n  nestweaver daemon --db {path} start\n\
+             If that also fails, move {wal} aside and retry — it is replayed or \
+             discarded on the next read-write open, and the database itself is intact."
+        )
+    )]
+    DatabaseWalUnreplayed {
+        path: String,
+        wal: String,
+        cause: String,
+    },
+
     #[error("{message}")]
     #[diagnostic(code(nestweaver::error))]
     General { message: String },
@@ -178,6 +213,28 @@ fn into_diagnostic(err: anyhow::Error) -> miette::Report {
     // ... No such file or directory" mentions a .lbug path and a missing
     // file, but mapping it to db_not_found produces the circular help text
     // "Run `nestweaver index` to create a database" — while running index.
+    // nw-126: a crashed daemon leaves an unreplayed WAL. The store says so
+    // precisely ("Couldn't replay shadow pages under read-only mode. Please
+    // re-open the database with read-write mode...") but that fell through to
+    // the bare `nestweaver::error` rendering, which states the problem and no
+    // remedy — and the advice it does give cannot be followed on the path that
+    // emitted it, since a read-only open can never perform the replay.
+    if lower.contains("shadow pages") || (lower.contains("replay") && lower.contains("read-only")) {
+        let path = message
+            .split("at ")
+            .nth(1)
+            .and_then(|s| s.split(':').next())
+            .unwrap_or("./nestweaver.lbug")
+            .trim()
+            .to_string();
+        return CliDiagnostic::DatabaseWalUnreplayed {
+            wal: format!("{path}.wal"),
+            path,
+            cause: message,
+        }
+        .into();
+    }
+
     if lower.contains("database not found")
         || (lower.contains("failed to open database") && lower.contains("no such file"))
     {
@@ -190,7 +247,45 @@ fn into_diagnostic(err: anyhow::Error) -> miette::Report {
             .unwrap_or("./nestweaver.lbug")
             .trim()
             .to_string();
-        return CliDiagnostic::DatabaseNotFound { path }.into();
+
+        // nw-126: these are TEXT heuristics, and text lies. The daemon's
+        // "failed to open database with write access at <path>; another
+        // process may hold the write lock" matched here and rendered a live
+        // 5.6 GB database as "not found", with help telling the user to
+        // `index` a new one over the top of it. Ask the filesystem instead of
+        // trusting the substring: if the file is really there, this is an
+        // availability failure, not a missing database, and the remedy is the
+        // opposite of creating one.
+        //
+        // Trim the path defensively — the same heuristics can capture trailing
+        // context clauses ("<path>; another process may...").
+        let candidate = path
+            .split(';')
+            .next()
+            .unwrap_or(&path)
+            .trim()
+            .trim_end_matches(['.', ','])
+            .to_string();
+        let on_disk = std::path::Path::new(&candidate);
+        if on_disk.exists() {
+            let wal = format!("{candidate}.wal");
+            if std::path::Path::new(&wal).exists() {
+                return CliDiagnostic::DatabaseWalUnreplayed {
+                    path: candidate,
+                    wal,
+                    cause: message,
+                }
+                .into();
+            }
+            return CliDiagnostic::DatabaseUnavailable {
+                path: candidate,
+                cause: message,
+            }
+            .into();
+        }
+        // Report the trimmed path here too, so a message that appended a
+        // context clause does not surface it as part of the filename.
+        return CliDiagnostic::DatabaseNotFound { path: candidate }.into();
     }
 
     if lower.contains("path") && lower.contains("does not exist")
@@ -693,6 +788,8 @@ fn impact_json_ok(
     note: Option<String>,
 ) -> serde_json::Value {
     let capped = matches!((total, returned), (Some(t), Some(r)) if r < t);
+    // Resolve before the payload borrows `nodes` (nw-123).
+    let returned = returned.unwrap_or_else(|| nodes_len(&nodes));
     let mut payload = serde_json::json!({
         "status": "ok",
         "symbol": symbol,
@@ -702,17 +799,81 @@ fn impact_json_ok(
         "truncated_by_depth": truncated_by_depth,
     });
     if let Some(obj) = payload.as_object_mut() {
-        if let Some(t) = total {
-            obj.insert("total".to_string(), serde_json::json!(t));
-        }
-        if let Some(r) = returned {
-            obj.insert("returned".to_string(), serde_json::json!(r));
-        }
+        // nw-123: `total` and `returned` used to be inserted only when the
+        // caller knew them, so the key SET varied by code path — the
+        // depth-truncated envelope carried them and the threshold-truncated one
+        // did not, leaving a consumer with `undefined` in exactly the case
+        // where the result is incomplete and the counts matter most. A stable
+        // schema is the whole point of this envelope, so both keys are always
+        // present.
+        //
+        // `returned` is never guessed: it is the length of the array we are
+        // actually returning. `total` is `null` when genuinely unknown rather
+        // than being backfilled from `returned`, which would assert
+        // completeness we did not establish (same rule as nw-073's null count).
+        obj.insert("returned".to_string(), serde_json::json!(returned));
+        obj.insert(
+            "total".to_string(),
+            match total {
+                Some(t) => serde_json::json!(t),
+                None => serde_json::Value::Null,
+            },
+        );
         if let Some(note) = note {
             obj.insert("note".to_string(), serde_json::json!(note));
         }
     }
     payload
+}
+
+/// Length of a JSON node collection, for envelopes that must report what they
+/// actually returned rather than what the caller happened to know.
+fn nodes_len(nodes: &serde_json::Value) -> u64 {
+    nodes.as_array().map(|a| a.len() as u64).unwrap_or(0)
+}
+
+/// Warn when a ranking is computed over edges built by a superseded resolver.
+///
+/// nw-124: a fix that changes persisted edge SHAPE (nw-103's import fan-out)
+/// cannot correct data already written. Upgrading therefore leaves `hubs`,
+/// `bridges` and PageRank confidently wrong for every repo not yet re-indexed,
+/// and previously nothing disclosed it. Emitted on stderr so `--json` consumers
+/// are told without the payload changing shape.
+fn warn_stale_resolver_rankings(store: &nestweaver_store::GraphStore, db_path: &std::path::Path) {
+    let Ok(repos) = store.list_repos(None) else {
+        return;
+    };
+    let uids: Vec<String> = repos.into_iter().map(|r| r.uid).collect();
+    if uids.is_empty() {
+        return;
+    }
+    if let Some(note) = nestweaver_engine::resolver_generation::staleness_note(db_path, &uids) {
+        eprintln!("warning: {note}");
+    }
+}
+
+/// Daemon-path counterpart to [`warn_stale_resolver_rankings`].
+///
+/// The daemon owns the store, so this path has no handle to enumerate repos
+/// and cannot report an exact stale count. It can still catch the case that
+/// matters most — and is the common one on upgrade — where the sidecar does not
+/// exist at all, meaning EVERY repo's edges predate the fix. Without this the
+/// warning would only ever appear on the direct path, which is the path users
+/// are told not to use.
+fn warn_stale_resolver_rankings_no_store(db_path: &std::path::Path) {
+    let sidecar = nestweaver_engine::sidecar_path(
+        db_path,
+        nestweaver_engine::resolver_generation::RESOLVER_GENERATION_SIDECAR,
+    );
+    if sidecar.exists() {
+        return;
+    }
+    eprintln!(
+        "warning: no resolver generation is recorded for this database, so every repo \
+         was indexed before the nw-103 import-fan-out fix — hub, bridge and PageRank \
+         rankings are NOT corrected by upgrading alone. Re-index each repo \
+         (`nestweaver index --repo <path>`) to get accurate rankings."
+    );
 }
 
 /// Ambiguous resolution — carries `candidates`, never `nodes`, so it cannot be
@@ -6542,6 +6703,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                     );
                                 }
                             }
+                            // nw-124: the daemon serves this path, so the
+                            // disclosure has to live here too — otherwise it
+                            // only ever fires on the direct path users are
+                            // told not to use.
+                            warn_stale_resolver_rankings_no_store(&db_path);
                             let stats = format!(
                                 "{} hubs in {} (via hybrid)",
                                 value.get("count").and_then(|v| v.as_u64()).unwrap_or(0),
@@ -6567,6 +6733,15 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             if let Ok(Some(clustering)) = load_clusters(&db_path) {
                 attach_cluster_ids(&mut hubs, &clustering);
             }
+
+            // nw-124: hub ranking is precisely what nw-103's import fan-out
+            // corrupted, and the fix cannot repair edges already on disk. On
+            // this machine the FIXED binary still returned the bug report's
+            // exact ranking until the repo was re-indexed. Say so rather than
+            // presenting stale numbers as current. Written to stderr so it
+            // reaches the user in --json mode too, without altering the
+            // documented bare-array payload.
+            warn_stale_resolver_rankings(&store, &db_path);
 
             if json {
                 println!("{}", serde_json::to_string_pretty(&hubs)?);
@@ -6645,6 +6820,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             );
                         }
                     }
+                    // nw-124: bridges are downstream of the same import
+                    // fan-out nw-103 fixed, so they carry the same staleness.
+                    warn_stale_resolver_rankings_no_store(&db_path);
                     let stats = format!(
                         "{} bridges in {} (via daemon)",
                         bridges.len(),
@@ -6658,6 +6836,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
 
             out.status("Computing betweenness centrality...");
             let mut bridges = find_bridge_nodes(&store, top)?;
+            warn_stale_resolver_rankings(&store, &db_path);
 
             // Attach community connection info if clustering sidecar exists.
             if let Ok(Some(clustering)) = load_clusters(&db_path) {
@@ -12374,13 +12553,59 @@ fn try_hybrid_json_rpc(
     match rt.block_on(nestweaver_client::hybrid::HybridClient::connect(
         db_path, config, &start_dir,
     )) {
-        Ok(mut hybrid) => rt.block_on(hybrid.query(rpc_name, &args)).ok(),
-        Err(_) => rt
-            .block_on(nestweaver_client::hybrid::query_configured_upstreams_only(
-                config, &start_dir, rpc_name, &args,
-            ))
-            .ok(),
+        Ok(mut hybrid) => match rt.block_on(hybrid.query(rpc_name, &args)) {
+            Ok(value) => Some(value),
+            Err(e) => {
+                warn_daemon_bypassed(db_path, rpc_name, &format!("{e:#}"));
+                None
+            }
+        },
+        Err(e) => {
+            let upstream = rt
+                .block_on(nestweaver_client::hybrid::query_configured_upstreams_only(
+                    config, &start_dir, rpc_name, &args,
+                ))
+                .ok();
+            if upstream.is_none() {
+                warn_daemon_bypassed(db_path, rpc_name, &format!("{e:#}"));
+            }
+            upstream
+        }
     }
+}
+
+/// Disclose that a command could not be served by the daemon and is about to be
+/// answered by the direct path instead.
+///
+/// nw-125: this fallback was completely silent — exit 0, nothing on stderr, a
+/// result that looks authoritative. Meanwhile asking for the same bypass
+/// explicitly is REFUSED, with a warning about WAL corruption and a demand for
+/// `NESTWEAVER_ALLOW_NO_DAEMON=1`. The tool policed a deliberate request while
+/// doing the same thing unprompted whenever the daemon was slow or down.
+///
+/// That matters beyond consistency: the direct path is not equivalent. It
+/// returns different rankings for `investigate` (nw-120), omits the embedding
+/// block from `brain status` (nw-121), and — the case that produced nw-126 —
+/// opens read-only, so it cannot replay a crashed daemon's WAL and converts a
+/// self-healing outage into a hard failure.
+///
+/// Warn once per process: a single command can route several RPCs through here,
+/// and repeating the paragraph per call would train the user to ignore it.
+fn warn_daemon_bypassed(db_path: &std::path::Path, rpc_name: &str, cause: &str) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    if WARNED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+    eprintln!(
+        "Warning: the daemon could not serve `{rpc_name}` for {} — answering from the \
+         direct path instead.\n  cause: {cause}\n  \
+         Results may differ from the daemon's, and writes are not protected by the \
+         daemon's single-writer lock. Start it with `nestweaver daemon --db {} start`, \
+         or raise NESTWEAVER_DAEMON_BOOT_TIMEOUT_SECS if it is simply slow to boot.",
+        db_path.display(),
+        db_path.display()
+    );
 }
 
 /// Unwrap the `{ "results": [...], "_meta": {...} }` envelope that the hybrid
@@ -13172,6 +13397,20 @@ fn run_brain(
                 println!("  Tags:      {tag_count}");
                 println!("  Wikilinks: {wikilink_count}");
                 println!("  Repos:     {}", repos.len());
+                // nw-121: the daemon prints an `Embedding:` block here and this
+                // path printed nothing at all — same command, same database,
+                // silently different answer. An omitted section reads as "no
+                // such concept", so a user could not tell that semantic
+                // retrieval state was simply unknown. Embedding state is
+                // RUNTIME state owned by the daemon (model actually loaded,
+                // device actually selected), so this path genuinely cannot
+                // report it — but saying so is not the same as saying nothing.
+                println!("Embedding:");
+                println!(
+                    "  State:            unknown (runtime state is held by the daemon; \
+                     start it with `nestweaver daemon --db {} start`)",
+                    db_path.display()
+                );
                 // Interaction tracking is opt-in (enabled via `mcp
                 // --track-interactions`). InteractionTracker::new touches
                 // the sidecar at startup so we can distinguish three states:
@@ -18654,6 +18893,133 @@ mod hybrid_cli_tests {
         let present = dir.path().join("present.lbug");
         std::fs::write(&present, b"").unwrap();
         assert!(require_existing_db(&present).is_ok());
+    }
+
+    /// nw-123: the impact envelope's key set must not depend on which
+    /// truncation path ran. `--depth 1` carried `returned`/`total`;
+    /// `--min-score 0.9` silently dropped them while still returning 3 nodes,
+    /// so a consumer got `undefined` precisely when the result was incomplete.
+    #[test]
+    fn impact_envelope_key_set_is_identical_across_truncation_paths() {
+        let nodes = serde_json::json!([{"name": "a"}, {"name": "b"}, {"name": "c"}]);
+
+        let by_depth = impact_json_ok("s", nodes.clone(), false, true, Some(9), Some(3), None);
+        // The threshold path is the one that used to omit the counts.
+        let by_threshold = impact_json_ok("s", nodes.clone(), true, false, None, None, None);
+
+        let keys = |v: &serde_json::Value| {
+            let mut k: Vec<String> = v.as_object().unwrap().keys().cloned().collect();
+            k.sort();
+            k
+        };
+        assert_eq!(
+            keys(&by_depth),
+            keys(&by_threshold),
+            "envelope keys must not vary by truncation path"
+        );
+
+        for env in [&by_depth, &by_threshold] {
+            assert!(env.get("returned").is_some(), "returned must always exist");
+            assert!(env.get("total").is_some(), "total must always exist");
+        }
+
+        // `returned` reflects what was actually returned, even when the caller
+        // did not supply it.
+        assert_eq!(by_threshold["returned"], serde_json::json!(3));
+        // An unknown total is null — never backfilled from `returned`, which
+        // would assert a completeness that was not established.
+        assert!(
+            by_threshold["total"].is_null(),
+            "unknown total must be null, not a fabricated count: {by_threshold}"
+        );
+        assert_eq!(by_depth["total"], serde_json::json!(9));
+    }
+
+    /// nw-126: the incident message, verbatim. A SIGKILLed daemon left a stale
+    /// WAL; the daemon's open failure was text-matched into `db_not_found` and
+    /// rendered a live 5.6 GB database as "Database not found", with help
+    /// telling the user to `index` a new one AT THAT PATH. Following it would
+    /// have destroyed data that was fully recoverable — the entire outage was
+    /// one stale 42-byte file.
+    ///
+    /// The guard is to consult the filesystem rather than the error text.
+    #[test]
+    fn existing_database_is_never_diagnosed_as_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        std::fs::write(&db, b"not empty").unwrap();
+
+        let err = anyhow::anyhow!(
+            "failed to open database with write access at {}; another process \
+             may hold the write lock: database error: no such file",
+            db.display()
+        );
+        let rendered = format!("{:?}", into_diagnostic(err));
+
+        assert!(
+            !rendered.contains("db_not_found"),
+            "a database that EXISTS must never be reported as not found: {rendered}"
+        );
+        assert!(
+            !rendered.contains("to create a database"),
+            "must never advise creating a database where one already exists — \
+             that is the data-destroying suggestion: {rendered}"
+        );
+        assert!(
+            rendered.contains("db_unavailable") || rendered.contains("db_wal_unreplayed"),
+            "expected an availability diagnostic, got: {rendered}"
+        );
+    }
+
+    /// nw-126: with a stale `.wal` present the diagnostic must name it and give
+    /// the read-write remedy, since replay is impossible on the read-only path
+    /// that usually reports the failure.
+    #[test]
+    fn stale_wal_is_named_with_a_read_write_remedy() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        std::fs::write(&db, b"data").unwrap();
+        std::fs::write(dir.path().join("brain.lbug.wal"), b"stale").unwrap();
+
+        let err = anyhow::anyhow!(
+            "failed to open database with write access at {}; another process \
+             may hold the write lock: no such file",
+            db.display()
+        );
+        let rendered = format!("{:?}", into_diagnostic(err));
+
+        assert!(
+            rendered.contains("db_wal_unreplayed"),
+            "a present .wal must be diagnosed specifically: {rendered}"
+        );
+        assert!(
+            rendered.contains("daemon") && rendered.contains("start"),
+            "the remedy must be the read-write open that can actually replay: {rendered}"
+        );
+    }
+
+    /// nw-126: the read-only path's own words. `open_read_only` reports
+    /// "Couldn't replay shadow pages under read-only mode. Please re-open the
+    /// database with read-write mode" — a correct diagnosis whose advice that
+    /// path structurally cannot follow. It previously fell through to a bare
+    /// `nestweaver::error` with no remedy at all.
+    #[test]
+    fn shadow_page_replay_failure_gets_an_actionable_diagnostic() {
+        let err = anyhow::anyhow!(
+            "failed to open database at /tmp/x/brain.lbug: database error: Runtime \
+             exception: Couldn't replay shadow pages under read-only mode. Please \
+             re-open the database with read-write mode to replay shadow pages."
+        );
+        let rendered = format!("{:?}", into_diagnostic(err));
+
+        assert!(
+            rendered.contains("db_wal_unreplayed"),
+            "expected the WAL diagnostic, got: {rendered}"
+        );
+        assert!(
+            !rendered.contains("to create a database"),
+            "must not advise creating a database: {rendered}"
+        );
     }
 
     /// A create-path store error ("open/create store at

--- a/src/main.rs
+++ b/src/main.rs
@@ -7065,6 +7065,30 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
             }
 
+            // nw-075: `--json` deliberately bypasses the daemon (its tool
+            // truncates member lists at 20), and this direct path never
+            // consulted the sidecar — so `clusters --json` recomputed on EVERY
+            // invocation while `--help` promises "cached in a sidecar ...
+            // subsequent invocations are instant", and the TEXT path really did
+            // cache via the daemon. Two output modes disagreeing about whether a
+            // cache exists, with the docs siding with the one that didn't.
+            //
+            // Reuse is gated on the resolution MATCHING, because the sidecar
+            // holds whichever resolution was computed last: serving a cache
+            // built at a different resolution would answer a question the caller
+            // did not ask. With an explicit --resolution the check needs no
+            // store at all, which is the fully-instant case the help describes.
+            if let Ok(Some(cached)) = load_clusters(&db_path)
+                && let Some(requested) = resolution
+                && (cached.resolution - requested).abs() < f64::EPSILON
+            {
+                out.status(&format!(
+                    "Using cached clusters (resolution={requested}) from sidecar."
+                ));
+                print_clusters_output(&cached, json)?;
+                return Ok((EXIT_SUCCESS, None));
+            }
+
             // Compute and save inside a block so the store is dropped
             // before any output. LadybugDB's connection finaliser can
             // trigger a panic during WAL checkpoint; wrapping in
@@ -7099,26 +7123,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 o
             };
 
-            if json {
-                println!("{}", serde_json::to_string_pretty(&output)?);
-            } else if output.communities.is_empty() {
-                println!("No communities detected (graph may be empty or fully disconnected).");
-            } else {
-                println!(
-                    "Clusters ({}, modularity={:.4}):\n",
-                    output.communities.len(),
-                    output.modularity
-                );
-                for c in &output.communities {
-                    println!(
-                        "  [{:>3}] {} ({} members, cohesion={:.2})",
-                        c.id, c.name, c.member_count, c.cohesion
-                    );
-                    for f in &c.key_files {
-                        println!("        {f}");
-                    }
-                }
-            }
+            print_clusters_output(&output, json)?;
             Ok((EXIT_SUCCESS, None))
         }
 
@@ -8508,6 +8513,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 truncated: false,
                                 scanned_fallback: false,
                                 stale_index: false,
+                                note: None,
                             }
                         });
                     if json {
@@ -15522,6 +15528,37 @@ fn apply_recency_bias_cli(
 fn render_cost_tokens(n: &nestweaver_engine::BrainNode) -> usize {
     // UID + title + kind + location + relevance (~10 chars) + JSON overhead
     (n.uid.len() + n.title.len() + n.kind.len() + n.location.len() + 10 + 80).div_ceil(4)
+}
+
+/// Render a `clusters` result in either mode.
+///
+/// Shared so the cached and freshly-computed paths cannot drift (nw-075): the
+/// whole point of serving a cache is that the caller cannot tell the difference.
+fn print_clusters_output(
+    output: &nestweaver_engine::ClusteringOutput,
+    json: bool,
+) -> anyhow::Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(output)?);
+    } else if output.communities.is_empty() {
+        println!("No communities detected (graph may be empty or fully disconnected).");
+    } else {
+        println!(
+            "Clusters ({}, modularity={:.4}):\n",
+            output.communities.len(),
+            output.modularity
+        );
+        for c in &output.communities {
+            println!(
+                "  [{:>3}] {} ({} members, cohesion={:.2})",
+                c.id, c.name, c.member_count, c.cohesion
+            );
+            for f in &c.key_files {
+                println!("        {f}");
+            }
+        }
+    }
+    Ok(())
 }
 
 fn print_brain_context_text(result: &BrainContextResult, cut: usize, token_budget: Option<usize>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10624,6 +10624,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let pidfile = nestweaver_daemon::pidfile_path(&instance_id);
             let socket = nestweaver_daemon::socket_path(&instance_id);
             let log_file = nestweaver_daemon::log_path(&instance_id);
+            // `log_file` is the real stderr sink (it goes in the plist and gets
+            // opened for redirect below). It is NOT what an operator should be
+            // told to read: tracing writes to `daemon.log.<date>` alongside it,
+            // so every human-facing pointer uses the hint instead. See nw-118.
+            let log_hint = nestweaver_daemon::log_hint(&instance_id);
 
             match action {
                 DaemonAction::Start {
@@ -10738,7 +10743,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                     .display()
                             );
                             eprintln!("  Socket: {}", socket.display());
-                            eprintln!("  Log:    {}", log_file.display());
+                            eprintln!("  Log:    {log_hint}");
 
                             // Poll connect_existing + health_check
                             // (wait_healthy never auto-starts) instead of the
@@ -10764,9 +10769,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                     // still turn into a healthy daemon.
                                     eprintln!(
                                         "Daemon is still booting under launchd; check \
-                                         `nestweaver daemon --db {} status` and the log at {}",
+                                         `nestweaver daemon --db {} status` and the logs at {}",
                                         db_path.display(),
-                                        log_file.display()
+                                        log_hint
                                     );
                                     return Ok((EXIT_SUCCESS, None));
                                 }
@@ -10928,7 +10933,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         );
                         eprintln!("  PID file: {}", pidfile.display());
                         eprintln!("  Socket:   {}", socket.display());
-                        eprintln!("  Log:      {}", log_file.display());
+                        eprintln!("  Log:      {log_hint}");
 
                         let daemonize = daemonize2::Daemonize::new()
                             .pid_file(&pidfile)
@@ -10981,9 +10986,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 if !parent.first_child_exit_status.success() {
                                     eprintln!(
                                         "Error: daemon failed to start (boot exit status {}). \
-                                         Check the log: {}",
+                                         Check the logs: {}",
                                         parent.first_child_exit_status,
-                                        log_file.display()
+                                        log_hint
                                     );
                                     std::process::exit(EXIT_ERROR);
                                 }
@@ -10994,8 +10999,8 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 }
                                 eprintln!(
                                     "Error: daemon did not start accepting connections within \
-                                     10s — it may have died during boot. Check the log: {}",
-                                    log_file.display()
+                                     10s — it may have died during boot. Check the logs: {}",
+                                    log_hint
                                 );
                                 std::process::exit(EXIT_ERROR);
                             }
@@ -11220,7 +11225,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         );
                         println!("  DB:     {}", db_path.display());
                         println!("  Socket: {}", socket.display());
-                        println!("  Log:    {}", log_file.display());
+                        println!("  Log:    {log_hint}");
                         print_daemon_embedding_status(&db_path);
                         return Ok((EXIT_SUCCESS, None));
                     }
@@ -11235,7 +11240,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             println!("Daemon is running (PID {pid})");
                             println!("  DB:     {}", db_path.display());
                             println!("  Socket: {}", socket.display());
-                            println!("  Log:    {}", log_file.display());
+                            println!("  Log:    {log_hint}");
                             print_daemon_embedding_status(&db_path);
                         } else {
                             println!(
@@ -11253,7 +11258,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         println!("Daemon is running (PID {pid}, serving socket)");
                         println!("  DB:     {}", db_path.display());
                         println!("  Socket: {}", socket.display());
-                        println!("  Log:    {}", log_file.display());
+                        println!("  Log:    {log_hint}");
                         print_daemon_embedding_status(&db_path);
                         return Ok((EXIT_SUCCESS, None));
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11186,8 +11186,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                     eprintln!(
                                         "Error: daemon failed to start (boot exit status {}). \
                                          Check the logs: {}",
-                                        parent.first_child_exit_status,
-                                        log_hint
+                                        parent.first_child_exit_status, log_hint
                                     );
                                     std::process::exit(EXIT_ERROR);
                                 }
@@ -19004,7 +19003,10 @@ mod hybrid_cli_tests {
 
         // Mixed: two direct, three semantic.
         let m = seed_header(5, 3);
-        assert!(m.contains("2 matched directly") && m.contains("3 via semantic search"), "{m}");
+        assert!(
+            m.contains("2 matched directly") && m.contains("3 via semantic search"),
+            "{m}"
+        );
     }
 
     /// Defensive: the counts arrive from a daemon response, so a malformed or


### PR DESCRIPTION
Sixteen defects found by a full manual regression of v2.7.2 against the installed artifact and the real production graph. **All sixteen are fixed here.**

Everything was verified against the live 120k-symbol graph and 981-note vault, not fixtures.

## Critical

**nw-126 — a daemon crash left the database unopenable, and the error told the user to create a new one.** A SIGKILLed daemon leaves `<db>.wal` with no `<db>.shadow`; lbug's failure ends in "No such file or directory", so the CLI's substring heuristic reported a live 5.6 GB database as `db_not_found` and advised `index --repo` to CREATE one at that path. Orphaned WALs are now RENAMED (never deleted — a log can hold committed work), and `into_diagnostic` consults the filesystem instead of the error text. Verified against the preserved failure state.

## High

**nw-127 — index reported failure for work that succeeded.** `infer_cross_repo_call_edges` ran unconditionally after the `skip_resolution` branch, walking unchanged files and issuing one store lookup per call site. **3440.6s exit 1 → 18s exit 0.** The timeout watchdog also sent nothing on trip; it now emits a terminal `Phase::Error`.

**nw-125 — the boot timeout fell back to the direct path silently.** Exit 0, zero bytes on stderr, while asking for that same bypass explicitly is *refused*. Now disclosed.

**nw-124 — nw-103's fix cannot repair edges already on disk.** New resolver-generation sidecar; `hubs`/`bridges` disclose staleness on both paths. Verified: after re-indexing all 34 repos the warning correctly goes silent and the fan-out artifacts are gone graph-wide.

## Medium

- **nw-119** — 77% of daemon boot was a full-graph walk defeated by a 2 KB sidecar. **53.9s → 0.85s.**
- **nw-118** — boot-failure messages named the stderr log, not the tracing log holding the error.
- **nw-102** — `brain context` counted semantic nearest neighbours as "resolved", so one response claimed a seed both resolved *and* unresolved.
- **nw-120** — `investigate` ranks differently daemon vs direct (the CLI hardcodes no embed model). Fixed as disclosure rather than parity: a per-invocation BERT load would be a real regression on a CI-only path.
- **nw-123** — impact envelope key set varied by truncation path.
- **nw-121** — direct-path `brain status` omitted the whole `Embedding:` block.
- **nw-097** — `regex-search --json` omitted the honesty note MCP already returned.
- **nw-109** — `query_extensions` key+value returned 0 for 100% of real data.
- **nw-075** — `clusters --json` recomputed every call while `--help` promised a cache.
- **nw-117** — `dead-code --json` diverged daemon vs direct.

## Low

- **nw-122** — `broken-links` printed a piped link's alias as its target. The edge now carries both; backlinks still read `display`, which is correct there — the one-line version of this fix would have broken them.

## Known limitations, stated rather than hidden

- Index cancellation is only observed at the pre-write boundary, so a long phase cannot be interrupted mid-flight.
- `investigate` still ranks differently on the two paths; that is now reported by the tool.

## Verification

- `cargo test --workspace`: 96 binaries, **3114 passed, 0 failed**
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- Release note added to CHANGELOG: repos must be re-indexed for nw-103 to take effect

## Upgrade note

nw-103's fix runs at index time and cannot correct edges already written. `hubs`/`bridges` now say so at runtime, but only re-indexing fixes the data. The same applies to nw-122's wikilink targets — pre-migration rows fall back to the display text until re-indexed.