### PR TITLE
fix(daemon): cancelled-index honesty — non-terminal timeout warning, committed-after-cancel reporting, pre-write poll

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ by an error message the tool can print, so they belong somewhere findable.
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `NESTWEAVER_DAEMON_BOOT_TIMEOUT_SECS` | 30 | How long a client waits for the daemon to bind its socket. Raise it on a slow cold start; the boot-failure message names it. Boot phase timings (`boot_ms`, `store_open_ms`, `extension_reconcile_ms`, `unattributed_ms`) are logged at bind so a slow boot is diagnosable rather than guessed at. |
-| `NESTWEAVER_INDEX_TIMEOUT_SECS` | 1800 | Overall ceiling for one index. On expiry the daemon requests cancellation and reports a terminal error naming this variable. Cancellation is COOPERATIVE and only observed at the next pre-write boundary, so the index may still be finishing — check the daemon log before assuming it stopped. |
+| `NESTWEAVER_INDEX_TIMEOUT_SECS` | 1800 | Overall ceiling for one index. On expiry the daemon requests cancellation and reports a non-terminal warning naming this variable. Cancellation is COOPERATIVE and only observed up to the pre-write boundary, so the final stream event says whether the run aborted before writing or committed anyway (committed-after-cancellation names `index --force` as the repair). |
 | `NESTWEAVER_DRAIN_TIMEOUT_SECS` | 660 | How long a shutting-down daemon drains active write RPCs. |
 | `NESTWEAVER_STOP_GRACE_SECS` | — | Grace period before a stopping daemon is escalated. |
 | `NESTWEAVER_INDEX_CPU_PERCENT` | 50 | Index CPU duty cycle, percent of one core (1–99; `0` or `>=100` disables). Also see the launchd note below. |

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -495,6 +495,61 @@ fn resolve_effective_instance_id(requested: &str, configured: &str) -> Result<St
     Ok(effective.to_string())
 }
 
+/// Build the terminal `Phase::Done` message for `IndexRepo`. When
+/// cancellation was requested (timeout or client disconnect) but the run had
+/// already passed the point where it could abort safely, say so plainly: the
+/// index COMMITTED, and a plain `Done` would be a lie about what the caller
+/// asked for. Name the repair.
+fn index_done_message(
+    files_count: usize,
+    symbols_count: usize,
+    edges_count: usize,
+    repo_path: &std::path::Path,
+    cancelled: bool,
+) -> String {
+    if cancelled {
+        format!(
+            "Done — {} files, {} symbols, {} edges. Cancellation was requested \
+             but the index had already passed its last cancellation point and \
+             COMMITTED anyway. To discard this run and re-index from scratch, \
+             run: nestweaver index --repo {} --force",
+            files_count,
+            symbols_count,
+            edges_count,
+            repo_path.display()
+        )
+    } else {
+        format!(
+            "Done — {} files, {} symbols, {} edges",
+            files_count, symbols_count, edges_count
+        )
+    }
+}
+
+#[cfg(test)]
+mod index_done_message_tests {
+    use super::*;
+
+    #[test]
+    fn cancelled_variant_reports_commit_and_names_repair() {
+        let message = index_done_message(12, 340, 1500, std::path::Path::new("/tmp/repo"), true);
+        assert!(message.contains("COMMITTED"), "{message}");
+        assert!(
+            message.contains("nestweaver index --repo /tmp/repo --force"),
+            "{message}"
+        );
+        assert!(message.contains("12 files"), "{message}");
+        assert!(message.contains("340 symbols"), "{message}");
+        assert!(message.contains("1500 edges"), "{message}");
+    }
+
+    #[test]
+    fn uncancelled_variant_is_the_plain_done_line() {
+        let message = index_done_message(12, 340, 1500, std::path::Path::new("/tmp/repo"), false);
+        assert_eq!(message, "Done — 12 files, 340 symbols, 1500 edges");
+    }
+}
+
 /// Stop and unregister any active file watcher. Idempotent.
 ///
 /// Called on EVERY shutdown path (gRPC Shutdown, SIGTERM, post-serve
@@ -3476,7 +3531,24 @@ impl NestWeaverDaemon for DaemonService {
                     // and the trigram rebuild scans the whole index — since
                     // nobody is waiting on the result. The graph itself is
                     // already indexed; these sidecars rebuild on the next index.
+                    // The terminal Done is still sent first: the stream must
+                    // not close without reporting the committed-after-cancel
+                    // outcome, or the client reads the committed index as a
+                    // truncated failure.
                     if cancel_for_index.load(std::sync::atomic::Ordering::Acquire) {
+                        let _ = tx.blocking_send(Ok(IndexProgress {
+                            phase: Phase::Done as i32,
+                            message: index_done_message(
+                                result.files_count,
+                                result.symbols_count,
+                                result.edges_count,
+                                &repo_path,
+                                true,
+                            ),
+                            files_processed: result.files_count as u64,
+                            files_total: result.files_count as u64,
+                            symbols_found: result.symbols_count as u64,
+                        }));
                         return;
                     }
 
@@ -3559,31 +3631,19 @@ impl NestWeaverDaemon for DaemonService {
                         }
                     }
 
-                    // DONE phase. When cancellation was requested (timeout or
-                    // client disconnect) but the run had already passed the
-                    // point where it could abort safely, say so plainly: the
-                    // index COMMITTED, and a plain `Done` would be a lie about
-                    // what the caller asked for. Name the repair.
-                    let message = if cancel_for_index.load(std::sync::atomic::Ordering::Acquire) {
-                        format!(
-                            "Done — {} files, {} symbols, {} edges. Cancellation was requested \
-                             but the index had already passed its last cancellation point and \
-                             COMMITTED anyway. To discard this run and re-index from scratch, \
-                             run: nestweaver index --repo {} --force",
+                    // DONE phase. Re-read the cancel flag here: cancellation
+                    // can still arrive while the post-index phases above run,
+                    // and the committed-after-cancel variant must say so
+                    // plainly rather than claim a clean `Done`.
+                    let _ = tx.blocking_send(Ok(IndexProgress {
+                        phase: Phase::Done as i32,
+                        message: index_done_message(
                             result.files_count,
                             result.symbols_count,
                             result.edges_count,
-                            repo_path.display()
-                        )
-                    } else {
-                        format!(
-                            "Done — {} files, {} symbols, {} edges",
-                            result.files_count, result.symbols_count, result.edges_count
-                        )
-                    };
-                    let _ = tx.blocking_send(Ok(IndexProgress {
-                        phase: Phase::Done as i32,
-                        message,
+                            &repo_path,
+                            cancel_for_index.load(std::sync::atomic::Ordering::Acquire),
+                        ),
                         files_processed: result.files_count as u64,
                         files_total: result.files_count as u64,
                         symbols_found: result.symbols_count as u64,

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -3367,23 +3367,25 @@ impl NestWeaverDaemon for DaemonService {
                         // reported as a FAILURE for an index that (because
                         // cancellation is cooperative and only observed at the
                         // pre-write boundary) may still be running and may still
-                        // succeed. Send a terminal Error event so the caller
-                        // learns what actually happened, names the knob, and is
-                        // warned not to assume the work stopped.
+                        // succeed. Send a NON-TERMINAL warning instead: the
+                        // progress tracker treats Done|Error as terminal, so a
+                        // terminal Error here would make the run's own late
+                        // Writing/Done events be rejected as AfterTerminal and
+                        // misreport a committed index as failed. The genuine
+                        // terminal event still follows and says whether the run
+                        // aborted before writing or committed anyway.
                         let _ = watch_tx
                             .send(Ok(IndexProgress {
-                                phase: Phase::Error as i32,
                                 message: format!(
                                     "index exceeded the {}s timeout and cancellation was requested \
                                      (raise NESTWEAVER_INDEX_TIMEOUT_SECS). Cancellation is \
                                      cooperative and is only observed at the next pre-write \
-                                     boundary, so the daemon may still be finishing this index — \
-                                     check the daemon log before assuming it stopped or retrying.",
+                                     boundary, so this run may still commit — the final stream \
+                                     event will say whether it aborted before writing or \
+                                     committed anyway.",
                                     index_timeout.as_secs()
                                 ),
-                                files_processed: 0,
-                                files_total: 0,
-                                symbols_found: 0,
+                                ..Default::default()
                             }))
                             .await;
                     }

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -3559,13 +3559,31 @@ impl NestWeaverDaemon for DaemonService {
                         }
                     }
 
-                    // DONE phase
-                    let _ = tx.blocking_send(Ok(IndexProgress {
-                        phase: Phase::Done as i32,
-                        message: format!(
+                    // DONE phase. When cancellation was requested (timeout or
+                    // client disconnect) but the run had already passed the
+                    // point where it could abort safely, say so plainly: the
+                    // index COMMITTED, and a plain `Done` would be a lie about
+                    // what the caller asked for. Name the repair.
+                    let message = if cancel_for_index.load(std::sync::atomic::Ordering::Acquire) {
+                        format!(
+                            "Done — {} files, {} symbols, {} edges. Cancellation was requested \
+                             but the index had already passed its last cancellation point and \
+                             COMMITTED anyway. To discard this run and re-index from scratch, \
+                             run: nestweaver index --repo {} --force",
+                            result.files_count,
+                            result.symbols_count,
+                            result.edges_count,
+                            repo_path.display()
+                        )
+                    } else {
+                        format!(
                             "Done — {} files, {} symbols, {} edges",
                             result.files_count, result.symbols_count, result.edges_count
-                        ),
+                        )
+                    };
+                    let _ = tx.blocking_send(Ok(IndexProgress {
+                        phase: Phase::Done as i32,
+                        message,
                         files_processed: result.files_count as u64,
                         files_total: result.files_count as u64,
                         symbols_found: result.symbols_count as u64,

--- a/crates/nestweaver-engine/src/backup.rs
+++ b/crates/nestweaver-engine/src/backup.rs
@@ -1033,6 +1033,7 @@ mod tests {
             "paused watcher publication",
             &crate::index::FileSystemIndexEpilogueIo,
             Some(&nestweaver_store::GraphScope::code_only()),
+            true,
         )
         .unwrap();
         let latest_generation = store.graph_generation();

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -7305,6 +7305,188 @@ function hello(name) { return "Hello " + name; }
         assert!(store.symbols_in_file("old.js").unwrap().is_empty());
     }
 
+    /// Trips the cancel flag inside `establish_marker`, which the index runs
+    /// immediately AFTER the pre-write cancellation poll — so the run passes
+    /// every abort point and can only observe the cancellation at the
+    /// committed finalizer, exactly like a timeout or Ctrl-C that lands
+    /// mid-write.
+    struct CancelOnMarkerIo {
+        cancel: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl IndexEpilogueIo for CancelOnMarkerIo {
+        fn establish_marker(&self, path: &Path) -> Result<(), anyhow::Error> {
+            FileSystemIndexEpilogueIo.establish_marker(path)?;
+            self.cancel
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn clear_marker(&self, path: &Path) -> Result<(), anyhow::Error> {
+            FileSystemIndexEpilogueIo.clear_marker(path)
+        }
+
+        fn remove_file(&self, path: &Path) -> std::io::Result<()> {
+            FileSystemIndexEpilogueIo.remove_file(path)
+        }
+
+        fn rename_file(&self, from: &Path, to: &Path) -> std::io::Result<()> {
+            FileSystemIndexEpilogueIo.rename_file(from, to)
+        }
+
+        fn save_generation(
+            &self,
+            store: &GraphStore,
+            path: &Path,
+            generation: u64,
+        ) -> Result<(), anyhow::Error> {
+            FileSystemIndexEpilogueIo.save_generation(store, path, generation)
+        }
+
+        fn compute_pagerank(
+            &self,
+            store: &GraphStore,
+            scope: &nestweaver_store::GraphScope,
+        ) -> Result<(), anyhow::Error> {
+            FileSystemIndexEpilogueIo.compute_pagerank(store, scope)
+        }
+
+        fn save_pagerank(&self, store: &GraphStore, path: &Path) -> Result<(), anyhow::Error> {
+            FileSystemIndexEpilogueIo.save_pagerank(store, path)
+        }
+    }
+
+    /// A cancellation observed only AFTER the last pre-write poll cannot abort
+    /// the run — the graph commits — but the publication must stay dirty:
+    /// `.index-dirty` survives and the durable generation is not advanced, so
+    /// the next open reconciles the publication fail-closed instead of
+    /// trusting a generation/PageRank that predates the commit.
+    #[test]
+    fn cancelled_commit_keeps_publication_dirty_and_generation_unpublished() {
+        use std::sync::{Arc, atomic::AtomicBool};
+
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        let db_path = dir.path().join("test.lbug");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(repo.join("kept.js"), "function kept() { return 1; }").unwrap();
+        let repo_url = "https://example.com/cancelled-commit";
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        let reader = crate::content_reader::FilesystemReader::new(&repo);
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        let result = index_with_reader_and_write_gate_and_io(
+            ReaderIndexRequest {
+                reader: &reader,
+                store: &store,
+                instance_id: "test",
+                repo_url,
+                indexed_sha: "sha-1",
+                name: None,
+                cancel: Some(&cancel),
+                epilogue_io: &CancelOnMarkerIo {
+                    cancel: Arc::clone(&cancel),
+                },
+            },
+            || Ok::<_, anyhow::Error>(()),
+        )
+        .expect("a cancellation past the last pre-write poll cannot abort the commit");
+
+        assert!(result.files_count > 0, "the run indexed the file");
+        assert!(
+            store
+                .list_repos(Some("test"))
+                .unwrap()
+                .iter()
+                .any(|repo| repo.url == repo_url),
+            "the cancelled run's graph mutation IS persisted"
+        );
+        let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
+        let generation_path = crate::sidecar_path(&db_path, ".generation");
+        assert!(
+            marker_path.exists(),
+            "a cancelled commit must leave the publication dirty"
+        );
+        assert!(
+            !generation_path.exists(),
+            "a cancelled commit must not durably advance the generation"
+        );
+        drop(store);
+
+        // Reconciliation on the next open is fail-closed: the committed graph
+        // is there, but the dirty marker blocks trusting generation/PageRank
+        // state until a successful writer heals the publication.
+        let reopened = GraphStore::open_or_create(&db_path).unwrap();
+        assert!(
+            reopened.is_index_publication_dirty(),
+            "the dirty marker must survive reopen"
+        );
+        assert_eq!(
+            reopened.graph_generation(),
+            u64::MAX,
+            "with no published `.generation` and the dirty marker present, reopen must \
+             report the fail-closed sentinel rather than a trustworthy generation"
+        );
+        assert!(
+            reopened
+                .list_repos(Some("test"))
+                .unwrap()
+                .iter()
+                .any(|repo| repo.url == repo_url),
+            "the committed graph survives reopen"
+        );
+    }
+
+    /// Control for the cancelled-commit test: the same run without a
+    /// cancellation retires `.index-dirty` and durably publishes the advanced
+    /// generation.
+    #[test]
+    fn uncancelled_commit_retires_marker_and_publishes_generation() {
+        use std::sync::{Arc, atomic::AtomicBool};
+
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        let db_path = dir.path().join("test.lbug");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(repo.join("kept.js"), "function kept() { return 1; }").unwrap();
+        let repo_url = "https://example.com/uncancelled-commit";
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        let generation_before = store.graph_generation();
+        let reader = crate::content_reader::FilesystemReader::new(&repo);
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        index_with_reader_and_write_gate_and_io(
+            ReaderIndexRequest {
+                reader: &reader,
+                store: &store,
+                instance_id: "test",
+                repo_url,
+                indexed_sha: "sha-1",
+                name: None,
+                cancel: Some(&cancel),
+                epilogue_io: &FileSystemIndexEpilogueIo,
+            },
+            || Ok::<_, anyhow::Error>(()),
+        )
+        .expect("an uncancelled index must succeed");
+
+        assert!(
+            !crate::sidecar_path(&db_path, ".index-dirty").exists(),
+            "a clean commit retires the dirty marker"
+        );
+        assert!(store.graph_generation() > generation_before);
+        assert_eq!(
+            fs::read_to_string(crate::sidecar_path(&db_path, ".generation"))
+                .unwrap()
+                .trim()
+                .parse::<u64>()
+                .unwrap(),
+            store.graph_generation(),
+            "a clean commit durably publishes the advanced generation"
+        );
+        assert!(!store.is_index_publication_dirty());
+    }
+
     #[test]
     fn marker_establishment_failure_aborts_before_full_graph_mutation() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -2273,6 +2273,20 @@ where
     drop(_phase_collect_span);
 
     let _write_guard = acquire_write_guard()?;
+
+    // Last cancellation observation point. Bailing in this window needs no
+    // teardown: the marker call below is what creates `.index-dirty` and
+    // reserves the generation, so nothing owned by this run exists yet and
+    // any pre-existing `.index-dirty` (a prior interrupted publication)
+    // stays untouched for its own recovery. A cancel that lands AFTER this
+    // poll still commits; the committed finalizer then keeps the
+    // publication dirty and the daemon reports committed-after-cancellation.
+    // The incremental path (`incremental_index_with_reader_and_write_gate`)
+    // takes no cancel token by design this cycle.
+    if cancel.is_some_and(|c| c.load(std::sync::atomic::Ordering::Acquire)) {
+        anyhow::bail!("index cancelled");
+    }
+
     let publication = establish_index_publication_marker_with_io(
         store,
         store.db_path(),

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -7447,6 +7447,40 @@ function hello(name) { return "Hello " + name; }
         );
     }
 
+    /// In-memory stores have no `.index-dirty` marker for a later open to
+    /// reconcile, so a cancelled-but-committed run must still bump the
+    /// in-memory generation — otherwise the commit is invisible to
+    /// generation-keyed snapshot readers.
+    #[test]
+    fn cancelled_commit_still_bumps_in_memory_generation() {
+        let store = GraphStore::in_memory().unwrap();
+        store.bump_graph_generation();
+        let before = store.graph_generation();
+
+        let lease = establish_index_publication_marker_with_io(
+            &store,
+            None,
+            "cancelled in-memory commit",
+            &FileSystemIndexEpilogueIo,
+        )
+        .unwrap();
+        finalize_committed_index_for_scope_with_io(
+            lease,
+            None,
+            "cancelled in-memory commit",
+            &FileSystemIndexEpilogueIo,
+            None,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            store.graph_generation(),
+            before + 1,
+            "in-memory stores have no dirty marker, so the generation bump must still run"
+        );
+    }
+
     /// Control for the cancelled-commit test: the same run without a
     /// cancellation retires `.index-dirty` and durably publishes the advanced
     /// generation.

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -828,21 +828,16 @@ fn finalize_committed_index_with_io(
     refresh_pagerank: bool,
 ) -> Result<(), DeletionReconciliationError> {
     let scope = refresh_pagerank.then(nestweaver_store::GraphScope::code_only);
-    finalize_committed_index_for_scope_with_io(
-        lease,
-        db_path,
-        operation,
-        io,
-        scope.as_ref(),
-        true,
-    )
+    finalize_committed_index_for_scope_with_io(lease, db_path, operation, io, scope.as_ref(), true)
 }
 
 /// `publish_clean`: when false (a run that committed AFTER cancellation was
-/// requested), only the invalidation preamble runs — the generation advance,
-/// `.index-dirty` retirement, and the scoped PageRank refresh are skipped so
-/// the publication stays dirty and the next open reconciles it instead of
-/// trusting generation/PageRank state that predates this commit.
+/// requested), the file-backed generation advance, `.index-dirty` retirement,
+/// and the scoped PageRank refresh are skipped so the publication stays dirty
+/// and the next open reconciles it instead of trusting generation/PageRank
+/// state that predates this commit. In-memory stores are the exception: they
+/// have no `.index-dirty` marker to reconcile on a later open, so their
+/// generation bump still runs (see below).
 pub(crate) fn finalize_committed_index_for_scope_with_io(
     lease: nestweaver_store::IndexPublicationLease<'_>,
     db_path: Option<&Path>,
@@ -930,6 +925,20 @@ pub(crate) fn finalize_committed_index_for_scope_with_io(
             } else {
                 publication_clean = true;
             }
+        }
+    } else if db_path.is_none() {
+        // In-memory stores have no `.index-dirty` marker for a later open to
+        // reconcile, so a cancelled-but-committed run would otherwise be
+        // invisible to generation-keyed snapshot readers. Bump the in-memory
+        // generation even though the file-backed clean-publish steps above
+        // stay skipped.
+        if let Err(error) = store.try_bump_graph_generation() {
+            push_reconciliation_failure(
+                &mut failures,
+                DeletionReconciliationStage::GenerationPersistence,
+                None,
+                format!("advance graph generation: {error:#}"),
+            );
         }
     }
 
@@ -2971,13 +2980,15 @@ where
     // finalizer (pagerank invalidation, failure aggregation, lease release)
     // is unchanged.
     let finalization = if cancel.is_some_and(|c| c.load(std::sync::atomic::Ordering::Acquire)) {
-        let scope = bump_generation_after_write.then(nestweaver_store::GraphScope::code_only);
         finalize_committed_index_for_scope_with_io(
             publication,
             store.db_path(),
             "index graph write (committed after cancellation)",
             epilogue_io,
-            scope.as_ref(),
+            // The scoped PageRank refresh is gated on `publication_clean`,
+            // which stays false for a cancelled commit — pass `None` so the
+            // skip is explicit rather than implied by a dead scope.
+            None,
             false,
         )
     } else {
@@ -7317,8 +7328,7 @@ function hello(name) { return "Hello " + name; }
     impl IndexEpilogueIo for CancelOnMarkerIo {
         fn establish_marker(&self, path: &Path) -> Result<(), anyhow::Error> {
             FileSystemIndexEpilogueIo.establish_marker(path)?;
-            self.cancel
-                .store(true, std::sync::atomic::Ordering::SeqCst);
+            self.cancel.store(true, std::sync::atomic::Ordering::SeqCst);
             Ok(())
         }
 

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -828,15 +828,28 @@ fn finalize_committed_index_with_io(
     refresh_pagerank: bool,
 ) -> Result<(), DeletionReconciliationError> {
     let scope = refresh_pagerank.then(nestweaver_store::GraphScope::code_only);
-    finalize_committed_index_for_scope_with_io(lease, db_path, operation, io, scope.as_ref())
+    finalize_committed_index_for_scope_with_io(
+        lease,
+        db_path,
+        operation,
+        io,
+        scope.as_ref(),
+        true,
+    )
 }
 
+/// `publish_clean`: when false (a run that committed AFTER cancellation was
+/// requested), only the invalidation preamble runs — the generation advance,
+/// `.index-dirty` retirement, and the scoped PageRank refresh are skipped so
+/// the publication stays dirty and the next open reconciles it instead of
+/// trusting generation/PageRank state that predates this commit.
 pub(crate) fn finalize_committed_index_for_scope_with_io(
     lease: nestweaver_store::IndexPublicationLease<'_>,
     db_path: Option<&Path>,
     operation: &str,
     io: &dyn IndexEpilogueIo,
     pagerank_scope: Option<&nestweaver_store::GraphScope>,
+    publish_clean: bool,
 ) -> Result<(), DeletionReconciliationError> {
     let mut failures = Vec::new();
     let store = lease.store();
@@ -852,64 +865,71 @@ pub(crate) fn finalize_committed_index_for_scope_with_io(
         true
     };
 
-    let generation_advanced = if db_path.is_some() {
-        lease.clean_generation()
-    } else {
-        store.try_bump_graph_generation()
-    };
-    let generation_durable = match generation_advanced {
-        Err(error) => {
-            push_reconciliation_failure(
-                &mut failures,
-                DeletionReconciliationStage::GenerationPersistence,
-                None,
-                format!("advance graph generation: {error:#}"),
-            );
-            false
-        }
-        Ok(generation) if db_path.is_some() => {
-            let generation_path = crate::sidecar_path(db_path.unwrap(), ".generation");
-            match io.save_generation(store, &generation_path, generation) {
-                Ok(()) => true,
-                Err(error) => {
-                    push_reconciliation_failure(
-                        &mut failures,
-                        DeletionReconciliationStage::GenerationPersistence,
-                        None,
-                        format!("{}: {error:#}", generation_path.display()),
-                    );
-                    false
+    // A cancelled-but-committed run skips the generation advance and the
+    // clean-publish/marker retirement below: `.index-dirty` and the reserved
+    // generation survive so the next open reconciles this publication as
+    // dirty (fail-closed) rather than treating it as a clean commit.
+    let mut publication_clean = false;
+    if publish_clean {
+        let generation_advanced = if db_path.is_some() {
+            lease.clean_generation()
+        } else {
+            store.try_bump_graph_generation()
+        };
+        let generation_durable = match generation_advanced {
+            Err(error) => {
+                push_reconciliation_failure(
+                    &mut failures,
+                    DeletionReconciliationStage::GenerationPersistence,
+                    None,
+                    format!("advance graph generation: {error:#}"),
+                );
+                false
+            }
+            Ok(generation) if db_path.is_some() => {
+                let generation_path = crate::sidecar_path(db_path.unwrap(), ".generation");
+                match io.save_generation(store, &generation_path, generation) {
+                    Ok(()) => true,
+                    Err(error) => {
+                        push_reconciliation_failure(
+                            &mut failures,
+                            DeletionReconciliationStage::GenerationPersistence,
+                            None,
+                            format!("{}: {error:#}", generation_path.display()),
+                        );
+                        false
+                    }
                 }
             }
-        }
-        Ok(_) => true,
-    };
+            Ok(_) => true,
+        };
 
-    let mut publication_clean = db_path.is_none();
-    if generation_durable
-        && pagerank_safe
-        && let Some(db_path) = db_path
-    {
-        let marker_path = crate::sidecar_path(db_path, ".index-dirty");
-        let retirement =
-            store.with_index_publication_rank_barrier(|| -> Result<(), anyhow::Error> {
-                lease.publish_clean_generation()?;
-                if let Err(error) = io.clear_marker(&marker_path) {
-                    lease.fail_clean_generation()?;
-                    return Err(error);
-                }
-                lease.complete_generation()?;
-                Ok(())
-            });
-        if let Err(error) = retirement {
-            push_reconciliation_failure(
-                &mut failures,
-                DeletionReconciliationStage::IndexPublicationMarkerRetirement,
-                None,
-                format!("{}: {error:#}", marker_path.display()),
-            );
-        } else {
-            publication_clean = true;
+        publication_clean = db_path.is_none();
+        if generation_durable
+            && pagerank_safe
+            && let Some(db_path) = db_path
+        {
+            let marker_path = crate::sidecar_path(db_path, ".index-dirty");
+            let retirement =
+                store.with_index_publication_rank_barrier(|| -> Result<(), anyhow::Error> {
+                    lease.publish_clean_generation()?;
+                    if let Err(error) = io.clear_marker(&marker_path) {
+                        lease.fail_clean_generation()?;
+                        return Err(error);
+                    }
+                    lease.complete_generation()?;
+                    Ok(())
+                });
+            if let Err(error) = retirement {
+                push_reconciliation_failure(
+                    &mut failures,
+                    DeletionReconciliationStage::IndexPublicationMarkerRetirement,
+                    None,
+                    format!("{}: {error:#}", marker_path.display()),
+                );
+            } else {
+                publication_clean = true;
+            }
         }
     }
 
@@ -2881,6 +2901,7 @@ where
                     "recovered index graph write",
                     epilogue_io,
                     Some(&nestweaver_store::GraphScope::unified()),
+                    true,
                 )
                 .map(|()| result)
                 .map_err(anyhow::Error::from),
@@ -2915,13 +2936,34 @@ where
 
     // The write guard stays alive through this mandatory epilogue. Publish
     // invalidation/generation/PageRank on success and every later graph error.
-    let finalization = finalize_committed_index_with_io(
-        publication,
-        store.db_path(),
-        "index graph write",
-        epilogue_io,
-        bump_generation_after_write,
-    );
+    //
+    // Cancellation observed here arrived past every pre-write observation
+    // point, so the graph committed anyway. Do NOT run the clean publish:
+    // `.index-dirty` and the reserved generation must survive so the next
+    // open reconciles this publication as dirty (fail-closed) instead of
+    // trusting a generation/PageRank that predates the commit. The daemon
+    // reports the outcome as committed-after-cancellation. The rest of the
+    // finalizer (pagerank invalidation, failure aggregation, lease release)
+    // is unchanged.
+    let finalization = if cancel.is_some_and(|c| c.load(std::sync::atomic::Ordering::Acquire)) {
+        let scope = bump_generation_after_write.then(nestweaver_store::GraphScope::code_only);
+        finalize_committed_index_for_scope_with_io(
+            publication,
+            store.db_path(),
+            "index graph write (committed after cancellation)",
+            epilogue_io,
+            scope.as_ref(),
+            false,
+        )
+    } else {
+        finalize_committed_index_with_io(
+            publication,
+            store.db_path(),
+            "index graph write",
+            epilogue_io,
+            bump_generation_after_write,
+        )
+    };
     match (graph_result, finalization) {
         (Ok(result), Ok(())) => {
             // nw-124: stamp WHICH resolver produced this repo's edges. Some
@@ -4809,6 +4851,7 @@ mod tests {
             "successful no-op recovery",
             &FileSystemIndexEpilogueIo,
             Some(&nestweaver_store::GraphScope::unified()),
+            true,
         )
         .unwrap();
 

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -1918,9 +1918,14 @@ where
 
         // Cooperative cancellation: once the daemon trips the flag (index
         // timeout or client disconnect), skip the expensive read+parse for
-        // every remaining file so all cores are freed promptly. The index
-        // then bails before any graph mutation (checked right after the
-        // collect), so no partial/empty graph is ever persisted.
+        // every remaining file so all cores are freed promptly. Cancellation
+        // is observed here per-file during parse, at the post-parse barrier
+        // below, and once more at the pre-write boundary after the write
+        // guard is acquired — all before any graph mutation, so an index
+        // cancelled at those points never persists a partial/empty graph.
+        // A cancel that lands after the pre-write boundary still commits;
+        // the daemon reports that as committed-after-cancellation and names
+        // `index --force` as the repair.
         if cancel.is_some_and(|c| c.load(std::sync::atomic::Ordering::Relaxed)) {
             parse_pb.inc(1);
             return ParseOutcome::Skipped(SkippedFile {
@@ -2016,10 +2021,16 @@ where
     parse_pb.finish_and_clear();
     drop(_phase2_span);
 
-    // Cooperative cancellation: if the flag tripped during the parallel parse,
-    // bail now — BEFORE collection, resolution, and any graph mutation — so a
-    // cancelled index never persists a partial/empty graph. The `?` returns
-    // ahead of the write gate below, preserving the no-partial-write invariant.
+    // Cooperative cancellation, post-parse barrier: if the flag tripped
+    // during the parallel parse, bail now — BEFORE collection, resolution,
+    // and any graph mutation. This is one of three observation points
+    // (per-file during parse above, here, and at the pre-write boundary
+    // after the write guard is acquired); an index cancelled at any of them
+    // persists nothing. The no-partial-write invariant does NOT extend past
+    // the pre-write boundary: a cancel landing after it still commits, the
+    // publication is left dirty for the next open to reconcile, and the
+    // daemon reports the run as committed-after-cancellation, naming
+    // `index --force` as the repair.
     if cancel.is_some_and(|c| c.load(std::sync::atomic::Ordering::Acquire)) {
         anyhow::bail!("index cancelled");
     }

--- a/crates/nestweaver-engine/src/watch_code.rs
+++ b/crates/nestweaver-engine/src/watch_code.rs
@@ -64,6 +64,7 @@ impl CodeWatcher {
             "code watcher batch",
             io,
             Some(&GraphScope::code_only()),
+            true,
         )
     }
 

--- a/crates/nestweaver-engine/src/watcher.rs
+++ b/crates/nestweaver-engine/src/watcher.rs
@@ -145,6 +145,7 @@ impl BrainWatcher {
             "brain watcher batch",
             io,
             Some(&GraphScope::unified()),
+            true,
         )
     }
 

--- a/crates/nestweaver-engine/tests/index_cancellation.rs
+++ b/crates/nestweaver-engine/tests/index_cancellation.rs
@@ -144,6 +144,52 @@ fn cancelled_index_stops_before_reading_or_parsing_any_file() {
     );
 }
 
+/// Cancellation that trips AT the write gate — after the per-file and
+/// post-parse barrier polls have already passed — must still abort the run
+/// before any graph mutation. The flag flips inside the caller-supplied
+/// `acquire_write_guard` closure, so the abort can only come from the poll at
+/// the pre-write boundary: `read_count() > 0` proves files were read and
+/// parsed (ruling out the earlier barrier), and the empty store proves no
+/// write slipped through.
+#[test]
+fn cancelled_at_the_write_gate_bails_after_parsing_without_writing() {
+    let store = GraphStore::in_memory().unwrap();
+    let spy = CountingReader::new(FilesystemReader::new(&testdata_js()));
+    let cancel = Arc::new(AtomicBool::new(false)); // trips only at the write gate
+    let cancel_in_guard = Arc::clone(&cancel);
+
+    let result = nestweaver_engine::index_with_reader_and_write_gate(
+        &spy,
+        &store,
+        "default",
+        "file:///test/js",
+        "abc",
+        None,
+        Some(&cancel),
+        move || {
+            cancel_in_guard.store(true, Ordering::SeqCst);
+            Ok::<(), anyhow::Error>(())
+        },
+    );
+
+    let err = match result {
+        Ok(_) => panic!("an index cancelled at the write gate must return an error"),
+        Err(e) => e,
+    };
+    assert!(
+        err.to_string().to_lowercase().contains("cancel"),
+        "error should mention cancellation, got: {err}"
+    );
+    assert!(
+        spy.read_count() > 0,
+        "the abort happens at the write gate, AFTER parsing — not at the earlier barrier"
+    );
+    assert!(
+        store.list_repos(None).unwrap().is_empty(),
+        "an index cancelled at the write gate must not write the repo into the store"
+    );
+}
+
 #[test]
 fn uncancelled_reader_index_still_reads_and_writes() {
     let store = GraphStore::in_memory().unwrap();

--- a/crates/nestweaver-proto/src/lib.rs
+++ b/crates/nestweaver-proto/src/lib.rs
@@ -304,6 +304,54 @@ mod index_progress_tracker_tests {
         );
     }
 
+    /// The watchdog's timeout warning is NON-TERMINAL (its phase defaults to
+    /// DISCOVERING), so the run's own late Writing/Done events still land and
+    /// the caller's outcome derives from the genuine terminal event. This is
+    /// the sequence a cancelled-but-committed index produces; back when the
+    /// watchdog emitted a terminal `Phase::Error`, the late Writing/Done
+    /// events were rejected as AfterTerminal and an index that had in fact
+    /// committed was misreported to the CLI as a failure.
+    #[test]
+    fn a_non_terminal_timeout_warning_lets_the_real_done_report_through() {
+        let mut tracker = IndexProgressTracker::default();
+        tracker
+            .observe(&progress(
+                Phase::Discovering,
+                "index exceeded the 1800s timeout and cancellation was requested \
+                 (raise NESTWEAVER_INDEX_TIMEOUT_SECS)",
+            ))
+            .unwrap();
+        tracker
+            .observe(&progress(
+                Phase::Writing,
+                "Indexed 239745 files, 3122546 symbols",
+            ))
+            .unwrap();
+        tracker
+            .observe(&progress(
+                Phase::Done,
+                "Done — 239745 files, 3122546 symbols, 4725058 edges. Cancellation was \
+                 requested but the index had already passed its last cancellation point and \
+                 COMMITTED anyway. To discard this run and re-index from scratch, \
+                 run: nestweaver index --repo /repos/big --force",
+            ))
+            .unwrap();
+
+        let message = tracker.finish().unwrap();
+        assert!(
+            message.contains("COMMITTED"),
+            "a committed-after-cancellation run must say so, got: {message}"
+        );
+        assert!(
+            message.contains("nestweaver index --repo /repos/big --force"),
+            "the repair must be named, got: {message}"
+        );
+        assert!(
+            message.contains("239745 files"),
+            "the real counts must survive, got: {message}"
+        );
+    }
+
     #[test]
     fn any_event_after_a_terminal_event_is_rejected() {
         for terminal in [Phase::Done, Phase::Error] {

--- a/crates/nestweaver-proto/src/lib.rs
+++ b/crates/nestweaver-proto/src/lib.rs
@@ -257,17 +257,21 @@ mod index_progress_tracker_tests {
         ));
     }
 
-    /// nw-127: a timeout must reach the caller as a REPORTED error naming the
-    /// cause, not as a truncated stream.
+    /// nw-127: an in-band terminal error must reach the caller as a REPORTED
+    /// error naming the cause, not as a truncated stream.
     ///
     /// The daemon's watchdog used to set its cancel flag and say nothing, so the
     /// client saw the stream simply end and rendered "index progress stream
     /// ended before completion" — indistinguishable from a crash, and shown as a
-    /// failure for an index that was still running and went on to SUCCEED.
-    /// Emitting a terminal `Phase::Error` is what turns that into an explanation.
+    /// failure for an index that was still running and went on to SUCCEED. The
+    /// watchdog now emits a non-terminal warning (naming
+    /// NESTWEAVER_INDEX_TIMEOUT_SECS) and lets the run's own terminal event
+    /// report whether it aborted before writing or committed anyway; what
+    /// remains pinned here is that any terminal `Phase::Error` still surfaces
+    /// as an explanation rather than a truncation.
     #[test]
     fn a_timeout_reported_in_band_beats_a_truncated_stream() {
-        // What the watchdog does now.
+        // A terminal Error event reported in-band.
         let mut reported = IndexProgressTracker::default();
         reported
             .observe(&progress(Phase::Writing, "still writing"))


### PR DESCRIPTION
## Group D — Cancelled-index honesty

Bug bash 2026-08-06, group D. Scope is **(c) honest reporting + (a1) pre-write
cancel poll only** from the cancelled-index backlog item. (a2) post-write
cancellation and (b) the run-level transaction are deliberately excluded —
see the stated landing point below.

### What lands

- `7568b69` **fix(daemon): report index timeout as a non-terminal stream
  warning** — the watchdog no longer sends a terminal `Phase::Error` when the
  `NESTWEAVER_INDEX_TIMEOUT_SECS` timeout fires. Under the old behavior the
  genuine late `Writing`/`Done` events were rejected as `AfterTerminal`, and a
  committed index was misreported as failed.
- `4a319eb` + `2a8cc61` **committed-after-cancel is reported, naming the
  repair** — when cancellation was requested but the run committed anyway,
  the terminal `Done` says so, keeps the real counts, and names
  `nestweaver index --repo <path> --force`. `2a8cc61` fixes a blocker found in
  adversarial review: the pre-existing early return that skips post-index
  sidecar phases on cancel also skipped the `Done` send, so the stream closed
  with no terminal event — the new message was unreachable in exactly the
  timeout scenario. The message text is extracted to a pure, unit-tested
  function.
- `f33b4fc` + `724bbb4` **a cancelled commit stays dirty** — the committed
  finalizer gains `publish_clean: bool`; a cancelled-but-committed run skips
  the generation advance, `.generation` save, and `.index-dirty` retirement,
  so the next open reconciles fail-closed (verified identical to crash
  recovery). In-memory stores have no marker to reconcile, so they still bump
  their generation (`724bbb4`).
- `d4486af` **(a1) one cancel poll at the pre-write boundary** — immediately
  after `acquire_write_guard()?`, before the publication-marker establishment
  that creates `.index-dirty`. No polls added anywhere past this point.
- `2b04bf9` docs: the false no-partial-write invariant comments and
  `CLAUDE.md:45` corrected to the new reality.
- Tests: `b7ca92d`, `d71c3d4`, `036da00`.

### User-visible behavior changes (disclosed per sign-off contract)

- A timeout-then-committed index now exits 0 with a `Done` message naming
  `index --force`, instead of exit 1 with a spurious failure. A
  timeout-then-aborted index still exits 1.
- The watchdog's in-band terminal `Phase::Error` on timeout is gone; the
  timeout now appears as a non-terminal warning event. CLI prints it inline;
  outcome is derived solely from the final terminal event.

### Stated landing point (not a shortfall)

- **Post-write cancellation ((a2)) remains unsupported this cycle.** A cancel
  landing after the pre-write boundary commits; that is now *honestly
  reported* (this group) but not *prevented* — (a2) without (b) leaves
  symbols without edges, which is worse than today.
- **The incremental path** (`incremental_index_with_reader_and_write_gate`)
  takes no cancel token at all, by design this cycle.

### Test-coverage waiver

The daemon-side emission points (the watchdog's non-terminal warning at
`server.rs`, and the committed-message selection in the `index_repo` Ok arm)
are covered by tracker-level contract tests (`proto/lib.rs`), unit tests on
the extracted message builder, and code inspection — no test fails if either
daemon branch is reverted. Deterministic daemon-level coverage needs the
message/phase orchestration extracted from the handler or a controllable
watchdog clock; noted here so a future refactor doesn't silently regress it.
Engine-side criteria (pre-write poll, dirty cancelled commit, in-memory
generation bump) have discriminating tests that fail on the pre-change code.

### Sign-off record

- Acceptance audit: every in-scope criterion SATISFIED with named tests, two
  daemon-side items landed as demonstrated behavior with the waiver above.
- Adversarial correctness review: one blocker (unreachable `Done` — fixed in
  `2a8cc61` and re-verified), one minor (in-memory generation — fixed in
  `724bbb4` + `036da00`), one nit (dead pagerank scope — fixed in `724bbb4`).
- CI gate: `cargo fmt --all -- --check`,
  `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo build --locked --tests`, `cargo test`, `cargo test -- daemon_` —
  green locally.
