### PR TITLE
fix(cli): embedding metadata truth — gated stamping, fingerprint reads, model guard, checkpointing

### DIFF
--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -5590,6 +5590,13 @@ impl NestWeaverDaemon for DaemonService {
                 // accepted write; gates the metadata stamp below (mirrors the
                 // CLI's `run_embed` tail).
                 let mut produced_dim: Option<usize> = None;
+                // Checkpoint the index to the sidecar about every five minutes
+                // so an interrupted pass keeps completed work. Per-batch
+                // flushing is not implementable: save_binary rewrites the
+                // entire sidecar on every call, so the cadence must stay coarse.
+                let mut flush_checkpoint = nestweaver_store::EmbeddingFlushCheckpoint::new(
+                    nestweaver_store::EMBED_CHECKPOINT_INTERVAL,
+                );
 
                 // Each embed run may legitimately force-switch the model once;
                 // re-arm the once-per-run clear guard on this long-lived index.
@@ -5635,6 +5642,9 @@ impl NestWeaverDaemon for DaemonService {
                                 }
                             }
                         }
+                        if let Err(e) = flush_checkpoint.flush_if_due(&store, succeeded as usize) {
+                            tracing::warn!("failed to checkpoint embedding index: {e}");
+                        }
                     }
                 }
 
@@ -5675,6 +5685,9 @@ impl NestWeaverDaemon for DaemonService {
                                 }
                             }
                         }
+                        if let Err(e) = flush_checkpoint.flush_if_due(&store, succeeded as usize) {
+                            tracing::warn!("failed to checkpoint embedding index: {e}");
+                        }
                     }
                 }
 
@@ -5714,6 +5727,9 @@ impl NestWeaverDaemon for DaemonService {
                                     failed += 1;
                                 }
                             }
+                        }
+                        if let Err(e) = flush_checkpoint.flush_if_due(&store, succeeded as usize) {
+                            tracing::warn!("failed to checkpoint embedding index: {e}");
                         }
                     }
                 }

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -5642,7 +5642,12 @@ impl NestWeaverDaemon for DaemonService {
                                 }
                             }
                         }
-                        if let Err(e) = flush_checkpoint.flush_if_due(&store, succeeded as usize) {
+                        if let Err(e) = flush_checkpoint.flush_if_due_with_stamp(
+                            &store,
+                            succeeded as usize,
+                            &embed_model_id,
+                            produced_dim,
+                        ) {
                             tracing::warn!("failed to checkpoint embedding index: {e}");
                         }
                     }
@@ -5685,7 +5690,12 @@ impl NestWeaverDaemon for DaemonService {
                                 }
                             }
                         }
-                        if let Err(e) = flush_checkpoint.flush_if_due(&store, succeeded as usize) {
+                        if let Err(e) = flush_checkpoint.flush_if_due_with_stamp(
+                            &store,
+                            succeeded as usize,
+                            &embed_model_id,
+                            produced_dim,
+                        ) {
                             tracing::warn!("failed to checkpoint embedding index: {e}");
                         }
                     }
@@ -5728,7 +5738,12 @@ impl NestWeaverDaemon for DaemonService {
                                 }
                             }
                         }
-                        if let Err(e) = flush_checkpoint.flush_if_due(&store, succeeded as usize) {
+                        if let Err(e) = flush_checkpoint.flush_if_due_with_stamp(
+                            &store,
+                            succeeded as usize,
+                            &embed_model_id,
+                            produced_dim,
+                        ) {
                             tracing::warn!("failed to checkpoint embedding index: {e}");
                         }
                     }

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -5615,7 +5615,12 @@ impl NestWeaverDaemon for DaemonService {
                             match model.embed_query(&text) {
                                 Ok(emb) => {
                                     let emb_dim = emb.len();
-                                    if store.add_embedding_with_force(&sym.uid, emb, force) {
+                                    if store.add_embedding_with_force(
+                                        &sym.uid,
+                                        emb,
+                                        &embed_model_id,
+                                        force,
+                                    ) {
                                         succeeded += 1;
                                         if produced_dim.is_none() {
                                             produced_dim = Some(emb_dim);
@@ -5650,7 +5655,12 @@ impl NestWeaverDaemon for DaemonService {
                             match model.embed_query(&text) {
                                 Ok(emb) => {
                                     let emb_dim = emb.len();
-                                    if store.add_embedding_with_force(&note.uid, emb, force) {
+                                    if store.add_embedding_with_force(
+                                        &note.uid,
+                                        emb,
+                                        &embed_model_id,
+                                        force,
+                                    ) {
                                         succeeded += 1;
                                         if produced_dim.is_none() {
                                             produced_dim = Some(emb_dim);
@@ -5685,7 +5695,12 @@ impl NestWeaverDaemon for DaemonService {
                             match model.embed_query(&text) {
                                 Ok(emb) => {
                                     let emb_dim = emb.len();
-                                    if store.add_embedding_with_force(&heading.uid, emb, force) {
+                                    if store.add_embedding_with_force(
+                                        &heading.uid,
+                                        emb,
+                                        &embed_model_id,
+                                        force,
+                                    ) {
                                         succeeded += 1;
                                         if produced_dim.is_none() {
                                             produced_dim = Some(emb_dim);

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -13999,6 +13999,98 @@ external_model = "unavailable-test-model"
         );
     }
 
+    /// A daemon embed that produces vectors stamps the fingerprint of the
+    /// model the daemon actually loaded (`status.model_id`) at the produced
+    /// dimension. Before the fix the embed RPC never called
+    /// `set_embedding_metadata` at all, so daemon-populated databases had no
+    /// fingerprint for any downstream guard — this test fails there because
+    /// the metadata stays `None`.
+    #[cfg(feature = "embed")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn embed_handler_stamps_the_loaded_models_fingerprint_after_a_productive_run() {
+        let state = test_state_with_writer();
+        insert_unembedded_symbol(&state.store, "sym-stamp");
+        let model = Arc::new(CountingEmbed {
+            calls: Arc::new(AtomicU32::new(0)),
+            vector: vec![0.1, 0.2, 0.3],
+        }) as Arc<dyn nestweaver_engine::EmbedQueryFn>;
+        let mut ready = state.embedding_runtime.status();
+        ready.state = "ready".to_string();
+        ready.selected_device = "cpu".to_string();
+        ready.model_id = "daemon-loaded-model".to_string();
+        state.embedding_runtime.publish_ready(ready, model);
+
+        let mut request = Request::new(EmbedRequest {
+            scope: "symbols".to_string(),
+            force: false,
+            batch_size: 8,
+        });
+        request.extensions_mut().insert(crate::auth::IsAdmin(true));
+        let response = DaemonService::new(state.clone())
+            .embed(request)
+            .await
+            .expect("a ready daemon must accept the embed RPC")
+            .into_inner();
+        assert_eq!(response.succeeded, 1);
+        assert_eq!(response.rejected, 0);
+
+        assert_eq!(
+            state.store.get_embedding_metadata().unwrap(),
+            Some(("daemon-loaded-model".to_string(), 3)),
+            "a productive daemon embed must stamp the model it loaded at the produced dimension"
+        );
+    }
+
+    /// A daemon embed with no eligible work produces nothing, so it must not
+    /// invent or overwrite metadata — the daemon-route analogue of the CLI's
+    /// Reproduction A. The recorded fingerprint names a different model than
+    /// the loaded one; a zero-work run must leave it untouched.
+    #[cfg(feature = "embed")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn embed_handler_without_eligible_work_leaves_metadata_untouched() {
+        let state = test_state_with_writer();
+        insert_unembedded_symbol(&state.store, "sym-noop");
+        assert!(state.store.add_embedding_with_force(
+            "sym-noop",
+            vec![0.1, 0.2, 0.3],
+            "recorded-model",
+            false,
+        ));
+        state
+            .store
+            .set_embedding_metadata("recorded-model", 3)
+            .unwrap();
+        let model = Arc::new(CountingEmbed {
+            calls: Arc::new(AtomicU32::new(0)),
+            vector: vec![0.1, 0.2, 0.3],
+        }) as Arc<dyn nestweaver_engine::EmbedQueryFn>;
+        let mut ready = state.embedding_runtime.status();
+        ready.state = "ready".to_string();
+        ready.selected_device = "cpu".to_string();
+        ready.model_id = "other-loaded-model".to_string();
+        state.embedding_runtime.publish_ready(ready, model);
+
+        let mut request = Request::new(EmbedRequest {
+            scope: "symbols".to_string(),
+            force: false,
+            batch_size: 8,
+        });
+        request.extensions_mut().insert(crate::auth::IsAdmin(true));
+        let response = DaemonService::new(state.clone())
+            .embed(request)
+            .await
+            .expect("a no-op embed is not an error")
+            .into_inner();
+        assert_eq!(response.succeeded, 0, "nothing was eligible to embed");
+        assert_eq!(response.skipped, 1);
+
+        assert_eq!(
+            state.store.get_embedding_metadata().unwrap(),
+            Some(("recorded-model".to_string(), 3)),
+            "a daemon embed that produced nothing must not overwrite the recorded fingerprint"
+        );
+    }
+
     #[tokio::test]
     async fn typed_brain_search_enforces_request_repo_visibility_and_preserves_counts() {
         use nestweaver_engine::authz::{Identity, StaticConfigPermissionSource};

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -5573,6 +5573,10 @@ impl NestWeaverDaemon for DaemonService {
                     )
                 }));
             };
+            // The model the daemon actually loaded (startup preference: the
+            // DB-recorded id wins, else the configured external/local model).
+            // Used to stamp embedding metadata after a productive run.
+            let embed_model_id = status.model_id.clone();
 
             let store = self.state.store.clone();
 
@@ -5582,6 +5586,10 @@ impl NestWeaverDaemon for DaemonService {
                 let mut rejected = 0u32;
                 let mut scoped = 0u64;
                 let mut eligible = 0u64;
+                // Dimension of the vectors THIS run produced, set on the first
+                // accepted write; gates the metadata stamp below (mirrors the
+                // CLI's `run_embed` tail).
+                let mut produced_dim: Option<usize> = None;
 
                 // Each embed run may legitimately force-switch the model once;
                 // re-arm the once-per-run clear guard on this long-lived index.
@@ -5606,8 +5614,12 @@ impl NestWeaverDaemon for DaemonService {
                             );
                             match model.embed_query(&text) {
                                 Ok(emb) => {
+                                    let emb_dim = emb.len();
                                     if store.add_embedding_with_force(&sym.uid, emb, force) {
                                         succeeded += 1;
+                                        if produced_dim.is_none() {
+                                            produced_dim = Some(emb_dim);
+                                        }
                                     } else {
                                         rejected += 1;
                                     }
@@ -5637,8 +5649,12 @@ impl NestWeaverDaemon for DaemonService {
                                 nestweaver_embed::preprocess::note_embed_text(&note.title, None);
                             match model.embed_query(&text) {
                                 Ok(emb) => {
+                                    let emb_dim = emb.len();
                                     if store.add_embedding_with_force(&note.uid, emb, force) {
                                         succeeded += 1;
+                                        if produced_dim.is_none() {
+                                            produced_dim = Some(emb_dim);
+                                        }
                                     } else {
                                         rejected += 1;
                                     }
@@ -5668,8 +5684,12 @@ impl NestWeaverDaemon for DaemonService {
                                 nestweaver_embed::preprocess::heading_embed_text("", &heading.text);
                             match model.embed_query(&text) {
                                 Ok(emb) => {
+                                    let emb_dim = emb.len();
                                     if store.add_embedding_with_force(&heading.uid, emb, force) {
                                         succeeded += 1;
+                                        if produced_dim.is_none() {
+                                            produced_dim = Some(emb_dim);
+                                        }
                                     } else {
                                         rejected += 1;
                                     }
@@ -5687,6 +5707,17 @@ impl NestWeaverDaemon for DaemonService {
                     && let Err(e) = store.flush_embedding_index()
                 {
                     tracing::warn!("failed to flush embedding index: {e}");
+                }
+
+                // Stamp the fingerprint only from vectors this run produced:
+                // a daemon embed that produced nothing must not invent (or
+                // overwrite) metadata. The daemon route previously never
+                // stamped at all, leaving daemon-populated databases without a
+                // fingerprint for the startup and CLI guards to check.
+                if let Some(dim) = produced_dim
+                    && let Err(e) = store.set_embedding_metadata(&embed_model_id, dim as u32)
+                {
+                    tracing::warn!("failed to record embedding model metadata: {e}");
                 }
 
                 tracing::info!(succeeded, failed, rejected, "embed RPC completed");

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -459,6 +459,7 @@ impl GraphStore {
         };
         store.init_schema()?;
         store.load_graph_generation(&store.generation_sidecar_path());
+        store.load_recorded_embedding_model_into_index();
         Ok(store)
     }
 
@@ -490,6 +491,7 @@ impl GraphStore {
         };
         store.init_schema()?;
         store.load_graph_generation(&store.generation_sidecar_path());
+        store.load_recorded_embedding_model_into_index();
         Ok(store)
     }
 
@@ -521,6 +523,7 @@ impl GraphStore {
             )),
         };
         store.load_graph_generation(&store.generation_sidecar_path());
+        store.load_recorded_embedding_model_into_index();
         Ok(store)
     }
 
@@ -576,6 +579,7 @@ impl GraphStore {
             )),
         };
         store.init_schema()?;
+        store.load_recorded_embedding_model_into_index();
         Ok(store)
     }
 
@@ -1164,6 +1168,29 @@ impl GraphStore {
         crate::search::EmbeddingIndex::load(&json_path).unwrap_or_default()
     }
 
+    /// Hand the embedding index the model id recorded in the database's
+    /// embedding metadata, so `add_embedding_with_force` can refuse a
+    /// same-dimension write from a different model. Read once here — never
+    /// per-add — and kept current by `set_embedding_metadata`. Absent or
+    /// unreadable metadata means unknown: the model guard stays off and the
+    /// dimension guard alone applies.
+    fn load_recorded_embedding_model_into_index(&self) {
+        let recorded = match self.get_embedding_metadata() {
+            Ok(recorded) => recorded.map(|(model_id, _)| model_id),
+            Err(e) => {
+                tracing::warn!(
+                    "could not read embedding metadata; the recorded-model write guard is \
+                     disabled for this store: {e}"
+                );
+                None
+            }
+        };
+        self.embedding_index
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .set_recorded_model_id(recorded);
+    }
+
     /// Compute the legacy JSON sidecar path for a given database path.
     fn embedding_sidecar_json_for(db_path: &Path) -> std::path::PathBuf {
         let mut s = db_path.as_os_str().to_owned();
@@ -1191,18 +1218,38 @@ impl GraphStore {
     ///
     /// Returns `false` when the dimension guard rejects the vector — callers
     /// must not count a rejected embedding as stored.
+    ///
+    /// This entry point names no producing model, so the recorded-model guard
+    /// is skipped (unknown producer); explicit embed runs should use
+    /// [`add_embedding_with_force`], which takes the model id.
+    ///
+    /// [`add_embedding_with_force`]: GraphStore::add_embedding_with_force
     #[must_use = "a false return means the dimension guard rejected the embedding"]
     pub fn add_embedding(&self, uid: &str, embedding: Vec<f32>) -> bool {
-        self.add_embedding_with_force(uid, embedding, false)
-    }
-
-    #[must_use = "a false return means the dimension guard rejected the embedding"]
-    pub fn add_embedding_with_force(&self, uid: &str, embedding: Vec<f32>, force: bool) -> bool {
         let mut idx = self
             .embedding_index
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        idx.add(uid, embedding, force)
+        idx.add(uid, embedding, false)
+    }
+
+    /// Add an embedding produced by `model_id`. Returns `false` when a guard
+    /// rejects the vector: the dimension guard, or — when the database has a
+    /// recorded embedding model — a same-dimension write from a different
+    /// model, unless `force` is set (a `--force` run re-embeds everything).
+    #[must_use = "a false return means a guard rejected the embedding"]
+    pub fn add_embedding_with_force(
+        &self,
+        uid: &str,
+        embedding: Vec<f32>,
+        model_id: &str,
+        force: bool,
+    ) -> bool {
+        let mut idx = self
+            .embedding_index
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        idx.add_with_model(uid, embedding, Some(model_id), force)
     }
 
     /// Re-arm the embedding index's once-per-run force-clear guard. Call at
@@ -1238,7 +1285,6 @@ impl GraphStore {
         }
         Ok(())
     }
-
     /// Remove embeddings for graph nodes that no longer exist, update the
     /// live index, and persist the repaired binary sidecar.
     ///

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -29,7 +29,9 @@ pub use read::{
 pub use regex::{
     CANDIDATE_CAP, DEFAULT_MAX_MILLIS, FileCount, PatternCount, RegexMatch, RegexSearchResult,
 };
-pub use search::{EmbeddingIndex, SearchResult};
+pub use search::{
+    EMBED_CHECKPOINT_INTERVAL, EmbeddingFlushCheckpoint, EmbeddingIndex, SearchResult,
+};
 pub use tantivy_index::{
     PRF_EXPANSION_TERMS, PRF_EXPANSION_WEIGHT, PRF_MAX_QUERY_TERMS, PRF_TOP_K,
     SEARCH_PRESENTATION_LIMIT_MAX, SearchHit, SearchLogicalIdentity, TantivyError, TantivyIndex,

--- a/crates/nestweaver-store/src/search.rs
+++ b/crates/nestweaver-store/src/search.rs
@@ -439,6 +439,11 @@ pub const EMBED_CHECKPOINT_INTERVAL: std::time::Duration = std::time::Duration::
 /// rewrites the entire sidecar file on every call (roughly a quarter of a
 /// gigabyte for a large graph), so the cadence must stay coarse — minutes,
 /// not batches.
+///
+/// Mid-run call sites (CLI and daemon embed loops) should use
+/// [`Self::flush_if_due_with_stamp`] so the model fingerprint travels with
+/// each checkpoint; plain `flush_if_due` remains for the final flush, which
+/// is followed by the run's tail stamp.
 pub struct EmbeddingFlushCheckpoint {
     interval: std::time::Duration,
     last_flush: std::time::Instant,
@@ -461,14 +466,60 @@ impl EmbeddingFlushCheckpoint {
         store: &GraphStore,
         success_count: usize,
     ) -> Result<bool, StoreError> {
-        if success_count == self.flushed_success_count || self.last_flush.elapsed() < self.interval
-        {
+        if !self.is_due(success_count) {
             return Ok(false);
         }
         store.flush_embedding_index()?;
+        self.record_flush(success_count);
+        Ok(true)
+    }
+
+    /// Checkpoint like [`Self::flush_if_due`], then stamp the flushed index's
+    /// fingerprint (`model_id`, `produced_dim`) into the embedding metadata.
+    ///
+    /// The fingerprint must travel with the checkpoint: a `--force` run
+    /// switching to a different model at the same dimension overwrites old
+    /// vectors as it goes, so a checkpoint that persisted vectors without
+    /// updating the metadata would leave a durable mixed-model index whose
+    /// metadata still names the OLD model — every open-time guard would pass
+    /// and a later non-force embed would see all-present embeddings and do
+    /// zero work. Stamping here means an interrupted force-switch instead
+    /// leaves a consistent (new-model, partial) index that the next run
+    /// resumes or re-embeds honestly.
+    ///
+    /// The stamp keys off `produced_dim` (the dimension of vectors THIS run
+    /// produced): when it is `None` the run produced nothing yet and the
+    /// existing fingerprint is left untouched. A failed stamp after a
+    /// successful flush only warns (matching the warn-only flush style at the
+    /// call sites); the flush itself still counts.
+    pub fn flush_if_due_with_stamp(
+        &mut self,
+        store: &GraphStore,
+        success_count: usize,
+        model_id: &str,
+        produced_dim: Option<usize>,
+    ) -> Result<bool, StoreError> {
+        if !self.is_due(success_count) {
+            return Ok(false);
+        }
+        store.flush_embedding_index()?;
+        self.record_flush(success_count);
+        if let Some(dim) = produced_dim
+            && !model_id.is_empty()
+            && let Err(e) = store.set_embedding_metadata(model_id, dim as u32)
+        {
+            tracing::warn!("failed to stamp embedding metadata at checkpoint: {e}");
+        }
+        Ok(true)
+    }
+
+    fn is_due(&self, success_count: usize) -> bool {
+        success_count != self.flushed_success_count && self.last_flush.elapsed() >= self.interval
+    }
+
+    fn record_flush(&mut self, success_count: usize) {
         self.last_flush = std::time::Instant::now();
         self.flushed_success_count = success_count;
-        Ok(true)
     }
 }
 
@@ -953,6 +1004,89 @@ mod tests {
         // Newly accepted work since the flush re-arms it.
         assert!(store.add_embedding("sym:b", vec![0.4_f32, 0.5, 0.6]));
         assert!(checkpoint.flush_if_due(&store, 2).unwrap());
+    }
+
+    #[test]
+    fn flush_if_due_with_stamp_stamps_the_fingerprint_with_the_checkpoint() {
+        // A due checkpoint persists vectors AND the fingerprint describing
+        // them, so an interrupted --force model switch leaves a consistent
+        // (new-model, partial) index instead of mixed vectors under the old
+        // model's metadata.
+        let dir = tempfile::tempdir().unwrap();
+        let store = GraphStore::create(&dir.path().join("ckpt.lbug")).unwrap();
+        let sidecar = store.embedding_sidecar_path().unwrap();
+        assert!(store.add_embedding_with_force(
+            "sym:a",
+            vec![0.1_f32, 0.2, 0.3],
+            "sentence-transformers/model-b",
+            true,
+        ));
+
+        let mut checkpoint = EmbeddingFlushCheckpoint::new(std::time::Duration::ZERO);
+        assert!(
+            checkpoint
+                .flush_if_due_with_stamp(&store, 1, "sentence-transformers/model-b", Some(3))
+                .unwrap(),
+            "a due checkpoint with newly accepted embeddings must flush"
+        );
+        assert!(sidecar.exists(), "the flush must persist the sidecar");
+        assert_eq!(
+            store.get_embedding_metadata().unwrap(),
+            Some(("sentence-transformers/model-b".to_string(), 3)),
+            "the checkpoint must stamp the fingerprint of the vectors it persisted"
+        );
+        // The in-memory recorded model refreshes too, so subsequent writes in
+        // the same run are guarded against the newly stamped model.
+        assert!(store.add_embedding_with_force(
+            "sym:b",
+            vec![0.4_f32, 0.5, 0.6],
+            "sentence-transformers/model-b",
+            false,
+        ));
+    }
+
+    #[test]
+    fn flush_if_due_with_stamp_without_new_work_neither_flushes_nor_stamps() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = GraphStore::create(&dir.path().join("ckpt.lbug")).unwrap();
+        let sidecar = store.embedding_sidecar_path().unwrap();
+
+        // A zero interval means always due; with no accepted embeddings the
+        // checkpoint must still not write or stamp (there is nothing new to
+        // persist).
+        let mut checkpoint = EmbeddingFlushCheckpoint::new(std::time::Duration::ZERO);
+        assert!(
+            !checkpoint
+                .flush_if_due_with_stamp(&store, 0, "sentence-transformers/model-b", Some(3))
+                .unwrap()
+        );
+        assert!(!sidecar.exists());
+        assert_eq!(store.get_embedding_metadata().unwrap(), None);
+    }
+
+    #[test]
+    fn flush_if_due_with_stamp_with_no_produced_dim_flushes_but_does_not_stamp() {
+        // `produced_dim == None` means this run produced nothing, so the
+        // pre-existing fingerprint must survive even when a flush fires.
+        let dir = tempfile::tempdir().unwrap();
+        let store = GraphStore::create(&dir.path().join("ckpt.lbug")).unwrap();
+        store
+            .set_embedding_metadata("sentence-transformers/model-a", 3)
+            .unwrap();
+        assert!(store.add_embedding("sym:a", vec![0.1_f32, 0.2, 0.3]));
+
+        let mut checkpoint = EmbeddingFlushCheckpoint::new(std::time::Duration::ZERO);
+        assert!(
+            checkpoint
+                .flush_if_due_with_stamp(&store, 1, "sentence-transformers/model-b", None)
+                .unwrap(),
+            "the flush decision keys off new accepts, not produced_dim"
+        );
+        assert_eq!(
+            store.get_embedding_metadata().unwrap(),
+            Some(("sentence-transformers/model-a".to_string(), 3)),
+            "a checkpoint with no produced vectors must not overwrite the fingerprint"
+        );
     }
 
     #[test]

--- a/crates/nestweaver-store/src/search.rs
+++ b/crates/nestweaver-store/src/search.rs
@@ -38,6 +38,11 @@ pub struct EmbeddingIndex {
     ///
     /// [`reset_force_guard`]: EmbeddingIndex::reset_force_guard
     force_cleared: bool,
+    /// The model id recorded in the database's embedding metadata, loaded once
+    /// by `GraphStore` at open (and refreshed when new metadata is stamped) —
+    /// never read per-add. `None` means unknown (never stamped, or unreadable),
+    /// and unknown always allows the write: the dimension guard still applies.
+    recorded_model_id: Option<String>,
 }
 
 impl Default for EmbeddingIndex {
@@ -51,7 +56,17 @@ impl EmbeddingIndex {
         Self {
             embeddings: HashMap::new(),
             force_cleared: false,
+            recorded_model_id: None,
         }
+    }
+
+    /// Record the model id the database's embedding metadata names as the
+    /// producer of this index's vectors. Called once by `GraphStore` at open
+    /// and again whenever new metadata is stamped; `None` marks the producer
+    /// as unknown, which disables the model guard (writes are then guarded by
+    /// dimension only).
+    pub fn set_recorded_model_id(&mut self, model_id: Option<String>) {
+        self.recorded_model_id = model_id;
     }
 
     /// Insert an embedding. Returns `true` if accepted, `false` if rejected
@@ -62,8 +77,47 @@ impl EmbeddingIndex {
     /// already stored, the entire index is cleared on the first mismatch so
     /// the new dimension becomes authoritative — this is the model-switch path.
     /// The clear happens at most once per run (see `force_cleared`).
+    ///
+    /// This entry point names no producing model, so the model guard is
+    /// skipped (unknown producer); embed runs should use [`add_with_model`].
+    ///
+    /// [`add_with_model`]: EmbeddingIndex::add_with_model
     #[must_use = "a false return means the dimension guard rejected the embedding"]
     pub fn add(&mut self, uid: &str, embedding: Vec<f32>, force: bool) -> bool {
+        self.add_with_model(uid, embedding, None, force)
+    }
+
+    /// Like [`add`], but also refuses a vector produced by a different model
+    /// than the one recorded for this index, even at the same dimension:
+    /// contrastively trained spaces share no basis, so mixing two models'
+    /// vectors makes the index unusable for retrieval. The rejection names
+    /// both model ids. `force` allows the switch (a `--force` run re-embeds
+    /// everything, so no mixture survives). A `None` recorded or incoming
+    /// model id is unknown and always allowed — the dimension guard still
+    /// applies.
+    ///
+    /// [`add`]: EmbeddingIndex::add
+    #[must_use = "a false return means a guard rejected the embedding"]
+    pub fn add_with_model(
+        &mut self,
+        uid: &str,
+        embedding: Vec<f32>,
+        model_id: Option<&str>,
+        force: bool,
+    ) -> bool {
+        if let (Some(recorded), Some(incoming)) = (self.recorded_model_id.as_deref(), model_id)
+            && recorded != incoming
+            && !force
+        {
+            tracing::warn!(
+                uid,
+                recorded,
+                incoming,
+                "skipping embedding from a different model than the one recorded for this \
+                 index (re-embed with --force to switch models)"
+            );
+            return false;
+        }
         if let Some(existing) = self.embeddings.values().next()
             && embedding.len() != existing.len()
         {
@@ -117,6 +171,7 @@ impl EmbeddingIndex {
         Ok(Self {
             embeddings,
             force_cleared: false,
+            recorded_model_id: None,
         })
     }
 
@@ -213,6 +268,7 @@ impl EmbeddingIndex {
         Ok(Self {
             embeddings,
             force_cleared: false,
+            recorded_model_id: None,
         })
     }
 

--- a/crates/nestweaver-store/src/search.rs
+++ b/crates/nestweaver-store/src/search.rs
@@ -424,6 +424,54 @@ fn atomic_replace_file(
     crate::durable_sidecar::atomic_replace_file(path, write).map_err(Into::into)
 }
 
+/// Default cadence for time-based embedding-index checkpoints during long
+/// embed passes (CLI direct loops and the daemon embed RPC).
+pub const EMBED_CHECKPOINT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// Time-based checkpoint for long embed passes.
+///
+/// An interrupted embed pass used to lose everything: the only flush ran
+/// once at the end. `flush_if_due` flushes at chunk boundaries once
+/// `interval` has elapsed and new embeddings were accepted since the last
+/// flush, so a killed pass keeps all work up to the last checkpoint.
+///
+/// Per-batch flushing is NOT implementable: `EmbeddingIndex::save_binary`
+/// rewrites the entire sidecar file on every call (roughly a quarter of a
+/// gigabyte for a large graph), so the cadence must stay coarse — minutes,
+/// not batches.
+pub struct EmbeddingFlushCheckpoint {
+    interval: std::time::Duration,
+    last_flush: std::time::Instant,
+    flushed_success_count: usize,
+}
+
+impl EmbeddingFlushCheckpoint {
+    pub fn new(interval: std::time::Duration) -> Self {
+        Self {
+            interval,
+            last_flush: std::time::Instant::now(),
+            flushed_success_count: 0,
+        }
+    }
+
+    /// Flush the embedding index when `interval` elapsed and `success_count`
+    /// advanced since the last flush. Returns whether a flush happened.
+    pub fn flush_if_due(
+        &mut self,
+        store: &GraphStore,
+        success_count: usize,
+    ) -> Result<bool, StoreError> {
+        if success_count == self.flushed_success_count || self.last_flush.elapsed() < self.interval
+        {
+            return Ok(false);
+        }
+        store.flush_embedding_index()?;
+        self.last_flush = std::time::Instant::now();
+        self.flushed_success_count = success_count;
+        Ok(true)
+    }
+}
+
 #[cfg(test)]
 fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
     if a.len() != b.len() || a.is_empty() {

--- a/crates/nestweaver-store/src/search.rs
+++ b/crates/nestweaver-store/src/search.rs
@@ -709,6 +709,252 @@ mod tests {
         assert_eq!(idx.dimension(), Some(3));
     }
 
+    // ── Recorded-model write guard ────────────────────────────────────
+    // A same-dimension model swap passes the dimension guard, but two
+    // contrastively trained embedding spaces share no basis, so a
+    // mixed-model index is unusable for retrieval. `add_with_model` refuses
+    // the write (naming both ids via tracing) unless the run is `--force`.
+
+    #[test]
+    fn add_with_model_rejects_a_different_recorded_model_at_the_same_dimension() {
+        let mut idx = EmbeddingIndex::new();
+        idx.set_recorded_model_id(Some("sentence-transformers/model-a".to_string()));
+        assert!(idx.add_with_model(
+            "sym:a",
+            vec![1.0_f32, 0.0, 0.0],
+            Some("sentence-transformers/model-a"),
+            false,
+        ));
+
+        // Same dimension, different producer — the hole the dimension guard
+        // cannot see. Must be rejected, and the index must stay untouched.
+        assert!(!idx.add_with_model(
+            "sym:b",
+            vec![0.0_f32, 1.0, 0.0],
+            Some("sentence-transformers/model-b"),
+            false,
+        ));
+        assert_eq!(idx.len(), 1, "a cross-model vector must not be added");
+        assert_eq!(idx.dimension(), Some(3));
+        assert!(idx.get("sym:b").is_none());
+    }
+
+    #[test]
+    fn add_with_model_accepts_the_recorded_model() {
+        let mut idx = EmbeddingIndex::new();
+        idx.set_recorded_model_id(Some("sentence-transformers/model-a".to_string()));
+        assert!(idx.add_with_model(
+            "sym:a",
+            vec![1.0_f32, 0.0, 0.0],
+            Some("sentence-transformers/model-a"),
+            false,
+        ));
+        assert!(idx.add_with_model(
+            "sym:b",
+            vec![0.0_f32, 1.0, 0.0],
+            Some("sentence-transformers/model-a"),
+            false,
+        ));
+        assert_eq!(idx.len(), 2);
+    }
+
+    #[test]
+    fn add_with_model_allows_any_model_when_none_is_recorded() {
+        // Absent metadata means unknown, not mismatch: a database that was
+        // never stamped must keep accepting writes (guarded by dimension
+        // only), or every pre-fingerprint database would be frozen.
+        let mut idx = EmbeddingIndex::new();
+        assert!(idx.add_with_model(
+            "sym:a",
+            vec![1.0_f32, 0.0, 0.0],
+            Some("sentence-transformers/model-a"),
+            false,
+        ));
+        assert!(idx.add_with_model(
+            "sym:b",
+            vec![0.0_f32, 1.0, 0.0],
+            Some("sentence-transformers/model-b"),
+            false,
+        ));
+        assert_eq!(idx.len(), 2);
+    }
+
+    #[test]
+    fn add_with_model_force_overrides_the_recorded_model_guard() {
+        // A --force run re-embeds everything, so no mixture survives; the
+        // switch must be allowed through.
+        let mut idx = EmbeddingIndex::new();
+        idx.set_recorded_model_id(Some("sentence-transformers/model-a".to_string()));
+        assert!(idx.add_with_model(
+            "sym:a",
+            vec![1.0_f32, 0.0, 0.0],
+            Some("sentence-transformers/model-a"),
+            false,
+        ));
+        assert!(idx.add_with_model(
+            "sym:b",
+            vec![0.0_f32, 1.0, 0.0],
+            Some("sentence-transformers/model-b"),
+            true,
+        ));
+        assert_eq!(idx.len(), 2);
+    }
+
+    #[test]
+    fn add_without_a_producer_model_skips_the_model_guard() {
+        // `add` names no producing model (unknown producer), so the model
+        // guard cannot fire on it; the dimension guard still applies.
+        let mut idx = EmbeddingIndex::new();
+        idx.set_recorded_model_id(Some("sentence-transformers/model-a".to_string()));
+        assert!(idx.add("sym:a", vec![1.0_f32, 0.0, 0.0], false));
+        assert!(idx.add("sym:b", vec![0.0_f32, 1.0, 0.0], false));
+        assert!(!idx.add("sym:c", vec![1.0_f32, 0.0], false));
+        assert_eq!(idx.len(), 2);
+    }
+
+    #[test]
+    fn store_model_guard_reads_the_recorded_model_from_a_reopened_database() {
+        // The recorded model id is persisted in the database's embedding
+        // metadata and handed to the index once at open — a store that
+        // reopens a stamped database must enforce the guard without anyone
+        // re-stamping.
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("model_guard.lbug");
+        {
+            let store = GraphStore::create(&db_path).unwrap();
+            store
+                .set_embedding_metadata("sentence-transformers/model-a", 3)
+                .unwrap();
+            assert!(store.add_embedding_with_force(
+                "sym:a",
+                vec![1.0_f32, 0.0, 0.0],
+                "sentence-transformers/model-a",
+                false,
+            ));
+            store.flush_embedding_index().unwrap();
+        }
+
+        let store = GraphStore::open(&db_path).unwrap();
+        assert!(
+            !store.add_embedding_with_force(
+                "sym:b",
+                vec![0.0_f32, 1.0, 0.0],
+                "sentence-transformers/model-b",
+                false,
+            ),
+            "a same-dimension write from a different model must be rejected"
+        );
+        assert!(!store.has_embedding("sym:b"));
+        assert!(store.add_embedding_with_force(
+            "sym:c",
+            vec![0.0_f32, 1.0, 0.0],
+            "sentence-transformers/model-a",
+            false,
+        ));
+        assert!(store.add_embedding_with_force(
+            "sym:d",
+            vec![1.0_f32, 1.0, 0.0],
+            "sentence-transformers/model-b",
+            true,
+        ));
+    }
+
+    #[test]
+    fn set_embedding_metadata_refreshes_the_in_memory_recorded_model() {
+        // Long-lived stores (the daemon) must check new writes against the
+        // fingerprint that was just stamped, not the one read at open.
+        let dir = tempfile::tempdir().unwrap();
+        let store = GraphStore::create(&dir.path().join("model_refresh.lbug")).unwrap();
+        store
+            .set_embedding_metadata("sentence-transformers/model-a", 3)
+            .unwrap();
+        assert!(!store.add_embedding_with_force(
+            "sym:a",
+            vec![1.0_f32, 0.0, 0.0],
+            "sentence-transformers/model-b",
+            false,
+        ));
+
+        store
+            .set_embedding_metadata("sentence-transformers/model-b", 3)
+            .unwrap();
+        assert!(
+            store.add_embedding_with_force(
+                "sym:a",
+                vec![1.0_f32, 0.0, 0.0],
+                "sentence-transformers/model-b",
+                false,
+            ),
+            "writes must be checked against the newly stamped model"
+        );
+        assert!(!store.add_embedding_with_force(
+            "sym:b",
+            vec![0.0_f32, 1.0, 0.0],
+            "sentence-transformers/model-a",
+            false,
+        ));
+    }
+
+    // ── Embedding flush checkpoint ─────────────────────────────────────
+    // An interrupted embed pass used to lose everything: the only flush ran
+    // once at the end. The checkpoint flushes at chunk boundaries once the
+    // interval elapsed AND new embeddings were accepted since the last
+    // flush. The 300s cadence itself lives in `EMBED_CHECKPOINT_INTERVAL`
+    // (per-batch flushing is not implementable — save_binary rewrites the
+    // whole sidecar), so these tests drive the helper with a zero/long
+    // interval instead.
+
+    #[test]
+    fn flush_if_due_does_not_flush_before_the_interval() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = GraphStore::create(&dir.path().join("ckpt.lbug")).unwrap();
+        assert!(store.add_embedding("sym:a", vec![0.1_f32, 0.2, 0.3]));
+        let sidecar = store.embedding_sidecar_path().unwrap();
+
+        let mut checkpoint = EmbeddingFlushCheckpoint::new(std::time::Duration::from_secs(3600));
+        assert!(
+            !checkpoint.flush_if_due(&store, 1).unwrap(),
+            "no flush may happen before the interval elapses"
+        );
+        assert!(!sidecar.exists(), "nothing may be written early");
+    }
+
+    #[test]
+    fn flush_if_due_without_new_work_never_flushes() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = GraphStore::create(&dir.path().join("ckpt.lbug")).unwrap();
+        let sidecar = store.embedding_sidecar_path().unwrap();
+
+        // A zero interval means always due; with no accepted embeddings the
+        // checkpoint must still not write (there is nothing new to persist).
+        let mut checkpoint = EmbeddingFlushCheckpoint::new(std::time::Duration::ZERO);
+        assert!(!checkpoint.flush_if_due(&store, 0).unwrap());
+        assert!(!sidecar.exists());
+    }
+
+    #[test]
+    fn flush_if_due_flushes_when_due_with_new_work() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = GraphStore::create(&dir.path().join("ckpt.lbug")).unwrap();
+        let sidecar = store.embedding_sidecar_path().unwrap();
+        assert!(store.add_embedding("sym:a", vec![0.1_f32, 0.2, 0.3]));
+
+        let mut checkpoint = EmbeddingFlushCheckpoint::new(std::time::Duration::ZERO);
+        assert!(
+            checkpoint.flush_if_due(&store, 1).unwrap(),
+            "a due checkpoint with newly accepted embeddings must flush"
+        );
+        assert!(sidecar.exists(), "the flush must persist the sidecar");
+
+        // A due checkpoint with no new accepts since the last flush must not
+        // rewrite the sidecar (each rewrite rewrites every vector).
+        assert!(!checkpoint.flush_if_due(&store, 1).unwrap());
+
+        // Newly accepted work since the flush re-arms it.
+        assert!(store.add_embedding("sym:b", vec![0.4_f32, 0.5, 0.6]));
+        assert!(checkpoint.flush_if_due(&store, 2).unwrap());
+    }
+
     #[test]
     fn vector_search_excludes_dimension_mismatched_vectors() {
         // Defense-in-depth for the query path: simulate a legacy/loaded index that

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -6434,14 +6434,24 @@ impl GraphStore {
             vec![("k", lbug::Value::String("embedding".to_string()))],
         );
 
-        exec_params(
+        let result = exec_params(
             &conn,
             "CREATE (:Meta {key: $k, value: $v})",
             vec![
                 ("k", lbug::Value::String("embedding".to_string())),
                 ("v", lbug::Value::String(value)),
             ],
-        )
+        );
+        if result.is_ok() {
+            // Keep the in-memory index's recorded model in sync with what was
+            // just persisted, so the recorded-model write guard in this
+            // long-lived store checks against the new fingerprint.
+            self.embedding_index
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .set_recorded_model_id(Some(model_id.to_string()));
+        }
+        result
     }
 
     /// Record that contract derivation failed for `repo_uid`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,58 @@ fn external_embedding_model(model: Option<&str>) -> &str {
     model.unwrap_or(DEFAULT_EXTERNAL_EMBEDDING_MODEL)
 }
 
+/// Batch embedder for the direct `--local` embed path. Abstracted from
+/// `nestweaver_embed::EmbedModel` so tests can inject a stub emitting
+/// fixed-dimension vectors instead of loading real model artifacts (the
+/// artifact cache is process-global and hard to stage hermetically).
+/// Deliberately free of `nestweaver_embed` types so `run_embed` keeps one
+/// signature with and without the `embed` feature.
+trait CliBatchEmbedder {
+    // Only called from the `embed`-gated local branch of `run_embed`.
+    #[cfg_attr(not(feature = "embed"), allow(dead_code))]
+    fn embed_batch(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>>;
+}
+
+#[cfg(feature = "embed")]
+impl CliBatchEmbedder for nestweaver_embed::EmbedModel {
+    fn embed_batch(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        self.embed(texts)
+    }
+}
+
+/// Production loader for the direct `--local` embed path, passed to
+/// `run_embed` as a parameter — the same loader-injection idiom as the
+/// daemon's `load_daemon_embedding_backend_with`.
+#[cfg(feature = "embed")]
+fn load_cli_local_embedder(
+    model_id: &str,
+    cache_dir: Option<&Path>,
+    accelerator: Option<CliEmbeddingAccelerator>,
+) -> anyhow::Result<Box<dyn CliBatchEmbedder>> {
+    let config = direct_local_embedding_config(model_id, cache_dir);
+    let policy = cli_embedding_device_policy(accelerator.unwrap_or(CliEmbeddingAccelerator::Auto));
+    let model = nestweaver_embed::EmbedModel::load_with_policy_and_artifact_mode(
+        &config,
+        policy,
+        cli_embedding_artifact_mode(),
+    )?;
+    Ok(Box::new(model))
+}
+
+/// Fallback loader for builds without the `embed` feature: keeps
+/// `run_embed`'s signature uniform and fails only if the local path runs.
+#[cfg(not(feature = "embed"))]
+fn load_cli_local_embedder(
+    _model_id: &str,
+    _cache_dir: Option<&Path>,
+    _accelerator: Option<CliEmbeddingAccelerator>,
+) -> anyhow::Result<Box<dyn CliBatchEmbedder>> {
+    anyhow::bail!(
+        "local embedding requires the `embed` feature; \
+         rebuild with `--features embed` or pass --endpoint"
+    );
+}
+
 fn local_embedding_model_id(model_id: Option<&str>) -> &str {
     model_id.unwrap_or(nestweaver_engine::config::DEFAULT_EMBEDDING_MODEL_ID)
 }
@@ -7374,6 +7426,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             force,
             stats,
             use_daemon,
+            load_cli_local_embedder,
         )
         .map(|c| (c, None)),
 
@@ -16212,7 +16265,7 @@ fn print_project_context_json(
 
 /// Generate embeddings for symbols, notes, and/or headings.
 #[allow(clippy::too_many_arguments)]
-fn run_embed(
+fn run_embed<Load>(
     db: Option<&Path>,
     local: bool,
     endpoint: Option<&str>,
@@ -16225,7 +16278,15 @@ fn run_embed(
     force: bool,
     stats: bool,
     use_daemon: bool,
-) -> anyhow::Result<i32> {
+    local_model_loader: Load,
+) -> anyhow::Result<i32>
+where
+    Load: Fn(
+        &str,
+        Option<&Path>,
+        Option<CliEmbeddingAccelerator>,
+    ) -> anyhow::Result<Box<dyn CliBatchEmbedder>>,
+{
     // Validate flags
     if local && endpoint.is_some() {
         anyhow::bail!("--local and --endpoint are mutually exclusive");
@@ -16408,6 +16469,12 @@ fn run_embed(
     let mut success_count = 0usize;
     let mut error_count = 0usize;
     let mut rejected_count = 0usize;
+    // Dimension of the vectors THIS run produced, set on the first accepted
+    // write. The metadata stamp below is gated on it: a run that produced
+    // nothing (everything already embedded, or every batch rejected) must not
+    // overwrite the recorded fingerprint with a fabricated (model, dimension)
+    // pair taken from pre-existing vectors.
+    let mut produced_dim: Option<usize> = None;
 
     if let Some(ep) = endpoint {
         // ── External API path ────────────────────────────────────
@@ -16446,8 +16513,12 @@ fn run_embed(
                     match rt.block_on(generate_embeddings_batch(ep, api_model, &text_refs)) {
                         Ok(embeddings) => {
                             for (sym, emb) in chunk.iter().zip(embeddings) {
+                                let emb_dim = emb.len();
                                 if store.add_embedding_with_force(&sym.uid, emb, force) {
                                     success_count += 1;
+                                    if produced_dim.is_none() {
+                                        produced_dim = Some(emb_dim);
+                                    }
                                 } else {
                                     rejected_count += 1;
                                 }
@@ -16486,8 +16557,12 @@ fn run_embed(
                     match rt.block_on(generate_embeddings_batch(ep, api_model, &text_refs)) {
                         Ok(embeddings) => {
                             for (note, emb) in chunk.iter().zip(embeddings) {
+                                let emb_dim = emb.len();
                                 if store.add_embedding_with_force(&note.uid, emb, force) {
                                     success_count += 1;
+                                    if produced_dim.is_none() {
+                                        produced_dim = Some(emb_dim);
+                                    }
                                 } else {
                                     rejected_count += 1;
                                 }
@@ -16545,8 +16620,12 @@ fn run_embed(
                     match rt.block_on(generate_embeddings_batch(ep, api_model, &text_refs)) {
                         Ok(embeddings) => {
                             for (h, emb) in chunk.iter().zip(embeddings) {
+                                let emb_dim = emb.len();
                                 if store.add_embedding_with_force(&h.uid, emb, force) {
                                     success_count += 1;
+                                    if produced_dim.is_none() {
+                                        produced_dim = Some(emb_dim);
+                                    }
                                 } else {
                                     rejected_count += 1;
                                 }
@@ -16565,15 +16644,8 @@ fn run_embed(
         // ── Local model path (default) ───────────────────────────
         #[cfg(feature = "embed")]
         {
-            let config = direct_local_embedding_config(local_model_id, cache_dir);
-            let policy =
-                cli_embedding_device_policy(accelerator.unwrap_or(CliEmbeddingAccelerator::Auto));
-            let embed_model = nestweaver_embed::EmbedModel::load_with_policy_and_artifact_mode(
-                &config,
-                policy,
-                cli_embedding_artifact_mode(),
-            )
-            .context("failed to load local embedding model")?;
+            let embed_model = local_model_loader(local_model_id, cache_dir, accelerator)
+                .context("failed to load local embedding model")?;
 
             if do_symbols {
                 let all = store
@@ -16604,12 +16676,15 @@ fn run_embed(
                             })
                             .collect();
                         let text_refs: Vec<&str> = texts.iter().map(|t| t.as_str()).collect();
-                        match embed_model.embed(&text_refs) {
+                        match embed_model.embed_batch(&text_refs) {
                             Ok(embeddings) => {
                                 for (sym, emb) in batch.iter().zip(embeddings.iter()) {
                                     if store.add_embedding_with_force(&sym.uid, emb.clone(), force)
                                     {
                                         success_count += 1;
+                                        if produced_dim.is_none() {
+                                            produced_dim = Some(emb.len());
+                                        }
                                     } else {
                                         rejected_count += 1;
                                     }
@@ -16648,12 +16723,15 @@ fn run_embed(
                             .map(|n| nestweaver_embed::preprocess::note_embed_text(&n.title, None))
                             .collect();
                         let text_refs: Vec<&str> = texts.iter().map(|t| t.as_str()).collect();
-                        match embed_model.embed(&text_refs) {
+                        match embed_model.embed_batch(&text_refs) {
                             Ok(embeddings) => {
                                 for (note, emb) in batch.iter().zip(embeddings.iter()) {
                                     if store.add_embedding_with_force(&note.uid, emb.clone(), force)
                                     {
                                         success_count += 1;
+                                        if produced_dim.is_none() {
+                                            produced_dim = Some(emb.len());
+                                        }
                                     } else {
                                         rejected_count += 1;
                                     }
@@ -16705,11 +16783,14 @@ fn run_embed(
                             })
                             .collect();
                         let text_refs: Vec<&str> = texts.iter().map(|t| t.as_str()).collect();
-                        match embed_model.embed(&text_refs) {
+                        match embed_model.embed_batch(&text_refs) {
                             Ok(embeddings) => {
                                 for (h, emb) in batch.iter().zip(embeddings.iter()) {
                                     if store.add_embedding_with_force(&h.uid, emb.clone(), force) {
                                         success_count += 1;
+                                        if produced_dim.is_none() {
+                                            produced_dim = Some(emb.len());
+                                        }
                                     } else {
                                         rejected_count += 1;
                                     }
@@ -16728,6 +16809,7 @@ fn run_embed(
 
         #[cfg(not(feature = "embed"))]
         {
+            let _ = &local_model_loader;
             anyhow::bail!(
                 "local embedding requires the `embed` feature; \
                  rebuild with `--features embed` or pass --endpoint"
@@ -16742,11 +16824,25 @@ fn run_embed(
         eprintln!("Warning: failed to save embedding sidecar: {e}");
     }
 
+    if rejected_count > 0 {
+        eprintln!(
+            "Error: {rejected_count} embedding(s) rejected due to dimension mismatch. \
+             Use --force to switch models (clears existing embeddings)."
+        );
+    }
+
     // Record which embedding model produced these vectors, so the daemon loads a matching
     // model at startup regardless of the compiled default or the instance config (see
     // run_server). This is what lets the shipped default stay light for most users while a
     // given DB transparently uses whatever model it was embedded with.
-    if let Some(dim) = store.embedding_index_dimension() {
+    //
+    // The stamped pair must describe vectors THIS run produced: the dimension
+    // comes from `produced_dim` (set on the first accepted write), never from
+    // pre-existing vectors, and a run that produced nothing — everything
+    // already embedded, or every batch rejected — stamps nothing. The stamp
+    // also sits below the rejection warning so a fully-rejected run cannot
+    // write the pair before the warning says the writes failed.
+    if let Some(dim) = produced_dim {
         let effective_model = if endpoint.is_some() {
             external_embedding_model(model)
         } else {
@@ -16757,12 +16853,16 @@ fn run_embed(
         {
             eprintln!("Warning: failed to record embedding model metadata: {e}");
         }
-    }
-
-    if rejected_count > 0 {
+    } else if let Some(requested) = (if endpoint.is_some() { model } else { model_id })
+        && let Ok(Some((recorded, _))) = store.get_embedding_metadata()
+        && recorded != requested
+    {
+        // Zero-work path with an explicit model mismatch: name it, or the run
+        // ends with "Done: 0 embedding(s)" and no hint that the requested
+        // model was never applied.
         eprintln!(
-            "Error: {rejected_count} embedding(s) rejected due to dimension mismatch. \
-             Use --force to switch models (clears existing embeddings)."
+            "No embeddings were produced; the database remains embedded with '{recorded}'. \
+             Re-run with --force to re-embed everything with '{requested}'."
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2420,7 +2420,9 @@ enum Commands {
     /// By default uses the bundled local model (sentence-transformers/all-MiniLM-L6-v2).
     /// Pass --endpoint to use an external OpenAI-compatible API instead.
     /// Only nodes that do not yet have an embedding are processed (incremental);
-    /// use --force to re-embed everything.
+    /// use --force to re-embed everything. The index is checkpointed to disk
+    /// about every 5 minutes and once at the end of the pass, so interrupting
+    /// a run keeps only the work completed up to the last checkpoint.
     #[command(
         after_help = "Examples:\n  nestweaver embed                           # local model, all node types\n  nestweaver embed --scope symbols           # only symbols\n  nestweaver embed --local --cache-dir /path/to/cache  # populate a configured daemon cache\n  nestweaver embed --endpoint https://api.openai.com --model text-embedding-3-small\n  nestweaver embed --force --stats            # re-embed everything, print timing"
     )]
@@ -16508,6 +16510,13 @@ where
     // overwrite the recorded fingerprint with a fabricated (model, dimension)
     // pair taken from pre-existing vectors.
     let mut produced_dim: Option<usize> = None;
+    // Checkpoint the index to the sidecar about every five minutes so an
+    // interrupted pass keeps completed work. Per-batch flushing is not
+    // implementable: save_binary rewrites the entire sidecar on every call,
+    // so the cadence must stay coarse.
+    let mut flush_checkpoint = nestweaver_store::EmbeddingFlushCheckpoint::new(
+        nestweaver_store::EMBED_CHECKPOINT_INTERVAL,
+    );
 
     if let Some(ep) = endpoint {
         // ── External API path ────────────────────────────────────
@@ -16562,6 +16571,9 @@ where
                             error_count += chunk.len();
                         }
                     }
+                    if let Err(e) = flush_checkpoint.flush_if_due(&store, success_count) {
+                        eprintln!("\n    Warning: failed to checkpoint embedding index: {e}");
+                    }
                 }
                 eprintln!();
             }
@@ -16606,6 +16618,9 @@ where
                             eprintln!("\n    Warning: batch embedding API error: {e}");
                             error_count += chunk.len();
                         }
+                    }
+                    if let Err(e) = flush_checkpoint.flush_if_due(&store, success_count) {
+                        eprintln!("\n    Warning: failed to checkpoint embedding index: {e}");
                     }
                 }
                 eprintln!();
@@ -16670,6 +16685,9 @@ where
                             error_count += chunk.len();
                         }
                     }
+                    if let Err(e) = flush_checkpoint.flush_if_due(&store, success_count) {
+                        eprintln!("\n    Warning: failed to checkpoint embedding index: {e}");
+                    }
                 }
                 eprintln!();
             }
@@ -16733,6 +16751,9 @@ where
                                 error_count += batch.len();
                             }
                         }
+                        if let Err(e) = flush_checkpoint.flush_if_due(&store, success_count) {
+                            eprintln!("\n    Warning: failed to checkpoint embedding index: {e}");
+                        }
                     }
                     eprintln!();
                 }
@@ -16783,6 +16804,9 @@ where
                                 eprintln!("\n    Warning: local embed error: {e}");
                                 error_count += batch.len();
                             }
+                        }
+                        if let Err(e) = flush_checkpoint.flush_if_due(&store, success_count) {
+                            eprintln!("\n    Warning: failed to checkpoint embedding index: {e}");
                         }
                     }
                     eprintln!();
@@ -16847,6 +16871,9 @@ where
                                 eprintln!("\n    Warning: local embed error: {e}");
                                 error_count += batch.len();
                             }
+                        }
+                        if let Err(e) = flush_checkpoint.flush_if_due(&store, success_count) {
+                            eprintln!("\n    Warning: failed to checkpoint embedding index: {e}");
                         }
                     }
                     eprintln!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -16466,6 +16466,38 @@ where
         anyhow::bail!("unknown --scope '{scope}': expected one of: all, symbols, notes, headings");
     }
 
+    // The direct paths (--local / --endpoint) resolve their model from flags
+    // alone and bypass the daemon route's recorded-model guard at the top of
+    // this function. Apply the same check here — reusing
+    // daemon_route_model_override_is_honored so the routes cannot drift — so a
+    // conflicting explicit model requires --force. Absent metadata means the
+    // database was never stamped: unknown, so proceed (first embed).
+    let recorded_model_id = store
+        .get_embedding_metadata()
+        .ok()
+        .flatten()
+        .map(|(model_id, _)| model_id);
+    if !force && let Some(recorded) = recorded_model_id.as_deref() {
+        // On the endpoint branch the comparison operand is the endpoint's
+        // model (--model, defaulting to the external default), never
+        // --model-id — comparing --model-id would bail on every correctly
+        // configured external run.
+        let requested = if endpoint.is_some() {
+            Some(external_embedding_model(model))
+        } else {
+            model_id
+        };
+        if daemon_route_model_override_is_honored(requested, Some(recorded)).is_err() {
+            // In the Err case `requested` is always Some (None is Ok).
+            anyhow::bail!(
+                "embedding model mismatch: the database was embedded with '{recorded}' but this \
+                 run requested '{}'; use the recorded model or pass --force to switch models \
+                 (re-embeds everything)",
+                requested.unwrap_or_default()
+            );
+        }
+    }
+
     let mut success_count = 0usize;
     let mut error_count = 0usize;
     let mut rejected_count = 0usize;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21125,3 +21125,455 @@ mod embed_accelerator_cli_tests {
             .expect("join");
     }
 }
+
+/// Regression tests for the embedding-metadata truth fixes: the recorded
+/// `(model_id, dimension)` fingerprint may only be written from vectors the
+/// run actually produced, and the direct `--local` / `--endpoint` paths must
+/// honor the fingerprint already recorded in the database.
+///
+/// Every test drives `run_embed` with an injected stub loader (the seam added
+/// for exactly this purpose) — no model artifacts, no network except the
+/// refused-loopback endpoint cases.
+#[cfg(all(test, feature = "embed"))]
+mod embed_metadata_truth_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    const RECORDED_MODEL: &str = "sentence-transformers/recorded-model";
+    const OTHER_MODEL: &str = "sentence-transformers/other-model";
+
+    /// A `CliBatchEmbedder` emitting fixed-dimension vectors, so tests reach
+    /// the embed loops without a warm artifact cache.
+    struct StubEmbedder {
+        dimension: usize,
+    }
+
+    impl CliBatchEmbedder for StubEmbedder {
+        fn embed_batch(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+            Ok(texts.iter().map(|_| vec![0.1_f32; self.dimension]).collect())
+        }
+    }
+
+    /// A loader standing in for `load_cli_local_embedder`: records how it was
+    /// called and hands back a `StubEmbedder` of the given dimension.
+    struct StubLoader {
+        dimension: usize,
+        calls: Arc<AtomicU32>,
+        loaded_model_ids: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl StubLoader {
+        fn new(dimension: usize) -> Self {
+            Self {
+                dimension,
+                calls: Arc::new(AtomicU32::new(0)),
+                loaded_model_ids: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn call_count(&self) -> u32 {
+            self.calls.load(Ordering::Relaxed)
+        }
+
+        fn loaded_model_ids(&self) -> Vec<String> {
+            self.loaded_model_ids.lock().unwrap().clone()
+        }
+
+        fn closure(
+            &self,
+        ) -> impl Fn(
+            &str,
+            Option<&Path>,
+            Option<CliEmbeddingAccelerator>,
+        ) -> anyhow::Result<Box<dyn CliBatchEmbedder>> {
+            let dimension = self.dimension;
+            let calls = self.calls.clone();
+            let loaded = self.loaded_model_ids.clone();
+            move |model_id, _cache_dir, _accelerator| {
+                calls.fetch_add(1, Ordering::Relaxed);
+                loaded.lock().unwrap().push(model_id.to_string());
+                Ok(Box::new(StubEmbedder { dimension }))
+            }
+        }
+    }
+
+    fn test_symbol(name: &str) -> nestweaver_schema::Symbol {
+        nestweaver_schema::Symbol {
+            uid: format!("sym:{name}"),
+            name: name.to_string(),
+            kind: nestweaver_schema::SymbolKind::Function,
+            repo_uid: "repo:test".to_string(),
+            file_path: "src/lib.rs".to_string(),
+            start_line: 1,
+            end_line: 1,
+            signature: format!("fn {name}()"),
+            summary: None,
+            content_hash: format!("hash-{name}"),
+            embedding: None,
+            pagerank_score: None,
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: nestweaver_schema::Visibility::Inferred,
+            type_info: None,
+            framework_hint: None,
+            canonical_id: None,
+        }
+    }
+
+    /// Seed a database with symbols, 3-dimensional sidecar embeddings for the
+    /// `embedded` subset, and an optional recorded `(model_id, dimension)`
+    /// fingerprint. The store is dropped so `run_embed` can reopen the DB.
+    fn seed_embed_db(
+        embedded: &[&str],
+        unembedded: &[&str],
+        metadata: Option<(&str, u32)>,
+    ) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("brain.lbug");
+        {
+            let store = nestweaver_store::GraphStore::create(&db_path).unwrap();
+            for name in embedded.iter().chain(unembedded.iter()) {
+                store.insert_symbol(&test_symbol(name)).unwrap();
+            }
+            let producer = metadata.map(|(model, _)| model).unwrap_or("seed-model");
+            for name in embedded {
+                assert!(
+                    store.add_embedding_with_force(
+                        &format!("sym:{name}"),
+                        vec![0.1_f32, 0.2, 0.3],
+                        producer,
+                        false,
+                    ),
+                    "fixture embedding must be accepted for {name}"
+                );
+            }
+            store.flush_embedding_index().unwrap();
+            if let Some((model, dim)) = metadata {
+                store.set_embedding_metadata(model, dim).unwrap();
+            }
+        }
+        (dir, db_path)
+    }
+
+    fn recorded_metadata(db_path: &Path) -> Option<(String, u32)> {
+        let store = nestweaver_store::GraphStore::open_read_only(db_path).unwrap();
+        store.get_embedding_metadata().unwrap()
+    }
+
+    /// Reproduction A: a fully embedded database re-embedded with a different
+    /// explicit `--model-id`. The run produces nothing, so the recorded
+    /// fingerprint must survive untouched — and the conflicting model must be
+    /// called out by name. Before the fix the tail stamped the requested
+    /// model against a pre-existing vector's dimension, fabricating a pair
+    /// that was never true together.
+    #[test]
+    fn conflicting_model_id_against_a_fully_embedded_db_leaves_metadata_untouched() {
+        let (_dir, db_path) = seed_embed_db(&["seeded"], &[], Some((RECORDED_MODEL, 3)));
+        let loader = StubLoader::new(3);
+
+        let error = run_embed(
+            Some(&db_path),
+            true, // --local
+            None,
+            None,
+            Some(OTHER_MODEL),
+            None,
+            None,
+            8,
+            "symbols",
+            false, // no --force
+            false,
+            false, // direct path
+            loader.closure(),
+        )
+        .expect_err("a conflicting explicit --model-id must bail, not silently stamp");
+
+        let message = format!("{error:#}");
+        assert!(message.contains(RECORDED_MODEL), "must name the recorded model: {message}");
+        assert!(message.contains(OTHER_MODEL), "must name the requested model: {message}");
+        assert_eq!(
+            loader.call_count(),
+            0,
+            "the bail must happen before the model is even loaded"
+        );
+        assert_eq!(
+            recorded_metadata(&db_path),
+            Some((RECORDED_MODEL.to_string(), 3)),
+            "a zero-work run must not overwrite the recorded fingerprint"
+        );
+    }
+
+    /// Reproduction B (dimension): every add is rejected by the dimension
+    /// guard. The run produced nothing, so the recorded pair must not move —
+    /// and the exit path must not claim success.
+    ///
+    /// The fixture records dimension 768 against a 3-dimensional index — the
+    /// poisoned state the unconditional stamp used to create — so the
+    /// pre-change stamp, which would have rewritten the pair to
+    /// `(RECORDED_MODEL, 3)` from a pre-existing vector, fails the "untouched"
+    /// assertion instead of coincidentally rewriting the same values.
+    #[test]
+    fn fully_rejected_embed_leaves_metadata_untouched_and_reports_failure() {
+        let (_dir, db_path) =
+            seed_embed_db(&["seeded"], &["pending"], Some((RECORDED_MODEL, 768)));
+        let loader = StubLoader::new(4); // stub emits the wrong dimension
+
+        let code = run_embed(
+            Some(&db_path),
+            true,
+            None,
+            None,
+            Some(RECORDED_MODEL), // matches the fingerprint, so only the dim guard fires
+            None,
+            None,
+            8,
+            "symbols",
+            false,
+            false,
+            false,
+            loader.closure(),
+        )
+        .expect("a rejected run still returns an exit code");
+
+        assert_eq!(loader.call_count(), 1);
+        assert_eq!(
+            code, EXIT_ERROR,
+            "a fully rejected run must not exit successfully"
+        );
+        assert_eq!(
+            recorded_metadata(&db_path),
+            Some((RECORDED_MODEL.to_string(), 768)),
+            "a run that produced no accepted vectors must not stamp"
+        );
+        let store = nestweaver_store::GraphStore::open_read_only(&db_path).unwrap();
+        assert!(
+            !store.has_embedding("sym:pending"),
+            "rejected vectors must not reach the index"
+        );
+    }
+
+    /// Reproduction B (model): forgetting `--model-id` on a database recorded
+    /// with a non-default model must not mix the compiled default's vectors
+    /// into the index. The CLI guard passes (no explicit model to conflict),
+    /// so the store's recorded-model guard is what rejects every write.
+    #[test]
+    fn embed_without_model_id_cannot_mix_the_default_model_into_a_recorded_index() {
+        let (_dir, db_path) =
+            seed_embed_db(&["seeded"], &["pending"], Some((RECORDED_MODEL, 3)));
+        assert_ne!(
+            RECORDED_MODEL,
+            nestweaver_engine::config::DEFAULT_EMBEDDING_MODEL_ID,
+            "the fixture needs a non-default recorded model for this test to mean anything"
+        );
+        let loader = StubLoader::new(3); // right dimension, wrong (default) model
+
+        let code = run_embed(
+            Some(&db_path),
+            true,
+            None,
+            None,
+            None, // no --model-id: resolves to the compiled default
+            None,
+            None,
+            8,
+            "symbols",
+            false,
+            false,
+            false,
+            loader.closure(),
+        )
+        .expect("a rejected run still returns an exit code");
+
+        assert_eq!(
+            loader.loaded_model_ids(),
+            vec![nestweaver_engine::config::DEFAULT_EMBEDDING_MODEL_ID.to_string()],
+        );
+        assert_eq!(code, EXIT_ERROR, "rejected writes must not report success");
+        assert_eq!(
+            recorded_metadata(&db_path),
+            Some((RECORDED_MODEL.to_string(), 3)),
+            "the recorded fingerprint must survive a fully rejected run"
+        );
+        let store = nestweaver_store::GraphStore::open_read_only(&db_path).unwrap();
+        assert!(!store.has_embedding("sym:pending"));
+    }
+
+    /// The escape hatch: an explicit `--model-id` that disagrees with the
+    /// recorded fingerprint proceeds under `--force`, and the successful run
+    /// re-stamps the fingerprint with the model it actually used.
+    #[test]
+    fn force_reembed_with_a_new_model_proceeds_and_restamps_the_fingerprint() {
+        let (_dir, db_path) = seed_embed_db(&["seeded"], &[], Some((RECORDED_MODEL, 3)));
+        let loader = StubLoader::new(3);
+
+        let code = run_embed(
+            Some(&db_path),
+            true,
+            None,
+            None,
+            Some(OTHER_MODEL),
+            None,
+            None,
+            8,
+            "symbols",
+            true, // --force
+            false,
+            false,
+            loader.closure(),
+        )
+        .expect("a forced re-embed must run");
+
+        assert_eq!(code, EXIT_SUCCESS);
+        assert_eq!(loader.loaded_model_ids(), vec![OTHER_MODEL.to_string()]);
+        assert_eq!(
+            recorded_metadata(&db_path),
+            Some((OTHER_MODEL.to_string(), 3)),
+            "a productive --force run must re-stamp the model it used"
+        );
+    }
+
+    /// A genuine run records the dimension of the vectors it wrote. The
+    /// database carries a stale 768-dimension fingerprint but an empty index;
+    /// the stub produces 3-dimensional vectors, so the stamp must say 3 —
+    /// never a dimension read back from anywhere else.
+    #[test]
+    fn a_productive_run_stamps_the_dimension_it_produced() {
+        let (_dir, db_path) = seed_embed_db(&[], &["pending"], Some((RECORDED_MODEL, 768)));
+        let loader = StubLoader::new(3);
+
+        let code = run_embed(
+            Some(&db_path),
+            true,
+            None,
+            None,
+            Some(RECORDED_MODEL),
+            None,
+            None,
+            8,
+            "symbols",
+            false,
+            false,
+            false,
+            loader.closure(),
+        )
+        .expect("a matching model id must not bail");
+
+        assert_eq!(code, EXIT_SUCCESS);
+        assert_eq!(
+            recorded_metadata(&db_path),
+            Some((RECORDED_MODEL.to_string(), 3)),
+            "the stamp must describe the vectors this run produced"
+        );
+    }
+
+    /// A `--force` run over a database with no embeddable nodes produces
+    /// nothing, so even with a conflicting requested model nothing is
+    /// stamped (the run explains the discrepancy on stderr instead).
+    #[test]
+    fn force_embed_with_no_eligible_nodes_does_not_stamp() {
+        let (_dir, db_path) = seed_embed_db(&[], &[], Some((RECORDED_MODEL, 3)));
+        let loader = StubLoader::new(3);
+
+        let code = run_embed(
+            Some(&db_path),
+            true,
+            None,
+            None,
+            Some(OTHER_MODEL),
+            None,
+            None,
+            8,
+            "all",
+            true, // --force, so the mismatch guard does not bail
+            false,
+            false,
+            loader.closure(),
+        )
+        .expect("a zero-work force run must not fail");
+
+        assert_eq!(code, EXIT_SUCCESS);
+        assert_eq!(
+            recorded_metadata(&db_path),
+            Some((RECORDED_MODEL.to_string(), 3)),
+            "no produced vectors, no stamp — even under --force"
+        );
+    }
+
+    /// The endpoint branch compares the recorded fingerprint against the
+    /// endpoint's model (`--model`, defaulting to the external default) —
+    /// never `--model-id`. A correctly configured external run carries a
+    /// local-model `--model-id` that must not trip the guard. The endpoint
+    /// is a refused loopback port: the guard passing means the run reaches
+    /// the HTTP batch and fails there (an exit code), rather than bailing.
+    #[test]
+    fn endpoint_embed_compares_the_fingerprint_against_the_endpoint_model() {
+        let (_dir, db_path) = seed_embed_db(
+            &["seeded"],
+            &["pending"],
+            Some((DEFAULT_EXTERNAL_EMBEDDING_MODEL, 3)),
+        );
+        let loader = StubLoader::new(3);
+
+        let code = run_embed(
+            Some(&db_path),
+            false,
+            Some("http://127.0.0.1:1"), // connection refused, fast
+            None,                       // --model defaults to the external default
+            Some(OTHER_MODEL),          // a local model id — irrelevant on this branch
+            None,
+            None,
+            8,
+            "symbols",
+            false,
+            false,
+            false,
+            loader.closure(),
+        )
+        .expect("the local --model-id must not bail the endpoint branch");
+
+        assert_eq!(
+            code, EXIT_ERROR,
+            "the batch fails against a refused endpoint, proving the guard let the run through"
+        );
+        assert_eq!(
+            recorded_metadata(&db_path),
+            Some((DEFAULT_EXTERNAL_EMBEDDING_MODEL.to_string(), 3)),
+            "a run that produced nothing must not stamp"
+        );
+        assert_eq!(loader.call_count(), 0, "the endpoint branch never loads a local model");
+    }
+
+    /// The flip side: an endpoint run whose `--model` disagrees with the
+    /// recorded fingerprint bails, naming both models.
+    #[test]
+    fn endpoint_embed_bails_when_the_endpoint_model_conflicts_with_the_fingerprint() {
+        let (_dir, db_path) = seed_embed_db(&["seeded"], &[], Some(("external-model-a", 3)));
+        let loader = StubLoader::new(3);
+
+        let error = run_embed(
+            Some(&db_path),
+            false,
+            Some("http://127.0.0.1:1"),
+            Some("external-model-b"),
+            None,
+            None,
+            None,
+            8,
+            "symbols",
+            false,
+            false,
+            false,
+            loader.closure(),
+        )
+        .expect_err("a conflicting --model must bail on the endpoint branch too");
+
+        let message = format!("{error:#}");
+        assert!(message.contains("external-model-a"), "must name the recorded model: {message}");
+        assert!(message.contains("external-model-b"), "must name the requested model: {message}");
+        assert_eq!(
+            recorded_metadata(&db_path),
+            Some(("external-model-a".to_string(), 3)),
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16377,15 +16377,16 @@ where
                         let elapsed = t0.elapsed();
                         if resp.rejected > 0 {
                             eprintln!(
-                                "Error: {} embedding(s) rejected due to dimension mismatch. \
-                                 Use --force to switch models (clears existing embeddings).",
+                                "Error: {} embedding(s) rejected by the embedding guards \
+                                 (model or dimension mismatch). Use --force to switch models \
+                                 (clears existing embeddings).",
                                 resp.rejected
                             );
                         }
                         if stats {
                             eprintln!(
                                 "Embed stats: {} succeeded, {} failed, \
-                                 {} rejected (dim mismatch), {} eligible, \
+                                 {} rejected (model/dim mismatch), {} eligible, \
                                  {} already embedded, {} scoped node(s), {:.2}s elapsed",
                                 resp.succeeded,
                                 resp.failed,
@@ -16546,7 +16547,7 @@ where
                         Ok(embeddings) => {
                             for (sym, emb) in chunk.iter().zip(embeddings) {
                                 let emb_dim = emb.len();
-                                if store.add_embedding_with_force(&sym.uid, emb, force) {
+                                if store.add_embedding_with_force(&sym.uid, emb, api_model, force) {
                                     success_count += 1;
                                     if produced_dim.is_none() {
                                         produced_dim = Some(emb_dim);
@@ -16590,7 +16591,8 @@ where
                         Ok(embeddings) => {
                             for (note, emb) in chunk.iter().zip(embeddings) {
                                 let emb_dim = emb.len();
-                                if store.add_embedding_with_force(&note.uid, emb, force) {
+                                if store.add_embedding_with_force(&note.uid, emb, api_model, force)
+                                {
                                     success_count += 1;
                                     if produced_dim.is_none() {
                                         produced_dim = Some(emb_dim);
@@ -16653,7 +16655,7 @@ where
                         Ok(embeddings) => {
                             for (h, emb) in chunk.iter().zip(embeddings) {
                                 let emb_dim = emb.len();
-                                if store.add_embedding_with_force(&h.uid, emb, force) {
+                                if store.add_embedding_with_force(&h.uid, emb, api_model, force) {
                                     success_count += 1;
                                     if produced_dim.is_none() {
                                         produced_dim = Some(emb_dim);
@@ -16711,8 +16713,12 @@ where
                         match embed_model.embed_batch(&text_refs) {
                             Ok(embeddings) => {
                                 for (sym, emb) in batch.iter().zip(embeddings.iter()) {
-                                    if store.add_embedding_with_force(&sym.uid, emb.clone(), force)
-                                    {
+                                    if store.add_embedding_with_force(
+                                        &sym.uid,
+                                        emb.clone(),
+                                        local_model_id,
+                                        force,
+                                    ) {
                                         success_count += 1;
                                         if produced_dim.is_none() {
                                             produced_dim = Some(emb.len());
@@ -16758,8 +16764,12 @@ where
                         match embed_model.embed_batch(&text_refs) {
                             Ok(embeddings) => {
                                 for (note, emb) in batch.iter().zip(embeddings.iter()) {
-                                    if store.add_embedding_with_force(&note.uid, emb.clone(), force)
-                                    {
+                                    if store.add_embedding_with_force(
+                                        &note.uid,
+                                        emb.clone(),
+                                        local_model_id,
+                                        force,
+                                    ) {
                                         success_count += 1;
                                         if produced_dim.is_none() {
                                             produced_dim = Some(emb.len());
@@ -16818,7 +16828,12 @@ where
                         match embed_model.embed_batch(&text_refs) {
                             Ok(embeddings) => {
                                 for (h, emb) in batch.iter().zip(embeddings.iter()) {
-                                    if store.add_embedding_with_force(&h.uid, emb.clone(), force) {
+                                    if store.add_embedding_with_force(
+                                        &h.uid,
+                                        emb.clone(),
+                                        local_model_id,
+                                        force,
+                                    ) {
                                         success_count += 1;
                                         if produced_dim.is_none() {
                                             produced_dim = Some(emb.len());
@@ -16858,8 +16873,9 @@ where
 
     if rejected_count > 0 {
         eprintln!(
-            "Error: {rejected_count} embedding(s) rejected due to dimension mismatch. \
-             Use --force to switch models (clears existing embeddings)."
+            "Error: {rejected_count} embedding(s) rejected by the embedding guards \
+             (model or dimension mismatch). Use --force to switch models \
+             (clears existing embeddings)."
         );
     }
 
@@ -16902,7 +16918,7 @@ where
         let elapsed = t0.elapsed();
         eprintln!(
             "Embed stats: {success_count} succeeded, {error_count} failed, \
-             {rejected_count} rejected (dim mismatch), {:.2}s elapsed",
+             {rejected_count} rejected (model/dim mismatch), {:.2}s elapsed",
             elapsed.as_secs_f64()
         );
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16571,7 +16571,12 @@ where
                             error_count += chunk.len();
                         }
                     }
-                    if let Err(e) = flush_checkpoint.flush_if_due(&store, success_count) {
+                    if let Err(e) = flush_checkpoint.flush_if_due_with_stamp(
+                        &store,
+                        success_count,
+                        api_model,
+                        produced_dim,
+                    ) {
                         eprintln!("\n    Warning: failed to checkpoint embedding index: {e}");
                     }
                 }
@@ -16619,7 +16624,12 @@ where
                             error_count += chunk.len();
                         }
                     }
-                    if let Err(e) = flush_checkpoint.flush_if_due(&store, success_count) {
+                    if let Err(e) = flush_checkpoint.flush_if_due_with_stamp(
+                        &store,
+                        success_count,
+                        api_model,
+                        produced_dim,
+                    ) {
                         eprintln!("\n    Warning: failed to checkpoint embedding index: {e}");
                     }
                 }
@@ -16685,7 +16695,12 @@ where
                             error_count += chunk.len();
                         }
                     }
-                    if let Err(e) = flush_checkpoint.flush_if_due(&store, success_count) {
+                    if let Err(e) = flush_checkpoint.flush_if_due_with_stamp(
+                        &store,
+                        success_count,
+                        api_model,
+                        produced_dim,
+                    ) {
                         eprintln!("\n    Warning: failed to checkpoint embedding index: {e}");
                     }
                 }
@@ -16751,7 +16766,12 @@ where
                                 error_count += batch.len();
                             }
                         }
-                        if let Err(e) = flush_checkpoint.flush_if_due(&store, success_count) {
+                        if let Err(e) = flush_checkpoint.flush_if_due_with_stamp(
+                            &store,
+                            success_count,
+                            local_model_id,
+                            produced_dim,
+                        ) {
                             eprintln!("\n    Warning: failed to checkpoint embedding index: {e}");
                         }
                     }
@@ -16805,7 +16825,12 @@ where
                                 error_count += batch.len();
                             }
                         }
-                        if let Err(e) = flush_checkpoint.flush_if_due(&store, success_count) {
+                        if let Err(e) = flush_checkpoint.flush_if_due_with_stamp(
+                            &store,
+                            success_count,
+                            local_model_id,
+                            produced_dim,
+                        ) {
                             eprintln!("\n    Warning: failed to checkpoint embedding index: {e}");
                         }
                     }
@@ -16872,7 +16897,12 @@ where
                                 error_count += batch.len();
                             }
                         }
-                        if let Err(e) = flush_checkpoint.flush_if_due(&store, success_count) {
+                        if let Err(e) = flush_checkpoint.flush_if_due_with_stamp(
+                            &store,
+                            success_count,
+                            local_model_id,
+                            produced_dim,
+                        ) {
                             eprintln!("\n    Warning: failed to checkpoint embedding index: {e}");
                         }
                     }
@@ -21151,7 +21181,10 @@ mod embed_metadata_truth_tests {
 
     impl CliBatchEmbedder for StubEmbedder {
         fn embed_batch(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
-            Ok(texts.iter().map(|_| vec![0.1_f32; self.dimension]).collect())
+            Ok(texts
+                .iter()
+                .map(|_| vec![0.1_f32; self.dimension])
+                .collect())
         }
     }
 
@@ -21290,8 +21323,14 @@ mod embed_metadata_truth_tests {
         .expect_err("a conflicting explicit --model-id must bail, not silently stamp");
 
         let message = format!("{error:#}");
-        assert!(message.contains(RECORDED_MODEL), "must name the recorded model: {message}");
-        assert!(message.contains(OTHER_MODEL), "must name the requested model: {message}");
+        assert!(
+            message.contains(RECORDED_MODEL),
+            "must name the recorded model: {message}"
+        );
+        assert!(
+            message.contains(OTHER_MODEL),
+            "must name the requested model: {message}"
+        );
         assert_eq!(
             loader.call_count(),
             0,
@@ -21315,8 +21354,7 @@ mod embed_metadata_truth_tests {
     /// assertion instead of coincidentally rewriting the same values.
     #[test]
     fn fully_rejected_embed_leaves_metadata_untouched_and_reports_failure() {
-        let (_dir, db_path) =
-            seed_embed_db(&["seeded"], &["pending"], Some((RECORDED_MODEL, 768)));
+        let (_dir, db_path) = seed_embed_db(&["seeded"], &["pending"], Some((RECORDED_MODEL, 768)));
         let loader = StubLoader::new(4); // stub emits the wrong dimension
 
         let code = run_embed(
@@ -21359,8 +21397,7 @@ mod embed_metadata_truth_tests {
     /// so the store's recorded-model guard is what rejects every write.
     #[test]
     fn embed_without_model_id_cannot_mix_the_default_model_into_a_recorded_index() {
-        let (_dir, db_path) =
-            seed_embed_db(&["seeded"], &["pending"], Some((RECORDED_MODEL, 3)));
+        let (_dir, db_path) = seed_embed_db(&["seeded"], &["pending"], Some((RECORDED_MODEL, 3)));
         assert_ne!(
             RECORDED_MODEL,
             nestweaver_engine::config::DEFAULT_EMBEDDING_MODEL_ID,
@@ -21541,7 +21578,11 @@ mod embed_metadata_truth_tests {
             Some((DEFAULT_EXTERNAL_EMBEDDING_MODEL.to_string(), 3)),
             "a run that produced nothing must not stamp"
         );
-        assert_eq!(loader.call_count(), 0, "the endpoint branch never loads a local model");
+        assert_eq!(
+            loader.call_count(),
+            0,
+            "the endpoint branch never loads a local model"
+        );
     }
 
     /// The flip side: an endpoint run whose `--model` disagrees with the
@@ -21569,8 +21610,14 @@ mod embed_metadata_truth_tests {
         .expect_err("a conflicting --model must bail on the endpoint branch too");
 
         let message = format!("{error:#}");
-        assert!(message.contains("external-model-a"), "must name the recorded model: {message}");
-        assert!(message.contains("external-model-b"), "must name the requested model: {message}");
+        assert!(
+            message.contains("external-model-a"),
+            "must name the recorded model: {message}"
+        );
+        assert!(
+            message.contains("external-model-b"),
+            "must name the requested model: {message}"
+        );
         assert_eq!(
             recorded_metadata(&db_path),
             Some(("external-model-a".to_string(), 3)),


### PR DESCRIPTION
## Group B — Embedding metadata truth

Bug bash 2026-08-06, group B. Four items in strict dependency order — the
stamping gate lands first because every other guard reads what it writes.

### What lands

- `fix(cli): stamp embedding metadata only from vectors the run produced` —
  the embed tail stamped `set_embedding_metadata` with the dimension of an
  arbitrary *pre-existing* vector, ungated on success. Now `produced_dim`
  is threaded from the first accepted write in all six CLI loops (and the
  three daemon loops), the stamp uses it, is gated on it, and sits below
  the rejection warning. Includes the `CliBatchEmbedder` loader-injection
  seam (mirrors the daemon's `load_daemon_embedding_backend_with`) so the
  reproductions are testable without a warm artifact cache.
- `fix(cli): read the recorded embedding fingerprint on direct embed paths` —
  direct `--local`/`--endpoint` runs now read the fingerprint from the DB
  before model resolution (the daemon route already did) and hard-bail on a
  conflicting explicit `--model-id`/`--model` without `--force`, naming both
  models. Deliberate deviation: `daemon_route_model_override_is_honored` is
  reused as the *predicate* but the error message is route-appropriate (the
  shared function's text recommends the daemon route).
- `fix(storage): refuse same-dimension writes from a different recorded
  model` — fingerprint step 1 only: the write guard compares the recorded
  `model_id`, in-memory, loaded once at open from the existing Meta blob.
  **No new persisted field.** Absent metadata = unknown = allowed;
  `--force` overrides.
- `fix(cli): checkpoint the embedding index during long passes` — time-based
  (~5 min) flush at chunk boundaries on both routes. Per-batch flushing is
  not implementable (`save_binary` rewrites the entire ~250 MB sidecar per
  call) — documented in the helper. `embed --help` now states the cadence.
- `fix(storage|cli|daemon): stamp the fingerprint with each checkpoint
  flush` — adversarial-review fix: without this, an interrupted same-dim
  `--force` model switch left a durably mixed index under the old model's
  fingerprint (a window the checkpoint commit opened). Durable state is now
  self-describing at every checkpoint.

### Behavioral changes (disclosed per sign-off contract)

- Direct `embed --local/--endpoint` **hard-bails** on a conflicting explicit
  `--model-id`/`--model` without `--force` (previously: silent mixing or a
  fabricated stamp).
- The daemon embed RPC **stamps embedding metadata for the first time** —
  daemon-populated databases previously had no fingerprint at all.
- The embedding index checkpoints ~every 5 minutes during a pass on both
  routes; an interrupted pass keeps work up to the last checkpoint.
- The store write guard refuses same-dimension writes from a different
  recorded model unless `--force`; rejection summaries read "model or
  dimension mismatch".

### Waivers / notes

- stderr explanation text is not asserted (in-process `eprintln`);
  metadata-unchanged assertions cover the behavior.
- `EMBED_CHECKPOINT_INTERVAL` (300s) is an unasserted constant; the helper
  is fully tested via its constructor.
- 4 of 8 CLI tests are non-discriminating by design (they pin the escape
  hatch and no-false-positive direction) — named in the test module.
- Store-guard rejections name both model ids at `tracing::warn` level; the
  CLI summary says "model or dimension mismatch" with a count.

### Sign-off record

- Acceptance audit: COMPLETE — every criterion in the four notes SATISFIED
  with discriminating tests or sanctioned seams; hazards (warm cache,
  both-loops dimension threading, endpoint `external_model` operand)
  verified; exclusions held (no brain-status counters, no streaming).
- Adversarial correctness review: one medium finding (checkpoint/mixed-model
  window) — fixed in the three checkpoint-stamp commits and covered by new
  store tests.
- Local gate: fmt, clippy (`--workspace --all-targets -D warnings`),
  `build --locked --tests`, `cargo test`, daemon tests — green.
