### PR TITLE
fix(deps)!: return lbug to upstream 0.19.1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,7 @@
 [env]
-# The temporary lbug wrapper pin contains the reviewed Ladybug source as an
-# immutable submodule. Always compile that source so Cargo cannot substitute an
-# unrelated prebuilt archive while the upstream release is pending.
+# Build lbug from source instead of linking its published prebuilt archive.
+# The prebuilt hides its zstd Huffman ASM symbols in the ELF, which breaks the
+# link on x86_64 Linux; compiling from source resolves those symbols and keeps
+# cross-platform release builds reproducible. See 6768374, "fix(ci): eliminate
+# zstd link errors and skip daemon tests on Linux".
 LBUG_BUILD_FROM_SOURCE = { value = "1", force = true }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,10 +87,11 @@ pre-commit install
 pre-commit install --hook-type commit-msg
 ```
 
-Keep `.cargo/config.toml` in place. It forces the reviewed Ladybug dependency
-to build from its immutable source pin; the initial native build can take
-several minutes. See [INSTALL.md](INSTALL.md#build-from-source) for CMake, C++,
-OpenSSL, zstd, `pkg-config`, and Protocol Buffers prerequisites.
+Keep `.cargo/config.toml` in place. It forces the Ladybug dependency to build
+from source instead of a prebuilt archive, which avoids zstd link errors; the
+initial native build can take several minutes. See
+[INSTALL.md](INSTALL.md#build-from-source) for CMake, C++, OpenSSL, zstd,
+`pkg-config`, and Protocol Buffers prerequisites.
 
 ### Check suite
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3649,8 +3649,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lbug"
-version = "0.18.2"
-source = "git+https://github.com/kory-io/ladybug-rust.git?rev=8992183ff8de526e8a852be8a97ad04b412f56ed#8992183ff8de526e8a852be8a97ad04b412f56ed"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a032d5968ac2260545e8c5cf05a123559de2c6ba2bd0dde11c0ed958dfa172"
 dependencies = [
  "cmake",
  "cxx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,9 +160,3 @@ test = false
 name = "index_benchmarks"
 harness = false
 test = false
-
-# Temporary source override for the filtered multi-segment string-scan fix.
-# Remove this patch after the upstream fix is released in an lbug version that
-# passes NestWeaver's storage regression suite.
-[patch.crates-io]
-lbug = { git = "https://github.com/kory-io/ladybug-rust.git", rev = "8992183ff8de526e8a852be8a97ad04b412f56ed" }

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,9 +63,9 @@ nestweaver --version
 
 The first source build compiles LadybugDB and can take several minutes. Keep
 the checkout's `.cargo/config.toml`: it forces `LBUG_BUILD_FROM_SOURCE=1` so
-the build uses the reviewed source pinned by `Cargo.lock`, rather than an
-unrelated prebuilt archive. Cargo fetches the pinned Ladybug submodule
-automatically.
+the build uses the Ladybug sources resolved by `Cargo.lock`, rather than a
+prebuilt archive whose hidden ELF symbols cause zstd link errors. Cargo
+vendors the Ladybug sources with the crate.
 
 If OpenSSL is installed in a non-default location and the linker cannot find
 `ssl` or `crypto`, expose that installation while building:
@@ -81,24 +81,6 @@ you want GPU-accelerated embeddings:
 ```sh
 cargo install --locked --path . --features metal
 ```
-
-### Temporary Ladybug source pin
-
-This revision temporarily patches `lbug` 0.18.2 to wrapper commit
-`8992183ff8de526e8a852be8a97ad04b412f56ed`, whose `lbug-src` submodule is
-pinned to Ladybug commit
-`9e221866e08371d380c8bd91f7bc98d101ebf723`. That commit backports the filtered
-multi-segment string-scan correction proposed in
-[LadybugDB/ladybug#737](https://github.com/LadybugDB/ladybug/pull/737).
-
-Do not remove the workspace `[patch.crates-io]` entry, delete
-`.cargo/config.toml`, or point `LBUG_LIBRARY_DIR`/`LBUG_INCLUDE_DIR` at a
-different Ladybug build when validating this fix. The temporary patch can be
-removed after upstream publishes an `lbug` release containing the correction
-and NestWeaver's storage regression suite passes against that release.
-
-Until a NestWeaver release containing this change is published, build this
-revision from source when you specifically need the filtered-scan correction.
 
 ## macOS app
 

--- a/README.md
+++ b/README.md
@@ -198,11 +198,11 @@ cargo install --locked --path .
 ```
 
 Source builds also require CMake, a C++20 compiler, OpenSSL and zstd
-development files, `pkg-config`, and Protocol Buffers. The checkout currently
-compiles an immutable LadybugDB source pin to include the filtered multi-segment
-string-scan correction; keep `.cargo/config.toml` intact. See
-[the source-build prerequisites and pin provenance](INSTALL.md#build-from-source)
-before building.
+development files, `pkg-config`, and Protocol Buffers. The checkout builds
+LadybugDB from source rather than downloading a prebuilt archive; keep
+`.cargo/config.toml` intact. See
+[the source-build prerequisites](INSTALL.md#build-from-source) before
+building.
 
 <details>
 <summary>Pre-built binaries</summary>
@@ -222,9 +222,7 @@ cargo install --locked --path .
 # cargo install --locked --path . --features metal
 ```
 
-The first build compiles the pinned LadybugDB source and may take several
-minutes. If you need the filtered-scan correction before a NestWeaver release
-containing it is available, use this source-build path.
+The first build compiles LadybugDB from source and may take several minutes.
 
 </details>
 

--- a/crates/nestweaver-store/Cargo.toml
+++ b/crates/nestweaver-store/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 [dependencies]
 nestweaver-algorithms = { workspace = true }
 nestweaver-schema = { workspace = true }
-lbug = "=0.18.2"
+lbug = "=0.19.1"
 # lbug's static archive still declares OpenSSL as a dynamic native dependency.
 # Unify it with Cargo's vendored OpenSSL build so release binaries do not depend
 # on a package-manager installation at runtime.

--- a/crates/nestweaver-store/build.rs
+++ b/crates/nestweaver-store/build.rs
@@ -9,7 +9,7 @@ mod build_support;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
-const LBUG_ABI_VERSION: &str = "0.18.2";
+const LBUG_ABI_VERSION: &str = "0.19.1";
 const LBUG_SOURCE_MANIFEST_ENV: &str = "NESTWEAVER_LBUG_SOURCE_MANIFEST";
 
 fn lbug_src_dir() -> Result<PathBuf, String> {

--- a/crates/nestweaver-store/tests/build_script_selection.rs
+++ b/crates/nestweaver-store/tests/build_script_selection.rs
@@ -5,26 +5,26 @@ use serde_json::json;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
-const LBUG_VERSION: &str = "0.18.2";
+const LBUG_VERSION: &str = "0.19.1";
 
 #[test]
 fn resolved_edge_uses_cargo_identity_when_exact_version_exists_across_sources() {
     let fixture = Fixture::new();
     let crates_io = fixture.lbug_package(
-        "registry+crates.io#lbug@0.18.2",
+        "registry+crates.io#lbug@0.19.1",
         "registry-a",
         LBUG_VERSION,
         true,
     );
     let mirror = fixture.lbug_package(
-        "registry+mirror#lbug@0.18.2",
+        "registry+mirror#lbug@0.19.1",
         "registry-b",
         LBUG_VERSION,
         true,
     );
     let metadata = fixture.metadata(
         vec![crates_io.clone(), mirror],
-        vec![dep("lbug", "registry+crates.io#lbug@0.18.2")],
+        vec![dep("lbug", "registry+crates.io#lbug@0.19.1")],
     );
 
     let selected = build_support::resolved_dependency_source(
@@ -35,7 +35,7 @@ fn resolved_edge_uses_cargo_identity_when_exact_version_exists_across_sources() 
     )
     .unwrap();
 
-    assert_eq!(selected.package_id, "registry+crates.io#lbug@0.18.2");
+    assert_eq!(selected.package_id, "registry+crates.io#lbug@0.19.1");
     assert_eq!(selected.version, LBUG_VERSION);
     assert_eq!(selected.source.as_deref(), Some("registry+crates.io"));
     assert_eq!(selected.source_dir, fixture.source_dir(&crates_io));
@@ -46,14 +46,14 @@ fn resolved_edge_selects_the_direct_dependency_when_multiple_versions_exist() {
     let fixture = Fixture::new();
     let old = fixture.lbug_package("registry+crates.io#lbug@0.16.1", "old", "0.16.1", true);
     let current = fixture.lbug_package(
-        "registry+crates.io#lbug@0.18.2",
+        "registry+crates.io#lbug@0.19.1",
         "current",
         LBUG_VERSION,
         true,
     );
     let metadata = fixture.metadata(
         vec![old, current.clone()],
-        vec![dep("lbug", "registry+crates.io#lbug@0.18.2")],
+        vec![dep("lbug", "registry+crates.io#lbug@0.19.1")],
     );
 
     let selected = build_support::resolved_dependency_source(
@@ -71,13 +71,13 @@ fn resolved_edge_selects_the_direct_dependency_when_multiple_versions_exist() {
 #[test]
 fn duplicate_direct_dependency_edges_are_rejected_as_ambiguous() {
     let fixture = Fixture::new();
-    let first = fixture.lbug_package("registry+a#lbug@0.18.2", "a", LBUG_VERSION, true);
-    let second = fixture.lbug_package("registry+b#lbug@0.18.2", "b", LBUG_VERSION, true);
+    let first = fixture.lbug_package("registry+a#lbug@0.19.1", "a", LBUG_VERSION, true);
+    let second = fixture.lbug_package("registry+b#lbug@0.19.1", "b", LBUG_VERSION, true);
     let metadata = fixture.metadata(
         vec![first, second],
         vec![
-            dep("lbug", "registry+a#lbug@0.18.2"),
-            dep("lbug", "registry+b#lbug@0.18.2"),
+            dep("lbug", "registry+a#lbug@0.19.1"),
+            dep("lbug", "registry+b#lbug@0.19.1"),
         ],
     );
 
@@ -93,17 +93,17 @@ fn duplicate_direct_dependency_edges_are_rejected_as_ambiguous() {
         error.contains("ambiguous direct dependency lbug"),
         "{error}"
     );
-    assert!(error.contains("registry+a#lbug@0.18.2"), "{error}");
-    assert!(error.contains("registry+b#lbug@0.18.2"), "{error}");
+    assert!(error.contains("registry+a#lbug@0.19.1"), "{error}");
+    assert!(error.contains("registry+b#lbug@0.19.1"), "{error}");
 }
 
 #[test]
 fn duplicate_records_for_the_resolved_package_identity_are_rejected() {
     let fixture = Fixture::new();
-    let package = fixture.lbug_package("registry+a#lbug@0.18.2", "a", LBUG_VERSION, true);
+    let package = fixture.lbug_package("registry+a#lbug@0.19.1", "a", LBUG_VERSION, true);
     let metadata = fixture.metadata(
         vec![package.clone(), package],
-        vec![dep("lbug", "registry+a#lbug@0.18.2")],
+        vec![dep("lbug", "registry+a#lbug@0.19.1")],
     );
 
     let error = build_support::resolved_dependency_source(
@@ -122,7 +122,7 @@ fn missing_resolved_package_source_is_reported() {
     let fixture = Fixture::new();
     let metadata = fixture.metadata(
         Vec::new(),
-        vec![dep("lbug", "registry+missing#lbug@0.18.2")],
+        vec![dep("lbug", "registry+missing#lbug@0.19.1")],
     );
 
     let error = build_support::resolved_dependency_source(
@@ -133,15 +133,15 @@ fn missing_resolved_package_source_is_reported() {
     )
     .unwrap_err();
 
-    assert!(error.contains("registry+missing#lbug@0.18.2"), "{error}");
+    assert!(error.contains("registry+missing#lbug@0.19.1"), "{error}");
     assert!(error.contains("has no package record"), "{error}");
 }
 
 #[test]
 fn missing_bundled_source_directory_is_reported() {
     let fixture = Fixture::new();
-    let package = fixture.lbug_package("registry+a#lbug@0.18.2", "a", LBUG_VERSION, false);
-    let metadata = fixture.metadata(vec![package], vec![dep("lbug", "registry+a#lbug@0.18.2")]);
+    let package = fixture.lbug_package("registry+a#lbug@0.19.1", "a", LBUG_VERSION, false);
+    let metadata = fixture.metadata(vec![package], vec![dep("lbug", "registry+a#lbug@0.19.1")]);
 
     let error = build_support::resolved_dependency_source(
         &metadata,
@@ -231,7 +231,7 @@ fn isolated_resolver_manifest_uses_an_exact_dependency() {
         build_support::write_isolated_resolver_manifest(temp.path(), "lbug", LBUG_VERSION).unwrap();
     let contents = std::fs::read_to_string(manifest).unwrap();
 
-    assert!(contents.contains("lbug = \"=0.18.2\""), "{contents}");
+    assert!(contents.contains("lbug = \"=0.19.1\""), "{contents}");
     assert!(contents.contains("[workspace]"), "{contents}");
 }
 
@@ -263,14 +263,14 @@ fn cargo_locates_the_workspace_before_metadata_resolution() {
 fn vendored_manifest_path_is_the_source_of_bundled_files() {
     let fixture = Fixture::new();
     let package = fixture.lbug_package(
-        "path+file:///vendor/lbug#0.18.2",
+        "path+file:///vendor/lbug#0.19.1",
         "vendor/lbug",
         LBUG_VERSION,
         true,
     );
     let metadata = fixture.metadata(
         vec![package.clone()],
-        vec![dep("lbug", "path+file:///vendor/lbug#0.18.2")],
+        vec![dep("lbug", "path+file:///vendor/lbug#0.19.1")],
     );
 
     let selected = build_support::resolved_dependency_source(
@@ -292,7 +292,7 @@ fn source_manifest_override_accepts_exact_lbug_package() {
     std::fs::create_dir_all(manifest.parent().unwrap().join("lbug-src")).unwrap();
     std::fs::write(
         &manifest,
-        "[package]\nname = \"lbug\"\nversion = \"0.18.2\"\n",
+        "[package]\nname = \"lbug\"\nversion = \"0.19.1\"\n",
     )
     .unwrap();
 
@@ -314,7 +314,7 @@ fn source_manifest_override_rejects_wrong_package_identity() {
     std::fs::create_dir_all(manifest.parent().unwrap().join("lbug-src")).unwrap();
     std::fs::write(
         &manifest,
-        "[package]\nname = \"lookalike\"\nversion = \"0.18.2\"\n",
+        "[package]\nname = \"lookalike\"\nversion = \"0.19.1\"\n",
     )
     .unwrap();
 
@@ -326,8 +326,8 @@ fn source_manifest_override_rejects_wrong_package_identity() {
     )
     .unwrap_err();
 
-    assert!(error.contains("expected package lbug 0.18.2"), "{error}");
-    assert!(error.contains("lookalike 0.18.2"), "{error}");
+    assert!(error.contains("expected package lbug 0.19.1"), "{error}");
+    assert!(error.contains("lookalike 0.19.1"), "{error}");
 }
 
 #[test]
@@ -349,7 +349,7 @@ fn source_manifest_override_rejects_wrong_abi_version() {
     )
     .unwrap_err();
 
-    assert!(error.contains("expected package lbug 0.18.2"), "{error}");
+    assert!(error.contains("expected package lbug 0.19.1"), "{error}");
     assert!(error.contains("lbug 0.18.1"), "{error}");
 }
 

--- a/crates/nestweaver-store/tests/ladybug_filtered_string_scan.rs
+++ b/crates/nestweaver-store/tests/ladybug_filtered_string_scan.rs
@@ -1,9 +1,24 @@
 use nestweaver_schema::{Note, NoteKind};
 use nestweaver_store::GraphStore;
 
-// Ladybug's default value-vector capacity is 2,048 rows. Crossing two complete
-// vectors makes this an end-to-end guard for filtered string reads that span
-// multiple scan batches instead of a single-vector happy path.
+// End-to-end correctness check on filtered string reads through `list_notes`:
+// NOTE_COUNT exceeds two of Ladybug's 2,048-row value vectors, so every
+// selected row's strings must survive a filtered read that spans multiple
+// output vectors, repeated for determinism.
+//
+// This is NOT a regression detector for the upstream filtered multi-segment
+// string-scan bug (LadybugDB/ladybug#737), despite what its size suggests. That
+// fix retightened one bound in `StringColumn::scanFiltered` from
+// `startOffsetInChunk + pos < state.metadata.numValues` (clamped against the
+// whole segment) to `pos < offsetInResult + numValuesToScan` (clamped against
+// the current scan batch). The two bounds only disagree when one output vector
+// is filled by more than one scan call, which happens at a *segment* boundary,
+// not a value-vector boundary. Segments are page-sized and far larger than
+// 2,048 rows, so this fixture lives inside a single segment, the scan never
+// splits, `numValuesToScan == selSize`, and buggy and fixed builds behave
+// identically. (Confirmed empirically: this test passes against unpatched
+// lbug 0.18.2.) Repairing it into a true #737 detector would require sizing
+// against segment capacity and is out of scope.
 const NOTE_COUNT: usize = 4_113;
 const SELECTED_VAULT: &str = "vlt:selected";
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -218,16 +218,22 @@ fn installation_docs_only_claim_live_channels() {
     }
 }
 
+/// Guards the Ladybug source-build configuration.
+///
+/// lbug's published prebuilt archive hides its zstd Huffman ASM symbols in the
+/// ELF, which breaks the link on x86_64 Linux. Building lbug from source is the
+/// fix, and it only works if every build path agrees: the workspace
+/// `.cargo/config.toml` must force `LBUG_BUILD_FROM_SOURCE`, CI workflows must
+/// append to that file rather than overwrite it, the Docker build context must
+/// include it, and the image must install the native toolchain the source build
+/// needs and resolve the committed lockfile with `--locked`.
+///
+/// Each of these has silently regressed before, and the failure only surfaces as
+/// a link error in a release build, so assert them here.
 #[test]
-fn ladybug_hotfix_dependency_is_immutable_and_built_from_source() {
-    const LBUG_RUST_FORK: &str = "https://github.com/kory-io/ladybug-rust.git";
-    const LBUG_RUST_REV: &str = "8992183ff8de526e8a852be8a97ad04b412f56ed";
-
+fn source_build_configuration_is_intact_and_reproducible() {
     let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let manifest = std::fs::read_to_string(repo_root.join("Cargo.toml")).unwrap();
-    let lockfile = std::fs::read_to_string(repo_root.join("Cargo.lock")).unwrap();
     let cargo_config = std::fs::read_to_string(repo_root.join(".cargo/config.toml")).unwrap();
-    let installation = std::fs::read_to_string(repo_root.join("INSTALL.md")).unwrap();
     let ci_workflow = std::fs::read_to_string(repo_root.join(".github/workflows/ci.yml")).unwrap();
     let release_workflow =
         std::fs::read_to_string(repo_root.join(".github/workflows/release-please.yml")).unwrap();
@@ -235,24 +241,8 @@ fn ladybug_hotfix_dependency_is_immutable_and_built_from_source() {
     let dockerignore = std::fs::read_to_string(repo_root.join(".dockerignore")).unwrap();
 
     assert!(
-        manifest.contains("[patch.crates-io]"),
-        "the temporary lbug fork must be a workspace-level crates.io patch"
-    );
-    assert!(
-        manifest.contains(&format!(
-            "lbug = {{ git = \"{LBUG_RUST_FORK}\", rev = \"{LBUG_RUST_REV}\" }}"
-        )),
-        "Cargo.toml must pin the reviewed lbug wrapper commit"
-    );
-    assert!(
-        lockfile.contains(&format!(
-            "source = \"git+{LBUG_RUST_FORK}?rev={LBUG_RUST_REV}#{LBUG_RUST_REV}\""
-        )),
-        "Cargo.lock must resolve lbug to the exact reviewed wrapper commit"
-    );
-    assert!(
         cargo_config.contains("LBUG_BUILD_FROM_SOURCE = { value = \"1\", force = true }"),
-        "workspace builds must compile the pinned Ladybug submodule instead of downloading a prebuilt archive"
+        "workspace builds must compile Ladybug from source instead of downloading a prebuilt archive"
     );
     for (workflow_name, workflow) in [
         ("ci.yml", ci_workflow.as_str()),
@@ -284,18 +274,6 @@ fn ladybug_hotfix_dependency_is_immutable_and_built_from_source() {
         dockerfile.contains("cargo build --locked --release --bin nestweaver"),
         "the Docker image must resolve the reviewed dependency lockfile without updating it"
     );
-    for required_provenance in [
-        LBUG_RUST_REV,
-        "9e221866e08371d380c8bd91f7bc98d101ebf723",
-        "https://github.com/LadybugDB/ladybug/pull/737",
-        ".cargo/config.toml",
-        "LBUG_BUILD_FROM_SOURCE=1",
-    ] {
-        assert!(
-            installation.contains(required_provenance),
-            "INSTALL.md must document Ladybug provenance and source-build requirement `{required_provenance}`"
-        );
-    }
 }
 
 #[test]


### PR DESCRIPTION
Removes the temporary `[patch.crates-io]` override that pinned `lbug` to the fork `kory-io/ladybug-rust @ 8992183`, and returns the repo to the published upstream crate at `0.19.1`.

The fork existed solely to backport the filtered multi-segment string-scan fix from [LadybugDB/ladybug#737](https://github.com/LadybugDB/ladybug/pull/737). That fix is in the published crate — verified directly against the registry sources, not inferred from changelogs: `lbug-0.19.1/lbug-src/src/storage/table/string_column.cpp:256` carries the corrected batch clamp `pos < offsetInResult + numValuesToScan`, and `:135` passes the matching `numValuesToScan` argument at the call site. The Rust API delta from `0.18.2` is zero (`diff -r` over both crates' `src/` trees reports no differing files).

## ⚠️ BREAKING: on-disk storage format v42 → v43

**Back up your database directory before first use of this release.**

`lbug 0.18.2` writes storage version 42; `0.19.x` writes 43.

- **Existing v42 databases are still read** by this release. `canReadStorageVersion` accepts 40, 41, 42 and the current version, so **no re-index is required**.
- **The migration is one-way and automatic.** The daemon rewrites the database to v43 on its shutdown checkpoint. Because the CLI always runs against a daemon, **even a read-only command such as `search` or `list-repos` will upgrade the file once that daemon exits.** Diagnostic isolation confirmed the CLI read path itself never writes to the file, but there is no supported way to run without the daemon, so **treat every command as an upgrade trigger.** Back up first — that is the only protection.
- **After the upgrade, older builds cannot open the database:** `Trying to read a database file with a different version. Database file version: 43, Current build storage version: 42`.

Back up the **whole database directory**, not just the `.lbug` file. The sidecars — `embeddings.bin`, `parsed_cache.bin`, the `tantivy/` index, and the pagerank / filemeta / manifest JSON — must be restored together with it, or you get a graph whose embeddings and search index disagree with its contents.

Restoring that backup is the **only** rollback path. Reverting the code does not revert an already-upgraded database.

Migration content was verified: re-running the Note/Section commands and a full unbudgeted `count-patterns --kinds Symbol` scan against an upgraded v43 copy produced byte-identical output to the v42 original.

## What changed

- `Cargo.toml` — `[patch.crates-io]` block and its comment removed.
- `crates/nestweaver-store/Cargo.toml` + `build.rs` — `=0.19.1` and `LBUG_ABI_VERSION` bumped in lockstep (`crate_manifest_pins_lbug_to_the_exact_abi_version` asserts they agree).
- `.cargo/config.toml` — **kept**, comment retargeted. It predates the pin (`6768374`) and forces a source build so the prebuilt archive's hidden zstd Huffman ASM ELF symbols cannot break the x86_64 Linux link. Deleting it would break the six CI steps that append to it without `mkdir`, and silently flip the Docker build onto the prebuilt path that `build.rs:103-111` warns produces `double free or corruption`.
- `tests/cli_test.rs` — the pin tripwire is **narrowed, not deleted**. Dropped only the pin-specific assertions (patch block, fork rev in `Cargo.lock`, INSTALL.md provenance); kept the guards on `.cargo/config.toml` contents, append-not-overwrite in the workflows, Dockerfile native deps and `--locked`, and `.dockerignore`. Renamed to `source_build_configuration_is_intact_and_reproducible`.
- `tests/build_script_selection.rs` — version fixtures bumped. The deliberate below-the-pin fixtures (`0.16.1`, `0.18.1`) are unchanged; they only need to stay below the pin.
- `INSTALL.md` / `README.md` / `CONTRIBUTING.md` — pin provenance removed, source-build instructions and native prerequisites retained.

## A note on the regression test

`ladybug_filtered_string_scan.rs` claimed to be the #737 regression guard. **It is not, and never was** — it passes against unpatched `lbug 0.18.2`, confirmed empirically.

The fix retightened a segment-wide clamp (`startOffsetInChunk + pos < state.metadata.numValues`) to a batch clamp. The two only disagree when one output vector is filled by more than one scan call — at a **segment** boundary. The test's `NOTE_COUNT = 4_113` is calibrated to the 2,048-row **value vector**, which is the wrong boundary; segments are page-sized (256 KiB), so the scan never splits and both code paths behave identically.

The test is kept as a cheap end-to-end check on filtered string reads via `list_notes`, with only its overclaiming comment corrected. Resizing it into a real segment-boundary detector was considered and deliberately dropped.

Because that test was never a valid gate, this change was validated by other means.

## Validation

All run locally against this branch.

| Gate | Result |
|---|---|
| `cargo test --locked --workspace` (debug) | 3,011 tests, 51 suites, 0 failures |
| Same suite, **release profile** | pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass |
| `cargo fmt --check` | pass |
| daemon-gated tests, `nestweaver-mcp --features daemon` | pass |
| `cargo audit` | pass |
| `config validate` | pass |
| `scripts/golden-check.sh` (the corruption/determinism guard) | pass — 6 files × 3 runs × 2 tools |

`0.19.1` is confirmed published and fetchable independently of the lockfile by `read_only_lockless_package_resolves_in_out_dir_without_source_writes` and `isolated_resolver_manifest_uses_an_exact_dependency`, which run `cargo metadata` against real crates.io from a tempdir outside the workspace.

### Differential vs the pinned build

The pre-upgrade binary was kept and every read path compared against it.

- **Code corpus** (461 files, 15,875 symbols, 36,966 edges): **179/183 commands byte-identical**, 2,997,618 output bytes on both sides.
- **A pre-existing production database** (multi-repo, ~86k symbols, with an attached note vault): **73/76 byte-identical**, including both bulk exports.
- **MCP live session**, all 40 tools driven over stdio JSON-RPC: **6,531/6,531 `regex_search` snippets verified byte-exact against the files on disk**, 60/60 `read_symbols` bodies byte-exact, filtered results an exact subset of unfiltered (symmetric difference 0). Unicode round-tripped byte-exact through the store (CJK, emoji, tabs, newlines, quotes, backslashes).

Note that `regex-search` and `count-patterns` do **not** exercise a storage-level filtered scan: `collect_candidates` (`crates/nestweaver-store/src/read.rs:1440`) issues `MATCH (s:Symbol) RETURN …` with no `WHERE` and filters in Rust, so the selection vector stays unfiltered. The query shapes that do produce filtered scans are `lookup_symbols_by_name` (`WHERE s.name`, read.rs:479), `symbols_for_repo` (`WHERE s.repo_uid`), and `sections_in_note` (`WHERE s.note_uid`, read.rs:1132). Those are covered by the dedicated stress run below.

### Multi-segment stress test

Because the shipped regression test never detected the bug, a purpose-built corpus was generated to saturate the triggering condition, and results were verified against **known generated ground truth** rather than only against the old binary.

Two corpora, each indexed separately by each binary: 3,000 JS files (169.5 MB) yielding **963,297 symbols**, and 4,000 markdown notes (203.4 MB) yielding 48,000 large high-entropy sections. Estimated segments spanned, uncompressed bytes ÷ 256 KiB:

| column | bytes | segments | rows/segment |
|---|---|---|---|
| `Section.text_content` | 201.8 MB | ~770 | ~62 |
| `Symbol.signature` | 160.7 MB | ~613 | ~1,571 |
| `Symbol.canonical_id` | 71.3 MB | ~272 | ~3,542 |
| `Symbol.uid` | 57.5 MB | ~219 | ~4,392 |

At ~62 rows per segment against a 2,048-row value vector, every output vector is necessarily filled by ~33 separate scan calls crossing segment boundaries — the bug's triggering condition saturated, not merely reached.

Filtered `WHERE s.name` scans at 0.031%, 0.31%, 6.2% and 12.5% selectivity returned exact counts with zero missing and zero spurious rows, every `name`/`canonical_id` byte-exact. All 4,000 notes read back **48,000/48,000 sections byte-exact** against the generated markdown. All 963,297 signature strings byte-equal to a generated signature. Bulk exports byte-identical (388 MB cypher, 523 MB graphml). Selectivity sweep on the section column matched ground truth at every point from 0.0125% to 87%.

**Zero missing, truncated, corrupted, empty, or spurious string values at any selectivity, in any column, on either binary** — across ~580 MB of returned string content.

One caveat on interpretation: the baseline binary carries the backported fix, so this differential compares two *fixed* builds. It demonstrates that `0.19.1` is correct against ground truth at saturation scale and indistinguishable from the fork; it does not attempt to show the original bug was reachable through nestweaver's query shapes.

**No missing, truncated, empty, or corrupted string was found by any method.** Zero U+FFFD, zero stray control characters, zero invalid UTF-8.

Every difference was chased to a benign root cause:
- three were an unoptimized debug build exhausting a default scan budget (byte-identical once re-run with `--max-millis 600000`, or in release);
- one was a single float digit in cluster modularity, where the **baseline disagrees with itself** across runs — parallel float-summation nondeterminism;
- four were stable result-ordering permutations with identical content and identical counts (sorted output byte-identical), attributable to storage-order differences between the v42 and v43 layouts.

### Scale, stated plainly

lbug's `MAX_SEGMENT_SIZE` default is 2^18 = 256 KiB.

In the *real* brain data, note and section columns total ~19 KB — under a tenth of a single segment — so they cannot span a segment boundary at all; the "notes are the biggest strings" assumption does not hold there, symbol snippets are larger (~10 segments). That gap is why the synthetic stress corpus above was built, and it reaches ~770 segments on the section column.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
