### PR TITLE
fix(engine): stop duplicate resolved-edge accumulation on empty resolution-deps sidecar

### DIFF
--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -91,6 +91,10 @@ pub type FileMetaCache = HashMap<String, CachedFileMeta>;
 /// unversioned flat map) fails deserialization and loads as empty — a
 /// deliberate fail-open that costs one full re-index and can never
 /// mis-classify a file.
+///
+/// Paired with `resolution_cache::CACHE_VERSION`: bumping one requires
+/// bumping the other (both sidecars must be invalidated together), enforced
+/// by `resolution_cache::tests::cache_version_moves_with_filemeta_version`.
 pub const FILEMETA_VERSION: u32 = 2;
 
 /// On-disk shape of `<db>.filemeta.json`: change-detection metadata keyed by

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -2701,12 +2701,18 @@ where
             .filter(|e| !e.target_uid.starts_with("unresolved:"))
             .collect();
 
-        // When doing incremental resolution, delete old resolved edges for
-        // affected files before inserting the new ones.
+        // Delete old resolved edges before inserting the new ones, or every
+        // re-resolution accumulates duplicates. Incremental resolution clears
+        // per affected file; a full (unfiltered) run re-creates every
+        // resolved edge in the repo, so it must clear them repo-wide. When
+        // `skip_resolution` holds, nothing is re-created and nothing is
+        // cleared.
         if let Some(ref filter) = resolve_filter {
             for file_path in filter {
                 let _ = store.delete_resolved_edges_for_file(&r_uid, file_path);
             }
+        } else if !skip_resolution {
+            let _ = store.delete_resolved_edges_for_repo(&r_uid);
         }
 
         let mut edges_count = insertable_edges.len();

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -2782,15 +2782,28 @@ where
             // sidecar (`is_empty_for_repo`), and the empty-deps cache bypass
             // above would force a full replacement on every index. On an
             // incremental run only the affected files were re-resolved, so
-            // only their entries are refreshed; other files' records carry
-            // over. Nothing is recorded when resolution was skipped: the
-            // previous records are still accurate.
+            // only their entries are refreshed (files in the resolve filter
+            // that were not actually fed to the resolver keep their previous
+            // records); other files' records carry over. Nothing is recorded
+            // when resolution was skipped: the previous records are still
+            // accurate.
             if !skip_resolution {
                 match &resolve_filter {
                     Some(filter) => {
+                        // Only files actually fed to the resolver may have
+                        // their records refreshed: a filter member that was
+                        // NOT re-resolved (e.g. an unchanged dependent on a
+                        // cold parsed cache) must keep its previous record
+                        // rather than be clobbered with an empty set.
+                        let resolved: std::collections::HashSet<_> = parsed_files_for_resolver
+                            .iter()
+                            .map(|(p, _, _, _)| p)
+                            .collect();
                         for file in filter {
-                            let deps = file_deps.remove(file).unwrap_or_default();
-                            rd.set_deps_for_repo(&r_uid, file.clone(), deps);
+                            if resolved.contains(file) {
+                                let deps = file_deps.remove(file).unwrap_or_default();
+                                rd.set_deps_for_repo(&r_uid, file.clone(), deps);
+                            }
                         }
                     }
                     None => {

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -1803,7 +1803,24 @@ where
     if let Some(out) = reidentified_old_uid_out {
         *out = reidentify_old_uid.clone();
     }
-    let filemeta_cache = if reidentify_old_uid.is_some() {
+    // An empty resolution-deps slice for this repo (missing/corrupt/stale
+    // sidecar — the loader fails open to empty) is unsafe to combine with a
+    // valid filemeta cache: unchanged files would stay classified Unchanged
+    // while full resolution runs with no stale-edge clear and no bulk
+    // delete, re-creating (duplicating) every resolved edge. Bypass the
+    // cache so every file classifies Parsed, `force_reindex` falls out
+    // below (`files_unchanged == 0`), and the atomic `bulk_reindex_write`
+    // replaces the repo's graph instead of accumulating edges on top of it.
+    let deps_empty_for_repo = resolution_deps
+        .as_ref()
+        .is_some_and(|rd| rd.is_empty_for_repo(&r_uid));
+    if deps_empty_for_repo && reidentify_old_uid.is_none() && filemeta_cache.is_some() {
+        tracing::warn!(
+            repo_uid = %r_uid,
+            "resolution deps empty for repo; bypassing filemeta cache to force a full replacement"
+        );
+    }
+    let filemeta_cache = if reidentify_old_uid.is_some() || deps_empty_for_repo {
         None
     } else {
         filemeta_cache
@@ -2752,8 +2769,31 @@ where
                         .insert(tgt_file.clone());
                 }
             }
-            for (file, deps) in file_deps {
-                rd.set_deps_for_repo(&r_uid, file, deps);
+            // Record the dep set for every file this run actually resolved —
+            // including files that resolve to ZERO outbound edges, recorded as
+            // an empty set. Without those entries a repo whose files have no
+            // cross-file edges would look identical to a missing/corrupt
+            // sidecar (`is_empty_for_repo`), and the empty-deps cache bypass
+            // above would force a full replacement on every index. On an
+            // incremental run only the affected files were re-resolved, so
+            // only their entries are refreshed; other files' records carry
+            // over. Nothing is recorded when resolution was skipped: the
+            // previous records are still accurate.
+            if !skip_resolution {
+                match &resolve_filter {
+                    Some(filter) => {
+                        for file in filter {
+                            let deps = file_deps.remove(file).unwrap_or_default();
+                            rd.set_deps_for_repo(&r_uid, file.clone(), deps);
+                        }
+                    }
+                    None => {
+                        for (path, _, _, _) in &parsed_files_for_resolver {
+                            let deps = file_deps.remove(path).unwrap_or_default();
+                            rd.set_deps_for_repo(&r_uid, path.clone(), deps);
+                        }
+                    }
+                }
             }
         }
 

--- a/crates/nestweaver-engine/src/resolution_cache.rs
+++ b/crates/nestweaver-engine/src/resolution_cache.rs
@@ -6,9 +6,21 @@ use serde::{Deserialize, Serialize};
 
 /// Sidecar format version. v2 = per-repo keying (nw-045). v1 (a flat,
 /// bare-rel-path `deps` map shared across all repos) fails deserialization
-/// and/or the version check and loads as empty — a deliberate fail-open that
-/// costs one full re-resolution and can never resurrect a stale cross-repo
-/// edge decision. Mirrors `index::FILEMETA_VERSION`.
+/// and/or the version check and loads as empty — a deliberate fail-open.
+///
+/// Hazard: fail-open does NOT merely cost one full re-resolution. With a
+/// valid filemeta sidecar, unchanged files stay classified Unchanged
+/// (`files_unchanged > 0`), so an empty deps map would run full resolution
+/// with no stale-edge clear and no bulk delete — re-creating (duplicating)
+/// every resolved edge. Mitigation: the indexer treats an empty deps slice
+/// for the repo as a filemeta-cache-bypass trigger, so every file
+/// classifies Parsed and the atomic `bulk_reindex_write` performs a full
+/// replacement. Only with that pairing does "never resurrects a stale
+/// cross-repo edge decision" hold.
+///
+/// Paired with `index::FILEMETA_VERSION`: bumping one requires bumping the
+/// other (both sidecars must be invalidated together), enforced by
+/// `tests::cache_version_moves_with_filemeta_version`.
 const CACHE_VERSION: u32 = 2;
 
 /// Maximum number of transitive reverse-dependency hops expanded when deciding
@@ -39,8 +51,12 @@ pub struct ResolutionDeps {
 impl ResolutionDeps {
     /// Load resolution deps from a MessagePack file. Missing, corrupt, or
     /// old-format (flat, pre-nw-045) files yield empty deps — a deliberate
-    /// fail-open that costs one full re-resolution and never resurrects a
-    /// stale cross-repo edge decision.
+    /// fail-open. Empty deps are hazardous when the filemeta sidecar is
+    /// still valid (`files_unchanged > 0`): full resolution would run with
+    /// no stale-edge clear and no bulk delete, duplicating every resolved
+    /// edge. The indexer closes that path by treating an empty deps slice
+    /// as a cache-bypass trigger that forces a full replacement, so the
+    /// fail-open can never resurrect a stale cross-repo edge decision.
     pub fn load(path: &Path) -> Self {
         let repos = match std::fs::read(path) {
             Ok(data) => match rmp_serde::from_slice::<ResolutionCacheFile>(&data) {
@@ -147,6 +163,19 @@ mod tests {
     use super::*;
 
     const R: &str = "repo:x";
+
+    #[test]
+    fn cache_version_moves_with_filemeta_version() {
+        // The resolution-deps sidecar and the filemeta sidecar are versioned
+        // together: a stale-resolution-deps fail-open is only safe because an
+        // empty deps slice forces the same full replacement a filemeta
+        // version bump triggers. Keep the two constants in lockstep.
+        assert_eq!(
+            CACHE_VERSION,
+            crate::index::FILEMETA_VERSION,
+            "bumping FILEMETA_VERSION requires bumping CACHE_VERSION (and vice versa)"
+        );
+    }
 
     #[test]
     fn affected_files_includes_changed_and_dependents() {

--- a/crates/nestweaver-engine/tests/edge_duplication_sidecar.rs
+++ b/crates/nestweaver-engine/tests/edge_duplication_sidecar.rs
@@ -1,0 +1,325 @@
+//! Group E (`fix/incremental-edge-duplication`): an incremental index must
+//! never create a second copy of a resolved edge it already created.
+//!
+//! Root cause (pre-change): edges are inserted with a bare `CREATE` and the
+//! stale-edge clear ran only when a resolve filter existed. A missing, corrupt,
+//! or stale-version `.resolution_deps.bin` sidecar fails open to an empty dep
+//! map; combined with a still-valid filemeta sidecar (`files_unchanged > 0`)
+//! that meant full unfiltered resolution re-`CREATE`d every resolved edge on
+//! top of the existing ones — multiplicity 2 per edge per affected run.
+//!
+//! The fix has three parts, each pinned here:
+//!   1. An empty-for-repo deps slice bypasses the filemeta cache, so every
+//!      file classifies Parsed and the atomic `bulk_reindex_write` replaces
+//!      the repo's graph instead of accumulating on top of it.
+//!   2. The stale-edge clear also runs repo-wide whenever full resolution
+//!      runs (no filter), not only per filtered file.
+//!   3. Resolution records dep sets for every re-resolved file INCLUDING
+//!      empty sets, so a repo whose files legitimately have zero cross-file
+//!      edges does not look empty-for-repo on the next run (which would
+//!      force a full replacement on every index).
+//!
+//! Multiplicities are measured through the public `load_typed_edges` read
+//! API: it returns one row per edge with no DISTINCT, so a duplicated
+//! (src, tgt, type) triple shows up with multiplicity > 1.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use nestweaver_engine::resolution_cache::ResolutionDeps;
+use nestweaver_engine::{load_filemeta_sidecar, sidecar_path};
+use nestweaver_schema::uid::repo_uid;
+use nestweaver_store::GraphStore;
+
+const INST: &str = "test";
+const URL: &str = "https://example.com/repo";
+
+/// Two-file fixture with a cross-file call (main.js → helper.js) and a
+/// same-file call (greet → hello inside main.js), so the tests can tell apart
+/// edges with both endpoints in an unchanged file (the duplication vector)
+/// from edges incident to a re-indexed file (deleted and re-created once).
+fn write_fixture(repo: &Path) {
+    std::fs::create_dir_all(repo).unwrap();
+    std::fs::write(
+        repo.join("main.js"),
+        "import { helper } from './helper.js';\n\
+         \n\
+         function greet() {\n\
+         \x20   return hello();\n\
+         }\n\
+         \n\
+         function hello() {\n\
+         \x20   return helper();\n\
+         }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        repo.join("helper.js"),
+        "export function helper() {\n\x20   return 41;\n}\n",
+    )
+    .unwrap();
+}
+
+/// (src_uid, tgt_uid, edge_type) → number of identical edges in the store.
+fn edge_multiplicities(store: &GraphStore) -> HashMap<(String, String, String), usize> {
+    let mut m = HashMap::new();
+    for (src, tgt, ty, _confidence, _evidence) in store.load_typed_edges().unwrap() {
+        *m.entry((src, tgt, ty)).or_insert(0) += 1;
+    }
+    m
+}
+
+/// The fixture must produce at least one CALLS and one IMPORTS edge, each
+/// exactly once — otherwise the multiplicity comparisons below prove nothing.
+fn sane_baseline(m: &HashMap<(String, String, String), usize>) {
+    assert!(
+        m.keys().any(|(_, _, ty)| ty == "CALLS"),
+        "fixture must produce a CALLS edge; got {m:?}"
+    );
+    assert!(
+        m.keys().any(|(_, _, ty)| ty == "IMPORTS"),
+        "fixture must produce a cross-file IMPORTS edge; got {m:?}"
+    );
+    assert!(
+        m.values().all(|&n| n == 1),
+        "fixture must not legitimately contain parallel edges; got {m:?}"
+    );
+}
+
+fn deps_sidecar(db: &Path) -> std::path::PathBuf {
+    sidecar_path(db, ".resolution_deps.bin")
+}
+
+/// The hazard precondition: the deps sidecar is empty for this repo while the
+/// filemeta sidecar still holds its slice — i.e. unchanged files WOULD stay
+/// classified Unchanged, which is exactly the gap that duplicated edges.
+fn assert_hazard_precondition(db: &Path, uid: &str) {
+    assert!(
+        ResolutionDeps::load(&deps_sidecar(db)).is_empty_for_repo(uid),
+        "deps sidecar must be empty for the repo or the test exercises nothing"
+    );
+    assert!(
+        load_filemeta_sidecar(&sidecar_path(db, ".filemeta.json"))
+            .repos
+            .contains_key(uid),
+        "filemeta slice must still be present (files_unchanged > 0 precondition)"
+    );
+}
+
+/// Trigger 1 (partial duplication): one file changed, one file unchanged, deps
+/// sidecar deleted. Pre-change the unchanged file kept its symbols and edges
+/// while full unfiltered resolution re-`CREATE`d its edges — the same-file
+/// CALLS edge greet→hello reached multiplicity 2. Post-change the empty deps
+/// slice bypasses the filemeta cache, so both files re-parse and the atomic
+/// full replacement leaves every multiplicity at 1.
+#[test]
+fn sidecar_deleted_with_one_changed_file_keeps_edge_multiplicities() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().join("repo");
+    let db = dir.path().join("t.lbug");
+    let uid = repo_uid(INST, URL);
+    write_fixture(&repo);
+
+    let store = GraphStore::open(&db).unwrap();
+    nestweaver_engine::index_directory_with_store(
+        &store, &repo, &db, INST, URL, "sha1", false, None,
+    )
+    .unwrap();
+    let baseline = edge_multiplicities(&store);
+    sane_baseline(&baseline);
+
+    // Change helper.js without changing its symbol or edge set (comment only).
+    // The sleep guarantees an mtime_secs delta so tiered change detection
+    // cannot skip the file as mtime-identical.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    std::fs::write(
+        repo.join("helper.js"),
+        "export function helper() {\n\x20   return 41;\n}\n// touched\n",
+    )
+    .unwrap();
+
+    std::fs::remove_file(deps_sidecar(&db)).unwrap();
+    assert_hazard_precondition(&db, &uid);
+
+    // Re-index WITHOUT --force.
+    let result = nestweaver_engine::index_directory_with_store(
+        &store, &repo, &db, INST, URL, "sha2", false, None,
+    )
+    .unwrap();
+
+    // Primary acceptance assertion first: identical multiplicities.
+    let after = edge_multiplicities(&store);
+    assert_eq!(
+        after, baseline,
+        "re-index with a deleted deps sidecar must not duplicate edges"
+    );
+    // And the mechanism: the empty deps slice must have bypassed the filemeta
+    // cache, forcing the atomic full-replacement path.
+    assert_eq!(
+        result.files_unchanged, 0,
+        "empty deps slice must bypass the filemeta cache (full-replacement path)"
+    );
+    assert_eq!(result.files_count, 2, "both files re-parsed");
+}
+
+/// Trigger 2 (total duplication): zero changed files, deps sidecar deleted.
+/// Pre-change the incremental branch performed NO deletes at all
+/// (`actually_changed_files` empty) and full resolution re-`CREATE`d EVERY
+/// resolved edge in the repo — multiplicity 2 across the board. Post-change
+/// the cache bypass forces the same full replacement as trigger 1.
+#[test]
+fn sidecar_deleted_with_zero_changed_files_keeps_edge_multiplicities() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().join("repo");
+    let db = dir.path().join("t.lbug");
+    let uid = repo_uid(INST, URL);
+    write_fixture(&repo);
+
+    let store = GraphStore::open(&db).unwrap();
+    nestweaver_engine::index_directory_with_store(
+        &store, &repo, &db, INST, URL, "sha1", false, None,
+    )
+    .unwrap();
+    let baseline = edge_multiplicities(&store);
+    sane_baseline(&baseline);
+
+    std::fs::remove_file(deps_sidecar(&db)).unwrap();
+    assert_hazard_precondition(&db, &uid);
+
+    // Re-index with NO file changes at all, without --force.
+    let result = nestweaver_engine::index_directory_with_store(
+        &store, &repo, &db, INST, URL, "sha1", false, None,
+    )
+    .unwrap();
+
+    // Primary acceptance assertion first: identical multiplicities.
+    let after = edge_multiplicities(&store);
+    assert_eq!(
+        after, baseline,
+        "zero-change re-index with a deleted deps sidecar must not duplicate edges"
+    );
+    assert!(
+        after.values().all(|&n| n == 1),
+        "every edge must have multiplicity exactly 1; got {after:?}"
+    );
+    // And the mechanism: the empty deps slice must have bypassed the filemeta
+    // cache, forcing the atomic full-replacement path.
+    assert_eq!(
+        result.files_unchanged, 0,
+        "empty deps slice must bypass the filemeta cache (full-replacement path)"
+    );
+}
+
+/// Trigger 3 (CACHE_VERSION bump): a well-formed sidecar written under a
+/// stale/wrong format version. `ResolutionDeps::load` fails open to empty on
+/// version mismatch (unit-pinned by `old_format_bin_loads_empty`), so the
+/// next index of ANY repository lands in the same empty-deps gap as a deleted
+/// sidecar. This is the acceptance criterion "a CACHE_VERSION bump does not
+/// duplicate edges" — the trigger is a routine maintenance action.
+#[test]
+fn stale_version_sidecar_keeps_edge_multiplicities() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().join("repo");
+    let db = dir.path().join("t.lbug");
+    let uid = repo_uid(INST, URL);
+    write_fixture(&repo);
+
+    let store = GraphStore::open(&db).unwrap();
+    nestweaver_engine::index_directory_with_store(
+        &store, &repo, &db, INST, URL, "sha1", false, None,
+    )
+    .unwrap();
+    let baseline = edge_multiplicities(&store);
+    sane_baseline(&baseline);
+
+    // Overwrite the sidecar with a well-formed MessagePack payload under a
+    // version the current loader rejects — what a CACHE_VERSION bump leaves
+    // on disk for every repo. Field order mirrors the private
+    // `ResolutionCacheFile` (version, repos); rmp-serde encodes structs as
+    // arrays, so this deserializes and then fails the version check. Even if
+    // the private struct's field order ever changes, deserialization fails
+    // and the loader still fails open — the test stays valid either way.
+    #[derive(serde::Serialize)]
+    struct StaleSidecar {
+        version: u32,
+        repos: HashMap<String, HashMap<String, HashSet<String>>>,
+    }
+    let stale = StaleSidecar {
+        version: u32::MAX, // any version != current CACHE_VERSION
+        repos: HashMap::from([(
+            uid.clone(),
+            HashMap::from([(
+                "main.js".to_string(),
+                HashSet::from(["helper.js".to_string()]),
+            )]),
+        )]),
+    };
+    let rd_path = deps_sidecar(&db);
+    std::fs::write(&rd_path, rmp_serde::to_vec(&stale).unwrap()).unwrap();
+    assert_hazard_precondition(&db, &uid);
+
+    // Re-index with no file changes, without --force.
+    let result = nestweaver_engine::index_directory_with_store(
+        &store, &repo, &db, INST, URL, "sha1", false, None,
+    )
+    .unwrap();
+
+    // Primary acceptance assertion first: identical multiplicities.
+    let after = edge_multiplicities(&store);
+    assert_eq!(
+        after, baseline,
+        "a CACHE_VERSION bump must not duplicate edges on the next index"
+    );
+    // And the mechanism: a stale-version sidecar must trigger the same cache
+    // bypass as a deleted one.
+    assert_eq!(
+        result.files_unchanged, 0,
+        "stale-version sidecar must trigger the same cache bypass as a deleted one"
+    );
+}
+
+/// Companion fix: files that resolve to ZERO outbound edges are still recorded
+/// in the deps sidecar (as empty sets), so a repo with no cross-file edges
+/// does NOT look empty-for-repo on the next run. Without the recording, the
+/// cache bypass above would misfire (and log its warn) on every index of such
+/// a repo — a perpetual full-replacement regression. `files_unchanged == 2`
+/// on the second run is the behavioral proof that the bypass branch (and its
+/// warn) did not fire: they share one `if`.
+#[test]
+fn no_edge_repo_records_empty_dep_sets_and_skips_full_replacement() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().join("repo");
+    let db = dir.path().join("t.lbug");
+    let uid = repo_uid(INST, URL);
+    std::fs::create_dir_all(&repo).unwrap();
+    std::fs::write(repo.join("a.js"), "function alpha() { return 1; }\n").unwrap();
+    std::fs::write(repo.join("b.js"), "function beta() { return 2; }\n").unwrap();
+
+    let store = GraphStore::open(&db).unwrap();
+    let result1 = nestweaver_engine::index_directory_with_store(
+        &store, &repo, &db, INST, URL, "sha1", false, None,
+    )
+    .unwrap();
+    assert_eq!(result1.files_count, 2);
+
+    // The recording itself: the repo's deps slice is non-empty even though
+    // neither file has any cross-file dependency.
+    let deps = ResolutionDeps::load(&deps_sidecar(&db));
+    assert!(
+        !deps.is_empty_for_repo(&uid),
+        "files with zero resolved edges must still be recorded (as empty sets), \
+         or the empty-deps cache bypass forces a full replacement on every index"
+    );
+
+    // Second index without --force: both files classify Unchanged, resolution
+    // is skipped, no forced full replacement.
+    let result2 = nestweaver_engine::index_directory_with_store(
+        &store, &repo, &db, INST, URL, "sha1", false, None,
+    )
+    .unwrap();
+    assert_eq!(
+        result2.files_unchanged, 2,
+        "recorded (empty) dep sets must keep the no-edge repo on the incremental path"
+    );
+    assert_eq!(result2.files_count, 0, "no files re-parsed");
+}

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -3158,6 +3158,54 @@ impl GraphStore {
         Ok(())
     }
 
+    /// Delete all resolved (semantic) edges originating from symbols in a
+    /// repo. Used when full (unfiltered) resolution runs: every resolved
+    /// edge is about to be re-created, so the stale set must be cleared
+    /// repo-wide or the edges accumulate as duplicates.
+    ///
+    /// Edge types deleted: CALLS, IMPORTS, EXTENDS_SYM, IMPLEMENTS_SYM,
+    /// INCLUDES_SYM, USES, ACCESSES, MEMBER_OF — deliberately the same list
+    /// as [`Self::delete_resolved_edges_for_file`], so "resolved edge" has
+    /// one definition across both helpers. CROSS_REPO_LINK is NOT included:
+    /// it is outside the per-file clear's list today, and the duplication
+    /// vector this helper guards (an empty resolution-deps sidecar forcing
+    /// an unfiltered re-resolution) routes through `bulk_reindex_write`,
+    /// whose DETACH DELETE of the repo's symbols already removes every
+    /// incident edge including CROSS_REPO_LINK before
+    /// `infer_cross_repo_call_edges` re-creates them. The re-CREATE-on-every
+    /// -run semantics of cross-repo inference on other paths are unchanged
+    /// here and are covered by the merge/uniqueness defense, not this
+    /// clear.
+    pub fn delete_resolved_edges_for_repo(&self, repo_uid: &str) -> Result<(), StoreError> {
+        let conn = self.conn()?;
+
+        // Same one-DELETE-per-rel-type pattern as the per-file variant;
+        // the WHERE clause is scoped to the repo instead of a single file.
+        for rel in &[
+            "CALLS",
+            "IMPORTS",
+            "EXTENDS_SYM",
+            "IMPLEMENTS_SYM",
+            "INCLUDES_SYM",
+            "USES",
+            "ACCESSES",
+            "MEMBER_OF",
+        ] {
+            let query = format!(
+                "MATCH (s:Symbol)-[r:{rel}]->() \
+                 WHERE s.repo_uid = $repo \
+                 DELETE r"
+            );
+            exec_params(
+                &conn,
+                &query,
+                vec![("repo", lbug::Value::String(repo_uid.to_string()))],
+            )
+            .map_err(|e| StoreError::Query(format!("delete {rel} edges for repo: {e}")))?;
+        }
+        Ok(())
+    }
+
     /// Delete a File node by its UID using `DETACH DELETE`, which removes all
     /// incident edges (REPO_HAS_FILE, FILE_HAS_SYMBOL) automatically.
     pub fn delete_file_node(&self, file_uid: &str) -> Result<(), StoreError> {

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -7102,6 +7102,97 @@ mod tests {
             .unwrap();
     }
 
+    /// The repo-wide resolved-edge clear deletes exactly the resolved rel
+    /// types for exactly the named repo: edges sourced from other repos
+    /// survive (including edges INTO the named repo), and CROSS_REPO_LINK —
+    /// deliberately excluded from the resolved-edge list — survives even for
+    /// the named repo.
+    #[test]
+    fn delete_resolved_edges_for_repo_scopes_by_repo_and_rel_type() {
+        let store = GraphStore::in_memory().expect("store");
+
+        let sym = |uid: &str, repo: &str| Symbol {
+            uid: uid.to_string(),
+            name: uid.to_string(),
+            kind: nestweaver_schema::SymbolKind::Function,
+            repo_uid: repo.to_string(),
+            file_path: format!("{uid}.js"),
+            start_line: 1,
+            end_line: 1,
+            signature: String::new(),
+            summary: None,
+            content_hash: uid.to_string(),
+            embedding: None,
+            pagerank_score: None,
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: nestweaver_schema::Visibility::Public,
+            type_info: None,
+            framework_hint: None,
+            canonical_id: None,
+        };
+        let edge = |src: &str, tgt: &str, ty: EdgeType| ResolvedEdge {
+            source_uid: src.to_string(),
+            target_uid: tgt.to_string(),
+            edge_type: ty,
+            confidence: 1.0,
+            link_type: None,
+            evidence: Vec::new(),
+        };
+
+        for s in [
+            sym("a1", "repo:a"),
+            sym("a2", "repo:a"),
+            sym("b1", "repo:b"),
+            sym("b2", "repo:b"),
+        ] {
+            store.insert_symbol(&s).unwrap();
+        }
+        store
+            .insert_edge(&edge("a1", "a2", EdgeType::Calls))
+            .unwrap();
+        store
+            .insert_edge(&edge("a1", "a2", EdgeType::MemberOf))
+            .unwrap();
+        store
+            .insert_edge(&edge("b1", "b2", EdgeType::Calls))
+            .unwrap();
+        store
+            .insert_edge(&edge("b1", "a1", EdgeType::Calls))
+            .unwrap();
+        let mut cross = edge("a1", "b1", EdgeType::CrossRepoLink);
+        cross.link_type = Some(nestweaver_schema::CrossRepoLinkType::SharedImport);
+        store.insert_edge(&cross).unwrap();
+
+        store.delete_resolved_edges_for_repo("repo:a").unwrap();
+
+        let remaining: std::collections::HashSet<(String, String, String)> = store
+            .load_typed_edges()
+            .unwrap()
+            .into_iter()
+            .map(|(src, tgt, ty, _conf, _ev)| (src, tgt, ty))
+            .collect();
+        assert_eq!(
+            remaining,
+            [
+                ("b1".to_string(), "b2".to_string(), "CALLS".to_string()),
+                ("b1".to_string(), "a1".to_string(), "CALLS".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+            "only repo:a's resolved edges (CALLS, MEMBER_OF) may be deleted"
+        );
+        // CROSS_REPO_LINK is deliberately outside the resolved-edge list and
+        // must survive even for the named repo. (`load_typed_edges` only
+        // walks ALL_SYMBOL_EDGE_TYPES, so assert via the dedicated reader.)
+        let cross_links = store.list_all_cross_repo_links(10).unwrap();
+        assert_eq!(
+            cross_links.len(),
+            1,
+            "the CROSS_REPO_LINK from repo:a must survive the repo-wide clear"
+        );
+    }
+
     /// nw-112: a merge must CONSERVE the wikilink graph.
     ///
     /// `reparent_vault` captures notes, headings, sections, tags and their edges


### PR DESCRIPTION
## Group E — Duplicate edge accumulation

Bug bash 2026-08-06, group E. Closes the duplication vector opened when the
resolution-deps sidecar loads empty (missing / corrupt / stale version)
while the filemeta cache is still valid: resolution ran unfiltered with no
stale-edge clear and no bulk delete, so every resolved edge was re-`CREATE`d
— total duplication in the zero-changed-files case.

### What lands

- `7f652a9` **version pairing tripwire** — `CACHE_VERSION` and
  `FILEMETA_VERSION` can no longer be bumped independently (unit test +
  reciprocal comments); the false "fail-open costs one full re-resolution"
  cost analysis is corrected to name the real hazard.
- `b2bdf84` **force full replacement when deps are empty for the repo** —
  via the filemeta-cache bypass (all files classify Parsed, `force_reindex`
  falls out, atomic `bulk_reindex_write` does the replacement), NOT by
  touching the `force_reindex` expression, which would have risked bulk
  delete with only a subset re-inserted. Companion: dep sets are now
  recorded for every re-resolved file **including empty sets**, so a
  legitimately edge-less repo no longer looks identical to a lost sidecar
  (without this, every index of such a repo would force full replacement).
- `2cdcc72` + `a03a4fa` **stale-edge clear runs whenever full resolution
  runs** — new repo-wide `delete_resolved_edges_for_repo` (same rel list as
  the per-file variant; `CROSS_REPO_LINK` deliberately excluded — the
  empty-sidecar vector routes through bulk delete, which removes incident
  edges including cross-repo links).
- `91a5fa3` review fix — dep records of filter members not actually
  re-resolved (cold parsed cache) are no longer clobbered with empty sets.
- Tests: `4c53e3a` (integration, pre-change failure empirically verified),
  `dc8b8ce` (store scoping), plus the pairing tripwire.

### Behavioral changes (disclosed per sign-off contract)

- First index after any resolution-deps sidecar loss or version bump is now
  an **atomic full replacement**, not an incremental run — slower by design.
- A one-per-repo `tracing::warn!` fires on that bypass path.
- Sidecar semantics: empty dep sets are now recorded, so
  `is_empty_for_repo` distinguishes "never resolved / lost" from
  "legitimately edgeless". Release discipline: the two sidecar versions are
  now test-pinned together.

### Waivers and scope notes

- **Incident-DB verification query NOT run** — demoted to record-keeping by
  the plan; the incident's 1.3→3.3 GB growth remains unconfirmed as
  duplication (scope growth is equally plausible). The record-keeping task
  stays open on the note.
- **MERGE/uniqueness-constraint defense in depth excluded** per plan — file
  and size separately. The CROSS_REPO_LINK incremental re-CREATE vector
  remains open under that exclusion; the Outcome sentence on the note
  ("cannot create a second copy of an edge it already created") is achieved
  for the resolved-edge list only.
- The repo-wide clear inherits the existing `let _ =` error-swallow pattern
  of the per-file clear (pre-existing; a failed clear + successful insert
  would still duplicate).

### Sign-off record

- Acceptance audit: AC1–AC3 SATISFIED with discriminating tests (test author
  empirically verified pre-change failure by reverting the fix files against
  the new tests and observing the exact duplication shapes); AC4 waived per
  plan. Correctness review: APPROVE with 3 low findings, 2 fixed pre-merge
  (`91a5fa3`, `dc8b8ce`), 1 accepted as inherent to the full-replacement
  strategy (bulk delete + partial re-insert exposure on transient read
  errors — pre-existing `force_reindex` semantics).
- Local gate: fmt, clippy (`--workspace --all-targets -D warnings`),
  `build --locked --tests`, `cargo test`, daemon tests — green.
