### PR TITLE
fix(daemon): preserve and enforce effective config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### ⚠ BREAKING CHANGES
+
+* **daemon/config:** commands that explicitly pass `--config` now fail when a current-version, already-running daemon cannot prove the same canonical configured path (including compiled-default daemons and daemons using a different config). Previously these commands could exit successfully while silently ignoring the requested configuration. Use `nestweaver daemon --db <db> restart --config <path>` to apply a different configuration. A verified version-upgrade restart still applies the explicit config to its verified successor. Relative paths and symlinks remain accepted when they canonicalize to the daemon's configured path. Editing that file in place does not trigger a path mismatch, but the daemon must still be restarted to load the changed contents.
 
 ### Bug Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4126,6 +4126,7 @@ dependencies = [
  "hyper-util",
  "libc",
  "nestweaver-daemon",
+ "nestweaver-engine",
  "nestweaver-federation",
  "nestweaver-proto",
  "nestweaver-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4169,6 +4169,7 @@ dependencies = [
  "prost",
  "rmp-serde",
  "rustls",
+ "serde",
  "serde_json",
  "sha2 0.11.0",
  "subtle",

--- a/crates/nestweaver-client/Cargo.toml
+++ b/crates/nestweaver-client/Cargo.toml
@@ -7,6 +7,7 @@ description = "Client for NestWeaver daemon — auto-start, connect, call RPCs"
 
 [dependencies]
 nestweaver-schema = { workspace = true }
+nestweaver-engine = { workspace = true }
 nestweaver-proto = { workspace = true }
 nestweaver-daemon = { workspace = true }
 nestweaver-federation = { workspace = true }

--- a/crates/nestweaver-client/src/autostart.rs
+++ b/crates/nestweaver-client/src/autostart.rs
@@ -155,7 +155,7 @@ impl SpawnLock {
             .read(true)
             .write(true)
             .truncate(false)
-            .open(&spawn_lock_path)
+            .open(spawn_lock_path)
             .with_context(|| format!("failed to open spawn lock {}", spawn_lock_path.display()))?;
         if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
             bail!(

--- a/crates/nestweaver-client/src/autostart.rs
+++ b/crates/nestweaver-client/src/autostart.rs
@@ -67,6 +67,57 @@ impl Drop for SpawnLock {
     }
 }
 
+/// Exclusive proof that no daemon owns the current pidfile inode.
+///
+/// Used by an explicit cold `daemon restart` only after acquiring SpawnLock
+/// and rechecking the socket. Stale sidecar contents are deliberately not read.
+pub struct UnownedPidfileLock {
+    file: fs::File,
+    owns_lock: bool,
+}
+
+impl UnownedPidfileLock {
+    pub fn acquire(db_path: &Path) -> Result<Self> {
+        let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
+        let pidfile = nestweaver_daemon::lifecycle::pidfile_path(&instance_id);
+        if let Some(parent) = pidfile.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("create runtime dir: {}", parent.display()))?;
+        }
+        let mut options = fs::OpenOptions::new();
+        options.create(true).read(true).write(true).truncate(false);
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+        let file = options
+            .open(&pidfile)
+            .with_context(|| format!("open pidfile: {}", pidfile.display()))?;
+        anyhow::ensure!(
+            try_acquire_pidfile_lock(&file)?,
+            "daemon pidfile {} is still owned; refusing a cold restart over a live or shutting-down daemon",
+            pidfile.display()
+        );
+        Ok(Self {
+            file,
+            owns_lock: true,
+        })
+    }
+
+    pub fn release(&mut self) {
+        if self.owns_lock {
+            unsafe {
+                libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
+            }
+            self.owns_lock = false;
+        }
+    }
+}
+
+impl Drop for UnownedPidfileLock {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
 /// Attempt to own this exact pidfile inode. `true` is authoritative evidence
 /// that no daemon holds it, regardless of whether its numeric contents happen
 /// to name a live (recycled) process.

--- a/crates/nestweaver-client/src/autostart.rs
+++ b/crates/nestweaver-client/src/autostart.rs
@@ -2,12 +2,18 @@
 
 use std::fs;
 use std::io::Read;
-use std::os::unix::io::AsRawFd;
+use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
 use tracing::{debug, info, warn};
+
+/// Internal locked-FD handoff used only by a parent that owns [`SpawnLock`]
+/// across spawning `nestweaver daemon start`.
+pub const PARENT_SPAWN_LOCK_FD_ENV: &str = "NESTWEAVER_PARENT_SPAWN_LOCK_FD";
 
 /// Serializes daemon spawns for one runtime instance.
 ///
@@ -18,6 +24,7 @@ use tracing::{debug, info, warn};
 pub struct SpawnLock {
     file: fs::File,
     instance_id: String,
+    unlock_on_drop: AtomicBool,
 }
 
 impl SpawnLock {
@@ -34,6 +41,107 @@ impl SpawnLock {
         tokio::task::spawn_blocking(move || Self::acquire(&db_path))
             .await
             .context("spawn-lock acquisition task failed")?
+    }
+
+    /// Configure a child command to inherit a duplicate of this exact locked
+    /// file description across `exec`.
+    pub fn configure_child_handoff(&self, command: &mut std::process::Command) -> Result<()> {
+        let handoff = self
+            .file
+            .try_clone()
+            .context("duplicate locked spawnlock for child handoff")?;
+        let fd = handoff.as_raw_fd();
+        command.env(PARENT_SPAWN_LOCK_FD_ENV, fd.to_string());
+        // SAFETY: the pre-exec closure performs only async-signal-safe fcntl.
+        // Capturing `handoff` keeps the descriptor alive in the parent Command
+        // and in the forked child until exec; clearing CLOEXEC publishes it to
+        // the new `daemon start` process.
+        unsafe {
+            command.pre_exec(move || {
+                let _keep_handoff_alive = &handoff;
+                if libc::fcntl(fd, libc::F_SETFD, 0) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        // From this point onward the OS-managed lifetime of the shared open
+        // file description is authoritative. Explicit LOCK_UN in either the
+        // parent or child would unlock every duplicate prematurely.
+        self.unlock_on_drop.store(false, Ordering::Release);
+        Ok(())
+    }
+
+    /// Adopt the locked file description inherited from an owning parent.
+    /// Ambient FD numbers are untrusted: duplicate first, validate the
+    /// duplicate against the exact no-follow path, and close the original only
+    /// after validation succeeds.
+    pub fn inherit_parent_handoff(db_path: &Path, inherited_fd: RawFd) -> Result<Self> {
+        anyhow::ensure!(
+            inherited_fd >= 3,
+            "invalid inherited parent spawnlock FD {inherited_fd}"
+        );
+        let duplicated_fd = unsafe { libc::fcntl(inherited_fd, libc::F_DUPFD_CLOEXEC, 3) };
+        if duplicated_fd == -1 {
+            bail!(
+                "cannot duplicate inherited parent spawnlock FD {inherited_fd}: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+        // SAFETY: F_DUPFD_CLOEXEC returned a new descriptor owned here.
+        let inherited = unsafe { fs::File::from_raw_fd(duplicated_fd) };
+        let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
+        let pidfile = nestweaver_daemon::lifecycle::pidfile_path(&instance_id);
+        let spawn_lock_path = pidfile.with_extension("spawnlock");
+        let mut options = fs::OpenOptions::new();
+        options.read(true).write(true);
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+        let expected = options.open(&spawn_lock_path).with_context(|| {
+            format!(
+                "inherited parent spawnlock cannot be matched because {} cannot be opened",
+                spawn_lock_path.display()
+            )
+        })?;
+        let inherited_meta = inherited
+            .metadata()
+            .context("stat inherited parent spawnlock")?;
+        let expected_meta = expected
+            .metadata()
+            .with_context(|| format!("stat expected spawnlock {}", spawn_lock_path.display()))?;
+        use std::os::unix::fs::MetadataExt;
+        anyhow::ensure!(
+            inherited_meta.file_type().is_file(),
+            "inherited parent spawnlock FD is not a regular file"
+        );
+        anyhow::ensure!(
+            inherited_meta.dev() == expected_meta.dev()
+                && inherited_meta.ino() == expected_meta.ino(),
+            "inherited parent spawnlock FD does not identify {}",
+            spawn_lock_path.display()
+        );
+        anyhow::ensure!(
+            !try_acquire_pidfile_lock(&expected)?,
+            "inherited parent spawnlock {} is not locked",
+            spawn_lock_path.display()
+        );
+        let inherited_lock =
+            unsafe { libc::flock(inherited.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        anyhow::ensure!(
+            inherited_lock == 0,
+            "inherited parent spawnlock FD identifies the right file but does not carry the parent's locked open-file description"
+        );
+        unsafe {
+            libc::close(inherited_fd);
+        }
+        Ok(Self {
+            file: inherited,
+            instance_id,
+            // This lock belongs to the shared open-file description handed
+            // off by the parent. Closing our duplicate is sufficient; an
+            // explicit LOCK_UN would also unlock the parent's descriptor.
+            unlock_on_drop: AtomicBool::new(false),
+        })
     }
 
     fn acquire_at(instance_id: String, spawn_lock_path: &Path) -> Result<Self> {
@@ -55,14 +163,33 @@ impl SpawnLock {
                 std::io::Error::last_os_error()
             );
         }
-        Ok(Self { file, instance_id })
+        Ok(Self {
+            file,
+            instance_id,
+            unlock_on_drop: AtomicBool::new(true),
+        })
+    }
+
+    /// Close a fork-inherited descriptor without issuing `LOCK_UN`.
+    ///
+    /// `flock` state is shared by file-description copies across `fork`. The
+    /// daemonized child must close its duplicate while the launcher keeps the
+    /// same lock through readiness and provenance attestation; explicitly
+    /// unlocking here would prematurely release the launcher's lock too.
+    pub fn close_in_forked_child_without_unlock(self) {
+        let this = std::mem::ManuallyDrop::new(self);
+        unsafe {
+            libc::close(this.file.as_raw_fd());
+        }
     }
 }
 
 impl Drop for SpawnLock {
     fn drop(&mut self) {
-        unsafe {
-            libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
+        if self.unlock_on_drop.load(Ordering::Acquire) {
+            unsafe {
+                libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
+            }
         }
     }
 }
@@ -133,12 +260,94 @@ fn try_acquire_pidfile_lock(file: &fs::File) -> std::io::Result<bool> {
     }
 }
 
+fn requested_config_remedy(db_path: &Path, requested: &crate::RestartConfig) -> String {
+    format!(
+        "Run `nestweaver daemon --db {} restart --config {}` to apply the requested configuration",
+        db_path.display(),
+        requested
+            .as_path()
+            .expect("explicit config is always configured")
+            .display()
+    )
+}
+
+/// Attest an explicit config using the exact pidfile inode whose held flock
+/// the caller has already observed. This synchronous seam protects public
+/// `ensure_daemon*` callers that do not have a gRPC HealthCheck; the async
+/// `DaemonClient` path performs the stronger HealthCheck/instance attestation
+/// again before returning.
+fn attest_requested_config_on_held_pidfile(
+    db_path: &Path,
+    requested_path: &Path,
+    pidfile: &mut fs::File,
+) -> Result<()> {
+    let requested = crate::RestartConfig::for_cold_start(Some(requested_path))?;
+    let remedy = requested_config_remedy(db_path, &requested);
+    let pid = read_pid_from_file(pidfile).ok_or_else(|| {
+        anyhow::anyhow!(
+            "running daemon pidfile has no valid PID; effective config is unknown. {remedy}"
+        )
+    })?;
+    anyhow::ensure!(pid > 0, "running daemon pidfile PID is invalid; {remedy}");
+    let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
+    let binding = nestweaver_daemon::lifecycle::read_effective_config_binding_for_verified_pid(
+        &instance_id,
+        pid as u32,
+    )
+    .with_context(|| {
+        format!(
+            "cannot verify the running daemon's effective config; effective config is unknown. {remedy}"
+        )
+    })?;
+    let effective = crate::select_restart_config(None, || Ok(binding)).with_context(|| {
+        format!(
+            "cannot verify the running daemon's effective config; effective config is unknown. {remedy}"
+        )
+    })?;
+    if effective != requested {
+        let effective = match effective {
+            crate::RestartConfig::Configured(path) => path.display().to_string(),
+            crate::RestartConfig::CompiledDefaults => "compiled defaults".to_string(),
+        };
+        anyhow::bail!(
+            "explicit --config {} does not match the running daemon's effective config ({effective}). {remedy}",
+            requested.as_path().unwrap().display()
+        );
+    }
+    Ok(())
+}
+
+fn attest_requested_config_for_running_daemon(db_path: &Path, requested_path: &Path) -> Result<()> {
+    let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
+    let pidfile_path = nestweaver_daemon::lifecycle::pidfile_path(&instance_id);
+    let mut options = fs::OpenOptions::new();
+    options.read(true).write(true);
+    use std::os::unix::fs::OpenOptionsExt;
+    options.custom_flags(libc::O_NOFOLLOW);
+    let mut pidfile = options
+        .open(&pidfile_path)
+        .with_context(|| format!("open live daemon pidfile: {}", pidfile_path.display()))?;
+    anyhow::ensure!(
+        !try_acquire_pidfile_lock(&pidfile)?,
+        "daemon socket accepts connections but its pidfile is not owned; refusing to accept explicit --config"
+    );
+    attest_requested_config_on_held_pidfile(db_path, requested_path, &mut pidfile)
+}
+
 /// Ensure a daemon is running for the given DB and return the socket path.
 ///
 /// Acquires an exclusive flock on the pidfile, checks whether a live daemon
 /// already exists, and spawns one if not. Uses exponential-backoff polling
 /// to wait for the socket to accept connections.
 pub fn ensure_daemon(db_path: &Path, config_path: Option<&Path>) -> Result<PathBuf> {
+    ensure_daemon_impl(db_path, config_path, true)
+}
+
+fn ensure_daemon_impl(
+    db_path: &Path,
+    config_path: Option<&Path>,
+    attest_existing: bool,
+) -> Result<PathBuf> {
     let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
     let rt_dir = nestweaver_daemon::lifecycle::runtime_dir(&instance_id);
     let sock = nestweaver_daemon::lifecycle::socket_path(&instance_id);
@@ -168,6 +377,9 @@ pub fn ensure_daemon(db_path: &Path, config_path: Option<&Path>) -> Result<PathB
             }
             // The socket inode can appear before the listener is ready.
             wait_for_socket(&sock)?;
+            if attest_existing && let Some(config_path) = config_path {
+                attest_requested_config_on_held_pidfile(db_path, config_path, &mut file)?;
+            }
             return Ok(sock);
         }
         Ok(true) => {}
@@ -204,7 +416,7 @@ pub fn ensure_daemon(db_path: &Path, config_path: Option<&Path>) -> Result<PathB
     // Serialize concurrent auto-starts on a SEPARATE spawn-lock. The pidfile
     // flock had to be released above for the daemon to take it.
     let spawn_lock = SpawnLock::acquire(db_path)?;
-    ensure_daemon_with_spawn_lock(db_path, config_path, &spawn_lock)
+    ensure_daemon_with_spawn_lock_impl(db_path, config_path, &spawn_lock, attest_existing)
 }
 
 /// Async-safe wrapper around the synchronous pidfile/spawn/socket-readiness
@@ -213,6 +425,20 @@ pub async fn ensure_daemon_async(db_path: &Path, config_path: Option<&Path>) -> 
     let db_path = db_path.to_path_buf();
     let config_path = config_path.map(Path::to_path_buf);
     tokio::task::spawn_blocking(move || ensure_daemon(&db_path, config_path.as_deref()))
+        .await
+        .context("daemon ensure task failed")?
+}
+
+/// Preserve an explicit config as a possible spawn argument, but defer
+/// incumbent attestation until DaemonClient has checked its protocol version.
+/// This keeps the verified old-version upgrade path available.
+pub(crate) async fn ensure_daemon_for_client_async(
+    db_path: &Path,
+    config_path: Option<&Path>,
+) -> Result<PathBuf> {
+    let db_path = db_path.to_path_buf();
+    let config_path = config_path.map(Path::to_path_buf);
+    tokio::task::spawn_blocking(move || ensure_daemon_impl(&db_path, config_path.as_deref(), false))
         .await
         .context("daemon ensure task failed")?
 }
@@ -227,6 +453,15 @@ pub fn ensure_daemon_with_spawn_lock(
     config_path: Option<&Path>,
     spawn_lock: &SpawnLock,
 ) -> Result<PathBuf> {
+    ensure_daemon_with_spawn_lock_impl(db_path, config_path, spawn_lock, true)
+}
+
+fn ensure_daemon_with_spawn_lock_impl(
+    db_path: &Path,
+    config_path: Option<&Path>,
+    spawn_lock: &SpawnLock,
+    attest_existing: bool,
+) -> Result<PathBuf> {
     let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
     anyhow::ensure!(
         spawn_lock.instance_id == instance_id,
@@ -239,6 +474,9 @@ pub fn ensure_daemon_with_spawn_lock(
     // Re-check: another client may have started the daemon while we waited for the spawn-lock.
     if socket_accepts_connections(&sock) {
         debug!("daemon started by a concurrent client while awaiting spawn lock");
+        if attest_existing && let Some(config_path) = config_path {
+            attest_requested_config_for_running_daemon(db_path, config_path)?;
+        }
         return Ok(sock);
     }
 
@@ -249,7 +487,7 @@ pub fn ensure_daemon_with_spawn_lock(
     let stale_pid = read_pid(&pidfile);
 
     // Spawn the daemon as a detached child.
-    spawn_daemon(db_path, config_path)?;
+    spawn_daemon(db_path, config_path, spawn_lock)?;
 
     // Poll until the socket accepts connections, then release the spawn-lock so the next
     // waiter's re-check observes a ready daemon instead of spawning another.
@@ -316,12 +554,13 @@ fn daemon_start_command(
 }
 
 /// Spawn `nestweaver daemon --db <path> start [--config <path>]` as a detached child.
-fn spawn_daemon(db_path: &Path, config_path: Option<&Path>) -> Result<()> {
+fn spawn_daemon(db_path: &Path, config_path: Option<&Path>, spawn_lock: &SpawnLock) -> Result<()> {
     let exe = std::env::current_exe().context("failed to determine current executable path")?;
 
     debug!(exe = %exe.display(), db = %db_path.display(), "spawning daemon");
 
     let mut cmd = daemon_start_command(&exe, db_path, config_path);
+    spawn_lock.configure_child_handoff(&mut cmd)?;
     cmd.stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -523,12 +762,44 @@ fn wait_for_socket_watching(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+    use std::os::fd::IntoRawFd;
     use std::os::unix::net::{UnixListener, UnixStream};
+
+    fn write_valid_config(dir: &Path, name: &str, instance: &str) -> PathBuf {
+        let path = dir.join(name);
+        fs::write(
+            &path,
+            format!(
+                r#"instance_id = "{instance}"
+repos = []
+
+[snapshot_storage]
+backend = "local"
+path = "{}"
+
+[workspace]
+backend = "local"
+path = "{}"
+
+[inference]
+endpoint = "http://localhost:11434"
+embedding_model = "nomic-embed-text"
+summary_model = "qwen2.5-coder:7b"
+
+[git]
+credential_method = "gh"
+"#,
+                dir.join("snapshots").display(),
+                dir.join("workspace").display()
+            ),
+        )
+        .unwrap();
+        path
+    }
 
     #[test]
     fn acquired_pidfile_flock_makes_even_a_live_numeric_pid_stale() {
-        use std::io::Write;
-
         let dir = tempfile::tempdir().unwrap();
         let pidfile = dir.path().join("daemon.pid");
         let mut file = fs::OpenOptions::new()
@@ -554,6 +825,71 @@ mod tests {
     }
 
     #[test]
+    fn ensure_daemon_early_returns_reject_a_different_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        let configured = write_valid_config(dir.path(), "configured.toml", "configured");
+        let requested = write_valid_config(dir.path(), "requested.toml", "requested");
+        let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(&db);
+        let runtime = nestweaver_daemon::lifecycle::runtime_dir(&instance_id);
+        let pidfile_path = nestweaver_daemon::lifecycle::pidfile_path(&instance_id);
+        let socket = nestweaver_daemon::lifecycle::socket_path(&instance_id);
+        fs::create_dir_all(&runtime).unwrap();
+        let mut owner = fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(true)
+            .open(&pidfile_path)
+            .unwrap();
+        writeln!(owner, "{}", std::process::id()).unwrap();
+        assert_eq!(
+            unsafe { libc::flock(owner.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+            0
+        );
+        nestweaver_daemon::lifecycle::write_effective_config_binding(
+            &instance_id,
+            &nestweaver_daemon::lifecycle::EffectiveConfigBinding::new(
+                std::process::id(),
+                nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::Configured {
+                    path: fs::canonicalize(&configured)
+                        .unwrap()
+                        .to_str()
+                        .unwrap()
+                        .to_string(),
+                },
+            ),
+        )
+        .unwrap();
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = std::thread::spawn(move || {
+            for _ in 0..2 {
+                drop(listener.accept().unwrap());
+            }
+        });
+
+        let error = ensure_daemon(&db, Some(&requested)).unwrap_err();
+        let message = format!("{error:#}");
+        assert!(message.contains(configured.file_name().unwrap().to_str().unwrap()));
+        assert!(message.contains(requested.file_name().unwrap().to_str().unwrap()));
+        assert!(message.contains("restart --config"));
+
+        let spawn_lock = SpawnLock::acquire(&db).unwrap();
+        let error = ensure_daemon_with_spawn_lock(&db, Some(&requested), &spawn_lock).unwrap_err();
+        let message = format!("{error:#}");
+        assert!(message.contains(configured.file_name().unwrap().to_str().unwrap()));
+        assert!(message.contains(requested.file_name().unwrap().to_str().unwrap()));
+        assert!(message.contains("restart --config"));
+        drop(spawn_lock);
+
+        server.join().unwrap();
+        unsafe { libc::flock(owner.as_raw_fd(), libc::LOCK_UN) };
+        drop(owner);
+        let _ = fs::remove_file(&socket);
+        let _ = fs::remove_dir_all(&runtime);
+    }
+
+    #[test]
     fn spawn_lock_blocks_a_concurrent_configless_contender_until_release() {
         let dir = tempfile::tempdir().unwrap();
         let lock_path = dir.path().join("daemon.spawnlock");
@@ -575,6 +911,79 @@ mod tests {
         rx.recv_timeout(Duration::from_secs(2))
             .expect("contender should proceed after transaction releases spawn lock");
         contender.join().unwrap();
+    }
+
+    #[test]
+    fn inherited_fd_is_validated_and_keeps_lock_continuity() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        let parent = SpawnLock::acquire(&db).unwrap();
+        let inherited_fd = parent.file.try_clone().unwrap().into_raw_fd();
+        let child = SpawnLock::inherit_parent_handoff(&db, inherited_fd).unwrap();
+
+        // Parent death/close alone must not release the transaction; the
+        // adopted duplicate shares the same locked open-file description.
+        parent.close_in_forked_child_without_unlock();
+        let contender_db = db.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let contender = std::thread::spawn(move || {
+            let lock = SpawnLock::acquire(&contender_db).unwrap();
+            tx.send(()).unwrap();
+            drop(lock);
+        });
+        assert!(rx.recv_timeout(Duration::from_millis(150)).is_err());
+        drop(child);
+        rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        contender.join().unwrap();
+    }
+
+    #[test]
+    fn inherited_fd_rejects_missing_and_wrong_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        // Use a descriptor outside the process table rather than closing a
+        // low-numbered FD that another parallel test could immediately reuse.
+        let missing = RawFd::MAX;
+        let error = match SpawnLock::inherit_parent_handoff(&db, missing) {
+            Err(error) => error,
+            Ok(_) => panic!("closed inherited FD must be rejected"),
+        };
+        assert!(format!("{error:#}").contains("cannot duplicate"));
+
+        // Ensure the expected path exists, then supply a different regular
+        // file descriptor. Validation must reject it without closing the
+        // untrusted original descriptor.
+        drop(SpawnLock::acquire(&db).unwrap());
+        let wrong = fs::File::open("/dev/null").unwrap().into_raw_fd();
+        let error = match SpawnLock::inherit_parent_handoff(&db, wrong) {
+            Err(error) => error,
+            Ok(_) => panic!("wrong inherited file must be rejected"),
+        };
+        assert!(format!("{error:#}").contains("not a regular file"));
+        assert_ne!(unsafe { libc::fcntl(wrong, libc::F_GETFD) }, -1);
+        unsafe { libc::close(wrong) };
+
+        // The right inode is not sufficient: a separately opened descriptor
+        // does not carry the parent's flock/open-file-description identity.
+        let parent = SpawnLock::acquire(&db).unwrap();
+        let spawn_lock_path = nestweaver_daemon::lifecycle::pidfile_path(
+            &nestweaver_daemon::lifecycle::instance_id_from_db_path(&db),
+        )
+        .with_extension("spawnlock");
+        let separate = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(spawn_lock_path)
+            .unwrap()
+            .into_raw_fd();
+        let error = match SpawnLock::inherit_parent_handoff(&db, separate) {
+            Err(error) => error,
+            Ok(_) => panic!("separate unlocked description must not authenticate"),
+        };
+        assert!(format!("{error:#}").contains("does not carry"));
+        assert_ne!(unsafe { libc::fcntl(separate, libc::F_GETFD) }, -1);
+        unsafe { libc::close(separate) };
+        drop(parent);
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -644,11 +1053,15 @@ mod tests {
 
     #[test]
     fn daemon_start_command_forwards_db_and_config() {
-        let command = daemon_start_command(
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        let spawn_lock = SpawnLock::acquire(&db).unwrap();
+        let mut command = daemon_start_command(
             Path::new("/opt/nestweaver"),
-            Path::new("/tmp/brain.lbug"),
+            &db,
             Some(Path::new("/tmp/nestweaver-instance.toml")),
         );
+        spawn_lock.configure_child_handoff(&mut command).unwrap();
 
         let args = command
             .get_args()
@@ -659,13 +1072,22 @@ mod tests {
             [
                 "daemon",
                 "--db",
-                "/tmp/brain.lbug",
+                db.to_str().unwrap(),
                 "start",
                 "--config",
                 "/tmp/nestweaver-instance.toml",
             ]
             .map(std::ffi::OsString::from)
         );
+        let fd = command
+            .get_envs()
+            .find_map(|(name, value)| (name == PARENT_SPAWN_LOCK_FD_ENV).then_some(value.unwrap()))
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .parse::<RawFd>()
+            .unwrap();
+        assert!(fd >= 3);
     }
 
     /// nw-114: a daemon that has already exited must be reported immediately,

--- a/crates/nestweaver-client/src/autostart.rs
+++ b/crates/nestweaver-client/src/autostart.rs
@@ -9,6 +9,79 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, bail};
 use tracing::{debug, info, warn};
 
+/// Serializes daemon spawns for one runtime instance.
+///
+/// Version-mismatch restarts acquire this before shutdown and retain it until
+/// the replacement is ready, so a concurrent config-less caller cannot win
+/// the gap between the old daemon releasing its pidfile and the replacement
+/// publishing its socket.
+pub struct SpawnLock {
+    file: fs::File,
+    instance_id: String,
+}
+
+impl SpawnLock {
+    pub fn acquire(db_path: &Path) -> Result<Self> {
+        let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
+        let pidfile = nestweaver_daemon::lifecycle::pidfile_path(&instance_id);
+        let spawn_lock_path = pidfile.with_extension("spawnlock");
+        Self::acquire_at(instance_id, &spawn_lock_path)
+    }
+
+    /// Acquire the blocking OS flock without blocking a Tokio executor thread.
+    pub async fn acquire_async(db_path: &Path) -> Result<Self> {
+        let db_path = db_path.to_path_buf();
+        tokio::task::spawn_blocking(move || Self::acquire(&db_path))
+            .await
+            .context("spawn-lock acquisition task failed")?
+    }
+
+    fn acquire_at(instance_id: String, spawn_lock_path: &Path) -> Result<Self> {
+        if let Some(parent) = spawn_lock_path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create spawn lock directory {}", parent.display())
+            })?;
+        }
+        let file = fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&spawn_lock_path)
+            .with_context(|| format!("failed to open spawn lock {}", spawn_lock_path.display()))?;
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+            bail!(
+                "flock on spawn lock failed: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+        Ok(Self { file, instance_id })
+    }
+}
+
+impl Drop for SpawnLock {
+    fn drop(&mut self) {
+        unsafe {
+            libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+}
+
+/// Attempt to own this exact pidfile inode. `true` is authoritative evidence
+/// that no daemon holds it, regardless of whether its numeric contents happen
+/// to name a live (recycled) process.
+fn try_acquire_pidfile_lock(file: &fs::File) -> std::io::Result<bool> {
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+        return Ok(true);
+    }
+    let error = std::io::Error::last_os_error();
+    if error.kind() == std::io::ErrorKind::WouldBlock {
+        Ok(false)
+    } else {
+        Err(error)
+    }
+}
+
 /// Ensure a daemon is running for the given DB and return the socket path.
 ///
 /// Acquires an exclusive flock on the pidfile, checks whether a live daemon
@@ -36,10 +109,8 @@ pub fn ensure_daemon(db_path: &Path, config_path: Option<&Path>) -> Result<PathB
     // for its process lifetime, regardless of whether launchd, a foreground
     // child, or a non-macOS daemonized launcher created it.
     let fd = file.as_raw_fd();
-    let ret = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
-    if ret != 0 {
-        let err = std::io::Error::last_os_error();
-        if err.kind() == std::io::ErrorKind::WouldBlock {
+    match try_acquire_pidfile_lock(&file) {
+        Ok(false) => {
             // Lock held by the running daemon — it's alive.
             if let Some(pid) = read_pid_from_file(&mut file) {
                 debug!(pid, "daemon already running (lock held)");
@@ -48,19 +119,15 @@ pub fn ensure_daemon(db_path: &Path, config_path: Option<&Path>) -> Result<PathB
             wait_for_socket(&sock)?;
             return Ok(sock);
         }
-        bail!("flock on pidfile failed: {}", err);
+        Ok(true) => {}
+        Err(error) => bail!("flock on pidfile failed: {error}"),
     }
 
-    // We acquired the lock, so no daemon holds it. Check if a process
-    // from the pidfile is still alive (shouldn't be, but be safe).
+    // We acquired the lock, so no daemon owns this pidfile. Its numeric PID is
+    // stale even if the kernel has recycled that number for another live
+    // process; never mistake numeric liveness for daemon ownership.
     if let Some(pid) = read_pid_from_file(&mut file) {
-        if is_process_alive(pid) {
-            debug!(pid, "daemon already running");
-            unsafe { libc::flock(fd, libc::LOCK_UN) };
-            wait_for_socket(&sock)?;
-            return Ok(sock);
-        }
-        warn!(pid, "stale daemon pid — cleaning up");
+        warn!(pid, "unowned daemon pidfile is stale — cleaning up");
     }
 
     // Clean up stale socket if present.
@@ -83,30 +150,43 @@ pub fn ensure_daemon(db_path: &Path, config_path: Option<&Path>) -> Result<PathB
     unsafe { libc::flock(fd, libc::LOCK_UN) };
     drop(file);
 
-    // Serialize concurrent auto-starts on a SEPARATE spawn-lock. The pidfile flock had to be
-    // released above for the daemon to take it, which opens a window where a fleet of clients
-    // starting at once could each spawn a daemon (only the DB write-lock would then absorb the
-    // pile-up). Holding this blocking lock across spawn + socket-wait, with a re-check, means
-    // exactly one client spawns and the rest observe the started daemon. Acquired AFTER releasing
-    // the pidfile flock so the spawned daemon can take that flock (otherwise: deadlock).
-    let spawn_lock_path = pidfile.with_extension("spawnlock");
-    let spawn_lock = fs::OpenOptions::new()
-        .create(true)
-        .read(true)
-        .write(true)
-        .truncate(false)
-        .open(&spawn_lock_path)
-        .with_context(|| format!("failed to open spawn lock {}", spawn_lock_path.display()))?;
-    if unsafe { libc::flock(spawn_lock.as_raw_fd(), libc::LOCK_EX) } != 0 {
-        bail!(
-            "flock on spawn lock failed: {}",
-            std::io::Error::last_os_error()
-        );
-    }
+    // Serialize concurrent auto-starts on a SEPARATE spawn-lock. The pidfile
+    // flock had to be released above for the daemon to take it.
+    let spawn_lock = SpawnLock::acquire(db_path)?;
+    ensure_daemon_with_spawn_lock(db_path, config_path, &spawn_lock)
+}
+
+/// Async-safe wrapper around the synchronous pidfile/spawn/socket-readiness
+/// protocol. All filesystem flocks and polling sleeps run off the executor.
+pub async fn ensure_daemon_async(db_path: &Path, config_path: Option<&Path>) -> Result<PathBuf> {
+    let db_path = db_path.to_path_buf();
+    let config_path = config_path.map(Path::to_path_buf);
+    tokio::task::spawn_blocking(move || ensure_daemon(&db_path, config_path.as_deref()))
+        .await
+        .context("daemon ensure task failed")?
+}
+
+/// Start a daemon while the caller retains the instance's spawn lock.
+///
+/// This is the commit half of a version-mismatch restart. The caller acquires
+/// the guard before shutting down the old daemon and passes the same guard
+/// through replacement readiness.
+pub fn ensure_daemon_with_spawn_lock(
+    db_path: &Path,
+    config_path: Option<&Path>,
+    spawn_lock: &SpawnLock,
+) -> Result<PathBuf> {
+    let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
+    anyhow::ensure!(
+        spawn_lock.instance_id == instance_id,
+        "spawn lock belongs to daemon instance {}, not {instance_id}",
+        spawn_lock.instance_id
+    );
+    let sock = nestweaver_daemon::lifecycle::socket_path(&instance_id);
+    let pidfile = nestweaver_daemon::lifecycle::pidfile_path(&instance_id);
 
     // Re-check: another client may have started the daemon while we waited for the spawn-lock.
     if socket_accepts_connections(&sock) {
-        unsafe { libc::flock(spawn_lock.as_raw_fd(), libc::LOCK_UN) };
         debug!("daemon started by a concurrent client while awaiting spawn lock");
         return Ok(sock);
     }
@@ -127,11 +207,28 @@ pub fn ensure_daemon(db_path: &Path, config_path: Option<&Path>) -> Result<PathB
     // waiting on was just spawned by us, so a process that has already exited
     // means it will never bind and there is nothing to wait for.
     let waited = wait_for_socket_watching(&sock, Some(&pidfile), stale_pid);
-    unsafe { libc::flock(spawn_lock.as_raw_fd(), libc::LOCK_UN) };
     waited?;
 
     info!("daemon started, socket at {}", sock.display());
     Ok(sock)
+}
+
+/// Async-safe guarded spawn/readiness commit. The guard is moved into the
+/// blocking task and returned only after readiness, letting the async caller
+/// retain it through successor identity/config verification.
+pub async fn ensure_daemon_with_spawn_lock_async(
+    db_path: &Path,
+    config_path: Option<&Path>,
+    spawn_lock: SpawnLock,
+) -> Result<(PathBuf, SpawnLock)> {
+    let db_path = db_path.to_path_buf();
+    let config_path = config_path.map(Path::to_path_buf);
+    tokio::task::spawn_blocking(move || {
+        let socket = ensure_daemon_with_spawn_lock(&db_path, config_path.as_deref(), &spawn_lock)?;
+        Ok((socket, spawn_lock))
+    })
+    .await
+    .context("guarded daemon spawn/readiness task failed")?
 }
 
 /// Read a PID from an already-opened pidfile.
@@ -376,6 +473,107 @@ fn wait_for_socket_watching(
 mod tests {
     use super::*;
     use std::os::unix::net::{UnixListener, UnixStream};
+
+    #[test]
+    fn acquired_pidfile_flock_makes_even_a_live_numeric_pid_stale() {
+        use std::io::Write;
+
+        let dir = tempfile::tempdir().unwrap();
+        let pidfile = dir.path().join("daemon.pid");
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(true)
+            .open(&pidfile)
+            .unwrap();
+        write!(file, "{}", std::process::id()).unwrap();
+        assert!(is_process_alive(std::process::id() as i32));
+        assert!(
+            try_acquire_pidfile_lock(&file).unwrap(),
+            "acquiring the flock is authoritative: no daemon owns this pidfile"
+        );
+        assert_eq!(
+            read_pid_from_file(&mut file),
+            Some(std::process::id() as i32)
+        );
+        unsafe {
+            libc::flock(file.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+
+    #[test]
+    fn spawn_lock_blocks_a_concurrent_configless_contender_until_release() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("daemon.spawnlock");
+        let first = SpawnLock::acquire_at("same-instance".to_string(), &lock_path).unwrap();
+        let contender_path = lock_path.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let contender = std::thread::spawn(move || {
+            let second =
+                SpawnLock::acquire_at("same-instance".to_string(), &contender_path).unwrap();
+            tx.send(()).unwrap();
+            drop(second);
+        });
+
+        assert!(
+            rx.recv_timeout(Duration::from_millis(150)).is_err(),
+            "contender must remain blocked across shutdown and replacement spawn"
+        );
+        drop(first);
+        rx.recv_timeout(Duration::from_secs(2))
+            .expect("contender should proceed after transaction releases spawn lock");
+        contender.join().unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn async_spawn_lock_contention_does_not_block_current_thread_timer() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        let first = SpawnLock::acquire(&db).unwrap();
+        let release = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(75)).await;
+            drop(first);
+        });
+
+        let second = tokio::time::timeout(Duration::from_secs(2), SpawnLock::acquire_async(&db))
+            .await
+            .expect("timer-driven holder release must run on a current-thread runtime")
+            .unwrap();
+        release.await.unwrap();
+        drop(second);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn async_ensure_production_seam_allows_timer_driven_transaction_holder() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(&db);
+        let socket = nestweaver_daemon::lifecycle::socket_path(&instance_id);
+        let runtime = nestweaver_daemon::lifecycle::runtime_dir(&instance_id);
+        let transaction_lock = SpawnLock::acquire(&db).unwrap();
+        let holder_socket = socket.clone();
+        let holder = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            if let Some(parent) = holder_socket.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            let _ = fs::remove_file(&holder_socket);
+            let listener = UnixListener::bind(&holder_socket).unwrap();
+            drop(transaction_lock);
+            listener
+        });
+
+        let ensured = tokio::time::timeout(Duration::from_secs(3), ensure_daemon_async(&db, None))
+            .await
+            .expect("blocking spawn-lock wait must not prevent the holder's timer")
+            .unwrap();
+        assert_eq!(ensured, socket);
+        let listener = holder.await.unwrap();
+        drop(listener);
+        let _ = fs::remove_file(&socket);
+        let _ = fs::remove_dir_all(runtime);
+    }
 
     #[test]
     fn daemon_start_command_does_not_pin_fork_routing() {

--- a/crates/nestweaver-client/src/hybrid.rs
+++ b/crates/nestweaver-client/src/hybrid.rs
@@ -314,6 +314,10 @@ impl HybridClient {
                         if let (Some(local_obj), Some(server_obj)) =
                             (result.as_object_mut(), server.as_object())
                         {
+                            // Do not expose daemon config provenance through this
+                            // Combined JSON merge. A missing local key is backfilled
+                            // from upstream, which could falsely label the local
+                            // daemon with a remote server's effective config.
                             for (k, v) in server_obj {
                                 if k.starts_with('_') {
                                     continue;

--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -186,7 +186,7 @@ fn open_verified_live_pidfile_at(path: &Path, health_pid: u32) -> Result<fs::Fil
     use std::os::unix::fs::OpenOptionsExt;
     options.custom_flags(libc::O_NOFOLLOW);
     let mut file = options
-        .open(&path)
+        .open(path)
         .with_context(|| format!("open existing daemon pidfile {}", path.display()))?;
     let metadata = file
         .metadata()

--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -323,6 +323,116 @@ fn verify_replacement_evidence(
     Ok(())
 }
 
+fn restart_with_requested_config_remedy(db_path: &Path, requested: &RestartConfig) -> String {
+    let requested = requested
+        .as_path()
+        .expect("explicit requested config is always configured");
+    format!(
+        "Run `nestweaver daemon --db {} restart --config {}` to apply the requested configuration",
+        db_path.display(),
+        requested.display()
+    )
+}
+
+fn verify_requested_config_evidence(
+    db_path: &Path,
+    health: &nestweaver_proto::HealthCheckResponse,
+    requested: &RestartConfig,
+    binding: nestweaver_daemon::lifecycle::EffectiveConfigBinding,
+) -> Result<()> {
+    let expected_instance = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
+    anyhow::ensure!(
+        health.instance_id == expected_instance,
+        "running daemon instance {} does not match requested DB instance {expected_instance}; {}",
+        health.instance_id,
+        restart_with_requested_config_remedy(db_path, requested)
+    );
+    anyhow::ensure!(health.pid != 0, "running daemon HealthCheck returned PID 0");
+    anyhow::ensure!(
+        binding.pid == health.pid,
+        "running daemon binding PID {} does not match HealthCheck PID {}; {}",
+        binding.pid,
+        health.pid,
+        restart_with_requested_config_remedy(db_path, requested)
+    );
+    let effective = select_restart_config(None, || Ok(binding)).with_context(|| {
+        format!(
+            "cannot verify the running daemon's effective config for explicit --config {}; effective config is unknown. {}",
+            requested.as_path().unwrap().display(),
+            restart_with_requested_config_remedy(db_path, requested)
+        )
+    })?;
+    if &effective != requested {
+        let effective_description = match &effective {
+            RestartConfig::Configured(path) => path.display().to_string(),
+            RestartConfig::CompiledDefaults => "compiled defaults".to_string(),
+        };
+        anyhow::bail!(
+            "explicit --config {} does not match the running daemon's effective config ({effective_description}). {}",
+            requested.as_path().unwrap().display(),
+            restart_with_requested_config_remedy(db_path, requested)
+        );
+    }
+    Ok(())
+}
+
+fn verify_requested_config_with_health(
+    db_path: &Path,
+    health: &nestweaver_proto::HealthCheckResponse,
+    requested_path: &Path,
+) -> Result<()> {
+    let requested = RestartConfig::for_cold_start(Some(requested_path))?;
+    let remedy = restart_with_requested_config_remedy(db_path, &requested);
+    let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
+    let _pidfile = open_verified_live_pidfile(&instance_id, health.pid).with_context(|| {
+        format!(
+            "cannot prove ownership for the running daemon while enforcing explicit --config {}. {}",
+            requested.as_path().unwrap().display(),
+            restart_with_requested_config_remedy(db_path, &requested)
+        )
+    })?;
+    let binding = nestweaver_daemon::lifecycle::read_effective_config_binding_for_verified_pid(
+        &instance_id,
+        health.pid,
+    )
+    .with_context(|| {
+        format!(
+            "cannot verify the running daemon's effective config for explicit --config {}; effective config is unknown. {}",
+            requested.as_path().unwrap().display(),
+            restart_with_requested_config_remedy(db_path, &requested)
+        )
+    })?;
+    verify_requested_config_evidence(db_path, health, &requested, binding).with_context(|| {
+        format!(
+            "the running daemon did not accept explicit --config {}; {remedy}",
+            requested.as_path().unwrap().display()
+        )
+    })
+}
+
+/// Require an already-running daemon to prove that it is honoring an explicit
+/// caller config. Canonical path identity is the contract; valid edits at the
+/// same path do not require a restart.
+pub async fn verify_running_daemon_config(db_path: &Path, requested_path: &Path) -> Result<()> {
+    let requested = RestartConfig::for_cold_start(Some(requested_path))?;
+    let remedy = restart_with_requested_config_remedy(db_path, &requested);
+    let mut client = DaemonClient::connect_existing(db_path)
+        .await
+        .with_context(|| {
+            format!(
+                "cannot reach a healthy running daemon to verify explicit --config {}; effective config is unknown. {remedy}",
+                requested.as_path().unwrap().display()
+            )
+        })?;
+    let health = client.health_check().await.with_context(|| {
+        format!(
+            "cannot verify HealthCheck for explicit --config {}; effective config is unknown. {remedy}",
+            requested.as_path().unwrap().display()
+        )
+    })?;
+    verify_requested_config_with_health(db_path, &health, requested_path)
+}
+
 /// Connect to a replacement and require current-version runtime identity,
 /// pidfile ownership, and exact effective-config agreement before accepting it.
 pub async fn connect_verified_replacement(
@@ -358,7 +468,7 @@ impl DaemonClient {
     /// version doesn't match this binary's version, it asks the daemon to
     /// gracefully drain active writes and shut down, then restarts.
     pub async fn connect(db_path: &Path, config_path: Option<&Path>) -> Result<Self> {
-        let sock_path = autostart::ensure_daemon_async(db_path, config_path).await?;
+        let sock_path = autostart::ensure_daemon_for_client_async(db_path, config_path).await?;
         let mut client = Self::connect_to_socket(&sock_path).await?;
 
         // Version check. Bounded so a connected-but-unresponsive daemon can't hang connect().
@@ -463,6 +573,11 @@ impl DaemonClient {
             .await?;
 
             info!("reconnected after daemon restart");
+        } else if let Some(requested_config) = config_path {
+            // A current-version daemon is not restarted, so success is allowed
+            // only after proving that the explicit caller config is the same
+            // canonical path as the daemon's typed live provenance.
+            verify_requested_config_with_health(db_path, &resp, requested_config)?;
         }
 
         Ok(client)
@@ -938,6 +1053,93 @@ credential_method = "gh"
             RestartConfig::for_cold_start(Some(&missing)).is_err(),
             "an explicit cold config is validated even though stale sidecar provenance is ignored"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn explicit_config_identity_is_canonical_for_relative_and_symlink_paths() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir_in(".").unwrap();
+        let real = valid_config(&dir, "real.toml");
+        let link = dir.path().join("alias.toml");
+        symlink(fs::canonicalize(&real).unwrap(), &link).unwrap();
+        let relative = RestartConfig::for_cold_start(Some(&real)).unwrap();
+        let aliased = RestartConfig::for_cold_start(Some(&link)).unwrap();
+        assert_eq!(relative, aliased);
+        assert!(relative.as_path().unwrap().is_absolute());
+    }
+
+    #[test]
+    fn explicit_config_evidence_names_requested_and_effective_mismatch_states() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        let requested_path = fs::canonicalize(valid_config(&dir, "requested.toml")).unwrap();
+        let effective_path = fs::canonicalize(valid_config(&dir, "effective.toml")).unwrap();
+        let requested = RestartConfig::Configured(requested_path.clone());
+        let health = nestweaver_proto::HealthCheckResponse {
+            instance_id: nestweaver_daemon::lifecycle::instance_id_from_db_path(&db),
+            pid: 91,
+            ..Default::default()
+        };
+
+        let different = verify_requested_config_evidence(
+            &db,
+            &health,
+            &requested,
+            binding(
+                91,
+                nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::Configured {
+                    path: effective_path.to_str().unwrap().to_string(),
+                },
+            ),
+        )
+        .unwrap_err();
+        let message = format!("{different:#}");
+        assert!(
+            message.contains(requested_path.to_str().unwrap()),
+            "{message}"
+        );
+        assert!(
+            message.contains(effective_path.to_str().unwrap()),
+            "{message}"
+        );
+        assert!(message.contains("daemon --db"), "{message}");
+        assert!(message.contains("restart --config"), "{message}");
+
+        let defaults = verify_requested_config_evidence(
+            &db,
+            &health,
+            &requested,
+            binding(
+                91,
+                nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::CompiledDefaults,
+            ),
+        )
+        .unwrap_err();
+        assert!(format!("{defaults:#}").contains("compiled defaults"));
+
+        // Editing valid contents at the SAME canonical path does not change
+        // identity; path equality remains sufficient.
+        fs::write(
+            &requested_path,
+            fs::read_to_string(&requested_path)
+                .unwrap()
+                .replace("restart-test", "restart-test-edited"),
+        )
+        .unwrap();
+        verify_requested_config_evidence(
+            &db,
+            &health,
+            &requested,
+            binding(
+                91,
+                nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::Configured {
+                    path: requested_path.to_str().unwrap().to_string(),
+                },
+            ),
+        )
+        .unwrap();
     }
 
     #[test]

--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -11,6 +11,8 @@ pub mod repo_identity;
 // existing callers (main binary, e2e tests).
 pub use nestweaver_federation::{dedup, discovery, merge, routing, upstream};
 
+use std::fs;
+use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -30,6 +32,316 @@ pub struct DaemonClient {
     inner: NestWeaverDaemonClient<Channel>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RestartConfig {
+    Configured(PathBuf),
+    CompiledDefaults,
+}
+
+impl RestartConfig {
+    pub fn as_path(&self) -> Option<&Path> {
+        match self {
+            Self::Configured(path) => Some(path),
+            Self::CompiledDefaults => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct PreparedRestart {
+    config: RestartConfig,
+    daemon_pid: u32,
+    /// The exact inode whose held flock and contents were cross-checked with
+    /// HealthCheck during PREPARE. COMMIT never reopens or rereads the path.
+    pidfile: fs::File,
+    owns_pidfile_lock: bool,
+}
+
+impl PreparedRestart {
+    pub fn config(&self) -> &RestartConfig {
+        &self.config
+    }
+
+    pub async fn wait_for_owner_release(&mut self) -> Result<()> {
+        let ceiling = nestweaver_schema::drain_ceiling_from_env();
+        self.wait_for_owner_release_for(std::time::Duration::from_secs(ceiling.saturating_add(5)))
+            .await
+    }
+
+    async fn wait_for_owner_release_for(&mut self, timeout: std::time::Duration) -> Result<()> {
+        let deadline = std::time::Instant::now() + timeout;
+
+        while std::time::Instant::now() < deadline {
+            if try_acquire_pidfile_lock(&self.pidfile)? {
+                self.owns_pidfile_lock = true;
+                return Ok(());
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
+        anyhow::bail!(
+            "daemon PID {} did not release its captured pidfile lock within {:.1}s; refusing to signal an uncertain PID or spawn a replacement. Stop the daemon manually, verify its identity, and retry",
+            self.daemon_pid,
+            timeout.as_secs_f64()
+        )
+    }
+
+    /// Release the old owner's now-acquired pidfile lock immediately before a
+    /// guarded replacement spawn. The caller must still hold [`autostart::SpawnLock`].
+    pub fn release_pidfile_lock(&mut self) {
+        if self.owns_pidfile_lock {
+            unsafe {
+                libc::flock(self.pidfile.as_raw_fd(), libc::LOCK_UN);
+            }
+            self.owns_pidfile_lock = false;
+        }
+    }
+}
+
+impl Drop for PreparedRestart {
+    fn drop(&mut self) {
+        self.release_pidfile_lock();
+    }
+}
+
+fn try_acquire_pidfile_lock(file: &fs::File) -> Result<bool> {
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+        return Ok(true);
+    }
+    let error = std::io::Error::last_os_error();
+    if error.kind() == std::io::ErrorKind::WouldBlock {
+        Ok(false)
+    } else {
+        Err(error).context("check captured daemon pidfile lock")
+    }
+}
+
+fn validate_restart_config(path: &Path) -> Result<PathBuf> {
+    let canonical = fs::canonicalize(path)
+        .with_context(|| format!("failed to canonicalize --config {}", path.display()))?;
+    anyhow::ensure!(
+        canonical.to_str().is_some(),
+        "canonical --config path is not valid UTF-8: {}",
+        canonical.display()
+    );
+    nestweaver_engine::InstanceConfig::from_file(&canonical)
+        .with_context(|| format!("invalid --config {}", canonical.display()))?;
+    Ok(canonical)
+}
+
+fn select_restart_config(
+    explicit_config: Option<&Path>,
+    binding: impl FnOnce() -> Result<
+        nestweaver_daemon::lifecycle::EffectiveConfigBinding,
+        nestweaver_daemon::lifecycle::EffectiveConfigBindingError,
+    >,
+) -> Result<RestartConfig> {
+    if let Some(path) = explicit_config {
+        return validate_restart_config(path).map(RestartConfig::Configured);
+    }
+
+    let binding = binding().context("read live daemon effective-config binding")?;
+    match binding.effective_config {
+        nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::Configured { path } => {
+            anyhow::ensure!(
+                !path.is_empty(),
+                "live daemon binding contains an empty config path"
+            );
+            let recorded = PathBuf::from(&path);
+            anyhow::ensure!(
+                recorded.is_absolute(),
+                "live daemon binding contains a non-absolute config path: {path}"
+            );
+            let canonical = validate_restart_config(&recorded)?;
+            anyhow::ensure!(
+                canonical == recorded,
+                "live daemon binding config path is not canonical: {}",
+                recorded.display()
+            );
+            Ok(RestartConfig::Configured(canonical))
+        }
+        nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::CompiledDefaults => {
+            Ok(RestartConfig::CompiledDefaults)
+        }
+    }
+}
+
+fn open_verified_live_pidfile(instance_id: &str, health_pid: u32) -> Result<fs::File> {
+    let path = nestweaver_daemon::lifecycle::pidfile_path(instance_id);
+    open_verified_live_pidfile_at(&path, health_pid)
+}
+
+fn open_verified_live_pidfile_at(path: &Path, health_pid: u32) -> Result<fs::File> {
+    anyhow::ensure!(health_pid != 0, "daemon HealthCheck returned PID 0");
+    let mut options = fs::OpenOptions::new();
+    options.read(true).write(true);
+    use std::os::unix::fs::OpenOptionsExt;
+    options.custom_flags(libc::O_NOFOLLOW);
+    let mut file = options
+        .open(&path)
+        .with_context(|| format!("open existing daemon pidfile {}", path.display()))?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("inspect daemon pidfile {}", path.display()))?;
+    anyhow::ensure!(
+        metadata.file_type().is_file(),
+        "daemon pidfile is not a regular file: {}",
+        path.display()
+    );
+
+    if try_acquire_pidfile_lock(&file)? {
+        unsafe {
+            libc::flock(file.as_raw_fd(), libc::LOCK_UN);
+        }
+        anyhow::bail!(
+            "daemon pidfile lock is not held at {}; the HealthCheck identity is no longer live",
+            path.display()
+        );
+    }
+
+    use std::io::{Read, Seek};
+    file.seek(std::io::SeekFrom::Start(0))?;
+    let mut contents = String::new();
+    file.by_ref().take(64).read_to_string(&mut contents)?;
+    let pidfile_pid = contents.trim().parse::<u32>().with_context(|| {
+        format!(
+            "daemon pidfile {} does not contain a valid PID",
+            path.display()
+        )
+    })?;
+    anyhow::ensure!(
+        pidfile_pid == health_pid,
+        "daemon pidfile PID {pidfile_pid} does not match HealthCheck PID {health_pid}"
+    );
+    Ok(file)
+}
+
+/// Capture trustworthy live daemon ownership and configuration before any
+/// shutdown request. Callers must not shut down when this returns an error.
+pub fn prepare_restart(
+    db_path: &Path,
+    health: &nestweaver_proto::HealthCheckResponse,
+    explicit_config: Option<&Path>,
+) -> Result<PreparedRestart> {
+    let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
+    let prepared = (|| {
+        anyhow::ensure!(
+            health.instance_id == instance_id,
+            "daemon HealthCheck instance {} does not match requested instance {instance_id}",
+            health.instance_id
+        );
+        let pidfile = open_verified_live_pidfile(&instance_id, health.pid)?;
+        let config = select_restart_config(explicit_config, || {
+            nestweaver_daemon::lifecycle::read_effective_config_binding_for_verified_pid(
+                &instance_id,
+                health.pid,
+            )
+        })?;
+        Ok(PreparedRestart {
+            config,
+            daemon_pid: health.pid,
+            pidfile,
+            owns_pidfile_lock: false,
+        })
+    })();
+
+    restart_prepare_result(db_path, prepared)
+}
+
+fn restart_prepare_result<T>(db_path: &Path, prepared: Result<T>) -> Result<T> {
+    prepared.with_context(|| {
+        format!(
+            "refusing automatic daemon restart because its live configuration and ownership could not be verified. \
+             The daemon has not been shut down. Re-run this command with --config <path>, or restart it manually \
+             with `nestweaver daemon --db {} restart --config <path>`",
+            db_path.display()
+        )
+    })
+}
+
+/// Transaction gate shared by production and ordering tests. Neither callback
+/// runs when PREPARE fails, and COMMIT cannot run unless Shutdown was accepted.
+async fn run_prepared_restart<T, Shutdown, ShutdownFuture, Commit, CommitFuture>(
+    prepared: Result<PreparedRestart>,
+    shutdown: Shutdown,
+    commit: Commit,
+) -> Result<T>
+where
+    Shutdown: FnOnce() -> ShutdownFuture,
+    ShutdownFuture: std::future::Future<Output = Result<bool>>,
+    Commit: FnOnce(PreparedRestart) -> CommitFuture,
+    CommitFuture: std::future::Future<Output = Result<T>>,
+{
+    let prepared = prepared?;
+    anyhow::ensure!(
+        shutdown().await?,
+        "daemon rejected shutdown; refusing to spawn a replacement"
+    );
+    commit(prepared).await
+}
+
+fn verify_replacement_evidence(
+    expected_instance_id: &str,
+    health: &nestweaver_proto::HealthCheckResponse,
+    expected_config: &RestartConfig,
+    binding: nestweaver_daemon::lifecycle::EffectiveConfigBinding,
+) -> Result<()> {
+    anyhow::ensure!(
+        health.version == env!("CARGO_PKG_VERSION"),
+        "replacement daemon version {} does not match client version {}",
+        health.version,
+        env!("CARGO_PKG_VERSION")
+    );
+    anyhow::ensure!(
+        health.instance_id == expected_instance_id,
+        "replacement daemon instance {} does not match expected instance {expected_instance_id}",
+        health.instance_id
+    );
+    anyhow::ensure!(
+        health.pid != 0,
+        "replacement daemon HealthCheck returned PID 0"
+    );
+    anyhow::ensure!(
+        binding.pid == health.pid,
+        "replacement effective-config binding PID {} does not match HealthCheck PID {}",
+        binding.pid,
+        health.pid
+    );
+    let actual_config = select_restart_config(None, || Ok(binding))?;
+    anyhow::ensure!(
+        &actual_config == expected_config,
+        "replacement daemon effective config {actual_config:?} does not match captured restart config {expected_config:?}"
+    );
+    Ok(())
+}
+
+/// Connect to a replacement and require current-version runtime identity,
+/// pidfile ownership, and exact effective-config agreement before accepting it.
+pub async fn connect_verified_replacement(
+    sock_path: &PathBuf,
+    db_path: &Path,
+    expected_config: &RestartConfig,
+) -> Result<DaemonClient> {
+    let mut client = DaemonClient::connect_to_socket(sock_path).await?;
+    let health = client.health_check().await?;
+    let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
+    // Hold the exact verified pidfile inode open until the sidecar and all
+    // post-spawn evidence have been checked.
+    let _pidfile = open_verified_live_pidfile(&instance_id, health.pid)?;
+    let binding = nestweaver_daemon::lifecycle::read_effective_config_binding_for_verified_pid(
+        &instance_id,
+        health.pid,
+    )?;
+    verify_replacement_evidence(&instance_id, &health, expected_config, binding).with_context(
+        || {
+            format!(
+                "replacement daemon at {} failed identity/config verification; stop it manually before retrying",
+                sock_path.display()
+            )
+        },
+    )?;
+    Ok(client)
+}
+
 impl DaemonClient {
     /// Connect to the daemon for the given database, auto-starting if needed.
     ///
@@ -37,7 +349,7 @@ impl DaemonClient {
     /// version doesn't match this binary's version, it asks the daemon to
     /// gracefully drain active writes and shut down, then restarts.
     pub async fn connect(db_path: &Path, config_path: Option<&Path>) -> Result<Self> {
-        let sock_path = autostart::ensure_daemon(db_path, config_path)?;
+        let sock_path = autostart::ensure_daemon_async(db_path, config_path).await?;
         let mut client = Self::connect_to_socket(&sock_path).await?;
 
         // Version check. Bounded so a connected-but-unresponsive daemon can't hang connect().
@@ -60,18 +372,86 @@ impl DaemonClient {
                 "version mismatch — requesting graceful daemon restart"
             );
 
-            // Ask the daemon to drain active writes and shut down.
-            let _ = client
-                .inner
-                .shutdown(nestweaver_proto::ShutdownRequest {})
-                .await;
+            // Capture the ORIGINAL daemon's trustworthy plan before waiting
+            // for the transaction lock. A concurrent/manual winner must later
+            // prove continuity with this plan; its own provenance can never be
+            // treated as the expectation.
+            let original_prepared = prepare_restart(db_path, &resp, config_path)?;
+            let expected_config = original_prepared.config.clone();
 
-            // Wait for the daemon process to exit.
-            Self::wait_for_exit(db_path).await?;
+            // PREPARE -> COMMIT. Retain the instance spawn lock through
+            // replacement verification. If another client completed the
+            // upgrade while we waited, verify it against the original plan.
+            let spawn_lock = autostart::SpawnLock::acquire_async(db_path).await?;
+            client = Self::connect_to_socket(&sock_path)
+                .await
+                .context("reconnect to daemon after acquiring restart spawn lock")?;
+            let locked_health = client.health_check().await.context(
+                "refusing automatic daemon restart: could not revalidate the live daemon after acquiring the spawn lock; no shutdown was requested",
+            )?;
+            if locked_health.version == our_version {
+                let verified = connect_verified_replacement(
+                    &sock_path,
+                    db_path,
+                    &expected_config,
+                )
+                .await
+                .context(
+                    "current-version daemon that won the restart race did not preserve the original effective config",
+                )?;
+                info!("another client completed and verified the daemon upgrade");
+                return Ok(verified);
+            }
+            let prepared = prepare_restart(db_path, &locked_health, config_path).and_then(|value| {
+                anyhow::ensure!(
+                    value.config == expected_config,
+                    "daemon effective config changed while waiting for the restart transaction lock; refusing shutdown"
+                );
+                Ok(value)
+            });
+            drop(original_prepared);
+            client = run_prepared_restart(
+                prepared,
+                || async {
+                    let shutdown = client
+                        .inner
+                        .shutdown(nestweaver_proto::ShutdownRequest {})
+                        .await
+                        .context("daemon shutdown request failed; refusing to spawn a replacement")?
+                        .into_inner();
+                    Ok(shutdown.ok)
+                },
+                |mut prepared| async move {
+                    // Wait on the already-open inode whose lock and PID were
+                    // verified during PREPARE. Never reread the path or signal
+                    // a successor.
+                    prepared.wait_for_owner_release().await?;
 
-            // Re-start and reconnect.
-            let sock_path = autostart::ensure_daemon(db_path, config_path)?;
-            client = Self::connect_to_socket(&sock_path).await?;
+                    // The old owner is gone and we hold its inode lock. A
+                    // stale socket cannot belong to a successor because the
+                    // spawn lock has covered the whole transaction.
+                    let stale_socket = nestweaver_daemon::lifecycle::socket_path(
+                        &nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path),
+                    );
+                    let _ = fs::remove_file(stale_socket);
+                    prepared.release_pidfile_lock();
+
+                    // Re-start from the captured owned decision; the sidecar
+                    // is never read again after the old daemon dies.
+                    let restart_config = prepared.config.clone();
+                    let (sock_path, spawn_lock) = autostart::ensure_daemon_with_spawn_lock_async(
+                        db_path,
+                        restart_config.as_path(),
+                        spawn_lock,
+                    )
+                    .await?;
+                    let verified =
+                        connect_verified_replacement(&sock_path, db_path, &restart_config).await;
+                    drop(spawn_lock);
+                    verified
+                },
+            )
+            .await?;
 
             info!("reconnected after daemon restart");
         }
@@ -116,48 +496,6 @@ impl DaemonClient {
                 .max_decoding_message_size(256 * 1024 * 1024)
                 .max_encoding_message_size(256 * 1024 * 1024),
         })
-    }
-
-    /// Wait for the daemon to exit after a Shutdown RPC was sent.
-    /// Falls back to SIGKILL after the drain ceiling + buffer. Async so the drain wait
-    /// (up to the drain ceiling) yields the tokio worker instead of blocking it.
-    async fn wait_for_exit(db_path: &Path) -> Result<()> {
-        let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
-        let pidfile = nestweaver_daemon::lifecycle::pidfile_path(&instance_id);
-
-        let ceiling = nestweaver_schema::drain_ceiling_from_env();
-
-        let start = std::time::Instant::now();
-        let timeout = std::time::Duration::from_secs(ceiling + 5);
-
-        while start.elapsed() < timeout {
-            match autostart::read_pid(&pidfile) {
-                Some(pid) if autostart::is_process_alive(pid) => {
-                    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-                }
-                _ => break,
-            }
-        }
-
-        // If still alive after ceiling + buffer, force kill.
-        if let Some(pid) = autostart::read_pid(&pidfile)
-            && autostart::is_process_alive(pid)
-        {
-            warn!(
-                pid,
-                ceiling, "daemon did not exit after drain timeout — sending SIGKILL"
-            );
-            unsafe { libc::kill(pid, libc::SIGKILL) };
-            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-        }
-
-        // Clean up socket.
-        let sock = nestweaver_daemon::lifecycle::socket_path(&instance_id);
-        if sock.exists() {
-            let _ = std::fs::remove_file(&sock);
-        }
-
-        Ok(())
     }
 
     /// Returns a mutable reference to the underlying gRPC client.
@@ -475,6 +813,482 @@ impl DaemonClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn valid_config(dir: &tempfile::TempDir, name: &str) -> PathBuf {
+        let path = dir.path().join(name);
+        fs::write(
+            &path,
+            format!(
+                r#"
+instance_id = "restart-test"
+repos = []
+
+[snapshot_storage]
+backend = "local"
+path = "{}"
+
+[workspace]
+backend = "local"
+path = "{}"
+
+[inference]
+endpoint = "http://localhost:11434"
+embedding_model = "nomic-embed-text"
+summary_model = "qwen2.5-coder:7b"
+
+[git]
+credential_method = "gh"
+"#,
+                dir.path().join("snapshots").display(),
+                dir.path().join("workspace").display()
+            ),
+        )
+        .unwrap();
+        path
+    }
+
+    fn binding(
+        pid: u32,
+        effective_config: nestweaver_daemon::lifecycle::EffectiveConfigBindingSource,
+    ) -> nestweaver_daemon::lifecycle::EffectiveConfigBinding {
+        nestweaver_daemon::lifecycle::EffectiveConfigBinding::new(pid, effective_config)
+    }
+
+    #[test]
+    fn explicit_config_precedes_even_absent_or_corrupt_live_binding() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = valid_config(&dir, "explicit.toml");
+        let mut binding_reads = 0;
+        let selected = select_restart_config(Some(&config), || {
+            binding_reads += 1;
+            unreachable!("an explicit config must bypass the live binding")
+        })
+        .unwrap();
+
+        assert_eq!(binding_reads, 0);
+        assert_eq!(
+            selected,
+            RestartConfig::Configured(fs::canonicalize(config).unwrap())
+        );
+    }
+
+    #[test]
+    fn explicit_config_must_be_parse_valid_before_shutdown() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("invalid.toml");
+        fs::write(&config, "not = [valid").unwrap();
+        let error = select_restart_config(Some(&config), || unreachable!()).unwrap_err();
+        assert!(
+            format!("{error:#}").contains("invalid --config"),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[test]
+    fn configured_and_compiled_default_bindings_become_owned_restart_args() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = valid_config(&dir, "bound.toml");
+        let canonical = fs::canonicalize(&config).unwrap();
+        let configured = select_restart_config(None, || {
+            Ok(binding(
+                7,
+                nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::Configured {
+                    path: canonical.to_str().unwrap().to_string(),
+                },
+            ))
+        })
+        .unwrap();
+        let defaults = select_restart_config(None, || {
+            Ok(binding(
+                7,
+                nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::CompiledDefaults,
+            ))
+        })
+        .unwrap();
+
+        assert_eq!(configured.as_path(), Some(canonical.as_path()));
+        assert_eq!(defaults.as_path(), None);
+    }
+
+    #[test]
+    fn captured_restart_config_does_not_reread_binding_after_shutdown() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = valid_config(&dir, "captured.toml");
+        let canonical = fs::canonicalize(config).unwrap();
+        let sidecar_marker = dir.path().join("effective-config.json");
+        fs::write(&sidecar_marker, "present").unwrap();
+        let selected = select_restart_config(None, || {
+            assert!(sidecar_marker.exists());
+            Ok(binding(
+                9,
+                nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::Configured {
+                    path: canonical.to_str().unwrap().to_string(),
+                },
+            ))
+        })
+        .unwrap();
+
+        fs::remove_file(sidecar_marker).unwrap();
+        assert_eq!(selected.as_path(), Some(canonical.as_path()));
+    }
+
+    #[test]
+    fn every_untrusted_binding_error_refuses_with_manual_restart_remedy() {
+        use nestweaver_daemon::lifecycle::EffectiveConfigBindingError as E;
+        let path = PathBuf::from("/tmp/effective-config.json");
+        let errors = vec![
+            E::Absent { path: path.clone() },
+            E::Read {
+                path: path.clone(),
+                source: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied"),
+            },
+            E::Corrupt {
+                path: path.clone(),
+                source:
+                    serde_json::from_str::<nestweaver_daemon::lifecycle::EffectiveConfigBinding>(
+                        "{",
+                    )
+                    .unwrap_err(),
+            },
+            E::Unsafe {
+                path: path.clone(),
+                reason: "unsafe owner".to_string(),
+            },
+            E::TooLarge {
+                path: path.clone(),
+                size: 65_537,
+                max: 65_536,
+            },
+            E::UnsupportedVersion {
+                path: path.clone(),
+                found: 99,
+                supported: 1,
+            },
+            E::PidMismatch {
+                path: path.clone(),
+                expected: 8,
+                found: 7,
+            },
+        ];
+
+        for binding_error in errors {
+            let prepare = select_restart_config(None, || Err(binding_error));
+            let mut shutdown_calls = 0;
+            let refused = restart_prepare_result(Path::new("/tmp/brain.lbug"), prepare)
+                .map(|_| shutdown_calls += 1)
+                .unwrap_err();
+            let message = format!("{refused:#}");
+            assert_eq!(shutdown_calls, 0, "PREPARE failure must precede shutdown");
+            assert!(
+                message.contains("daemon has not been shut down"),
+                "{message}"
+            );
+            assert!(message.contains("--config <path>"), "{message}");
+        }
+    }
+
+    #[test]
+    fn unknown_binding_provenance_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let error = select_restart_config(None, || {
+            Ok(binding(
+                3,
+                nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::Configured {
+                    path: String::new(),
+                },
+            ))
+        })
+        .unwrap_err();
+        assert!(format!("{error:#}").contains("empty config path"));
+
+        let missing = dir.path().join("old-daemon-had-no-sidecar");
+        let old_daemon = restart_prepare_result::<RestartConfig>(
+            Path::new("/tmp/brain.lbug"),
+            Err(
+                nestweaver_daemon::lifecycle::EffectiveConfigBindingError::Absent { path: missing }
+                    .into(),
+            ),
+        )
+        .unwrap_err();
+        assert!(format!("{old_daemon:#}").contains("restart it manually"));
+    }
+
+    #[test]
+    fn prepare_requires_held_same_inode_flock_and_matching_health_pid() {
+        use std::io::{Seek, Write};
+
+        let dir = tempfile::tempdir().unwrap();
+        let pidfile = dir.path().join("daemon.pid");
+        let mut owner = fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(true)
+            .open(&pidfile)
+            .unwrap();
+        write!(owner, "41").unwrap();
+
+        let free = open_verified_live_pidfile_at(&pidfile, 41).unwrap_err();
+        assert!(format!("{free:#}").contains("lock is not held"));
+
+        assert_eq!(unsafe { libc::flock(owner.as_raw_fd(), libc::LOCK_EX) }, 0);
+        open_verified_live_pidfile_at(&pidfile, 41)
+            .expect("held same-inode flock plus matching PID is trusted");
+
+        // Rewriting the path contents cannot redirect COMMIT to a foreign PID:
+        // PREPARE reads the same locked inode it just checked.
+        owner.set_len(0).unwrap();
+        owner.seek(std::io::SeekFrom::Start(0)).unwrap();
+        write!(owner, "42").unwrap();
+        let mismatch = open_verified_live_pidfile_at(&pidfile, 41).unwrap_err();
+        assert!(
+            format!("{mismatch:#}").contains("does not match HealthCheck PID 41"),
+            "unexpected error: {mismatch:#}"
+        );
+        unsafe {
+            libc::flock(owner.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+
+    #[test]
+    fn prepare_rejects_zero_pid_and_wrong_instance_before_sidecar_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let pidfile = dir.path().join("daemon.pid");
+        fs::write(&pidfile, "1").unwrap();
+        let zero = open_verified_live_pidfile_at(&pidfile, 0).unwrap_err();
+        assert!(format!("{zero:#}").contains("PID 0"));
+
+        let db = dir.path().join("brain.lbug");
+        let health = nestweaver_proto::HealthCheckResponse {
+            instance_id: "wrong-instance".to_string(),
+            pid: 1,
+            ..Default::default()
+        };
+        let wrong = prepare_restart(&db, &health, None).unwrap_err();
+        assert!(format!("{wrong:#}").contains("does not match requested instance"));
+    }
+
+    #[tokio::test]
+    async fn transaction_gate_never_shuts_down_on_prepare_error_or_spawns_on_shutdown_failure() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let shutdowns = Arc::new(AtomicUsize::new(0));
+        let spawns = Arc::new(AtomicUsize::new(0));
+        let shutdown_counter = Arc::clone(&shutdowns);
+        let spawn_counter = Arc::clone(&spawns);
+        let prepare_error = run_prepared_restart::<(), _, _, _, _>(
+            Err(anyhow::anyhow!("prepare failed")),
+            move || async move {
+                shutdown_counter.fetch_add(1, Ordering::SeqCst);
+                Ok(true)
+            },
+            move |_| async move {
+                spawn_counter.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(format!("{prepare_error:#}").contains("prepare failed"));
+        assert_eq!(shutdowns.load(Ordering::SeqCst), 0);
+        assert_eq!(spawns.load(Ordering::SeqCst), 0);
+
+        let file = tempfile::tempfile().unwrap();
+        let prepared = PreparedRestart {
+            config: RestartConfig::CompiledDefaults,
+            daemon_pid: std::process::id(),
+            pidfile: file,
+            owns_pidfile_lock: false,
+        };
+        let spawns = Arc::new(AtomicUsize::new(0));
+        let spawn_counter = Arc::clone(&spawns);
+        let shutdown_error = run_prepared_restart::<(), _, _, _, _>(
+            Ok(prepared),
+            || async { Ok(false) },
+            move |_| async move {
+                spawn_counter.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(format!("{shutdown_error:#}").contains("refusing to spawn"));
+        assert_eq!(spawns.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn owner_release_timeout_never_signals_or_spawns() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let dir = tempfile::tempdir().unwrap();
+        let pidfile = dir.path().join("daemon.pid");
+        let owner = fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&pidfile)
+            .unwrap();
+        assert_eq!(unsafe { libc::flock(owner.as_raw_fd(), libc::LOCK_EX) }, 0);
+        let observed = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&pidfile)
+            .unwrap();
+        let mut child = std::process::Command::new("sleep")
+            .arg("10")
+            .spawn()
+            .unwrap();
+        let prepared = PreparedRestart {
+            config: RestartConfig::CompiledDefaults,
+            daemon_pid: child.id(),
+            pidfile: observed,
+            owns_pidfile_lock: false,
+        };
+        let spawns = Arc::new(AtomicUsize::new(0));
+        let spawn_counter = Arc::clone(&spawns);
+        let error = run_prepared_restart::<(), _, _, _, _>(
+            Ok(prepared),
+            || async { Ok(true) },
+            move |mut prepared| async move {
+                prepared
+                    .wait_for_owner_release_for(std::time::Duration::from_millis(40))
+                    .await?;
+                spawn_counter.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(format!("{error:#}").contains("refusing to signal"));
+        assert_eq!(spawns.load(Ordering::SeqCst), 0);
+        assert!(
+            child.try_wait().unwrap().is_none(),
+            "timeout must not signal the uncertain captured numeric PID"
+        );
+        child.kill().unwrap();
+        child.wait().unwrap();
+        unsafe {
+            libc::flock(owner.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+
+    #[test]
+    fn replacement_evidence_accepts_configured_and_compiled_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = fs::canonicalize(valid_config(&dir, "replacement.toml")).unwrap();
+        let configured = RestartConfig::Configured(config.clone());
+        let health = nestweaver_proto::HealthCheckResponse {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            instance_id: "expected".to_string(),
+            pid: 71,
+            ..Default::default()
+        };
+        verify_replacement_evidence(
+            "expected",
+            &health,
+            &configured,
+            binding(
+                71,
+                nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::Configured {
+                    path: config.to_str().unwrap().to_string(),
+                },
+            ),
+        )
+        .unwrap();
+        verify_replacement_evidence(
+            "expected",
+            &health,
+            &RestartConfig::CompiledDefaults,
+            binding(
+                71,
+                nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::CompiledDefaults,
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn replacement_evidence_rejects_config_version_instance_and_pid_mismatches() {
+        let valid_health = nestweaver_proto::HealthCheckResponse {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            instance_id: "expected".to_string(),
+            pid: 81,
+            ..Default::default()
+        };
+        let actual_defaults = || {
+            binding(
+                81,
+                nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::CompiledDefaults,
+            )
+        };
+
+        let config_mismatch = verify_replacement_evidence(
+            "expected",
+            &valid_health,
+            &RestartConfig::Configured(PathBuf::from("/expected/config.toml")),
+            actual_defaults(),
+        )
+        .unwrap_err();
+        assert!(format!("{config_mismatch:#}").contains("does not match captured"));
+
+        let wrong_version = nestweaver_proto::HealthCheckResponse {
+            version: "0.0.0-old".to_string(),
+            ..valid_health.clone()
+        };
+        assert!(
+            format!(
+                "{:#}",
+                verify_replacement_evidence(
+                    "expected",
+                    &wrong_version,
+                    &RestartConfig::CompiledDefaults,
+                    actual_defaults(),
+                )
+                .unwrap_err()
+            )
+            .contains("does not match client version")
+        );
+
+        let wrong_instance = nestweaver_proto::HealthCheckResponse {
+            instance_id: "unexpected".to_string(),
+            ..valid_health.clone()
+        };
+        assert!(
+            format!(
+                "{:#}",
+                verify_replacement_evidence(
+                    "expected",
+                    &wrong_instance,
+                    &RestartConfig::CompiledDefaults,
+                    actual_defaults(),
+                )
+                .unwrap_err()
+            )
+            .contains("does not match expected instance")
+        );
+
+        let wrong_pid = binding(
+            82,
+            nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::CompiledDefaults,
+        );
+        assert!(
+            format!(
+                "{:#}",
+                verify_replacement_evidence(
+                    "expected",
+                    &valid_health,
+                    &RestartConfig::CompiledDefaults,
+                    wrong_pid,
+                )
+                .unwrap_err()
+            )
+            .contains("does not match HealthCheck PID")
+        );
+    }
 
     /// `wait_healthy` must keep polling until the timeout and then
     /// report not-healthy (rather than declaring failure after a short fixed

--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -45,6 +45,15 @@ impl RestartConfig {
             Self::CompiledDefaults => None,
         }
     }
+
+    /// Choose a cold-start decision without consulting any stale live-binding
+    /// sidecar. An explicit config remains canonical, UTF-8, and parse-valid.
+    pub fn for_cold_start(explicit_config: Option<&Path>) -> Result<Self> {
+        match explicit_config {
+            Some(path) => validate_restart_config(path).map(Self::Configured),
+            None => Ok(Self::CompiledDefaults),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -260,7 +269,7 @@ fn restart_prepare_result<T>(db_path: &Path, prepared: Result<T>) -> Result<T> {
 
 /// Transaction gate shared by production and ordering tests. Neither callback
 /// runs when PREPARE fails, and COMMIT cannot run unless Shutdown was accepted.
-async fn run_prepared_restart<T, Shutdown, ShutdownFuture, Commit, CommitFuture>(
+pub async fn run_prepared_restart<T, Shutdown, ShutdownFuture, Commit, CommitFuture>(
     prepared: Result<PreparedRestart>,
     shutdown: Shutdown,
     commit: Commit,
@@ -908,6 +917,27 @@ credential_method = "gh"
 
         assert_eq!(configured.as_path(), Some(canonical.as_path()));
         assert_eq!(defaults.as_path(), None);
+    }
+
+    #[test]
+    fn cold_restart_ignores_stale_provenance_and_uses_explicit_or_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let explicit = valid_config(&dir, "cold-explicit.toml");
+        let canonical = fs::canonicalize(&explicit).unwrap();
+
+        assert_eq!(
+            RestartConfig::for_cold_start(None).unwrap(),
+            RestartConfig::CompiledDefaults
+        );
+        assert_eq!(
+            RestartConfig::for_cold_start(Some(&explicit)).unwrap(),
+            RestartConfig::Configured(canonical)
+        );
+        let missing = dir.path().join("stale-sidecar-config.toml");
+        assert!(
+            RestartConfig::for_cold_start(Some(&missing)).is_err(),
+            "an explicit cold config is validated even though stale sidecar provenance is ignored"
+        );
     }
 
     #[test]

--- a/crates/nestweaver-daemon/Cargo.toml
+++ b/crates/nestweaver-daemon/Cargo.toml
@@ -27,6 +27,7 @@ tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
 serde_json = { workspace = true }
+serde = { workspace = true }
 rmp-serde = { workspace = true }
 hmac = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/nestweaver-daemon/src/lifecycle.rs
+++ b/crates/nestweaver-daemon/src/lifecycle.rs
@@ -2,6 +2,164 @@
 
 use std::path::{Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
+
+pub const EFFECTIVE_CONFIG_BINDING_VERSION: u32 = 1;
+const EFFECTIVE_CONFIG_BINDING_FILE: &str = "effective-config.json";
+const EFFECTIVE_CONFIG_BINDING_MAX_BYTES: u64 = 64 * 1024;
+static EFFECTIVE_CONFIG_TEMP_SEQUENCE: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+fn effective_config_temp_path(parent: &Path, sequence: u64) -> PathBuf {
+    parent.join(format!(
+        ".{EFFECTIVE_CONFIG_BINDING_FILE}.{}.{}.tmp",
+        std::process::id(),
+        sequence
+    ))
+}
+
+/// The configuration source a live daemon actually uses.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "source", rename_all = "snake_case")]
+pub enum EffectiveConfigBindingSource {
+    Configured { path: String },
+    CompiledDefaults,
+}
+
+/// Versioned daemon-owned live binding between an instance, PID, and its
+/// effective configuration. This record is meaningful only while `pid` still
+/// identifies the daemon holding the corresponding pidfile lock.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EffectiveConfigBinding {
+    pub version: u32,
+    pub pid: u32,
+    pub effective_config: EffectiveConfigBindingSource,
+}
+
+impl EffectiveConfigBinding {
+    pub fn new(pid: u32, effective_config: EffectiveConfigBindingSource) -> Self {
+        Self {
+            version: EFFECTIVE_CONFIG_BINDING_VERSION,
+            pid,
+            effective_config,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum EffectiveConfigBindingError {
+    Absent {
+        path: PathBuf,
+    },
+    Read {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    Corrupt {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    Unsafe {
+        path: PathBuf,
+        reason: String,
+    },
+    TooLarge {
+        path: PathBuf,
+        size: u64,
+        max: u64,
+    },
+    UnsupportedVersion {
+        path: PathBuf,
+        found: u32,
+        supported: u32,
+    },
+    PidMismatch {
+        path: PathBuf,
+        expected: u32,
+        found: u32,
+    },
+    Serialize {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    Write {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+impl std::fmt::Display for EffectiveConfigBindingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Absent { path } => {
+                write!(f, "effective-config binding is absent: {}", path.display())
+            }
+            Self::Read { path, source } => write!(
+                f,
+                "failed to read effective-config binding {}: {source}",
+                path.display()
+            ),
+            Self::Corrupt { path, source } => write!(
+                f,
+                "effective-config binding {} is corrupt: {source}",
+                path.display()
+            ),
+            Self::Unsafe { path, reason } => write!(
+                f,
+                "effective-config binding {} is unsafe: {reason}",
+                path.display()
+            ),
+            Self::TooLarge { path, size, max } => write!(
+                f,
+                "effective-config binding {} is too large ({size} bytes; maximum {max})",
+                path.display()
+            ),
+            Self::UnsupportedVersion {
+                path,
+                found,
+                supported,
+            } => write!(
+                f,
+                "effective-config binding {} has unsupported version {found} (supported: {supported})",
+                path.display()
+            ),
+            Self::PidMismatch {
+                path,
+                expected,
+                found,
+            } => write!(
+                f,
+                "effective-config binding {} belongs to PID {found}, expected PID {expected}",
+                path.display()
+            ),
+            Self::Serialize { path, source } => write!(
+                f,
+                "failed to serialize effective-config binding {}: {source}",
+                path.display()
+            ),
+            Self::Write { path, source } => write!(
+                f,
+                "failed to publish effective-config binding {}: {source}",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for EffectiveConfigBindingError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Read { source, .. } | Self::Write { source, .. } => Some(source),
+            Self::Corrupt { source, .. } | Self::Serialize { source, .. } => Some(source),
+            Self::Absent { .. }
+            | Self::Unsafe { .. }
+            | Self::TooLarge { .. }
+            | Self::UnsupportedVersion { .. }
+            | Self::PidMismatch { .. } => None,
+        }
+    }
+}
+
 /// Canonicalize a database path even before the database file exists.
 ///
 /// `std::fs::canonicalize(path)` only succeeds once the file exists. Daemon
@@ -187,6 +345,298 @@ pub fn pidfile_path(instance_id: &str) -> PathBuf {
     runtime_dir(instance_id).join("daemon.pid")
 }
 
+/// Path to the daemon-owned effective-config live binding for an instance.
+pub fn effective_config_binding_path(instance_id: &str) -> PathBuf {
+    runtime_dir(instance_id).join(EFFECTIVE_CONFIG_BINDING_FILE)
+}
+
+#[cfg(unix)]
+fn verify_effective_config_runtime_dir_for_owner(
+    dir: &Path,
+    expected_uid: u32,
+) -> std::io::Result<()> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let metadata = std::fs::symlink_metadata(dir)?;
+    if !metadata.file_type().is_dir() || metadata.file_type().is_symlink() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "effective-config runtime path {} is not a real directory",
+                dir.display()
+            ),
+        ));
+    }
+    if metadata.uid() != expected_uid {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "effective-config runtime directory {} is owned by uid {} (expected {})",
+                dir.display(),
+                metadata.uid(),
+                expected_uid
+            ),
+        ));
+    }
+    let mode = metadata.permissions().mode() & 0o777;
+    if mode & 0o077 != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "effective-config runtime directory {} has unsafe mode {mode:04o}",
+                dir.display()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn secure_effective_config_runtime_dir_for_owner(
+    dir: &Path,
+    expected_uid: u32,
+) -> std::io::Result<()> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    match std::fs::symlink_metadata(dir) {
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::create_dir_all(dir)?;
+        }
+        Err(error) => return Err(error),
+    }
+    let metadata = std::fs::symlink_metadata(dir)?;
+    if metadata.file_type().is_dir()
+        && !metadata.file_type().is_symlink()
+        && metadata.uid() == expected_uid
+        && metadata.permissions().mode() & 0o777 != 0o700
+    {
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))?;
+    }
+    verify_effective_config_runtime_dir_for_owner(dir, expected_uid)
+}
+
+fn secure_effective_config_runtime_dir(dir: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        secure_effective_config_runtime_dir_for_owner(dir, unsafe { libc::geteuid() })
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(dir)
+    }
+}
+
+/// Atomically publish a live effective-config binding beside the pidfile.
+///
+/// The temporary file is created in the same directory, synced, and renamed
+/// over the destination so readers observe either the complete old record or
+/// the complete new record. On Unix the record is explicitly mode 0600.
+pub fn write_effective_config_binding(
+    instance_id: &str,
+    binding: &EffectiveConfigBinding,
+) -> Result<(), EffectiveConfigBindingError> {
+    let path = effective_config_binding_path(instance_id);
+    let bytes = serde_json::to_vec_pretty(binding).map_err(|source| {
+        EffectiveConfigBindingError::Serialize {
+            path: path.clone(),
+            source,
+        }
+    })?;
+    let parent = path
+        .parent()
+        .expect("effective-config binding path always has a runtime directory");
+    secure_effective_config_runtime_dir(parent).map_err(|source| {
+        EffectiveConfigBindingError::Write {
+            path: path.clone(),
+            source,
+        }
+    })?;
+
+    let (temp_path, mut file) = loop {
+        let sequence =
+            EFFECTIVE_CONFIG_TEMP_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let candidate = effective_config_temp_path(parent, sequence);
+        let mut options = std::fs::OpenOptions::new();
+        options.create_new(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        match options.open(&candidate) {
+            Ok(file) => break (candidate, file),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(source) => {
+                return Err(EffectiveConfigBindingError::Write { path, source });
+            }
+        }
+    };
+    let mut published = false;
+    let write_result = (|| -> std::io::Result<()> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        }
+        use std::io::Write;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        std::fs::rename(&temp_path, &path)?;
+        published = true;
+        // Persist the directory entry. If this fails, publication failed even
+        // though rename made the file visible, so the error path unlinks it.
+        std::fs::File::open(parent)?.sync_all()?;
+        Ok(())
+    })();
+    if let Err(source) = write_result {
+        let _ = std::fs::remove_file(if published { &path } else { &temp_path });
+        return Err(EffectiveConfigBindingError::Write { path, source });
+    }
+    Ok(())
+}
+
+/// Read and validate the schema version of an instance's live binding.
+pub fn read_effective_config_binding(
+    instance_id: &str,
+) -> Result<EffectiveConfigBinding, EffectiveConfigBindingError> {
+    let path = effective_config_binding_path(instance_id);
+    #[cfg(unix)]
+    {
+        let parent = path
+            .parent()
+            .expect("effective-config binding path always has a runtime directory");
+        if let Err(error) =
+            verify_effective_config_runtime_dir_for_owner(parent, unsafe { libc::geteuid() })
+        {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                return Err(EffectiveConfigBindingError::Absent { path });
+            }
+            return Err(EffectiveConfigBindingError::Unsafe {
+                path,
+                reason: error.to_string(),
+            });
+        }
+    }
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    let file = match options.open(&path) {
+        Ok(file) => file,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+            return Err(EffectiveConfigBindingError::Absent { path });
+        }
+        #[cfg(unix)]
+        Err(source) if source.raw_os_error() == Some(libc::ELOOP) => {
+            return Err(EffectiveConfigBindingError::Unsafe {
+                path,
+                reason: "symbolic links are not accepted".to_string(),
+            });
+        }
+        Err(source) => {
+            return Err(EffectiveConfigBindingError::Read { path, source });
+        }
+    };
+    let metadata = file
+        .metadata()
+        .map_err(|source| EffectiveConfigBindingError::Read {
+            path: path.clone(),
+            source,
+        })?;
+    if !metadata.file_type().is_file() {
+        return Err(EffectiveConfigBindingError::Unsafe {
+            path,
+            reason: "record is not a regular file".to_string(),
+        });
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        let owner = metadata.uid();
+        let expected_owner = unsafe { libc::geteuid() };
+        if owner != expected_owner {
+            return Err(EffectiveConfigBindingError::Unsafe {
+                path,
+                reason: format!("owned by uid {owner}, expected uid {expected_owner}"),
+            });
+        }
+        let mode = metadata.permissions().mode() & 0o777;
+        if mode & 0o077 != 0 {
+            return Err(EffectiveConfigBindingError::Unsafe {
+                path,
+                reason: format!("mode {mode:04o} grants group or other access"),
+            });
+        }
+    }
+    if metadata.len() > EFFECTIVE_CONFIG_BINDING_MAX_BYTES {
+        return Err(EffectiveConfigBindingError::TooLarge {
+            path,
+            size: metadata.len(),
+            max: EFFECTIVE_CONFIG_BINDING_MAX_BYTES,
+        });
+    }
+    use std::io::Read;
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(EFFECTIVE_CONFIG_BINDING_MAX_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|source| EffectiveConfigBindingError::Read {
+            path: path.clone(),
+            source,
+        })?;
+    if bytes.len() as u64 > EFFECTIVE_CONFIG_BINDING_MAX_BYTES {
+        return Err(EffectiveConfigBindingError::TooLarge {
+            path,
+            size: bytes.len() as u64,
+            max: EFFECTIVE_CONFIG_BINDING_MAX_BYTES,
+        });
+    }
+    let binding: EffectiveConfigBinding =
+        serde_json::from_slice(&bytes).map_err(|source| EffectiveConfigBindingError::Corrupt {
+            path: path.clone(),
+            source,
+        })?;
+    if binding.version != EFFECTIVE_CONFIG_BINDING_VERSION {
+        return Err(EffectiveConfigBindingError::UnsupportedVersion {
+            path,
+            found: binding.version,
+            supported: EFFECTIVE_CONFIG_BINDING_VERSION,
+        });
+    }
+    Ok(binding)
+}
+
+/// Read a binding and require its integer PID to match a daemon identity the
+/// caller has already verified through kernel socket/health evidence plus the
+/// held pidfile lock. This helper does not itself prove process liveness or
+/// ownership; PID equality alone is vulnerable to stale files and PID reuse.
+pub fn read_effective_config_binding_for_verified_pid(
+    instance_id: &str,
+    expected_pid: u32,
+) -> Result<EffectiveConfigBinding, EffectiveConfigBindingError> {
+    let binding = read_effective_config_binding(instance_id)?;
+    if binding.pid != expected_pid {
+        return Err(EffectiveConfigBindingError::PidMismatch {
+            path: effective_config_binding_path(instance_id),
+            expected: expected_pid,
+            found: binding.pid,
+        });
+    }
+    Ok(binding)
+}
+
+/// Remove an instance's live binding. Absence is already the desired state.
+pub fn remove_effective_config_binding(instance_id: &str) -> std::io::Result<()> {
+    match std::fs::remove_file(effective_config_binding_path(instance_id)) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
 /// Directory for daemon log files.
 pub fn log_dir(instance_id: &str) -> PathBuf {
     dirs::state_dir()
@@ -271,9 +721,10 @@ pub fn stop_legacy_hash_daemon(db_path: &Path) {
 
     let old_pid_path = pidfile_path(&old_id);
     let old_sock_path = socket_path(&old_id);
+    let old_binding_path = effective_config_binding_path(&old_id);
     let old_rt_dir = runtime_dir(&old_id);
 
-    if !old_pid_path.exists() && !old_sock_path.exists() {
+    if !old_pid_path.exists() && !old_sock_path.exists() && !old_binding_path.exists() {
         return;
     }
 
@@ -332,6 +783,7 @@ pub fn stop_legacy_hash_daemon(db_path: &Path) {
     // Clean up stale runtime artifacts.
     let _ = std::fs::remove_file(&old_sock_path);
     let _ = std::fs::remove_file(&old_pid_path);
+    let _ = std::fs::remove_file(&old_binding_path);
     let _ = std::fs::remove_dir(&old_rt_dir);
 }
 
@@ -343,6 +795,289 @@ mod tests {
     // Tests that mutate environment variables must hold this lock to avoid
     // racing with each other under `cargo test`'s default parallel execution.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_xdg_runtime<T>(root: &Path, test: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let previous = std::env::var_os("XDG_RUNTIME_DIR");
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", root);
+        }
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(test));
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var("XDG_RUNTIME_DIR", value),
+                None => std::env::remove_var("XDG_RUNTIME_DIR"),
+            }
+        }
+        match result {
+            Ok(value) => value,
+            Err(panic) => std::panic::resume_unwind(panic),
+        }
+    }
+
+    #[test]
+    fn effective_config_binding_paths_are_isolated_per_instance() {
+        let temp = tempfile::tempdir().unwrap();
+        with_xdg_runtime(temp.path(), || {
+            let first = effective_config_binding_path("instance-a");
+            let second = effective_config_binding_path("instance-b");
+            assert_ne!(first, second);
+            assert_eq!(first.file_name().unwrap(), EFFECTIVE_CONFIG_BINDING_FILE);
+            assert!(first.starts_with(runtime_dir("instance-a")));
+            assert!(second.starts_with(runtime_dir("instance-b")));
+
+            let first_binding =
+                EffectiveConfigBinding::new(101, EffectiveConfigBindingSource::CompiledDefaults);
+            let second_binding = EffectiveConfigBinding::new(
+                202,
+                EffectiveConfigBindingSource::Configured {
+                    path: "/second.toml".to_string(),
+                },
+            );
+            write_effective_config_binding("instance-a", &first_binding).unwrap();
+            write_effective_config_binding("instance-b", &second_binding).unwrap();
+            assert_eq!(
+                read_effective_config_binding("instance-a").unwrap(),
+                first_binding
+            );
+            assert_eq!(
+                read_effective_config_binding("instance-b").unwrap(),
+                second_binding
+            );
+        });
+    }
+
+    #[test]
+    fn effective_config_binding_roundtrips_configured_and_defaults() {
+        let temp = tempfile::tempdir().unwrap();
+        with_xdg_runtime(temp.path(), || {
+            let configured = EffectiveConfigBinding::new(
+                41,
+                EffectiveConfigBindingSource::Configured {
+                    path: "/canonical/instance.toml".to_string(),
+                },
+            );
+            write_effective_config_binding("roundtrip", &configured).unwrap();
+            assert_eq!(
+                read_effective_config_binding_for_verified_pid("roundtrip", 41).unwrap(),
+                configured
+            );
+
+            let defaults =
+                EffectiveConfigBinding::new(42, EffectiveConfigBindingSource::CompiledDefaults);
+            write_effective_config_binding("roundtrip", &defaults).unwrap();
+            assert_eq!(
+                read_effective_config_binding_for_verified_pid("roundtrip", 42).unwrap(),
+                defaults
+            );
+        });
+    }
+
+    #[test]
+    fn effective_config_binding_reports_absent_corrupt_version_and_pid_errors() {
+        let temp = tempfile::tempdir().unwrap();
+        with_xdg_runtime(temp.path(), || {
+            assert!(matches!(
+                read_effective_config_binding("errors"),
+                Err(EffectiveConfigBindingError::Absent { .. })
+            ));
+
+            let binding =
+                EffectiveConfigBinding::new(7, EffectiveConfigBindingSource::CompiledDefaults);
+            write_effective_config_binding("errors", &binding).unwrap();
+            let path = effective_config_binding_path("errors");
+            std::fs::write(&path, b"not json").unwrap();
+            assert!(matches!(
+                read_effective_config_binding("errors"),
+                Err(EffectiveConfigBindingError::Corrupt { .. })
+            ));
+
+            std::fs::write(
+                &path,
+                br#"{"version":99,"pid":7,"effective_config":{"source":"compiled_defaults"}}"#,
+            )
+            .unwrap();
+            assert!(matches!(
+                read_effective_config_binding("errors"),
+                Err(EffectiveConfigBindingError::UnsupportedVersion {
+                    found: 99,
+                    supported: EFFECTIVE_CONFIG_BINDING_VERSION,
+                    ..
+                })
+            ));
+
+            write_effective_config_binding("errors", &binding).unwrap();
+            assert!(matches!(
+                read_effective_config_binding_for_verified_pid("errors", 8),
+                Err(EffectiveConfigBindingError::PidMismatch {
+                    expected: 8,
+                    found: 7,
+                    ..
+                })
+            ));
+        });
+    }
+
+    #[test]
+    fn effective_config_binding_replacement_leaves_one_complete_record() {
+        let temp = tempfile::tempdir().unwrap();
+        with_xdg_runtime(temp.path(), || {
+            for pid in 1..=20 {
+                let binding = EffectiveConfigBinding::new(
+                    pid,
+                    EffectiveConfigBindingSource::Configured {
+                        path: format!("/config/{pid}.toml"),
+                    },
+                );
+                write_effective_config_binding("replace", &binding).unwrap();
+                assert_eq!(read_effective_config_binding("replace").unwrap(), binding);
+            }
+            let parent = effective_config_binding_path("replace")
+                .parent()
+                .unwrap()
+                .to_path_buf();
+            let entries = std::fs::read_dir(parent)
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap();
+            assert_eq!(entries.len(), 1, "atomic replacement left a temp artifact");
+            assert_eq!(entries[0].file_name(), EFFECTIVE_CONFIG_BINDING_FILE);
+        });
+    }
+
+    #[test]
+    fn effective_config_binding_retries_stale_temp_name_collision() {
+        let temp = tempfile::tempdir().unwrap();
+        with_xdg_runtime(temp.path(), || {
+            let path = effective_config_binding_path("collision");
+            let parent = path.parent().unwrap();
+            std::fs::create_dir_all(parent).unwrap();
+            let sequence =
+                EFFECTIVE_CONFIG_TEMP_SEQUENCE.load(std::sync::atomic::Ordering::Relaxed);
+            let stale_temp = effective_config_temp_path(parent, sequence);
+            std::fs::write(&stale_temp, b"orphan from crashed daemon").unwrap();
+            let binding =
+                EffectiveConfigBinding::new(7, EffectiveConfigBindingSource::CompiledDefaults);
+
+            write_effective_config_binding("collision", &binding).unwrap();
+
+            assert_eq!(read_effective_config_binding("collision").unwrap(), binding);
+            assert!(
+                stale_temp.exists(),
+                "writer must not overwrite stale temp files"
+            );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn effective_config_binding_is_private_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        with_xdg_runtime(temp.path(), || {
+            let binding =
+                EffectiveConfigBinding::new(7, EffectiveConfigBindingSource::CompiledDefaults);
+            write_effective_config_binding("permissions", &binding).unwrap();
+            let mode = std::fs::metadata(effective_config_binding_path("permissions"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o600);
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn effective_config_binding_secures_or_rejects_precreated_runtime_dir() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = temp.path().join("runtime");
+        std::fs::create_dir(&runtime).unwrap();
+        std::fs::set_permissions(&runtime, std::fs::Permissions::from_mode(0o777)).unwrap();
+        secure_effective_config_runtime_dir_for_owner(&runtime, unsafe { libc::geteuid() })
+            .unwrap();
+        assert_eq!(
+            std::fs::metadata(&runtime).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+
+        let error = secure_effective_config_runtime_dir_for_owner(
+            &runtime,
+            unsafe { libc::geteuid() }.saturating_add(1),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+
+        let target = temp.path().join("target");
+        let linked = temp.path().join("linked");
+        std::fs::create_dir(&target).unwrap();
+        std::os::unix::fs::symlink(&target, &linked).unwrap();
+        let error =
+            secure_effective_config_runtime_dir_for_owner(&linked, unsafe { libc::geteuid() })
+                .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn effective_config_binding_reader_rejects_unsafe_mode_and_oversize() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        with_xdg_runtime(temp.path(), || {
+            let binding =
+                EffectiveConfigBinding::new(7, EffectiveConfigBindingSource::CompiledDefaults);
+            write_effective_config_binding("unsafe", &binding).unwrap();
+            let path = effective_config_binding_path("unsafe");
+            let parent = path.parent().unwrap();
+            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o755)).unwrap();
+            assert!(matches!(
+                read_effective_config_binding("unsafe"),
+                Err(EffectiveConfigBindingError::Unsafe { .. })
+            ));
+            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+            assert!(matches!(
+                read_effective_config_binding("unsafe"),
+                Err(EffectiveConfigBindingError::Unsafe { .. })
+            ));
+
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+            std::fs::write(
+                &path,
+                vec![b' '; EFFECTIVE_CONFIG_BINDING_MAX_BYTES as usize + 1],
+            )
+            .unwrap();
+            assert!(matches!(
+                read_effective_config_binding("unsafe"),
+                Err(EffectiveConfigBindingError::TooLarge { .. })
+            ));
+        });
+    }
+
+    #[test]
+    fn legacy_runtime_cleanup_removes_effective_config_binding() {
+        let temp = tempfile::tempdir().unwrap();
+        with_xdg_runtime(temp.path(), || {
+            let db_path = temp.path().join("brain.lbug");
+            let old_id = legacy_instance_id_from_db_path(&db_path);
+            assert_ne!(old_id, instance_id_from_db_path(&db_path));
+            let binding =
+                EffectiveConfigBinding::new(7, EffectiveConfigBindingSource::CompiledDefaults);
+            write_effective_config_binding(&old_id, &binding).unwrap();
+            let binding_path = effective_config_binding_path(&old_id);
+            assert!(binding_path.exists());
+
+            stop_legacy_hash_daemon(&db_path);
+
+            assert!(!binding_path.exists());
+            assert!(!runtime_dir(&old_id).exists());
+        });
+    }
 
     #[test]
     fn instance_id_is_8_hex_chars() {

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -432,6 +432,34 @@ fn load_daemon_instance_config(
     }
 }
 
+fn live_binding_source(
+    provenance: &EffectiveConfigProvenance,
+) -> lifecycle::EffectiveConfigBindingSource {
+    match provenance {
+        EffectiveConfigProvenance::Configured(path) => {
+            lifecycle::EffectiveConfigBindingSource::Configured {
+                path: path
+                    .to_str()
+                    .expect("configured provenance is validated as UTF-8 at startup")
+                    .to_string(),
+            }
+        }
+        EffectiveConfigProvenance::CompiledDefaults => {
+            lifecycle::EffectiveConfigBindingSource::CompiledDefaults
+        }
+    }
+}
+
+struct EffectiveConfigBindingCleanup {
+    instance_id: String,
+}
+
+impl Drop for EffectiveConfigBindingCleanup {
+    fn drop(&mut self) {
+        let _ = lifecycle::remove_effective_config_binding(&self.instance_id);
+    }
+}
+
 pub struct DaemonState {
     pub store: Arc<GraphStore>,
     pub tantivy: Option<Arc<TantivyIndex>>,
@@ -7630,6 +7658,12 @@ pub async fn run_server(
     // lifetime; released on drop. A daemonize child proves it inherited the
     // launcher's lock instead of trying to acquire a conflicting second flock.
     let _pid_guard = claim_instance_lock(&instance_id)?;
+    // We now exclusively own this instance's pidfile lock, so any binding left
+    // by a crashed predecessor is stale. Clear it before fallible startup work;
+    // a failed boot must not leave old provenance looking live.
+    lifecycle::remove_effective_config_binding(&instance_id).with_context(|| {
+        format!("remove stale effective-config binding for instance {instance_id}")
+    })?;
 
     // Snapshot replica: materialize the snapshot into a private working copy and
     // serve it read-only. `read_only` gates out the write RPCs (via the
@@ -7744,6 +7778,19 @@ pub async fn run_server(
     // warning buried in the rotating log file.
     let (instance_cfg, effective_config) =
         load_daemon_instance_config(config_path, server_opts.is_some())?;
+    let live_binding = lifecycle::EffectiveConfigBinding::new(
+        std::process::id(),
+        live_binding_source(&effective_config),
+    );
+    lifecycle::write_effective_config_binding(&instance_id, &live_binding).with_context(|| {
+        format!("publish effective-config binding for daemon instance {instance_id}")
+    })?;
+    // Removes the binding on every normal return path, including startup
+    // errors after publication. A process crash can still leave a stale file;
+    // later consumers must validate its PID before trusting it.
+    let _effective_config_binding_cleanup = EffectiveConfigBindingCleanup {
+        instance_id: instance_id.clone(),
+    };
 
     // nw-019: graph-data identity — the config's logical `instance_id` when we
     // have a parsed config, else fall back to the runtime hash so a config-less
@@ -9233,6 +9280,9 @@ pub async fn run_server(
     }
 
     let _ = std::fs::remove_file(&sock_path);
+    // The RAII owner removes the live binding before the pidfile lock is
+    // released. On earlier error returns its Drop provides the same cleanup.
+    drop(_effective_config_binding_cleanup);
     // Drop the instance lock's pidfile on clean shutdown (the flock itself is
     // released when `_pid_guard` drops at end of scope).
     let _ = std::fs::remove_file(lifecycle::pidfile_path(&instance_id));

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -346,6 +346,92 @@ fn daemon_metal_compiled() -> bool {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EffectiveConfigProvenance {
+    Configured(PathBuf),
+    CompiledDefaults,
+}
+
+fn configured_provenance(path: &Path) -> anyhow::Result<EffectiveConfigProvenance> {
+    let canonical = std::fs::canonicalize(path)
+        .with_context(|| format!("failed to canonicalize --config {}", path.display()))?;
+    anyhow::ensure!(
+        canonical.to_str().is_some(),
+        "canonical --config path is not valid UTF-8: {}",
+        canonical.display()
+    );
+    Ok(EffectiveConfigProvenance::Configured(canonical))
+}
+
+fn effective_config_proto(provenance: &EffectiveConfigProvenance) -> EffectiveConfig {
+    use effective_config::Source;
+
+    let source = match provenance {
+        EffectiveConfigProvenance::Configured(path) => Source::ConfiguredPath(
+            path.to_str()
+                .expect("configured provenance is validated as UTF-8 at startup")
+                .to_string(),
+        ),
+        EffectiveConfigProvenance::CompiledDefaults => {
+            Source::CompiledDefaults(effective_config::CompiledDefaults {})
+        }
+    };
+    EffectiveConfig {
+        source: Some(source),
+    }
+}
+
+fn load_daemon_instance_config(
+    config_path: Option<&Path>,
+    server_mode: bool,
+) -> anyhow::Result<(
+    Option<Arc<nestweaver_engine::InstanceConfig>>,
+    EffectiveConfigProvenance,
+)> {
+    match config_path {
+        None => Ok((None, EffectiveConfigProvenance::CompiledDefaults)),
+        Some(path) => match nestweaver_engine::InstanceConfig::from_file(path) {
+            Ok(config) => {
+                let provenance = configured_provenance(path)?;
+                tracing::info!(
+                    config = %path.display(),
+                    "loaded instance config (ranking, response, features)"
+                );
+                Ok((Some(Arc::new(config)), provenance))
+            }
+            Err(error) if path.exists() => {
+                // Present but broken. Surface to the console (docker/foreground
+                // operators never see the rotating log) and fail fast in server
+                // mode so a typo can't masquerade as a healthy-but-empty server.
+                eprintln!(
+                    "[daemon] failed to parse --config {}: {error}",
+                    path.display()
+                );
+                tracing::error!(
+                    config = %path.display(),
+                    error = %error,
+                    "failed to parse --config"
+                );
+                if server_mode {
+                    anyhow::bail!(
+                        "invalid --config {}: {error} (server mode requires a parseable config)",
+                        path.display()
+                    );
+                }
+                Ok((None, EffectiveConfigProvenance::CompiledDefaults))
+            }
+            Err(error) => {
+                tracing::warn!(
+                    config = %path.display(),
+                    error = %error,
+                    "instance config not found — using built-in defaults"
+                );
+                Ok((None, EffectiveConfigProvenance::CompiledDefaults))
+            }
+        },
+    }
+}
+
 pub struct DaemonState {
     pub store: Arc<GraphStore>,
     pub tantivy: Option<Arc<TantivyIndex>>,
@@ -374,6 +460,10 @@ pub struct DaemonState {
     /// daemon start. Used by tool dispatch (e.g. F6 `[ranking]` priors in
     /// `brain_search`) via the `set_current_instance_config` thread-local.
     pub instance_cfg: Option<Arc<nestweaver_engine::InstanceConfig>>,
+    /// Effective configuration used by this process. Configured paths are
+    /// canonicalized at startup; `CompiledDefaults` represents the process's
+    /// actual configless/default mode.
+    pub(crate) effective_config: EffectiveConfigProvenance,
     /// Per-repo authorization policy (R9/R9b), built ONCE at startup from
     /// `[authz]` config — not rebuilt per request. No `[authz]` ⇒ a disabled
     /// source that resolves every identity to `VisibleRepos::All`. Mirrors the
@@ -4621,6 +4711,7 @@ impl NestWeaverDaemon for DaemonService {
             indexing_repo,
             queue_depth,
             embedding_status: Some(embedding_status),
+            effective_config: Some(effective_config_proto(&self.state.effective_config)),
         }))
     }
 
@@ -7651,40 +7742,8 @@ pub async fn run_server(
     // malformed config means the server would silently index nothing and have no
     // webhook secret; that failure must be loud (stderr) and fatal rather than a
     // warning buried in the rotating log file.
-    let instance_cfg = match config_path {
-        None => None,
-        Some(p) => match nestweaver_engine::InstanceConfig::from_file(p) {
-            Ok(c) => {
-                tracing::info!(
-                    config = %p.display(),
-                    "loaded instance config (ranking, response, features)"
-                );
-                Some(Arc::new(c))
-            }
-            Err(e) if p.exists() => {
-                // Present but broken. Surface to the console (docker/foreground
-                // operators never see the rotating log) and fail fast in server
-                // mode so a typo can't masquerade as a healthy-but-empty server.
-                eprintln!("[daemon] failed to parse --config {}: {e}", p.display());
-                tracing::error!(config = %p.display(), error = %e, "failed to parse --config");
-                if server_opts.is_some() {
-                    anyhow::bail!(
-                        "invalid --config {}: {e} (server mode requires a parseable config)",
-                        p.display()
-                    );
-                }
-                None
-            }
-            Err(e) => {
-                tracing::warn!(
-                    config = %p.display(),
-                    error = %e,
-                    "instance config not found — using built-in defaults"
-                );
-                None
-            }
-        },
-    };
+    let (instance_cfg, effective_config) =
+        load_daemon_instance_config(config_path, server_opts.is_some())?;
 
     // nw-019: graph-data identity — the config's logical `instance_id` when we
     // have a parsed config, else fall back to the runtime hash so a config-less
@@ -7814,6 +7873,7 @@ pub async fn run_server(
         watcher_stop: std::sync::Mutex::new(None),
         next_watcher_id: std::sync::atomic::AtomicU64::new(0),
         instance_cfg,
+        effective_config,
         permission_source,
         embedding_runtime: Arc::new(EmbeddingRuntime::unavailable(embedding_status)),
         write_mutex: Arc::new(tokio::sync::Mutex::new(())),
@@ -14052,6 +14112,7 @@ mod startup_helper_tests {
             watcher_stop: std::sync::Mutex::new(None),
             next_watcher_id: std::sync::atomic::AtomicU64::new(0),
             instance_cfg: None,
+            effective_config: EffectiveConfigProvenance::CompiledDefaults,
             permission_source: build_daemon_permission_source(None),
             embedding_runtime: Arc::new(EmbeddingRuntime::unavailable(initial_embedding_status(
                 &nestweaver_engine::config::EmbeddingConfig::default(),
@@ -14073,6 +14134,37 @@ mod startup_helper_tests {
             worker_handle: std::sync::Mutex::new(None),
             ui_server: std::sync::Mutex::new(None),
         })
+    }
+
+    fn write_provenance_test_config(path: &Path, root: &Path) {
+        std::fs::write(
+            path,
+            format!(
+                r#"
+instance_id = "provenance-test"
+repos = []
+
+[snapshot_storage]
+backend = "local"
+path = "{}"
+
+[workspace]
+backend = "local"
+path = "{}"
+
+[inference]
+endpoint = "http://localhost:11434"
+embedding_model = "nomic-embed-text"
+summary_model = "qwen2.5-coder:7b"
+
+[git]
+credential_method = "gh"
+"#,
+                root.join("snapshots").display(),
+                root.join("workspace").display()
+            ),
+        )
+        .unwrap();
     }
 
     /// Build a minimal `DaemonState` over the given store and permission
@@ -14097,6 +14189,7 @@ mod startup_helper_tests {
             watcher_stop: std::sync::Mutex::new(None),
             next_watcher_id: std::sync::atomic::AtomicU64::new(0),
             instance_cfg: None,
+            effective_config: EffectiveConfigProvenance::CompiledDefaults,
             permission_source,
             embedding_runtime: Arc::new(EmbeddingRuntime::unavailable(initial_embedding_status(
                 &nestweaver_engine::config::EmbeddingConfig::default(),
@@ -14137,11 +14230,16 @@ mod startup_helper_tests {
             });
         let service = DaemonService::new(state);
 
-        let typed = service
+        let response = service
             .brain_status(Request::new(BrainStatusRequest {}))
             .await
             .expect("typed brain status")
-            .into_inner()
+            .into_inner();
+        assert!(matches!(
+            response.effective_config.unwrap().source,
+            Some(effective_config::Source::CompiledDefaults(_))
+        ));
+        let typed = response
             .embedding_status
             .expect("structured embedding status");
         assert_eq!(typed.state, "failed");
@@ -14163,6 +14261,68 @@ mod startup_helper_tests {
         assert_eq!(value["embedding_status"]["requested_device"], "metal");
         assert_eq!(value["embedding_status"]["selected_device"], "");
         assert_eq!(value["embedding_status"]["fallback_used"], false);
+        assert!(
+            value.get("effective_config").is_none(),
+            "effective config provenance must remain typed-only so Combined federation cannot backfill it"
+        );
+    }
+
+    #[tokio::test]
+    async fn typed_status_reports_canonical_configured_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        let config = dir.path().join("instance.toml");
+        std::fs::write(&config, "instance_id = 'test'").unwrap();
+        let noncanonical = nested.join("..").join("instance.toml");
+
+        let mut state = test_state_with_writer();
+        Arc::get_mut(&mut state).unwrap().effective_config =
+            configured_provenance(&noncanonical).unwrap();
+        let response = DaemonService::new(state)
+            .brain_status(Request::new(BrainStatusRequest {}))
+            .await
+            .expect("typed brain status")
+            .into_inner();
+
+        assert!(matches!(
+            response.effective_config.unwrap().source,
+            Some(effective_config::Source::ConfiguredPath(path))
+                if path == std::fs::canonicalize(config).unwrap().to_str().unwrap()
+        ));
+    }
+
+    #[test]
+    fn production_config_loader_couples_parsed_config_to_canonical_provenance() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("instance.toml");
+        write_provenance_test_config(&config_path, dir.path());
+
+        let (config, provenance) = load_daemon_instance_config(Some(&config_path), false).unwrap();
+
+        assert_eq!(config.unwrap().instance_id, "provenance-test");
+        assert_eq!(
+            provenance,
+            EffectiveConfigProvenance::Configured(std::fs::canonicalize(config_path).unwrap())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn production_config_loader_rejects_non_utf8_config_provenance() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let name = OsString::from_vec(b"instance-\xff.toml".to_vec());
+        let config_path = dir.path().join(name);
+        write_provenance_test_config(&config_path, dir.path());
+
+        let error = load_daemon_instance_config(Some(&config_path), false).unwrap_err();
+        assert!(
+            error.to_string().contains("not valid UTF-8"),
+            "unexpected error: {error:#}"
+        );
     }
 
     #[tokio::test]

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -383,7 +383,7 @@ fn effective_config_proto(provenance: &EffectiveConfigProvenance) -> EffectiveCo
 
 fn load_daemon_instance_config(
     config_path: Option<&Path>,
-    server_mode: bool,
+    _server_mode: bool,
 ) -> anyhow::Result<(
     Option<Arc<nestweaver_engine::InstanceConfig>>,
     EffectiveConfigProvenance,
@@ -399,34 +399,23 @@ fn load_daemon_instance_config(
                 );
                 Ok((Some(Arc::new(config)), provenance))
             }
-            Err(error) if path.exists() => {
-                // Present but broken. Surface to the console (docker/foreground
-                // operators never see the rotating log) and fail fast in server
-                // mode so a typo can't masquerade as a healthy-but-empty server.
-                eprintln!(
-                    "[daemon] failed to parse --config {}: {error}",
-                    path.display()
-                );
+            Err(error) => {
+                // Any explicitly supplied config is a binding, not a hint.
+                // This applies equally to UDS and network server modes: a
+                // version-mismatch restart prevalidates its captured path, but
+                // the file can disappear or change before the replacement
+                // parses it. Falling back here would silently fork identity and
+                // widen configured authorization to compiled defaults.
+                eprintln!("[daemon] cannot honor --config {}: {error}", path.display());
                 tracing::error!(
                     config = %path.display(),
                     error = %error,
-                    "failed to parse --config"
+                    "cannot honor explicitly supplied --config"
                 );
-                if server_mode {
-                    anyhow::bail!(
-                        "invalid --config {}: {error} (server mode requires a parseable config)",
-                        path.display()
-                    );
-                }
-                Ok((None, EffectiveConfigProvenance::CompiledDefaults))
-            }
-            Err(error) => {
-                tracing::warn!(
-                    config = %path.display(),
-                    error = %error,
-                    "instance config not found — using built-in defaults"
-                );
-                Ok((None, EffectiveConfigProvenance::CompiledDefaults))
+                anyhow::bail!(
+                    "invalid or unreadable --config {}: {error}; explicitly supplied config must be honored",
+                    path.display()
+                )
             }
         },
     }
@@ -7771,11 +7760,10 @@ pub async fn run_server(
     // tool dispatch (e.g. F6 `[ranking]` priors in `brain_search`) can apply
     // it without re-parsing the file per RPC.
     //
-    // Distinguish a MISSING file (non-fatal — the daemon serves with built-in
-    // defaults) from a file that is PRESENT but unparseable. In server mode a
-    // malformed config means the server would silently index nothing and have no
-    // webhook secret; that failure must be loud (stderr) and fatal rather than a
-    // warning buried in the rotating log file.
+    // An explicitly supplied path is a binding, not a discovery hint. Missing,
+    // unreadable, or malformed input is fatal in both UDS and network server
+    // modes; otherwise a restart-time file race could silently demote the
+    // instance to compiled-default identity and authorization.
     let (instance_cfg, effective_config) =
         load_daemon_instance_config(config_path, server_opts.is_some())?;
     let live_binding = lifecycle::EffectiveConfigBinding::new(
@@ -14372,6 +14360,41 @@ credential_method = "gh"
         assert!(
             error.to_string().contains("not valid UTF-8"),
             "unexpected error: {error:#}"
+        );
+    }
+
+    #[test]
+    fn uds_config_loader_rejects_missing_explicit_config_without_default_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("deleted-after-restart-prepare.toml");
+
+        let error = load_daemon_instance_config(Some(&missing), false).unwrap_err();
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("invalid or unreadable --config"),
+            "{message}"
+        );
+        assert!(
+            message.contains("explicitly supplied config must be honored"),
+            "{message}"
+        );
+    }
+
+    #[test]
+    fn uds_config_loader_rejects_malformed_explicit_config_without_default_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let malformed = dir.path().join("changed-after-restart-prepare.toml");
+        std::fs::write(&malformed, "instance_id = [not-valid").unwrap();
+
+        let error = load_daemon_instance_config(Some(&malformed), false).unwrap_err();
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("invalid or unreadable --config"),
+            "{message}"
+        );
+        assert!(
+            message.contains("explicitly supplied config must be honored"),
+            "{message}"
         );
     }
 

--- a/crates/nestweaver-proto/src/lib.rs
+++ b/crates/nestweaver-proto/src/lib.rs
@@ -5,8 +5,9 @@ pub mod nestweaver_daemon_v1 {
 pub use nestweaver_daemon_v1::*;
 
 #[cfg(test)]
-mod embedding_telemetry_contract_tests {
+mod additive_status_contract_tests {
     use super::*;
+    use prost::Message;
 
     #[test]
     fn status_and_hybrid_responses_expose_additive_embedding_telemetry() {
@@ -43,6 +44,42 @@ mod embedding_telemetry_contract_tests {
             degraded_components: vec!["semantic".to_string()],
         };
         assert_eq!(context.degraded_components, ["semantic"]);
+    }
+
+    #[test]
+    fn effective_config_roundtrip_preserves_all_three_provenance_states() {
+        use effective_config::Source;
+
+        let configured = BrainStatusResponse {
+            effective_config: Some(EffectiveConfig {
+                source: Some(Source::ConfiguredPath("/tmp/instance.toml".to_string())),
+            }),
+            ..Default::default()
+        };
+        let configured =
+            BrainStatusResponse::decode(configured.encode_to_vec().as_slice()).unwrap();
+        assert!(matches!(
+            configured.effective_config.unwrap().source,
+            Some(Source::ConfiguredPath(path)) if path == "/tmp/instance.toml"
+        ));
+
+        let defaults = BrainStatusResponse {
+            effective_config: Some(EffectiveConfig {
+                source: Some(Source::CompiledDefaults(
+                    effective_config::CompiledDefaults {},
+                )),
+            }),
+            ..Default::default()
+        };
+        let defaults = BrainStatusResponse::decode(defaults.encode_to_vec().as_slice()).unwrap();
+        assert!(matches!(
+            defaults.effective_config.unwrap().source,
+            Some(Source::CompiledDefaults(_))
+        ));
+
+        let unknown = BrainStatusResponse::default();
+        let unknown = BrainStatusResponse::decode(unknown.encode_to_vec().as_slice()).unwrap();
+        assert!(unknown.effective_config.is_none());
     }
 }
 

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -243,6 +243,18 @@ message EmbeddingStatus {
   bool metal_compiled = 7;
   bool fallback_used = 8;        // invariant: always false
 }
+message EffectiveConfig {
+  // The daemon's effective configuration source. Absence of EffectiveConfig
+  // on BrainStatusResponse means an older daemon that cannot report it.
+  oneof source {
+    string configured_path = 1;       // canonical absolute path
+    CompiledDefaults compiled_defaults = 2;
+  }
+
+  // An explicit marker rather than an empty path, so defaults cannot be
+  // confused with unknown provenance from an older daemon.
+  message CompiledDefaults {}
+}
 message BrainStatusResponse {
   int32 vault_count = 1;
   int32 notes = 2;
@@ -257,6 +269,7 @@ message BrainStatusResponse {
   string indexing_repo = 11;  // repo currently being indexed (empty if idle)
   int32 queue_depth = 12;     // number of pending + running jobs
   EmbeddingStatus embedding_status = 13;
+  EffectiveConfig effective_config = 14;
 }
 
 // repo_states — per-repo indexed SHA and metadata for staleness comparison

--- a/src/main.rs
+++ b/src/main.rs
@@ -1353,6 +1353,50 @@ fn embedding_status_from_json(value: &serde_json::Value) -> nestweaver_proto::Em
     }
 }
 
+fn format_effective_config(config: Option<&nestweaver_proto::EffectiveConfig>) -> String {
+    use nestweaver_proto::effective_config::Source;
+
+    match config.and_then(|config| config.source.as_ref()) {
+        Some(Source::ConfiguredPath(path)) if !path.is_empty() => path.clone(),
+        Some(Source::CompiledDefaults(_)) => "none — compiled defaults".to_string(),
+        Some(Source::ConfiguredPath(_)) | None => "unknown (older daemon)".to_string(),
+    }
+}
+
+fn format_daemon_status_response(
+    response: Result<&nestweaver_proto::BrainStatusResponse, &str>,
+) -> String {
+    match response {
+        Ok(status) => {
+            let mut lines = vec![format!(
+                "Config: {}",
+                format_effective_config(status.effective_config.as_ref())
+            )];
+            lines.push("Embedding:".to_string());
+            if let Some(embedding) = status.embedding_status.as_ref() {
+                lines.push(format_embedding_status(embedding));
+            } else {
+                lines.push("  State:            unknown (older daemon)".to_string());
+            }
+            lines.join("\n")
+        }
+        Err(error) => [
+            "Config: unknown (daemon unreachable)".to_string(),
+            "Embedding:".to_string(),
+            "  State:            unavailable (daemon booting or unreachable)".to_string(),
+            format!("  Error:            {error}"),
+        ]
+        .join("\n"),
+    }
+}
+
+fn format_daemon_not_running_status(summary: &str) -> String {
+    format!(
+        "{summary}\n{}",
+        format_daemon_status_response(Err("daemon is not running"))
+    )
+}
+
 fn print_daemon_embedding_status(db_path: &Path) {
     let result = tokio::runtime::Runtime::new()
         .map_err(anyhow::Error::from)
@@ -1364,18 +1408,87 @@ fn print_daemon_embedding_status(db_path: &Path) {
         });
     match result {
         Ok(status) => {
-            println!("Embedding:");
-            if let Some(status) = status.embedding_status {
-                println!("{}", format_embedding_status(&status));
-            } else {
-                println!("  State:            unknown (older daemon)");
-            }
+            println!("{}", format_daemon_status_response(Ok(&status)));
         }
         Err(error) => {
-            println!("Embedding:");
-            println!("  State:            unavailable (daemon booting or unreachable)");
-            println!("  Error:            {error:#}");
+            let error = format!("{error:#}");
+            println!("{}", format_daemon_status_response(Err(&error)));
         }
+    }
+}
+
+#[cfg(test)]
+mod daemon_status_renderer_tests {
+    use super::*;
+    use nestweaver_proto::effective_config::{CompiledDefaults, Source};
+
+    fn embedding() -> nestweaver_proto::EmbeddingStatus {
+        nestweaver_proto::EmbeddingStatus {
+            state: "ready".to_string(),
+            backend: "local".to_string(),
+            requested_device: "auto".to_string(),
+            selected_device: "cpu".to_string(),
+            model_id: "test-model".to_string(),
+            error: String::new(),
+            metal_compiled: false,
+            fallback_used: false,
+        }
+    }
+
+    #[test]
+    fn configured_path_and_embedding_share_one_status_render() {
+        let status = nestweaver_proto::BrainStatusResponse {
+            effective_config: Some(nestweaver_proto::EffectiveConfig {
+                source: Some(Source::ConfiguredPath(
+                    "/canonical/instance.toml".to_string(),
+                )),
+            }),
+            embedding_status: Some(embedding()),
+            ..Default::default()
+        };
+
+        let output = format_daemon_status_response(Ok(&status));
+        assert!(output.starts_with("Config: /canonical/instance.toml\nEmbedding:\n"));
+        assert!(output.contains("  State:            ready"));
+        assert!(output.contains("  Model:            test-model"));
+    }
+
+    #[test]
+    fn compiled_defaults_are_explicit() {
+        let status = nestweaver_proto::BrainStatusResponse {
+            effective_config: Some(nestweaver_proto::EffectiveConfig {
+                source: Some(Source::CompiledDefaults(CompiledDefaults {})),
+            }),
+            embedding_status: Some(embedding()),
+            ..Default::default()
+        };
+
+        let output = format_daemon_status_response(Ok(&status));
+        assert!(output.starts_with("Config: none — compiled defaults\nEmbedding:\n"));
+    }
+
+    #[test]
+    fn absent_old_wire_fields_are_reported_as_unknown() {
+        let output =
+            format_daemon_status_response(Ok(&nestweaver_proto::BrainStatusResponse::default()));
+        assert!(output.starts_with("Config: unknown (older daemon)\nEmbedding:\n"));
+        assert!(output.contains("  State:            unknown (older daemon)"));
+    }
+
+    #[test]
+    fn unreachable_daemon_reports_config_and_embedding_honestly() {
+        let output = format_daemon_status_response(Err("transport refused"));
+        assert!(output.starts_with("Config: unknown (daemon unreachable)\nEmbedding:\n"));
+        assert!(output.contains("unavailable (daemon booting or unreachable)"));
+        assert!(output.ends_with("  Error:            transport refused"));
+    }
+
+    #[test]
+    fn not_running_command_path_still_reports_config_provenance() {
+        let output = format_daemon_not_running_status("Daemon is not running.");
+        assert!(output.starts_with(
+            "Daemon is not running.\nConfig: unknown (daemon unreachable)\nEmbedding:\n"
+        ));
     }
 }
 
@@ -11497,7 +11610,10 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             print_daemon_embedding_status(&db_path);
                         } else {
                             println!(
-                                "Daemon is not running (pidfile PID {pid} belongs to another process)."
+                                "{}",
+                                format_daemon_not_running_status(&format!(
+                                    "Daemon is not running (pidfile PID {pid} belongs to another process)."
+                                ))
                             );
                         }
                         return Ok((EXIT_SUCCESS, None));
@@ -11515,7 +11631,10 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         print_daemon_embedding_status(&db_path);
                         return Ok((EXIT_SUCCESS, None));
                     }
-                    println!("Daemon is not running.");
+                    println!(
+                        "{}",
+                        format_daemon_not_running_status("Daemon is not running.")
+                    );
                     Ok((EXIT_SUCCESS, None))
                 }
                 DaemonAction::Gc => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5189,6 +5189,187 @@ fn daemon_identity_verified(
     daemon_socket_reported_pid(socket) == Some(pid)
 }
 
+fn daemon_restart_start_args(
+    db_path: &std::path::Path,
+    idle_timeout: u64,
+    restart_config: &nestweaver_client::RestartConfig,
+) -> Vec<std::ffi::OsString> {
+    let mut args = vec![
+        "daemon".into(),
+        "--db".into(),
+        db_path.as_os_str().to_owned(),
+        "start".into(),
+        "--idle-timeout".into(),
+        idle_timeout.to_string().into(),
+    ];
+    if let Some(config) = restart_config.as_path() {
+        args.push("--config".into());
+        args.push(config.as_os_str().to_owned());
+    }
+    args
+}
+
+async fn start_and_verify_restarted_daemon(
+    db_path: &std::path::Path,
+    executable: PathBuf,
+    args: Vec<std::ffi::OsString>,
+    restart_config: &nestweaver_client::RestartConfig,
+    spawn_lock: nestweaver_client::autostart::SpawnLock,
+) -> anyhow::Result<()> {
+    let status = tokio::task::spawn_blocking(move || {
+        std::process::Command::new(executable).args(args).status()
+    })
+    .await
+    .context("daemon restart command task failed")?
+    .context("failed to execute daemon start")?;
+    anyhow::ensure!(status.success(), "daemon start failed with {status}");
+
+    // `daemon start` preserves existing platform routing. Persistent macOS
+    // agents use KeepAlive.Crashed, so the preceding successful gRPC shutdown
+    // exits 0 and is not respawned; `start` then bootouts/reinstalls the plist.
+    // launchd may report a still-booting success, so wait for health without
+    // auto-starting before final trust checks.
+    nestweaver_client::DaemonClient::wait_healthy(db_path, std::time::Duration::from_secs(60))
+        .await?;
+    let socket =
+        nestweaver_daemon::socket_path(&nestweaver_daemon::instance_id_from_db_path(db_path));
+    let verified =
+        nestweaver_client::connect_verified_replacement(&socket, db_path, restart_config).await;
+    drop(spawn_lock);
+    verified.map(|_| ())
+}
+
+async fn restart_verified_live_under_lock(
+    db_path: &std::path::Path,
+    idle_timeout: u64,
+    explicit_config: Option<&std::path::Path>,
+    original: nestweaver_client::PreparedRestart,
+    expected_config: nestweaver_client::RestartConfig,
+    spawn_lock: nestweaver_client::autostart::SpawnLock,
+) -> anyhow::Result<()> {
+    let mut client = nestweaver_client::DaemonClient::connect_existing(db_path)
+        .await
+        .context("reconnect to live daemon after acquiring restart transaction lock")?;
+    let locked_health = client.health_check().await.context(
+        "could not revalidate live daemon after acquiring restart transaction lock; no shutdown was attempted",
+    )?;
+    let prepared = nestweaver_client::prepare_restart(db_path, &locked_health, explicit_config)
+        .and_then(|prepared| {
+            anyhow::ensure!(
+                prepared.config() == &expected_config,
+                "daemon effective config changed while waiting for the restart transaction lock; no shutdown was attempted"
+            );
+            Ok(prepared)
+        });
+    drop(original);
+
+    // PREPARE includes every fallible local decision needed to launch. In
+    // particular, a broken current_exe lookup must leave the live daemon
+    // untouched rather than discovering the failure after Shutdown.
+    let executable = std::env::current_exe().context("cannot determine binary path")?;
+    let start_args = daemon_restart_start_args(db_path, idle_timeout, &expected_config);
+
+    nestweaver_client::run_prepared_restart(
+        prepared,
+        || async {
+            let response = client
+                .inner_mut()
+                .shutdown(nestweaver_proto::ShutdownRequest {})
+                .await
+                .context("daemon shutdown request failed; refusing to start a replacement")?
+                .into_inner();
+            Ok(response.ok)
+        },
+        |mut prepared| async move {
+            prepared.wait_for_owner_release().await?;
+            prepared.release_pidfile_lock();
+            start_and_verify_restarted_daemon(
+                db_path,
+                executable,
+                start_args,
+                prepared.config(),
+                spawn_lock,
+            )
+            .await
+        },
+    )
+    .await
+}
+
+async fn restart_live_daemon_preserving_config(
+    db_path: &std::path::Path,
+    idle_timeout: u64,
+    explicit_config: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
+    match nestweaver_client::DaemonClient::connect_existing(db_path).await {
+        Ok(mut client) => {
+            let original_health = client.health_check().await?;
+            let original =
+                nestweaver_client::prepare_restart(db_path, &original_health, explicit_config)?;
+            let expected_config = original.config().clone();
+            let spawn_lock =
+                nestweaver_client::autostart::SpawnLock::acquire_async(db_path).await?;
+            restart_verified_live_under_lock(
+                db_path,
+                idle_timeout,
+                explicit_config,
+                original,
+                expected_config,
+                spawn_lock,
+            )
+            .await
+        }
+        Err(_) => {
+            // Serialize against auto-start, then recheck: a concurrent client
+            // may have published a daemon while the first connection failed.
+            let spawn_lock =
+                nestweaver_client::autostart::SpawnLock::acquire_async(db_path).await?;
+            if let Ok(mut winner) = nestweaver_client::DaemonClient::connect_existing(db_path).await
+            {
+                let health = winner.health_check().await?;
+                let original =
+                    nestweaver_client::prepare_restart(db_path, &health, explicit_config)?;
+                let expected_config = original.config().clone();
+                return restart_verified_live_under_lock(
+                    db_path,
+                    idle_timeout,
+                    explicit_config,
+                    original,
+                    expected_config,
+                    spawn_lock,
+                )
+                .await;
+            }
+
+            // No healthy socket winner. Prove the current pidfile inode is
+            // unowned before treating this as cold; an unresponsive live
+            // daemon fails here instead of being overlapped. Stale sidecar
+            // state is intentionally ignored on this branch.
+            let mut unowned = nestweaver_client::autostart::UnownedPidfileLock::acquire(db_path)?;
+            if nestweaver_client::DaemonClient::connect_existing(db_path)
+                .await
+                .is_ok()
+            {
+                anyhow::bail!(
+                    "a daemon became connectable while proving cold-start ownership; refusing to overlap it"
+                );
+            }
+            let restart_config = nestweaver_client::RestartConfig::for_cold_start(explicit_config)?;
+            let executable = std::env::current_exe().context("cannot determine binary path")?;
+            let start_args = daemon_restart_start_args(db_path, idle_timeout, &restart_config);
+            unowned.release();
+            start_and_verify_restarted_daemon(
+                db_path,
+                executable,
+                start_args,
+                &restart_config,
+                spawn_lock,
+            )
+            .await
+        }
+    }
+}
+
 /// nw-087: commands that operate on an existing database must fail
 /// `db_not_found` when the file is absent — never autostart a daemon that
 /// CREATES an empty DB (a typo'd `--db` must not false-green). The message is
@@ -11693,53 +11874,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     idle_timeout,
                     config,
                 } => {
-                    // Stop if running.
-                    if let Ok(pid_str) = std::fs::read_to_string(&pidfile)
-                        && let Ok(pid) = pid_str.trim().parse::<i32>()
-                        && unsafe { libc::kill(pid, 0) } == 0
-                    {
-                        eprintln!("Stopping daemon (PID {pid})...");
-                        unsafe { libc::kill(pid, libc::SIGTERM) };
-                        for _ in 0..50 {
-                            std::thread::sleep(std::time::Duration::from_millis(100));
-                            if unsafe { libc::kill(pid, 0) } != 0 {
-                                break;
-                            }
-                        }
-                        if unsafe { libc::kill(pid, 0) } == 0 {
-                            unsafe { libc::kill(pid, libc::SIGKILL) };
-                            std::thread::sleep(std::time::Duration::from_millis(200));
-                        }
-                        remove_unowned_daemon_runtime(
-                            &pidfile,
-                            &socket,
-                            &nestweaver_daemon::effective_config_binding_path(&instance_id),
-                        );
-                        eprintln!("Daemon stopped.");
-                    }
-
-                    // Re-exec ourselves to start the daemon fresh.
-                    let exe =
-                        std::env::current_exe().unwrap_or_else(|_| PathBuf::from("nestweaver"));
-                    let mut start_args: Vec<String> = vec![
-                        "daemon".to_string(),
-                        "--db".to_string(),
-                        db_path.display().to_string(),
-                        "start".to_string(),
-                        "--idle-timeout".to_string(),
-                        idle_timeout.to_string(),
-                    ];
-                    if let Some(cfg) = config.as_deref() {
-                        start_args.push("--config".to_string());
-                        start_args.push(cfg.display().to_string());
-                    }
-                    let status = std::process::Command::new(&exe)
-                        .args(&start_args)
-                        .status()
-                        .with_context(|| "failed to restart daemon")?;
-                    if !status.success() {
-                        anyhow::bail!("daemon start failed with {status}");
-                    }
+                    let runtime = tokio::runtime::Runtime::new()
+                        .context("failed to create daemon restart runtime")?;
+                    runtime.block_on(restart_live_daemon_preserving_config(
+                        &db_path,
+                        idle_timeout,
+                        config.as_deref(),
+                    ))?;
                     Ok((EXIT_SUCCESS, None))
                 }
             }
@@ -18799,6 +18940,57 @@ fn impact_item_to_result(
 #[cfg(test)]
 mod abs_for_daemon_tests {
     use super::*;
+
+    fn restart_args(config: &nestweaver_client::RestartConfig) -> Vec<std::ffi::OsString> {
+        daemon_restart_start_args(std::path::Path::new("/tmp/brain.lbug"), 123, config)
+    }
+
+    #[test]
+    fn restart_without_flag_preserves_captured_configured_path() {
+        let args = restart_args(&nestweaver_client::RestartConfig::Configured(
+            "/canonical/instance.toml".into(),
+        ));
+        assert_eq!(
+            args,
+            [
+                "daemon",
+                "--db",
+                "/tmp/brain.lbug",
+                "start",
+                "--idle-timeout",
+                "123",
+                "--config",
+                "/canonical/instance.toml",
+            ]
+            .map(std::ffi::OsString::from)
+        );
+    }
+
+    #[test]
+    fn restart_without_flag_preserves_captured_compiled_defaults() {
+        let args = restart_args(&nestweaver_client::RestartConfig::CompiledDefaults);
+        assert_eq!(
+            args,
+            [
+                "daemon",
+                "--db",
+                "/tmp/brain.lbug",
+                "start",
+                "--idle-timeout",
+                "123",
+            ]
+            .map(std::ffi::OsString::from)
+        );
+    }
+
+    #[test]
+    fn restart_explicit_override_is_the_spawned_config_decision() {
+        let args = restart_args(&nestweaver_client::RestartConfig::Configured(
+            "/explicit/override.toml".into(),
+        ));
+        assert_eq!(args[6], "--config");
+        assert_eq!(args[7], "/explicit/override.toml");
+    }
 
     #[test]
     fn relative_path_becomes_absolute_never_bare_relative() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5072,13 +5072,18 @@ fn pidfile_flock_held(pidfile: &std::path::Path) -> bool {
 /// another starter cannot acquire this inode before the stale socket is
 /// removed, and the pidfile is unlinked last so a later starter gets a fresh
 /// inode that this cleanup never touches.
-#[cfg(target_os = "macos")]
-fn remove_unowned_daemon_runtime(pidfile: &std::path::Path, socket: &std::path::Path) {
+fn remove_unowned_daemon_runtime(
+    pidfile: &std::path::Path,
+    socket: &std::path::Path,
+    effective_config_binding: &std::path::Path,
+) {
     use std::os::unix::io::AsRawFd;
 
     let Ok(file) = std::fs::OpenOptions::new()
+        .create(true)
         .read(true)
         .write(true)
+        .truncate(false)
         .open(pidfile)
     else {
         return;
@@ -5089,6 +5094,7 @@ fn remove_unowned_daemon_runtime(pidfile: &std::path::Path, socket: &std::path::
     }
 
     let _ = std::fs::remove_file(socket);
+    let _ = std::fs::remove_file(effective_config_binding);
     let _ = std::fs::remove_file(pidfile);
     unsafe {
         libc::flock(fd, libc::LOCK_UN);
@@ -11221,7 +11227,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                     let _ = child.kill();
                                     let _ = child.wait();
                                 }
-                                remove_unowned_daemon_runtime(&pidfile, &socket);
+                                remove_unowned_daemon_runtime(
+                                    &pidfile,
+                                    &socket,
+                                    &nestweaver_daemon::effective_config_binding_path(&instance_id),
+                                );
                                 anyhow::bail!(
                                     "temporary daemon for {} did not become healthy: {error:#}",
                                     db_path_abs.display()
@@ -11515,8 +11525,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         } else {
                             println!("Daemon is not running.");
                         }
-                        let _ = std::fs::remove_file(&pidfile);
-                        let _ = std::fs::remove_file(&socket);
+                        remove_unowned_daemon_runtime(
+                            &pidfile,
+                            &socket,
+                            &nestweaver_daemon::effective_config_binding_path(&instance_id),
+                        );
                         return Ok((EXIT_SUCCESS, None));
                     };
 
@@ -11561,8 +11574,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         std::thread::sleep(std::time::Duration::from_millis(100));
                         if unsafe { libc::kill(pid, 0) } != 0 {
                             eprintln!("Daemon stopped.");
-                            let _ = std::fs::remove_file(&pidfile);
-                            let _ = std::fs::remove_file(&socket);
+                            remove_unowned_daemon_runtime(
+                                &pidfile,
+                                &socket,
+                                &nestweaver_daemon::effective_config_binding_path(&instance_id),
+                            );
                             return Ok((EXIT_SUCCESS, None));
                         }
                     }
@@ -11574,8 +11590,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         libc::kill(pid, libc::SIGKILL);
                     }
                     std::thread::sleep(std::time::Duration::from_millis(200));
-                    let _ = std::fs::remove_file(&pidfile);
-                    let _ = std::fs::remove_file(&socket);
+                    remove_unowned_daemon_runtime(
+                        &pidfile,
+                        &socket,
+                        &nestweaver_daemon::effective_config_binding_path(&instance_id),
+                    );
                     eprintln!("Daemon killed.");
                     Ok((EXIT_SUCCESS, None))
                 }
@@ -11691,8 +11710,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             unsafe { libc::kill(pid, libc::SIGKILL) };
                             std::thread::sleep(std::time::Duration::from_millis(200));
                         }
-                        let _ = std::fs::remove_file(&pidfile);
-                        let _ = std::fs::remove_file(&socket);
+                        remove_unowned_daemon_runtime(
+                            &pidfile,
+                            &socket,
+                            &nestweaver_daemon::effective_config_binding_path(&instance_id),
+                        );
                         eprintln!("Daemon stopped.");
                     }
 
@@ -20879,14 +20901,15 @@ mod daemon_cli_tests {
         );
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(unix)]
     #[test]
-    fn macos_failed_start_cleanup_preserves_concurrent_owner() {
+    fn unowned_runtime_cleanup_preserves_concurrent_owner_and_removes_binding() {
         use std::os::unix::io::AsRawFd;
 
         let dir = tempfile::tempdir().unwrap();
         let pidfile = dir.path().join("daemon.pid");
         let socket = dir.path().join("daemon.sock");
+        let binding = dir.path().join("effective-config.json");
         let owner = std::fs::OpenOptions::new()
             .create(true)
             .read(true)
@@ -20895,19 +20918,25 @@ mod daemon_cli_tests {
             .open(&pidfile)
             .unwrap();
         std::fs::write(&socket, "incumbent socket").unwrap();
+        std::fs::write(&binding, "incumbent binding").unwrap();
         assert_eq!(unsafe { libc::flock(owner.as_raw_fd(), libc::LOCK_EX) }, 0);
 
-        remove_unowned_daemon_runtime(&pidfile, &socket);
+        remove_unowned_daemon_runtime(&pidfile, &socket, &binding);
         assert!(
             pidfile.exists(),
             "a concurrent owner's pidfile must survive"
         );
         assert!(socket.exists(), "a concurrent owner's socket must survive");
+        assert!(
+            binding.exists(),
+            "a concurrent owner's effective-config binding must survive"
+        );
 
         assert_eq!(unsafe { libc::flock(owner.as_raw_fd(), libc::LOCK_UN) }, 0);
         drop(owner);
-        remove_unowned_daemon_runtime(&pidfile, &socket);
+        remove_unowned_daemon_runtime(&pidfile, &socket, &binding);
         assert!(!socket.exists(), "unowned socket must be retired");
+        assert!(!binding.exists(), "unowned binding must be retired");
         assert!(!pidfile.exists(), "unowned pidfile must be retired");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5209,6 +5209,38 @@ fn daemon_restart_start_args(
     args
 }
 
+fn verify_explicit_config_before_start_success(
+    db_path: &std::path::Path,
+    config_path: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
+    let Some(config_path) = config_path else {
+        return Ok(());
+    };
+    let runtime = tokio::runtime::Runtime::new()
+        .context("create runtime for explicit daemon config verification")?;
+    runtime.block_on(nestweaver_client::verify_running_daemon_config(
+        db_path,
+        config_path,
+    ))
+}
+
+fn acquire_daemon_start_spawn_lock(
+    db_path: &std::path::Path,
+    inherited_fd: Option<std::ffi::OsString>,
+) -> anyhow::Result<Option<nestweaver_client::autostart::SpawnLock>> {
+    if let Some(inherited_fd) = inherited_fd {
+        let inherited_fd = inherited_fd
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("inherited parent spawnlock FD is not valid UTF-8"))?
+            .parse::<std::os::fd::RawFd>()
+            .context("inherited parent spawnlock FD is not an integer")?;
+        nestweaver_client::autostart::SpawnLock::inherit_parent_handoff(db_path, inherited_fd)
+            .map(Some)
+    } else {
+        nestweaver_client::autostart::SpawnLock::acquire(db_path).map(Some)
+    }
+}
+
 async fn start_and_verify_restarted_daemon(
     db_path: &std::path::Path,
     executable: PathBuf,
@@ -5216,12 +5248,12 @@ async fn start_and_verify_restarted_daemon(
     restart_config: &nestweaver_client::RestartConfig,
     spawn_lock: nestweaver_client::autostart::SpawnLock,
 ) -> anyhow::Result<()> {
-    let status = tokio::task::spawn_blocking(move || {
-        std::process::Command::new(executable).args(args).status()
-    })
-    .await
-    .context("daemon restart command task failed")?
-    .context("failed to execute daemon start")?;
+    let mut command = daemon_restart_command(executable, args);
+    spawn_lock.configure_child_handoff(&mut command)?;
+    let status = tokio::task::spawn_blocking(move || command.status())
+        .await
+        .context("daemon restart command task failed")?
+        .context("failed to execute daemon start")?;
     anyhow::ensure!(status.success(), "daemon start failed with {status}");
 
     // `daemon start` preserves existing platform routing. Persistent macOS
@@ -5237,6 +5269,15 @@ async fn start_and_verify_restarted_daemon(
         nestweaver_client::connect_verified_replacement(&socket, db_path, restart_config).await;
     drop(spawn_lock);
     verified.map(|_| ())
+}
+
+fn daemon_restart_command(
+    executable: PathBuf,
+    args: Vec<std::ffi::OsString>,
+) -> std::process::Command {
+    let mut command = std::process::Command::new(executable);
+    command.args(args);
+    command
 }
 
 async fn restart_verified_live_under_lock(
@@ -11190,11 +11231,27 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     config,
                     track_interactions,
                 } => {
+                    // Serialize every direct start from incumbent preflight
+                    // through readiness and final config attestation. Parents
+                    // in autostart/restart already hold this exact lock and
+                    // mark only their child command to avoid self-deadlock.
+                    let inherited_spawn_lock =
+                        std::env::var_os(nestweaver_client::autostart::PARENT_SPAWN_LOCK_FD_ENV);
+                    let mut start_spawn_lock =
+                        acquire_daemon_start_spawn_lock(&db_path, inherited_spawn_lock)?;
                     if track_interactions {
                         eprintln!(
                             "note: --track-interactions is an MCP flag, not a daemon flag. \
                              Use: nestweaver mcp --track-interactions"
                         );
+                    }
+                    if let Some(requested_config) = config.as_deref() {
+                        // Validate before any platform-specific stop/install or
+                        // daemonize mutation. A bad explicit path must leave an
+                        // already-running daemon untouched.
+                        let _ = nestweaver_client::RestartConfig::for_cold_start(Some(
+                            requested_config,
+                        ))?;
                     }
                     std::fs::create_dir_all(&runtime_dir).with_context(|| {
                         format!("create runtime dir: {}", runtime_dir.display())
@@ -11231,6 +11288,41 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 .ok()
                                 .filter(|v| v.trim().parse::<u32>().is_ok());
                             let config_abs = config.as_deref().map(abs_for_daemon);
+
+                            // An explicit start against a live incumbent is an
+                            // assertion about that daemon, not permission to
+                            // replace it. Attest before bootout or SIGTERM so a
+                            // mismatch, old wire, or missing provenance leaves
+                            // the incumbent untouched. A stale launchd job or
+                            // live pidfile with no healthy RPC is likewise not
+                            // safe to mutate implicitly.
+                            if let Some(requested_config) = config_abs.as_deref() {
+                                let launchd_owned =
+                                    nestweaver_daemon::launchd::is_running(&instance_id);
+                                // The held flock, not a numeric PID plus
+                                // kill(0), is the ownership proof. The latter
+                                // could identify an unrelated recycled PID.
+                                let live_pidfile = pidfile_flock_held(&pidfile);
+                                match verify_explicit_config_before_start_success(
+                                    &db_path_abs,
+                                    Some(requested_config),
+                                ) {
+                                    Ok(()) => {
+                                        eprintln!("Daemon already running with requested config.");
+                                        return Ok((EXIT_SUCCESS, None));
+                                    }
+                                    Err(error) if launchd_owned || live_pidfile => {
+                                        return Err(error).context(
+                                            "refusing to stop a launchd/pidfile-owned incumbent before explicit --config provenance is verified",
+                                        );
+                                    }
+                                    Err(_) => {
+                                        // No live ownership evidence: this is
+                                        // a cold start; final attestation below
+                                        // still protects a concurrent winner.
+                                    }
+                                }
+                            }
                             let plist = nestweaver_daemon::launchd::generate_plist_with_config(
                                 &instance_id,
                                 &binary_path,
@@ -11312,8 +11404,19 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 &db_path,
                                 std::time::Duration::from_secs(60),
                             )) {
-                                Ok(_) => return Ok((EXIT_SUCCESS, None)),
-                                Err(_) => {
+                                Ok(_) => {
+                                    verify_explicit_config_before_start_success(
+                                        &db_path,
+                                        config.as_deref(),
+                                    )?;
+                                    return Ok((EXIT_SUCCESS, None));
+                                }
+                                Err(error) => {
+                                    if config.is_some() {
+                                        return Err(error).context(
+                                            "daemon start cannot confirm that the running launchd agent honors explicit --config",
+                                        );
+                                    }
                                     // Deliberately NOT reaping the half-booted
                                     // agent: launchd owns its lifecycle and a
                                     // bootout here would race launchd's next
@@ -11397,6 +11500,10 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                     }
                                     eprintln!("Daemon already running (PID {}).", health.pid);
                                 }
+                                verify_explicit_config_before_start_success(
+                                    &db_path_abs,
+                                    config_abs.as_deref(),
+                                )?;
                                 Ok((EXIT_SUCCESS, None))
                             }
                             Err(error) => {
@@ -11458,6 +11565,10 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 } else {
                                     eprintln!("Daemon already running (PID {pid_trimmed}).");
                                 }
+                                verify_explicit_config_before_start_success(
+                                    &db_path,
+                                    config.as_deref(),
+                                )?;
                                 return Ok((EXIT_SUCCESS, None));
                             }
                             anyhow::bail!("flock on pidfile failed: {err}");
@@ -11505,6 +11616,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         match unsafe { daemonize.execute() } {
                             daemonize2::Outcome::Child(Ok(_)) => {
                                 // We are now the daemon process.
+                                if let Some(lock) = start_spawn_lock.take() {
+                                    lock.close_in_forked_child_without_unlock();
+                                }
                                 // daemonize2's pidfile flock was acquired before
                                 // the fork and is inherited by this child. Mark
                                 // that ownership only after `execute()` returns in
@@ -11551,6 +11665,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 }
                                 if wait_for_daemon_boot(&socket, std::time::Duration::from_secs(10))
                                 {
+                                    if let Err(error) = verify_explicit_config_before_start_success(
+                                        &db_path,
+                                        config.as_deref(),
+                                    ) {
+                                        eprintln!("Error: {error:#}");
+                                        std::process::exit(EXIT_ERROR);
+                                    }
                                     eprintln!("Daemon started.");
                                     std::process::exit(EXIT_SUCCESS);
                                 }
@@ -18990,6 +19111,65 @@ mod abs_for_daemon_tests {
         ));
         assert_eq!(args[6], "--config");
         assert_eq!(args[7], "/explicit/override.toml");
+    }
+
+    #[test]
+    fn restart_child_command_marks_parent_spawn_lock_ownership() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        let spawn_lock = nestweaver_client::autostart::SpawnLock::acquire(&db).unwrap();
+        let mut command = daemon_restart_command(
+            PathBuf::from("/opt/nestweaver"),
+            restart_args(&nestweaver_client::RestartConfig::CompiledDefaults),
+        );
+        spawn_lock.configure_child_handoff(&mut command).unwrap();
+        let fd = command
+            .get_envs()
+            .find_map(|(name, value)| {
+                (name == nestweaver_client::autostart::PARENT_SPAWN_LOCK_FD_ENV)
+                    .then_some(value.unwrap())
+            })
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .parse::<std::os::fd::RawFd>()
+            .unwrap();
+        assert!(fd >= 3);
+    }
+
+    #[test]
+    fn direct_start_serialization_rejects_missing_fd_and_blocks_contenders() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+
+        // Leave the expected lock file present but unowned. Ambient marker
+        // state alone must not bypass direct-start serialization.
+        drop(acquire_daemon_start_spawn_lock(&db, None).unwrap().unwrap());
+        let forged = match acquire_daemon_start_spawn_lock(&db, Some("-1".into())) {
+            Err(error) => error,
+            Ok(_) => panic!("forged parent marker must not skip an unowned spawn lock"),
+        };
+        assert!(format!("{forged:#}").contains("invalid inherited"));
+
+        let first = acquire_daemon_start_spawn_lock(&db, None).unwrap().unwrap();
+
+        let contender_db = db.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let contender = std::thread::spawn(move || {
+            let second = acquire_daemon_start_spawn_lock(&contender_db, None)
+                .unwrap()
+                .unwrap();
+            tx.send(()).unwrap();
+            drop(second);
+        });
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_millis(150))
+                .is_err()
+        );
+        drop(first);
+        rx.recv_timeout(std::time::Duration::from_secs(2))
+            .expect("direct start contender should proceed after readiness owner releases");
+        contender.join().unwrap();
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4264,18 +4264,18 @@ fn vault_registrations_for_root(
     db_path: &Path,
     config: Option<&Path>,
     root: &Path,
-) -> Vec<(String, String)> {
+) -> anyhow::Result<Vec<(String, String)>> {
     let root_str = root.to_string_lossy().to_string();
     let matches_root = |candidate: &str| candidate == root_str;
 
-    if let Some(value) = try_hybrid_json_rpc(
+    if let Some(value) = try_hybrid_json_rpc_checked(
         use_daemon,
         db_path,
         config,
         "brain_status",
         serde_json::json!({}),
-    ) {
-        return value
+    )? {
+        return Ok(value
             .get("vaults")
             .and_then(|v| v.as_array())
             .map(|vaults| {
@@ -4294,14 +4294,14 @@ fn vault_registrations_for_root(
                     })
                     .collect()
             })
-            .unwrap_or_default();
+            .unwrap_or_default());
     }
 
     // Direct fallback. A missing database is not an error here.
     if !db_path.exists() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
-    match open_store(Some(db_path)) {
+    Ok(match open_store(Some(db_path)) {
         Ok(store) => store
             .list_vaults(None)
             .map(|vaults| {
@@ -4316,7 +4316,7 @@ fn vault_registrations_for_root(
             tracing::debug!("vault_registrations_for_root: store read skipped: {error}");
             Vec::new()
         }
-    }
+    })
 }
 
 /// The instance the caller EXPLICITLY asked for, if any.
@@ -5829,9 +5829,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 if let Some(ref inst) = instance {
                     args["instance"] = serde_json::json!(inst);
                 }
-                if let Some(value) =
-                    try_hybrid_json_rpc(true, &db_path, config_opt.as_deref(), "list_repos", args)
-                {
+                if let Some(value) = try_hybrid_json_rpc_checked(
+                    true,
+                    &db_path,
+                    config_opt.as_deref(),
+                    "list_repos",
+                    args,
+                )? {
                     let value = unwrap_hybrid_payload(value);
                     let repo_count = value.as_array().map(|a| a.len()).unwrap_or(0);
                     if json {
@@ -6501,13 +6505,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             "intent": intent.clone().unwrap_or_default(),
                             "include_seeds": true,
                         });
-                        if let Some(result_json) = try_hybrid_json_rpc(
+                        if let Some(result_json) = try_hybrid_json_rpc_checked(
                             use_daemon,
                             db_path,
                             config.as_deref(),
                             "brain_context",
                             hybrid_args,
-                        ) {
+                        )? {
                             let result: nestweaver_engine::BrainContextResult =
                                 serde_json::from_value(result_json)?;
                             let effective_limit = limit.unwrap_or(30);
@@ -6597,13 +6601,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     "intent": intent.clone().unwrap_or_default(),
                     "include_seeds": true,
                 });
-                if let Some(result_json) = try_hybrid_json_rpc(
+                if let Some(result_json) = try_hybrid_json_rpc_checked(
                     use_daemon,
                     db_path,
                     config.as_deref(),
                     "brain_context",
                     hybrid_args,
-                ) {
+                )? {
                     let result: nestweaver_engine::BrainContextResult =
                         serde_json::from_value(result_json)?;
                     let cut = match token_budget {
@@ -6726,13 +6730,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             if use_daemon {
                 let db_path = db.clone().unwrap_or_else(default_db_path);
                 let args = serde_json::json!({});
-                if let Some(value) = try_hybrid_json_rpc(
+                if let Some(value) = try_hybrid_json_rpc_checked(
                     true,
                     &db_path,
                     config_opt.as_deref(),
                     "suggest_links",
                     args,
-                ) {
+                )? {
                     if json {
                         println!("{}", serde_json::to_string_pretty(&value)?);
                     } else {
@@ -6912,9 +6916,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 if let Some(ref c) = config {
                     args["config"] = serde_json::json!(c.to_string_lossy());
                 }
-                if let Some(value) =
-                    try_hybrid_json_rpc(true, &db_path, config.as_deref(), "brain_guide", args)
-                {
+                if let Some(value) = try_hybrid_json_rpc_checked(
+                    true,
+                    &db_path,
+                    config.as_deref(),
+                    "brain_guide",
+                    args,
+                )? {
                     // brain_guide returns { "guide": "<markdown>" }. Extract the
                     // raw markdown body — printing the JSON object would emit an
                     // envelope with escaped newlines instead of a usable guide.
@@ -7065,73 +7073,54 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             require_existing_db(&db_path)?;
 
             // ── hybrid guard (routes through local + upstream) ────
-            if use_daemon && let Ok(rt) = tokio::runtime::Runtime::new() {
-                let start_dir =
-                    std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-                let connect = rt.block_on(nestweaver_client::hybrid::HybridClient::connect(
-                    &db_path,
-                    config.as_deref(),
-                    &start_dir,
-                ));
-                if let Ok(mut hybrid) = connect {
-                    let rpc = rt.block_on(hybrid.query(
-                        "hub_nodes",
-                        &serde_json::json!({
-                            "top_n": top,
-                        }),
-                    ));
-                    match rpc {
-                        Ok(value) => {
-                            // Deserialize into the direct path's type so
-                            // both output modes match direct output byte-for-byte
-                            // (the daemon envelope carries _meta/count the direct
-                            // path never prints).
-                            let hubs: Vec<HubNode> = value
-                                .get("hubs")
-                                .and_then(|v| serde_json::from_value(v.clone()).ok())
-                                .unwrap_or_default();
-                            if json {
-                                println!("{}", serde_json::to_string_pretty(&hubs)?);
-                            } else if hubs.is_empty() {
-                                println!("No hub nodes found (graph may be empty).");
-                            } else {
-                                println!("Top {} hub nodes (by total degree):\n", hubs.len());
-                                for h in &hubs {
-                                    let cluster = h
-                                        .cluster_id
-                                        .map(|id| format!(" cluster={id}"))
-                                        .unwrap_or_default();
-                                    println!(
-                                        "  {} ({}) in={} out={} total={} pr={:.4}{cluster}",
-                                        h.name,
-                                        h.file_path,
-                                        h.in_degree,
-                                        h.out_degree,
-                                        h.total_degree,
-                                        h.pagerank_score,
-                                    );
-                                }
-                            }
-                            // nw-124: the daemon serves this path, so the
-                            // disclosure has to live here too — otherwise it
-                            // only ever fires on the direct path users are
-                            // told not to use.
-                            warn_stale_resolver_rankings_no_store(&db_path);
-                            let stats = format!(
-                                "{} hubs in {} (via hybrid)",
-                                value.get("count").and_then(|v| v.as_u64()).unwrap_or(0),
-                                format_elapsed(t0.elapsed())
-                            );
-                            return Ok((EXIT_SUCCESS, Some(stats)));
-                        }
-                        Err(e) => {
-                            eprintln!(
-                                "warning: hybrid hub_nodes query failed ({}); falling back to direct DB read",
-                                e
-                            );
-                        }
+            if let Some(value) = try_hybrid_json_rpc_checked(
+                use_daemon,
+                &db_path,
+                config.as_deref(),
+                "hub_nodes",
+                serde_json::json!({ "top_n": top }),
+            )? {
+                // Deserialize into the direct path's type so
+                // both output modes match direct output byte-for-byte
+                // (the daemon envelope carries _meta/count the direct
+                // path never prints).
+                let hubs: Vec<HubNode> = value
+                    .get("hubs")
+                    .and_then(|v| serde_json::from_value(v.clone()).ok())
+                    .unwrap_or_default();
+                if json {
+                    println!("{}", serde_json::to_string_pretty(&hubs)?);
+                } else if hubs.is_empty() {
+                    println!("No hub nodes found (graph may be empty).");
+                } else {
+                    println!("Top {} hub nodes (by total degree):\n", hubs.len());
+                    for h in &hubs {
+                        let cluster = h
+                            .cluster_id
+                            .map(|id| format!(" cluster={id}"))
+                            .unwrap_or_default();
+                        println!(
+                            "  {} ({}) in={} out={} total={} pr={:.4}{cluster}",
+                            h.name,
+                            h.file_path,
+                            h.in_degree,
+                            h.out_degree,
+                            h.total_degree,
+                            h.pagerank_score,
+                        );
                     }
                 }
+                // nw-124: the daemon serves this path, so the
+                // disclosure has to live here too — otherwise it
+                // only ever fires on the direct path users are
+                // told not to use.
+                warn_stale_resolver_rankings_no_store(&db_path);
+                let stats = format!(
+                    "{} hubs in {} (via hybrid)",
+                    value.get("count").and_then(|v| v.as_u64()).unwrap_or(0),
+                    format_elapsed(t0.elapsed())
+                );
+                return Ok((EXIT_SUCCESS, Some(stats)));
             }
 
             let store = open_store(Some(&db_path))?;
@@ -7189,9 +7178,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // ── daemon guard ──────────────────────────────────────
             if use_daemon {
                 let args = bridge_nodes_rpc_args(top);
-                if let Some(value) =
-                    try_hybrid_json_rpc(true, &db_path, config_opt.as_deref(), "bridge_nodes", args)
-                {
+                if let Some(value) = try_hybrid_json_rpc_checked(
+                    true,
+                    &db_path,
+                    config_opt.as_deref(),
+                    "bridge_nodes",
+                    args,
+                )? {
                     // Deserialize the tool's `bridges` array into the
                     // direct path's type so both modes render identically.
                     let bridges: Vec<nestweaver_engine::BridgeNode> = serde_json::from_value(
@@ -7417,9 +7410,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 if let Some(r) = resolution {
                     args["resolution"] = serde_json::json!(r);
                 }
-                if let Some(value) =
-                    try_hybrid_json_rpc(true, &db_path, config_opt.as_deref(), "clusters", args)
-                {
+                if let Some(value) = try_hybrid_json_rpc_checked(
+                    true,
+                    &db_path,
+                    config_opt.as_deref(),
+                    "clusters",
+                    args,
+                )? {
                     // The tool returns {clusters: [...]} with `size` where
                     // the direct path's ClusteringOutput uses `communities` and
                     // `member_count`. Rebuild the real structs so both modes
@@ -7802,13 +7799,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // paths therefore produce one payload and render through one
             // function, so the output format follows --json rather than whether
             // a daemon happens to be running (nw-108).
-            let payload = match try_hybrid_json_rpc(
+            let payload = match try_hybrid_json_rpc_checked(
                 use_daemon,
                 &db_path,
                 config.as_deref(),
                 "blast_radius",
                 args.clone(),
-            ) {
+            )? {
                 Some(value) => value,
                 None => {
                     let store = open_store(Some(&db_path))?;
@@ -7847,13 +7844,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 "max_depth": max_depth,
             });
 
-            let payload = match try_hybrid_json_rpc(
+            let payload = match try_hybrid_json_rpc_checked(
                 use_daemon,
                 &db_path,
                 config.as_deref(),
                 "flow_trace",
                 args.clone(),
-            ) {
+            )? {
                 Some(value) => value,
                 None => {
                     let store = open_store(Some(&db_path))?;
@@ -8704,14 +8701,36 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
         } => {
             let db_path = db.unwrap_or_else(default_db_path);
 
+            let daemon_connection = if use_daemon {
+                match tokio::runtime::Runtime::new() {
+                    Ok(rt) => match rt.block_on(nestweaver_client::DaemonClient::connect(
+                        &db_path,
+                        config.as_deref().map(std::path::Path::as_ref),
+                    )) {
+                        Ok(client) => Some((rt, client)),
+                        Err(error) if config.is_some() => {
+                            return Err(error).context(
+                                "explicit config could not be honored by the daemon for UI; refusing direct fallback",
+                            );
+                        }
+                        Err(error) => {
+                            tracing::warn!(
+                                "daemon UI connection failed, falling back to direct: {error:#}"
+                            );
+                            None
+                        }
+                    },
+                    Err(error) if config.is_some() => {
+                        return Err(error).context("create runtime for explicit-config daemon UI");
+                    }
+                    Err(_) => None,
+                }
+            } else {
+                None
+            };
+
             let mut daemon_ok = false;
-            if use_daemon
-                && let Ok(rt) = tokio::runtime::Runtime::new()
-                && let Ok(mut client) = rt.block_on(nestweaver_client::DaemonClient::connect(
-                    &db_path,
-                    config.as_deref().map(std::path::Path::as_ref),
-                ))
-            {
+            if let Some((rt, mut client)) = daemon_connection {
                 let watch_repo_path = if watch {
                     detect_repo_root().display().to_string()
                 } else {
@@ -8773,8 +8792,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             }
                         }
                     }
-                    Err(e) => {
-                        tracing::warn!("ServeUi RPC failed, falling back to direct: {e}");
+                    Err(error) if config.is_some() => {
+                        return Err(error).context(
+                            "explicit-config daemon UI request failed; refusing direct fallback",
+                        );
+                    }
+                    Err(error) => {
+                        tracing::warn!("ServeUi RPC failed, falling back to direct: {error}");
                     }
                 }
             }
@@ -8828,9 +8852,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             if use_daemon {
                 let db_path = db.clone().unwrap_or_else(default_db_path);
                 let args = serde_json::json!({ "query": query, "limit": limit });
-                if let Some(value) =
-                    try_hybrid_json_rpc(true, &db_path, config.as_deref(), "search_symbols", args)
-                {
+                if let Some(value) = try_hybrid_json_rpc_checked(
+                    true,
+                    &db_path,
+                    config.as_deref(),
+                    "search_symbols",
+                    args,
+                )? {
                     if json {
                         // Normalize to the same bare-array shape the direct path emits (below):
                         // unwrap the {results, _meta} hybrid envelope so `search --json` yields
@@ -8911,9 +8939,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 if let Some(ms) = max_millis {
                     args["max_millis"] = serde_json::json!(ms);
                 }
-                if let Some(value) =
-                    try_hybrid_json_rpc(true, &db_path, config.as_deref(), "regex_search", args)
-                {
+                if let Some(value) = try_hybrid_json_rpc_checked(
+                    true,
+                    &db_path,
+                    config.as_deref(),
+                    "regex_search",
+                    args,
+                )? {
                     // Strip the hybrid `_meta` provenance so both output
                     // modes match the direct path byte-for-byte.
                     let res: nestweaver_store::regex::RegexSearchResult =
@@ -9035,9 +9067,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 if let Some(ref k) = kinds {
                     args["kinds"] = serde_json::json!(k);
                 }
-                if let Some(value) =
-                    try_hybrid_json_rpc(true, &db_path, config.as_deref(), "count_patterns", args)
-                {
+                if let Some(value) = try_hybrid_json_rpc_checked(
+                    true,
+                    &db_path,
+                    config.as_deref(),
+                    "count_patterns",
+                    args,
+                )? {
                     // The tool wraps counts in {"patterns": [...]}
                     // (plus a hybrid `_meta`); rebuild the real PatternCount
                     // structs so daemon output is byte-identical to the direct
@@ -9114,9 +9150,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 let db_path = db.clone().unwrap_or_else(default_db_path);
                 let args =
                     read_symbols_rpc_args(&targets, neighbors, token_budget, root.as_deref());
-                if let Some(value) =
-                    try_hybrid_json_rpc(true, &db_path, config.as_deref(), "read_symbols", args)
-                {
+                if let Some(value) = try_hybrid_json_rpc_checked(
+                    true,
+                    &db_path,
+                    config.as_deref(),
+                    "read_symbols",
+                    args,
+                )? {
                     println!("{}", serde_json::to_string_pretty(&value)?);
                     return Ok((EXIT_SUCCESS, None));
                 }
@@ -9857,7 +9897,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // silently ignored.
             if use_daemon && repo_filter.is_none() && min_score.is_none() && confidence <= 0.0 {
                 let db_path = db.clone().unwrap_or_else(default_db_path);
-                if let Some(value) = try_hybrid_json_rpc(
+                if let Some(value) = try_hybrid_json_rpc_checked(
                     true,
                     &db_path,
                     config_opt.as_deref(),
@@ -9870,7 +9910,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         "symbol": name_or_uid,
                         "depth": depth,
                     }),
-                ) {
+                )? {
                     // Honor the daemon tool's status so daemon mode matches the direct path's
                     // exit-code contract (not_found=2, ambiguous=3) instead of always exit 0.
                     match value.get("status").and_then(|v| v.as_str()) {
@@ -10319,40 +10359,23 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let token_budget = token_budget.unwrap_or(if detailed { 3000 } else { 1000 });
             let db_path = db.unwrap_or_else(default_db_path);
 
-            if use_daemon && let Ok(rt) = tokio::runtime::Runtime::new() {
-                let start_dir =
-                    std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-                let connect = rt.block_on(nestweaver_client::hybrid::HybridClient::connect(
-                    &db_path,
-                    config.as_deref(),
-                    &start_dir,
-                ));
-                if let Ok(mut hybrid) = connect {
-                    let rpc = rt.block_on(hybrid.query(
-                        "project_context",
-                        &serde_json::json!({
-                            "project": name,
-                            "token_budget": token_budget,
-                            "response_format": response_format,
-                            "include_components": include_components,
-                            "since": since.clone().unwrap_or_default(),
-                            "recency_weight": recency_weight,
-                            "recency_half_life_days": recency_half_life_days,
-                        }),
-                    ));
-                    match rpc {
-                        Ok(value) => {
-                            render_project_context_daemon_response(&value, json, token_budget);
-                            return Ok((EXIT_SUCCESS, None));
-                        }
-                        Err(e) => {
-                            tracing::info!(
-                                "hybrid project_context query failed ({}); falling back to direct mode",
-                                e
-                            );
-                        }
-                    }
-                }
+            if let Some(value) = try_hybrid_json_rpc_checked(
+                use_daemon,
+                &db_path,
+                config.as_deref(),
+                "project_context",
+                serde_json::json!({
+                    "project": name,
+                    "token_budget": token_budget,
+                    "response_format": response_format,
+                    "include_components": include_components,
+                    "since": since.clone().unwrap_or_default(),
+                    "recency_weight": recency_weight,
+                    "recency_half_life_days": recency_half_life_days,
+                }),
+            )? {
+                render_project_context_daemon_response(&value, json, token_budget);
+                return Ok((EXIT_SUCCESS, None));
             }
 
             let store = open_store(Some(&db_path))?;
@@ -12835,13 +12858,13 @@ fn run_memory(
             // ── daemon guard ──────────────────────────────────────
             if use_daemon {
                 let args = serde_json::json!({});
-                if let Some(value) = try_hybrid_json_rpc(
+                if let Some(value) = try_hybrid_json_rpc_checked(
                     true,
                     &db_path,
                     config.as_deref(),
                     "brain_memory_lint",
                     args,
-                ) {
+                )? {
                     println!("{}", serde_json::to_string_pretty(&value)?);
                     return Ok((EXIT_SUCCESS, None));
                 }
@@ -12900,13 +12923,13 @@ fn run_memory(
             // ── daemon guard ──────────────────────────────────────
             if use_daemon {
                 let args = serde_json::json!({ "apply": apply });
-                if let Some(value) = try_hybrid_json_rpc(
+                if let Some(value) = try_hybrid_json_rpc_checked(
                     true,
                     &db_path,
                     config.as_deref(),
                     "brain_memory_consolidate",
                     args,
-                ) {
+                )? {
                     println!("{}", serde_json::to_string_pretty(&value)?);
                     return Ok((EXIT_SUCCESS, None));
                 }
@@ -12959,13 +12982,13 @@ fn run_memory(
                     "edge_types": edge_types,
                     "depth": depth,
                 });
-                if let Some(value) = try_hybrid_json_rpc(
+                if let Some(value) = try_hybrid_json_rpc_checked(
                     true,
                     &db_path,
                     config.as_deref(),
                     "brain_memory_related",
                     args,
-                ) {
+                )? {
                     println!("{}", serde_json::to_string_pretty(&value)?);
                     return Ok((EXIT_SUCCESS, None));
                 }
@@ -12998,20 +13021,27 @@ fn run_memory(
 
 /// Dispatch a read-only brain command through the `HybridClient`, which
 /// queries the local daemon **and** any configured upstream servers.
-/// Returns `Some(json_value)` on success, `None` if the daemon is
-/// unavailable or the RPC fails (caller should fall through to
-/// direct-disk mode).
-fn try_hybrid_json_rpc(
+/// Returns `Some(json_value)` on success and `None` when a configless caller
+/// may use the legacy direct-disk fallback. With an explicit config, daemon
+/// connection or hybrid query failures are returned: falling through would
+/// silently discard configured provenance/upstreams while still exiting 0.
+fn try_hybrid_json_rpc_checked(
     use_daemon: bool,
     db_path: &std::path::Path,
     config: Option<&std::path::Path>,
     rpc_name: &str,
     args: serde_json::Value,
-) -> Option<serde_json::Value> {
+) -> anyhow::Result<Option<serde_json::Value>> {
     if !use_daemon {
-        return None;
+        return Ok(None);
     }
-    let rt = tokio::runtime::Runtime::new().ok()?;
+    let rt = match tokio::runtime::Runtime::new() {
+        Ok(runtime) => runtime,
+        Err(error) if config.is_some() => {
+            return Err(error).context("create runtime for explicit-config daemon query");
+        }
+        Err(_) => return Ok(None),
+    };
     let start_dir = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
     // nw-087: a read/query against a NONEXISTENT local db must not autostart a
     // daemon that CREATES an empty store — that turns a typo'd `--db` path into a
@@ -13021,23 +13051,56 @@ fn try_hybrid_json_rpc(
     // `db_not_found` and a non-zero exit. `index` creates dbs and does NOT route
     // through here, so it is unaffected.
     if !db_path.exists() {
-        return rt
-            .block_on(nestweaver_client::hybrid::query_configured_upstreams_only(
-                config, &start_dir, rpc_name, &args,
-            ))
-            .ok();
+        if let Some(config_path) = config {
+            nestweaver_engine::InstanceConfig::from_file(config_path).with_context(|| {
+                format!(
+                    "load explicit instance config {} before missing-DB upstream routing",
+                    config_path.display()
+                )
+            })?;
+        }
+        let discovered =
+            nestweaver_client::discovery::discover_upstreams_with_config(&start_dir, config);
+        if discovered.is_empty() {
+            return Ok(None);
+        }
+        return match rt.block_on(nestweaver_client::hybrid::query_configured_upstreams_only(
+            config, &start_dir, rpc_name, &args,
+        )) {
+            Ok(value) => Ok(Some(value)),
+            Err(error) if config.is_some() => Err(error).with_context(|| {
+                format!(
+                    "explicit-config upstream query {rpc_name} failed; refusing direct fallback"
+                )
+            }),
+            Err(_) => Ok(None),
+        };
     }
     match rt.block_on(nestweaver_client::hybrid::HybridClient::connect(
         db_path, config, &start_dir,
     )) {
         Ok(mut hybrid) => match rt.block_on(hybrid.query(rpc_name, &args)) {
-            Ok(value) => Some(value),
+            Ok(value) => Ok(Some(value)),
             Err(e) => {
+                if config.is_some() {
+                    return Err(e).with_context(|| {
+                        format!(
+                            "explicit-config hybrid query {rpc_name} failed; refusing direct fallback"
+                        )
+                    });
+                }
                 warn_daemon_bypassed(db_path, rpc_name, &format!("{e:#}"));
-                None
+                Ok(None)
             }
         },
         Err(e) => {
+            if config.is_some() {
+                return Err(e).with_context(|| {
+                    format!(
+                        "explicit config could not be honored by the daemon for {rpc_name}; refusing direct fallback"
+                    )
+                });
+            }
             let upstream = rt
                 .block_on(nestweaver_client::hybrid::query_configured_upstreams_only(
                     config, &start_dir, rpc_name, &args,
@@ -13046,8 +13109,47 @@ fn try_hybrid_json_rpc(
             if upstream.is_none() {
                 warn_daemon_bypassed(db_path, rpc_name, &format!("{e:#}"));
             }
-            upstream
+            Ok(upstream)
         }
+    }
+}
+
+/// Configless compatibility wrapper. Callers with an explicit config must use
+/// [`try_hybrid_json_rpc_checked`] and propagate its error.
+fn try_hybrid_json_rpc(
+    use_daemon: bool,
+    db_path: &std::path::Path,
+    config: Option<&std::path::Path>,
+    rpc_name: &str,
+    args: serde_json::Value,
+) -> Option<serde_json::Value> {
+    debug_assert!(
+        !use_daemon || config.is_none(),
+        "explicit-config callers must use try_hybrid_json_rpc_checked"
+    );
+    match try_hybrid_json_rpc_checked(use_daemon, db_path, config, rpc_name, args) {
+        Ok(value) => value,
+        Err(error) => {
+            warn_daemon_bypassed(db_path, rpc_name, &format!("{error:#}"));
+            None
+        }
+    }
+}
+
+fn hybrid_source_label(value: &serde_json::Value) -> &'static str {
+    if value
+        .get("_meta")
+        .and_then(|meta| meta.get("sources"))
+        .and_then(|sources| sources.as_array())
+        .is_some_and(|sources| {
+            sources
+                .iter()
+                .any(|source| source.as_str() == Some("server"))
+        })
+    {
+        "daemon+hybrid"
+    } else {
+        "daemon"
     }
 }
 
@@ -13315,8 +13417,10 @@ fn run_brain(
 
             if use_daemon {
                 let rt = tokio::runtime::Runtime::new()?;
-                let mut client =
-                    rt.block_on(nestweaver_client::DaemonClient::connect(&db_path, None))?;
+                let mut client = rt.block_on(nestweaver_client::DaemonClient::connect(
+                    &db_path,
+                    config.as_deref(),
+                ))?;
                 // Absolute path: the daemon runs with CWD=/ and would otherwise resolve
                 // a client-relative vault path against the wrong directory (indexing 0).
                 let vault_abs = abs_for_daemon(&path);
@@ -13506,13 +13610,13 @@ fn run_brain(
             let db_path = db_resolved.as_path();
 
             // ── daemon guard ──────────────────────────────────────
-            if let Some(value) = try_hybrid_json_rpc(
+            if let Some(value) = try_hybrid_json_rpc_checked(
                 use_daemon,
                 db_path,
                 config.as_deref(),
                 "brain_status",
                 serde_json::json!({}),
-            ) {
+            )? {
                 if json {
                     // Inject upstream info into JSON output.
                     let mut value = value;
@@ -13962,13 +14066,13 @@ fn run_brain(
             require_existing_db(&db_path)?;
 
             // ── daemon guard ──────────────────────────────────────
-            if let Some(value) = try_hybrid_json_rpc(
+            if let Some(value) = try_hybrid_json_rpc_checked(
                 use_daemon,
                 &db_path,
                 None,
                 "stale_check",
                 serde_json::json!({}),
-            ) {
+            )? {
                 // Emit the exact JSON shape the direct path
                 // produces (the hybrid `_meta` envelope — whose background
                 // `stale_repos` verdict could contradict the tool's fresh
@@ -14469,7 +14573,7 @@ fn run_brain(
             // rows. The command documented in this repo's own CLAUDE.md did
             // this.
             let existing =
-                vault_registrations_for_root(use_daemon, &db_path, config.as_deref(), &canonical);
+                vault_registrations_for_root(use_daemon, &db_path, config.as_deref(), &canonical)?;
             let explicit = explicit_instance_id(instance.as_deref(), config.as_deref());
             let instance_id = match existing.as_slice() {
                 // Nothing registered here yet — a genuine create.
@@ -14535,8 +14639,10 @@ fn run_brain(
             if use_daemon && since.is_none() {
                 // Route full refresh through daemon's IndexVault RPC
                 let rt = tokio::runtime::Runtime::new()?;
-                let mut client =
-                    rt.block_on(nestweaver_client::DaemonClient::connect(&db_path, None))?;
+                let mut client = rt.block_on(nestweaver_client::DaemonClient::connect(
+                    &db_path,
+                    config.as_deref(),
+                ))?;
                 let req = nestweaver_proto::IndexVaultRequest {
                     // Absolute path: the daemon runs with CWD=/ and would otherwise
                     // resolve a client-relative vault path against the wrong directory.
@@ -14867,84 +14973,103 @@ fn run_brain(
             // and stay in sync with live re-indexing. Falls through to the
             // direct-disk implementation below when `--no-daemon` is set,
             // `NESTWEAVER_NO_DAEMON` is in the env, or the daemon is down.
-            if use_daemon && let Ok(rt) = tokio::runtime::Runtime::new() {
-                let cwd = std::env::current_dir().unwrap_or_default();
-                let connect = rt.block_on(nestweaver_client::hybrid::HybridClient::connect(
-                    &db_path,
-                    config.as_deref(),
-                    &cwd,
-                ));
-                if let Ok(mut hybrid) = connect {
-                    if hybrid.has_upstreams() {
-                        // Route through HybridClient::query for upstream routing.
-                        let params = serde_json::json!({
-                            "query": raw_query,
-                            "limit": limit,
-                            "prf": prf,
-                        });
-                        let rpc = rt.block_on(hybrid.query("brain_search", &params));
-                        match rpc {
-                            Ok(result) => {
-                                if json {
-                                    println!("{}", serde_json::to_string_pretty(&result)?);
-                                } else {
-                                    render_brain_search_json(&result)?;
+            if use_daemon {
+                let rt = match tokio::runtime::Runtime::new() {
+                    Ok(runtime) => Some(runtime),
+                    Err(error) if config.is_some() => {
+                        return Err(error)
+                            .context("create runtime for explicit-config brain search");
+                    }
+                    Err(_) => None,
+                };
+                if let Some(rt) = rt {
+                    let cwd = std::env::current_dir().unwrap_or_default();
+                    match rt.block_on(nestweaver_client::hybrid::HybridClient::connect(
+                        &db_path,
+                        config.as_deref(),
+                        &cwd,
+                    )) {
+                        Ok(mut hybrid) if hybrid.has_upstreams() => {
+                            let params = serde_json::json!({
+                                "query": raw_query,
+                                "limit": limit,
+                                "prf": prf,
+                            });
+                            match rt.block_on(hybrid.query("brain_search", &params)) {
+                                Ok(result) => {
+                                    if json {
+                                        println!("{}", serde_json::to_string_pretty(&result)?);
+                                    } else {
+                                        render_brain_search_json(&result)?;
+                                    }
+                                    let count = result
+                                        .get("results")
+                                        .and_then(|v| v.as_array())
+                                        .map(|a| a.len())
+                                        .unwrap_or(0);
+                                    let stats = format!(
+                                        "{} results in {} (via daemon+hybrid)",
+                                        count,
+                                        format_elapsed(t0.elapsed())
+                                    );
+                                    return Ok((EXIT_SUCCESS, Some(stats)));
                                 }
-                                let count = result
-                                    .get("results")
-                                    .and_then(|v| v.as_array())
-                                    .map(|a| a.len())
-                                    .unwrap_or(0);
-                                let stats = format!(
-                                    "{} results in {} (via daemon+hybrid)",
-                                    count,
-                                    format_elapsed(t0.elapsed())
-                                );
-                                return Ok((EXIT_SUCCESS, Some(stats)));
-                            }
-                            Err(e) => {
-                                eprintln!(
-                                    "warning: hybrid search failed ({}); falling back to direct DB read",
-                                    e
-                                );
+                                Err(error) if config.is_some() => {
+                                    return Err(error).context(
+                                        "explicit-config hybrid brain search failed; refusing direct fallback",
+                                    );
+                                }
+                                Err(error) => warn_daemon_bypassed(
+                                    &db_path,
+                                    "brain_search",
+                                    &format!("{error:#}"),
+                                ),
                             }
                         }
-                    } else {
-                        // No upstreams — use typed RPC for efficiency.
-                        let req = nestweaver_proto::BrainSearchRequest {
-                            query: raw_query.clone(),
-                            limit: limit as i32,
-                            response_format: None,
-                            include_bodies: false,
-                            prf,
-                            rerank: false,
-                            root: None,
-                        };
-                        let rpc = rt.block_on(async {
-                            hybrid.inner_mut().search(req).await.map(|r| r.into_inner())
-                        });
-                        match rpc {
-                            Ok(resp) => {
-                                render_brain_search_response(&resp, json)?;
-                                let stats = format!(
-                                    "{} results in {} (via daemon)",
-                                    resp.results.len(),
-                                    format_elapsed(t0.elapsed())
-                                );
-                                return Ok((EXIT_SUCCESS, Some(stats)));
+                        Ok(mut hybrid) => {
+                            let req = nestweaver_proto::BrainSearchRequest {
+                                query: raw_query.clone(),
+                                limit: limit as i32,
+                                response_format: None,
+                                include_bodies: false,
+                                prf,
+                                rerank: false,
+                                root: None,
+                            };
+                            match rt.block_on(async {
+                                hybrid.inner_mut().search(req).await.map(|r| r.into_inner())
+                            }) {
+                                Ok(resp) => {
+                                    render_brain_search_response(&resp, json)?;
+                                    let stats = format!(
+                                        "{} results in {} (via daemon)",
+                                        resp.results.len(),
+                                        format_elapsed(t0.elapsed())
+                                    );
+                                    return Ok((EXIT_SUCCESS, Some(stats)));
+                                }
+                                Err(error) if config.is_some() => {
+                                    return Err(error).context(
+                                        "explicit-config daemon brain search failed; refusing direct fallback",
+                                    );
+                                }
+                                Err(error) => warn_daemon_bypassed(
+                                    &db_path,
+                                    "brain_search",
+                                    &format!("{error:#}"),
+                                ),
                             }
-                            Err(status) => {
-                                eprintln!(
-                                    "warning: daemon search RPC failed ({}); falling back to direct DB read",
-                                    status.message()
-                                );
-                            }
+                        }
+                        Err(error) if config.is_some() => {
+                            return Err(error).context(
+                                "explicit config could not be honored by the daemon for brain_search; refusing direct fallback",
+                            );
+                        }
+                        Err(error) => {
+                            warn_daemon_bypassed(&db_path, "brain_search", &format!("{error:#}"));
                         }
                     }
                 }
-                // Connect failed → silently fall through (daemon may not be
-                // running for this DB; the direct-disk path is the legacy
-                // behavior and remains correct).
             }
 
             let store = open_store(Some(&db_path))?;
@@ -15041,20 +15166,9 @@ fn run_brain(
             // `--prefer-instance` are applied client-side and the daemon
             // proto does not yet carry them, so fall through to the local
             // path when either is set.
-            if use_daemon
-                && !no_tests
-                && prefer_instance.is_none()
-                && let Ok(rt) = tokio::runtime::Runtime::new()
-            {
-                let cwd = std::env::current_dir().unwrap_or_default();
-                let connect = rt.block_on(nestweaver_client::hybrid::HybridClient::connect(
-                    &db_path,
-                    config_path.as_deref(),
-                    &cwd,
-                ));
-                if let Ok(mut hybrid) = connect {
-                    // Build params JSON — used by both hybrid and typed paths.
-                    let context_params = serde_json::json!({
+            if use_daemon && !no_tests && prefer_instance.is_none() {
+                // Build params JSON — used by both hybrid and typed paths.
+                let context_params = serde_json::json!({
                         "seeds": seeds,
                         "token_budget": token_budget.unwrap_or(0),
                         "repos": repos,
@@ -15075,44 +15189,35 @@ fn run_brain(
                         "since": since.as_deref().unwrap_or(""),
                         "recency_weight": recency_weight,
                         "recency_half_life_days": recency_half_life_days,
-                    });
+                });
 
-                    // Route through hybrid.query for upstream merge.
-                    let rpc = rt.block_on(hybrid.query("brain_context", &context_params));
-                    match rpc {
-                        Ok(result_json) => {
-                            let result: nestweaver_engine::BrainContextResult =
-                                serde_json::from_value(result_json)?;
-                            let cut = match token_budget {
-                                Some(budget) => token_budgeted_truncate(&result.connected, budget),
-                                None => limit.min(result.connected.len()),
-                            };
-                            if json {
-                                print_brain_context_json(&result, cut)?;
-                            } else {
-                                print_brain_context_text(&result, cut, token_budget);
-                            }
-                            let source = if hybrid.has_upstreams() {
-                                "daemon+hybrid"
-                            } else {
-                                "daemon"
-                            };
-                            let node_count = result.seeds.len() + cut;
-                            let stats = format!(
-                                "{} nodes in {} (via {})",
-                                node_count,
-                                format_elapsed(t0.elapsed()),
-                                source,
-                            );
-                            return Ok((EXIT_SUCCESS, Some(stats)));
-                        }
-                        Err(e) => {
-                            eprintln!(
-                                "warning: daemon context RPC failed ({}); falling back to direct DB read",
-                                e
-                            );
-                        }
+                if let Some(result_json) = try_hybrid_json_rpc_checked(
+                    true,
+                    &db_path,
+                    config_path.as_deref(),
+                    "brain_context",
+                    context_params,
+                )? {
+                    let source = hybrid_source_label(&result_json);
+                    let result: nestweaver_engine::BrainContextResult =
+                        serde_json::from_value(result_json)?;
+                    let cut = match token_budget {
+                        Some(budget) => token_budgeted_truncate(&result.connected, budget),
+                        None => limit.min(result.connected.len()),
+                    };
+                    if json {
+                        print_brain_context_json(&result, cut)?;
+                    } else {
+                        print_brain_context_text(&result, cut, token_budget);
                     }
+                    let node_count = result.seeds.len() + cut;
+                    let stats = format!(
+                        "{} nodes in {} (via {})",
+                        node_count,
+                        format_elapsed(t0.elapsed()),
+                        source,
+                    );
+                    return Ok((EXIT_SUCCESS, Some(stats)));
                 }
             }
 
@@ -15434,13 +15539,13 @@ fn run_brain(
             let cfg = load_instance_config_opt(config.as_deref());
             let limit = resolve_limit(limit, cfg.as_ref(), 50);
 
-            if let Some(value) = try_hybrid_json_rpc(
+            if let Some(value) = try_hybrid_json_rpc_checked(
                 use_daemon,
                 &db_path,
                 config.as_deref(),
                 "brain_broken_links",
                 serde_json::json!({ "max_suggestions": max_suggestions, "limit": limit }),
-            ) {
+            )? {
                 if json {
                     println!("{}", serde_json::to_string_pretty(&value)?);
                 } else if let Some(arr) = value.get("broken_links") {
@@ -15545,13 +15650,13 @@ fn run_brain(
                     args["allowlist"] = serde_json::json!(allow);
                 }
                 args["limit"] = serde_json::json!(limit);
-                if let Some(value) = try_hybrid_json_rpc(
+                if let Some(value) = try_hybrid_json_rpc_checked(
                     use_daemon,
                     &db_path,
                     config.as_deref(),
                     "brain_orphan_documents",
                     args,
-                ) {
+                )? {
                     if json {
                         println!("{}", serde_json::to_string_pretty(&value)?);
                     } else if let Some(arr) = value.get("orphans") {
@@ -15626,13 +15731,13 @@ fn run_brain(
             let cfg = load_instance_config_opt(config.as_deref());
             let limit = resolve_limit(limit, cfg.as_ref(), 50);
 
-            if let Some(value) = try_hybrid_json_rpc(
+            if let Some(value) = try_hybrid_json_rpc_checked(
                 use_daemon,
                 &db_path,
                 config.as_deref(),
                 "brain_topic_clusters",
                 serde_json::json!({ "resolution": resolution, "limit": limit }),
-            ) {
+            )? {
                 if json {
                     println!("{}", serde_json::to_string_pretty(&value)?);
                 } else if let Some(arr) = value.get("clusters") {
@@ -15708,13 +15813,13 @@ fn run_brain(
                 if let Some(ref t) = tag {
                     args["tag"] = serde_json::json!(t);
                 }
-                if let Some(value) = try_hybrid_json_rpc(
+                if let Some(value) = try_hybrid_json_rpc_checked(
                     use_daemon,
                     &db_path,
                     config.as_deref(),
                     "brain_tag_graph",
                     args,
-                ) {
+                )? {
                     if json {
                         println!("{}", serde_json::to_string_pretty(&value)?);
                     } else if tag.is_some() {
@@ -15817,13 +15922,13 @@ fn run_brain(
             // missing --db, matching the other read commands.
             require_existing_db(&db_path)?;
 
-            if let Some(value) = try_hybrid_json_rpc(
+            if let Some(value) = try_hybrid_json_rpc_checked(
                 use_daemon,
                 &db_path,
                 config.as_deref(),
                 "brain_doc_stats",
                 serde_json::json!({ "top_tags_limit": top_tags_limit }),
-            ) {
+            )? {
                 if json {
                     println!("{}", serde_json::to_string_pretty(&value)?);
                 } else {
@@ -17956,7 +18061,7 @@ mod refresh_instance_resolution_tests {
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("absent.lbug");
         let root = dir.path().join("vault");
-        let found = vault_registrations_for_root(false, &missing, None, &root);
+        let found = vault_registrations_for_root(false, &missing, None, &root).unwrap();
         assert!(found.is_empty(), "got: {found:?}");
     }
 }
@@ -19612,6 +19717,35 @@ mod snapshot_build_guard_tests {
 mod hybrid_cli_tests {
     use super::*;
 
+    fn valid_local_instance_config(dir: &std::path::Path, extra: &str) -> String {
+        format!(
+            r#"
+instance_id = "missing-db-test"
+repos = []
+
+[snapshot_storage]
+backend = "local"
+path = "{}"
+
+[workspace]
+backend = "local"
+path = "{}"
+
+[inference]
+endpoint = "http://localhost:11434"
+embedding_model = "nomic-embed-text"
+summary_model = "qwen2.5-coder:7b"
+
+[git]
+credential_method = "gh"
+
+{extra}
+"#,
+            dir.join("snapshots").display(),
+            dir.join("workspace").display(),
+        )
+    }
+
     /// The CLI must send the exact arg names the MCP tools read —
     /// `top_n` for bridge_nodes, `changed_files` (array) for affected_tests.
     #[test]
@@ -20136,6 +20270,95 @@ mod hybrid_cli_tests {
         let items: Vec<String> =
             serde_json::from_value(unwrap_hybrid_payload(bare)).unwrap_or_default();
         assert_eq!(items, vec!["x".to_string()]);
+    }
+
+    #[test]
+    fn missing_db_does_not_swallow_explicit_config_upstream_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing_db = dir.path().join("missing.lbug");
+        let invalid_config = dir.path().join("invalid.toml");
+        std::fs::write(&invalid_config, "this is not valid = [toml").unwrap();
+
+        let error = try_hybrid_json_rpc_checked(
+            true,
+            &missing_db,
+            Some(&invalid_config),
+            "list_repos",
+            serde_json::json!({}),
+        )
+        .expect_err("an explicit config error must not become direct fallback");
+
+        assert!(
+            format!("{error:#}").contains("load explicit instance config"),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[test]
+    fn missing_db_with_valid_local_only_config_preserves_direct_not_found_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing_db = dir.path().join("missing.lbug");
+        let config = dir.path().join("instance.toml");
+        std::fs::write(&config, valid_local_instance_config(dir.path(), "")).unwrap();
+
+        let value = try_hybrid_json_rpc_checked(
+            true,
+            &missing_db,
+            Some(&config),
+            "list_repos",
+            serde_json::json!({}),
+        )
+        .expect("a valid local-only config is not an upstream failure");
+
+        assert!(value.is_none());
+    }
+
+    #[test]
+    fn missing_db_with_unusable_configured_upstream_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing_db = dir.path().join("missing.lbug");
+        let config = dir.path().join("instance.toml");
+        std::fs::write(
+            &config,
+            valid_local_instance_config(
+                dir.path(),
+                r#"
+[[upstream]]
+name = "unreachable"
+url = "http://127.0.0.1:1"
+mode = "primary"
+timeout = "20ms"
+"#,
+            ),
+        )
+        .unwrap();
+
+        let error = try_hybrid_json_rpc_checked(
+            true,
+            &missing_db,
+            Some(&config),
+            "list_repos",
+            serde_json::json!({}),
+        )
+        .expect_err("a declared but unusable upstream must fail closed");
+
+        assert!(format!("{error:#}").contains("refusing direct fallback"));
+    }
+
+    #[test]
+    fn hybrid_source_label_distinguishes_daemon_only_from_server_merge() {
+        assert_eq!(
+            hybrid_source_label(&serde_json::json!({
+                "_meta": { "sources": ["local"] }
+            })),
+            "daemon"
+        );
+        assert_eq!(
+            hybrid_source_label(&serde_json::json!({
+                "_meta": { "sources": ["local", "server"] }
+            })),
+            "daemon+hybrid"
+        );
     }
 }
 

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -1128,6 +1128,206 @@ fn daemon_crash_recovery() {
         .stdout(contains("running").and(contains("PID")));
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn daemon_restart_preserves_and_overrides_live_effective_config_without_early_shutdown() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_dir = dir.path().join("repo");
+    let db_path = dir.path().join("restart-config").join("test.lbug");
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+    write_test_repo(&repo_dir);
+    create_db(&repo_dir, &db_path);
+    let _guard = DaemonGuard::new(&db_path);
+
+    let write_config = |name: &str, instance_id: &str| {
+        let path = dir.path().join(name);
+        std::fs::write(
+            &path,
+            format!(
+                r#"
+instance_id = "{instance_id}"
+repos = []
+
+[snapshot_storage]
+backend = "local"
+path = "{}"
+
+[workspace]
+backend = "local"
+path = "{}"
+
+[inference]
+endpoint = "http://localhost:11434"
+embedding_model = "nomic-embed-text"
+summary_model = "qwen2.5-coder:7b"
+
+[git]
+credential_method = "gh"
+"#,
+                dir.path()
+                    .join(format!("{instance_id}-snapshots"))
+                    .display(),
+                dir.path()
+                    .join(format!("{instance_id}-workspace"))
+                    .display(),
+            ),
+        )
+        .unwrap();
+        path
+    };
+    let config_a = write_config("a.toml", "restart-a");
+    let config_b = write_config("b.toml", "restart-b");
+    let canonical_a = std::fs::canonicalize(&config_a).unwrap();
+    let canonical_b = std::fs::canonicalize(&config_b).unwrap();
+    let instance_id = nestweaver_daemon::instance_id_from_db_path(&db_path);
+    let pidfile = nestweaver_daemon::pidfile_path(&instance_id);
+    let read_pid = || {
+        std::fs::read_to_string(&pidfile)
+            .unwrap()
+            .trim()
+            .parse::<i32>()
+            .unwrap()
+    };
+    let status = || {
+        let output = daemon_action_cmd(&db_path, "status").output().unwrap();
+        assert!(output.status.success(), "status failed: {output:?}");
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    };
+    let index_and_assert_instance = |repo_name: &str, expected_instance: &str| {
+        let indexed_repo = dir.path().join(repo_name);
+        write_test_repo(&indexed_repo);
+        daemon_cmd()
+            .args([
+                "index",
+                "--repo",
+                &indexed_repo.display().to_string(),
+                "--db",
+                &db_path.display().to_string(),
+            ])
+            .assert()
+            .success();
+        let output = daemon_cmd()
+            .args([
+                "list-repos",
+                "--db",
+                &db_path.display().to_string(),
+                "--json",
+            ])
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let repos: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert!(
+            repos.as_array().unwrap().iter().any(|repo| {
+                repo.get("instance_id").and_then(|value| value.as_str()) == Some(expected_instance)
+            }),
+            "no indexed repo retained logical instance {expected_instance}: {repos}"
+        );
+    };
+
+    daemon_action_cmd(&db_path, "start")
+        .arg("--config")
+        .arg(&config_a)
+        .assert()
+        .success();
+    let pid_a = read_pid();
+    assert!(status().contains(&format!("Config: {}", canonical_a.display())));
+
+    daemon_action_cmd(&db_path, "restart").assert().success();
+    let pid_preserved = read_pid();
+    assert_ne!(
+        pid_preserved, pid_a,
+        "restart must replace the daemon process"
+    );
+    assert!(status().contains(&format!("Config: {}", canonical_a.display())));
+    index_and_assert_instance("repo-after-a", "restart-a");
+
+    let binding_path = nestweaver_daemon::effective_config_binding_path(&instance_id);
+    std::fs::remove_file(&binding_path).unwrap();
+    daemon_action_cmd(&db_path, "restart")
+        .assert()
+        .failure()
+        .stderr(contains("daemon has not been shut down"));
+    assert_eq!(read_pid(), pid_preserved);
+    assert_eq!(unsafe { libc::kill(pid_preserved, 0) }, 0);
+    assert!(status().contains(&format!("Config: {}", canonical_a.display())));
+
+    nestweaver_daemon::lifecycle::write_effective_config_binding(
+        &instance_id,
+        &nestweaver_daemon::lifecycle::EffectiveConfigBinding::new(
+            pid_preserved as u32,
+            nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::Configured {
+                path: canonical_a.to_str().unwrap().to_string(),
+            },
+        ),
+    )
+    .unwrap();
+    std::fs::write(&binding_path, "{not-json").unwrap();
+    daemon_action_cmd(&db_path, "restart")
+        .assert()
+        .failure()
+        .stderr(contains("daemon has not been shut down"));
+    assert_eq!(read_pid(), pid_preserved);
+    assert_eq!(unsafe { libc::kill(pid_preserved, 0) }, 0);
+
+    // Explicit config bypasses the corrupt provenance value but still uses
+    // the already-verified live PID/pidfile ownership evidence.
+    daemon_action_cmd(&db_path, "restart")
+        .arg("--config")
+        .arg(&config_b)
+        .assert()
+        .success();
+    let pid_overridden = read_pid();
+    assert_ne!(pid_overridden, pid_preserved);
+    assert!(status().contains(&format!("Config: {}", canonical_b.display())));
+    index_and_assert_instance("repo-after-b", "restart-b");
+
+    let missing = dir.path().join("missing.toml");
+    daemon_action_cmd(&db_path, "restart")
+        .arg("--config")
+        .arg(&missing)
+        .assert()
+        .failure()
+        .stderr(contains("daemon has not been shut down"));
+    assert_eq!(read_pid(), pid_overridden);
+    assert_eq!(unsafe { libc::kill(pid_overridden, 0) }, 0);
+
+    let malformed = dir.path().join("malformed.toml");
+    std::fs::write(&malformed, "instance_id = [invalid").unwrap();
+    daemon_action_cmd(&db_path, "restart")
+        .arg("--config")
+        .arg(&malformed)
+        .assert()
+        .failure()
+        .stderr(contains("daemon has not been shut down"));
+    assert_eq!(read_pid(), pid_overridden);
+    assert_eq!(unsafe { libc::kill(pid_overridden, 0) }, 0);
+
+    // Cold restart ignores a stale sidecar. Omitted config is an explicit
+    // compiled-default decision; an explicit path is still validated/chosen.
+    daemon_action_cmd(&db_path, "stop").assert().success();
+    nestweaver_daemon::lifecycle::write_effective_config_binding(
+        &instance_id,
+        &nestweaver_daemon::lifecycle::EffectiveConfigBinding::new(
+            999,
+            nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::Configured {
+                path: canonical_b.to_str().unwrap().to_string(),
+            },
+        ),
+    )
+    .unwrap();
+    daemon_action_cmd(&db_path, "restart").assert().success();
+    assert!(status().contains("Config: none"));
+
+    daemon_action_cmd(&db_path, "stop").assert().success();
+    daemon_action_cmd(&db_path, "restart")
+        .arg("--config")
+        .arg(&config_a)
+        .assert()
+        .success();
+    assert!(status().contains(&format!("Config: {}", canonical_a.display())));
+}
+
 #[test]
 fn daemon_concurrent_mcp() {
     let dir = tempfile::tempdir().unwrap();

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -1133,9 +1133,12 @@ fn daemon_crash_recovery() {
 fn daemon_restart_preserves_and_overrides_live_effective_config_without_early_shutdown() {
     let dir = tempfile::tempdir().unwrap();
     let repo_dir = dir.path().join("repo");
+    let vault_dir = dir.path().join("vault");
     let db_path = dir.path().join("restart-config").join("test.lbug");
     std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
     write_test_repo(&repo_dir);
+    std::fs::create_dir_all(&vault_dir).unwrap();
+    std::fs::write(vault_dir.join("note.md"), "# Config continuity\n").unwrap();
     create_db(&repo_dir, &db_path);
     let _guard = DaemonGuard::new(&db_path);
 
@@ -1193,6 +1196,20 @@ credential_method = "gh"
         assert!(output.status.success(), "status failed: {output:?}");
         String::from_utf8_lossy(&output.stdout).into_owned()
     };
+    let list_vaults = || {
+        let output = daemon_cmd()
+            .args([
+                "brain",
+                "list",
+                "--json",
+                "--db",
+                &db_path.display().to_string(),
+            ])
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "brain list failed: {output:?}");
+        output.stdout
+    };
     let index_and_assert_instance = |repo_name: &str, expected_instance: &str| {
         let indexed_repo = dir.path().join(repo_name);
         write_test_repo(&indexed_repo);
@@ -1232,6 +1249,20 @@ credential_method = "gh"
         .success();
     let pid_a = read_pid();
     assert!(status().contains(&format!("Config: {}", canonical_a.display())));
+
+    daemon_cmd()
+        .args([
+            "brain",
+            "add",
+            &vault_dir.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+            "--config",
+            &config_a.display().to_string(),
+        ])
+        .assert()
+        .success();
+    let vaults_before_mismatch = list_vaults();
 
     // A direct start against a live daemon may succeed only when the explicit
     // path canonicalizes to the daemon's typed configured provenance. Neither
@@ -1300,6 +1331,104 @@ credential_method = "gh"
         .failure()
         .stderr(contains("restart --config"));
     assert_eq!(read_pid(), pid_a);
+    assert_eq!(unsafe { libc::kill(pid_a, 0) }, 0);
+    assert_eq!(list_vaults(), vaults_before_mismatch);
+
+    // Read commands must enforce the same identity contract. In particular,
+    // brain search used to swallow HybridClient::connect's mismatch and return
+    // a successful direct-disk result, silently discarding the explicit config.
+    daemon_cmd()
+        .args([
+            "brain",
+            "search",
+            "test",
+            "--db",
+            &db_path.display().to_string(),
+            "--config",
+            &config_b.display().to_string(),
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            contains("refusing direct")
+                .and(contains("fallback"))
+                .and(contains("restart --config")),
+        );
+    assert_eq!(read_pid(), pid_a);
+    assert_eq!(unsafe { libc::kill(pid_a, 0) }, 0);
+
+    daemon_cmd()
+        .args([
+            "brain",
+            "add",
+            &vault_dir.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+            "--config",
+            &config_b.display().to_string(),
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("restart --config"));
+    assert_eq!(read_pid(), pid_a);
+    assert_eq!(unsafe { libc::kill(pid_a, 0) }, 0);
+    assert_eq!(list_vaults(), vaults_before_mismatch);
+
+    daemon_cmd()
+        .args([
+            "brain",
+            "refresh",
+            &vault_dir.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+            "--config",
+            &config_b.display().to_string(),
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("restart --config"));
+    assert_eq!(read_pid(), pid_a);
+    assert_eq!(unsafe { libc::kill(pid_a, 0) }, 0);
+    assert_eq!(list_vaults(), vaults_before_mismatch);
+
+    // An explicit, authorized direct bypass is not a daemon fallback and must
+    // retain its legacy behavior even when the live daemon uses another config.
+    no_daemon_cmd()
+        .args([
+            "--no-daemon",
+            "brain",
+            "search",
+            "test",
+            "--db",
+            &db_path.display().to_string(),
+            "--config",
+            &config_b.display().to_string(),
+        ])
+        .assert()
+        .success();
+
+    let occupied_ui_port = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let occupied_ui_port_arg = occupied_ui_port.local_addr().unwrap().port().to_string();
+    daemon_cmd()
+        .args([
+            "ui",
+            "--no-open",
+            "--port",
+            &occupied_ui_port_arg,
+            "--db",
+            &db_path.display().to_string(),
+            "--config",
+            &config_b.display().to_string(),
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            contains("refusing direct")
+                .and(contains("fallback"))
+                .and(contains("restart --config")),
+        );
+    assert_eq!(read_pid(), pid_a);
+    assert_eq!(unsafe { libc::kill(pid_a, 0) }, 0);
 
     daemon_action_cmd(&db_path, "restart").assert().success();
     let pid_preserved = read_pid();
@@ -1381,6 +1510,21 @@ credential_method = "gh"
 
     // Cold restart ignores a stale sidecar. Omitted config is an explicit
     // compiled-default decision; an explicit path is still validated/chosen.
+    daemon_action_cmd(&db_path, "stop").assert().success();
+    // A configless query preserves legacy availability when it starts with no
+    // daemon (autostart where possible, direct fallback if connect cannot win).
+    daemon_cmd()
+        .args([
+            "brain",
+            "search",
+            "test",
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .assert()
+        .success();
+    // The query may have autostarted a compiled-default daemon; restore the
+    // stopped precondition for the stale-sidecar cold-start case below.
     daemon_action_cmd(&db_path, "stop").assert().success();
     nestweaver_daemon::lifecycle::write_effective_config_binding(
         &instance_id,

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -1233,6 +1233,74 @@ credential_method = "gh"
     let pid_a = read_pid();
     assert!(status().contains(&format!("Config: {}", canonical_a.display())));
 
+    // A direct start against a live daemon may succeed only when the explicit
+    // path canonicalizes to the daemon's typed configured provenance. Neither
+    // a relative spelling nor a symlink changes config identity.
+    daemon_action_cmd(&db_path, "start")
+        .arg("--config")
+        .arg(&config_a)
+        .assert()
+        .success();
+    assert_eq!(read_pid(), pid_a);
+
+    let original_a = std::fs::read_to_string(&config_a).unwrap();
+    std::fs::write(&config_a, format!("{original_a}\n# valid live edit\n")).unwrap();
+    daemon_action_cmd(&db_path, "start")
+        .arg("--config")
+        .arg(&config_a)
+        .assert()
+        .success();
+    assert_eq!(read_pid(), pid_a);
+    std::fs::write(&config_a, original_a).unwrap();
+
+    let config_a_alias = dir.path().join("a-alias.toml");
+    std::os::unix::fs::symlink(&canonical_a, &config_a_alias).unwrap();
+    daemon_action_cmd(&db_path, "start")
+        .arg("--config")
+        .arg(&config_a_alias)
+        .assert()
+        .success();
+    assert_eq!(read_pid(), pid_a);
+
+    let mut relative_start = daemon_action_cmd(&db_path, "start");
+    relative_start
+        .current_dir(dir.path())
+        .arg("--config")
+        .arg("a.toml")
+        .assert()
+        .success();
+    assert_eq!(read_pid(), pid_a);
+
+    daemon_action_cmd(&db_path, "start")
+        .arg("--config")
+        .arg(&config_b)
+        .assert()
+        .failure()
+        .stderr(
+            contains(canonical_a.to_str().unwrap())
+                .and(contains(canonical_b.to_str().unwrap()))
+                .and(contains("restart --config")),
+        );
+    assert_eq!(read_pid(), pid_a);
+    assert_eq!(unsafe { libc::kill(pid_a, 0) }, 0);
+
+    // Exercise DaemonClient::connect's same-version early-success gate, not
+    // only the direct daemon-start path.
+    daemon_cmd()
+        .args([
+            "index",
+            "--repo",
+            &repo_dir.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+            "--config",
+            &config_b.display().to_string(),
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("restart --config"));
+    assert_eq!(read_pid(), pid_a);
+
     daemon_action_cmd(&db_path, "restart").assert().success();
     let pid_preserved = read_pid();
     assert_ne!(
@@ -1244,6 +1312,14 @@ credential_method = "gh"
 
     let binding_path = nestweaver_daemon::effective_config_binding_path(&instance_id);
     std::fs::remove_file(&binding_path).unwrap();
+    daemon_action_cmd(&db_path, "start")
+        .arg("--config")
+        .arg(&config_a)
+        .assert()
+        .failure()
+        .stderr(contains("effective config is unknown"));
+    assert_eq!(read_pid(), pid_preserved);
+    assert_eq!(unsafe { libc::kill(pid_preserved, 0) }, 0);
     daemon_action_cmd(&db_path, "restart")
         .assert()
         .failure()
@@ -1318,6 +1394,15 @@ credential_method = "gh"
     .unwrap();
     daemon_action_cmd(&db_path, "restart").assert().success();
     assert!(status().contains("Config: none"));
+    let pid_defaults = read_pid();
+    daemon_action_cmd(&db_path, "start")
+        .arg("--config")
+        .arg(&config_a)
+        .assert()
+        .failure()
+        .stderr(contains("compiled defaults").and(contains("restart --config")));
+    assert_eq!(read_pid(), pid_defaults);
+    assert_eq!(unsafe { libc::kill(pid_defaults, 0) }, 0);
 
     daemon_action_cmd(&db_path, "stop").assert().success();
     daemon_action_cmd(&db_path, "restart")

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -2196,7 +2196,9 @@ async fn hybrid_brain_search_merge_combines_local_and_server_sources() {
     index_repo(&local_repo, &db_local);
 
     let server = helpers::server_guard::ServerGuard::start_with_auth(&db_server, HYBRID_TOKEN);
-    let _local_guard = helpers::server_guard::ServerGuard::start(&db_local);
+    let cfg_path = dir.path().join("instance.toml");
+    write_upstream_config(&cfg_path, "server", &server.grpc_addr(), HYBRID_TOKEN);
+    let _local_guard = helpers::server_guard::ServerGuard::start_with_config(&db_local, &cfg_path);
 
     let mut local = connect_local(&db_local).await;
 
@@ -2323,8 +2325,6 @@ async fn hybrid_brain_search_merge_combines_local_and_server_sources() {
     // Exercise the real non-JSON CLI renderer through daemon + configured
     // merge routing. A hybrid result must never claim it is a substring
     // fallback merely because its engine is not the single-source "bm25".
-    let cfg_path = dir.path().join("instance.toml");
-    write_upstream_config(&cfg_path, "server", &server.grpc_addr(), HYBRID_TOKEN);
     // Retry-bound the CLI probe: even with the generous upstream timeout, a
     // transient ejection under CI load may yield a local-only first answer;
     // the circuit breaker re-probes and recovers, so the hybrid path must


### PR DESCRIPTION
## Summary

- expose typed effective-config provenance in daemon status and render configured, compiled-default, old-daemon, and unreachable states
- persist a private PID-bound live config binding and preserve it across automatic version upgrades and explicit daemon restarts
- reject explicit config that cannot be honored, using canonical path identity and verified successor state
- serialize start and restart handoffs with authenticated locked-FD transfer across exec

## Validation

- cargo test -p nestweaver-proto: 7 passed
- cargo test -p nestweaver-client --lib: 57 passed
- cargo test -p nestweaver-daemon --lib --all-features: 232 passed
- cargo test --bin nestweaver: 124 passed
- focused Linux daemon restart/config E2E: passed
- cargo check --workspace --all-targets: passed
- cargo fmt and diff checks: passed

## Compatibility and limitations

- protobuf field 14 is wire-additive; downstream exhaustive Rust struct literals may need the generated field
- real lifecycle E2E coverage is Linux-only; launchd and temporary macOS paths are covered by focused code and unit review
- no actual old-binary process E2E; old-wire absence and restart transaction behavior are tested separately
- no dedicated VisibleRepos restart E2E; exact config preservation and logical instance continuity are tested
- workspace all-features is not runnable on Linux because it enables the intentional Apple-only objc2 dependency

## Breaking behavior

A current-version daemon now rejects an explicit config unless it can prove the same canonical configured path. Use daemon restart with the requested config to apply a different path or reload edited contents. Verified version-upgrade restarts still apply the explicit config to the verified successor.