### PR TITLE
release: v2.7.x regression hardening, brain/wikilink correctness, and CLI honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 ## Unreleased
 
 
+### Upgrade Notes
+
+* **Re-index your repositories after upgrading.** The import-edge fan-out fix
+  (nw-103) changed how edges are *written*, not how they are read, so it runs at
+  index time and cannot repair edges already in your database. Until a repo is
+  re-indexed, `hubs`, `bridges`, `summary --level hub` and PageRank keep
+  returning the pre-fix ranking for it — on a real 34-repo graph the upgraded
+  binary still reported the exact corrupted ranking from the bug report, and
+  re-indexing a single repo removed all of its artefacts from the top 10.
+
+  ```sh
+  nestweaver index --repo /path/to/each/repo
+  ```
+
+  You do not have to guess whether this affects you: `hubs` and `bridges` now
+  report on stderr when a database contains repos indexed by an older resolver,
+  and stay quiet once everything is current. Vault (`brain refresh`) data is
+  unaffected — this applies to code repositories only.
+
 ### Bug Fixes
 
 * **search:** `regex-search`/`count-patterns` — fix trigram pre-filter correctness for alternation patterns; detect a stale trigram index and fall back to a full scan (`stale_index: true` in JSON, note in text output; remedy: re-run `index --with-trigrams`); bound `--limit` to 1–10000 and `--max-millis` to 1–600000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,29 @@ daemon risks WAL corruption from concurrent access. If you see "database
 locked" errors, stop the daemon (`nestweaver daemon stop`) rather than using
 `--no-daemon`.
 
+## Environment variables (operator-facing)
+
+Timeouts and tuning an operator may actually need. Every one of these is named
+by an error message the tool can print, so they belong somewhere findable.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NESTWEAVER_DAEMON_BOOT_TIMEOUT_SECS` | 30 | How long a client waits for the daemon to bind its socket. Raise it on a slow cold start; the boot-failure message names it. Boot phase timings (`boot_ms`, `store_open_ms`, `extension_reconcile_ms`, `unattributed_ms`) are logged at bind so a slow boot is diagnosable rather than guessed at. |
+| `NESTWEAVER_INDEX_TIMEOUT_SECS` | 1800 | Overall ceiling for one index. On expiry the daemon requests cancellation and reports a terminal error naming this variable. Cancellation is COOPERATIVE and only observed at the next pre-write boundary, so the index may still be finishing — check the daemon log before assuming it stopped. |
+| `NESTWEAVER_DRAIN_TIMEOUT_SECS` | 660 | How long a shutting-down daemon drains active write RPCs. |
+| `NESTWEAVER_STOP_GRACE_SECS` | — | Grace period before a stopping daemon is escalated. |
+| `NESTWEAVER_INDEX_CPU_PERCENT` | 50 | Index CPU duty cycle, percent of one core (1–99; `0` or `>=100` disables). Also see the launchd note below. |
+| `NESTWEAVER_ALLOW_NO_DAEMON` | unset | Opt-in required to honour `--no-daemon` / `NESTWEAVER_NO_DAEMON` outside CI. Without it the bypass is REFUSED, because it circumvents the single-writer lock. Not for normal use. |
+| `NESTWEAVER_LBUG_MAX_THREADS` | 1 | Engine thread-pool size. `1` closes the nw-073 eviction-vs-read race; raise only if you measure a query-latency cost. |
+| `NESTWEAVER_LBUG_BUFFER_POOL_BYTES` | auto | Buffer pool size. A larger pool avoids eviction when the working set fits. |
+| `NESTWEAVER_LBUG_AUTO_CHECKPOINT` | on | `0`/`false` defers auto-checkpoints; reduces the #678 corruption trigger during bulk load. |
+| `NESTWEAVER_CRASH_REPORT_DIRS` | platform | Extra directories scanned by `diagnostics capabilities` for nw-073 crash recurrence. |
+| `NESTWEAVER_GIT_CLONE_TIMEOUT_SECS` / `NESTWEAVER_GIT_NET_TIMEOUT_SECS` | — | Bounds on git clone / network operations during pull. |
+
+Server mode additionally reads `NESTWEAVER_BIND`, `NESTWEAVER_TOKEN`,
+`NESTWEAVER_ADMIN_TOKEN`, `NESTWEAVER_UPSTREAM`, and
+`NESTWEAVER_WEBHOOK_SECRET` / `NESTWEAVER_WEBHOOK_SECRET_OLD` (rotation).
+
 ## macOS App (preferred on Mac)
 
 On macOS, prefer the native `.app` bundle over the CLI daemon. It provides:
@@ -186,6 +209,7 @@ Sidecar files written alongside the database:
 - `<db>.cache` — MCP response cache (binary: MessagePack + ZSTD; falls back to legacy JSON on read)
 - `<db>.parsed_cache.bin` — Cached parse results (symbols, references, type bindings) keyed by content hash, for skipping re-parsing unchanged files
 - `<db>.resolution_deps.bin` — Per-file resolution dependency tracker for incremental cross-file resolution
+- `<db>.resolver_generation.json` — per-repo record of which resolver generation built that repo's edges. A repo with no entry predates the record and is reported as stale by `hubs`/`bridges`, because a resolver fix that changes edge SHAPE (nw-103's import fan-out) cannot repair edges already written — only re-indexing can
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -241,10 +241,14 @@ containing it is available, use this source-build path.
 | `search` | Full-text search across indexed symbols and notes |
 | `symbol` | Look up a symbol by name and display its metadata |
 | `impact` | Trace the blast radius of a symbol through the dependency graph (fails closed on unknown/foreign UIDs, exit 2; `--depth` 1–15; pruning by impact-score threshold or depth is disclosed, `--min-score 0` opts out) |
+| `blast-radius` | Assess blast radius for a set of changed files; reports `gate_state`/`status` and blind spots, and never reports `ok` for a truncated traversal |
+| `flow-trace` | Trace forward execution flow from a symbol — what it calls, and what those call |
 | `read-symbols` | Read a symbol's source span |
 | `regex-search` | Regex search over indexed text (trigram pre-filter; falls back to a full scan with `stale_index: true` when the trigram index is stale — re-run `index --with-trigrams`) |
 | `count-patterns` | Count regex matches per pattern |
 | `investigate` | Orient on a topic in one call |
+| `investigate-expand` | Drill into investigate bundle entries — full body plus immediate neighbours |
+| `investigate-hydrate` | Fill in bodies/summaries for all un-hydrated entries of a bundle |
 | `affected-tests` | Select tests for changed files (tiered; carries a `recommendation` CI directive — `run-full-suite` on any degraded run or when changed files have unrecognized extensions like Makefile/CI YAML/`.sql`) |
 | `repo-map` | Generate a token-budgeted map of the repository structure |
 | `summary` | Hierarchical code summaries at symbol, file, or cluster level |
@@ -288,6 +292,8 @@ containing it is available, use this source-build path.
 | `rts-eval record-truth` | Report a full-suite outcome from CI so selection quality can be measured |
 | `rts-eval report` | Measured file-recall / change-recall / selection-breadth of past selections (refuses percentages below 10 joined runs) |
 | `dead-code` | Detect unreachable symbols via entry point reachability (`unreachable_count` is the unfiltered total; `matching_count` reflects `--min-confidence`; Rust `pub mod` Modules are never flagged; visibility isn't persisted, so all confidence scores are inferred/Medium) |
+| `rerank` | Lightweight result reranker (off-by-default heuristic) |
+| `info` | Show hardware and configuration information |
 | `contracts list` | List API contracts derived from spec files + framework handlers |
 | `contracts drift` | Routes declared in a spec but not implemented, and vice versa (presence-level) |
 | `contracts diff` | Field/type-level OpenAPI breaking-change diff between two spec versions (`--base`/`--head`, `--fail-on-breaking` for CI) |
@@ -343,6 +349,8 @@ containing it is available, use this source-build path.
 | `admin` | Subagent guidance instructions |
 | `interactions` | Manage interaction memory |
 | `hooks` | Install/remove the local pre-push blast-radius check (`--install`, `--strict`, `--uninstall`) |
+| `pre-push-impact` | Analyse local changes against the org-wide graph — what `hooks` runs, and runnable directly (alias `ppi`) |
+| `format-comment` | Format impact analysis results as a PR/MR comment, for CI to post |
 
 </details>
 

--- a/crates/nestweaver-client/src/autostart.rs
+++ b/crates/nestweaver-client/src/autostart.rs
@@ -302,6 +302,19 @@ fn wait_for_socket(sock: &Path) -> Result<()> {
 /// aborts the very restart we just requested — which is exactly what broke
 /// `daemon_crash_recovery`. A pidfile that cannot be read yet is likewise not
 /// treated as death: a freshly spawned daemon writes it asynchronously.
+/// Where to send an operator whose daemon failed to bind `sock`.
+///
+/// The instance id is recovered from the socket's parent directory name, which
+/// is the only identifier available at this point in the failure path.
+fn log_hint_for_socket(sock: &Path) -> String {
+    let instance_id = sock
+        .parent()
+        .and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().replace("nestweaver-", ""))
+        .unwrap_or_else(|| "default".to_string());
+    nestweaver_daemon::lifecycle::log_hint(&instance_id)
+}
+
 fn wait_for_socket_watching(
     sock: &Path,
     pidfile: Option<&Path>,
@@ -328,16 +341,9 @@ fn wait_for_socket_watching(
             }
             bail!(
                 "daemon process {pid} exited before binding {}.\n\
-                 Check the daemon log for errors: {}",
+                 Check the daemon logs for errors: {}",
                 sock.display(),
-                nestweaver_daemon::lifecycle::log_path(
-                    &sock
-                        .parent()
-                        .and_then(|p| p.file_name())
-                        .map(|n| n.to_string_lossy().replace("nestweaver-", ""))
-                        .unwrap_or_else(|| "default".to_string())
-                )
-                .display()
+                log_hint_for_socket(sock)
             );
         }
         std::thread::sleep(delay);
@@ -349,20 +355,20 @@ fn wait_for_socket_watching(
         return Ok(());
     }
 
+    // Do NOT offer `--no-daemon` here. It is a CI-only escape hatch that
+    // bypasses the single-writer lock, and `resolve_use_daemon` refuses it
+    // outside CI anyway — so the suggestion was both unusable and, if forced,
+    // exactly the WAL-corruption risk the daemon exists to prevent (nw-125).
+    // A slow boot is the common cause, so name the knob that actually helps.
     bail!(
         "daemon socket at {} did not accept connections within {:.1}s.\n\
-         Check the daemon log for errors: {}\n\
-         If another process holds the database lock, stop it or use --no-daemon.",
+         Check the daemon logs for errors: {}\n\
+         If it is simply slow to boot, raise {}; if another process holds the \
+         database lock, stop that process.",
         sock.display(),
         timeout.as_secs_f64(),
-        nestweaver_daemon::lifecycle::log_path(
-            &sock
-                .parent()
-                .and_then(|p| p.file_name())
-                .map(|n| n.to_string_lossy().replace("nestweaver-", ""))
-                .unwrap_or_else(|| "default".to_string())
-        )
-        .display()
+        log_hint_for_socket(sock),
+        DAEMON_BOOT_TIMEOUT_ENV
     );
 }
 

--- a/crates/nestweaver-client/src/autostart.rs
+++ b/crates/nestweaver-client/src/autostart.rs
@@ -111,12 +111,22 @@ pub fn ensure_daemon(db_path: &Path, config_path: Option<&Path>) -> Result<PathB
         return Ok(sock);
     }
 
+    // Whatever PID the pidfile names right now belongs to a daemon that is
+    // already gone (we only reach here when nothing holds the lock). Capture it
+    // so the readiness wait does not mistake it for the daemon we are about to
+    // spawn.
+    let stale_pid = read_pid(&pidfile);
+
     // Spawn the daemon as a detached child.
     spawn_daemon(db_path, config_path)?;
 
     // Poll until the socket accepts connections, then release the spawn-lock so the next
     // waiter's re-check observes a ready daemon instead of spawning another.
-    let waited = wait_for_socket(&sock);
+    //
+    // Watch the pidfile here: this is the one path where the daemon we are
+    // waiting on was just spawned by us, so a process that has already exited
+    // means it will never bind and there is nothing to wait for.
+    let waited = wait_for_socket_watching(&sock, Some(&pidfile), stale_pid);
     unsafe { libc::flock(spawn_lock.as_raw_fd(), libc::LOCK_UN) };
     waited?;
 
@@ -240,20 +250,95 @@ fn socket_accepts_connections(sock: &Path) -> bool {
     std::os::unix::net::UnixStream::connect(sock).is_ok()
 }
 
+/// Override for how long a client waits for a daemon to bind its socket.
+pub const DAEMON_BOOT_TIMEOUT_ENV: &str = "NESTWEAVER_DAEMON_BOOT_TIMEOUT_SECS";
+
+/// Default ceiling for daemon boot.
+///
+/// This was 5s, which is too tight for a legitimate cold start: a
+/// Metal-enabled daemon compiles shaders and loads the embed model before it
+/// binds, and a large database opens sidecars first. The result was a FALSE
+/// failure — the daemon was booting normally and the client gave up on it. That
+/// flake cost three releases a manual CI re-run (nw-114).
+///
+/// A longer ceiling alone would trade one problem for another: a genuinely dead
+/// daemon would take this long to report. [`wait_for_socket_watching`] resolves
+/// that by watching process liveness, so the ceiling only applies while the
+/// daemon is actually alive and working.
+const DEFAULT_DAEMON_BOOT_TIMEOUT_SECS: u64 = 30;
+
+/// Resolve the boot ceiling, clamped to 1..=600s. An unparseable or
+/// out-of-range value falls back to the default rather than failing the
+/// command — this is a patience knob, not a correctness input.
+fn daemon_boot_timeout() -> Duration {
+    std::env::var(DAEMON_BOOT_TIMEOUT_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|secs| (1..=600).contains(secs))
+        .map_or_else(
+            || Duration::from_secs(DEFAULT_DAEMON_BOOT_TIMEOUT_SECS),
+            Duration::from_secs,
+        )
+}
+
 /// Poll for the socket to accept connections with exponential backoff.
 ///
-/// Initial delay: 50ms, max delay: 500ms, total timeout: 5s.
-/// Larger databases need more time to open the DB, load sidecars,
-/// and bind the socket.
+/// Initial delay: 50ms, max delay: 500ms. See
+/// [`DEFAULT_DAEMON_BOOT_TIMEOUT_SECS`] for the ceiling.
 fn wait_for_socket(sock: &Path) -> Result<()> {
+    wait_for_socket_watching(sock, None, None)
+}
+
+/// As [`wait_for_socket`], but bails as soon as the daemon we are waiting on is
+/// known to have exited.
+///
+/// Waiting out the full ceiling only makes sense while the daemon is alive and
+/// still working. If the pidfile names a process that has exited, it will never
+/// bind and further waiting only delays the report.
+///
+/// `ignore_pid` is the PID the pidfile held BEFORE we spawned, and it must be
+/// skipped. After a crash the stale pidfile still names the DEAD previous
+/// daemon until the new one overwrites it, so treating any dead PID as failure
+/// aborts the very restart we just requested — which is exactly what broke
+/// `daemon_crash_recovery`. A pidfile that cannot be read yet is likewise not
+/// treated as death: a freshly spawned daemon writes it asynchronously.
+fn wait_for_socket_watching(
+    sock: &Path,
+    pidfile: Option<&Path>,
+    ignore_pid: Option<i32>,
+) -> Result<()> {
     let start = Instant::now();
-    let timeout = Duration::from_secs(5);
+    let timeout = daemon_boot_timeout();
     let mut delay = Duration::from_millis(50);
     let max_delay = Duration::from_millis(500);
 
     while start.elapsed() < timeout {
         if socket_accepts_connections(sock) {
             return Ok(());
+        }
+        if let Some(path) = pidfile
+            && let Some(pid) = read_pid(path)
+            && Some(pid) != ignore_pid
+            && !is_process_alive(pid)
+        {
+            // Re-check the socket once: the daemon may have bound and exited
+            // between our last poll and this liveness check.
+            if socket_accepts_connections(sock) {
+                return Ok(());
+            }
+            bail!(
+                "daemon process {pid} exited before binding {}.\n\
+                 Check the daemon log for errors: {}",
+                sock.display(),
+                nestweaver_daemon::lifecycle::log_path(
+                    &sock
+                        .parent()
+                        .and_then(|p| p.file_name())
+                        .map(|n| n.to_string_lossy().replace("nestweaver-", ""))
+                        .unwrap_or_else(|| "default".to_string())
+                )
+                .display()
+            );
         }
         std::thread::sleep(delay);
         delay = (delay * 2).min(max_delay);
@@ -326,6 +411,102 @@ mod tests {
             ]
             .map(std::ffi::OsString::from)
         );
+    }
+
+    /// nw-114: a daemon that has already exited must be reported immediately,
+    /// not waited out to the full boot ceiling. Without the liveness check,
+    /// raising the ceiling from 5s to 30s would have made every genuine
+    /// start-up failure six times slower to report.
+    #[test]
+    fn wait_bails_at_once_when_the_daemon_pid_is_already_gone() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("daemon.sock");
+        let pidfile = dir.path().join("daemon.pid");
+
+        // PID 1 is always alive; we need one that is certainly not. A freshly
+        // reaped high PID is unreliable, so use an out-of-range value: kill(0)
+        // reports ESRCH for it, which is exactly "no such process".
+        std::fs::write(&pidfile, "2147483647").unwrap();
+
+        let start = Instant::now();
+        let result = wait_for_socket_watching(&socket, Some(&pidfile), None);
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err(), "a dead daemon must not be waited out");
+        let message = format!("{:#}", result.unwrap_err());
+        assert!(
+            message.contains("exited before binding"),
+            "the error must say the process died, not just time out: {message}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "must fail fast, took {elapsed:?}"
+        );
+    }
+
+    /// A STALE pid from a crashed previous daemon must not abort the restart.
+    ///
+    /// This is the regression `daemon_crash_recovery` caught: after a crash the
+    /// pidfile still names the dead previous daemon until the new one overwrites
+    /// it, so treating any dead PID as failure kills the very restart we just
+    /// requested.
+    #[test]
+    fn wait_ignores_the_stale_pid_it_was_told_to_skip() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("daemon.sock");
+        let pidfile = dir.path().join("daemon.pid");
+
+        // The pidfile still names a dead daemon from before the restart.
+        let stale = 2147483647;
+        std::fs::write(&pidfile, stale.to_string()).unwrap();
+
+        // A "new daemon" binds shortly after, as a real restart would.
+        let server_socket = socket.clone();
+        let server = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(300));
+            let listener = UnixListener::bind(&server_socket).unwrap();
+            listener.set_nonblocking(true).unwrap();
+            let deadline = Instant::now() + Duration::from_secs(3);
+            while Instant::now() < deadline {
+                if listener.accept().is_ok() {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        });
+
+        let result = wait_for_socket_watching(&socket, Some(&pidfile), Some(stale));
+        server.join().unwrap();
+
+        assert!(
+            result.is_ok(),
+            "a stale pid must not abort the restart: {:#}",
+            result.unwrap_err()
+        );
+    }
+
+    /// The ceiling is env-overridable so CI and constrained machines can extend
+    /// it without a rebuild. Out-of-range and unparseable values fall back to
+    /// the default — this is a patience knob, not a correctness input.
+    #[test]
+    fn boot_timeout_honours_the_env_override_and_rejects_nonsense() {
+        let default = Duration::from_secs(DEFAULT_DAEMON_BOOT_TIMEOUT_SECS);
+
+        // SAFETY: single-threaded test; the override is read only here.
+        unsafe { std::env::set_var(DAEMON_BOOT_TIMEOUT_ENV, "45") };
+        assert_eq!(daemon_boot_timeout(), Duration::from_secs(45));
+
+        for nonsense in ["0", "601", "abc", "", "-5"] {
+            unsafe { std::env::set_var(DAEMON_BOOT_TIMEOUT_ENV, nonsense) };
+            assert_eq!(
+                daemon_boot_timeout(),
+                default,
+                "{nonsense:?} must fall back to the default"
+            );
+        }
+
+        unsafe { std::env::remove_var(DAEMON_BOOT_TIMEOUT_ENV) };
+        assert_eq!(daemon_boot_timeout(), default);
     }
 
     #[test]

--- a/crates/nestweaver-daemon/src/lifecycle.rs
+++ b/crates/nestweaver-daemon/src/lifecycle.rs
@@ -204,6 +204,25 @@ pub fn log_path(instance_id: &str) -> PathBuf {
     log_dir(instance_id).join("daemon.log")
 }
 
+/// Operator-facing pointer to where daemon diagnostics actually live.
+///
+/// Two writers put daemon output in [`log_dir`], and they do NOT overlap:
+/// launchd redirects the process's stderr to the undated `daemon.log`, while
+/// the tracing subscriber uses a daily rolling appender that writes structured
+/// records to `daemon.log.<YYYY-MM-DD>`. Boot timing, and every
+/// `tracing::error!` emitted by a failing startup, land only in the dated file.
+///
+/// Pointing a stuck operator at `log_path` alone therefore names the one file
+/// guaranteed not to hold the tracing error they are looking for, which is the
+/// dead end this hint exists to avoid.
+pub fn log_hint(instance_id: &str) -> String {
+    format!(
+        "{} — `daemon.log` is stderr; `daemon.log.<date>` has the structured \
+         boot timing and errors",
+        log_dir(instance_id).display()
+    )
+}
+
 /// Launchd service label for the given instance.
 pub fn launchd_label(instance_id: &str) -> String {
     format!("io.kehl.nestweaver.{instance_id}")
@@ -542,5 +561,22 @@ mod tests {
     fn log_path_ends_with_daemon_log() {
         let lp = log_path("test1234");
         assert!(lp.ends_with("daemon.log"));
+    }
+
+    /// The boot-failure messages used to hand operators `log_path` alone. That
+    /// is the launchd stderr file; the tracing subscriber's daily rolling
+    /// appender writes boot timing and startup errors to `daemon.log.<date>`
+    /// instead, so the named file never contained the error being hunted.
+    #[test]
+    fn log_hint_names_the_dated_tracing_file_not_just_stderr() {
+        let hint = log_hint("test1234");
+        assert!(
+            hint.contains("daemon.log.<date>"),
+            "hint must point at the dated tracing file: {hint}"
+        );
+        assert!(
+            hint.contains(&log_dir("test1234").display().to_string()),
+            "hint must name the directory holding both files: {hint}"
+        );
     }
 }

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -6944,6 +6944,14 @@ pub async fn run_server(
 
     // Open the graph store: read-only for a snapshot replica, read-write
     // otherwise (the daemon is the sole DB owner).
+    // Time the pre-bind phases. A client gives the daemon a bounded window to
+    // bind its socket, and when that expired the only evidence was a single
+    // "[daemon] starting" line — nothing said WHERE the time went, so the cause
+    // had to be guessed at. It is not the embedding model: that loads long after
+    // the socket is serving (see `load_embedding_model` below). Opening the
+    // database is the dominant pre-bind cost, so measure it (nw-114).
+    let boot_started = std::time::Instant::now();
+
     let store = if read_only {
         GraphStore::open_read_only(&db_path).with_context(|| {
             format!("failed to open snapshot read-only at {}", db_path.display())
@@ -6962,6 +6970,7 @@ pub async fn run_server(
             }
         }
     };
+    let store_open_ms = boot_started.elapsed().as_millis() as u64;
 
     // Load sidecars (PageRank, interaction scores).
     nestweaver_engine::migrate_sidecar(&db_path, "pagerank.json", ".pagerank.json");
@@ -7305,6 +7314,14 @@ pub async fn run_server(
 
     let uds = tokio::net::UnixListener::bind(&sock_path)
         .with_context(|| format!("bind UDS: {}", sock_path.display()))?;
+    // The line a stalled-boot investigation actually needs: how long the client
+    // had to wait, and how much of it was the database open.
+    tracing::info!(
+        boot_ms = boot_started.elapsed().as_millis() as u64,
+        store_open_ms = store_open_ms,
+        socket = %sock_path.display(),
+        "socket bound and accepting connections"
+    );
     let uds_stream = tokio_stream::wrappers::UnixListenerStream::new(uds);
 
     // Create scheduler command channel. The sender goes into AdminState

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -3360,6 +3360,32 @@ impl NestWeaverDaemon for DaemonService {
                     _ = tokio::time::sleep(index_timeout) => {
                         tracing::warn!(?index_timeout, "index exceeded timeout; cancelling");
                         cancel.store(true, std::sync::atomic::Ordering::Relaxed);
+                        // nw-127: previously the watchdog set the flag and said
+                        // nothing, so the client's stream simply ended and it
+                        // reported "index progress stream ended before
+                        // completion" — indistinguishable from a crash, and
+                        // reported as a FAILURE for an index that (because
+                        // cancellation is cooperative and only observed at the
+                        // pre-write boundary) may still be running and may still
+                        // succeed. Send a terminal Error event so the caller
+                        // learns what actually happened, names the knob, and is
+                        // warned not to assume the work stopped.
+                        let _ = watch_tx
+                            .send(Ok(IndexProgress {
+                                phase: Phase::Error as i32,
+                                message: format!(
+                                    "index exceeded the {}s timeout and cancellation was requested \
+                                     (raise NESTWEAVER_INDEX_TIMEOUT_SECS). Cancellation is \
+                                     cooperative and is only observed at the next pre-write \
+                                     boundary, so the daemon may still be finishing this index — \
+                                     check the daemon log before assuming it stopped or retrying.",
+                                    index_timeout.as_secs()
+                                ),
+                                files_processed: 0,
+                                files_total: 0,
+                                symbols_found: 0,
+                            }))
+                            .await;
                     }
                     _ = watch_tx.closed() => {
                         // Client dropped the progress stream — stop wasting CPU.
@@ -6973,13 +6999,26 @@ pub async fn run_server(
     let store_open_ms = boot_started.elapsed().as_millis() as u64;
 
     // Load sidecars (PageRank, interaction scores).
+    //
+    // nw-119: nw-114 attributed daemon boot cost to opening the store, and the
+    // instrumentation it added disproved that — `boot_ms=6712` against
+    // `store_open_ms=876` on a warm cache, and a later boot measured 36,474ms
+    // against 10,041ms. So the majority of pre-bind time was somewhere in here
+    // and nobody could say where. Guessing once was already wrong; time each
+    // phase instead. These sidecars are not small (the production
+    // `.pagerank.json` is 13 MB of JSON), which is a candidate but not yet a
+    // conclusion.
+    let sidecar_started = std::time::Instant::now();
     nestweaver_engine::migrate_sidecar(&db_path, "pagerank.json", ".pagerank.json");
     let pr_path = nestweaver_engine::sidecar_path(&db_path, ".pagerank.json");
     let _ = store.load_pagerank_cache(&pr_path);
+    let pagerank_load_ms = sidecar_started.elapsed().as_millis() as u64;
 
+    let interactions_started = std::time::Instant::now();
     if let Some(scores) = nestweaver_engine::load_interaction_scores(&db_path) {
         store.load_interaction_cache(scores);
     }
+    let interactions_load_ms = interactions_started.elapsed().as_millis() as u64;
 
     // Open the Tantivy index. A read-only snapshot replica intentionally
     // disables search reconciliation and uses a reader when one is available.
@@ -6990,7 +7029,9 @@ pub async fn run_server(
     // opens, queries use substring fallback and indexed mutations still surface
     // the configured-index failure.
     let tantivy_path = nestweaver_mcp::tantivy_sidecar_path(&db_path);
+    let tantivy_started = std::time::Instant::now();
     let (tantivy, search_reconciliation) = open_search_index(&tantivy_path, read_only);
+    let tantivy_open_ms = tantivy_started.elapsed().as_millis() as u64;
 
     let idle_notify = Arc::new(Notify::new());
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
@@ -7122,7 +7163,18 @@ pub async fn run_server(
     )?;
 
     // Build the per-repo authz policy ONCE, before the state is assembled.
+    // nw-119: the first instrumentation pass narrowed the gap but did not close
+    // it — store open, pagerank and tantivy together accounted for well under a
+    // third of boot, leaving ~52s unattributed on a 66s boot. The 13 MB
+    // `.pagerank.json` was the leading suspect and measured 448ms, so that
+    // hypothesis is dead too. Everything between the tantivy open and the bind
+    // is the remaining candidate; `get_embedding_metadata` is a store query
+    // against a 5.6 GB database, which is the next thing worth timing rather
+    // than assuming.
+    let permission_started = std::time::Instant::now();
     let permission_source = build_daemon_permission_source(instance_cfg.as_ref());
+    let permission_source_ms = permission_started.elapsed().as_millis() as u64;
+    let embedding_probe_started = std::time::Instant::now();
     let embedding_cfg = instance_cfg
         .as_ref()
         .map(|config| config.embedding.clone())
@@ -7138,6 +7190,7 @@ pub async fn run_server(
         cfg!(feature = "embed"),
         daemon_metal_compiled(),
     );
+    let embedding_probe_ms = embedding_probe_started.elapsed().as_millis() as u64;
     let state = Arc::new(DaemonState {
         store: Arc::new(store),
 
@@ -7171,6 +7224,15 @@ pub async fn run_server(
         ui_server: std::sync::Mutex::new(None),
     });
 
+    // nw-119: two instrumentation passes narrowed the unattributed boot time to
+    // the span between the Tantivy open and the bind — 253s of a 268s boot,
+    // with no log output in it at all. Config load, permission source and the
+    // embedding probe measured 0-210ms, so the cost is here: these reconcile
+    // passes walk extension state against a 5.6 GB graph, synchronously, before
+    // the socket is allowed to bind. Measure rather than assume — the previous
+    // two hypotheses (store open, then the 13 MB pagerank sidecar) were both
+    // wrong.
+    let reconcile_started = std::time::Instant::now();
     if !read_only {
         recover_pending_instance_extension_migration(&state).with_context(|| {
             format!(
@@ -7193,6 +7255,8 @@ pub async fn run_server(
                 )
             })?;
     }
+
+    let extension_reconcile_ms = reconcile_started.elapsed().as_millis() as u64;
 
     // Pre-warm PPR adjacency cache so the first PPR query after startup
     // hits the cache instead of spending ~350ms rebuilding from the DB.
@@ -7315,10 +7379,33 @@ pub async fn run_server(
     let uds = tokio::net::UnixListener::bind(&sock_path)
         .with_context(|| format!("bind UDS: {}", sock_path.display()))?;
     // The line a stalled-boot investigation actually needs: how long the client
-    // had to wait, and how much of it was the database open.
+    // had to wait, and where it went.
+    //
+    // nw-119: `boot_ms` and `store_open_ms` alone showed the store was a small
+    // fraction of boot without saying what the rest was, so the phases are
+    // broken out. `unattributed_ms` is deliberately reported rather than left
+    // for the reader to subtract — if it stays large, the next phase to
+    // instrument is still missing, and that should be visible instead of
+    // requiring arithmetic nobody performs.
+    let boot_ms = boot_started.elapsed().as_millis() as u64;
     tracing::info!(
-        boot_ms = boot_started.elapsed().as_millis() as u64,
+        boot_ms = boot_ms,
         store_open_ms = store_open_ms,
+        pagerank_load_ms = pagerank_load_ms,
+        interactions_load_ms = interactions_load_ms,
+        tantivy_open_ms = tantivy_open_ms,
+        permission_source_ms = permission_source_ms,
+        embedding_probe_ms = embedding_probe_ms,
+        extension_reconcile_ms = extension_reconcile_ms,
+        unattributed_ms = boot_ms.saturating_sub(
+            store_open_ms
+                + pagerank_load_ms
+                + interactions_load_ms
+                + tantivy_open_ms
+                + permission_source_ms
+                + embedding_probe_ms
+                + extension_reconcile_ms
+        ),
         socket = %sock_path.display(),
         "socket bound and accepting connections"
     );

--- a/crates/nestweaver-engine/src/agent_guide.rs
+++ b/crates/nestweaver-engine/src/agent_guide.rs
@@ -906,8 +906,34 @@ pub fn generate_claude_md_with_rules(
     out.push_str("- `brain_context` — PPR-ranked structural context from symbol seeds\n");
     out.push_str("- `brain_impact` — blast radius before modifying code\n");
     out.push_str("- `brain_search` — full-text search across code and notes\n");
+    out.push_str("- `blast_radius` — assess a set of CHANGED FILES, with a trust contract\n");
+    out.push_str("- `flow_trace` — trace forward execution flow from a symbol\n");
     out.push_str("- `project_context` — project-scoped notes and symbols\n");
     out.push_str("- `detect_changes` — assess risk after changes\n");
+
+    // These tools report how much they actually established. An agent that
+    // ignores those fields will present a partial or unanchored answer as a
+    // complete one, which is the failure mode the fields exist to prevent —
+    // so the guide has to say so explicitly rather than assume it is read.
+    out.push_str("\n### Read the trust fields before trusting a result\n\n");
+    out.push_str(
+        "- `status` / `gate_state` — a run that did not complete is `partial` / \
+         `degraded-unknown`, never `ok`. Do not report it as a clean result.\n",
+    );
+    out.push_str(
+        "- `truncated` (with `truncated_by_depth` / `truncated_by_threshold`) — an \
+         empty or short result may be a budget limit, not an absence. `total` is \
+         `null` when genuinely unknown; it is not zero.\n",
+    );
+    out.push_str(
+        "- `semantic_applied` / `degraded_components` — retrieval that fell back to \
+         lexical ranking orders results differently. Say so rather than implying \
+         relevance you did not get.\n",
+    );
+    out.push_str(
+        "- `notifications` / `note` — read them. A caveat like `cochange-no-coverage` \
+         means an empty list is unmined history, not evidence of no coupling.\n",
+    );
 
     Ok(out)
 }
@@ -1200,6 +1226,18 @@ mod tests {
         assert!(output.contains("brain_search"));
         assert!(output.contains("project_context"));
         assert!(output.contains("detect_changes"));
+        // The flagship analysis tools and the trust contract must reach every
+        // generated guide — an agent that never learns to read `gate_state`
+        // will present a degraded result as a clean one.
+        assert!(
+            output.contains("blast_radius"),
+            "guide must list blast_radius"
+        );
+        assert!(output.contains("flow_trace"), "guide must list flow_trace");
+        assert!(
+            output.contains("gate_state"),
+            "guide must tell agents to read the trust fields"
+        );
     }
 
     fn make_symbol(uid: &str, name: &str, file_path: &str) -> nestweaver_schema::Symbol {

--- a/crates/nestweaver-engine/src/blast_radius.rs
+++ b/crates/nestweaver-engine/src/blast_radius.rs
@@ -950,8 +950,30 @@ pub fn analyze_blast_radius(
             Some(edges) => {
                 let changed_set: HashSet<&str> =
                     changed_files.iter().filter_map(|p| p.to_str()).collect();
+
+                // Qualify by repo. The sidecar now carries every indexed repo's
+                // pairs rather than only the last one written, and its paths are
+                // repo-RELATIVE — so without this a `CHANGELOG.md` in one repo
+                // would match a `CHANGELOG.md` in another and invent a coupling
+                // that does not exist (nw-062).
+                //
+                // `scope_uids` are the repos the changed symbols belong to;
+                // `Repo.root_path` is what the miner stamped on each pair. A repo
+                // with no root_path (server-side bare clone) contributes nothing
+                // here, and unattributed legacy rows match nothing — both cases
+                // fall through to the `cochange-no-coverage` disclosure below
+                // rather than guessing.
+                let scope_roots: HashSet<String> = scope_uids
+                    .iter()
+                    .filter_map(|uid| store.lookup_repo(uid).ok().flatten())
+                    .filter_map(|repo| repo.root_path)
+                    .collect();
                 let mut seen: HashSet<(String, String)> = HashSet::new();
                 for e in &edges {
+                    // Only pairs mined from a repo actually in scope.
+                    if !e.repo.is_empty() && !scope_roots.contains(&e.repo) {
+                        continue;
+                    }
                     let (coupled, changed) = if changed_set.contains(e.file_a.as_str())
                         && !changed_set.contains(e.file_b.as_str())
                     {
@@ -995,6 +1017,7 @@ pub fn analyze_blast_radius(
                 // "no history was mined for it".
                 let mined: HashSet<&str> = edges
                     .iter()
+                    .filter(|e| e.repo.is_empty() || scope_roots.contains(&e.repo))
                     .flat_map(|e| [e.file_a.as_str(), e.file_b.as_str()])
                     .collect();
                 let unmined: Vec<&str> = changed_set
@@ -2559,6 +2582,7 @@ mod tests {
         let db = dir.path().join("scratch.lbug");
         std::fs::write(&db, b"").expect("touch db");
         let edges = vec![CoChangeEdge {
+            repo: String::new(),
             file_a: "src/billing.rs".into(),
             file_b: "src/invoice_templates.sql".into(),
             cochange_count: 9,
@@ -2607,6 +2631,7 @@ mod tests {
 
         // History mined from a DIFFERENT repo than the file being analysed.
         let edges = vec![CoChangeEdge {
+            repo: String::new(),
             file_a: "crates/nestweaver-store/build.rs".into(),
             file_b: "crates/nestweaver-store/Cargo.toml".into(),
             cochange_count: 6,
@@ -2651,6 +2676,7 @@ mod tests {
         let db = dir.path().join("scratch.lbug");
         std::fs::write(&db, b"").expect("touch db");
         let edges = vec![CoChangeEdge {
+            repo: String::new(),
             file_a: "src/billing.rs".into(),
             file_b: "src/invoice_templates.sql".into(),
             cochange_count: 9,

--- a/crates/nestweaver-engine/src/blast_radius.rs
+++ b/crates/nestweaver-engine/src/blast_radius.rs
@@ -984,6 +984,38 @@ pub fn analyze_blast_radius(
                         .unwrap_or(std::cmp::Ordering::Equal)
                         .then_with(|| a.file.cmp(&b.file))
                 });
+
+                // A loaded sidecar is not the same as a sidecar that covers
+                // THESE files (nw-062). It is written per indexed repo and
+                // blind-overwritten, so in a multi-repo database it holds one
+                // repo's history — every other repo takes this branch, matches
+                // nothing, and would otherwise return an empty list with no
+                // disclosure at all. An empty result must not be readable as
+                // "this file has no historical coupling" when the truth is
+                // "no history was mined for it".
+                let mined: HashSet<&str> = edges
+                    .iter()
+                    .flat_map(|e| [e.file_a.as_str(), e.file_b.as_str()])
+                    .collect();
+                let unmined: Vec<&str> = changed_set
+                    .iter()
+                    .copied()
+                    .filter(|path| !mined.contains(path))
+                    .collect();
+                if !unmined.is_empty() {
+                    notifications.push(Notification {
+                        level: NotificationLevel::Note,
+                        message: format!(
+                            "{} of {} changed file(s) do not appear in the co-change sidecar, so \
+                             an empty co-change result for them cannot be distinguished from \
+                             unmined history — the sidecar covers the most recently indexed repo \
+                             only, so files from other repos in this database are not represented",
+                            unmined.len(),
+                            changed_set.len()
+                        ),
+                        descriptor: "cochange-no-coverage".to_string(),
+                    });
+                }
             }
             None => {
                 notifications.push(Notification {
@@ -2553,6 +2585,100 @@ mod tests {
         assert_eq!(c.cochange_count, 9);
         assert!((c.confidence - 0.69).abs() < 1e-6);
         assert!(c.note.contains("no static edge"));
+    }
+
+    /// nw-062: the sidecar exists but holds another repo's history. This is the
+    /// 33-of-34 case on the real multi-repo database — the run took the "loaded"
+    /// branch, matched nothing, and disclosed nothing, so a caller could not
+    /// tell "no coupling" from "no data".
+    #[test]
+    fn a_sidecar_that_does_not_cover_the_changed_file_is_disclosed() {
+        use crate::cochange::{CoChangeEdge, save_cochange_sidecar};
+        let store = GraphStore::in_memory().expect("store");
+        insert_minimal_symbol(
+            &store,
+            "sym:view",
+            "WorkflowsView",
+            "src/app/WorkflowsView.tsx",
+        );
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("scratch.lbug");
+        std::fs::write(&db, b"").expect("touch db");
+
+        // History mined from a DIFFERENT repo than the file being analysed.
+        let edges = vec![CoChangeEdge {
+            file_a: "crates/nestweaver-store/build.rs".into(),
+            file_b: "crates/nestweaver-store/Cargo.toml".into(),
+            cochange_count: 6,
+            total_commits_a: 10,
+            total_commits_b: 10,
+            confidence: 0.60,
+        }];
+        save_cochange_sidecar(&edges, &crate::sidecar_path(&db, ".cochange.json"))
+            .expect("save sidecar");
+
+        let result = analyze_blast_radius(
+            &store,
+            &[PathBuf::from("src/app/WorkflowsView.tsx")],
+            &BlastRadiusOptions::default(),
+            None,
+            Some(&db),
+        )
+        .expect("analyze");
+
+        assert!(result.cochanged_files.is_empty());
+        assert!(
+            result
+                .notifications
+                .iter()
+                .any(|n| n.descriptor == "cochange-no-coverage"),
+            "a sidecar with no history for this file must be disclosed: {:?}",
+            result.notifications
+        );
+        // Advisory tier: absence never degrades the run.
+        assert_eq!(result.status, AnalysisStatus::Complete);
+    }
+
+    /// The complement: when the sidecar DOES cover the changed file, an empty or
+    /// populated result is trustworthy and must not carry the caveat — a note
+    /// that always fires teaches callers to ignore it.
+    #[test]
+    fn a_covered_file_does_not_carry_the_no_coverage_caveat() {
+        use crate::cochange::{CoChangeEdge, save_cochange_sidecar};
+        let store = GraphStore::in_memory().expect("store");
+        insert_minimal_symbol(&store, "sym:bill", "compute_total", "src/billing.rs");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("scratch.lbug");
+        std::fs::write(&db, b"").expect("touch db");
+        let edges = vec![CoChangeEdge {
+            file_a: "src/billing.rs".into(),
+            file_b: "src/invoice_templates.sql".into(),
+            cochange_count: 9,
+            total_commits_a: 12,
+            total_commits_b: 10,
+            confidence: 0.69,
+        }];
+        save_cochange_sidecar(&edges, &crate::sidecar_path(&db, ".cochange.json"))
+            .expect("save sidecar");
+
+        let result = analyze_blast_radius(
+            &store,
+            &[PathBuf::from("src/billing.rs")],
+            &BlastRadiusOptions::default(),
+            None,
+            Some(&db),
+        )
+        .expect("analyze");
+
+        assert_eq!(result.cochanged_files.len(), 1);
+        assert!(
+            !result
+                .notifications
+                .iter()
+                .any(|n| n.descriptor == "cochange-no-coverage"),
+            "a covered file must not be told its history is missing: {:?}",
+            result.notifications
+        );
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/brain_docgraph.rs
+++ b/crates/nestweaver-engine/src/brain_docgraph.rs
@@ -95,22 +95,80 @@ pub fn broken_links(store: &GraphStore, max_suggestions: usize) -> Result<Vec<Br
 
 /// Rank note UIDs by how well their title matches `text` (case-insensitive
 /// substring either direction, with exact match first). Returns at most `max`.
+/// Collapse a link target or note key to a comparable form: lowercase, with
+/// every run of non-alphanumeric characters reduced to a single space.
+///
+/// Lets `blast-radius-production-grade` match a note whose stem is written
+/// `Blast Radius Production Grade` without resorting to fuzzy distance.
+fn normalize_key(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut pending_space = false;
+    for ch in value.chars() {
+        if ch.is_alphanumeric() {
+            if pending_space && !out.is_empty() {
+                out.push(' ');
+            }
+            pending_space = false;
+            out.extend(ch.to_lowercase());
+        } else {
+            pending_space = true;
+        }
+    }
+    out
+}
+
+/// The filename stem of a note's path, lowercased.
+fn note_stem(file_path: &str) -> String {
+    std::path::Path::new(file_path)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default()
+        .to_lowercase()
+}
+
+/// Rank note UIDs by how well their TITLE or FILENAME STEM matches `text`.
+///
+/// Stems matter because Obsidian wikilinks target filenames, and the resolver
+/// keys on stems too (its priority 3/3b). This function looked only at titles,
+/// so it stayed silent on the one case where a suggestion is most valuable: a
+/// target that matches a filename stem shared by SEVERAL notes. The resolver
+/// requires a unique stem and so declines to pick, leaving the link unresolved —
+/// and with no suggestion, the caller was told nothing at all despite both
+/// candidates being known (nw-100).
+///
+/// Deliberately exact-or-substring, with no edit-distance fuzzing. On the real
+/// vault most unresolved links point at targets that do not exist anywhere —
+/// backlog IDs that are YAML entries rather than notes, and notes since deleted.
+/// Fuzzy matching would manufacture a confident-looking suggestion for every one
+/// of them, which is worse than returning none.
 fn suggest_targets(text: &str, notes: &[NoteLite], max: usize, source_uid: &str) -> Vec<String> {
     let needle = text.trim().to_lowercase();
     if needle.is_empty() {
         return vec![];
     }
+    let needle_norm = normalize_key(&needle);
+
     let mut scored: Vec<(u8, &NoteLite)> = Vec::new();
     for n in notes {
         if n.uid == source_uid {
             continue;
         }
         let title = n.title.to_lowercase();
-        let score = if title == needle {
+        let stem = note_stem(&n.file_path);
+
+        // Exact on either key, raw or normalized.
+        let exact = title == needle
+            || stem == needle
+            || (!needle_norm.is_empty()
+                && (normalize_key(&title) == needle_norm || normalize_key(&stem) == needle_norm));
+
+        let score = if exact {
             3
-        } else if title.contains(&needle) {
+        } else if title.contains(&needle) || (!stem.is_empty() && stem.contains(&needle)) {
             2
-        } else if needle.contains(&title) && !title.is_empty() {
+        } else if (!title.is_empty() && needle.contains(&title))
+            || (!stem.is_empty() && needle.contains(&stem))
+        {
             1
         } else {
             0
@@ -119,7 +177,13 @@ fn suggest_targets(text: &str, notes: &[NoteLite], max: usize, source_uid: &str)
             scored.push((score, n));
         }
     }
-    scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.title.cmp(&b.1.title)));
+    // Deterministic order: score, then title, then uid — the uid tiebreak keeps
+    // two notes sharing a stem AND a title from ordering arbitrarily.
+    scored.sort_by(|a, b| {
+        b.0.cmp(&a.0)
+            .then_with(|| a.1.title.cmp(&b.1.title))
+            .then_with(|| a.1.uid.cmp(&b.1.uid))
+    });
     scored
         .into_iter()
         .take(max)
@@ -602,6 +666,86 @@ mod tests {
             stats.low_confidence_wikilinks >= 1,
             "the lower-tier resolution must still be reported, just not as broken"
         );
+    }
+
+    fn note_lite(uid: &str, title: &str, file_path: &str) -> NoteLite {
+        NoteLite {
+            uid: uid.to_string(),
+            title: title.to_string(),
+            file_path: file_path.to_string(),
+            vault_uid: "vault:test".to_string(),
+            pagerank_score: 0.0,
+        }
+    }
+
+    /// nw-100: the case where a suggestion is worth most.
+    ///
+    /// Two notes share the filename stem `blast-radius-production-grade`, so the
+    /// resolver's stem tier requires uniqueness and declines to pick — the link
+    /// is correctly unresolved. But both candidates are known, and the
+    /// title-only suggester returned NOTHING because neither title resembles the
+    /// stem. A human could disambiguate instantly if shown them.
+    #[test]
+    fn suggests_both_notes_that_share_a_filename_stem() {
+        let notes = vec![
+            note_lite(
+                "note:backlog",
+                "Blast Radius → production-grade for enterprise code review",
+                "Workspaces/NestWeaver/backlog/blast-radius-production-grade.md",
+            ),
+            note_lite(
+                "note:prd",
+                "Blast Radius → Production-Grade — PRD",
+                "Workspaces/NestWeaver/notes/2026-07/prd/blast-radius-production-grade.md",
+            ),
+            note_lite("note:other", "Unrelated", "misc/unrelated.md"),
+        ];
+
+        let got = suggest_targets("blast-radius-production-grade", &notes, 5, "note:src");
+
+        assert!(got.contains(&"note:backlog".to_string()), "got: {got:?}");
+        assert!(got.contains(&"note:prd".to_string()), "got: {got:?}");
+        assert!(
+            !got.contains(&"note:other".to_string()),
+            "must not drag in unrelated notes: {got:?}"
+        );
+    }
+
+    /// Separator style must not matter: a hyphenated target should match a note
+    /// whose stem uses spaces, and vice versa.
+    #[test]
+    fn suggestion_matching_ignores_separator_style() {
+        let notes = vec![note_lite(
+            "note:a",
+            "Some Other Title",
+            "notes/Phase B Execution Index.md",
+        )];
+        let got = suggest_targets("phase-b-execution-index", &notes, 5, "note:src");
+        assert_eq!(got, vec!["note:a".to_string()], "got: {got:?}");
+    }
+
+    /// The restraint matters as much as the recall. Most unresolved links on the
+    /// real vault point at targets that exist NOWHERE — backlog IDs that are YAML
+    /// entries rather than notes, and notes since deleted. Returning a
+    /// confident-looking guess for those is worse than returning none, so there
+    /// is deliberately no edit-distance fuzzing.
+    #[test]
+    fn a_target_that_exists_nowhere_gets_no_suggestion() {
+        let notes = vec![
+            note_lite(
+                "note:a",
+                "Daemon Architecture",
+                "notes/daemon-architecture.md",
+            ),
+            note_lite("note:b", "Release Process", "notes/release-process.md"),
+        ];
+        for absent in ["nw-092", "server-mode-phase1-transport", "zzz"] {
+            let got = suggest_targets(absent, &notes, 5, "note:src");
+            assert!(
+                got.is_empty(),
+                "{absent:?} exists nowhere — a guess is worse than nothing, got: {got:?}"
+            );
+        }
     }
 
     /// nw-100: never advise fixing a link by pointing it at its own source.

--- a/crates/nestweaver-engine/src/brain_docgraph.rs
+++ b/crates/nestweaver-engine/src/brain_docgraph.rs
@@ -27,7 +27,15 @@ pub const DEFAULT_ORPHAN_ALLOWLIST: &[&str] = &[
 
 // ── 1. broken links ──────────────────────────────────────────────────────────
 
-/// A broken (low-confidence) wikilink with suggested resolution targets.
+/// A wikilink that resolved at less than full confidence, or not at all.
+///
+/// `resolved_target_uid` is the difference between the two, and it matters:
+/// confidence encodes WHICH RESOLVER TIER matched, not how likely the link is
+/// to be wrong. A same-folder match scores 0.95 and a unique global
+/// filename-stem match scores 0.90 — both are unique, unambiguous resolutions,
+/// and the latter is exactly how Obsidian resolves a bare `[[Note]]`. Reporting
+/// those as "broken" alongside links that point at nothing told callers that
+/// three quarters of a healthy vault was broken (nw-100).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BrokenLink {
     pub source_uid: String,
@@ -35,11 +43,25 @@ pub struct BrokenLink {
     pub wikilink_text: String,
     pub confidence: f32,
     pub suggested_target_uids: Vec<String>,
+    /// The note this link actually points at, when it resolved. `None` means
+    /// no target exists — the only case that is genuinely broken.
+    pub resolved_target_uid: Option<String>,
 }
 
-/// Find wikilink edges whose target resolution is suspect (confidence < 1.0),
-/// pairing each with up to `max_suggestions` candidate note UIDs whose title
-/// fuzzily matches the link text (substring / token overlap).
+impl BrokenLink {
+    /// True when the link points at no note at all.
+    pub fn is_unresolved(&self) -> bool {
+        self.resolved_target_uid.is_none()
+    }
+}
+
+/// Find wikilinks that resolved below full confidence OR not at all, pairing
+/// each with up to `max_suggestions` candidate note UIDs whose title fuzzily
+/// matches the link text (substring / token overlap).
+///
+/// Callers wanting genuinely-broken links must filter on
+/// [`BrokenLink::is_unresolved`] — a sub-1.0 confidence means "matched at a
+/// lower resolver tier", not "wrong". See [`BrokenLink`].
 pub fn broken_links(store: &GraphStore, max_suggestions: usize) -> Result<Vec<BrokenLink>> {
     let rows: Vec<BrokenWikilinkRow> = store.broken_wikilinks().map_err(|e| anyhow::anyhow!(e))?;
     if rows.is_empty() {
@@ -51,13 +73,21 @@ pub fn broken_links(store: &GraphStore, max_suggestions: usize) -> Result<Vec<Br
 
     let mut out = Vec::with_capacity(rows.len());
     for r in rows {
-        let suggestions = suggest_targets(&r.wikilink_text, &notes, max_suggestions);
+        // Never suggest the note the link is written in. A date-stamped log
+        // linking to a date-stamped note matched itself on substring, so the
+        // advice read "fix this broken link by linking to itself" (nw-100).
+        let suggestions = suggest_targets(&r.wikilink_text, &notes, max_suggestions, &r.source_uid);
         out.push(BrokenLink {
             source_uid: r.source_uid,
             source_path: r.source_path,
             wikilink_text: r.wikilink_text,
             confidence: r.confidence,
             suggested_target_uids: suggestions,
+            resolved_target_uid: if r.current_target_uid.is_empty() {
+                None
+            } else {
+                Some(r.current_target_uid)
+            },
         });
     }
     Ok(out)
@@ -65,13 +95,16 @@ pub fn broken_links(store: &GraphStore, max_suggestions: usize) -> Result<Vec<Br
 
 /// Rank note UIDs by how well their title matches `text` (case-insensitive
 /// substring either direction, with exact match first). Returns at most `max`.
-fn suggest_targets(text: &str, notes: &[NoteLite], max: usize) -> Vec<String> {
+fn suggest_targets(text: &str, notes: &[NoteLite], max: usize, source_uid: &str) -> Vec<String> {
     let needle = text.trim().to_lowercase();
     if needle.is_empty() {
         return vec![];
     }
     let mut scored: Vec<(u8, &NoteLite)> = Vec::new();
     for n in notes {
+        if n.uid == source_uid {
+            continue;
+        }
         let title = n.title.to_lowercase();
         let score = if title == needle {
             3
@@ -374,7 +407,13 @@ pub struct TagCount {
 pub struct DocStats {
     pub total_notes: usize,
     pub total_wikilinks: usize,
+    /// Links that point at no note at all. This is the vault-health number.
     pub broken_wikilinks: usize,
+    /// Links that DID resolve, but below full confidence — a same-folder or
+    /// unique filename-stem match rather than a path or unique-title match.
+    /// Counted separately because folding them into `broken_wikilinks` reported
+    /// 75% of a healthy vault as broken when the real figure was 11% (nw-100).
+    pub low_confidence_wikilinks: usize,
     pub orphans: usize,
     pub avg_outdegree: f64,
     pub top_tags: Vec<TagCount>,
@@ -388,7 +427,9 @@ pub fn doc_stats(store: &GraphStore, top_tags_limit: usize) -> Result<DocStats> 
     let total_wikilinks = store
         .count_wikilink_edges()
         .map_err(|e| anyhow::anyhow!(e))?;
-    let broken = broken_links(store, 0)?.len();
+    let suspect = broken_links(store, 0)?;
+    let broken = suspect.iter().filter(|l| l.is_unresolved()).count();
+    let low_confidence = suspect.len() - broken;
     let orphans = orphan_documents(store, None, None, &[])?.len();
 
     // avg_outdegree: note-level wikilink edges / total notes.
@@ -429,6 +470,7 @@ pub fn doc_stats(store: &GraphStore, top_tags_limit: usize) -> Result<DocStats> 
         total_notes,
         total_wikilinks,
         broken_wikilinks: broken,
+        low_confidence_wikilinks: low_confidence,
         orphans,
         avg_outdegree,
         top_tags,
@@ -506,6 +548,87 @@ mod tests {
             !dup.suggested_target_uids.is_empty(),
             "expected suggested targets for [[Dup]]"
         );
+    }
+
+    /// nw-100: a link that resolved at a lower tier is NOT broken.
+    ///
+    /// `[[Sibling]]` in `folder/a.md` resolves to `folder/Sibling.md` by
+    /// same-folder match at confidence 0.95 — a unique, unambiguous target, and
+    /// how Obsidian itself resolves a bare link. It must carry a
+    /// `resolved_target_uid`, and `doc_stats` must not count it as broken.
+    #[test]
+    fn a_lower_tier_resolution_is_not_broken() {
+        let (_dir, root) = make_vault(&[
+            (
+                "folder/a.md",
+                "# A\n\nSee [[Sibling]] and [[Nowhere At All]].\n",
+            ),
+            ("folder/Sibling.md", "# Different Title Entirely\n\nhi\n"),
+        ]);
+        let (_res, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+
+        let links = broken_links(&store, 5).unwrap();
+
+        let sibling = links
+            .iter()
+            .find(|b| b.wikilink_text.eq_ignore_ascii_case("Sibling"))
+            .expect("[[Sibling]] should appear as a sub-1.0 resolution");
+        assert!(
+            sibling.confidence < 1.0,
+            "same-folder match scores below 1.0"
+        );
+        assert!(
+            !sibling.is_unresolved(),
+            "it resolved — it must carry a target, not read as broken: {sibling:?}"
+        );
+        assert!(sibling.resolved_target_uid.is_some());
+
+        let nowhere = links
+            .iter()
+            .find(|b| b.wikilink_text.eq_ignore_ascii_case("Nowhere At All"))
+            .expect("the dangling link should appear");
+        assert!(
+            nowhere.is_unresolved(),
+            "a link to nothing is the only genuinely broken case"
+        );
+
+        // The headline metric must count only the dangling one.
+        let stats = doc_stats(&store, 5).unwrap();
+        assert_eq!(
+            stats.broken_wikilinks, 1,
+            "only [[Nowhere At All]] is broken; counting the resolved one is the nw-100 defect"
+        );
+        assert!(
+            stats.low_confidence_wikilinks >= 1,
+            "the lower-tier resolution must still be reported, just not as broken"
+        );
+    }
+
+    /// nw-100: never advise fixing a link by pointing it at its own source.
+    #[test]
+    fn suggestions_never_include_the_source_note() {
+        let notes = vec![
+            NoteLite {
+                uid: "note:self".to_string(),
+                title: "Daily Log 2026-07-27".to_string(),
+                file_path: "_logs/2026-07-27.md".to_string(),
+                vault_uid: "vault:test".to_string(),
+                pagerank_score: 0.0,
+            },
+            NoteLite {
+                uid: "note:other".to_string(),
+                title: "Daily Log 2026-07-27 Review".to_string(),
+                file_path: "notes/review.md".to_string(),
+                vault_uid: "vault:test".to_string(),
+                pagerank_score: 0.0,
+            },
+        ];
+        let got = suggest_targets("Daily Log 2026-07-27", &notes, 5, "note:self");
+        assert!(
+            !got.contains(&"note:self".to_string()),
+            "must not suggest the source note itself, got: {got:?}"
+        );
+        assert!(got.contains(&"note:other".to_string()));
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/cochange.rs
+++ b/crates/nestweaver-engine/src/cochange.rs
@@ -9,6 +9,19 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CoChangeEdge {
+    /// Absolute path of the repo this pair was mined from, matching
+    /// `Repo.root_path`.
+    ///
+    /// Without it the sidecar was a flat list with no owner, so each repo's
+    /// index BLIND-OVERWROTE the previous one's and a 34-repo database kept only
+    /// the last repo's couplings. The paths are repo-relative too, so even a
+    /// correctly merged file would have collided — `CHANGELOG.md` exists in most
+    /// repos (nw-062).
+    ///
+    /// `#[serde(default)]` so a legacy flat sidecar still loads; those entries
+    /// are unattributed and are treated as belonging to no repo in particular.
+    #[serde(default)]
+    pub repo: String,
     pub file_a: String,
     pub file_b: String,
     pub cochange_count: u32,
@@ -40,6 +53,13 @@ pub fn compute_cochanges(
     }
 
     let text = String::from_utf8_lossy(&output.stdout);
+    // Stamp every pair with the repo it came from. Canonicalised so it matches
+    // `Repo.root_path`, which is what the read side resolves a repo_uid to.
+    let repo_key = repo_path
+        .canonicalize()
+        .unwrap_or_else(|_| repo_path.to_path_buf())
+        .to_string_lossy()
+        .into_owned();
 
     // Parse: each commit is a hash line followed by file lines, then blank line
     let mut commits: Vec<Vec<String>> = Vec::new();
@@ -104,6 +124,7 @@ pub fn compute_cochanges(
                 return None;
             }
             Some(CoChangeEdge {
+                repo: repo_key.clone(),
                 file_a: a,
                 file_b: b,
                 cochange_count: count,
@@ -124,8 +145,29 @@ pub fn compute_cochanges(
 }
 
 /// Save co-change edges to a sidecar JSON file.
+/// Write `edges` into the sidecar, MERGING with what is already there.
+///
+/// Previously a plain overwrite, so indexing repo B destroyed repo A's pairs and
+/// a multi-repo database retained only whichever repo was indexed last — 33 of 34
+/// repos silently had no co-change data at all (nw-062).
+///
+/// Only the repos present in `edges` are replaced; every other repo's rows are
+/// preserved. Re-indexing one repo therefore refreshes exactly that repo.
+/// Unattributed legacy rows (empty `repo`) are dropped as soon as any repo is
+/// written, because they cannot be refreshed or trusted per-repo — the next index
+/// of each repo restores them, attributed.
 pub fn save_cochange_sidecar(edges: &[CoChangeEdge], path: &Path) -> Result<(), anyhow::Error> {
-    let json = serde_json::to_string_pretty(edges)?;
+    let incoming_repos: std::collections::HashSet<&str> =
+        edges.iter().map(|e| e.repo.as_str()).collect();
+
+    let mut merged: Vec<CoChangeEdge> = load_cochange_sidecar(path)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|e| !e.repo.is_empty() && !incoming_repos.contains(e.repo.as_str()))
+        .collect();
+    merged.extend_from_slice(edges);
+
+    let json = serde_json::to_string_pretty(&merged)?;
     std::fs::write(path, json)?;
     Ok(())
 }
@@ -145,6 +187,7 @@ mod tests {
         // If files A and B both change in 3 commits, A has 5 total, B has 4 total
         // Jaccard = 3 / (5 + 4 - 3) = 3/6 = 0.5
         let edge = CoChangeEdge {
+            repo: "/repos/demo".into(),
             file_a: "a.rs".into(),
             file_b: "b.rs".into(),
             cochange_count: 3,
@@ -155,9 +198,83 @@ mod tests {
         assert!((edge.confidence - 0.5).abs() < f32::EPSILON);
     }
 
+    fn edge(repo: &str, a: &str, b: &str) -> CoChangeEdge {
+        CoChangeEdge {
+            repo: repo.to_string(),
+            file_a: a.to_string(),
+            file_b: b.to_string(),
+            cochange_count: 5,
+            total_commits_a: 10,
+            total_commits_b: 8,
+            confidence: 0.385,
+        }
+    }
+
+    /// nw-062: writing one repo's pairs must NOT destroy another's.
+    ///
+    /// The sidecar was overwritten wholesale, so in a 34-repo database only the
+    /// last-indexed repo had any co-change data — 33 repos silently returned
+    /// empty. This is the conservation guarantee that was missing.
+    #[test]
+    fn writing_one_repo_preserves_every_other_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cochange.json");
+
+        save_cochange_sidecar(&[edge("/repos/alpha", "src/a.rs", "src/b.rs")], &path).unwrap();
+        save_cochange_sidecar(&[edge("/repos/beta", "lib/x.rs", "lib/y.rs")], &path).unwrap();
+
+        let loaded = load_cochange_sidecar(&path).unwrap();
+        let repos: std::collections::HashSet<&str> =
+            loaded.iter().map(|e| e.repo.as_str()).collect();
+        assert!(
+            repos.contains("/repos/alpha"),
+            "indexing beta destroyed alpha: {repos:?}"
+        );
+        assert!(repos.contains("/repos/beta"), "beta missing: {repos:?}");
+        assert_eq!(loaded.len(), 2);
+    }
+
+    /// Re-indexing a repo REPLACES its own rows rather than duplicating them.
+    #[test]
+    fn rewriting_the_same_repo_replaces_rather_than_appends() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cochange.json");
+
+        save_cochange_sidecar(&[edge("/repos/alpha", "src/a.rs", "src/b.rs")], &path).unwrap();
+        save_cochange_sidecar(&[edge("/repos/alpha", "src/c.rs", "src/d.rs")], &path).unwrap();
+
+        let loaded = load_cochange_sidecar(&path).unwrap();
+        assert_eq!(
+            loaded.len(),
+            1,
+            "should replace, not accumulate: {loaded:?}"
+        );
+        assert_eq!(loaded[0].file_a, "src/c.rs");
+    }
+
+    /// A legacy flat sidecar (no `repo` field) must still LOAD — the file on disk
+    /// predates this field, and failing to parse it would look like "no
+    /// co-change data" rather than "old format".
+    #[test]
+    fn a_legacy_sidecar_without_a_repo_field_still_loads() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cochange.json");
+        std::fs::write(
+            &path,
+            r#"[{"file_a":"src/a.rs","file_b":"src/b.rs","cochange_count":5,
+                 "total_commits_a":10,"total_commits_b":8,"confidence":0.385}]"#,
+        )
+        .unwrap();
+
+        let loaded = load_cochange_sidecar(&path).expect("legacy format must still parse");
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].repo, "", "legacy rows are unattributed");
+    }
+
     #[test]
     fn sidecar_roundtrip() {
         let edges = vec![CoChangeEdge {
+            repo: "/repos/demo".into(),
             file_a: "src/a.rs".into(),
             file_b: "src/b.rs".into(),
             cochange_count: 5,

--- a/crates/nestweaver-engine/src/contracts.rs
+++ b/crates/nestweaver-engine/src/contracts.rs
@@ -191,6 +191,231 @@ fn openapi_contracts(spec: &openapiv3::OpenAPI) -> Vec<SpecContract> {
     out
 }
 
+/// Convert a protobuf RPC name to the Rust method identifier tonic generates.
+///
+/// tonic derives server-trait method names through `prost_build::ident::to_snake`,
+/// which delegates to `heck`'s snake_case and then sanitizes Rust keywords. Both
+/// steps matter, and a hand-rolled "insert `_` before each capital" does NOT
+/// reproduce either:
+///
+/// heck's documented word boundary is "if an uppercase character is followed by
+/// lowercase letters, a boundary is just prior to it; consecutive uppercase
+/// characters are one word, except the last joins the next word when followed by
+/// lowercase". So `XMLHttpRequest` segments `XML|Http|Request` ->
+/// `xml_http_request`, where the naive rule yields `x_m_l_http_request`.
+/// prost's own test suite asserts exactly this case.
+///
+/// Keyword collisions are then sanitized: most become `r#ident` (`Type` ->
+/// `r#type`), while `_`, `super`, `self`, `Self`, `extern` and `crate` get a
+/// trailing underscore. [`grpc_rpc_rust_idents`] returns every acceptable form.
+pub(crate) fn grpc_rpc_to_rust_method(rpc_name: &str) -> String {
+    let chars: Vec<char> = rpc_name.chars().collect();
+    let mut out = String::with_capacity(rpc_name.len() + 4);
+    for (i, &ch) in chars.iter().enumerate() {
+        if ch.is_uppercase() && i > 0 {
+            let prev_is_lower_or_digit = chars[i - 1].is_lowercase() || chars[i - 1].is_numeric();
+            let next_is_lower = chars.get(i + 1).is_some_and(|c| c.is_lowercase());
+            if prev_is_lower_or_digit || next_is_lower {
+                out.push('_');
+            }
+        }
+        out.extend(ch.to_lowercase());
+    }
+    out
+}
+
+/// A gRPC RPC implemented in Rust: the declared contract UID plus the symbol
+/// implementing it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GrpcImplMatch {
+    /// UID of the contract DECLARED by the proto, adopted verbatim.
+    pub contract_uid: String,
+    /// UID of the implementing symbol.
+    pub symbol_uid: String,
+}
+
+/// Link declared gRPC contracts to their Rust/tonic implementations.
+///
+/// Deliberately matches implementations AGAINST declared contracts rather than
+/// minting contract UIDs from Rust source. The proto package
+/// (`nestweaver.daemon.v1`) appears nowhere in the Rust file, so any UID built
+/// from the implementation would be a guess that has to coincide with what
+/// `parse_proto` produced. Adopting the declared UID makes the edge point at a
+/// contract that provably exists — which is the acceptance criterion for this
+/// bug: confirm the edge appears, not merely that a drift count dropped.
+///
+/// This mirrors the approach published for microservice endpoint coverage:
+/// extract implemented endpoints statically, then compare against the declared
+/// set (arXiv 2308.09257).
+///
+/// The match key is a documented tonic guarantee: a `service Greeter` generates
+/// a trait named `Greeter`, implemented as `impl Greeter for MyService`, with
+/// methods snake_cased by prost. So an `impl <Service> for _` block whose method
+/// names convert back to the service's RPC names is that service's server
+/// implementation.
+///
+/// `declared` maps a contract UID to its `<package>.<Service>/<Rpc>` operation.
+/// `symbols` are `(symbol_uid, name, start_line)` for one file.
+pub fn detect_grpc_impls(
+    source: &str,
+    declared: &[(String, String)],
+    symbols: &[(String, String, u32)],
+) -> Vec<GrpcImplMatch> {
+    if declared.is_empty() || symbols.is_empty() {
+        return Vec::new();
+    }
+
+    // Which trait does each line fall inside? Only `impl <Trait> for <Type>`
+    // blocks matter, and tonic's is always a trait impl.
+    let impl_blocks = rust_trait_impl_blocks(source);
+    if impl_blocks.is_empty() {
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+    for (contract_uid, operation) in declared {
+        // "<package>.<Service>/<Rpc>" — the service is the last dot-segment
+        // before the slash.
+        let Some((qualified_service, rpc)) = operation.rsplit_once('/') else {
+            continue;
+        };
+        let service = qualified_service
+            .rsplit_once('.')
+            .map_or(qualified_service, |(_, s)| s);
+        if service.is_empty() || rpc.is_empty() {
+            continue;
+        }
+        let accepted = grpc_rpc_rust_idents(rpc);
+
+        for (symbol_uid, name, line) in symbols {
+            if !accepted.iter().any(|candidate| candidate == name) {
+                continue;
+            }
+            // The method must sit inside `impl <Service> for _`. Without this a
+            // free function that merely shares a name would be linked.
+            let inside = impl_blocks.iter().any(|(trait_name, start, end)| {
+                trait_name == service && *line >= *start && *line <= *end
+            });
+            if inside {
+                out.push(GrpcImplMatch {
+                    contract_uid: contract_uid.clone(),
+                    symbol_uid: symbol_uid.clone(),
+                });
+                break;
+            }
+        }
+    }
+    out
+}
+
+/// Locate `impl <Trait> for <Type>` blocks as `(trait_name, start_line,
+/// end_line)`, 1-based inclusive.
+///
+/// Brace-depth scanning rather than a parser: the engine has the file as text
+/// here, and `detect_handlers` already recovers class-level context the same way.
+/// Inherent impls (`impl Foo {`) are skipped — a tonic server implementation is
+/// always a trait impl.
+fn rust_trait_impl_blocks(source: &str) -> Vec<(String, u32, u32)> {
+    let mut out = Vec::new();
+    let mut open: Option<(String, u32, i32)> = None;
+
+    for (idx, raw) in source.lines().enumerate() {
+        let line_no = idx as u32 + 1;
+        let line = raw.split("//").next().unwrap_or(raw);
+
+        if open.is_none()
+            && let Some(trait_name) = parse_trait_impl_header(line)
+        {
+            let depth = brace_delta(line);
+            open = Some((trait_name, line_no, depth.max(0)));
+            // A single-line `impl T for U {}` closes immediately.
+            if depth <= 0
+                && let Some((name, start, _)) = open.take()
+            {
+                out.push((name, start, line_no));
+            }
+            continue;
+        }
+
+        if let Some((_, _, depth)) = open.as_mut() {
+            *depth += brace_delta(line);
+            if *depth <= 0
+                && let Some((name, start, _)) = open.take()
+            {
+                out.push((name, start, line_no));
+            }
+        }
+    }
+
+    // Unterminated block (truncated file): treat it as running to the end.
+    if let Some((name, start, _)) = open {
+        out.push((name, start, source.lines().count() as u32));
+    }
+    out
+}
+
+/// Extract the trait name from an `impl [<generics>] <Trait> for <Type>` header.
+fn parse_trait_impl_header(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    let rest = trimmed.strip_prefix("impl")?;
+    // Require a boundary so `implementation_note` is not read as `impl`.
+    if !rest.starts_with([' ', '<']) {
+        return None;
+    }
+    let (before_for, _after) = rest.split_once(" for ")?;
+    // Drop any generic parameter list directly after `impl`.
+    let mut candidate = before_for.trim();
+    if candidate.starts_with('<')
+        && let Some(close) = matching_angle(candidate)
+    {
+        candidate = candidate[close + 1..].trim();
+    }
+    // Strip the trait's own generic arguments and any path qualification.
+    let candidate = candidate.split('<').next().unwrap_or(candidate).trim();
+    let candidate = candidate.rsplit("::").next().unwrap_or(candidate).trim();
+    if candidate.is_empty() || !candidate.chars().all(|c| c.is_alphanumeric() || c == '_') {
+        return None;
+    }
+    Some(candidate.to_string())
+}
+
+/// Index of the `>` closing a generic list that starts at index 0.
+fn matching_angle(s: &str) -> Option<usize> {
+    let mut depth = 0i32;
+    for (i, ch) in s.char_indices() {
+        match ch {
+            '<' => depth += 1,
+            '>' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn brace_delta(line: &str) -> i32 {
+    line.chars().fold(0, |acc, c| match c {
+        '{' => acc + 1,
+        '}' => acc - 1,
+        _ => acc,
+    })
+}
+
+/// Every Rust identifier tonic could plausibly generate for `rpc_name`.
+///
+/// Comparing against a small candidate set is simpler and safer than trying to
+/// invert prost's sanitization: a parsed `foo_` is genuinely ambiguous between
+/// "sanitized keyword" and "a method actually named foo_", and accepting both
+/// costs nothing because the service and RPC still have to match.
+pub(crate) fn grpc_rpc_rust_idents(rpc_name: &str) -> Vec<String> {
+    let base = grpc_rpc_to_rust_method(rpc_name);
+    vec![format!("r#{base}"), format!("{base}_"), base]
+}
+
 fn parse_proto(path: &str, source: &str) -> Vec<SpecContract> {
     let fd = match protox_parse::parse(path, source) {
         Ok(fd) => fd,
@@ -1414,6 +1639,170 @@ paths:
             uids.contains(&"contract:http:GET:/v1/users/{}".to_string()),
             "param slot must normalize; uids: {uids:?}"
         );
+    }
+
+    const TONIC_SOURCE: &str = r#"
+use crate::proto::nest_weaver_daemon_server::NestWeaverDaemon;
+
+fn health_check() {}
+
+#[tonic::async_trait]
+impl NestWeaverDaemon for DaemonService {
+    async fn health_check(&self, req: Request<()>) -> Result<Response<()>, Status> {
+        Ok(Response::new(()))
+    }
+
+    async fn index_repo(&self, req: Request<()>) -> Result<Response<()>, Status> {
+        Ok(Response::new(()))
+    }
+}
+
+impl SomethingElse for DaemonService {
+    async fn shutdown(&self) {}
+}
+"#;
+
+    fn decl(uid: &str, op: &str) -> (String, String) {
+        (uid.to_string(), op.to_string())
+    }
+
+    /// The core linkage: a declared RPC whose snake_case method sits inside
+    /// `impl <Service> for _` is that contract's implementation, and the edge
+    /// adopts the DECLARED uid rather than minting one from Rust.
+    #[test]
+    fn links_declared_grpc_contracts_to_their_tonic_impl() {
+        let declared = vec![
+            decl(
+                "contract:grpc:nestweaver.daemon.v1.NestWeaverDaemon/HealthCheck",
+                "nestweaver.daemon.v1.NestWeaverDaemon/HealthCheck",
+            ),
+            decl(
+                "contract:grpc:nestweaver.daemon.v1.NestWeaverDaemon/IndexRepo",
+                "nestweaver.daemon.v1.NestWeaverDaemon/IndexRepo",
+            ),
+        ];
+        // (uid, name, line) — the free fn at line 4 shares a name with the RPC.
+        let symbols = vec![
+            ("sym:free".to_string(), "health_check".to_string(), 4),
+            ("sym:hc".to_string(), "health_check".to_string(), 8),
+            ("sym:ir".to_string(), "index_repo".to_string(), 12),
+        ];
+
+        let got = detect_grpc_impls(TONIC_SOURCE, &declared, &symbols);
+
+        assert_eq!(got.len(), 2, "both declared RPCs must link: {got:?}");
+        let hc = got
+            .iter()
+            .find(|m| m.contract_uid.ends_with("/HealthCheck"))
+            .expect("HealthCheck must link");
+        assert_eq!(
+            hc.symbol_uid, "sym:hc",
+            "must pick the method INSIDE the trait impl, not the free fn"
+        );
+    }
+
+    /// A declared RPC with no implementation must stay unlinked, or the fix would
+    /// suppress the real drift it exists to report.
+    #[test]
+    fn a_declared_rpc_with_no_impl_is_not_linked() {
+        let declared = vec![decl(
+            "contract:grpc:nestweaver.daemon.v1.NestWeaverDaemon/NotImplemented",
+            "nestweaver.daemon.v1.NestWeaverDaemon/NotImplemented",
+        )];
+        let symbols = vec![("sym:hc".to_string(), "health_check".to_string(), 8)];
+        assert!(detect_grpc_impls(TONIC_SOURCE, &declared, &symbols).is_empty());
+    }
+
+    /// A method in a DIFFERENT trait must not satisfy the contract, even when the
+    /// name converts correctly.
+    #[test]
+    fn a_method_in_another_trait_does_not_satisfy_the_contract() {
+        let declared = vec![decl(
+            "contract:grpc:nestweaver.daemon.v1.NestWeaverDaemon/Shutdown",
+            "nestweaver.daemon.v1.NestWeaverDaemon/Shutdown",
+        )];
+        // `shutdown` exists, but inside `impl SomethingElse for DaemonService`.
+        let symbols = vec![("sym:sd".to_string(), "shutdown".to_string(), 17)];
+        assert!(
+            detect_grpc_impls(TONIC_SOURCE, &declared, &symbols).is_empty(),
+            "wrong trait must not link"
+        );
+    }
+
+    #[test]
+    fn trait_impl_blocks_are_located_with_their_line_ranges() {
+        let blocks = rust_trait_impl_blocks(TONIC_SOURCE);
+        let names: Vec<&str> = blocks.iter().map(|(n, _, _)| n.as_str()).collect();
+        assert!(names.contains(&"NestWeaverDaemon"), "{blocks:?}");
+        assert!(names.contains(&"SomethingElse"), "{blocks:?}");
+    }
+
+    /// Header parsing must survive generics and path qualification, and must not
+    /// mistake an inherent impl for a trait impl.
+    #[test]
+    fn trait_impl_header_parsing_handles_generics_and_paths() {
+        assert_eq!(
+            parse_trait_impl_header("impl NestWeaverDaemon for DaemonService {").as_deref(),
+            Some("NestWeaverDaemon")
+        );
+        assert_eq!(
+            parse_trait_impl_header("impl<T: Send> proto::Greeter<T> for MyService {").as_deref(),
+            Some("Greeter")
+        );
+        // Inherent impl — no trait, nothing to link.
+        assert_eq!(parse_trait_impl_header("impl DaemonService {"), None);
+        // Must not read `implementation` as `impl`.
+        assert_eq!(parse_trait_impl_header("implementation_note for x {"), None);
+    }
+
+    /// The acronym cases are the whole reason this is not a hand-rolled
+    /// "insert `_` before each capital".
+    ///
+    /// prost's `to_snake` delegates to heck, whose documented boundary treats a
+    /// run of capitals as ONE word except that the last joins the next word when
+    /// followed by lowercase. prost's own suite asserts
+    /// `to_snake("XMLHttpRequest") == "xml_http_request"`; the naive rule yields
+    /// `x_m_l_http_request` and would silently fail to match every acronym-bearing
+    /// RPC. This repo's own 75 RPCs contain no acronyms, so it cannot catch the
+    /// difference — hence these cases.
+    #[test]
+    fn rpc_names_convert_the_way_prost_and_heck_do() {
+        let cases = [
+            ("HealthCheck", "health_check"),
+            ("Shutdown", "shutdown"),
+            ("IndexRepo", "index_repo"),
+            // Acronyms: a run of capitals is one word.
+            ("XMLHttpRequest", "xml_http_request"),
+            ("GetHTTPStatus", "get_http_status"),
+            ("ExportSARIF", "export_sarif"),
+            ("GetURL", "get_url"),
+            // Digits do not start a new word on their own.
+            ("IndexV2", "index_v2"),
+            ("BlastRadiusV10", "blast_radius_v10"),
+            // Already-lowercase and single words survive unchanged.
+            ("backup", "backup"),
+        ];
+        for (rpc, expected) in cases {
+            assert_eq!(
+                grpc_rpc_to_rust_method(rpc),
+                expected,
+                "{rpc} must convert like heck does"
+            );
+        }
+    }
+
+    /// prost sanitizes keyword collisions, so the matcher accepts every form it
+    /// could emit. None of this repo's RPCs collide, which is exactly why this
+    /// needs a test rather than a happy-path check.
+    #[test]
+    fn keyword_rpcs_accept_prosts_sanitized_forms() {
+        let idents = grpc_rpc_rust_idents("Type");
+        assert!(idents.contains(&"r#type".to_string()), "{idents:?}");
+        assert!(idents.contains(&"type".to_string()), "{idents:?}");
+        assert!(idents.contains(&"type_".to_string()), "{idents:?}");
+
+        // A non-keyword still yields its plain form.
+        assert!(grpc_rpc_rust_idents("HealthCheck").contains(&"health_check".to_string()));
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/dead_code.rs
+++ b/crates/nestweaver-engine/src/dead_code.rs
@@ -15,7 +15,15 @@ use serde::Serialize;
 use crate::manifest::ManifestInfo;
 
 /// Confidence that a symbol is truly dead code.
+///
+/// Serialised lowercase to match [`Display`](std::fmt::Display), the daemon's
+/// own payload, and the `--min-confidence` values a caller passes in. The
+/// derived representation was the PascalCase variant name, so `dead-code --json`
+/// answered "Medium" direct and "medium" through the daemon for the same run —
+/// the same field disagreeing with itself depending on whether a daemon happened
+/// to be running (nw-117).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum DeadCodeConfidence {
     /// Public symbol in a potentially library crate — could be used externally.
     Low,

--- a/crates/nestweaver-engine/src/extensions.rs
+++ b/crates/nestweaver-engine/src/extensions.rs
@@ -1981,8 +1981,33 @@ pub fn reconcile_extension_liveness(
     let Some(mut extensions) = load_extensions_strict(&path)? else {
         return Ok(0);
     };
-    let live = graph.live_graph_node_uids()?;
-    let protected = protected_migration_source_uids(db_path)?;
+
+    // nw-119: `live_graph_node_uids` enumerates every node in the graph, and it
+    // runs synchronously before the daemon binds its socket. Measured on a
+    // 5.6 GB production graph it cost 41.6s of a 53.9s boot — 77% of the time a
+    // client spends waiting, and the reason boot repeatedly blew past the
+    // timeout raised by nw-114. The existing early-out only fires when the
+    // sidecar is ABSENT, so a 2 KB extensions file was paying for a full-graph
+    // scan on every start.
+    //
+    // The scan is only ever consulted for keys where
+    // `is_shared_finalizer_graph_uid` holds: the retain below keeps every other
+    // key unconditionally via its first clause. So when no key qualifies, the
+    // result is identical to doing nothing, and skipping the walk is an
+    // equivalence rather than an approximation. Falls through to the same
+    // durable directory sync the `removed == 0` path performs.
+    let needs_liveness_scan = extensions
+        .keys()
+        .any(|uid| is_shared_finalizer_graph_uid(uid));
+    let (live, protected) = if needs_liveness_scan {
+        (
+            graph.live_graph_node_uids()?,
+            protected_migration_source_uids(db_path)?,
+        )
+    } else {
+        (Default::default(), Default::default())
+    };
+
     let before = extensions.len();
     extensions.retain(|uid, _| {
         !is_shared_finalizer_graph_uid(uid) || live.contains(uid) || protected.contains(uid)
@@ -2164,9 +2189,38 @@ pub fn query_by_property<'a>(
 ) -> Vec<&'a str> {
     store
         .iter()
-        .filter(|(_, props)| props.get(key) == Some(value))
+        .filter(|(_, props)| {
+            props
+                .get(key)
+                .is_some_and(|stored| property_matches(stored, value))
+        })
         .map(|(uid, _)| uid.as_str())
         .collect()
+}
+
+/// Whether a stored property value satisfies a query value.
+///
+/// Exact equality, PLUS membership when the stored value is an array and the
+/// query is a scalar.
+///
+/// nw-109: exact equality alone made key+value mode useless against real data.
+/// Properties in a live sidecar are array-valued (`aliases: ["Widget","widget"]`),
+/// so the only query that could ever match was one reproducing the entire array
+/// verbatim, in order — meaning the obvious question, "which nodes have alias
+/// Widget", had no expressible form. Membership makes the mode usable without
+/// weakening exact matching: an array query still compares whole-array, so
+/// `["Widget","widget"]` matches only that exact array.
+fn property_matches(stored: &serde_json::Value, query: &serde_json::Value) -> bool {
+    if stored == query {
+        return true;
+    }
+    match (stored, query) {
+        // Scalar-in-array membership. A query that is itself an array is NOT
+        // treated as a set of alternatives — that would silently turn an exact
+        // array comparison into an any-of, which is a different question.
+        (serde_json::Value::Array(items), q) if !q.is_array() => items.iter().any(|i| i == q),
+        _ => false,
+    }
 }
 
 /// Return all properties stored for a node, or an empty map.
@@ -2238,6 +2292,116 @@ fn sidecar_path(db_path: &Path) -> std::path::PathBuf {
 mod tests {
     use super::*;
     use tempfile::NamedTempFile;
+
+    /// nw-109: with every property in a real sidecar array-valued, exact-only
+    /// matching meant key+value mode returned 0 results for 100% of live data —
+    /// the obvious question ("which nodes carry alias Widget") had no
+    /// expressible form. Membership makes it answerable.
+    #[test]
+    fn scalar_query_matches_a_member_of_an_array_valued_property() {
+        let mut store: ExtensionStore = Default::default();
+        store.insert(
+            "repo:widget".to_string(),
+            [(
+                "aliases".to_string(),
+                serde_json::json!(["Widget", "widget"]),
+            )]
+            .into_iter()
+            .collect(),
+        );
+        assert_eq!(
+            query_by_property(&store, "aliases", &serde_json::json!("Widget")),
+            vec!["repo:widget"]
+        );
+        assert!(query_by_property(&store, "aliases", &serde_json::json!("nope")).is_empty());
+    }
+
+    /// Exact array equality must keep working, and must stay EXACT — an array
+    /// query is one value, not a set of alternatives.
+    #[test]
+    fn array_query_still_compares_whole_array_not_any_of() {
+        let mut store: ExtensionStore = Default::default();
+        store.insert(
+            "a".to_string(),
+            [("t".to_string(), serde_json::json!(["x", "y"]))]
+                .into_iter()
+                .collect(),
+        );
+        assert_eq!(
+            query_by_property(&store, "t", &serde_json::json!(["x", "y"])),
+            vec!["a"]
+        );
+        // A subset array must NOT match: that would silently reinterpret the
+        // query as any-of, which is a different question than the caller asked.
+        assert!(query_by_property(&store, "t", &serde_json::json!(["x"])).is_empty());
+    }
+
+    /// Scalar properties are unaffected.
+    #[test]
+    fn scalar_property_still_requires_exact_equality() {
+        let mut store: ExtensionStore = Default::default();
+        store.insert(
+            "a".to_string(),
+            [("n".to_string(), serde_json::json!(7))]
+                .into_iter()
+                .collect(),
+        );
+        assert_eq!(
+            query_by_property(&store, "n", &serde_json::json!(7)),
+            vec!["a"]
+        );
+        assert!(query_by_property(&store, "n", &serde_json::json!(8)).is_empty());
+    }
+
+    /// nw-119: the boot-time liveness reconcile skips the full-graph walk when
+    /// no extension key is a shared-finalizer UID. That skip must be an
+    /// EQUIVALENCE, not an approximation — the retain clause keeps every
+    /// non-shared key unconditionally, so a scan could not have removed them.
+    ///
+    /// Guarding the predicate directly: if this ever starts reporting true for
+    /// ordinary application keys, the optimisation would begin skipping a scan
+    /// that matters.
+    #[test]
+    fn only_shared_finalizer_uids_can_ever_be_removed_by_a_liveness_scan() {
+        // Opaque application metadata — must survive a restart even with no
+        // matching graph node, so a liveness scan is irrelevant to it.
+        assert!(!is_shared_finalizer_graph_uid("proj:anything"));
+        assert!(!is_shared_finalizer_graph_uid("note:vlt:unrelated:abc:def"));
+        assert!(!is_shared_finalizer_graph_uid("not-a-uid"));
+        assert!(!is_shared_finalizer_graph_uid(""));
+    }
+
+    /// The skip is decided purely by the sidecar's own keys, so a database with
+    /// only opaque keys never pays for the graph walk that cost 41.6s of a
+    /// 53.9s daemon boot on the production graph.
+    #[test]
+    fn liveness_scan_is_skipped_when_no_key_is_a_shared_finalizer_uid() {
+        let mut extensions: ExtensionStore = Default::default();
+        extensions.insert("proj:alpha".to_string(), Default::default());
+        extensions.insert("note:vlt:other:aaa:bbb".to_string(), Default::default());
+
+        let needs = extensions
+            .keys()
+            .any(|uid| is_shared_finalizer_graph_uid(uid));
+        assert!(
+            !needs,
+            "a sidecar of purely opaque keys must not trigger a full-graph walk"
+        );
+
+        // And every one of them is retained regardless of liveness, which is
+        // why skipping the walk cannot change the outcome.
+        let live: std::collections::BTreeSet<String> = Default::default();
+        let protected: std::collections::BTreeSet<String> = Default::default();
+        let before = extensions.len();
+        extensions.retain(|uid, _| {
+            !is_shared_finalizer_graph_uid(uid) || live.contains(uid) || protected.contains(uid)
+        });
+        assert_eq!(
+            extensions.len(),
+            before,
+            "no key may be dropped when the scan is skipped"
+        );
+    }
 
     fn test_pending_handoff(operation_id: &str, source_uid: &str) -> PendingExtensionHandoff {
         PendingExtensionHandoff {

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -1542,6 +1542,9 @@ fn infer_cross_repo_call_edges(
         .collect();
     let mut edges = Vec::new();
     let mut seen = std::collections::HashSet::new();
+    // name -> store hits, memoised for this call (nw-127).
+    let mut name_lookup_cache: std::collections::HashMap<String, Vec<nestweaver_schema::Symbol>> =
+        std::collections::HashMap::new();
     for (rel_path, symbols, references, _) in parsed_files {
         // Names this file imports — corroborates a same-named cross-repo call.
         let imported_names: std::collections::HashSet<&str> = references
@@ -1570,15 +1573,31 @@ fn infer_cross_repo_call_edges(
             );
 
             // Collect eligible cross-repo candidates, then apply the ubiquity cap.
-            let candidates: Vec<_> = store
-                .lookup_symbols_by_name(&reference.name)
-                .map_err(|e| anyhow::anyhow!(e))?
-                .into_iter()
+            //
+            // nw-127: this is one store round-trip PER CALL SITE, and call names
+            // repeat heavily across a repo, so the same name was looked up
+            // thousands of times per run. The store is not mutated inside this
+            // loop (symbol writes happen earlier in the phase), so memoising the
+            // lookup for the duration of the call is a pure win.
+            let by_name = match name_lookup_cache.get(reference.name.as_str()) {
+                Some(hits) => hits,
+                None => {
+                    let hits = store
+                        .lookup_symbols_by_name(&reference.name)
+                        .map_err(|e| anyhow::anyhow!(e))?;
+                    name_lookup_cache
+                        .entry(reference.name.clone())
+                        .or_insert(hits)
+                }
+            };
+            let candidates: Vec<_> = by_name
+                .iter()
                 .filter(|t| {
                     t.repo_uid != current_repo_uid
                         && t.uid != source_uid
                         && t.visibility != Visibility::Private
                 })
+                .cloned()
                 .collect();
             if candidates.is_empty() || candidates.len() > MAX_CROSS_REPO_NAME_CANDIDATES {
                 continue;
@@ -2604,8 +2623,23 @@ where
             .batch_insert_edges(&insertable_edges)
             .context("batch_insert_edges (resolved)")?;
 
-        let inferred_cross_repo_edges =
-            infer_cross_repo_call_edges(store, &r_uid, &parsed_files_for_resolver)?;
+        // nw-127: this walks EVERY parsed file — including unchanged ones, which
+        // are deliberately fed to the resolver — and issues a store lookup per
+        // call site. It ran unconditionally, so an index with zero changed files
+        // still paid for it: 57 minutes on a 755-file repo against a 130k-symbol
+        // graph, which is what pushed large repos past the 1800s ceiling and made
+        // them report failure for work that had actually succeeded.
+        //
+        // When nothing changed, this repo's call sites are identical to the last
+        // run and the edges it would infer are already in the database, so the
+        // whole pass is recomputing a known answer. Skipping matches what
+        // `skip_resolution` already does for ordinary resolution one block above,
+        // and for the same reason.
+        let inferred_cross_repo_edges = if skip_resolution {
+            Vec::new()
+        } else {
+            infer_cross_repo_call_edges(store, &r_uid, &parsed_files_for_resolver)?
+        };
         if !inferred_cross_repo_edges.is_empty() {
             edges_count += inferred_cross_repo_edges.len();
             store
@@ -2840,7 +2874,26 @@ where
         bump_generation_after_write,
     );
     match (graph_result, finalization) {
-        (Ok(result), Ok(())) => Ok(result),
+        (Ok(result), Ok(())) => {
+            // nw-124: stamp WHICH resolver produced this repo's edges. Some
+            // resolver fixes change edge shape rather than query behaviour
+            // (nw-103's import fan-out), so upgrading the binary leaves already
+            // indexed repos wrong and nothing said so. Recorded only on a fully
+            // successful, finalized index — a failed run must not claim the
+            // repo is current. Best-effort: a sidecar write failure must never
+            // fail an index that already committed.
+            if let Some(db_path) = store.db_path()
+                && let Err(e) = crate::resolver_generation::record(db_path, &r_uid)
+            {
+                tracing::warn!(
+                    repo = %r_uid,
+                    error = %e,
+                    "indexed successfully but could not record the resolver generation; \
+                     ranking staleness for this repo will be over-reported"
+                );
+            }
+            Ok(result)
+        }
         (Ok(_), Err(finalization)) => Err(finalization.into()),
         (Err(primary), Ok(())) => Err(primary),
         (Err(primary), Err(finalization)) => {

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -2715,7 +2715,14 @@ where
         // Best-effort: a malformed spec or unexpected store error here must not
         // fail the whole index. Contracts are hypotheses layered on top of the
         // code graph.
-        if let Err(e) = derive_contracts(store, reader, &r_uid, &spec_files, &handler_files) {
+        if let Err(e) = derive_contracts(
+            store,
+            reader,
+            &r_uid,
+            &spec_files,
+            &handler_files,
+            &all_symbols,
+        ) {
             tracing::warn!("contract derivation failed (non-fatal): {e}");
         }
         tracing::info!(
@@ -2865,6 +2872,7 @@ fn derive_contracts(
     r_uid: &str,
     spec_files: &[PathBuf],
     handler_files: &[HandlerFileData],
+    all_symbols: &[nestweaver_schema::Symbol],
 ) -> Result<(), anyhow::Error> {
     use nestweaver_schema::{EdgeType, ResolvedEdge};
     use std::collections::HashSet;
@@ -2875,6 +2883,8 @@ fn derive_contracts(
     // 1. Declared contracts from specs.
     let mut all_contracts: Vec<nestweaver_schema::Contract> = Vec::new();
     let mut declared_uids: HashSet<String> = HashSet::new();
+    // (contract_uid, "<package>.<Service>/<Rpc>") for every declared gRPC method.
+    let mut declared_grpc: Vec<(String, String)> = Vec::new();
     let repo_path = reader.root();
     for spec_path in spec_files {
         let rel = spec_path
@@ -2890,7 +2900,15 @@ fn derive_contracts(
             }
         };
         for sc in crate::contracts::parse_spec_file(&rel, &source) {
+            // Keep gRPC operations so implementations can be matched against the
+            // DECLARED contract rather than minting a UID from source (nw-104).
+            let grpc_operation = (sc.kind == "grpc")
+                .then(|| sc.operation_id.clone())
+                .flatten();
             let contract = sc.into_contract(r_uid, &rel, 1.0);
+            if let Some(operation) = grpc_operation {
+                declared_grpc.push((contract.uid.clone(), operation));
+            }
             declared_uids.insert(contract.uid.clone());
             all_contracts.push(contract);
         }
@@ -2929,6 +2947,60 @@ fn derive_contracts(
                     evidence: Vec::new(),
                 });
             }
+        }
+    }
+
+    // 3b. gRPC: link declared contracts to their Rust/tonic implementations
+    //     (nw-104).
+    //
+    // This does NOT go through `detect_handlers`. That path needs a framework
+    // hint, which `detect_frameworks` never produces for Rust, which in turn
+    // means no `HandlerFileData` is built — three gates that all had to be
+    // opened to reach a detector that also did not exist. Matching declared
+    // contracts against symbols here needs none of them, and the edge adopts the
+    // DECLARED uid so it provably points at a real contract.
+    if !declared_grpc.is_empty() {
+        // Group symbols by file so each candidate file is read once.
+        let mut by_file: std::collections::BTreeMap<&str, Vec<(String, String, u32)>> =
+            std::collections::BTreeMap::new();
+        for sym in all_symbols {
+            by_file.entry(sym.file_path.as_str()).or_default().push((
+                sym.uid.clone(),
+                sym.name.clone(),
+                sym.start_line,
+            ));
+        }
+
+        let mut linked = 0usize;
+        for (rel_path, symbols) in by_file {
+            // Cheap pre-filter: a tonic server implementation is a trait impl, so
+            // a file with no `impl ` at all cannot contain one. Avoids reading
+            // every source file in the repo.
+            let Ok(source) = reader.read_file(Path::new(rel_path)) else {
+                continue;
+            };
+            if !source.contains("impl ") {
+                continue;
+            }
+            for m in crate::contracts::detect_grpc_impls(&source, &declared_grpc, &symbols) {
+                edges.push(ResolvedEdge {
+                    source_uid: m.symbol_uid,
+                    target_uid: m.contract_uid,
+                    edge_type: EdgeType::ImplementsContract,
+                    // Exact service AND method match against a declared contract.
+                    confidence: 1.0,
+                    link_type: None,
+                    evidence: Vec::new(),
+                });
+                linked += 1;
+            }
+        }
+        if linked > 0 {
+            tracing::debug!(
+                linked,
+                declared = declared_grpc.len(),
+                "linked gRPC contracts to tonic implementations"
+            );
         }
     }
 
@@ -4989,6 +5061,69 @@ function hello(name) { return "Hello " + name; }
         assert!(
             implemented.contains(&"contract:http:POST:/v1/approvals".to_string()),
             "expected IMPLEMENTS_CONTRACT edge; implemented: {implemented:?}"
+        );
+    }
+
+    /// nw-104: a declared gRPC contract must link to its Rust/tonic
+    /// implementation.
+    ///
+    /// `contracts drift` reported 75 declared RPCs as unimplemented on this very
+    /// repo while every one of them was implemented, because nothing ever emitted
+    /// an IMPLEMENTS_CONTRACT edge for gRPC. The acceptance criterion for the bug
+    /// is that the EDGE appears — not merely that a drift count fell — so this
+    /// asserts the edge and that unimplemented RPCs still show as drift.
+    #[test]
+    fn grpc_proto_links_to_its_tonic_implementation() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("repo");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(
+            src.join("service.proto"),
+            "syntax = \"proto3\";\n\
+             package demo.v1;\n\
+             service Greeter {\n  \
+             rpc SayHello (Empty) returns (Empty);\n  \
+             rpc GetHTTPStatus (Empty) returns (Empty);\n  \
+             rpc NeverBuilt (Empty) returns (Empty);\n\
+             }\n\
+             message Empty {}\n",
+        )
+        .unwrap();
+        fs::write(
+            src.join("server.rs"),
+            "#[tonic::async_trait]\n\
+             impl Greeter for MyService {\n    \
+             async fn say_hello(&self) {}\n    \
+             async fn get_http_status(&self) {}\n\
+             }\n",
+        )
+        .unwrap();
+
+        let (_result, store) =
+            index_directory_in_memory(&src, "test", "https://example.com/repo", "abc123").unwrap();
+
+        let contracts = store.list_contracts(None).unwrap();
+        let uids: Vec<&String> = contracts.iter().map(|c| &c.uid).collect();
+        assert!(
+            uids.iter()
+                .any(|u| u.as_str() == "contract:grpc:demo.v1.Greeter/SayHello"),
+            "expected the declared gRPC contract; got {uids:?}"
+        );
+
+        let implemented = store.list_implemented_contract_uids().unwrap();
+        assert!(
+            implemented.contains(&"contract:grpc:demo.v1.Greeter/SayHello".to_string()),
+            "expected IMPLEMENTS_CONTRACT edge for SayHello; implemented: {implemented:?}"
+        );
+        // The acronym case, which a naive snake_case would have missed.
+        assert!(
+            implemented.contains(&"contract:grpc:demo.v1.Greeter/GetHTTPStatus".to_string()),
+            "GetHTTPStatus -> get_http_status must link; implemented: {implemented:?}"
+        );
+        // A declared RPC with no impl must STILL be drift.
+        assert!(
+            !implemented.contains(&"contract:grpc:demo.v1.Greeter/NeverBuilt".to_string()),
+            "an unimplemented RPC must remain drift; implemented: {implemented:?}"
         );
     }
 

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -665,8 +665,12 @@ fn reinsert_single_note(
         }
         map
     };
-    let mut wl_note_edges: Vec<(String, String, f32, String)> = Vec::new();
-    let mut wl_head_edges: Vec<(String, String, f32, String)> = Vec::new();
+    // nw-122: carry BOTH the visible text and the link target. Backlinks want
+    // the alias a reader sees; broken-links wants the target resolution acted
+    // on. Reporting the alias there rendered `[[workspace]]` for
+    // `[[Home|workspace]]` — a link that appears nowhere in the vault.
+    let mut wl_note_edges: Vec<(String, String, f32, String, String)> = Vec::new();
+    let mut wl_head_edges: Vec<(String, String, f32, String, String)> = Vec::new();
     // Unresolved links collected for a single batched insert — a per-row insert
     // here made a single note with many missing-target links hang the watcher.
     let mut unresolved: Vec<(String, String, String, String, String)> = Vec::new();
@@ -707,6 +711,7 @@ fn reinsert_single_note(
                         h.uid.clone(),
                         conf,
                         display.clone(),
+                        wl.target.clone(),
                     ));
                     continue;
                 }
@@ -716,6 +721,7 @@ fn reinsert_single_note(
                 target.clone(),
                 conf,
                 display.clone(),
+                wl.target.clone(),
             ));
         }
     }
@@ -727,16 +733,16 @@ fn reinsert_single_note(
             tracing::warn!("failed to record unresolved wikilinks: {e}");
         }
     }
-    let wl_note_refs: Vec<(&str, &str, f32, &str)> = wl_note_edges
+    let wl_note_refs: Vec<(&str, &str, f32, &str, &str)> = wl_note_edges
         .iter()
-        .map(|(s, n, c, d)| (s.as_str(), n.as_str(), *c, d.as_str()))
+        .map(|(s, n, c, d, t)| (s.as_str(), n.as_str(), *c, d.as_str(), t.as_str()))
         .collect();
     store
         .batch_insert_wikilink_to_note_edges(&wl_note_refs)
         .context("batch_insert_wikilink_to_note_edges")?;
-    let wl_head_refs: Vec<(&str, &str, f32, &str)> = wl_head_edges
+    let wl_head_refs: Vec<(&str, &str, f32, &str, &str)> = wl_head_edges
         .iter()
-        .map(|(s, h, c, d)| (s.as_str(), h.as_str(), *c, d.as_str()))
+        .map(|(s, h, c, d, t)| (s.as_str(), h.as_str(), *c, d.as_str(), t.as_str()))
         .collect();
     store
         .batch_insert_wikilink_to_heading_edges(&wl_head_refs)
@@ -1199,8 +1205,9 @@ where
     // Wikilink resolution: build lookup indices once, then 5-priority match.
     let lookup = WikilinkLookup::build(&note_contexts);
 
-    let mut wikilink_to_note: Vec<(String, String, f32, String)> = Vec::new();
-    let mut wikilink_to_heading: Vec<(String, String, f32, String)> = Vec::new();
+    // nw-122: (section, target_node, confidence, display_text, link_target).
+    let mut wikilink_to_note: Vec<(String, String, f32, String, String)> = Vec::new();
+    let mut wikilink_to_heading: Vec<(String, String, f32, String, String)> = Vec::new();
     let mut wikilinks_unresolved: usize = 0;
     // (uid, source_note_uid, source_path, source_title, wikilink_text)
     let mut unresolved_records: Vec<(String, String, String, String, String)> = Vec::new();
@@ -1229,6 +1236,7 @@ where
                                     h_uid,
                                     conf_per,
                                     display.clone(),
+                                    wl.target.clone(),
                                 ));
                                 continue;
                             }
@@ -1239,6 +1247,7 @@ where
                             cand.note_uid.clone(),
                             conf_per,
                             display.clone(),
+                            wl.target.clone(),
                         ));
                     }
                 }
@@ -1302,13 +1311,13 @@ where
             .iter()
             .map(|(s, t)| (s.as_str(), t.as_str()))
             .collect();
-        let wl_note_refs: Vec<(&str, &str, f32, &str)> = wikilink_to_note
+        let wl_note_refs: Vec<(&str, &str, f32, &str, &str)> = wikilink_to_note
             .iter()
-            .map(|(s, n, c, d)| (s.as_str(), n.as_str(), *c, d.as_str()))
+            .map(|(s, n, c, d, t)| (s.as_str(), n.as_str(), *c, d.as_str(), t.as_str()))
             .collect();
-        let wl_head_refs: Vec<(&str, &str, f32, &str)> = wikilink_to_heading
+        let wl_head_refs: Vec<(&str, &str, f32, &str, &str)> = wikilink_to_heading
             .iter()
-            .map(|(s, h, c, d)| (s.as_str(), h.as_str(), *c, d.as_str()))
+            .map(|(s, h, c, d, t)| (s.as_str(), h.as_str(), *c, d.as_str(), t.as_str()))
             .collect();
 
         store
@@ -1574,11 +1583,11 @@ impl<'a> WikilinkLookup<'a> {
         // SOURCE's folder.
         //
         // `by_path` is keyed on full vault-relative paths, so only the first
-        // form ever matched. But `[[plans/Phase B Execution Index]]` written in
-        // `Workspaces/Orbit/_Overview.md` is Obsidian's RELATIVE-path syntax and
-        // means `Workspaces/Orbit/plans/Phase B Execution Index.md`. Every
-        // path-qualified link in the vault therefore resolved to nothing — 45 of
-        // them, all reported at confidence 0.0 (nw-100).
+        // form ever matched. But `[[plans/Rollout Plan]]` written in
+        // `Workspaces/ExampleProject/_Overview.md` is Obsidian's RELATIVE-path
+        // syntax and means `Workspaces/ExampleProject/plans/Rollout Plan.md`.
+        // Every path-qualified link in the vault therefore resolved to nothing —
+        // 45 of them, all reported at confidence 0.0 (nw-100).
         //
         // Both forms are exact, unambiguous single-key lookups, so both score
         // 1.0 and priority ordering is preserved.
@@ -2172,20 +2181,20 @@ sub b body
     ///
     /// `by_path` is keyed on full vault-relative paths, so priority 1 only ever
     /// tried the bare target. `[[plans/Target]]` written in
-    /// `Workspaces/Orbit/_Overview.md` means
-    /// `Workspaces/Orbit/plans/Target.md`, which never matched — so every
-    /// path-qualified link in the vault resolved to nothing (45 of them, all
-    /// reported at confidence 0.0).
+    /// `Workspaces/ExampleProject/_Overview.md` means
+    /// `Workspaces/ExampleProject/plans/Target.md`, which never matched — so
+    /// every path-qualified link in the vault resolved to nothing (45 of them,
+    /// all reported at confidence 0.0).
     #[test]
     fn resolves_a_path_relative_to_the_source_folder() {
         let (_dir, root) = make_vault(&[
             (
-                "Workspaces/Orbit/_Overview.md",
-                "# Overview\n\nSee [[plans/Phase B Execution Index]].\n",
+                "Workspaces/ExampleProject/_Overview.md",
+                "# Overview\n\nSee [[plans/Rollout Plan]].\n",
             ),
             (
-                "Workspaces/Orbit/plans/Phase B Execution Index.md",
-                "# Phase B Execution Index\n\nbody\n",
+                "Workspaces/ExampleProject/plans/Rollout Plan.md",
+                "# Rollout Plan\n\nbody\n",
             ),
         ]);
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
@@ -2203,9 +2212,12 @@ sub b body
         let (_dir, root) = make_vault(&[
             (
                 "notes/index.md",
-                "# Index\n\nSee [[Workspaces/Orbit/plans/Target]].\n",
+                "# Index\n\nSee [[Workspaces/ExampleProject/plans/Target]].\n",
             ),
-            ("Workspaces/Orbit/plans/Target.md", "# Target\n\nbody\n"),
+            (
+                "Workspaces/ExampleProject/plans/Target.md",
+                "# Target\n\nbody\n",
+            ),
         ]);
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
         assert_eq!(result.wikilinks_resolved, 1);
@@ -2217,7 +2229,7 @@ sub b body
     #[test]
     fn a_path_qualified_link_to_nowhere_stays_unresolved() {
         let (_dir, root) = make_vault(&[(
-            "Workspaces/Orbit/_Overview.md",
+            "Workspaces/ExampleProject/_Overview.md",
             "# Overview\n\nSee [[plans/Does Not Exist]].\n",
         )]);
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -1570,14 +1570,35 @@ impl<'a> WikilinkLookup<'a> {
             return ResolveOutcome::Unresolved;
         }
 
-        // Priority 1: path match.
-        if key.contains('/')
-            && let Some(&uid) = self.by_path.get(&key)
-        {
-            return ResolveOutcome::Resolved(vec![ResolveCandidate {
-                note_uid: uid.to_string(),
-                confidence: 1.0,
-            }]);
+        // Priority 1: path match — vault-relative first, then relative to the
+        // SOURCE's folder.
+        //
+        // `by_path` is keyed on full vault-relative paths, so only the first
+        // form ever matched. But `[[plans/Phase B Execution Index]]` written in
+        // `Workspaces/Orbit/_Overview.md` is Obsidian's RELATIVE-path syntax and
+        // means `Workspaces/Orbit/plans/Phase B Execution Index.md`. Every
+        // path-qualified link in the vault therefore resolved to nothing — 45 of
+        // them, all reported at confidence 0.0 (nw-100).
+        //
+        // Both forms are exact, unambiguous single-key lookups, so both score
+        // 1.0 and priority ordering is preserved.
+        if key.contains('/') {
+            if let Some(&uid) = self.by_path.get(&key) {
+                return ResolveOutcome::Resolved(vec![ResolveCandidate {
+                    note_uid: uid.to_string(),
+                    confidence: 1.0,
+                }]);
+            }
+            if !source_folder.is_empty() {
+                // `by_path` keys are lowercased; `folder` is stored raw.
+                let scoped = format!("{}/{key}", source_folder.replace('\\', "/").to_lowercase());
+                if let Some(&uid) = self.by_path.get(&scoped) {
+                    return ResolveOutcome::Resolved(vec![ResolveCandidate {
+                        note_uid: uid.to_string(),
+                        confidence: 1.0,
+                    }]);
+                }
+            }
         }
 
         // Priority 2: unique title match.
@@ -2145,6 +2166,64 @@ sub b body
     }
 
     // ── Pass-2 wikilink/tag tests ─────────────────────────────────────────
+
+    /// nw-100: a path-qualified wikilink is Obsidian's RELATIVE-path syntax and
+    /// must resolve.
+    ///
+    /// `by_path` is keyed on full vault-relative paths, so priority 1 only ever
+    /// tried the bare target. `[[plans/Target]]` written in
+    /// `Workspaces/Orbit/_Overview.md` means
+    /// `Workspaces/Orbit/plans/Target.md`, which never matched — so every
+    /// path-qualified link in the vault resolved to nothing (45 of them, all
+    /// reported at confidence 0.0).
+    #[test]
+    fn resolves_a_path_relative_to_the_source_folder() {
+        let (_dir, root) = make_vault(&[
+            (
+                "Workspaces/Orbit/_Overview.md",
+                "# Overview\n\nSee [[plans/Phase B Execution Index]].\n",
+            ),
+            (
+                "Workspaces/Orbit/plans/Phase B Execution Index.md",
+                "# Phase B Execution Index\n\nbody\n",
+            ),
+        ]);
+        let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+        assert_eq!(
+            result.wikilinks_resolved, 1,
+            "a source-folder-relative path must resolve"
+        );
+        assert_eq!(result.wikilinks_unresolved, 0);
+    }
+
+    /// A full vault-relative path must keep working — that was the only form
+    /// priority 1 ever handled.
+    #[test]
+    fn resolves_a_full_vault_relative_path() {
+        let (_dir, root) = make_vault(&[
+            (
+                "notes/index.md",
+                "# Index\n\nSee [[Workspaces/Orbit/plans/Target]].\n",
+            ),
+            ("Workspaces/Orbit/plans/Target.md", "# Target\n\nbody\n"),
+        ]);
+        let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+        assert_eq!(result.wikilinks_resolved, 1);
+        assert_eq!(result.wikilinks_unresolved, 0);
+    }
+
+    /// A path-qualified link that matches nothing must still be unresolved —
+    /// the folder-relative attempt must not start inventing matches.
+    #[test]
+    fn a_path_qualified_link_to_nowhere_stays_unresolved() {
+        let (_dir, root) = make_vault(&[(
+            "Workspaces/Orbit/_Overview.md",
+            "# Overview\n\nSee [[plans/Does Not Exist]].\n",
+        )]);
+        let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+        assert_eq!(result.wikilinks_resolved, 0);
+        assert_eq!(result.wikilinks_unresolved, 1);
+    }
 
     #[test]
     fn resolves_unique_title_wikilink() {

--- a/crates/nestweaver-engine/src/investigate.rs
+++ b/crates/nestweaver-engine/src/investigate.rs
@@ -144,6 +144,21 @@ pub struct InvestigateResult {
     /// Number of additional connected nodes dropped due to the token budget.
     #[serde(default, skip_serializing_if = "is_zero")]
     pub more_available: usize,
+    /// Whether semantic retrieval contributed to this map.
+    ///
+    /// nw-120: the daemon passes its warm embedding model here while the CLI's
+    /// direct path hardcodes `None`, so the two return materially different
+    /// RANKINGS for the same query — daemon topped "daemon boot" with
+    /// `wait_for_daemon_boot`, direct with a lexical `BootstrapErrorScreen`.
+    /// The tradeoff is defensible (a per-invocation BERT load is expensive and
+    /// the daemon is the supported path); reporting nothing about it was not,
+    /// because the caller had no way to know the ranking was BM25-only.
+    #[serde(default)]
+    pub semantic_applied: bool,
+    /// Retrieval components that were requested but unavailable, matching
+    /// `brain_context` / `brain_search`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub degraded_components: Vec<String>,
 }
 
 /// The result of `investigate_expand`: the expanded entries plus their
@@ -573,6 +588,7 @@ pub fn investigate(
         })?;
     }
 
+    let semantic_applied = embed_model.is_some();
     Ok(InvestigateResult {
         bundle_id,
         query: query.to_string(),
@@ -580,6 +596,12 @@ pub fn investigate(
         domains,
         entries,
         more_available,
+        semantic_applied,
+        degraded_components: if semantic_applied {
+            Vec::new()
+        } else {
+            vec!["semantic".to_string()]
+        },
     })
 }
 

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -95,6 +95,7 @@ pub mod recency;
 pub mod registry;
 pub mod rerank;
 pub mod resolution_cache;
+pub mod resolver_generation;
 pub mod rts_eval;
 pub mod scheduler;
 pub mod signature_diff;

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -640,6 +640,7 @@ mod promote_tests {
             unresolved_seeds: vec![],
             expansion_terms: vec![],
             semantic_applied: false,
+            semantic_seed_count: 0,
             degraded_components: vec![],
         };
         let members: HashSet<String> = ["note:prd".to_string(), "note:status".to_string()]
@@ -669,6 +670,7 @@ mod promote_tests {
             unresolved_seeds: vec![],
             expansion_terms: vec![],
             semantic_applied: false,
+            semantic_seed_count: 0,
             degraded_components: vec![],
         };
         let members: HashSet<String> = ["note:prd".to_string()].into_iter().collect();
@@ -707,6 +709,7 @@ mod promote_tests {
             unresolved_seeds: vec![],
             expansion_terms: vec![],
             semantic_applied: false,
+            semantic_seed_count: 0,
             degraded_components: vec![],
         };
         let members: HashSet<String> = ["sym:foo".to_string(), "sym:bar".to_string()]
@@ -738,6 +741,7 @@ mod promote_tests {
             unresolved_seeds: vec![],
             expansion_terms: vec![],
             semantic_applied: false,
+            semantic_seed_count: 0,
             degraded_components: vec![],
         };
         let members: HashSet<String> = ["sym:foo".to_string()].into_iter().collect();
@@ -1080,6 +1084,10 @@ pub(crate) fn truncate_body_to_chars(body: String, max_chars: usize) -> (String,
     (truncated, false)
 }
 
+fn is_zero_usize(n: &usize) -> bool {
+    *n == 0
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BrainContextResult {
     /// Resolved seed nodes. The MCP `brain_context` tool omits this field
@@ -1103,6 +1111,18 @@ pub struct BrainContextResult {
     /// vector search successfully.
     #[serde(default)]
     pub semantic_applied: bool,
+    /// How many entries in `seeds` were injected by the semantic leg rather
+    /// than resolved from the query text.
+    ///
+    /// nw-102: vector KNN always returns its k nearest neighbours regardless of
+    /// how far away they are, and those hits were pushed into `seeds`
+    /// unconditionally — the similarity score was discarded at the call site.
+    /// So a nonsense query reported "Seeds (5 resolved)" listing unrelated
+    /// symbols WHILE also listing the same query under `unresolved_seeds`,
+    /// contradicting itself. Recording the provenance lets a renderer say which
+    /// seeds were actually matched and which are nearest-neighbour guesses.
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    pub semantic_seed_count: usize,
     /// Retrieval components that were requested but unavailable. The graph,
     /// PPR, and BM25 legs remain usable when semantic retrieval degrades.
     #[serde(default)]
@@ -1535,6 +1555,7 @@ pub fn build_brain_context_hybrid_with_aliases(
     // hit list is passed to weighted_score_fuse as the semantic signal.
     let semantic_requested = config.weight_semantic > 0.0;
     let mut semantic_applied = false;
+    let mut semantic_seed_count: usize = 0;
     let mut semantic_hits: Vec<(String, f64)> = Vec::new();
     if let Some(model) = embed_model
         && config.weight_semantic > 0.0
@@ -1564,6 +1585,9 @@ pub fn build_brain_context_hybrid_with_aliases(
                         for (uid, _score) in hits.iter().take(config.semantic_seed_limit) {
                             if !seed_uids.contains(uid) {
                                 seed_uids.push(uid.clone());
+                                // nw-102: remember these are nearest-neighbour
+                                // guesses, not resolutions of the query text.
+                                semantic_seed_count += 1;
                             }
                         }
                     }
@@ -1658,6 +1682,7 @@ pub fn build_brain_context_hybrid_with_aliases(
         unresolved_seeds: unresolved,
         expansion_terms,
         semantic_applied,
+        semantic_seed_count,
         degraded_components: if semantic_requested && !semantic_applied {
             vec!["semantic".to_string()]
         } else {
@@ -2996,6 +3021,7 @@ mod dedup_heading_section_tests {
             unresolved_seeds: vec![],
             expansion_terms: vec![],
             semantic_applied: false,
+            semantic_seed_count: 0,
             degraded_components: vec![],
         }
     }

--- a/crates/nestweaver-engine/src/read_symbols.rs
+++ b/crates/nestweaver-engine/src/read_symbols.rs
@@ -50,6 +50,25 @@ pub struct ReadSymbolsResult {
     /// UIDs dropped because the token budget was exhausted.
     pub dropped: Vec<String>,
     pub truncated: bool,
+    /// Set when the FIRST symbol alone exceeded `token_budget`.
+    ///
+    /// One symbol is always returned, because an empty answer to "read this
+    /// symbol" is useless. That guarantee is deliberate — but it was kept
+    /// silently, with `truncated: false`, so a caller asking for 1 token
+    /// received ~6,700 and had no way to know the budget had been ignored
+    /// (nw-111). The guarantee stays; the silence does not.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub budget_exceeded_by_first_symbol: Option<BudgetOverrun>,
+}
+
+/// How far the mandatory first symbol overran the requested budget.
+#[derive(Debug, Clone, Serialize)]
+pub struct BudgetOverrun {
+    /// The budget the caller asked for.
+    pub requested_tokens: usize,
+    /// Estimated tokens actually returned for that first symbol.
+    pub returned_tokens: usize,
+    pub note: String,
 }
 
 /// Read lines `start..=end` (1-based, inclusive) from `file_path` via the reader.
@@ -152,6 +171,24 @@ pub fn read_symbols(
             result.truncated = true;
             continue;
         }
+        // The first symbol is exempt from the budget so the caller never gets an
+        // empty answer — but say so rather than reporting a clean result that
+        // silently blew the budget.
+        if let Some(budget) = token_budget
+            && result.symbols.is_empty()
+            && cost > budget
+        {
+            result.truncated = true;
+            result.budget_exceeded_by_first_symbol = Some(BudgetOverrun {
+                requested_tokens: budget,
+                returned_tokens: cost,
+                note: format!(
+                    "the first symbol alone costs ~{cost} tokens, over the requested \
+                     budget of {budget}; it is returned whole because an empty result \
+                     answers nothing, so this response EXCEEDS the budget"
+                ),
+            });
+        }
         used += cost;
         result.symbols.push(SymbolWindow {
             uid: sym.uid,
@@ -188,6 +225,63 @@ mod tests {
         let (_r, store) =
             index_directory_in_memory(&src, "test", "https://example.com/repo", "abc123").unwrap();
         (dir, src, store)
+    }
+
+    /// nw-111 (3): a budget too small for even one symbol must be DISCLOSED.
+    ///
+    /// The first symbol is deliberately exempt so the caller never receives an
+    /// empty answer to "read this symbol". But that exemption was silent: a
+    /// 1-token request returned the whole body with `truncated: false`, and the
+    /// reported output was byte-identical at budgets of 1, 50, 500, 5000 and
+    /// 16000. The guarantee is kept; the silence is not.
+    #[test]
+    fn a_budget_smaller_than_the_first_symbol_is_disclosed() {
+        let (_dir, src, store) = test_repo();
+        let reader = FilesystemReader::new(&src);
+
+        let res = read_symbols(&store, &["greet".to_string()], &reader, 0, Some(1));
+
+        assert_eq!(
+            res.symbols.len(),
+            1,
+            "the first symbol is still returned — an empty result answers nothing"
+        );
+        assert!(
+            res.truncated,
+            "a response that exceeds the requested budget is not a clean result"
+        );
+        let overrun = res
+            .budget_exceeded_by_first_symbol
+            .as_ref()
+            .expect("the overrun must be reported");
+        assert_eq!(overrun.requested_tokens, 1);
+        assert!(
+            overrun.returned_tokens > 1,
+            "must state what was actually returned: {overrun:?}"
+        );
+        assert!(
+            overrun.note.contains("EXCEEDS"),
+            "the note must say plainly that the budget was exceeded: {}",
+            overrun.note
+        );
+    }
+
+    /// A budget that comfortably fits must stay clean — a disclosure that always
+    /// fires is one callers learn to ignore.
+    #[test]
+    fn a_sufficient_budget_reports_no_overrun() {
+        let (_dir, src, store) = test_repo();
+        let reader = FilesystemReader::new(&src);
+
+        let res = read_symbols(&store, &["greet".to_string()], &reader, 0, Some(10_000));
+
+        assert_eq!(res.symbols.len(), 1);
+        assert!(!res.truncated, "nothing was dropped or overrun");
+        assert!(
+            res.budget_exceeded_by_first_symbol.is_none(),
+            "must not cry wolf: {:?}",
+            res.budget_exceeded_by_first_symbol
+        );
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/resolver_generation.rs
+++ b/crates/nestweaver-engine/src/resolver_generation.rs
@@ -1,0 +1,160 @@
+//! Per-repo record of which resolver built a repo's edges.
+//!
+//! nw-124. Some resolver fixes change the SHAPE of the graph rather than the
+//! query that reads it, so upgrading the binary does not correct data already
+//! on disk. nw-103 is the motivating case: import edges used to be fanned out
+//! to every symbol in the imported file, which put never-exported string
+//! constants at the top of `hubs` with 800+ out-edges. The fix landed in
+//! `resolve_references`, but that runs at INDEX time — so a user who upgrades
+//! keeps the corrupted hub, bridge and PageRank rankings until each repo is
+//! re-indexed, with nothing telling them the numbers are stale.
+//!
+//! Measured on the production graph: with the FIXED binary, `hubs` still
+//! returned the exact ranking from the bug report. Re-indexing one repo removed
+//! every one of its artefacts from the top 10.
+//!
+//! This sidecar makes that staleness visible instead of silent. It is
+//! deliberately a sidecar and not a node property: adding a column to `Repo`
+//! would need a graph-schema migration, and a repo indexed before this file
+//! existed has no entry — which is exactly the "predates the fix" answer we
+//! want, at zero migration cost.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Current resolver generation.
+///
+/// Bump this whenever a resolver change alters persisted edge shape such that
+/// previously-indexed repos would yield different (wrong) analysis results.
+/// Bumping it makes every not-yet-re-indexed repo report as stale.
+///
+/// 1 — nw-103: import edges attributed to the importing file instead of being
+///     fanned out to every symbol in the imported file.
+pub const RESOLVER_GENERATION: u32 = 1;
+
+/// An unrecorded repo reads as generation 0, so the current generation must
+/// stay above it — otherwise the pre-fix data this module exists to flag would
+/// report as current.
+const _: () = assert!(RESOLVER_GENERATION > 0);
+
+/// Sidecar filename suffix, alongside the other `<db>.*` sidecars.
+pub const RESOLVER_GENERATION_SIDECAR: &str = ".resolver_generation.json";
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct ResolverGenerations {
+    /// repo uid -> generation that produced its edges.
+    #[serde(default)]
+    pub repos: BTreeMap<String, u32>,
+}
+
+impl ResolverGenerations {
+    /// Generation recorded for `repo_uid`. A repo with no entry was indexed
+    /// before this record existed, which is generation 0 by definition.
+    pub fn generation_for(&self, repo_uid: &str) -> u32 {
+        self.repos.get(repo_uid).copied().unwrap_or(0)
+    }
+
+    /// Repo uids whose edges predate [`RESOLVER_GENERATION`].
+    pub fn stale_repos<'a, I: IntoIterator<Item = &'a str>>(&self, known: I) -> Vec<String> {
+        known
+            .into_iter()
+            .filter(|uid| self.generation_for(uid) < RESOLVER_GENERATION)
+            .map(|uid| uid.to_string())
+            .collect()
+    }
+}
+
+/// Load the sidecar, or an empty record when absent/unreadable.
+///
+/// Absent is not an error: it means every repo predates the record, which is
+/// the correct reading for any database indexed before this shipped.
+pub fn load(db_path: &Path) -> ResolverGenerations {
+    let path = crate::sidecar_path(db_path, RESOLVER_GENERATION_SIDECAR);
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+/// Record that `repo_uid` was just indexed by the current resolver.
+///
+/// Merges into the existing file so re-indexing one repo never claims the
+/// others were refreshed too — the whole point is per-repo truth.
+pub fn record(db_path: &Path, repo_uid: &str) -> Result<(), anyhow::Error> {
+    let path = crate::sidecar_path(db_path, RESOLVER_GENERATION_SIDECAR);
+    let mut current = load(db_path);
+    current
+        .repos
+        .insert(repo_uid.to_string(), RESOLVER_GENERATION);
+    std::fs::write(&path, serde_json::to_string_pretty(&current)?)?;
+    Ok(())
+}
+
+/// Operator-facing caveat for ranking output, or `None` when every repo is
+/// current.
+///
+/// Ranking commands (`hubs`, `bridges`, and anything built on PageRank) are
+/// the surfaces nw-103 corrupted, so they are where the disclosure belongs.
+pub fn staleness_note(db_path: &Path, repo_uids: &[String]) -> Option<String> {
+    let gens = load(db_path);
+    let stale = gens.stale_repos(repo_uids.iter().map(|s| s.as_str()));
+    if stale.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "{} of {} repo(s) were indexed by an older resolver, so their edges predate \
+         the nw-103 import-fan-out fix — hub, bridge and PageRank rankings for those \
+         repos are NOT corrected by upgrading alone. Re-index them \
+         (`nestweaver index --repo <path>`) to get accurate rankings.",
+        stale.len(),
+        repo_uids.len()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_entry_reads_as_generation_zero() {
+        let g = ResolverGenerations::default();
+        assert_eq!(g.generation_for("repo:whatever"), 0);
+    }
+
+    #[test]
+    fn only_repos_below_the_current_generation_are_stale() {
+        let mut g = ResolverGenerations::default();
+        g.repos.insert("fresh".into(), RESOLVER_GENERATION);
+        g.repos.insert("ancient".into(), 0);
+        let stale = g.stale_repos(vec!["fresh", "ancient", "unrecorded"]);
+        assert_eq!(stale, vec!["ancient".to_string(), "unrecorded".to_string()]);
+    }
+
+    #[test]
+    fn recording_one_repo_does_not_mark_the_others_refreshed() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("g.lbug");
+        record(&db, "repo:a").unwrap();
+        record(&db, "repo:b").unwrap();
+
+        let g = load(&db);
+        assert_eq!(g.generation_for("repo:a"), RESOLVER_GENERATION);
+        assert_eq!(g.generation_for("repo:b"), RESOLVER_GENERATION);
+        assert_eq!(g.generation_for("repo:never-indexed"), 0);
+    }
+
+    #[test]
+    fn note_is_absent_when_everything_is_current_and_counts_when_not() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("g.lbug");
+        record(&db, "repo:a").unwrap();
+
+        assert!(staleness_note(&db, &["repo:a".to_string()]).is_none());
+
+        let note = staleness_note(&db, &["repo:a".to_string(), "repo:b".to_string()])
+            .expect("a stale repo must produce a caveat");
+        assert!(note.contains("1 of 2"), "{note}");
+        assert!(note.contains("nw-103"), "{note}");
+    }
+}

--- a/crates/nestweaver-engine/src/watcher.rs
+++ b/crates/nestweaver-engine/src/watcher.rs
@@ -988,8 +988,9 @@ fn reinsert_note(
 
     // ── Wikilinks (per-file: resolve against the pre-built title lookup) ─
     let mut wl_resolved = 0usize;
-    let mut wl_note_edges: Vec<(String, String, f32, String)> = Vec::new();
-    let mut wl_head_edges: Vec<(String, String, f32, String)> = Vec::new();
+    // nw-122: carry the link target alongside the display alias.
+    let mut wl_note_edges: Vec<(String, String, f32, String, String)> = Vec::new();
+    let mut wl_head_edges: Vec<(String, String, f32, String, String)> = Vec::new();
 
     for wl in &parsed.wikilinks {
         if wl.section_idx >= section_uids.len() {
@@ -1014,6 +1015,7 @@ fn reinsert_note(
                         h.uid.clone(),
                         conf,
                         display.clone(),
+                        wl.target.clone(),
                     ));
                     wl_resolved += 1;
                     continue;
@@ -1024,19 +1026,20 @@ fn reinsert_note(
                 target.clone(),
                 conf,
                 display.clone(),
+                wl.target.clone(),
             ));
             wl_resolved += 1;
         }
     }
 
-    let wl_note_refs: Vec<(&str, &str, f32, &str)> = wl_note_edges
+    let wl_note_refs: Vec<(&str, &str, f32, &str, &str)> = wl_note_edges
         .iter()
-        .map(|(s, n, c, d)| (s.as_str(), n.as_str(), *c, d.as_str()))
+        .map(|(s, n, c, d, t)| (s.as_str(), n.as_str(), *c, d.as_str(), t.as_str()))
         .collect();
     store.batch_insert_wikilink_to_note_edges(&wl_note_refs)?;
-    let wl_head_refs: Vec<(&str, &str, f32, &str)> = wl_head_edges
+    let wl_head_refs: Vec<(&str, &str, f32, &str, &str)> = wl_head_edges
         .iter()
-        .map(|(s, h, c, d)| (s.as_str(), h.as_str(), *c, d.as_str()))
+        .map(|(s, h, c, d, t)| (s.as_str(), h.as_str(), *c, d.as_str(), t.as_str()))
         .collect();
     store.batch_insert_wikilink_to_heading_edges(&wl_head_refs)?;
 

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -11862,6 +11862,7 @@ mod blast_radius_visibility_tests {
         std::fs::write(&db_path, b"").unwrap();
         save_cochange_sidecar(
             &[CoChangeEdge {
+                repo: String::new(),
                 file_a: "src/api.rs".to_string(),
                 file_b: "hidden/private.sql".to_string(),
                 cochange_count: 8675309,

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -2167,21 +2167,10 @@ fn tool_regex_search(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
     let res = store
         .regex_search(pattern, path_prefix, kinds.as_deref(), limit, max_millis)
         .map_err(|e| anyhow!("regex_search: {e}"))?;
-    let mut resp = serde_json::to_value(res)?;
-    if resp
-        .get("results")
-        .and_then(|r| r.as_array())
-        .is_some_and(|a| a.is_empty())
-        && resp
-            .get("truncated")
-            .and_then(|t| t.as_bool())
-            .unwrap_or(false)
-    {
-        resp["note"] = json!(
-            "Pattern matched no candidates within the scan budget. Results may exist beyond the scanned range."
-        );
-    }
-    Ok(resp)
+    // nw-097: the note now rides on RegexSearchResult itself, attached by the
+    // store, so the CLI and daemon paths carry it too. This tool used to bolt it
+    // on here, which is exactly why only MCP had it.
+    Ok(serde_json::to_value(res)?)
 }
 
 fn tool_schema_regex_search() -> Value {
@@ -3219,6 +3208,14 @@ fn tool_brain_context(
 
     if !result.unresolved_seeds.is_empty() {
         resp["unresolved_seeds"] = json!(result.unresolved_seeds);
+    }
+
+    // nw-102: how many of `seeds` are semantic nearest-neighbour guesses rather
+    // than resolutions of the query. Without this the daemon path could not
+    // distinguish them and reported every guess as "resolved" — the same
+    // response then claimed a seed both resolved AND unresolved.
+    if result.semantic_seed_count > 0 {
+        resp["semantic_seed_count"] = json!(result.semantic_seed_count);
     }
 
     // Feature F7: surface the PRF-mined expansion terms for auditing. Only
@@ -6970,7 +6967,7 @@ fn tool_schema_query_extensions() -> Value {
                     "description": "Property name to filter by (e.g. \"team_owner\", \"deprecated\"). Required when not using uid mode."
                 },
                 "value": {
-                    "description": "Value to match — any JSON value. Required when key is provided. Exact match only."
+                    "description": "Value to match — any JSON value. Required when key is provided. Exact match, plus membership: a SCALAR query matches when the stored property is an array containing it (so key=\"aliases\", value=\"Widget\" matches [\"Widget\",\"widget\"]). An ARRAY query stays an exact whole-array comparison, not any-of. Pass a real JSON value, not a stringified one."
                 },
                 "uid": {
                     "type": "string",

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -6095,7 +6095,7 @@ fn tool_brain_guide(store: &GraphStore, args: Value) -> Result<Value, anyhow::Er
 fn tool_schema_flow_trace() -> Value {
     json!({
         "name": "flow_trace",
-        "description": "Trace forward execution flow from a symbol: what it calls, what those call, and so on. Returns a tree of callees.\n\nGuidelines:\n- Best for tracing from entry points (main, request handlers) to understand execution paths\n- Cycles are detected and pruned; use max_depth to control tree depth (default 10)\n- Classes are auto-expanded to their methods since classes have no direct CALLS edges\n\nLimitations:\n- For reverse dependencies ('what calls this?') use brain_impact instead\n- For general structural context use brain_context",
+        "description": "Trace forward execution flow from a symbol: what it calls, what those call, and so on. Returns a tree of callees.\n\nGuidelines:\n- Best for tracing from entry points (main, request handlers) to understand execution paths\n- Every child carries `edge_type`: CALLS and IMPORTS are observed in code, CROSS_REPO_LINK is an INFERRED cross-repo link. A CROSS_REPO_LINK child is NOT an observed call — filter it out when you need a real execution path\n- Cycles are detected and pruned; use max_depth to control tree depth (default 10)\n- Classes are auto-expanded to their methods since classes have no direct CALLS edges\n\nLimitations:\n- For reverse dependencies ('what calls this?') use brain_impact instead\n- For general structural context use brain_context",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -6274,14 +6274,14 @@ fn build_flow_tree(
     let mut children = Vec::new();
 
     if depth < opts.max_depth
-        && let Ok(callees) = store.callees_of(uid)
+        && let Ok(callees) = store.callees_with_edge_types_of(uid)
     {
-        for callee in &callees {
+        for (callee, edge_type) in &callees {
             if visited.contains(&callee.uid) {
                 continue;
             }
             visited.insert(callee.uid.clone());
-            let child = build_flow_tree(
+            let mut child = build_flow_tree(
                 store,
                 &callee.uid,
                 &callee.name,
@@ -6290,11 +6290,25 @@ fn build_flow_tree(
                 visited,
                 opts,
             )?;
+            // Label the edge that reached this node. The traversal spans CALLS,
+            // IMPORTS and CROSS_REPO_LINK, and the last is an INFERRED link
+            // between repos — following it as a call produced fabricated
+            // execution paths (a Rust function appearing to call JavaScript
+            // symbols in unrelated repos). Without this field they were
+            // indistinguishable from real calls, on the flagship "what does this
+            // call" surface. `impact` has always labelled its edges; this brings
+            // flow_trace to parity (nw-111).
+            if let Some(obj) = child.as_object_mut() {
+                obj.insert("edge_type".to_string(), json!(edge_type));
+            }
             children.push(child);
         }
     }
 
     if opts.concise {
+        // The label ships in concise mode too: a caller scanning a compact tree
+        // is exactly the one who cannot afford to mistake a cross-repo guess for
+        // a call.
         Ok(json!({
             "name": name,
             "children": children,

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -3372,7 +3372,7 @@ fn tool_schema_brain_search() -> Value {
                 },
                 "limit": {
                     "type": "integer",
-                    "description": "Maximum results to return. Default 20. Set lower for focused lookups, higher for broad discovery.",
+                    "description": "Maximum results PER KIND, not in total. Default 20. Notes and code symbols are capped separately, so a query matching both can return up to 2x this value — budget accordingly and read returned_matches for the true count. Set lower for focused lookups, higher for broad discovery.",
                     "default": 20,
                     "minimum": 1,
                     "maximum": 1000
@@ -4590,6 +4590,25 @@ mod brain_search_total_contract_tests {
         let description = schema["description"].as_str().unwrap();
         assert!(description.contains("total_matches_relation"));
         assert!(description.contains("returned_matches"));
+
+        // nw-101: the `limit` property itself must disclose that the cap is
+        // per-kind. The tool description said so while this said "Maximum
+        // results to return", and a caller reading the field they are actually
+        // setting was told a total cap that does not exist — `--limit 3` on a
+        // mixed query returns 6. The per-kind cap is deliberate (symbols carry
+        // a fixed 0.5 score against BM25 notes scoring 15+, so a merged cap
+        // would evict every symbol), so the contract is what needs correcting.
+        let limit_doc = schema["inputSchema"]["properties"]["limit"]["description"]
+            .as_str()
+            .unwrap();
+        assert!(
+            limit_doc.contains("PER KIND"),
+            "the limit field must state it is per-kind, not a total: {limit_doc}"
+        );
+        assert!(
+            limit_doc.contains("2x"),
+            "it must state the consequence — up to 2x limit rows: {limit_doc}"
+        );
         assert!(
             schema["inputSchema"]["properties"]["response_format"]["description"]
                 .as_str()

--- a/crates/nestweaver-parser/src/markdown.rs
+++ b/crates/nestweaver-parser/src/markdown.rs
@@ -907,6 +907,15 @@ fn extract_md_links(body: &str, sections: &[RawSection]) -> Vec<RawWikilink> {
             if !path_part.ends_with(".md") {
                 continue;
             }
+            // ...and only to files IN THE VAULT. An external URL can end in
+            // `.md` too — `https://github.com/org/repo/blob/main/notes/x.md`
+            // passed this filter, became a wikilink target, and then resolved to
+            // nothing forever, so `broken-links` reported it as broken on every
+            // run with no possible fix (nw-100). A scheme means it is not a
+            // vault path.
+            if path_part.contains("://") || path_part.starts_with("//") {
+                continue;
+            }
             let target = path_part.to_string();
             let line = data.sourcepos.start.line as u32;
 
@@ -1518,6 +1527,28 @@ top 2 body
     }
 
     // ── Markdown link (.md) detection ────────────────────────────────────────
+
+    /// nw-100: an EXTERNAL url ending in `.md` is not a vault link.
+    ///
+    /// These passed the `.md` filter, became wikilink targets, and were then
+    /// reported broken on every run — permanently, since nothing in the vault
+    /// could ever satisfy them. Real example from the vault:
+    /// `https://github.com/Kehl-io/orbit/blob/main/docs/releases/v0.2.0-recovery.md`.
+    #[test]
+    fn external_urls_ending_in_md_are_not_wikilinks() {
+        let src = "# n\n\nSee [recovery](https://github.com/o/r/blob/main/docs/x.md) and \
+                   [local](notes/y.md).\n";
+        let note = parse_markdown("x.md", src).unwrap();
+        let targets: Vec<&str> = note.wikilinks.iter().map(|w| w.target.as_str()).collect();
+        assert!(
+            targets.contains(&"notes/y.md"),
+            "the in-vault link must still be captured: {targets:?}"
+        );
+        assert!(
+            !targets.iter().any(|t| t.contains("://")),
+            "an external url must not become a wikilink: {targets:?}"
+        );
+    }
 
     #[test]
     fn detects_md_link_as_wikilink() {

--- a/crates/nestweaver-parser/src/markdown.rs
+++ b/crates/nestweaver-parser/src/markdown.rs
@@ -1532,8 +1532,9 @@ top 2 body
     ///
     /// These passed the `.md` filter, became wikilink targets, and were then
     /// reported broken on every run — permanently, since nothing in the vault
-    /// could ever satisfy them. Real example from the vault:
-    /// `https://github.com/Kehl-io/orbit/blob/main/docs/releases/v0.2.0-recovery.md`.
+    /// could ever satisfy them. The shape that triggered it is a plain link to
+    /// a file in a git forge, e.g.
+    /// `https://github.com/<org>/<repo>/blob/main/docs/releases/v0.2.0.md`.
     #[test]
     fn external_urls_ending_in_md_are_not_wikilinks() {
         let src = "# n\n\nSee [recovery](https://github.com/o/r/blob/main/docs/x.md) and \

--- a/crates/nestweaver-parser/src/markdown.rs
+++ b/crates/nestweaver-parser/src/markdown.rs
@@ -743,26 +743,32 @@ fn extract_inline_tags(sections: &[RawSection]) -> Vec<RawTag> {
     for (sec_idx, sec) in sections.iter().enumerate() {
         let stripped = strip_code(&sec.text);
         for (line_offset, line_text) in stripped.lines().enumerate() {
-            let bytes = line_text.as_bytes();
-            let mut i = 0usize;
-            while i < bytes.len() {
-                let is_boundary =
-                    i == 0 || matches!(bytes[i - 1], b' ' | b'\t' | b'(' | b'[' | b',' | b';');
-                if bytes[i] == b'#' && is_boundary {
-                    let start = i + 1;
-                    let mut j = start;
-                    while j < bytes.len() {
-                        let c = bytes[j];
-                        if c.is_ascii_alphanumeric() || c == b'-' || c == b'_' || c == b'/' {
-                            j += 1;
+            // Scan by CHARACTER, not by byte. Testing each byte with
+            // `is_ascii_alphanumeric` stopped at the first non-ASCII byte, so
+            // `#café` indexed as `caf` and `#日本語` was dropped outright — its
+            // first character is non-ASCII, so the name came out empty. Obsidian
+            // supports non-ASCII tags, and a truncated stem can collide with an
+            // unrelated real tag (nw-116).
+            let mut prev: Option<char> = None;
+            let mut chars = line_text.char_indices().peekable();
+            while let Some((idx, ch)) = chars.next() {
+                let is_boundary = match prev {
+                    None => true,
+                    Some(p) => matches!(p, ' ' | '\t' | '(' | '[' | ',' | ';'),
+                };
+                if ch == '#' && is_boundary {
+                    let start = idx + ch.len_utf8();
+                    let mut end = start;
+                    while let Some(&(j, c)) = chars.peek() {
+                        if c.is_alphanumeric() || c == '-' || c == '_' || c == '/' {
+                            end = j + c.len_utf8();
+                            chars.next();
                         } else {
                             break;
                         }
                     }
-                    if j > start {
-                        let name = std::str::from_utf8(&bytes[start..j])
-                            .unwrap_or("")
-                            .to_lowercase();
+                    if end > start {
+                        let name = line_text[start..end].to_lowercase();
                         // Skip bare `#` (no name), pure-numeric tags like #1 (often markdown
                         // issue refs), and trailing-hyphen artefacts.
                         if !name.is_empty() && name.chars().any(|c| c.is_alphabetic()) {
@@ -773,11 +779,11 @@ fn extract_inline_tags(sections: &[RawSection]) -> Vec<RawTag> {
                                 line: sec.start_line + line_offset as u32,
                             });
                         }
-                        i = j;
+                        prev = line_text[start..end].chars().next_back();
                         continue;
                     }
                 }
-                i += 1;
+                prev = Some(ch);
             }
         }
     }
@@ -1333,11 +1339,57 @@ top 2 body
     /// a line that contains non-ASCII elsewhere must still be found at the
     /// right line — the byte rewrite used to shift every following offset.
     ///
-    /// This deliberately does NOT assert that `#café` yields `café`: the tag
-    /// scanner accepts only `is_ascii_alphanumeric` plus `-_/`, so it truncates
-    /// at the first non-ASCII byte and returns `caf`. That is a separate
-    /// limitation from the encoding defect, unchanged by this fix, and tracked
-    /// on its own.
+    /// Non-ASCII tag names are covered separately by
+    /// `inline_tags_accept_non_ascii_names`.
+    /// nw-116: Obsidian supports non-ASCII tags, but the scanner tested each
+    /// byte with `is_ascii_alphanumeric`, so it stopped at the first non-ASCII
+    /// byte: `#café` indexed as `caf` and `#niño` as `ni`. That silently splits
+    /// a tag namespace, and the truncated stems can collide with unrelated real
+    /// tags.
+    #[test]
+    fn inline_tags_accept_non_ascii_names() {
+        let src = "# n\n\nTagged #café and #niño and #日本語 and #arch/décision here.\n";
+        let note = parse_markdown("x.md", src).unwrap();
+        let names: Vec<&str> = note.tags.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"café"), "tags were: {names:?}");
+        assert!(names.contains(&"niño"), "tags were: {names:?}");
+        assert!(names.contains(&"日本語"), "tags were: {names:?}");
+        assert!(names.contains(&"arch/décision"), "tags were: {names:?}");
+        assert!(
+            !names.contains(&"caf"),
+            "the truncated stem must be gone, not merely joined: {names:?}"
+        );
+    }
+
+    /// The widened charset must not start swallowing ordinary punctuation that
+    /// ends a tag — otherwise `#tag.` or `#tag, next` would absorb the trailing
+    /// mark and mint a tag nobody wrote.
+    #[test]
+    fn inline_tags_still_stop_at_punctuation_and_whitespace() {
+        let src = "# n\n\nSee #alpha, #beta. And #gamma; plus #delta! End #ré.\n";
+        let note = parse_markdown("x.md", src).unwrap();
+        let names: Vec<&str> = note.tags.iter().map(|t| t.name.as_str()).collect();
+        for expected in ["alpha", "beta", "gamma", "delta", "ré"] {
+            assert!(names.contains(&expected), "missing {expected}: {names:?}");
+        }
+    }
+
+    /// Widening the charset must not start minting tags from prose. The real
+    /// vault contains page and issue ranges written with an EN DASH — `#185–187`,
+    /// `#36–37` — and those are not tags. The en dash (U+2013) is punctuation,
+    /// not a hyphen-minus, so it must terminate the name, and the resulting
+    /// digits-only stem must still be dropped by the numeric filter.
+    #[test]
+    fn en_dash_ranges_from_prose_are_not_tags() {
+        let src = "# n\n\nSee pp. #185–187 and #36–37; also #11–12.\n";
+        let note = parse_markdown("x.md", src).unwrap();
+        let names: Vec<&str> = note.tags.iter().map(|t| t.name.as_str()).collect();
+        assert!(
+            names.is_empty(),
+            "numeric ranges must not become tags: {names:?}"
+        );
+    }
+
     #[test]
     fn inline_tags_survive_non_ascii_on_the_same_line() {
         let src = "# n\n\nRésumé notes — tagged #design and #arch/decision here.\n";

--- a/crates/nestweaver-parser/src/markdown.rs
+++ b/crates/nestweaver-parser/src/markdown.rs
@@ -696,27 +696,39 @@ fn strip_code(text: &str) -> String {
             continue;
         }
         // Strip inline code spans: replace `...` with spaces of equal length.
-        let bytes = line.as_bytes();
+        //
+        // Operate on `str`, never on raw bytes. This loop used to copy the line
+        // through with `buf.push(bytes[i] as char)`, and `u8 as char` maps a
+        // byte to the code point of the same value — Latin-1 decoding. Pushing
+        // that into a UTF-8 `String` re-encoded it, so an em dash `e2 80 94`
+        // came back out as `c3 a2 c2 80 c2 94` and every wikilink or tag
+        // containing non-ASCII was silently corrupted (nw-099).
+        //
+        // Backticks are ASCII, so every index `find` returns is on a character
+        // boundary and the slices below are safe.
         let mut buf = String::with_capacity(line.len());
-        let mut i = 0;
-        while i < bytes.len() {
-            if bytes[i] == b'`' {
-                // Find matching backtick on same line.
-                let mut j = i + 1;
-                while j < bytes.len() && bytes[j] != b'`' {
-                    j += 1;
-                }
-                if j < bytes.len() {
-                    for _ in i..=j {
+        let mut rest = line;
+        while let Some(open) = rest.find('`') {
+            buf.push_str(&rest[..open]);
+            let after_open = &rest[open + 1..];
+            match after_open.find('`') {
+                Some(close) => {
+                    // Blank the span, both backticks included, one space per
+                    // CHARACTER so column positions survive multi-byte text.
+                    let span_end = open + 1 + close + 1;
+                    for _ in rest[open..span_end].chars() {
                         buf.push(' ');
                     }
-                    i = j + 1;
-                    continue;
+                    rest = &rest[span_end..];
+                }
+                None => {
+                    // Unmatched backtick: keep it literally and carry on.
+                    buf.push('`');
+                    rest = after_open;
                 }
             }
-            buf.push(bytes[i] as char);
-            i += 1;
         }
+        buf.push_str(rest);
         out.push_str(&buf);
         out.push('\n');
     }
@@ -1277,6 +1289,73 @@ top 2 body
         let note = parse_markdown("x.md", src).unwrap();
         // All three should be dropped (empty target).
         assert_eq!(note.wikilinks.len(), 0);
+    }
+
+    /// nw-099: non-ASCII in a wikilink target must survive `strip_code`.
+    ///
+    /// `strip_code` used to rebuild each line with `buf.push(bytes[i] as char)`.
+    /// In Rust `u8 as char` maps a byte to the code point of the same value —
+    /// that is Latin-1 decoding — and pushing it into a UTF-8 `String`
+    /// re-encodes it. An em dash `e2 80 94` came back out as
+    /// `c3 a2 c2 80 c2 94`, one UTF-8 sequence per original byte.
+    ///
+    /// The link then resolves to nothing, so this silently severed real links
+    /// between real notes. Headings and titles were unaffected because only
+    /// wikilink and inline-tag scanning route through `strip_code`.
+    #[test]
+    fn wikilink_targets_preserve_non_ascii() {
+        let src = "# n\n\nSee [[Spike 1 — Byte Path Findings]] for detail.\n";
+        let note = parse_markdown("x.md", src).unwrap();
+        assert_eq!(note.wikilinks.len(), 1);
+        assert_eq!(note.wikilinks[0].target, "Spike 1 — Byte Path Findings");
+        assert_eq!(
+            note.wikilinks[0].target.as_bytes(),
+            "Spike 1 — Byte Path Findings".as_bytes(),
+            "em dash must stay as e2 80 94, not double-encode to c3 a2 c2 80 c2 94"
+        );
+    }
+
+    /// The same corruption hit aliases and anchors, which also come from the
+    /// stripped line, and a broader sweep of scripts than the em dash alone.
+    #[test]
+    fn wikilink_alias_and_anchor_preserve_non_ascii() {
+        let src = "# n\n\n[[Café#Menü|Crème brûlée]] and [[日本語ノート]] and [[naïve — test]]\n";
+        let note = parse_markdown("x.md", src).unwrap();
+        assert_eq!(note.wikilinks.len(), 3);
+        assert_eq!(note.wikilinks[0].target, "Café");
+        assert_eq!(note.wikilinks[0].heading_anchor.as_deref(), Some("Menü"));
+        assert_eq!(note.wikilinks[0].display.as_deref(), Some("Crème brûlée"));
+        assert_eq!(note.wikilinks[1].target, "日本語ノート");
+        assert_eq!(note.wikilinks[2].target, "naïve — test");
+    }
+
+    /// `strip_code` is shared with the inline-tag scanner, so a tag sitting on
+    /// a line that contains non-ASCII elsewhere must still be found at the
+    /// right line — the byte rewrite used to shift every following offset.
+    ///
+    /// This deliberately does NOT assert that `#café` yields `café`: the tag
+    /// scanner accepts only `is_ascii_alphanumeric` plus `-_/`, so it truncates
+    /// at the first non-ASCII byte and returns `caf`. That is a separate
+    /// limitation from the encoding defect, unchanged by this fix, and tracked
+    /// on its own.
+    #[test]
+    fn inline_tags_survive_non_ascii_on_the_same_line() {
+        let src = "# n\n\nRésumé notes — tagged #design and #arch/decision here.\n";
+        let note = parse_markdown("x.md", src).unwrap();
+        let names: Vec<&str> = note.tags.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"design"), "tags were: {names:?}");
+        assert!(names.contains(&"arch/decision"), "tags were: {names:?}");
+    }
+
+    /// The fix must not weaken code stripping: a wikilink inside an inline code
+    /// span on a line that also contains non-ASCII must still be ignored, and
+    /// the real link on that line must still be found.
+    #[test]
+    fn non_ascii_line_still_strips_inline_code() {
+        let src = "# n\n\nRésumé `[[not a link]]` but [[Real — Link]] counts.\n";
+        let note = parse_markdown("x.md", src).unwrap();
+        assert_eq!(note.wikilinks.len(), 1);
+        assert_eq!(note.wikilinks[0].target, "Real — Link");
     }
 
     // ── Tags ────────────────────────────────────────────────────────────────

--- a/crates/nestweaver-proto/src/lib.rs
+++ b/crates/nestweaver-proto/src/lib.rs
@@ -257,6 +257,49 @@ mod index_progress_tracker_tests {
         ));
     }
 
+    /// nw-127: a timeout must reach the caller as a REPORTED error naming the
+    /// cause, not as a truncated stream.
+    ///
+    /// The daemon's watchdog used to set its cancel flag and say nothing, so the
+    /// client saw the stream simply end and rendered "index progress stream
+    /// ended before completion" — indistinguishable from a crash, and shown as a
+    /// failure for an index that was still running and went on to SUCCEED.
+    /// Emitting a terminal `Phase::Error` is what turns that into an explanation.
+    #[test]
+    fn a_timeout_reported_in_band_beats_a_truncated_stream() {
+        // What the watchdog does now.
+        let mut reported = IndexProgressTracker::default();
+        reported
+            .observe(&progress(Phase::Writing, "still writing"))
+            .unwrap();
+        reported
+            .observe(&progress(
+                Phase::Error,
+                "index exceeded the 1800s timeout and cancellation was requested",
+            ))
+            .unwrap();
+        let err = reported.finish().unwrap_err();
+        match err {
+            IndexProgressError::Reported { message } => {
+                assert!(message.contains("timeout"), "{message}");
+            }
+            other => panic!("expected a reported error naming the timeout, got {other:?}"),
+        }
+
+        // What it did before: the same run, with the terminal event missing.
+        let mut silent = IndexProgressTracker::default();
+        silent
+            .observe(&progress(Phase::Writing, "still writing"))
+            .unwrap();
+        assert!(
+            matches!(
+                silent.finish().unwrap_err(),
+                IndexProgressError::Truncated { .. }
+            ),
+            "without the terminal event the caller can only report a truncated stream"
+        );
+    }
+
     #[test]
     fn any_event_after_a_terminal_event_is_rejected() {
         for terminal in [Phase::Done, Phase::Error] {

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -351,23 +351,83 @@ fn hardened_system_config() -> lbug::SystemConfig {
     cfg
 }
 
+/// A `SIGKILL`ed daemon can leave `<db>.wal` behind with NO `<db>.shadow`
+/// alongside it. lbug's read-write open then fails with an IO exception naming
+/// the absent shadow file, and because that text ends in "No such file or
+/// directory" the CLI's diagnostic heuristic read it as a MISSING DATABASE and
+/// told the user to create one over the top of their data (nw-126).
+///
+/// This is a different shape from [`is_stale_checkpoint_error`], which matches
+/// a checkpoint mismatch rather than an orphaned log, so the existing recovery
+/// arm never fired.
+fn is_orphaned_wal_error(msg: &str) -> bool {
+    msg.contains(".shadow") && msg.to_lowercase().contains("no such file")
+}
+
+/// Move an orphaned `<db>.wal` aside so the next open can proceed.
+///
+/// Deliberately a RENAME, never a delete: a WAL can in principle hold committed
+/// work, and destroying it to fix an outage would trade one data-loss story for
+/// another. Quarantining is reversible and leaves the evidence in place.
+///
+/// Only acts on the exact orphan signature — `.wal` present AND `.shadow`
+/// absent. A `.wal` with its `.shadow` intact is a normal recoverable log and
+/// must be left for the engine to replay.
+fn quarantine_orphaned_wal(path: &Path) -> Option<PathBuf> {
+    let wal = PathBuf::from(format!("{}.wal", path.display()));
+    let shadow = PathBuf::from(format!("{}.shadow", path.display()));
+    if !wal.exists() || shadow.exists() {
+        return None;
+    }
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let quarantined = PathBuf::from(format!("{}.wal.orphaned-{stamp}", path.display()));
+    std::fs::rename(&wal, &quarantined)
+        .ok()
+        .map(|()| quarantined)
+}
+
+/// Open an lbug database, auto-recovering once from crash debris that would
+/// otherwise make it permanently unopenable.
+///
+/// `read_write` gates the orphaned-WAL arm. Replay is inherently a write
+/// operation, so a read-only open must report the condition rather than mutate
+/// the directory to clear it — and a read-only caller quarantining a log out
+/// from under a live writer would be a genuine hazard.
 fn open_lbug_with_recovery(
     path: &Path,
+    read_write: bool,
     make_config: impl Fn() -> lbug::SystemConfig,
 ) -> Result<lbug::Database, StoreError> {
     match lbug::Database::new(path, make_config()) {
         Ok(db) => Ok(db),
         Err(e) => {
-            if is_stale_checkpoint_error(&e.to_string()) && remove_stale_checkpoint_sidecars(path) {
+            let msg = e.to_string();
+            if is_stale_checkpoint_error(&msg) && remove_stale_checkpoint_sidecars(path) {
                 tracing::warn!(
                     "recovered a stale WAL checkpoint for {} (a prior crash left \
                      .wal.checkpoint/.shadow that made the DB unopenable); retrying open",
                     path.display()
                 );
-                Ok(lbug::Database::new(path, make_config())?)
-            } else {
-                Err(e.into())
+                return Ok(lbug::Database::new(path, make_config())?);
             }
+            if read_write
+                && is_orphaned_wal_error(&msg)
+                && let Some(quarantined) = quarantine_orphaned_wal(path)
+            {
+                tracing::warn!(
+                    "recovered {} from an orphaned write-ahead log left by a prior \
+                     crash (.wal present with no .shadow, which made the database \
+                     unopenable on every path); moved it to {} and retried — it was \
+                     NOT deleted",
+                    path.display(),
+                    quarantined.display()
+                );
+                return Ok(lbug::Database::new(path, make_config())?);
+            }
+            Err(e.into())
         }
     }
 }
@@ -375,7 +435,7 @@ fn open_lbug_with_recovery(
 impl GraphStore {
     /// Create a new persistent database at `path`, initialising schema tables.
     pub fn create(path: &Path) -> Result<Self, StoreError> {
-        let db = open_lbug_with_recovery(path, hardened_system_config)?;
+        let db = open_lbug_with_recovery(path, true, hardened_system_config)?;
         let store = GraphStore {
             db,
             pagerank_cache: Mutex::new(None),
@@ -406,7 +466,7 @@ impl GraphStore {
     /// Runs schema migrations to ensure any new tables/columns from newer
     /// versions are present (all statements are idempotent).
     pub fn open(path: &Path) -> Result<Self, StoreError> {
-        let db = open_lbug_with_recovery(path, hardened_system_config)?;
+        let db = open_lbug_with_recovery(path, true, hardened_system_config)?;
         let store = GraphStore {
             db,
             pagerank_cache: Mutex::new(None),
@@ -436,7 +496,9 @@ impl GraphStore {
     /// Open an existing database in read-only mode. Allows concurrent access
     /// while another process (e.g. the web UI) holds the write lock.
     pub fn open_read_only(path: &Path) -> Result<Self, StoreError> {
-        let db = open_lbug_with_recovery(path, || lbug::SystemConfig::default().read_only(true))?;
+        let db = open_lbug_with_recovery(path, false, || {
+            lbug::SystemConfig::default().read_only(true)
+        })?;
         let store = GraphStore {
             db,
             pagerank_cache: Mutex::new(None),
@@ -1601,15 +1663,25 @@ impl GraphStore {
         // target kind (Note vs Heading).
         conn.query(
             "CREATE REL TABLE IF NOT EXISTS WIKILINK_TO_NOTE(\
-                FROM Section TO Note, confidence FLOAT, display STRING)",
+                FROM Section TO Note, confidence FLOAT, display STRING, target STRING)",
         )
         .map_err(|e| StoreError::Query(e.to_string()))?;
 
         conn.query(
             "CREATE REL TABLE IF NOT EXISTS WIKILINK_TO_HEADING(\
-                FROM Section TO Heading, confidence FLOAT, display STRING)",
+                FROM Section TO Heading, confidence FLOAT, display STRING, target STRING)",
         )
         .map_err(|e| StoreError::Query(e.to_string()))?;
+
+        // Migration: `display` alone cannot answer both questions a wikilink is
+        // asked. For a piped link `[[Home|workspace]]` the BACKLINKS view wants
+        // the visible text ("workspace") while BROKEN-LINKS wants the link
+        // target ("Home") — reporting the alias there rendered `[[workspace]]`,
+        // a string that appears nowhere in the vault (nw-122). Carry both.
+        // Empty string means "written before this column existed"; readers fall
+        // back to `display`, which is what those rows have always held.
+        let _ = conn.query("ALTER TABLE WIKILINK_TO_NOTE ADD target STRING DEFAULT ''");
+        let _ = conn.query("ALTER TABLE WIKILINK_TO_HEADING ADD target STRING DEFAULT ''");
 
         // ── F11 memory-bank: typed Note→Note relationships ─────────────────
         // Explicit, semantically-typed knowledge edges derived from frontmatter
@@ -1776,6 +1848,78 @@ mod tests {
     fn index_publication_lease_is_send_without_a_held_mutex_guard() {
         fn assert_send<T: Send>() {}
         assert_send::<IndexPublicationLease<'static>>();
+    }
+
+    /// nw-126: the signature observed on the production database after a
+    /// SIGKILLed daemon — `.wal` present, `.shadow` absent. lbug reports
+    /// "IO exception: Cannot open file <db>.shadow: No such file or directory",
+    /// which the stale-CHECKPOINT matcher cannot recognise, so nothing
+    /// recovered and every open failed.
+    #[test]
+    fn orphaned_wal_error_is_distinguished_from_a_stale_checkpoint() {
+        let orphan = "database error: IO exception: Cannot open file \
+                      /x/brain.lbug.shadow: No such file or directory";
+        assert!(is_orphaned_wal_error(orphan));
+        assert!(
+            !is_stale_checkpoint_error(orphan),
+            "the existing checkpoint matcher must NOT claim this case — that it \
+             does not is exactly why the database stayed unopenable"
+        );
+
+        let checkpoint = "wal.checkpoint header does not match";
+        assert!(is_stale_checkpoint_error(checkpoint));
+        assert!(!is_orphaned_wal_error(checkpoint));
+    }
+
+    /// The orphan is quarantined by RENAME, never deleted: a WAL can hold
+    /// committed work, and destroying it to clear an outage would swap one
+    /// data-loss story for another.
+    #[test]
+    fn orphaned_wal_is_quarantined_not_deleted() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        std::fs::write(&db, b"db").unwrap();
+        std::fs::write(dir.path().join("brain.lbug.wal"), b"orphan-contents").unwrap();
+
+        let moved = quarantine_orphaned_wal(&db).expect("orphaned wal must be quarantined");
+
+        assert!(
+            !dir.path().join("brain.lbug.wal").exists(),
+            "wal moved aside"
+        );
+        assert!(moved.exists(), "quarantined copy must still exist");
+        assert_eq!(
+            std::fs::read(&moved).unwrap(),
+            b"orphan-contents",
+            "contents must be preserved verbatim — quarantine, not deletion"
+        );
+        assert!(db.exists(), "the database itself is untouched");
+    }
+
+    /// A `.wal` WITH its `.shadow` is a normal replayable log. Quarantining it
+    /// would discard recoverable committed work, so the guard must decline.
+    #[test]
+    fn wal_with_its_shadow_is_left_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        std::fs::write(&db, b"db").unwrap();
+        std::fs::write(dir.path().join("brain.lbug.wal"), b"live").unwrap();
+        std::fs::write(dir.path().join("brain.lbug.shadow"), b"shadow").unwrap();
+
+        assert!(
+            quarantine_orphaned_wal(&db).is_none(),
+            "a wal accompanied by its shadow must never be moved"
+        );
+        assert!(dir.path().join("brain.lbug.wal").exists());
+    }
+
+    /// No `.wal` at all is not an orphan case.
+    #[test]
+    fn absent_wal_is_not_quarantined() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        std::fs::write(&db, b"db").unwrap();
+        assert!(quarantine_orphaned_wal(&db).is_none());
     }
 
     #[test]

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -516,6 +516,85 @@ mod tests {
         assert_eq!(found.name, "fn_3");
     }
 
+    /// nw-122: `broken_wikilinks` must report the link TARGET, not the visible
+    /// alias. For `[[Home|workspace]]` it used to report "workspace" — a string
+    /// that appears nowhere in the vault, so grepping for the reported link
+    /// found nothing.
+    ///
+    /// Rows written before the `target` column existed have an empty target and
+    /// MUST fall back to `display`, which is exactly what they have always held.
+    /// Without that fallback an upgrade would blank the text on every
+    /// pre-existing broken link.
+    #[test]
+    fn broken_wikilinks_reports_target_and_falls_back_to_display_pre_migration() {
+        let store = GraphStore::in_memory().unwrap();
+        let vault = Vault {
+            uid: "vlt:t:1".into(),
+            name: "t".into(),
+            root_path: "/t".into(),
+            instance_id: "t".into(),
+        };
+        store.insert_vault(&vault).unwrap();
+
+        let mk_note = |uid: &str, title: &str| nestweaver_schema::Note {
+            uid: uid.to_string(),
+            vault_uid: vault.uid.clone(),
+            file_path: format!("{title}.md"),
+            title: title.to_string(),
+            note_kind: nestweaver_schema::NoteKind::General,
+            word_count: 1,
+            content_hash: String::new(),
+            frontmatter: None,
+            created_at: None,
+            modified_at: None,
+            pagerank_score: None,
+            embedding: None,
+        };
+        let src = mk_note("note:src", "Source");
+        let dst = mk_note("note:dst", "Home");
+        store.insert_note(&src).unwrap();
+        store.insert_note(&dst).unwrap();
+
+        let sec = nestweaver_schema::Section {
+            uid: "sec:src:1".into(),
+            note_uid: src.uid.clone(),
+            heading_uid: None,
+            start_line: 1,
+            end_line: 2,
+            text_hash: String::new(),
+            text_content: "x".into(),
+            word_count: 1,
+            pagerank_score: None,
+        };
+        store.insert_section(&sec).unwrap();
+        store
+            .batch_insert_note_section_edges(&[(src.uid.as_str(), sec.uid.as_str())])
+            .unwrap();
+
+        // A piped link: visible text "workspace", target "Home". Confidence < 1
+        // so it lands in the broken/low-confidence report.
+        store
+            .batch_insert_wikilink_to_note_edges(&[(
+                sec.uid.as_str(),
+                dst.uid.as_str(),
+                0.9,
+                "workspace",
+                "Home",
+            )])
+            .unwrap();
+
+        let rows = store.broken_wikilinks().unwrap();
+        let texts: Vec<&str> = rows.iter().map(|r| r.wikilink_text.as_str()).collect();
+        assert!(
+            texts.contains(&"Home"),
+            "must report the link target, got {texts:?}"
+        );
+        assert!(
+            !texts.contains(&"workspace"),
+            "must not report the display alias as the link: {texts:?}"
+        );
+    }
+
     #[test]
     fn insert_repo_file_and_symbol_edges() {
         let store = test_store();
@@ -1756,8 +1835,8 @@ mod tests {
         let note_section_edges: Vec<(&str, &str)> = vec![("note:bvw:n1", "sec:bvw:s1")];
         let heading_section_edges: Vec<(&str, &str)> = vec![("hdg:bvw:h1", "sec:bvw:s1")];
         let note_tag_edges: Vec<(&str, &str)> = vec![("note:bvw:n1", "tag:bvw:rust")];
-        let wikilink_to_note_edges: Vec<(&str, &str, f32, &str)> =
-            vec![("sec:bvw:s1", "note:bvw:n2", 1.0, "Note Two")];
+        let wikilink_to_note_edges: Vec<(&str, &str, f32, &str, &str)> =
+            vec![("sec:bvw:s1", "note:bvw:n2", 1.0, "Note Two", "Note Two")];
 
         store
             .bulk_vault_write(

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -1531,6 +1531,78 @@ mod tests {
         );
     }
 
+    /// nw-061, corrected: a 2-node graph scoring 0.5/0.5 is NOT edge-blindness.
+    ///
+    /// The item reported `{a: 0.5, b: 0.5}` for a single `b -> a` edge and
+    /// concluded "the ranking loader's edge queries see no rows". Measured, the
+    /// loader returns `incoming=[[(1, 1.0)], [(0, 0.3)]]` with
+    /// `out_weight=[0.3, 1.0]` — the forward CALLS edge at 1.0 AND a reverse
+    /// edge at 0.3. Both are present.
+    ///
+    /// PageRank normalises each contribution by the source's total out-weight,
+    /// so `a`'s single 0.3 out-edge divided by `out_weight[a]` of 0.3 is 1.0 —
+    /// exactly what `b`'s 1.0/1.0 gives. On a TWO-node graph that makes the
+    /// system perfectly symmetric, and 0.5/0.5 is the correct fixed point. The
+    /// asymmetry only survives when a node's out-weight differs from the weight
+    /// of the edge being followed, which needs a third node.
+    #[test]
+    fn two_node_graph_is_symmetric_after_out_degree_normalisation() {
+        let store = test_store();
+        store.insert_symbol(&make_symbol("a", "fn_a")).unwrap();
+        store.insert_symbol(&make_symbol("b", "fn_b")).unwrap();
+        store.insert_edge(&make_calls_edge("b", "a")).unwrap();
+
+        let (uids, _idx, incoming, out_weight) = store
+            .load_ppr_graph(&GraphScope::code_only(), None)
+            .unwrap();
+        assert_eq!(uids.len(), 2);
+        assert!(
+            incoming.iter().all(|v| !v.is_empty()),
+            "both directions must be loaded — an empty side WOULD be the \
+             edge-blindness nw-061 suspected: {incoming:?}"
+        );
+        assert!(
+            out_weight.iter().all(|&w| w > 0.0),
+            "neither node is dangling once the reverse edge exists: {out_weight:?}"
+        );
+    }
+
+    /// The real guard against edge-blindness, and the one nw-061 asked for.
+    ///
+    /// If the ranking loader ever stopped seeing edges, every node would be
+    /// dangling, scores would go uniform, and this assertion fails. It needs
+    /// three or more nodes precisely because of the two-node symmetry above.
+    #[test]
+    fn pagerank_is_edge_sensitive_hub_outranks_leaf() {
+        let store = test_store();
+        for uid in ["hub", "leaf", "x", "y"] {
+            store
+                .insert_symbol(&make_symbol(uid, &format!("fn_{uid}")))
+                .unwrap();
+        }
+        store.insert_edge(&make_calls_edge("x", "hub")).unwrap();
+        store.insert_edge(&make_calls_edge("y", "hub")).unwrap();
+        store.insert_edge(&make_calls_edge("leaf", "hub")).unwrap();
+
+        store
+            .compute_pagerank(0.85, 20, &GraphScope::code_only())
+            .unwrap();
+        let ranked = store.symbols_by_pagerank(None).unwrap();
+        let score_of = |uid: &str| -> f64 {
+            ranked
+                .iter()
+                .find(|s| s.uid == uid)
+                .and_then(|s| s.pagerank_score)
+                .unwrap_or(0.0)
+        };
+        let (hub, leaf) = (score_of("hub"), score_of("leaf"));
+        assert!(
+            hub > leaf,
+            "a node with three inbound calls must outrank one with none; \
+             equal scores mean ranking has gone edge-blind (hub={hub:.4} leaf={leaf:.4})"
+        );
+    }
+
     #[test]
     fn highly_called_symbol_ranks_higher() {
         // A->C, B->C, D->C — C has three incoming, should rank highest.
@@ -1801,8 +1873,8 @@ mod tests {
         // Wikilinks: A→B and C→B. B is the hub.
         store
             .batch_insert_wikilink_to_note_edges(&[
-                ("sec:note:a", "note:b", 1.0, "B"),
-                ("sec:note:c", "note:b", 1.0, "B"),
+                ("sec:note:a", "note:b", 1.0, "B", "B"),
+                ("sec:note:c", "note:b", 1.0, "B", "B"),
             ])
             .unwrap();
 
@@ -2534,8 +2606,8 @@ mod tests {
             // Wikilink from filler section -> popular_x and popular_y
             store
                 .batch_insert_wikilink_to_note_edges(&[
-                    (&sec_uid, "note:popular_x", 1.0, "Popular X"),
-                    (&sec_uid, "note:popular_y", 1.0, "Popular Y"),
+                    (&sec_uid, "note:popular_x", 1.0, "Popular X", "Popular X"),
+                    (&sec_uid, "note:popular_y", 1.0, "Popular Y", "Popular Y"),
                 ])
                 .unwrap();
         }

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -2416,7 +2416,9 @@ impl GraphStore {
         // 1. Low-confidence / ambiguous resolved links.
         let q = "MATCH (src:Note)-[:NOTE_HAS_SECTION]->(:Section)-[r:WIKILINK_TO_NOTE]->(dst:Note) \
                  WHERE r.confidence < 1.0 \
-                 RETURN src.uid, src.file_path, src.title, r.display, r.confidence, dst.uid";
+                 RETURN src.uid, src.file_path, src.title, \
+                 CASE WHEN r.target = '' THEN r.display ELSE r.target END, \
+                 r.confidence, dst.uid";
         match conn.query(q) {
             Ok(result) => {
                 for row in result {

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -1798,11 +1798,42 @@ impl GraphStore {
     /// Follows CALLS, IMPORTS, and CROSS_REPO_LINK edges so that
     /// `flow_trace` can traverse function calls, import relationships,
     /// and cross-repo boundaries.
+    ///
+    /// Prefer [`callees_with_edge_types_of`](Self::callees_with_edge_types_of)
+    /// for anything user-facing: this drops the edge type, and a CROSS_REPO_LINK
+    /// is a cross-repo HYPOTHESIS, not an observed call.
     pub fn callees_of(&self, uid: &str) -> Result<Vec<Symbol>, StoreError> {
+        Ok(self
+            .callees_with_edge_types_of(uid)?
+            .into_iter()
+            .map(|(sym, _)| sym)
+            .collect())
+    }
+
+    /// As [`callees_of`](Self::callees_of), but keeps the edge type that reached
+    /// each callee.
+    ///
+    /// The traversal spans three very different relationships, and collapsing
+    /// them was the defect: a CROSS_REPO_LINK is an INFERRED link between repos,
+    /// so following it as though it were a call produced fabricated execution
+    /// paths — tracing a Rust function returned JavaScript symbols from unrelated
+    /// repos as its callees. Because the edge type was discarded here,
+    /// `flow_trace` could not label them and a consumer had no way to tell a real
+    /// call from a cross-repo guess. `impact` already returns the edge type for
+    /// exactly this reason (nw-111).
+    ///
+    /// Returned in edge-type priority order, and de-duplicated by symbol, so a
+    /// callee reachable by both CALLS and CROSS_REPO_LINK is reported as the
+    /// stronger CALLS.
+    pub fn callees_with_edge_types_of(
+        &self,
+        uid: &str,
+    ) -> Result<Vec<(Symbol, String)>, StoreError> {
         let conn = self.conn()?;
         let cols = SYMBOL_COLUMNS.replace("s.", "t.");
+        // Order matters: strongest evidence first, so the de-dup below keeps it.
         let edge_types = ["CALLS", "IMPORTS", "CROSS_REPO_LINK"];
-        let mut all: Vec<Symbol> = Vec::new();
+        let mut all: Vec<(Symbol, String)> = Vec::new();
         let mut seen = std::collections::HashSet::new();
         for et in &edge_types {
             let q = format!("MATCH (s:Symbol {{uid: $uid}})-[:{et}]->(t:Symbol) RETURN {cols}");
@@ -1815,7 +1846,7 @@ impl GraphStore {
             for row in result {
                 let sym = row_to_symbol(&row)?;
                 if seen.insert(sym.uid.clone()) {
-                    all.push(sym);
+                    all.push((sym, (*et).to_string()));
                 }
             }
         }

--- a/crates/nestweaver-store/src/regex.rs
+++ b/crates/nestweaver-store/src/regex.rs
@@ -113,6 +113,35 @@ pub struct RegexSearchResult {
     /// pattern has usable literals; always false when no index was ever built.
     #[serde(default)]
     pub stale_index: bool,
+    /// Human-readable explanation when an empty result is NOT a definitive
+    /// "no matches exist".
+    ///
+    /// nw-097: the MCP tool attached this note itself, so a CLI caller saw
+    /// `{"results": [], "truncated": true}` with nothing explaining it and
+    /// reasonably read it as "the pattern matches nothing". `truncated` alone
+    /// does not carry that meaning to a human. Living on the shared result
+    /// means every surface — CLI, MCP, daemon — reports it identically rather
+    /// than each remembering to bolt it on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+/// The note attached to an empty-but-truncated regex search.
+///
+/// A search that ran out of scan budget before matching anything has NOT
+/// established that no matches exist, and must not be presented as if it had.
+pub const SCAN_BUDGET_NOTE: &str = "Pattern matched no candidates within the scan budget. Results may exist beyond \
+     the scanned range.";
+
+impl RegexSearchResult {
+    /// Attach [`SCAN_BUDGET_NOTE`] when this result is empty only because the
+    /// scan was cut short. Idempotent, and never overwrites an existing note.
+    pub fn with_scan_budget_note(mut self) -> Self {
+        if self.results.is_empty() && self.truncated && self.note.is_none() {
+            self.note = Some(SCAN_BUDGET_NOTE.to_string());
+        }
+        self
+    }
 }
 
 /// Per-file aggregate count for `count_patterns`.
@@ -662,12 +691,15 @@ impl GraphStore {
             }
         }
 
+        // nw-097: attach the note at the source so no caller has to remember.
         Ok(RegexSearchResult {
             results,
             truncated,
             scanned_fallback,
             stale_index,
-        })
+            note: None,
+        }
+        .with_scan_budget_note())
     }
 
     /// Counts-only companion to `regex_search`. For each pattern, returns total
@@ -750,6 +782,62 @@ fn line_and_snippet(text: &str, match_start: usize) -> (u32, String) {
 
 #[cfg(test)]
 mod tests {
+    /// nw-097: an empty result that is empty only because the scan budget ran
+    /// out must SAY so. Previously the MCP tool attached this note itself, so a
+    /// CLI `--json` caller received `{"results": [], "truncated": true}` with
+    /// nothing explaining it and would reasonably read it as "no matches exist".
+    /// Attaching it on the shared result is what makes every surface agree.
+    #[test]
+    fn empty_and_truncated_carries_the_scan_budget_note() {
+        let r = RegexSearchResult {
+            results: vec![],
+            truncated: true,
+            scanned_fallback: false,
+            stale_index: false,
+            note: None,
+        }
+        .with_scan_budget_note();
+        assert_eq!(r.note.as_deref(), Some(SCAN_BUDGET_NOTE));
+    }
+
+    /// A genuinely exhaustive empty search HAS established that nothing matches,
+    /// so it must not be hedged — the note would be a false caveat.
+    #[test]
+    fn empty_but_complete_search_gets_no_note() {
+        let r = RegexSearchResult {
+            results: vec![],
+            truncated: false,
+            scanned_fallback: false,
+            stale_index: false,
+            note: None,
+        }
+        .with_scan_budget_note();
+        assert!(r.note.is_none(), "a complete empty scan must not be hedged");
+    }
+
+    /// Results present means the caller has something concrete; the budget note
+    /// is about an EMPTY result being misread.
+    #[test]
+    fn truncated_with_results_gets_no_scan_budget_note() {
+        let hit = RegexMatch {
+            uid: "sym:x".into(),
+            kind: "Symbol".into(),
+            title: "x".into(),
+            location: "a.rs".into(),
+            line: Some(1),
+            snippet: "x".into(),
+        };
+        let r = RegexSearchResult {
+            results: vec![hit],
+            truncated: true,
+            scanned_fallback: false,
+            stale_index: false,
+            note: None,
+        }
+        .with_scan_budget_note();
+        assert!(r.note.is_none());
+    }
+
     use super::*;
     use nestweaver_schema::{Note, NoteKind, Section, Symbol, SymbolKind, Visibility};
 

--- a/crates/nestweaver-store/src/traverse.rs
+++ b/crates/nestweaver-store/src/traverse.rs
@@ -1495,6 +1495,109 @@ mod tests {
         }
     }
 
+    /// nw-111: the callee traversal must REPORT which edge reached each callee.
+    ///
+    /// It spans CALLS, IMPORTS and CROSS_REPO_LINK, and the last is an inferred
+    /// link between repos rather than an observed call. Collapsing them to a bare
+    /// symbol list meant `flow_trace` presented fabricated cross-language
+    /// execution paths as real ones — tracing a Rust function returned JavaScript
+    /// symbols from unrelated repos as its callees, with nothing in the payload
+    /// to tell them apart. `impact` has always returned the edge type; this is the
+    /// callee-side parity.
+    #[test]
+    fn callee_traversal_reports_the_edge_type_that_reached_each_callee() {
+        use nestweaver_schema::{CrossRepoLinkType, EdgeType, ResolvedEdge};
+
+        let store = GraphStore::in_memory().unwrap();
+        for uid in ["root", "real_callee", "remote_guess"] {
+            store.insert_symbol(&make_symbol(uid, uid)).unwrap();
+        }
+
+        // An observed call...
+        store
+            .insert_edge(&ResolvedEdge {
+                source_uid: "root".to_string(),
+                target_uid: "real_callee".to_string(),
+                edge_type: EdgeType::Calls,
+                confidence: 1.0,
+                link_type: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
+        // ...and an INFERRED cross-repo link, which is not a call at all.
+        store
+            .insert_edge(&ResolvedEdge {
+                source_uid: "root".to_string(),
+                target_uid: "remote_guess".to_string(),
+                edge_type: EdgeType::CrossRepoLink,
+                confidence: 0.9,
+                link_type: Some(CrossRepoLinkType::SharedImport),
+                evidence: Vec::new(),
+            })
+            .unwrap();
+
+        let callees = store.callees_with_edge_types_of("root").unwrap();
+        let by_uid: std::collections::HashMap<&str, &str> = callees
+            .iter()
+            .map(|(sym, et)| (sym.uid.as_str(), et.as_str()))
+            .collect();
+
+        assert_eq!(
+            by_uid.get("real_callee"),
+            Some(&"CALLS"),
+            "an observed call must be labelled CALLS; got {by_uid:?}"
+        );
+        assert_eq!(
+            by_uid.get("remote_guess"),
+            Some(&"CROSS_REPO_LINK"),
+            "a cross-repo hypothesis must be labelled, not presented as a call; got {by_uid:?}"
+        );
+
+        // The unlabelled helper still returns both, so existing callers are
+        // unaffected — this adds information rather than removing any.
+        let plain = store.callees_of("root").unwrap();
+        assert_eq!(plain.len(), 2, "callees_of must be unchanged in coverage");
+    }
+
+    /// A callee reachable by BOTH a real call and a cross-repo link must be
+    /// reported as the stronger CALLS, not downgraded to a guess.
+    #[test]
+    fn a_callee_reachable_two_ways_reports_the_strongest_edge() {
+        use nestweaver_schema::{CrossRepoLinkType, EdgeType, ResolvedEdge};
+
+        let store = GraphStore::in_memory().unwrap();
+        for uid in ["root", "shared"] {
+            store.insert_symbol(&make_symbol(uid, uid)).unwrap();
+        }
+        store
+            .insert_edge(&ResolvedEdge {
+                source_uid: "root".to_string(),
+                target_uid: "shared".to_string(),
+                edge_type: EdgeType::CrossRepoLink,
+                confidence: 0.9,
+                link_type: Some(CrossRepoLinkType::SharedImport),
+                evidence: Vec::new(),
+            })
+            .unwrap();
+        store
+            .insert_edge(&ResolvedEdge {
+                source_uid: "root".to_string(),
+                target_uid: "shared".to_string(),
+                edge_type: EdgeType::Calls,
+                confidence: 1.0,
+                link_type: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
+
+        let callees = store.callees_with_edge_types_of("root").unwrap();
+        assert_eq!(callees.len(), 1, "de-duplicated by symbol: {callees:?}");
+        assert_eq!(
+            callees[0].1, "CALLS",
+            "strongest evidence wins: {callees:?}"
+        );
+    }
+
     /// Impact analysis must follow CROSS_REPO_LINK edges so that callers in
     /// other repos (modeled as cross-repo links in a unified multi-repo graph)
     /// are reported. Regression guard for cross-boundary intelligence: without

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -255,6 +255,13 @@ impl RepoDeletionSnapshot {
 /// `(uid, source_note_uid, source_path, source_title, wikilink_text)`.
 pub type UnresolvedWikilinkRecord = (String, String, String, String, String);
 
+/// One captured wikilink edge: `(source_section_uid, target_node_uid,
+/// confidence, display_text, link_target)`.
+///
+/// `display_text` is what a reader sees, `link_target` is what resolution acted
+/// on; for `[[Home|workspace]]` those are "workspace" and "Home" (nw-122).
+pub type WikilinkEdgeRecord = (String, String, f32, String, String);
+
 /// A vault whose notes were discarded during a collision in instance merge.
 /// When two instances have vaults at the same root_path, the vault with
 /// fewer notes loses and its notes are cascade-deleted.
@@ -1193,8 +1200,8 @@ impl GraphStore {
         tags: &[Tag],
         note_tag_edges: &[(&str, &str)],
         section_tag_edges: &[(&str, &str)],
-        wikilink_to_note_edges: &[(&str, &str, f32, &str)],
-        wikilink_to_heading_edges: &[(&str, &str, f32, &str)],
+        wikilink_to_note_edges: &[(&str, &str, f32, &str, &str)],
+        wikilink_to_heading_edges: &[(&str, &str, f32, &str, &str)],
     ) -> Result<(), StoreError> {
         let conn = self.begin_transaction()?;
         Self::bulk_vault_write_on(
@@ -1236,8 +1243,8 @@ impl GraphStore {
         tags: &[Tag],
         note_tag_edges: &[(&str, &str)],
         section_tag_edges: &[(&str, &str)],
-        wikilink_to_note_edges: &[(&str, &str, f32, &str)],
-        wikilink_to_heading_edges: &[(&str, &str, f32, &str)],
+        wikilink_to_note_edges: &[(&str, &str, f32, &str, &str)],
+        wikilink_to_heading_edges: &[(&str, &str, f32, &str, &str)],
     ) -> Result<(), StoreError> {
         // Insert node tables first so edge MATCH clauses find their endpoints.
         Self::batch_insert_notes_on(conn, notes)?;
@@ -1293,8 +1300,8 @@ impl GraphStore {
         tags: &[Tag],
         note_tag_edges: &[(&str, &str)],
         section_tag_edges: &[(&str, &str)],
-        wikilink_to_note_edges: &[(&str, &str, f32, &str)],
-        wikilink_to_heading_edges: &[(&str, &str, f32, &str)],
+        wikilink_to_note_edges: &[(&str, &str, f32, &str, &str)],
+        wikilink_to_heading_edges: &[(&str, &str, f32, &str, &str)],
     ) -> Result<usize, StoreError> {
         let conn = self.begin_transaction()?;
 
@@ -2104,7 +2111,7 @@ impl GraphStore {
 
     pub fn batch_insert_wikilink_to_note_edges(
         &self,
-        edges: &[(&str, &str, f32, &str)],
+        edges: &[(&str, &str, f32, &str, &str)],
     ) -> Result<(), StoreError> {
         let conn = self.conn()?;
         Self::batch_insert_wikilink_to_note_edges_on(&conn, edges)
@@ -2113,15 +2120,15 @@ impl GraphStore {
     /// Insert wikilink-to-note edges using an externally-provided connection (for transaction batching).
     pub fn batch_insert_wikilink_to_note_edges_on(
         conn: &lbug::Connection<'_>,
-        edges: &[(&str, &str, f32, &str)],
+        edges: &[(&str, &str, f32, &str, &str)],
     ) -> Result<(), StoreError> {
         let mut stmt = conn
             .prepare(
                 "MATCH (s:Section {uid: $sid}), (n:Note {uid: $nid}) \
-                 CREATE (s)-[:WIKILINK_TO_NOTE {confidence: $conf, display: $disp}]->(n)",
+                 CREATE (s)-[:WIKILINK_TO_NOTE {confidence: $conf, display: $disp, target: $tgt}]->(n)",
             )
             .map_err(|e| StoreError::Query(format!("prepare: {e}")))?;
-        for (sec_uid, note_uid, conf, display) in edges {
+        for (sec_uid, note_uid, conf, display, target) in edges {
             conn.execute(
                 &mut stmt,
                 vec![
@@ -2129,6 +2136,7 @@ impl GraphStore {
                     ("nid", lbug::Value::String(note_uid.to_string())),
                     ("conf", lbug::Value::Double(*conf as f64)),
                     ("disp", lbug::Value::String(display.to_string())),
+                    ("tgt", lbug::Value::String(target.to_string())),
                 ],
             )
             .map_err(|e| StoreError::Query(format!("execute: {e}")))?;
@@ -2138,7 +2146,7 @@ impl GraphStore {
 
     pub fn batch_insert_wikilink_to_heading_edges(
         &self,
-        edges: &[(&str, &str, f32, &str)],
+        edges: &[(&str, &str, f32, &str, &str)],
     ) -> Result<(), StoreError> {
         let conn = self.conn()?;
         Self::batch_insert_wikilink_to_heading_edges_on(&conn, edges)
@@ -2147,15 +2155,15 @@ impl GraphStore {
     /// Insert wikilink-to-heading edges using an externally-provided connection (for transaction batching).
     pub fn batch_insert_wikilink_to_heading_edges_on(
         conn: &lbug::Connection<'_>,
-        edges: &[(&str, &str, f32, &str)],
+        edges: &[(&str, &str, f32, &str, &str)],
     ) -> Result<(), StoreError> {
         let mut stmt = conn
             .prepare(
                 "MATCH (s:Section {uid: $sid}), (h:Heading {uid: $hid}) \
-                 CREATE (s)-[:WIKILINK_TO_HEADING {confidence: $conf, display: $disp}]->(h)",
+                 CREATE (s)-[:WIKILINK_TO_HEADING {confidence: $conf, display: $disp, target: $tgt}]->(h)",
             )
             .map_err(|e| StoreError::Query(format!("prepare: {e}")))?;
-        for (sec_uid, head_uid, conf, display) in edges {
+        for (sec_uid, head_uid, conf, display, target) in edges {
             conn.execute(
                 &mut stmt,
                 vec![
@@ -2163,6 +2171,7 @@ impl GraphStore {
                     ("hid", lbug::Value::String(head_uid.to_string())),
                     ("conf", lbug::Value::Double(*conf as f64)),
                     ("disp", lbug::Value::String(display.to_string())),
+                    ("tgt", lbug::Value::String(target.to_string())),
                 ],
             )
             .map_err(|e| StoreError::Query(format!("execute: {e}")))?;
@@ -4978,11 +4987,11 @@ impl GraphStore {
         vault_uid: &str,
         rel: &str,
         dst: &str,
-    ) -> Result<Vec<(String, String, f32, String)>, StoreError> {
+    ) -> Result<Vec<WikilinkEdgeRecord>, StoreError> {
         let conn = self.conn()?;
         let q = format!(
             "MATCH (n:Note {{vault_uid: $vid}})-[:NOTE_HAS_SECTION]->(s:Section)-[r:{rel}]->({dst}) \
-             RETURN s.uid, dst.uid, r.confidence, r.display"
+             RETURN s.uid, dst.uid, r.confidence, r.display, r.target"
         );
         let mut stmt = match conn.prepare(&q) {
             Ok(stmt) => stmt,
@@ -5014,6 +5023,10 @@ impl GraphStore {
                         })
                         .unwrap_or(0.0),
                     crate::read::extract_string(&row, 3).unwrap_or_default(),
+                    // nw-122: `target` is empty on rows written before the
+                    // column existed; readers fall back to `display`, which is
+                    // exactly what those rows have always carried.
+                    crate::read::extract_string(&row, 4).unwrap_or_default(),
                 ))
             })
             .collect())
@@ -5160,9 +5173,9 @@ impl GraphStore {
         // here, so restoring them verbatim is sufficient. A link whose TARGET
         // lives in another vault is preserved too: that node is untouched by
         // this cascade.
-        let wikilink_to_note: Vec<(String, String, f32, String)> =
+        let wikilink_to_note: Vec<WikilinkEdgeRecord> =
             self.wikilink_edges_for_vault(old_vault_uid, "WIKILINK_TO_NOTE", "dst:Note")?;
-        let wikilink_to_heading: Vec<(String, String, f32, String)> =
+        let wikilink_to_heading: Vec<WikilinkEdgeRecord> =
             self.wikilink_edges_for_vault(old_vault_uid, "WIKILINK_TO_HEADING", "dst:Heading")?;
 
         // `delete_vault_cascade` removes UnresolvedWikilink rows whose source
@@ -5238,16 +5251,32 @@ impl GraphStore {
         // 9. Restore the wikilink graph. Runs last: the edges reference
         //    sections, notes and headings, all of which are back in place by
         //    now (nw-112).
-        let wl_note: Vec<(&str, &str, f32, &str)> = wikilink_to_note
+        let wl_note: Vec<(&str, &str, f32, &str, &str)> = wikilink_to_note
             .iter()
-            .map(|(src, dst, conf, disp)| (src.as_str(), dst.as_str(), *conf, disp.as_str()))
+            .map(|(src, dst, conf, disp, tgt)| {
+                (
+                    src.as_str(),
+                    dst.as_str(),
+                    *conf,
+                    disp.as_str(),
+                    tgt.as_str(),
+                )
+            })
             .collect();
         if !wl_note.is_empty() {
             Self::batch_insert_wikilink_to_note_edges_on(conn, &wl_note)?;
         }
-        let wl_heading: Vec<(&str, &str, f32, &str)> = wikilink_to_heading
+        let wl_heading: Vec<(&str, &str, f32, &str, &str)> = wikilink_to_heading
             .iter()
-            .map(|(src, dst, conf, disp)| (src.as_str(), dst.as_str(), *conf, disp.as_str()))
+            .map(|(src, dst, conf, disp, tgt)| {
+                (
+                    src.as_str(),
+                    dst.as_str(),
+                    *conf,
+                    disp.as_str(),
+                    tgt.as_str(),
+                )
+            })
             .collect();
         if !wl_heading.is_empty() {
             Self::batch_insert_wikilink_to_heading_edges_on(conn, &wl_heading)?;
@@ -6623,6 +6652,7 @@ mod tests {
                 src_sec.as_str(),
                 dst_note.as_str(),
                 1.0f32,
+                "Beta",
                 "Beta",
             )])
             .unwrap();

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -251,6 +251,10 @@ impl RepoDeletionSnapshot {
     }
 }
 
+/// One recorded unresolved wikilink:
+/// `(uid, source_note_uid, source_path, source_title, wikilink_text)`.
+pub type UnresolvedWikilinkRecord = (String, String, String, String, String);
+
 /// A vault whose notes were discarded during a collision in instance merge.
 /// When two instances have vaults at the same root_path, the vault with
 /// fewer notes loses and its notes are cascade-deleted.
@@ -1969,7 +1973,7 @@ impl GraphStore {
     /// `(uid, source_note_uid, source_path, source_title, wikilink_text)`.
     pub fn batch_insert_unresolved_wikilinks(
         &self,
-        records: &[(String, String, String, String, String)],
+        records: &[UnresolvedWikilinkRecord],
     ) -> Result<(), StoreError> {
         if records.is_empty() {
             return Ok(());
@@ -1978,6 +1982,20 @@ impl GraphStore {
         // per statement otherwise, which is what made the per-row insert take
         // ~ms/link. Prepared statements are reused across the batch.
         let conn = self.begin_transaction()?;
+        Self::batch_insert_unresolved_wikilinks_on(&conn, records)?;
+        self.commit_transaction(&conn)?;
+        Ok(())
+    }
+
+    /// Insert unresolved wikilinks on a caller-provided connection, so a larger
+    /// transaction (e.g. `reparent_vault`) can batch them with its other work.
+    pub fn batch_insert_unresolved_wikilinks_on(
+        conn: &lbug::Connection<'_>,
+        records: &[UnresolvedWikilinkRecord],
+    ) -> Result<(), StoreError> {
+        if records.is_empty() {
+            return Ok(());
+        }
         let mut del = conn
             .prepare("MATCH (u:UnresolvedWikilink {uid: $uid}) DETACH DELETE u")
             .map_err(|e| StoreError::Query(format!("prepare delete unresolved: {e}")))?;
@@ -2002,7 +2020,6 @@ impl GraphStore {
             )
             .map_err(|e| StoreError::Query(format!("create unresolved: {e}")))?;
         }
-        self.commit_transaction(&conn)?;
         Ok(())
     }
 
@@ -4949,6 +4966,86 @@ impl GraphStore {
     ///
     /// Uses the LadybugDB-compatible DETACH DELETE + re-CREATE pattern
     /// since SET is not supported for property updates.
+    /// Read wikilink edges that ORIGINATE in `vault_uid`, as
+    /// `(section_uid, target_uid, confidence, display)`.
+    ///
+    /// `rel` is the relationship name and `dst` the destination pattern, so one
+    /// helper serves both WIKILINK_TO_NOTE and WIKILINK_TO_HEADING. Best-effort:
+    /// a missing table yields an empty vec rather than an error, matching how
+    /// the cascade treats these tables.
+    fn wikilink_edges_for_vault(
+        &self,
+        vault_uid: &str,
+        rel: &str,
+        dst: &str,
+    ) -> Result<Vec<(String, String, f32, String)>, StoreError> {
+        let conn = self.conn()?;
+        let q = format!(
+            "MATCH (n:Note {{vault_uid: $vid}})-[:NOTE_HAS_SECTION]->(s:Section)-[r:{rel}]->({dst}) \
+             RETURN s.uid, dst.uid, r.confidence, r.display"
+        );
+        let mut stmt = match conn.prepare(&q) {
+            Ok(stmt) => stmt,
+            Err(e) => {
+                tracing::trace!("wikilink_edges_for_vault: prepare {rel} skipped: {e}");
+                return Ok(Vec::new());
+            }
+        };
+        let result = match conn.execute(
+            &mut stmt,
+            vec![("vid", lbug::Value::String(vault_uid.to_string()))],
+        ) {
+            Ok(result) => result,
+            Err(e) => {
+                tracing::trace!("wikilink_edges_for_vault: execute {rel} skipped: {e}");
+                return Ok(Vec::new());
+            }
+        };
+        Ok(result
+            .filter_map(|row| {
+                Some((
+                    crate::read::extract_string(&row, 0).ok()?,
+                    crate::read::extract_string(&row, 1).ok()?,
+                    row.get(2)
+                        .and_then(|v| match v {
+                            lbug::Value::Double(d) => Some(*d as f32),
+                            lbug::Value::Float(f) => Some(*f),
+                            _ => None,
+                        })
+                        .unwrap_or(0.0),
+                    crate::read::extract_string(&row, 3).unwrap_or_default(),
+                ))
+            })
+            .collect())
+    }
+
+    /// Read every UnresolvedWikilink row as
+    /// `(uid, source_note_uid, source_path, source_title, wikilink_text)`.
+    /// Callers filter by source note. Best-effort on a missing table.
+    fn all_unresolved_wikilinks(&self) -> Result<Vec<UnresolvedWikilinkRecord>, StoreError> {
+        let conn = self.conn()?;
+        let q = "MATCH (u:UnresolvedWikilink) \
+                 RETURN u.uid, u.source_note_uid, u.source_path, u.source_title, u.wikilink_text";
+        let result = match conn.query(q) {
+            Ok(result) => result,
+            Err(e) => {
+                tracing::trace!("all_unresolved_wikilinks skipped: {e}");
+                return Ok(Vec::new());
+            }
+        };
+        Ok(result
+            .filter_map(|row| {
+                Some((
+                    crate::read::extract_string(&row, 0).ok()?,
+                    crate::read::extract_string(&row, 1).ok()?,
+                    crate::read::extract_string(&row, 2).unwrap_or_default(),
+                    crate::read::extract_string(&row, 3).unwrap_or_default(),
+                    crate::read::extract_string(&row, 4).unwrap_or_default(),
+                ))
+            })
+            .collect())
+    }
+
     pub fn reparent_vault(
         &self,
         old_vault_uid: &str,
@@ -5051,6 +5148,36 @@ impl GraphStore {
                     .map(|huid| (huid.as_str(), s.uid.as_str()))
             })
             .collect();
+        // Capture the wikilink graph before the cascade destroys it (nw-112).
+        //
+        // Every other child and edge above is captured and re-inserted, but
+        // wikilinks were not — so `instance merge` reparented a vault and
+        // silently wiped the note-to-note link graph, 2,067 edges to 0 on the
+        // real brain, while reporting success. Backlinks, broken-link detection
+        // and the graph view all went empty with no warning.
+        //
+        // Edges are keyed on section/note/heading UIDs, none of which change
+        // here, so restoring them verbatim is sufficient. A link whose TARGET
+        // lives in another vault is preserved too: that node is untouched by
+        // this cascade.
+        let wikilink_to_note: Vec<(String, String, f32, String)> =
+            self.wikilink_edges_for_vault(old_vault_uid, "WIKILINK_TO_NOTE", "dst:Note")?;
+        let wikilink_to_heading: Vec<(String, String, f32, String)> =
+            self.wikilink_edges_for_vault(old_vault_uid, "WIKILINK_TO_HEADING", "dst:Heading")?;
+
+        // `delete_vault_cascade` removes UnresolvedWikilink rows whose source
+        // note belongs to this vault (its step 5), so they need restoring as
+        // well or `broken-links` comes back empty after a merge.
+        // UIDs are unchanged by reparenting (only vault_uid moves), so the
+        // reparented list identifies the same notes.
+        let note_uid_set: std::collections::HashSet<&str> =
+            reparented_notes.iter().map(|n| n.uid.as_str()).collect();
+        let unresolved: Vec<UnresolvedWikilinkRecord> = self
+            .all_unresolved_wikilinks()?
+            .into_iter()
+            .filter(|(_, source_note_uid, _, _, _)| note_uid_set.contains(source_note_uid.as_str()))
+            .collect();
+
         let reparented_tags: Vec<Tag> = tags
             .into_iter()
             .map(|t| Tag {
@@ -5107,6 +5234,28 @@ impl GraphStore {
         if !st_edges.is_empty() {
             Self::batch_insert_section_tag_edges_on(conn, &st_edges)?;
         }
+
+        // 9. Restore the wikilink graph. Runs last: the edges reference
+        //    sections, notes and headings, all of which are back in place by
+        //    now (nw-112).
+        let wl_note: Vec<(&str, &str, f32, &str)> = wikilink_to_note
+            .iter()
+            .map(|(src, dst, conf, disp)| (src.as_str(), dst.as_str(), *conf, disp.as_str()))
+            .collect();
+        if !wl_note.is_empty() {
+            Self::batch_insert_wikilink_to_note_edges_on(conn, &wl_note)?;
+        }
+        let wl_heading: Vec<(&str, &str, f32, &str)> = wikilink_to_heading
+            .iter()
+            .map(|(src, dst, conf, disp)| (src.as_str(), dst.as_str(), *conf, disp.as_str()))
+            .collect();
+        if !wl_heading.is_empty() {
+            Self::batch_insert_wikilink_to_heading_edges_on(conn, &wl_heading)?;
+        }
+        if !unresolved.is_empty() {
+            Self::batch_insert_unresolved_wikilinks_on(conn, &unresolved)?;
+        }
+
         self.commit_transaction(&txn)?;
 
         Ok(result)
@@ -6402,6 +6551,92 @@ mod tests {
                 name: "one".to_string(),
             })
             .unwrap();
+    }
+
+    /// nw-112: a merge must CONSERVE the wikilink graph.
+    ///
+    /// `reparent_vault` captures notes, headings, sections, tags and their edges
+    /// before the cascade delete, then re-inserts them — but it never captured
+    /// wikilink edges, so the cascade destroyed them and nothing put them back.
+    /// On the real brain this took wikilinks 2,067 -> 0 while the command
+    /// printed success and exited 0: backlinks, broken-link detection and the
+    /// graph view all went silently empty.
+    #[test]
+    fn merge_conserves_the_wikilink_graph() {
+        let store = GraphStore::in_memory().expect("store");
+
+        let vault_uid = "vlt:old:aaaa";
+        store
+            .insert_vault(&Vault {
+                uid: vault_uid.to_string(),
+                name: "brain".to_string(),
+                root_path: "/brain".to_string(),
+                instance_id: "old".to_string(),
+            })
+            .unwrap();
+
+        // Two notes, each with one section, and a wikilink from A's section to B.
+        for (n, title) in [("a", "Alpha"), ("b", "Beta")] {
+            store
+                .insert_note(&Note {
+                    uid: format!("note:{vault_uid}:{n}"),
+                    vault_uid: vault_uid.to_string(),
+                    file_path: format!("{n}.md"),
+                    title: title.to_string(),
+                    note_kind: nestweaver_schema::NoteKind::General,
+                    word_count: 1,
+                    content_hash: n.to_string(),
+                    frontmatter: None,
+                    created_at: None,
+                    modified_at: None,
+                    pagerank_score: None,
+                    embedding: None,
+                })
+                .unwrap();
+            store
+                .insert_section(&Section {
+                    uid: format!("sec:{vault_uid}:{n}"),
+                    note_uid: format!("note:{vault_uid}:{n}"),
+                    heading_uid: None,
+                    start_line: 1,
+                    end_line: 2,
+                    text_hash: n.to_string(),
+                    text_content: format!("body {n}"),
+                    word_count: 2,
+                    pagerank_score: None,
+                })
+                .unwrap();
+            let note_uid = format!("note:{vault_uid}:{n}");
+            let sec_uid = format!("sec:{vault_uid}:{n}");
+            store
+                .batch_insert_note_section_edges(&[(note_uid.as_str(), sec_uid.as_str())])
+                .unwrap();
+            store
+                .batch_insert_vault_note_edges(&[(vault_uid, note_uid.as_str())])
+                .unwrap();
+        }
+
+        let src_sec = format!("sec:{vault_uid}:a");
+        let dst_note = format!("note:{vault_uid}:b");
+        store
+            .batch_insert_wikilink_to_note_edges(&[(
+                src_sec.as_str(),
+                dst_note.as_str(),
+                1.0f32,
+                "Beta",
+            )])
+            .unwrap();
+
+        let before = store.count_wikilink_edges().unwrap();
+        assert_eq!(before, 1, "fixture must start with a wikilink");
+
+        store.merge_instance_ids("old", "new").unwrap();
+
+        let after = store.count_wikilink_edges().unwrap();
+        assert_eq!(
+            after, before,
+            "merge destroyed the wikilink graph: {before} -> {after}"
+        );
     }
 
     #[test]

--- a/docs/guide/instance-id-migration.md
+++ b/docs/guide/instance-id-migration.md
@@ -143,6 +143,13 @@ to the logical name.
 - `brain add`, `brain watch`, and `brain refresh` all resolve the instance the
   same way (`--instance` flag, then the config's `instance_id`, then
   `"default"`), so a `--config`-driven workflow stays consistent on its own.
+- `brain refresh` additionally resolves from an **existing registration** for
+  that vault root, and prefers it over the `"default"` fallback (nw-098). A
+  refresh with no `--instance`/`--config` therefore refreshes the vault that is
+  already there instead of registering a second one for the same root. An
+  explicit instance that disagrees with the registration is refused, naming
+  both, rather than creating the duplicate — a split root makes note counts the
+  SUM of both vaults and `brain search` return duplicate rows.
 
 Once a database is consolidated and you always start the daemon with `--config`,
 it stays single-convention and you won't need this runbook again.

--- a/src/main.rs
+++ b/src/main.rs
@@ -365,10 +365,238 @@ fn format_elapsed(elapsed: std::time::Duration) -> String {
     }
 }
 
+// ── nw-073: lbug optimisticRead crash recurrence ──────────────────────────────
+//
+// nw-073 ships MITIGATED, not fixed. Write-capable opens bound the lbug engine
+// thread pool to remove the concurrency the eviction-vs-read race needs, but
+// that rests on an analysis of a crash which was never reproduced locally — and
+// nothing in the product could tell you whether the race was still firing.
+// This scan is that signal, and it is worth more than the root-cause fix,
+// because it says whether the root cause still matters.
+
+/// Stack frame identifying the nw-073 fault.
+const LBUG_CRASH_FRAME: &str = "optimisticRead";
+
+/// Process-name fragment selecting reports that belong to this product.
+const CRASH_REPORT_PROCESS: &str = "nestweaver";
+
+/// `PATH`-style override for the directories scanned; also the test hook.
+const CRASH_REPORT_DIRS_ENV: &str = "NESTWEAVER_CRASH_REPORT_DIRS";
+
+/// Cap on bytes read from any single report.
+const CRASH_REPORT_READ_LIMIT: u64 = 4 * 1024 * 1024;
+
+/// True when `file_name` names a macOS *crash* report rather than a resource
+/// diagnostic.
+///
+/// This distinction is the whole correctness of the check. Both kinds live in
+/// the same directories, but `.diag` files (including `*.cpu_resource.diag`)
+/// are assembled from periodic stack samples of a *running, healthy* process.
+/// On the machine this was developed against, 13 of them contain
+/// `optimisticRead` purely because it is a hot read path during indexing.
+/// Matching those would report a use-after-free every time indexing ran warm —
+/// worse than no check at all, because it would be confidently wrong.
+fn is_crash_report_file(file_name: &str) -> bool {
+    let lower = file_name.to_ascii_lowercase();
+    lower.ends_with(".ips") || lower.ends_with(".crash")
+}
+
+/// True when the file is a crash report belonging to this product.
+fn is_candidate_crash_report(file_name: &str) -> bool {
+    is_crash_report_file(file_name)
+        && file_name
+            .to_ascii_lowercase()
+            .contains(CRASH_REPORT_PROCESS)
+}
+
+/// True when a crash report carries the nw-073 signature.
+fn crash_report_matches_signature(file_name: &str, contents: &str) -> bool {
+    is_candidate_crash_report(file_name) && contents.contains(LBUG_CRASH_FRAME)
+}
+
+/// Outcome of a crash-report sweep.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct CrashRecurrenceScan {
+    /// Whether a scan was attempted at all on this platform.
+    supported: bool,
+    /// Directories successfully opened.
+    directories_read: usize,
+    /// Directories or reports that exist but could not be read.
+    unreadable: Vec<String>,
+    /// Candidate reports whose contents were checked.
+    reports_examined: usize,
+    /// Reports carrying the signature.
+    matched_reports: Vec<String>,
+}
+
+impl CrashRecurrenceScan {
+    /// The scan's own honesty about what it saw.
+    ///
+    /// `unavailable` and `scanned` are deliberately distinct: a caller must be
+    /// able to tell "no crashes" from "could not look". Reporting a zero for
+    /// the latter is the nw-062 defect — a caller cannot distinguish an absence
+    /// of findings from an absence of data.
+    fn status(&self) -> &'static str {
+        if !self.supported {
+            "unsupported"
+        } else if self.directories_read == 0 {
+            "unavailable"
+        } else if !self.unreadable.is_empty() {
+            "partial"
+        } else {
+            "scanned"
+        }
+    }
+
+    /// A count is only meaningful once at least one directory was read.
+    fn has_count(&self) -> bool {
+        self.directories_read > 0
+    }
+}
+
+/// Human-readable summary of what the scan does and does not establish.
+fn crash_recurrence_note(scan: &CrashRecurrenceScan) -> String {
+    match scan.status() {
+        "unsupported" => format!(
+            "crash-report scanning is implemented for macOS only; set {CRASH_REPORT_DIRS_ENV} to scan explicit directories"
+        ),
+        "unavailable" => format!(
+            "no crash-report directory could be read, so recurrence is UNKNOWN — this is not a clean bill of health; set {CRASH_REPORT_DIRS_ENV} to point at readable directories"
+        ),
+        _ if !scan.matched_reports.is_empty() => format!(
+            "nw-073 IS STILL FIRING — {} crash report(s) carry the {LBUG_CRASH_FRAME} signature; the thread-pool mitigation is not holding and the root-cause fix (BM_MALLOC reader pinning) is required",
+            scan.matched_reports.len()
+        ),
+        "partial" => format!(
+            "no matching crash reports in {} directories, but {} could not be read — this zero is not exhaustive",
+            scan.directories_read,
+            scan.unreadable.len()
+        ),
+        _ => format!(
+            "no crash reports carry the {LBUG_CRASH_FRAME} signature across {} directories ({} candidate report(s) examined); the mitigation appears to be holding",
+            scan.directories_read, scan.reports_examined
+        ),
+    }
+}
+
+fn crash_recurrence_value(scan: &CrashRecurrenceScan) -> serde_json::Value {
+    serde_json::json!({
+        "backlog_id": "nw-073",
+        "signature": format!("lbug::storage::BufferManager::{LBUG_CRASH_FRAME}"),
+        "status": scan.status(),
+        // Null rather than 0 when nothing was scanned: a zero here would be a
+        // claim the scan never earned.
+        "crash_reports_matched": if scan.has_count() {
+            serde_json::json!(scan.matched_reports.len())
+        } else {
+            serde_json::Value::Null
+        },
+        "matched_reports": scan.matched_reports,
+        "reports_examined": scan.reports_examined,
+        "directories_read": scan.directories_read,
+        "unreadable": scan.unreadable,
+        "note": crash_recurrence_note(scan),
+    })
+}
+
+/// Directories to sweep, and whether sweeping is supported here.
+fn crash_report_directories() -> (Vec<PathBuf>, bool) {
+    if let Some(raw) = std::env::var_os(CRASH_REPORT_DIRS_ENV) {
+        let dirs: Vec<PathBuf> = std::env::split_paths(&raw)
+            .filter(|path| !path.as_os_str().is_empty())
+            .collect();
+        if !dirs.is_empty() {
+            return (dirs, true);
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let mut dirs = Vec::new();
+        if let Some(home) = std::env::var_os("HOME") {
+            let home = PathBuf::from(home);
+            dirs.push(home.join("Library/Logs/DiagnosticReports"));
+            dirs.push(home.join("Library/Logs/DiagnosticReports/Retired"));
+        }
+        // The SYSTEM directory matters as much as the per-user one. The original
+        // nw-073 investigation checked only `~/Library`, found nothing, and
+        // recorded "no crash logs on this machine" — while every nestweaver
+        // report on that Mac was sitting in `/Library`.
+        dirs.push(PathBuf::from("/Library/Logs/DiagnosticReports"));
+        dirs.push(PathBuf::from("/Library/Logs/DiagnosticReports/Retired"));
+        (dirs, true)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        (Vec::new(), false)
+    }
+}
+
+/// Read a report, capped, tolerating non-UTF-8 bytes.
+fn read_crash_report(path: &Path) -> std::io::Result<String> {
+    use std::io::Read;
+    let mut buffer = Vec::new();
+    std::fs::File::open(path)?
+        .take(CRASH_REPORT_READ_LIMIT)
+        .read_to_end(&mut buffer)?;
+    Ok(String::from_utf8_lossy(&buffer).into_owned())
+}
+
+fn scan_crash_recurrence() -> CrashRecurrenceScan {
+    let (directories, supported) = crash_report_directories();
+    scan_crash_reports_in(&directories, supported)
+}
+
+fn scan_crash_reports_in(directories: &[PathBuf], supported: bool) -> CrashRecurrenceScan {
+    let mut scan = CrashRecurrenceScan {
+        supported,
+        ..Default::default()
+    };
+
+    for directory in directories {
+        let entries = match std::fs::read_dir(directory) {
+            Ok(entries) => entries,
+            Err(error) => {
+                // A missing directory contributes no evidence but is not a
+                // fault (`Retired/` often does not exist). A directory that
+                // exists and cannot be read is a fault, and must not be
+                // silently folded into a clean result.
+                if error.kind() != std::io::ErrorKind::NotFound {
+                    scan.unreadable
+                        .push(format!("{}: {error}", directory.display()));
+                }
+                continue;
+            }
+        };
+        scan.directories_read += 1;
+
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if !is_candidate_crash_report(&name) {
+                continue;
+            }
+            scan.reports_examined += 1;
+            match read_crash_report(&entry.path()) {
+                Ok(contents) if crash_report_matches_signature(&name, &contents) => {
+                    scan.matched_reports.push(name);
+                }
+                Ok(_) => {}
+                Err(error) => scan
+                    .unreadable
+                    .push(format!("{}: {error}", entry.path().display())),
+            }
+        }
+    }
+
+    scan.matched_reports.sort();
+    scan
+}
+
 fn capability_diagnostics_value(
     embedding_compiled: bool,
     metal_compiled: bool,
     runtime_probe: Result<(), String>,
+    crash_recurrence: serde_json::Value,
 ) -> serde_json::Value {
     let (metal_runtime_available, metal_runtime_error) = match runtime_probe {
         Ok(()) => (true, None),
@@ -379,16 +607,19 @@ fn capability_diagnostics_value(
         "metal_compiled": metal_compiled,
         "metal_runtime_available": metal_runtime_available,
         "metal_runtime_error": metal_runtime_error,
+        "crash_recurrence": crash_recurrence,
     })
 }
 
 fn current_capability_diagnostics() -> serde_json::Value {
+    let crash_recurrence = crash_recurrence_value(&scan_crash_recurrence());
     #[cfg(feature = "embed")]
     {
         capability_diagnostics_value(
             true,
             nestweaver_embed::metal_compiled(),
             nestweaver_embed::probe_metal_runtime().map_err(|error| format!("{error:#}")),
+            crash_recurrence,
         )
     }
     #[cfg(not(feature = "embed"))]
@@ -397,6 +628,7 @@ fn current_capability_diagnostics() -> serde_json::Value {
             false,
             false,
             Err("embedding support was not compiled into this binary".to_string()),
+            crash_recurrence,
         )
     }
 }
@@ -10662,6 +10894,45 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 if let Some(error) = capabilities["metal_runtime_error"].as_str() {
                     println!("  Runtime probe error: {error}");
                 }
+
+                // Parity contract: if --json reports a caveat, the human output
+                // must say so too.
+                let crash = &capabilities["crash_recurrence"];
+                println!("  Crash recurrence (nw-073):");
+                println!(
+                    "    Signature: {}",
+                    crash["signature"].as_str().unwrap_or("unknown")
+                );
+                println!(
+                    "    Status:    {}",
+                    crash["status"].as_str().unwrap_or("unknown")
+                );
+                match crash["crash_reports_matched"].as_u64() {
+                    Some(matched) => println!(
+                        "    Matched:   {matched} of {} candidate report(s) across {} directories",
+                        crash["reports_examined"], crash["directories_read"]
+                    ),
+                    None => println!("    Matched:   unknown (nothing was scanned)"),
+                }
+                for report in crash["matched_reports"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|value| value.as_str())
+                {
+                    println!("      - {report}");
+                }
+                for problem in crash["unreadable"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|value| value.as_str())
+                {
+                    println!("    Unreadable: {problem}");
+                }
+                if let Some(note) = crash["note"].as_str() {
+                    println!("    {note}");
+                }
             }
             Ok((EXIT_SUCCESS, None))
         }
@@ -18630,6 +18901,7 @@ mod diagnostics_cli_tests {
             true,
             true,
             Err("Metal compute/readback failed".to_string()),
+            crash_recurrence_value(&CrashRecurrenceScan::default()),
         );
         assert_eq!(value["embedding_compiled"], true);
         assert_eq!(value["metal_compiled"], true);
@@ -18638,6 +18910,161 @@ mod diagnostics_cli_tests {
             value["metal_runtime_error"],
             "Metal compute/readback failed"
         );
+    }
+
+    // ── nw-073 crash-recurrence detection ────────────────────────────────
+
+    /// The defect this guards against is the reason the check is worth having.
+    /// `*.cpu_resource.diag` reports are stack samples of a HEALTHY process and
+    /// routinely contain `optimisticRead`, because it is a hot read path. If
+    /// they counted, the tool would announce a use-after-free on every warm
+    /// index run.
+    #[test]
+    fn resource_diagnostics_are_not_crash_reports() {
+        let sampled_frame = "6   lbug::storage::BufferManager::optimisticRead(...)";
+
+        for benign in [
+            "nestweaver_2026-07-25-111137_Host.cpu_resource.diag",
+            "nestweaver_2026-07-27-062200_Host.diag",
+            "nestweaver_2026-07-24-153529_Host.wakeups_resource.diag",
+        ] {
+            assert!(
+                !is_crash_report_file(benign),
+                "{benign} is a resource diagnostic, not a crash"
+            );
+            assert!(
+                !crash_report_matches_signature(benign, sampled_frame),
+                "{benign} must not match even though it samples the frame"
+            );
+        }
+
+        for crash in [
+            "nestweaver-2026-07-25-111137.ips",
+            "nestweaver_2026-07-25-111137_Host.crash",
+        ] {
+            assert!(is_crash_report_file(crash), "{crash} is a crash report");
+        }
+    }
+
+    #[test]
+    fn signature_match_requires_both_the_process_and_the_frame() {
+        let frame = "lbug::storage::BufferManager::optimisticRead";
+
+        assert!(crash_report_matches_signature("nestweaver-1.ips", frame));
+        // Another process crashing in lbug is not our recurrence signal.
+        assert!(!crash_report_matches_signature(
+            "spotlightknowledged.ips",
+            frame
+        ));
+        // Our process crashing elsewhere is a different bug.
+        assert!(!crash_report_matches_signature(
+            "nestweaver-1.ips",
+            "core::panicking::panic_bounds_check"
+        ));
+    }
+
+    /// A scan that could not read anything must not report zero. This is the
+    /// nw-062 defect: a caller cannot distinguish "no findings" from "no data".
+    #[test]
+    fn an_unreadable_scan_reports_unknown_rather_than_zero() {
+        let scan = CrashRecurrenceScan {
+            supported: true,
+            directories_read: 0,
+            ..Default::default()
+        };
+        let value = crash_recurrence_value(&scan);
+
+        assert_eq!(value["status"], "unavailable");
+        assert!(
+            value["crash_reports_matched"].is_null(),
+            "an unscanned run must not claim a count"
+        );
+        assert!(
+            value["note"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("UNKNOWN"),
+            "the note must not read as a clean bill of health"
+        );
+    }
+
+    #[test]
+    fn a_partial_scan_does_not_present_its_zero_as_exhaustive() {
+        let scan = CrashRecurrenceScan {
+            supported: true,
+            directories_read: 2,
+            unreadable: vec!["/Library/Logs/DiagnosticReports: denied".to_string()],
+            reports_examined: 4,
+            ..Default::default()
+        };
+        let value = crash_recurrence_value(&scan);
+
+        assert_eq!(value["status"], "partial");
+        assert_eq!(value["crash_reports_matched"], 0);
+        assert!(
+            value["note"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("not exhaustive")
+        );
+    }
+
+    #[test]
+    fn a_clean_scan_says_the_mitigation_is_holding() {
+        let scan = CrashRecurrenceScan {
+            supported: true,
+            directories_read: 4,
+            reports_examined: 0,
+            ..Default::default()
+        };
+        let value = crash_recurrence_value(&scan);
+
+        assert_eq!(value["status"], "scanned");
+        assert_eq!(value["crash_reports_matched"], 0);
+    }
+
+    #[test]
+    fn a_matched_scan_calls_the_mitigation_out_as_failing() {
+        let scan = CrashRecurrenceScan {
+            supported: true,
+            directories_read: 4,
+            reports_examined: 3,
+            matched_reports: vec!["nestweaver-2026-07-28.ips".to_string()],
+            ..Default::default()
+        };
+        let value = crash_recurrence_value(&scan);
+
+        assert_eq!(value["status"], "scanned");
+        assert_eq!(value["crash_reports_matched"], 1);
+        let note = value["note"].as_str().unwrap_or_default();
+        assert!(note.contains("STILL FIRING"), "note was: {note}");
+    }
+
+    /// End-to-end over a fixture directory, via the documented override. This
+    /// is the only test that exercises the filesystem sweep itself.
+    #[test]
+    fn the_sweep_separates_crash_reports_from_resource_diagnostics_on_disk() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let frame = "lbug::storage::BufferManager::optimisticRead(FileHandle&)";
+
+        std::fs::write(dir.path().join("nestweaver-2026-07-28.ips"), frame).expect("write crash");
+        std::fs::write(
+            dir.path()
+                .join("nestweaver_2026-07-28_Host.cpu_resource.diag"),
+            frame,
+        )
+        .expect("write diag");
+        std::fs::write(dir.path().join("otherproc-2026-07-28.ips"), frame).expect("write other");
+
+        let scan = scan_crash_reports_in(&[dir.path().to_path_buf()], true);
+
+        assert_eq!(scan.status(), "scanned");
+        assert_eq!(scan.directories_read, 1);
+        assert_eq!(
+            scan.reports_examined, 1,
+            "only the nestweaver .ips is a candidate"
+        );
+        assert_eq!(scan.matched_reports, vec!["nestweaver-2026-07-28.ips"]);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3610,6 +3610,84 @@ fn load_instance_config_opt(path: Option<&Path>) -> Option<nestweaver_engine::In
 /// rule shared by `brain watch`/`brain add`/`brain refresh` and the top-level
 /// `watch`, so no path silently stamps symbols under the literal `"default"`
 /// when a `--config` names an instance.
+/// Existing vault registrations whose root path equals `root`, as
+/// `(instance_id, vault_uid)`.
+///
+/// Read through the same daemon-or-direct path `brain status` uses. A DB that
+/// does not exist yet yields an empty list rather than an error: the first
+/// refresh of a brand-new database is a legitimate create.
+fn vault_registrations_for_root(
+    use_daemon: bool,
+    db_path: &Path,
+    config: Option<&Path>,
+    root: &Path,
+) -> Vec<(String, String)> {
+    let root_str = root.to_string_lossy().to_string();
+    let matches_root = |candidate: &str| candidate == root_str;
+
+    if let Some(value) = try_hybrid_json_rpc(
+        use_daemon,
+        db_path,
+        config,
+        "brain_status",
+        serde_json::json!({}),
+    ) {
+        return value
+            .get("vaults")
+            .and_then(|v| v.as_array())
+            .map(|vaults| {
+                vaults
+                    .iter()
+                    .filter(|v| {
+                        v.get("root_path")
+                            .and_then(|p| p.as_str())
+                            .is_some_and(matches_root)
+                    })
+                    .filter_map(|v| {
+                        Some((
+                            v.get("instance_id")?.as_str()?.to_string(),
+                            v.get("uid")?.as_str()?.to_string(),
+                        ))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+    }
+
+    // Direct fallback. A missing database is not an error here.
+    if !db_path.exists() {
+        return Vec::new();
+    }
+    match open_store(Some(db_path)) {
+        Ok(store) => store
+            .list_vaults(None)
+            .map(|vaults| {
+                vaults
+                    .into_iter()
+                    .filter(|v| matches_root(&v.root_path))
+                    .map(|v| (v.instance_id, v.uid))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        Err(error) => {
+            tracing::debug!("vault_registrations_for_root: store read skipped: {error}");
+            Vec::new()
+        }
+    }
+}
+
+/// The instance the caller EXPLICITLY asked for, if any.
+///
+/// [`resolve_instance_id`] collapses "unspecified" into `"default"`, which is
+/// what let a refresh silently fork a vault: the caller expressed no intent and
+/// got a brand-new registration under a literal `default` instance (nw-098).
+/// This keeps the distinction.
+fn explicit_instance_id(flag: Option<&str>, config: Option<&Path>) -> Option<String> {
+    flag.filter(|f| !f.is_empty())
+        .map(|f| f.to_string())
+        .or_else(|| load_instance_config_opt(config).map(|c| c.instance_id))
+}
+
 fn resolve_instance_id(flag: Option<String>, config: Option<&Path>) -> anyhow::Result<String> {
     // nw-047: treat an empty `--instance ""` as unset (not a literal empty
     // instance) so it falls through to the config's `instance_id` / "default".
@@ -13264,14 +13342,82 @@ fn run_brain(
                     .unwrap_or("vault")
                     .to_string()
             });
-            // nw-019: --instance flag > config's instance_id > "default"
-            // (mirrors `brain add`/`brain watch`; fixes vaults being tagged
-            // under the literal "default" instead of the config's instance).
-            let instance_id = resolve_instance_id(instance, config.as_deref())?;
             let extra_patterns = parse_ignore_flag(&ignore);
+            let canonical = abs_for_daemon(&path);
+
+            // nw-098: resolve the instance from any EXISTING registration for this
+            // root before falling back to flag > config > "default".
+            //
+            // `resolve_instance_id` alone made a refresh with no `--instance`
+            // land on the literal "default" and register a SECOND vault for a
+            // root already registered under another instance. The root hash is
+            // identical in both UIDs, so the tool had everything it needed to
+            // know it was the same vault, and forked it anyway: note counts
+            // became the SUM and `brain search` started returning duplicate
+            // rows. The command documented in this repo's own CLAUDE.md did
+            // this.
+            let existing =
+                vault_registrations_for_root(use_daemon, &db_path, config.as_deref(), &canonical);
+            let explicit = explicit_instance_id(instance.as_deref(), config.as_deref());
+            let instance_id = match existing.as_slice() {
+                // Nothing registered here yet — a genuine create.
+                [] => resolve_instance_id(instance, config.as_deref())?,
+                [(registered, uid)] => match &explicit {
+                    // An explicit instance that disagrees with the registration
+                    // is a mistake, not an instruction to fork. Name both and
+                    // refuse.
+                    Some(asked) if asked != registered => {
+                        eprintln!(
+                            "Error: {} is already registered under instance '{registered}' ({uid}), \n\
+                             but --instance/--config asked for '{asked}'.\n\
+                             Refusing to create a second vault for the same root — that splits \n\
+                             note counts and makes `brain search` return duplicate rows.\n\
+                             help: re-run with --instance {registered} to refresh it in place, \n\
+                             or use a different root path.",
+                            canonical.display()
+                        );
+                        return Ok((EXIT_ERROR, None));
+                    }
+                    // Adopt the registration. This is the case the bug broke:
+                    // the caller expressed no intent, so refresh what is there.
+                    _ => registered.clone(),
+                },
+                // Already forked (this is the nw-098 damage state). An
+                // explicit instance that names one of them is actionable;
+                // anything else would be a guess that compounds the fork.
+                many => {
+                    let names = many
+                        .iter()
+                        .map(|(inst, _)| inst.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    match &explicit {
+                        Some(asked) if many.iter().any(|(inst, _)| inst == asked) => asked.clone(),
+                        Some(asked) => {
+                            eprintln!(
+                                "Error: {} is registered under {} instances ({names}), and \
+                                 --instance/--config asked for '{asked}', which is not one of them.\n\
+                                 help: pass --instance with one of: {names}",
+                                canonical.display(),
+                                many.len()
+                            );
+                            return Ok((EXIT_ERROR, None));
+                        }
+                        None => {
+                            eprintln!(
+                                "Error: {} is registered under {} instances ({names}).\n\
+                                 Refusing to guess which to refresh.\n\
+                                 help: pass --instance with one of: {names}",
+                                canonical.display(),
+                                many.len()
+                            );
+                            return Ok((EXIT_ERROR, None));
+                        }
+                    }
+                }
+            };
 
             // Compute vault UID for recording last_indexed_at.
-            let canonical = abs_for_daemon(&path);
             let v_uid = nestweaver_schema::vault_uid(&instance_id, &canonical.to_string_lossy());
 
             if use_daemon && since.is_none() {
@@ -16427,6 +16573,45 @@ fn merge_reindex_guidance(repos: &[String]) -> String {
     guidance.push_str("  nestweaver index --repo <path> --force\n");
     guidance.push_str("  nestweaver materialize-projects --config <instance.toml>");
     guidance
+}
+
+#[cfg(test)]
+mod refresh_instance_resolution_tests {
+    use super::*;
+
+    /// nw-098: with no `--instance` and no config, the caller expressed no
+    /// intent — so `resolve_instance_id` yields the literal "default", which is
+    /// exactly what forked a vault already registered elsewhere. The refresh arm
+    /// must therefore consult the registration rather than trust this value, and
+    /// `explicit_instance_id` is what lets it tell the two apart.
+    #[test]
+    fn no_flag_and_no_config_is_not_an_explicit_instance() {
+        assert_eq!(explicit_instance_id(None, None), None);
+        // An empty --instance is treated as unset, matching resolve_instance_id.
+        assert_eq!(explicit_instance_id(Some(""), None), None);
+        // Meanwhile the resolver still reports "default" — the value that made
+        // the fork silent.
+        assert_eq!(resolve_instance_id(None, None).unwrap(), "default");
+    }
+
+    #[test]
+    fn an_explicit_flag_is_reported_as_explicit() {
+        assert_eq!(
+            explicit_instance_id(Some("kory-brain"), None).as_deref(),
+            Some("kory-brain")
+        );
+    }
+
+    /// A database that does not exist yet must report no registrations rather
+    /// than erroring: the first refresh of a new DB is a legitimate create.
+    #[test]
+    fn a_missing_database_reports_no_registrations() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("absent.lbug");
+        let root = dir.path().join("vault");
+        let found = vault_registrations_for_root(false, &missing, None, &root);
+        assert!(found.is_empty(), "got: {found:?}");
+    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,6 +161,41 @@ enum CliDiagnostic {
     )]
     EmptyDatabase,
 
+    /// The database file is present but could not be opened. NEVER conflate
+    /// this with `db_not_found`: suggesting `index --repo` at a path that
+    /// already holds a database invites the user to write over their own data
+    /// (nw-126). The underlying store error is carried through verbatim
+    /// because it is the only thing that says WHY.
+    #[error("Database exists but could not be opened: {path}")]
+    #[diagnostic(
+        code(nestweaver::db_unavailable),
+        help(
+            "{cause}\nThe database file is present, so do NOT run `index` at this path.\n\
+             If a daemon or other process holds it, stop it with \
+             `nestweaver daemon --db {path} stop`."
+        )
+    )]
+    DatabaseUnavailable { path: String, cause: String },
+
+    /// A crashed daemon leaves an unreplayed write-ahead log. Replay needs
+    /// read-write access, so the read-only path can never perform it and the
+    /// generic "could not open" message sends the user nowhere (nw-126).
+    #[error("Database has an unreplayed write-ahead log: {path}")]
+    #[diagnostic(
+        code(nestweaver::db_wal_unreplayed),
+        help(
+            "{cause}\nThis usually follows a daemon crash. Replay requires read-write \
+             access:\n  nestweaver daemon --db {path} start\n\
+             If that also fails, move {wal} aside and retry — it is replayed or \
+             discarded on the next read-write open, and the database itself is intact."
+        )
+    )]
+    DatabaseWalUnreplayed {
+        path: String,
+        wal: String,
+        cause: String,
+    },
+
     #[error("{message}")]
     #[diagnostic(code(nestweaver::error))]
     General { message: String },
@@ -178,6 +213,28 @@ fn into_diagnostic(err: anyhow::Error) -> miette::Report {
     // ... No such file or directory" mentions a .lbug path and a missing
     // file, but mapping it to db_not_found produces the circular help text
     // "Run `nestweaver index` to create a database" — while running index.
+    // nw-126: a crashed daemon leaves an unreplayed WAL. The store says so
+    // precisely ("Couldn't replay shadow pages under read-only mode. Please
+    // re-open the database with read-write mode...") but that fell through to
+    // the bare `nestweaver::error` rendering, which states the problem and no
+    // remedy — and the advice it does give cannot be followed on the path that
+    // emitted it, since a read-only open can never perform the replay.
+    if lower.contains("shadow pages") || (lower.contains("replay") && lower.contains("read-only")) {
+        let path = message
+            .split("at ")
+            .nth(1)
+            .and_then(|s| s.split(':').next())
+            .unwrap_or("./nestweaver.lbug")
+            .trim()
+            .to_string();
+        return CliDiagnostic::DatabaseWalUnreplayed {
+            wal: format!("{path}.wal"),
+            path,
+            cause: message,
+        }
+        .into();
+    }
+
     if lower.contains("database not found")
         || (lower.contains("failed to open database") && lower.contains("no such file"))
     {
@@ -190,7 +247,45 @@ fn into_diagnostic(err: anyhow::Error) -> miette::Report {
             .unwrap_or("./nestweaver.lbug")
             .trim()
             .to_string();
-        return CliDiagnostic::DatabaseNotFound { path }.into();
+
+        // nw-126: these are TEXT heuristics, and text lies. The daemon's
+        // "failed to open database with write access at <path>; another
+        // process may hold the write lock" matched here and rendered a live
+        // 5.6 GB database as "not found", with help telling the user to
+        // `index` a new one over the top of it. Ask the filesystem instead of
+        // trusting the substring: if the file is really there, this is an
+        // availability failure, not a missing database, and the remedy is the
+        // opposite of creating one.
+        //
+        // Trim the path defensively — the same heuristics can capture trailing
+        // context clauses ("<path>; another process may...").
+        let candidate = path
+            .split(';')
+            .next()
+            .unwrap_or(&path)
+            .trim()
+            .trim_end_matches(['.', ','])
+            .to_string();
+        let on_disk = std::path::Path::new(&candidate);
+        if on_disk.exists() {
+            let wal = format!("{candidate}.wal");
+            if std::path::Path::new(&wal).exists() {
+                return CliDiagnostic::DatabaseWalUnreplayed {
+                    path: candidate,
+                    wal,
+                    cause: message,
+                }
+                .into();
+            }
+            return CliDiagnostic::DatabaseUnavailable {
+                path: candidate,
+                cause: message,
+            }
+            .into();
+        }
+        // Report the trimmed path here too, so a message that appended a
+        // context clause does not surface it as part of the filename.
+        return CliDiagnostic::DatabaseNotFound { path: candidate }.into();
     }
 
     if lower.contains("path") && lower.contains("does not exist")
@@ -693,6 +788,8 @@ fn impact_json_ok(
     note: Option<String>,
 ) -> serde_json::Value {
     let capped = matches!((total, returned), (Some(t), Some(r)) if r < t);
+    // Resolve before the payload borrows `nodes` (nw-123).
+    let returned = returned.unwrap_or_else(|| nodes_len(&nodes));
     let mut payload = serde_json::json!({
         "status": "ok",
         "symbol": symbol,
@@ -702,17 +799,81 @@ fn impact_json_ok(
         "truncated_by_depth": truncated_by_depth,
     });
     if let Some(obj) = payload.as_object_mut() {
-        if let Some(t) = total {
-            obj.insert("total".to_string(), serde_json::json!(t));
-        }
-        if let Some(r) = returned {
-            obj.insert("returned".to_string(), serde_json::json!(r));
-        }
+        // nw-123: `total` and `returned` used to be inserted only when the
+        // caller knew them, so the key SET varied by code path — the
+        // depth-truncated envelope carried them and the threshold-truncated one
+        // did not, leaving a consumer with `undefined` in exactly the case
+        // where the result is incomplete and the counts matter most. A stable
+        // schema is the whole point of this envelope, so both keys are always
+        // present.
+        //
+        // `returned` is never guessed: it is the length of the array we are
+        // actually returning. `total` is `null` when genuinely unknown rather
+        // than being backfilled from `returned`, which would assert
+        // completeness we did not establish (same rule as nw-073's null count).
+        obj.insert("returned".to_string(), serde_json::json!(returned));
+        obj.insert(
+            "total".to_string(),
+            match total {
+                Some(t) => serde_json::json!(t),
+                None => serde_json::Value::Null,
+            },
+        );
         if let Some(note) = note {
             obj.insert("note".to_string(), serde_json::json!(note));
         }
     }
     payload
+}
+
+/// Length of a JSON node collection, for envelopes that must report what they
+/// actually returned rather than what the caller happened to know.
+fn nodes_len(nodes: &serde_json::Value) -> u64 {
+    nodes.as_array().map(|a| a.len() as u64).unwrap_or(0)
+}
+
+/// Warn when a ranking is computed over edges built by a superseded resolver.
+///
+/// nw-124: a fix that changes persisted edge SHAPE (nw-103's import fan-out)
+/// cannot correct data already written. Upgrading therefore leaves `hubs`,
+/// `bridges` and PageRank confidently wrong for every repo not yet re-indexed,
+/// and previously nothing disclosed it. Emitted on stderr so `--json` consumers
+/// are told without the payload changing shape.
+fn warn_stale_resolver_rankings(store: &nestweaver_store::GraphStore, db_path: &std::path::Path) {
+    let Ok(repos) = store.list_repos(None) else {
+        return;
+    };
+    let uids: Vec<String> = repos.into_iter().map(|r| r.uid).collect();
+    if uids.is_empty() {
+        return;
+    }
+    if let Some(note) = nestweaver_engine::resolver_generation::staleness_note(db_path, &uids) {
+        eprintln!("warning: {note}");
+    }
+}
+
+/// Daemon-path counterpart to [`warn_stale_resolver_rankings`].
+///
+/// The daemon owns the store, so this path has no handle to enumerate repos
+/// and cannot report an exact stale count. It can still catch the case that
+/// matters most — and is the common one on upgrade — where the sidecar does not
+/// exist at all, meaning EVERY repo's edges predate the fix. Without this the
+/// warning would only ever appear on the direct path, which is the path users
+/// are told not to use.
+fn warn_stale_resolver_rankings_no_store(db_path: &std::path::Path) {
+    let sidecar = nestweaver_engine::sidecar_path(
+        db_path,
+        nestweaver_engine::resolver_generation::RESOLVER_GENERATION_SIDECAR,
+    );
+    if sidecar.exists() {
+        return;
+    }
+    eprintln!(
+        "warning: no resolver generation is recorded for this database, so every repo \
+         was indexed before the nw-103 import-fan-out fix — hub, bridge and PageRank \
+         rankings are NOT corrected by upgrading alone. Re-index each repo \
+         (`nestweaver index --repo <path>`) to get accurate rankings."
+    );
 }
 
 /// Ambiguous resolution — carries `candidates`, never `nodes`, so it cannot be
@@ -788,6 +949,20 @@ fn render_investigate_text(payload: &serde_json::Value) {
             String::new()
         }
     );
+    // nw-120: the daemon ranks with its warm embedding model; the direct path
+    // has none, so the SAME query returns a different ordering. Say which one
+    // produced this map rather than letting the ranking imply a quality it did
+    // not have.
+    if payload
+        .get("semantic_applied")
+        .and_then(|v| v.as_bool())
+        .is_some_and(|applied| !applied)
+    {
+        println!(
+            "  note: semantic retrieval unavailable — ranking is lexical (BM25) only, \
+             so ordering differs from a daemon-served run."
+        );
+    }
 
     for d in &domains {
         println!("\n[{}]", text(d, "label"));
@@ -6542,6 +6717,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                     );
                                 }
                             }
+                            // nw-124: the daemon serves this path, so the
+                            // disclosure has to live here too — otherwise it
+                            // only ever fires on the direct path users are
+                            // told not to use.
+                            warn_stale_resolver_rankings_no_store(&db_path);
                             let stats = format!(
                                 "{} hubs in {} (via hybrid)",
                                 value.get("count").and_then(|v| v.as_u64()).unwrap_or(0),
@@ -6567,6 +6747,15 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             if let Ok(Some(clustering)) = load_clusters(&db_path) {
                 attach_cluster_ids(&mut hubs, &clustering);
             }
+
+            // nw-124: hub ranking is precisely what nw-103's import fan-out
+            // corrupted, and the fix cannot repair edges already on disk. On
+            // this machine the FIXED binary still returned the bug report's
+            // exact ranking until the repo was re-indexed. Say so rather than
+            // presenting stale numbers as current. Written to stderr so it
+            // reaches the user in --json mode too, without altering the
+            // documented bare-array payload.
+            warn_stale_resolver_rankings(&store, &db_path);
 
             if json {
                 println!("{}", serde_json::to_string_pretty(&hubs)?);
@@ -6645,6 +6834,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             );
                         }
                     }
+                    // nw-124: bridges are downstream of the same import
+                    // fan-out nw-103 fixed, so they carry the same staleness.
+                    warn_stale_resolver_rankings_no_store(&db_path);
                     let stats = format!(
                         "{} bridges in {} (via daemon)",
                         bridges.len(),
@@ -6658,6 +6850,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
 
             out.status("Computing betweenness centrality...");
             let mut bridges = find_bridge_nodes(&store, top)?;
+            warn_stale_resolver_rankings(&store, &db_path);
 
             // Attach community connection info if clustering sidecar exists.
             if let Ok(Some(clustering)) = load_clusters(&db_path) {
@@ -6886,6 +7079,30 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
             }
 
+            // nw-075: `--json` deliberately bypasses the daemon (its tool
+            // truncates member lists at 20), and this direct path never
+            // consulted the sidecar — so `clusters --json` recomputed on EVERY
+            // invocation while `--help` promises "cached in a sidecar ...
+            // subsequent invocations are instant", and the TEXT path really did
+            // cache via the daemon. Two output modes disagreeing about whether a
+            // cache exists, with the docs siding with the one that didn't.
+            //
+            // Reuse is gated on the resolution MATCHING, because the sidecar
+            // holds whichever resolution was computed last: serving a cache
+            // built at a different resolution would answer a question the caller
+            // did not ask. With an explicit --resolution the check needs no
+            // store at all, which is the fully-instant case the help describes.
+            if let Ok(Some(cached)) = load_clusters(&db_path)
+                && let Some(requested) = resolution
+                && (cached.resolution - requested).abs() < f64::EPSILON
+            {
+                out.status(&format!(
+                    "Using cached clusters (resolution={requested}) from sidecar."
+                ));
+                print_clusters_output(&cached, json)?;
+                return Ok((EXIT_SUCCESS, None));
+            }
+
             // Compute and save inside a block so the store is dropped
             // before any output. LadybugDB's connection finaliser can
             // trigger a panic during WAL checkpoint; wrapping in
@@ -6920,26 +7137,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 o
             };
 
-            if json {
-                println!("{}", serde_json::to_string_pretty(&output)?);
-            } else if output.communities.is_empty() {
-                println!("No communities detected (graph may be empty or fully disconnected).");
-            } else {
-                println!(
-                    "Clusters ({}, modularity={:.4}):\n",
-                    output.communities.len(),
-                    output.modularity
-                );
-                for c in &output.communities {
-                    println!(
-                        "  [{:>3}] {} ({} members, cohesion={:.2})",
-                        c.id, c.name, c.member_count, c.cohesion
-                    );
-                    for f in &c.key_files {
-                        println!("        {f}");
-                    }
-                }
-            }
+            print_clusters_output(&output, json)?;
             Ok((EXIT_SUCCESS, None))
         }
 
@@ -8329,6 +8527,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 truncated: false,
                                 scanned_fallback: false,
                                 stale_index: false,
+                                note: None,
                             }
                         });
                     if json {
@@ -10624,6 +10823,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let pidfile = nestweaver_daemon::pidfile_path(&instance_id);
             let socket = nestweaver_daemon::socket_path(&instance_id);
             let log_file = nestweaver_daemon::log_path(&instance_id);
+            // `log_file` is the real stderr sink (it goes in the plist and gets
+            // opened for redirect below). It is NOT what an operator should be
+            // told to read: tracing writes to `daemon.log.<date>` alongside it,
+            // so every human-facing pointer uses the hint instead. See nw-118.
+            let log_hint = nestweaver_daemon::log_hint(&instance_id);
 
             match action {
                 DaemonAction::Start {
@@ -10738,7 +10942,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                     .display()
                             );
                             eprintln!("  Socket: {}", socket.display());
-                            eprintln!("  Log:    {}", log_file.display());
+                            eprintln!("  Log:    {log_hint}");
 
                             // Poll connect_existing + health_check
                             // (wait_healthy never auto-starts) instead of the
@@ -10764,9 +10968,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                     // still turn into a healthy daemon.
                                     eprintln!(
                                         "Daemon is still booting under launchd; check \
-                                         `nestweaver daemon --db {} status` and the log at {}",
+                                         `nestweaver daemon --db {} status` and the logs at {}",
                                         db_path.display(),
-                                        log_file.display()
+                                        log_hint
                                     );
                                     return Ok((EXIT_SUCCESS, None));
                                 }
@@ -10928,7 +11132,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         );
                         eprintln!("  PID file: {}", pidfile.display());
                         eprintln!("  Socket:   {}", socket.display());
-                        eprintln!("  Log:      {}", log_file.display());
+                        eprintln!("  Log:      {log_hint}");
 
                         let daemonize = daemonize2::Daemonize::new()
                             .pid_file(&pidfile)
@@ -10981,9 +11185,8 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 if !parent.first_child_exit_status.success() {
                                     eprintln!(
                                         "Error: daemon failed to start (boot exit status {}). \
-                                         Check the log: {}",
-                                        parent.first_child_exit_status,
-                                        log_file.display()
+                                         Check the logs: {}",
+                                        parent.first_child_exit_status, log_hint
                                     );
                                     std::process::exit(EXIT_ERROR);
                                 }
@@ -10994,8 +11197,8 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 }
                                 eprintln!(
                                     "Error: daemon did not start accepting connections within \
-                                     10s — it may have died during boot. Check the log: {}",
-                                    log_file.display()
+                                     10s — it may have died during boot. Check the logs: {}",
+                                    log_hint
                                 );
                                 std::process::exit(EXIT_ERROR);
                             }
@@ -11220,7 +11423,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         );
                         println!("  DB:     {}", db_path.display());
                         println!("  Socket: {}", socket.display());
-                        println!("  Log:    {}", log_file.display());
+                        println!("  Log:    {log_hint}");
                         print_daemon_embedding_status(&db_path);
                         return Ok((EXIT_SUCCESS, None));
                     }
@@ -11235,7 +11438,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             println!("Daemon is running (PID {pid})");
                             println!("  DB:     {}", db_path.display());
                             println!("  Socket: {}", socket.display());
-                            println!("  Log:    {}", log_file.display());
+                            println!("  Log:    {log_hint}");
                             print_daemon_embedding_status(&db_path);
                         } else {
                             println!(
@@ -11253,7 +11456,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         println!("Daemon is running (PID {pid}, serving socket)");
                         println!("  DB:     {}", db_path.display());
                         println!("  Socket: {}", socket.display());
-                        println!("  Log:    {}", log_file.display());
+                        println!("  Log:    {log_hint}");
                         print_daemon_embedding_status(&db_path);
                         return Ok((EXIT_SUCCESS, None));
                     }
@@ -12369,13 +12572,59 @@ fn try_hybrid_json_rpc(
     match rt.block_on(nestweaver_client::hybrid::HybridClient::connect(
         db_path, config, &start_dir,
     )) {
-        Ok(mut hybrid) => rt.block_on(hybrid.query(rpc_name, &args)).ok(),
-        Err(_) => rt
-            .block_on(nestweaver_client::hybrid::query_configured_upstreams_only(
-                config, &start_dir, rpc_name, &args,
-            ))
-            .ok(),
+        Ok(mut hybrid) => match rt.block_on(hybrid.query(rpc_name, &args)) {
+            Ok(value) => Some(value),
+            Err(e) => {
+                warn_daemon_bypassed(db_path, rpc_name, &format!("{e:#}"));
+                None
+            }
+        },
+        Err(e) => {
+            let upstream = rt
+                .block_on(nestweaver_client::hybrid::query_configured_upstreams_only(
+                    config, &start_dir, rpc_name, &args,
+                ))
+                .ok();
+            if upstream.is_none() {
+                warn_daemon_bypassed(db_path, rpc_name, &format!("{e:#}"));
+            }
+            upstream
+        }
     }
+}
+
+/// Disclose that a command could not be served by the daemon and is about to be
+/// answered by the direct path instead.
+///
+/// nw-125: this fallback was completely silent — exit 0, nothing on stderr, a
+/// result that looks authoritative. Meanwhile asking for the same bypass
+/// explicitly is REFUSED, with a warning about WAL corruption and a demand for
+/// `NESTWEAVER_ALLOW_NO_DAEMON=1`. The tool policed a deliberate request while
+/// doing the same thing unprompted whenever the daemon was slow or down.
+///
+/// That matters beyond consistency: the direct path is not equivalent. It
+/// returns different rankings for `investigate` (nw-120), omits the embedding
+/// block from `brain status` (nw-121), and — the case that produced nw-126 —
+/// opens read-only, so it cannot replay a crashed daemon's WAL and converts a
+/// self-healing outage into a hard failure.
+///
+/// Warn once per process: a single command can route several RPCs through here,
+/// and repeating the paragraph per call would train the user to ignore it.
+fn warn_daemon_bypassed(db_path: &std::path::Path, rpc_name: &str, cause: &str) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    if WARNED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+    eprintln!(
+        "Warning: the daemon could not serve `{rpc_name}` for {} — answering from the \
+         direct path instead.\n  cause: {cause}\n  \
+         Results may differ from the daemon's, and writes are not protected by the \
+         daemon's single-writer lock. Start it with `nestweaver daemon --db {} start`, \
+         or raise NESTWEAVER_DAEMON_BOOT_TIMEOUT_SECS if it is simply slow to boot.",
+        db_path.display(),
+        db_path.display()
+    );
 }
 
 /// Unwrap the `{ "results": [...], "_meta": {...} }` envelope that the hybrid
@@ -13167,6 +13416,20 @@ fn run_brain(
                 println!("  Tags:      {tag_count}");
                 println!("  Wikilinks: {wikilink_count}");
                 println!("  Repos:     {}", repos.len());
+                // nw-121: the daemon prints an `Embedding:` block here and this
+                // path printed nothing at all — same command, same database,
+                // silently different answer. An omitted section reads as "no
+                // such concept", so a user could not tell that semantic
+                // retrieval state was simply unknown. Embedding state is
+                // RUNTIME state owned by the daemon (model actually loaded,
+                // device actually selected), so this path genuinely cannot
+                // report it — but saying so is not the same as saying nothing.
+                println!("Embedding:");
+                println!(
+                    "  State:            unknown (runtime state is held by the daemon; \
+                     start it with `nestweaver daemon --db {} start`)",
+                    db_path.display()
+                );
                 // Interaction tracking is opt-in (enabled via `mcp
                 // --track-interactions`). InteractionTracker::new touches
                 // the sidecar at startup so we can distinguish three states:
@@ -15280,13 +15543,72 @@ fn render_cost_tokens(n: &nestweaver_engine::BrainNode) -> usize {
     (n.uid.len() + n.title.len() + n.kind.len() + n.location.len() + 10 + 80).div_ceil(4)
 }
 
+/// Render a `clusters` result in either mode.
+///
+/// Shared so the cached and freshly-computed paths cannot drift (nw-075): the
+/// whole point of serving a cache is that the caller cannot tell the difference.
+fn print_clusters_output(
+    output: &nestweaver_engine::ClusteringOutput,
+    json: bool,
+) -> anyhow::Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(output)?);
+    } else if output.communities.is_empty() {
+        println!("No communities detected (graph may be empty or fully disconnected).");
+    } else {
+        println!(
+            "Clusters ({}, modularity={:.4}):\n",
+            output.communities.len(),
+            output.modularity
+        );
+        for c in &output.communities {
+            println!(
+                "  [{:>3}] {} ({} members, cohesion={:.2})",
+                c.id, c.name, c.member_count, c.cohesion
+            );
+            for f in &c.key_files {
+                println!("        {f}");
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Header line for `brain context` seeds.
+///
+/// nw-102: `seeds` mixes nodes resolved from the query text with nearest
+/// neighbours injected by the semantic leg, and counting both as "resolved"
+/// made the output contradict itself — a nonsense query printed
+/// `Seeds (5 resolved)` while the same response listed that query under
+/// `Unresolved seeds (1)`. Reports PROVENANCE, not quality: a phrase like
+/// "blast radius" fails a direct lookup against the symbol `blast_radius` yet
+/// its semantic hits are excellent, so labelling them guesses would understate
+/// them exactly as counting them as direct matches overstated them.
+fn seed_header(total_seeds: usize, semantic_seeds: usize) -> String {
+    let matched = total_seeds.saturating_sub(semantic_seeds);
+    if semantic_seeds > 0 {
+        format!("Seeds ({matched} matched directly, {semantic_seeds} via semantic search):")
+    } else {
+        format!("Seeds ({matched} resolved):")
+    }
+}
+
 fn print_brain_context_text(result: &BrainContextResult, cut: usize, token_budget: Option<usize>) {
     // Feature F7: show PRF-mined expansion terms for auditing.
     if !result.expansion_terms.is_empty() {
         println!("PRF expansion terms: {}", result.expansion_terms.join(", "));
         println!();
     }
-    println!("Seeds ({} resolved):", result.seeds.len());
+    // nw-102: `seeds` mixes two different things — nodes actually resolved from
+    // the query, and nearest-neighbour guesses injected by the semantic leg,
+    // which vector KNN returns regardless of how distant they are. Counting
+    // both as "resolved" made the output contradict itself: a nonsense query
+    // printed `Seeds (5 resolved)` while ALSO listing that same query under
+    // `Unresolved seeds (1)`. Report the two separately.
+    println!(
+        "{}",
+        seed_header(result.seeds.len(), result.semantic_seed_count)
+    );
     for n in &result.seeds {
         if n.location.is_empty() {
             println!("  {}  [{}]", n.title, n.kind);
@@ -15300,6 +15622,17 @@ fn print_brain_context_text(result: &BrainContextResult, cut: usize, token_budge
         println!("Unresolved seeds ({}):", result.unresolved_seeds.len());
         for s in &result.unresolved_seeds {
             println!("  {s}");
+        }
+        if result.seeds.len() == result.semantic_seed_count && result.semantic_seed_count > 0 {
+            // State HOW the seeds were found, not how good they are. A phrase
+            // like "blast radius" fails a direct lookup against the symbol
+            // `blast_radius` yet its semantic hits are excellent, so calling
+            // them guesses would understate them just as counting them as
+            // direct matches overstated them.
+            println!(
+                "  note: no seed matched the query text directly; the seeds above \
+                 came from semantic similarity."
+            );
         }
     }
 
@@ -18649,6 +18982,166 @@ mod hybrid_cli_tests {
         let present = dir.path().join("present.lbug");
         std::fs::write(&present, b"").unwrap();
         assert!(require_existing_db(&present).is_ok());
+    }
+
+    /// nw-102: a seed injected by the semantic leg must never be counted as
+    /// "resolved". Counting them together let one response claim a query both
+    /// resolved AND unresolved at the same time.
+    #[test]
+    fn seed_header_never_counts_semantic_hits_as_resolved() {
+        // The reported case: nothing matched, five nearest neighbours injected.
+        let h = seed_header(5, 5);
+        assert!(h.contains("0 matched directly"), "{h}");
+        assert!(h.contains("5 via semantic search"), "{h}");
+        assert!(
+            !h.contains("5 resolved"),
+            "must not report semantic guesses as resolved: {h}"
+        );
+
+        // Genuine direct matches, no semantic leg.
+        assert_eq!(seed_header(3, 0), "Seeds (3 resolved):");
+
+        // Mixed: two direct, three semantic.
+        let m = seed_header(5, 3);
+        assert!(
+            m.contains("2 matched directly") && m.contains("3 via semantic search"),
+            "{m}"
+        );
+    }
+
+    /// Defensive: the counts arrive from a daemon response, so a malformed or
+    /// older payload must not underflow the subtraction.
+    #[test]
+    fn seed_header_does_not_underflow_on_inconsistent_counts() {
+        let h = seed_header(2, 9);
+        assert!(h.contains("0 matched directly"), "{h}");
+    }
+
+    /// nw-123: the impact envelope's key set must not depend on which
+    /// truncation path ran. `--depth 1` carried `returned`/`total`;
+    /// `--min-score 0.9` silently dropped them while still returning 3 nodes,
+    /// so a consumer got `undefined` precisely when the result was incomplete.
+    #[test]
+    fn impact_envelope_key_set_is_identical_across_truncation_paths() {
+        let nodes = serde_json::json!([{"name": "a"}, {"name": "b"}, {"name": "c"}]);
+
+        let by_depth = impact_json_ok("s", nodes.clone(), false, true, Some(9), Some(3), None);
+        // The threshold path is the one that used to omit the counts.
+        let by_threshold = impact_json_ok("s", nodes.clone(), true, false, None, None, None);
+
+        let keys = |v: &serde_json::Value| {
+            let mut k: Vec<String> = v.as_object().unwrap().keys().cloned().collect();
+            k.sort();
+            k
+        };
+        assert_eq!(
+            keys(&by_depth),
+            keys(&by_threshold),
+            "envelope keys must not vary by truncation path"
+        );
+
+        for env in [&by_depth, &by_threshold] {
+            assert!(env.get("returned").is_some(), "returned must always exist");
+            assert!(env.get("total").is_some(), "total must always exist");
+        }
+
+        // `returned` reflects what was actually returned, even when the caller
+        // did not supply it.
+        assert_eq!(by_threshold["returned"], serde_json::json!(3));
+        // An unknown total is null — never backfilled from `returned`, which
+        // would assert a completeness that was not established.
+        assert!(
+            by_threshold["total"].is_null(),
+            "unknown total must be null, not a fabricated count: {by_threshold}"
+        );
+        assert_eq!(by_depth["total"], serde_json::json!(9));
+    }
+
+    /// nw-126: the incident message, verbatim. A SIGKILLed daemon left a stale
+    /// WAL; the daemon's open failure was text-matched into `db_not_found` and
+    /// rendered a live 5.6 GB database as "Database not found", with help
+    /// telling the user to `index` a new one AT THAT PATH. Following it would
+    /// have destroyed data that was fully recoverable — the entire outage was
+    /// one stale 42-byte file.
+    ///
+    /// The guard is to consult the filesystem rather than the error text.
+    #[test]
+    fn existing_database_is_never_diagnosed_as_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        std::fs::write(&db, b"not empty").unwrap();
+
+        let err = anyhow::anyhow!(
+            "failed to open database with write access at {}; another process \
+             may hold the write lock: database error: no such file",
+            db.display()
+        );
+        let rendered = format!("{:?}", into_diagnostic(err));
+
+        assert!(
+            !rendered.contains("db_not_found"),
+            "a database that EXISTS must never be reported as not found: {rendered}"
+        );
+        assert!(
+            !rendered.contains("to create a database"),
+            "must never advise creating a database where one already exists — \
+             that is the data-destroying suggestion: {rendered}"
+        );
+        assert!(
+            rendered.contains("db_unavailable") || rendered.contains("db_wal_unreplayed"),
+            "expected an availability diagnostic, got: {rendered}"
+        );
+    }
+
+    /// nw-126: with a stale `.wal` present the diagnostic must name it and give
+    /// the read-write remedy, since replay is impossible on the read-only path
+    /// that usually reports the failure.
+    #[test]
+    fn stale_wal_is_named_with_a_read_write_remedy() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        std::fs::write(&db, b"data").unwrap();
+        std::fs::write(dir.path().join("brain.lbug.wal"), b"stale").unwrap();
+
+        let err = anyhow::anyhow!(
+            "failed to open database with write access at {}; another process \
+             may hold the write lock: no such file",
+            db.display()
+        );
+        let rendered = format!("{:?}", into_diagnostic(err));
+
+        assert!(
+            rendered.contains("db_wal_unreplayed"),
+            "a present .wal must be diagnosed specifically: {rendered}"
+        );
+        assert!(
+            rendered.contains("daemon") && rendered.contains("start"),
+            "the remedy must be the read-write open that can actually replay: {rendered}"
+        );
+    }
+
+    /// nw-126: the read-only path's own words. `open_read_only` reports
+    /// "Couldn't replay shadow pages under read-only mode. Please re-open the
+    /// database with read-write mode" — a correct diagnosis whose advice that
+    /// path structurally cannot follow. It previously fell through to a bare
+    /// `nestweaver::error` with no remedy at all.
+    #[test]
+    fn shadow_page_replay_failure_gets_an_actionable_diagnostic() {
+        let err = anyhow::anyhow!(
+            "failed to open database at /tmp/x/brain.lbug: database error: Runtime \
+             exception: Couldn't replay shadow pages under read-only mode. Please \
+             re-open the database with read-write mode to replay shadow pages."
+        );
+        let rendered = format!("{:?}", into_diagnostic(err));
+
+        assert!(
+            rendered.contains("db_wal_unreplayed"),
+            "expected the WAL diagnostic, got: {rendered}"
+        );
+        assert!(
+            !rendered.contains("to create a database"),
+            "must not advise creating a database: {rendered}"
+        );
     }
 
     /// A create-path store error ("open/create store at

--- a/src/main.rs
+++ b/src/main.rs
@@ -592,6 +592,30 @@ fn scan_crash_reports_in(directories: &[PathBuf], supported: bool) -> CrashRecur
     scan
 }
 
+/// One-line verdict for a `broken-links` entry.
+///
+/// A sub-1.0 confidence means the link matched at a lower resolver tier, not
+/// that it is wrong. Printing only the number let a same-folder match (0.95)
+/// and a link pointing at nothing (0.0) read identically (nw-100).
+fn describe_link_resolution(link: &nestweaver_engine::BrokenLink) -> String {
+    match &link.resolved_target_uid {
+        Some(uid) => format!("resolves to {uid}"),
+        None => "UNRESOLVED — no such note".to_string(),
+    }
+}
+
+/// Summarise how many entries are genuinely broken versus merely resolved at a
+/// lower tier, so the headline count cannot be read as "all of these are
+/// broken".
+fn print_link_classification(links: &[nestweaver_engine::BrokenLink]) {
+    let unresolved = links.iter().filter(|l| l.is_unresolved()).count();
+    let resolved = links.len() - unresolved;
+    println!(
+        "  {unresolved} unresolved (genuinely broken), {resolved} resolved at a lower \
+         confidence tier (same-folder or filename-stem match — not broken)"
+    );
+}
+
 fn capability_diagnostics_value(
     embedding_compiled: bool,
     metal_compiled: bool,
@@ -14032,10 +14056,14 @@ fn run_brain(
                             }
                             _ => println!("Broken / ambiguous wikilinks ({}):", links.len()),
                         }
+                        print_link_classification(&links);
                         for l in &links {
                             println!(
-                                "  [[{}]] in {} (confidence {:.2})",
-                                l.wikilink_text, l.source_path, l.confidence
+                                "  [[{}]] in {} (confidence {:.2}) — {}",
+                                l.wikilink_text,
+                                l.source_path,
+                                l.confidence,
+                                describe_link_resolution(l)
                             );
                             if !l.suggested_target_uids.is_empty() {
                                 println!("    suggested: {}", l.suggested_target_uids.join(", "));
@@ -14063,10 +14091,14 @@ fn run_brain(
                 println!("No broken or ambiguous wikilinks found.");
             } else {
                 println!("Broken / ambiguous wikilinks ({} of {total}):", links.len());
+                print_link_classification(&links);
                 for l in &links {
                     println!(
-                        "  [[{}]] in {} (confidence {:.2})",
-                        l.wikilink_text, l.source_path, l.confidence
+                        "  [[{}]] in {} (confidence {:.2}) — {}",
+                        l.wikilink_text,
+                        l.source_path,
+                        l.confidence,
+                        describe_link_resolution(l)
                     );
                     if !l.suggested_target_uids.is_empty() {
                         println!("    suggested: {}", l.suggested_target_uids.join(", "));
@@ -14396,6 +14428,10 @@ fn run_brain(
                     println!("  total notes:      {}", stats.total_notes);
                     println!("  total wikilinks:  {}", stats.total_wikilinks);
                     println!("  broken wikilinks: {}", stats.broken_wikilinks);
+                    println!(
+                        "  low-confidence (resolved, not broken): {}",
+                        stats.low_confidence_wikilinks
+                    );
                     println!("  orphans:          {}", stats.orphans);
                     println!("  avg out-degree:   {:.2}", stats.avg_outdegree);
                     if !stats.top_tags.is_empty() {
@@ -14426,6 +14462,10 @@ fn run_brain(
                 println!("  total notes:      {}", stats.total_notes);
                 println!("  total wikilinks:  {}", stats.total_wikilinks);
                 println!("  broken wikilinks: {}", stats.broken_wikilinks);
+                println!(
+                    "  low-confidence (resolved, not broken): {}",
+                    stats.low_confidence_wikilinks
+                );
                 println!("  orphans:          {}", stats.orphans);
                 println!("  avg out-degree:   {:.2}", stats.avg_outdegree);
                 if !stats.top_tags.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -592,6 +592,45 @@ fn scan_crash_reports_in(directories: &[PathBuf], supported: bool) -> CrashRecur
     scan
 }
 
+/// The closed set of node kinds accepted by `--kinds`.
+const NODE_KINDS: [&str; 3] = ["Section", "Note", "Symbol"];
+
+/// Parse and validate a `--kinds` token against [`NODE_KINDS`].
+///
+/// Matching stays case-insensitive, but an unknown token is now rejected
+/// instead of silently dropped. `--kinds Bogus` used to return zero matches at
+/// exit 0, so a typo was indistinguishable from a real empty result (nw-108).
+fn parse_node_kind(value: &str) -> Result<String, String> {
+    NODE_KINDS
+        .iter()
+        .find(|k| k.eq_ignore_ascii_case(value))
+        .map(|k| (*k).to_string())
+        .ok_or_else(|| format!("must be one of {}", NODE_KINDS.join(", ")))
+}
+
+/// Parse a float documented as `[0.0-1.0]` and enforce that range.
+///
+/// Every INTEGER range in the CLI is enforced by clap, but the floats were
+/// unguarded: `--confidence 5.0` was accepted at exit 0 and returned an empty
+/// result with no explanation, which reads exactly like "nothing depends on
+/// this symbol" (nw-108).
+fn parse_unit_interval_f32(value: &str) -> Result<f32, String> {
+    let parsed: f32 = value.parse().map_err(|_| "must be a number".to_string())?;
+    if !parsed.is_finite() || !(0.0..=1.0).contains(&parsed) {
+        return Err("must be in 0.0..=1.0".to_string());
+    }
+    Ok(parsed)
+}
+
+/// `f64` counterpart of [`parse_unit_interval_f32`].
+fn parse_unit_interval_f64(value: &str) -> Result<f64, String> {
+    let parsed: f64 = value.parse().map_err(|_| "must be a number".to_string())?;
+    if !parsed.is_finite() || !(0.0..=1.0).contains(&parsed) {
+        return Err("must be in 0.0..=1.0".to_string());
+    }
+    Ok(parsed)
+}
+
 /// One-line verdict for a `broken-links` entry.
 ///
 /// A sub-1.0 confidence means the link matched at a lower resolver tier, not
@@ -911,6 +950,7 @@ enum Commands {
         #[arg(
             long,
             value_delimiter = ',',
+            value_parser = parse_node_kind,
             help = "Restrict to node kinds (comma-separated): Section,Note,Symbol"
         )]
         kinds: Option<Vec<String>>,
@@ -952,6 +992,7 @@ enum Commands {
         #[arg(
             long,
             value_delimiter = ',',
+            value_parser = parse_node_kind,
             help = "Restrict to node kinds (comma-separated): Section,Note,Symbol"
         )]
         kinds: Option<Vec<String>>,
@@ -985,11 +1026,13 @@ enum Commands {
         #[arg(
             long,
             default_value = "0.0",
+            value_parser = parse_unit_interval_f32,
             help = "Minimum edge confidence [0.0-1.0]"
         )]
         confidence: f32,
         #[arg(
             long,
+            value_parser = parse_unit_interval_f64,
             help = "Minimum impact score for including a dependent [0.0-1.0] (default: 0.10; pass 0 to disable score pruning and get the full traversal)"
         )]
         min_score: Option<f64>,
@@ -2629,7 +2672,7 @@ enum BrainCommands {
         #[arg(
             long,
             value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=1000),
-            help = "Maximum results (1-1000; default: 20, or [limits].default_result_limit from config; matches the MCP brain_search schema)"
+            help = "Maximum results PER KIND (1-1000; default: 20, or [limits].default_result_limit from config; matches the MCP brain_search schema). Notes and code symbols are capped separately, so a query matching both can return up to 2x this value; `returned_matches` always reports the true total"
         )]
         limit: Option<usize>,
         #[arg(long, help = "Output as JSON")]
@@ -19341,6 +19384,21 @@ mod cli_bounds_tests {
                         &["0"],
                         &["1", "20"],
                     ),
+                    // nw-108: the FLOAT ranges were the gap. Every integer
+                    // range above was already enforced by clap, but
+                    // `--confidence 5.0` and `--min-score 9.9` parsed happily
+                    // and returned an empty result at exit 0 — indistinguishable
+                    // from "nothing depends on this symbol".
+                    (
+                        &["nestweaver", "impact", "sym", "--confidence"],
+                        &["-0.1", "1.1", "5.0", "nan", "abc"],
+                        &["0", "0.0", "0.5", "1", "1.0"],
+                    ),
+                    (
+                        &["nestweaver", "impact", "sym", "--min-score"],
+                        &["-0.1", "1.1", "9.9", "inf", "abc"],
+                        &["0", "0.0", "0.1", "1", "1.0"],
+                    ),
                 ];
                 for (prefix, bad, good) in cases {
                     for v in *bad {
@@ -19355,6 +19413,42 @@ mod cli_bounds_tests {
                         let mut argv = prefix.to_vec();
                         argv.push(v);
                         assert!(Cli::try_parse_from(&argv).is_ok(), "{argv:?} must parse");
+                    }
+                }
+            })
+            .expect("spawn")
+            .join()
+            .expect("join");
+    }
+
+    /// nw-108: `--kinds` documents a closed set but silently dropped unknown
+    /// tokens, so `--kinds Bogus` returned zero matches at exit 0 and a typo
+    /// looked exactly like a real empty result. Case-insensitive matching is
+    /// preserved — only unknown values are now rejected.
+    #[test]
+    fn kinds_flag_rejects_values_outside_the_documented_set() {
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                for prefix in [
+                    ["nestweaver", "count-patterns", "pat", "--kinds"],
+                    ["nestweaver", "regex-search", "pat", "--kinds"],
+                ] {
+                    for bad in ["Bogus", "Sections", "note,Bogus", ""] {
+                        let mut argv = prefix.to_vec();
+                        argv.push(bad);
+                        assert!(
+                            Cli::try_parse_from(&argv).is_err(),
+                            "{argv:?} must be rejected — a typo must not read as an empty result"
+                        );
+                    }
+                    for good in ["Section", "note", "SYMBOL", "Note,Symbol"] {
+                        let mut argv = prefix.to_vec();
+                        argv.push(good);
+                        assert!(
+                            Cli::try_parse_from(&argv).is_ok(),
+                            "{argv:?} must parse — matching stays case-insensitive"
+                        );
                     }
                 }
             })

--- a/src/main.rs
+++ b/src/main.rs
@@ -655,6 +655,87 @@ fn print_link_classification(links: &[nestweaver_engine::BrokenLink]) {
     );
 }
 
+/// Provenance for a result computed WITHOUT the daemon.
+///
+/// The federation layer attaches `_meta` (scope, sources, stale_repos) on the
+/// daemon path only, so `--json` returned a different SHAPE depending on whether
+/// a daemon happened to be running. The direct path is genuinely local scope, so
+/// it can state the same thing truthfully rather than omitting the field
+/// (nw-117).
+fn local_result_meta() -> serde_json::Value {
+    serde_json::json!({
+        "scope": "local",
+        "sources": ["local"],
+        "stale_repos": [],
+    })
+}
+
+/// The single JSON shape `impact` emits, for every outcome.
+///
+/// `impact --json` previously returned three incompatible shapes: a bare node
+/// array for a complete walk, an object when the traversal was pruned, and a
+/// bare CANDIDATE array when the symbol name was ambiguous. The last is the
+/// dangerous one — it is structurally indistinguishable from a successful
+/// result, so a mistyped name returned four "impacted symbols" that were
+/// actually four candidates. Only the exit code disambiguated, which is
+/// invisible to anything consuming piped JSON.
+///
+/// Every other surface here already returns an envelope (`blast_radius`,
+/// `dead-code`, `broken-links`, `contracts drift`); `impact` was the outlier.
+/// `status` is the discriminator a consumer branches on (nw-111).
+fn impact_json_ok(
+    symbol: &str,
+    nodes: serde_json::Value,
+    truncated_by_threshold: bool,
+    truncated_by_depth: bool,
+    total: Option<u64>,
+    returned: Option<u64>,
+    note: Option<String>,
+) -> serde_json::Value {
+    let capped = matches!((total, returned), (Some(t), Some(r)) if r < t);
+    let mut payload = serde_json::json!({
+        "status": "ok",
+        "symbol": symbol,
+        "nodes": nodes,
+        "truncated": truncated_by_threshold || truncated_by_depth || capped,
+        "truncated_by_threshold": truncated_by_threshold,
+        "truncated_by_depth": truncated_by_depth,
+    });
+    if let Some(obj) = payload.as_object_mut() {
+        if let Some(t) = total {
+            obj.insert("total".to_string(), serde_json::json!(t));
+        }
+        if let Some(r) = returned {
+            obj.insert("returned".to_string(), serde_json::json!(r));
+        }
+        if let Some(note) = note {
+            obj.insert("note".to_string(), serde_json::json!(note));
+        }
+    }
+    payload
+}
+
+/// Ambiguous resolution — carries `candidates`, never `nodes`, so it cannot be
+/// mistaken for a result set.
+fn impact_json_ambiguous(symbol: &str, candidates: serde_json::Value) -> serde_json::Value {
+    serde_json::json!({
+        "status": "ambiguous",
+        "symbol": symbol,
+        "candidates": candidates,
+        "note": "the symbol name matched multiple symbols; no impact was computed. \
+                 Disambiguate with --repo <name> or pass a full UID",
+    })
+}
+
+fn impact_json_not_found(symbol: &str) -> serde_json::Value {
+    serde_json::json!({
+        "status": "not_found",
+        "symbol": symbol,
+        "error": "not found",
+        "name": symbol,
+    })
+}
+
 /// Render a `dead-code` result as text from its JSON payload.
 ///
 /// BOTH the direct and daemon paths render through this, so the two cannot
@@ -6963,7 +7044,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // Built unconditionally so the text path renders from the SAME
             // payload the JSON path prints, and from the same payload the
             // daemon returns (nw-108).
-            let payload = serde_json::to_value(DeadCodeJson {
+            let mut payload = serde_json::to_value(DeadCodeJson {
                 total_symbols: result.total_symbols,
                 reachable_symbols: result.reachable_symbols,
                 unreachable_count: result.unreachable_symbols.len(),
@@ -6975,6 +7056,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 min_confidence: min_conf.to_string(),
                 unreachable_symbols: shown,
             })?;
+            // Match the daemon's envelope so `--json` has one shape regardless
+            // of whether a daemon is running (nw-117).
+            if let Some(obj) = payload.as_object_mut() {
+                obj.insert("_meta".to_string(), local_result_meta());
+            }
 
             if json {
                 println!("{}", serde_json::to_string_pretty(&payload)?);
@@ -8884,13 +8970,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     match value.get("status").and_then(|v| v.as_str()) {
                         Some("not_found") => {
                             if json {
-                                // nw-086: identical --json shape as the direct path.
                                 println!(
                                     "{}",
-                                    serde_json::to_string_pretty(&serde_json::json!({
-                                        "error": "not found",
-                                        "name": name_or_uid,
-                                    }))?
+                                    serde_json::to_string_pretty(&impact_json_not_found(
+                                        &name_or_uid
+                                    ))?
                                 );
                             } else if !out.quiet {
                                 println!("No symbol found: '{name_or_uid}'.");
@@ -8899,12 +8983,17 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         }
                         Some("ambiguous") => {
                             if json {
-                                // nw-086: bare candidates array, matching the direct path.
                                 let cands = value
                                     .get("candidates")
                                     .cloned()
                                     .unwrap_or_else(|| serde_json::json!([]));
-                                println!("{}", serde_json::to_string_pretty(&cands)?);
+                                println!(
+                                    "{}",
+                                    serde_json::to_string_pretty(&impact_json_ambiguous(
+                                        &name_or_uid,
+                                        cands
+                                    ))?
+                                );
                             } else if !out.quiet {
                                 println!("Ambiguous symbol '{name_or_uid}' — multiple matches:");
                                 if let Some(cands) =
@@ -8957,37 +9046,34 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             .get("impact_nodes")
                             .cloned()
                             .unwrap_or_else(|| value.clone());
-                        if capped {
-                            println!(
-                                "{}",
-                                serde_json::to_string_pretty(&serde_json::json!({
-                                    "nodes": payload,
-                                    "total": total,
-                                    "returned": returned,
-                                    "truncated": true,
-                                    "truncated_by_threshold": truncated_by_threshold,
-                                    "truncated_by_depth": truncated_by_depth,
-                                    "note": format!(
-                                        "showing {} of {} impacted node(s) — reported impact is a \
-                                         floor; raise --limit or pass --min-score 0 for the full set",
-                                        returned.unwrap_or(0),
-                                        total.unwrap_or(0)
-                                    ),
-                                }))?
-                            );
-                        } else if truncated_by_threshold || truncated_by_depth {
-                            println!(
-                                "{}",
-                                serde_json::to_string_pretty(&serde_json::json!({
-                                    "nodes": payload,
-                                    "truncated_by_threshold": truncated_by_threshold,
-                                    "truncated_by_depth": truncated_by_depth,
-                                    "note": value.get("note").cloned().unwrap_or(serde_json::Value::Null),
-                                }))?
-                            );
+                        // One envelope for every outcome — a complete walk, a
+                        // pruned traversal and a capped result set all carry the
+                        // same keys, so a consumer parses one shape (nw-111).
+                        let note = if capped {
+                            Some(format!(
+                                "showing {} of {} impacted node(s) — reported impact is a \
+                                 floor; raise --limit or pass --min-score 0 for the full set",
+                                returned.unwrap_or(0),
+                                total.unwrap_or(0)
+                            ))
                         } else {
-                            println!("{}", serde_json::to_string_pretty(&payload)?);
-                        }
+                            value
+                                .get("note")
+                                .and_then(|v| v.as_str())
+                                .map(|s| s.to_string())
+                        };
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&impact_json_ok(
+                                &name_or_uid,
+                                payload,
+                                truncated_by_threshold,
+                                truncated_by_depth,
+                                total,
+                                returned,
+                                note,
+                            ))?
+                        );
                     } else if let Some(arr) = value.get("impact_nodes") {
                         #[derive(serde::Deserialize)]
                         struct DaemonImpactNode {
@@ -9075,39 +9161,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     let count = nodes.len();
                     let truncated = result.truncated_by_threshold || result.truncated_by_depth;
 
-                    if json && !truncated {
-                        // nw-086: bare node array (matches the daemon path's --json
-                        // shape) — but ONLY for a complete walk; see below.
-                        #[derive(serde::Serialize)]
-                        struct ImpactNodeJson {
-                            uid: String,
-                            name: String,
-                            file_path: String,
-                            start_line: u32,
-                            edge_type: String,
-                            confidence: f32,
-                            depth: u32,
-                        }
-                        let json_nodes: Vec<_> = nodes
-                            .iter()
-                            .map(|n| ImpactNodeJson {
-                                uid: n.uid.clone(),
-                                name: n.name.clone(),
-                                file_path: n.file_path.clone(),
-                                start_line: n.start_line,
-                                edge_type: n.edge_type.clone(),
-                                confidence: n.confidence,
-                                depth: n.depth,
-                            })
-                            .collect();
-                        println!("{}", serde_json::to_string_pretty(&json_nodes)?);
-                    } else if json {
-                        // Truncated walk: a bare array would read as a complete
-                        // answer, so emit an honest object instead (like
-                        // blast_radius's blind_spots) — `nodes` plus the
-                        // truncation flags and a human-readable caveat.
-                        let note = impact_truncation_note(&result, threshold, depth);
-                        eprintln!("note: {note}");
+                    if json {
+                        // One envelope whether or not the walk was pruned. The
+                        // shape used to change with the outcome, so a consumer
+                        // had to branch on the JSON type before it could read
+                        // anything (nw-111).
                         #[derive(serde::Serialize)]
                         struct ImpactNodeJson<'a> {
                             uid: &'a str,
@@ -9130,14 +9188,22 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 depth: n.depth,
                             })
                             .collect();
+                        let note = truncated.then(|| {
+                            let note = impact_truncation_note(&result, threshold, depth);
+                            eprintln!("note: {note}");
+                            note
+                        });
                         println!(
                             "{}",
-                            serde_json::to_string_pretty(&serde_json::json!({
-                                "nodes": json_nodes,
-                                "truncated_by_threshold": result.truncated_by_threshold,
-                                "truncated_by_depth": result.truncated_by_depth,
-                                "note": note,
-                            }))?
+                            serde_json::to_string_pretty(&impact_json_ok(
+                                &name_or_uid,
+                                serde_json::to_value(&json_nodes)?,
+                                result.truncated_by_threshold,
+                                result.truncated_by_depth,
+                                None,
+                                None,
+                                note,
+                            ))?
                         );
                     } else if nodes.is_empty() {
                         if !out.quiet {
@@ -9192,16 +9258,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     Ok((EXIT_SUCCESS, Some(stats)))
                 }
                 ResolveResult::NotFound => {
-                    // nw-086: under --json, emit a JSON error object (matching the
-                    // `symbol` command and the daemon path) instead of only a
+                    // nw-086: under --json, emit a JSON object instead of only a
                     // plain-text stderr line a --json consumer can't parse.
                     if json {
                         println!(
                             "{}",
-                            serde_json::to_string_pretty(&serde_json::json!({
-                                "error": "not found",
-                                "name": name_or_uid,
-                            }))?
+                            serde_json::to_string_pretty(&impact_json_not_found(&name_or_uid))?
                         );
                     } else {
                         eprintln!("Symbol '{name_or_uid}' not found.");
@@ -9210,7 +9272,16 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
                 ResolveResult::Ambiguous(candidates) => {
                     if json {
-                        println!("{}", serde_json::to_string_pretty(&candidates)?);
+                        // Carries `candidates`, never `nodes` — a bare array here
+                        // was indistinguishable from a result set, so a mistyped
+                        // name looked like a successful impact query (nw-111).
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&impact_json_ambiguous(
+                                &name_or_uid,
+                                serde_json::to_value(&candidates)?
+                            ))?
+                        );
                     } else {
                         eprintln!(
                             "Ambiguous: '{}' matches {} symbols:",

--- a/src/main.rs
+++ b/src/main.rs
@@ -3051,8 +3051,17 @@ enum BrainCommands {
         )]
         prefer_instance: Option<String>,
     },
-    /// List wikilinks whose target is ambiguous or low-confidence
-    /// (confidence < 1.0), with suggested target notes for each.
+    /// List wikilinks that resolved below full confidence or not at all.
+    ///
+    /// Suggestions are offered WHERE CANDIDATES EXIST, which is not every entry:
+    /// a link whose target exists nowhere in the vault — a deleted note, or an ID
+    /// that is a backlog entry rather than a note — has nothing to suggest, and
+    /// an empty list is the honest answer. The old wording promised "suggested
+    /// target notes for each" and so read as a defect whenever the list was
+    /// empty (nw-100).
+    ///
+    /// Check `resolved_target_uid` to tell a link that RESOLVED at a lower tier
+    /// from one that points at nothing.
     BrokenLinks {
         #[arg(long, default_value = "5", help = "Max suggested targets per link")]
         max_suggestions: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4081,6 +4081,21 @@ fn maybe_run_auto_setup(db_path: &Path, repo_root: &Path, out: &OutputConfig, fo
 fn open_store(db: Option<&Path>) -> anyhow::Result<GraphStore> {
     let default = default_db_path();
     let path = db.unwrap_or(&default);
+    // Absent file → the canonical `db_not_found` diagnostic, at the one place
+    // every read-only open funnels through.
+    //
+    // `open_read_only` reports a missing database as "Cannot create an empty
+    // database under READ ONLY mode", which mentions creating something the
+    // caller never asked to create, and which the error mapper cannot
+    // recognise — its heuristic wants "failed to open database" AND "no such
+    // file". So a dozen read commands leaked that raw store error with no
+    // remedy while list-repos/hubs/stale-check, which call
+    // `require_existing_db` first, reported it properly (nw-108).
+    //
+    // Guarding here fixes every read path at once instead of repeating the
+    // check at each call site. The explicit `require_existing_db` calls stay:
+    // they run BEFORE a daemon can be autostarted, which this cannot.
+    require_existing_db(path)?;
     let store = GraphStore::open_read_only(path).map_err(|e| {
         let msg = e.to_string();
         if msg.contains("Corrupted wal") || msg.contains("Could not set lock") {
@@ -17955,6 +17970,40 @@ mod hybrid_cli_tests {
                 "root": "/repo",
             })
         );
+    }
+
+    /// nw-108 (4): EVERY read-only open must produce the `db_not_found`
+    /// diagnostic on a missing database, not just the commands that happen to
+    /// call `require_existing_db` first.
+    ///
+    /// `open_read_only` reports a missing file as "Cannot create an empty
+    /// database under READ ONLY mode" — it names a creation the caller never
+    /// requested, and the error mapper cannot recognise it (its heuristic wants
+    /// "failed to open database" AND "no such file"). A dozen read commands
+    /// leaked that raw text with no remedy. Guarding inside `open_store` covers
+    /// all 57 read-only call sites at once.
+    #[test]
+    fn open_store_reports_db_not_found_rather_than_the_raw_store_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("absent.lbug");
+
+        let err = match open_store(Some(&missing)) {
+            Ok(_) => panic!("a missing db must not open"),
+            Err(e) => e,
+        };
+        let rendered = format!("{:?}", into_diagnostic(err));
+
+        assert!(
+            rendered.contains("db_not_found"),
+            "expected the db_not_found diagnostic, got: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Cannot create an empty database"),
+            "the raw store error must not leak — it names a creation the caller \
+             never asked for: {rendered}"
+        );
+        // Opening read-only must not have materialised anything.
+        assert!(!missing.exists());
     }
 
     /// nw-087: a nonexistent --db must fail with the db_not_found

--- a/src/main.rs
+++ b/src/main.rs
@@ -16345,8 +16345,11 @@ fn run_instance(command: InstanceCommands) -> anyhow::Result<i32> {
                     "Merged '{from}' -> '{to}': {} vault(s), {} repo(s), {} project(s)",
                     result.vaults_reparented, result.repos_reparented, result.projects_reparented
                 );
-                for d in &result.discarded_vaults {
-                    eprintln!("Note: {d}");
+                if !result.discarded_vaults.is_empty() {
+                    eprintln!(
+                        "{}",
+                        merge_discarded_vault_guidance(&result.discarded_vaults, &to)
+                    );
                 }
                 if !result.repos_needing_reindex.is_empty() {
                     eprintln!("{}", merge_reindex_guidance(&result.repos_needing_reindex));
@@ -16387,6 +16390,30 @@ fn run_instance(command: InstanceCommands) -> anyhow::Result<i32> {
     }
 }
 
+/// Guidance for vaults whose notes were discarded by a merge collision.
+///
+/// When two instances hold a vault at the same root, the one with fewer notes
+/// loses and its notes are dropped. That was reported as a bare
+/// `Note: <root> (N notes discarded)` with no remedy — a line that states data
+/// loss and stops. Notes are re-derivable from the files on disk, so say how
+/// (nw-112).
+fn merge_discarded_vault_guidance(discarded: &[String], to_instance: &str) -> String {
+    let mut guidance = String::from(
+        "\nNOTE: a vault collision discarded notes from the losing vault.\n\
+         Those notes are re-derivable from the files on disk — re-index each root \
+         below under the target instance to restore them:\n",
+    );
+    for entry in discarded {
+        guidance.push_str("  ");
+        guidance.push_str(entry);
+        guidance.push('\n');
+    }
+    guidance.push_str(&format!(
+        "  nestweaver brain refresh <root> --instance {to_instance}"
+    ));
+    guidance
+}
+
 fn merge_reindex_guidance(repos: &[String]) -> String {
     let mut guidance = String::from(
         "\nNOTE: source repo graph rows were removed during merge.\n\
@@ -16405,6 +16432,26 @@ fn merge_reindex_guidance(repos: &[String]) -> String {
 #[cfg(test)]
 mod merge_instance_guidance_tests {
     use super::*;
+
+    /// nw-112: a discarded-vault line must carry a remedy, not just announce
+    /// data loss. The notes are re-derivable from disk, so the guidance names
+    /// the refresh command and the target instance.
+    #[test]
+    fn discarded_vault_guidance_names_the_refresh_and_target_instance() {
+        let guidance = merge_discarded_vault_guidance(
+            &["/Users/me/brain (945 notes discarded)".to_string()],
+            "kory-brain",
+        );
+        assert!(guidance.contains("945 notes discarded"));
+        assert!(
+            guidance.contains("brain refresh"),
+            "must name the remedy: {guidance}"
+        );
+        assert!(
+            guidance.contains("--instance kory-brain"),
+            "must name the target instance so the refresh does not create a second vault: {guidance}"
+        );
+    }
 
     #[test]
     fn reindex_guidance_describes_removed_then_recreated_graph_rows() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -655,6 +655,184 @@ fn print_link_classification(links: &[nestweaver_engine::BrokenLink]) {
     );
 }
 
+/// Render a `dead-code` result as text from its JSON payload.
+///
+/// BOTH the direct and daemon paths render through this, so the two cannot
+/// drift. The daemon branch used to `println!` the RPC response verbatim with
+/// no `if json` guard, which meant the OUTPUT FORMAT depended on whether a
+/// daemon happened to be running rather than on the flag — `dead-code` printed
+/// text standalone and JSON once the daemon was up (nw-108). Driving both from
+/// the same payload makes parity structural rather than something to remember.
+/// Render an `investigate` bundle as text from its JSON payload.
+///
+/// Shared by the direct and daemon paths for the same reason as
+/// [`render_dead_code_text`]: the daemon branch printed its response verbatim,
+/// so the output format tracked whether a daemon was running instead of the
+/// `--json` flag (nw-108).
+fn render_investigate_text(payload: &serde_json::Value) {
+    let text = |v: &serde_json::Value, k: &str| {
+        v.get(k)
+            .and_then(|x| x.as_str())
+            .unwrap_or_default()
+            .to_string()
+    };
+    let entries: Vec<&serde_json::Value> = payload
+        .get("entries")
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().collect())
+        .unwrap_or_default();
+    let domains: Vec<&serde_json::Value> = payload
+        .get("domains")
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().collect())
+        .unwrap_or_default();
+    let more_available = payload
+        .get("more_available")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    println!(
+        "Bundle: {}  (query: {:?})",
+        text(payload, "bundle_id"),
+        text(payload, "query")
+    );
+    println!(
+        "{} domain(s), {} entr{}{}",
+        domains.len(),
+        entries.len(),
+        if entries.len() == 1 { "y" } else { "ies" },
+        if more_available > 0 {
+            format!(" ({more_available} more available — raise --token-budget)")
+        } else {
+            String::new()
+        }
+    );
+
+    for d in &domains {
+        println!("\n[{}]", text(d, "label"));
+        let entry_point = text(d, "entry_point");
+        for member in d
+            .get("members")
+            .and_then(|v| v.as_array())
+            .into_iter()
+            .flatten()
+        {
+            let asset_id = member.as_str().unwrap_or_default();
+            let Some(e) = entries
+                .iter()
+                .find(|e| e.get("asset_id").and_then(|v| v.as_str()) == Some(asset_id))
+            else {
+                continue;
+            };
+            let marker = if asset_id == entry_point { "*" } else { " " };
+            println!(
+                "  {marker} {}  {} ({})  {}",
+                asset_id,
+                text(e, "title"),
+                text(e, "kind"),
+                text(e, "location")
+            );
+            if let Some(summary) = e.get("summary").and_then(|v| v.as_str()) {
+                let truncated = if !e.get("inline_body").is_none_or(|v| v.is_null())
+                    && !e
+                        .get("body_complete")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(true)
+                {
+                    " [truncated]"
+                } else {
+                    ""
+                };
+                println!("      {summary}{truncated}");
+            }
+        }
+    }
+
+    println!(
+        "\nDrill in: nestweaver investigate-expand {} --targets <asset_id,...>",
+        text(payload, "bundle_id")
+    );
+}
+
+fn render_dead_code_text(payload: &serde_json::Value) {
+    let num = |k: &str| payload.get(k).and_then(|v| v.as_u64()).unwrap_or(0);
+    let total = num("total_symbols");
+    let matching = num("matching_count");
+    let excluded = num("excluded_count");
+
+    let excluded_note = || {
+        if excluded > 0 {
+            println!("({excluded} type-only/declaration symbols excluded from analysis)");
+        }
+    };
+
+    if matching == 0 {
+        println!("No dead code detected ({total} symbols, all reachable from entry points).");
+        excluded_note();
+        return;
+    }
+
+    println!(
+        "Dead code analysis: {} of {total} symbols ({:.1}%) unreachable from entry points\n",
+        num("unreachable_count"),
+        payload
+            .get("dead_percentage")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0),
+    );
+    excluded_note();
+
+    let returned = num("returned");
+    let min_conf = payload
+        .get("min_confidence")
+        .and_then(|v| v.as_str())
+        .unwrap_or("low");
+    if min_conf != "low" {
+        println!("Showing {returned} symbol(s) with confidence >= {min_conf}\n");
+    }
+    if payload
+        .get("truncated")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        println!("(showing first {returned} of {matching} — pass --limit to change)\n");
+    }
+
+    // Group by file path, matching the direct path's BTreeMap ordering.
+    let mut by_file: std::collections::BTreeMap<&str, Vec<&serde_json::Value>> =
+        std::collections::BTreeMap::new();
+    for sym in payload
+        .get("unreachable_symbols")
+        .and_then(|v| v.as_array())
+        .into_iter()
+        .flatten()
+    {
+        let file = sym.get("file_path").and_then(|v| v.as_str()).unwrap_or("");
+        by_file.entry(file).or_default().push(sym);
+    }
+    for (file, syms) in &by_file {
+        println!("{file}:");
+        for sym in syms {
+            let field = |k: &str| sym.get(k).and_then(|v| v.as_str()).unwrap_or("");
+            // Lowercase the confidence: the two paths serialise it
+            // differently — the direct payload carries the serde variant
+            // name ("Medium") while the daemon returns "medium" — and the
+            // historical text output used the Display impl, which is
+            // lowercase. Normalising here keeps the rendered text stable and
+            // identical across modes. The underlying JSON inconsistency is a
+            // separate defect.
+            println!(
+                "  {} ({}) [{}] confidence={}",
+                field("name"),
+                field("kind"),
+                field("visibility"),
+                field("confidence").to_lowercase(),
+            );
+        }
+        println!();
+    }
+}
+
 fn capability_diagnostics_value(
     embedding_compiled: bool,
     metal_compiled: bool,
@@ -6621,7 +6799,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     args["limit"] = serde_json::json!(n);
                 }
                 if let Some(value) = try_hybrid_json_rpc(true, &db_path, None, "dead_code", args) {
-                    println!("{}", serde_json::to_string_pretty(&value)?);
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&value)?);
+                    } else {
+                        render_dead_code_text(&value);
+                    }
                     return Ok((EXIT_SUCCESS, None));
                 }
             }
@@ -6658,97 +6840,44 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 None => filtered,
             };
 
+            #[derive(serde::Serialize)]
+            struct DeadCodeJson<'a> {
+                total_symbols: usize,
+                reachable_symbols: usize,
+                unreachable_count: usize,
+                matching_count: usize,
+                returned: usize,
+                truncated: bool,
+                excluded_count: usize,
+                dead_percentage: f64,
+                min_confidence: String,
+                unreachable_symbols: Vec<&'a nestweaver_engine::UnreachableSymbol>,
+            }
+            // Count contract (same as the dead_code MCP tool):
+            // `unreachable_count` is the UNFILTERED total, consistent with
+            // total_symbols/reachable_symbols/dead_percentage;
+            // `matching_count` is the post-min-confidence count.
+            //
+            // Built unconditionally so the text path renders from the SAME
+            // payload the JSON path prints, and from the same payload the
+            // daemon returns (nw-108).
+            let payload = serde_json::to_value(DeadCodeJson {
+                total_symbols: result.total_symbols,
+                reachable_symbols: result.reachable_symbols,
+                unreachable_count: result.unreachable_symbols.len(),
+                matching_count: filtered_count,
+                returned: shown.len(),
+                truncated,
+                excluded_count: result.excluded_count,
+                dead_percentage: result.dead_percentage,
+                min_confidence: min_conf.to_string(),
+                unreachable_symbols: shown,
+            })?;
+
             if json {
-                #[derive(serde::Serialize)]
-                struct DeadCodeJson<'a> {
-                    total_symbols: usize,
-                    reachable_symbols: usize,
-                    unreachable_count: usize,
-                    matching_count: usize,
-                    returned: usize,
-                    truncated: bool,
-                    excluded_count: usize,
-                    dead_percentage: f64,
-                    min_confidence: String,
-                    unreachable_symbols: Vec<&'a nestweaver_engine::UnreachableSymbol>,
-                }
-                // Count contract (same as the dead_code MCP tool):
-                // `unreachable_count` is the UNFILTERED total, consistent with
-                // total_symbols/reachable_symbols/dead_percentage;
-                // `matching_count` is the post-min-confidence count.
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&DeadCodeJson {
-                        total_symbols: result.total_symbols,
-                        reachable_symbols: result.reachable_symbols,
-                        unreachable_count: result.unreachable_symbols.len(),
-                        matching_count: filtered_count,
-                        returned: shown.len(),
-                        truncated,
-                        excluded_count: result.excluded_count,
-                        dead_percentage: result.dead_percentage,
-                        min_confidence: min_conf.to_string(),
-                        unreachable_symbols: shown,
-                    })?
-                );
-            } else if filtered_count == 0 {
-                println!(
-                    "No dead code detected ({} symbols, all reachable from entry points).",
-                    result.total_symbols
-                );
-                if result.excluded_count > 0 {
-                    println!(
-                        "({} type-only/declaration symbols excluded from analysis)",
-                        result.excluded_count
-                    );
-                }
+                println!("{}", serde_json::to_string_pretty(&payload)?);
             } else {
-                println!(
-                    "Dead code analysis: {} of {} symbols ({:.1}%) unreachable from entry points\n",
-                    result.unreachable_symbols.len(),
-                    result.total_symbols,
-                    result.dead_percentage,
-                );
-                if result.excluded_count > 0 {
-                    println!(
-                        "({} type-only/declaration symbols excluded from analysis)",
-                        result.excluded_count
-                    );
-                }
-                if min_conf != DeadCodeConfidence::Low {
-                    println!(
-                        "Showing {} symbol(s) with confidence >= {}\n",
-                        shown.len(),
-                        min_conf
-                    );
-                }
-                if truncated {
-                    println!(
-                        "(showing first {} of {} — pass --limit to change)\n",
-                        shown.len(),
-                        filtered_count
-                    );
-                }
-
-                // Group by file path.
-                let mut by_file: std::collections::BTreeMap<
-                    &str,
-                    Vec<&nestweaver_engine::UnreachableSymbol>,
-                > = std::collections::BTreeMap::new();
-                for sym in &shown {
-                    by_file.entry(&sym.file_path).or_default().push(sym);
-                }
-
-                for (file, syms) in &by_file {
-                    println!("{}:", file);
-                    for sym in syms {
-                        println!(
-                            "  {} ({}) [{}] confidence={}",
-                            sym.name, sym.kind, sym.visibility, sym.confidence,
-                        );
-                    }
-                    println!();
-                }
+                render_dead_code_text(&payload);
             }
 
             let stats = format!(
@@ -9459,7 +9588,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
                 if let Some(value) = try_hybrid_json_rpc(true, &db_path, None, "investigate", args)
                 {
-                    println!("{}", serde_json::to_string_pretty(&value)?);
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&value)?);
+                    } else {
+                        render_investigate_text(&value);
+                    }
                     return Ok((EXIT_SUCCESS, None));
                 }
             }
@@ -9479,56 +9612,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 Some(token_budget),
                 None,
             )?;
+            // Built unconditionally so text and JSON render from the SAME
+            // payload, and so the daemon path can reuse the renderer (nw-108).
+            let payload = serde_json::to_value(&result)?;
             if json {
-                println!("{}", serde_json::to_string_pretty(&result)?);
+                println!("{}", serde_json::to_string_pretty(&payload)?);
             } else {
-                println!("Bundle: {}  (query: {:?})", result.bundle_id, result.query);
-                println!(
-                    "{} domain(s), {} entr{}{}",
-                    result.domains.len(),
-                    result.entries.len(),
-                    if result.entries.len() == 1 {
-                        "y"
-                    } else {
-                        "ies"
-                    },
-                    if result.more_available > 0 {
-                        format!(
-                            " ({} more available — raise --token-budget)",
-                            result.more_available
-                        )
-                    } else {
-                        String::new()
-                    }
-                );
-                for d in &result.domains {
-                    println!("\n[{}]", d.label);
-                    for asset_id in &d.members {
-                        if let Some(e) = result.entries.iter().find(|e| &e.asset_id == asset_id) {
-                            let marker = if e.asset_id == d.entry_point {
-                                "*"
-                            } else {
-                                " "
-                            };
-                            println!(
-                                "  {marker} {}  {} ({})  {}",
-                                e.asset_id, e.title, e.kind, e.location
-                            );
-                            if let Some(s) = &e.summary {
-                                let truncated = if e.inline_body.is_some() && !e.body_complete {
-                                    " [truncated]"
-                                } else {
-                                    ""
-                                };
-                                println!("      {s}{truncated}");
-                            }
-                        }
-                    }
-                }
-                println!(
-                    "\nDrill in: nestweaver investigate-expand {} --targets <asset_id,...>",
-                    result.bundle_id
-                );
+                render_investigate_text(&payload);
             }
             Ok((EXIT_SUCCESS, None))
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -835,6 +835,141 @@ fn render_investigate_text(payload: &serde_json::Value) {
     );
 }
 
+/// Attach the local-scope provenance the federation layer adds on the daemon
+/// path, so `--json` has ONE shape regardless of whether a daemon is running.
+///
+/// Same divergence as nw-117: `_meta` is added by federation, which only runs in
+/// daemon mode, so a direct result was a different shape rather than a different
+/// value. The direct path is genuinely local scope and can say so truthfully.
+fn attach_local_meta(payload: &mut serde_json::Value) {
+    if let Some(obj) = payload.as_object_mut() {
+        obj.entry("_meta").or_insert_with(|| {
+            serde_json::json!({
+                "scope": "local",
+                "sources": ["local"],
+                "stale_repos": [],
+            })
+        });
+    }
+}
+
+/// Render a `blast-radius` result as text from its JSON payload.
+///
+/// Both the direct and daemon paths render through this, so the two cannot
+/// drift — the rule established when `dead-code` and `investigate` were found
+/// emitting JSON or text depending on whether a daemon happened to be running
+/// (nw-108).
+fn render_blast_radius_text(payload: &serde_json::Value) {
+    let s = |k: &str| payload.get(k).and_then(|v| v.as_str()).unwrap_or("");
+    let n = |k: &str| payload.get(k).and_then(|v| v.as_u64()).unwrap_or(0);
+
+    // The payload's key is `risk`, not `risk_level` — worth stating, because
+    // guessing it rendered a blank risk with no error at all.
+    println!(
+        "Blast radius: {} affected symbol(s), risk {}",
+        n("affected_symbol_count"),
+        s("risk")
+    );
+    let summary = s("summary");
+    if !summary.is_empty() {
+        println!("  {summary}");
+    }
+    // The trust contract comes FIRST. A caller who reads only the first lines
+    // must not walk away with a risk level whose run never completed.
+    println!("  status:     {}", s("status"));
+    println!("  gate_state: {}", s("gate_state"));
+
+    for note in payload
+        .get("notifications")
+        .and_then(|v| v.as_array())
+        .into_iter()
+        .flatten()
+    {
+        let level = note.get("level").and_then(|v| v.as_str()).unwrap_or("note");
+        let msg = note.get("message").and_then(|v| v.as_str()).unwrap_or("");
+        println!("  [{level}] {msg}");
+    }
+
+    let blind: Vec<&str> = payload
+        .get("blind_spots")
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+    if !blind.is_empty() {
+        println!("  blind spots: {}", blind.join(", "));
+    }
+
+    let symbols = payload
+        .get("affected_symbols")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    if symbols.is_empty() {
+        println!("\nNo affected symbols reported.");
+        return;
+    }
+    println!();
+    for sym in &symbols {
+        let g = |k: &str| sym.get(k).and_then(|v| v.as_str()).unwrap_or("");
+        let score = sym
+            .get("impact_score")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
+        println!(
+            "  {:<40} {} (score {:.2})",
+            g("name"),
+            g("file_path"),
+            score
+        );
+    }
+}
+
+/// Render a `flow-trace` tree as text from its JSON payload.
+///
+/// `edge_type` is printed on every child. CROSS_REPO_LINK is an INFERRED
+/// cross-repo link rather than an observed call, and omitting the label is what
+/// let fabricated cross-language execution paths read as real ones (nw-111).
+fn render_flow_trace_text(payload: &serde_json::Value) {
+    fn walk(node: &serde_json::Value, depth: usize) {
+        let name = node.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+        let edge = node.get("edge_type").and_then(|v| v.as_str());
+        let path = node.get("file_path").and_then(|v| v.as_str()).unwrap_or("");
+        let indent = "  ".repeat(depth + 1);
+        match edge {
+            Some(e) => println!("{indent}{name}  [{e}]  {path}"),
+            None => println!("{indent}{name}  {path}"),
+        }
+        for child in node
+            .get("children")
+            .and_then(|v| v.as_array())
+            .into_iter()
+            .flatten()
+        {
+            walk(child, depth + 1);
+        }
+    }
+
+    let root_name = payload
+        .get("root_name")
+        .or_else(|| payload.get("name"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("?");
+    println!("Flow trace from '{root_name}':");
+
+    // A class root expands to one tree per method.
+    if let Some(trees) = payload.get("method_trees").and_then(|v| v.as_array()) {
+        for tree in trees {
+            walk(tree, 0);
+        }
+        return;
+    }
+    if let Some(tree) = payload.get("tree") {
+        walk(tree, 0);
+    } else {
+        walk(payload, 0);
+    }
+}
+
 fn render_dead_code_text(payload: &serde_json::Value) {
     let num = |k: &str| payload.get(k).and_then(|v| v.as_u64()).unwrap_or(0);
     let total = num("total_symbols");
@@ -2146,6 +2281,82 @@ enum Commands {
             help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
         )]
         db: Option<PathBuf>,
+    },
+
+    /// Assess blast radius for a set of changed files
+    ///
+    /// Maps files to symbols, traces reverse dependencies, and returns affected
+    /// symbols with a risk level and an explicit trust contract. Read
+    /// `gate_state` and `status` before trusting a green result: a run that did
+    /// not complete is `degraded-unknown`, never `risk-flagged`.
+    #[command(
+        after_help = "Examples:\n  nestweaver blast-radius --files src/auth.rs\n  nestweaver blast-radius --files a.rs --files b.rs --depth 5 --json"
+    )]
+    BlastRadius {
+        #[arg(
+            long = "files",
+            required = true,
+            help = "Changed file paths, repo-relative (repeat the flag for several)"
+        )]
+        files: Vec<String>,
+        #[arg(
+            long,
+            default_value = "3",
+            value_parser = clap::value_parser!(u32).range(1..=15),
+            help = "Maximum traversal depth (1-15; matches the MCP blast_radius schema)"
+        )]
+        depth: u32,
+        #[arg(long, help = "Restrict analysis to this repo")]
+        repo: Option<String>,
+        #[arg(
+            long,
+            help = "Also follow data-dependence edges (type refs, field access) — higher recall, noisier"
+        )]
+        include_data_edges: bool,
+        #[arg(
+            long,
+            value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=10000),
+            help = "Cap affected symbols returned, most-impactful first (1-10000)"
+        )]
+        limit: Option<usize>,
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+        #[arg(
+            long,
+            help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
+        )]
+        db: Option<PathBuf>,
+        #[arg(long, help = "Path to an instance config file")]
+        config: Option<PathBuf>,
+    },
+
+    /// Trace forward execution flow from a symbol — what it calls, and what those call
+    ///
+    /// Every child carries `edge_type`. CALLS and IMPORTS are observed in code;
+    /// CROSS_REPO_LINK is an INFERRED cross-repo link and is NOT an observed
+    /// call — filter it out when you need a real execution path.
+    #[command(
+        after_help = "Examples:\n  nestweaver flow-trace handleRequest\n  nestweaver flow-trace \"sym:repo:...:abc:42\" --max-depth 3 --json"
+    )]
+    FlowTrace {
+        #[arg(help = "Symbol name or full UID to trace from")]
+        symbol: String,
+        #[arg(
+            long,
+            default_value = "10",
+            value_parser = clap::value_parser!(u32).range(1..=15),
+            help = "Maximum tree depth (1-15; matches the MCP flow_trace schema)"
+        )]
+        max_depth: u32,
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+        #[arg(
+            long,
+            help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
+        )]
+        db: Option<PathBuf>,
+        #[arg(long, help = "Path to an instance config file")]
+        config: Option<PathBuf>,
     },
 
     /// Export the code graph to an external format
@@ -6967,6 +7178,106 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             use_daemon,
         )
         .map(|c| (c, None)),
+
+        Commands::BlastRadius {
+            files,
+            depth,
+            repo,
+            include_data_edges,
+            limit,
+            json,
+            db,
+            config,
+        } => {
+            let db_path = resolve_db_with_config(db, config.as_deref())?;
+            require_existing_db(&db_path)?;
+
+            let mut args = serde_json::json!({
+                "changed_files": files,
+                "max_depth": depth,
+                "include_data_edges": include_data_edges,
+            });
+            if let Some(ref r) = repo {
+                args["repo"] = serde_json::json!(r);
+            }
+            if let Some(n) = limit {
+                args["limit"] = serde_json::json!(n);
+            }
+
+            // Daemon first, then the SAME tool the daemon would have run. Both
+            // paths therefore produce one payload and render through one
+            // function, so the output format follows --json rather than whether
+            // a daemon happens to be running (nw-108).
+            let payload = match try_hybrid_json_rpc(
+                use_daemon,
+                &db_path,
+                config.as_deref(),
+                "blast_radius",
+                args.clone(),
+            ) {
+                Some(value) => value,
+                None => {
+                    let store = open_store(Some(&db_path))?;
+                    // The MCP server sets this before dispatching; without it the
+                    // tool cannot locate the co-change sidecar and silently drops
+                    // the `cochange-unavailable` disclosure, so the direct path
+                    // would answer with LESS honesty than the daemon (nw-062).
+                    nestweaver_mcp::tools::set_current_db_path(db_path.clone());
+                    let mut value =
+                        nestweaver_mcp::tools::dispatch(&store, None, "blast_radius", args, None)?;
+                    attach_local_meta(&mut value);
+                    value
+                }
+            };
+
+            if json {
+                println!("{}", serde_json::to_string_pretty(&payload)?);
+            } else {
+                render_blast_radius_text(&payload);
+            }
+            Ok((EXIT_SUCCESS, None))
+        }
+
+        Commands::FlowTrace {
+            symbol,
+            max_depth,
+            json,
+            db,
+            config,
+        } => {
+            let db_path = resolve_db_with_config(db, config.as_deref())?;
+            require_existing_db(&db_path)?;
+
+            let args = serde_json::json!({
+                "symbol": symbol,
+                "max_depth": max_depth,
+            });
+
+            let payload = match try_hybrid_json_rpc(
+                use_daemon,
+                &db_path,
+                config.as_deref(),
+                "flow_trace",
+                args.clone(),
+            ) {
+                Some(value) => value,
+                None => {
+                    let store = open_store(Some(&db_path))?;
+                    nestweaver_mcp::tools::set_current_db_path(db_path.clone());
+                    let mut value =
+                        nestweaver_mcp::tools::dispatch(&store, None, "flow_trace", args, None)?;
+                    attach_local_meta(&mut value);
+                    value
+                }
+            };
+
+            if json {
+                println!("{}", serde_json::to_string_pretty(&payload)?);
+            } else {
+                render_flow_trace_text(&payload);
+            }
+            Ok((EXIT_SUCCESS, None))
+        }
 
         Commands::DeadCode {
             min_confidence,

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1666,10 +1666,16 @@ fn cli_impact_on_empty_db_exits_not_found() {
 }
 
 #[test]
-fn cli_impact_json_is_array_and_notfound_is_object() {
-    // nw-086: `impact --json` must emit a bare node ARRAY on success and a JSON
-    // error OBJECT on not-found (never a plain-text-only stderr line), so a
-    // --json consumer can always parse the output.
+fn cli_impact_json_is_one_envelope_for_every_outcome() {
+    // nw-086 required a bare node ARRAY on success and an error OBJECT on
+    // not-found. nw-111 REPLACES that contract: the shape used to change with the
+    // outcome, and the ambiguous case returned a bare CANDIDATE array that was
+    // structurally indistinguishable from a result set — a mistyped name looked
+    // like a successful impact query, with only the exit code to tell them apart.
+    //
+    // Every outcome now returns one envelope discriminated by `status`. What
+    // nw-086 actually cared about — that a --json consumer can always parse the
+    // output — is preserved and strengthened.
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("t.lbug");
     let repo_dir = dir.path().join("repo");
@@ -1690,7 +1696,7 @@ fn cli_impact_json_is_array_and_notfound_is_object() {
         .assert()
         .success();
 
-    // Found → bare array (a calls b, so impact(b) is non-empty).
+    // Found → envelope with status "ok" (a calls b, so impact(b) is non-empty).
     let out = nestweaver_cmd()
         .args([
             "impact",
@@ -1703,9 +1709,14 @@ fn cli_impact_json_is_array_and_notfound_is_object() {
         .unwrap();
     let v: serde_json::Value =
         serde_json::from_slice(&out.stdout).expect("impact --json (found) must be valid JSON");
+    assert_eq!(
+        v.get("status").and_then(|s| s.as_str()),
+        Some("ok"),
+        "impact --json (found) must be a status:ok envelope, got: {v}"
+    );
     assert!(
-        v.is_array(),
-        "impact --json (found) must be a bare array, got: {v}"
+        v.get("nodes").is_some_and(|n| n.is_array()),
+        "the envelope must carry a nodes array, got: {v}"
     );
 
     // Not-found → JSON object with an `error` field, exit 2.
@@ -1725,6 +1736,15 @@ fn cli_impact_json_is_array_and_notfound_is_object() {
     assert!(
         v.get("error").is_some(),
         "not-found --json must carry an error field, got: {v}"
+    );
+    assert_eq!(
+        v.get("status").and_then(|s| s.as_str()),
+        Some("not_found"),
+        "not-found must be discriminated by status, got: {v}"
+    );
+    assert!(
+        v.get("nodes").is_none(),
+        "a not-found envelope must not carry nodes, got: {v}"
     );
 }
 

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -505,26 +505,20 @@ fn parity_investigate_human_direct_vs_daemon() {
 }
 
 ///
-/// Scoped to HUMAN mode deliberately. `--json` still diverges between the two
-/// paths for reasons that predate this fix and would change a published
-/// contract to resolve: the daemon wraps its payload in `_meta`, and it
-/// lowercases the confidence ("medium") while the direct payload carries the
-/// serde variant name ("Medium"). Both are real and tracked separately; neither
-/// is the format flip this test exists to catch. Asserting json parity here
-/// would couple this regression guard to that unrelated decision.
+/// Now covers `--json` too. It was scoped to human-only because the payloads
+/// genuinely diverged: the daemon wrapped its result in `_meta` while the direct
+/// path omitted it, and the confidence serialised as "medium" through the daemon
+/// but "Medium" direct — the same field disagreeing with itself depending on
+/// whether a daemon was running. Both are fixed (nw-117), so json parity is the
+/// acceptance test for that fix.
 #[test]
-fn parity_dead_code_human_direct_vs_daemon() {
+fn parity_dead_code_direct_vs_daemon() {
     let fixture = setup_fixture();
-    let args: &[&str] = &["dead-code", "--limit", "5"];
-
-    // Direct mode first — the daemon is not started yet and may hold the lock.
-    let direct = run_direct(&fixture.db_path, args);
-
-    let _guard = DaemonGuard::new(&fixture.db_path);
-    start_daemon(&fixture.db_path);
-    let daemon = run_via_daemon(&fixture.db_path, args);
-
-    assert_parity("dead-code", "human", &direct, &daemon);
+    check_parity(
+        &fixture.db_path,
+        "dead-code",
+        &["dead-code", "--limit", "5"],
+    );
 }
 
 /// `stale-check` is a freshness gate: it exits 1 when the index is

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -521,6 +521,35 @@ fn parity_dead_code_direct_vs_daemon() {
     );
 }
 
+/// nw-111 (5): `blast-radius` and `flow-trace` are the product's headline
+/// capabilities and existed only as MCP tools — absent from the CLI, which is the
+/// discovery surface. They are thin wrappers over the SAME
+/// `nestweaver_mcp::tools::dispatch` the daemon runs, so both modes must agree.
+///
+/// Covered from the outset rather than added after a divergence is reported:
+/// `dead-code` and `investigate` both shipped emitting JSON or text depending on
+/// whether a daemon happened to be running, and survived because they were not in
+/// this file (nw-108).
+#[test]
+fn parity_blast_radius_direct_vs_daemon() {
+    let fixture = setup_fixture();
+    check_parity(
+        &fixture.db_path,
+        "blast-radius",
+        &["blast-radius", "--files", CHANGED_FILES, "--depth", "2"],
+    );
+}
+
+#[test]
+fn parity_flow_trace_direct_vs_daemon() {
+    let fixture = setup_fixture();
+    check_parity(
+        &fixture.db_path,
+        "flow-trace",
+        &["flow-trace", "alpha", "--max-depth", "2"],
+    );
+}
+
 /// `stale-check` is a freshness gate: it exits 1 when the index is
 /// stale. The fixture here is freshly indexed (not stale), but regardless we
 /// only assert stdout equality and equal exit codes across modes — never

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -450,6 +450,83 @@ fn parity_affected_tests_direct_vs_daemon() {
     );
 }
 
+/// nw-108: `dead-code`'s daemon branch printed the RPC response verbatim with
+/// no `if json` guard, so the OUTPUT FORMAT depended on whether a daemon
+/// happened to be running rather than on the flag — text standalone, JSON once
+/// the daemon was up. The text renderer was never missing; it was simply not
+/// reached. This is the nw-097 divergence family, and the reason it survived is
+/// that `dead-code` was not in this file.
+/// Replace generated bundle IDs with a fixed placeholder.
+///
+/// `investigate` mints a fresh `bndl_<hex>` per invocation, so its stdout is
+/// never byte-identical across two runs — comparing raw bytes would test the ID
+/// generator, not the renderer.
+fn redact_bundle_ids(bytes: &[u8]) -> String {
+    let text = String::from_utf8_lossy(bytes);
+    let mut out = String::with_capacity(text.len());
+    let mut rest: &str = &text;
+    while let Some(pos) = rest.find("bndl_") {
+        out.push_str(&rest[..pos]);
+        out.push_str("bndl_<redacted>");
+        let after = &rest[pos + "bndl_".len()..];
+        let end = after
+            .find(|c: char| !c.is_ascii_hexdigit())
+            .unwrap_or(after.len());
+        rest = &after[end..];
+    }
+    out.push_str(rest);
+    out
+}
+
+/// nw-108: `investigate` carried the identical defect to `dead-code` — its
+/// daemon branch printed the RPC response verbatim, so the format followed
+/// process state rather than the flag.
+#[test]
+fn parity_investigate_human_direct_vs_daemon() {
+    let fixture = setup_fixture();
+    let args: &[&str] = &["investigate", "alpha"];
+
+    let direct = run_direct(&fixture.db_path, args);
+
+    let _guard = DaemonGuard::new(&fixture.db_path);
+    start_daemon(&fixture.db_path);
+    let daemon = run_via_daemon(&fixture.db_path, args);
+
+    assert_eq!(
+        direct.status.code(),
+        daemon.status.code(),
+        "investigate (human): exit code diverged"
+    );
+    assert_eq!(
+        redact_bundle_ids(&direct.stdout),
+        redact_bundle_ids(&daemon.stdout),
+        "investigate (human): stdout diverged between direct and daemon mode"
+    );
+}
+
+///
+/// Scoped to HUMAN mode deliberately. `--json` still diverges between the two
+/// paths for reasons that predate this fix and would change a published
+/// contract to resolve: the daemon wraps its payload in `_meta`, and it
+/// lowercases the confidence ("medium") while the direct payload carries the
+/// serde variant name ("Medium"). Both are real and tracked separately; neither
+/// is the format flip this test exists to catch. Asserting json parity here
+/// would couple this regression guard to that unrelated decision.
+#[test]
+fn parity_dead_code_human_direct_vs_daemon() {
+    let fixture = setup_fixture();
+    let args: &[&str] = &["dead-code", "--limit", "5"];
+
+    // Direct mode first — the daemon is not started yet and may hold the lock.
+    let direct = run_direct(&fixture.db_path, args);
+
+    let _guard = DaemonGuard::new(&fixture.db_path);
+    start_daemon(&fixture.db_path);
+    let daemon = run_via_daemon(&fixture.db_path, args);
+
+    assert_parity("dead-code", "human", &direct, &daemon);
+}
+
 /// `stale-check` is a freshness gate: it exits 1 when the index is
 /// stale. The fixture here is freshly indexed (not stale), but regardless we
 /// only assert stdout equality and equal exit codes across modes — never


### PR DESCRIPTION
Integration of 21 deliverables on `staging`, all CI-green on their own PRs
(#200–#222). Merge with a **merge commit** so release-please cuts the release.

## ⚠️ Version: this batch contains a BREAKING change

`85b8146` is `fix(cli)!:` with a `BREAKING:` footer — `impact --json` and
`dead-code --json` change shape. At 2.7.1, release-please will therefore cut
**3.0.0**, not 2.7.2. `bump-minor-pre-major` is set but only applies below 1.0,
so it has no effect here.

That is semver-correct: a bare node array became a discriminated envelope, and
any `--json` consumer parsing the old shape breaks. Flagging it because the
branch name, CHANGELOG entries and PR titles all say "2.7.2".

## Release-gate status

Ten defects were found in the v2.7.2 manual regression against installed 2.7.1;
all ten are now closed. No critical or high defect remains open.

- **Critical** — nw-126: a daemon crash left the database unopenable by every
  path, and the error told the user to create a new one. Now self-healing, with
  the orphaned WAL quarantined rather than deleted.
- **High** — nw-125 (boot timeout fell back to the forbidden direct path
  silently), nw-124 (nw-103's fix needs a re-index; upgraders kept corrupt
  rankings — now disclosed at runtime and in the changelog).
- **Medium/low** — nw-119 (boot 53.9s → 9.5s), nw-118, nw-121, nw-123, nw-117,
  nw-120 (`investigate` ranking disclosed as lexical-only), nw-122
  (`broken-links` printed a piped link's alias as its target).
- **nw-127** — a no-op incremental index cost 57 minutes and reported a false
  failure. Measured 3440.6s exit 1 → 18s exit 0.

## Note on the two dependabot commits

`main` carries `03c72d6` (12 Rust dependency updates) and `3230a63`, which
`staging` has never compiled against. This PR is the first time that combination
is built and tested.