### PR TITLE
fix embeddings cache defaults and startup diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4213,6 +4213,7 @@ dependencies = [
  "anyhow",
  "apollo-parser",
  "blake3",
+ "dirs",
  "globset",
  "html2md",
  "ignore",

--- a/README.md
+++ b/README.md
@@ -515,6 +515,9 @@ model_id = "sentence-transformers/all-MiniLM-L6-v2"
 # cache_dir defaults to the platform-native cache directory:
 # ~/Library/Caches/nestweaver/models on macOS, $XDG_CACHE_HOME/nestweaver/models
 # (or ~/.cache/nestweaver/models) on Linux. Explicit values may use ~/.
+# If unavailable or non-UTF-8, a UTF-8 HOME uses ~/.cache first. The final
+# fallback is /var/cache/nestweaver/models on Unix or C:\ProgramData\nestweaver\models
+# on Windows; set cache_dir explicitly if that system location is not writable.
 # cache_dir = "~/Library/Caches/nestweaver/models"
 accelerator = "auto" # auto | metal | cpu; see the policy table above
 weight_ppr = 0.40

--- a/README.md
+++ b/README.md
@@ -512,7 +512,10 @@ Configure the model and fusion weights in `instance.toml`:
 # Shipped default; the model a DB was actually embedded with is recorded and
 # auto-loaded by the daemon. Set this to override the default for fresh instances.
 model_id = "sentence-transformers/all-MiniLM-L6-v2"
-cache_dir = "~/.cache/nestweaver/models"
+# cache_dir defaults to the platform-native cache directory:
+# ~/Library/Caches/nestweaver/models on macOS, $XDG_CACHE_HOME/nestweaver/models
+# (or ~/.cache/nestweaver/models) on Linux. Explicit values may use ~/.
+# cache_dir = "~/Library/Caches/nestweaver/models"
 accelerator = "auto" # auto | metal | cpu; see the policy table above
 weight_ppr = 0.40
 weight_bm25 = 0.25

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -6781,6 +6781,111 @@ mod embedding_load_config_tests {
         assert_eq!(embeddings[0].len(), 4);
         assert!(embeddings[0].iter().all(|value| value.is_finite()));
     }
+
+    #[test]
+    fn missing_artifact_fails_startup_and_names_model_and_dir() {
+        let cache = tempfile::tempdir().expect("cache tempdir");
+        let artifacts = write_complete_hf_cache(cache.path());
+        std::fs::remove_file(&artifacts.weights).expect("remove weights fixture");
+        let config = nestweaver_embed::EmbedConfig {
+            model_id: "test-owner/test-model".to_string(),
+            cache_dir: cache.path().to_path_buf(),
+            external_endpoint: None,
+            external_model: None,
+        };
+
+        let error = load_daemon_embedding_backend_with(
+            &config,
+            nestweaver_embed::DevicePolicy::Cpu,
+            nestweaver_embed::EmbedModel::load_with_policy_and_artifact_mode,
+        )
+        .err()
+        .expect("a cache missing an artifact must fail the startup load");
+
+        let cfg = nestweaver_engine::config::EmbeddingConfig {
+            model_id: "test-owner/test-model".to_string(),
+            ..Default::default()
+        };
+        let status = finalize_embedding_status(
+            initial_embedding_status(&cfg, None, true, false),
+            None,
+            Err(format!("{error:#}")),
+        );
+        assert_eq!(status.state, "failed");
+        assert!(
+            status.error.contains("test-owner/test-model"),
+            "startup error must name the model id: {}",
+            status.error
+        );
+        assert!(
+            status.error.contains(&cache.path().display().to_string()),
+            "startup error must name the cache directory searched: {}",
+            status.error
+        );
+    }
+
+    #[test]
+    fn ready_status_carries_the_model_id_and_resolved_cache_dir() {
+        // The ready-path startup diagnostic logs status.model_id and the
+        // resolved cache_dir (cloned before the move into
+        // embedding_load_config); pin the values that line reports so a
+        // wrong-but-populated cache stays visible.
+        let cache = tempfile::tempdir().expect("cache tempdir");
+        write_complete_hf_cache(cache.path());
+        let cfg = nestweaver_engine::config::EmbeddingConfig {
+            model_id: "test-owner/test-model".to_string(),
+            cache_dir: cache.path().display().to_string(),
+            ..Default::default()
+        };
+        let cache_dir = nestweaver_engine::resolve_user_path(&cfg.cache_dir);
+        assert!(cache_dir.is_absolute());
+        assert_eq!(cache_dir, cache.path());
+
+        let load_config = embedding_load_config(&cfg, cache_dir.clone(), None);
+        let model = load_daemon_embedding_backend_with(
+            &load_config,
+            nestweaver_embed::DevicePolicy::Cpu,
+            nestweaver_embed::EmbedModel::load_with_policy_and_artifact_mode,
+        )
+        .expect("complete fixture cache must load");
+        let probe = probe_embedding_model(&model).expect("readiness probe must pass");
+        let status = finalize_embedding_status(
+            initial_embedding_status(&cfg, None, true, false),
+            None,
+            Ok(probe),
+        );
+        assert_eq!(status.state, "ready");
+        assert_eq!(status.model_id, "test-owner/test-model");
+        assert_eq!(load_config.cache_dir, cache_dir);
+    }
+
+    #[test]
+    fn legacy_cache_hint_reports_a_complete_model_in_the_legacy_dir() {
+        let legacy = tempfile::tempdir().expect("legacy tempdir");
+        write_complete_hf_cache(legacy.path());
+        let resolved = tempfile::tempdir().expect("resolved tempdir");
+
+        let hint = legacy_cache_hint_at(legacy.path(), resolved.path(), "test-owner/test-model")
+            .expect("a complete model in the legacy dir must produce a hint");
+        assert!(hint.contains("test-owner/test-model"));
+        assert!(hint.contains(&legacy.path().display().to_string()));
+        assert!(hint.contains("cache-only"));
+    }
+
+    #[test]
+    fn legacy_cache_hint_is_absent_when_nothing_is_findable_elsewhere() {
+        let legacy = tempfile::tempdir().expect("legacy tempdir");
+        let resolved = tempfile::tempdir().expect("resolved tempdir");
+        // Empty legacy dir: nothing to point the user at.
+        assert!(
+            legacy_cache_hint_at(legacy.path(), resolved.path(), "test-owner/test-model").is_none()
+        );
+        // Legacy == resolved: the configured dir IS the legacy dir, so there
+        // is no second location to report.
+        assert!(
+            legacy_cache_hint_at(legacy.path(), legacy.path(), "test-owner/test-model").is_none()
+        );
+    }
 }
 
 #[cfg(feature = "embed")]

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -6902,6 +6902,42 @@ async fn probe_loaded_embedding_model(
     }
 }
 
+/// If the model's artifacts are complete in the legacy (pre-platform-native)
+/// default cache directory but that is not where the daemon looked, say so.
+/// Cache-only probe: pure filesystem, no network — preserves the daemon's
+/// cache-only startup contract.
+#[cfg(feature = "embed")]
+fn legacy_cache_hint(resolved_dir: &std::path::Path, model_id: &str) -> Option<String> {
+    let legacy_dir =
+        nestweaver_engine::resolve_user_path(nestweaver_engine::config::LEGACY_EMBEDDING_CACHE_DIR);
+    legacy_cache_hint_at(&legacy_dir, resolved_dir, model_id)
+}
+
+#[cfg(feature = "embed")]
+fn legacy_cache_hint_at(
+    legacy_dir: &std::path::Path,
+    resolved_dir: &std::path::Path,
+    model_id: &str,
+) -> Option<String> {
+    if legacy_dir == resolved_dir {
+        return None;
+    }
+    let probe = nestweaver_embed::EmbedConfig {
+        model_id: model_id.to_string(),
+        cache_dir: legacy_dir.to_path_buf(),
+        external_endpoint: None,
+        external_model: None,
+    };
+    nestweaver_embed::resolve_model_artifacts(&probe, nestweaver_embed::ArtifactMode::CacheOnly)
+        .ok()?;
+    Some(format!(
+        "model '{model_id}' was found in the legacy cache directory '{}'; \
+         set [embedding] cache_dir in instance.toml or move the cache — \
+         the daemon is cache-only and will not re-download",
+        legacy_dir.display()
+    ))
+}
+
 /// Load the embedding model into `state.embedding_runtime`. MUST be called on the daemon's main
 /// (block_on) thread: candle compiles Metal shaders via MTLCompilerService, an Aqua
 /// per-session XPC service reachable from the main thread but NOT from a tokio worker/blocking
@@ -7015,13 +7051,26 @@ async fn load_embedding_model(state: &std::sync::Arc<DaemonState>) {
             }
         },
         Err(e) => {
-            let status = finalize_embedding_status(
+            let mut status = finalize_embedding_status(
                 state.embedding_runtime.status(),
                 state.store.embedding_index_dimension(),
                 Err(format!("{e:#}")),
             );
+            // Local-only: an external endpoint never consults the cache, so a
+            // legacy-cache hit would be a red herring for its failures.
+            let hint = if config.external_endpoint.is_none() {
+                legacy_cache_hint(&cache_dir, &config.model_id)
+            } else {
+                None
+            };
+            if let Some(hint) = &hint {
+                status.error = format!("{}; {hint}", status.error);
+            }
             state.embedding_runtime.publish_unavailable(status);
-            tracing::warn!("Failed to load embedding model: {e}");
+            match hint {
+                Some(hint) => tracing::warn!("Failed to load embedding model: {e}; {hint}"),
+                None => tracing::warn!("Failed to load embedding model: {e}"),
+            }
         }
     }
 }

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -6891,7 +6891,7 @@ mod embedding_load_config_tests {
             .finish();
 
         tracing::subscriber::with_default(subscriber, || {
-            log_embedding_ready("local", "cpu", "test-owner/test-model", cache.path());
+            log_embedding_ready("local", "cpu", "test-owner/test-model", Some(cache.path()));
         });
 
         let rendered = {
@@ -7036,6 +7036,33 @@ mod embedding_load_config_tests {
         assert!(status.error.contains("~/models"));
         assert!(status.error.contains("no home directory"));
         assert!(status.error.contains("absolute path"));
+    }
+
+    #[test]
+    fn external_embedding_ignores_unexpandable_local_cache_dir() {
+        let cfg = nestweaver_engine::config::EmbeddingConfig {
+            cache_dir: "~/models".to_string(),
+            external_endpoint: Some("http://127.0.0.1:11434/v1".to_string()),
+            external_model: Some("test-external-model".to_string()),
+            ..Default::default()
+        };
+        let resolver_called = std::cell::Cell::new(false);
+
+        let cache_dir = embedding_cache_dir_for_load_with(&cfg, |_| {
+            resolver_called.set(true);
+            Err(
+                nestweaver_engine::ResolveUserPathError::HomeDirectoryUnavailable {
+                    input: cfg.cache_dir.clone(),
+                },
+            )
+        })
+        .expect("external embedding must not resolve an irrelevant local cache path");
+
+        assert!(!resolver_called.get());
+        assert!(cache_dir.as_os_str().is_empty());
+        let load_config = embedding_load_config(&cfg, cache_dir, None);
+        assert_eq!(load_config.external_endpoint, cfg.external_endpoint);
+        assert_eq!(load_config.external_model, cfg.external_model);
     }
 }
 
@@ -7259,19 +7286,45 @@ fn embedding_cache_dir_resolution_failure_status(
 }
 
 #[cfg(feature = "embed")]
+fn embedding_cache_dir_for_load_with<E, Resolve>(
+    cfg: &nestweaver_engine::config::EmbeddingConfig,
+    resolve: Resolve,
+) -> Result<std::path::PathBuf, E>
+where
+    Resolve: FnOnce(&str) -> Result<std::path::PathBuf, E>,
+{
+    if cfg.external_endpoint.is_some() {
+        // External backends do not consume Hugging Face artifacts. Keep their
+        // construction independent of an irrelevant local cache path.
+        Ok(std::path::PathBuf::new())
+    } else {
+        resolve(&cfg.cache_dir)
+    }
+}
+
+#[cfg(feature = "embed")]
 fn log_embedding_ready(
     backend: &str,
     selected_device: &str,
     model_id: &str,
-    cache_dir: &std::path::Path,
+    cache_dir: Option<&std::path::Path>,
 ) {
-    tracing::info!(
-        backend,
-        device = selected_device,
-        model_id,
-        cache_dir = %cache_dir.display(),
-        "Embedding model ready"
-    );
+    if let Some(cache_dir) = cache_dir {
+        tracing::info!(
+            backend,
+            device = selected_device,
+            model_id,
+            cache_dir = %cache_dir.display(),
+            "Embedding model ready"
+        );
+    } else {
+        tracing::info!(
+            backend,
+            device = selected_device,
+            model_id,
+            "Embedding model ready"
+        );
+    }
 }
 
 /// Load the embedding model into `state.embedding_runtime`. MUST be called on the daemon's main
@@ -7332,23 +7385,26 @@ async fn load_embedding_model(state: &std::sync::Arc<DaemonState>) {
             );
         }
     }
-    // Resolve the configured cache dir: expand a leading tilde and absolutize
-    // relative paths so diagnostics always name a usable location.
-    let cache_dir = match nestweaver_engine::resolve_user_path(&cfg.cache_dir) {
-        Ok(cache_dir) => cache_dir,
-        Err(error) => {
-            let status = embedding_cache_dir_resolution_failure_status(
-                state.embedding_runtime.status(),
-                state.store.embedding_index_dimension(),
-                &cfg.cache_dir,
-                &error,
-            );
-            let message = status.error.clone();
-            state.embedding_runtime.publish_unavailable(status);
-            tracing::warn!("Failed to resolve embedding cache directory: {message}");
-            return;
-        }
-    };
+    // Local backends resolve the configured cache dir: expand a leading tilde
+    // and absolutize relative paths so diagnostics always name a usable
+    // location. External backends do not consume this setting and must remain
+    // independent of it.
+    let cache_dir =
+        match embedding_cache_dir_for_load_with(&cfg, nestweaver_engine::resolve_user_path) {
+            Ok(cache_dir) => cache_dir,
+            Err(error) => {
+                let status = embedding_cache_dir_resolution_failure_status(
+                    state.embedding_runtime.status(),
+                    state.store.embedding_index_dimension(),
+                    &cfg.cache_dir,
+                    &error,
+                );
+                let message = status.error.clone();
+                state.embedding_runtime.publish_unavailable(status);
+                tracing::warn!("Failed to resolve embedding cache directory: {message}");
+                return;
+            }
+        };
     let policy = daemon_embedding_device_policy(cfg.accelerator);
     let config = embedding_load_config(&cfg, cache_dir.clone(), stored_model_id.as_deref());
     let loaded = load_daemon_embedding_backend_with(
@@ -7373,10 +7429,15 @@ async fn load_embedding_model(state: &std::sync::Arc<DaemonState>) {
                         std::sync::Arc::new(model)
                             as std::sync::Arc<dyn nestweaver_engine::EmbedQueryFn>,
                     );
-                    // Name the model and the resolved cache dir: a populated
-                    // but WRONG cache loads fine, and only this line makes the
-                    // wrong model visible.
-                    log_embedding_ready(&backend, &selected_device, &model_id, &cache_dir);
+                    // Name the model and, for local backends, the resolved
+                    // cache dir: a populated but WRONG cache loads fine, and
+                    // only this line makes the wrong model visible. External
+                    // backends do not use the local cache setting.
+                    let cache_dir = config
+                        .external_endpoint
+                        .is_none()
+                        .then_some(cache_dir.as_path());
+                    log_embedding_ready(&backend, &selected_device, &model_id, cache_dir);
                 } else {
                     let error = status.error.clone();
                     state.embedding_runtime.publish_unavailable(status);

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -6837,7 +6837,8 @@ mod embedding_load_config_tests {
             cache_dir: cache.path().display().to_string(),
             ..Default::default()
         };
-        let cache_dir = nestweaver_engine::resolve_user_path(&cfg.cache_dir);
+        let cache_dir = nestweaver_engine::resolve_user_path(&cfg.cache_dir)
+            .expect("absolute fixture cache path must resolve");
         assert!(cache_dir.is_absolute());
         assert_eq!(cache_dir, cache.path());
 
@@ -6857,6 +6858,54 @@ mod embedding_load_config_tests {
         assert_eq!(status.state, "ready");
         assert_eq!(status.model_id, "test-owner/test-model");
         assert_eq!(load_config.cache_dir, cache_dir);
+    }
+
+    #[test]
+    fn ready_startup_log_names_model_and_absolute_cache_dir() {
+        #[derive(Clone)]
+        struct BufferWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+        impl std::io::Write for BufferWriter {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                self.0
+                    .lock()
+                    .expect("capture ready log")
+                    .extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let cache = tempfile::tempdir().expect("cache tempdir");
+        assert!(cache.path().is_absolute());
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let writer = captured.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .without_time()
+            .with_target(false)
+            .with_writer(move || BufferWriter(writer.clone()))
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            log_embedding_ready("local", "cpu", "test-owner/test-model", cache.path());
+        });
+
+        let rendered = {
+            let bytes = captured.lock().expect("read captured ready log");
+            String::from_utf8(bytes.clone()).expect("tracing output must be UTF-8")
+        };
+        assert!(rendered.contains("Embedding model ready"), "{rendered}");
+        assert!(rendered.contains("model_id"), "{rendered}");
+        assert!(rendered.contains("test-owner/test-model"), "{rendered}");
+        assert!(rendered.contains("cache_dir"), "{rendered}");
+        assert!(
+            rendered.contains(&cache.path().display().to_string()),
+            "{rendered}"
+        );
     }
 
     #[test]
@@ -6885,6 +6934,108 @@ mod embedding_load_config_tests {
         assert!(
             legacy_cache_hint_at(legacy.path(), legacy.path(), "test-owner/test-model").is_none()
         );
+    }
+
+    #[test]
+    fn missing_artifact_failure_publishes_legacy_cache_hint_in_status() {
+        let legacy = tempfile::tempdir().expect("legacy tempdir");
+        write_complete_hf_cache(legacy.path());
+        let resolved = tempfile::tempdir().expect("resolved tempdir");
+        let config = nestweaver_embed::EmbedConfig {
+            model_id: "test-owner/test-model".to_string(),
+            cache_dir: resolved.path().to_path_buf(),
+            external_endpoint: None,
+            external_model: None,
+        };
+        let error = anyhow::Error::new(nestweaver_embed::MissingModelArtifactError {
+            model_id: config.model_id.clone(),
+            filename: "model.safetensors".to_string(),
+            cache_dir: config.cache_dir.clone(),
+        })
+        .context("local embedding startup failed");
+        let cfg = nestweaver_engine::config::EmbeddingConfig {
+            model_id: config.model_id.clone(),
+            cache_dir: resolved.path().display().to_string(),
+            ..Default::default()
+        };
+
+        let (status, hint) = embedding_load_failure_status_at(
+            initial_embedding_status(&cfg, None, true, false),
+            None,
+            &error,
+            &config,
+            legacy.path(),
+            resolved.path(),
+        );
+
+        let hint = hint.expect("typed missing-artifact failure must report the legacy cache");
+        assert_eq!(status.state, "failed");
+        assert!(status.error.contains("local embedding startup failed"));
+        assert!(status.error.contains("model.safetensors"));
+        assert!(
+            status
+                .error
+                .contains(&resolved.path().display().to_string())
+        );
+        assert!(status.error.contains(&hint));
+        assert!(hint.contains(&legacy.path().display().to_string()));
+    }
+
+    #[test]
+    fn non_artifact_local_failure_gets_no_legacy_cache_hint() {
+        let legacy = tempfile::tempdir().expect("legacy tempdir");
+        write_complete_hf_cache(legacy.path());
+        let resolved = tempfile::tempdir().expect("resolved tempdir");
+        let config = nestweaver_embed::EmbedConfig {
+            model_id: "test-owner/test-model".to_string(),
+            cache_dir: resolved.path().to_path_buf(),
+            external_endpoint: None,
+            external_model: None,
+        };
+        let error = anyhow::anyhow!("Metal device initialization failed");
+        let cfg = nestweaver_engine::config::EmbeddingConfig {
+            model_id: config.model_id.clone(),
+            cache_dir: resolved.path().display().to_string(),
+            ..Default::default()
+        };
+
+        let (status, hint) = embedding_load_failure_status_at(
+            initial_embedding_status(&cfg, None, true, true),
+            None,
+            &error,
+            &config,
+            legacy.path(),
+            resolved.path(),
+        );
+
+        assert!(hint.is_none());
+        assert_eq!(status.state, "failed");
+        assert!(status.error.contains("Metal device initialization failed"));
+        assert!(!status.error.contains("legacy cache"));
+        assert!(!status.error.contains(&legacy.path().display().to_string()));
+    }
+
+    #[test]
+    fn unexpandable_embedding_cache_dir_becomes_actionable_failed_status() {
+        let cfg = nestweaver_engine::config::EmbeddingConfig {
+            cache_dir: "~/models".to_string(),
+            ..Default::default()
+        };
+        let error = nestweaver_engine::ResolveUserPathError::HomeDirectoryUnavailable {
+            input: cfg.cache_dir.clone(),
+        };
+
+        let status = embedding_cache_dir_resolution_failure_status(
+            initial_embedding_status(&cfg, None, true, false),
+            None,
+            &cfg.cache_dir,
+            &error,
+        );
+
+        assert_eq!(status.state, "failed");
+        assert!(status.error.contains("~/models"));
+        assert!(status.error.contains("no home directory"));
+        assert!(status.error.contains("absolute path"));
     }
 }
 
@@ -7007,17 +7158,6 @@ async fn probe_loaded_embedding_model(
     }
 }
 
-/// If the model's artifacts are complete in the legacy (pre-platform-native)
-/// default cache directory but that is not where the daemon looked, say so.
-/// Cache-only probe: pure filesystem, no network — preserves the daemon's
-/// cache-only startup contract.
-#[cfg(feature = "embed")]
-fn legacy_cache_hint(resolved_dir: &std::path::Path, model_id: &str) -> Option<String> {
-    let legacy_dir =
-        nestweaver_engine::resolve_user_path(nestweaver_engine::config::LEGACY_EMBEDDING_CACHE_DIR);
-    legacy_cache_hint_at(&legacy_dir, resolved_dir, model_id)
-}
-
 #[cfg(feature = "embed")]
 fn legacy_cache_hint_at(
     legacy_dir: &std::path::Path,
@@ -7041,6 +7181,97 @@ fn legacy_cache_hint_at(
          the daemon is cache-only and will not re-download",
         legacy_dir.display()
     ))
+}
+
+#[cfg(feature = "embed")]
+fn embedding_load_failure_status_at(
+    current_status: EmbeddingRuntimeStatus,
+    embedding_dimension: Option<usize>,
+    error: &anyhow::Error,
+    config: &nestweaver_embed::EmbedConfig,
+    legacy_dir: &std::path::Path,
+    resolved_dir: &std::path::Path,
+) -> (EmbeddingRuntimeStatus, Option<String>) {
+    let mut status = finalize_embedding_status(
+        current_status,
+        embedding_dimension,
+        Err(format!("{error:#}")),
+    );
+    // A local load can also fail during device selection or model
+    // construction. Only a typed missing-artifact cause makes another cache
+    // location relevant remediation.
+    let missing_artifact = error
+        .chain()
+        .any(|cause| cause.is::<nestweaver_embed::MissingModelArtifactError>());
+    let hint = if config.external_endpoint.is_none() && missing_artifact {
+        legacy_cache_hint_at(legacy_dir, resolved_dir, &config.model_id)
+    } else {
+        None
+    };
+    if let Some(hint) = &hint {
+        status.error = format!("{}; {hint}", status.error);
+    }
+    (status, hint)
+}
+
+#[cfg(feature = "embed")]
+fn embedding_load_failure_status(
+    current_status: EmbeddingRuntimeStatus,
+    embedding_dimension: Option<usize>,
+    error: &anyhow::Error,
+    config: &nestweaver_embed::EmbedConfig,
+    resolved_dir: &std::path::Path,
+) -> (EmbeddingRuntimeStatus, Option<String>) {
+    let Ok(legacy_dir) =
+        nestweaver_engine::resolve_user_path(nestweaver_engine::config::LEGACY_EMBEDDING_CACHE_DIR)
+    else {
+        let status = finalize_embedding_status(
+            current_status,
+            embedding_dimension,
+            Err(format!("{error:#}")),
+        );
+        return (status, None);
+    };
+    embedding_load_failure_status_at(
+        current_status,
+        embedding_dimension,
+        error,
+        config,
+        &legacy_dir,
+        resolved_dir,
+    )
+}
+
+#[cfg(feature = "embed")]
+fn embedding_cache_dir_resolution_failure_status(
+    current_status: EmbeddingRuntimeStatus,
+    embedding_dimension: Option<usize>,
+    configured_cache_dir: &str,
+    error: &nestweaver_engine::ResolveUserPathError,
+) -> EmbeddingRuntimeStatus {
+    finalize_embedding_status(
+        current_status,
+        embedding_dimension,
+        Err(format!(
+            "failed to resolve configured embedding cache directory '{configured_cache_dir}': {error}"
+        )),
+    )
+}
+
+#[cfg(feature = "embed")]
+fn log_embedding_ready(
+    backend: &str,
+    selected_device: &str,
+    model_id: &str,
+    cache_dir: &std::path::Path,
+) {
+    tracing::info!(
+        backend,
+        device = selected_device,
+        model_id,
+        cache_dir = %cache_dir.display(),
+        "Embedding model ready"
+    );
 }
 
 /// Load the embedding model into `state.embedding_runtime`. MUST be called on the daemon's main
@@ -7103,7 +7334,21 @@ async fn load_embedding_model(state: &std::sync::Arc<DaemonState>) {
     }
     // Resolve the configured cache dir: expand a leading tilde and absolutize
     // relative paths so diagnostics always name a usable location.
-    let cache_dir = nestweaver_engine::resolve_user_path(&cfg.cache_dir);
+    let cache_dir = match nestweaver_engine::resolve_user_path(&cfg.cache_dir) {
+        Ok(cache_dir) => cache_dir,
+        Err(error) => {
+            let status = embedding_cache_dir_resolution_failure_status(
+                state.embedding_runtime.status(),
+                state.store.embedding_index_dimension(),
+                &cfg.cache_dir,
+                &error,
+            );
+            let message = status.error.clone();
+            state.embedding_runtime.publish_unavailable(status);
+            tracing::warn!("Failed to resolve embedding cache directory: {message}");
+            return;
+        }
+    };
     let policy = daemon_embedding_device_policy(cfg.accelerator);
     let config = embedding_load_config(&cfg, cache_dir.clone(), stored_model_id.as_deref());
     let loaded = load_daemon_embedding_backend_with(
@@ -7131,13 +7376,7 @@ async fn load_embedding_model(state: &std::sync::Arc<DaemonState>) {
                     // Name the model and the resolved cache dir: a populated
                     // but WRONG cache loads fine, and only this line makes the
                     // wrong model visible.
-                    tracing::info!(
-                        backend,
-                        device = selected_device,
-                        model_id,
-                        cache_dir = %cache_dir.display(),
-                        "Embedding model ready"
-                    );
+                    log_embedding_ready(&backend, &selected_device, &model_id, &cache_dir);
                 } else {
                     let error = status.error.clone();
                     state.embedding_runtime.publish_unavailable(status);
@@ -7156,21 +7395,13 @@ async fn load_embedding_model(state: &std::sync::Arc<DaemonState>) {
             }
         },
         Err(e) => {
-            let mut status = finalize_embedding_status(
+            let (status, hint) = embedding_load_failure_status(
                 state.embedding_runtime.status(),
                 state.store.embedding_index_dimension(),
-                Err(format!("{e:#}")),
+                &e,
+                &config,
+                &cache_dir,
             );
-            // Local-only: an external endpoint never consults the cache, so a
-            // legacy-cache hit would be a red herring for its failures.
-            let hint = if config.external_endpoint.is_none() {
-                legacy_cache_hint(&cache_dir, &config.model_id)
-            } else {
-                None
-            };
-            if let Some(hint) = &hint {
-                status.error = format!("{}; {hint}", status.error);
-            }
             state.embedding_runtime.publish_unavailable(status);
             match hint {
                 Some(hint) => tracing::warn!("Failed to load embedding model: {e}; {hint}"),
@@ -14030,6 +14261,92 @@ mod startup_helper_tests {
             0,
             "incremental embedding must consult the sidecar index, not graph-row fields"
         );
+    }
+
+    #[cfg(feature = "embed")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[cfg(not(target_os = "macos"))]
+    async fn missing_local_artifact_keeps_daemon_healthy_and_reports_failed_status() {
+        let cache = tempfile::tempdir().expect("cache tempdir");
+        assert!(
+            cache.path().is_absolute(),
+            "the startup diagnostic fixture must use an absolute cache path"
+        );
+        let config = nestweaver_engine::InstanceConfig::from_toml_str(&format!(
+            r#"
+instance_id = "missing-local-artifact-test"
+
+[snapshot_storage]
+backend = "local"
+path = "/tmp/snapshots"
+
+[workspace]
+backend = "local"
+path = "/tmp/workspace"
+
+[inference]
+endpoint = "http://localhost:8080"
+embedding_model = "unused"
+summary_model = "unused"
+
+[git]
+credential_method = "ssh"
+
+[embedding]
+model_id = "test-owner/group-f-missing-artifact"
+cache_dir = {:?}
+accelerator = "cpu"
+"#,
+            cache.path().display().to_string()
+        ))
+        .expect("valid local embedding fixture config");
+        let mut state = test_state_with_writer();
+        let state_mut = Arc::get_mut(&mut state).expect("test owns the only state Arc");
+        state_mut.instance_cfg = Some(Arc::new(config.clone()));
+        state_mut
+            .embedding_runtime
+            .publish_unavailable(initial_embedding_status(
+                &config.embedding,
+                None,
+                true,
+                daemon_metal_compiled(),
+            ));
+
+        load_embedding_model(&state).await;
+
+        let (status, model) = state.embedding_runtime.snapshot();
+        assert_eq!(status.state, "failed");
+        assert_eq!(status.backend, "local");
+        assert_eq!(status.model_id, "test-owner/group-f-missing-artifact");
+        assert!(
+            status.error.contains("test-owner/group-f-missing-artifact"),
+            "startup failure must name the configured model: {}",
+            status.error
+        );
+        assert!(
+            status.error.contains(&cache.path().display().to_string()),
+            "startup failure must name the absolute cache directory: {}",
+            status.error
+        );
+        assert!(model.is_none(), "a failed load must not publish a model");
+
+        let service = DaemonService::new(state);
+        service
+            .health_check(Request::new(HealthCheckRequest {}))
+            .await
+            .expect("a non-semantic RPC must remain usable");
+        let typed = service
+            .brain_status(Request::new(BrainStatusRequest {}))
+            .await
+            .expect("status RPC must remain usable")
+            .into_inner()
+            .embedding_status
+            .expect("structured embedding status");
+        assert_eq!(typed.state, "failed");
+        assert_eq!(typed.backend, "local");
+        assert_eq!(typed.model_id, "test-owner/group-f-missing-artifact");
+        assert!(typed.error.contains("test-owner/group-f-missing-artifact"));
+        assert!(typed.error.contains(&cache.path().display().to_string()));
     }
 
     #[cfg(feature = "embed")]

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -6964,7 +6964,7 @@ async fn load_embedding_model(state: &std::sync::Arc<DaemonState>) {
     // relative paths so diagnostics always name a usable location.
     let cache_dir = nestweaver_engine::resolve_user_path(&cfg.cache_dir);
     let policy = daemon_embedding_device_policy(cfg.accelerator);
-    let config = embedding_load_config(&cfg, cache_dir, stored_model_id.as_deref());
+    let config = embedding_load_config(&cfg, cache_dir.clone(), stored_model_id.as_deref());
     let loaded = load_daemon_embedding_backend_with(
         &config,
         policy,
@@ -6981,12 +6981,22 @@ async fn load_embedding_model(state: &std::sync::Arc<DaemonState>) {
                 if status.state == "ready" {
                     let backend = status.backend.clone();
                     let selected_device = status.selected_device.clone();
+                    let model_id = status.model_id.clone();
                     state.embedding_runtime.publish_ready(
                         status,
                         std::sync::Arc::new(model)
                             as std::sync::Arc<dyn nestweaver_engine::EmbedQueryFn>,
                     );
-                    tracing::info!(backend, device = selected_device, "Embedding model ready");
+                    // Name the model and the resolved cache dir: a populated
+                    // but WRONG cache loads fine, and only this line makes the
+                    // wrong model visible.
+                    tracing::info!(
+                        backend,
+                        device = selected_device,
+                        model_id,
+                        cache_dir = %cache_dir.display(),
+                        "Embedding model ready"
+                    );
                 } else {
                     let error = status.error.clone();
                     state.embedding_runtime.publish_unavailable(status);

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -6960,16 +6960,9 @@ async fn load_embedding_model(state: &std::sync::Arc<DaemonState>) {
             );
         }
     }
-    // Expand tilde in cache_dir using the home directory.
-    let cache_dir = if cfg.cache_dir.starts_with("~/") {
-        if let Some(home) = dirs::home_dir() {
-            home.join(&cfg.cache_dir[2..])
-        } else {
-            std::path::PathBuf::from(&cfg.cache_dir)
-        }
-    } else {
-        std::path::PathBuf::from(&cfg.cache_dir)
-    };
+    // Resolve the configured cache dir: expand a leading tilde and absolutize
+    // relative paths so diagnostics always name a usable location.
+    let cache_dir = nestweaver_engine::resolve_user_path(&cfg.cache_dir);
     let policy = daemon_embedding_device_policy(cfg.accelerator);
     let config = embedding_load_config(&cfg, cache_dir, stored_model_id.as_deref());
     let loaded = load_daemon_embedding_backend_with(

--- a/crates/nestweaver-embed/src/lib.rs
+++ b/crates/nestweaver-embed/src/lib.rs
@@ -87,9 +87,11 @@ pub struct EmbedConfig {
 impl Default for EmbedConfig {
     fn default() -> Self {
         Self {
-            // Keep in sync with nestweaver_engine::config::DEFAULT_EMBEDDING_MODEL_ID
-            // (the canonical constant; this crate sits below nestweaver-engine in
-            // the dependency graph, so it cannot reference it directly).
+            // Keep in sync with nestweaver_engine::config — both the
+            // DEFAULT_EMBEDDING_MODEL_ID constant and the
+            // default_embedding_cache_dir() default (this crate sits below
+            // nestweaver-engine in the dependency graph, so it cannot
+            // reference either directly).
             model_id: "sentence-transformers/all-MiniLM-L6-v2".to_string(),
             cache_dir: default_cache_dir(),
             external_endpoint: None,

--- a/crates/nestweaver-embed/src/lib.rs
+++ b/crates/nestweaver-embed/src/lib.rs
@@ -101,10 +101,22 @@ impl Default for EmbedConfig {
 }
 
 fn default_cache_dir() -> PathBuf {
+    #[cfg(not(windows))]
+    const FALLBACK: &str = "/var/cache/nestweaver/models";
+    #[cfg(windows)]
+    const FALLBACK: &str = r"C:\ProgramData\nestweaver\models";
+
+    // InstanceConfig persists this default as a UTF-8 String. Use the native
+    // cache only when both sides can represent it exactly; never silently
+    // replace non-UTF-8 bytes or fall back relative to a caller's CWD.
+    let utf8_model_dir = |root: PathBuf| {
+        let path = root.join("nestweaver").join("models");
+        path.to_str().is_some().then_some(path)
+    };
     dirs::cache_dir()
-        .unwrap_or_else(|| PathBuf::from(".cache"))
-        .join("nestweaver")
-        .join("models")
+        .and_then(&utf8_model_dir)
+        .or_else(|| dirs::home_dir().and_then(|home| utf8_model_dir(home.join(".cache"))))
+        .unwrap_or_else(|| PathBuf::from(FALLBACK))
 }
 
 pub struct EmbedModel {

--- a/crates/nestweaver-engine/Cargo.toml
+++ b/crates/nestweaver-engine/Cargo.toml
@@ -17,6 +17,7 @@ rmp-serde = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 blake3 = { workspace = true }
+dirs = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/crates/nestweaver-engine/src/config.rs
+++ b/crates/nestweaver-engine/src/config.rs
@@ -287,8 +287,10 @@ pub struct EmbeddingConfig {
     /// Directory where downloaded model weights are stored. Default: the
     /// platform-native cache directory — `~/Library/Caches/nestweaver/models`
     /// on macOS, `$XDG_CACHE_HOME/nestweaver/models` (or
-    /// `~/.cache/nestweaver/models`) on Linux. An explicit leading `~/` is
-    /// expanded at startup via [`crate::resolve_user_path`].
+    /// `~/.cache/nestweaver/models`) on Linux. If that path is unavailable or
+    /// not UTF-8, a UTF-8 home directory supplies `~/.cache/nestweaver/models`;
+    /// only then does it use [`FALLBACK_EMBEDDING_CACHE_DIR`]. An explicit
+    /// leading `~/` is expanded at startup via [`crate::resolve_user_path`].
     #[serde(default = "default_embedding_cache_dir")]
     pub cache_dir: String,
     /// Accelerator used by the local embedding backend. Default: automatically
@@ -352,6 +354,13 @@ pub const DEFAULT_EMBEDDING_MODEL_ID: &str = "sentence-transformers/all-MiniLM-L
 /// longer a default anywhere.
 pub const LEGACY_EMBEDDING_CACHE_DIR: &str = "~/.cache/nestweaver/models";
 
+/// Absolute fallback used when the platform cache directory is unavailable or
+/// cannot be represented in `InstanceConfig`'s UTF-8 `String` field.
+#[cfg(not(windows))]
+pub const FALLBACK_EMBEDDING_CACHE_DIR: &str = "/var/cache/nestweaver/models";
+#[cfg(windows)]
+pub const FALLBACK_EMBEDDING_CACHE_DIR: &str = r"C:\ProgramData\nestweaver\models";
+
 fn default_model_id() -> String {
     DEFAULT_EMBEDDING_MODEL_ID.to_string()
 }
@@ -359,12 +368,17 @@ fn default_embedding_cache_dir() -> String {
     // Platform-native default; keep in sync with nestweaver-embed's
     // `default_cache_dir`, which sits below this crate in the dependency
     // graph and cannot call this function.
+    let utf8_model_dir = |root: std::path::PathBuf| {
+        root.join("nestweaver")
+            .join("models")
+            .into_os_string()
+            .into_string()
+            .ok()
+    };
     dirs::cache_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from(".cache"))
-        .join("nestweaver")
-        .join("models")
-        .to_string_lossy()
-        .into_owned()
+        .and_then(&utf8_model_dir)
+        .or_else(|| dirs::home_dir().and_then(|home| utf8_model_dir(home.join(".cache"))))
+        .unwrap_or_else(|| FALLBACK_EMBEDDING_CACHE_DIR.to_string())
 }
 fn default_weight_ppr() -> f64 {
     0.40

--- a/crates/nestweaver-engine/src/config.rs
+++ b/crates/nestweaver-engine/src/config.rs
@@ -346,6 +346,12 @@ pub enum EmbeddingAccelerator {
 /// other way); keep the two in sync.
 pub const DEFAULT_EMBEDDING_MODEL_ID: &str = "sentence-transformers/all-MiniLM-L6-v2";
 
+/// The pre-platform-native embedding cache-dir default, as a literal
+/// user-facing path. Kept so the daemon can detect models left behind in the
+/// legacy location by older installs and point the user at them; it is no
+/// longer a default anywhere.
+pub const LEGACY_EMBEDDING_CACHE_DIR: &str = "~/.cache/nestweaver/models";
+
 fn default_model_id() -> String {
     DEFAULT_EMBEDDING_MODEL_ID.to_string()
 }

--- a/crates/nestweaver-engine/src/config.rs
+++ b/crates/nestweaver-engine/src/config.rs
@@ -284,8 +284,11 @@ pub struct EmbeddingConfig {
     /// recorded embedding model overrides this at daemon startup.
     #[serde(default = "default_model_id")]
     pub model_id: String,
-    /// Directory where downloaded model weights are stored.
-    /// Default: `"~/.cache/nestweaver/models"`.
+    /// Directory where downloaded model weights are stored. Default: the
+    /// platform-native cache directory — `~/Library/Caches/nestweaver/models`
+    /// on macOS, `$XDG_CACHE_HOME/nestweaver/models` (or
+    /// `~/.cache/nestweaver/models`) on Linux. An explicit leading `~/` is
+    /// expanded at startup via [`crate::resolve_user_path`].
     #[serde(default = "default_embedding_cache_dir")]
     pub cache_dir: String,
     /// Accelerator used by the local embedding backend. Default: automatically
@@ -347,7 +350,15 @@ fn default_model_id() -> String {
     DEFAULT_EMBEDDING_MODEL_ID.to_string()
 }
 fn default_embedding_cache_dir() -> String {
-    "~/.cache/nestweaver/models".to_string()
+    // Platform-native default; keep in sync with nestweaver-embed's
+    // `default_cache_dir`, which sits below this crate in the dependency
+    // graph and cannot call this function.
+    dirs::cache_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from(".cache"))
+        .join("nestweaver")
+        .join("models")
+        .to_string_lossy()
+        .into_owned()
 }
 fn default_weight_ppr() -> f64 {
     0.40

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -16,6 +16,41 @@ pub fn sidecar_path(db_path: &Path, suffix: &str) -> PathBuf {
     PathBuf::from(s)
 }
 
+/// Resolve a user-supplied path string to an absolute [`PathBuf`].
+///
+/// - A leading `~/` (or a bare `~`) expands against [`dirs::home_dir`]. When no
+///   home directory is known the input is returned unchanged rather than
+///   absolutized, so a literal `~/...` never silently becomes a `./~/...`
+///   directory relative to the working directory.
+/// - Absolute paths pass through unchanged.
+/// - Relative paths are absolutized against the current working directory
+///   (lexically, without touching the filesystem), so a relative configured
+///   path never prints as relative in an error message.
+pub fn resolve_user_path(input: &str) -> PathBuf {
+    resolve_user_path_with_home(input, dirs::home_dir())
+}
+
+fn resolve_user_path_with_home(input: &str, home: Option<PathBuf>) -> PathBuf {
+    let expanded = if input == "~" {
+        match home {
+            Some(home) => home,
+            None => return PathBuf::from(input),
+        }
+    } else if let Some(rest) = input.strip_prefix("~/") {
+        match home {
+            Some(home) => home.join(rest),
+            None => return PathBuf::from(input),
+        }
+    } else {
+        PathBuf::from(input)
+    };
+    if expanded.is_absolute() {
+        expanded
+    } else {
+        std::path::absolute(&expanded).unwrap_or(expanded)
+    }
+}
+
 /// Migrate a sidecar from the old `with_extension` naming convention to the
 /// new `push` convention. If the old-convention path exists and the
 /// new-convention path does not, renames the old file to the new location.
@@ -262,3 +297,50 @@ pub use summaries::{
 };
 pub use watch_code::CodeWatcher;
 pub use watcher::{BrainWatcher, ShutdownHandle, UpdateOutcome};
+
+#[cfg(test)]
+mod resolve_user_path_tests {
+    use super::*;
+
+    #[test]
+    fn tilde_slash_expands_against_home() {
+        assert_eq!(
+            resolve_user_path_with_home("~/cache/models", Some(PathBuf::from("/home/tester"))),
+            PathBuf::from("/home/tester/cache/models")
+        );
+    }
+
+    #[test]
+    fn bare_tilde_is_the_home_directory() {
+        assert_eq!(
+            resolve_user_path_with_home("~", Some(PathBuf::from("/home/tester"))),
+            PathBuf::from("/home/tester")
+        );
+    }
+
+    #[test]
+    fn absolute_path_passes_through_unchanged() {
+        assert_eq!(
+            resolve_user_path_with_home("/var/cache/models", Some(PathBuf::from("/home/tester"))),
+            PathBuf::from("/var/cache/models")
+        );
+    }
+
+    #[test]
+    fn relative_path_is_absolutized() {
+        let resolved = resolve_user_path_with_home("rel/cache", None);
+        assert!(resolved.is_absolute());
+        assert!(resolved.ends_with(Path::new("rel").join("cache")));
+    }
+
+    #[test]
+    fn tilde_without_home_stays_literal() {
+        // Never absolutize an unexpandable `~`: a literal `./~/...` directory
+        // is worse than an honest `~/...` in an error message.
+        assert_eq!(
+            resolve_user_path_with_home("~/cache", None),
+            PathBuf::from("~/cache")
+        );
+        assert_eq!(resolve_user_path_with_home("~", None), PathBuf::from("~"));
+    }
+}

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -16,38 +16,79 @@ pub fn sidecar_path(db_path: &Path, suffix: &str) -> PathBuf {
     PathBuf::from(s)
 }
 
+/// Failure while resolving a user-supplied path.
+#[derive(Debug, thiserror::Error)]
+pub enum ResolveUserPathError {
+    /// An empty path would otherwise resolve to the process working directory,
+    /// which is never a safe interpretation of user input.
+    #[error("cannot resolve an empty user path; configure a non-empty path")]
+    EmptyPath,
+    /// `~` requires a discoverable home directory; never reinterpret it as a
+    /// relative path when one is unavailable.
+    #[error(
+        "cannot expand user path '{input}': no home directory is available; configure an absolute path"
+    )]
+    HomeDirectoryUnavailable { input: String },
+    /// Resolving an ordinary relative path requires the process working
+    /// directory.
+    #[error("cannot resolve relative user path '{input}' against the current directory: {source}")]
+    CurrentDirectoryUnavailable {
+        input: String,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
 /// Resolve a user-supplied path string to an absolute [`PathBuf`].
 ///
 /// - A leading `~/` (or a bare `~`) expands against [`dirs::home_dir`]. When no
-///   home directory is known the input is returned unchanged rather than
-///   absolutized, so a literal `~/...` never silently becomes a `./~/...`
-///   directory relative to the working directory.
+///   home directory is known, resolution fails rather than treating `~` as a
+///   relative directory.
 /// - Absolute paths pass through unchanged.
 /// - Relative paths are absolutized against the current working directory
 ///   (lexically, without touching the filesystem), so a relative configured
 ///   path never prints as relative in an error message.
-pub fn resolve_user_path(input: &str) -> PathBuf {
+pub fn resolve_user_path(input: &str) -> Result<PathBuf, ResolveUserPathError> {
     resolve_user_path_with_home(input, dirs::home_dir())
 }
 
-fn resolve_user_path_with_home(input: &str, home: Option<PathBuf>) -> PathBuf {
+fn resolve_user_path_with_home(
+    input: &str,
+    home: Option<PathBuf>,
+) -> Result<PathBuf, ResolveUserPathError> {
+    if input.trim().is_empty() {
+        return Err(ResolveUserPathError::EmptyPath);
+    }
     let expanded = if input == "~" {
         match home {
             Some(home) => home,
-            None => return PathBuf::from(input),
+            None => {
+                return Err(ResolveUserPathError::HomeDirectoryUnavailable {
+                    input: input.to_string(),
+                });
+            }
         }
     } else if let Some(rest) = input.strip_prefix("~/") {
         match home {
             Some(home) => home.join(rest),
-            None => return PathBuf::from(input),
+            None => {
+                return Err(ResolveUserPathError::HomeDirectoryUnavailable {
+                    input: input.to_string(),
+                });
+            }
         }
     } else {
         PathBuf::from(input)
     };
     if expanded.is_absolute() {
-        expanded
+        Ok(expanded)
     } else {
-        std::path::absolute(&expanded).unwrap_or(expanded)
+        std::path::absolute(&expanded).map_err(|source| {
+            ResolveUserPathError::CurrentDirectoryUnavailable {
+                input: input.to_string(),
+                source,
+            }
+        })
     }
 }
 
@@ -305,7 +346,8 @@ mod resolve_user_path_tests {
     #[test]
     fn tilde_slash_expands_against_home() {
         assert_eq!(
-            resolve_user_path_with_home("~/cache/models", Some(PathBuf::from("/home/tester"))),
+            resolve_user_path_with_home("~/cache/models", Some(PathBuf::from("/home/tester")))
+                .expect("home-backed tilde path must resolve"),
             PathBuf::from("/home/tester/cache/models")
         );
     }
@@ -313,7 +355,8 @@ mod resolve_user_path_tests {
     #[test]
     fn bare_tilde_is_the_home_directory() {
         assert_eq!(
-            resolve_user_path_with_home("~", Some(PathBuf::from("/home/tester"))),
+            resolve_user_path_with_home("~", Some(PathBuf::from("/home/tester")))
+                .expect("bare tilde must resolve to home"),
             PathBuf::from("/home/tester")
         );
     }
@@ -321,26 +364,48 @@ mod resolve_user_path_tests {
     #[test]
     fn absolute_path_passes_through_unchanged() {
         assert_eq!(
-            resolve_user_path_with_home("/var/cache/models", Some(PathBuf::from("/home/tester"))),
+            resolve_user_path_with_home("/var/cache/models", Some(PathBuf::from("/home/tester")))
+                .expect("absolute path must resolve"),
             PathBuf::from("/var/cache/models")
         );
     }
 
     #[test]
     fn relative_path_is_absolutized() {
-        let resolved = resolve_user_path_with_home("rel/cache", None);
+        let resolved =
+            resolve_user_path_with_home("rel/cache", None).expect("relative path must resolve");
         assert!(resolved.is_absolute());
         assert!(resolved.ends_with(Path::new("rel").join("cache")));
     }
 
     #[test]
-    fn tilde_without_home_stays_literal() {
-        // Never absolutize an unexpandable `~`: a literal `./~/...` directory
-        // is worse than an honest `~/...` in an error message.
-        assert_eq!(
-            resolve_user_path_with_home("~/cache", None),
-            PathBuf::from("~/cache")
-        );
-        assert_eq!(resolve_user_path_with_home("~", None), PathBuf::from("~"));
+    fn tilde_without_home_fails_closed() {
+        for input in ["~/cache", "~/", "~"] {
+            let error = resolve_user_path_with_home(input, None)
+                .expect_err("tilde without a home directory must fail");
+            assert!(matches!(
+                &error,
+                ResolveUserPathError::HomeDirectoryUnavailable { input: failed }
+                    if failed == input
+            ));
+            assert!(error.to_string().contains("configure an absolute path"));
+        }
+    }
+
+    #[test]
+    fn empty_path_fails_closed_without_erasing_meaningful_spaces() {
+        for input in ["", " ", "\t\r\n"] {
+            let error = resolve_user_path_with_home(input, Some(PathBuf::from("/home/tester")))
+                .expect_err("empty user paths must not resolve to the working directory");
+            assert!(matches!(error, ResolveUserPathError::EmptyPath));
+            assert!(error.to_string().contains("non-empty path"));
+        }
+
+        let resolved = resolve_user_path_with_home(
+            "cache dir/with spaces",
+            Some(PathBuf::from("/home/tester")),
+        )
+        .expect("a meaningful path containing spaces must resolve");
+        assert!(resolved.ends_with(Path::new("cache dir").join("with spaces")));
     }
 }

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -5267,6 +5267,28 @@ fn tool_schema_brain_add_source() -> Value {
     })
 }
 
+fn resolve_add_source_path(raw_path: &str) -> Result<std::path::PathBuf, anyhow::Error> {
+    nestweaver_engine::resolve_user_path(raw_path).map_err(anyhow::Error::new)
+}
+
+#[cfg(test)]
+mod add_source_path_tests {
+    use super::*;
+
+    #[test]
+    fn empty_path_is_rejected_instead_of_becoming_the_working_directory() {
+        let cwd = std::env::current_dir().expect("working directory");
+        assert!(cwd.is_dir(), "test requires an existing working directory");
+
+        for input in ["", " ", "\t\r\n"] {
+            let error = resolve_add_source_path(input)
+                .expect_err("an empty source path must fail before source indexing");
+            assert!(error.is::<nestweaver_engine::ResolveUserPathError>());
+            assert!(error.to_string().contains("non-empty path"));
+        }
+    }
+}
+
 fn tool_brain_add_source(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error> {
     // Always route through the daemon (start it if needed). This ensures
     // consistent write serialization whether or not the MCP server itself
@@ -5306,7 +5328,7 @@ fn tool_brain_add_source(store: &GraphStore, args: Value) -> Result<Value, anyho
             .get("path")
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow!("'path' must be a string"))?;
-        let path = nestweaver_engine::resolve_user_path(raw_path);
+        let path = resolve_add_source_path(raw_path)?;
         let path = path.as_path();
         if !path.exists() {
             return Err(anyhow!("path does not exist: {}", path.display()));
@@ -5431,31 +5453,42 @@ fn match_repo_target<'a>(
     repos: &'a [nestweaver_schema::Repo],
     target: &str,
 ) -> Vec<&'a nestweaver_schema::Repo> {
-    let expand = |input: &str| -> String {
+    let expand = |input: &str| -> Option<String> {
         nestweaver_engine::resolve_user_path(input)
-            .to_string_lossy()
-            .into_owned()
+            .ok()
+            .map(|path| path.to_string_lossy().into_owned())
     };
     let target_trimmed = target.trim_end_matches('/');
-    let canonical_target = std::fs::canonicalize(expand(target_trimmed))
+    let expanded_target = expand(target_trimmed);
+    if (target_trimmed == "~" || target_trimmed.starts_with("~/")) && expanded_target.is_none() {
+        return Vec::new();
+    }
+    let canonical_target = expanded_target
+        .as_deref()
+        .and_then(|path| std::fs::canonicalize(path).ok())
         .map(|p| format!("file://{}", p.display()))
         .unwrap_or_default();
     let url_target = if target_trimmed.starts_with("file://") {
         target_trimmed.to_string()
     } else if std::path::Path::new(target_trimmed).is_absolute() || target_trimmed.starts_with("~/")
     {
-        let expanded = expand(target_trimmed);
-        std::fs::canonicalize(&expanded)
-            .map(|p| format!("file://{}", p.display()))
-            .unwrap_or_else(|_| format!("file://{expanded}"))
+        expanded_target
+            .as_deref()
+            .map(|expanded| {
+                std::fs::canonicalize(expanded)
+                    .map(|p| format!("file://{}", p.display()))
+                    .unwrap_or_else(|_| format!("file://{expanded}"))
+            })
+            .unwrap_or_default()
     } else {
         String::new()
     };
     // A path target may refer to a repo identified by its git origin remote
     // rather than a file:// URL — try that identity too (read from git config,
     // never fetched).
-    let origin_target = std::fs::canonicalize(expand(target_trimmed))
-        .ok()
+    let origin_target = expanded_target
+        .as_deref()
+        .and_then(|path| std::fs::canonicalize(path).ok())
         .filter(|p| p.join(".git").exists())
         .and_then(|p| nestweaver_engine::read_origin_url(&p).ok())
         .unwrap_or_default();
@@ -9247,11 +9280,13 @@ fn dispatch_add_source_via_daemon(
     rt: &tokio::runtime::Runtime,
     args: serde_json::Value,
 ) -> Result<serde_json::Value, anyhow::Error> {
-    let path = args
+    let raw_path = args
         .get("path")
         .and_then(|v| v.as_str())
-        .ok_or_else(|| anyhow::anyhow!("'path' is required for brain_add_source"))?
-        .to_string();
+        .ok_or_else(|| anyhow::anyhow!("'path' is required for brain_add_source"))?;
+    let path = resolve_add_source_path(raw_path)?
+        .to_string_lossy()
+        .into_owned();
 
     // Vault schema promises "Defaults to the directory name" — resolve it
     // here, but ONLY for vaults: forwarding "" blanks a vault's stored

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -5306,8 +5306,8 @@ fn tool_brain_add_source(store: &GraphStore, args: Value) -> Result<Value, anyho
             .get("path")
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow!("'path' must be a string"))?;
-        let expanded = expand_tilde(raw_path);
-        let path = Path::new(&expanded);
+        let path = nestweaver_engine::resolve_user_path(raw_path);
+        let path = path.as_path();
         if !path.exists() {
             return Err(anyhow!("path does not exist: {}", path.display()));
         }
@@ -5432,12 +5432,9 @@ fn match_repo_target<'a>(
     target: &str,
 ) -> Vec<&'a nestweaver_schema::Repo> {
     let expand = |input: &str| -> String {
-        if let Some(stripped) = input.strip_prefix("~/")
-            && let Ok(home) = std::env::var("HOME")
-        {
-            return format!("{home}/{stripped}");
-        }
-        input.to_string()
+        nestweaver_engine::resolve_user_path(input)
+            .to_string_lossy()
+            .into_owned()
     };
     let target_trimmed = target.trim_end_matches('/');
     let canonical_target = std::fs::canonicalize(expand(target_trimmed))
@@ -8493,18 +8490,6 @@ fn tool_get_summary(store: &GraphStore, args: Value) -> Result<Value, anyhow::Er
         "cached": from_cache,
         "summaries": text,
     }))
-}
-
-/// Expand a leading `~/` to the user's home directory. Returns the input
-/// unchanged when no expansion is possible.
-#[cfg(not(feature = "daemon"))]
-fn expand_tilde(input: &str) -> String {
-    if let Some(stripped) = input.strip_prefix("~/")
-        && let Ok(home) = std::env::var("HOME")
-    {
-        return format!("{home}/{stripped}");
-    }
-    input.to_string()
 }
 
 /// Shallow check: does the directory contain any `.md` file in its tree?

--- a/docs/guide/instance-config.md
+++ b/docs/guide/instance-config.md
@@ -114,6 +114,9 @@ model_id = "sentence-transformers/all-MiniLM-L6-v2"  # default for fresh DBs; th
 # cache_dir defaults to the platform-native cache directory:
 # ~/Library/Caches/nestweaver/models on macOS, $XDG_CACHE_HOME/nestweaver/models
 # (or ~/.cache/nestweaver/models) on Linux. Explicit values may use ~/.
+# If unavailable or non-UTF-8, a UTF-8 HOME uses ~/.cache first. The final
+# fallback is /var/cache/nestweaver/models on Unix or C:\ProgramData\nestweaver\models
+# on Windows; set cache_dir explicitly if that system location is not writable.
 # cache_dir = "~/Library/Caches/nestweaver/models"
 accelerator = "auto" # auto | metal | cpu
 
@@ -135,7 +138,7 @@ semantic_search_limit = 200    # top-k semantic hits fed into fusion
 | Field | Default | Description |
 |-------|---------|-------------|
 | `model_id` | `"sentence-transformers/all-MiniLM-L6-v2"` | Default local model for fresh DBs (any mean-pooled BERT-compatible HF model). The model a DB was embedded with is recorded and auto-loaded, overriding this. |
-| `cache_dir` | platform-native | Hugging Face cache root. Default: `~/Library/Caches/nestweaver/models` on macOS, `$XDG_CACHE_HOME/nestweaver/models` (or `~/.cache/nestweaver/models`) on Linux. An explicit leading `~/` is still expanded against the user's home directory. |
+| `cache_dir` | platform-native | Hugging Face cache root. Default: `~/Library/Caches/nestweaver/models` on macOS, `$XDG_CACHE_HOME/nestweaver/models` (or `~/.cache/nestweaver/models`) on Linux. If unavailable or non-UTF-8, a UTF-8 home supplies `~/.cache/nestweaver/models`; only then does it fall back to `/var/cache/nestweaver/models` on Unix or `C:\ProgramData\nestweaver\models` on Windows. Set `cache_dir` explicitly if the final system location is not writable. An explicit leading `~/` is expanded against the user's home directory. |
 | `accelerator` | `"auto"` | Local device policy; exact behavior is below. Ignored for an external backend. |
 | `external_endpoint` | — | Optional authoritative external embedding API endpoint |
 | `external_model` | — | Model name for the external endpoint |

--- a/docs/guide/instance-config.md
+++ b/docs/guide/instance-config.md
@@ -111,7 +111,10 @@ works.
 ```toml
 [embedding]
 model_id = "sentence-transformers/all-MiniLM-L6-v2"  # default for fresh DBs; the embedded model is recorded & auto-loaded
-cache_dir = "~/.cache/nestweaver/models"
+# cache_dir defaults to the platform-native cache directory:
+# ~/Library/Caches/nestweaver/models on macOS, $XDG_CACHE_HOME/nestweaver/models
+# (or ~/.cache/nestweaver/models) on Linux. Explicit values may use ~/.
+# cache_dir = "~/Library/Caches/nestweaver/models"
 accelerator = "auto" # auto | metal | cpu
 
 # Optional: use an authoritative external API instead of the local model.
@@ -132,7 +135,7 @@ semantic_search_limit = 200    # top-k semantic hits fed into fusion
 | Field | Default | Description |
 |-------|---------|-------------|
 | `model_id` | `"sentence-transformers/all-MiniLM-L6-v2"` | Default local model for fresh DBs (any mean-pooled BERT-compatible HF model). The model a DB was embedded with is recorded and auto-loaded, overriding this. |
-| `cache_dir` | `"~/.cache/nestweaver/models"` | Hugging Face cache root. The daemon expands a leading `~/` against its user's home directory. |
+| `cache_dir` | platform-native | Hugging Face cache root. Default: `~/Library/Caches/nestweaver/models` on macOS, `$XDG_CACHE_HOME/nestweaver/models` (or `~/.cache/nestweaver/models`) on Linux. An explicit leading `~/` is still expanded against the user's home directory. |
 | `accelerator` | `"auto"` | Local device policy; exact behavior is below. Ignored for an external backend. |
 | `external_endpoint` | — | Optional authoritative external embedding API endpoint |
 | `external_model` | — | Model name for the external endpoint |

--- a/examples/nestweaver-instance.toml
+++ b/examples/nestweaver-instance.toml
@@ -39,7 +39,11 @@ summary_model = "qwen2.5-coder:7b"
 # directly and never fall back to a local model.
 [embedding]
 model_id = "sentence-transformers/all-MiniLM-L6-v2"
-cache_dir = "~/.cache/nestweaver/models"
+# cache_dir defaults to the platform-native cache directory:
+# ~/Library/Caches/nestweaver/models on macOS, $XDG_CACHE_HOME/nestweaver/models
+# (or ~/.cache/nestweaver/models) on Linux. Uncomment to override; a leading ~/
+# in an explicit value is expanded at startup.
+# cache_dir = "~/.cache/nestweaver/models"
 # auto: Metal in a Metal-enabled build; CPU only when Metal is not compiled.
 #       A Metal failure is reported; auto does not retry on CPU.
 # metal: require compiled Metal plus successful device and full inference probes;

--- a/examples/nestweaver-instance.toml
+++ b/examples/nestweaver-instance.toml
@@ -43,6 +43,9 @@ model_id = "sentence-transformers/all-MiniLM-L6-v2"
 # ~/Library/Caches/nestweaver/models on macOS, $XDG_CACHE_HOME/nestweaver/models
 # (or ~/.cache/nestweaver/models) on Linux. Uncomment to override; a leading ~/
 # in an explicit value is expanded at startup.
+# If unavailable or non-UTF-8, a UTF-8 HOME uses ~/.cache first. The final
+# fallback is /var/cache/nestweaver/models on Unix or C:\ProgramData\nestweaver\models
+# on Windows; set cache_dir explicitly if that system location is not writable.
 # cache_dir = "~/.cache/nestweaver/models"
 # auto: Metal in a Metal-enabled build; CPU only when Metal is not compiled.
 #       A Metal failure is reported; auto does not retry on CPU.

--- a/src/main.rs
+++ b/src/main.rs
@@ -14290,6 +14290,16 @@ fn run_brain(
             // path. A naive `vault_uid` lookup misses these cases even
             // though `brain status` clearly shows the row.
             let path_matches = |stored: &str| -> bool {
+                if stored == "~" || stored.starts_with("~/") {
+                    let Ok(expanded) = nestweaver_engine::resolve_user_path(stored) else {
+                        return false;
+                    };
+                    if expanded.to_string_lossy() == *canon_str {
+                        return true;
+                    }
+                    return std::fs::canonicalize(&expanded)
+                        .is_ok_and(|path| path.to_string_lossy() == *canon_str);
+                }
                 if stored == canon_str || stored == raw_str {
                     return true;
                 }
@@ -14298,17 +14308,6 @@ fn run_brain(
                     .unwrap_or_else(|_| stored.to_string());
                 if stored_canon == *canon_str {
                     return true;
-                }
-                if stored.starts_with("~/") {
-                    let expanded = nestweaver_engine::resolve_user_path(stored);
-                    if expanded.to_string_lossy() == *canon_str {
-                        return true;
-                    }
-                    if let Ok(c) = std::fs::canonicalize(&expanded)
-                        && c.to_string_lossy() == *canon_str
-                    {
-                        return true;
-                    }
                 }
                 false
             };
@@ -21125,10 +21124,83 @@ mod embed_accelerator_cli_tests {
         // dirs::cache_dir() in-process, so no environment manipulation is
         // needed for determinism.
         let engine_default = nestweaver_engine::config::EmbeddingConfig::default().cache_dir;
-        let engine_resolved = nestweaver_engine::resolve_user_path(&engine_default);
+        let engine_resolved = nestweaver_engine::resolve_user_path(&engine_default)
+            .expect("default engine cache path must resolve");
         let embed_default = nestweaver_embed::EmbedConfig::default().cache_dir;
         let embed_resolved = std::path::absolute(&embed_default).unwrap_or(embed_default);
         assert_eq!(engine_resolved, embed_resolved);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_xdg_cache_home_keeps_engine_and_embed_defaults_identical() {
+        const CHILD_MARKER: &str = "NESTWEAVER_TEST_XDG_DEFAULT_CHILD";
+        const CHILD_SENTINEL: &str = "NESTWEAVER_XDG_DEFAULT_CHILD_OK";
+
+        if let Some(case) = std::env::var_os(CHILD_MARKER) {
+            let case = case.to_str().expect("child case marker must be UTF-8");
+            let engine_default = nestweaver_engine::config::EmbeddingConfig::default().cache_dir;
+            let engine_resolved = nestweaver_engine::resolve_user_path(&engine_default)
+                .expect("default engine cache path must resolve");
+            let embed_default = nestweaver_embed::EmbedConfig::default().cache_dir;
+            let embed_resolved = std::path::absolute(&embed_default).unwrap_or(embed_default);
+            assert_eq!(engine_resolved, embed_resolved);
+            let expected = match case {
+                "utf8" => std::path::PathBuf::from(
+                    std::env::var_os("XDG_CACHE_HOME").expect("child XDG cache root"),
+                )
+                .join("nestweaver")
+                .join("models"),
+                "non-utf8" => std::path::PathBuf::from(
+                    std::env::var_os("HOME").expect("child home directory"),
+                )
+                .join(".cache")
+                .join("nestweaver")
+                .join("models"),
+                other => panic!("unexpected child case: {other}"),
+            };
+            assert_eq!(engine_resolved, expected);
+            println!("{CHILD_SENTINEL}:{case}");
+            return;
+        }
+
+        // `dirs::cache_dir()` reads process-global environment. Re-run only
+        // this test in a child process so setting XDG_CACHE_HOME cannot race
+        // any other test. Exercise both the native UTF-8 path and the shared
+        // user-writable home fallback for a path InstanceConfig cannot
+        // represent.
+        use std::os::unix::ffi::OsStringExt;
+
+        let root = tempfile::tempdir().expect("XDG cache test tempdir");
+        let utf8_root = root.path().join("utf8-cache");
+        let non_utf8_root = root
+            .path()
+            .join(std::ffi::OsString::from_vec(b"cache-\xff".to_vec()));
+        for (case, xdg_root) in [("utf8", utf8_root), ("non-utf8", non_utf8_root)] {
+            let home = root.path().join(format!("home-{case}"));
+            let output = std::process::Command::new(
+                std::env::current_exe().expect("locate the current test binary"),
+            )
+            .arg("--exact")
+            .arg("embed_accelerator_cli_tests::linux_xdg_cache_home_keeps_engine_and_embed_defaults_identical")
+            .arg("--nocapture")
+            .env(CHILD_MARKER, case)
+            .env("XDG_CACHE_HOME", &xdg_root)
+            .env("HOME", &home)
+            .output()
+            .expect("run isolated XDG cache regression child");
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+
+            assert!(
+                output.status.success(),
+                "isolated XDG cache regression ({case}) failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            );
+            assert!(
+                stdout.contains(&format!("{CHILD_SENTINEL}:{case}")),
+                "isolated XDG child ({case}) did not execute the selected test:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            );
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -21117,6 +21117,21 @@ mod embed_accelerator_cli_tests {
     }
 
     #[test]
+    fn engine_and_embed_default_cache_dirs_resolve_identically() {
+        // Regression guard for the default-cache-dir divergence: the
+        // config-driven daemon default (`EmbeddingConfig::cache_dir`) and the
+        // `embed --local` default (`EmbedConfig::cache_dir`) must resolve to
+        // the same directory on every platform. Both sides consult
+        // dirs::cache_dir() in-process, so no environment manipulation is
+        // needed for determinism.
+        let engine_default = nestweaver_engine::config::EmbeddingConfig::default().cache_dir;
+        let engine_resolved = nestweaver_engine::resolve_user_path(&engine_default);
+        let embed_default = nestweaver_embed::EmbedConfig::default().cache_dir;
+        let embed_resolved = std::path::absolute(&embed_default).unwrap_or(embed_default);
+        assert_eq!(engine_resolved, embed_resolved);
+    }
+
+    #[test]
     fn external_metadata_uses_the_actual_default_api_model() {
         assert_eq!(
             external_embedding_model(None),

--- a/src/main.rs
+++ b/src/main.rs
@@ -14282,14 +14282,13 @@ fn run_brain(
             };
 
             // Helper: a stored vault matches the caller's path if any of its
-            // representations (canonical, literal, shell-expanded `~`)
+            // representations (canonical, literal, tilde-expanded `~`)
             // resolve to the same absolute path. `brain add` may have
             // registered the vault with a literal `~/...` string (from a
             // config file or programmatic call) while the caller of
             // `brain remove` typically passes a shell-expanded absolute
             // path. A naive `vault_uid` lookup misses these cases even
             // though `brain status` clearly shows the row.
-            let home = std::env::var("HOME").ok();
             let path_matches = |stored: &str| -> bool {
                 if stored == canon_str || stored == raw_str {
                     return true;
@@ -14300,9 +14299,9 @@ fn run_brain(
                 if stored_canon == *canon_str {
                     return true;
                 }
-                if let (Some(h), Some(rest)) = (home.as_deref(), stored.strip_prefix("~/")) {
-                    let expanded = format!("{h}/{rest}");
-                    if expanded == *canon_str {
+                if stored.starts_with("~/") {
+                    let expanded = nestweaver_engine::resolve_user_path(stored);
+                    if expanded.to_string_lossy() == *canon_str {
                         return true;
                     }
                     if let Ok(c) = std::fs::canonicalize(&expanded)


### PR DESCRIPTION
## Summary

- make direct local embedding and daemon configuration choose the same platform-native model cache
- expand configured user paths through one fallible resolver, rejecting empty or unexpandable paths instead of creating literal tilde or current-working-directory targets
- make local embedding startup diagnostics name the model and absolute cache directory while preserving degraded daemon availability
- detect complete models in the legacy cache and report an actionable migration hint only for typed missing-artifact failures
- keep external embedding backends independent of the unused local cache setting

## Why

The CLI and daemon previously derived their default cache locations differently. On macOS this could download a model successfully through direct embedding and then leave the daemon unable to find it. Literal tilde handling and relative fallbacks could also produce working-directory-dependent paths. Finally, the startup error lacked enough context to diagnose the mismatch.

This change gives both entry points the same deterministic cache policy, keeps daemon startup cache-only for local artifacts, and persists actionable failure details without preventing non-semantic service work.

## Behavior and compatibility

- Default selection is exact UTF-8 platform cache directory, then exact UTF-8 home/.cache, then a fixed absolute platform fallback.
- Local cache paths fail closed when empty, when tilde cannot be expanded, or when a relative path cannot be made absolute.
- A complete legacy ~/.cache model is detected but never moved or downloaded automatically.
- External endpoints bypass local cache resolution and retain their existing readiness probe.
- Existing explicit cache_dir values remain authoritative.

## Validation

- cargo fmt --all -- --check
- cargo clippy --locked --workspace --all-targets -- -D warnings
- cargo build --locked --tests
- cargo test --locked: 294 unit and integration tests passed; the macOS-only Metal suite was platform-gated on Linux
- focused resolver, daemon diagnostics, degraded health/status RPC, MCP empty-path, default parity, XDG fallback, and documentation-contract tests
- three independent adversarial review passes against the live staging diff

## Known limitations

1. There is no single macOS end-to-end test that runs default embed --local and then a default-config daemon. Coverage is compositional: cross-default equality, cache-only daemon fixtures, and the macOS Metal smoke workflow using an explicit shared cache.
2. Missing-model availability is tested through the real loader followed by direct health and typed status service calls, not by launching a complete socket-owning daemon process. This avoids the Candle Metal process-main-thread constraint in the Rust test harness.
3. The default algorithm is duplicated in engine and embed because embed is below engine in the dependency graph. Equality tests and keep-in-sync comments guard the contract.
4. If neither the native cache path nor HOME is UTF-8, the fixed system fallback may be unwritable. Documentation directs users to set an explicit cache_dir; the implementation does not silently fall back to a relative path.
5. No network at local startup means no Hugging Face or model-artifact fetch. An explicitly configured external endpoint retains its existing readiness probe.
6. Ready diagnostics omit cache_dir for external backends because that setting is unused; the model identifier remains logged.

## Integration notes

- Based on the current staging branch after the embedding metadata truth work.
- The diff does not modify embedding fingerprint stamping, checkpoint progress, or search guards.
- The Metal smoke workflow already uses one explicit cache for population and daemon startup, so no workflow change is required.
