### PR TITLE
fix: close end-to-end CLI, daemon, watcher, and MCP regressions

### DIFF
--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -652,6 +652,36 @@ impl DaemonClient {
         Ok(resp.into_inner())
     }
 
+    /// List Contract nodes through the daemon, optionally resolving an exact
+    /// repository UID or case-insensitive repository display name there.
+    pub async fn list_contracts(
+        &mut self,
+        repo: Option<&str>,
+    ) -> Result<Vec<nestweaver_schema::Contract>> {
+        let response = self
+            .inner
+            .list_contracts(nestweaver_proto::ListContractsRequest {
+                repo: repo.map(str::to_string),
+            })
+            .await
+            .context("list_contracts RPC failed")?
+            .into_inner();
+        Ok(response
+            .contracts
+            .into_iter()
+            .map(|contract| nestweaver_schema::Contract {
+                uid: contract.uid,
+                kind: contract.kind,
+                verb: contract.verb,
+                path: contract.path,
+                operation_id: contract.operation_id,
+                repo_uid: contract.repo_uid,
+                source_path: contract.source_path,
+                confidence: contract.confidence,
+            })
+            .collect())
+    }
+
     /// The running daemon's own PID, as reported over its socket.
     ///
     /// Cross-check this against a pidfile PID before signaling that PID: a

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -3807,14 +3807,15 @@ impl NestWeaverDaemon for DaemonService {
                 symbols_found: 0,
             }));
 
-            let index_result = nestweaver_engine::index_markdown_directory_with_store(
-                &state.store,
-                &vault_path,
-                &state.db_path,
-                &instance_id,
-                &vault_name,
-                &extra_patterns,
-            );
+            let index_result =
+                nestweaver_engine::index_markdown_directory_with_store_and_deletion_count(
+                    &state.store,
+                    &vault_path,
+                    &state.db_path,
+                    &instance_id,
+                    &vault_name,
+                    &extra_patterns,
+                );
 
             match index_result {
                 Ok(result) => {
@@ -3822,11 +3823,13 @@ impl NestWeaverDaemon for DaemonService {
                         phase: Phase::Writing as i32,
                         message: format!(
                             "Indexed {} notes, {} headings, {} sections",
-                            result.notes_count, result.headings_count, result.sections_count
+                            result.index.notes_count,
+                            result.index.headings_count,
+                            result.index.sections_count
                         ),
-                        files_processed: result.notes_count as u64,
-                        files_total: result.notes_count as u64,
-                        symbols_found: result.headings_count as u64,
+                        files_processed: result.index.notes_count as u64,
+                        files_total: result.index.notes_count as u64,
+                        symbols_found: result.index.headings_count as u64,
                     }));
 
                     // Rebuild Tantivy search index so BM25 search reflects
@@ -3847,16 +3850,12 @@ impl NestWeaverDaemon for DaemonService {
                     // DONE phase
                     let _ = tx.blocking_send(Ok(IndexProgress {
                         phase: Phase::Done as i32,
-                        message: format!(
-                            "Done — {} notes, {} headings, {} sections, {} tags",
-                            result.notes_count,
-                            result.headings_count,
-                            result.sections_count,
-                            result.tags_count
+                        message: nestweaver_engine::index_md::format_markdown_refresh_summary(
+                            &result,
                         ),
-                        files_processed: result.notes_count as u64,
-                        files_total: result.notes_count as u64,
-                        symbols_found: result.headings_count as u64,
+                        files_processed: result.index.notes_count as u64,
+                        files_total: result.index.notes_count as u64,
+                        symbols_found: result.index.headings_count as u64,
                     }));
                 }
                 Err(e) => {

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -72,6 +72,150 @@ fn arm_disconnect_cancel(cancel: Arc<AtomicBool>) -> tokio_util::sync::DropGuard
     token.drop_guard()
 }
 
+fn list_contracts_impl(
+    store: &GraphStore,
+    repo_filter: Option<&str>,
+    visible: &nestweaver_engine::authz::VisibleRepos,
+) -> Result<ListContractsResponse, Status> {
+    let repo_is_visible = |repo_uid: &str| match visible {
+        nestweaver_engine::authz::VisibleRepos::All => true,
+        nestweaver_engine::authz::VisibleRepos::Only(_) => {
+            !repo_uid.is_empty() && visible.allows(repo_uid)
+        }
+    };
+    let repo_uid = if let Some(filter) = repo_filter {
+        let repos = nestweaver_engine::list_repos(store, None)
+            .map_err(|error| Status::internal(format!("list repositories: {error:#}")))?;
+        let visible_repos: Vec<_> = repos
+            .iter()
+            .filter(|repo| repo_is_visible(&repo.uid))
+            .collect();
+        // Preserve the direct CLI resolver's precedence: an exact UID must
+        // beat an earlier repo whose display name happens to equal that UID.
+        let repo = visible_repos
+            .iter()
+            .copied()
+            .find(|repo| repo.uid == filter)
+            .or_else(|| {
+                let needle = filter.to_lowercase();
+                visible_repos.iter().copied().find(|repo| {
+                    nestweaver_engine::repo_display_name(repo).to_lowercase() == needle
+                })
+            })
+            .ok_or_else(|| {
+                Status::invalid_argument(format!("no indexed repo matches --repo '{filter}'"))
+            })?;
+        Some(repo.uid.clone())
+    } else {
+        None
+    };
+
+    let mut contracts = store
+        .list_contracts(repo_uid.as_deref())
+        .map_err(|error| Status::internal(format!("list contracts: {error}")))?;
+    contracts.retain(|contract| repo_is_visible(&contract.repo_uid));
+    contracts.sort_by(|left, right| left.uid.cmp(&right.uid));
+
+    Ok(ListContractsResponse {
+        contracts: contracts
+            .into_iter()
+            .map(|contract| ContractRecord {
+                uid: contract.uid,
+                kind: contract.kind,
+                verb: contract.verb,
+                path: contract.path,
+                operation_id: contract.operation_id,
+                repo_uid: contract.repo_uid,
+                source_path: contract.source_path,
+                confidence: contract.confidence,
+            })
+            .collect(),
+    })
+}
+
+#[cfg(test)]
+mod list_contracts_tests {
+    use std::collections::HashSet;
+
+    use nestweaver_engine::authz::VisibleRepos;
+    use nestweaver_schema::{Contract, Repo};
+
+    use super::*;
+
+    fn repo(uid: &str, name: &str) -> Repo {
+        Repo {
+            uid: uid.to_string(),
+            url: format!("https://example.test/{name}.git"),
+            indexed_sha: "abc".to_string(),
+            staleness_commits_behind: 0,
+            instance_id: "test".to_string(),
+            name: Some(name.to_string()),
+            root_path: None,
+        }
+    }
+
+    fn contract(uid: &str, repo_uid: &str) -> Contract {
+        Contract {
+            uid: uid.to_string(),
+            kind: "http".to_string(),
+            verb: Some("GET".to_string()),
+            path: Some(format!("/{uid}")),
+            operation_id: None,
+            repo_uid: repo_uid.to_string(),
+            source_path: "openapi.yaml".to_string(),
+            confidence: 1.0,
+        }
+    }
+
+    #[test]
+    fn list_contracts_prefers_exact_uid_and_filters_hidden_repos() {
+        let store = GraphStore::in_memory().unwrap();
+        // The first repo's display name collides with the second repo's exact
+        // UID. Exact UID must win regardless of list order.
+        store.insert_repo(&repo("repo:display", "target")).unwrap();
+        store.insert_repo(&repo("target", "exact")).unwrap();
+        store
+            .insert_repo(&repo("repo:unicode", "Überblick"))
+            .unwrap();
+        store
+            .insert_contract(&contract("contract:display", "repo:display"))
+            .unwrap();
+        store
+            .insert_contract(&contract("contract:exact", "target"))
+            .unwrap();
+        store
+            .insert_contract(&contract("contract:unicode", "repo:unicode"))
+            .unwrap();
+
+        let exact = list_contracts_impl(&store, Some("target"), &VisibleRepos::All).unwrap();
+        assert_eq!(exact.contracts.len(), 1);
+        assert_eq!(exact.contracts[0].uid, "contract:exact");
+
+        let unicode = list_contracts_impl(&store, Some("überblick"), &VisibleRepos::All).unwrap();
+        assert_eq!(unicode.contracts.len(), 1);
+        assert_eq!(unicode.contracts[0].uid, "contract:unicode");
+
+        let empty = list_contracts_impl(&store, Some(""), &VisibleRepos::All).unwrap_err();
+        assert_eq!(empty.code(), tonic::Code::InvalidArgument);
+        assert!(
+            empty
+                .message()
+                .contains("no indexed repo matches --repo ''")
+        );
+
+        let visible = VisibleRepos::Only(HashSet::from(["target".to_string()]));
+        let unfiltered = list_contracts_impl(&store, None, &visible).unwrap();
+        assert_eq!(unfiltered.contracts.len(), 1);
+        assert_eq!(unfiltered.contracts[0].uid, "contract:exact");
+
+        for filter in ["repo:display", "does-not-exist"] {
+            let error = list_contracts_impl(&store, Some(filter), &visible).unwrap_err();
+            assert_eq!(error.code(), tonic::Code::InvalidArgument);
+            assert!(error.message().contains("no indexed repo matches --repo"));
+        }
+    }
+}
+
 /// RAII guard that decrements a connection counter on drop.
 /// Fixes cancellation-safety: if a client disconnects mid-RPC or
 /// the async task is cancelled, the counter is still decremented.
@@ -4919,6 +5063,22 @@ impl NestWeaverDaemon for DaemonService {
         json_rpc!(self, r, "count_patterns")
     }
 
+    async fn list_contracts(
+        &self,
+        request: Request<ListContractsRequest>,
+    ) -> Result<Response<ListContractsResponse>, Status> {
+        let visible = self.state.visible_repos_for(request.extensions())?;
+        let repo = request.into_inner().repo;
+        let state = Arc::clone(&self.state);
+        let _guard = ConnectionGuard::read(&state);
+        tokio::task::spawn_blocking(move || {
+            list_contracts_impl(&state.store, repo.as_deref(), &visible)
+        })
+        .await
+        .map_err(|error| Status::internal(format!("task panicked: {error}")))?
+        .map(Response::new)
+    }
+
     async fn cross_repo_contracts(
         &self,
         r: Request<JsonRequest>,
@@ -6143,6 +6303,7 @@ const READ_ONLY_ALLOWED_METHODS: &[&str] = &[
     "Investigate",
     "InvestigateExpand",
     "InvestigateHydrate",
+    "ListContracts",
     "ListProjectsJson",
     "ListReposJson",
     "ListServicesJson",
@@ -15377,6 +15538,7 @@ external_model = "unavailable-test-model"
             "Investigate",
             "InvestigateExpand",
             "InvestigateHydrate",
+            "ListContracts",
             "ListProjectsJson",
             "ListReposJson",
             "ListServicesJson",

--- a/crates/nestweaver-engine/src/contracts.rs
+++ b/crates/nestweaver-engine/src/contracts.rs
@@ -141,6 +141,38 @@ pub fn parse_spec_file(path: &str, source: &str) -> Vec<SpecContract> {
     }
 }
 
+/// Parse a watched spec without the full-indexer's best-effort fallback.
+///
+/// A live watcher replaces an already-published contract graph, so treating a
+/// transient or malformed save as an empty spec would incorrectly clear the
+/// prior contracts. Watcher planning uses this strict seam before opening its
+/// publication transaction.
+pub(crate) fn parse_spec_file_strict(
+    path: &str,
+    source: &str,
+) -> Result<Vec<SpecContract>, String> {
+    match spec_kind(path) {
+        Some(SpecFileKind::OpenApiYaml) => serde_yaml_ng::from_str::<openapiv3::OpenAPI>(source)
+            .map(|spec| openapi_contracts(&spec))
+            .map_err(|error| error.to_string()),
+        Some(SpecFileKind::OpenApiJson) => serde_json::from_str::<openapiv3::OpenAPI>(source)
+            .map(|spec| openapi_contracts(&spec))
+            .map_err(|error| error.to_string()),
+        Some(SpecFileKind::Proto) => protox_parse::parse(path, source)
+            .map(|_| parse_proto(path, source))
+            .map_err(|error| error.to_string()),
+        Some(SpecFileKind::GraphQl) => {
+            let parsed = apollo_parser::Parser::new(source).parse();
+            if let Some(error) = parsed.errors().next() {
+                Err(error.to_string())
+            } else {
+                Ok(parse_graphql(source))
+            }
+        }
+        None => Err(format!("unsupported contract spec path: {path}")),
+    }
+}
+
 fn parse_openapi_yaml(source: &str) -> Vec<SpecContract> {
     match serde_yaml_ng::from_str::<openapiv3::OpenAPI>(source) {
         Ok(spec) => openapi_contracts(&spec),

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -2897,14 +2897,23 @@ where
         // heals on the next clean index.
         let mut contracts_derived = 0usize;
         let mut contracts_status = crate::blast_radius::AnalysisStatus::Complete;
-        match derive_contracts(
-            store,
-            reader,
-            &r_uid,
-            &spec_files,
-            &handler_files,
-            &all_symbols,
-        ) {
+        let contract_result = if files_unchanged == 0 {
+            derive_contracts(
+                store,
+                reader,
+                &r_uid,
+                &spec_files,
+                &handler_files,
+                &all_symbols,
+            )
+        } else {
+            // A tiered/full pass may skip unchanged files, so its accumulated
+            // phase inputs are incomplete. Rebuild the whole-repo derived view
+            // only in that partial case; a true force/full parse reuses the
+            // inputs it already collected.
+            derive_contracts_from_current_repo(store, reader, &r_uid, repo_url)
+        };
+        match contract_result {
             Ok(count) => {
                 contracts_derived = count;
                 if let Err(e) = store.clear_contract_derivation_failed(&r_uid) {
@@ -3195,6 +3204,219 @@ impl ContractSet {
     }
 }
 
+/// Rebuild the whole-repo inputs consumed by contract derivation.
+///
+/// Full indexing accumulates these while parsing every file. Incremental
+/// indexing parses only changed files, but contracts are a derived whole-repo
+/// view: a renamed spec or an unchanged controller can affect the same route.
+/// Rescanning the lightweight contract inputs keeps incremental semantics
+/// identical to force/full indexing without replacing the whole code graph.
+fn collect_contract_derivation_inputs(
+    reader: &dyn crate::content_reader::ContentReader,
+    r_uid: &str,
+    repo_url: &str,
+) -> Result<
+    (
+        Vec<PathBuf>,
+        Vec<HandlerFileData>,
+        Vec<nestweaver_schema::Symbol>,
+    ),
+    anyhow::Error,
+> {
+    let mut spec_files = Vec::new();
+    let mut handler_files = Vec::new();
+    let mut all_symbols = Vec::new();
+    let repo_path = reader.root();
+    let discovered_files = reader
+        .list_files()
+        .context("list files for incremental contract derivation")?;
+    for rel_path in &discovered_files {
+        let abs_path = repo_path.join(&rel_path);
+        if crate::contracts::is_spec_file(&abs_path.to_string_lossy()) {
+            spec_files.push(abs_path);
+        }
+    }
+    let has_grpc_specs = spec_files.iter().any(|path| {
+        path.extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("proto"))
+    });
+
+    for rel_path in discovered_files {
+        let abs_path = repo_path.join(&rel_path);
+
+        let Some(lang) = detect_language(&abs_path) else {
+            continue;
+        };
+        if is_minified_or_bundled(&abs_path) {
+            continue;
+        }
+        if reader
+            .file_meta(&rel_path)
+            .context("read contract input metadata")?
+            .is_some_and(|(_, size)| size > crate::index_md::MAX_FILE_SIZE_BYTES)
+        {
+            tracing::debug!(path = %rel_path.display(), "skip oversized contract input before read");
+            continue;
+        }
+        let source = match reader.read_file(&rel_path) {
+            Ok(source) => source,
+            Err(error) => {
+                tracing::debug!(path = %rel_path.display(), "skip unreadable handler candidate: {error}");
+                continue;
+            }
+        };
+        if source.len() as u64 > crate::index_md::MAX_FILE_SIZE_BYTES {
+            tracing::debug!(path = %rel_path.display(), "skip oversized contract input");
+            continue;
+        }
+        let controller_candidate = match lang {
+            nestweaver_schema::Language::Java | nestweaver_schema::Language::Kotlin => {
+                source.contains("@RestController") || source.contains("@Controller")
+            }
+            nestweaver_schema::Language::JavaScript | nestweaver_schema::Language::TypeScript => {
+                source.contains("@Controller")
+            }
+            _ => false,
+        };
+        let grpc_candidate =
+            has_grpc_specs && lang == nestweaver_schema::Language::Rust && source.contains("impl ");
+        if !controller_candidate && !grpc_candidate {
+            continue;
+        }
+        let parsed = match parse_source(&abs_path, &source) {
+            Ok(parsed) => parsed,
+            Err(error) => {
+                tracing::debug!(path = %rel_path.display(), "skip unparseable handler candidate: {error}");
+                continue;
+            }
+        };
+        let rel_path_string = rel_path.to_string_lossy().into_owned();
+        if grpc_candidate {
+            all_symbols.extend(parsed.symbols.iter().map(|symbol| {
+                let scope = symbol.scope_chain.as_deref().unwrap_or("");
+                nestweaver_schema::Symbol {
+                    uid: symbol_uid(r_uid, &rel_path_string, &symbol.name, symbol.start_line),
+                    name: symbol.name.clone(),
+                    kind: symbol.kind,
+                    repo_uid: r_uid.to_string(),
+                    file_path: rel_path_string.clone(),
+                    start_line: symbol.start_line,
+                    end_line: symbol.end_line,
+                    signature: symbol.signature.clone(),
+                    summary: None,
+                    content_hash: symbol.content_hash.clone(),
+                    embedding: None,
+                    pagerank_score: None,
+                    is_entry_point: symbol.is_entry_point,
+                    entry_point_kind: symbol.entry_point_kind,
+                    visibility: symbol.visibility,
+                    type_info: symbol.type_info.clone(),
+                    framework_hint: None,
+                    canonical_id: Some(canonical_symbol_id(
+                        repo_url,
+                        &rel_path_string,
+                        &symbol.name,
+                        scope,
+                    )),
+                }
+            }));
+        }
+        if !controller_candidate {
+            continue;
+        }
+
+        let Some(lang_str) = crate::contracts::framework_language_str(lang) else {
+            continue;
+        };
+
+        let mut hint_by_index: HashMap<usize, nestweaver_schema::FrameworkHint> =
+            nestweaver_parser::detect_frameworks(&parsed.symbols, &rel_path_string, lang_str)
+                .into_iter()
+                .collect();
+        let class_starts: Vec<(usize, u32)> = parsed
+            .symbols
+            .iter()
+            .enumerate()
+            .filter(|(_, symbol)| symbol.kind == nestweaver_schema::SymbolKind::Class)
+            .map(|(index, symbol)| (index, symbol.start_line))
+            .collect();
+        if let Some(controller_index) =
+            crate::contracts::detect_nestjs_controller_index(&source, &class_starts)
+        {
+            hint_by_index.entry(controller_index).or_insert_with(|| {
+                nestweaver_schema::FrameworkHint {
+                    framework: "nestjs".into(),
+                    role: "controller".into(),
+                }
+            });
+        }
+
+        let Some((controller_index, framework)) = hint_by_index.iter().find_map(|(index, hint)| {
+            (hint.role == "controller").then(|| (*index, hint.framework.clone()))
+        }) else {
+            continue;
+        };
+        let class_signature = parsed
+            .symbols
+            .get(controller_index)
+            .map(|symbol| symbol.signature.clone())
+            .unwrap_or_default();
+        let symbols = parsed
+            .symbols
+            .iter()
+            .map(|symbol| {
+                (
+                    symbol_uid(r_uid, &rel_path_string, &symbol.name, symbol.start_line),
+                    crate::contracts::HandlerSymbol {
+                        name: symbol.name.clone(),
+                        signature: symbol.signature.clone(),
+                        start_line: symbol.start_line,
+                    },
+                )
+            })
+            .collect();
+        handler_files.push(HandlerFileData {
+            framework,
+            class_signature,
+            rel_path: rel_path_string,
+            symbols,
+        });
+    }
+
+    spec_files.sort();
+    handler_files.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
+    Ok((spec_files, handler_files, all_symbols))
+}
+
+fn prepare_incremental_contract_derivation(
+    reader: &dyn crate::content_reader::ContentReader,
+    r_uid: &str,
+    repo_url: &str,
+) -> Result<ContractDerivationPlan, anyhow::Error> {
+    let (spec_files, handler_files, all_symbols) =
+        collect_contract_derivation_inputs(reader, r_uid, repo_url)?;
+    prepare_contract_derivation(reader, r_uid, &spec_files, &handler_files, &all_symbols)
+}
+
+fn derive_contracts_from_current_repo(
+    store: &GraphStore,
+    reader: &dyn crate::content_reader::ContentReader,
+    r_uid: &str,
+    repo_url: &str,
+) -> Result<usize, anyhow::Error> {
+    let (spec_files, handler_files, all_symbols) =
+        collect_contract_derivation_inputs(reader, r_uid, repo_url)?;
+    derive_contracts(
+        store,
+        reader,
+        r_uid,
+        &spec_files,
+        &handler_files,
+        &all_symbols,
+    )
+}
+
 /// F2-core: build the API contract graph for one repo.
 ///
 /// 1. Parse spec files into **declared** [`nestweaver_schema::Contract`] nodes
@@ -3215,6 +3437,27 @@ fn derive_contracts(
     handler_files: &[HandlerFileData],
     all_symbols: &[nestweaver_schema::Symbol],
 ) -> Result<usize, anyhow::Error> {
+    let plan = prepare_contract_derivation(reader, r_uid, spec_files, handler_files, all_symbols)?;
+    let conn = store.begin_transaction()?;
+    let count = apply_contract_derivation_on(&conn, r_uid, &plan)?;
+    store.commit_transaction(&conn)?;
+    Ok(count)
+}
+
+struct ContractDerivationPlan {
+    contracts: Vec<nestweaver_schema::Contract>,
+    edges: Vec<nestweaver_schema::ResolvedEdge>,
+}
+
+/// Prepare contract rows and implementation edges without mutating the graph.
+/// All source reads and parsing finish before an incremental transaction opens.
+fn prepare_contract_derivation(
+    reader: &dyn crate::content_reader::ContentReader,
+    r_uid: &str,
+    spec_files: &[PathBuf],
+    handler_files: &[HandlerFileData],
+    all_symbols: &[nestweaver_schema::Symbol],
+) -> Result<ContractDerivationPlan, anyhow::Error> {
     use nestweaver_schema::{EdgeType, ResolvedEdge};
 
     // 1. Declared contracts from specs.
@@ -3352,8 +3595,23 @@ fn derive_contracts(
     // `ContractSet` guarantees that. Note the collapse is intentionally visible
     // in edge cardinality: two handlers whose routes normalize to one UID both
     // keep their IMPLEMENTS_CONTRACT edge onto the surviving contract.
-    let all_contracts = all_contracts.into_contracts();
+    let contracts = all_contracts.into_contracts();
 
+    Ok(ContractDerivationPlan { contracts, edges })
+}
+
+/// Replace one repo's derived contract graph on an existing transaction.
+///
+/// Incremental indexing uses this seam so changed symbols, source paths,
+/// contracts, implementation edges, and the indexed SHA publish as one unit.
+/// Any contract write failure therefore rolls the whole incremental mutation
+/// back, retaining the previously committed graph rather than leaving new
+/// symbols paired with stale or missing derived edges.
+fn apply_contract_derivation_on(
+    conn: &nestweaver_store::DbConnection<'_>,
+    r_uid: &str,
+    plan: &ContractDerivationPlan,
+) -> Result<usize, anyhow::Error> {
     // Clear + insert + edges must be ONE transaction. Previously the clear ran
     // on its own connection ahead of the inserts, so any failure in between
     // (e.g. a single row the COPY rejects) left the repo with zero contracts
@@ -3365,14 +3623,12 @@ fn derive_contracts(
     // No explicit rollback on the error paths, matching `bulk_reindex_write`:
     // a statement that throws inside an explicit transaction already rolls it
     // back, and dropping the connection rolls back anything still open.
-    let conn = store.begin_transaction()?;
-    GraphStore::clear_repo_contracts_on(&conn, r_uid)?;
-    GraphStore::batch_insert_contracts_on(&conn, &all_contracts)?;
-    if !edges.is_empty() {
-        GraphStore::batch_insert_edges_on(&conn, &edges)?;
+    GraphStore::clear_repo_contracts_on(conn, r_uid)?;
+    GraphStore::batch_insert_contracts_on(conn, &plan.contracts)?;
+    if !plan.edges.is_empty() {
+        GraphStore::batch_insert_edges_on(conn, &plan.edges)?;
     }
-    store.commit_transaction(&conn)?;
-    Ok(all_contracts.len())
+    Ok(plan.contracts.len())
 }
 
 /// Returns true if the file looks like a minified bundle, webpack output,
@@ -3599,6 +3855,8 @@ fn incremental_index_with_name_and_io(
     // any mutation (the per-file `DETACH DELETE` destroys the edges we walk).
     let (changed_files, removed_files) = partition_changed_removed(&changes);
     let rdeps = collect_reverse_dep_files(&store, &r_uid, &changed_files, &removed_files);
+    let contract_plan = prepare_incremental_contract_derivation(&reader, &r_uid, repo_url)
+        .context("prepare incremental contract derivation")?;
 
     let publication = establish_index_publication_marker_with_io(
         &store,
@@ -3715,6 +3973,15 @@ fn incremental_index_with_name_and_io(
         );
     }
 
+    if let Err(error) = apply_contract_derivation_on(&txn, &r_uid, &contract_plan) {
+        drop(txn);
+        if let Err(marker_error) = store.set_contract_derivation_failed(&r_uid, &error.to_string())
+        {
+            tracing::warn!("recording contract derivation failure failed: {marker_error}");
+        }
+        return Err(error).context("apply incremental contract derivation");
+    }
+
     // 6. Update the stored SHA inside the transaction, then commit.
     // If we crash before commit, the next run replays from the old SHA.
     nestweaver_store::GraphStore::update_repo_sha_on(&txn, &r_uid, &new_sha)
@@ -3724,6 +3991,9 @@ fn incremental_index_with_name_and_io(
         .commit_transaction(&txn)
         .with_context(|| "commit incremental transaction")?;
     drop(txn);
+    if let Err(error) = store.clear_contract_derivation_failed(&r_uid) {
+        tracing::warn!("clearing contract derivation marker failed: {error}");
+    }
 
     finalize_committed_index_with_io(
         publication,
@@ -3788,6 +4058,8 @@ where
     // edges we walk here, so this ordering is correctness-critical.
     let (changed_files, removed_files) = partition_changed_removed(&changes);
     let rdeps = collect_reverse_dep_files(store, &r_uid, &changed_files, &removed_files);
+    let contract_plan = prepare_incremental_contract_derivation(reader, &r_uid, repo_url)
+        .context("prepare server incremental contract derivation")?;
 
     let _write_guard = acquire_write_guard()?;
     let publication = establish_index_publication_marker_with_io(
@@ -3896,12 +4168,24 @@ where
         );
     }
 
+    if let Err(error) = apply_contract_derivation_on(&txn, &r_uid, &contract_plan) {
+        drop(txn);
+        if let Err(marker_error) = store.set_contract_derivation_failed(&r_uid, &error.to_string())
+        {
+            tracing::warn!("recording contract derivation failure failed: {marker_error}");
+        }
+        return Err(error).context("apply server incremental contract derivation");
+    }
+
     nestweaver_store::GraphStore::update_repo_sha_on(&txn, &r_uid, new_sha)
         .with_context(|| "update_repo_sha")?;
     store
         .commit_transaction(&txn)
         .with_context(|| "commit incremental transaction")?;
     drop(txn);
+    if let Err(error) = store.clear_contract_derivation_failed(&r_uid) {
+        tracing::warn!("clearing contract derivation marker failed: {error}");
+    }
 
     finalize_committed_index_with_io(
         publication,
@@ -5424,6 +5708,380 @@ function hello(name) { return "Hello " + name; }
         assert!(
             implemented.contains(&"contract:http:POST:/v1/approvals".to_string()),
             "expected IMPLEMENTS_CONTRACT edge; implemented: {implemented:?}"
+        );
+    }
+
+    #[test]
+    fn contract_collector_skips_reported_oversize_before_reading() {
+        struct OversizeReader {
+            root: PathBuf,
+        }
+        impl crate::content_reader::ContentReader for OversizeReader {
+            fn read_file(&self, _rel_path: &Path) -> anyhow::Result<String> {
+                panic!("oversized contract candidate must not be read")
+            }
+            fn list_files(&self) -> anyhow::Result<Vec<PathBuf>> {
+                Ok(vec![PathBuf::from("HugeController.java")])
+            }
+            fn file_meta(&self, _rel_path: &Path) -> anyhow::Result<Option<(u64, u64)>> {
+                Ok(Some((0, crate::index_md::MAX_FILE_SIZE_BYTES + 1)))
+            }
+            fn root(&self) -> &Path {
+                &self.root
+            }
+            fn version_id(&self) -> &str {
+                "oversize-test"
+            }
+        }
+
+        let reader = OversizeReader {
+            root: PathBuf::from("/unused"),
+        };
+        let (specs, handlers, symbols) = collect_contract_derivation_inputs(
+            &reader,
+            "repo:test:oversize",
+            "https://example.com/oversize",
+        )
+        .unwrap();
+        assert!(specs.is_empty());
+        assert!(handlers.is_empty());
+        assert!(symbols.is_empty());
+    }
+
+    #[test]
+    fn incremental_refreshes_contracts_like_force_and_rolls_back_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        let incremental_db = dir.path().join("incremental.lbug");
+        let forced_db = dir.path().join("forced.lbug");
+        fs::create_dir_all(&repo).unwrap();
+        let spec = |methods: &str| {
+            format!(
+                "openapi: 3.0.0\ninfo: {{ title: t, version: \"1.0\" }}\npaths:\n  /v1/items:\n{methods}"
+            )
+        };
+        fs::write(
+            repo.join("openapi.yaml"),
+            spec(
+                "    get:\n      operationId: listItems\n      responses: { \"200\": { description: ok } }\n",
+            ),
+        )
+        .unwrap();
+        fs::write(
+            repo.join("ItemsController.java"),
+            "@RestController\n@RequestMapping(\"/v1/items\")\npublic class ItemsController {\n  @GetMapping\n  public void list() {}\n}\n",
+        )
+        .unwrap();
+
+        let git = |args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            String::from_utf8(output.stdout).unwrap().trim().to_string()
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "NestWeaver Test"]);
+        git(&["add", "."]);
+        git(&["commit", "-q", "-m", "initial GET"]);
+        let first_sha = git(&["rev-parse", "HEAD"]);
+        let repo_url = "https://example.com/contract-refresh";
+        let repo_uid = nestweaver_schema::repo_uid("test", repo_url);
+        index_directory(&repo, &incremental_db, "test", repo_url, &first_sha).unwrap();
+        index_directory(&repo, &forced_db, "test", repo_url, &first_sha).unwrap();
+
+        let other_repo = dir.path().join("other-repo");
+        fs::create_dir_all(&other_repo).unwrap();
+        fs::write(
+            other_repo.join("openapi.yaml"),
+            "openapi: 3.0.0\ninfo: { title: other, version: \"1.0\" }\npaths:\n  /other:\n    get:\n      responses: { \"200\": { description: ok } }\n",
+        )
+        .unwrap();
+        let other_url = "https://example.com/contract-refresh-other";
+        let other_uid = nestweaver_schema::repo_uid("test", other_url);
+        index_directory(&other_repo, &incremental_db, "test", other_url, "other-sha").unwrap();
+        let other_store = GraphStore::open_or_create(&incremental_db).unwrap();
+        let other_contracts = |store: &GraphStore| {
+            let mut contracts: Vec<(String, String)> = store
+                .list_contracts(Some(&other_uid))
+                .unwrap()
+                .into_iter()
+                .map(|contract| (contract.uid, contract.source_path))
+                .collect();
+            contracts.sort();
+            contracts
+        };
+        let other_before = other_contracts(&other_store);
+        drop(other_store);
+
+        fs::rename(repo.join("openapi.yaml"), repo.join("openapi.v2.yaml")).unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "rename spec only"]);
+        let rename_sha = git(&["rev-parse", "HEAD"]);
+        let rename_result = incremental_index(&repo, &incremental_db, "test", repo_url).unwrap();
+        assert!(!rename_result.fell_back_to_full);
+        let renamed_store = GraphStore::open_or_create(&incremental_db).unwrap();
+        let renamed_get = renamed_store
+            .list_contracts(Some(&repo_uid))
+            .unwrap()
+            .into_iter()
+            .find(|contract| contract.uid == "contract:http:GET:/v1/items")
+            .expect("GET survives a spec-only rename");
+        assert_eq!(renamed_get.source_path, "openapi.v2.yaml");
+        assert!(
+            renamed_store
+                .list_implemented_contract_uids()
+                .unwrap()
+                .contains(&renamed_get.uid),
+            "unchanged controller must be relinked after spec-only rename"
+        );
+        drop(renamed_store);
+        let tiered = index_directory(&repo, &forced_db, "test", repo_url, &rename_sha).unwrap();
+        assert!(
+            tiered.files_unchanged > 0,
+            "control must exercise the partial/tiered full path"
+        );
+        let tiered_store = GraphStore::open_or_create(&forced_db).unwrap();
+        assert_eq!(
+            tiered_store
+                .list_contracts(Some(&repo_uid))
+                .unwrap()
+                .into_iter()
+                .find(|contract| contract.uid == "contract:http:GET:/v1/items")
+                .unwrap()
+                .source_path,
+            "openapi.v2.yaml"
+        );
+        drop(tiered_store);
+
+        fs::write(
+            repo.join("openapi.v2.yaml"),
+            spec(
+                "    get:\n      operationId: listItems\n      responses: { \"200\": { description: ok } }\n    post:\n      operationId: createItem\n      responses: { \"200\": { description: ok } }\n",
+            ),
+        )
+        .unwrap();
+        fs::write(
+            repo.join("ItemsController.java"),
+            "@RestController\n@RequestMapping(\"/v1/items\")\npublic class ItemsController {\n  @GetMapping\n  public void list() {}\n  @PostMapping\n  public void create() {}\n}\n",
+        )
+        .unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "add POST"]);
+        let second_sha = git(&["rev-parse", "HEAD"]);
+
+        let incremental = incremental_index(&repo, &incremental_db, "test", repo_url).unwrap();
+        assert!(!incremental.fell_back_to_full, "must exercise incremental");
+        index_directory_with_options(&repo, &forced_db, "test", repo_url, &second_sha, true, None)
+            .unwrap();
+
+        let snapshot = |store: &GraphStore| {
+            let mut contracts: Vec<(String, String)> = store
+                .list_contracts(Some(&repo_uid))
+                .unwrap()
+                .into_iter()
+                .filter(|contract| contract.repo_uid == repo_uid)
+                .map(|contract| (contract.uid, contract.source_path))
+                .collect();
+            contracts.sort();
+            let mut implemented = store.list_implemented_contract_uids().unwrap();
+            implemented.sort();
+            (contracts, implemented)
+        };
+        let implementation_pairs = |store: &GraphStore| {
+            let mut pairs = Vec::new();
+            for symbol in store.lookup_symbols_by_repo(&repo_uid).unwrap() {
+                for (contract_uid, _) in store.contracts_implemented_by(&symbol.uid).unwrap() {
+                    pairs.push((symbol.name.clone(), contract_uid));
+                }
+            }
+            pairs.sort();
+            pairs
+        };
+        let drift = |store: &GraphStore| {
+            crate::contracts::drift_envelope(
+                crate::contracts::drift_for_store(store, Some(&repo_uid)).unwrap(),
+                50,
+            )
+        };
+        let incremental_store = GraphStore::open_or_create(&incremental_db).unwrap();
+        let forced_store = GraphStore::open_or_create(&forced_db).unwrap();
+        let incremental_snapshot = snapshot(&incremental_store);
+        assert_eq!(incremental_snapshot, snapshot(&forced_store));
+        assert_eq!(
+            implementation_pairs(&incremental_store),
+            implementation_pairs(&forced_store)
+        );
+        assert_eq!(drift(&incremental_store), drift(&forced_store));
+        assert_eq!(
+            implementation_pairs(&incremental_store),
+            vec![
+                (
+                    "create".to_string(),
+                    "contract:http:POST:/v1/items".to_string(),
+                ),
+                (
+                    "list".to_string(),
+                    "contract:http:GET:/v1/items".to_string(),
+                ),
+            ]
+        );
+        assert_eq!(
+            other_contracts(&incremental_store),
+            other_before,
+            "refreshing one repo must not alter another repo's contracts"
+        );
+        assert_eq!(
+            incremental_snapshot.0,
+            vec![
+                (
+                    "contract:http:GET:/v1/items".to_string(),
+                    "openapi.v2.yaml".to_string(),
+                ),
+                (
+                    "contract:http:POST:/v1/items".to_string(),
+                    "openapi.v2.yaml".to_string(),
+                ),
+            ]
+        );
+        assert_eq!(
+            incremental_snapshot.1,
+            vec![
+                "contract:http:GET:/v1/items".to_string(),
+                "contract:http:POST:/v1/items".to_string(),
+            ]
+        );
+        drop(incremental_store);
+        drop(forced_store);
+
+        fs::write(
+            repo.join("openapi.v2.yaml"),
+            spec(
+                "    post:\n      operationId: createItem\n      responses: { \"200\": { description: ok } }\n",
+            ),
+        )
+        .unwrap();
+        fs::write(
+            repo.join("ItemsController.java"),
+            "@RestController\n@RequestMapping(\"/v1/items\")\npublic class ItemsController {\n  @PostMapping\n  public void create() {}\n}\n",
+        )
+        .unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "delete GET"]);
+        let third_sha = git(&["rev-parse", "HEAD"]);
+        let deletion = incremental_index(&repo, &incremental_db, "test", repo_url).unwrap();
+        assert!(!deletion.fell_back_to_full);
+        index_directory_with_options(&repo, &forced_db, "test", repo_url, &third_sha, true, None)
+            .unwrap();
+        let incremental_store = GraphStore::open_or_create(&incremental_db).unwrap();
+        let forced_store = GraphStore::open_or_create(&forced_db).unwrap();
+        let post_only_snapshot = snapshot(&incremental_store);
+        assert_eq!(post_only_snapshot, snapshot(&forced_store));
+        assert_eq!(
+            implementation_pairs(&incremental_store),
+            implementation_pairs(&forced_store)
+        );
+        assert_eq!(drift(&incremental_store), drift(&forced_store));
+        assert_eq!(
+            implementation_pairs(&incremental_store),
+            vec![(
+                "create".to_string(),
+                "contract:http:POST:/v1/items".to_string(),
+            )]
+        );
+        assert_eq!(
+            post_only_snapshot.0,
+            vec![(
+                "contract:http:POST:/v1/items".to_string(),
+                "openapi.v2.yaml".to_string(),
+            )]
+        );
+        assert_eq!(
+            post_only_snapshot.1,
+            vec!["contract:http:POST:/v1/items".to_string()]
+        );
+
+        // Poison the next replacement with a UID owned by another repo. The
+        // contract COPY fails after the changed controller/spec were parsed,
+        // and the single incremental transaction must retain the prior graph.
+        incremental_store
+            .batch_insert_contracts(&[nestweaver_schema::Contract {
+                uid: "contract:http:PUT:/v1/items".to_string(),
+                kind: "http".to_string(),
+                verb: Some("PUT".to_string()),
+                path: Some("/v1/items".to_string()),
+                operation_id: None,
+                repo_uid: "repo:other".to_string(),
+                source_path: "other.yaml".to_string(),
+                confidence: 1.0,
+            }])
+            .unwrap();
+        let generation_path = crate::sidecar_path(&incremental_db, ".generation");
+        let generation_before_failed_apply = fs::read(&generation_path).unwrap();
+        drop(incremental_store);
+        drop(forced_store);
+        fs::write(
+            repo.join("openapi.v2.yaml"),
+            spec(
+                "    get:\n      operationId: listItems\n      responses: { \"200\": { description: ok } }\n    post:\n      operationId: createItem\n      responses: { \"200\": { description: ok } }\n    put:\n      operationId: replaceItem\n      responses: { \"200\": { description: ok } }\n",
+            ),
+        )
+        .unwrap();
+        fs::write(
+            repo.join("ItemsController.java"),
+            "@RestController\n@RequestMapping(\"/v1/items\")\npublic class ItemsController {\n  @GetMapping\n  public void list() {}\n  @PostMapping\n  public void create() {}\n  @PutMapping\n  public void replace() {}\n}\n",
+        )
+        .unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "add colliding PUT"]);
+
+        let error = incremental_index(&repo, &incremental_db, "test", repo_url)
+            .expect_err("contract replacement failure must abort incremental publication");
+        assert!(
+            format!("{error:#}").contains("apply incremental contract derivation"),
+            "unexpected error: {error:#}"
+        );
+        let incremental_store = GraphStore::open_or_create(&incremental_db).unwrap();
+        assert_eq!(
+            fs::read(&generation_path).unwrap(),
+            generation_before_failed_apply,
+            "a failed transactional apply must not publish a new generation"
+        );
+        assert_eq!(snapshot(&incremental_store), post_only_snapshot);
+        assert_eq!(
+            other_contracts(&incremental_store),
+            other_before,
+            "a failed replacement must not alter another repo"
+        );
+        assert_eq!(
+            incremental_store
+                .lookup_repo(&repo_uid)
+                .unwrap()
+                .unwrap()
+                .indexed_sha,
+            third_sha,
+            "failed derivation must roll back the indexed SHA"
+        );
+        assert!(
+            incremental_store
+                .lookup_symbols_by_name_in_repo("replace", &repo_uid)
+                .unwrap()
+                .is_empty(),
+            "failed derivation must roll back the new handler symbol"
+        );
+        assert!(
+            incremental_store
+                .contract_derivation_failures(Some(&repo_uid))
+                .unwrap()
+                .contains(&repo_uid),
+            "the failed best-effort contract phase remains diagnosable"
         );
     }
 

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -3215,6 +3215,7 @@ fn collect_contract_derivation_inputs(
     reader: &dyn crate::content_reader::ContentReader,
     r_uid: &str,
     repo_url: &str,
+    strict: bool,
 ) -> Result<
     (
         Vec<PathBuf>,
@@ -3261,6 +3262,11 @@ fn collect_contract_derivation_inputs(
         }
         let source = match reader.read_file(&rel_path) {
             Ok(source) => source,
+            Err(error) if strict => {
+                return Err(error).with_context(|| {
+                    format!("read contract handler candidate {}", rel_path.display())
+                });
+            }
             Err(error) => {
                 tracing::debug!(path = %rel_path.display(), "skip unreadable handler candidate: {error}");
                 continue;
@@ -3286,6 +3292,11 @@ fn collect_contract_derivation_inputs(
         }
         let parsed = match parse_source(&abs_path, &source) {
             Ok(parsed) => parsed,
+            Err(error) if strict => {
+                return Err(error).with_context(|| {
+                    format!("parse contract handler candidate {}", rel_path.display())
+                });
+            }
             Err(error) => {
                 tracing::debug!(path = %rel_path.display(), "skip unparseable handler candidate: {error}");
                 continue;
@@ -3395,8 +3406,140 @@ fn prepare_incremental_contract_derivation(
     repo_url: &str,
 ) -> Result<ContractDerivationPlan, anyhow::Error> {
     let (spec_files, handler_files, all_symbols) =
-        collect_contract_derivation_inputs(reader, r_uid, repo_url)?;
-    prepare_contract_derivation(reader, r_uid, &spec_files, &handler_files, &all_symbols)
+        collect_contract_derivation_inputs(reader, r_uid, repo_url, false)?;
+    prepare_contract_derivation(
+        reader,
+        r_uid,
+        &spec_files,
+        &handler_files,
+        &all_symbols,
+        false,
+    )
+}
+
+pub(crate) fn prepare_watcher_contract_derivation(
+    reader: &dyn crate::content_reader::ContentReader,
+    r_uid: &str,
+    repo_url: &str,
+) -> Result<ContractDerivationPlan, anyhow::Error> {
+    prepare_watcher_contract_derivation_with_hooks(reader, r_uid, repo_url, || {}, || {})
+}
+
+pub(crate) fn watcher_contract_input_snapshot(
+    reader: &dyn crate::content_reader::ContentReader,
+) -> Result<std::collections::BTreeMap<String, String>, anyhow::Error> {
+    let files = reader
+        .list_files()
+        .context("list files for watcher contract snapshot")?;
+    let has_grpc_specs = files.iter().any(|path| {
+        crate::contracts::is_spec_file(&path.to_string_lossy())
+            && path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("proto"))
+    });
+    let mut snapshot = std::collections::BTreeMap::new();
+    for rel_path in files {
+        let abs_path = reader.root().join(&rel_path);
+        let is_spec = crate::contracts::is_spec_file(&abs_path.to_string_lossy());
+        let language = detect_language(&abs_path);
+        if !is_spec && language.is_none() {
+            continue;
+        }
+        if !is_spec && is_minified_or_bundled(&abs_path) {
+            continue;
+        }
+        if reader
+            .file_meta(&rel_path)
+            .with_context(|| format!("read watcher contract metadata {}", rel_path.display()))?
+            .is_some_and(|(_, size)| size > crate::index_md::MAX_FILE_SIZE_BYTES)
+        {
+            continue;
+        }
+        let source = reader
+            .read_file(&rel_path)
+            .with_context(|| format!("read watcher contract input {}", rel_path.display()))?;
+        if source.len() as u64 > crate::index_md::MAX_FILE_SIZE_BYTES {
+            continue;
+        }
+        let candidate = if is_spec {
+            true
+        } else {
+            match language.expect("checked above") {
+                nestweaver_schema::Language::Java | nestweaver_schema::Language::Kotlin => {
+                    source.contains("@RestController") || source.contains("@Controller")
+                }
+                nestweaver_schema::Language::JavaScript
+                | nestweaver_schema::Language::TypeScript => source.contains("@Controller"),
+                nestweaver_schema::Language::Rust => has_grpc_specs && source.contains("impl "),
+                _ => false,
+            }
+        };
+        if candidate {
+            snapshot.insert(
+                rel_path.to_string_lossy().into_owned(),
+                crate::hash::blake3_hex(&source),
+            );
+        }
+    }
+    Ok(snapshot)
+}
+
+fn prepare_watcher_contract_derivation_with_hooks<F, G>(
+    reader: &dyn crate::content_reader::ContentReader,
+    r_uid: &str,
+    repo_url: &str,
+    before_plan: F,
+    after_plan: G,
+) -> Result<ContractDerivationPlan, anyhow::Error>
+where
+    F: FnOnce(),
+    G: FnOnce(),
+{
+    let before = watcher_contract_input_snapshot(reader)?;
+    before_plan();
+    let observed = watcher_contract_input_snapshot(reader)?;
+    let (spec_files, handler_files, all_symbols) =
+        collect_contract_derivation_inputs(reader, r_uid, repo_url, true)?;
+    let mut plan = prepare_contract_derivation(
+        reader,
+        r_uid,
+        &spec_files,
+        &handler_files,
+        &all_symbols,
+        true,
+    )?;
+    after_plan();
+    let after = watcher_contract_input_snapshot(reader)?;
+    let plan_reads_match_observed = plan
+        .input_hashes
+        .iter()
+        .all(|(path, hash)| observed.get(path) == Some(hash));
+    if before != observed || observed != after || !plan_reads_match_observed {
+        let changed: Vec<_> = before
+            .keys()
+            .chain(observed.keys())
+            .chain(after.keys())
+            .chain(plan.input_hashes.keys())
+            .filter(|path| {
+                before.get(*path) != observed.get(*path)
+                    || observed.get(*path) != after.get(*path)
+                    || plan
+                        .input_hashes
+                        .get(*path)
+                        .is_some_and(|hash| observed.get(*path) != Some(hash))
+            })
+            .cloned()
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        anyhow::bail!(
+            "contract inputs changed while watcher plan was prepared: {}",
+            changed.join(", ")
+        );
+    }
+    plan.observed_input_hashes = observed;
+    Ok(plan)
 }
 
 fn derive_contracts_from_current_repo(
@@ -3406,7 +3549,7 @@ fn derive_contracts_from_current_repo(
     repo_url: &str,
 ) -> Result<usize, anyhow::Error> {
     let (spec_files, handler_files, all_symbols) =
-        collect_contract_derivation_inputs(reader, r_uid, repo_url)?;
+        collect_contract_derivation_inputs(reader, r_uid, repo_url, false)?;
     derive_contracts(
         store,
         reader,
@@ -3437,16 +3580,19 @@ fn derive_contracts(
     handler_files: &[HandlerFileData],
     all_symbols: &[nestweaver_schema::Symbol],
 ) -> Result<usize, anyhow::Error> {
-    let plan = prepare_contract_derivation(reader, r_uid, spec_files, handler_files, all_symbols)?;
+    let plan =
+        prepare_contract_derivation(reader, r_uid, spec_files, handler_files, all_symbols, false)?;
     let conn = store.begin_transaction()?;
     let count = apply_contract_derivation_on(&conn, r_uid, &plan)?;
     store.commit_transaction(&conn)?;
     Ok(count)
 }
 
-struct ContractDerivationPlan {
+pub(crate) struct ContractDerivationPlan {
     contracts: Vec<nestweaver_schema::Contract>,
     edges: Vec<nestweaver_schema::ResolvedEdge>,
+    pub(crate) input_hashes: std::collections::BTreeMap<String, String>,
+    pub(crate) observed_input_hashes: std::collections::BTreeMap<String, String>,
 }
 
 /// Prepare contract rows and implementation edges without mutating the graph.
@@ -3457,11 +3603,13 @@ fn prepare_contract_derivation(
     spec_files: &[PathBuf],
     handler_files: &[HandlerFileData],
     all_symbols: &[nestweaver_schema::Symbol],
+    strict: bool,
 ) -> Result<ContractDerivationPlan, anyhow::Error> {
     use nestweaver_schema::{EdgeType, ResolvedEdge};
 
     // 1. Declared contracts from specs.
     let mut all_contracts = ContractSet::new();
+    let mut input_hashes = std::collections::BTreeMap::new();
     // (contract_uid, "<package>.<Service>/<Rpc>") for every declared gRPC method.
     let mut declared_grpc: Vec<(String, String)> = Vec::new();
     let repo_path = reader.root();
@@ -3473,12 +3621,23 @@ fn prepare_contract_derivation(
             .into_owned();
         let source = match reader.read_file(Path::new(&rel)) {
             Ok(s) => s,
+            Err(error) if strict => {
+                return Err(error).with_context(|| format!("read watched contract spec {rel}"));
+            }
             Err(e) => {
                 tracing::debug!("skip unreadable spec {rel}: {e}");
                 continue;
             }
         };
-        for sc in crate::contracts::parse_spec_file(&rel, &source) {
+        let parsed_specs = if strict {
+            input_hashes.insert(rel.clone(), crate::hash::blake3_hex(&source));
+            crate::contracts::parse_spec_file_strict(&rel, &source)
+                .map_err(anyhow::Error::msg)
+                .with_context(|| format!("parse watched contract spec {rel}"))?
+        } else {
+            crate::contracts::parse_spec_file(&rel, &source)
+        };
+        for sc in parsed_specs {
             // Keep gRPC operations so implementations can be matched against the
             // DECLARED contract rather than minting a UID from source (nw-104).
             let grpc_operation = (sc.kind == "grpc")
@@ -3506,9 +3665,16 @@ fn prepare_contract_derivation(
         // class-level base path (@RequestMapping / @Controller) is usually
         // dropped. Read the raw source to recover it; fall back to the
         // truncated signature if the file is unreadable.
-        let base_source = reader
-            .read_file(Path::new(&hf.rel_path))
-            .unwrap_or_else(|_| hf.class_signature.clone());
+        let base_source = match reader.read_file(Path::new(&hf.rel_path)) {
+            Ok(source) => source,
+            Err(error) if strict => {
+                return Err(error).with_context(|| format!("read watched handler {}", hf.rel_path));
+            }
+            Err(_) => hf.class_signature.clone(),
+        };
+        if strict {
+            input_hashes.insert(hf.rel_path.clone(), crate::hash::blake3_hex(&base_source));
+        }
         let matches = crate::contracts::detect_handlers(&hf.framework, &base_source, &handler_syms);
         for m in matches {
             let contract_uid = m.contract.uid();
@@ -3545,6 +3711,21 @@ fn prepare_contract_derivation(
     // opened to reach a detector that also did not exist. Matching declared
     // contracts against symbols here needs none of them, and the edge adopts the
     // DECLARED uid so it provably points at a real contract.
+    if strict {
+        for rel_path in all_symbols
+            .iter()
+            .map(|symbol| symbol.file_path.as_str())
+            .collect::<std::collections::BTreeSet<_>>()
+        {
+            if input_hashes.contains_key(rel_path) {
+                continue;
+            }
+            let source = reader
+                .read_file(Path::new(rel_path))
+                .with_context(|| format!("read watched gRPC candidate {rel_path}"))?;
+            input_hashes.insert(rel_path.to_string(), crate::hash::blake3_hex(&source));
+        }
+    }
     if !declared_grpc.is_empty() {
         // Group symbols by file so each candidate file is read once.
         let mut by_file: std::collections::BTreeMap<&str, Vec<(String, String, u32)>> =
@@ -3562,9 +3743,17 @@ fn prepare_contract_derivation(
             // Cheap pre-filter: a tonic server implementation is a trait impl, so
             // a file with no `impl ` at all cannot contain one. Avoids reading
             // every source file in the repo.
-            let Ok(source) = reader.read_file(Path::new(rel_path)) else {
-                continue;
+            let source = match reader.read_file(Path::new(rel_path)) {
+                Ok(source) => source,
+                Err(error) if strict => {
+                    return Err(error)
+                        .with_context(|| format!("read watched gRPC handler {rel_path}"));
+                }
+                Err(_) => continue,
             };
+            if strict {
+                input_hashes.insert(rel_path.to_string(), crate::hash::blake3_hex(&source));
+            }
             if !source.contains("impl ") {
                 continue;
             }
@@ -3597,7 +3786,12 @@ fn prepare_contract_derivation(
     // keep their IMPLEMENTS_CONTRACT edge onto the surviving contract.
     let contracts = all_contracts.into_contracts();
 
-    Ok(ContractDerivationPlan { contracts, edges })
+    Ok(ContractDerivationPlan {
+        contracts,
+        edges,
+        input_hashes,
+        observed_input_hashes: std::collections::BTreeMap::new(),
+    })
 }
 
 /// Replace one repo's derived contract graph on an existing transaction.
@@ -3607,7 +3801,7 @@ fn prepare_contract_derivation(
 /// Any contract write failure therefore rolls the whole incremental mutation
 /// back, retaining the previously committed graph rather than leaving new
 /// symbols paired with stale or missing derived edges.
-fn apply_contract_derivation_on(
+pub(crate) fn apply_contract_derivation_on(
     conn: &nestweaver_store::DbConnection<'_>,
     r_uid: &str,
     plan: &ContractDerivationPlan,
@@ -4464,7 +4658,7 @@ fn reresolve_affected_dependents(
 
     let db_symbols = nestweaver_store::GraphStore::lookup_symbols_by_repo_on(conn, r_uid)
         .with_context(|| "lookup_symbols_by_repo_on for forward edge resolution")?;
-    let insertable = build_reresolve_edges(reader, r_uid, changed, rdeps, &db_symbols)?;
+    let insertable = build_reresolve_edges(reader, r_uid, changed, rdeps, &db_symbols, None)?;
 
     // Runs inside the same transaction as the mutation loop.
     let count = insertable.len();
@@ -4475,33 +4669,40 @@ fn reresolve_affected_dependents(
     Ok(count)
 }
 
-/// Non-transactional variant of [`reresolve_affected_dependents`] for the
-/// live code watcher (`watch_code.rs`), which interleaves its mutations with
-/// store-level (non-txn) calls. Same nw-008 Phase 2 semantics: re-insert ONLY
-/// the cross-file edges the per-file `DETACH DELETE` destroyed.
-pub(crate) fn reresolve_affected_dependents_on_store(
+/// Prepare the live watcher's reverse-dependent edges before publication.
+///
+/// The watcher supplies the frozen replacement symbols that its transaction
+/// will publish. This produces the same post-mutation symbol view as
+/// [`reresolve_affected_dependents`] without reading source after the dirty
+/// marker has been established.
+pub(crate) fn prepare_watcher_reresolve_edges(
     reader: &dyn crate::content_reader::ContentReader,
     store: &nestweaver_store::GraphStore,
     r_uid: &str,
     changed: &std::collections::HashSet<String>,
+    removed: &std::collections::HashSet<String>,
     rdeps: &std::collections::HashSet<String>,
-) -> Result<usize, anyhow::Error> {
+    replacement_symbols: &[nestweaver_schema::Symbol],
+    prepared_file_data: &std::collections::HashMap<String, (Vec<RawSymbol>, Vec<RawReference>)>,
+) -> Result<Vec<nestweaver_schema::ResolvedEdge>, anyhow::Error> {
     if changed.is_empty() {
-        return Ok(0);
+        return Ok(Vec::new());
     }
-
-    let db_symbols = store
+    let mut symbols = store
         .lookup_symbols_by_repo(r_uid)
-        .with_context(|| "lookup_symbols_by_repo for forward edge resolution")?;
-    let insertable = build_reresolve_edges(reader, r_uid, changed, rdeps, &db_symbols)?;
-
-    let count = insertable.len();
-    if count > 0 {
-        store
-            .batch_insert_edges(&insertable)
-            .with_context(|| "batch_insert_edges (transitive re-resolution)")?;
-    }
-    Ok(count)
+        .with_context(|| "lookup_symbols_by_repo for watcher edge preparation")?;
+    symbols.retain(|symbol| {
+        !changed.contains(&symbol.file_path) && !removed.contains(&symbol.file_path)
+    });
+    symbols.extend_from_slice(replacement_symbols);
+    build_reresolve_edges(
+        reader,
+        r_uid,
+        changed,
+        rdeps,
+        &symbols,
+        Some(prepared_file_data),
+    )
 }
 
 /// Shared core of nw-008 Phase 2. Re-parse `S = changed ∪ rdeps` from
@@ -4523,6 +4724,9 @@ fn build_reresolve_edges(
     changed: &std::collections::HashSet<String>,
     rdeps: &std::collections::HashSet<String>,
     db_symbols: &[nestweaver_schema::Symbol],
+    prepared_file_data: Option<
+        &std::collections::HashMap<String, (Vec<RawSymbol>, Vec<RawReference>)>,
+    >,
 ) -> Result<Vec<nestweaver_schema::ResolvedEdge>, anyhow::Error> {
     // S = changed ∪ rdeps — files whose references need re-resolution.
     let mut scope: std::collections::HashSet<String> = changed.clone();
@@ -4535,22 +4739,29 @@ fn build_reresolve_edges(
     for rel_str in &scope {
         let rel_path = Path::new(rel_str.as_str());
         let abs_path = reader.root().join(rel_path);
-        let source = match reader.read_file(rel_path) {
-            Ok(s) => s,
-            Err(_) => continue, // deleted/unreadable — nothing to re-resolve from
-        };
-        let parsed = match parse_source(&abs_path, &source) {
-            Ok(p) => p,
-            Err(_) => continue,
+        let (raw_symbols, raw_references) = if let Some((symbols, references)) =
+            prepared_file_data.and_then(|prepared| prepared.get(rel_str))
+        {
+            (symbols.clone(), references.clone())
+        } else {
+            let source = match reader.read_file(rel_path) {
+                Ok(s) => s,
+                Err(_) => continue, // deleted/unreadable — nothing to re-resolve from
+            };
+            let parsed = match parse_source(&abs_path, &source) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+            (parsed.symbols, parsed.references)
         };
         if let Some(lang) = detect_language(&abs_path) {
             *lang_counts.entry(lang).or_insert(0) += 1;
         }
-        for raw_sym in &parsed.symbols {
+        for raw_sym in &raw_symbols {
             let s_uid = symbol_uid(r_uid, rel_str, &raw_sym.name, raw_sym.start_line);
             uid_to_file.insert(s_uid, rel_str.clone());
         }
-        file_data.push((rel_str.clone(), parsed.symbols, parsed.references));
+        file_data.push((rel_str.clone(), raw_symbols, raw_references));
     }
 
     if file_data.is_empty() {
@@ -5741,11 +5952,133 @@ function hello(name) { return "Hello " + name; }
             &reader,
             "repo:test:oversize",
             "https://example.com/oversize",
+            false,
         )
         .unwrap();
         assert!(specs.is_empty());
         assert!(handlers.is_empty());
         assert!(symbols.is_empty());
+    }
+
+    #[test]
+    fn watcher_contract_plan_rejects_create_delete_and_second_save_races() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        let get = "openapi: 3.0.0\ninfo: { title: t, version: \"1\" }\npaths:\n  /items:\n    get:\n      responses: { \"200\": { description: ok } }\n";
+        let post = "openapi: 3.0.0\ninfo: { title: t, version: \"1\" }\npaths:\n  /items:\n    post:\n      responses: { \"200\": { description: ok } }\n";
+        let spec = repo.join("openapi.yaml");
+        fs::write(&spec, get).unwrap();
+        let reader = crate::content_reader::FilesystemReader::new(&repo);
+
+        let created = repo.join("openapi.v2.yaml");
+        let error = prepare_watcher_contract_derivation_with_hooks(
+            &reader,
+            "repo:test:watch-race",
+            "file:///watch-race",
+            || {},
+            || fs::write(&created, post).unwrap(),
+        )
+        .err()
+        .unwrap();
+        assert!(error.to_string().contains("openapi.v2.yaml"));
+        fs::remove_file(&created).unwrap();
+
+        let error = prepare_watcher_contract_derivation_with_hooks(
+            &reader,
+            "repo:test:watch-race",
+            "file:///watch-race",
+            || {},
+            || fs::remove_file(&spec).unwrap(),
+        )
+        .err()
+        .unwrap();
+        assert!(error.to_string().contains("openapi.yaml"));
+        fs::write(&spec, get).unwrap();
+
+        let error = prepare_watcher_contract_derivation_with_hooks(
+            &reader,
+            "repo:test:watch-race",
+            "file:///watch-race",
+            || {},
+            || fs::write(&spec, post).unwrap(),
+        )
+        .err()
+        .unwrap();
+        assert!(error.to_string().contains("openapi.yaml"));
+
+        fs::write(&spec, get).unwrap();
+        let controller = repo.join("ItemsController.java");
+        let controller_get = "@RestController\n@RequestMapping(\"/items\")\npublic class ItemsController { @GetMapping public void get() {} }\n";
+        let controller_post = "@RestController\n@RequestMapping(\"/items\")\npublic class ItemsController { @PostMapping public void post() {} }\n";
+        fs::write(&controller, controller_get).unwrap();
+        let error = prepare_watcher_contract_derivation_with_hooks(
+            &reader,
+            "repo:test:watch-race",
+            "file:///watch-race",
+            || {},
+            || fs::write(&controller, controller_post).unwrap(),
+        )
+        .err()
+        .unwrap();
+        assert!(error.to_string().contains("ItemsController.java"));
+
+        fs::write(&controller, controller_get).unwrap();
+        let error = prepare_watcher_contract_derivation_with_hooks(
+            &reader,
+            "repo:test:watch-race",
+            "file:///watch-race",
+            || {},
+            || fs::remove_file(&controller).unwrap(),
+        )
+        .err()
+        .unwrap();
+        assert!(error.to_string().contains("ItemsController.java"));
+
+        let error = prepare_watcher_contract_derivation_with_hooks(
+            &reader,
+            "repo:test:watch-race",
+            "file:///watch-race",
+            || {},
+            || fs::write(&controller, controller_get).unwrap(),
+        )
+        .err()
+        .unwrap();
+        assert!(error.to_string().contains("ItemsController.java"));
+
+        fs::write(&spec, get).unwrap();
+        let error = prepare_watcher_contract_derivation_with_hooks(
+            &reader,
+            "repo:test:watch-race",
+            "file:///watch-race",
+            || fs::write(&spec, post).unwrap(),
+            || fs::write(&spec, get).unwrap(),
+        )
+        .err()
+        .expect("old→new→old must reject the hybrid plan");
+        assert!(error.to_string().contains("openapi.yaml"));
+
+        let error = prepare_watcher_contract_derivation_with_hooks(
+            &reader,
+            "repo:test:watch-race",
+            "file:///watch-race",
+            || fs::remove_file(&spec).unwrap(),
+            || fs::write(&spec, get).unwrap(),
+        )
+        .err()
+        .expect("spec delete→identical recreate must reject the hybrid plan");
+        assert!(error.to_string().contains("openapi.yaml"));
+
+        let error = prepare_watcher_contract_derivation_with_hooks(
+            &reader,
+            "repo:test:watch-race",
+            "file:///watch-race",
+            || fs::remove_file(&controller).unwrap(),
+            || fs::write(&controller, controller_get).unwrap(),
+        )
+        .err()
+        .expect("controller delete→identical recreate must reject the hybrid plan");
+        assert!(error.to_string().contains("ItemsController.java"));
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -20,6 +20,12 @@ use serde::{Deserialize, Serialize};
 /// The 4th field carries the retained source string (up to 2 MB) so Phase 3
 /// can build type environments without re-reading files from disk.
 type ParsedFileEntry = (String, Vec<RawSymbol>, Vec<RawReference>, Option<String>);
+type ContractDerivationInputs = (
+    Vec<PathBuf>,
+    Vec<HandlerFileData>,
+    Vec<nestweaver_schema::Symbol>,
+);
+pub(crate) type PreparedFileData = HashMap<String, (Vec<RawSymbol>, Vec<RawReference>)>;
 
 /// F2.2: data captured per Spring/NestJS controller file so handler →
 /// contract edges can be derived after the bulk symbol insert.
@@ -3216,14 +3222,7 @@ fn collect_contract_derivation_inputs(
     r_uid: &str,
     repo_url: &str,
     strict: bool,
-) -> Result<
-    (
-        Vec<PathBuf>,
-        Vec<HandlerFileData>,
-        Vec<nestweaver_schema::Symbol>,
-    ),
-    anyhow::Error,
-> {
+) -> Result<ContractDerivationInputs, anyhow::Error> {
     let mut spec_files = Vec::new();
     let mut handler_files = Vec::new();
     let mut all_symbols = Vec::new();
@@ -3232,7 +3231,7 @@ fn collect_contract_derivation_inputs(
         .list_files()
         .context("list files for incremental contract derivation")?;
     for rel_path in &discovered_files {
-        let abs_path = repo_path.join(&rel_path);
+        let abs_path = repo_path.join(rel_path);
         if crate::contracts::is_spec_file(&abs_path.to_string_lossy()) {
             spec_files.push(abs_path);
         }
@@ -4675,33 +4674,37 @@ fn reresolve_affected_dependents(
 /// will publish. This produces the same post-mutation symbol view as
 /// [`reresolve_affected_dependents`] without reading source after the dirty
 /// marker has been established.
+pub(crate) struct WatcherReresolveInputs<'a> {
+    pub(crate) changed: &'a std::collections::HashSet<String>,
+    pub(crate) removed: &'a std::collections::HashSet<String>,
+    pub(crate) rdeps: &'a std::collections::HashSet<String>,
+    pub(crate) replacement_symbols: &'a [nestweaver_schema::Symbol],
+    pub(crate) prepared_file_data: &'a PreparedFileData,
+}
+
 pub(crate) fn prepare_watcher_reresolve_edges(
     reader: &dyn crate::content_reader::ContentReader,
     store: &nestweaver_store::GraphStore,
     r_uid: &str,
-    changed: &std::collections::HashSet<String>,
-    removed: &std::collections::HashSet<String>,
-    rdeps: &std::collections::HashSet<String>,
-    replacement_symbols: &[nestweaver_schema::Symbol],
-    prepared_file_data: &std::collections::HashMap<String, (Vec<RawSymbol>, Vec<RawReference>)>,
+    inputs: WatcherReresolveInputs<'_>,
 ) -> Result<Vec<nestweaver_schema::ResolvedEdge>, anyhow::Error> {
-    if changed.is_empty() {
+    if inputs.changed.is_empty() {
         return Ok(Vec::new());
     }
     let mut symbols = store
         .lookup_symbols_by_repo(r_uid)
         .with_context(|| "lookup_symbols_by_repo for watcher edge preparation")?;
     symbols.retain(|symbol| {
-        !changed.contains(&symbol.file_path) && !removed.contains(&symbol.file_path)
+        !inputs.changed.contains(&symbol.file_path) && !inputs.removed.contains(&symbol.file_path)
     });
-    symbols.extend_from_slice(replacement_symbols);
+    symbols.extend_from_slice(inputs.replacement_symbols);
     build_reresolve_edges(
         reader,
         r_uid,
-        changed,
-        rdeps,
+        inputs.changed,
+        inputs.rdeps,
         &symbols,
-        Some(prepared_file_data),
+        Some(inputs.prepared_file_data),
     )
 }
 
@@ -4724,9 +4727,7 @@ fn build_reresolve_edges(
     changed: &std::collections::HashSet<String>,
     rdeps: &std::collections::HashSet<String>,
     db_symbols: &[nestweaver_schema::Symbol],
-    prepared_file_data: Option<
-        &std::collections::HashMap<String, (Vec<RawSymbol>, Vec<RawReference>)>,
-    >,
+    prepared_file_data: Option<&PreparedFileData>,
 ) -> Result<Vec<nestweaver_schema::ResolvedEdge>, anyhow::Error> {
     // S = changed ∪ rdeps — files whose references need re-resolution.
     let mut scope: std::collections::HashSet<String> = changed.clone();

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -37,6 +37,30 @@ pub struct MarkdownIndexResult {
     pub skipped: Vec<SkippedFile>,
 }
 
+/// Full-refresh outcome with the committed cascade count. Kept separate from
+/// [`MarkdownIndexResult`] so existing callers that construct or destructure
+/// the stable index result are not broken by an added public field.
+pub struct MarkdownRefreshResult {
+    pub index: MarkdownIndexResult,
+    pub notes_deleted: usize,
+}
+
+/// Canonical full-refresh summary shared by direct CLI and daemon progress.
+pub fn format_markdown_refresh_summary(result: &MarkdownRefreshResult) -> String {
+    format!(
+        "Refreshed vault '{}': dropped {} stale note(s), reindexed {} note(s), \
+         {} heading(s), {} section(s), {} tag(s), {} wikilink(s) ({} unresolved).",
+        result.index.vault_name,
+        result.notes_deleted,
+        result.index.notes_count,
+        result.index.headings_count,
+        result.index.sections_count,
+        result.index.tags_count,
+        result.index.wikilinks_resolved,
+        result.index.wikilinks_unresolved,
+    )
+}
+
 /// Directory names skipped when walking a vault. Includes `.obsidian` (config),
 /// `.trash` (Obsidian's recycle bin), and common synthetic dirs.
 const SKIP_DIRS: &[&str] = &[
@@ -101,9 +125,28 @@ pub fn index_markdown_directory_with_ignore(
     vault_name: &str,
     extra_ignore_patterns: &[String],
 ) -> Result<MarkdownIndexResult, anyhow::Error> {
+    index_markdown_directory_with_ignore_and_deletion_count(
+        vault_root,
+        db_path,
+        instance_id,
+        vault_name,
+        extra_ignore_patterns,
+    )
+    .map(|result| result.index)
+}
+
+/// Like [`index_markdown_directory_with_ignore`], but also returns the number
+/// of old notes deleted by the successfully committed replacement transaction.
+pub fn index_markdown_directory_with_ignore_and_deletion_count(
+    vault_root: &Path,
+    db_path: &Path,
+    instance_id: &str,
+    vault_name: &str,
+    extra_ignore_patterns: &[String],
+) -> Result<MarkdownRefreshResult, anyhow::Error> {
     let store = GraphStore::open_or_create(db_path)
         .with_context(|| format!("failed to open/create GraphStore at {}", db_path.display()))?;
-    index_markdown_directory_with_store(
+    index_markdown_directory_with_store_and_deletion_count(
         &store,
         vault_root,
         db_path,
@@ -122,6 +165,27 @@ pub fn index_markdown_directory_with_store(
     vault_name: &str,
     extra_ignore_patterns: &[String],
 ) -> Result<MarkdownIndexResult, anyhow::Error> {
+    index_markdown_directory_with_store_and_deletion_count(
+        store,
+        vault_root,
+        db_path,
+        instance_id,
+        vault_name,
+        extra_ignore_patterns,
+    )
+    .map(|result| result.index)
+}
+
+/// Like [`index_markdown_directory_with_store`], but also returns the number
+/// of old notes deleted by the successfully committed replacement transaction.
+pub fn index_markdown_directory_with_store_and_deletion_count(
+    store: &GraphStore,
+    vault_root: &Path,
+    db_path: &Path,
+    instance_id: &str,
+    vault_name: &str,
+    extra_ignore_patterns: &[String],
+) -> Result<MarkdownRefreshResult, anyhow::Error> {
     let canonical = std::fs::canonicalize(vault_root).unwrap_or_else(|_| vault_root.to_path_buf());
     let reader = crate::content_reader::FilesystemReader::new(&canonical);
     let ignore_set = crate::brainignore::load_brain_ignore(&canonical, extra_ignore_patterns);
@@ -174,7 +238,7 @@ pub fn index_markdown_directory_in_memory(
     let reader = crate::content_reader::FilesystemReader::new(&canonical);
     let ignore_set = crate::brainignore::load_brain_ignore(&canonical, &[]);
     let result = index_into_store(&reader, &store, instance_id, vault_name, &ignore_set)?;
-    Ok((result, store))
+    Ok((result.index, store))
 }
 
 /// Index markdown notes from a caller-provided [`ContentReader`] into `store`.
@@ -194,7 +258,7 @@ pub fn index_markdown_with_reader(
     vault_name: &str,
 ) -> Result<MarkdownIndexResult, anyhow::Error> {
     let ignore_set = crate::brainignore::load_brain_ignore(reader.root(), &[]);
-    index_into_store(reader, store, instance_id, vault_name, &ignore_set)
+    index_into_store(reader, store, instance_id, vault_name, &ignore_set).map(|result| result.index)
 }
 
 /// Server-mode vault entry point: index the markdown exposed by `reader` and
@@ -252,7 +316,7 @@ where
         }
     }
 
-    Ok(result)
+    Ok(result.index)
 }
 
 /// Upsert the `Repo` node for `repo_url` so its `indexed_sha` equals `sha`,
@@ -757,7 +821,7 @@ fn index_into_store(
     instance_id: &str,
     vault_name: &str,
     ignore_set: &GlobSet,
-) -> Result<MarkdownIndexResult, anyhow::Error> {
+) -> Result<MarkdownRefreshResult, anyhow::Error> {
     index_into_store_with_write_gate(
         reader,
         store,
@@ -788,7 +852,7 @@ fn index_into_store_with_write_gate<G, F>(
     ignore_set: &GlobSet,
     record_repo_sha: Option<&str>,
     acquire_write_guard: F,
-) -> Result<MarkdownIndexResult, anyhow::Error>
+) -> Result<MarkdownRefreshResult, anyhow::Error>
 where
     F: FnOnce() -> Result<G, anyhow::Error>,
 {
@@ -1282,7 +1346,7 @@ where
     let wikilinks_resolved = wikilink_to_note.len() + wikilink_to_heading.len();
 
     // 3 & 4. Flush all nodes and edges for this vault in one transaction.
-    {
+    let notes_deleted = {
         let vault_note_refs: Vec<(&str, &str)> = edge_pairs
             .iter()
             .map(|(v, n)| (v.as_str(), n.as_str()))
@@ -1343,8 +1407,8 @@ where
                 &wl_note_refs,
                 &wl_head_refs,
             )
-            .context("bulk_vault_reindex_write")?;
-    }
+            .context("bulk_vault_reindex_write")?
+    };
 
     // Persist genuinely-unresolved wikilinks so broken-links surfaces them.
     // Dedup by uid first (many identical `[[missing]]` links in one section share
@@ -1404,16 +1468,19 @@ where
         elapsed.as_secs_f64(),
     );
 
-    Ok(MarkdownIndexResult {
-        vault_uid: v_uid,
-        vault_name: vault_name.to_string(),
-        notes_count,
-        headings_count,
-        sections_count,
-        tags_count,
-        wikilinks_resolved,
-        wikilinks_unresolved,
-        skipped,
+    Ok(MarkdownRefreshResult {
+        index: MarkdownIndexResult {
+            vault_uid: v_uid,
+            vault_name: vault_name.to_string(),
+            notes_count,
+            headings_count,
+            sections_count,
+            tags_count,
+            wikilinks_resolved,
+            wikilinks_unresolved,
+            skipped,
+        },
+        notes_deleted,
     })
 }
 
@@ -2787,6 +2854,93 @@ sub b body
         assert!(
             store.graph_generation() > 0,
             "vault indexing must advance the graph generation"
+        );
+    }
+
+    #[test]
+    fn direct_and_daemon_refresh_entry_points_report_committed_delete_counts_equally() {
+        let (_dir, root) = make_vault(&[("a.md", "# A\n\nalpha\n"), ("b.md", "# B\n\nbeta\n")]);
+        let temp = tempfile::tempdir().unwrap();
+        let direct_db = temp.path().join("direct.lbug");
+        let daemon_db = temp.path().join("daemon.lbug");
+
+        let direct_first = index_markdown_directory_with_ignore_and_deletion_count(
+            &root,
+            &direct_db,
+            "default",
+            "vault",
+            &[],
+        )
+        .unwrap();
+        let daemon_store = GraphStore::open_or_create(&daemon_db).unwrap();
+        let daemon_first = index_markdown_directory_with_store_and_deletion_count(
+            &daemon_store,
+            &root,
+            &daemon_db,
+            "default",
+            "vault",
+            &[],
+        )
+        .unwrap();
+        assert_eq!(direct_first.notes_deleted, 0);
+        assert_eq!(daemon_first.notes_deleted, 0);
+
+        let direct_unchanged = index_markdown_directory_with_ignore_and_deletion_count(
+            &root,
+            &direct_db,
+            "default",
+            "vault",
+            &[],
+        )
+        .unwrap();
+        let daemon_unchanged = index_markdown_directory_with_store_and_deletion_count(
+            &daemon_store,
+            &root,
+            &daemon_db,
+            "default",
+            "vault",
+            &[],
+        )
+        .unwrap();
+        assert_eq!(direct_unchanged.notes_deleted, 2);
+        assert_eq!(daemon_unchanged.notes_deleted, 2);
+        assert_eq!(
+            format_markdown_refresh_summary(&direct_unchanged),
+            format_markdown_refresh_summary(&daemon_unchanged)
+        );
+
+        fs::remove_file(root.join("a.md")).unwrap();
+        fs::write(root.join("b.md"), "# B changed\n\nnew beta\n").unwrap();
+        fs::write(root.join("c.md"), "# C\n\ngamma\n").unwrap();
+        let direct_changed = index_markdown_directory_with_ignore_and_deletion_count(
+            &root,
+            &direct_db,
+            "default",
+            "vault",
+            &[],
+        )
+        .unwrap();
+        let daemon_changed = index_markdown_directory_with_store_and_deletion_count(
+            &daemon_store,
+            &root,
+            &daemon_db,
+            "default",
+            "vault",
+            &[],
+        )
+        .unwrap();
+        assert_eq!(direct_changed.notes_deleted, 2);
+        assert_eq!(direct_changed.index.notes_count, 2);
+        assert_eq!(daemon_changed.notes_deleted, 2);
+        assert_eq!(daemon_changed.index.notes_count, 2);
+        assert_eq!(
+            format_markdown_refresh_summary(&direct_changed),
+            format_markdown_refresh_summary(&daemon_changed)
+        );
+        assert_eq!(
+            format_markdown_refresh_summary(&direct_changed),
+            "Refreshed vault 'vault': dropped 2 stale note(s), reindexed 2 note(s), \
+             2 heading(s), 2 section(s), 0 tag(s), 0 wikilink(s) (0 unresolved)."
         );
     }
 

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -281,11 +281,12 @@ pub use index::{
     save_filemeta_sidecar,
 };
 pub use index_md::{
-    MarkdownIndexResult, MarkdownSinceResult, index_markdown_directory,
-    index_markdown_directory_in_memory, index_markdown_directory_since,
-    index_markdown_directory_since_with_ignore, index_markdown_directory_with_ignore,
-    index_markdown_directory_with_store, index_markdown_with_reader,
-    index_markdown_with_reader_and_write_gate, load_alias_sidecar,
+    MarkdownIndexResult, MarkdownRefreshResult, MarkdownSinceResult,
+    format_markdown_refresh_summary, index_markdown_directory, index_markdown_directory_in_memory,
+    index_markdown_directory_since, index_markdown_directory_since_with_ignore,
+    index_markdown_directory_with_ignore, index_markdown_directory_with_ignore_and_deletion_count,
+    index_markdown_directory_with_store, index_markdown_directory_with_store_and_deletion_count,
+    index_markdown_with_reader, index_markdown_with_reader_and_write_gate, load_alias_sidecar,
 };
 pub use interactions::{
     EventType, InteractionData, InteractionStore, InteractionTracker, NodeScore,

--- a/crates/nestweaver-engine/src/watch_code.rs
+++ b/crates/nestweaver-engine/src/watch_code.rs
@@ -23,6 +23,7 @@ use nestweaver_store::{GraphScope, GraphStore};
 use notify::RecursiveMode;
 use notify_debouncer_mini::{DebouncedEvent, new_debouncer};
 
+use crate::content_reader::ContentReader;
 use crate::index::{is_minified_or_bundled, path_in_skip_dir};
 use crate::watcher::ShutdownHandle;
 
@@ -34,6 +35,17 @@ pub struct CodeWatcher {
     repo_root: PathBuf,
     instance_id: String,
     stop_flag: Arc<AtomicBool>,
+}
+
+#[derive(Debug)]
+enum WatchBatchOutcome {
+    Published { files_processed: usize },
+    Skipped { reason: anyhow::Error },
+}
+
+enum PreparedPath {
+    Replace(PreparedCodeFile),
+    Delete { rel_path: String },
 }
 
 impl CodeWatcher {
@@ -120,48 +132,9 @@ impl CodeWatcher {
         store: Arc<GraphStore>,
         on_change: Option<Box<dyn Fn() + Send>>,
     ) -> Result<(), anyhow::Error> {
-        // Identity decision (see `resolve_watch_identity`): adopt an existing
-        // `file://` graph rather than re-identifying+pruning, so a watch-first
-        // start over a legacy DB never empties the graph.
-        let root_path = self.repo_root.display().to_string();
-        let (repo_url, r_uid) = resolve_watch_identity(&store, &self.instance_id, &self.repo_root)?;
-
-        // Ensure the Repo node exists so incremental updates can attach
-        // File and Symbol nodes. If there's no prior index we create a
-        // minimal Repo node; the watcher will populate it file-by-file.
-        if store.lookup_repo(&r_uid)?.is_none() {
-            let publication = self.establish_graph_publication_with_io(
-                &store,
-                &crate::index::FileSystemIndexEpilogueIo,
-            )?;
-            let insert_result = store
-                .insert_repo(&nestweaver_schema::Repo {
-                    uid: r_uid.clone(),
-                    url: repo_url.clone(),
-                    indexed_sha: "watch".to_string(),
-                    staleness_commits_behind: 0,
-                    instance_id: self.instance_id.clone(),
-                    name: None,
-                    root_path: Some(root_path.clone()),
-                })
-                .context("insert initial Repo node");
-            let finalization = self.finalize_graph_publication_with_io(
-                publication,
-                &crate::index::FileSystemIndexEpilogueIo,
-            );
-            match (insert_result, finalization) {
-                (Ok(()), Ok(())) => {}
-                (Err(error), Ok(())) => return Err(error),
-                (Ok(()), Err(error)) => return Err(error.into()),
-                (Err(error), Err(finalization)) => {
-                    return Err(error.context(format!(
-                        "initial Repo insert also failed mandatory publication: {finalization}"
-                    )));
-                }
-            }
-        }
-
-        // Channel from the debouncer into our loop.
+        // Register before inspecting or cold-indexing the tree. Events that
+        // race the initial snapshot are queued by the debouncer and replayed
+        // below, closing the former scan-then-watch lost-event window.
         let (tx, rx) = std::sync::mpsc::channel::<DebounceResult>();
         let mut debouncer = new_debouncer(
             Duration::from_secs(2),
@@ -175,11 +148,71 @@ impl CodeWatcher {
             .watch(&self.repo_root, RecursiveMode::Recursive)
             .with_context(|| format!("watch {}", self.repo_root.display()))?;
 
+        // Identity decision (see `resolve_watch_identity`): adopt an existing
+        // `file://` graph rather than re-identifying+pruning, so a watch-first
+        // start over a legacy DB never empties the graph.
+        let (repo_url, r_uid) = resolve_watch_identity(&store, &self.instance_id, &self.repo_root)?;
+
+        // A contract plan is a whole-repo view and must never point at
+        // unchanged controllers that a minimal watch-first graph omitted.
+        // Cold watchers therefore publish an authoritative initial source +
+        // contract snapshot through the exact same atomic batch seam.
+        if store.lookup_repo(&r_uid)?.is_none() {
+            loop {
+                let reader = crate::content_reader::FilesystemReader::new(&self.repo_root);
+                let initial_paths: Vec<PathBuf> = reader
+                    .list_files()
+                    .context("list files for initial watcher snapshot")?
+                    .into_iter()
+                    .map(|path| self.repo_root.join(path))
+                    .filter(|path| is_watcher_input(path))
+                    .filter(|path| !path_in_skip_dir(path))
+                    .filter(|path| !is_minified_or_bundled(path))
+                    .collect();
+                match self.process_batch_and_notify(
+                    &store,
+                    &r_uid,
+                    &repo_url,
+                    &initial_paths,
+                    &crate::index::FileSystemIndexEpilogueIo,
+                    on_change.as_deref().map(|callback| callback as &dyn Fn()),
+                )? {
+                    WatchBatchOutcome::Published { .. } => break,
+                    WatchBatchOutcome::Skipped { reason } => {
+                        // A save racing the cold snapshot is expected to be
+                        // queued because notification was registered first.
+                        // Wait through one debounce window, discard those
+                        // paths, and rebuild the authoritative whole-repo
+                        // snapshot. If no event arrives, this is a stable bad
+                        // input rather than a race and startup fails clearly.
+                        match rx.recv_timeout(Duration::from_millis(2250)) {
+                            Ok(Ok(_)) => {
+                                let _ = drain_queued_events(&rx);
+                                continue;
+                            }
+                            Ok(Err(error)) => {
+                                return Err(anyhow::Error::new(error).context(
+                                    "notification failed while retrying initial watcher snapshot",
+                                ));
+                            }
+                            Err(_) => {
+                                return Err(reason.context(
+                                    "cannot start code watcher without an authoritative initial graph",
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         tracing::info!(
             repo = %self.repo_root.display(),
             db = %self.db_path.display(),
             "CodeWatcher running"
         );
+
+        let mut replay_batch = drain_queued_events(&rx);
 
         loop {
             if self.stop_flag.load(Ordering::Relaxed) {
@@ -187,38 +220,42 @@ impl CodeWatcher {
                 return Ok(());
             }
 
-            let batch = match rx.recv_timeout(Duration::from_millis(250)) {
-                Ok(Ok(events)) => events,
-                Ok(Err(err)) => {
-                    if !self.repo_root.exists() {
-                        tracing::error!(
-                            repo = %self.repo_root.display(),
-                            "repo root no longer exists; watcher exiting"
-                        );
-                        return Err(anyhow::anyhow!(
-                            "repo root '{}' was deleted or unmounted",
-                            self.repo_root.display()
-                        ));
+            let batch = if !replay_batch.is_empty() {
+                std::mem::take(&mut replay_batch)
+            } else {
+                match rx.recv_timeout(Duration::from_millis(250)) {
+                    Ok(Ok(events)) => events,
+                    Ok(Err(err)) => {
+                        if !self.repo_root.exists() {
+                            tracing::error!(
+                                repo = %self.repo_root.display(),
+                                "repo root no longer exists; watcher exiting"
+                            );
+                            return Err(anyhow::anyhow!(
+                                "repo root '{}' was deleted or unmounted",
+                                self.repo_root.display()
+                            ));
+                        }
+                        tracing::warn!("notify error: {err}");
+                        continue;
                     }
-                    tracing::warn!("notify error: {err}");
-                    continue;
-                }
-                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                    if !self.repo_root.exists() {
-                        tracing::error!(
-                            repo = %self.repo_root.display(),
-                            "repo root vanished during watch; exiting"
-                        );
-                        return Err(anyhow::anyhow!(
-                            "repo root '{}' was deleted or unmounted",
-                            self.repo_root.display()
-                        ));
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                        if !self.repo_root.exists() {
+                            tracing::error!(
+                                repo = %self.repo_root.display(),
+                                "repo root vanished during watch; exiting"
+                            );
+                            return Err(anyhow::anyhow!(
+                                "repo root '{}' was deleted or unmounted",
+                                self.repo_root.display()
+                            ));
+                        }
+                        continue;
                     }
-                    continue;
-                }
-                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                    tracing::warn!("code debouncer disconnected; exiting");
-                    return Ok(());
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                        tracing::warn!("code debouncer disconnected; exiting");
+                        return Ok(());
+                    }
                 }
             };
 
@@ -229,11 +266,14 @@ impl CodeWatcher {
                 unique_paths.insert(event.path.clone());
             }
 
-            // Filter to supported source files not in skip dirs.
+            // Contract specs are first-class watcher inputs even though they
+            // are not parser-supported source files. A spec-only edit must
+            // refresh the derived Contract nodes and IMPLEMENTS_CONTRACT
+            // edges just like an ordinary incremental index.
             let relevant: Vec<PathBuf> = unique_paths
                 .into_iter()
                 .filter(|p| !path_in_skip_dir(p))
-                .filter(|p| is_supported_source(p))
+                .filter(|p| is_watcher_input(p))
                 .filter(|p| !is_minified_or_bundled(p))
                 .collect();
 
@@ -241,79 +281,83 @@ impl CodeWatcher {
                 continue;
             }
 
-            // Publish a dirty marker and reserve N+1 before the first graph
-            // mutation. Any later error leaves reopen fail-closed until the
-            // mandatory N+2 finalization completes.
-            let publication = self.establish_graph_publication_with_io(
-                &store,
-                &crate::index::FileSystemIndexEpilogueIo,
-            )?;
-
             let start = Instant::now();
-            // Per-file PRE-mutation failures are logged and skipped inside
-            // `reindex_paths`: a single unreadable file must not kill the
-            // watch session (the next edit batch retries), and because the
-            // reindex re-parses BEFORE deleting, a failed file keeps its
-            // previous graph data instead of vanishing from the graph while
-            // still on disk. A POST-mutation failure (delete landed, later
-            // insert failed) is different: the graph holds partial data, so
-            // the batch is reported as failed after publication finalizes —
-            // it must not look cleanly successful.
-            let (files_processed, batch_error) = self.reindex_paths(&store, &r_uid, &relevant);
-
-            let finalization = self.finalize_graph_publication_with_io(
-                publication,
+            let outcome = self.process_batch_and_notify(
+                &store,
+                &r_uid,
+                &repo_url,
+                &relevant,
                 &crate::index::FileSystemIndexEpilogueIo,
-            );
-            if finalization.is_ok() && batch_error.is_none() {
-                let duration = start.elapsed();
-                tracing::info!(
-                    files_processed,
-                    elapsed_secs = format!("{:.1}", duration.as_secs_f64()),
-                    "Re-indexed {} file(s) ({:.1}s)",
-                    files_processed,
-                    duration.as_secs_f64()
-                );
-
-                if let Some(ref cb) = on_change {
-                    cb();
+                on_change.as_deref().map(|callback| callback as &dyn Fn()),
+            )?;
+            let files_processed = match outcome {
+                WatchBatchOutcome::Published { files_processed } => files_processed,
+                WatchBatchOutcome::Skipped { reason } => {
+                    tracing::warn!(
+                        error = %reason,
+                        "skipping transient watcher batch before publication; previous graph preserved"
+                    );
+                    continue;
                 }
-            }
-            if let Err(error) = finalization {
-                anyhow::bail!("code watcher batch failed mandatory graph publication: {error}");
-            }
-            if let Some(error) = batch_error {
-                anyhow::bail!(
-                    "code watcher batch partially failed mid-mutation (partial index data; \
-                     the next edit retries, or repair with `nestweaver index --force`): {error}"
-                );
-            }
+            };
+            let duration = start.elapsed();
+            tracing::info!(
+                files_processed,
+                elapsed_secs = format!("{:.1}", duration.as_secs_f64()),
+                "Re-indexed {} file(s) ({:.1}s)",
+                files_processed,
+                duration.as_secs_f64()
+            );
+
+            // Notification is coupled to the published outcome by
+            // `process_batch_and_notify`; skipped/dirty batches cannot emit a
+            // false-positive SSE change event.
         }
     }
 
-    /// Re-index one batch of changed paths against the live graph. Returns
-    /// the number of files processed plus the FIRST post-mutation failure,
-    /// if any — a post-mutation failure means the graph holds partial data
-    /// for that file and the batch must not be reported as cleanly
-    /// successful. Mirrors the engine's incremental index
-    /// (`index.rs::incremental_index_with_name_and_io`): nw-008 Phase 0
-    /// collects reverse-dependents from the live graph BEFORE any mutation,
-    /// and Phase 2 re-resolves them afterwards so the cross-file edges the
-    /// per-file `DETACH DELETE` destroys are restored — without this, a
-    /// watcher reindex leaves the file's symbols in place but strips ALL
-    /// their incoming and outgoing cross-file CALLS/IMPORTS edges.
-    fn reindex_paths(
+    /// Prepare and atomically publish one watcher batch.
+    ///
+    /// All whole-repo contract reads and parsing finish before publication is
+    /// established. Source replacement, reverse-dependent resolution, and
+    /// contract replacement then share one transaction. Any failure before
+    /// commit preserves the previously committed graph; because finalization
+    /// is deliberately skipped, `.index-dirty` remains as the durable
+    /// fail-closed signal and callers cannot report success.
+    fn process_batch_with_io(
         &self,
         store: &GraphStore,
         r_uid: &str,
+        repo_url: &str,
         relevant: &[PathBuf],
-    ) -> (usize, Option<anyhow::Error>) {
-        // Partition into changed (still on disk) / removed (deleted), keeping
-        // the absolute path alongside for the mutation loop.
+        epilogue_io: &dyn crate::index::IndexEpilogueIo,
+    ) -> Result<WatchBatchOutcome, anyhow::Error> {
+        self.process_batch_with_io_and_hook(store, r_uid, repo_url, relevant, epilogue_io, || {})
+    }
+
+    fn process_batch_with_io_and_hook<F>(
+        &self,
+        store: &GraphStore,
+        r_uid: &str,
+        repo_url: &str,
+        relevant: &[PathBuf],
+        epilogue_io: &dyn crate::index::IndexEpilogueIo,
+        after_plan: F,
+    ) -> Result<WatchBatchOutcome, anyhow::Error>
+    where
+        F: FnOnce(),
+    {
+        let insert_initial_repo = store.lookup_repo(r_uid)?.is_none();
+        let reader = crate::content_reader::FilesystemReader::new(&self.repo_root);
+        let contract_plan =
+            match crate::index::prepare_watcher_contract_derivation(&reader, r_uid, repo_url) {
+                Ok(plan) => plan,
+                Err(reason) => return Ok(WatchBatchOutcome::Skipped { reason }),
+            };
+        after_plan();
+        let mut prepared_paths = Vec::new();
         let mut changed: HashSet<String> = HashSet::new();
         let mut removed: HashSet<String> = HashSet::new();
-        let mut paths: Vec<PathBuf> = Vec::new();
-        for path in relevant {
+        for path in relevant.iter().filter(|path| is_supported_source(path)) {
             let rel_path = match path.strip_prefix(&self.repo_root) {
                 Ok(r) => r,
                 Err(_) => {
@@ -325,122 +369,216 @@ impl CodeWatcher {
                 }
             };
             let rel_str = rel_path.to_string_lossy().into_owned();
-            if path.exists() {
-                changed.insert(rel_str);
-            } else {
-                removed.insert(rel_str);
+            match std::fs::metadata(path) {
+                Ok(metadata) if metadata.is_file() => {
+                    let prepared =
+                        match prepare_code_file(&self.repo_root, rel_path, r_uid, repo_url) {
+                            Ok(prepared) => prepared,
+                            Err(reason) => return Ok(WatchBatchOutcome::Skipped { reason }),
+                        };
+                    if contract_plan
+                        .input_hashes
+                        .get(&rel_str)
+                        .is_some_and(|expected| expected != &prepared.file.content_hash)
+                    {
+                        return Ok(WatchBatchOutcome::Skipped {
+                            reason: anyhow::anyhow!(
+                                "watched controller changed while contract batch was being prepared: {rel_str}"
+                            ),
+                        });
+                    }
+                    changed.insert(rel_str);
+                    prepared_paths.push(PreparedPath::Replace(prepared));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    removed.insert(rel_str.clone());
+                    prepared_paths.push(PreparedPath::Delete { rel_path: rel_str });
+                }
+                Ok(_) => continue,
+                Err(error) => {
+                    return Ok(WatchBatchOutcome::Skipped {
+                        reason: anyhow::Error::new(error)
+                            .context(format!("inspect watched path {}", path.display())),
+                    });
+                }
             }
-            paths.push(path.clone());
+        }
+
+        let final_contract_snapshot = match crate::index::watcher_contract_input_snapshot(&reader) {
+            Ok(snapshot) => snapshot,
+            Err(reason) => return Ok(WatchBatchOutcome::Skipped { reason }),
+        };
+        if final_contract_snapshot != contract_plan.observed_input_hashes {
+            return Ok(WatchBatchOutcome::Skipped {
+                reason: anyhow::anyhow!(
+                    "contract inputs changed after watcher plan while changed paths were frozen"
+                ),
+            });
         }
 
         // nw-008 Phase 0 — transitive reverse-dependents from the LIVE graph,
         // BEFORE any mutation (the per-file `DETACH DELETE` destroys the
         // edges this query walks).
         let rdeps = crate::index::collect_reverse_dep_files(store, r_uid, &changed, &removed);
+        let replacement_symbols: Vec<_> = prepared_paths
+            .iter()
+            .filter_map(|path| match path {
+                PreparedPath::Replace(file) => Some(file.symbols.iter()),
+                PreparedPath::Delete { .. } => None,
+            })
+            .flatten()
+            .cloned()
+            .collect();
+        let prepared_file_data: std::collections::HashMap<_, _> = prepared_paths
+            .iter()
+            .filter_map(|path| match path {
+                PreparedPath::Replace(file) => Some((
+                    file.rel_path.clone(),
+                    (file.raw_symbols.clone(), file.raw_references.clone()),
+                )),
+                PreparedPath::Delete { .. } => None,
+            })
+            .collect();
+        let reresolved_edges = match crate::index::prepare_watcher_reresolve_edges(
+            &reader,
+            store,
+            r_uid,
+            &changed,
+            &removed,
+            &rdeps,
+            &replacement_symbols,
+            &prepared_file_data,
+        ) {
+            Ok(edges) => edges,
+            Err(reason) => return Ok(WatchBatchOutcome::Skipped { reason }),
+        };
+
+        // No graph mutation, including a failure marker, occurs before the
+        // complete plan above exists. Once publication starts, every failure
+        // intentionally leaves the dirty marker for reopen reconciliation.
+        let publication = self
+            .establish_graph_publication_with_io(store, epilogue_io)
+            .map_err(anyhow::Error::from)?;
+        reject_recovered_publication(&publication)?;
+        let txn = store
+            .begin_transaction()
+            .context("begin code watcher batch transaction")?;
+        if insert_initial_repo {
+            nestweaver_store::GraphStore::insert_repo_on(
+                &txn,
+                &nestweaver_schema::Repo {
+                    uid: r_uid.to_string(),
+                    url: repo_url.to_string(),
+                    indexed_sha: "watch".to_string(),
+                    staleness_commits_behind: 0,
+                    instance_id: self.instance_id.clone(),
+                    name: None,
+                    root_path: Some(self.repo_root.display().to_string()),
+                },
+            )
+            .context("insert initial watcher Repo node")?;
+        }
 
         let mut files_processed = 0usize;
-        let mut first_post_mutation_error: Option<anyhow::Error> = None;
-        for path in &paths {
-            let rel_path = match path.strip_prefix(&self.repo_root) {
-                Ok(r) => r,
-                Err(_) => continue, // already logged above
-            };
-            let rel_str = rel_path.to_string_lossy();
-
-            if path.exists() {
-                // File was created or modified: re-parse, then replace.
-                match reindex_file(&self.repo_root, rel_path, r_uid, store) {
-                    Ok(Some(syms)) => {
+        for prepared_path in &prepared_paths {
+            match prepared_path {
+                PreparedPath::Replace(prepared) => {
+                    let symbols = apply_prepared_code_file(&txn, r_uid, prepared)
+                        .with_context(|| format!("apply watched file {}", prepared.rel_path))?;
+                    tracing::debug!(path = %prepared.rel_path, symbols, "re-indexed file");
+                    files_processed += 1;
+                }
+                PreparedPath::Delete { rel_path } => {
+                    let removed_count = nestweaver_store::GraphStore::delete_symbols_in_file_on(
+                        &txn, r_uid, rel_path,
+                    )
+                    .with_context(|| format!("delete symbols for removed file {rel_path}"))?;
+                    let f_uid = nestweaver_schema::file_uid(r_uid, rel_path);
+                    nestweaver_store::GraphStore::delete_file_node_on(&txn, &f_uid)
+                        .with_context(|| format!("delete removed File node {rel_path}"))?;
+                    if removed_count > 0 {
                         tracing::debug!(
-                            path = %rel_str,
-                            symbols = syms,
-                            "re-indexed file"
-                        );
-                        files_processed += 1;
-                    }
-                    Ok(None) => {
-                        // Parse failure — old graph data preserved
-                        // (reindex_file deletes only after a successful
-                        // read+parse). Do NOT re-resolve edges for this
-                        // file below: its edges were never deleted, and
-                        // edge insert is CREATE (duplicates).
-                        changed.remove(rel_str.as_ref());
-                    }
-                    Err(ReindexError::PreMutation(e)) => {
-                        // Same keep-old-data treatment for pre-mutation
-                        // read/store errors (delete never landed).
-                        changed.remove(rel_str.as_ref());
-                        tracing::warn!(
-                            path = %rel_str,
-                            error = %e,
-                            "failed to re-index file; keeping previous index data"
+                            path = %rel_path,
+                            removed = removed_count,
+                            "deleted symbols for removed file"
                         );
                     }
-                    Err(ReindexError::PostMutation(e)) => {
-                        // The delete already landed: the graph holds PARTIAL
-                        // data for this file, not the old data. Keep the file
-                        // in `changed` so Phase 2 re-resolves whatever edges
-                        // it can, and report the batch as failed instead of
-                        // publishing it as cleanly successful.
-                        if first_post_mutation_error.is_none() {
-                            first_post_mutation_error = Some(anyhow::anyhow!("{rel_str}: {e}"));
-                        }
-                        tracing::error!(
-                            path = %rel_str,
-                            error = %e,
-                            "re-index failed mid-mutation; graph holds partial data for this file"
-                        );
-                    }
+                    files_processed += 1;
                 }
-            } else {
-                // File was deleted: remove its symbols and File node.
-                let removed_count = match store.delete_symbols_in_file(r_uid, &rel_str) {
-                    Ok(removed) => removed,
-                    Err(error) => {
-                        tracing::warn!("delete symbols for removed file {rel_str}: {error}");
-                        0
-                    }
-                };
-                let f_uid = nestweaver_schema::file_uid(r_uid, &rel_str);
-                if let Err(error) = store.delete_file_node(&f_uid) {
-                    tracing::warn!("delete removed File node {rel_str}: {error}");
-                }
-                if removed_count > 0 {
-                    tracing::debug!(
-                        path = %rel_str,
-                        removed = removed_count,
-                        "deleted symbols for removed file"
-                    );
-                }
-                files_processed += 1;
             }
         }
 
-        // nw-008 Phase 2 — re-resolve reverse-dependents and surgically
-        // restore the cross-file edges the per-file `DETACH DELETE` removed.
-        let reader = crate::content_reader::FilesystemReader::new(&self.repo_root);
-        match crate::index::reresolve_affected_dependents_on_store(
-            &reader, store, r_uid, &changed, &rdeps,
-        ) {
-            Ok(reresolved) if reresolved > 0 => {
-                tracing::info!(
-                    edges = reresolved,
-                    rdeps = rdeps.len(),
-                    "restored cross-file edges via transitive re-resolution"
+        let reresolved = reresolved_edges.len();
+        if !reresolved_edges.is_empty() {
+            nestweaver_store::GraphStore::batch_insert_edges_on(&txn, &reresolved_edges)
+                .context("insert prepared watcher reverse-dependent edges")?;
+        }
+        if reresolved > 0 {
+            tracing::info!(
+                edges = reresolved,
+                rdeps = rdeps.len(),
+                "restored cross-file edges via transitive re-resolution"
+            );
+        }
+
+        if let Err(error) = crate::index::apply_contract_derivation_on(&txn, r_uid, &contract_plan)
+        {
+            drop(txn);
+            if let Err(marker_error) =
+                store.set_contract_derivation_failed(r_uid, &error.to_string())
+            {
+                tracing::warn!(
+                    "recording watcher contract derivation failure failed: {marker_error}"
                 );
             }
-            Ok(_) => {}
-            Err(e) => {
-                tracing::warn!("transitive re-resolution failed: {e:#}");
-            }
+            return Err(error).context("apply watcher contract derivation");
         }
 
-        (files_processed, first_post_mutation_error)
+        store
+            .commit_transaction(&txn)
+            .context("commit code watcher batch transaction")?;
+        drop(txn);
+        if let Err(error) = store.clear_contract_derivation_failed(r_uid) {
+            tracing::warn!("clearing watcher contract derivation marker failed: {error}");
+        }
+        self.finalize_graph_publication_with_io(publication, epilogue_io)
+            .map_err(anyhow::Error::from)?;
+        Ok(WatchBatchOutcome::Published { files_processed })
+    }
+
+    fn process_batch_and_notify(
+        &self,
+        store: &GraphStore,
+        r_uid: &str,
+        repo_url: &str,
+        relevant: &[PathBuf],
+        epilogue_io: &dyn crate::index::IndexEpilogueIo,
+        on_change: Option<&dyn Fn()>,
+    ) -> Result<WatchBatchOutcome, anyhow::Error> {
+        let outcome = self.process_batch_with_io(store, r_uid, repo_url, relevant, epilogue_io)?;
+        if matches!(outcome, WatchBatchOutcome::Published { .. })
+            && let Some(callback) = on_change
+        {
+            callback();
+        }
+        Ok(outcome)
     }
 }
 
 /// The debouncer callback type.
 type DebounceResult = Result<Vec<DebouncedEvent>, notify::Error>;
+
+fn drain_queued_events(rx: &std::sync::mpsc::Receiver<DebounceResult>) -> Vec<DebouncedEvent> {
+    let mut events = Vec::new();
+    loop {
+        match rx.try_recv() {
+            Ok(Ok(mut queued)) => events.append(&mut queued),
+            Ok(Err(error)) => tracing::warn!("notify error queued during watcher startup: {error}"),
+            Err(std::sync::mpsc::TryRecvError::Empty) => return events,
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => return events,
+        }
+    }
+}
 
 /// Decide the repo identity `(url, uid)` the watcher indexes under.
 ///
@@ -496,73 +634,51 @@ fn is_supported_source(path: &Path) -> bool {
     detect_language(path).is_some()
 }
 
-/// Parse a single source file and insert its File node, Symbol nodes, and
-/// edges. Returns `Ok(Some(n))` when the file was re-indexed (n symbols
-/// inserted), or `Ok(None)` when the reindex was SKIPPED and the file's
-/// previous graph data was kept. Mirrors the logic in
-/// `index.rs::process_added_or_modified_file`.
-///
-/// The file is read and parsed BEFORE any graph mutation: on a read or
-/// parse failure the file's previous symbols stay in the graph. The old
-/// code deleted the file's symbols first, so a transient read error (or a
-/// mid-save partial write) left the file's symbols deleted from the graph
-/// while the file was still on disk.
-fn reindex_file(
+fn is_watcher_input(path: &Path) -> bool {
+    is_supported_source(path) || crate::contracts::is_spec_file(&path.to_string_lossy())
+}
+
+struct PreparedCodeFile {
+    rel_path: String,
+    file: nestweaver_schema::File,
+    symbols: Vec<nestweaver_schema::Symbol>,
+    file_symbol_edges: Vec<(String, String)>,
+    resolved_edges: Vec<nestweaver_schema::ResolvedEdge>,
+    raw_symbols: Vec<nestweaver_parser::RawSymbol>,
+    raw_references: Vec<nestweaver_parser::RawReference>,
+}
+
+/// Read, parse, resolve, and annotate a watched source before publication.
+/// The returned object owns every row needed by the transaction, eliminating
+/// the read/delete/re-read race that could otherwise erase a transiently
+/// malformed half-save.
+fn prepare_code_file(
     repo_root: &Path,
     rel_path: &Path,
     r_uid: &str,
-    store: &GraphStore,
-) -> Result<Option<usize>, ReindexError> {
+    repo_url: &str,
+) -> Result<PreparedCodeFile, anyhow::Error> {
     use nestweaver_parser::{RawReference, RawSymbol, parse_source};
     use nestweaver_resolver::{discover_workspace_context, resolve_references_with_context};
-    use nestweaver_schema::{File, Symbol, file_uid, symbol_uid};
+    use nestweaver_schema::{File, Symbol, canonical_symbol_id, file_uid, symbol_uid};
 
     let abs_path = repo_root.join(rel_path);
     let rel_str = rel_path.to_string_lossy().into_owned();
 
-    let source = std::fs::read_to_string(&abs_path).map_err(|e| {
-        ReindexError::PreMutation(anyhow::anyhow!("read {}: {e}", abs_path.display()))
-    })?;
-
-    let parsed = match parse_source(&abs_path, &source) {
-        Ok(p) => p,
-        Err(e) => {
-            tracing::warn!(path = %abs_path.display(), "parse error: {e}; keeping previous index data");
-            return Ok(None);
-        }
-    };
-
-    // Only now that the fresh parse is in hand: drop the stale symbols.
-    // From this point on the file's graph data is being MUTATED — a failure
-    // here is not "kept previous data".
-    let removed = store.delete_symbols_in_file(r_uid, &rel_str).map_err(|e| {
-        ReindexError::PostMutation(anyhow::anyhow!("delete_symbols_in_file {rel_str}: {e}"))
-    })?;
-    if removed > 0 {
-        tracing::debug!(
-            path = %rel_str,
-            removed,
-            "removed stale symbols before re-index"
-        );
-    }
+    let source = std::fs::read_to_string(&abs_path)
+        .with_context(|| format!("read watched source {}", abs_path.display()))?;
+    let parsed = parse_source(&abs_path, &source)
+        .with_context(|| format!("parse watched source {}", abs_path.display()))?;
 
     let content_hash = crate::hash::blake3_hex(&source);
     let f_uid = file_uid(r_uid, &rel_str);
 
-    // Insert or replace the File node.
     let file = File {
         uid: f_uid.clone(),
         path: rel_str.clone(),
         repo_uid: r_uid.to_string(),
         content_hash,
     };
-    store
-        .insert_file(&file)
-        .map_err(|e| ReindexError::PostMutation(anyhow::anyhow!("insert_file {rel_str}: {e}")))?;
-    store.insert_repo_file_edge(r_uid, &f_uid).map_err(|e| {
-        ReindexError::PostMutation(anyhow::anyhow!("insert_repo_file_edge {rel_str}: {e}"))
-    })?;
-
     let mut symbols: Vec<Symbol> = Vec::new();
     let mut file_sym_pairs: Vec<(String, String)> = Vec::new();
 
@@ -606,6 +722,7 @@ fn reindex_file(
 
     for (sym_idx, raw_sym) in parsed.symbols.iter().enumerate() {
         let s_uid = symbol_uid(r_uid, &rel_str, &raw_sym.name, raw_sym.start_line);
+        let scope = raw_sym.scope_chain.as_deref().unwrap_or("");
         let sym = Symbol {
             uid: s_uid.clone(),
             name: raw_sym.name.clone(),
@@ -624,31 +741,19 @@ fn reindex_file(
             visibility: raw_sym.visibility,
             type_info: raw_sym.type_info.clone(),
             framework_hint: hint_by_index.remove(&sym_idx),
-            canonical_id: None,
+            canonical_id: Some(canonical_symbol_id(
+                repo_url,
+                &rel_str,
+                &raw_sym.name,
+                scope,
+            )),
         };
         symbols.push(sym);
         file_sym_pairs.push((f_uid.clone(), s_uid));
     }
 
-    let sym_count = symbols.len();
-
-    store.batch_insert_symbols(&symbols).map_err(|e| {
-        ReindexError::PostMutation(anyhow::anyhow!("batch_insert_symbols {rel_str}: {e}"))
-    })?;
-
-    let file_sym_refs: Vec<(&str, &str)> = file_sym_pairs
-        .iter()
-        .map(|(f, s)| (f.as_str(), s.as_str()))
-        .collect();
-    store
-        .batch_insert_file_symbol_edges(&file_sym_refs)
-        .map_err(|e| {
-            ReindexError::PostMutation(anyhow::anyhow!(
-                "batch_insert_file_symbol_edges {rel_str}: {e}"
-            ))
-        })?;
-
-    // Resolve cross-file edges within this file.
+    // Resolve cross-file edges within this file while the source snapshot is
+    // still the exact snapshot represented by `symbols`.
     let lang = detect_language(&abs_path).unwrap_or(nestweaver_schema::Language::JavaScript);
 
     // Load workspace context for JS/TS monorepo resolution.
@@ -672,37 +777,54 @@ fn reindex_file(
     )];
     let resolved_edges =
         resolve_references_with_context(&file_data, lang, r_uid, &workspace_ctx, None, None);
-    let insertable_edges: Vec<_> = resolved_edges
+    let resolved_edges: Vec<_> = resolved_edges
         .into_iter()
         .filter(|e| !e.target_uid.starts_with("unresolved:"))
         .collect();
-    if !insertable_edges.is_empty() {
-        store.batch_insert_edges(&insertable_edges).map_err(|e| {
-            ReindexError::PostMutation(anyhow::anyhow!("batch_insert_edges {rel_str}: {e}"))
-        })?;
-    }
 
-    Ok(Some(sym_count))
+    Ok(PreparedCodeFile {
+        rel_path: rel_str,
+        file,
+        symbols,
+        file_symbol_edges: file_sym_pairs,
+        resolved_edges,
+        raw_symbols: parsed.symbols,
+        raw_references: parsed.references,
+    })
 }
 
-/// Why a watcher re-index of one file failed, split by whether the file's
-/// graph data had already been mutated. Callers must NOT treat a
-/// `PostMutation` failure as "previous data preserved": the
-/// delete already landed, so the graph holds partial data for the file and
-/// the batch must not publish as cleanly successful.
-enum ReindexError {
-    /// Failed before any mutation (read/parse/delete) — old graph data intact.
-    PreMutation(anyhow::Error),
-    /// Failed after the file's symbols were deleted — partial data.
-    PostMutation(anyhow::Error),
+fn apply_prepared_code_file(
+    txn: &nestweaver_store::DbConnection<'_>,
+    r_uid: &str,
+    prepared: &PreparedCodeFile,
+) -> Result<usize, anyhow::Error> {
+    nestweaver_store::GraphStore::delete_symbols_in_file_on(txn, r_uid, &prepared.rel_path)?;
+    let old_file_uid = nestweaver_schema::file_uid(r_uid, &prepared.rel_path);
+    nestweaver_store::GraphStore::delete_file_node_on(txn, &old_file_uid)?;
+    nestweaver_store::GraphStore::insert_file_on(txn, &prepared.file)?;
+    nestweaver_store::GraphStore::insert_repo_file_edge_on(txn, r_uid, &prepared.file.uid)?;
+    nestweaver_store::GraphStore::batch_insert_symbols_on(txn, &prepared.symbols)?;
+    let file_symbol_edges: Vec<(&str, &str)> = prepared
+        .file_symbol_edges
+        .iter()
+        .map(|(file, symbol)| (file.as_str(), symbol.as_str()))
+        .collect();
+    nestweaver_store::GraphStore::batch_insert_file_symbol_edges_on(txn, &file_symbol_edges)?;
+    if !prepared.resolved_edges.is_empty() {
+        nestweaver_store::GraphStore::batch_insert_edges_on(txn, &prepared.resolved_edges)?;
+    }
+    Ok(prepared.symbols.len())
 }
 
-impl std::fmt::Display for ReindexError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::PreMutation(e) | Self::PostMutation(e) => write!(f, "{e}"),
-        }
+fn reject_recovered_publication(
+    publication: &nestweaver_store::IndexPublicationLease<'_>,
+) -> Result<(), anyhow::Error> {
+    if publication.is_recovered() {
+        anyhow::bail!(
+            "code watcher found an incomplete prior index publication; refusing to retire unknown dirty state (repair with `nestweaver index --force`)"
+        );
     }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -806,6 +928,25 @@ mod tests {
         assert!(!path_in_skip_dir(p));
     }
 
+    #[test]
+    fn startup_event_drain_replays_every_queued_batch() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        tx.send(Ok(vec![DebouncedEvent::new(
+            PathBuf::from("openapi.yaml"),
+            notify_debouncer_mini::DebouncedEventKind::Any,
+        )]))
+        .unwrap();
+        tx.send(Ok(vec![DebouncedEvent::new(
+            PathBuf::from("ItemsController.java"),
+            notify_debouncer_mini::DebouncedEventKind::Any,
+        )]))
+        .unwrap();
+        let replay = drain_queued_events(&rx);
+        assert_eq!(replay.len(), 2);
+        assert_eq!(replay[0].path, PathBuf::from("openapi.yaml"));
+        assert_eq!(replay[1].path, PathBuf::from("ItemsController.java"));
+    }
+
     /// Index a small JS fixture repo (a.js ← b.js ← c.js) into an in-memory
     /// store under its `file://` identity, returning the store, repo uid,
     /// and canonical repo root.
@@ -836,6 +977,28 @@ mod tests {
         (store, r_uid, canonical_root)
     }
 
+    fn index_contract_fixture(dir: &tempfile::TempDir) -> (GraphStore, String, String, PathBuf) {
+        let repo_root = dir.path().join("contract-repo");
+        std::fs::create_dir_all(&repo_root).unwrap();
+        std::fs::write(
+            repo_root.join("openapi.yaml"),
+            "openapi: 3.0.0\ninfo: { title: t, version: \"1\" }\npaths:\n  /v1/items:\n    get:\n      responses: { \"200\": { description: ok } }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo_root.join("ItemsController.java"),
+            "@RestController\n@RequestMapping(\"/v1/items\")\npublic class ItemsController {\n  @GetMapping\n  public void list() {}\n}\n",
+        )
+        .unwrap();
+        let canonical_root = std::fs::canonicalize(&repo_root).unwrap();
+        let repo_url = format!("file://{}", canonical_root.display());
+        let r_uid = nestweaver_schema::repo_uid("test", &repo_url);
+        let (_result, store) =
+            crate::index::index_directory_in_memory(&canonical_root, "test", &repo_url, "sha1")
+                .unwrap();
+        (store, r_uid, repo_url, canonical_root)
+    }
+
     fn uid_of(store: &GraphStore, r_uid: &str, name: &str) -> String {
         store
             .lookup_symbols_by_repo(r_uid)
@@ -844,6 +1007,24 @@ mod tests {
             .find(|s| s.name == name)
             .unwrap_or_else(|| panic!("symbol {name} should be indexed"))
             .uid
+    }
+
+    fn process_fixture_batch(
+        watcher: &CodeWatcher,
+        store: &GraphStore,
+        r_uid: &str,
+        root: &Path,
+        paths: &[PathBuf],
+    ) -> WatchBatchOutcome {
+        watcher
+            .process_batch_with_io(
+                store,
+                r_uid,
+                &format!("file://{}", root.display()),
+                paths,
+                &crate::index::FileSystemIndexEpilogueIo,
+            )
+            .unwrap()
     }
 
     /// Regression (CRITICAL — edge loss across watch reindex): a watcher
@@ -885,9 +1066,18 @@ mod tests {
         )
         .unwrap();
         let watcher = CodeWatcher::new(dir.path().join("brain.lbug"), &canonical_root, "test");
-        let (processed, batch_error) =
-            watcher.reindex_paths(&store, &r_uid, &[canonical_root.join("src/b.js")]);
-        assert!(batch_error.is_none(), "{batch_error:?}");
+        let WatchBatchOutcome::Published {
+            files_processed: processed,
+        } = process_fixture_batch(
+            &watcher,
+            &store,
+            &r_uid,
+            &canonical_root,
+            &[canonical_root.join("src/b.js")],
+        )
+        else {
+            panic!("valid watcher batch must publish")
+        };
         assert_eq!(processed, 1);
 
         // THE critical assertions: outgoing (alpha→helper) and incoming
@@ -927,14 +1117,15 @@ mod tests {
         )
         .unwrap();
         let watcher = CodeWatcher::new(dir.path().join("brain.lbug"), &canonical_root, "test");
-        let (processed, batch_error) =
-            watcher.reindex_paths(&store, &r_uid, &[canonical_root.join("src/b.js")]);
-        assert!(batch_error.is_none(), "{batch_error:?}");
-
-        assert_eq!(
-            processed, 0,
-            "an unreadable file is skipped, not half-processed"
-        );
+        let WatchBatchOutcome::Skipped { .. } = process_fixture_batch(
+            &watcher,
+            &store,
+            &r_uid,
+            &canonical_root,
+            &[canonical_root.join("src/b.js")],
+        ) else {
+            panic!("an unreadable file must skip before publication")
+        };
         assert!(
             store
                 .lookup_symbols_by_repo(&r_uid)
@@ -960,9 +1151,18 @@ mod tests {
             "import { helper } from './a.js';\nexport function alpha() { return helper() + 3; }\n",
         )
         .unwrap();
-        let (processed, batch_error) =
-            watcher.reindex_paths(&store, &r_uid, &[canonical_root.join("src/b.js")]);
-        assert!(batch_error.is_none(), "{batch_error:?}");
+        let WatchBatchOutcome::Published {
+            files_processed: processed,
+        } = process_fixture_batch(
+            &watcher,
+            &store,
+            &r_uid,
+            &canonical_root,
+            &[canonical_root.join("src/b.js")],
+        )
+        else {
+            panic!("valid retry must publish")
+        };
         assert_eq!(processed, 1, "the batch after a failure must re-index");
         let alpha_uid = uid_of(&store, &r_uid, "alpha");
         assert!(
@@ -985,10 +1185,18 @@ mod tests {
 
         std::fs::remove_file(canonical_root.join("src/b.js")).unwrap();
         let watcher = CodeWatcher::new(dir.path().join("brain.lbug"), &canonical_root, "test");
-        let (processed, batch_error) =
-            watcher.reindex_paths(&store, &r_uid, &[canonical_root.join("src/b.js")]);
-        assert!(batch_error.is_none(), "{batch_error:?}");
-
+        let WatchBatchOutcome::Published {
+            files_processed: processed,
+        } = process_fixture_batch(
+            &watcher,
+            &store,
+            &r_uid,
+            &canonical_root,
+            &[canonical_root.join("src/b.js")],
+        )
+        else {
+            panic!("delete batch must publish")
+        };
         assert_eq!(processed, 1);
         assert!(
             !store
@@ -1006,6 +1214,400 @@ mod tests {
                 .iter()
                 .any(|s| s.name == "helper" || s.name == "gamma"),
         );
+    }
+
+    #[test]
+    fn spec_only_watcher_batch_refreshes_contract_source_and_notifies_once() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let dir = tempfile::tempdir().unwrap();
+        let (store, r_uid, repo_url, root) = index_contract_fixture(&dir);
+        let old = root.join("openapi.yaml");
+        let renamed = root.join("openapi.v2.yaml");
+        std::fs::rename(&old, &renamed).unwrap();
+        let watcher = CodeWatcher::new(dir.path().join("watch.lbug"), &root, "test");
+        let notifications = AtomicUsize::new(0);
+
+        let outcome = watcher
+            .process_batch_and_notify(
+                &store,
+                &r_uid,
+                &repo_url,
+                &[old, renamed],
+                &crate::index::FileSystemIndexEpilogueIo,
+                Some(&|| {
+                    notifications.fetch_add(1, Ordering::SeqCst);
+                }),
+            )
+            .unwrap();
+        assert!(matches!(
+            outcome,
+            WatchBatchOutcome::Published { files_processed: 0 }
+        ));
+        assert_eq!(notifications.load(Ordering::SeqCst), 1);
+        let get = store
+            .list_contracts(Some(&r_uid))
+            .unwrap()
+            .into_iter()
+            .find(|contract| contract.uid == "contract:http:GET:/v1/items")
+            .unwrap();
+        assert_eq!(get.source_path, "openapi.v2.yaml");
+        assert!(
+            store
+                .list_implemented_contract_uids()
+                .unwrap()
+                .contains(&get.uid)
+        );
+    }
+
+    #[test]
+    fn controller_and_spec_batch_publish_matching_edges_and_symbol_metadata() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let dir = tempfile::tempdir().unwrap();
+        let (store, r_uid, repo_url, root) = index_contract_fixture(&dir);
+        let spec = root.join("openapi.yaml");
+        let controller = root.join("ItemsController.java");
+        std::fs::write(
+            &spec,
+            "openapi: 3.0.0\ninfo: { title: t, version: \"1\" }\npaths:\n  /v1/items:\n    get:\n      responses: { \"200\": { description: ok } }\n    post:\n      responses: { \"200\": { description: ok } }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &controller,
+            "@RestController\n@RequestMapping(\"/v1/items\")\npublic class ItemsController {\n  @GetMapping\n  public void list() {}\n  @PostMapping\n  public void create() {}\n}\n",
+        )
+        .unwrap();
+        let watcher = CodeWatcher::new(dir.path().join("watch.lbug"), &root, "test");
+        let notifications = AtomicUsize::new(0);
+
+        let outcome = watcher
+            .process_batch_and_notify(
+                &store,
+                &r_uid,
+                &repo_url,
+                &[spec, controller],
+                &crate::index::FileSystemIndexEpilogueIo,
+                Some(&|| {
+                    notifications.fetch_add(1, Ordering::SeqCst);
+                }),
+            )
+            .unwrap();
+        assert!(matches!(
+            outcome,
+            WatchBatchOutcome::Published { files_processed: 1 }
+        ));
+        assert_eq!(notifications.load(Ordering::SeqCst), 1);
+        let symbols = store.lookup_symbols_by_repo(&r_uid).unwrap();
+        let create = symbols
+            .iter()
+            .find(|symbol| symbol.name == "create")
+            .expect("modified controller method must publish");
+        assert!(create.canonical_id.is_some());
+        assert_eq!(
+            store.contracts_implemented_by(&create.uid).unwrap()[0].0,
+            "contract:http:POST:/v1/items"
+        );
+        let controller_class = symbols
+            .iter()
+            .find(|symbol| symbol.name == "ItemsController")
+            .unwrap();
+        assert_eq!(
+            controller_class
+                .framework_hint
+                .as_ref()
+                .map(|hint| hint.role.as_str()),
+            Some("controller")
+        );
+    }
+
+    #[test]
+    fn malformed_spec_skips_before_publication_and_preserves_contracts() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let dir = tempfile::tempdir().unwrap();
+        let (store, r_uid, repo_url, root) = index_contract_fixture(&dir);
+        let spec = root.join("openapi.yaml");
+        let before: Vec<_> = store
+            .list_contracts(Some(&r_uid))
+            .unwrap()
+            .into_iter()
+            .map(|contract| (contract.uid, contract.source_path))
+            .collect();
+        std::fs::write(&spec, "openapi: [unfinished").unwrap();
+        let db_path = dir.path().join("watch.lbug");
+        let watcher = CodeWatcher::new(&db_path, &root, "test");
+        let notifications = AtomicUsize::new(0);
+
+        let outcome = watcher
+            .process_batch_and_notify(
+                &store,
+                &r_uid,
+                &repo_url,
+                &[spec],
+                &crate::index::FileSystemIndexEpilogueIo,
+                Some(&|| {
+                    notifications.fetch_add(1, Ordering::SeqCst);
+                }),
+            )
+            .unwrap();
+        assert!(matches!(outcome, WatchBatchOutcome::Skipped { .. }));
+        assert_eq!(notifications.load(Ordering::SeqCst), 0);
+        let after: Vec<_> = store
+            .list_contracts(Some(&r_uid))
+            .unwrap()
+            .into_iter()
+            .map(|contract| (contract.uid, contract.source_path))
+            .collect();
+        assert_eq!(after, before);
+        assert!(!crate::sidecar_path(&db_path, ".index-dirty").exists());
+    }
+
+    #[test]
+    fn final_snapshot_rejects_after_plan_spec_and_controller_mutations() {
+        let dir = tempfile::tempdir().unwrap();
+        let (store, r_uid, repo_url, root) = index_contract_fixture(&dir);
+        let db_path = dir.path().join("watch.lbug");
+        let watcher = CodeWatcher::new(&db_path, &root, "test");
+        let spec = root.join("openapi.yaml");
+        let controller = root.join("ItemsController.java");
+        let spec_get = std::fs::read_to_string(&spec).unwrap();
+        let controller_get = std::fs::read_to_string(&controller).unwrap();
+        let spec_post = "openapi: 3.0.0\ninfo: { title: t, version: \"1\" }\npaths:\n  /v1/items:\n    post:\n      responses: { \"200\": { description: ok } }\n";
+        let controller_post = "@RestController\n@RequestMapping(\"/v1/items\")\npublic class ItemsController { @PostMapping public void create() {} }\n";
+
+        let outcome = watcher
+            .process_batch_with_io_and_hook(
+                &store,
+                &r_uid,
+                &repo_url,
+                std::slice::from_ref(&spec),
+                &crate::index::FileSystemIndexEpilogueIo,
+                || std::fs::write(&spec, spec_post).unwrap(),
+            )
+            .unwrap();
+        assert!(matches!(outcome, WatchBatchOutcome::Skipped { .. }));
+        std::fs::write(&spec, &spec_get).unwrap();
+
+        let outcome = watcher
+            .process_batch_with_io_and_hook(
+                &store,
+                &r_uid,
+                &repo_url,
+                std::slice::from_ref(&spec),
+                &crate::index::FileSystemIndexEpilogueIo,
+                || std::fs::remove_file(&spec).unwrap(),
+            )
+            .unwrap();
+        assert!(matches!(outcome, WatchBatchOutcome::Skipped { .. }));
+        std::fs::write(&spec, &spec_get).unwrap();
+
+        let created_spec = root.join("openapi.v2.yaml");
+        let outcome = watcher
+            .process_batch_with_io_and_hook(
+                &store,
+                &r_uid,
+                &repo_url,
+                std::slice::from_ref(&spec),
+                &crate::index::FileSystemIndexEpilogueIo,
+                || std::fs::write(&created_spec, spec_post).unwrap(),
+            )
+            .unwrap();
+        assert!(matches!(outcome, WatchBatchOutcome::Skipped { .. }));
+        std::fs::remove_file(&created_spec).unwrap();
+
+        let outcome = watcher
+            .process_batch_with_io_and_hook(
+                &store,
+                &r_uid,
+                &repo_url,
+                std::slice::from_ref(&controller),
+                &crate::index::FileSystemIndexEpilogueIo,
+                || std::fs::write(&controller, controller_post).unwrap(),
+            )
+            .unwrap();
+        assert!(matches!(outcome, WatchBatchOutcome::Skipped { .. }));
+        std::fs::write(&controller, &controller_get).unwrap();
+
+        let outcome = watcher
+            .process_batch_with_io_and_hook(
+                &store,
+                &r_uid,
+                &repo_url,
+                std::slice::from_ref(&controller),
+                &crate::index::FileSystemIndexEpilogueIo,
+                || std::fs::remove_file(&controller).unwrap(),
+            )
+            .unwrap();
+        assert!(matches!(outcome, WatchBatchOutcome::Skipped { .. }));
+        std::fs::write(&controller, &controller_get).unwrap();
+
+        let created_controller = root.join("NewController.java");
+        let outcome = watcher
+            .process_batch_with_io_and_hook(
+                &store,
+                &r_uid,
+                &repo_url,
+                std::slice::from_ref(&controller),
+                &crate::index::FileSystemIndexEpilogueIo,
+                || std::fs::write(&created_controller, controller_post).unwrap(),
+            )
+            .unwrap();
+        assert!(matches!(outcome, WatchBatchOutcome::Skipped { .. }));
+        assert!(!crate::sidecar_path(&db_path, ".index-dirty").exists());
+    }
+
+    #[test]
+    fn contract_apply_failure_rolls_back_source_and_stays_dirty_without_notification() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let dir = tempfile::tempdir().unwrap();
+        let (store, r_uid, repo_url, root) = index_contract_fixture(&dir);
+        store
+            .batch_insert_contracts(&[nestweaver_schema::Contract {
+                uid: "contract:http:POST:/v1/items".into(),
+                kind: "http".into(),
+                verb: Some("POST".into()),
+                path: Some("/v1/items".into()),
+                operation_id: None,
+                repo_uid: "repo:other".into(),
+                source_path: "openapi.yaml".into(),
+                confidence: 1.0,
+            }])
+            .unwrap();
+        std::fs::write(
+            root.join("openapi.yaml"),
+            "openapi: 3.0.0\ninfo: { title: t, version: \"1\" }\npaths:\n  /v1/items:\n    get:\n      responses: { \"200\": { description: ok } }\n    post:\n      responses: { \"200\": { description: ok } }\n",
+        )
+        .unwrap();
+        let controller = root.join("ItemsController.java");
+        std::fs::write(
+            &controller,
+            "@RestController\n@RequestMapping(\"/v1/items\")\npublic class ItemsController {\n  @GetMapping public void list() {}\n  @PostMapping public void create() {}\n}\n",
+        )
+        .unwrap();
+        let db_path = dir.path().join("watch.lbug");
+        let watcher = CodeWatcher::new(&db_path, &root, "test");
+        let notifications = AtomicUsize::new(0);
+
+        let error = watcher
+            .process_batch_and_notify(
+                &store,
+                &r_uid,
+                &repo_url,
+                &[controller, root.join("openapi.yaml")],
+                &crate::index::FileSystemIndexEpilogueIo,
+                Some(&|| {
+                    notifications.fetch_add(1, Ordering::SeqCst);
+                }),
+            )
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("apply watcher contract derivation")
+        );
+        assert_eq!(notifications.load(Ordering::SeqCst), 0);
+        assert!(crate::sidecar_path(&db_path, ".index-dirty").exists());
+        assert_eq!(
+            store
+                .lookup_symbols_by_repo(&r_uid)
+                .unwrap()
+                .iter()
+                .filter(|symbol| symbol.name == "create")
+                .count(),
+            0,
+            "source mutation must roll back with contract replacement"
+        );
+        assert_eq!(store.list_contracts(Some(&r_uid)).unwrap().len(), 1);
+        assert_eq!(
+            store.contract_derivation_failures(Some(&r_uid)).unwrap(),
+            vec![r_uid]
+        );
+    }
+
+    #[test]
+    fn fresh_watcher_batch_builds_authoritative_source_and_contract_graph() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let dir = tempfile::tempdir().unwrap();
+        let repo_root = dir.path().join("fresh-repo");
+        std::fs::create_dir_all(&repo_root).unwrap();
+        std::fs::write(
+            repo_root.join("openapi.yaml"),
+            "openapi: 3.0.0\ninfo: { title: t, version: \"1\" }\npaths:\n  /fresh:\n    get:\n      responses: { \"200\": { description: ok } }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo_root.join("FreshController.java"),
+            "@RestController\n@RequestMapping(\"/fresh\")\npublic class FreshController {\n  @GetMapping public void get() {}\n}\n",
+        )
+        .unwrap();
+        let root = std::fs::canonicalize(repo_root).unwrap();
+        let repo_url = format!("file://{}", root.display());
+        let r_uid = nestweaver_schema::repo_uid("test", &repo_url);
+        let store = GraphStore::in_memory().unwrap();
+        let watcher = CodeWatcher::new(dir.path().join("watch.lbug"), &root, "test");
+        let notifications = AtomicUsize::new(0);
+
+        let outcome = watcher
+            .process_batch_and_notify(
+                &store,
+                &r_uid,
+                &repo_url,
+                &[root.join("openapi.yaml"), root.join("FreshController.java")],
+                &crate::index::FileSystemIndexEpilogueIo,
+                Some(&|| {
+                    notifications.fetch_add(1, Ordering::SeqCst);
+                }),
+            )
+            .unwrap();
+        assert!(matches!(
+            outcome,
+            WatchBatchOutcome::Published { files_processed: 1 }
+        ));
+        assert_eq!(notifications.load(Ordering::SeqCst), 1);
+        assert!(store.lookup_repo(&r_uid).unwrap().is_some());
+        let get_symbol = store
+            .lookup_symbols_by_repo(&r_uid)
+            .unwrap()
+            .into_iter()
+            .find(|symbol| symbol.name == "get")
+            .expect("cold watcher must index unchanged controller source");
+        assert_eq!(
+            store.contracts_implemented_by(&get_symbol.uid).unwrap()[0].0,
+            "contract:http:GET:/fresh"
+        );
+    }
+
+    #[test]
+    fn recovered_dirty_publication_is_refused_without_graph_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let (store, r_uid, repo_url, root) = index_contract_fixture(&dir);
+        let db_path = dir.path().join("watch.lbug");
+        let watcher = CodeWatcher::new(&db_path, &root, "test");
+        let publication = watcher
+            .establish_graph_publication_with_io(&store, &crate::index::FileSystemIndexEpilogueIo)
+            .unwrap();
+        drop(publication);
+        let before = store.list_contracts(Some(&r_uid)).unwrap().len();
+
+        let error = watcher
+            .process_batch_with_io(
+                &store,
+                &r_uid,
+                &repo_url,
+                &[root.join("openapi.yaml")],
+                &crate::index::FileSystemIndexEpilogueIo,
+            )
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("incomplete prior index publication")
+        );
+        assert!(crate::sidecar_path(&db_path, ".index-dirty").exists());
+        assert_eq!(store.list_contracts(Some(&r_uid)).unwrap().len(), before);
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/watch_code.rs
+++ b/crates/nestweaver-engine/src/watch_code.rs
@@ -44,7 +44,7 @@ enum WatchBatchOutcome {
 }
 
 enum PreparedPath {
-    Replace(PreparedCodeFile),
+    Replace(Box<PreparedCodeFile>),
     Delete { rel_path: String },
 }
 
@@ -388,7 +388,7 @@ impl CodeWatcher {
                         });
                     }
                     changed.insert(rel_str);
-                    prepared_paths.push(PreparedPath::Replace(prepared));
+                    prepared_paths.push(PreparedPath::Replace(Box::new(prepared)));
                 }
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                     removed.insert(rel_str.clone());
@@ -443,11 +443,13 @@ impl CodeWatcher {
             &reader,
             store,
             r_uid,
-            &changed,
-            &removed,
-            &rdeps,
-            &replacement_symbols,
-            &prepared_file_data,
+            crate::index::WatcherReresolveInputs {
+                changed: &changed,
+                removed: &removed,
+                rdeps: &rdeps,
+                replacement_symbols: &replacement_symbols,
+                prepared_file_data: &prepared_file_data,
+            },
         ) {
             Ok(edges) => edges,
             Err(reason) => return Ok(WatchBatchOutcome::Skipped { reason }),

--- a/crates/nestweaver-mcp/src/http.rs
+++ b/crates/nestweaver-mcp/src/http.rs
@@ -4,6 +4,8 @@
 //! JSON-RPC 2.0 bodies.  Handles `initialize`, `tools/list`, and
 //! `tools/call` — the latter delegates to the same `tools::dispatch`
 //! function used by the stdio server.
+//! HTTP accepts one JSON-RPC request per POST. Batch arrays are intentionally
+//! unsupported and return `-32600` rather than being partially dispatched.
 
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -15,6 +17,7 @@ use axum::http::HeaderMap;
 use axum::{
     Json, Router,
     extract::{ConnectInfo, State},
+    response::{IntoResponse, Response},
     routing::post,
 };
 use dashmap::DashMap;
@@ -554,19 +557,6 @@ pub fn router(state: Arc<McpHttpState>) -> Router {
         .with_state(state)
 }
 
-/// JSON-RPC request as received over HTTP (same shape as the stdio wire
-/// format but parsed from the request body instead of a line).
-#[derive(serde::Deserialize)]
-struct JsonRpcRequest {
-    #[allow(dead_code)]
-    jsonrpc: String,
-    id: Option<Value>,
-    method: String,
-    #[allow(dead_code)]
-    #[serde(default)]
-    params: Option<Value>,
-}
-
 /// Optional peer-address extractor.
 ///
 /// `ConnectInfo<SocketAddr>` *rejects* the request when connection info is
@@ -596,12 +586,7 @@ impl<S: Send + Sync> axum::extract::FromRequestParts<S> for OptionalPeerAddr {
 /// Build a JSON-RPC 2.0 error response tuple in the exact shape `handle_mcp`
 /// returns, so its several early-rejection paths (session / rate-limit / parse /
 /// auth / method-not-found) can't drift in envelope structure.
-fn jsonrpc_error(
-    status: axum::http::StatusCode,
-    id: Value,
-    code: i32,
-    message: &str,
-) -> (axum::http::StatusCode, HeaderMap, Json<Value>) {
+fn jsonrpc_error(status: axum::http::StatusCode, id: Value, code: i32, message: &str) -> Response {
     (
         status,
         HeaderMap::new(),
@@ -611,6 +596,36 @@ fn jsonrpc_error(
             "error": { "code": code, "message": message }
         })),
     )
+        .into_response()
+}
+
+fn jsonrpc_http_response(
+    notification: bool,
+    status: axum::http::StatusCode,
+    headers: HeaderMap,
+    body: Value,
+) -> Response {
+    if notification {
+        // JSON-RPC notifications are dispatched but never produce a JSON-RPC
+        // response. HTTP still needs a transport response, so use an empty 202.
+        (axum::http::StatusCode::ACCEPTED, headers).into_response()
+    } else {
+        (status, headers, Json(body)).into_response()
+    }
+}
+
+fn jsonrpc_http_error(
+    notification: bool,
+    status: axum::http::StatusCode,
+    id: Value,
+    code: i32,
+    message: &str,
+) -> Response {
+    if notification {
+        (status, HeaderMap::new()).into_response()
+    } else {
+        jsonrpc_error(status, id, code, message)
+    }
 }
 
 async fn handle_mcp(
@@ -621,8 +636,8 @@ async fn handle_mcp(
     // for keying.
     OptionalPeerAddr(peer_addr): OptionalPeerAddr,
     headers: HeaderMap,
-    Json(req): Json<JsonRpcRequest>,
-) -> (axum::http::StatusCode, HeaderMap, Json<Value>) {
+    raw_request: Result<Json<Value>, axum::extract::rejection::JsonRejection>,
+) -> Response {
     let peer_ip = peer_addr.map(|addr| addr.ip());
     let provided_bearer = headers
         .get("authorization")
@@ -646,7 +661,13 @@ async fn handle_mcp(
                     query_match || admin_match
                 } => {}
             _ => {
-                return jsonrpc_error(
+                let notification = raw_request
+                    .as_ref()
+                    .ok()
+                    .and_then(|Json(value)| crate::protocol::validate_request(value.clone()).ok())
+                    .is_some_and(|request| request.id.is_none());
+                return jsonrpc_http_error(
+                    notification,
                     axum::http::StatusCode::UNAUTHORIZED,
                     Value::Null,
                     error_code::INVALID_REQUEST,
@@ -655,6 +676,55 @@ async fn handle_mcp(
             }
         }
     }
+
+    let apply_untrusted_rate_limit = || {
+        if !state.server_mode || admin_bypass_rate_limit {
+            return None;
+        }
+        let client_key = http_client_rate_limit_key(provided_bearer, None, peer_ip, false, false);
+        (!state.client_rate_limiter.check(&client_key)).then(|| {
+            jsonrpc_error(
+                axum::http::StatusCode::TOO_MANY_REQUESTS,
+                Value::Null,
+                error_code::INVALID_REQUEST,
+                "rate limit exceeded: too many requests per minute",
+            )
+        })
+    };
+
+    let raw_request = match raw_request {
+        Ok(Json(value)) => value,
+        Err(error) => {
+            if let Some(response) = apply_untrusted_rate_limit() {
+                return response;
+            }
+            return jsonrpc_error(
+                axum::http::StatusCode::OK,
+                Value::Null,
+                error_code::PARSE_ERROR,
+                &format!("invalid JSON: {error}"),
+            );
+        }
+    };
+
+    let req = match crate::protocol::validate_request(raw_request) {
+        Ok(request) => request,
+        Err(error) => {
+            // Invalid envelopes cannot supply a trusted session id. They still
+            // consume the server-mode client bucket so malformed traffic
+            // cannot bypass the normal boundary limiter.
+            if let Some(response) = apply_untrusted_rate_limit() {
+                return response;
+            }
+            return jsonrpc_error(
+                axum::http::StatusCode::OK,
+                error.response_id,
+                error_code::INVALID_REQUEST,
+                &error.message,
+            );
+        }
+    };
+    let notification = req.id.is_none();
 
     let id = req.id.clone().unwrap_or(Value::Null);
 
@@ -671,7 +741,8 @@ async fn handle_mcp(
         && req.method != "initialize"
         && !state.sessions.contains_key(sid)
     {
-        return jsonrpc_error(
+        return jsonrpc_http_error(
+            notification,
             axum::http::StatusCode::OK,
             id.clone(),
             error_code::INVALID_REQUEST,
@@ -700,7 +771,8 @@ async fn handle_mcp(
         );
 
         if !admin_bypass_rate_limit && !state.client_rate_limiter.check(&client_key) {
-            return jsonrpc_error(
+            return jsonrpc_http_error(
+                notification,
                 axum::http::StatusCode::TOO_MANY_REQUESTS,
                 Value::Null,
                 error_code::INVALID_REQUEST,
@@ -718,7 +790,8 @@ async fn handle_mcp(
             && !check_session_rate_limit(&state.sessions, sid)
             && !admin_bypass_rate_limit
         {
-            return jsonrpc_error(
+            return jsonrpc_http_error(
+                notification,
                 axum::http::StatusCode::TOO_MANY_REQUESTS,
                 Value::Null,
                 error_code::INVALID_REQUEST,
@@ -773,7 +846,12 @@ async fn handle_mcp(
                 }
             });
 
-            return (axum::http::StatusCode::OK, resp_headers, Json(body));
+            return jsonrpc_http_response(
+                notification,
+                axum::http::StatusCode::OK,
+                resp_headers,
+                body,
+            );
         }
 
         "notifications/initialized" | "initialized" => json!({
@@ -803,7 +881,8 @@ async fn handle_mcp(
                 .unwrap_or(Value::Object(serde_json::Map::new()));
 
             let Some(name) = name else {
-                return jsonrpc_error(
+                return jsonrpc_http_error(
+                    notification,
                     axum::http::StatusCode::OK,
                     id.clone(),
                     error_code::INVALID_PARAMS,
@@ -812,14 +891,15 @@ async fn handle_mcp(
             };
 
             if let Err(error) = tools::validate_tool_arguments(&name, &arguments) {
-                return (
+                return jsonrpc_http_response(
+                    notification,
                     axum::http::StatusCode::OK,
                     HeaderMap::new(),
-                    Json(json!({
+                    json!({
                         "jsonrpc": "2.0",
                         "id": id,
                         "result": tools::wrap_tool_error(&error.to_string()),
-                    })),
+                    }),
                 );
             }
 
@@ -831,7 +911,8 @@ async fn handle_mcp(
             // there is no writable store to mutate. Mirrors the gRPC
             // `ReadOnlyGuard` chokepoint.
             if state.read_only && MUTATING_TOOLS.contains(&name.as_str()) {
-                return jsonrpc_error(
+                return jsonrpc_http_error(
+                    notification,
                     axum::http::StatusCode::OK,
                     id.clone(),
                     error_code::INVALID_REQUEST,
@@ -848,7 +929,8 @@ async fn handle_mcp(
                 && state.auth_token.is_some()
                 && !admin_bypass_rate_limit
             {
-                return jsonrpc_error(
+                return jsonrpc_http_error(
+                    notification,
                     axum::http::StatusCode::FORBIDDEN,
                     id.clone(),
                     error_code::INVALID_REQUEST,
@@ -888,7 +970,8 @@ async fn handle_mcp(
                         state.permission_source.visible_repos(&identity, &repos)
                     }
                     AuthzRepoListing::FailLoud(msg) => {
-                        return jsonrpc_error(
+                        return jsonrpc_http_error(
+                            notification,
                             axum::http::StatusCode::SERVICE_UNAVAILABLE,
                             id.clone(),
                             error_code::INTERNAL_ERROR,
@@ -917,7 +1000,8 @@ async fn handle_mcp(
                 match apply_safeguard_params(&mut arguments) {
                     Ok(limits) => applied_limits = limits,
                     Err(message) => {
-                        return jsonrpc_error(
+                        return jsonrpc_http_error(
+                            notification,
                             axum::http::StatusCode::OK,
                             id.clone(),
                             error_code::INVALID_PARAMS,
@@ -1075,7 +1159,12 @@ async fn handle_mcp(
         }),
     };
 
-    (axum::http::StatusCode::OK, HeaderMap::new(), Json(response))
+    jsonrpc_http_response(
+        notification,
+        axum::http::StatusCode::OK,
+        HeaderMap::new(),
+        response,
+    )
 }
 
 #[cfg(test)]
@@ -1404,6 +1493,168 @@ mod tests {
         assert_eq!(json["id"], 1);
         assert_eq!(json["result"]["protocolVersion"], PROTOCOL_VERSION);
         assert_eq!(json["result"]["serverInfo"]["name"], SERVER_NAME);
+    }
+
+    #[tokio::test]
+    async fn http_validates_jsonrpc_version_and_ids_before_dispatch() {
+        for (body, expected_id) in [
+            (
+                json!({"jsonrpc": "1.0", "id": "version-id", "method": "ping"}),
+                json!("version-id"),
+            ),
+            (
+                json!({"jsonrpc": "2.0", "id": true, "method": "ping"}),
+                Value::Null,
+            ),
+            (json!([]), Value::Null),
+        ] {
+            let request = Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap();
+            let response = test_app().oneshot(request).await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let response: Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(response["error"]["code"], error_code::INVALID_REQUEST);
+            assert_eq!(response["id"], expected_id);
+        }
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/mcp")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                br#"{"jsonrpc":"2.0","id":null,"method":"ping"}"#.as_slice(),
+            ))
+            .unwrap();
+        let response = test_app().oneshot(request).await.unwrap();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let response: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(response["id"], Value::Null);
+        assert_eq!(response["result"], json!({}));
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/mcp")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                br#"{"jsonrpc":"2.0","method":"ping"}"#.as_slice(),
+            ))
+            .unwrap();
+        let response = test_app().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(
+            bytes.is_empty(),
+            "HTTP notifications must have no JSON body"
+        );
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/mcp")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                br#"{"jsonrpc":"2.0","method":"tools/call","params":{}}"#.as_slice(),
+            ))
+            .unwrap();
+        let response = test_app().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(
+            bytes.is_empty(),
+            "post-validation notification errors must have no JSON body"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_http_envelopes_are_authenticated_and_rate_limited_first() {
+        let invalid = |bearer: Option<&str>| {
+            let mut builder = Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("content-type", "application/json");
+            if let Some(bearer) = bearer {
+                builder = builder.header("authorization", format!("Bearer {bearer}"));
+            }
+            builder
+                .body(Body::from(
+                    br#"{"jsonrpc":"1.0","id":"bad","method":"ping"}"#.as_slice(),
+                ))
+                .unwrap()
+        };
+
+        let response = test_auth_app().oneshot(invalid(None)).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let response = test_auth_app()
+            .oneshot(invalid(Some("wrong-token")))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let notification = Request::builder()
+            .method("POST")
+            .uri("/mcp")
+            .header("content-type", "application/json")
+            .header("authorization", "Bearer wrong-token")
+            .body(Body::from(
+                br#"{"jsonrpc":"2.0","method":"ping"}"#.as_slice(),
+            ))
+            .unwrap();
+        let response = test_auth_app().oneshot(notification).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(body.is_empty(), "notification auth errors must be bodyless");
+
+        let app = test_server_auth_app_with_limiter(1);
+        let first = app
+            .clone()
+            .oneshot(invalid(Some("shared-query-token")))
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(first.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["error"]["code"], error_code::INVALID_REQUEST);
+        assert_eq!(body["id"], "bad");
+
+        let second = app
+            .oneshot(invalid(Some("shared-query-token")))
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
+    async fn malformed_http_json_is_a_jsonrpc_parse_error() {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/mcp")
+            .header("content-type", "application/json")
+            .body(Body::from(br#"{"jsonrpc":"2.0""#.as_slice()))
+            .unwrap();
+        let response = test_app().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["error"]["code"], error_code::PARSE_ERROR);
+        assert_eq!(body["id"], Value::Null);
     }
 
     #[tokio::test]

--- a/crates/nestweaver-mcp/src/lib.rs
+++ b/crates/nestweaver-mcp/src/lib.rs
@@ -204,7 +204,12 @@ pub fn run_stdio_server(
                     error_code::PARSE_ERROR,
                     format!("invalid JSON: {e}"),
                 );
-                write_response(&mut stdout, &Frame::Error(resp))?;
+                if closed_stdout_ends_session(
+                    write_response(&mut stdout, &Frame::Error(resp)),
+                    tracker.as_ref(),
+                )? {
+                    return Ok(());
+                }
                 continue;
             }
         };
@@ -217,7 +222,12 @@ pub fn run_stdio_server(
                     error_code::INVALID_REQUEST,
                     "empty batch array",
                 );
-                write_response(&mut stdout, &Frame::Error(resp))?;
+                if closed_stdout_ends_session(
+                    write_response(&mut stdout, &Frame::Error(resp)),
+                    tracker.as_ref(),
+                )? {
+                    return Ok(());
+                }
                 continue;
             }
             let mut responses: Vec<Value> = Vec::new();
@@ -253,9 +263,12 @@ pub fn run_stdio_server(
             }
             if !responses.is_empty() {
                 let serialized = serde_json::to_string(&responses)?;
-                stdout.write_all(serialized.as_bytes())?;
-                stdout.write_all(b"\n")?;
-                stdout.flush()?;
+                if closed_stdout_ends_session(
+                    write_stdout_frame(&mut stdout, serialized.as_bytes()).map_err(Into::into),
+                    tracker.as_ref(),
+                )? {
+                    return Ok(());
+                }
             }
         } else {
             // Single request.
@@ -267,7 +280,12 @@ pub fn run_stdio_server(
                         error_code::INVALID_REQUEST,
                         format!("invalid request: {}", e.message),
                     );
-                    write_response(&mut stdout, &Frame::Error(resp))?;
+                    if closed_stdout_ends_session(
+                        write_response(&mut stdout, &Frame::Error(resp)),
+                        tracker.as_ref(),
+                    )? {
+                        return Ok(());
+                    }
                     continue;
                 }
             };
@@ -283,7 +301,10 @@ pub fn run_stdio_server(
                 }
                 continue;
             }
-            write_response(&mut stdout, &outcome)?;
+            if closed_stdout_ends_session(write_response(&mut stdout, &outcome), tracker.as_ref())?
+            {
+                return Ok(());
+            }
         }
     }
 }
@@ -349,7 +370,12 @@ pub fn run_stdio_server_daemon(
                     error_code::PARSE_ERROR,
                     format!("invalid JSON: {e}"),
                 );
-                write_response(&mut stdout, &Frame::Error(resp))?;
+                if closed_stdout_ends_session(
+                    write_response(&mut stdout, &Frame::Error(resp)),
+                    tracker.as_ref(),
+                )? {
+                    return Ok(());
+                }
                 continue;
             }
         };
@@ -361,7 +387,12 @@ pub fn run_stdio_server_daemon(
                     error_code::INVALID_REQUEST,
                     "empty batch array",
                 );
-                write_response(&mut stdout, &Frame::Error(resp))?;
+                if closed_stdout_ends_session(
+                    write_response(&mut stdout, &Frame::Error(resp)),
+                    tracker.as_ref(),
+                )? {
+                    return Ok(());
+                }
                 continue;
             }
             let mut responses: Vec<Value> = Vec::new();
@@ -397,9 +428,12 @@ pub fn run_stdio_server_daemon(
             }
             if !responses.is_empty() {
                 let serialized = serde_json::to_string(&responses)?;
-                stdout.write_all(serialized.as_bytes())?;
-                stdout.write_all(b"\n")?;
-                stdout.flush()?;
+                if closed_stdout_ends_session(
+                    write_stdout_frame(&mut stdout, serialized.as_bytes()).map_err(Into::into),
+                    tracker.as_ref(),
+                )? {
+                    return Ok(());
+                }
             }
         } else {
             let req = match protocol::validate_request(parsed) {
@@ -410,7 +444,12 @@ pub fn run_stdio_server_daemon(
                         error_code::INVALID_REQUEST,
                         format!("invalid request: {}", e.message),
                     );
-                    write_response(&mut stdout, &Frame::Error(resp))?;
+                    if closed_stdout_ends_session(
+                        write_response(&mut stdout, &Frame::Error(resp)),
+                        tracker.as_ref(),
+                    )? {
+                        return Ok(());
+                    }
                     continue;
                 }
             };
@@ -426,7 +465,10 @@ pub fn run_stdio_server_daemon(
                 }
                 continue;
             }
-            write_response(&mut stdout, &outcome)?;
+            if closed_stdout_ends_session(write_response(&mut stdout, &outcome), tracker.as_ref())?
+            {
+                return Ok(());
+            }
         }
     }
 }
@@ -517,14 +559,67 @@ enum Frame {
     Error(ErrorResponse),
 }
 
-fn write_response(out: &mut std::io::StdoutLock<'_>, frame: &Frame) -> Result<(), anyhow::Error> {
+#[derive(Debug)]
+pub struct StdoutWriteError(std::io::Error);
+
+impl StdoutWriteError {
+    pub fn kind(&self) -> std::io::ErrorKind {
+        self.0.kind()
+    }
+}
+
+impl std::fmt::Display for StdoutWriteError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "failed writing MCP response to stdout: {}",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for StdoutWriteError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+fn write_stdout_frame(out: &mut impl Write, serialized: &[u8]) -> Result<(), StdoutWriteError> {
+    out.write_all(serialized).map_err(StdoutWriteError)?;
+    out.write_all(b"\n").map_err(StdoutWriteError)?;
+    out.flush().map_err(StdoutWriteError)
+}
+
+fn closed_stdout_ends_session(
+    result: Result<(), anyhow::Error>,
+    tracker: Option<&nestweaver_engine::InteractionTracker>,
+) -> Result<bool, anyhow::Error> {
+    match result {
+        Ok(()) => Ok(false),
+        Err(error)
+            if error
+                .downcast_ref::<StdoutWriteError>()
+                .is_some_and(|stdout| stdout.kind() == std::io::ErrorKind::BrokenPipe) =>
+        {
+            // The client is gone. Flush durable session state just like the
+            // stdin-EOF path, but do not infer terminal success from a closed
+            // response pipe.
+            if let Some(tracker) = tracker {
+                let _ = tracker.flush();
+            }
+            crate::tools::flush_response_cache();
+            Ok(true)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn write_response(out: &mut impl Write, frame: &Frame) -> Result<(), anyhow::Error> {
     let serialized = match frame {
         Frame::Success(r) => serde_json::to_string(r)?,
         Frame::Error(e) => serde_json::to_string(e)?,
     };
-    out.write_all(serialized.as_bytes())?;
-    out.write_all(b"\n")?;
-    out.flush()?;
+    write_stdout_frame(out, serialized.as_bytes())?;
     Ok(())
 }
 

--- a/crates/nestweaver-mcp/src/lib.rs
+++ b/crates/nestweaver-mcp/src/lib.rs
@@ -222,13 +222,13 @@ pub fn run_stdio_server(
             }
             let mut responses: Vec<Value> = Vec::new();
             for item in arr {
-                let req: protocol::Request = match serde_json::from_value(item) {
+                let req = match protocol::validate_request(item) {
                     Ok(r) => r,
                     Err(e) => {
                         responses.push(serde_json::to_value(error(
-                            Value::Null,
+                            e.response_id,
                             error_code::INVALID_REQUEST,
-                            format!("invalid request in batch: {e}"),
+                            format!("invalid request in batch: {}", e.message),
                         ))?);
                         continue;
                     }
@@ -259,13 +259,13 @@ pub fn run_stdio_server(
             }
         } else {
             // Single request.
-            let req: protocol::Request = match serde_json::from_value(parsed) {
+            let req = match protocol::validate_request(parsed) {
                 Ok(r) => r,
                 Err(e) => {
                     let resp = error(
-                        Value::Null,
+                        e.response_id,
                         error_code::INVALID_REQUEST,
-                        format!("invalid request: {e}"),
+                        format!("invalid request: {}", e.message),
                     );
                     write_response(&mut stdout, &Frame::Error(resp))?;
                     continue;
@@ -366,13 +366,13 @@ pub fn run_stdio_server_daemon(
             }
             let mut responses: Vec<Value> = Vec::new();
             for item in arr {
-                let req: protocol::Request = match serde_json::from_value(item) {
+                let req = match protocol::validate_request(item) {
                     Ok(r) => r,
                     Err(e) => {
                         responses.push(serde_json::to_value(error(
-                            Value::Null,
+                            e.response_id,
                             error_code::INVALID_REQUEST,
-                            format!("invalid request in batch: {e}"),
+                            format!("invalid request in batch: {}", e.message),
                         ))?);
                         continue;
                     }
@@ -402,13 +402,13 @@ pub fn run_stdio_server_daemon(
                 stdout.flush()?;
             }
         } else {
-            let req: protocol::Request = match serde_json::from_value(parsed) {
+            let req = match protocol::validate_request(parsed) {
                 Ok(r) => r,
                 Err(e) => {
                     let resp = error(
-                        Value::Null,
+                        e.response_id,
                         error_code::INVALID_REQUEST,
-                        format!("invalid request: {e}"),
+                        format!("invalid request: {}", e.message),
                     );
                     write_response(&mut stdout, &Frame::Error(resp))?;
                     continue;

--- a/crates/nestweaver-mcp/src/protocol.rs
+++ b/crates/nestweaver-mcp/src/protocol.rs
@@ -6,7 +6,7 @@
 //! line-delimited JSON over stdio. Keeping it local also means dependency
 //! drift in upstream MCP crates never breaks brain integration.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 use serde_json::Value;
 
 /// Protocol version we advertise. Matches the version Claude Code's MCP
@@ -14,14 +14,92 @@ use serde_json::Value;
 pub const PROTOCOL_VERSION: &str = "2024-11-05";
 
 /// JSON-RPC 2.0 request. `id` is absent for notifications.
-#[derive(Debug, Deserialize)]
+#[derive(Debug)]
 pub struct Request {
     pub jsonrpc: String,
-    #[serde(default)]
     pub id: Option<Value>,
     pub method: String,
-    #[serde(default)]
     pub params: Option<Value>,
+}
+
+#[derive(Debug)]
+pub struct InvalidRequest {
+    /// Correlate envelope failures when the supplied ID itself is valid.
+    /// Illegal ID shapes always use null, per JSON-RPC 2.0.
+    pub response_id: Value,
+    pub message: String,
+}
+
+pub fn validate_request(value: Value) -> Result<Request, InvalidRequest> {
+    let Value::Object(mut object) = value else {
+        return Err(InvalidRequest {
+            response_id: Value::Null,
+            message: "JSON-RPC request must be an object".to_string(),
+        });
+    };
+
+    // Resolve ID validity first: every later envelope error can then preserve
+    // a legal correlation ID, while a boolean/array/object ID must answer null.
+    let id = match object.remove("id") {
+        None => None,
+        Some(value @ (Value::Null | Value::String(_) | Value::Number(_))) => Some(value),
+        Some(_) => {
+            return Err(InvalidRequest {
+                response_id: Value::Null,
+                message: "JSON-RPC request id must be a string, number, or null".to_string(),
+            });
+        }
+    };
+    let response_id = id.clone().unwrap_or(Value::Null);
+
+    let jsonrpc = match object.remove("jsonrpc") {
+        Some(Value::String(version)) if version == "2.0" => version,
+        _ => {
+            return Err(InvalidRequest {
+                response_id,
+                message: "jsonrpc must be exactly '2.0'".to_string(),
+            });
+        }
+    };
+    let method = match object.remove("method") {
+        Some(Value::String(method)) => method,
+        _ => {
+            return Err(InvalidRequest {
+                response_id,
+                message: "JSON-RPC request method must be a string".to_string(),
+            });
+        }
+    };
+    // Preserve the existing MCP compatibility policy: params remains an
+    // optional arbitrary JSON value here. Method/tool-specific validation
+    // returns -32602 or an in-band tool error; this envelope hardening does not
+    // newly reject clients that send null params.
+    let params = match object.remove("params") {
+        None | Some(Value::Null) => None,
+        Some(value) => Some(value),
+    };
+    Ok(Request {
+        jsonrpc,
+        id,
+        method,
+        params,
+    })
+}
+
+impl std::fmt::Display for InvalidRequest {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl<'de> Deserialize<'de> for Request {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        validate_request(value).map_err(de::Error::custom)
+    }
 }
 
 /// JSON-RPC 2.0 success response.
@@ -74,5 +152,73 @@ pub fn error(id: Value, code: i32, message: impl Into<String>) -> ErrorResponse 
             message: message.into(),
             data: None,
         },
+    }
+}
+
+#[cfg(test)]
+mod request_validation_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn parse(value: Value) -> Result<Request, serde_json::Error> {
+        serde_json::from_value(value)
+    }
+
+    #[test]
+    fn request_requires_jsonrpc_2_0() {
+        for version in [json!("1.0"), json!("2.1"), Value::Null, json!(2)] {
+            assert!(
+                parse(json!({"jsonrpc": version, "id": 1, "method": "ping"})).is_err(),
+                "accepted invalid jsonrpc version {version}"
+            );
+        }
+        let error =
+            validate_request(json!({"jsonrpc": "1.0", "id": "correlated", "method": "ping"}))
+                .unwrap_err();
+        assert_eq!(error.response_id, json!("correlated"));
+    }
+
+    #[test]
+    fn request_rejects_illegal_id_shapes() {
+        for id in [
+            json!(true),
+            json!(false),
+            json!([]),
+            json!([1]),
+            json!({}),
+            json!({"x": 1}),
+        ] {
+            assert!(
+                parse(json!({"jsonrpc": "2.0", "id": id, "method": "ping"})).is_err(),
+                "accepted illegal request id {id}"
+            );
+        }
+        let error = validate_request(json!({
+            "jsonrpc": "2.0", "id": true, "method": "ping"
+        }))
+        .unwrap_err();
+        assert_eq!(error.response_id, Value::Null);
+    }
+
+    #[test]
+    fn request_preserves_valid_and_explicit_null_ids() {
+        for id in [
+            json!("request-1"),
+            json!(0),
+            json!(-1),
+            json!(1.5),
+            Value::Null,
+        ] {
+            let request = parse(json!({"jsonrpc": "2.0", "id": id, "method": "ping"})).unwrap();
+            assert_eq!(request.id, Some(id));
+        }
+        let notification = parse(json!({"jsonrpc": "2.0", "method": "ping"})).unwrap();
+        assert_eq!(notification.id, None);
+
+        let explicit_null_params = parse(json!({
+            "jsonrpc": "2.0", "id": 1, "method": "ping", "params": null
+        }))
+        .unwrap();
+        assert_eq!(explicit_null_params.params, None);
     }
 }

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -674,8 +674,13 @@ impl GraphStore {
 
     pub fn insert_repo(&self, repo: &Repo) -> Result<(), StoreError> {
         let conn = self.conn()?;
+        Self::insert_repo_on(&conn, repo)
+    }
+
+    /// Insert a Repo node using an externally-provided transaction.
+    pub fn insert_repo_on(conn: &lbug::Connection<'_>, repo: &Repo) -> Result<(), StoreError> {
         exec_params(
-            &conn,
+            conn,
             "CREATE (:Repo {uid: $uid, url: $url, indexed_sha: $sha, \
              staleness_commits_behind: $scb, instance_id: $iid, name: $name, \
              root_path: $root_path})",

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -193,6 +193,31 @@ message JsonResponse {
   string result_json = 1;
 }
 
+// Exact daemon contract for `nestweaver contracts list`. This is deliberately
+// separate from CrossRepoContracts, which accepts a symbol uid/name and
+// returns implementation/reference hypotheses rather than Contract nodes.
+message ListContractsRequest {
+  // Omitted means all repositories; when present, accepts an exact repo UID
+  // or a case-insensitive repository display name. An empty present value is
+  // invalid rather than an alias for omission.
+  optional string repo = 1;
+}
+
+message ContractRecord {
+  string uid = 1;
+  string kind = 2;
+  optional string verb = 3;
+  optional string path = 4;
+  optional string operation_id = 5;
+  string repo_uid = 6;
+  string source_path = 7;
+  float confidence = 8;
+}
+
+message ListContractsResponse {
+  repeated ContractRecord contracts = 1;
+}
+
 // ─── Typed messages for hot-path RPCs ────────────────────────────────
 
 // brain_search
@@ -615,6 +640,7 @@ service NestWeaverDaemon {
   rpc ReadSymbols(JsonRequest) returns (JsonResponse);
   rpc RegexSearch(JsonRequest) returns (JsonResponse);
   rpc CountPatterns(JsonRequest) returns (JsonResponse);
+  rpc ListContracts(ListContractsRequest) returns (ListContractsResponse);
   rpc CrossRepoContracts(JsonRequest) returns (JsonResponse);
   rpc ContractDrift(JsonRequest) returns (JsonResponse);
   rpc DeadCode(JsonRequest) returns (JsonResponse);

--- a/src/main.rs
+++ b/src/main.rs
@@ -17514,30 +17514,59 @@ fn resolve_contract_repo_filter(
     anyhow::bail!("no indexed repo matches --repo '{filter}'")
 }
 
-/// Human rendering of the daemon `cross_repo_contracts` result (used by
-/// `contracts list` without `--json`), so the daemon path honors the `--json`
-/// flag instead of always dumping raw JSON like the direct-store path's table.
-fn render_cross_repo_contracts_human(value: &serde_json::Value) {
-    match value.get("contracts").and_then(|v| v.as_array()) {
-        Some(rows) if !rows.is_empty() => {
-            let total = value
-                .get("total")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(rows.len() as u64);
-            println!(
-                "Cross-repo contract links ({total} total). NOTE: links are \
-                 hypotheses, not ground truth — see confidence.\n"
-            );
-            for r in rows {
-                let sn = r.get("source_name").and_then(|v| v.as_str()).unwrap_or("?");
-                let tn = r.get("target_name").and_then(|v| v.as_str()).unwrap_or("?");
-                let lt = r.get("link_type").and_then(|v| v.as_str()).unwrap_or("");
-                let conf = r.get("confidence").and_then(|v| v.as_f64()).unwrap_or(0.0);
-                println!("  {sn} -> {tn}  [{lt}, confidence {conf:.2}]");
+fn render_contract_list(
+    contracts: &[nestweaver_schema::Contract],
+    json: bool,
+) -> anyhow::Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(contracts)?);
+    } else if contracts.is_empty() {
+        println!(
+            "No contracts found. Index a repo with OpenAPI/proto/GraphQL specs or \
+             Spring/NestJS controllers first."
+        );
+    } else {
+        println!(
+            "API contracts ({} total). NOTE: contract links are hypotheses, \
+             not ground truth — see confidence.\n",
+            contracts.len()
+        );
+        for contract in contracts {
+            println!("{}", contract.uid);
+            println!("  kind:       {}", contract.kind);
+            if let Some(ref verb) = contract.verb {
+                println!("  verb:       {verb}");
             }
+            if let Some(ref path) = contract.path {
+                println!("  path:       {path}");
+            }
+            if let Some(ref operation) = contract.operation_id {
+                println!("  operation:  {operation}");
+            }
+            println!("  source:     {}", contract.source_path);
+            println!("  confidence: {:.2}", contract.confidence);
+            println!();
         }
-        _ => println!("No cross-repo contract links found."),
     }
+    Ok(())
+}
+
+fn list_contracts_via_daemon(
+    db_path: &std::path::Path,
+    repo: Option<&str>,
+) -> anyhow::Result<Vec<nestweaver_schema::Contract>> {
+    let runtime = tokio::runtime::Runtime::new().context("create runtime for contracts list")?;
+    runtime
+        .block_on(async {
+            let mut client = nestweaver_client::DaemonClient::connect(db_path, None).await?;
+            client.list_contracts(repo).await
+        })
+        .with_context(|| {
+            format!(
+                "daemon contracts list failed for {}; refusing direct-store fallback while the daemon owns the database",
+                db_path.display()
+            )
+        })
 }
 
 /// Human rendering of the daemon `contract_drift` result (`contracts drift`
@@ -17599,61 +17628,22 @@ fn run_contracts(
 ) -> anyhow::Result<(i32, Option<String>)> {
     match command {
         ContractCommands::List { repo, json, db } => {
-            // ── daemon guard ──────────────────────────────────────
-            if use_daemon {
-                let db_path = db.clone().unwrap_or_else(default_db_path);
-                let mut args = serde_json::json!({});
-                if let Some(ref r) = repo {
-                    args["repo"] = serde_json::json!(r);
-                }
-                if let Some(value) =
-                    try_hybrid_json_rpc(true, &db_path, None, "cross_repo_contracts", args)
-                {
-                    if json {
-                        println!("{}", serde_json::to_string_pretty(&value)?);
-                    } else {
-                        render_cross_repo_contracts_human(&value);
-                    }
-                    return Ok((EXIT_SUCCESS, None));
-                }
-            }
-            let store = open_store(db.as_deref())?;
-            let repo_uid = resolve_contract_repo_filter(&store, repo.as_deref())?;
-            let mut contracts = store
-                .list_contracts(repo_uid.as_deref())
-                .map_err(|e| anyhow::anyhow!(e))?;
-            contracts.sort_by(|a, b| a.uid.cmp(&b.uid));
-
-            if json {
-                println!("{}", serde_json::to_string_pretty(&contracts)?);
-            } else if contracts.is_empty() {
-                println!(
-                    "No contracts found. Index a repo with OpenAPI/proto/GraphQL specs or \
-                     Spring/NestJS controllers first."
-                );
+            let db_path = db.clone().unwrap_or_else(default_db_path);
+            // Read-only query: reject a typo'd path before daemon autostart can
+            // create an empty database and false-green with an empty list.
+            require_existing_db(&db_path)?;
+            let contracts = if use_daemon {
+                list_contracts_via_daemon(&db_path, repo.as_deref())?
             } else {
-                println!(
-                    "API contracts ({} total). NOTE: contract links are hypotheses, \
-                     not ground truth — see confidence.\n",
-                    contracts.len()
-                );
-                for c in &contracts {
-                    println!("{}", c.uid);
-                    println!("  kind:       {}", c.kind);
-                    if let Some(ref v) = c.verb {
-                        println!("  verb:       {v}");
-                    }
-                    if let Some(ref p) = c.path {
-                        println!("  path:       {p}");
-                    }
-                    if let Some(ref op) = c.operation_id {
-                        println!("  operation:  {op}");
-                    }
-                    println!("  source:     {}", c.source_path);
-                    println!("  confidence: {:.2}", c.confidence);
-                    println!();
-                }
-            }
+                let store = open_store(Some(&db_path))?;
+                let repo_uid = resolve_contract_repo_filter(&store, repo.as_deref())?;
+                let mut contracts = store
+                    .list_contracts(repo_uid.as_deref())
+                    .map_err(|e| anyhow::anyhow!(e))?;
+                contracts.sort_by(|left, right| left.uid.cmp(&right.uid));
+                contracts
+            };
+            render_contract_list(&contracts, json)?;
             Ok((EXIT_SUCCESS, None))
         }
         ContractCommands::Drift { repo, json, db } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18483,6 +18483,177 @@ fn ensure_no_live_daemon_for_snapshot_build(db_path: &Path) -> anyhow::Result<()
 /// applies fallback/merge/primary routing across upstream servers. Write
 /// operations (brain_add_source, brain_remove_source, prune_stale) go
 /// through the standard gRPC path.
+fn dispatch_hybrid_mcp_request(
+    hybrid: &mut nestweaver_client::hybrid::HybridClient,
+    rt: &tokio::runtime::Runtime,
+    lite: bool,
+    write_tools: &std::collections::HashSet<&str>,
+    request: &nestweaver_mcp::protocol::Request,
+) -> serde_json::Value {
+    let id = request.id.clone().unwrap_or(serde_json::Value::Null);
+    match request.method.as_str() {
+        "initialize" => serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": { "tools": {} },
+                "serverInfo": {
+                    "name": "nestweaver-brain",
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+            }
+        }),
+        "notifications/initialized" | "initialized" => serde_json::json!({
+            "jsonrpc": "2.0", "id": id, "result": null
+        }),
+        "tools/list" => serde_json::json!({
+            "jsonrpc": "2.0", "id": id,
+            "result": nestweaver_mcp::tools::tool_list(lite),
+        }),
+        "tools/call" => {
+            let params = request.params.clone().unwrap_or(serde_json::Value::Null);
+            let name = params
+                .get("name")
+                .and_then(|value| value.as_str())
+                .unwrap_or("");
+            let arguments = params
+                .get("arguments")
+                .cloned()
+                .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+            if name.is_empty() {
+                serde_json::json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "error": { "code": -32602, "message": "tools/call: 'name' is required" }
+                })
+            } else if let Err(error) = nestweaver_mcp::tools::enforce_tool_allowed(name) {
+                serde_json::json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "result": nestweaver_mcp::tools::wrap_tool_error(&error.to_string()),
+                })
+            } else if let Err(error) =
+                nestweaver_mcp::tools::validate_tool_arguments(name, &arguments)
+            {
+                serde_json::json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "result": nestweaver_mcp::tools::wrap_tool_error(&error.to_string()),
+                })
+            } else {
+                let dispatched = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    if write_tools.contains(name) {
+                        nestweaver_mcp::tools::dispatch_via_daemon(
+                            hybrid.inner_mut(),
+                            rt,
+                            name,
+                            arguments.clone(),
+                        )
+                    } else {
+                        rt.block_on(hybrid.query(name, &arguments))
+                    }
+                }));
+                match dispatched {
+                    Ok(Ok(result)) => serde_json::json!({
+                        "jsonrpc": "2.0", "id": id,
+                        "result": nestweaver_mcp::tools::wrap_tool_result(result),
+                    }),
+                    Ok(Err(error)) => serde_json::json!({
+                        "jsonrpc": "2.0", "id": id,
+                        "result": nestweaver_mcp::tools::wrap_tool_error(&error.to_string()),
+                    }),
+                    Err(_) => serde_json::json!({
+                        "jsonrpc": "2.0", "id": id,
+                        "result": nestweaver_mcp::tools::wrap_tool_error(
+                            &format!("tool '{name}' panicked")
+                        ),
+                    }),
+                }
+            }
+        }
+        "ping" => serde_json::json!({ "jsonrpc": "2.0", "id": id, "result": {} }),
+        method => serde_json::json!({
+            "jsonrpc": "2.0", "id": id,
+            "error": { "code": -32601, "message": format!("method not implemented: {method}") }
+        }),
+    }
+}
+
+fn process_hybrid_mcp_envelope(
+    parsed: serde_json::Value,
+    mut dispatch: impl FnMut(&nestweaver_mcp::protocol::Request) -> serde_json::Value,
+) -> Option<serde_json::Value> {
+    let invalid = |error: nestweaver_mcp::protocol::InvalidRequest| {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": error.response_id,
+            "error": { "code": -32600, "message": error.message }
+        })
+    };
+    if let serde_json::Value::Array(items) = parsed {
+        if items.is_empty() {
+            return Some(serde_json::json!({
+                "jsonrpc": "2.0", "id": null,
+                "error": { "code": -32600, "message": "empty batch array" }
+            }));
+        }
+        let mut responses = Vec::new();
+        for item in items {
+            match nestweaver_mcp::protocol::validate_request(item) {
+                Ok(request) => {
+                    let notification = request.id.is_none();
+                    let result = dispatch(&request);
+                    if !notification {
+                        responses.push(result);
+                    }
+                }
+                Err(error) => responses.push(invalid(error)),
+            }
+        }
+        (!responses.is_empty()).then_some(serde_json::Value::Array(responses))
+    } else {
+        match nestweaver_mcp::protocol::validate_request(parsed) {
+            Ok(request) => {
+                let notification = request.id.is_none();
+                let result = dispatch(&request);
+                (!notification).then_some(result)
+            }
+            Err(error) => Some(invalid(error)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod hybrid_mcp_envelope_tests {
+    use super::process_hybrid_mcp_envelope;
+    use serde_json::{Value, json};
+
+    #[test]
+    fn hybrid_envelope_rejects_before_dispatch_and_distinguishes_null_notification() {
+        let mut dispatched = Vec::new();
+        let response = process_hybrid_mcp_envelope(
+            json!([
+                {"jsonrpc":"1.0","id":"version","method":"ping"},
+                {"jsonrpc":"2.0","id":true,"method":"ping"},
+                {"jsonrpc":"2.0","id":null,"method":"ping"},
+                {"jsonrpc":"2.0","method":"ping"}
+            ]),
+            |request| {
+                dispatched.push(request.id.clone());
+                json!({"jsonrpc":"2.0","id":request.id.clone().unwrap_or(Value::Null),"result":{}})
+            },
+        )
+        .unwrap();
+
+        assert_eq!(dispatched, vec![Some(Value::Null), None]);
+        let responses = response.as_array().unwrap();
+        assert_eq!(responses.len(), 3, "notification response must be omitted");
+        assert_eq!(responses[0]["error"]["code"], -32600);
+        assert_eq!(responses[0]["id"], "version");
+        assert_eq!(responses[1]["error"]["code"], -32600);
+        assert_eq!(responses[1]["id"], Value::Null);
+        assert_eq!(responses[2]["id"], Value::Null);
+    }
+}
+
 fn run_mcp_hybrid(
     mut hybrid: nestweaver_client::hybrid::HybridClient,
     rt: tokio::runtime::Runtime,
@@ -18549,133 +18720,15 @@ fn run_mcp_hybrid(
             }
         };
 
-        let id = parsed.get("id").cloned().unwrap_or(serde_json::Value::Null);
-        let method = parsed.get("method").and_then(|v| v.as_str()).unwrap_or("");
+        let response = process_hybrid_mcp_envelope(parsed, |request| {
+            dispatch_hybrid_mcp_request(&mut hybrid, &rt, lite, &write_tools, request)
+        });
 
-        let response = match method {
-            "initialize" => serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "result": {
-                    "protocolVersion": "2024-11-05",
-                    "capabilities": { "tools": {} },
-                    "serverInfo": {
-                        "name": "nestweaver-brain",
-                        "version": env!("CARGO_PKG_VERSION"),
-                    },
-                }
-            }),
-            "notifications/initialized" | "initialized" => continue,
-            "tools/list" => serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "result": nestweaver_mcp::tools::tool_list(lite),
-            }),
-            "tools/call" => {
-                let params = parsed
-                    .get("params")
-                    .cloned()
-                    .unwrap_or(serde_json::Value::Null);
-                let name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
-                let arguments = params
-                    .get("arguments")
-                    .cloned()
-                    .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
-
-                if name.is_empty() {
-                    serde_json::json!({
-                        "jsonrpc": "2.0",
-                        "id": id,
-                        "error": { "code": -32602, "message": "tools/call: 'name' is required" }
-                    })
-                } else if let Err(error) = nestweaver_mcp::tools::enforce_tool_allowed(name) {
-                    // The HybridClient read path dispatches queries itself
-                    // and would otherwise bypass the --tools/--lite gate. Same
-                    // error text as the local and daemon-proxy paths.
-                    serde_json::json!({
-                        "jsonrpc": "2.0",
-                        "id": id,
-                        "result": nestweaver_mcp::tools::wrap_tool_error(&error.to_string()),
-                    })
-                } else if let Err(error) =
-                    nestweaver_mcp::tools::validate_tool_arguments(name, &arguments)
-                {
-                    serde_json::json!({
-                        "jsonrpc": "2.0",
-                        "id": id,
-                        "result": nestweaver_mcp::tools::wrap_tool_error(&error.to_string()),
-                    })
-                } else if write_tools.contains(name) {
-                    // Write operations go through standard gRPC dispatch.
-                    let grpc = hybrid.inner_mut();
-                    let dispatched = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        nestweaver_mcp::tools::dispatch_via_daemon(
-                            grpc,
-                            &rt,
-                            name,
-                            arguments.clone(),
-                        )
-                    }));
-                    match dispatched {
-                        Ok(Ok(result)) => {
-                            serde_json::json!({
-                                "jsonrpc": "2.0",
-                                "id": id,
-                                "result": nestweaver_mcp::tools::wrap_tool_result(result),
-                            })
-                        }
-                        Ok(Err(e)) => serde_json::json!({
-                            "jsonrpc": "2.0",
-                            "id": id,
-                            "result": nestweaver_mcp::tools::wrap_tool_error(&e.to_string()),
-                        }),
-                        Err(_) => serde_json::json!({
-                            "jsonrpc": "2.0",
-                            "id": id,
-                            "result": nestweaver_mcp::tools::wrap_tool_error(
-                                &format!("tool '{name}' panicked")
-                            ),
-                        }),
-                    }
-                } else {
-                    // Read queries go through HybridClient for routing.
-                    let dispatched = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        rt.block_on(hybrid.query(name, &arguments))
-                    }));
-                    match dispatched {
-                        Ok(Ok(result)) => {
-                            serde_json::json!({
-                                "jsonrpc": "2.0",
-                                "id": id,
-                                "result": nestweaver_mcp::tools::wrap_tool_result(result),
-                            })
-                        }
-                        Ok(Err(e)) => serde_json::json!({
-                            "jsonrpc": "2.0",
-                            "id": id,
-                            "result": nestweaver_mcp::tools::wrap_tool_error(&e.to_string()),
-                        }),
-                        Err(_) => serde_json::json!({
-                            "jsonrpc": "2.0",
-                            "id": id,
-                            "result": nestweaver_mcp::tools::wrap_tool_error(
-                                &format!("tool '{name}' panicked")
-                            ),
-                        }),
-                    }
-                }
-            }
-            "ping" => serde_json::json!({ "jsonrpc": "2.0", "id": id, "result": {} }),
-            _ => serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "error": { "code": -32601, "message": format!("method not implemented: {method}") }
-            }),
-        };
-
-        serde_json::to_writer(&mut stdout, &response)?;
-        stdout.write_all(b"\n")?;
-        stdout.flush()?;
+        if let Some(response) = response {
+            serde_json::to_writer(&mut stdout, &response)?;
+            stdout.write_all(b"\n")?;
+            stdout.flush()?;
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,86 @@
+static STDOUT_FAILED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+#[derive(Debug)]
+struct StdoutWriteFailure(std::io::Error);
+
+impl std::fmt::Display for StdoutWriteFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "failed writing to stdout: {}", self.0)
+    }
+}
+
+impl std::error::Error for StdoutWriteFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+fn write_cli_stdout(
+    writer: &mut impl std::io::Write,
+    arguments: std::fmt::Arguments<'_>,
+    newline: bool,
+) -> std::io::Result<()> {
+    writer.write_fmt(arguments)?;
+    if newline {
+        writer.write_all(b"\n")?;
+    }
+    Ok(())
+}
+
+fn raise_stdout_failure(error: std::io::Error) -> ! {
+    use std::sync::atomic::Ordering;
+    // Set this before unwinding: destructors may print, and a second panic
+    // during unwinding would abort instead of reaching the typed boundary.
+    STDOUT_FAILED.store(true, Ordering::Relaxed);
+    std::panic::resume_unwind(Box::new(StdoutWriteFailure(error)));
+}
+
+struct TypedStdout;
+
+impl std::io::Write for TypedStdout {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        match std::io::stdout().lock().write(buffer) {
+            Ok(written) => Ok(written),
+            Err(error) => raise_stdout_failure(error),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match std::io::stdout().lock().flush() {
+            Ok(()) => Ok(()),
+            Err(error) => raise_stdout_failure(error),
+        }
+    }
+}
+
+#[cfg(not(test))]
+fn print_cli_stdout(arguments: std::fmt::Arguments<'_>, newline: bool) {
+    use std::sync::atomic::Ordering;
+    if STDOUT_FAILED.load(Ordering::Relaxed) {
+        return;
+    }
+    // TypedStdout converts the otherwise-untyped `io::Error` into the one
+    // unwind payload accepted by the process boundary.
+    let _ = write_cli_stdout(&mut TypedStdout, arguments, newline);
+}
+
+// Keep unit-test output on the standard harness capture path. Production CLI
+// output (including `setup`, declared below) uses the typed stdout boundary.
+#[cfg(not(test))]
+macro_rules! print {
+    ($($arg:tt)*) => {{
+        crate::print_cli_stdout(format_args!($($arg)*), false)
+    }};
+}
+
+#[cfg(not(test))]
+macro_rules! println {
+    () => {{ crate::print_cli_stdout(format_args!(""), true) }};
+    ($($arg:tt)*) => {{
+        crate::print_cli_stdout(format_args!($($arg)*), true)
+    }};
+}
+
 mod setup;
 
 use std::io::IsTerminal;
@@ -1407,9 +1490,7 @@ fn print_daemon_embedding_status(db_path: &Path) {
             })
         });
     match result {
-        Ok(status) => {
-            println!("{}", format_daemon_status_response(Ok(&status)));
-        }
+        Ok(status) => println!("{}", format_daemon_status_response(Ok(&status))),
         Err(error) => {
             let error = format!("{error:#}");
             println!("{}", format_daemon_status_response(Err(&error)));
@@ -1489,6 +1570,29 @@ mod daemon_status_renderer_tests {
         assert!(output.starts_with(
             "Daemon is not running.\nConfig: unknown (daemon unreachable)\nEmbedding:\n"
         ));
+    }
+
+    struct ClosedStdout;
+
+    impl std::io::Write for ClosedStdout {
+        fn write(&mut self, _buffer: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "consumer closed",
+            ))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn daemon_status_renderer_reaches_typed_stdout_boundary() {
+        let output = format_daemon_not_running_status("Daemon is not running.");
+        let error =
+            write_cli_stdout(&mut ClosedStdout, format_args!("{output}"), true).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe);
     }
 }
 
@@ -5654,6 +5758,40 @@ fn read_symbols_rpc_args(
 
 // ── Entry point ───────────────────────────────────────────────────────────────
 
+fn run_with_stdout_boundary<T>(operation: impl FnOnce() -> T) -> Result<T, StdoutWriteFailure> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(operation)) {
+        Ok(value) => Ok(value),
+        Err(payload) => match payload.downcast::<StdoutWriteFailure>() {
+            Ok(stdout) => Err(*stdout),
+            Err(payload) => std::panic::resume_unwind(payload),
+        },
+    }
+}
+
+#[cfg(test)]
+mod broken_pipe_policy_tests {
+    use super::*;
+
+    #[test]
+    fn typed_boundary_distinguishes_closed_pipe_from_other_stdout_errors() {
+        for (kind, expected_normal) in [
+            (std::io::ErrorKind::BrokenPipe, true),
+            (std::io::ErrorKind::PermissionDenied, false),
+        ] {
+            let outcome = run_with_stdout_boundary(|| {
+                std::panic::resume_unwind(Box::new(StdoutWriteFailure(std::io::Error::new(
+                    kind, "test",
+                ))))
+            })
+            .unwrap_err();
+            assert_eq!(
+                outcome.0.kind() == std::io::ErrorKind::BrokenPipe,
+                expected_normal
+            );
+        }
+    }
+}
+
 fn main() {
     // Install miette as the global error/panic report handler for rich
     // diagnostics (colours, help text, error codes) on supported terminals.
@@ -5688,7 +5826,22 @@ fn main() {
     let out = OutputConfig::from_cli(&cli);
     let show_stats = cli.stats;
 
-    let exit_code = match run(cli, &out) {
+    // Keep the existing renderer surface (including helper modules) safe when
+    // a downstream consumer such as `head` closes the pipe. Typed stdout
+    // failures use `resume_unwind`, so they never invoke the panic hook;
+    // unrelated panics retain normal behavior and resume unwinding.
+
+    let run_result = match run_with_stdout_boundary(|| run(cli, &out)) {
+        Ok(result) => result,
+        Err(error) if error.0.kind() == std::io::ErrorKind::BrokenPipe => {
+            process::exit(EXIT_SUCCESS)
+        }
+        Err(error) => {
+            eprintln!("{error}");
+            process::exit(EXIT_ERROR)
+        }
+    };
+    let exit_code = match run_result {
         Ok((code, summary)) => {
             if let (true, Some(s)) = (show_stats, summary) {
                 eprintln!("stats: {s}");
@@ -5696,6 +5849,13 @@ fn main() {
             code
         }
         Err(e) => {
+            if let Some(stdout) = e.downcast_ref::<nestweaver_mcp::StdoutWriteError>() {
+                if stdout.kind() == std::io::ErrorKind::BrokenPipe {
+                    process::exit(EXIT_SUCCESS);
+                }
+                eprintln!("{stdout}");
+                process::exit(EXIT_ERROR);
+            }
             let report = into_diagnostic(e);
             eprintln!("{report:?}");
             EXIT_ERROR
@@ -8080,7 +8240,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     std::fs::File::create(path)
                         .with_context(|| format!("failed to create {}", path.display()))?,
                 ),
-                None => Box::new(std::io::stdout().lock()),
+                None => Box::new(TypedStdout),
             };
             let mut writer = std::io::BufWriter::new(write_to);
 
@@ -8096,6 +8256,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     return Ok((EXIT_ERROR, None));
                 }
             }
+            std::io::Write::flush(&mut writer)?;
 
             if let Some(path) = &output {
                 out.status(&format!("Exported graph to {}", path.display()));
@@ -8106,8 +8267,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
         }
 
         Commands::Completions { shell } => {
+            use clap_complete::Generator;
             let mut cmd = Cli::command();
-            clap_complete::generate(shell, &mut cmd, "nestweaver", &mut std::io::stdout());
+            cmd.set_bin_name("nestweaver");
+            cmd.build();
+            shell.try_generate(&cmd, &mut TypedStdout)?;
             Ok((EXIT_SUCCESS, None))
         }
 
@@ -18683,7 +18847,7 @@ fn run_mcp_hybrid(
     tracing::info!("brain MCP server ready on stdio (hybrid routing mode)");
 
     let stdin = std::io::stdin();
-    let mut stdout = std::io::stdout().lock();
+    let mut stdout = TypedStdout;
     let mut line = String::new();
     let mut reader = stdin.lock();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,10 +20,10 @@ use nestweaver_engine::{
     generate_cursor_rule_with_rules, generate_guide_with_tools, generate_repo_map,
     generate_summaries, get_last_indexed_at, incremental_index_with_name,
     index_directory_with_options, index_markdown_directory_since_with_ignore,
-    index_markdown_directory_with_ignore, list_repos, list_services, load_alias_sidecar,
-    load_clusters, load_extensions, lookup_symbol, record_last_indexed_at, render_text,
-    save_clusters, save_cochange_sidecar, save_summaries, search_symbols, suggest_links,
-    truncate_to_budget,
+    index_markdown_directory_with_ignore, index_markdown_directory_with_ignore_and_deletion_count,
+    list_repos, list_services, load_alias_sidecar, load_clusters, load_extensions, lookup_symbol,
+    record_last_indexed_at, render_text, save_clusters, save_cochange_sidecar, save_summaries,
+    search_symbols, suggest_links, truncate_to_budget,
 };
 use nestweaver_schema::{DEFAULT_DRAIN_CEILING_SECS, Symbol, parse_drain_ceiling};
 use nestweaver_store::{GraphStore, QueryIntent, TantivyIndex};
@@ -14704,18 +14704,12 @@ fn run_brain(
                     result.wikilinks_resolved,
                 );
             } else {
-                // Full refresh: cascade-delete all notes then re-index from scratch.
-                let store = open_store(Some(&db_path))?;
-                let existing = store.list_notes(Some(&v_uid)).unwrap_or_default();
-                let drop_count = existing.len();
-                for n in &existing {
-                    if let Err(e) = store.delete_note_cascade(&n.uid) {
-                        tracing::warn!("delete_note_cascade {} failed: {e}", n.uid);
-                    }
-                }
-                drop(store);
-
-                let result = index_markdown_directory_with_ignore(
+                // Full refresh: the markdown indexer's writable store performs
+                // the old-vault cascade and replacement in one transaction.
+                // Its returned delete count is therefore committed truth; a
+                // failed cascade/write propagates and cannot be reported as a
+                // successful dropped note.
+                let result = index_markdown_directory_with_ignore_and_deletion_count(
                     &path,
                     &db_path,
                     &instance_id,
@@ -14730,16 +14724,8 @@ fn run_brain(
                 }
 
                 println!(
-                    "Refreshed vault '{}': dropped {} stale note(s), reindexed {} note(s), \
-                     {} heading(s), {} section(s), {} tag(s), {} wikilink(s) ({} unresolved).",
-                    result.vault_name,
-                    drop_count,
-                    result.notes_count,
-                    result.headings_count,
-                    result.sections_count,
-                    result.tags_count,
-                    result.wikilinks_resolved,
-                    result.wikilinks_unresolved,
+                    "{}",
+                    nestweaver_engine::index_md::format_markdown_refresh_summary(&result)
                 );
             }
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -2431,6 +2431,61 @@ credential_method = "gh"
     );
 }
 
+#[test]
+fn brain_refresh_direct_reports_only_committed_atomic_deletions() {
+    let dir = tempfile::tempdir().unwrap();
+    let vault = dir.path().join("vault");
+    let db = dir.path().join("brain.lbug");
+    std::fs::create_dir_all(&vault).unwrap();
+    std::fs::write(vault.join("a.md"), "# A\n\nalpha\n").unwrap();
+    std::fs::write(vault.join("b.md"), "# B\n\nbeta\n").unwrap();
+
+    nestweaver_cmd()
+        .args(["brain", "refresh"])
+        .arg(&vault)
+        .args(["--instance", "direct-test", "--db"])
+        .arg(&db)
+        .assert()
+        .success()
+        .stdout(contains("dropped 0 stale note(s), reindexed 2 note(s)"))
+        .stderr(
+            contains("read-only")
+                .not()
+                .and(contains("delete_note_cascade").not()),
+        );
+
+    nestweaver_cmd()
+        .args(["brain", "refresh"])
+        .arg(&vault)
+        .args(["--instance", "direct-test", "--db"])
+        .arg(&db)
+        .assert()
+        .success()
+        .stdout(contains("dropped 2 stale note(s), reindexed 2 note(s)"))
+        .stderr(
+            contains("read-only")
+                .not()
+                .and(contains("delete_note_cascade").not()),
+        );
+
+    std::fs::remove_file(vault.join("a.md")).unwrap();
+    std::fs::write(vault.join("b.md"), "# B changed\n\nnew beta\n").unwrap();
+    std::fs::write(vault.join("c.md"), "# C\n\ngamma\n").unwrap();
+    nestweaver_cmd()
+        .args(["brain", "refresh"])
+        .arg(&vault)
+        .args(["--instance", "direct-test", "--db"])
+        .arg(&db)
+        .assert()
+        .success()
+        .stdout(contains("dropped 2 stale note(s), reindexed 2 note(s)"))
+        .stderr(
+            contains("read-only")
+                .not()
+                .and(contains("delete_note_cascade").not()),
+        );
+}
+
 /// nw-047: the no-daemon `index` direct-write path must resolve the instance
 /// id as `--instance` > config `instance_id` > "default" (was
 /// `instance.unwrap_or("default")`, which ignored the config). Without a

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -15,6 +15,18 @@ use std::path::Path;
 use std::process::{Command as StdCommand, Stdio};
 use std::time::Duration;
 
+#[cfg(unix)]
+fn closed_pipe_stdout() -> Stdio {
+    use std::os::fd::FromRawFd;
+    let mut fds = [-1; 2];
+    assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0, "create pipe");
+    assert_eq!(unsafe { libc::close(fds[0]) }, 0, "close pipe reader");
+    // SAFETY: pipe returned an owned write descriptor, and Stdio takes sole
+    // ownership through File.
+    let writer = unsafe { std::fs::File::from_raw_fd(fds[1]) };
+    Stdio::from(writer)
+}
+
 /// Helper: build a `Command` for the `nestweaver` binary **without** setting
 /// `NESTWEAVER_NO_DAEMON`. This is the key difference from `cli_test.rs`'s
 /// `nestweaver_cmd()` — we want the daemon path exercised.
@@ -578,6 +590,145 @@ fn daemon_start_stop() {
         .assert()
         .success()
         .stdout(contains("not running"));
+}
+
+#[cfg(unix)]
+#[test]
+fn live_daemon_status_pipe_to_head_exits_quietly() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_dir = dir.path().join("repo");
+    let db_path = dir.path().join("broken-pipe").join("test.lbug");
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+    write_test_repo(&repo_dir);
+    create_db(&repo_dir, &db_path);
+
+    let _guard = DaemonGuard::new(&db_path);
+    start_daemon(&db_path);
+
+    for args in [
+        vec!["daemon", "--db", db_path.to_str().unwrap(), "status"],
+        vec!["list-repos", "--db", db_path.to_str().unwrap(), "--json"],
+    ] {
+        let output = StdCommand::new(bin_path())
+            .args(&args)
+            .env_remove("NESTWEAVER_NO_DAEMON")
+            .env_remove("NESTWEAVER_ALLOW_NO_DAEMON")
+            .stdout(closed_pipe_stdout())
+            .stderr(Stdio::piped())
+            .output()
+            .expect("run command with a deterministically closed stdout");
+        assert!(
+            output.status.success(),
+            "closed-stdout command {args:?} exited {:?}; stderr: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(!stderr.contains("panicked"), "unexpected panic: {stderr}");
+        assert!(
+            !stderr.contains("failed writing to stdout"),
+            "broken pipe must be quiet: {stderr}"
+        );
+    }
+
+    let mut mcp = StdCommand::new(bin_path())
+        .args(["mcp", "--db", db_path.to_str().unwrap()])
+        .env_remove("NESTWEAVER_NO_DAEMON")
+        .env_remove("NESTWEAVER_ALLOW_NO_DAEMON")
+        .stdin(Stdio::piped())
+        .stdout(closed_pipe_stdout())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn daemon-proxy MCP with closed stdout");
+    mcp.stdin
+        .take()
+        .unwrap()
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}\n")
+        .unwrap();
+    let output = mcp.wait_with_output().expect("wait for MCP closed stdout");
+    assert!(
+        output.status.success(),
+        "MCP closed stdout exited {:?}; stderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!String::from_utf8_lossy(&output.stderr).contains("panicked"));
+
+    let output = StdCommand::new("bash")
+        .args([
+            "-c",
+            "set -o pipefail; \"$1\" daemon --db \"$2\" status | head -n 4",
+            "nestweaver-broken-pipe-test",
+            bin_path().to_str().unwrap(),
+            db_path.to_str().unwrap(),
+        ])
+        .env_remove("NESTWEAVER_NO_DAEMON")
+        .env_remove("NESTWEAVER_ALLOW_NO_DAEMON")
+        .output()
+        .expect("run daemon status pipeline");
+
+    assert!(
+        output.status.success(),
+        "pipeline exited {:?}; stderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.contains("panicked"), "unexpected panic: {stderr}");
+    assert!(
+        !stderr.contains("failed printing to stdout"),
+        "unexpected stdout diagnostic: {stderr}"
+    );
+
+    for command in [
+        "set -o pipefail; \"$1\" list-repos --db \"$2\" --json | head -n 1",
+        "set -o pipefail; \"$1\" completions bash | head -n 1",
+    ] {
+        let output = StdCommand::new("bash")
+            .args([
+                "-c",
+                command,
+                "nestweaver-broken-pipe-test",
+                bin_path().to_str().unwrap(),
+                db_path.to_str().unwrap(),
+            ])
+            .env_remove("NESTWEAVER_NO_DAEMON")
+            .env_remove("NESTWEAVER_ALLOW_NO_DAEMON")
+            .output()
+            .expect("run stdout pipeline");
+        assert!(
+            output.status.success(),
+            "pipeline `{command}` exited {:?}; stderr: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            !String::from_utf8_lossy(&output.stderr).contains("panicked"),
+            "pipeline `{command}` panicked"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let full = std::fs::OpenOptions::new()
+            .write(true)
+            .open("/dev/full")
+            .expect("/dev/full is available on Linux");
+        let output = StdCommand::new(bin_path())
+            .args(["daemon", "--db", db_path.to_str().unwrap(), "status"])
+            .env_remove("NESTWEAVER_NO_DAEMON")
+            .stdout(Stdio::from(full))
+            .stderr(Stdio::piped())
+            .output()
+            .expect("run status with a failing stdout device");
+        assert_eq!(output.status.code(), Some(1));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("failed writing to stdout"),
+            "genuine stdout failure must be diagnostic: {stderr}"
+        );
+        assert!(!stderr.contains("panicked"), "typed failure leaked a panic");
+    }
 }
 
 #[cfg(not(target_os = "macos"))]

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -353,6 +353,40 @@ fn mcp_tool_call_in_mode(
     String::from_utf8_lossy(&output.stdout).to_string()
 }
 
+fn mcp_raw_in_mode(db_path: &Path, input: &str, mode: McpMode) -> std::process::Output {
+    let mut command = StdCommand::new(bin_path());
+    command.args(["mcp", "--db", &db_path.display().to_string()]);
+    match mode {
+        McpMode::Direct => {
+            command
+                .env("NESTWEAVER_NO_DAEMON", "1")
+                .env("NESTWEAVER_ALLOW_NO_DAEMON", "1");
+        }
+        McpMode::Daemon => {
+            command
+                .env_remove("NESTWEAVER_NO_DAEMON")
+                .env_remove("NESTWEAVER_ALLOW_NO_DAEMON")
+                .env_remove("NESTWEAVER_UPSTREAM");
+            #[cfg(not(target_os = "macos"))]
+            command.env("NESTWEAVER_DAEMON_FORK", "1");
+        }
+    }
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn nestweaver mcp");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    drop(child.stdin.take());
+    child.wait_with_output().expect("failed to read mcp output")
+}
+
 /// Index a repo, creating the DB. Uses `NESTWEAVER_NO_DAEMON=1`.
 fn create_db(repo_dir: &Path, db_path: &Path) {
     no_daemon_cmd()
@@ -411,6 +445,109 @@ fn index_via_daemon(repo_dir: &Path, db_path: &Path) {
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn mcp_jsonrpc_envelope_validation_matches_direct_and_daemon_modes() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_dir = dir.path().join("repo");
+    let db_path = dir.path().join("db").join("test.lbug");
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+    write_test_repo(&repo_dir);
+    create_db(&repo_dir, &db_path);
+
+    let input = concat!(
+        "{\"jsonrpc\":\"1.0\",\"id\":\"bad-version\",\"method\":\"ping\"}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":true,\"method\":\"ping\"}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":[],\"method\":\"ping\"}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":{},\"method\":\"ping\"}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":null,\"method\":\"ping\"}\n",
+        "{\"jsonrpc\":\"2.0\",\"method\":\"ping\"}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":\"string-id\",\"method\":\"ping\"}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":42,\"method\":\"ping\"}\n",
+        "[{\"jsonrpc\":\"1.0\",\"id\":1,\"method\":\"ping\"},",
+        "{\"jsonrpc\":\"2.0\",\"id\":false,\"method\":\"ping\"},",
+        "{\"jsonrpc\":\"2.0\",\"id\":null,\"method\":\"ping\"},",
+        "{\"jsonrpc\":\"2.0\",\"method\":\"ping\"},",
+        "{\"jsonrpc\":\"2.0\",\"id\":8,\"method\":\"ping\"}]\n",
+    );
+
+    let _guard = DaemonGuard::new(&db_path);
+    start_daemon(&db_path);
+    let mut baseline: Option<Vec<serde_json::Value>> = None;
+    for (label, mode) in [("direct", McpMode::Direct), ("daemon", McpMode::Daemon)] {
+        let output = mcp_raw_in_mode(&db_path, input, mode);
+        assert!(
+            output.status.success(),
+            "{label} MCP exited {:?}: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let frames: Vec<serde_json::Value> = String::from_utf8(output.stdout)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("stdout line must be one JSON frame"))
+            .collect();
+        assert_eq!(frames.len(), 8, "{label}: notification emitted a frame");
+
+        for frame in &frames[..4] {
+            assert_eq!(frame["jsonrpc"], "2.0");
+            assert_eq!(frame["error"]["code"], -32600);
+        }
+        assert_eq!(frames[0]["id"], "bad-version");
+        for frame in &frames[1..4] {
+            assert_eq!(frame["id"], serde_json::Value::Null);
+        }
+        assert_eq!(frames[4]["id"], serde_json::Value::Null);
+        assert_eq!(frames[4]["result"], serde_json::json!({}));
+        assert_eq!(frames[5]["id"], "string-id");
+        assert_eq!(frames[6]["id"], 42);
+
+        let batch = frames[7]
+            .as_array()
+            .expect("batch response must be an array");
+        assert_eq!(batch.len(), 4, "batch notification must be omitted");
+        assert_eq!(batch[0]["error"]["code"], -32600);
+        assert_eq!(batch[0]["id"], 1);
+        assert_eq!(batch[1]["error"]["code"], -32600);
+        assert_eq!(batch[1]["id"], serde_json::Value::Null);
+        assert_eq!(batch[2]["id"], serde_json::Value::Null);
+        assert_eq!(batch[2]["result"], serde_json::json!({}));
+        assert_eq!(batch[3]["id"], 8);
+
+        if let Some(expected) = &baseline {
+            assert_eq!(&frames, expected, "direct/daemon wire behavior diverged");
+        } else {
+            baseline = Some(frames);
+        }
+    }
+
+    // A ping-only daemon-mode run could false-green through a local fallback.
+    // These fields are injected by the daemon's `brain_status_json` wrapper
+    // and are absent from direct MCP dispatch, so they pin that the proxy half
+    // reached the daemon even for a local UDS daemon (`server_mode == false`).
+    let sentinel = mcp_raw_in_mode(
+        &db_path,
+        "{\"jsonrpc\":\"2.0\",\"id\":\"daemon-sentinel\",\"method\":\"tools/call\",\"params\":{\"name\":\"brain_status\",\"arguments\":{}}}\n",
+        McpMode::Daemon,
+    );
+    assert!(
+        sentinel.status.success(),
+        "daemon MCP sentinel failed: {}",
+        String::from_utf8_lossy(&sentinel.stderr)
+    );
+    let sentinel: serde_json::Value =
+        serde_json::from_slice(&sentinel.stdout).expect("one daemon sentinel response");
+    assert_eq!(sentinel["id"], "daemon-sentinel");
+    let structured = &sentinel["result"]["structuredContent"];
+    assert!(
+        structured.get("embedding_status").is_some(),
+        "daemon brain_status must inject embedding_status: {sentinel}"
+    );
+    assert!(
+        structured.get("queue_depth").is_some(),
+        "daemon brain_status must inject queue_depth: {sentinel}"
+    );
+}
 
 #[test]
 fn daemon_start_stop() {

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -232,6 +232,22 @@ fn setup_fixture() -> Fixture {
     Fixture { _dir: dir, db_path }
 }
 
+fn setup_contract_fixture() -> Fixture {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_dir = dir.path().join("ContrÁct-Repo");
+    let db_path = dir.path().join("db").join("contracts.lbug");
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+    write_repo_files(
+        &repo_dir,
+        &[(
+            "openapi.yaml",
+            "openapi: 3.0.0\ninfo:\n  title: Contract fixture\n  version: 1.0.0\npaths:\n  /widgets:\n    get:\n      operationId: listWidgets\n      responses:\n        '200':\n          description: ok\n",
+        )],
+    );
+    create_db(&repo_dir, &db_path);
+    Fixture { _dir: dir, db_path }
+}
+
 // ─── Mode runners ────────────────────────────────────────────────────────────
 
 /// Run the CLI in DIRECT mode (no daemon), returning the raw process output.
@@ -461,6 +477,116 @@ fn parity_affected_tests_direct_vs_daemon() {
 fn parity_contracts_drift_direct_vs_daemon() {
     let fixture = setup_fixture();
     check_parity(&fixture.db_path, "contracts drift", &["contracts", "drift"]);
+}
+
+/// `contracts list` must use its dedicated daemon RPC, not the unrelated
+/// symbol-oriented `cross_repo_contracts` tool followed by a direct DB read.
+/// This covers both renderers, both repo-filter forms, and finally makes the
+/// DB file unreadable after daemon startup: the already-open daemon can still
+/// answer, while any direct-store fallback would fail.
+#[test]
+fn parity_contracts_list_uses_daemon_without_direct_store_fallback() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let fixture = setup_contract_fixture();
+    let direct_human = run_direct(&fixture.db_path, &["contracts", "list"]);
+    let direct_json = run_direct(&fixture.db_path, &["contracts", "list", "--json"]);
+    assert_successful_output(&direct_human, "direct contracts list");
+    assert_successful_output(&direct_json, "direct contracts list --json");
+    let contracts: Vec<serde_json::Value> = serde_json::from_slice(&direct_json.stdout).unwrap();
+    assert_eq!(contracts.len(), 1);
+    let repo_uid = contracts[0]["repo_uid"].as_str().unwrap().to_string();
+
+    let direct_name = run_direct(
+        &fixture.db_path,
+        &["contracts", "list", "--repo", "contráct-repo", "--json"],
+    );
+    let direct_uid = run_direct(
+        &fixture.db_path,
+        &["contracts", "list", "--repo", &repo_uid, "--json"],
+    );
+
+    let _guard = DaemonGuard::new(&fixture.db_path);
+    start_daemon(&fixture.db_path);
+    let daemon_human = run_via_daemon(&fixture.db_path, &["contracts", "list"]);
+    let daemon_json = run_via_daemon(&fixture.db_path, &["contracts", "list", "--json"]);
+    let daemon_name = run_via_daemon(
+        &fixture.db_path,
+        &["contracts", "list", "--repo", "contráct-repo", "--json"],
+    );
+    let daemon_uid = run_via_daemon(
+        &fixture.db_path,
+        &["contracts", "list", "--repo", &repo_uid, "--json"],
+    );
+
+    assert_parity("contracts list", "human", &direct_human, &daemon_human);
+    assert_parity("contracts list", "json", &direct_json, &daemon_json);
+    assert_parity(
+        "contracts list --repo non-ASCII case-folded name",
+        "json",
+        &direct_name,
+        &daemon_name,
+    );
+    assert_parity(
+        "contracts list --repo uid",
+        "json",
+        &direct_uid,
+        &daemon_uid,
+    );
+    for output in [&daemon_human, &daemon_json, &daemon_name, &daemon_uid] {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("fallback"),
+            "unexpected fallback: {stderr}"
+        );
+        assert!(
+            !stderr.contains("cross_repo_contracts"),
+            "wrong daemon tool was invoked: {stderr}"
+        );
+    }
+
+    let original_mode = std::fs::metadata(&fixture.db_path)
+        .unwrap()
+        .permissions()
+        .mode();
+    std::fs::set_permissions(&fixture.db_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+    let daemon_without_disk_access =
+        run_via_daemon(&fixture.db_path, &["contracts", "list", "--json"]);
+    let daemon_error_without_fallback = run_via_daemon(
+        &fixture.db_path,
+        &[
+            "contracts",
+            "list",
+            "--repo",
+            "definitely-unknown",
+            "--json",
+        ],
+    );
+    std::fs::set_permissions(
+        &fixture.db_path,
+        std::fs::Permissions::from_mode(original_mode),
+    )
+    .unwrap();
+    assert_successful_output(
+        &daemon_without_disk_access,
+        "daemon contracts list with unreadable DB path",
+    );
+    assert_eq!(daemon_without_disk_access.stdout, direct_json.stdout);
+    assert!(daemon_without_disk_access.stderr.is_empty());
+    assert!(!daemon_error_without_fallback.status.success());
+    let error = String::from_utf8_lossy(&daemon_error_without_fallback.stderr);
+    assert!(error.contains("no indexed repo matches --repo 'definitely-unknown'"));
+    assert!(error.contains("refusing direct-store fallback"));
+    assert!(!error.contains("cross_repo_contracts"));
+
+    let explicit_empty = run_via_daemon(
+        &fixture.db_path,
+        &["contracts", "list", "--repo", "", "--json"],
+    );
+    assert!(!explicit_empty.status.success());
+    let empty_error = String::from_utf8_lossy(&explicit_empty.stderr);
+    assert!(empty_error.contains("no indexed repo matches --repo ''"));
+    assert!(empty_error.contains("refusing direct-store fallback"));
 }
 
 /// nw-108: `dead-code`'s daemon branch printed the RPC response verbatim with


### PR DESCRIPTION
## Summary

This PR fixes six issues found during an end-to-end regression hunt across NestWeaver's CLI, daemon, watcher, and MCP transports:

- refresh derived contracts atomically during Git incremental indexing;
- make live code-watch batches publish source and contract changes as one consistent snapshot;
- make full `brain refresh` use the writable atomic replacement path and report committed deletion counts;
- route `contracts list` through a dedicated, authz-aware daemon RPC without direct-store fallback;
- validate JSON-RPC versions and request IDs consistently across direct, daemon-proxy, hybrid, and HTTP MCP paths;
- treat a closed stdout consumer as a clean CLI/MCP session end while preserving real output failures.

## Why

The bug hunt reproduced stale contract nodes and implementation edges after incremental/spec changes, noisy read-only deletion attempts during direct vault refresh, an incorrect daemon routing target for `contracts list`, invalid JSON-RPC envelopes being dispatched, and exit-101 panics when a downstream pipe closed stdout.

The fixes favor fail-closed behavior and atomic publication. Failed contract derivation no longer publishes a mixed code/contract graph or advances the indexed SHA/generation. Explicit daemon reads never silently fall back to the daemon-owned database. Invalid JSON-RPC envelopes never reach tool dispatch.

## Validation

- Independent correctness and adversarial acceptance reviews signed off each increment and the combined six-commit range.
- Incremental contract tests cover spec rename, added/changed/deleted routes and handlers, exact implementation edges, force/tiered/drift parity, multi-repo isolation, and graph/SHA/generation rollback.
- Watcher tests cover fresh initialization, spec-only and controller changes, callback ordering, malformed input, ABA/input races, recovered publication state, and atomic collision rollback.
- Vault refresh tests cover first/unchanged/changed replacement counts, direct/daemon entry-point parity, rollback, and a real no-daemon CLI regression.
- Contracts-list tests cover live-daemon human/JSON parity, UID/name/Unicode/empty filters, authz visibility, stable ordering, unreadable on-disk DB, and refusal to fall back.
- MCP tests cover direct, daemon-proxy, hybrid, stdio batch, HTTP auth/rate-limit ordering, malformed JSON, invalid IDs/version, explicit-null IDs, and notification suppression.
- Closed-stdout tests cover deterministic pre-closed pipes for human, JSON, and daemon-proxy MCP output; real `head` pipelines; completions; and `/dev/full` non-BrokenPipe failure handling.
- Formatting and diff checks are clean.

## Compatibility and limitations

- Manual Git incremental indexing still returns early when the recorded SHA already equals `HEAD`; pre-existing same-SHA stale contract data needs a new commit, watcher event, or `--force` repair.
- Incremental and watcher correctness currently require a whole-repository contract-input scan. Parsing remains restricted to contract candidates.
- MCP over HTTP intentionally accepts one JSON-RPC request per POST and rejects batch arrays with `-32600`; stdio batch remains supported.
- JSON-RPC `params` remains compatibility-permissive rather than newly enforcing the Object/Array recommendation.
- The vault deletion-count fix applies to full refresh. `--since` deletion semantics and global alias/embedding/PPR reconciliation remain separate follow-ups.
- Contract UIDs remain globally keyed; cross-repository same-route collisions are a separate known design item and fail closed here.
- The branch does not add a CHANGELOG entry; this description records the user-visible changes and limits.
