### PR TITLE
fix: close validated v4.1.0 end-to-end regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,9 +604,15 @@ NestWeaver exposes 40 tools via the [Model Context Protocol](https://modelcontex
 
 ```sh
 nestweaver mcp --db ./nestweaver.lbug
-nestweaver mcp --tools context,search,symbol --db ./nestweaver.lbug   # allowlist specific tools
+nestweaver mcp --tools brain_context,brain_search,read_symbols --db ./nestweaver.lbug   # allowlist specific tools
 NESTWEAVER_NO_DAEMON=1 nestweaver mcp --no-daemon --db ./nestweaver.lbug   # read-only direct mode (CI/testing)
 ```
+
+Direct mode advertises 35 read-only tools and rejects mutations before
+dispatch. Daemon-backed stdio exposes all 40 tools. `--tools` names are exact,
+case-sensitive registry names; unknown, duplicate, empty, or transport-
+unavailable names fail at startup instead of silently producing an empty tool
+surface.
 
 The MCP server automatically starts a background daemon that owns the database. Multiple MCP servers, CLI commands, and IDE integrations can share the same database concurrently without lock contention. The daemon exits after 1 hour of inactivity.
 

--- a/crates/nestweaver-client/src/autostart.rs
+++ b/crates/nestweaver-client/src/autostart.rs
@@ -878,7 +878,7 @@ credential_method = "gh"
     }
 
     #[test]
-    fn ensure_daemon_early_returns_reject_a_different_config() {
+    fn ensure_daemon_held_pidfile_rejects_a_different_config() {
         let dir = tempfile::tempdir().unwrap();
         let db = dir.path().join("brain.lbug");
         let configured = write_valid_config(dir.path(), "configured.toml", "configured");
@@ -916,9 +916,7 @@ credential_method = "gh"
         .unwrap();
         let listener = UnixListener::bind(&socket).unwrap();
         let server = std::thread::spawn(move || {
-            for _ in 0..2 {
-                drop(listener.accept().unwrap());
-            }
+            drop(listener.accept().unwrap());
         });
 
         let error = ensure_daemon(&db, Some(&requested)).unwrap_err();
@@ -926,14 +924,6 @@ credential_method = "gh"
         assert!(message.contains(configured.file_name().unwrap().to_str().unwrap()));
         assert!(message.contains(requested.file_name().unwrap().to_str().unwrap()));
         assert!(message.contains("restart --config"));
-
-        let spawn_lock = SpawnLock::acquire(&db).unwrap();
-        let error = ensure_daemon_with_spawn_lock(&db, Some(&requested), &spawn_lock).unwrap_err();
-        let message = format!("{error:#}");
-        assert!(message.contains(configured.file_name().unwrap().to_str().unwrap()));
-        assert!(message.contains(requested.file_name().unwrap().to_str().unwrap()));
-        assert!(message.contains("restart --config"));
-        drop(spawn_lock);
 
         server.join().unwrap();
         unsafe { libc::flock(owner.as_raw_fd(), libc::LOCK_UN) };
@@ -1055,37 +1045,6 @@ credential_method = "gh"
             .unwrap();
         release.await.unwrap();
         drop(second);
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn async_ensure_production_seam_allows_timer_driven_transaction_holder() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = dir.path().join("brain.lbug");
-        let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(&db);
-        let socket = nestweaver_daemon::lifecycle::socket_path(&instance_id);
-        let runtime = nestweaver_daemon::lifecycle::runtime_dir(&instance_id);
-        let transaction_lock = SpawnLock::acquire(&db).unwrap();
-        let holder_socket = socket.clone();
-        let holder = tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            if let Some(parent) = holder_socket.parent() {
-                fs::create_dir_all(parent).unwrap();
-            }
-            let _ = fs::remove_file(&holder_socket);
-            let listener = UnixListener::bind(&holder_socket).unwrap();
-            drop(transaction_lock);
-            listener
-        });
-
-        let ensured = tokio::time::timeout(Duration::from_secs(3), ensure_daemon_async(&db, None))
-            .await
-            .expect("blocking spawn-lock wait must not prevent the holder's timer")
-            .unwrap();
-        assert_eq!(ensured, socket);
-        let listener = holder.await.unwrap();
-        drop(listener);
-        let _ = fs::remove_file(&socket);
-        let _ = fs::remove_dir_all(runtime);
     }
 
     #[test]

--- a/crates/nestweaver-client/src/autostart.rs
+++ b/crates/nestweaver-client/src/autostart.rs
@@ -317,23 +317,6 @@ fn attest_requested_config_on_held_pidfile(
     Ok(())
 }
 
-fn attest_requested_config_for_running_daemon(db_path: &Path, requested_path: &Path) -> Result<()> {
-    let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
-    let pidfile_path = nestweaver_daemon::lifecycle::pidfile_path(&instance_id);
-    let mut options = fs::OpenOptions::new();
-    options.read(true).write(true);
-    use std::os::unix::fs::OpenOptionsExt;
-    options.custom_flags(libc::O_NOFOLLOW);
-    let mut pidfile = options
-        .open(&pidfile_path)
-        .with_context(|| format!("open live daemon pidfile: {}", pidfile_path.display()))?;
-    anyhow::ensure!(
-        !try_acquire_pidfile_lock(&pidfile)?,
-        "daemon socket accepts connections but its pidfile is not owned; refusing to accept explicit --config"
-    );
-    attest_requested_config_on_held_pidfile(db_path, requested_path, &mut pidfile)
-}
-
 /// Ensure a daemon is running for the given DB and return the socket path.
 ///
 /// Acquires an exclusive flock on the pidfile, checks whether a live daemon

--- a/crates/nestweaver-client/src/autostart.rs
+++ b/crates/nestweaver-client/src/autostart.rs
@@ -348,6 +348,17 @@ fn ensure_daemon_impl(
     config_path: Option<&Path>,
     attest_existing: bool,
 ) -> Result<PathBuf> {
+    // An explicit path is a security-relevant assertion, not a child-process
+    // hint. Validate it before creating runtime directories, taking locks,
+    // cleaning sockets, or spawning anything so malformed proxy/MCP config
+    // errors surface immediately with the real IO/TOML cause.
+    let explicit_config = match config_path {
+        Some(path) => Some(crate::RestartConfig::for_cold_start(Some(path))?),
+        None => None,
+    };
+    let config_path = explicit_config
+        .as_ref()
+        .and_then(crate::RestartConfig::as_path);
     let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
     let rt_dir = nestweaver_daemon::lifecycle::runtime_dir(&instance_id);
     let sock = nestweaver_daemon::lifecycle::socket_path(&instance_id);
@@ -416,7 +427,12 @@ fn ensure_daemon_impl(
     // Serialize concurrent auto-starts on a SEPARATE spawn-lock. The pidfile
     // flock had to be released above for the daemon to take it.
     let spawn_lock = SpawnLock::acquire(db_path)?;
-    ensure_daemon_with_spawn_lock_impl(db_path, config_path, &spawn_lock, attest_existing)
+    ensure_daemon_with_spawn_lock_impl(
+        db_path,
+        config_path,
+        &spawn_lock,
+        ColdStartSelection::Automatic,
+    )
 }
 
 /// Async-safe wrapper around the synchronous pidfile/spawn/socket-readiness
@@ -453,14 +469,22 @@ pub fn ensure_daemon_with_spawn_lock(
     config_path: Option<&Path>,
     spawn_lock: &SpawnLock,
 ) -> Result<PathBuf> {
-    ensure_daemon_with_spawn_lock_impl(db_path, config_path, spawn_lock, true)
+    ensure_daemon_with_spawn_lock_impl(db_path, config_path, spawn_lock, ColdStartSelection::Exact)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ColdStartSelection {
+    /// Caller is auto-starting after proving no incumbent; reuse durable intent.
+    Automatic,
+    /// Caller already captured a live restart decision; `None` means defaults.
+    Exact,
 }
 
 fn ensure_daemon_with_spawn_lock_impl(
     db_path: &Path,
     config_path: Option<&Path>,
     spawn_lock: &SpawnLock,
-    attest_existing: bool,
+    selection: ColdStartSelection,
 ) -> Result<PathBuf> {
     let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
     anyhow::ensure!(
@@ -470,13 +494,20 @@ fn ensure_daemon_with_spawn_lock_impl(
     );
     let sock = nestweaver_daemon::lifecycle::socket_path(&instance_id);
     let pidfile = nestweaver_daemon::lifecycle::pidfile_path(&instance_id);
+    let restart_config = match selection {
+        ColdStartSelection::Automatic => {
+            crate::RestartConfig::for_automatic_cold_start(db_path, config_path)?
+        }
+        ColdStartSelection::Exact => crate::RestartConfig::for_cold_start(config_path)?,
+    };
 
     // Re-check: another client may have started the daemon while we waited for the spawn-lock.
     if socket_accepts_connections(&sock) {
         debug!("daemon started by a concurrent client while awaiting spawn lock");
-        if attest_existing && let Some(config_path) = config_path {
-            attest_requested_config_for_running_daemon(db_path, config_path)?;
-        }
+        // The winner is not trusted merely because it accepted a Unix
+        // connection. It must attest the same automatic/captured config plan
+        // before this contender releases the transaction lock.
+        wait_for_daemon_ready(db_path, None, &restart_config)?;
         return Ok(sock);
     }
 
@@ -487,7 +518,7 @@ fn ensure_daemon_with_spawn_lock_impl(
     let stale_pid = read_pid(&pidfile);
 
     // Spawn the daemon as a detached child.
-    spawn_daemon(db_path, config_path, spawn_lock)?;
+    spawn_daemon(db_path, restart_config.as_path(), spawn_lock)?;
 
     // Poll until the socket accepts connections, then release the spawn-lock so the next
     // waiter's re-check observes a ready daemon instead of spawning another.
@@ -495,7 +526,7 @@ fn ensure_daemon_with_spawn_lock_impl(
     // Watch the pidfile here: this is the one path where the daemon we are
     // waiting on was just spawned by us, so a process that has already exited
     // means it will never bind and there is nothing to wait for.
-    let waited = wait_for_socket_watching(&sock, Some(&pidfile), stale_pid);
+    let waited = wait_for_daemon_ready(db_path, stale_pid, &restart_config);
     waited?;
 
     info!("daemon started, socket at {}", sock.display());
@@ -657,7 +688,7 @@ const DEFAULT_DAEMON_BOOT_TIMEOUT_SECS: u64 = 30;
 /// Resolve the boot ceiling, clamped to 1..=600s. An unparseable or
 /// out-of-range value falls back to the default rather than failing the
 /// command — this is a patience knob, not a correctness input.
-fn daemon_boot_timeout() -> Duration {
+pub fn daemon_boot_timeout() -> Duration {
     std::env::var(DAEMON_BOOT_TIMEOUT_ENV)
         .ok()
         .and_then(|raw| raw.trim().parse::<u64>().ok())
@@ -666,6 +697,25 @@ fn daemon_boot_timeout() -> Duration {
             || Duration::from_secs(DEFAULT_DAEMON_BOOT_TIMEOUT_SECS),
             Duration::from_secs,
         )
+}
+
+fn wait_for_daemon_ready(
+    db_path: &Path,
+    ignore_pid: Option<i32>,
+    expected_config: &crate::RestartConfig,
+) -> Result<()> {
+    let timeout = daemon_boot_timeout();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("create runtime for daemon readiness")?;
+    runtime.block_on(crate::DaemonClient::wait_ready(
+        db_path,
+        timeout,
+        ignore_pid,
+        expected_config,
+    ))?;
+    Ok(())
 }
 
 /// Poll for the socket to accept connections with exponential backoff.
@@ -796,6 +846,26 @@ credential_method = "gh"
         )
         .unwrap();
         path
+    }
+
+    #[test]
+    fn explicit_config_is_validated_before_runtime_or_lock_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        let malformed = dir.path().join("malformed.toml");
+        fs::write(&malformed, "instance_id = [broken").unwrap();
+        let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(&db);
+        let runtime = nestweaver_daemon::lifecycle::runtime_dir(&instance_id);
+        let _ = fs::remove_dir_all(&runtime);
+
+        let error = ensure_daemon(&db, Some(&malformed)).unwrap_err();
+        let message = format!("{error:#}");
+        assert!(message.contains("invalid --config"), "{message}");
+        assert!(message.contains("malformed.toml"), "{message}");
+        assert!(
+            !runtime.exists(),
+            "bad explicit config must fail before runtime-dir/pidfile mutation"
+        );
     }
 
     #[test]

--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -54,6 +54,53 @@ impl RestartConfig {
             None => Ok(Self::CompiledDefaults),
         }
     }
+
+    /// Select configuration for an automatic cold start.
+    ///
+    /// Explicit caller intent wins. Otherwise the last configured daemon that
+    /// reached readiness is reused. Only genuine record absence selects
+    /// compiled defaults; corrupt, unsafe, or now-invalid persisted intent
+    /// fails closed because it controls identity and authorization.
+    pub fn for_automatic_cold_start(
+        db_path: &Path,
+        explicit_config: Option<&Path>,
+    ) -> Result<Self> {
+        if let Some(path) = explicit_config {
+            return validate_restart_config(path).map(Self::Configured);
+        }
+
+        let record = match nestweaver_daemon::lifecycle::read_last_successful_config(db_path) {
+            Ok(record) => record,
+            Err(nestweaver_daemon::lifecycle::LastSuccessfulConfigError::Absent { .. }) => {
+                return Ok(Self::CompiledDefaults);
+            }
+            Err(error) => {
+                anyhow::bail!(
+                    "cannot honor persisted daemon configuration for {}: {error}. \
+                     To deliberately reset this database to compiled defaults, run \
+                     `nestweaver daemon --db {} start`",
+                    db_path.display(),
+                    db_path.display()
+                );
+            }
+        };
+        let recorded = PathBuf::from(&record.config_path);
+        let canonical = validate_restart_config(&recorded).with_context(|| {
+            format!(
+                "persisted daemon config {} for {} is no longer usable; automatic startup refuses to fall back to compiled defaults. To deliberately reset, run `nestweaver daemon --db {} start`",
+                recorded.display(),
+                db_path.display(),
+                db_path.display()
+            )
+        })?;
+        anyhow::ensure!(
+            canonical == recorded,
+            "persisted daemon config path is not canonical: {}. To deliberately reset, run `nestweaver daemon --db {} start`",
+            recorded.display(),
+            db_path.display()
+        );
+        Ok(Self::Configured(canonical))
+    }
 }
 
 #[derive(Debug)]
@@ -735,6 +782,97 @@ impl DaemonClient {
             tokio::time::sleep(delay).await;
             delay = (delay * 2).min(max_delay);
         }
+    }
+
+    /// Wait for a just-spawned daemon using one end-to-end deadline budget.
+    ///
+    /// Connection establishment, gRPC health, pidfile ownership, and live
+    /// effective-config attestation all fit inside `timeout`. `ignore_pid` is
+    /// the unowned pidfile value observed before spawn and must not be mistaken
+    /// for the replacement dying before it has rewritten the pidfile.
+    pub async fn wait_ready(
+        db_path: &Path,
+        timeout: std::time::Duration,
+        ignore_pid: Option<i32>,
+        expected_config: &RestartConfig,
+    ) -> Result<nestweaver_proto::HealthCheckResponse> {
+        let started = std::time::Instant::now();
+        let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
+        let pidfile = nestweaver_daemon::lifecycle::pidfile_path(&instance_id);
+        let mut delay = std::time::Duration::from_millis(50);
+        let max_delay = std::time::Duration::from_millis(500);
+
+        loop {
+            let remaining = timeout.saturating_sub(started.elapsed());
+            if remaining.is_zero() {
+                break;
+            }
+
+            match tokio::time::timeout(remaining, Self::connect_existing(db_path)).await {
+                Ok(Ok(mut client)) => {
+                    let remaining = timeout.saturating_sub(started.elapsed());
+                    match tokio::time::timeout(remaining, client.health_check()).await {
+                        Ok(Ok(health)) => {
+                            // Health is the externally visible readiness
+                            // boundary. By contract, durable configured intent
+                            // and the live binding are already published.
+                            if started.elapsed() >= timeout {
+                                break;
+                            }
+                            let _owned = open_verified_live_pidfile(&instance_id, health.pid)?;
+                            let binding = nestweaver_daemon::lifecycle::read_effective_config_binding_for_verified_pid(
+                                &instance_id,
+                                health.pid,
+                            )?;
+                            verify_replacement_evidence(
+                                &instance_id,
+                                &health,
+                                expected_config,
+                                binding,
+                            )?;
+                            if started.elapsed() >= timeout {
+                                break;
+                            }
+                            return Ok(health);
+                        }
+                        Ok(Err(error)) => tracing::debug!(
+                            "wait_ready: daemon connected but health is not ready: {error:#}"
+                        ),
+                        Err(_) => break,
+                    }
+                }
+                Ok(Err(error)) => {
+                    tracing::debug!("wait_ready: daemon not connectable yet: {error:#}")
+                }
+                Err(_) => break,
+            }
+
+            if let Some(pid) = autostart::read_pid(&pidfile)
+                && Some(pid) != ignore_pid
+                && !autostart::is_process_alive(pid)
+            {
+                anyhow::bail!(
+                    "daemon process {pid} exited before becoming healthy for {}. Check the daemon logs: {}",
+                    db_path.display(),
+                    nestweaver_daemon::lifecycle::log_hint(&instance_id)
+                );
+            }
+
+            let remaining = timeout.saturating_sub(started.elapsed());
+            if remaining.is_zero() {
+                break;
+            }
+            tokio::time::sleep(delay.min(remaining)).await;
+            delay = (delay * 2).min(max_delay);
+        }
+
+        anyhow::bail!(
+            "daemon for {} did not become healthy and attest its effective configuration within {:.1}s. Check the daemon logs: {}. If startup is simply slow, raise {}",
+            db_path.display(),
+            timeout.as_secs_f64(),
+            nestweaver_daemon::lifecycle::log_hint(&instance_id),
+            autostart::DAEMON_BOOT_TIMEOUT_ENV
+        )
     }
 
     /// Returns a reference to the underlying gRPC client.

--- a/crates/nestweaver-daemon/src/lifecycle.rs
+++ b/crates/nestweaver-daemon/src/lifecycle.rs
@@ -7,7 +7,12 @@ use serde::{Deserialize, Serialize};
 pub const EFFECTIVE_CONFIG_BINDING_VERSION: u32 = 1;
 const EFFECTIVE_CONFIG_BINDING_FILE: &str = "effective-config.json";
 const EFFECTIVE_CONFIG_BINDING_MAX_BYTES: u64 = 64 * 1024;
+pub const LAST_SUCCESSFUL_CONFIG_VERSION: u32 = 1;
+const LAST_SUCCESSFUL_CONFIG_FILE: &str = "last-successful-config.json";
+const LAST_SUCCESSFUL_CONFIG_MAX_BYTES: u64 = 64 * 1024;
 static EFFECTIVE_CONFIG_TEMP_SEQUENCE: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+static LAST_SUCCESSFUL_CONFIG_TEMP_SEQUENCE: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
 fn effective_config_temp_path(parent: &Path, sequence: u64) -> PathBuf {
@@ -16,6 +21,205 @@ fn effective_config_temp_path(parent: &Path, sequence: u64) -> PathBuf {
         std::process::id(),
         sequence
     ))
+}
+
+fn last_successful_config_temp_path(parent: &Path, sequence: u64) -> PathBuf {
+    parent.join(format!(
+        ".{LAST_SUCCESSFUL_CONFIG_FILE}.{}.{}.tmp",
+        std::process::id(),
+        sequence
+    ))
+}
+
+fn last_successful_config_backup_path(parent: &Path, sequence: u64) -> PathBuf {
+    parent.join(format!(
+        ".{LAST_SUCCESSFUL_CONFIG_FILE}.{}.{}.bak",
+        std::process::id(),
+        sequence
+    ))
+}
+
+/// Full, stable identity of a database path for persistent local state.
+///
+/// Unlike [`instance_id_from_db_path`], this is never truncated for a unix
+/// socket limit. Database contents are deliberately excluded: replacing or
+/// updating the database at the same canonical path keeps the same local
+/// startup intent.
+pub fn database_path_fingerprint(db_path: &Path) -> String {
+    use sha2::{Digest, Sha256};
+
+    let canonical = canonical_db_path(db_path);
+    let canonical = if canonical.is_absolute() {
+        canonical
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(&canonical))
+            .unwrap_or(canonical)
+    };
+    let mut hasher = Sha256::new();
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        hasher.update(canonical.as_os_str().as_bytes());
+    }
+    #[cfg(not(unix))]
+    hasher.update(canonical.to_string_lossy().as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// Daemon-owned persistent startup intent for one canonical database path.
+///
+/// This is intentionally separate from [`EffectiveConfigBinding`]: the latter
+/// is live PID attestation and is removed on exit, while this record survives
+/// idle exit and crashes so a later automatic cold start preserves identity
+/// and authorization.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LastSuccessfulConfig {
+    pub version: u32,
+    pub database_fingerprint: String,
+    pub config_path: String,
+}
+
+impl LastSuccessfulConfig {
+    pub fn new(db_path: &Path, config_path: &Path) -> Result<Self, LastSuccessfulConfigError> {
+        let record_path = last_successful_config_path(db_path);
+        let canonical = std::fs::canonicalize(config_path).map_err(|source| {
+            LastSuccessfulConfigError::Read {
+                path: config_path.to_path_buf(),
+                source,
+            }
+        })?;
+        let config_path = canonical
+            .to_str()
+            .ok_or_else(|| LastSuccessfulConfigError::Unsafe {
+                path: record_path,
+                reason: format!(
+                    "canonical config path is not valid UTF-8: {}",
+                    canonical.display()
+                ),
+            })?;
+        Ok(Self {
+            version: LAST_SUCCESSFUL_CONFIG_VERSION,
+            database_fingerprint: database_path_fingerprint(db_path),
+            config_path: config_path.to_string(),
+        })
+    }
+}
+
+#[derive(Debug)]
+pub enum LastSuccessfulConfigError {
+    Absent {
+        path: PathBuf,
+    },
+    Read {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    Corrupt {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    Unsafe {
+        path: PathBuf,
+        reason: String,
+    },
+    TooLarge {
+        path: PathBuf,
+        size: u64,
+        max: u64,
+    },
+    UnsupportedVersion {
+        path: PathBuf,
+        found: u32,
+        supported: u32,
+    },
+    FingerprintMismatch {
+        path: PathBuf,
+        expected: String,
+        found: String,
+    },
+    Serialize {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    Write {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+impl std::fmt::Display for LastSuccessfulConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Absent { path } => write!(
+                f,
+                "last-successful-config record is absent: {}",
+                path.display()
+            ),
+            Self::Read { path, source } => write!(
+                f,
+                "failed to read last-successful-config record {}: {source}",
+                path.display()
+            ),
+            Self::Corrupt { path, source } => write!(
+                f,
+                "last-successful-config record {} is corrupt: {source}",
+                path.display()
+            ),
+            Self::Unsafe { path, reason } => write!(
+                f,
+                "last-successful-config record {} is unsafe: {reason}",
+                path.display()
+            ),
+            Self::TooLarge { path, size, max } => write!(
+                f,
+                "last-successful-config record {} is too large ({size} bytes; maximum {max})",
+                path.display()
+            ),
+            Self::UnsupportedVersion {
+                path,
+                found,
+                supported,
+            } => write!(
+                f,
+                "last-successful-config record {} has unsupported version {found} (supported: {supported})",
+                path.display()
+            ),
+            Self::FingerprintMismatch {
+                path,
+                expected,
+                found,
+            } => write!(
+                f,
+                "last-successful-config record {} belongs to database fingerprint {found}, expected {expected}",
+                path.display()
+            ),
+            Self::Serialize { path, source } => write!(
+                f,
+                "failed to serialize last-successful-config record {}: {source}",
+                path.display()
+            ),
+            Self::Write { path, source } => write!(
+                f,
+                "failed to publish last-successful-config record {}: {source}",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LastSuccessfulConfigError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Read { source, .. } | Self::Write { source, .. } => Some(source),
+            Self::Corrupt { source, .. } | Self::Serialize { source, .. } => Some(source),
+            Self::Absent { .. }
+            | Self::Unsafe { .. }
+            | Self::TooLarge { .. }
+            | Self::UnsupportedVersion { .. }
+            | Self::FingerprintMismatch { .. } => None,
+        }
+    }
 }
 
 /// The configuration source a live daemon actually uses.
@@ -350,6 +554,95 @@ pub fn effective_config_binding_path(instance_id: &str) -> PathBuf {
     runtime_dir(instance_id).join(EFFECTIVE_CONFIG_BINDING_FILE)
 }
 
+fn persistent_state_root() -> PathBuf {
+    dirs::state_dir()
+        .unwrap_or_else(|| {
+            dirs::home_dir()
+                .unwrap_or_else(|| PathBuf::from("/tmp"))
+                .join(".local/state")
+        })
+        .join("nestweaver")
+}
+
+/// Private state directory for one database's persistent startup intent.
+pub fn last_successful_config_dir(db_path: &Path) -> PathBuf {
+    persistent_state_root()
+        .join("config-intent")
+        .join(database_path_fingerprint(db_path))
+}
+
+/// Path to the daemon-owned persistent startup-intent record.
+pub fn last_successful_config_path(db_path: &Path) -> PathBuf {
+    last_successful_config_dir(db_path).join(LAST_SUCCESSFUL_CONFIG_FILE)
+}
+
+#[cfg(unix)]
+fn verify_persistent_config_dir_for_owner(dir: &Path, expected_uid: u32) -> std::io::Result<()> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let metadata = std::fs::symlink_metadata(dir)?;
+    if !metadata.file_type().is_dir() || metadata.file_type().is_symlink() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "persistent config state path {} is not a real directory",
+                dir.display()
+            ),
+        ));
+    }
+    if metadata.uid() != expected_uid {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "persistent config state directory {} is owned by uid {} (expected {})",
+                dir.display(),
+                metadata.uid(),
+                expected_uid
+            ),
+        ));
+    }
+    let mode = metadata.permissions().mode() & 0o777;
+    if mode != 0o700 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "persistent config state directory {} has unsafe mode {mode:04o} (expected 0700)",
+                dir.display()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn secure_persistent_config_dir(dir: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        match std::fs::symlink_metadata(dir) {
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                std::fs::create_dir_all(dir)?;
+            }
+            Err(error) => return Err(error),
+        }
+        let metadata = std::fs::symlink_metadata(dir)?;
+        let expected_uid = unsafe { libc::geteuid() };
+        if metadata.file_type().is_dir()
+            && !metadata.file_type().is_symlink()
+            && metadata.uid() == expected_uid
+            && metadata.permissions().mode() & 0o777 != 0o700
+        {
+            std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))?;
+        }
+        verify_persistent_config_dir_for_owner(dir, expected_uid)
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(dir)
+    }
+}
+
 #[cfg(unix)]
 fn verify_effective_config_runtime_dir_for_owner(
     dir: &Path,
@@ -453,7 +746,7 @@ pub fn write_effective_config_binding(
         }
     })?;
 
-    let (temp_path, mut file) = loop {
+    let (temp_path, mut file, sequence) = loop {
         let sequence =
             EFFECTIVE_CONFIG_TEMP_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let candidate = effective_config_temp_path(parent, sequence);
@@ -465,7 +758,7 @@ pub fn write_effective_config_binding(
             options.mode(0o600);
         }
         match options.open(&candidate) {
-            Ok(file) => break (candidate, file),
+            Ok(file) => break (candidate, file, sequence),
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
             Err(source) => {
                 return Err(EffectiveConfigBindingError::Write { path, source });
@@ -637,16 +930,288 @@ pub fn remove_effective_config_binding(instance_id: &str) -> std::io::Result<()>
     }
 }
 
+/// Atomically publish the configured path that most recently reached daemon
+/// readiness for this database.
+pub fn write_last_successful_config(
+    db_path: &Path,
+    config_path: &Path,
+) -> Result<LastSuccessfulConfig, LastSuccessfulConfigError> {
+    let path = last_successful_config_path(db_path);
+    let record = LastSuccessfulConfig::new(db_path, config_path)?;
+    let bytes = serde_json::to_vec_pretty(&record).map_err(|source| {
+        LastSuccessfulConfigError::Serialize {
+            path: path.clone(),
+            source,
+        }
+    })?;
+    let parent = path
+        .parent()
+        .expect("last-successful-config path always has a state directory");
+    secure_persistent_config_dir(parent).map_err(|source| LastSuccessfulConfigError::Write {
+        path: path.clone(),
+        source,
+    })?;
+
+    let (temp_path, mut file, sequence) = loop {
+        let sequence =
+            LAST_SUCCESSFUL_CONFIG_TEMP_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let candidate = last_successful_config_temp_path(parent, sequence);
+        let mut options = std::fs::OpenOptions::new();
+        options.create_new(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        match options.open(&candidate) {
+            Ok(file) => break (candidate, file, sequence),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(source) => return Err(LastSuccessfulConfigError::Write { path, source }),
+        }
+    };
+
+    // Preserve the previous durable inode across any post-rename publication
+    // error. A hard-link backup is local to this private directory and avoids
+    // copying or parsing the old contents, so even a corrupt-but-safe record
+    // can be replaced explicitly without losing the last known bytes if the
+    // new directory entry cannot be synced.
+    let backup_path = match std::fs::symlink_metadata(&path) {
+        Ok(metadata) => {
+            if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+                let _ = std::fs::remove_file(&temp_path);
+                return Err(LastSuccessfulConfigError::Unsafe {
+                    path,
+                    reason: "existing record is not a regular non-symlink file".to_string(),
+                });
+            }
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::{MetadataExt, PermissionsExt};
+                let expected_owner = unsafe { libc::geteuid() };
+                let mode = metadata.permissions().mode() & 0o777;
+                if metadata.uid() != expected_owner || mode != 0o600 {
+                    let _ = std::fs::remove_file(&temp_path);
+                    return Err(LastSuccessfulConfigError::Unsafe {
+                        path,
+                        reason: format!(
+                            "existing record owner/mode is unsafe (uid {}, mode {mode:04o})",
+                            metadata.uid()
+                        ),
+                    });
+                }
+            }
+            let backup = last_successful_config_backup_path(parent, sequence);
+            let link_result = match std::fs::hard_link(&path, &backup) {
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    // A process can die after restoring/publishing the
+                    // authoritative destination but before removing its
+                    // private backup. The destination is authoritative here;
+                    // discard only this colliding internal artifact and retry.
+                    std::fs::remove_file(&backup).and_then(|()| std::fs::hard_link(&path, &backup))
+                }
+                result => result,
+            };
+            if let Err(source) = link_result {
+                let _ = std::fs::remove_file(&temp_path);
+                return Err(LastSuccessfulConfigError::Write {
+                    path: path.clone(),
+                    source,
+                });
+            }
+            Some(backup)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(source) => {
+            let _ = std::fs::remove_file(&temp_path);
+            return Err(LastSuccessfulConfigError::Read { path, source });
+        }
+    };
+
+    let mut published = false;
+    let write_result = (|| -> std::io::Result<()> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        }
+        use std::io::Write;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        std::fs::rename(&temp_path, &path)?;
+        published = true;
+        std::fs::File::open(parent)?.sync_all()?;
+        Ok(())
+    })();
+    if let Err(source) = write_result {
+        if published {
+            let _ = std::fs::remove_file(&path);
+            if let Some(backup) = &backup_path {
+                let _ = std::fs::rename(backup, &path);
+                let _ = std::fs::File::open(parent).and_then(|directory| directory.sync_all());
+            }
+        } else {
+            let _ = std::fs::remove_file(&temp_path);
+        }
+        return Err(LastSuccessfulConfigError::Write { path, source });
+    }
+    if let Some(backup) = backup_path {
+        let _ = std::fs::remove_file(backup);
+        let _ = std::fs::File::open(parent).and_then(|directory| directory.sync_all());
+    }
+    Ok(record)
+}
+
+/// Read and fully validate the persistent startup intent for `db_path`.
+pub fn read_last_successful_config(
+    db_path: &Path,
+) -> Result<LastSuccessfulConfig, LastSuccessfulConfigError> {
+    let path = last_successful_config_path(db_path);
+    let parent = path
+        .parent()
+        .expect("last-successful-config path always has a state directory");
+    #[cfg(unix)]
+    if let Err(error) = verify_persistent_config_dir_for_owner(parent, unsafe { libc::geteuid() }) {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            return Err(LastSuccessfulConfigError::Absent { path });
+        }
+        return Err(LastSuccessfulConfigError::Unsafe {
+            path,
+            reason: error.to_string(),
+        });
+    }
+
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    let file = match options.open(&path) {
+        Ok(file) => file,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+            return Err(LastSuccessfulConfigError::Absent { path });
+        }
+        #[cfg(unix)]
+        Err(source) if source.raw_os_error() == Some(libc::ELOOP) => {
+            return Err(LastSuccessfulConfigError::Unsafe {
+                path,
+                reason: "symbolic links are not accepted".to_string(),
+            });
+        }
+        Err(source) => return Err(LastSuccessfulConfigError::Read { path, source }),
+    };
+    let metadata = file
+        .metadata()
+        .map_err(|source| LastSuccessfulConfigError::Read {
+            path: path.clone(),
+            source,
+        })?;
+    if !metadata.file_type().is_file() {
+        return Err(LastSuccessfulConfigError::Unsafe {
+            path,
+            reason: "record is not a regular file".to_string(),
+        });
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        let owner = metadata.uid();
+        let expected_owner = unsafe { libc::geteuid() };
+        if owner != expected_owner {
+            return Err(LastSuccessfulConfigError::Unsafe {
+                path,
+                reason: format!("owned by uid {owner}, expected uid {expected_owner}"),
+            });
+        }
+        let mode = metadata.permissions().mode() & 0o777;
+        if mode != 0o600 {
+            return Err(LastSuccessfulConfigError::Unsafe {
+                path,
+                reason: format!("mode {mode:04o}, expected 0600"),
+            });
+        }
+    }
+    if metadata.len() > LAST_SUCCESSFUL_CONFIG_MAX_BYTES {
+        return Err(LastSuccessfulConfigError::TooLarge {
+            path,
+            size: metadata.len(),
+            max: LAST_SUCCESSFUL_CONFIG_MAX_BYTES,
+        });
+    }
+    use std::io::Read;
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(LAST_SUCCESSFUL_CONFIG_MAX_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|source| LastSuccessfulConfigError::Read {
+            path: path.clone(),
+            source,
+        })?;
+    if bytes.len() as u64 > LAST_SUCCESSFUL_CONFIG_MAX_BYTES {
+        return Err(LastSuccessfulConfigError::TooLarge {
+            path,
+            size: bytes.len() as u64,
+            max: LAST_SUCCESSFUL_CONFIG_MAX_BYTES,
+        });
+    }
+    let record: LastSuccessfulConfig =
+        serde_json::from_slice(&bytes).map_err(|source| LastSuccessfulConfigError::Corrupt {
+            path: path.clone(),
+            source,
+        })?;
+    if record.version != LAST_SUCCESSFUL_CONFIG_VERSION {
+        return Err(LastSuccessfulConfigError::UnsupportedVersion {
+            path,
+            found: record.version,
+            supported: LAST_SUCCESSFUL_CONFIG_VERSION,
+        });
+    }
+    let expected = database_path_fingerprint(db_path);
+    if record.database_fingerprint != expected {
+        return Err(LastSuccessfulConfigError::FingerprintMismatch {
+            path,
+            expected,
+            found: record.database_fingerprint,
+        });
+    }
+    if record.config_path.is_empty() || !Path::new(&record.config_path).is_absolute() {
+        return Err(LastSuccessfulConfigError::Unsafe {
+            path,
+            reason: "config path must be a non-empty absolute path".to_string(),
+        });
+    }
+    Ok(record)
+}
+
+/// Clear persistent configured intent after a manual default start has become
+/// healthy and its live default provenance has been attested.
+pub fn remove_last_successful_config(db_path: &Path) -> Result<(), LastSuccessfulConfigError> {
+    let path = last_successful_config_path(db_path);
+    let parent = path
+        .parent()
+        .expect("last-successful-config path always has a state directory");
+    #[cfg(unix)]
+    if let Err(error) = verify_persistent_config_dir_for_owner(parent, unsafe { libc::geteuid() }) {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            return Ok(());
+        }
+        return Err(LastSuccessfulConfigError::Unsafe {
+            path,
+            reason: error.to_string(),
+        });
+    }
+    match std::fs::remove_file(&path) {
+        Ok(()) => std::fs::File::open(parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|source| LastSuccessfulConfigError::Write { path, source }),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(LastSuccessfulConfigError::Write { path, source }),
+    }
+}
+
 /// Directory for daemon log files.
 pub fn log_dir(instance_id: &str) -> PathBuf {
-    dirs::state_dir()
-        .unwrap_or_else(|| {
-            dirs::home_dir()
-                .unwrap_or_else(|| PathBuf::from("/tmp"))
-                .join(".local/state")
-        })
-        .join("nestweaver")
-        .join(instance_id)
+    persistent_state_root().join(instance_id)
 }
 
 /// Path to the daemon log file.
@@ -813,6 +1378,200 @@ mod tests {
             Ok(value) => value,
             Err(panic) => std::panic::resume_unwind(panic),
         }
+    }
+
+    fn with_xdg_state<T>(root: &Path, test: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let previous = std::env::var_os("XDG_STATE_HOME");
+        unsafe {
+            std::env::set_var("XDG_STATE_HOME", root);
+        }
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(test));
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var("XDG_STATE_HOME", value),
+                None => std::env::remove_var("XDG_STATE_HOME"),
+            }
+        }
+        match result {
+            Ok(value) => value,
+            Err(panic) => std::panic::resume_unwind(panic),
+        }
+    }
+
+    #[test]
+    fn last_successful_config_roundtrips_with_full_path_identity() {
+        let temp = tempfile::tempdir().unwrap();
+        with_xdg_state(temp.path(), || {
+            let db = temp.path().join("db").join("brain.lbug");
+            std::fs::create_dir_all(db.parent().unwrap()).unwrap();
+            let config = temp.path().join("instance.toml");
+            std::fs::write(&config, "instance_id = \"test\"\n").unwrap();
+
+            let written = write_last_successful_config(&db, &config).unwrap();
+            let read = read_last_successful_config(&db).unwrap();
+            assert_eq!(read, written);
+            assert_eq!(read.database_fingerprint.len(), 64);
+            assert_eq!(
+                Path::new(&read.config_path),
+                std::fs::canonicalize(&config).unwrap()
+            );
+            assert!(
+                last_successful_config_path(&db)
+                    .to_string_lossy()
+                    .contains(&read.database_fingerprint),
+                "the state path itself must use the full fingerprint"
+            );
+
+            let replacement = temp.path().join("replacement.toml");
+            std::fs::write(&replacement, "instance_id = \"replacement\"\n").unwrap();
+            write_last_successful_config(&db, &replacement).unwrap();
+            let entries = std::fs::read_dir(last_successful_config_dir(&db))
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap();
+            assert_eq!(entries.len(), 1, "replacement left a temp/backup artifact");
+            assert_eq!(entries[0].file_name(), LAST_SUCCESSFUL_CONFIG_FILE);
+        });
+    }
+
+    #[test]
+    fn last_successful_config_is_isolated_and_survives_live_binding_cleanup() {
+        let temp = tempfile::tempdir().unwrap();
+        with_xdg_state(temp.path(), || {
+            let config = temp.path().join("instance.toml");
+            std::fs::write(&config, "instance_id = \"test\"\n").unwrap();
+            let first = temp.path().join("first.lbug");
+            let second = temp.path().join("second.lbug");
+            write_last_successful_config(&first, &config).unwrap();
+            write_last_successful_config(&second, &config).unwrap();
+            assert_ne!(
+                last_successful_config_path(&first),
+                last_successful_config_path(&second)
+            );
+
+            let instance = instance_id_from_db_path(&first);
+            let _ = remove_effective_config_binding(&instance);
+            assert!(read_last_successful_config(&first).is_ok());
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn last_successful_config_enforces_private_modes_and_fingerprint() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        with_xdg_state(temp.path(), || {
+            let db = temp.path().join("brain.lbug");
+            let config = temp.path().join("instance.toml");
+            std::fs::write(&config, "instance_id = \"test\"\n").unwrap();
+            write_last_successful_config(&db, &config).unwrap();
+            let path = last_successful_config_path(&db);
+            let parent = path.parent().unwrap();
+            assert_eq!(
+                std::fs::metadata(parent).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+            assert_eq!(
+                std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+
+            let mut record = read_last_successful_config(&db).unwrap();
+            record.database_fingerprint = "0".repeat(64);
+            std::fs::write(&path, serde_json::to_vec(&record).unwrap()).unwrap();
+            assert!(matches!(
+                read_last_successful_config(&db),
+                Err(LastSuccessfulConfigError::FingerprintMismatch { .. })
+            ));
+
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
+            assert!(matches!(
+                read_last_successful_config(&db),
+                Err(LastSuccessfulConfigError::Unsafe { .. })
+            ));
+        });
+    }
+
+    #[test]
+    fn last_successful_config_remove_is_idempotent() {
+        let temp = tempfile::tempdir().unwrap();
+        with_xdg_state(temp.path(), || {
+            let db = temp.path().join("brain.lbug");
+            let config = temp.path().join("instance.toml");
+            std::fs::write(&config, "instance_id = \"test\"\n").unwrap();
+            write_last_successful_config(&db, &config).unwrap();
+            remove_last_successful_config(&db).unwrap();
+            remove_last_successful_config(&db).unwrap();
+            assert!(matches!(
+                read_last_successful_config(&db),
+                Err(LastSuccessfulConfigError::Absent { .. })
+            ));
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn last_successful_config_rejects_corrupt_version_oversize_and_symlink() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        with_xdg_state(temp.path(), || {
+            let db = temp.path().join("brain.lbug");
+            let config = temp.path().join("instance.toml");
+            std::fs::write(&config, "instance_id = \"test\"\n").unwrap();
+            write_last_successful_config(&db, &config).unwrap();
+            let path = last_successful_config_path(&db);
+
+            std::fs::write(&path, b"not-json").unwrap();
+            assert!(matches!(
+                read_last_successful_config(&db),
+                Err(LastSuccessfulConfigError::Corrupt { .. })
+            ));
+
+            let record = LastSuccessfulConfig::new(&db, &config).unwrap();
+            let unsupported = LastSuccessfulConfig {
+                version: LAST_SUCCESSFUL_CONFIG_VERSION + 1,
+                ..record
+            };
+            std::fs::write(&path, serde_json::to_vec(&unsupported).unwrap()).unwrap();
+            assert!(matches!(
+                read_last_successful_config(&db),
+                Err(LastSuccessfulConfigError::UnsupportedVersion { .. })
+            ));
+
+            std::fs::write(
+                &path,
+                vec![b' '; LAST_SUCCESSFUL_CONFIG_MAX_BYTES as usize + 1],
+            )
+            .unwrap();
+            assert!(matches!(
+                read_last_successful_config(&db),
+                Err(LastSuccessfulConfigError::TooLarge { .. })
+            ));
+
+            std::fs::remove_file(&path).unwrap();
+            let target = temp.path().join("target.json");
+            std::fs::write(&target, b"{}").unwrap();
+            std::os::unix::fs::symlink(&target, &path).unwrap();
+            assert!(matches!(
+                read_last_successful_config(&db),
+                Err(LastSuccessfulConfigError::Unsafe { .. })
+            ));
+
+            std::fs::remove_file(&path).unwrap();
+            std::fs::write(&path, serde_json::to_vec(&unsupported).unwrap()).unwrap();
+            std::fs::set_permissions(
+                path.parent().unwrap(),
+                std::fs::Permissions::from_mode(0o755),
+            )
+            .unwrap();
+            assert!(matches!(
+                read_last_successful_config(&db),
+                Err(LastSuccessfulConfigError::Unsafe { .. })
+            ));
+        });
     }
 
     #[test]

--- a/crates/nestweaver-daemon/src/lifecycle.rs
+++ b/crates/nestweaver-daemon/src/lifecycle.rs
@@ -64,7 +64,13 @@ pub fn database_path_fingerprint(db_path: &Path) -> String {
     }
     #[cfg(not(unix))]
     hasher.update(canonical.to_string_lossy().as_bytes());
-    format!("{:x}", hasher.finalize())
+    let digest = hasher.finalize();
+    let mut fingerprint = String::with_capacity(digest.len() * 2);
+    use std::fmt::Write as _;
+    for byte in digest {
+        write!(&mut fingerprint, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    fingerprint
 }
 
 /// Daemon-owned persistent startup intent for one canonical database path.
@@ -746,7 +752,7 @@ pub fn write_effective_config_binding(
         }
     })?;
 
-    let (temp_path, mut file, sequence) = loop {
+    let (temp_path, mut file) = loop {
         let sequence =
             EFFECTIVE_CONFIG_TEMP_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let candidate = effective_config_temp_path(parent, sequence);
@@ -758,7 +764,7 @@ pub fn write_effective_config_binding(
             options.mode(0o600);
         }
         match options.open(&candidate) {
-            Ok(file) => break (candidate, file, sequence),
+            Ok(file) => break (candidate, file),
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
             Err(source) => {
                 return Err(EffectiveConfigBindingError::Write { path, source });

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -87,23 +87,14 @@ fn list_contracts_impl(
         let repos = nestweaver_engine::list_repos(store, None)
             .map_err(|error| Status::internal(format!("list repositories: {error:#}")))?;
         let visible_repos: Vec<_> = repos
-            .iter()
+            .into_iter()
             .filter(|repo| repo_is_visible(&repo.uid))
             .collect();
-        // Preserve the direct CLI resolver's precedence: an exact UID must
-        // beat an earlier repo whose display name happens to equal that UID.
-        let repo = visible_repos
-            .iter()
-            .copied()
-            .find(|repo| repo.uid == filter)
-            .or_else(|| {
-                let needle = filter.to_lowercase();
-                visible_repos.iter().copied().find(|repo| {
-                    nestweaver_engine::repo_display_name(repo).to_lowercase() == needle
-                })
-            })
-            .ok_or_else(|| {
-                Status::invalid_argument(format!("no indexed repo matches --repo '{filter}'"))
+        let repo =
+            nestweaver_engine::resolve_repo_selector(&visible_repos, filter).map_err(|error| {
+                Status::invalid_argument(format!(
+                    "no indexed repo matches --repo '{filter}': {error}"
+                ))
             })?;
         Some(repo.uid.clone())
     } else {
@@ -4006,6 +3997,117 @@ impl NestWeaverDaemon for DaemonService {
                     let _ = tx.blocking_send(Ok(IndexProgress {
                         phase: Phase::Error as i32,
                         message: format!("IndexVault failed: {e:#}"),
+                        files_processed: 0,
+                        files_total: 0,
+                        symbols_found: 0,
+                    }));
+                }
+            }
+        });
+
+        Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
+            rx,
+        )))
+    }
+
+    type RefreshVaultSinceStream = ProgressStream;
+
+    async fn refresh_vault_since(
+        &self,
+        request: Request<RefreshVaultSinceRequest>,
+    ) -> Result<Response<Self::RefreshVaultSinceStream>, Status> {
+        if let Some(crate::auth::IsAdmin(false)) | None =
+            request.extensions().get::<crate::auth::IsAdmin>()
+        {
+            return Err(Status::permission_denied("admin token required"));
+        }
+        let req = request.into_inner();
+        let vault_path = PathBuf::from(&req.vault_path);
+        let vault_name = req.vault_name.clone();
+        let extra_patterns = req.extra_ignore_patterns.clone();
+        let instance_id =
+            resolve_effective_instance_id(&req.instance_id, &self.state.data_instance_id)?;
+        let since = std::time::UNIX_EPOCH
+            .checked_add(Duration::from_secs(req.since_unix_seconds))
+            .ok_or_else(|| Status::invalid_argument("since_unix_seconds is out of range"))?;
+        let state = self.state.clone();
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<IndexProgress, Status>>(16);
+        let guard = ConnectionGuard::write(&self.state);
+        let write_lock = self.state.write_mutex.clone();
+        tokio::task::spawn_blocking(move || {
+            let _write_lock = write_lock.blocking_lock();
+            let _guard = guard;
+            let _ = tx.blocking_send(Ok(IndexProgress {
+                phase: Phase::Discovering as i32,
+                message: format!(
+                    "Scanning vault {} for files modified since {}",
+                    vault_path.display(),
+                    req.since_unix_seconds
+                ),
+                files_processed: 0,
+                files_total: 0,
+                symbols_found: 0,
+            }));
+
+            match nestweaver_engine::index_markdown_directory_since_with_store_and_ignore(
+                &state.store,
+                &vault_path,
+                &instance_id,
+                &vault_name,
+                since,
+                &extra_patterns,
+            ) {
+                Ok(result) => {
+                    if let Some(ref tantivy) = state.tantivy
+                        && tantivy.has_writer()
+                    {
+                        if let Err(error) = tantivy.reindex_from_store(&state.store) {
+                            let _ = tx.blocking_send(Ok(IndexProgress {
+                                phase: Phase::Error as i32,
+                                message: format!(
+                                    "RefreshVaultSince committed graph changes but Tantivy rebuild failed: {error:#}"
+                                ),
+                                files_processed: result.files_checked as u64,
+                                files_total: result.files_checked as u64,
+                                symbols_found: result.headings_count as u64,
+                            }));
+                            return;
+                        }
+                    }
+                    let vault_uid = nestweaver_schema::vault_uid(
+                        &instance_id,
+                        &std::fs::canonicalize(&vault_path)
+                            .unwrap_or_else(|_| vault_path.clone())
+                            .to_string_lossy(),
+                    );
+                    if let Err(error) =
+                        nestweaver_engine::record_last_indexed_at(&state.db_path, &vault_uid)
+                    {
+                        tracing::warn!(%error, "failed to record incremental vault timestamp");
+                    }
+                    let _ = tx.blocking_send(Ok(IndexProgress {
+                        phase: Phase::Done as i32,
+                        message: format!(
+                            "Incremental refresh of vault '{}': checked {} file(s), updated {} note(s), dropped {} prior note(s), {} heading(s), {} section(s), {} tag(s), {} wikilink(s).",
+                            result.vault_name,
+                            result.files_checked,
+                            result.notes_updated,
+                            result.notes_deleted,
+                            result.headings_count,
+                            result.sections_count,
+                            result.tags_count,
+                            result.wikilinks_resolved,
+                        ),
+                        files_processed: result.files_checked as u64,
+                        files_total: result.files_checked as u64,
+                        symbols_found: result.headings_count as u64,
+                    }));
+                }
+                Err(error) => {
+                    let _ = tx.blocking_send(Ok(IndexProgress {
+                        phase: Phase::Error as i32,
+                        message: format!("RefreshVaultSince failed: {error:#}"),
                         files_processed: 0,
                         files_total: 0,
                         symbols_found: 0,
@@ -15424,6 +15526,7 @@ external_model = "unavailable-test-model"
         "WatchCode",
         "IndexRepo",
         "IndexVault",
+        "RefreshVaultSince",
         "RemoveRepo",
         "MergeInstance",
         // Previously UNGUARDED — the core of finding #10.
@@ -15535,6 +15638,7 @@ external_model = "unavailable-test-model"
             "ImpactAnalysis",
             "IndexRepo",
             "IndexVault",
+            "RefreshVaultSince",
             "Investigate",
             "InvestigateExpand",
             "InvestigateHydrate",

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -8341,6 +8341,7 @@ pub async fn run_server(
 
     let uds = tokio::net::UnixListener::bind(&sock_path)
         .with_context(|| format!("bind UDS: {}", sock_path.display()))?;
+
     // The line a stalled-boot investigation actually needs: how long the client
     // had to wait, and where it went.
     //
@@ -9474,6 +9475,23 @@ pub async fn run_server(
     // the load, and semantic search returns "model not loaded" until it completes. candle needs
     // the main thread for Metal, and this keeps cache resolution and model construction from
     // delaying the bind.
+    //
+    // Durable configured intent is published at this final readiness barrier:
+    // the authoritative store, authorization, listener, and all fallible
+    // pre-serve setup are complete, while no gRPC health request can yet be
+    // served. Optional embedding readiness is deliberately outside this
+    // barrier. Network `server` mode has no local cold-autostart lifecycle and
+    // therefore does not own this local UDS restart intent.
+    if server_opts.is_none()
+        && let Some(config_path) = config_path
+    {
+        lifecycle::write_last_successful_config(&db_path, config_path).with_context(|| {
+            format!(
+                "publish last successful config for daemon database {}",
+                db_path.display()
+            )
+        })?;
+    }
     let uds_serve = tokio::spawn(
         tonic::transport::Server::builder()
             .add_service(uds_svc)

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -7916,6 +7916,12 @@ pub async fn run_server(
         format!("remove stale effective-config binding for instance {instance_id}")
     })?;
 
+    // Parse explicit config before snapshot compatibility checks. Core-schema
+    // snapshots deliberately support configless replicas; extension snapshots
+    // require this config so their effective schema can be mediated.
+    let (instance_cfg, effective_config) =
+        load_daemon_instance_config(config_path, server_opts.is_some())?;
+
     // Snapshot replica: materialize the snapshot into a private working copy and
     // serve it read-only. `read_only` gates out the write RPCs (via the
     // `ReadOnlyGuard` transport layer) and the write machinery
@@ -7927,23 +7933,23 @@ pub async fn run_server(
         .is_some();
     let db_path = if let Some(snapshot_dir) = server_opts.as_ref().and_then(|o| o.snapshot.clone())
     {
-        let cfg = config_path.and_then(|p| nestweaver_engine::InstanceConfig::from_file(p).ok());
-        let (_, _, schema_hash) = nestweaver_engine::schema_hashes(cfg.as_ref());
-        let embedding_model = cfg
+        let schema_hash = instance_cfg
             .as_ref()
-            .map(|c| c.embedding.model_id.clone())
-            .unwrap_or_else(|| "unknown".to_string());
+            .map(|cfg| nestweaver_engine::schema_hashes(Some(cfg)).2);
+        let embedding_model = instance_cfg
+            .as_ref()
+            .map(|cfg| cfg.embedding.model_id.as_str());
         // Private per-replica working dir keyed on the instance id so two
         // co-located replicas (distinct `--db` under one parent) never share a
         // mutable path and clobber each other's materialized copy.
         let working_dir = replica_working_dir(&db_path, &instance_id);
         tracing::info!(snapshot = %snapshot_dir.display(), "booting as read-only snapshot replica");
-        nestweaver_engine::materialize_snapshot(
+        nestweaver_engine::materialize_snapshot_with_config(
             &snapshot_dir,
             &working_dir,
             env!("CARGO_PKG_VERSION"),
-            &schema_hash,
-            &embedding_model,
+            schema_hash.as_deref(),
+            embedding_model,
         )
         .with_context(|| format!("failed to materialize snapshot {}", snapshot_dir.display()))?
     } else {
@@ -8026,8 +8032,6 @@ pub async fn run_server(
     // unreadable, or malformed input is fatal in both UDS and network server
     // modes; otherwise a restart-time file race could silently demote the
     // instance to compiled-default identity and authorization.
-    let (instance_cfg, effective_config) =
-        load_daemon_instance_config(config_path, server_opts.is_some())?;
     let live_binding = lifecycle::EffectiveConfigBinding::new(
         std::process::id(),
         live_binding_source(&effective_config),

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -269,6 +269,7 @@ struct EmbeddingRuntimeStatus {
 }
 
 #[derive(Clone)]
+#[cfg_attr(not(feature = "embed"), allow(dead_code))]
 enum EmbeddingRuntimeSnapshot {
     Unavailable {
         status: EmbeddingRuntimeStatus,
@@ -298,6 +299,7 @@ struct EmbeddingRuntime {
     snapshot: std::sync::RwLock<EmbeddingRuntimeSnapshot>,
 }
 
+#[cfg_attr(not(feature = "embed"), allow(dead_code))]
 impl EmbeddingRuntime {
     fn unavailable(status: EmbeddingRuntimeStatus) -> Self {
         assert_ne!(status.state, "ready");
@@ -4061,9 +4063,9 @@ impl NestWeaverDaemon for DaemonService {
                 Ok(result) => {
                     if let Some(ref tantivy) = state.tantivy
                         && tantivy.has_writer()
+                        && let Err(error) = tantivy.reindex_from_store(&state.store)
                     {
-                        if let Err(error) = tantivy.reindex_from_store(&state.store) {
-                            let _ = tx.blocking_send(Ok(IndexProgress {
+                        let _ = tx.blocking_send(Ok(IndexProgress {
                                 phase: Phase::Error as i32,
                                 message: format!(
                                     "RefreshVaultSince committed graph changes but Tantivy rebuild failed: {error:#}"
@@ -4072,8 +4074,7 @@ impl NestWeaverDaemon for DaemonService {
                                 files_total: result.files_checked as u64,
                                 symbols_found: result.headings_count as u64,
                             }));
-                            return;
-                        }
+                        return;
                     }
                     let vault_uid = nestweaver_schema::vault_uid(
                         &instance_id,

--- a/crates/nestweaver-engine/src/contracts.rs
+++ b/crates/nestweaver-engine/src/contracts.rs
@@ -29,7 +29,7 @@
 //! explicitly out of scope here.
 
 use nestweaver_schema::{
-    Contract, Language, contract_shape_key, contract_uid, normalize_http_path,
+    Contract, Language, contract_shape_key, normalize_http_path, scoped_contract_uid,
 };
 
 use crate::blast_radius::AnalysisStatus;
@@ -80,7 +80,7 @@ impl SpecContract {
 
     /// Mint this contract's owning repository-scoped node UID.
     pub fn uid(&self, repo_uid: &str) -> String {
-        contract_uid(
+        scoped_contract_uid(
             repo_uid,
             &self.kind,
             self.verb.as_deref(),

--- a/crates/nestweaver-engine/src/contracts.rs
+++ b/crates/nestweaver-engine/src/contracts.rs
@@ -2347,12 +2347,12 @@ paths:
         assert_eq!(report.declared_not_implemented.len(), 1);
         assert_eq!(
             report.declared_not_implemented[0].uid,
-            "contract:http:GET:/v1/approvals/{}"
+            "contract:repo-1:http:GET:/v1/approvals/{}"
         );
         assert_eq!(report.implemented_not_declared.len(), 1);
         assert_eq!(
             report.implemented_not_declared[0].uid,
-            "contract:http:DELETE:/v1/approvals/{}"
+            "contract:repo-1:http:DELETE:/v1/approvals/{}"
         );
         assert!(!report.is_clean());
     }

--- a/crates/nestweaver-engine/src/contracts.rs
+++ b/crates/nestweaver-engine/src/contracts.rs
@@ -28,7 +28,9 @@
 //! `CONSUMES` via fetch/axios/HTTP literals and GraphQL *consumers* are
 //! explicitly out of scope here.
 
-use nestweaver_schema::{Contract, Language, contract_uid, normalize_http_path};
+use nestweaver_schema::{
+    Contract, Language, contract_shape_key, contract_uid, normalize_http_path,
+};
 
 use crate::blast_radius::AnalysisStatus;
 
@@ -65,9 +67,21 @@ pub struct SpecContract {
 }
 
 impl SpecContract {
-    /// Mint the UID this contract will be stored under.
-    pub fn uid(&self) -> String {
+    /// Return the repository-independent normalized shape used for discovery
+    /// and same-owner deduplication, never as stored node identity.
+    pub fn shape_key(&self) -> String {
+        contract_shape_key(
+            &self.kind,
+            self.verb.as_deref(),
+            self.path.as_deref(),
+            self.operation_id.as_deref(),
+        )
+    }
+
+    /// Mint this contract's owning repository-scoped node UID.
+    pub fn uid(&self, repo_uid: &str) -> String {
         contract_uid(
+            repo_uid,
             &self.kind,
             self.verb.as_deref(),
             self.path.as_deref(),
@@ -78,7 +92,7 @@ impl SpecContract {
     /// Build a full [`Contract`] node bound to a repo + source file.
     pub fn into_contract(self, repo_uid: &str, source_path: &str, confidence: f32) -> Contract {
         Contract {
-            uid: self.uid(),
+            uid: self.uid(repo_uid),
             kind: self.kind,
             verb: self.verb,
             path: self.path,
@@ -1063,10 +1077,12 @@ pub fn drift_for_store(
 ) -> Result<DriftReport, nestweaver_store::StoreError> {
     let repo_uid = resolve_repo_uid(store, repo_uid)?;
     let all = store.list_contracts(repo_uid.as_deref())?;
-    let implemented: std::collections::HashSet<String> = store
-        .list_implemented_contract_uids()?
-        .into_iter()
-        .collect();
+    let implemented: std::collections::HashSet<String> = match repo_uid.as_deref() {
+        Some(owner) => store.list_implemented_contract_uids_for_repo(owner)?,
+        None => store.list_implemented_contract_uids()?,
+    }
+    .into_iter()
+    .collect();
 
     let (declared, code_derived): (Vec<Contract>, Vec<Contract>) =
         all.into_iter().partition(|c| is_spec_file(&c.source_path));
@@ -1838,7 +1854,7 @@ paths:
       responses: { "200": { description: ok } }
 "#;
         let contracts = parse_spec_file("openapi.yaml", spec);
-        let uids: Vec<String> = contracts.iter().map(|c| c.uid()).collect();
+        let uids: Vec<String> = contracts.iter().map(|c| c.shape_key()).collect();
         assert!(
             uids.contains(&"contract:http:POST:/v1/approvals".to_string()),
             "uids: {uids:?}"
@@ -2025,7 +2041,7 @@ message CreateReq {}
 message CreateResp {}
 "#;
         let contracts = parse_spec_file("approvals.proto", proto);
-        let uids: Vec<String> = contracts.iter().map(|c| c.uid()).collect();
+        let uids: Vec<String> = contracts.iter().map(|c| c.shape_key()).collect();
         assert_eq!(uids, vec!["contract:grpc:approvals.v1.Approvals/Create"]);
     }
 
@@ -2040,7 +2056,7 @@ type Query {
 }
 "#;
         let contracts = parse_spec_file("schema.graphql", schema);
-        let uids: Vec<String> = contracts.iter().map(|c| c.uid()).collect();
+        let uids: Vec<String> = contracts.iter().map(|c| c.shape_key()).collect();
         assert!(
             uids.contains(&"contract:graphql:Mutation.createApproval".to_string()),
             "uids: {uids:?}"
@@ -2077,11 +2093,17 @@ type Query {
         assert_eq!(matches.len(), 2);
         // create: base path only, no sub-path → base-path-inferred (0.8).
         let create = &matches[0];
-        assert_eq!(create.contract.uid(), "contract:http:POST:/v1/approvals");
+        assert_eq!(
+            create.contract.shape_key(),
+            "contract:http:POST:/v1/approvals"
+        );
         assert_eq!(create.confidence, 0.8);
         // get: explicit sub-path → exact (1.0), param normalized.
         let get = &matches[1];
-        assert_eq!(get.contract.uid(), "contract:http:GET:/v1/approvals/{}");
+        assert_eq!(
+            get.contract.shape_key(),
+            "contract:http:GET:/v1/approvals/{}"
+        );
         assert_eq!(get.confidence, 1.0);
     }
 
@@ -2095,7 +2117,10 @@ type Query {
         }];
         let matches = detect_handlers("nestjs", class_sig, &symbols);
         assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].contract.uid(), "contract:http:GET:/approvals/{}");
+        assert_eq!(
+            matches[0].contract.shape_key(),
+            "contract:http:GET:/approvals/{}"
+        );
         assert_eq!(matches[0].confidence, 1.0);
     }
 
@@ -2118,7 +2143,7 @@ type Query {
         let matches = detect_handlers("nestjs", source, &symbols);
         assert_eq!(matches.len(), 1, "matches: {matches:?}");
         assert_eq!(
-            matches[0].contract.uid(),
+            matches[0].contract.shape_key(),
             "contract:http:POST:/v1/approvals"
         );
         assert_eq!(matches[0].confidence, 1.0);
@@ -2154,7 +2179,7 @@ type Query {
             2,
             "both handlers must match; got {matches:?}"
         );
-        let uids: Vec<String> = matches.iter().map(|m| m.contract.uid()).collect();
+        let uids: Vec<String> = matches.iter().map(|m| m.contract.shape_key()).collect();
         assert!(
             uids.contains(&"contract:http:GET:/v1/health".to_string()),
             "GET /v1/health missing; uids: {uids:?}"
@@ -2195,7 +2220,7 @@ type Query {
             2,
             "both handlers must match; got {matches:?}"
         );
-        let uids: Vec<String> = matches.iter().map(|m| m.contract.uid()).collect();
+        let uids: Vec<String> = matches.iter().map(|m| m.contract.shape_key()).collect();
         assert!(uids.contains(&"contract:http:GET:/v1/health".to_string()));
         assert!(uids.contains(&"contract:http:POST:/v1/users".to_string()));
     }
@@ -2218,7 +2243,7 @@ type Query {
         let matches = detect_handlers("spring", source, &symbols);
         assert_eq!(matches.len(), 1, "matches: {matches:?}");
         assert_eq!(
-            matches[0].contract.uid(),
+            matches[0].contract.shape_key(),
             "contract:http:POST:/v1/approvals/submit"
         );
         assert_eq!(matches[0].confidence, 1.0);
@@ -2285,8 +2310,8 @@ paths:
         assert_eq!(declared.len(), 1);
         assert_eq!(handlers.len(), 1);
         assert_eq!(
-            declared[0].uid(),
-            handlers[0].contract.uid(),
+            declared[0].shape_key(),
+            handlers[0].contract.shape_key(),
             "spec and handler must agree on UID"
         );
     }

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -5976,14 +5976,14 @@ function hello(name) { return "Hello " + name; }
 
         let implemented_repo = nestweaver_schema::repo_uid("test", implemented_url);
         let declared_only_repo = nestweaver_schema::repo_uid("test", declared_only_url);
-        let implemented_uid = nestweaver_schema::contract_uid(
+        let implemented_uid = nestweaver_schema::scoped_contract_uid(
             &implemented_repo,
             "http",
             Some("GET"),
             Some("/health"),
             None,
         );
-        let declared_only_uid = nestweaver_schema::contract_uid(
+        let declared_only_uid = nestweaver_schema::scoped_contract_uid(
             &declared_only_repo,
             "http",
             Some("GET"),
@@ -6044,7 +6044,7 @@ function hello(name) { return "Hello " + name; }
         );
 
         let scoped = nestweaver_schema::Contract {
-            uid: nestweaver_schema::contract_uid(
+            uid: nestweaver_schema::scoped_contract_uid(
                 repo_a,
                 "http",
                 Some("GET"),
@@ -6640,7 +6640,7 @@ function hello(name) { return "Hello " + name; }
         );
 
         let invalid = nestweaver_schema::Contract {
-            uid: nestweaver_schema::contract_uid(
+            uid: nestweaver_schema::scoped_contract_uid(
                 &repo_uid,
                 "http",
                 Some("GET"),

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -2319,7 +2319,41 @@ where
 
     drop(_phase_collect_span);
 
+    // Contract specifications are part of the publication input, not a
+    // best-effort decoration applied after the code graph has changed. Parse
+    // every recognized spec before the write boundary so malformed or
+    // unreadable input cannot advance the graph, SHA, generation, or caches.
+    // A full parse already accumulated complete handler/symbol inputs; a warm
+    // pass rebuilds the whole-repo view because unchanged files are absent
+    // from those collections.
+    spec_files.sort();
+    handler_files.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
+    let contract_plan_result = if files_unchanged == 0 {
+        prepare_contract_derivation(
+            reader,
+            &r_uid,
+            &spec_files,
+            &handler_files,
+            &all_symbols,
+            true,
+        )
+    } else {
+        prepare_incremental_contract_derivation(reader, &r_uid, repo_url)
+    };
+
     let _write_guard = acquire_write_guard()?;
+
+    let contract_plan = match contract_plan_result {
+        Ok(plan) => plan,
+        Err(error) => {
+            if let Err(marker_error) =
+                store.set_contract_derivation_failed(&r_uid, &error.to_string())
+            {
+                tracing::warn!("recording contract derivation failure failed: {marker_error}");
+            }
+            return Err(error).context("prepare strict contract derivation");
+        }
+    };
 
     // Last cancellation observation point. Bailing in this window needs no
     // teardown: the marker call below is what creates `.index-dirty` and
@@ -2885,59 +2919,36 @@ where
 
         // ── Phase 4 (F2-core): derive the API contract graph ──────────────────
         let _phase_contracts_span = tracing::info_span!("index_phase_contracts").entered();
-        // Deterministic input order for the whole phase: `FilesystemReader`
-        // walks in readdir order while `GitReader` walks git-sorted, so without
-        // this the same repo feeds the contract phase in a different order on
-        // different machines (and after unrelated file churn).
-        spec_files.sort();
-        handler_files.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
-        // Best-effort: a malformed spec or unexpected store error here must not
-        // fail the whole index. Contracts are hypotheses layered on top of the
-        // code graph.
-        //
-        // Non-fatal is not the same as invisible: the failure is RECORDED here,
-        // both on the returned `IndexResult` and as a durable per-repo marker,
-        // because drift is recomputed at query time and a repo with no
-        // contracts is otherwise indistinguishable from a repo whose contracts
-        // could not be derived. A successful run clears the marker so a repo
-        // heals on the next clean index.
-        let mut contracts_derived = 0usize;
-        let mut contracts_status = crate::blast_radius::AnalysisStatus::Complete;
-        let contract_result = if files_unchanged == 0 {
-            derive_contracts(
-                store,
-                reader,
-                &r_uid,
-                &spec_files,
-                &handler_files,
-                &all_symbols,
-            )
-        } else {
-            // A tiered/full pass may skip unchanged files, so its accumulated
-            // phase inputs are incomplete. Rebuild the whole-repo derived view
-            // only in that partial case; a true force/full parse reuses the
-            // inputs it already collected.
-            derive_contracts_from_current_repo(store, reader, &r_uid, repo_url)
-        };
-        match contract_result {
-            Ok(count) => {
-                contracts_derived = count;
-                if let Err(e) = store.clear_contract_derivation_failed(&r_uid) {
-                    tracing::warn!("clearing contract derivation marker failed: {e}");
+        // The complete plan above is immutable across the write boundary. Its
+        // replacement, generation migration, and current-repo debt clear are
+        // one transaction; an invalid write plan therefore retains the prior
+        // derived graph.
+        let contract_txn = store
+            .begin_transaction()
+            .context("begin full contract derivation transaction")?;
+        let contracts_derived =
+            match apply_contract_derivation_on(&contract_txn, &r_uid, &contract_plan) {
+                Ok(count) => count,
+                Err(error) => {
+                    drop(contract_txn);
+                    if let Err(marker_error) =
+                        store.set_contract_derivation_failed(&r_uid, &error.to_string())
+                    {
+                        tracing::warn!(
+                            "recording contract derivation failure failed: {marker_error}"
+                        );
+                    }
+                    return Err(error).context("apply full contract derivation");
                 }
-            }
-            Err(e) => {
-                tracing::warn!("contract derivation failed (non-fatal): {e}");
-                contracts_status = crate::blast_radius::AnalysisStatus::Degraded;
-                // Best-effort: if even the marker cannot be written the run is
-                // still degraded, it just cannot say so at query time.
-                if let Err(marker_err) =
-                    store.set_contract_derivation_failed(&r_uid, &e.to_string())
-                {
-                    tracing::warn!("recording contract derivation failure failed: {marker_err}");
-                }
-            }
+            };
+        store
+            .commit_transaction(&contract_txn)
+            .context("commit full contract derivation transaction")?;
+        drop(contract_txn);
+        if let Err(error) = store.clear_contract_derivation_failed(&r_uid) {
+            tracing::warn!("clearing contract derivation marker failed: {error}");
         }
+        let contracts_status = crate::blast_radius::AnalysisStatus::Complete;
         tracing::info!(
             spec_files = spec_files.len(),
             handler_files = handler_files.len(),
@@ -3405,14 +3416,14 @@ fn prepare_incremental_contract_derivation(
     repo_url: &str,
 ) -> Result<ContractDerivationPlan, anyhow::Error> {
     let (spec_files, handler_files, all_symbols) =
-        collect_contract_derivation_inputs(reader, r_uid, repo_url, false)?;
+        collect_contract_derivation_inputs(reader, r_uid, repo_url, true)?;
     prepare_contract_derivation(
         reader,
         r_uid,
         &spec_files,
         &handler_files,
         &all_symbols,
-        false,
+        true,
     )
 }
 
@@ -3541,24 +3552,6 @@ where
     Ok(plan)
 }
 
-fn derive_contracts_from_current_repo(
-    store: &GraphStore,
-    reader: &dyn crate::content_reader::ContentReader,
-    r_uid: &str,
-    repo_url: &str,
-) -> Result<usize, anyhow::Error> {
-    let (spec_files, handler_files, all_symbols) =
-        collect_contract_derivation_inputs(reader, r_uid, repo_url, false)?;
-    derive_contracts(
-        store,
-        reader,
-        r_uid,
-        &spec_files,
-        &handler_files,
-        &all_symbols,
-    )
-}
-
 /// F2-core: build the API contract graph for one repo.
 ///
 /// 1. Parse spec files into **declared** [`nestweaver_schema::Contract`] nodes
@@ -3569,24 +3562,6 @@ fn derive_contracts_from_current_repo(
 /// 3. Emit `IMPLEMENTS_CONTRACT` edges (handler Symbol → Contract) carrying the
 ///    match confidence (1.0 exact verb+path, 0.8 base-path-inferred).
 ///
-/// Returns the number of Contract nodes written, so the caller can report
-/// "derived N" rather than only "did not blow up".
-fn derive_contracts(
-    store: &GraphStore,
-    reader: &dyn crate::content_reader::ContentReader,
-    r_uid: &str,
-    spec_files: &[PathBuf],
-    handler_files: &[HandlerFileData],
-    all_symbols: &[nestweaver_schema::Symbol],
-) -> Result<usize, anyhow::Error> {
-    let plan =
-        prepare_contract_derivation(reader, r_uid, spec_files, handler_files, all_symbols, false)?;
-    let conn = store.begin_transaction()?;
-    let count = apply_contract_derivation_on(&conn, r_uid, &plan)?;
-    store.commit_transaction(&conn)?;
-    Ok(count)
-}
-
 pub(crate) struct ContractDerivationPlan {
     contracts: Vec<nestweaver_schema::Contract>,
     edges: Vec<nestweaver_schema::ResolvedEdge>,
@@ -3676,7 +3651,7 @@ fn prepare_contract_derivation(
         }
         let matches = crate::contracts::detect_handlers(&hf.framework, &base_source, &handler_syms);
         for m in matches {
-            let contract_uid = m.contract.uid();
+            let contract_uid = m.contract.uid(r_uid);
             // Mint a code-derived contract only when no spec declared this UID.
             // The set is authoritative either way — inserting a code-derived row
             // over a declared one loses on provenance — but skipping the work is
@@ -3816,11 +3791,14 @@ pub(crate) fn apply_contract_derivation_on(
     // No explicit rollback on the error paths, matching `bulk_reindex_write`:
     // a statement that throws inside an explicit transaction already rolls it
     // back, and dropping the connection rolls back anything still open.
+    GraphStore::ensure_contract_derivation_v2_on(conn)?;
     GraphStore::clear_repo_contracts_on(conn, r_uid)?;
     GraphStore::batch_insert_contracts_on(conn, &plan.contracts)?;
     if !plan.edges.is_empty() {
         GraphStore::batch_insert_edges_on(conn, &plan.edges)?;
     }
+    GraphStore::clear_contract_derivation_debt_on(conn, r_uid)?;
+    GraphStore::clear_contract_derivation_failed_on(conn, r_uid)?;
     Ok(plan.contracts.len())
 }
 
@@ -4048,8 +4026,17 @@ fn incremental_index_with_name_and_io(
     // any mutation (the per-file `DETACH DELETE` destroys the edges we walk).
     let (changed_files, removed_files) = partition_changed_removed(&changes);
     let rdeps = collect_reverse_dep_files(&store, &r_uid, &changed_files, &removed_files);
-    let contract_plan = prepare_incremental_contract_derivation(&reader, &r_uid, repo_url)
-        .context("prepare incremental contract derivation")?;
+    let contract_plan = match prepare_incremental_contract_derivation(&reader, &r_uid, repo_url) {
+        Ok(plan) => plan,
+        Err(error) => {
+            if let Err(marker_error) =
+                store.set_contract_derivation_failed(&r_uid, &error.to_string())
+            {
+                tracing::warn!("recording contract derivation failure failed: {marker_error}");
+            }
+            return Err(error).context("prepare incremental contract derivation");
+        }
+    };
 
     let publication = establish_index_publication_marker_with_io(
         &store,
@@ -4251,10 +4238,20 @@ where
     // edges we walk here, so this ordering is correctness-critical.
     let (changed_files, removed_files) = partition_changed_removed(&changes);
     let rdeps = collect_reverse_dep_files(store, &r_uid, &changed_files, &removed_files);
-    let contract_plan = prepare_incremental_contract_derivation(reader, &r_uid, repo_url)
-        .context("prepare server incremental contract derivation")?;
+    let contract_plan_result = prepare_incremental_contract_derivation(reader, &r_uid, repo_url);
 
     let _write_guard = acquire_write_guard()?;
+    let contract_plan = match contract_plan_result {
+        Ok(plan) => plan,
+        Err(error) => {
+            if let Err(marker_error) =
+                store.set_contract_derivation_failed(&r_uid, &error.to_string())
+            {
+                tracing::warn!("recording contract derivation failure failed: {marker_error}");
+            }
+            return Err(error).context("prepare server incremental contract derivation");
+        }
+    };
     let publication = establish_index_publication_marker_with_io(
         store,
         store.db_path(),
@@ -5069,6 +5066,13 @@ fn content_hash_hex(s: &str) -> String {
 mod tests {
     use super::*;
     use std::fs;
+
+    fn owned_contract_uid(repo_uid: &str, bare_shape: &str) -> String {
+        format!(
+            "contract:{repo_uid}:{}",
+            bare_shape.trim_start_matches("contract:")
+        )
+    }
 
     fn insert_publication_graph(store: &GraphStore, publisher: &str) {
         let repo_uid = format!("repo:publisher-{publisher}");
@@ -5909,7 +5913,7 @@ function hello(name) { return "Hello " + name; }
         assert!(
             contracts
                 .iter()
-                .any(|c| c.uid == "contract:http:POST:/v1/approvals"),
+                .any(|c| c.uid.ends_with(":http:POST:/v1/approvals")),
             "expected declared contract; got {:?}",
             contracts.iter().map(|c| &c.uid).collect::<Vec<_>>()
         );
@@ -5918,8 +5922,145 @@ function hello(name) { return "Hello " + name; }
         // no sub-path; UID still matches the spec's POST /v1/approvals).
         let implemented = store.list_implemented_contract_uids().unwrap();
         assert!(
-            implemented.contains(&"contract:http:POST:/v1/approvals".to_string()),
+            implemented
+                .iter()
+                .any(|uid| uid.ends_with(":http:POST:/v1/approvals")),
             "expected IMPLEMENTS_CONTRACT edge; implemented: {implemented:?}"
+        );
+    }
+
+    #[test]
+    fn identical_contract_shapes_are_owned_and_drifted_per_repository() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = GraphStore::in_memory().unwrap();
+        let spec = "openapi: 3.0.0\ninfo: { title: t, version: \"1\" }\npaths:\n  /health:\n    get:\n      responses: { \"200\": { description: ok } }\n";
+        let implemented_dir = dir.path().join("implemented");
+        let declared_only_dir = dir.path().join("declared-only");
+        fs::create_dir_all(&implemented_dir).unwrap();
+        fs::create_dir_all(&declared_only_dir).unwrap();
+        fs::write(implemented_dir.join("openapi.yaml"), spec).unwrap();
+        fs::write(declared_only_dir.join("openapi.yaml"), spec).unwrap();
+        fs::write(
+            implemented_dir.join("HealthController.java"),
+            "@RestController\npublic class HealthController {\n  @GetMapping(\"/health\")\n  public void health() {}\n}\n",
+        )
+        .unwrap();
+
+        let implemented_url = "https://example.com/implemented";
+        let declared_only_url = "https://example.com/declared-only";
+        for (root, url, sha) in [
+            (&implemented_dir, implemented_url, "a"),
+            (&declared_only_dir, declared_only_url, "b"),
+        ] {
+            let reader = crate::content_reader::FilesystemReader::new(root);
+            index_into_store(
+                &reader, &store, "test", url, sha, None, None, None, None, None, None,
+            )
+            .unwrap();
+        }
+
+        let implemented_repo = nestweaver_schema::repo_uid("test", implemented_url);
+        let declared_only_repo = nestweaver_schema::repo_uid("test", declared_only_url);
+        let implemented_uid = nestweaver_schema::contract_uid(
+            &implemented_repo,
+            "http",
+            Some("GET"),
+            Some("/health"),
+            None,
+        );
+        let declared_only_uid = nestweaver_schema::contract_uid(
+            &declared_only_repo,
+            "http",
+            Some("GET"),
+            Some("/health"),
+            None,
+        );
+        assert_ne!(implemented_uid, declared_only_uid);
+        assert_eq!(
+            store
+                .list_implemented_contract_uids_for_repo(&implemented_repo)
+                .unwrap(),
+            vec![implemented_uid]
+        );
+        assert!(
+            store
+                .list_implemented_contract_uids_for_repo(&declared_only_repo)
+                .unwrap()
+                .is_empty()
+        );
+        let drift = crate::contracts::drift_for_store(&store, Some(&declared_only_repo)).unwrap();
+        assert_eq!(drift.declared_not_implemented.len(), 1);
+        assert_eq!(drift.declared_not_implemented[0].uid, declared_only_uid);
+    }
+
+    #[test]
+    fn contract_v2_migration_purges_legacy_globally_and_tracks_repo_debt() {
+        let store = GraphStore::in_memory().unwrap();
+        let repo_a = "repo:test:a";
+        let repo_b = "repo:test:b";
+        for uid in [repo_a, repo_b] {
+            store
+                .insert_repo(&nestweaver_schema::Repo {
+                    uid: uid.to_string(),
+                    url: format!("https://example.com/{uid}"),
+                    indexed_sha: "old".into(),
+                    staleness_commits_behind: 0,
+                    instance_id: "test".into(),
+                    name: None,
+                    root_path: None,
+                })
+                .unwrap();
+        }
+        store
+            .batch_insert_contracts(&[nestweaver_schema::Contract {
+                uid: "contract:http:GET:/legacy".into(),
+                kind: "http".into(),
+                verb: Some("GET".into()),
+                path: Some("/legacy".into()),
+                operation_id: None,
+                repo_uid: repo_a.into(),
+                source_path: "legacy.yaml".into(),
+                confidence: 1.0,
+            }])
+            .unwrap();
+        assert_eq!(
+            store.contract_derivation_failures(None).unwrap(),
+            vec![repo_a.to_string(), repo_b.to_string()]
+        );
+
+        let scoped = nestweaver_schema::Contract {
+            uid: nestweaver_schema::contract_uid(
+                repo_a,
+                "http",
+                Some("GET"),
+                Some("/current"),
+                None,
+            ),
+            kind: "http".into(),
+            verb: Some("GET".into()),
+            path: Some("/current".into()),
+            operation_id: None,
+            repo_uid: repo_a.into(),
+            source_path: "openapi.yaml".into(),
+            confidence: 1.0,
+        };
+        let plan = ContractDerivationPlan {
+            contracts: vec![scoped.clone()],
+            edges: Vec::new(),
+            input_hashes: std::collections::BTreeMap::new(),
+            observed_input_hashes: std::collections::BTreeMap::new(),
+        };
+        let transaction = store.begin_transaction().unwrap();
+        apply_contract_derivation_on(&transaction, repo_a, &plan).unwrap();
+        store.commit_transaction(&transaction).unwrap();
+        drop(transaction);
+
+        let all = store.list_contracts(None).unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].uid, scoped.uid);
+        assert_eq!(
+            store.contract_derivation_failures(None).unwrap(),
+            vec![repo_b.to_string()]
         );
     }
 
@@ -6166,7 +6307,9 @@ function hello(name) { return "Hello " + name; }
             .list_contracts(Some(&repo_uid))
             .unwrap()
             .into_iter()
-            .find(|contract| contract.uid == "contract:http:GET:/v1/items")
+            .find(|contract| {
+                contract.uid == owned_contract_uid(&repo_uid, "contract:http:GET:/v1/items")
+            })
             .expect("GET survives a spec-only rename");
         assert_eq!(renamed_get.source_path, "openapi.v2.yaml");
         assert!(
@@ -6188,7 +6331,9 @@ function hello(name) { return "Hello " + name; }
                 .list_contracts(Some(&repo_uid))
                 .unwrap()
                 .into_iter()
-                .find(|contract| contract.uid == "contract:http:GET:/v1/items")
+                .find(|contract| {
+                    contract.uid == owned_contract_uid(&repo_uid, "contract:http:GET:/v1/items")
+                })
                 .unwrap()
                 .source_path,
             "openapi.v2.yaml"
@@ -6259,11 +6404,11 @@ function hello(name) { return "Hello " + name; }
             vec![
                 (
                     "create".to_string(),
-                    "contract:http:POST:/v1/items".to_string(),
+                    owned_contract_uid(&repo_uid, "contract:http:POST:/v1/items"),
                 ),
                 (
                     "list".to_string(),
-                    "contract:http:GET:/v1/items".to_string(),
+                    owned_contract_uid(&repo_uid, "contract:http:GET:/v1/items"),
                 ),
             ]
         );
@@ -6276,11 +6421,11 @@ function hello(name) { return "Hello " + name; }
             incremental_snapshot.0,
             vec![
                 (
-                    "contract:http:GET:/v1/items".to_string(),
+                    owned_contract_uid(&repo_uid, "contract:http:GET:/v1/items"),
                     "openapi.v2.yaml".to_string(),
                 ),
                 (
-                    "contract:http:POST:/v1/items".to_string(),
+                    owned_contract_uid(&repo_uid, "contract:http:POST:/v1/items"),
                     "openapi.v2.yaml".to_string(),
                 ),
             ]
@@ -6288,8 +6433,8 @@ function hello(name) { return "Hello " + name; }
         assert_eq!(
             incremental_snapshot.1,
             vec![
-                "contract:http:GET:/v1/items".to_string(),
-                "contract:http:POST:/v1/items".to_string(),
+                owned_contract_uid(&repo_uid, "contract:http:GET:/v1/items"),
+                owned_contract_uid(&repo_uid, "contract:http:POST:/v1/items"),
             ]
         );
         drop(incremental_store);
@@ -6327,72 +6472,44 @@ function hello(name) { return "Hello " + name; }
             implementation_pairs(&incremental_store),
             vec![(
                 "create".to_string(),
-                "contract:http:POST:/v1/items".to_string(),
+                owned_contract_uid(&repo_uid, "contract:http:POST:/v1/items"),
             )]
         );
         assert_eq!(
             post_only_snapshot.0,
             vec![(
-                "contract:http:POST:/v1/items".to_string(),
+                owned_contract_uid(&repo_uid, "contract:http:POST:/v1/items"),
                 "openapi.v2.yaml".to_string(),
             )]
         );
         assert_eq!(
             post_only_snapshot.1,
-            vec!["contract:http:POST:/v1/items".to_string()]
+            vec![owned_contract_uid(
+                &repo_uid,
+                "contract:http:POST:/v1/items"
+            )]
         );
 
-        // Poison the next replacement with a UID owned by another repo. The
-        // contract COPY fails after the changed controller/spec were parsed,
-        // and the single incremental transaction must retain the prior graph.
-        incremental_store
-            .batch_insert_contracts(&[nestweaver_schema::Contract {
-                uid: "contract:http:PUT:/v1/items".to_string(),
-                kind: "http".to_string(),
-                verb: Some("PUT".to_string()),
-                path: Some("/v1/items".to_string()),
-                operation_id: None,
-                repo_uid: "repo:other".to_string(),
-                source_path: "other.yaml".to_string(),
-                confidence: 1.0,
-            }])
-            .unwrap();
         let generation_path = crate::sidecar_path(&incremental_db, ".generation");
-        let generation_before_failed_apply = fs::read(&generation_path).unwrap();
+        let generation_before_failure = fs::read(&generation_path).unwrap();
         drop(incremental_store);
         drop(forced_store);
-        fs::write(
-            repo.join("openapi.v2.yaml"),
-            spec(
-                "    get:\n      operationId: listItems\n      responses: { \"200\": { description: ok } }\n    post:\n      operationId: createItem\n      responses: { \"200\": { description: ok } }\n    put:\n      operationId: replaceItem\n      responses: { \"200\": { description: ok } }\n",
-            ),
-        )
-        .unwrap();
-        fs::write(
-            repo.join("ItemsController.java"),
-            "@RestController\n@RequestMapping(\"/v1/items\")\npublic class ItemsController {\n  @GetMapping\n  public void list() {}\n  @PostMapping\n  public void create() {}\n  @PutMapping\n  public void replace() {}\n}\n",
-        )
-        .unwrap();
+        fs::write(repo.join("openapi.v2.yaml"), "openapi: [malformed").unwrap();
         git(&["add", "-A"]);
-        git(&["commit", "-q", "-m", "add colliding PUT"]);
+        git(&["commit", "-q", "-m", "malformed spec"]);
 
         let error = incremental_index(&repo, &incremental_db, "test", repo_url)
-            .expect_err("contract replacement failure must abort incremental publication");
+            .expect_err("strict incremental contract preflight must fail");
         assert!(
-            format!("{error:#}").contains("apply incremental contract derivation"),
+            format!("{error:#}").contains("prepare incremental contract derivation"),
             "unexpected error: {error:#}"
         );
         let incremental_store = GraphStore::open_or_create(&incremental_db).unwrap();
-        assert_eq!(
-            fs::read(&generation_path).unwrap(),
-            generation_before_failed_apply,
-            "a failed transactional apply must not publish a new generation"
-        );
         assert_eq!(snapshot(&incremental_store), post_only_snapshot);
         assert_eq!(
-            other_contracts(&incremental_store),
-            other_before,
-            "a failed replacement must not alter another repo"
+            fs::read(&generation_path).unwrap(),
+            generation_before_failure,
+            "strict preflight failure must not publish a generation"
         );
         assert_eq!(
             incremental_store
@@ -6401,41 +6518,21 @@ function hello(name) { return "Hello " + name; }
                 .unwrap()
                 .indexed_sha,
             third_sha,
-            "failed derivation must roll back the indexed SHA"
+            "strict preflight failure must retain the indexed SHA"
         );
-        assert!(
-            incremental_store
-                .lookup_symbols_by_name_in_repo("replace", &repo_uid)
-                .unwrap()
-                .is_empty(),
-            "failed derivation must roll back the new handler symbol"
-        );
-        assert!(
+        assert_eq!(other_contracts(&incremental_store), other_before);
+        assert_eq!(
             incremental_store
                 .contract_derivation_failures(Some(&repo_uid))
-                .unwrap()
-                .contains(&repo_uid),
-            "the failed best-effort contract phase remains diagnosable"
+                .unwrap(),
+            vec![repo_uid]
         );
     }
 
-    /// A failure inside `derive_contracts` must leave the PREVIOUS contract
-    /// graph intact.
-    ///
-    /// The clear used to run on its own connection ahead of the COPY, so a
-    /// single row the COPY rejected wiped every Contract and every
-    /// IMPLEMENTS_CONTRACT edge for the repo — not a partial result, nothing —
-    /// while the caller only warned and the index still reported success.
-    ///
-    /// The rejected row here is a real one: `contracts::contract_uid` mints a
-    /// UID from kind/verb/path alone, with no repo component, so a route
-    /// another repo has already declared collides on `Contract`'s primary key.
-    /// `clear_repo_contracts` deletes only this repo's rows, so the other
-    /// repo's row is still there when the COPY runs.
-    ///
-    /// Assertions are on the CONTENTS of the graph, never on the `Result` of
-    /// an `index_*` call: derivation errors are swallowed by the caller, so a
-    /// `Result` assertion would pass with or without the fix.
+    /// An explicitly invalid prepared plan must leave the previous derived
+    /// graph intact. This is the fault seam for atomic replacement tests;
+    /// cross-repository UID collisions are no longer a valid way to provoke a
+    /// write failure because v2 Contract identities include their owner.
     #[test]
     fn failed_contract_derivation_preserves_existing_contracts() {
         let dir = tempfile::tempdir().unwrap();
@@ -6489,40 +6586,32 @@ function hello(name) { return "Hello " + name; }
             "expected a seeded IMPLEMENTS_CONTRACT edge"
         );
 
-        // A Contract owned by a DIFFERENT repo, under a UID this repo's next
-        // derivation also mints.
-        store
-            .batch_insert_contracts(&[nestweaver_schema::Contract {
-                uid: "contract:http:GET:/v1/shared".to_string(),
-                kind: "http".to_string(),
-                verb: Some("GET".to_string()),
-                path: Some("/v1/shared".to_string()),
-                operation_id: None,
-                repo_uid: "repo:other".to_string(),
-                source_path: "openapi.yaml".to_string(),
-                confidence: 1.0,
-            }])
-            .unwrap();
-
-        // Re-derive this repo's contracts from a spec that declares the shared
-        // route. The COPY must reject the colliding row.
-        let poisoned = dir.path().join("poisoned");
-        fs::create_dir_all(&poisoned).unwrap();
-        let spec = poisoned.join("openapi.yaml");
-        fs::write(
-            &spec,
-            "openapi: 3.0.0\n\
-             info: { title: t, version: \"1.0\" }\n\
-             paths:\n  \
-             /v1/shared:\n    \
-             get:\n      \
-             operationId: getShared\n      \
-             responses: { \"200\": { description: ok } }\n",
-        )
-        .unwrap();
-        let reader = crate::content_reader::FilesystemReader::new(&poisoned);
-        let err = derive_contracts(&store, &reader, &repo_uid, &[spec], &[], &[])
-            .expect_err("a colliding contract UID must fail the COPY");
+        let invalid = nestweaver_schema::Contract {
+            uid: nestweaver_schema::contract_uid(
+                &repo_uid,
+                "http",
+                Some("GET"),
+                Some("/v1/invalid"),
+                None,
+            ),
+            kind: "http".to_string(),
+            verb: Some("GET".to_string()),
+            path: Some("/v1/invalid".to_string()),
+            operation_id: None,
+            repo_uid: repo_uid.clone(),
+            source_path: "invalid-plan.yaml".to_string(),
+            confidence: 1.0,
+        };
+        let invalid_plan = ContractDerivationPlan {
+            contracts: vec![invalid.clone(), invalid],
+            edges: Vec::new(),
+            input_hashes: std::collections::BTreeMap::new(),
+            observed_input_hashes: std::collections::BTreeMap::new(),
+        };
+        let transaction = store.begin_transaction().unwrap();
+        let err = apply_contract_derivation_on(&transaction, &repo_uid, &invalid_plan)
+            .expect_err("duplicate rows in an explicit invalid plan must fail COPY");
+        drop(transaction);
         assert!(
             err.to_string().contains("COPY Contract"),
             "expected the COPY to be what failed; got {err}"
@@ -6592,34 +6681,44 @@ function hello(name) { return "Hello " + name; }
         let uids: Vec<&String> = contracts.iter().map(|c| &c.uid).collect();
         assert!(
             uids.iter()
-                .any(|u| u.as_str() == "contract:grpc:demo.v1.Greeter/SayHello"),
+                .any(|u| u.ends_with(":grpc:demo.v1.Greeter/SayHello")),
             "expected the declared gRPC contract; got {uids:?}"
         );
 
         let implemented = store.list_implemented_contract_uids().unwrap();
         assert!(
-            implemented.contains(&"contract:grpc:demo.v1.Greeter/SayHello".to_string()),
+            implemented
+                .iter()
+                .any(|uid| uid.ends_with(":grpc:demo.v1.Greeter/SayHello")),
             "expected IMPLEMENTS_CONTRACT edge for SayHello; implemented: {implemented:?}"
         );
         // The acronym case, which a naive snake_case would have missed.
         assert!(
-            implemented.contains(&"contract:grpc:demo.v1.Greeter/GetHTTPStatus".to_string()),
+            implemented
+                .iter()
+                .any(|uid| uid.ends_with(":grpc:demo.v1.Greeter/GetHTTPStatus")),
             "GetHTTPStatus -> get_http_status must link; implemented: {implemented:?}"
         );
         // A declared RPC with no impl must STILL be drift.
         assert!(
-            !implemented.contains(&"contract:grpc:demo.v1.Greeter/NeverBuilt".to_string()),
+            !implemented
+                .iter()
+                .any(|uid| uid.ends_with(":grpc:demo.v1.Greeter/NeverBuilt")),
             "an unimplemented RPC must remain drift; implemented: {implemented:?}"
         );
     }
 
     // ── Contract derivation status (degraded vs genuinely empty) ──────────
 
-    /// Index `src` into `store` a second time, reusing the private full-index
-    /// entry point so the contract phase — and its swallow — actually runs.
+    /// Index `src` into `store` a second time through the private full-index
+    /// entry point so strict preflight behavior is directly observable.
     /// `index_directory_in_memory` always mints a fresh store, which is no use
     /// when the point is to re-index a store that has been poisoned.
-    fn reindex_into(store: &GraphStore, src: &Path, sha: &str) -> IndexResult {
+    fn reindex_into(
+        store: &GraphStore,
+        src: &Path,
+        sha: &str,
+    ) -> Result<IndexResult, anyhow::Error> {
         let reader = crate::content_reader::FilesystemReader::new(src);
         let local_root = src.display().to_string();
         index_into_store(
@@ -6635,7 +6734,6 @@ function hello(name) { return "Hello " + name; }
             None,
             Some(&local_root),
         )
-        .expect("indexing must succeed even when contract derivation does not")
     }
 
     /// Write a repo whose only content is an OpenAPI spec declaring
@@ -6665,18 +6763,8 @@ function hello(name) { return "Hello " + name; }
         .unwrap();
     }
 
-    /// A repo whose contract derivation FAILED must not be reported as clean.
-    ///
-    /// Assertions are on the reported STATUS and on graph contents, never on
-    /// the `Result` of the index call: derivation errors are swallowed, so
-    /// `index_*` returns `Ok` with or without this fix and a `Result`
-    /// assertion would prove nothing.
-    ///
-    /// The failure induced here is the observed one: `contract_uid` mints a UID
-    /// with no repo component, so a route another repo already declared
-    /// collides on `Contract`'s primary key and the bulk COPY rejects the row —
-    /// discarding every contract and every IMPLEMENTS_CONTRACT edge for this
-    /// repo while the index still reports success.
+    /// A malformed recognized spec fails before graph/SHA publication, retains
+    /// the prior derived graph, and remains query-visible as degraded.
     #[test]
     fn degraded_contract_derivation_is_not_reported_clean() {
         let dir = tempfile::tempdir().unwrap();
@@ -6703,33 +6791,42 @@ function hello(name) { return "Hello " + name; }
             .repo_uid
             .clone();
 
-        // Poison: hand this repo's UID to a DIFFERENT repo, so the next
-        // derivation's COPY hits a duplicate primary key it cannot clear.
-        store.clear_repo_contracts(&repo_uid).unwrap();
-        store
-            .batch_insert_contracts(&[nestweaver_schema::Contract {
-                uid: "contract:http:GET:/v1/shared".to_string(),
-                kind: "http".to_string(),
-                verb: Some("GET".to_string()),
-                path: Some("/v1/shared".to_string()),
-                operation_id: None,
-                repo_uid: "repo:other".to_string(),
-                source_path: "openapi.yaml".to_string(),
-                confidence: 1.0,
-            }])
+        let contracts_before: Vec<_> = store
+            .list_contracts(Some(&repo_uid))
+            .unwrap()
+            .into_iter()
+            .map(|contract| (contract.uid, contract.source_path))
+            .collect();
+        let implemented_before = store
+            .list_implemented_contract_uids_for_repo(&repo_uid)
             .unwrap();
+        let sha_before = store.lookup_repo(&repo_uid).unwrap().unwrap().indexed_sha;
+        fs::write(src.join("openapi.yaml"), "openapi: [malformed").unwrap();
 
-        let second = reindex_into(&store, &src, "def456");
-
-        // 1. The index result says so.
-        assert_eq!(
-            second.contracts_status,
-            crate::blast_radius::AnalysisStatus::Degraded,
-            "a failed contract phase must be reported as degraded"
+        let error = reindex_into(&store, &src, "def456")
+            .expect_err("malformed recognized spec must fail strict preflight");
+        assert!(
+            format!("{error:#}").contains("prepare strict contract derivation"),
+            "unexpected error: {error:#}"
         );
         assert_eq!(
-            second.contracts_derived, 0,
-            "a failed derivation writes no contracts"
+            store
+                .list_contracts(Some(&repo_uid))
+                .unwrap()
+                .into_iter()
+                .map(|contract| (contract.uid, contract.source_path))
+                .collect::<Vec<_>>(),
+            contracts_before
+        );
+        assert_eq!(
+            store
+                .list_implemented_contract_uids_for_repo(&repo_uid)
+                .unwrap(),
+            implemented_before
+        );
+        assert_eq!(
+            store.lookup_repo(&repo_uid).unwrap().unwrap().indexed_sha,
+            sha_before
         );
 
         // 2. The query-time drift analysis says so. This assertion is the one
@@ -6751,9 +6848,15 @@ function hello(name) { return "Hello " + name; }
         assert_eq!(envelope["clean"], serde_json::json!(false));
         assert_eq!(envelope["contracts_status"], serde_json::json!("degraded"));
 
-        // A clean re-index heals the repo: the marker is cleared, not sticky.
-        store.clear_repo_contracts("repo:other").unwrap();
-        let third = reindex_into(&store, &src, "ghi789");
+        // A valid empty plan is success, replaces the old derived rows, and
+        // heals the repo rather than being mistaken for another failure.
+        fs::remove_file(src.join("SharedController.java")).unwrap();
+        fs::write(
+            src.join("openapi.yaml"),
+            "openapi: 3.0.0\ninfo: { title: t, version: \"1.0\" }\npaths: {}\n",
+        )
+        .unwrap();
+        let third = reindex_into(&store, &src, "ghi789").unwrap();
         assert_eq!(
             third.contracts_status,
             crate::blast_radius::AnalysisStatus::Complete,
@@ -6766,6 +6869,7 @@ function hello(name) { return "Hello " + name; }
                 .is_empty(),
             "the failure marker must not survive a successful derivation"
         );
+        assert!(store.list_contracts(Some(&repo_uid)).unwrap().is_empty());
     }
 
     /// The counterpart the fix must NOT break: a repo that genuinely declares
@@ -6848,7 +6952,7 @@ function hello(name) { return "Hello " + name; }
         assert_unique_contract_uids(&contracts);
         let collapsed: Vec<&nestweaver_schema::Contract> = contracts
             .iter()
-            .filter(|c| c.uid == "contract:http:GET:/users/{}")
+            .filter(|c| c.uid.ends_with(":http:GET:/users/{}"))
             .collect();
         assert_eq!(
             collapsed.len(),
@@ -6870,7 +6974,7 @@ function hello(name) { return "Hello " + name; }
             assert!(
                 implemented
                     .iter()
-                    .any(|(uid, _)| uid == "contract:http:GET:/users/{}"),
+                    .any(|(uid, _)| uid.ends_with(":http:GET:/users/{}")),
                 "{handler} must link to the surviving contract; got {implemented:?}"
             );
         }
@@ -6900,7 +7004,7 @@ function hello(name) { return "Hello " + name; }
         assert_unique_contract_uids(&contracts);
         let survivor = contracts
             .iter()
-            .find(|c| c.uid == "contract:http:GET:/v1/items")
+            .find(|c| c.uid.ends_with(":http:GET:/v1/items"))
             .expect("the declared route survives the collapse");
         // Both copies are declared at confidence 1.0, so the tie-break falls to
         // the lexicographically smallest source_path — NOT to collection order.
@@ -6935,11 +7039,12 @@ function hello(name) { return "Hello " + name; }
         assert_unique_contract_uids(&contracts);
         let uids: Vec<&str> = contracts.iter().map(|c| c.uid.as_str()).collect();
         assert!(
-            uids.contains(&"contract:grpc:demo.v1.Greeter/SayHello"),
+            uids.iter()
+                .any(|uid| uid.ends_with(":grpc:demo.v1.Greeter/SayHello")),
             "the duplicated RPC must survive exactly once; got {uids:?}"
         );
         assert!(
-            uids.contains(&"contract:graphql:Query.me"),
+            uids.iter().any(|uid| uid.ends_with(":graphql:Query.me")),
             "the duplicated GraphQL field must survive exactly once; got {uids:?}"
         );
     }
@@ -7038,9 +7143,10 @@ function hello(name) { return "Hello " + name; }
 
         let report = crate::contracts::drift_for_store(&store, None).unwrap();
         assert_eq!(report.declared_not_implemented.len(), 1);
-        assert_eq!(
-            report.declared_not_implemented[0].uid,
-            "contract:http:GET:/v1/items"
+        assert!(
+            report.declared_not_implemented[0]
+                .uid
+                .ends_with(":http:GET:/v1/items")
         );
         assert!(report.implemented_not_declared.is_empty());
     }
@@ -7082,7 +7188,9 @@ function hello(name) { return "Hello " + name; }
         // The handler implements the spec-declared contract (exact verb+path).
         let implemented = store.list_implemented_contract_uids().unwrap();
         assert!(
-            implemented.contains(&"contract:http:POST:/v1/approvals".to_string()),
+            implemented
+                .iter()
+                .any(|uid| uid.ends_with(":http:POST:/v1/approvals")),
             "expected IMPLEMENTS_CONTRACT edge; implemented: {implemented:?}"
         );
 
@@ -7152,11 +7260,15 @@ function hello(name) { return "Hello " + name; }
 
         let implemented = store.list_implemented_contract_uids().unwrap();
         assert!(
-            implemented.contains(&"contract:http:GET:/v1/health".to_string()),
+            implemented
+                .iter()
+                .any(|uid| uid.ends_with(":http:GET:/v1/health")),
             "GET /v1/health must be implemented; implemented: {implemented:?}"
         );
         assert!(
-            implemented.contains(&"contract:http:POST:/v1/users".to_string()),
+            implemented
+                .iter()
+                .any(|uid| uid.ends_with(":http:POST:/v1/users")),
             "POST /v1/users must be implemented; implemented: {implemented:?}"
         );
 

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -3262,6 +3262,21 @@ fn collect_contract_derivation_inputs(
         if is_minified_or_bundled(&abs_path) {
             continue;
         }
+        // Only these languages can contribute handler-derived contracts.
+        // Filtering before metadata/read is important in strict mode: an
+        // unreadable unrelated Python/Go/etc. file must not abort otherwise
+        // valid contract publication.
+        let eligible_handler_language = matches!(
+            lang,
+            nestweaver_schema::Language::Java
+                | nestweaver_schema::Language::Kotlin
+                | nestweaver_schema::Language::JavaScript
+                | nestweaver_schema::Language::TypeScript
+        ) || (has_grpc_specs
+            && lang == nestweaver_schema::Language::Rust);
+        if !eligible_handler_language {
+            continue;
+        }
         if reader
             .file_meta(&rel_path)
             .context("read contract input metadata")?
@@ -6095,6 +6110,44 @@ function hello(name) { return "Hello " + name; }
             "repo:test:oversize",
             "https://example.com/oversize",
             false,
+        )
+        .unwrap();
+        assert!(specs.is_empty());
+        assert!(handlers.is_empty());
+        assert!(symbols.is_empty());
+    }
+
+    #[test]
+    fn strict_contract_collector_ignores_unreadable_irrelevant_languages() {
+        struct IrrelevantReader {
+            root: PathBuf,
+        }
+        impl crate::content_reader::ContentReader for IrrelevantReader {
+            fn read_file(&self, _rel_path: &Path) -> anyhow::Result<String> {
+                panic!("irrelevant language must be filtered before reading")
+            }
+            fn list_files(&self) -> anyhow::Result<Vec<PathBuf>> {
+                Ok(vec![PathBuf::from("unreadable.py")])
+            }
+            fn file_meta(&self, _rel_path: &Path) -> anyhow::Result<Option<(u64, u64)>> {
+                panic!("irrelevant language must be filtered before metadata")
+            }
+            fn root(&self) -> &Path {
+                &self.root
+            }
+            fn version_id(&self) -> &str {
+                "irrelevant-language-test"
+            }
+        }
+
+        let reader = IrrelevantReader {
+            root: PathBuf::from("/unused"),
+        };
+        let (specs, handlers, symbols) = collect_contract_derivation_inputs(
+            &reader,
+            "repo:test:irrelevant",
+            "https://example.com/irrelevant",
+            true,
         )
         .unwrap();
         assert!(specs.is_empty());

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -396,7 +396,27 @@ pub fn index_markdown_directory_since_with_ignore(
 ) -> Result<MarkdownSinceResult, anyhow::Error> {
     let store = GraphStore::open_or_create(db_path)
         .with_context(|| format!("failed to open/create GraphStore at {}", db_path.display()))?;
+    index_markdown_directory_since_with_store_and_ignore(
+        &store,
+        vault_root,
+        instance_id,
+        vault_name,
+        since,
+        extra_ignore_patterns,
+    )
+}
 
+/// Daemon-owned variant of [`index_markdown_directory_since_with_ignore`].
+/// The caller supplies the already-open single writer and is responsible for
+/// holding its process-level write gate for the duration of the refresh.
+pub fn index_markdown_directory_since_with_store_and_ignore(
+    store: &GraphStore,
+    vault_root: &Path,
+    instance_id: &str,
+    vault_name: &str,
+    since: std::time::SystemTime,
+    extra_ignore_patterns: &[String],
+) -> Result<MarkdownSinceResult, anyhow::Error> {
     let canonical = std::fs::canonicalize(vault_root).unwrap_or_else(|_| vault_root.to_path_buf());
     let reader = crate::content_reader::FilesystemReader::new(&canonical);
     let root_str = canonical.to_string_lossy().into_owned();
@@ -412,6 +432,13 @@ pub fn index_markdown_directory_since_with_ignore(
             instance_id: instance_id.to_string(),
         })
         .context("upsert_vault")?;
+    let existing_notes = store
+        .list_notes(Some(&v_uid))
+        .context("list existing vault notes")?;
+    let existing_note_uids = existing_notes
+        .iter()
+        .map(|note| note.uid.clone())
+        .collect::<std::collections::HashSet<_>>();
 
     let since_secs = since
         .duration_since(std::time::UNIX_EPOCH)
@@ -484,13 +511,13 @@ pub fn index_markdown_directory_since_with_ignore(
         // Delete old note data (cascade). Safe when note doesn't exist.
         if let Err(e) = store.delete_note_cascade(&n_uid) {
             tracing::warn!("delete_note_cascade {n_uid} failed: {e}");
-        } else {
+        } else if existing_note_uids.contains(&n_uid) {
             notes_deleted += 1;
         }
 
         let abs_path = vault_root.join(&rel_path);
         let (h_count, s_count, wl_count, t_count) =
-            reinsert_single_note(&store, &v_uid, &n_uid, &abs_path, &rel_path_str, &parsed)
+            reinsert_single_note(store, &v_uid, &n_uid, &abs_path, &rel_path_str, &parsed)
                 .with_context(|| format!("reinsert_single_note {rel_path_str}"))?;
 
         total_headings += h_count;
@@ -498,6 +525,19 @@ pub fn index_markdown_directory_since_with_ignore(
         total_wikilinks += wl_count;
         total_tags += t_count;
         notes_updated += 1;
+    }
+
+    // Files deleted since the last refresh are absent from `list_files`, so
+    // discover them from the incumbent graph. This is safe regardless of the
+    // timestamp: a registered Note whose vault-relative file no longer exists
+    // cannot still be current. Ignored files remain on disk and are preserved.
+    for note in &existing_notes {
+        if !vault_root.join(&note.file_path).exists() {
+            store
+                .delete_note_cascade(&note.uid)
+                .with_context(|| format!("delete removed note {}", note.file_path))?;
+            notes_deleted += 1;
+        }
     }
 
     // Advance + persist the graph generation when any note was mutated.
@@ -3018,6 +3058,39 @@ sub b body
         assert!(
             g2 > g1,
             "the since refresh must advance and persist the graph generation ({g1} -> {g2})"
+        );
+    }
+
+    #[test]
+    fn since_refresh_reuses_daemon_owned_store_without_second_writer() {
+        let (_dir, root) = make_vault(&[
+            ("a.md", "# A\n\nalpha body\n"),
+            ("removed.md", "# Removed\n\nold body\n"),
+        ]);
+        let db_path = root.join("brain.lbug");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        index_markdown_directory_with_store(&store, &root, &db_path, "owned", "v", &[]).unwrap();
+
+        fs::write(root.join("a.md"), "# A\n\nbeta body\n").unwrap();
+        fs::remove_file(root.join("removed.md")).unwrap();
+        let result = index_markdown_directory_since_with_store_and_ignore(
+            &store,
+            &root,
+            "owned",
+            "v",
+            std::time::UNIX_EPOCH,
+            &[],
+        )
+        .expect("daemon-owned refresh must not attempt a second GraphStore writer");
+
+        assert_eq!(result.notes_updated, 1);
+        assert_eq!(result.notes_deleted, 2, "one replacement plus one removed file");
+        assert_eq!(store.count_notes().unwrap(), 1);
+        let notes = store.list_notes(None).unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(
+            notes[0].vault_uid,
+            nestweaver_schema::vault_uid("owned", &root.to_string_lossy())
         );
     }
 

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -419,22 +419,26 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
 ) -> Result<MarkdownSinceResult, anyhow::Error> {
     let canonical = std::fs::canonicalize(vault_root).unwrap_or_else(|_| vault_root.to_path_buf());
     let reader = crate::content_reader::FilesystemReader::new(&canonical);
-    let root_str = canonical.to_string_lossy().into_owned();
-    let vault_root: &Path = &canonical;
-    let v_uid = vault_uid(instance_id, &root_str);
-    let ignore_set = crate::brainignore::load_brain_ignore(vault_root, extra_ignore_patterns);
+    let ignore_set = crate::brainignore::load_brain_ignore(&canonical, extra_ignore_patterns);
+    index_markdown_since_with_reader(store, &reader, instance_id, vault_name, since, &ignore_set)
+}
 
-    store
-        .upsert_vault(&Vault {
-            uid: v_uid.clone(),
-            name: vault_name.to_string(),
-            root_path: root_str.clone(),
-            instance_id: instance_id.to_string(),
-        })
-        .context("upsert_vault")?;
+fn index_markdown_since_with_reader(
+    store: &GraphStore,
+    reader: &dyn ContentReader,
+    instance_id: &str,
+    vault_name: &str,
+    since: std::time::SystemTime,
+    ignore_set: &GlobSet,
+) -> Result<MarkdownSinceResult, anyhow::Error> {
+    let vault_root = reader.root();
+    let root_str = vault_root.to_string_lossy().into_owned();
+    let v_uid = vault_uid(instance_id, &root_str);
+
     let existing_notes = store
         .list_notes(Some(&v_uid))
         .context("list existing vault notes")?;
+    let vault_existed = store.lookup_vault(&v_uid).is_ok();
     let existing_note_uids = existing_notes
         .iter()
         .map(|note| note.uid.clone())
@@ -447,16 +451,9 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
 
     let all_files = reader.list_files()?;
 
-    struct ParsedCandidate {
-        rel_path: String,
-        abs_path: PathBuf,
-        note_uid: String,
-        parsed: ParsedNote,
-        changed: bool,
-    }
-
     let mut files_checked = 0usize;
     let mut candidates = Vec::new();
+    let mut indexed_paths: HashMap<String, (String, PathBuf)> = HashMap::new();
 
     for rel_path in all_files {
         if !is_markdown(&rel_path) {
@@ -468,7 +465,7 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
         }
         // Apply .brainignore patterns.
         let rel_str = rel_path.to_string_lossy();
-        if crate::brainignore::is_ignored(&rel_str, &ignore_set) {
+        if crate::brainignore::is_ignored(&rel_str, ignore_set) {
             tracing::debug!("brainignore: skipping {}", rel_str);
             continue;
         }
@@ -503,6 +500,12 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
                 continue;
             }
         };
+        if !changed {
+            if existing_note_uids.contains(&n_uid) {
+                indexed_paths.insert(n_uid, (rel_path_str, vault_root.join(&rel_path)));
+            }
+            continue;
+        }
         let source = match reader.read_file(&rel_path) {
             Ok(s) => s,
             Err(err) => {
@@ -562,7 +565,7 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
         .filter(|candidate| candidate.changed)
         .count();
     let notes_deleted = delete_note_uids.len();
-    if notes_updated == 0 && notes_deleted == 0 {
+    if notes_updated == 0 && notes_deleted == 0 && vault_existed {
         return Ok(MarkdownSinceResult {
             vault_name: vault_name.to_string(),
             files_checked,
@@ -572,6 +575,156 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
             sections_count: 0,
             tags_count: 0,
             wikilinks_resolved: 0,
+        });
+    }
+
+    let mut affected_names = std::collections::HashSet::new();
+    for note in &existing_notes {
+        if changed_uids.contains(&note.uid) || removed_uids.contains(&note.uid) {
+            affected_names.insert(note.uid.to_lowercase());
+            let stored = note_context_from_stored(note, Vec::new());
+            add_note_identity(
+                &mut affected_names,
+                &note.title,
+                &note.file_path,
+                &stored.aliases,
+            );
+        }
+    }
+    for candidate in &candidates {
+        affected_names.insert(candidate.note_uid.to_lowercase());
+        add_note_identity(
+            &mut affected_names,
+            &candidate.parsed.title,
+            &candidate.rel_path,
+            &candidate.parsed.aliases,
+        );
+    }
+
+    let sections = store
+        .list_sections_by_vault(&v_uid)
+        .context("list existing vault sections")?;
+    let section_note: HashMap<String, String> = sections
+        .into_iter()
+        .map(|section| (section.uid, section.note_uid))
+        .collect();
+    let note_path_by_uid: HashMap<&str, &str> = existing_notes
+        .iter()
+        .map(|note| (note.uid.as_str(), note.file_path.as_str()))
+        .collect();
+    let existing_headings = store
+        .list_headings_by_vault(&v_uid)
+        .context("list existing vault headings")?;
+    let heading_note: HashMap<String, String> = existing_headings
+        .iter()
+        .map(|heading| (heading.uid.clone(), heading.note_uid.clone()))
+        .collect();
+    let mut affected_sources = changed_uids.clone();
+    for (relation, destination) in [
+        ("WIKILINK_TO_NOTE", "dst:Note"),
+        ("WIKILINK_TO_HEADING", "dst:Heading"),
+    ] {
+        for (source_section, target, _, _, link_target) in
+            store.wikilink_edges_for_vault(&v_uid, relation, destination)?
+        {
+            let target_note = if relation == "WIKILINK_TO_NOTE" {
+                Some(target.as_str())
+            } else {
+                heading_note.get(&target).map(String::as_str)
+            };
+            let normalized_target = link_target.trim().replace('\\', "/").to_lowercase();
+            let source_relative_affected = section_note
+                .get(&source_section)
+                .and_then(|source_uid| note_path_by_uid.get(source_uid.as_str()))
+                .and_then(|path| Path::new(path).parent())
+                .map(|folder| {
+                    let joined = folder
+                        .join(&normalized_target)
+                        .to_string_lossy()
+                        .replace('\\', "/");
+                    affected_names.contains(&joined)
+                        || affected_names
+                            .iter()
+                            .any(|identity| identity.ends_with(&format!("/{normalized_target}")))
+                })
+                .unwrap_or(false);
+            if (target_note
+                .is_some_and(|uid| changed_uids.contains(uid) || removed_uids.contains(uid))
+                || affected_names.contains(&normalized_target)
+                || source_relative_affected)
+                && let Some(source_note) = section_note.get(&source_section)
+            {
+                affected_sources.insert(source_note.clone());
+            }
+        }
+    }
+    for (_, source_note, source_path, _, link_target) in store.all_unresolved_wikilinks()? {
+        let normalized = link_target.trim().replace('\\', "/").to_lowercase();
+        let joined = Path::new(&source_path).parent().map(|folder| {
+            folder
+                .join(&normalized)
+                .to_string_lossy()
+                .replace('\\', "/")
+        });
+        if affected_names.contains(&normalized)
+            || joined
+                .as_ref()
+                .is_some_and(|path| affected_names.contains(path))
+            || affected_names
+                .iter()
+                .any(|identity| identity.ends_with(&format!("/{normalized}")))
+        {
+            affected_sources.insert(source_note);
+        }
+    }
+    for (source, target, _) in store.typed_note_edges()? {
+        if changed_uids.contains(&source)
+            || changed_uids.contains(&target)
+            || removed_uids.contains(&target)
+        {
+            affected_sources.insert(source);
+        }
+    }
+    for note in &existing_notes {
+        if removed_uids.contains(&note.uid) || changed_uids.contains(&note.uid) {
+            continue;
+        }
+        let context = note_context_from_stored(note, Vec::new());
+        let affected = ["supersedes", "depends_on", "caused_by", "relates_to"]
+            .into_iter()
+            .flat_map(|key| frontmatter_list(&context.frontmatter, key))
+            .any(|reference| {
+                let normalized = reference.trim().replace('\\', "/").to_lowercase();
+                affected_names.contains(&normalized)
+                    || affected_names
+                        .iter()
+                        .any(|identity| identity.ends_with(&format!("/{normalized}")))
+            });
+        if affected {
+            affected_sources.insert(note.uid.clone());
+        }
+    }
+    affected_sources.retain(|uid| !removed_uids.contains(uid));
+    for source_uid in affected_sources
+        .iter()
+        .filter(|uid| !changed_uids.contains(*uid))
+    {
+        let Some((rel_path, abs_path)) = indexed_paths.get(source_uid) else {
+            return Err(anyhow::anyhow!(
+                "cannot safely rebuild affected indexed note {source_uid}; its source is ignored or unavailable"
+            ));
+        };
+        let source = reader
+            .read_file(Path::new(rel_path))
+            .with_context(|| format!("read affected indexed note {rel_path}"))?;
+        let parsed = parse_markdown(rel_path, &source)
+            .with_context(|| format!("parse affected indexed note {rel_path}"))?;
+        candidates.push(ParsedCandidate {
+            rel_path: rel_path.clone(),
+            abs_path: abs_path.clone(),
+            note_uid: source_uid.clone(),
+            parsed,
+            changed: false,
         });
     }
 
@@ -593,37 +746,46 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
         )?);
     }
 
-    // Resolve against the complete prospective title/heading graph, never the
-    // partially-mutated file order.
+    // Resolve against the complete prospective graph with the same resolver
+    // used by full indexing (path, same-folder stem, title, alias, ambiguity,
+    // confidence, and heading-anchor semantics).
     let deleted_set: std::collections::HashSet<&str> =
         delete_note_uids.iter().map(String::as_str).collect();
-    let mut title_lookup: HashMap<String, Vec<String>> = HashMap::new();
-    let mut heading_lookup: HashMap<String, Vec<Heading>> = HashMap::new();
-    for note in &existing_notes {
-        if !deleted_set.contains(note.uid.as_str()) {
-            title_lookup
-                .entry(note.title.to_lowercase())
-                .or_default()
-                .push(note.uid.clone());
-            heading_lookup.insert(
-                note.uid.clone(),
-                store.headings_in_note(&note.uid).unwrap_or_default(),
-            );
-        }
-    }
-    for graph in &prepared {
-        title_lookup
-            .entry(graph.note.title.to_lowercase())
-            .or_default()
-            .push(graph.note.uid.clone());
-        heading_lookup.insert(graph.note.uid.clone(), graph.headings.clone());
-    }
-
     let prospective_uids: std::collections::HashSet<String> = existing_notes
         .iter()
         .filter(|note| !deleted_set.contains(note.uid.as_str()))
         .map(|note| note.uid.clone())
         .chain(prepared.iter().map(|graph| graph.note.uid.clone()))
+        .collect();
+    let mut note_contexts: Vec<NoteContext> = candidates
+        .iter()
+        .filter(|candidate| prospective_uids.contains(&candidate.note_uid))
+        .map(note_context_from_candidate)
+        .collect();
+    let represented: std::collections::HashSet<String> = note_contexts
+        .iter()
+        .map(|context| context.note_uid.clone())
+        .collect();
+    let all_headings = existing_headings;
+    let mut headings_by_note: HashMap<String, Vec<Heading>> = HashMap::new();
+    for heading in all_headings {
+        headings_by_note
+            .entry(heading.note_uid.clone())
+            .or_default()
+            .push(heading);
+    }
+    for note in &existing_notes {
+        if prospective_uids.contains(&note.uid) && !represented.contains(&note.uid) {
+            note_contexts.push(note_context_from_stored(
+                note,
+                headings_by_note.remove(&note.uid).unwrap_or_default(),
+            ));
+        }
+    }
+    let lookup = WikilinkLookup::build(&note_contexts);
+    let context_by_uid: HashMap<&str, &NoteContext> = note_contexts
+        .iter()
+        .map(|context| (context.note_uid.as_str(), context))
         .collect();
     let mut rebuild_link_source_uids = Vec::new();
     let mut wikilink_to_note = Vec::new();
@@ -635,25 +797,17 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
             continue;
         }
         rebuild_link_source_uids.push(candidate.note_uid.clone());
-        let section_uids: Vec<String> = candidate
-            .parsed
-            .sections
-            .iter()
-            .map(|section| {
-                let text_hash = crate::hash::blake3_hex(&section.text);
-                section_uid(&candidate.note_uid, section.start_line, &text_hash[..12])
-            })
-            .collect();
-        for wikilink in &candidate.parsed.wikilinks {
-            let Some(source_section) = section_uids.get(wikilink.section_idx) else {
+        let context = context_by_uid[&candidate.note_uid.as_str()];
+        for wikilink in &context.wikilinks {
+            let Some(source_section) = context.section_uids.get(wikilink.section_idx) else {
                 continue;
             };
             let display = wikilink
                 .display
                 .clone()
                 .unwrap_or_else(|| wikilink.target.clone());
-            let Some(targets) = title_lookup.get(&wikilink.target.to_lowercase()) else {
-                unresolved.push((
+            match lookup.resolve(&wikilink.target, &context.folder) {
+                ResolveOutcome::Unresolved => unresolved.push((
                     format!(
                         "unresolved:{}:{}",
                         source_section,
@@ -663,39 +817,34 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
                     candidate.rel_path.clone(),
                     candidate.parsed.title.clone(),
                     wikilink.target.clone(),
-                ));
-                continue;
-            };
-            let confidence = 1.0 / targets.len() as f32;
-            for target_uid in targets {
-                let mut resolved_heading = false;
-                if let Some(anchor) = &wikilink.heading_anchor {
-                    let slug = nestweaver_parser::markdown::slugify(anchor);
-                    if let Some(heading) = heading_lookup
-                        .get(target_uid)
-                        .and_then(|headings| headings.iter().find(|heading| heading.slug == slug))
-                    {
-                        wikilink_to_heading.push((
-                            source_section.clone(),
-                            heading.uid.clone(),
-                            confidence,
-                            display.clone(),
-                            wikilink.target.clone(),
-                        ));
-                        resolved_heading = true;
+                )),
+                ResolveOutcome::Resolved(targets) => {
+                    let confidence = targets[0].confidence / targets.len().max(1) as f32;
+                    for target in targets {
+                        if let Some(anchor) = &wikilink.heading_anchor
+                            && let Some(heading_uid) =
+                                lookup.find_heading(&target.note_uid, &slugify_anchor(anchor))
+                        {
+                            wikilink_to_heading.push((
+                                source_section.clone(),
+                                heading_uid,
+                                confidence,
+                                display.clone(),
+                                wikilink.target.clone(),
+                            ));
+                        } else {
+                            wikilink_to_note.push((
+                                source_section.clone(),
+                                target.note_uid,
+                                confidence,
+                                display.clone(),
+                                wikilink.target.clone(),
+                            ));
+                        }
+                        if candidate.changed {
+                            changed_wikilinks += 1;
+                        }
                     }
-                }
-                if !resolved_heading {
-                    wikilink_to_note.push((
-                        source_section.clone(),
-                        target_uid.clone(),
-                        confidence,
-                        display.clone(),
-                        wikilink.target.clone(),
-                    ));
-                }
-                if candidate.changed {
-                    changed_wikilinks += 1;
                 }
             }
         }
@@ -704,6 +853,10 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
     rebuild_link_source_uids.dedup();
     let mut unresolved_seen = std::collections::HashSet::new();
     unresolved.retain(|record| unresolved_seen.insert(record.0.clone()));
+    let typed_edges = derive_typed_edges(&note_contexts, &lookup)
+        .into_iter()
+        .filter(|edge| rebuild_link_source_uids.contains(&edge.source_uid))
+        .collect::<Vec<_>>();
 
     let mut notes = Vec::new();
     let mut headings = Vec::new();
@@ -755,7 +908,12 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
         .collect();
     store
         .incremental_vault_refresh_atomically(
-            &v_uid,
+            &Vault {
+                uid: v_uid.clone(),
+                name: vault_name.to_string(),
+                root_path: root_str,
+                instance_id: instance_id.to_string(),
+            },
             &delete_note_uids,
             &rebuild_link_source_uids,
             &notes,
@@ -772,6 +930,7 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
             &wikilink_note_refs,
             &wikilink_heading_refs,
             &unresolved,
+            &typed_edges,
         )
         .context("atomic incremental vault refresh")?;
 
@@ -807,6 +966,134 @@ struct PreparedNoteGraph {
     note_tag_edges: Vec<(String, String)>,
     section_tag_edges: Vec<(String, String)>,
     tags_count: usize,
+}
+
+struct ParsedCandidate {
+    rel_path: String,
+    abs_path: PathBuf,
+    note_uid: String,
+    parsed: ParsedNote,
+    changed: bool,
+}
+
+fn add_note_identity(
+    identities: &mut HashSet<String>,
+    title: &str,
+    path: &str,
+    aliases: &[String],
+) {
+    identities.insert(title.to_lowercase());
+    let normalized = path.replace('\\', "/").to_lowercase();
+    identities.insert(normalized.clone());
+    if let Some(without_extension) = normalized
+        .strip_suffix(".md")
+        .or_else(|| normalized.strip_suffix(".markdown"))
+    {
+        identities.insert(without_extension.to_string());
+    }
+    if let Some(stem) = Path::new(path).file_stem().and_then(|stem| stem.to_str()) {
+        identities.insert(stem.to_lowercase());
+    }
+    identities.extend(aliases.iter().map(|alias| alias.to_lowercase()));
+}
+
+fn note_context_from_candidate(candidate: &ParsedCandidate) -> NoteContext {
+    let heading_uids: Vec<String> = candidate
+        .parsed
+        .headings
+        .iter()
+        .map(|heading| heading_uid(&candidate.note_uid, &heading.slug, heading.start_line))
+        .collect();
+    let section_uids = candidate
+        .parsed
+        .sections
+        .iter()
+        .map(|section| {
+            let hash = crate::hash::blake3_hex(&section.text);
+            section_uid(&candidate.note_uid, section.start_line, &hash[..12])
+        })
+        .collect();
+    NoteContext {
+        note_uid: candidate.note_uid.clone(),
+        rel_path: candidate.rel_path.clone(),
+        title: candidate.parsed.title.clone(),
+        folder: Path::new(&candidate.rel_path)
+            .parent()
+            .map(|path| path.to_string_lossy().into_owned())
+            .unwrap_or_default(),
+        aliases: candidate.parsed.aliases.clone(),
+        heading_uids,
+        heading_slugs: candidate
+            .parsed
+            .headings
+            .iter()
+            .map(|heading| heading.slug.clone())
+            .collect(),
+        section_uids,
+        wikilinks: candidate.parsed.wikilinks.clone(),
+        tags: candidate.parsed.tags.clone(),
+        frontmatter: candidate.parsed.frontmatter.clone(),
+        section_heading_text: candidate
+            .parsed
+            .sections
+            .iter()
+            .map(|section| {
+                section
+                    .heading_idx
+                    .and_then(|index| candidate.parsed.headings.get(index))
+                    .map(|heading| heading.text.to_lowercase())
+            })
+            .collect(),
+    }
+}
+
+fn note_context_from_stored(note: &Note, headings: Vec<Heading>) -> NoteContext {
+    let frontmatter = note
+        .frontmatter
+        .as_deref()
+        .and_then(|json| serde_json::from_str(json).ok())
+        .unwrap_or(serde_json::Value::Null);
+    let mut aliases = Vec::new();
+    for key in ["alias", "aliases"] {
+        if let Some(value) = frontmatter.get(key) {
+            match value {
+                serde_json::Value::Array(values) => aliases.extend(
+                    values
+                        .iter()
+                        .filter_map(|value| value.as_str().map(str::to_owned)),
+                ),
+                serde_json::Value::String(value) => aliases.push(value.clone()),
+                _ => {}
+            }
+        }
+    }
+    aliases = aliases
+        .into_iter()
+        .map(|alias| alias.trim().to_string())
+        .filter(|alias| !alias.is_empty())
+        .collect();
+    aliases.sort();
+    aliases.dedup();
+    NoteContext {
+        note_uid: note.uid.clone(),
+        rel_path: note.file_path.clone(),
+        title: note.title.clone(),
+        folder: Path::new(&note.file_path)
+            .parent()
+            .map(|path| path.to_string_lossy().into_owned())
+            .unwrap_or_default(),
+        aliases,
+        heading_uids: headings.iter().map(|heading| heading.uid.clone()).collect(),
+        heading_slugs: headings
+            .iter()
+            .map(|heading| heading.slug.clone())
+            .collect(),
+        section_uids: Vec::new(),
+        wikilinks: Vec::new(),
+        tags: Vec::new(),
+        frontmatter,
+        section_heading_text: Vec::new(),
+    }
 }
 
 fn string_edge_refs(edges: &[(String, String)]) -> Vec<(&str, &str)> {
@@ -3319,6 +3606,189 @@ sub b body
         let tags = store.list_tags(None).unwrap();
         assert_eq!(tags.len(), 1);
         assert_eq!(tags[0].name, "new");
+    }
+
+    #[test]
+    fn since_refresh_uses_full_path_alias_and_confidence_resolution() {
+        let (_dir, root) = make_vault(&[(
+            "folder/source.md",
+            "# Source\n\n[[plans/Rollout]]\n\n[[Short]]\n",
+        )]);
+        let store = GraphStore::in_memory().unwrap();
+        let db_path = root.join("unused.lbug");
+        index_markdown_directory_with_store(&store, &root, &db_path, "owned", "v", &[]).unwrap();
+        assert_eq!(store.count_wikilink_edges().unwrap(), 0);
+
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let since = std::time::SystemTime::now();
+        fs::create_dir_all(root.join("folder/plans")).unwrap();
+        fs::write(
+            root.join("folder/plans/Rollout.md"),
+            "---\nalias: Short\n---\n# Rollout\n",
+        )
+        .unwrap();
+        let result = index_markdown_directory_since_with_store_and_ignore(
+            &store,
+            &root,
+            "owned",
+            "v",
+            since,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(result.notes_updated, 1);
+        assert_eq!(store.count_wikilink_edges().unwrap(), 2);
+        let suspect = store.broken_wikilinks().unwrap();
+        assert!(
+            suspect
+                .iter()
+                .any(|link| (link.confidence - 0.7).abs() < 0.001)
+        );
+    }
+
+    #[test]
+    fn since_refresh_rederives_unresolved_frontmatter_typed_reference() {
+        let (_dir, root) = make_vault(&[("a.md", "---\ndepends_on:\n  - Future\n---\n# A\n")]);
+        let store = GraphStore::in_memory().unwrap();
+        let db_path = root.join("unused.lbug");
+        index_markdown_directory_with_store(&store, &root, &db_path, "owned", "v", &[]).unwrap();
+        assert!(store.typed_note_edges().unwrap().is_empty());
+
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let since = std::time::SystemTime::now();
+        fs::write(root.join("future.md"), "# Future\n").unwrap();
+        let result = index_markdown_directory_since_with_store_and_ignore(
+            &store,
+            &root,
+            "owned",
+            "v",
+            since,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(result.notes_updated, 1);
+        let typed = store.typed_note_edges().unwrap();
+        assert_eq!(typed.len(), 1);
+        assert_eq!(typed[0].2, "DEPENDS_ON");
+    }
+
+    #[test]
+    fn since_refresh_reads_only_changed_and_affected_sources() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct CountingReader {
+            inner: crate::content_reader::FilesystemReader,
+            reads: AtomicUsize,
+        }
+        impl ContentReader for CountingReader {
+            fn read_file(&self, rel_path: &Path) -> anyhow::Result<String> {
+                self.reads.fetch_add(1, Ordering::SeqCst);
+                self.inner.read_file(rel_path)
+            }
+            fn list_files(&self) -> anyhow::Result<Vec<PathBuf>> {
+                self.inner.list_files()
+            }
+            fn file_meta(&self, rel_path: &Path) -> anyhow::Result<Option<(u64, u64)>> {
+                self.inner.file_meta(rel_path)
+            }
+            fn root(&self) -> &Path {
+                self.inner.root()
+            }
+            fn version_id(&self) -> &str {
+                self.inner.version_id()
+            }
+        }
+
+        let files = (0..101)
+            .map(|index| {
+                (
+                    format!("note-{index}.md"),
+                    format!("# Note {index}\n\nbody\n"),
+                )
+            })
+            .collect::<Vec<_>>();
+        let borrowed = files
+            .iter()
+            .map(|(path, body)| (path.as_str(), body.as_str()))
+            .collect::<Vec<_>>();
+        let (_dir, root) = make_vault(&borrowed);
+        let store = GraphStore::in_memory().unwrap();
+        let db_path = root.join("unused.lbug");
+        index_markdown_directory_with_store(&store, &root, &db_path, "owned", "old", &[]).unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let since = std::time::SystemTime::now();
+        fs::write(root.join("note-100.md"), "# Changed leaf\n\nnew body\n").unwrap();
+        let reader = CountingReader {
+            inner: crate::content_reader::FilesystemReader::new(&root),
+            reads: AtomicUsize::new(0),
+        };
+        let ignore_set = crate::brainignore::load_brain_ignore(&root, &[]);
+        let result =
+            index_markdown_since_with_reader(&store, &reader, "owned", "new", since, &ignore_set)
+                .unwrap();
+        assert_eq!(result.notes_updated, 1);
+        assert_eq!(reader.reads.load(Ordering::SeqCst), 1);
+
+        let generation = store.graph_generation();
+        let result = index_markdown_since_with_reader(
+            &store,
+            &reader,
+            "owned",
+            "must-not-overwrite-noop",
+            std::time::SystemTime::now() + std::time::Duration::from_secs(60),
+            &ignore_set,
+        )
+        .unwrap();
+        assert_eq!(result.notes_updated, 0);
+        assert_eq!(
+            reader.reads.load(Ordering::SeqCst),
+            1,
+            "no-op reads no content"
+        );
+        assert_eq!(
+            store.graph_generation(),
+            generation,
+            "no-op opens no mutation"
+        );
+        assert_eq!(
+            store
+                .lookup_vault(&vault_uid("owned", &root.to_string_lossy()))
+                .unwrap()
+                .name,
+            "new"
+        );
+    }
+
+    #[test]
+    fn since_refresh_creates_a_never_indexed_empty_vault_once() {
+        let (_dir, root) = make_vault(&[]);
+        let store = GraphStore::in_memory().unwrap();
+        let result = index_markdown_directory_since_with_store_and_ignore(
+            &store,
+            &root,
+            "owned",
+            "empty",
+            std::time::SystemTime::now(),
+            &[],
+        )
+        .unwrap();
+        assert_eq!(result.notes_updated, 0);
+        let uid = vault_uid("owned", &root.to_string_lossy());
+        assert_eq!(store.lookup_vault(&uid).unwrap().name, "empty");
+        let generation = store.graph_generation();
+
+        index_markdown_directory_since_with_store_and_ignore(
+            &store,
+            &root,
+            "owned",
+            "renamed-noop",
+            std::time::SystemTime::now(),
+            &[],
+        )
+        .unwrap();
+        assert_eq!(store.lookup_vault(&uid).unwrap().name, "empty");
+        assert_eq!(store.graph_generation(), generation);
     }
 
     /// Build `n` distinct notes for a vault, with `make_note(0)` reusable so a

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -659,6 +659,13 @@ fn index_markdown_since_with_reader(
         }
     }
     for (_, source_note, source_path, _, link_target) in store.all_unresolved_wikilinks()? {
+        // The unresolved table is database-global. Only sources belonging to
+        // this vault may participate in its affected-source closure; otherwise
+        // a matching target added in vault A can make vault B's source appear
+        // "unavailable" and abort A's refresh.
+        if !existing_note_uids.contains(&source_note) {
+            continue;
+        }
         let normalized = link_target.trim().replace('\\', "/").to_lowercase();
         let joined = Path::new(&source_path).parent().map(|folder| {
             folder
@@ -3670,6 +3677,33 @@ sub b body
         let typed = store.typed_note_edges().unwrap();
         assert_eq!(typed.len(), 1);
         assert_eq!(typed[0].2, "DEPENDS_ON");
+    }
+
+    #[test]
+    fn since_refresh_ignores_other_vaults_matching_unresolved_targets() {
+        let (_a_dir, root_a) = make_vault(&[("a.md", "# A\n")]);
+        let (_b_dir, root_b) = make_vault(&[("b.md", "# B\n\n[[Future]]\n")]);
+        let store = GraphStore::in_memory().unwrap();
+        let db_path = root_a.join("unused.lbug");
+        index_markdown_directory_with_store(&store, &root_a, &db_path, "owned", "a", &[]).unwrap();
+        index_markdown_directory_with_store(&store, &root_b, &db_path, "owned", "b", &[]).unwrap();
+        let unresolved_before = store.all_unresolved_wikilinks().unwrap();
+        assert_eq!(unresolved_before.len(), 1);
+
+        let since = std::time::SystemTime::now();
+        fs::write(root_a.join("future.md"), "# Future\n").unwrap();
+        let result = index_markdown_directory_since_with_store_and_ignore(
+            &store,
+            &root_a,
+            "owned",
+            "a",
+            since,
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(result.notes_updated, 1);
+        assert_eq!(store.all_unresolved_wikilinks().unwrap(), unresolved_before);
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -362,8 +362,8 @@ pub struct MarkdownSinceResult {
 }
 
 /// Incrementally refresh only the files in `vault_root` whose filesystem
-/// modification time is >= `since`. For each matching file the old Note
-/// (and its descendants) is cascade-deleted then re-parsed and re-inserted.
+/// modification time is >= `since`. For each matching file the old Note and
+/// its descendants are atomically replaced by the re-parsed graph.
 /// Files that have not changed are untouched.
 ///
 /// If the vault has never been indexed this function creates it first and
@@ -508,17 +508,16 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
 
         let n_uid = note_uid(&v_uid, &rel_path_str);
 
-        // Delete old note data (cascade). Safe when note doesn't exist.
-        if let Err(e) = store.delete_note_cascade(&n_uid) {
-            tracing::warn!("delete_note_cascade {n_uid} failed: {e}");
-        } else if existing_note_uids.contains(&n_uid) {
-            notes_deleted += 1;
-        }
-
         let abs_path = vault_root.join(&rel_path);
         let (h_count, s_count, wl_count, t_count) =
             reinsert_single_note(store, &v_uid, &n_uid, &abs_path, &rel_path_str, &parsed)
                 .with_context(|| format!("reinsert_single_note {rel_path_str}"))?;
+
+        // Replacement commits the incumbent deletion and the new graph in one
+        // transaction, so this count reflects committed truth.
+        if existing_note_uids.contains(&n_uid) {
+            notes_deleted += 1;
+        }
 
         total_headings += h_count;
         total_sections += s_count;
@@ -534,7 +533,7 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
     for note in &existing_notes {
         if !vault_root.join(&note.file_path).exists() {
             store
-                .delete_note_cascade(&note.uid)
+                .delete_note_cascade_atomic(&note.uid)
                 .with_context(|| format!("delete removed note {}", note.file_path))?;
             notes_deleted += 1;
         }
@@ -561,8 +560,8 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
     })
 }
 
-/// Insert a single note (and all its descendants: headings, sections, tags,
-/// wikilinks) into the store. Mirrors the watcher's per-file insertion logic.
+/// Atomically replace a single note (and all its descendants: headings,
+/// sections, tags, wikilinks). Mirrors the watcher's per-file insertion logic.
 /// Returns `(headings_count, sections_count, wikilinks_resolved, tags_count)`.
 fn reinsert_single_note(
     store: &GraphStore,
@@ -591,25 +590,20 @@ fn reinsert_single_note(
         Err(_) => (None, None),
     };
 
-    store
-        .insert_note(&Note {
-            uid: n_uid.to_string(),
-            vault_uid: v_uid.to_string(),
-            file_path: rel_path.to_string(),
-            title: parsed.title.clone(),
-            note_kind: parsed.note_kind,
-            word_count: parsed.word_count,
-            content_hash: parsed.content_hash.clone(),
-            frontmatter: frontmatter_json,
-            created_at,
-            modified_at,
-            pagerank_score: None,
-            embedding: None,
-        })
-        .context("insert_note")?;
-    store
-        .insert_vault_note_edge(v_uid, n_uid)
-        .context("insert_vault_note_edge")?;
+    let note = Note {
+        uid: n_uid.to_string(),
+        vault_uid: v_uid.to_string(),
+        file_path: rel_path.to_string(),
+        title: parsed.title.clone(),
+        note_kind: parsed.note_kind,
+        word_count: parsed.word_count,
+        content_hash: parsed.content_hash.clone(),
+        frontmatter: frontmatter_json,
+        created_at,
+        modified_at,
+        pagerank_score: None,
+        embedding: None,
+    };
 
     // Headings.
     let heading_uids: Vec<String> = parsed
@@ -633,13 +627,10 @@ fn reinsert_single_note(
             embedding: None,
         })
         .collect();
-    store
-        .batch_insert_headings(&headings)
-        .context("batch_insert_headings")?;
-    let nh_edges: Vec<(&str, &str)> = heading_uids.iter().map(|h| (n_uid, h.as_str())).collect();
-    store
-        .batch_insert_note_heading_edges(&nh_edges)
-        .context("batch_insert_note_heading_edges")?;
+    let nh_edges: Vec<(String, String)> = heading_uids
+        .iter()
+        .map(|h| (n_uid.to_string(), h.clone()))
+        .collect();
 
     let mut parent_edges: Vec<(String, String)> = Vec::new();
     for (idx, h) in parsed.headings.iter().enumerate() {
@@ -650,13 +641,6 @@ fn reinsert_single_note(
             }
         }
     }
-    let parent_refs: Vec<(&str, &str)> = parent_edges
-        .iter()
-        .map(|(c, p)| (c.as_str(), p.as_str()))
-        .collect();
-    store
-        .batch_insert_heading_parent_edges(&parent_refs)
-        .context("batch_insert_heading_parent_edges")?;
 
     // Sections.
     let mut section_uids: Vec<String> = Vec::with_capacity(parsed.sections.len());
@@ -685,23 +669,6 @@ fn reinsert_single_note(
         }
         section_uids.push(s_uid);
     }
-    store
-        .batch_insert_sections(&sections)
-        .context("batch_insert_sections")?;
-    let ns_refs: Vec<(&str, &str)> = ns_edges
-        .iter()
-        .map(|(a, b)| (a.as_str(), b.as_str()))
-        .collect();
-    store
-        .batch_insert_note_section_edges(&ns_refs)
-        .context("batch_insert_note_section_edges")?;
-    let hs_refs: Vec<(&str, &str)> = hs_edges
-        .iter()
-        .map(|(a, b)| (a.as_str(), b.as_str()))
-        .collect();
-    store
-        .batch_insert_heading_section_edges(&hs_refs)
-        .context("batch_insert_heading_section_edges")?;
 
     // Tags.
     let mut local_tag_uids: HashMap<String, String> = HashMap::new();
@@ -735,27 +702,13 @@ fn reinsert_single_note(
             }
         }
     }
-    for t in &new_tag_nodes {
-        if let Err(e) = store.insert_tag(t)
-            && !e.is_duplicate()
-        {
-            tracing::warn!("insert_tag {} failed: {e}", t.name);
-        }
-    }
-    let nt_refs: Vec<(&str, &str)> = note_tag_edges
-        .iter()
-        .map(|(a, b)| (a.as_str(), b.as_str()))
+    let existing_tag_uids: std::collections::HashSet<String> = store
+        .list_tags(Some(v_uid))
+        .unwrap_or_default()
+        .into_iter()
+        .map(|tag| tag.uid)
         .collect();
-    store
-        .batch_insert_note_tag_edges(&nt_refs)
-        .context("batch_insert_note_tag_edges")?;
-    let st_refs: Vec<(&str, &str)> = section_tag_edges
-        .iter()
-        .map(|(a, b)| (a.as_str(), b.as_str()))
-        .collect();
-    store
-        .batch_insert_section_tag_edges(&st_refs)
-        .context("batch_insert_section_tag_edges")?;
+    new_tag_nodes.retain(|tag| !existing_tag_uids.contains(&tag.uid));
     let tags_count = local_tag_uids.len();
 
     // Wikilinks: resolve against all notes currently in the DB.
@@ -763,10 +716,16 @@ fn reinsert_single_note(
     let title_lookup: HashMap<String, Vec<String>> = {
         let mut map: HashMap<String, Vec<String>> = HashMap::new();
         for n in &all_notes {
+            if n.uid == n_uid {
+                continue;
+            }
             map.entry(n.title.to_lowercase())
                 .or_default()
                 .push(n.uid.clone());
         }
+        map.entry(parsed.title.to_lowercase())
+            .or_default()
+            .push(n_uid.to_string());
         map
     };
     // nw-122: carry BOTH the visible text and the link target. Backlinks want
@@ -807,9 +766,12 @@ fn reinsert_single_note(
         for target in candidates {
             if let Some(anchor) = &wl.heading_anchor {
                 let anchor_slug = nestweaver_parser::markdown::slugify(anchor);
-                if let Ok(headings) = store.headings_in_note(target)
-                    && let Some(h) = headings.iter().find(|h| h.slug == anchor_slug)
-                {
+                let target_headings = if target == n_uid {
+                    headings.clone()
+                } else {
+                    store.headings_in_note(target).unwrap_or_default()
+                };
+                if let Some(h) = target_headings.iter().find(|h| h.slug == anchor_slug) {
                     wl_head_edges.push((
                         source_section.clone(),
                         h.uid.clone(),
@@ -830,27 +792,58 @@ fn reinsert_single_note(
         }
     }
     let wl_resolved = wl_note_edges.len() + wl_head_edges.len();
-    {
-        let mut seen = std::collections::HashSet::new();
-        unresolved.retain(|(uid, ..)| seen.insert(uid.clone()));
-        if let Err(e) = store.batch_insert_unresolved_wikilinks(&unresolved) {
-            tracing::warn!("failed to record unresolved wikilinks: {e}");
-        }
-    }
+    let mut seen = std::collections::HashSet::new();
+    unresolved.retain(|(uid, ..)| seen.insert(uid.clone()));
     let wl_note_refs: Vec<(&str, &str, f32, &str, &str)> = wl_note_edges
         .iter()
         .map(|(s, n, c, d, t)| (s.as_str(), n.as_str(), *c, d.as_str(), t.as_str()))
         .collect();
-    store
-        .batch_insert_wikilink_to_note_edges(&wl_note_refs)
-        .context("batch_insert_wikilink_to_note_edges")?;
     let wl_head_refs: Vec<(&str, &str, f32, &str, &str)> = wl_head_edges
         .iter()
         .map(|(s, h, c, d, t)| (s.as_str(), h.as_str(), *c, d.as_str(), t.as_str()))
         .collect();
-    store
-        .batch_insert_wikilink_to_heading_edges(&wl_head_refs)
-        .context("batch_insert_wikilink_to_heading_edges")?;
+    let vault_note_edges = [(v_uid, n_uid)];
+    let nh_refs: Vec<(&str, &str)> = nh_edges
+        .iter()
+        .map(|(a, b)| (a.as_str(), b.as_str()))
+        .collect();
+    let ns_refs: Vec<(&str, &str)> = ns_edges
+        .iter()
+        .map(|(a, b)| (a.as_str(), b.as_str()))
+        .collect();
+    let hs_refs: Vec<(&str, &str)> = hs_edges
+        .iter()
+        .map(|(a, b)| (a.as_str(), b.as_str()))
+        .collect();
+    let parent_refs: Vec<(&str, &str)> = parent_edges
+        .iter()
+        .map(|(a, b)| (a.as_str(), b.as_str()))
+        .collect();
+    let nt_refs: Vec<(&str, &str)> = note_tag_edges
+        .iter()
+        .map(|(a, b)| (a.as_str(), b.as_str()))
+        .collect();
+    let st_refs: Vec<(&str, &str)> = section_tag_edges
+        .iter()
+        .map(|(a, b)| (a.as_str(), b.as_str()))
+        .collect();
+    store.replace_note_atomically(
+        n_uid,
+        &[note],
+        &headings,
+        &sections,
+        &vault_note_edges,
+        &nh_refs,
+        &ns_refs,
+        &hs_refs,
+        &parent_refs,
+        &new_tag_nodes,
+        &nt_refs,
+        &st_refs,
+        &wl_note_refs,
+        &wl_head_refs,
+        &unresolved,
+    )?;
 
     Ok((headings.len(), sections.len(), wl_resolved, tags_count))
 }
@@ -3095,6 +3088,33 @@ sub b body
             notes[0].vault_uid,
             nestweaver_schema::vault_uid("owned", &root.to_string_lossy())
         );
+        assert_eq!(notes[0].title, "A");
+    }
+
+    #[test]
+    fn since_refresh_atomically_replaces_a_tagged_incumbent() {
+        let (_dir, root) = make_vault(&[("a.md", "# Old\n\n#keep old body\n")]);
+        let store = GraphStore::in_memory().unwrap();
+        let db_path = root.join("unused.lbug");
+        index_markdown_directory_with_store(&store, &root, &db_path, "owned", "v", &[]).unwrap();
+
+        fs::write(root.join("a.md"), "# New\n\n#keep new body\n").unwrap();
+        let result = index_markdown_directory_since_with_store_and_ignore(
+            &store,
+            &root,
+            "owned",
+            "v",
+            std::time::SystemTime::UNIX_EPOCH,
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(result.notes_updated, 1);
+        assert_eq!(result.notes_deleted, 1);
+        let notes = store.list_notes(None).unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].title, "New");
+        assert_eq!(store.list_tags(None).unwrap().len(), 1);
     }
 
     /// Build `n` distinct notes for a vault, with `make_note(0)` reusable so a

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -447,13 +447,16 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
 
     let all_files = reader.list_files()?;
 
+    struct ParsedCandidate {
+        rel_path: String,
+        abs_path: PathBuf,
+        note_uid: String,
+        parsed: ParsedNote,
+        changed: bool,
+    }
+
     let mut files_checked = 0usize;
-    let mut notes_updated = 0usize;
-    let mut notes_deleted = 0usize;
-    let mut total_headings = 0usize;
-    let mut total_sections = 0usize;
-    let mut total_tags = 0usize;
-    let mut total_wikilinks = 0usize;
+    let mut candidates = Vec::new();
 
     for rel_path in all_files {
         if !is_markdown(&rel_path) {
@@ -471,82 +474,313 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
         }
 
         files_checked += 1;
+        let rel_path_str = rel_str.into_owned();
+        let n_uid = note_uid(&v_uid, &rel_path_str);
 
-        // Filter by modification time via ContentReader metadata.
-        // Bare repos (GitBareReader) return None — skip mtime filter, always process.
-        match reader.file_meta(&rel_path) {
+        // Parse successfully-readable unchanged files too: if any target note
+        // changes, their outgoing links must be rebuilt in the same transaction
+        // so inbound backlinks survive and rename resolution is order-independent.
+        let changed = match reader.file_meta(&rel_path) {
             Ok(Some((mtime_secs, file_size))) => {
-                if mtime_secs < since_secs {
-                    continue;
-                }
                 if file_size > MAX_FILE_SIZE_BYTES {
-                    tracing::warn!("skipping oversized file: {}", rel_str);
+                    if existing_note_uids.contains(&n_uid) {
+                        return Err(anyhow::anyhow!(
+                            "cannot safely rebuild wikilinks for oversized indexed note {rel_path_str}"
+                        ));
+                    }
+                    tracing::warn!("skipping oversized file: {}", rel_path_str);
                     continue;
                 }
+                mtime_secs >= since_secs
             }
-            Ok(None) => {} // bare repo: no mtime, process unconditionally
-            Err(_) => continue,
-        };
-
-        let source = match reader.read_file(&rel_path) {
-            Ok(s) => s,
-            Err(err) => {
-                tracing::warn!("read error {}: {err}", rel_str);
+            Ok(None) => true, // bare repo: no mtime, process unconditionally
+            Err(error) => {
+                if existing_note_uids.contains(&n_uid) {
+                    return Err(anyhow::anyhow!(
+                        "cannot safely read metadata for indexed note {rel_path_str}: {error}"
+                    ));
+                }
                 continue;
             }
         };
-
-        let rel_path_str = rel_str.into_owned();
+        let source = match reader.read_file(&rel_path) {
+            Ok(s) => s,
+            Err(err) => {
+                if existing_note_uids.contains(&n_uid) {
+                    return Err(anyhow::anyhow!(
+                        "cannot safely rebuild wikilinks for indexed note {rel_path_str}: {err}"
+                    ));
+                }
+                tracing::warn!("read error {}: {err}", rel_path_str);
+                continue;
+            }
+        };
 
         let parsed: ParsedNote = match parse_markdown(&rel_path_str, &source) {
             Ok(p) => p,
             Err(err) => {
+                if existing_note_uids.contains(&n_uid) {
+                    return Err(anyhow::anyhow!(
+                        "cannot safely rebuild wikilinks for indexed note {rel_path_str}: {err}"
+                    ));
+                }
                 tracing::warn!("parse error {rel_path_str}: {err}");
                 continue;
             }
         };
-
-        let n_uid = note_uid(&v_uid, &rel_path_str);
-
-        let abs_path = vault_root.join(&rel_path);
-        let (h_count, s_count, wl_count, t_count) =
-            reinsert_single_note(store, &v_uid, &n_uid, &abs_path, &rel_path_str, &parsed)
-                .with_context(|| format!("reinsert_single_note {rel_path_str}"))?;
-
-        // Replacement commits the incumbent deletion and the new graph in one
-        // transaction, so this count reflects committed truth.
-        if existing_note_uids.contains(&n_uid) {
-            notes_deleted += 1;
-        }
-
-        total_headings += h_count;
-        total_sections += s_count;
-        total_wikilinks += wl_count;
-        total_tags += t_count;
-        notes_updated += 1;
+        candidates.push(ParsedCandidate {
+            rel_path: rel_path_str,
+            abs_path: vault_root.join(&rel_path),
+            note_uid: n_uid,
+            parsed,
+            changed,
+        });
     }
 
-    // Files deleted since the last refresh are absent from `list_files`, so
-    // discover them from the incumbent graph. This is safe regardless of the
-    // timestamp: a registered Note whose vault-relative file no longer exists
-    // cannot still be current. Ignored files remain on disk and are preserved.
+    let removed_uids: std::collections::HashSet<String> = existing_notes
+        .iter()
+        .filter(|note| !vault_root.join(&note.file_path).exists())
+        .map(|note| note.uid.clone())
+        .collect();
+    let changed_uids: std::collections::HashSet<String> = candidates
+        .iter()
+        .filter(|candidate| candidate.changed)
+        .map(|candidate| candidate.note_uid.clone())
+        .collect();
+    let mut delete_note_uids: Vec<String> = removed_uids.iter().cloned().collect();
+    delete_note_uids.extend(
+        changed_uids
+            .iter()
+            .filter(|uid| existing_note_uids.contains(*uid))
+            .cloned(),
+    );
+    delete_note_uids.sort();
+    delete_note_uids.dedup();
+
+    let notes_updated = candidates
+        .iter()
+        .filter(|candidate| candidate.changed)
+        .count();
+    let notes_deleted = delete_note_uids.len();
+    if notes_updated == 0 && notes_deleted == 0 {
+        return Ok(MarkdownSinceResult {
+            vault_name: vault_name.to_string(),
+            files_checked,
+            notes_updated: 0,
+            notes_deleted: 0,
+            headings_count: 0,
+            sections_count: 0,
+            tags_count: 0,
+            wikilinks_resolved: 0,
+        });
+    }
+
+    let existing_tag_uids: std::collections::HashSet<String> = store
+        .list_tags(Some(&v_uid))
+        .context("list existing vault tags")?
+        .into_iter()
+        .map(|tag| tag.uid)
+        .collect();
+    let mut prepared = Vec::new();
+    for candidate in candidates.iter().filter(|candidate| candidate.changed) {
+        prepared.push(prepare_single_note(
+            &v_uid,
+            &candidate.note_uid,
+            &candidate.abs_path,
+            &candidate.rel_path,
+            &candidate.parsed,
+            &existing_tag_uids,
+        )?);
+    }
+
+    // Resolve against the complete prospective title/heading graph, never the
+    // partially-mutated file order.
+    let deleted_set: std::collections::HashSet<&str> =
+        delete_note_uids.iter().map(String::as_str).collect();
+    let mut title_lookup: HashMap<String, Vec<String>> = HashMap::new();
+    let mut heading_lookup: HashMap<String, Vec<Heading>> = HashMap::new();
     for note in &existing_notes {
-        if !vault_root.join(&note.file_path).exists() {
-            store
-                .delete_note_cascade_atomic(&note.uid)
-                .with_context(|| format!("delete removed note {}", note.file_path))?;
-            notes_deleted += 1;
+        if !deleted_set.contains(note.uid.as_str()) {
+            title_lookup
+                .entry(note.title.to_lowercase())
+                .or_default()
+                .push(note.uid.clone());
+            heading_lookup.insert(
+                note.uid.clone(),
+                store.headings_in_note(&note.uid).unwrap_or_default(),
+            );
         }
     }
+    for graph in &prepared {
+        title_lookup
+            .entry(graph.note.title.to_lowercase())
+            .or_default()
+            .push(graph.note.uid.clone());
+        heading_lookup.insert(graph.note.uid.clone(), graph.headings.clone());
+    }
+
+    let prospective_uids: std::collections::HashSet<String> = existing_notes
+        .iter()
+        .filter(|note| !deleted_set.contains(note.uid.as_str()))
+        .map(|note| note.uid.clone())
+        .chain(prepared.iter().map(|graph| graph.note.uid.clone()))
+        .collect();
+    let mut rebuild_link_source_uids = Vec::new();
+    let mut wikilink_to_note = Vec::new();
+    let mut wikilink_to_heading = Vec::new();
+    let mut unresolved = Vec::new();
+    let mut changed_wikilinks = 0usize;
+    for candidate in &candidates {
+        if !prospective_uids.contains(&candidate.note_uid) {
+            continue;
+        }
+        rebuild_link_source_uids.push(candidate.note_uid.clone());
+        let section_uids: Vec<String> = candidate
+            .parsed
+            .sections
+            .iter()
+            .map(|section| {
+                let text_hash = crate::hash::blake3_hex(&section.text);
+                section_uid(&candidate.note_uid, section.start_line, &text_hash[..12])
+            })
+            .collect();
+        for wikilink in &candidate.parsed.wikilinks {
+            let Some(source_section) = section_uids.get(wikilink.section_idx) else {
+                continue;
+            };
+            let display = wikilink
+                .display
+                .clone()
+                .unwrap_or_else(|| wikilink.target.clone());
+            let Some(targets) = title_lookup.get(&wikilink.target.to_lowercase()) else {
+                unresolved.push((
+                    format!(
+                        "unresolved:{}:{}",
+                        source_section,
+                        crate::hash::blake3_hex_short(&wikilink.target)
+                    ),
+                    candidate.note_uid.clone(),
+                    candidate.rel_path.clone(),
+                    candidate.parsed.title.clone(),
+                    wikilink.target.clone(),
+                ));
+                continue;
+            };
+            let confidence = 1.0 / targets.len() as f32;
+            for target_uid in targets {
+                let mut resolved_heading = false;
+                if let Some(anchor) = &wikilink.heading_anchor {
+                    let slug = nestweaver_parser::markdown::slugify(anchor);
+                    if let Some(heading) = heading_lookup
+                        .get(target_uid)
+                        .and_then(|headings| headings.iter().find(|heading| heading.slug == slug))
+                    {
+                        wikilink_to_heading.push((
+                            source_section.clone(),
+                            heading.uid.clone(),
+                            confidence,
+                            display.clone(),
+                            wikilink.target.clone(),
+                        ));
+                        resolved_heading = true;
+                    }
+                }
+                if !resolved_heading {
+                    wikilink_to_note.push((
+                        source_section.clone(),
+                        target_uid.clone(),
+                        confidence,
+                        display.clone(),
+                        wikilink.target.clone(),
+                    ));
+                }
+                if candidate.changed {
+                    changed_wikilinks += 1;
+                }
+            }
+        }
+    }
+    rebuild_link_source_uids.sort();
+    rebuild_link_source_uids.dedup();
+    let mut unresolved_seen = std::collections::HashSet::new();
+    unresolved.retain(|record| unresolved_seen.insert(record.0.clone()));
+
+    let mut notes = Vec::new();
+    let mut headings = Vec::new();
+    let mut sections = Vec::new();
+    let mut vault_note_edges = Vec::new();
+    let mut note_heading_edges = Vec::new();
+    let mut note_section_edges = Vec::new();
+    let mut heading_section_edges = Vec::new();
+    let mut heading_parent_edges = Vec::new();
+    let mut tags = Vec::new();
+    let mut note_tag_edges = Vec::new();
+    let mut section_tag_edges = Vec::new();
+    let mut tag_seen = std::collections::HashSet::new();
+    let total_headings = prepared.iter().map(|graph| graph.headings.len()).sum();
+    let total_sections = prepared.iter().map(|graph| graph.sections.len()).sum();
+    let total_tags = prepared.iter().map(|graph| graph.tags_count).sum();
+    for graph in prepared {
+        notes.push(graph.note);
+        headings.extend(graph.headings);
+        sections.extend(graph.sections);
+        vault_note_edges.extend(graph.vault_note_edges);
+        note_heading_edges.extend(graph.note_heading_edges);
+        note_section_edges.extend(graph.note_section_edges);
+        heading_section_edges.extend(graph.heading_section_edges);
+        heading_parent_edges.extend(graph.heading_parent_edges);
+        tags.extend(
+            graph
+                .tags
+                .into_iter()
+                .filter(|tag| tag_seen.insert(tag.uid.clone())),
+        );
+        note_tag_edges.extend(graph.note_tag_edges);
+        section_tag_edges.extend(graph.section_tag_edges);
+    }
+    let vault_note_refs = string_edge_refs(&vault_note_edges);
+    let note_heading_refs = string_edge_refs(&note_heading_edges);
+    let note_section_refs = string_edge_refs(&note_section_edges);
+    let heading_section_refs = string_edge_refs(&heading_section_edges);
+    let heading_parent_refs = string_edge_refs(&heading_parent_edges);
+    let note_tag_refs = string_edge_refs(&note_tag_edges);
+    let section_tag_refs = string_edge_refs(&section_tag_edges);
+    let wikilink_note_refs: Vec<_> = wikilink_to_note
+        .iter()
+        .map(|(s, t, c, d, l)| (s.as_str(), t.as_str(), *c, d.as_str(), l.as_str()))
+        .collect();
+    let wikilink_heading_refs: Vec<_> = wikilink_to_heading
+        .iter()
+        .map(|(s, t, c, d, l)| (s.as_str(), t.as_str(), *c, d.as_str(), l.as_str()))
+        .collect();
+    store
+        .incremental_vault_refresh_atomically(
+            &v_uid,
+            &delete_note_uids,
+            &rebuild_link_source_uids,
+            &notes,
+            &headings,
+            &sections,
+            &vault_note_refs,
+            &note_heading_refs,
+            &note_section_refs,
+            &heading_section_refs,
+            &heading_parent_refs,
+            &tags,
+            &note_tag_refs,
+            &section_tag_refs,
+            &wikilink_note_refs,
+            &wikilink_heading_refs,
+            &unresolved,
+        )
+        .context("atomic incremental vault refresh")?;
 
     // Advance + persist the graph generation when any note was mutated.
     // An in-place edit deletes and recreates the note's sections, leaving the
     // candidate-node count unchanged — the generation bump is the only signal
     // that stales the trigram posting table (mirrors `index.rs` and the full
     // vault index above).
-    if notes_updated > 0 || notes_deleted > 0 {
-        store.bump_and_persist_generation();
-    }
+    store.bump_and_persist_generation();
 
     Ok(MarkdownSinceResult {
         vault_name: vault_name.to_string(),
@@ -556,21 +790,42 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
         headings_count: total_headings,
         sections_count: total_sections,
         tags_count: total_tags,
-        wikilinks_resolved: total_wikilinks,
+        wikilinks_resolved: changed_wikilinks,
     })
 }
 
-/// Atomically replace a single note (and all its descendants: headings,
-/// sections, tags, wikilinks). Mirrors the watcher's per-file insertion logic.
-/// Returns `(headings_count, sections_count, wikilinks_resolved, tags_count)`.
-fn reinsert_single_note(
-    store: &GraphStore,
+struct PreparedNoteGraph {
+    note: Note,
+    headings: Vec<Heading>,
+    sections: Vec<Section>,
+    vault_note_edges: Vec<(String, String)>,
+    note_heading_edges: Vec<(String, String)>,
+    note_section_edges: Vec<(String, String)>,
+    heading_section_edges: Vec<(String, String)>,
+    heading_parent_edges: Vec<(String, String)>,
+    tags: Vec<Tag>,
+    note_tag_edges: Vec<(String, String)>,
+    section_tag_edges: Vec<(String, String)>,
+    tags_count: usize,
+}
+
+fn string_edge_refs(edges: &[(String, String)]) -> Vec<(&str, &str)> {
+    edges
+        .iter()
+        .map(|(left, right)| (left.as_str(), right.as_str()))
+        .collect()
+}
+
+/// Prepare one replacement note without mutating the graph. All preparations
+/// complete before the incremental refresh opens its single transaction.
+fn prepare_single_note(
     v_uid: &str,
     n_uid: &str,
     path: &Path,
     rel_path: &str,
     parsed: &ParsedNote,
-) -> Result<(usize, usize, usize, usize), anyhow::Error> {
+    existing_tag_uids: &std::collections::HashSet<String>,
+) -> Result<PreparedNoteGraph, anyhow::Error> {
     let frontmatter_json = if parsed
         .frontmatter
         .as_object()
@@ -702,150 +957,22 @@ fn reinsert_single_note(
             }
         }
     }
-    let existing_tag_uids: std::collections::HashSet<String> = store
-        .list_tags(Some(v_uid))
-        .unwrap_or_default()
-        .into_iter()
-        .map(|tag| tag.uid)
-        .collect();
     new_tag_nodes.retain(|tag| !existing_tag_uids.contains(&tag.uid));
     let tags_count = local_tag_uids.len();
-
-    // Wikilinks: resolve against all notes currently in the DB.
-    let all_notes = store.list_notes(None).unwrap_or_default();
-    let title_lookup: HashMap<String, Vec<String>> = {
-        let mut map: HashMap<String, Vec<String>> = HashMap::new();
-        for n in &all_notes {
-            if n.uid == n_uid {
-                continue;
-            }
-            map.entry(n.title.to_lowercase())
-                .or_default()
-                .push(n.uid.clone());
-        }
-        map.entry(parsed.title.to_lowercase())
-            .or_default()
-            .push(n_uid.to_string());
-        map
-    };
-    // nw-122: carry BOTH the visible text and the link target. Backlinks want
-    // the alias a reader sees; broken-links wants the target resolution acted
-    // on. Reporting the alias there rendered `[[workspace]]` for
-    // `[[Home|workspace]]` — a link that appears nowhere in the vault.
-    let mut wl_note_edges: Vec<(String, String, f32, String, String)> = Vec::new();
-    let mut wl_head_edges: Vec<(String, String, f32, String, String)> = Vec::new();
-    // Unresolved links collected for a single batched insert — a per-row insert
-    // here made a single note with many missing-target links hang the watcher.
-    let mut unresolved: Vec<(String, String, String, String, String)> = Vec::new();
-
-    for wl in &parsed.wikilinks {
-        if wl.section_idx >= section_uids.len() {
-            continue;
-        }
-        let source_section = &section_uids[wl.section_idx];
-        let display = wl.display.clone().unwrap_or_else(|| wl.target.clone());
-        let key = wl.target.to_lowercase();
-        let Some(candidates) = title_lookup.get(&key) else {
-            // Genuinely unresolved — record so broken-links can surface it.
-            let uw_uid = format!(
-                "unresolved:{}:{}",
-                source_section,
-                crate::hash::blake3_hex_short(&wl.target)
-            );
-            unresolved.push((
-                uw_uid,
-                n_uid.to_string(),
-                rel_path.to_string(),
-                parsed.title.clone(),
-                wl.target.clone(),
-            ));
-            continue;
-        };
-        let n = candidates.len() as f32;
-        let conf = if n == 1.0 { 1.0 } else { 1.0 / n };
-        for target in candidates {
-            if let Some(anchor) = &wl.heading_anchor {
-                let anchor_slug = nestweaver_parser::markdown::slugify(anchor);
-                let target_headings = if target == n_uid {
-                    headings.clone()
-                } else {
-                    store.headings_in_note(target).unwrap_or_default()
-                };
-                if let Some(h) = target_headings.iter().find(|h| h.slug == anchor_slug) {
-                    wl_head_edges.push((
-                        source_section.clone(),
-                        h.uid.clone(),
-                        conf,
-                        display.clone(),
-                        wl.target.clone(),
-                    ));
-                    continue;
-                }
-            }
-            wl_note_edges.push((
-                source_section.clone(),
-                target.clone(),
-                conf,
-                display.clone(),
-                wl.target.clone(),
-            ));
-        }
-    }
-    let wl_resolved = wl_note_edges.len() + wl_head_edges.len();
-    let mut seen = std::collections::HashSet::new();
-    unresolved.retain(|(uid, ..)| seen.insert(uid.clone()));
-    let wl_note_refs: Vec<(&str, &str, f32, &str, &str)> = wl_note_edges
-        .iter()
-        .map(|(s, n, c, d, t)| (s.as_str(), n.as_str(), *c, d.as_str(), t.as_str()))
-        .collect();
-    let wl_head_refs: Vec<(&str, &str, f32, &str, &str)> = wl_head_edges
-        .iter()
-        .map(|(s, h, c, d, t)| (s.as_str(), h.as_str(), *c, d.as_str(), t.as_str()))
-        .collect();
-    let vault_note_edges = [(v_uid, n_uid)];
-    let nh_refs: Vec<(&str, &str)> = nh_edges
-        .iter()
-        .map(|(a, b)| (a.as_str(), b.as_str()))
-        .collect();
-    let ns_refs: Vec<(&str, &str)> = ns_edges
-        .iter()
-        .map(|(a, b)| (a.as_str(), b.as_str()))
-        .collect();
-    let hs_refs: Vec<(&str, &str)> = hs_edges
-        .iter()
-        .map(|(a, b)| (a.as_str(), b.as_str()))
-        .collect();
-    let parent_refs: Vec<(&str, &str)> = parent_edges
-        .iter()
-        .map(|(a, b)| (a.as_str(), b.as_str()))
-        .collect();
-    let nt_refs: Vec<(&str, &str)> = note_tag_edges
-        .iter()
-        .map(|(a, b)| (a.as_str(), b.as_str()))
-        .collect();
-    let st_refs: Vec<(&str, &str)> = section_tag_edges
-        .iter()
-        .map(|(a, b)| (a.as_str(), b.as_str()))
-        .collect();
-    store.replace_note_atomically(
-        n_uid,
-        &[note],
-        &headings,
-        &sections,
-        &vault_note_edges,
-        &nh_refs,
-        &ns_refs,
-        &hs_refs,
-        &parent_refs,
-        &new_tag_nodes,
-        &nt_refs,
-        &st_refs,
-        &wl_note_refs,
-        &wl_head_refs,
-        &unresolved,
-    )?;
-
-    Ok((headings.len(), sections.len(), wl_resolved, tags_count))
+    Ok(PreparedNoteGraph {
+        note,
+        headings,
+        sections,
+        vault_note_edges: vec![(v_uid.to_string(), n_uid.to_string())],
+        note_heading_edges: nh_edges,
+        note_section_edges: ns_edges,
+        heading_section_edges: hs_edges,
+        heading_parent_edges: parent_edges,
+        tags: new_tag_nodes,
+        note_tag_edges,
+        section_tag_edges,
+        tags_count,
+    })
 }
 
 fn index_into_store(
@@ -3115,6 +3242,83 @@ sub b body
         assert_eq!(notes.len(), 1);
         assert_eq!(notes[0].title, "New");
         assert_eq!(store.list_tags(None).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn since_refresh_preserves_unchanged_inbound_wikilink_to_changed_note() {
+        let (_dir, root) = make_vault(&[
+            ("a.md", "# A\n\n[[B#Target]]\n"),
+            ("b.md", "# B\n\n## Target\n\nold body\n"),
+        ]);
+        let store = GraphStore::in_memory().unwrap();
+        let db_path = root.join("unused.lbug");
+        index_markdown_directory_with_store(&store, &root, &db_path, "owned", "v", &[]).unwrap();
+        assert_eq!(store.count_wikilink_edges().unwrap(), 1);
+
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let since = std::time::SystemTime::now();
+        fs::write(root.join("b.md"), "# B\n\n## Target\n\nchanged body\n").unwrap();
+        index_markdown_directory_since_with_store_and_ignore(
+            &store,
+            &root,
+            "owned",
+            "v",
+            since,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(store.count_wikilink_edges().unwrap(), 1);
+    }
+
+    #[test]
+    fn since_refresh_resolves_two_renamed_notes_independent_of_file_order() {
+        let (_dir, root) = make_vault(&[
+            ("a.md", "# Old A\n\n[[Old B]]\n"),
+            ("z.md", "# Old B\n\n[[Old A]]\n"),
+        ]);
+        let store = GraphStore::in_memory().unwrap();
+        let db_path = root.join("unused.lbug");
+        index_markdown_directory_with_store(&store, &root, &db_path, "owned", "v", &[]).unwrap();
+
+        fs::write(root.join("a.md"), "# New A\n\n[[New B]]\n").unwrap();
+        fs::write(root.join("z.md"), "# New B\n\n[[New A]]\n").unwrap();
+        index_markdown_directory_since_with_store_and_ignore(
+            &store,
+            &root,
+            "owned",
+            "v",
+            std::time::SystemTime::UNIX_EPOCH,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(store.count_wikilink_edges().unwrap(), 2);
+    }
+
+    #[test]
+    fn since_refresh_garbage_collects_replaced_and_deleted_orphan_tags() {
+        let (_dir, root) = make_vault(&[
+            ("a.md", "# A\n\n#old body\n"),
+            ("b.md", "# B\n\n#sole body\n"),
+        ]);
+        let store = GraphStore::in_memory().unwrap();
+        let db_path = root.join("unused.lbug");
+        index_markdown_directory_with_store(&store, &root, &db_path, "owned", "v", &[]).unwrap();
+        assert_eq!(store.list_tags(None).unwrap().len(), 2);
+
+        fs::write(root.join("a.md"), "# A\n\n#new body\n").unwrap();
+        fs::remove_file(root.join("b.md")).unwrap();
+        index_markdown_directory_since_with_store_and_ignore(
+            &store,
+            &root,
+            "owned",
+            "v",
+            std::time::SystemTime::UNIX_EPOCH,
+            &[],
+        )
+        .unwrap();
+        let tags = store.list_tags(None).unwrap();
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].name, "new");
     }
 
     /// Build `n` distinct notes for a vault, with `make_note(0)` reusable so a

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -454,6 +454,7 @@ fn index_markdown_since_with_reader(
     let mut files_checked = 0usize;
     let mut candidates = Vec::new();
     let mut indexed_paths: HashMap<String, (String, PathBuf)> = HashMap::new();
+    let mut eligible_note_uids = HashSet::new();
 
     for rel_path in all_files {
         if !is_markdown(&rel_path) {
@@ -473,10 +474,10 @@ fn index_markdown_since_with_reader(
         files_checked += 1;
         let rel_path_str = rel_str.into_owned();
         let n_uid = note_uid(&v_uid, &rel_path_str);
+        eligible_note_uids.insert(n_uid.clone());
 
-        // Parse successfully-readable unchanged files too: if any target note
-        // changes, their outgoing links must be rebuilt in the same transaction
-        // so inbound backlinks survive and rename resolution is order-independent.
+        // Parse changed files now. Unchanged sources are read later only when
+        // the affected-source closure shows their outgoing links may change.
         let changed = match reader.file_meta(&rel_path) {
             Ok(Some((mtime_secs, file_size))) => {
                 if file_size > MAX_FILE_SIZE_BYTES {
@@ -542,7 +543,7 @@ fn index_markdown_since_with_reader(
 
     let removed_uids: std::collections::HashSet<String> = existing_notes
         .iter()
-        .filter(|note| !vault_root.join(&note.file_path).exists())
+        .filter(|note| !eligible_note_uids.contains(&note.uid))
         .map(|note| note.uid.clone())
         .collect();
     let changed_uids: std::collections::HashSet<String> = candidates
@@ -3823,6 +3824,29 @@ sub b body
         .unwrap();
         assert_eq!(store.lookup_vault(&uid).unwrap().name, "empty");
         assert_eq!(store.graph_generation(), generation);
+    }
+
+    #[test]
+    fn since_refresh_deletes_an_incumbent_that_becomes_ignored() {
+        let (_dir, root) = make_vault(&[("kept.md", "# Kept\n"), ("ignored.md", "# Old\n")]);
+        let store = GraphStore::in_memory().unwrap();
+        let db_path = root.join("unused.lbug");
+        index_markdown_directory_with_store(&store, &root, &db_path, "owned", "v", &[]).unwrap();
+
+        let result = index_markdown_directory_since_with_store_and_ignore(
+            &store,
+            &root,
+            "owned",
+            "v",
+            std::time::SystemTime::now() + std::time::Duration::from_secs(60),
+            &["ignored.md".to_string()],
+        )
+        .unwrap();
+        assert_eq!(result.notes_updated, 0);
+        assert_eq!(result.notes_deleted, 1);
+        let notes = store.list_notes(None).unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].title, "Kept");
     }
 
     /// Build `n` distinct notes for a vault, with `make_note(0)` reusable so a

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -3712,6 +3712,7 @@ sub b body
         let unresolved_before = store.all_unresolved_wikilinks().unwrap();
         assert_eq!(unresolved_before.len(), 1);
 
+        std::thread::sleep(std::time::Duration::from_millis(1100));
         let since = std::time::SystemTime::now();
         fs::write(root_a.join("future.md"), "# Future\n").unwrap();
         let result = index_markdown_directory_since_with_store_and_ignore(

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -3084,7 +3084,10 @@ sub b body
         .expect("daemon-owned refresh must not attempt a second GraphStore writer");
 
         assert_eq!(result.notes_updated, 1);
-        assert_eq!(result.notes_deleted, 2, "one replacement plus one removed file");
+        assert_eq!(
+            result.notes_deleted, 2,
+            "one replacement plus one removed file"
+        );
         assert_eq!(store.count_notes().unwrap(), 1);
         let notes = store.list_notes(None).unwrap();
         assert_eq!(notes.len(), 1);

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -914,6 +914,26 @@ fn index_markdown_since_with_reader(
         .iter()
         .map(|(s, t, c, d, l)| (s.as_str(), t.as_str(), *c, d.as_str(), l.as_str()))
         .collect();
+    // A replacement DETACH-deletes the incumbent Note. Preserve materialized
+    // project membership for replacements, but intentionally not for notes
+    // that are truly removed from the vault.
+    let replacement_uids: std::collections::HashSet<&str> =
+        notes.iter().map(|note| note.uid.as_str()).collect();
+    let mut project_note_edges = Vec::new();
+    for project in store
+        .list_projects()
+        .context("list materialized projects")?
+    {
+        for note_uid in store
+            .list_project_note_uids(&project.uid)
+            .with_context(|| format!("list notes for project {}", project.uid))?
+        {
+            if replacement_uids.contains(note_uid.as_str()) {
+                project_note_edges.push((project.uid.clone(), note_uid));
+            }
+        }
+    }
+    let project_note_refs = string_edge_refs(&project_note_edges);
     store
         .incremental_vault_refresh_atomically(
             &Vault {
@@ -939,6 +959,7 @@ fn index_markdown_since_with_reader(
             &wikilink_heading_refs,
             &unresolved,
             &typed_edges,
+            &project_note_refs,
         )
         .context("atomic incremental vault refresh")?;
 
@@ -3705,6 +3726,68 @@ sub b body
 
         assert_eq!(result.notes_updated, 1);
         assert_eq!(store.all_unresolved_wikilinks().unwrap(), unresolved_before);
+    }
+
+    #[test]
+    fn since_refresh_preserves_project_membership_for_replacements_only() {
+        let (_dir, root) = make_vault(&[("a.md", "# A\n\nold\n")]);
+        let store = GraphStore::in_memory().unwrap();
+        let db_path = root.join("unused.lbug");
+        index_markdown_directory_with_store(&store, &root, &db_path, "owned", "v", &[]).unwrap();
+        let note_uid = store.list_notes(None).unwrap()[0].uid.clone();
+        let project_uid = "proj:test:incremental-membership";
+        store
+            .insert_project(&nestweaver_schema::Project {
+                uid: project_uid.to_string(),
+                name: "Incremental membership".to_string(),
+                summary: None,
+                instance_id: "owned".to_string(),
+            })
+            .unwrap();
+        store
+            .batch_insert_project_note_edges(&[(project_uid, &note_uid)])
+            .unwrap();
+
+        fs::write(root.join("a.md"), "# A\n\nnew\n").unwrap();
+        index_markdown_directory_since_with_store_and_ignore(
+            &store,
+            &root,
+            "owned",
+            "v",
+            std::time::SystemTime::UNIX_EPOCH,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(
+            store.list_project_note_uids(project_uid).unwrap(),
+            vec![note_uid.clone()]
+        );
+
+        // Full authoritative replacement has the same stable-UID preservation
+        // contract; the refresh workflow may materialize projects later, but
+        // it must not erase already-valid membership in the meantime.
+        index_markdown_directory_with_store(&store, &root, &db_path, "owned", "v", &[]).unwrap();
+        assert_eq!(
+            store.list_project_note_uids(project_uid).unwrap(),
+            vec![note_uid.clone()]
+        );
+
+        fs::remove_file(root.join("a.md")).unwrap();
+        index_markdown_directory_since_with_store_and_ignore(
+            &store,
+            &root,
+            "owned",
+            "v",
+            std::time::SystemTime::UNIX_EPOCH,
+            &[],
+        )
+        .unwrap();
+        assert!(
+            store
+                .list_project_note_uids(project_uid)
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -153,11 +153,25 @@ pub fn resolve_repo_selector<'a>(
         }
     }
 
-    if let Some(repo) = repos
+    let exact_locations = repos
         .iter()
-        .find(|repo| repo.url == selector || repo.local_root().is_some_and(|root| root == selector))
-    {
-        return Ok(repo);
+        .filter(|repo| {
+            repo.url == selector || repo.local_root().is_some_and(|root| root == selector)
+        })
+        .collect::<Vec<_>>();
+    match exact_locations.as_slice() {
+        [repo] => return Ok(*repo),
+        [] => {}
+        _ => {
+            let candidates = exact_locations
+                .iter()
+                .map(|repo| format!("{} ({})", repo_display_name(repo), repo.uid))
+                .collect::<Vec<_>>()
+                .join(", ");
+            anyhow::bail!(
+                "repository selector '{selector}' is ambiguous; use an exact UID: {candidates}"
+            );
+        }
     }
 
     let matches = repos
@@ -553,6 +567,45 @@ mod repo_selector_tests {
             repo("repo:b", "file:///b", Some("SAME"), Some("/b")),
         ];
         let error = resolve_repo_selector(&repos, "Same")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("ambiguous"), "{error}");
+        assert!(
+            error.contains("repo:a") && error.contains("repo:b"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn selector_rejects_duplicate_exact_urls_and_local_roots() {
+        let duplicate_url = vec![
+            repo(
+                "repo:a",
+                "https://example.test/shared.git",
+                Some("a"),
+                Some("/a"),
+            ),
+            repo(
+                "repo:b",
+                "https://example.test/shared.git",
+                Some("b"),
+                Some("/b"),
+            ),
+        ];
+        let error = resolve_repo_selector(&duplicate_url, "https://example.test/shared.git")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("ambiguous"), "{error}");
+        assert!(
+            error.contains("repo:a") && error.contains("repo:b"),
+            "{error}"
+        );
+
+        let duplicate_root = vec![
+            repo("repo:a", "file:///a", Some("a"), Some("/work/shared")),
+            repo("repo:b", "file:///b", Some("b"), Some("/work/shared")),
+        ];
+        let error = resolve_repo_selector(&duplicate_root, "/work/shared")
             .unwrap_err()
             .to_string();
         assert!(error.contains("ambiguous"), "{error}");

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -115,6 +115,76 @@ pub fn repo_display_name(repo: &nestweaver_schema::Repo) -> String {
         .unwrap_or_else(|| crate::pull::repo_name_from_url(&repo.url))
 }
 
+/// Resolve a user-facing repository selector deterministically.
+///
+/// Candidates must already be filtered for the caller's authorization scope.
+/// Resolution precedence is exact UID, Unicode-lowercase display name, exact
+/// local root or URL, then an unambiguous URL/root substring. Ambiguous names or
+/// substrings fail instead of selecting whichever row the store returned first.
+pub fn resolve_repo_selector<'a>(
+    repos: &'a [nestweaver_schema::Repo],
+    selector: &str,
+) -> Result<&'a nestweaver_schema::Repo, anyhow::Error> {
+    if selector.trim().is_empty() {
+        anyhow::bail!("repository selector cannot be empty");
+    }
+
+    if let Some(repo) = repos.iter().find(|repo| repo.uid == selector) {
+        return Ok(repo);
+    }
+
+    let needle = selector.to_lowercase();
+    let names = repos
+        .iter()
+        .filter(|repo| repo_display_name(repo).to_lowercase() == needle)
+        .collect::<Vec<_>>();
+    match names.as_slice() {
+        [repo] => return Ok(*repo),
+        [] => {}
+        _ => {
+            let candidates = names
+                .iter()
+                .map(|repo| format!("{} ({})", repo_display_name(repo), repo.uid))
+                .collect::<Vec<_>>()
+                .join(", ");
+            anyhow::bail!(
+                "repository selector '{selector}' is ambiguous; use an exact UID: {candidates}"
+            );
+        }
+    }
+
+    if let Some(repo) = repos
+        .iter()
+        .find(|repo| repo.url == selector || repo.local_root().is_some_and(|root| root == selector))
+    {
+        return Ok(repo);
+    }
+
+    let matches = repos
+        .iter()
+        .filter(|repo| {
+            repo.url.contains(selector)
+                || repo
+                    .local_root()
+                    .is_some_and(|root| root.contains(selector))
+        })
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [repo] => Ok(*repo),
+        [] => anyhow::bail!("repo '{selector}' not found in graph"),
+        _ => {
+            let candidates = matches
+                .iter()
+                .map(|repo| format!("{} ({})", repo_display_name(repo), repo.uid))
+                .collect::<Vec<_>>()
+                .join(", ");
+            anyhow::bail!(
+                "repository selector '{selector}' is ambiguous; use an exact UID: {candidates}"
+            )
+        }
+    }
+}
+
 pub mod admin;
 pub mod affected_tests;
 pub mod agent_guide;
@@ -284,9 +354,10 @@ pub use index_md::{
     MarkdownIndexResult, MarkdownRefreshResult, MarkdownSinceResult,
     format_markdown_refresh_summary, index_markdown_directory, index_markdown_directory_in_memory,
     index_markdown_directory_since, index_markdown_directory_since_with_ignore,
-    index_markdown_directory_with_ignore, index_markdown_directory_with_ignore_and_deletion_count,
-    index_markdown_directory_with_store, index_markdown_directory_with_store_and_deletion_count,
-    index_markdown_with_reader, index_markdown_with_reader_and_write_gate, load_alias_sidecar,
+    index_markdown_directory_since_with_store_and_ignore, index_markdown_directory_with_ignore,
+    index_markdown_directory_with_ignore_and_deletion_count, index_markdown_directory_with_store,
+    index_markdown_directory_with_store_and_deletion_count, index_markdown_with_reader,
+    index_markdown_with_reader_and_write_gate, load_alias_sidecar,
 };
 pub use interactions::{
     EventType, InteractionData, InteractionStore, InteractionTracker, NodeScore,
@@ -408,5 +479,86 @@ mod resolve_user_path_tests {
         )
         .expect("a meaningful path containing spaces must resolve");
         assert!(resolved.ends_with(Path::new("cache dir").join("with spaces")));
+    }
+}
+
+#[cfg(test)]
+mod repo_selector_tests {
+    use super::*;
+    use nestweaver_schema::Repo;
+
+    fn repo(uid: &str, url: &str, name: Option<&str>, root: Option<&str>) -> Repo {
+        Repo {
+            uid: uid.to_string(),
+            url: url.to_string(),
+            indexed_sha: String::new(),
+            staleness_commits_behind: 0,
+            instance_id: "test".to_string(),
+            name: name.map(str::to_owned),
+            root_path: root.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn selector_uses_uid_name_root_url_and_rejects_ambiguity() {
+        let repos = vec![
+            repo(
+                "repo:exact",
+                "https://example.test/org/api.git",
+                Some("Überblick"),
+                Some("/work/api"),
+            ),
+            repo(
+                "repo:other",
+                "https://example.test/other/api.git",
+                Some("Worker"),
+                Some("/work/worker"),
+            ),
+        ];
+
+        assert_eq!(
+            resolve_repo_selector(&repos, "repo:exact").unwrap().uid,
+            "repo:exact"
+        );
+        assert_eq!(
+            resolve_repo_selector(&repos, "überblick").unwrap().uid,
+            "repo:exact"
+        );
+        assert_eq!(
+            resolve_repo_selector(&repos, "/work/worker").unwrap().uid,
+            "repo:other"
+        );
+        assert_eq!(
+            resolve_repo_selector(&repos, "other/api").unwrap().uid,
+            "repo:other"
+        );
+        assert!(
+            resolve_repo_selector(&repos, "api.git")
+                .unwrap_err()
+                .to_string()
+                .contains("ambiguous")
+        );
+        assert!(
+            resolve_repo_selector(&repos, "")
+                .unwrap_err()
+                .to_string()
+                .contains("empty")
+        );
+    }
+
+    #[test]
+    fn selector_rejects_duplicate_exact_display_names() {
+        let repos = vec![
+            repo("repo:a", "file:///a", Some("same"), Some("/a")),
+            repo("repo:b", "file:///b", Some("SAME"), Some("/b")),
+        ];
+        let error = resolve_repo_selector(&repos, "Same")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("ambiguous"), "{error}");
+        assert!(
+            error.contains("repo:a") && error.contains("repo:b"),
+            "{error}"
+        );
     }
 }

--- a/crates/nestweaver-engine/src/snapshot.rs
+++ b/crates/nestweaver-engine/src/snapshot.rs
@@ -559,7 +559,8 @@ pub fn load_snapshot_with_config(
     // this source tree has a reader capability newer than its package version;
     // using the explicit capability lets it read snapshots it writes while the
     // raised stamp still makes every pre-v2 reader fail closed.
-    let reader_version = if stamp.format_version >= 2
+    let reader_version = if engine_version == env!("CARGO_PKG_VERSION")
+        && stamp.format_version >= 2
         && semver_ge(MIN_SNAPSHOT_READER_VERSION, &stamp.min_compatible_engine)
     {
         MIN_SNAPSHOT_READER_VERSION
@@ -955,7 +956,7 @@ mod tests {
         let db_path = materialize_snapshot(
             &snap_dir,
             &work,
-            "0.1.0",
+            env!("CARGO_PKG_VERSION"),
             "schema-hash-abc",
             "text-embedding-3-small",
         )
@@ -978,7 +979,7 @@ mod tests {
             materialize_snapshot(
                 &snap_dir,
                 &work2,
-                "0.1.0",
+                env!("CARGO_PKG_VERSION"),
                 "WRONG-schema-hash",
                 "text-embedding-3-small",
             )
@@ -1069,7 +1070,7 @@ mod tests {
 
         let result = load_snapshot(
             &snap_dir,
-            "0.1.0",
+            env!("CARGO_PKG_VERSION"),
             "new-schema-hash",
             "text-embedding-3-small",
         );
@@ -1103,7 +1104,7 @@ mod tests {
 
         let result = load_snapshot(
             &snap_dir,
-            "0.1.0",
+            env!("CARGO_PKG_VERSION"),
             "schema-hash-abc",
             "text-embedding-ada-002",
         );

--- a/crates/nestweaver-engine/src/snapshot.rs
+++ b/crates/nestweaver-engine/src/snapshot.rs
@@ -695,7 +695,7 @@ fn publish_restored_directory(staging: &Path, destination: &Path) -> Result<(), 
         nestweaver_store::durable_sidecar::sync_parent_directory_durable(destination)?;
         std::fs::remove_dir_all(staging)?;
         nestweaver_store::durable_sidecar::sync_parent_directory_durable(destination)?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/crates/nestweaver-engine/src/snapshot.rs
+++ b/crates/nestweaver-engine/src/snapshot.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
+use std::fs::File;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// The oldest engine version that can read the current snapshot format.
 ///
@@ -7,9 +9,15 @@ use std::path::{Path, PathBuf};
 /// way (new required files, changed checksum format, etc.).  Routine engine
 /// releases that don't touch the snapshot wire format should leave this alone.
 pub const MIN_SNAPSHOT_READER_VERSION: &str = "0.11.0";
+pub const SNAPSHOT_FORMAT_VERSION: u32 = 2;
+pub const SNAPSHOT_CAPABILITY_EMBEDDINGS: &str = "embedding-sidecar-v1";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Stamp {
+    #[serde(default)]
+    pub format_version: u32,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
     pub instance_id: String,
     pub engine_version: String,
     pub min_compatible_engine: String,
@@ -18,6 +26,8 @@ pub struct Stamp {
     pub schema_hash_effective: String,
     pub embedding_model_id: String,
     pub embedding_dimension: u32,
+    #[serde(default)]
+    pub embedding_count: u64,
     pub built_at: String,
     pub repos: Vec<RepoStamp>,
 }
@@ -56,12 +66,13 @@ const CHECKSUM_FILE: &str = "checksum.blake3";
 const SIDECAR_PAGERANK: &str = "pagerank.json";
 const SIDECAR_MANIFESTS: &str = "manifests.json";
 const SIDECAR_TANTIVY_DIR: &str = "tantivy";
+const SIDECAR_EMBEDDINGS: &str = "embeddings.bin";
 
 /// Core files that MUST be present and checksummed in every snapshot.
 const CORE_FILES: &[&str] = &[GRAPH_FILE, MANIFEST_FILE, STAMP_FILE];
 
 /// Sidecar files that are checksummed when present.
-const SIDECAR_FILES: &[&str] = &[SIDECAR_PAGERANK, SIDECAR_MANIFESTS];
+const SIDECAR_FILES: &[&str] = &[SIDECAR_PAGERANK, SIDECAR_MANIFESTS, SIDECAR_EMBEDDINGS];
 
 /// Compute per-file BLAKE3 checksums for all core files and any present
 /// sidecars.  Returns a checksum-style string: one `<hash>  <filename>\n`
@@ -147,6 +158,7 @@ fn verify_checksums(snapshot_dir: &Path) -> Result<(), anyhow::Error> {
 
     if stored.contains("  ") {
         // New per-file format
+        let mut referenced = std::collections::BTreeSet::new();
         for line in stored.lines() {
             let line = line.trim();
             if line.is_empty() {
@@ -155,6 +167,17 @@ fn verify_checksums(snapshot_dir: &Path) -> Result<(), anyhow::Error> {
             let (expected_hash, filename) = line
                 .split_once("  ")
                 .ok_or_else(|| anyhow::anyhow!("malformed checksum line: {line}"))?;
+            let relative = Path::new(filename);
+            if relative.is_absolute()
+                || relative
+                    .components()
+                    .any(|component| !matches!(component, std::path::Component::Normal(_)))
+            {
+                anyhow::bail!("checksum contains unsafe artifact path: {filename}");
+            }
+            if !referenced.insert(filename.to_string()) {
+                anyhow::bail!("checksum contains duplicate artifact: {filename}");
+            }
             let file_path = snapshot_dir.join(filename);
             if !file_path.exists() {
                 anyhow::bail!("checksum references missing file: {filename}");
@@ -168,6 +191,25 @@ fn verify_checksums(snapshot_dir: &Path) -> Result<(), anyhow::Error> {
                      expected {expected_hash}, got {actual}"
                 );
             }
+        }
+        for required in CORE_FILES {
+            if !referenced.contains(*required) {
+                anyhow::bail!("checksum manifest omits required artifact: {required}");
+            }
+        }
+        let mut actual = std::collections::BTreeSet::new();
+        for (relative, _) in collect_files_recursive(snapshot_dir, "")? {
+            let relative = relative.trim_start_matches('/');
+            if relative != CHECKSUM_FILE && relative != "checksum.sha256" {
+                actual.insert(relative.to_string());
+            }
+        }
+        if actual != referenced {
+            anyhow::bail!(
+                "checksum manifest does not exactly cover snapshot artifacts (listed {}, present {})",
+                referenced.len(),
+                actual.len()
+            );
         }
     } else {
         // Legacy single-hash format: concatenated hash of core files
@@ -199,7 +241,7 @@ pub fn build_snapshot(
     stamp: &Stamp,
     manifest: &Manifest,
     db_path: &Path,
-) -> Result<(), anyhow::Error> {
+) -> Result<Stamp, anyhow::Error> {
     let store = nestweaver_store::GraphStore::open(db_path)
         .map_err(|error| anyhow::anyhow!("failed to open snapshot database: {error}"))?;
     build_snapshot_from_store(output_dir, stamp, manifest, &store)
@@ -212,7 +254,7 @@ pub fn build_snapshot_from_store(
     stamp: &Stamp,
     manifest: &Manifest,
     store: &nestweaver_store::GraphStore,
-) -> Result<(), anyhow::Error> {
+) -> Result<Stamp, anyhow::Error> {
     let db_path = store
         .db_path()
         .ok_or_else(|| anyhow::anyhow!("cannot snapshot an in-memory graph store"))?;
@@ -222,15 +264,91 @@ pub fn build_snapshot_from_store(
     publication.ensure_clean_for_snapshot().map_err(|error| {
         anyhow::anyhow!("refusing snapshot of dirty index publication: {error}")
     })?;
-    store
-        .checkpoint()
-        .map_err(|error| anyhow::anyhow!("snapshot CHECKPOINT failed: {error}"))?;
-
-    let result = build_snapshot_files(output_dir, stamp, manifest, db_path);
-    publication.release().map_err(|error| {
-        anyhow::anyhow!("failed to release snapshot publication lease: {error}")
+    if output_dir.exists() {
+        anyhow::bail!(
+            "snapshot destination {} already exists; snapshots are immutable, choose a new destination",
+            output_dir.display()
+        );
+    }
+    let staging = sibling_staging_path(output_dir, "snapshot-build")?;
+    std::fs::create_dir(&staging).map_err(|error| {
+        anyhow::anyhow!(
+            "failed to create snapshot staging dir {}: {error}",
+            staging.display()
+        )
     })?;
-    result
+
+    let result = (|| {
+        let embedding_lease = store
+            .stage_embeddings_for_snapshot(&staging.join(SIDECAR_EMBEDDINGS))
+            .map_err(|error| anyhow::anyhow!("failed to stage embeddings: {error}"))?;
+        store
+            .checkpoint()
+            .map_err(|error| anyhow::anyhow!("snapshot CHECKPOINT failed: {error}"))?;
+
+        let mut authoritative_stamp = stamp.clone();
+        let embedding = embedding_lease.state();
+        authoritative_stamp.format_version = SNAPSHOT_FORMAT_VERSION;
+        authoritative_stamp.capabilities = vec![SNAPSHOT_CAPABILITY_EMBEDDINGS.to_string()];
+        authoritative_stamp.embedding_model_id = embedding.model_id.clone();
+        authoritative_stamp.embedding_dimension = embedding.dimension;
+        authoritative_stamp.embedding_count = embedding.count;
+        build_snapshot_files(&staging, &authoritative_stamp, manifest, db_path)?;
+        sync_directory_tree(&staging)?;
+        std::fs::rename(&staging, output_dir).map_err(|error| {
+            anyhow::anyhow!(
+                "failed to atomically publish snapshot {}: {error}",
+                output_dir.display()
+            )
+        })?;
+        nestweaver_store::durable_sidecar::sync_parent_directory_durable(output_dir)?;
+        Ok(authoritative_stamp)
+    })();
+
+    if result.is_err() {
+        let _ = std::fs::remove_dir_all(&staging);
+    }
+    let release = publication
+        .release()
+        .map_err(|error| anyhow::anyhow!("failed to release snapshot publication lease: {error}"));
+    match (result, release) {
+        (Ok(stamp), Ok(())) => Ok(stamp),
+        (Err(error), _) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+    }
+}
+
+static STAGING_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+fn sibling_staging_path(destination: &Path, purpose: &str) -> Result<PathBuf, anyhow::Error> {
+    let parent = destination
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent)?;
+    let name = destination
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("destination must have a file name"))?
+        .to_string_lossy();
+    let sequence = STAGING_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    Ok(parent.join(format!(
+        ".{name}.{purpose}.{}.{}",
+        std::process::id(),
+        sequence
+    )))
+}
+
+fn sync_directory_tree(root: &Path) -> Result<(), anyhow::Error> {
+    for entry in std::fs::read_dir(root)? {
+        let path = entry?.path();
+        if path.is_dir() {
+            sync_directory_tree(&path)?;
+        } else {
+            File::open(&path)?.sync_all()?;
+        }
+    }
+    File::open(root)?.sync_all()?;
+    Ok(())
 }
 
 fn build_snapshot_files(
@@ -239,10 +357,6 @@ fn build_snapshot_files(
     manifest: &Manifest,
     db_path: &Path,
 ) -> Result<(), anyhow::Error> {
-    std::fs::create_dir_all(output_dir).map_err(|e| {
-        anyhow::anyhow!("failed to create output_dir {}: {e}", output_dir.display())
-    })?;
-
     // ── Core files ──────────────────────────────────────────────────────────
     std::fs::copy(db_path, output_dir.join(GRAPH_FILE))
         .map_err(|e| anyhow::anyhow!("failed to copy graph file: {e}"))?;
@@ -253,15 +367,15 @@ fn build_snapshot_files(
     let stamp_json = serde_json::to_string_pretty(stamp)?;
     std::fs::write(output_dir.join(STAMP_FILE), &stamp_json)?;
 
-    // ── Sidecars (best-effort) ──────────────────────────────────────────────
+    // ── Sidecars ────────────────────────────────────────────────────────────
     let pagerank_src = crate::sidecar_path(db_path, &format!(".{SIDECAR_PAGERANK}"));
     if pagerank_src.exists() {
-        if let Err(e) = std::fs::copy(&pagerank_src, output_dir.join(SIDECAR_PAGERANK)) {
-            tracing::warn!(
-                src = %pagerank_src.display(),
-                "build_snapshot: failed to copy pagerank sidecar: {e}"
-            );
-        }
+        std::fs::copy(&pagerank_src, output_dir.join(SIDECAR_PAGERANK)).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to copy pagerank sidecar {}: {e}",
+                pagerank_src.display()
+            )
+        })?;
     } else {
         tracing::debug!(
             src = %pagerank_src.display(),
@@ -271,12 +385,12 @@ fn build_snapshot_files(
 
     let manifests_src = crate::sidecar_path(db_path, &format!(".{SIDECAR_MANIFESTS}"));
     if manifests_src.exists() {
-        if let Err(e) = std::fs::copy(&manifests_src, output_dir.join(SIDECAR_MANIFESTS)) {
-            tracing::warn!(
-                src = %manifests_src.display(),
-                "build_snapshot: failed to copy manifests sidecar: {e}"
-            );
-        }
+        std::fs::copy(&manifests_src, output_dir.join(SIDECAR_MANIFESTS)).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to copy manifests sidecar {}: {e}",
+                manifests_src.display()
+            )
+        })?;
     } else {
         tracing::debug!(
             src = %manifests_src.display(),
@@ -286,12 +400,12 @@ fn build_snapshot_files(
 
     let tantivy_src = crate::sidecar_path(db_path, ".tantivy");
     if tantivy_src.exists() && tantivy_src.is_dir() {
-        if let Err(e) = copy_dir_all(&tantivy_src, &output_dir.join(SIDECAR_TANTIVY_DIR)) {
-            tracing::warn!(
-                src = %tantivy_src.display(),
-                "build_snapshot: failed to copy tantivy directory: {e}"
-            );
-        }
+        copy_dir_all(&tantivy_src, &output_dir.join(SIDECAR_TANTIVY_DIR)).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to copy tantivy directory {}: {e}",
+                tantivy_src.display()
+            )
+        })?;
     } else {
         tracing::debug!(
             src = %tantivy_src.display(),
@@ -316,6 +430,65 @@ pub fn verify_snapshot(snapshot_dir: &Path) -> Result<Stamp, anyhow::Error> {
     let stamp_json = std::fs::read_to_string(snapshot_dir.join(STAMP_FILE))
         .map_err(|e| anyhow::anyhow!("failed to read stamp.json: {e}"))?;
     let stamp: Stamp = serde_json::from_str(&stamp_json)?;
+
+    if stamp.format_version > SNAPSHOT_FORMAT_VERSION {
+        anyhow::bail!(
+            "snapshot format {} is newer than this engine supports ({SNAPSHOT_FORMAT_VERSION})",
+            stamp.format_version
+        );
+    }
+    let embedding_path = snapshot_dir.join(SIDECAR_EMBEDDINGS);
+    if stamp.format_version == 0 {
+        if (stamp.embedding_dimension > 0 || stamp.embedding_count > 0) && !embedding_path.exists()
+        {
+            anyhow::bail!(
+                "legacy snapshot claims embeddings but omits embeddings.bin; rebuild the snapshot from the source database"
+            );
+        }
+    } else {
+        if !stamp
+            .capabilities
+            .iter()
+            .any(|capability| capability == SNAPSHOT_CAPABILITY_EMBEDDINGS)
+        {
+            anyhow::bail!(
+                "snapshot format {} does not declare embedding-sidecar capability",
+                stamp.format_version
+            );
+        }
+        if stamp.embedding_count > 0 && !embedding_path.exists() {
+            anyhow::bail!(
+                "snapshot contains {} embeddings but embeddings.bin is missing",
+                stamp.embedding_count
+            );
+        }
+        if stamp.embedding_count > 0 {
+            let checksums = std::fs::read_to_string(snapshot_dir.join(CHECKSUM_FILE))?;
+            if !checksums
+                .lines()
+                .any(|line| line.ends_with("  embeddings.bin"))
+            {
+                anyhow::bail!(
+                    "snapshot embedding artifact is not covered by the checksum manifest"
+                );
+            }
+        }
+    }
+    if embedding_path.exists() {
+        let embeddings = nestweaver_store::EmbeddingIndex::load_binary(&embedding_path)
+            .map_err(|error| anyhow::anyhow!("invalid snapshot embedding artifact: {error}"))?;
+        let count = u64::try_from(embeddings.len())?;
+        let dimension = u32::try_from(embeddings.dimension().unwrap_or(0))?;
+        if count != stamp.embedding_count || dimension != stamp.embedding_dimension {
+            anyhow::bail!(
+                "snapshot embedding metadata mismatch: stamp count/dimension={}/{}, artifact={}/{}",
+                stamp.embedding_count,
+                stamp.embedding_dimension,
+                count,
+                dimension
+            );
+        }
+    }
 
     Ok(stamp)
 }
@@ -347,6 +520,24 @@ pub fn load_snapshot(
     expected_schema_hash: &str,
     expected_embedding_model: &str,
 ) -> Result<(Stamp, PathBuf), anyhow::Error> {
+    load_snapshot_with_config(
+        snapshot_dir,
+        engine_version,
+        Some(expected_schema_hash),
+        Some(expected_embedding_model),
+    )
+}
+
+/// Config-aware snapshot compatibility gate. Core snapshots can be loaded
+/// without a config; extension snapshots require the caller's effective hash.
+/// A supplied embedding model is an additional assertion, while absent config
+/// trusts the verified snapshot/database fingerprint.
+pub fn load_snapshot_with_config(
+    snapshot_dir: &Path,
+    engine_version: &str,
+    expected_schema_hash: Option<&str>,
+    expected_embedding_model: Option<&str>,
+) -> Result<(Stamp, PathBuf), anyhow::Error> {
     let stamp = verify_snapshot(snapshot_dir)?;
 
     // The snapshot requires at least min_compatible_engine to load it.
@@ -360,7 +551,21 @@ pub fn load_snapshot(
         );
     }
 
-    if stamp.schema_hash_effective != expected_schema_hash {
+    let running_core = nestweaver_schema::core_schema_hash();
+    if stamp.schema_hash_core != running_core {
+        anyhow::bail!(
+            "snapshot core schema hash mismatch: snapshot has '{}' but engine expects '{}'; rebuild the snapshot",
+            stamp.schema_hash_core,
+            running_core
+        );
+    }
+
+    if stamp.schema_hash_extensions != "none" && expected_schema_hash.is_none() {
+        anyhow::bail!("snapshot uses schema extensions and requires the matching instance config");
+    }
+    if let Some(expected_schema_hash) = expected_schema_hash
+        && stamp.schema_hash_effective != expected_schema_hash
+    {
         anyhow::bail!(
             "snapshot schema hash mismatch: snapshot has '{}' but engine expects '{}'; \
              rebuild the snapshot to pick up the new schema",
@@ -369,7 +574,10 @@ pub fn load_snapshot(
         );
     }
 
-    if stamp.embedding_model_id != expected_embedding_model {
+    if let Some(expected_embedding_model) = expected_embedding_model
+        && !stamp.embedding_model_id.is_empty()
+        && stamp.embedding_model_id != expected_embedding_model
+    {
         anyhow::bail!(
             "snapshot embedding model mismatch: snapshot used '{}' but engine expects '{}'; \
              rebuild the snapshot with the correct embedding model",
@@ -396,21 +604,36 @@ pub fn materialize_snapshot(
     expected_schema_hash: &str,
     expected_embedding_model: &str,
 ) -> Result<PathBuf, anyhow::Error> {
+    materialize_snapshot_with_config(
+        snapshot_dir,
+        working_dir,
+        engine_version,
+        Some(expected_schema_hash),
+        Some(expected_embedding_model),
+    )
+}
+
+pub fn materialize_snapshot_with_config(
+    snapshot_dir: &Path,
+    working_dir: &Path,
+    engine_version: &str,
+    expected_schema_hash: Option<&str>,
+    expected_embedding_model: Option<&str>,
+) -> Result<PathBuf, anyhow::Error> {
     // Compat gate first — refuse an incompatible snapshot before touching disk.
-    load_snapshot(
+    load_snapshot_with_config(
         snapshot_dir,
         engine_version,
         expected_schema_hash,
         expected_embedding_model,
     )?;
 
-    std::fs::create_dir_all(working_dir).map_err(|e| {
-        anyhow::anyhow!(
-            "failed to create working dir {}: {e}",
-            working_dir.display()
-        )
-    })?;
-    let db_path = working_dir.join(GRAPH_FILE);
+    let staging = sibling_staging_path(working_dir, "snapshot-restore")?;
+    if staging.exists() {
+        std::fs::remove_dir_all(&staging)?;
+    }
+    std::fs::create_dir(&staging)?;
+    let db_path = staging.join(GRAPH_FILE);
     std::fs::copy(snapshot_dir.join(GRAPH_FILE), &db_path)
         .map_err(|e| anyhow::anyhow!("failed to copy snapshot graph file: {e}"))?;
 
@@ -418,13 +641,14 @@ pub fn materialize_snapshot(
     for (src_name, suffix) in [
         (SIDECAR_PAGERANK, ".pagerank.json"),
         (SIDECAR_MANIFESTS, ".manifests.json"),
+        (SIDECAR_EMBEDDINGS, ".embeddings.bin"),
     ] {
         let src = snapshot_dir.join(src_name);
         if src.exists() {
             let dst = crate::sidecar_path(&db_path, suffix);
-            if let Err(e) = std::fs::copy(&src, &dst) {
-                tracing::warn!(src = %src.display(), "materialize_snapshot: sidecar relocate failed: {e}");
-            }
+            std::fs::copy(&src, &dst).map_err(|e| {
+                anyhow::anyhow!("failed to restore snapshot sidecar {}: {e}", src.display())
+            })?;
         }
     }
 
@@ -432,12 +656,53 @@ pub fn materialize_snapshot(
     let tantivy_src = snapshot_dir.join(SIDECAR_TANTIVY_DIR);
     if tantivy_src.is_dir() {
         let tantivy_dst = crate::sidecar_path(&db_path, ".tantivy");
-        if let Err(e) = nestweaver_storage::copy_dir_all(&tantivy_src, &tantivy_dst) {
-            tracing::warn!("materialize_snapshot: tantivy relocate failed: {e}");
-        }
+        nestweaver_storage::copy_dir_all(&tantivy_src, &tantivy_dst)
+            .map_err(|e| anyhow::anyhow!("failed to restore snapshot tantivy index: {e}"))?;
+    }
+    sync_directory_tree(&staging)?;
+    publish_restored_directory(&staging, working_dir)?;
+    Ok(working_dir.join(GRAPH_FILE))
+}
+
+fn publish_restored_directory(staging: &Path, destination: &Path) -> Result<(), anyhow::Error> {
+    if !destination.exists() {
+        std::fs::rename(staging, destination)?;
+        nestweaver_store::durable_sidecar::sync_parent_directory_durable(destination)?;
+        return Ok(());
     }
 
-    Ok(db_path)
+    #[cfg(target_os = "linux")]
+    {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+        let old = CString::new(destination.as_os_str().as_bytes())?;
+        let new = CString::new(staging.as_os_str().as_bytes())?;
+        // RENAME_EXCHANGE is one namespace operation: readers see either the
+        // complete old tree or the complete verified replacement.
+        let result = unsafe {
+            libc::syscall(
+                libc::SYS_renameat2,
+                libc::AT_FDCWD,
+                new.as_ptr(),
+                libc::AT_FDCWD,
+                old.as_ptr(),
+                libc::RENAME_EXCHANGE,
+            )
+        };
+        if result != 0 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        nestweaver_store::durable_sidecar::sync_parent_directory_durable(destination)?;
+        std::fs::remove_dir_all(staging)?;
+        nestweaver_store::durable_sidecar::sync_parent_directory_durable(destination)?;
+        return Ok(());
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    anyhow::bail!(
+        "atomic replacement of an existing replica directory is unsupported on this platform; remove {} while the replica is stopped and retry",
+        destination.display()
+    )
 }
 
 /// Compute `(core, extensions, effective)` schema hashes for `cfg`. This MUST
@@ -486,14 +751,17 @@ mod tests {
         model: &str,
     ) -> Stamp {
         Stamp {
+            format_version: 0,
+            capabilities: Vec::new(),
             instance_id: "test-instance".to_string(),
             engine_version: engine_version.to_string(),
             min_compatible_engine: min_compatible.to_string(),
-            schema_hash_core: "core-hash".to_string(),
-            schema_hash_extensions: "ext-hash".to_string(),
+            schema_hash_core: nestweaver_schema::core_schema_hash(),
+            schema_hash_extensions: "none".to_string(),
             schema_hash_effective: schema_hash.to_string(),
             embedding_model_id: model.to_string(),
             embedding_dimension: 1536,
+            embedding_count: 0,
             built_at: "2026-05-22T00:00:00Z".to_string(),
             repos: vec![RepoStamp {
                 url: "https://github.com/example/repo".to_string(),
@@ -806,5 +1074,131 @@ mod tests {
 
         let loaded = verify_snapshot(&snap_dir).unwrap();
         assert_eq!(loaded.instance_id, "test-instance");
+    }
+
+    #[test]
+    fn snapshot_preserves_authoritative_embeddings_and_semantic_results() {
+        let dir = tempfile::tempdir().unwrap();
+        let snap_dir = dir.path().join("snapshot");
+        let db = make_test_db(dir.path());
+        let store = nestweaver_store::GraphStore::open(&db).unwrap();
+        store.set_embedding_metadata("persisted-model", 3).unwrap();
+        assert!(store.add_embedding("sym:a", vec![1.0, 0.0, 0.0]));
+        assert!(store.add_embedding("sym:b", vec![0.0, 1.0, 0.0]));
+
+        let stamp = build_snapshot_from_store(
+            &snap_dir,
+            &make_stamp("4.1.0", "0.11.0", "schema", "caller-lie"),
+            &make_manifest(),
+            &store,
+        )
+        .unwrap();
+        assert_eq!(stamp.format_version, SNAPSHOT_FORMAT_VERSION);
+        assert_eq!(stamp.embedding_model_id, "persisted-model");
+        assert_eq!(stamp.embedding_dimension, 3);
+        assert_eq!(stamp.embedding_count, 2);
+        assert!(snap_dir.join(SIDECAR_EMBEDDINGS).exists());
+        verify_snapshot(&snap_dir).unwrap();
+
+        let work = dir.path().join("work");
+        let materialized =
+            materialize_snapshot_with_config(&snap_dir, &work, "4.1.0", None, None).unwrap();
+        let replica = nestweaver_store::GraphStore::open_read_only(&materialized).unwrap();
+        assert_eq!(replica.embedding_count(), 2);
+        assert_eq!(replica.embedding_dimension().unwrap(), 3);
+        assert_eq!(replica.vector_search(&[1.0, 0.0, 0.0], 1)[0].0, "sym:a");
+    }
+
+    #[test]
+    fn failed_restore_preserves_existing_replica() {
+        let dir = tempfile::tempdir().unwrap();
+        let snap_dir = dir.path().join("snapshot");
+        let db = make_test_db(dir.path());
+        let stamp = make_stamp("4.1.0", "0.11.0", "schema", "");
+        build_snapshot(&snap_dir, &stamp, &make_manifest(), &db).unwrap();
+
+        let work = dir.path().join("work");
+        std::fs::create_dir(&work).unwrap();
+        std::fs::write(work.join("sentinel"), b"old replica").unwrap();
+        std::fs::write(snap_dir.join(GRAPH_FILE), b"tampered").unwrap();
+
+        assert!(materialize_snapshot_with_config(&snap_dir, &work, "4.1.0", None, None).is_err());
+        assert_eq!(
+            std::fs::read(work.join("sentinel")).unwrap(),
+            b"old replica"
+        );
+    }
+
+    #[test]
+    fn build_never_replaces_an_existing_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let snap_dir = dir.path().join("snapshot");
+        std::fs::create_dir(&snap_dir).unwrap();
+        std::fs::write(snap_dir.join("sentinel"), b"published snapshot").unwrap();
+        let db = make_test_db(dir.path());
+
+        let error = build_snapshot(
+            &snap_dir,
+            &make_stamp("4.1.0", "0.11.0", "schema", ""),
+            &make_manifest(),
+            &db,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("snapshots are immutable"));
+        assert_eq!(
+            std::fs::read(snap_dir.join("sentinel")).unwrap(),
+            b"published snapshot"
+        );
+    }
+
+    #[test]
+    fn extension_snapshot_requires_config_but_core_snapshot_does_not() {
+        let dir = tempfile::tempdir().unwrap();
+        let core_dir = dir.path().join("core");
+        let db = make_test_db(dir.path());
+        let core = make_stamp("4.1.0", "0.11.0", "core-effective", "");
+        build_snapshot(&core_dir, &core, &make_manifest(), &db).unwrap();
+        load_snapshot_with_config(&core_dir, "4.1.0", None, None).unwrap();
+
+        let extension_dir = dir.path().join("extension");
+        let mut extension = core;
+        extension.schema_hash_extensions = "extension-hash".to_string();
+        extension.schema_hash_effective = "extension-effective".to_string();
+        build_snapshot(&extension_dir, &extension, &make_manifest(), &db).unwrap();
+        let error = load_snapshot_with_config(&extension_dir, "4.1.0", None, None).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("requires the matching instance config")
+        );
+        load_snapshot_with_config(&extension_dir, "4.1.0", Some("extension-effective"), None)
+            .unwrap();
+    }
+
+    #[test]
+    fn legacy_claimed_embeddings_without_artifact_fail_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let snapshot = dir.path();
+        let mut stamp = make_stamp("0.10.0", "0.10.0", "schema", "legacy-model");
+        stamp.format_version = 0;
+        stamp.embedding_dimension = 3;
+        std::fs::write(snapshot.join(GRAPH_FILE), b"graph").unwrap();
+        std::fs::write(snapshot.join(MANIFEST_FILE), b"{\"repos\":[]}").unwrap();
+        std::fs::write(
+            snapshot.join(STAMP_FILE),
+            serde_json::to_vec_pretty(&stamp).unwrap(),
+        )
+        .unwrap();
+        let mut hasher = blake3::Hasher::new();
+        for name in CORE_FILES {
+            hasher.update(&std::fs::read(snapshot.join(name)).unwrap());
+        }
+        std::fs::write(
+            snapshot.join(CHECKSUM_FILE),
+            hasher.finalize().to_hex().as_bytes(),
+        )
+        .unwrap();
+        let error = verify_snapshot(snapshot).unwrap_err();
+        assert!(error.to_string().contains("omits embeddings.bin"));
     }
 }

--- a/crates/nestweaver-engine/src/snapshot.rs
+++ b/crates/nestweaver-engine/src/snapshot.rs
@@ -8,7 +8,14 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// Bump this ONLY when the snapshot layout changes in a backwards-incompatible
 /// way (new required files, changed checksum format, etc.).  Routine engine
 /// releases that don't touch the snapshot wire format should leave this alone.
-pub const MIN_SNAPSHOT_READER_VERSION: &str = "0.11.0";
+/// Snapshot-format capability level implemented by this reader.
+///
+/// Format v2 makes the embedding sidecar part of the authoritative snapshot
+/// state.  The first shipped reader did not understand that invariant, so v2
+/// writers must fence it out even while this development tree still reports
+/// the older package version.  New readers compare against this capability
+/// level; old readers compare against their package version and reject v2.
+pub const MIN_SNAPSHOT_READER_VERSION: &str = "4.1.1";
 pub const SNAPSHOT_FORMAT_VERSION: u32 = 2;
 pub const SNAPSHOT_CAPABILITY_EMBEDDINGS: &str = "embedding-sidecar-v1";
 
@@ -290,6 +297,12 @@ pub fn build_snapshot_from_store(
         let embedding = embedding_lease.state();
         authoritative_stamp.format_version = SNAPSHOT_FORMAT_VERSION;
         authoritative_stamp.capabilities = vec![SNAPSHOT_CAPABILITY_EMBEDDINGS.to_string()];
+        if !semver_ge(
+            &authoritative_stamp.min_compatible_engine,
+            MIN_SNAPSHOT_READER_VERSION,
+        ) {
+            authoritative_stamp.min_compatible_engine = MIN_SNAPSHOT_READER_VERSION.to_string();
+        }
         authoritative_stamp.embedding_model_id = embedding.model_id.clone();
         authoritative_stamp.embedding_dimension = embedding.dimension;
         authoritative_stamp.embedding_count = embedding.count;
@@ -542,7 +555,18 @@ pub fn load_snapshot_with_config(
 
     // The snapshot requires at least min_compatible_engine to load it.
     // If the running engine_version < min_compatible_engine, reject.
-    if !semver_ge(engine_version, &stamp.min_compatible_engine) {
+    // `engine_version` remains the application compatibility input.  For v2,
+    // this source tree has a reader capability newer than its package version;
+    // using the explicit capability lets it read snapshots it writes while the
+    // raised stamp still makes every pre-v2 reader fail closed.
+    let reader_version = if stamp.format_version >= 2
+        && semver_ge(MIN_SNAPSHOT_READER_VERSION, &stamp.min_compatible_engine)
+    {
+        MIN_SNAPSHOT_READER_VERSION
+    } else {
+        engine_version
+    };
+    if !semver_ge(reader_version, &stamp.min_compatible_engine) {
         anyhow::bail!(
             "snapshot requires engine >= {} but current engine is {}; \
              rebuild the snapshot with a newer engine or downgrade the min_compatible_engine requirement",
@@ -620,6 +644,24 @@ pub fn materialize_snapshot_with_config(
     expected_schema_hash: Option<&str>,
     expected_embedding_model: Option<&str>,
 ) -> Result<PathBuf, anyhow::Error> {
+    materialize_snapshot_with_config_and_hook(
+        snapshot_dir,
+        working_dir,
+        engine_version,
+        expected_schema_hash,
+        expected_embedding_model,
+        || {},
+    )
+}
+
+fn materialize_snapshot_with_config_and_hook(
+    snapshot_dir: &Path,
+    working_dir: &Path,
+    engine_version: &str,
+    expected_schema_hash: Option<&str>,
+    expected_embedding_model: Option<&str>,
+    after_source_verification: impl FnOnce(),
+) -> Result<PathBuf, anyhow::Error> {
     // Compat gate first — refuse an incompatible snapshot before touching disk.
     load_snapshot_with_config(
         snapshot_dir,
@@ -627,41 +669,61 @@ pub fn materialize_snapshot_with_config(
         expected_schema_hash,
         expected_embedding_model,
     )?;
+    after_source_verification();
 
     let staging = sibling_staging_path(working_dir, "snapshot-restore")?;
     if staging.exists() {
         std::fs::remove_dir_all(&staging)?;
     }
     std::fs::create_dir(&staging)?;
-    let db_path = staging.join(GRAPH_FILE);
-    std::fs::copy(snapshot_dir.join(GRAPH_FILE), &db_path)
-        .map_err(|e| anyhow::anyhow!("failed to copy snapshot graph file: {e}"))?;
+    let verified_snapshot = staging.join("verified-snapshot");
+    let result = (|| {
+        // Copy the snapshot representation first, then verify the copied bytes.
+        // The source can change after the initial gate; only this staged,
+        // checksum-verified copy is allowed to become the live replica.
+        nestweaver_storage::copy_dir_all(snapshot_dir, &verified_snapshot)?;
+        load_snapshot_with_config(
+            &verified_snapshot,
+            engine_version,
+            expected_schema_hash,
+            expected_embedding_model,
+        )?;
 
-    // Relocate JSON sidecars into the store's `<db><suffix>` convention.
-    for (src_name, suffix) in [
-        (SIDECAR_PAGERANK, ".pagerank.json"),
-        (SIDECAR_MANIFESTS, ".manifests.json"),
-        (SIDECAR_EMBEDDINGS, ".embeddings.bin"),
-    ] {
-        let src = snapshot_dir.join(src_name);
-        if src.exists() {
-            let dst = crate::sidecar_path(&db_path, suffix);
-            std::fs::copy(&src, &dst).map_err(|e| {
-                anyhow::anyhow!("failed to restore snapshot sidecar {}: {e}", src.display())
-            })?;
+        let db_path = staging.join(GRAPH_FILE);
+        std::fs::rename(verified_snapshot.join(GRAPH_FILE), &db_path)
+            .map_err(|e| anyhow::anyhow!("failed to stage verified snapshot graph file: {e}"))?;
+
+        // Relocate JSON sidecars into the store's `<db><suffix>` convention.
+        for (src_name, suffix) in [
+            (SIDECAR_PAGERANK, ".pagerank.json"),
+            (SIDECAR_MANIFESTS, ".manifests.json"),
+            (SIDECAR_EMBEDDINGS, ".embeddings.bin"),
+        ] {
+            let src = verified_snapshot.join(src_name);
+            if src.exists() {
+                let dst = crate::sidecar_path(&db_path, suffix);
+                std::fs::rename(&src, &dst).map_err(|e| {
+                    anyhow::anyhow!("failed to stage verified sidecar {}: {e}", src.display())
+                })?;
+            }
         }
-    }
 
-    // Relocate the Tantivy index directory into `<db>.tantivy`.
-    let tantivy_src = snapshot_dir.join(SIDECAR_TANTIVY_DIR);
-    if tantivy_src.is_dir() {
-        let tantivy_dst = crate::sidecar_path(&db_path, ".tantivy");
-        nestweaver_storage::copy_dir_all(&tantivy_src, &tantivy_dst)
-            .map_err(|e| anyhow::anyhow!("failed to restore snapshot tantivy index: {e}"))?;
+        // Relocate the Tantivy index directory into `<db>.tantivy`.
+        let tantivy_src = verified_snapshot.join(SIDECAR_TANTIVY_DIR);
+        if tantivy_src.is_dir() {
+            let tantivy_dst = crate::sidecar_path(&db_path, ".tantivy");
+            std::fs::rename(&tantivy_src, &tantivy_dst)
+                .map_err(|e| anyhow::anyhow!("failed to stage verified tantivy index: {e}"))?;
+        }
+        std::fs::remove_dir_all(&verified_snapshot)?;
+        sync_directory_tree(&staging)?;
+        publish_restored_directory(&staging, working_dir)?;
+        Ok(working_dir.join(GRAPH_FILE))
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_dir_all(&staging);
     }
-    sync_directory_tree(&staging)?;
-    publish_restored_directory(&staging, working_dir)?;
-    Ok(working_dir.join(GRAPH_FILE))
+    result
 }
 
 fn publish_restored_directory(staging: &Path, destination: &Path) -> Result<(), anyhow::Error> {
@@ -1024,6 +1086,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let snap_dir = dir.path().join("snapshot");
         let db = make_test_db(dir.path());
+        let store = nestweaver_store::GraphStore::open(&db).unwrap();
+        store
+            .set_embedding_metadata("text-embedding-3-small", 3)
+            .unwrap();
+        assert!(store.add_embedding("symbol:test", vec![1.0, 0.0, 0.0]));
 
         let stamp = make_stamp(
             "0.1.0",
@@ -1032,7 +1099,7 @@ mod tests {
             "text-embedding-3-small",
         );
         let manifest = make_manifest();
-        build_snapshot(&snap_dir, &stamp, &manifest, &db).unwrap();
+        build_snapshot_from_store(&snap_dir, &stamp, &manifest, &store).unwrap();
 
         let result = load_snapshot(
             &snap_dir,
@@ -1110,6 +1177,30 @@ mod tests {
     }
 
     #[test]
+    fn v2_snapshot_fences_old_reader_but_current_reader_accepts_its_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let snap_dir = dir.path().join("snapshot");
+        let db = make_test_db(dir.path());
+
+        let stamp = build_snapshot(
+            &snap_dir,
+            &make_stamp("4.1.0", "0.11.0", "schema", ""),
+            &make_manifest(),
+            &db,
+        )
+        .unwrap();
+
+        assert_eq!(stamp.format_version, SNAPSHOT_FORMAT_VERSION);
+        assert_eq!(stamp.min_compatible_engine, MIN_SNAPSHOT_READER_VERSION);
+        assert!(
+            !semver_ge("4.1.0", &stamp.min_compatible_engine),
+            "the last pre-v2 reader must reject the raised compatibility floor"
+        );
+        load_snapshot_with_config(&snap_dir, "4.1.0", None, None)
+            .expect("the v2-capable reader must accept the v2 snapshot it wrote");
+    }
+
+    #[test]
     fn failed_restore_preserves_existing_replica() {
         let dir = tempfile::tempdir().unwrap();
         let snap_dir = dir.path().join("snapshot");
@@ -1126,6 +1217,49 @@ mod tests {
         assert_eq!(
             std::fs::read(work.join("sentinel")).unwrap(),
             b"old replica"
+        );
+    }
+
+    #[test]
+    fn restore_reverifies_copied_bytes_before_atomic_promotion() {
+        let dir = tempfile::tempdir().unwrap();
+        let snap_dir = dir.path().join("snapshot");
+        let db = make_test_db(dir.path());
+        build_snapshot(
+            &snap_dir,
+            &make_stamp("4.1.0", "0.11.0", "schema", ""),
+            &make_manifest(),
+            &db,
+        )
+        .unwrap();
+
+        let work = dir.path().join("work");
+        std::fs::create_dir(&work).unwrap();
+        std::fs::write(work.join("sentinel"), b"old replica").unwrap();
+
+        let error = materialize_snapshot_with_config_and_hook(
+            &snap_dir,
+            &work,
+            "4.1.0",
+            None,
+            None,
+            || std::fs::write(snap_dir.join(GRAPH_FILE), b"changed after verification").unwrap(),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("integrity check failed"));
+        assert_eq!(
+            std::fs::read(work.join("sentinel")).unwrap(),
+            b"old replica"
+        );
+        let staging_prefix = ".work.snapshot-restore.";
+        assert!(
+            std::fs::read_dir(dir.path()).unwrap().all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(staging_prefix)),
+            "a rejected staged copy must be cleaned up"
         );
     }
 

--- a/crates/nestweaver-engine/src/watch_code.rs
+++ b/crates/nestweaver-engine/src/watch_code.rs
@@ -1251,7 +1251,7 @@ mod tests {
             .list_contracts(Some(&r_uid))
             .unwrap()
             .into_iter()
-            .find(|contract| contract.uid == "contract:http:GET:/v1/items")
+            .find(|contract| contract.uid.ends_with(":http:GET:/v1/items"))
             .unwrap();
         assert_eq!(get.source_path, "openapi.v2.yaml");
         assert!(
@@ -1306,9 +1306,10 @@ mod tests {
             .find(|symbol| symbol.name == "create")
             .expect("modified controller method must publish");
         assert!(create.canonical_id.is_some());
-        assert_eq!(
-            store.contracts_implemented_by(&create.uid).unwrap()[0].0,
-            "contract:http:POST:/v1/items"
+        assert!(
+            store.contracts_implemented_by(&create.uid).unwrap()[0]
+                .0
+                .ends_with(":http:POST:/v1/items")
         );
         let controller_class = symbols
             .iter()
@@ -1460,75 +1461,6 @@ mod tests {
     }
 
     #[test]
-    fn contract_apply_failure_rolls_back_source_and_stays_dirty_without_notification() {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
-        let dir = tempfile::tempdir().unwrap();
-        let (store, r_uid, repo_url, root) = index_contract_fixture(&dir);
-        store
-            .batch_insert_contracts(&[nestweaver_schema::Contract {
-                uid: "contract:http:POST:/v1/items".into(),
-                kind: "http".into(),
-                verb: Some("POST".into()),
-                path: Some("/v1/items".into()),
-                operation_id: None,
-                repo_uid: "repo:other".into(),
-                source_path: "openapi.yaml".into(),
-                confidence: 1.0,
-            }])
-            .unwrap();
-        std::fs::write(
-            root.join("openapi.yaml"),
-            "openapi: 3.0.0\ninfo: { title: t, version: \"1\" }\npaths:\n  /v1/items:\n    get:\n      responses: { \"200\": { description: ok } }\n    post:\n      responses: { \"200\": { description: ok } }\n",
-        )
-        .unwrap();
-        let controller = root.join("ItemsController.java");
-        std::fs::write(
-            &controller,
-            "@RestController\n@RequestMapping(\"/v1/items\")\npublic class ItemsController {\n  @GetMapping public void list() {}\n  @PostMapping public void create() {}\n}\n",
-        )
-        .unwrap();
-        let db_path = dir.path().join("watch.lbug");
-        let watcher = CodeWatcher::new(&db_path, &root, "test");
-        let notifications = AtomicUsize::new(0);
-
-        let error = watcher
-            .process_batch_and_notify(
-                &store,
-                &r_uid,
-                &repo_url,
-                &[controller, root.join("openapi.yaml")],
-                &crate::index::FileSystemIndexEpilogueIo,
-                Some(&|| {
-                    notifications.fetch_add(1, Ordering::SeqCst);
-                }),
-            )
-            .unwrap_err();
-        assert!(
-            error
-                .to_string()
-                .contains("apply watcher contract derivation")
-        );
-        assert_eq!(notifications.load(Ordering::SeqCst), 0);
-        assert!(crate::sidecar_path(&db_path, ".index-dirty").exists());
-        assert_eq!(
-            store
-                .lookup_symbols_by_repo(&r_uid)
-                .unwrap()
-                .iter()
-                .filter(|symbol| symbol.name == "create")
-                .count(),
-            0,
-            "source mutation must roll back with contract replacement"
-        );
-        assert_eq!(store.list_contracts(Some(&r_uid)).unwrap().len(), 1);
-        assert_eq!(
-            store.contract_derivation_failures(Some(&r_uid)).unwrap(),
-            vec![r_uid]
-        );
-    }
-
-    #[test]
     fn fresh_watcher_batch_builds_authoritative_source_and_contract_graph() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -1576,9 +1508,10 @@ mod tests {
             .into_iter()
             .find(|symbol| symbol.name == "get")
             .expect("cold watcher must index unchanged controller source");
-        assert_eq!(
-            store.contracts_implemented_by(&get_symbol.uid).unwrap()[0].0,
-            "contract:http:GET:/fresh"
+        assert!(
+            store.contracts_implemented_by(&get_symbol.uid).unwrap()[0]
+                .0
+                .ends_with(":http:GET:/fresh")
         );
     }
 

--- a/crates/nestweaver-mcp/src/lib.rs
+++ b/crates/nestweaver-mcp/src/lib.rs
@@ -61,6 +61,14 @@ pub fn tantivy_sidecar_path(db_path: &Path) -> std::path::PathBuf {
     nestweaver_engine::sidecar_path(db_path, ".tantivy")
 }
 
+/// Open the graph for direct stdio serving without ever attempting to become
+/// a writer. A direct MCP process is a read-only peer of the daemon/watcher;
+/// briefly taking the writer lock first can race or block the actual owner.
+fn open_direct_read_only_store(db_path: &Path) -> Result<GraphStore, anyhow::Error> {
+    GraphStore::open_read_only(db_path)
+        .with_context(|| format!("open read-only GraphStore at {}", db_path.display()))
+}
+
 /// Run the brain server on stdio until the client closes stdin or sends
 /// no more lines. Returns Ok on clean shutdown; errors only on truly
 /// unrecoverable conditions (the database failing to open, etc.). Per-call
@@ -91,8 +99,7 @@ pub fn run_stdio_server(
         })
         .transpose()?;
 
-    let store = GraphStore::open_or_readonly(db_path)
-        .with_context(|| format!("open GraphStore at {}", db_path.display()))?;
+    let store = open_direct_read_only_store(db_path)?;
     // Pre-load the PageRank sidecar if present — same behaviour as the CLI.
     nestweaver_engine::migrate_sidecar(db_path, "pagerank.json", ".pagerank.json");
     let pr_path = nestweaver_engine::sidecar_path(db_path, ".pagerank.json");
@@ -1319,4 +1326,17 @@ fn direct_stdio_explicit_config_fails_before_opening_the_graph() {
         .to_string();
     assert!(error.contains("load --config"), "{error}");
     assert!(!db.exists(), "config failure must precede graph creation");
+}
+
+#[test]
+fn direct_stdio_store_coexists_with_a_live_writer_without_taking_its_lock() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("graph.lbug");
+    let writer = GraphStore::create(&db).expect("create live writer");
+
+    let reader = open_direct_read_only_store(&db)
+        .expect("direct MCP read-only store must coexist with the writer");
+
+    drop(reader);
+    drop(writer);
 }

--- a/crates/nestweaver-mcp/src/lib.rs
+++ b/crates/nestweaver-mcp/src/lib.rs
@@ -72,6 +72,25 @@ pub fn run_stdio_server(
     track_interactions: bool,
     config_path: Option<&Path>,
 ) -> Result<(), anyhow::Error> {
+    // Explicit configuration is an assertion. Validate it before opening the
+    // graph or emitting any protocol frame; falling back to compiled defaults
+    // can silently change identity, authorization, ranking, and limits.
+    let explicit_config = config_path
+        .map(|path| {
+            let canonical = std::fs::canonicalize(path)
+                .with_context(|| format!("canonicalize --config {}", path.display()))?;
+            let display = canonical
+                .to_str()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("--config path is not valid UTF-8: {}", canonical.display())
+                })?
+                .to_string();
+            let config = nestweaver_engine::InstanceConfig::from_file(&canonical)
+                .with_context(|| format!("load --config {display}"))?;
+            Ok::<_, anyhow::Error>((config, display))
+        })
+        .transpose()?;
+
     let store = GraphStore::open_or_readonly(db_path)
         .with_context(|| format!("open GraphStore at {}", db_path.display()))?;
     // Pre-load the PageRank sidecar if present — same behaviour as the CLI.
@@ -115,17 +134,12 @@ pub fn run_stdio_server(
     tools::set_current_db_path(canonical_db);
     tools::set_allow_add_sources(allow_add_sources);
     tools::set_lite_mode(lite);
+    tools::set_direct_read_only(true);
 
     // Load instance config so tools can read [limits], [response], [ranking], etc.
     // Try explicit --config path first, then auto-discover instance.toml next to the DB.
-    let (instance_cfg, cfg_source) = if let Some(p) = config_path {
-        match nestweaver_engine::InstanceConfig::from_file(p) {
-            Ok(c) => (Some(c), Some(p.display().to_string())),
-            Err(e) => {
-                tracing::warn!(path = %p.display(), error = %e, "failed to load --config");
-                (None, None)
-            }
-        }
+    let (instance_cfg, cfg_source) = if let Some((config, source)) = explicit_config {
+        (Some(config), Some(source))
     } else {
         let sibling = db_path.parent().map(|d| d.join("instance.toml"));
         match sibling.as_deref().and_then(|s| {
@@ -1286,4 +1300,23 @@ mod tests {
         maybe_record_terminal_success(&tracker);
         assert_eq!(tracker.pending_count(), 0);
     }
+}
+#[test]
+fn direct_stdio_explicit_config_fails_before_opening_the_graph() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("graph.lbug");
+    let missing = dir.path().join("missing.toml");
+    let error = run_stdio_server(&db, false, false, false, Some(&missing))
+        .expect_err("missing explicit config must fail closed")
+        .to_string();
+    assert!(error.contains("canonicalize --config"), "{error}");
+    assert!(!db.exists(), "config failure must precede graph creation");
+
+    let malformed = dir.path().join("invalid.toml");
+    std::fs::write(&malformed, "[instance\n").unwrap();
+    let error = run_stdio_server(&db, false, false, false, Some(&malformed))
+        .expect_err("malformed explicit config must fail closed")
+        .to_string();
+    assert!(error.contains("load --config"), "{error}");
+    assert!(!db.exists(), "config failure must precede graph creation");
 }

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -4268,6 +4268,17 @@ mod brain_search_total_contract_tests {
     fn degraded_repo_is_not_reported_clean_by_either_contract_tool() {
         let store = GraphStore::in_memory().unwrap();
         store
+            .insert_repo(&nestweaver_schema::Repo {
+                uid: "repo:broken".to_string(),
+                url: "https://example.test/broken".to_string(),
+                indexed_sha: "broken-sha".to_string(),
+                staleness_commits_behind: 0,
+                instance_id: "test-instance".to_string(),
+                name: None,
+                root_path: None,
+            })
+            .unwrap();
+        store
             .set_contract_derivation_failed("repo:broken", "COPY Contract: duplicate primary key")
             .unwrap();
 

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -349,7 +349,60 @@ pub fn tool_list(lite: bool) -> Value {
                 .is_some_and(|n| names.iter().any(|a| a == n))
         });
     }
+    if is_direct_read_only() {
+        tools.retain(|tool| {
+            tool["name"]
+                .as_str()
+                .is_some_and(|name| !crate::http::MUTATING_TOOLS.contains(&name))
+        });
+    }
     json!({ "tools": tools })
+}
+
+/// Validate an explicit CLI tool selection against the selected transport.
+/// This runs before the MCP loop starts so a typo or unavailable direct-mode
+/// mutator cannot silently produce a zero-tool server.
+pub fn validate_tool_selection(
+    names: Option<&[String]>,
+    lite: bool,
+    direct_read_only: bool,
+) -> Result<(), anyhow::Error> {
+    let registered = all_tool_schemas()
+        .into_iter()
+        .filter_map(|tool| tool["name"].as_str().map(str::to_owned))
+        .collect::<std::collections::BTreeSet<_>>();
+    let Some(names) = names else {
+        return Ok(());
+    };
+    if names.is_empty() {
+        anyhow::bail!("--tools must name at least one MCP tool");
+    }
+    let mut seen = std::collections::BTreeSet::new();
+    for name in names {
+        if name.trim().is_empty() {
+            anyhow::bail!("--tools contains an empty tool name");
+        }
+        if !seen.insert(name.as_str()) {
+            anyhow::bail!("--tools contains duplicate tool name '{name}'");
+        }
+        if !registered.contains(name) {
+            anyhow::bail!(
+                "unknown MCP tool '{name}'; use `nestweaver mcp --help` and `tools/list` for registered names"
+            );
+        }
+        if direct_read_only && crate::http::MUTATING_TOOLS.contains(&name.as_str()) {
+            anyhow::bail!(
+                "MCP tool '{name}' is unavailable in direct read-only mode; remove --no-daemon to route mutations through the daemon"
+            );
+        }
+    }
+    if lite && !names.iter().any(|name| LITE_TOOLS.contains(&name.as_str())) {
+        anyhow::bail!(
+            "--lite and --tools have no tools in common; lite tools: {}",
+            LITE_TOOLS.join(", ")
+        );
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -366,6 +419,73 @@ mod tool_schema_validation_tests {
         validate_tool_arguments(name, &args)
             .expect_err("arguments should fail schema validation")
             .to_string()
+    }
+
+    #[test]
+    fn explicit_tool_selection_is_transport_aware_and_never_silently_empty() {
+        validate_tool_selection(
+            Some(&["brain_context".to_string(), "brain_search".to_string()]),
+            false,
+            true,
+        )
+        .expect("read tools are available directly");
+
+        for (names, lite, direct, needle) in [
+            (
+                vec!["context".to_string()],
+                false,
+                false,
+                "unknown MCP tool",
+            ),
+            (vec!["".to_string()], false, false, "empty tool name"),
+            (
+                vec!["brain_search".to_string(), "brain_search".to_string()],
+                false,
+                false,
+                "duplicate",
+            ),
+            (
+                vec!["brain_add_source".to_string()],
+                false,
+                true,
+                "unavailable in direct read-only mode",
+            ),
+            (
+                vec!["read_symbols".to_string()],
+                true,
+                false,
+                "no tools in common",
+            ),
+        ] {
+            let error = validate_tool_selection(Some(&names), lite, direct)
+                .expect_err("invalid selection must fail before startup")
+                .to_string();
+            assert!(error.contains(needle), "{error}");
+        }
+    }
+
+    #[test]
+    fn readme_tool_allowlist_examples_only_use_registered_names() {
+        let readme = include_str!("../../../README.md");
+        let registered = all_tool_schemas()
+            .into_iter()
+            .filter_map(|tool| tool["name"].as_str().map(str::to_owned))
+            .collect::<std::collections::BTreeSet<_>>();
+        let mut examples = 0;
+        for line in readme.lines() {
+            let Some(rest) = line.split("nestweaver mcp --tools ").nth(1) else {
+                continue;
+            };
+            let names = rest.split_whitespace().next().unwrap_or_default();
+            for name in names.split(',') {
+                assert!(
+                    registered.contains(name),
+                    "README --tools example names unregistered tool '{name}'"
+                );
+            }
+            examples += 1;
+        }
+        assert!(examples > 0, "README must contain a tested --tools example");
     }
 
     #[test]
@@ -795,6 +915,24 @@ mod tool_schema_validation_tests {
         dispatch(&store, None, "brain_status", json!({}), None)
             .expect("lite tools must dispatch in lite mode");
         set_lite_mode(false);
+
+        set_direct_read_only(true);
+        let listed = tool_list(false);
+        let names = listed["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|tool| tool["name"].as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names.len(), 35);
+        for mutator in crate::http::MUTATING_TOOLS {
+            assert!(!names.contains(mutator), "direct mode advertised {mutator}");
+            let error = dispatch(&store, None, mutator, json!({}), None)
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("direct read-only mode"), "{error}");
+        }
+        set_direct_read_only(false);
     }
 
     #[cfg(feature = "daemon")]
@@ -1171,6 +1309,11 @@ pub fn tool_doc_entries() -> Vec<(String, String, String, Vec<String>)> {
 /// The allowlist error text is part of the CLI/MCP contract — keep it
 /// in sync with the `tools/list` filtering in [`tool_list`].
 pub fn enforce_tool_allowed(name: &str) -> Result<(), anyhow::Error> {
+    if is_direct_read_only() && crate::http::MUTATING_TOOLS.contains(&name) {
+        return Err(anyhow!(
+            "tool '{name}' is unavailable in direct read-only mode; remove --no-daemon to route mutations through the daemon"
+        ));
+    }
     if is_lite_mode() && !LITE_TOOLS.contains(&name) {
         return Err(anyhow!(
             "tool '{name}' is not available in lite mode; allowed: {}",
@@ -1267,7 +1410,7 @@ fn dispatch_uncached(
         "stale_check" => tool_stale_check(store),
         "set_extension" => tool_set_extension(args),
         "query_extensions" => tool_query_extensions(args),
-        "brain_diff" => tool_brain_diff(store, args),
+        "brain_diff" => tool_brain_diff(store, args, visible),
         "project_context" => tool_project_context(store, tantivy, args, embed_model, cancel),
         "dead_code" => tool_dead_code(store, args, cancel),
         "hub_nodes" => tool_hub_nodes(store, args),
@@ -5321,7 +5464,7 @@ fn tool_brain_add_source(store: &GraphStore, args: Value) -> Result<Value, anyho
         if !ALLOW_ADD_SOURCES.with(|c| c.get()) {
             return Err(anyhow!(
                 "brain_add_source is disabled in --no-daemon mode. \
-             Use daemon mode (the default) or pass --allow-mcp-add-sources."
+             Use a daemon-enabled build and daemon mode (the default)."
             ));
         }
         let raw_path = args
@@ -7122,7 +7265,11 @@ fn tool_schema_brain_diff() -> Value {
     })
 }
 
-fn tool_brain_diff(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error> {
+fn tool_brain_diff(
+    store: &GraphStore,
+    args: Value,
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
+) -> Result<Value, anyhow::Error> {
     use nestweaver_engine::git_diff;
 
     let repo_name = args
@@ -7136,17 +7283,15 @@ fn tool_brain_diff(store: &GraphStore, args: Value) -> Result<Value, anyhow::Err
         .map(|n| n as usize)
         .unwrap_or_else(configured_result_limit);
 
-    // Find the repo in the graph.
-    let repos = store.list_repos(None)?;
-    let repo = repos
-        .iter()
-        .find(|r| {
-            r.url.contains(repo_name) || {
-                let name_part = r.url.split('/').next_back().unwrap_or("");
-                name_part == repo_name
-            }
-        })
-        .ok_or_else(|| anyhow!("repo '{}' not found in graph", repo_name))?;
+    // Find the repo in the graph using the shared deterministic selector. The
+    // caller supplies the already-visible repository set in authenticated
+    // server dispatches, so the helper cannot widen authorization scope.
+    let repos = store
+        .list_repos(None)?
+        .into_iter()
+        .filter(|repo| visible.is_none_or(|scope| scope.allows(&repo.uid)))
+        .collect::<Vec<_>>();
+    let repo = nestweaver_engine::resolve_repo_selector(&repos, repo_name)?;
 
     let Some(repo_path) = repo.local_root() else {
         anyhow::bail!(
@@ -8573,6 +8718,7 @@ thread_local! {
         const { std::cell::RefCell::new(None) };
     static TRACK_INTERACTIONS: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
     static SERVER_MODE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static DIRECT_READ_ONLY: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
     // F16 response cache: size cap (MiB) and per-session hit/miss counters.
     static CACHE_MAX_SIZE_MB: std::cell::Cell<u64> =
         const { std::cell::Cell::new(nestweaver_store::cache::DEFAULT_MAX_SIZE_MB) };
@@ -8632,6 +8778,14 @@ pub fn set_allow_add_sources(allowed: bool) {
 
 pub fn set_lite_mode(lite: bool) {
     LITE_MODE.with(|c| c.set(lite));
+}
+
+pub fn set_direct_read_only(direct: bool) {
+    DIRECT_READ_ONLY.with(|value| value.set(direct));
+}
+
+pub fn is_direct_read_only() -> bool {
+    DIRECT_READ_ONLY.with(|value| value.get())
 }
 
 pub fn set_allowed_tools(names: Vec<String>) {

--- a/crates/nestweaver-schema/src/lib.rs
+++ b/crates/nestweaver-schema/src/lib.rs
@@ -18,7 +18,7 @@ pub use nodes::{
 pub use repo_url::{normalized_repo_key, repo_name};
 pub use uid::{
     PATH_PLACEHOLDER, canonical_symbol_id, contract_shape_key, contract_uid, file_uid, heading_uid,
-    normalize_http_path, note_uid, project_uid, repo_uid, scope_hash, section_uid, service_uid,
-    symbol_uid, tag_uid, truncated_hash, vault_uid,
+    normalize_http_path, note_uid, project_uid, repo_uid, scope_hash, scoped_contract_uid,
+    section_uid, service_uid, symbol_uid, tag_uid, truncated_hash, vault_uid,
 };
 pub use version::{core_schema_hash, effective_schema_hash};

--- a/crates/nestweaver-schema/src/lib.rs
+++ b/crates/nestweaver-schema/src/lib.rs
@@ -17,7 +17,7 @@ pub use nodes::{
 };
 pub use repo_url::{normalized_repo_key, repo_name};
 pub use uid::{
-    PATH_PLACEHOLDER, canonical_symbol_id, contract_uid, file_uid, heading_uid,
+    PATH_PLACEHOLDER, canonical_symbol_id, contract_shape_key, contract_uid, file_uid, heading_uid,
     normalize_http_path, note_uid, project_uid, repo_uid, scope_hash, section_uid, service_uid,
     symbol_uid, tag_uid, truncated_hash, vault_uid,
 };

--- a/crates/nestweaver-schema/src/uid.rs
+++ b/crates/nestweaver-schema/src/uid.rs
@@ -286,7 +286,11 @@ pub fn normalize_http_path(path: &str) -> String {
     out
 }
 
-/// Mint a deterministic UID for a [`crate::nodes::Contract`] node.
+/// Mint the repository-independent normalized shape of an API contract.
+///
+/// A shape is useful for discovery, but is NOT object identity: two unrelated
+/// services commonly expose the same verb and path. Callers must never use a
+/// bare shape to create implementation edges or satisfy per-repo drift.
 ///
 /// Schemes (per F2-core spec):
 /// - HTTP:    `contract:http:POST:/v1/approvals`  (verb upper-cased, path normalized)
@@ -295,7 +299,7 @@ pub fn normalize_http_path(path: &str) -> String {
 ///
 /// `verb`/`path` are only consulted for HTTP. For gRPC and GraphQL the
 /// `operation_id` carries the fully-qualified identifier.
-pub fn contract_uid(
+pub fn contract_shape_key(
     kind: &str,
     verb: Option<&str>,
     path: Option<&str>,
@@ -312,6 +316,26 @@ pub fn contract_uid(
             format!("contract:{other}:{op}")
         }
     }
+}
+
+/// Mint the deterministic, repository-scoped UID for a
+/// [`crate::nodes::Contract`] node.
+///
+/// `Contract.repo_uid` is singular ownership, so the primary key carries the
+/// same namespace. This mirrors File, Service, and Symbol identity and prevents
+/// unrelated repositories that expose the same route from colliding globally.
+pub fn contract_uid(
+    repo_uid: &str,
+    kind: &str,
+    verb: Option<&str>,
+    path: Option<&str>,
+    operation_id: Option<&str>,
+) -> String {
+    let shape = contract_shape_key(kind, verb, path, operation_id);
+    format!(
+        "contract:{repo_uid}:{}",
+        shape.trim_start_matches("contract:")
+    )
 }
 
 #[cfg(test)]
@@ -558,24 +582,54 @@ mod tests {
 
     #[test]
     fn contract_uid_http_scheme() {
-        let uid = contract_uid("http", Some("post"), Some("/v1/approvals/"), None);
-        assert_eq!(uid, "contract:http:POST:/v1/approvals");
+        let repo = "repo:test:abc123";
+        let uid = contract_uid(repo, "http", Some("post"), Some("/v1/approvals/"), None);
+        assert_eq!(uid, "contract:repo:test:abc123:http:POST:/v1/approvals");
         // Two differently-written-but-equivalent routes mint the same UID.
-        let a = contract_uid("http", Some("GET"), Some("/users/{id}"), None);
-        let b = contract_uid("http", Some("get"), Some("/users/:userId"), None);
+        let a = contract_uid(repo, "http", Some("GET"), Some("/users/{id}"), None);
+        let b = contract_uid(repo, "http", Some("get"), Some("/users/:userId"), None);
         assert_eq!(a, b, "equivalent routes must collide: {a} vs {b}");
+        assert_ne!(
+            a,
+            contract_uid(
+                "repo:test:other",
+                "http",
+                Some("GET"),
+                Some("/users/{id}"),
+                None
+            ),
+            "the same shape in another repo is a different Contract node"
+        );
     }
 
     #[test]
     fn contract_uid_grpc_scheme() {
-        let uid = contract_uid("grpc", None, None, Some("approvals.v1.Approvals/Create"));
-        assert_eq!(uid, "contract:grpc:approvals.v1.Approvals/Create");
+        let uid = contract_uid(
+            "repo:test:abc123",
+            "grpc",
+            None,
+            None,
+            Some("approvals.v1.Approvals/Create"),
+        );
+        assert_eq!(
+            uid,
+            "contract:repo:test:abc123:grpc:approvals.v1.Approvals/Create"
+        );
     }
 
     #[test]
     fn contract_uid_graphql_scheme() {
-        let uid = contract_uid("graphql", None, None, Some("Mutation.createApproval"));
-        assert_eq!(uid, "contract:graphql:Mutation.createApproval");
+        let uid = contract_uid(
+            "repo:test:abc123",
+            "graphql",
+            None,
+            None,
+            Some("Mutation.createApproval"),
+        );
+        assert_eq!(
+            uid,
+            "contract:repo:test:abc123:graphql:Mutation.createApproval"
+        );
     }
 
     #[test]

--- a/crates/nestweaver-schema/src/uid.rs
+++ b/crates/nestweaver-schema/src/uid.rs
@@ -318,13 +318,27 @@ pub fn contract_shape_key(
     }
 }
 
+/// Mint the historical repository-independent contract shape UID.
+///
+/// This public helper is retained for source compatibility. Stored
+/// [`crate::nodes::Contract`] nodes must use [`scoped_contract_uid`] so two
+/// repositories with the same route do not collide.
+pub fn contract_uid(
+    kind: &str,
+    verb: Option<&str>,
+    path: Option<&str>,
+    operation_id: Option<&str>,
+) -> String {
+    contract_shape_key(kind, verb, path, operation_id)
+}
+
 /// Mint the deterministic, repository-scoped UID for a
 /// [`crate::nodes::Contract`] node.
 ///
 /// `Contract.repo_uid` is singular ownership, so the primary key carries the
 /// same namespace. This mirrors File, Service, and Symbol identity and prevents
 /// unrelated repositories that expose the same route from colliding globally.
-pub fn contract_uid(
+pub fn scoped_contract_uid(
     repo_uid: &str,
     kind: &str,
     verb: Option<&str>,
@@ -583,15 +597,20 @@ mod tests {
     #[test]
     fn contract_uid_http_scheme() {
         let repo = "repo:test:abc123";
-        let uid = contract_uid(repo, "http", Some("post"), Some("/v1/approvals/"), None);
+        assert_eq!(
+            contract_uid("http", Some("post"), Some("/v1/approvals/"), None),
+            "contract:http:POST:/v1/approvals",
+            "the pre-v4.1 public shape helper remains source-compatible"
+        );
+        let uid = scoped_contract_uid(repo, "http", Some("post"), Some("/v1/approvals/"), None);
         assert_eq!(uid, "contract:repo:test:abc123:http:POST:/v1/approvals");
         // Two differently-written-but-equivalent routes mint the same UID.
-        let a = contract_uid(repo, "http", Some("GET"), Some("/users/{id}"), None);
-        let b = contract_uid(repo, "http", Some("get"), Some("/users/:userId"), None);
+        let a = scoped_contract_uid(repo, "http", Some("GET"), Some("/users/{id}"), None);
+        let b = scoped_contract_uid(repo, "http", Some("get"), Some("/users/:userId"), None);
         assert_eq!(a, b, "equivalent routes must collide: {a} vs {b}");
         assert_ne!(
             a,
-            contract_uid(
+            scoped_contract_uid(
                 "repo:test:other",
                 "http",
                 Some("GET"),
@@ -604,7 +623,7 @@ mod tests {
 
     #[test]
     fn contract_uid_grpc_scheme() {
-        let uid = contract_uid(
+        let uid = scoped_contract_uid(
             "repo:test:abc123",
             "grpc",
             None,
@@ -619,7 +638,7 @@ mod tests {
 
     #[test]
     fn contract_uid_graphql_scheme() {
-        let uid = contract_uid(
+        let uid = scoped_contract_uid(
             "repo:test:abc123",
             "graphql",
             None,

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -269,6 +269,29 @@ pub struct GraphStore {
     pub(crate) ppr_result_cache: Mutex<lru::LruCache<u64, Vec<(String, f64)>>>,
 }
 
+/// Authoritative embedding state captured while the in-memory embedding mutex
+/// remained held for the complete flush/metadata/count/stage operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddingSnapshotState {
+    pub model_id: String,
+    pub dimension: u32,
+    pub count: u64,
+}
+
+/// Lease retaining the embedding mutex after the snapshot artifact and its
+/// metadata have been captured. Snapshot callers keep this alive through the
+/// graph checkpoint and remaining artifact staging.
+pub struct EmbeddingSnapshotLease<'a> {
+    state: EmbeddingSnapshotState,
+    _guard: std::sync::MutexGuard<'a, crate::search::EmbeddingIndex>,
+}
+
+impl EmbeddingSnapshotLease<'_> {
+    pub fn state(&self) -> &EmbeddingSnapshotState {
+        &self.state
+    }
+}
+
 /// True if `msg` is lbug's stale-checkpoint open failure. A crash/OOM/SIGKILL
 /// during lbug's WAL auto-checkpoint (which fires as the WAL grows mid-index, and
 /// also during a backup) can leave a `<db>.wal.checkpoint` whose embedded database
@@ -1284,6 +1307,63 @@ impl GraphStore {
                 .map_err(|e| StoreError::Query(format!("save binary embedding sidecar: {e}")))?;
         }
         Ok(())
+    }
+
+    /// Durably flush and stage the authoritative embedding artifact without
+    /// allowing an embedding writer to interleave between the recorded
+    /// metadata/count and the copied bytes.
+    pub fn stage_embeddings_for_snapshot(
+        &self,
+        destination: &Path,
+    ) -> Result<EmbeddingSnapshotLease<'_>, StoreError> {
+        let idx = self
+            .embedding_index
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let count = u64::try_from(idx.len())
+            .map_err(|_| StoreError::Query("embedding count does not fit u64".to_string()))?;
+        let index_dimension = u32::try_from(idx.dimension().unwrap_or(0))
+            .map_err(|_| StoreError::Query("embedding dimension does not fit u32".to_string()))?;
+        let metadata = self.get_embedding_metadata()?;
+
+        let (model_id, dimension) = match metadata {
+            Some((model_id, dimension)) => {
+                if count > 0 && dimension != index_dimension {
+                    return Err(StoreError::Query(format!(
+                        "embedding metadata dimension {dimension} does not match sidecar dimension {index_dimension}"
+                    )));
+                }
+                (model_id, if count > 0 { dimension } else { 0 })
+            }
+            None if count > 0 => {
+                return Err(StoreError::Query(
+                    "embedding sidecar contains vectors but database embedding metadata is absent; re-embed before taking a snapshot"
+                        .to_string(),
+                ));
+            }
+            None => (String::new(), 0),
+        };
+
+        // Flush the canonical sidecar first, then serialize the exact same
+        // mutex-protected index into the snapshot staging directory. Both
+        // writes use atomic_replace_file (file fsync + rename + parent fsync).
+        if let Some(path) = self.embedding_sidecar_path() {
+            idx.save_binary(&path).map_err(|error| {
+                StoreError::Query(format!("flush binary embedding sidecar: {error}"))
+            })?;
+        }
+        idx.save_binary(destination).map_err(|error| {
+            StoreError::Query(format!("stage binary embedding sidecar: {error}"))
+        })?;
+
+        Ok(EmbeddingSnapshotLease {
+            state: EmbeddingSnapshotState {
+                model_id,
+                dimension,
+                count,
+            },
+            _guard: idx,
+        })
     }
     /// Remove embeddings for graph nodes that no longer exist, update the
     /// live index, and persist the repaired binary sidecar.

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -2366,6 +2366,53 @@ mod tests {
             "failed retirement must preserve fallback"
         );
     }
+
+    #[test]
+    fn snapshot_embedding_lease_serializes_metadata_updates() {
+        use std::sync::{Arc, mpsc};
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let store = Arc::new(GraphStore::open_or_create(&db_path).unwrap());
+        store.set_embedding_metadata("model-a", 3).unwrap();
+        assert!(store.add_embedding("symbol:a", vec![1.0, 0.0, 0.0]));
+
+        let staged = dir.path().join("snapshot-embeddings.bin");
+        let lease = store.stage_embeddings_for_snapshot(&staged).unwrap();
+        assert_eq!(lease.state().model_id, "model-a");
+        assert_eq!(lease.state().dimension, 3);
+        assert_eq!(lease.state().count, 1);
+
+        let updater = Arc::clone(&store);
+        let (completed_tx, completed_rx) = mpsc::channel();
+        let join = std::thread::spawn(move || {
+            updater.set_embedding_metadata("model-b", 3).unwrap();
+            completed_tx.send(()).unwrap();
+        });
+
+        assert!(
+            completed_rx
+                .recv_timeout(Duration::from_millis(100))
+                .is_err(),
+            "metadata update must wait while snapshot owns the embedding lease"
+        );
+        assert_eq!(
+            store.get_embedding_metadata().unwrap(),
+            Some(("model-a".to_string(), 3)),
+            "snapshot lease must retain a coherent database/vector fingerprint"
+        );
+
+        drop(lease);
+        completed_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("metadata update should complete once snapshot releases the lease");
+        join.join().unwrap();
+        assert_eq!(
+            store.get_embedding_metadata().unwrap(),
+            Some(("model-b".to_string(), 3))
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -11,7 +11,10 @@ pub mod tantivy_index;
 pub mod traverse;
 pub mod write;
 
-pub use db::{EmbeddingIndexReconciliation, GraphStore, IndexPublicationLease};
+pub use db::{
+    EmbeddingIndexReconciliation, EmbeddingSnapshotLease, EmbeddingSnapshotState, GraphStore,
+    IndexPublicationLease,
+};
 pub use error::{CancelReason, StoreError};
 
 /// Re-export the LadybugDB connection type so callers can use transactional

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -318,6 +318,27 @@ mod tests {
         assert_eq!(repos[0].url, "https://github.com/example/repo-1");
     }
 
+    #[test]
+    fn removed_repositories_do_not_leak_contract_failure_or_migration_debt() {
+        let store = test_store();
+        let repo = make_repo("repo-removed-debt");
+        store.insert_repo(&repo).unwrap();
+        store
+            .set_contract_derivation_failed(&repo.uid, "malformed fixture")
+            .unwrap();
+        let transaction = store.begin_transaction().unwrap();
+        GraphStore::ensure_contract_derivation_v2_on(&transaction).unwrap();
+        store.commit_transaction(&transaction).unwrap();
+        drop(transaction);
+
+        assert_eq!(
+            store.contract_derivation_failures(None).unwrap(),
+            vec![repo.uid.clone()]
+        );
+        store.delete_repo_node(&repo.uid).unwrap();
+        assert!(store.contract_derivation_failures(None).unwrap().is_empty());
+    }
+
     /// `root_path` round-trips through insert → list_repos/lookup_repo:
     /// `Some(path)` survives, `None` stays `None` (stored as '' and mapped
     /// back on read).

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -2127,6 +2127,46 @@ impl GraphStore {
         result.map(|row| extract_string(&row, 0)).collect()
     }
 
+    /// Return implemented Contract UIDs owned by one repository.
+    ///
+    /// Contract shapes may be identical across repositories. Drift must stay
+    /// owner-local even if a damaged or partially migrated database contains
+    /// an unexpected edge, so scope both the handler and Contract endpoints.
+    pub fn list_implemented_contract_uids_for_repo(
+        &self,
+        repo_uid: &str,
+    ) -> Result<Vec<String>, StoreError> {
+        let conn = self.conn()?;
+        let mut stmt = match conn.prepare(
+            "MATCH (s:Symbol)-[:IMPLEMENTS_CONTRACT]->(c:Contract) \
+             WHERE s.repo_uid = $repo_uid AND c.repo_uid = $repo_uid \
+             RETURN DISTINCT c.uid",
+        ) {
+            Ok(stmt) => stmt,
+            Err(error) => {
+                tracing::trace!(
+                    "list_implemented_contract_uids_for_repo: query skipped \
+                     (table may not exist): {error}"
+                );
+                return Ok(vec![]);
+            }
+        };
+        let result = match conn.execute(
+            &mut stmt,
+            vec![("repo_uid", Value::String(repo_uid.to_string()))],
+        ) {
+            Ok(result) => result,
+            Err(error) => {
+                tracing::trace!(
+                    "list_implemented_contract_uids_for_repo: query skipped \
+                     (table may not exist): {error}"
+                );
+                return Ok(vec![]);
+            }
+        };
+        result.map(|row| extract_string(&row, 0)).collect()
+    }
+
     /// Look up a Project by name (case-insensitive).
     pub fn lookup_project_by_name(&self, name: &str) -> Result<Option<Project>, StoreError> {
         let all = self.list_projects()?;
@@ -2631,43 +2671,76 @@ impl GraphStore {
     /// `repo_uid` scopes the answer to a single repo (the drift analysis is
     /// optionally repo-filtered); `None` reports every degraded repo in the DB.
     ///
-    /// Reads the markers written by
-    /// [`GraphStore::set_contract_derivation_failed`]. Absent markers — and an
-    /// old DB with no `Meta` table — mean "nothing known to be degraded", which
-    /// is the pre-existing behaviour, not a claim of health.
+    /// Reads explicit failure and v2 migration-debt markers. An indexed legacy
+    /// database without the v2 generation marker is conservatively degraded
+    /// for every repository until each scoped derivation has published.
     pub fn contract_derivation_failures(
         &self,
         repo_uid: Option<&str>,
     ) -> Result<Vec<String>, StoreError> {
         let conn = self.conn()?;
+        let indexed_repos = || -> Result<Vec<String>, StoreError> {
+            let rows = conn
+                .query("MATCH (r:Repo) RETURN r.uid")
+                .map_err(|error| StoreError::Query(format!("list contract-debt repos: {error}")))?;
+            rows.map(|row| extract_string(&row, 0)).collect()
+        };
         // The Meta table holds a handful of singleton rows, so scanning it and
         // filtering the prefix in Rust avoids depending on a string-predicate
         // dialect for a set this small.
-        let mut stmt = match conn.prepare("MATCH (m:Meta) RETURN m.key") {
+        let mut stmt = match conn.prepare("MATCH (m:Meta) RETURN m.key, m.value") {
             Ok(s) => s,
-            // Meta table doesn't exist on older databases — treat as absent.
-            Err(_) => return Ok(Vec::new()),
+            // An indexed pre-v2 database with no Meta table owes derivation for
+            // every repo; fall through to the generation-debt expansion below.
+            Err(_) => {
+                let mut repos: Vec<String> = indexed_repos()?
+                    .into_iter()
+                    .filter(|uid| repo_uid.is_none_or(|want| want == uid))
+                    .collect();
+                repos.sort();
+                return Ok(repos);
+            }
         };
         let result = match conn.execute(&mut stmt, vec![]) {
             Ok(r) => r,
-            Err(_) => return Ok(Vec::new()),
+            Err(_) => {
+                let mut repos: Vec<String> = indexed_repos()?
+                    .into_iter()
+                    .filter(|uid| repo_uid.is_none_or(|want| want == uid))
+                    .collect();
+                repos.sort();
+                return Ok(repos);
+            }
         };
-        let prefix = crate::write::CONTRACT_DERIVATION_FAILED_PREFIX;
-        let mut out: Vec<String> = Vec::new();
+        let failure_prefix = crate::write::CONTRACT_DERIVATION_FAILED_PREFIX;
+        let debt_prefix = crate::write::CONTRACT_DERIVATION_DEBT_PREFIX;
+        let mut generation = None;
+        let mut out = std::collections::BTreeSet::new();
         for row in result {
             let Ok(key) = extract_string(&row, 0) else {
                 continue;
             };
-            let Some(uid) = key.strip_prefix(prefix) else {
+            if key == crate::write::CONTRACT_DERIVATION_GENERATION_KEY {
+                generation = extract_string(&row, 1).ok();
                 continue;
-            };
+            }
+            let uid = key
+                .strip_prefix(failure_prefix)
+                .or_else(|| key.strip_prefix(debt_prefix));
+            let Some(uid) = uid else { continue };
             if repo_uid.is_some_and(|want| want != uid) {
                 continue;
             }
-            out.push(uid.to_string());
+            out.insert(uid.to_string());
         }
-        out.sort();
-        Ok(out)
+        if generation.as_deref() != Some(crate::write::CONTRACT_DERIVATION_GENERATION) {
+            for uid in indexed_repos()? {
+                if repo_uid.is_none_or(|want| want == uid) {
+                    out.insert(uid);
+                }
+            }
+        }
+        Ok(out.into_iter().collect())
     }
 }
 

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -2714,6 +2714,9 @@ impl GraphStore {
         };
         let failure_prefix = crate::write::CONTRACT_DERIVATION_FAILED_PREFIX;
         let debt_prefix = crate::write::CONTRACT_DERIVATION_DEBT_PREFIX;
+        let indexed_repos = indexed_repos()?
+            .into_iter()
+            .collect::<std::collections::BTreeSet<_>>();
         let mut generation = None;
         let mut out = std::collections::BTreeSet::new();
         for row in result {
@@ -2728,13 +2731,19 @@ impl GraphStore {
                 .strip_prefix(failure_prefix)
                 .or_else(|| key.strip_prefix(debt_prefix));
             let Some(uid) = uid else { continue };
+            // Failure/debt markers may outlive a removed Repo on databases
+            // written by older versions. They must not make a nonexistent
+            // repository permanently degrade database-wide contract status.
+            if !indexed_repos.contains(uid) {
+                continue;
+            }
             if repo_uid.is_some_and(|want| want != uid) {
                 continue;
             }
             out.insert(uid.to_string());
         }
         if generation.as_deref() != Some(crate::write::CONTRACT_DERIVATION_GENERATION) {
-            for uid in indexed_repos()? {
+            for uid in indexed_repos {
                 if repo_uid.is_none_or(|want| want == uid) {
                     out.insert(uid);
                 }

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -2078,8 +2078,15 @@ impl GraphStore {
     /// silently succeeds if the table does not exist.
     pub fn delete_unresolved_wikilinks_for_note(&self, note_uid: &str) -> Result<(), StoreError> {
         let conn = self.conn()?;
+        Self::delete_unresolved_wikilinks_for_note_on(&conn, note_uid)
+    }
+
+    fn delete_unresolved_wikilinks_for_note_on(
+        conn: &lbug::Connection<'_>,
+        note_uid: &str,
+    ) -> Result<(), StoreError> {
         if let Err(e) = exec_params(
-            &conn,
+            conn,
             "MATCH (u:UnresolvedWikilink {source_note_uid: $uid}) DETACH DELETE u",
             vec![("uid", lbug::Value::String(note_uid.to_string()))],
         ) {
@@ -2415,14 +2422,34 @@ impl GraphStore {
     /// the next reindex pass.
     pub fn delete_note_cascade(&self, note_uid: &str) -> Result<(), StoreError> {
         let conn = self.conn()?;
+        Self::delete_note_cascade_on(&conn, note_uid)
+    }
 
+    /// Atomically delete one note and all of its owned graph data.
+    pub fn delete_note_cascade_atomic(&self, note_uid: &str) -> Result<(), StoreError> {
+        let conn = self.begin_transaction()?;
+        if let Err(error) = Self::delete_note_cascade_on(&conn, note_uid) {
+            return match self.rollback_transaction(&conn) {
+                Ok(()) => Err(error),
+                Err(rollback) => Err(StoreError::Query(format!(
+                    "{error}; atomic note deletion rollback failed: {rollback}"
+                ))),
+            };
+        }
+        self.commit_transaction(&conn)
+    }
+
+    fn delete_note_cascade_on(
+        conn: &lbug::Connection<'_>,
+        note_uid: &str,
+    ) -> Result<(), StoreError> {
         // 1. Drop every Section whose ownership property references this
         //    note, including fragments whose NOTE_HAS_SECTION edge is missing.
         //    DETACH removes the
         //    NOTE_HAS_SECTION, HEADING_HAS_SECTION, WIKILINK_TO_NOTE
         //    (incoming) and SECTION_TAGGED_WITH edges along with it.
         exec_params(
-            &conn,
+            conn,
             "MATCH (s:Section) WHERE s.note_uid = $uid DETACH DELETE s",
             vec![("uid", lbug::Value::String(note_uid.to_string()))],
         )?;
@@ -2431,7 +2458,7 @@ impl GraphStore {
         //    independent pass also handles a missing or corrupt note_uid
         //    property.
         exec_params(
-            &conn,
+            conn,
             "MATCH (n:Note {uid: $uid})-[:NOTE_HAS_SECTION]->(s:Section) DETACH DELETE s",
             vec![("uid", lbug::Value::String(note_uid.to_string()))],
         )?;
@@ -2443,7 +2470,7 @@ impl GraphStore {
         //    section was dropped above), HEADING_PARENT (both directions),
         //    and WIKILINK_TO_HEADING (incoming).
         exec_params(
-            &conn,
+            conn,
             "MATCH (h:Heading) WHERE h.note_uid = $uid DETACH DELETE h",
             vec![("uid", lbug::Value::String(note_uid.to_string()))],
         )?;
@@ -2452,7 +2479,7 @@ impl GraphStore {
         //    independent pass also handles a missing or corrupt note_uid
         //    property.
         exec_params(
-            &conn,
+            conn,
             "MATCH (n:Note {uid: $uid})-[:NOTE_HAS_HEADING]->(h:Heading) DETACH DELETE h",
             vec![("uid", lbug::Value::String(note_uid.to_string()))],
         )?;
@@ -2461,16 +2488,68 @@ impl GraphStore {
         //    NOTE_TAGGED_WITH, PROJECT_INCLUDES_NOTE, and any incoming
         //    WIKILINK_TO_NOTE edges from other notes' sections.
         exec_params(
-            &conn,
+            conn,
             "MATCH (n:Note {uid: $uid}) DETACH DELETE n",
             vec![("uid", lbug::Value::String(note_uid.to_string()))],
         )?;
 
         // 6. Drop any recorded unresolved-wikilink rows for this note so they
         //    do not linger after re-index (e.g. once the target note appears).
-        self.delete_unresolved_wikilinks_for_note(note_uid)?;
+        Self::delete_unresolved_wikilinks_for_note_on(conn, note_uid)?;
 
         Ok(())
+    }
+
+    /// Delete an incumbent note and insert its complete replacement in one
+    /// transaction. If any replacement write fails, the incumbent remains.
+    #[allow(clippy::too_many_arguments)]
+    pub fn replace_note_atomically(
+        &self,
+        note_uid: &str,
+        notes: &[Note],
+        headings: &[Heading],
+        sections: &[Section],
+        vault_note_edges: &[(&str, &str)],
+        note_heading_edges: &[(&str, &str)],
+        note_section_edges: &[(&str, &str)],
+        heading_section_edges: &[(&str, &str)],
+        heading_parent_edges: &[(&str, &str)],
+        tags: &[Tag],
+        note_tag_edges: &[(&str, &str)],
+        section_tag_edges: &[(&str, &str)],
+        wikilink_to_note_edges: &[(&str, &str, f32, &str, &str)],
+        wikilink_to_heading_edges: &[(&str, &str, f32, &str, &str)],
+        unresolved_wikilinks: &[UnresolvedWikilinkRecord],
+    ) -> Result<(), StoreError> {
+        let conn = self.begin_transaction()?;
+        let mutation = Self::delete_note_cascade_on(&conn, note_uid).and_then(|()| {
+            Self::bulk_vault_write_on(
+                &conn,
+                notes,
+                headings,
+                sections,
+                vault_note_edges,
+                note_heading_edges,
+                note_section_edges,
+                heading_section_edges,
+                heading_parent_edges,
+                tags,
+                note_tag_edges,
+                section_tag_edges,
+                wikilink_to_note_edges,
+                wikilink_to_heading_edges,
+            )?;
+            Self::batch_insert_unresolved_wikilinks_on(&conn, unresolved_wikilinks)
+        });
+        if let Err(error) = mutation {
+            return match self.rollback_transaction(&conn) {
+                Ok(()) => Err(error),
+                Err(rollback) => Err(StoreError::Query(format!(
+                    "{error}; atomic note replacement rollback failed: {rollback}"
+                ))),
+            };
+        }
+        self.commit_transaction(&conn)
     }
 
     /// Cascade-delete a Vault and every Note belonging to it using bulk
@@ -7401,6 +7480,68 @@ mod tests {
             after, before,
             "merge destroyed the wikilink graph: {before} -> {after}"
         );
+    }
+
+    #[test]
+    fn atomic_note_replacement_failure_preserves_incumbent() {
+        let store = GraphStore::in_memory().expect("store");
+        let vault_uid = "vlt:replace:atomic";
+        let note_uid = "note:vlt:replace:atomic:a";
+        store
+            .insert_vault(&Vault {
+                uid: vault_uid.to_string(),
+                name: "brain".to_string(),
+                root_path: "/brain".to_string(),
+                instance_id: "test".to_string(),
+            })
+            .unwrap();
+        let incumbent = Note {
+            uid: note_uid.to_string(),
+            vault_uid: vault_uid.to_string(),
+            file_path: "a.md".to_string(),
+            title: "Incumbent".to_string(),
+            note_kind: nestweaver_schema::NoteKind::General,
+            word_count: 1,
+            content_hash: "old".to_string(),
+            frontmatter: None,
+            created_at: None,
+            modified_at: None,
+            pagerank_score: None,
+            embedding: None,
+        };
+        store.insert_note(&incumbent).unwrap();
+        store.insert_vault_note_edge(vault_uid, note_uid).unwrap();
+
+        let replacement = Note {
+            title: "Replacement".to_string(),
+            content_hash: "new".to_string(),
+            ..incumbent.clone()
+        };
+        let error = store
+            .replace_note_atomically(
+                note_uid,
+                &[replacement.clone(), replacement],
+                &[],
+                &[],
+                &[(vault_uid, note_uid)],
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+            )
+            .expect_err("duplicate replacement UID must fail after the staged delete");
+        assert!(!error.to_string().is_empty());
+
+        let notes = store.list_notes(Some(vault_uid)).unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].title, "Incumbent");
+        assert_eq!(notes[0].content_hash, "old");
     }
 
     #[test]

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -6507,6 +6507,14 @@ impl GraphStore {
     /// is keyed by the fixed string `"embedding"` — only one such record
     /// can exist at a time. Calling this again replaces any previous value.
     pub fn set_embedding_metadata(&self, model_id: &str, dimension: u32) -> Result<(), StoreError> {
+        // Lock order is embedding index -> database. Snapshot capture uses the
+        // same order while retaining the index guard through metadata capture
+        // and sidecar staging. Taking the database connection first here would
+        // permit an AB/BA deadlock and a model/vector split-brain snapshot.
+        let mut embedding_index = self
+            .embedding_index
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
         let conn = self.conn()?;
 
         // Encode both fields into a single JSON string so we can use the
@@ -6535,10 +6543,7 @@ impl GraphStore {
             // Keep the in-memory index's recorded model in sync with what was
             // just persisted, so the recorded-model write guard in this
             // long-lived store checks against the new fingerprint.
-            self.embedding_index
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .set_recorded_model_id(Some(model_id.to_string()));
+            embedding_index.set_recorded_model_id(Some(model_id.to_string()));
         }
         result
     }

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -2508,7 +2508,7 @@ impl GraphStore {
     #[allow(clippy::too_many_arguments)]
     pub fn incremental_vault_refresh_atomically(
         &self,
-        vault_uid: &str,
+        vault: &Vault,
         delete_note_uids: &[String],
         rebuild_link_source_uids: &[String],
         notes: &[Note],
@@ -2525,9 +2525,20 @@ impl GraphStore {
         wikilink_to_note_edges: &[(&str, &str, f32, &str, &str)],
         wikilink_to_heading_edges: &[(&str, &str, f32, &str, &str)],
         unresolved_wikilinks: &[UnresolvedWikilinkRecord],
+        typed_edges: &[ResolvedEdge],
     ) -> Result<(), StoreError> {
         let conn = self.begin_transaction()?;
         let mutation = (|| {
+            exec_params(
+                &conn,
+                "MERGE (v:Vault {uid: $uid}) SET v.name = $name, v.root_path = $rp, v.instance_id = $iid",
+                vec![
+                    ("uid", lbug::Value::String(vault.uid.clone())),
+                    ("name", lbug::Value::String(vault.name.clone())),
+                    ("rp", lbug::Value::String(vault.root_path.clone())),
+                    ("iid", lbug::Value::String(vault.instance_id.clone())),
+                ],
+            )?;
             // Rebuild every successfully-parsed source's outgoing links. This
             // preserves inbound links to replaced targets and makes title
             // resolution a function of the prospective graph, not file order.
@@ -2545,6 +2556,13 @@ impl GraphStore {
                     vec![("uid", lbug::Value::String(note_uid.clone()))],
                 )?;
                 Self::delete_unresolved_wikilinks_for_note_on(&conn, note_uid)?;
+                for rel in ["SUPERSEDES", "DEPENDS_ON", "CAUSED_BY", "RELATES_TO"] {
+                    exec_params(
+                        &conn,
+                        &format!("MATCH (n:Note {{uid: $uid}})-[r:{rel}]->() DELETE r"),
+                        vec![("uid", lbug::Value::String(note_uid.clone()))],
+                    )?;
+                }
             }
             for note_uid in delete_note_uids {
                 Self::delete_note_cascade_on(&conn, note_uid)?;
@@ -2566,12 +2584,13 @@ impl GraphStore {
                 wikilink_to_heading_edges,
             )?;
             Self::batch_insert_unresolved_wikilinks_on(&conn, unresolved_wikilinks)?;
+            Self::batch_insert_edges_on(&conn, typed_edges)?;
             exec_params(
                 &conn,
                 "MATCH (t:Tag) WHERE t.vault_uid = $vid \
                  AND NOT (t)<-[:NOTE_TAGGED_WITH]-() \
                  AND NOT (t)<-[:SECTION_TAGGED_WITH]-() DETACH DELETE t",
-                vec![("vid", lbug::Value::String(vault_uid.to_string()))],
+                vec![("vid", lbug::Value::String(vault.uid.clone()))],
             )
         })();
         if let Err(error) = mutation {
@@ -5213,7 +5232,7 @@ impl GraphStore {
     /// helper serves both WIKILINK_TO_NOTE and WIKILINK_TO_HEADING. Best-effort:
     /// a missing table yields an empty vec rather than an error, matching how
     /// the cascade treats these tables.
-    fn wikilink_edges_for_vault(
+    pub fn wikilink_edges_for_vault(
         &self,
         vault_uid: &str,
         rel: &str,
@@ -5243,6 +5262,8 @@ impl GraphStore {
         };
         Ok(result
             .filter_map(|row| {
+                let display = crate::read::extract_string(&row, 3).unwrap_or_default();
+                let target = crate::read::extract_string(&row, 4).unwrap_or_default();
                 Some((
                     crate::read::extract_string(&row, 0).ok()?,
                     crate::read::extract_string(&row, 1).ok()?,
@@ -5253,11 +5274,11 @@ impl GraphStore {
                             _ => None,
                         })
                         .unwrap_or(0.0),
-                    crate::read::extract_string(&row, 3).unwrap_or_default(),
+                    display.clone(),
                     // nw-122: `target` is empty on rows written before the
                     // column existed; readers fall back to `display`, which is
                     // exactly what those rows have always carried.
-                    crate::read::extract_string(&row, 4).unwrap_or_default(),
+                    if target.is_empty() { display } else { target },
                 ))
             })
             .collect())
@@ -5266,7 +5287,7 @@ impl GraphStore {
     /// Read every UnresolvedWikilink row as
     /// `(uid, source_note_uid, source_path, source_title, wikilink_text)`.
     /// Callers filter by source note. Best-effort on a missing table.
-    fn all_unresolved_wikilinks(&self) -> Result<Vec<UnresolvedWikilinkRecord>, StoreError> {
+    pub fn all_unresolved_wikilinks(&self) -> Result<Vec<UnresolvedWikilinkRecord>, StoreError> {
         let conn = self.conn()?;
         let q = "MATCH (u:UnresolvedWikilink) \
                  RETURN u.uid, u.source_note_uid, u.source_path, u.source_title, u.wikilink_text";
@@ -7552,6 +7573,48 @@ mod tests {
             store.insert_note(note).unwrap();
             store.insert_vault_note_edge(vault_uid, &note.uid).unwrap();
         }
+        let old_section = Section {
+            uid: format!("sec:{vault_uid}:a"),
+            note_uid: old_a.uid.clone(),
+            heading_uid: None,
+            start_line: 1,
+            end_line: 2,
+            text_hash: "old-section".to_string(),
+            text_content: "[[Incumbent b]] #old".to_string(),
+            word_count: 2,
+            pagerank_score: None,
+        };
+        store.insert_section(&old_section).unwrap();
+        store
+            .batch_insert_note_section_edges(&[(old_a.uid.as_str(), old_section.uid.as_str())])
+            .unwrap();
+        store
+            .batch_insert_wikilink_to_note_edges(&[(
+                old_section.uid.as_str(),
+                old_b.uid.as_str(),
+                1.0,
+                "Incumbent b",
+                "Incumbent b",
+            )])
+            .unwrap();
+        let old_tag = Tag {
+            uid: format!("tag:{vault_uid}:old"),
+            vault_uid: vault_uid.to_string(),
+            name: "old".to_string(),
+        };
+        store.insert_tag(&old_tag).unwrap();
+        store
+            .batch_insert_note_tag_edges(&[(old_a.uid.as_str(), old_tag.uid.as_str())])
+            .unwrap();
+        store
+            .insert_unresolved_wikilink(
+                "unresolved:old",
+                &old_a.uid,
+                &old_a.file_path,
+                &old_a.title,
+                "Missing",
+            )
+            .unwrap();
         let generation = store.graph_generation();
         let replacement = Note {
             title: "Replacement".to_string(),
@@ -7560,13 +7623,19 @@ mod tests {
         };
         let error = store
             .incremental_vault_refresh_atomically(
-                vault_uid,
+                &Vault {
+                    uid: vault_uid.to_string(),
+                    name: "new-name".to_string(),
+                    root_path: "/new-root".to_string(),
+                    instance_id: "new-instance".to_string(),
+                },
                 &[old_a.uid.clone(), old_b.uid.clone()],
                 &[],
                 &[replacement.clone(), replacement],
                 &[],
                 &[],
                 &[(vault_uid, old_a.uid.as_str())],
+                &[],
                 &[],
                 &[],
                 &[],
@@ -7586,6 +7655,13 @@ mod tests {
         assert!(notes.iter().any(|note| note.title == "Incumbent a"));
         assert!(notes.iter().any(|note| note.title == "Incumbent b"));
         assert!(notes.iter().all(|note| note.content_hash == "old"));
+        let vault = store.lookup_vault(vault_uid).unwrap();
+        assert_eq!(vault.name, "brain");
+        assert_eq!(vault.root_path, "/brain");
+        assert_eq!(vault.instance_id, "test");
+        assert_eq!(store.count_wikilink_edges().unwrap(), 1);
+        assert_eq!(store.all_unresolved_wikilinks().unwrap().len(), 1);
+        assert_eq!(store.list_tags(Some(vault_uid)).unwrap().len(), 1);
         assert_eq!(store.graph_generation(), generation);
     }
 

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -2500,12 +2500,17 @@ impl GraphStore {
         Ok(())
     }
 
-    /// Delete an incumbent note and insert its complete replacement in one
-    /// transaction. If any replacement write fails, the incumbent remains.
+    /// Apply a complete incremental vault refresh in one transaction.
+    ///
+    /// Every incumbent replacement/removal, every replacement node and edge,
+    /// the vault's rebuilt wikilinks, and orphan-tag cleanup commit together.
+    /// Any pre-commit failure rolls the entire old graph back.
     #[allow(clippy::too_many_arguments)]
-    pub fn replace_note_atomically(
+    pub fn incremental_vault_refresh_atomically(
         &self,
-        note_uid: &str,
+        vault_uid: &str,
+        delete_note_uids: &[String],
+        rebuild_link_source_uids: &[String],
         notes: &[Note],
         headings: &[Heading],
         sections: &[Section],
@@ -2522,7 +2527,28 @@ impl GraphStore {
         unresolved_wikilinks: &[UnresolvedWikilinkRecord],
     ) -> Result<(), StoreError> {
         let conn = self.begin_transaction()?;
-        let mutation = Self::delete_note_cascade_on(&conn, note_uid).and_then(|()| {
+        let mutation = (|| {
+            // Rebuild every successfully-parsed source's outgoing links. This
+            // preserves inbound links to replaced targets and makes title
+            // resolution a function of the prospective graph, not file order.
+            for note_uid in rebuild_link_source_uids {
+                exec_params(
+                    &conn,
+                    "MATCH (s:Section) WHERE s.note_uid = $uid \
+                     MATCH (s)-[r:WIKILINK_TO_NOTE]->() DELETE r",
+                    vec![("uid", lbug::Value::String(note_uid.clone()))],
+                )?;
+                exec_params(
+                    &conn,
+                    "MATCH (s:Section) WHERE s.note_uid = $uid \
+                     MATCH (s)-[r:WIKILINK_TO_HEADING]->() DELETE r",
+                    vec![("uid", lbug::Value::String(note_uid.clone()))],
+                )?;
+                Self::delete_unresolved_wikilinks_for_note_on(&conn, note_uid)?;
+            }
+            for note_uid in delete_note_uids {
+                Self::delete_note_cascade_on(&conn, note_uid)?;
+            }
             Self::bulk_vault_write_on(
                 &conn,
                 notes,
@@ -2539,13 +2565,20 @@ impl GraphStore {
                 wikilink_to_note_edges,
                 wikilink_to_heading_edges,
             )?;
-            Self::batch_insert_unresolved_wikilinks_on(&conn, unresolved_wikilinks)
-        });
+            Self::batch_insert_unresolved_wikilinks_on(&conn, unresolved_wikilinks)?;
+            exec_params(
+                &conn,
+                "MATCH (t:Tag) WHERE t.vault_uid = $vid \
+                 AND NOT (t)<-[:NOTE_TAGGED_WITH]-() \
+                 AND NOT (t)<-[:SECTION_TAGGED_WITH]-() DETACH DELETE t",
+                vec![("vid", lbug::Value::String(vault_uid.to_string()))],
+            )
+        })();
         if let Err(error) = mutation {
             return match self.rollback_transaction(&conn) {
                 Ok(()) => Err(error),
                 Err(rollback) => Err(StoreError::Query(format!(
-                    "{error}; atomic note replacement rollback failed: {rollback}"
+                    "{error}; atomic incremental vault refresh rollback failed: {rollback}"
                 ))),
             };
         }
@@ -7488,10 +7521,9 @@ mod tests {
     }
 
     #[test]
-    fn atomic_note_replacement_failure_preserves_incumbent() {
+    fn whole_incremental_refresh_failure_preserves_both_incumbents_and_generation() {
         let store = GraphStore::in_memory().expect("store");
         let vault_uid = "vlt:replace:atomic";
-        let note_uid = "note:vlt:replace:atomic:a";
         store
             .insert_vault(&Vault {
                 uid: vault_uid.to_string(),
@@ -7500,11 +7532,11 @@ mod tests {
                 instance_id: "test".to_string(),
             })
             .unwrap();
-        let incumbent = Note {
-            uid: note_uid.to_string(),
+        let incumbent = |suffix: &str| Note {
+            uid: format!("note:vlt:replace:atomic:{suffix}"),
             vault_uid: vault_uid.to_string(),
-            file_path: "a.md".to_string(),
-            title: "Incumbent".to_string(),
+            file_path: format!("{suffix}.md"),
+            title: format!("Incumbent {suffix}"),
             note_kind: nestweaver_schema::NoteKind::General,
             word_count: 1,
             content_hash: "old".to_string(),
@@ -7514,21 +7546,27 @@ mod tests {
             pagerank_score: None,
             embedding: None,
         };
-        store.insert_note(&incumbent).unwrap();
-        store.insert_vault_note_edge(vault_uid, note_uid).unwrap();
-
+        let old_a = incumbent("a");
+        let old_b = incumbent("b");
+        for note in [&old_a, &old_b] {
+            store.insert_note(note).unwrap();
+            store.insert_vault_note_edge(vault_uid, &note.uid).unwrap();
+        }
+        let generation = store.graph_generation();
         let replacement = Note {
             title: "Replacement".to_string(),
             content_hash: "new".to_string(),
-            ..incumbent.clone()
+            ..old_a.clone()
         };
         let error = store
-            .replace_note_atomically(
-                note_uid,
+            .incremental_vault_refresh_atomically(
+                vault_uid,
+                &[old_a.uid.clone(), old_b.uid.clone()],
+                &[],
                 &[replacement.clone(), replacement],
                 &[],
                 &[],
-                &[(vault_uid, note_uid)],
+                &[(vault_uid, old_a.uid.as_str())],
                 &[],
                 &[],
                 &[],
@@ -7544,9 +7582,11 @@ mod tests {
         assert!(!error.to_string().is_empty());
 
         let notes = store.list_notes(Some(vault_uid)).unwrap();
-        assert_eq!(notes.len(), 1);
-        assert_eq!(notes[0].title, "Incumbent");
-        assert_eq!(notes[0].content_hash, "old");
+        assert_eq!(notes.len(), 2);
+        assert!(notes.iter().any(|note| note.title == "Incumbent a"));
+        assert!(notes.iter().any(|note| note.title == "Incumbent b"));
+        assert!(notes.iter().all(|note| note.content_hash == "old"));
+        assert_eq!(store.graph_generation(), generation);
     }
 
     #[test]

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -41,6 +41,11 @@ const COPY_CSV_OPTS: &str = "(PARALLEL=FALSE, DELIM=',', QUOTE='\"', ESCAPE='\"'
 /// carries that distinction across the two, so it is written by the indexer and
 /// read by [`GraphStore::contract_derivation_failures`].
 pub const CONTRACT_DERIVATION_FAILED_PREFIX: &str = "contract_derivation_failed:";
+/// Current repository-scoped Contract identity generation.
+pub const CONTRACT_DERIVATION_GENERATION: &str = "2";
+pub const CONTRACT_DERIVATION_GENERATION_KEY: &str = "contract_derivation_generation";
+/// Per-repo debt left by the global v1 -> v2 Contract identity migration.
+pub const CONTRACT_DERIVATION_DEBT_PREFIX: &str = "contract_derivation_debt:";
 
 /// What a classified destructive store mutation can prove about durable state.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -6506,15 +6511,118 @@ impl GraphStore {
     /// has no marker to clear.
     pub fn clear_contract_derivation_failed(&self, repo_uid: &str) -> Result<(), StoreError> {
         let conn = self.conn()?;
-        let _ = exec_params(
-            &conn,
+        Self::clear_contract_derivation_failed_on(&conn, repo_uid)
+    }
+
+    /// Clear a repository's failure marker on the caller's transaction.
+    pub fn clear_contract_derivation_failed_on(
+        conn: &lbug::Connection<'_>,
+        repo_uid: &str,
+    ) -> Result<(), StoreError> {
+        exec_params(
+            conn,
             "MATCH (m:Meta {key: $k}) DETACH DELETE m",
             vec![(
                 "k",
                 lbug::Value::String(format!("{CONTRACT_DERIVATION_FAILED_PREFIX}{repo_uid}")),
             )],
+        )
+    }
+
+    /// Upgrade the derived Contract graph from global v1 UIDs to repository-
+    /// scoped v2 UIDs inside the caller's publication transaction.
+    ///
+    /// Contract rows are wholly derived. The first v2 publisher therefore
+    /// removes every legacy row, marks every indexed repo as owing a v2
+    /// derivation, and records the generation atomically. The current repo's
+    /// debt is cleared only after its scoped rows and edges have landed.
+    pub fn ensure_contract_derivation_v2_on(conn: &lbug::Connection<'_>) -> Result<(), StoreError> {
+        let generation = {
+            let mut stmt = conn
+                .prepare("MATCH (m:Meta {key: $k}) RETURN m.value")
+                .map_err(|e| StoreError::Query(format!("prepare contract generation: {e}")))?;
+            let mut rows = conn
+                .execute(
+                    &mut stmt,
+                    vec![(
+                        "k",
+                        lbug::Value::String(CONTRACT_DERIVATION_GENERATION_KEY.to_string()),
+                    )],
+                )
+                .map_err(|e| StoreError::Query(format!("read contract generation: {e}")))?;
+            rows.next()
+                .and_then(|row| crate::read::extract_string(&row, 0).ok())
+        };
+        if generation.as_deref() == Some(CONTRACT_DERIVATION_GENERATION) {
+            return Ok(());
+        }
+
+        let repo_uids: Vec<String> = conn
+            .query("MATCH (r:Repo) RETURN r.uid")
+            .map_err(|e| StoreError::Query(format!("list repos for contract migration: {e}")))?
+            .filter_map(|row| crate::read::extract_string(&row, 0).ok())
+            .collect();
+
+        conn.query("MATCH (c:Contract) DETACH DELETE c")
+            .map_err(|e| StoreError::Query(format!("purge legacy contracts: {e}")))?;
+
+        for repo_uid in repo_uids {
+            let key = format!("{CONTRACT_DERIVATION_DEBT_PREFIX}{repo_uid}");
+            let _ = exec_params(
+                conn,
+                "MATCH (m:Meta {key: $k}) DETACH DELETE m",
+                vec![("k", lbug::Value::String(key.clone()))],
+            );
+            exec_params(
+                conn,
+                "CREATE (:Meta {key: $k, value: $v})",
+                vec![
+                    ("k", lbug::Value::String(key)),
+                    (
+                        "v",
+                        lbug::Value::String(CONTRACT_DERIVATION_GENERATION.to_string()),
+                    ),
+                ],
+            )?;
+        }
+
+        let _ = exec_params(
+            conn,
+            "MATCH (m:Meta {key: $k}) DETACH DELETE m",
+            vec![(
+                "k",
+                lbug::Value::String(CONTRACT_DERIVATION_GENERATION_KEY.to_string()),
+            )],
         );
-        Ok(())
+        exec_params(
+            conn,
+            "CREATE (:Meta {key: $k, value: $v})",
+            vec![
+                (
+                    "k",
+                    lbug::Value::String(CONTRACT_DERIVATION_GENERATION_KEY.to_string()),
+                ),
+                (
+                    "v",
+                    lbug::Value::String(CONTRACT_DERIVATION_GENERATION.to_string()),
+                ),
+            ],
+        )
+    }
+
+    /// Clear one repository's migration debt on the caller's transaction.
+    pub fn clear_contract_derivation_debt_on(
+        conn: &lbug::Connection<'_>,
+        repo_uid: &str,
+    ) -> Result<(), StoreError> {
+        exec_params(
+            conn,
+            "MATCH (m:Meta {key: $k}) DETACH DELETE m",
+            vec![(
+                "k",
+                lbug::Value::String(format!("{CONTRACT_DERIVATION_DEBT_PREFIX}{repo_uid}")),
+            )],
+        )
     }
 }
 

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -1345,6 +1345,26 @@ impl GraphStore {
         wikilink_to_note_edges: &[(&str, &str, f32, &str, &str)],
         wikilink_to_heading_edges: &[(&str, &str, f32, &str, &str)],
     ) -> Result<usize, StoreError> {
+        // Project membership is derived outside the vault hierarchy, but the
+        // authoritative vault replacement DETACH-deletes every old Note.
+        // Preserve membership for stable note UIDs that survive the refresh;
+        // truly removed notes intentionally lose their project edges.
+        let replacement_uids: std::collections::HashSet<&str> =
+            notes.iter().map(|note| note.uid.as_str()).collect();
+        let mut preserved_project_edges = Vec::new();
+        if vault_existed {
+            for project in self.list_projects()? {
+                for note_uid in self.list_project_note_uids(&project.uid)? {
+                    if replacement_uids.contains(note_uid.as_str()) {
+                        preserved_project_edges.push((project.uid.clone(), note_uid));
+                    }
+                }
+            }
+        }
+        let preserved_project_refs = preserved_project_edges
+            .iter()
+            .map(|(project, note)| (project.as_str(), note.as_str()))
+            .collect::<Vec<_>>();
         let conn = self.begin_transaction()?;
 
         // Delete old vault data within the transaction (if it existed).
@@ -1383,6 +1403,7 @@ impl GraphStore {
             wikilink_to_note_edges,
             wikilink_to_heading_edges,
         )?;
+        Self::batch_insert_project_note_edges_on(&conn, &preserved_project_refs)?;
 
         self.commit_transaction(&conn)?;
         Ok(deleted)
@@ -2526,6 +2547,7 @@ impl GraphStore {
         wikilink_to_heading_edges: &[(&str, &str, f32, &str, &str)],
         unresolved_wikilinks: &[UnresolvedWikilinkRecord],
         typed_edges: &[ResolvedEdge],
+        project_note_edges: &[(&str, &str)],
     ) -> Result<(), StoreError> {
         let conn = self.begin_transaction()?;
         let mutation = (|| {
@@ -2585,6 +2607,7 @@ impl GraphStore {
             )?;
             Self::batch_insert_unresolved_wikilinks_on(&conn, unresolved_wikilinks)?;
             Self::batch_insert_edges_on(&conn, typed_edges)?;
+            Self::batch_insert_project_note_edges_on(&conn, project_note_edges)?;
             exec_params(
                 &conn,
                 "MATCH (t:Tag) WHERE t.vault_uid = $vid \
@@ -4622,6 +4645,15 @@ impl GraphStore {
         edges: &[(&str, &str)],
     ) -> Result<(), StoreError> {
         let conn = self.conn()?;
+        Self::batch_insert_project_note_edges_on(&conn, edges)
+    }
+
+    /// Insert materialized project-note membership using an existing
+    /// transaction connection.
+    pub fn batch_insert_project_note_edges_on(
+        conn: &lbug::Connection<'_>,
+        edges: &[(&str, &str)],
+    ) -> Result<(), StoreError> {
         let mut stmt = conn
             .prepare(
                 "MATCH (p:Project {uid: $pid}), (n:Note {uid: $nid}) \
@@ -7635,6 +7667,7 @@ mod tests {
                 &[],
                 &[],
                 &[(vault_uid, old_a.uid.as_str())],
+                &[],
                 &[],
                 &[],
                 &[],

--- a/docs/architecture/project-brain.md
+++ b/docs/architecture/project-brain.md
@@ -135,7 +135,7 @@ MCP tool call: brain_context(seeds, token_budget)
 | `nestweaver-engine` | **Major change** | New `connectors/` submodule with `Connector` trait, `CodeConnector` (extracted from current `index.rs`), `MarkdownConnector` (new). New `sync/` submodule with `notify`-based file watcher. New `query/` extensions for unified retrieval and token budgeting. |
 | `nestweaver-storage` | **Unchanged** | Snapshot transport is already domain-agnostic. |
 | `nestweaver-mcp` | **Replace stub** | Implement against `rmcp` (the official Rust MCP SDK) with the tool set defined in §7. |
-| Root CLI (`src/main.rs`) | **Extended** | New commands (`index-vault`, `note`, `notes`, `wikilinks`, `tag`, `project`, `brain`, `mcp serve`, `watch`). Existing commands gain `--include-notes` / `--scope` flags. |
+| Root CLI (`src/main.rs`) | **Extended** | New commands (`index-vault`, `note`, `notes`, `wikilinks`, `tag`, `project`, `brain`, `mcp`, `watch`). Existing commands gain `--include-notes` / `--scope` flags. |
 
 The new crate `nestweaver-md-parser` is **not** recommended; keep Markdown in `nestweaver-parser` behind a module boundary. Avoiding workspace churn matters more than crate purity here.
 
@@ -565,7 +565,10 @@ greedy_token_budgeted(ranked_nodes, budget):
 
 The MCP server is implemented in `nestweaver-mcp` using **`rmcp`** (the official Rust MCP SDK, `rmcp` crate). Transport: stdio (default for Claude Desktop / Claude Code integration). SSE/HTTP optional behind a feature flag.
 
-Launched via `nestweaver mcp serve [--db PATH] [--config PATH]`. Holds the `GraphStore` and PPR caches in memory for the lifetime of the process. Optionally launches the file watcher (`nestweaver mcp serve --watch`) so the brain stays live without a separate `nestweaver watch` daemon.
+Launched via `nestweaver mcp [--db PATH] [--config PATH]`. The normal path
+proxies through the database-owning daemon; `--no-daemon` is an explicitly
+read-only CI/testing surface. File watching is managed separately through
+`nestweaver watch` / `nestweaver brain watch`.
 
 ### 7.2 Tool catalogue
 
@@ -1157,7 +1160,7 @@ Watching for changes. The brain stays current automatically.
   Daemon registered with launchd (com.nestweaver.daemon)
 
 Try: nestweaver brain context "your most-edited topic"
-     nestweaver mcp serve   # then add to Claude Desktop config
+     nestweaver mcp         # then add to your MCP client config
 ```
 
 Every line of that output is information the user actually needs. Nothing is jargon. The numbers prove the system found their stuff. The next-step suggestions are concrete.

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -43,6 +43,16 @@ message IndexVaultRequest {
   string instance_id = 4;
 }
 
+// Incremental vault refresh is a distinct method so an older daemon cannot
+// ignore a newly-added field and accidentally perform a full replacement.
+message RefreshVaultSinceRequest {
+  string vault_path = 1;
+  string vault_name = 2;
+  repeated string extra_ignore_patterns = 3;
+  string instance_id = 4;
+  uint64 since_unix_seconds = 5;
+}
+
 message RefreshBrainRequest {}
 
 message ReindexSearchRequest {}
@@ -582,6 +592,7 @@ service NestWeaverDaemon {
   // Indexing (server-streaming)
   rpc IndexRepo(IndexRepoRequest) returns (stream IndexProgress);
   rpc IndexVault(IndexVaultRequest) returns (stream IndexProgress);
+  rpc RefreshVaultSince(RefreshVaultSinceRequest) returns (stream IndexProgress);
   rpc RefreshBrain(RefreshBrainRequest) returns (stream IndexProgress);
   rpc ReindexSearch(ReindexSearchRequest) returns (ReindexSearchResponse);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11846,15 +11846,51 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 let pid_text =
                                     std::fs::read_to_string(&pidfile).unwrap_or_default();
                                 let pid_trimmed = pid_text.trim();
+                                if config.is_none() {
+                                    // A retry after a slow configless manual
+                                    // start must finish the reset only when the
+                                    // healthy pidfile owner attests compiled
+                                    // defaults. A configured incumbent is a
+                                    // no-op and retains durable intent; a
+                                    // missing/corrupt/PID-mismatched binding
+                                    // fails closed.
+                                    let runtime = tokio::runtime::Runtime::new()
+                                        .context("failed to create tokio runtime")?;
+                                    let health = runtime.block_on(
+                                        nestweaver_client::DaemonClient::wait_healthy(
+                                            &db_path,
+                                            nestweaver_client::autostart::daemon_boot_timeout(),
+                                        ),
+                                    )?;
+                                    let binding = nestweaver_daemon::lifecycle::
+                                        read_effective_config_binding_for_verified_pid(
+                                            &instance_id,
+                                            health.pid,
+                                        )
+                                        .context(
+                                            "cannot attest the already-running daemon's effective configuration",
+                                        )?;
+                                    if matches!(
+                                        binding.effective_config,
+                                        nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::CompiledDefaults
+                                    ) {
+                                        finish_manual_default_reset(
+                                            &db_path,
+                                            parent_driven_start,
+                                            &requested_start_config,
+                                        )?;
+                                    }
+                                } else {
+                                    verify_explicit_config_before_start_success(
+                                        &db_path,
+                                        config.as_deref(),
+                                    )?;
+                                }
                                 if pid_trimmed.is_empty() {
                                     eprintln!("Daemon already running (starting up).");
                                 } else {
                                     eprintln!("Daemon already running (PID {pid_trimmed}).");
                                 }
-                                verify_explicit_config_before_start_success(
-                                    &db_path,
-                                    config.as_deref(),
-                                )?;
                                 return Ok((EXIT_SUCCESS, None));
                             }
                             anyhow::bail!("flock on pidfile failed: {err}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -14960,12 +14960,13 @@ fn run_brain(
 
                 println!(
                     "Incremental refresh of vault '{}' (since {}): \
-                     checked {} file(s), updated {} note(s), \
+                     checked {} file(s), updated {} note(s), dropped {} prior note(s), \
                      {} heading(s), {} section(s), {} tag(s), {} wikilink(s).",
                     result.vault_name,
                     since_str,
                     result.files_checked,
                     result.notes_updated,
+                    result.notes_deleted,
                     result.headings_count,
                     result.sections_count,
                     result.tags_count,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6279,7 +6279,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     args["instance"] = serde_json::json!(inst);
                 }
                 if let Some(value) =
-                    try_hybrid_json_rpc(true, &db_path, None, "list_services", args)
+                    try_hybrid_json_rpc(true, &db_path, None, "list_services", args)?
                 {
                     let value = unwrap_hybrid_payload(value);
                     if json {
@@ -6340,7 +6340,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     args["instance"] = serde_json::json!(inst);
                 }
                 if let Some(value) =
-                    try_hybrid_json_rpc(true, &db_path, None, "service_summary", args)
+                    try_hybrid_json_rpc(true, &db_path, None, "service_summary", args)?
                 {
                     if json {
                         println!("{}", serde_json::to_string_pretty(&value)?);
@@ -6414,7 +6414,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             if use_daemon {
                 let db_path = db.clone().unwrap_or_else(default_db_path);
                 let args = serde_json::json!({ "token_budget": token_budget });
-                if let Some(value) = try_hybrid_json_rpc(true, &db_path, None, "repo_map", args) {
+                if let Some(value) = try_hybrid_json_rpc(true, &db_path, None, "repo_map", args)? {
                     let map = value["map"].as_str().unwrap_or("");
                     if json {
                         // Match the direct path's {map, token_count} shape — the daemon tool
@@ -6471,7 +6471,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     args["repo"] = serde_json::json!(rf);
                 }
                 if let Some(value) =
-                    try_hybrid_json_rpc(true, db_path, None, "cross_repo_contracts", args)
+                    try_hybrid_json_rpc(true, db_path, None, "cross_repo_contracts", args)?
                 {
                     if json {
                         println!("{}", serde_json::to_string_pretty(&value)?);
@@ -7503,7 +7503,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 if let Some(ref t) = target {
                     args["target"] = serde_json::json!(t);
                 }
-                if let Some(value) = try_hybrid_json_rpc(true, &db_path, None, "get_summary", args)
+                if let Some(value) = try_hybrid_json_rpc(true, &db_path, None, "get_summary", args)?
                     && let Some(text) = value.get("summaries").and_then(|v| v.as_str())
                 {
                     if text.is_empty() {
@@ -8081,7 +8081,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 if let Some(n) = limit {
                     args["limit"] = serde_json::json!(n);
                 }
-                if let Some(value) = try_hybrid_json_rpc(true, &db_path, None, "dead_code", args) {
+                if let Some(value) = try_hybrid_json_rpc(true, &db_path, None, "dead_code", args)? {
                     if json {
                         println!("{}", serde_json::to_string_pretty(&value)?);
                     } else {
@@ -8404,7 +8404,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     "files": file_strs,
                     "depth": depth,
                 });
-                if let Some(value) = try_hybrid_json_rpc(true, &db_path, None, "pr_impact", args) {
+                if let Some(value) = try_hybrid_json_rpc(true, &db_path, None, "pr_impact", args)? {
                     // The daemon serializes a full BlastRadiusResult; decode it so
                     // both the concise banner and the strict exit code see the real
                     // gate state (missing fields default via serde on old daemons).
@@ -8550,7 +8550,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // path produces so human/JSON output is identical either way.
             let daemon_result: Option<nestweaver_engine::AffectedTestsResult> = if use_daemon {
                 let args = affected_tests_rpc_args(&changed_files);
-                match try_hybrid_json_rpc(true, &db_path, None, "affected_tests", args) {
+                match try_hybrid_json_rpc(true, &db_path, None, "affected_tests", args)? {
                     Some(value) => Some(
                         serde_json::from_value(value)
                             .context("decoding daemon affected_tests result")?,
@@ -8732,6 +8732,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         return Ok((EXIT_ERROR, None));
                     }
                     Err(e) => {
+                        ensure_direct_store_fallback_allowed(&db_path, config.as_deref())
+                            .with_context(|| {
+                                format!(
+                                    "watch via daemon failed ({e:#}); refusing direct watcher fallback"
+                                )
+                            })?;
                         // No daemon running for this DB — safe to watch directly.
                         eprintln!("warning: daemon unavailable ({e:#}); running watcher directly");
                     }
@@ -8915,22 +8921,28 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         config.as_deref().map(std::path::Path::as_ref),
                     )) {
                         Ok(client) => Some((rt, client)),
-                        Err(error) if config.is_some() => {
-                            return Err(error).context(
-                                "explicit config could not be honored by the daemon for UI; refusing direct fallback",
-                            );
-                        }
                         Err(error) => {
+                            ensure_direct_store_fallback_allowed(&db_path, config.as_deref())
+                                .with_context(|| {
+                                    format!(
+                                        "daemon UI connection failed ({error:#}); refusing direct fallback"
+                                    )
+                                })?;
                             tracing::warn!(
                                 "daemon UI connection failed, falling back to direct: {error:#}"
                             );
                             None
                         }
                     },
-                    Err(error) if config.is_some() => {
-                        return Err(error).context("create runtime for explicit-config daemon UI");
+                    Err(error) => {
+                        ensure_direct_store_fallback_allowed(&db_path, config.as_deref())
+                            .with_context(|| {
+                                format!(
+                                    "create runtime for daemon UI failed ({error}); refusing direct fallback"
+                                )
+                            })?;
+                        None
                     }
-                    Err(_) => None,
                 }
             } else {
                 None
@@ -8999,12 +9011,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             }
                         }
                     }
-                    Err(error) if config.is_some() => {
-                        return Err(error).context(
-                            "explicit-config daemon UI request failed; refusing direct fallback",
-                        );
-                    }
                     Err(error) => {
+                        ensure_direct_store_fallback_allowed(&db_path, config.as_deref())
+                            .with_context(|| {
+                                format!(
+                                    "daemon UI request failed ({error:#}); refusing direct fallback"
+                                )
+                            })?;
                         tracing::warn!("ServeUi RPC failed, falling back to direct: {error}");
                     }
                 }
@@ -9436,7 +9449,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     args["instance"] = serde_json::json!(inst);
                 }
                 if let Some(value) =
-                    try_hybrid_json_rpc(true, &db_path, None, "symbol_lookup", args)
+                    try_hybrid_json_rpc(true, &db_path, None, "symbol_lookup", args)?
                 {
                     let status = value
                         .get("status")
@@ -10465,7 +10478,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let materialized: Vec<nestweaver_schema::Project> = if use_daemon {
                 let db_path = resolved_db.clone();
                 let args = serde_json::json!({});
-                try_hybrid_json_rpc(true, &db_path, None, "list_projects", args)
+                try_hybrid_json_rpc(true, &db_path, None, "list_projects", args)?
                     .and_then(|v| serde_json::from_value(unwrap_hybrid_payload(v)).ok())
                     .unwrap_or_else(|| {
                         // Daemon unreachable / RPC failed — fall back to a direct read, but
@@ -10895,7 +10908,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 if let Some(ref r) = root {
                     args["root"] = serde_json::json!(r);
                 }
-                if let Some(value) = try_hybrid_json_rpc(true, &db_path, None, "investigate", args)
+                if let Some(value) = try_hybrid_json_rpc(true, &db_path, None, "investigate", args)?
                 {
                     if json {
                         println!("{}", serde_json::to_string_pretty(&value)?);
@@ -10962,7 +10975,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     args["root"] = serde_json::json!(r);
                 }
                 if let Some(value) =
-                    try_hybrid_json_rpc(true, &db_path, None, "investigate_expand", args)
+                    try_hybrid_json_rpc(true, &db_path, None, "investigate_expand", args)?
                 {
                     println!("{}", serde_json::to_string_pretty(&value)?);
                     return Ok((EXIT_SUCCESS, None));
@@ -11020,7 +11033,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     args["root"] = serde_json::json!(r);
                 }
                 if let Some(value) =
-                    try_hybrid_json_rpc(true, &db_path, None, "investigate_hydrate", args)
+                    try_hybrid_json_rpc(true, &db_path, None, "investigate_hydrate", args)?
                 {
                     println!("{}", serde_json::to_string_pretty(&value)?);
                     return Ok((EXIT_SUCCESS, None));
@@ -11119,7 +11132,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     "vault": vault_abs.to_string_lossy(),
                 });
                 if let Some(value) =
-                    try_hybrid_json_rpc(true, &db_path, None, "detect_implicit_projects", args)
+                    try_hybrid_json_rpc(true, &db_path, None, "detect_implicit_projects", args)?
                 {
                     let detected: Vec<String> =
                         serde_json::from_value(unwrap_hybrid_payload(value)).unwrap_or_default();
@@ -13333,6 +13346,28 @@ fn run_memory(
 /// may use the legacy direct-disk fallback. With an explicit config, daemon
 /// connection or hybrid query failures are returned: falling through would
 /// silently discard configured provenance/upstreams while still exiting 0.
+fn ensure_direct_store_fallback_allowed(
+    db_path: &std::path::Path,
+    explicit_config: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
+    if let Some(config) = explicit_config {
+        anyhow::bail!(
+            "explicit config {} cannot be honored by the direct store; refusing direct fallback",
+            config.display()
+        );
+    }
+
+    match nestweaver_client::RestartConfig::for_automatic_cold_start(db_path, None)? {
+        nestweaver_client::RestartConfig::CompiledDefaults => Ok(()),
+        nestweaver_client::RestartConfig::Configured(config) => anyhow::bail!(
+            "persisted daemon config {} for {} cannot be honored by the direct store, which refuses to fall back. Retry the daemon or deliberately reset with `nestweaver daemon --db {} start`",
+            config.display(),
+            db_path.display(),
+            db_path.display()
+        ),
+    }
+}
+
 fn try_hybrid_json_rpc_checked(
     use_daemon: bool,
     db_path: &std::path::Path,
@@ -13345,10 +13380,14 @@ fn try_hybrid_json_rpc_checked(
     }
     let rt = match tokio::runtime::Runtime::new() {
         Ok(runtime) => runtime,
-        Err(error) if config.is_some() => {
-            return Err(error).context("create runtime for explicit-config daemon query");
+        Err(error) => {
+            ensure_direct_store_fallback_allowed(db_path, config).with_context(|| {
+                format!(
+                    "create runtime for daemon query {rpc_name} failed ({error}); refusing direct fallback"
+                )
+            })?;
+            return Ok(None);
         }
-        Err(_) => return Ok(None),
     };
     let start_dir = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
     // nw-087: a read/query against a NONEXISTENT local db must not autostart a
@@ -13390,25 +13429,19 @@ fn try_hybrid_json_rpc_checked(
         Ok(mut hybrid) => match rt.block_on(hybrid.query(rpc_name, &args)) {
             Ok(value) => Ok(Some(value)),
             Err(e) => {
-                if config.is_some() {
-                    return Err(e).with_context(|| {
-                        format!(
-                            "explicit-config hybrid query {rpc_name} failed; refusing direct fallback"
-                        )
-                    });
-                }
+                ensure_direct_store_fallback_allowed(db_path, config).with_context(|| {
+                    format!("hybrid query {rpc_name} failed ({e:#}); refusing direct fallback")
+                })?;
                 warn_daemon_bypassed(db_path, rpc_name, &format!("{e:#}"));
                 Ok(None)
             }
         },
         Err(e) => {
-            if config.is_some() {
-                return Err(e).with_context(|| {
-                    format!(
-                        "explicit config could not be honored by the daemon for {rpc_name}; refusing direct fallback"
-                    )
-                });
-            }
+            ensure_direct_store_fallback_allowed(db_path, config).with_context(|| {
+                format!(
+                    "daemon configuration could not be safely honored for {rpc_name} ({e:#}); refusing direct fallback"
+                )
+            })?;
             let upstream = rt
                 .block_on(nestweaver_client::hybrid::query_configured_upstreams_only(
                     config, &start_dir, rpc_name, &args,
@@ -13430,18 +13463,12 @@ fn try_hybrid_json_rpc(
     config: Option<&std::path::Path>,
     rpc_name: &str,
     args: serde_json::Value,
-) -> Option<serde_json::Value> {
+) -> anyhow::Result<Option<serde_json::Value>> {
     debug_assert!(
         !use_daemon || config.is_none(),
         "explicit-config callers must use try_hybrid_json_rpc_checked"
     );
-    match try_hybrid_json_rpc_checked(use_daemon, db_path, config, rpc_name, args) {
-        Ok(value) => value,
-        Err(error) => {
-            warn_daemon_bypassed(db_path, rpc_name, &format!("{error:#}"));
-            None
-        }
-    }
+    try_hybrid_json_rpc_checked(use_daemon, db_path, config, rpc_name, args)
 }
 
 fn hybrid_source_label(value: &serde_json::Value) -> &'static str {
@@ -13855,7 +13882,7 @@ fn run_brain(
 
             if use_daemon
                 && let Some(value) =
-                    try_hybrid_json_rpc(true, db_path, None, "list_vaults", serde_json::json!({}))
+                    try_hybrid_json_rpc(true, db_path, None, "list_vaults", serde_json::json!({}))?
             {
                 println!("{}", serde_json::to_string_pretty(&value)?);
                 return Ok((EXIT_SUCCESS, None));
@@ -15118,21 +15145,25 @@ fn run_brain(
             let v_uid_raw = nestweaver_schema::vault_uid(instance_id, &raw_str);
 
             // Fetch vault list via daemon RPC (preferred) or direct store open (fallback).
-            let fetch_vaults = |inst_filter: Option<&str>| -> Vec<nestweaver_schema::Vault> {
-                let mut args = serde_json::json!({});
-                if let Some(inst) = inst_filter {
-                    args["instance"] = serde_json::json!(inst);
-                }
-                if let Some(value) =
-                    try_hybrid_json_rpc(use_daemon, &db_path, None, "list_vaults", args)
-                {
-                    serde_json::from_value(unwrap_hybrid_payload(value)).unwrap_or_default()
-                } else if let Ok(store) = GraphStore::open_read_only(&db_path) {
-                    store.list_vaults(inst_filter).unwrap_or_default()
-                } else {
-                    Vec::new()
-                }
-            };
+            let fetch_vaults =
+                |inst_filter: Option<&str>| -> anyhow::Result<Vec<nestweaver_schema::Vault>> {
+                    let mut args = serde_json::json!({});
+                    if let Some(inst) = inst_filter {
+                        args["instance"] = serde_json::json!(inst);
+                    }
+                    if let Some(value) =
+                        try_hybrid_json_rpc(use_daemon, &db_path, None, "list_vaults", args)?
+                    {
+                        Ok(
+                            serde_json::from_value(unwrap_hybrid_payload(value))
+                                .unwrap_or_default(),
+                        )
+                    } else if let Ok(store) = GraphStore::open_read_only(&db_path) {
+                        Ok(store.list_vaults(inst_filter).unwrap_or_default())
+                    } else {
+                        Ok(Vec::new())
+                    }
+                };
 
             // Helper: a stored vault matches the caller's path if any of its
             // representations (canonical, literal, tilde-expanded `~`)
@@ -15177,7 +15208,7 @@ fn run_brain(
             let mut uids_to_remove: Vec<String> = Vec::new();
             if instance_specified {
                 // Check if the direct UID exists in the vault list
-                let instance_vaults = fetch_vaults(Some(instance_id));
+                let instance_vaults = fetch_vaults(Some(instance_id))?;
                 let has_canon = instance_vaults.iter().any(|v| v.uid == v_uid_canon);
                 let has_raw = instance_vaults.iter().any(|v| v.uid == v_uid_raw);
                 if has_canon {
@@ -15201,7 +15232,7 @@ fn run_brain(
                 }
             } else {
                 uids_to_remove.push(v_uid_canon);
-                let all_vaults = fetch_vaults(None);
+                let all_vaults = fetch_vaults(None)?;
                 for v in &all_vaults {
                     if path_matches(&v.root_path) && !uids_to_remove.contains(&v.uid) {
                         uids_to_remove.push(v.uid.clone());
@@ -15215,7 +15246,7 @@ fn run_brain(
                 .unwrap_or("vault")
                 .to_string();
             // Resolve vault name from the daemon vault list instead of direct store access
-            let all_known_vaults = fetch_vaults(None);
+            let all_known_vaults = fetch_vaults(None)?;
             for uid in &uids_to_remove {
                 if let Some(v) = all_known_vaults.iter().find(|v| v.uid == *uid) {
                     vault_name.clone_from(&v.name);
@@ -15253,32 +15284,62 @@ fn run_brain(
         BrainCommands::ReindexSearch { db } => {
             let db_path = db.unwrap_or_else(default_db_path);
 
-            if use_daemon && let Ok(rt) = tokio::runtime::Runtime::new() {
-                let connect = rt.block_on(nestweaver_client::DaemonClient::connect(&db_path, None));
-                if let Ok(mut client) = connect {
-                    let rpc = rt.block_on(async {
-                        client
-                            .inner_mut()
-                            .reindex_search(nestweaver_proto::ReindexSearchRequest {})
-                            .await
-                            .map(|r| r.into_inner())
-                    });
-                    match rpc {
-                        Ok(resp) => {
-                            let sidecar = tantivy_sidecar_path_for(&db_path);
-                            println!(
-                                "Tantivy reindex complete: {} document(s) at {} (via daemon)",
-                                resp.document_count,
-                                sidecar.display()
-                            );
-                            return Ok((EXIT_SUCCESS, None));
+            if use_daemon {
+                match tokio::runtime::Runtime::new() {
+                    Ok(rt) => {
+                        let connect =
+                            rt.block_on(nestweaver_client::DaemonClient::connect(&db_path, None));
+                        match connect {
+                            Ok(mut client) => {
+                                let rpc = rt.block_on(async {
+                                    client
+                                        .inner_mut()
+                                        .reindex_search(nestweaver_proto::ReindexSearchRequest {})
+                                        .await
+                                        .map(|r| r.into_inner())
+                                });
+                                match rpc {
+                                    Ok(resp) => {
+                                        let sidecar = tantivy_sidecar_path_for(&db_path);
+                                        println!(
+                                            "Tantivy reindex complete: {} document(s) at {} (via daemon)",
+                                            resp.document_count,
+                                            sidecar.display()
+                                        );
+                                        return Ok((EXIT_SUCCESS, None));
+                                    }
+                                    Err(status) => {
+                                        ensure_direct_store_fallback_allowed(&db_path, None)
+                                            .with_context(|| {
+                                                format!(
+                                                    "daemon reindex RPC failed ({}); refusing direct fallback",
+                                                    status.message()
+                                                )
+                                            })?;
+                                        eprintln!(
+                                            "warning: daemon reindex RPC failed ({}); falling back to direct mode",
+                                            status.message()
+                                        );
+                                    }
+                                }
+                            }
+                            Err(error) => {
+                                ensure_direct_store_fallback_allowed(&db_path, None).with_context(
+                                    || {
+                                        format!(
+                                            "daemon search-index connection failed ({error:#}); refusing direct fallback"
+                                        )
+                                    },
+                                )?;
+                            }
                         }
-                        Err(status) => {
-                            eprintln!(
-                                "warning: daemon reindex RPC failed ({}); falling back to direct mode",
-                                status.message()
-                            );
-                        }
+                    }
+                    Err(error) => {
+                        ensure_direct_store_fallback_allowed(&db_path, None).with_context(|| {
+                            format!(
+                                "create runtime for daemon search-index rebuild failed ({error}); refusing direct fallback"
+                            )
+                        })?;
                     }
                 }
             }
@@ -15320,11 +15381,15 @@ fn run_brain(
             if use_daemon {
                 let rt = match tokio::runtime::Runtime::new() {
                     Ok(runtime) => Some(runtime),
-                    Err(error) if config.is_some() => {
-                        return Err(error)
-                            .context("create runtime for explicit-config brain search");
+                    Err(error) => {
+                        ensure_direct_store_fallback_allowed(&db_path, config.as_deref())
+                            .with_context(|| {
+                                format!(
+                                    "create runtime for brain search failed ({error}); refusing direct fallback"
+                                )
+                            })?;
+                        None
                     }
-                    Err(_) => None,
                 };
                 if let Some(rt) = rt {
                     let cwd = std::env::current_dir().unwrap_or_default();
@@ -15358,16 +15423,22 @@ fn run_brain(
                                     );
                                     return Ok((EXIT_SUCCESS, Some(stats)));
                                 }
-                                Err(error) if config.is_some() => {
-                                    return Err(error).context(
-                                        "explicit-config hybrid brain search failed; refusing direct fallback",
+                                Err(error) => {
+                                    ensure_direct_store_fallback_allowed(
+                                        &db_path,
+                                        config.as_deref(),
+                                    )
+                                    .with_context(|| {
+                                        format!(
+                                            "hybrid brain search failed ({error:#}); refusing direct fallback"
+                                        )
+                                    })?;
+                                    warn_daemon_bypassed(
+                                        &db_path,
+                                        "brain_search",
+                                        &format!("{error:#}"),
                                     );
                                 }
-                                Err(error) => warn_daemon_bypassed(
-                                    &db_path,
-                                    "brain_search",
-                                    &format!("{error:#}"),
-                                ),
                             }
                         }
                         Ok(mut hybrid) => {
@@ -15392,24 +15463,31 @@ fn run_brain(
                                     );
                                     return Ok((EXIT_SUCCESS, Some(stats)));
                                 }
-                                Err(error) if config.is_some() => {
-                                    return Err(error).context(
-                                        "explicit-config daemon brain search failed; refusing direct fallback",
+                                Err(error) => {
+                                    ensure_direct_store_fallback_allowed(
+                                        &db_path,
+                                        config.as_deref(),
+                                    )
+                                    .with_context(|| {
+                                        format!(
+                                            "daemon brain search failed ({error:#}); refusing direct fallback"
+                                        )
+                                    })?;
+                                    warn_daemon_bypassed(
+                                        &db_path,
+                                        "brain_search",
+                                        &format!("{error:#}"),
                                     );
                                 }
-                                Err(error) => warn_daemon_bypassed(
-                                    &db_path,
-                                    "brain_search",
-                                    &format!("{error:#}"),
-                                ),
                             }
                         }
-                        Err(error) if config.is_some() => {
-                            return Err(error).context(
-                                "explicit config could not be honored by the daemon for brain_search; refusing direct fallback",
-                            );
-                        }
                         Err(error) => {
+                            ensure_direct_store_fallback_allowed(&db_path, config.as_deref())
+                                .with_context(|| {
+                                    format!(
+                                        "daemon configuration could not be safely honored for brain_search ({error:#}); refusing direct fallback"
+                                    )
+                                })?;
                             warn_daemon_bypassed(&db_path, "brain_search", &format!("{error:#}"));
                         }
                     }
@@ -18004,7 +18082,7 @@ fn run_contracts(
                     args["repo"] = serde_json::json!(r);
                 }
                 if let Some(value) =
-                    try_hybrid_json_rpc(true, &db_path, None, "contract_drift", args)
+                    try_hybrid_json_rpc(true, &db_path, None, "contract_drift", args)?
                 {
                     if json {
                         println!("{}", serde_json::to_string_pretty(&value)?);
@@ -19156,7 +19234,7 @@ fn run_snapshot(command: SnapshotCommands, _use_daemon: bool) -> anyhow::Result<
                 let mut args = serde_json::json!({});
                 args["instance"] = serde_json::json!(&instance_id);
                 if let Some(value) =
-                    try_hybrid_json_rpc(false, &db_path, config.as_deref(), "list_repos", args)
+                    try_hybrid_json_rpc(false, &db_path, config.as_deref(), "list_repos", args)?
                 {
                     serde_json::from_value(unwrap_hybrid_payload(value))
                         .context("failed to deserialize repos from daemon response")?
@@ -19179,7 +19257,7 @@ fn run_snapshot(command: SnapshotCommands, _use_daemon: bool) -> anyhow::Result<
                     config.as_deref(),
                     "embedding_dimension",
                     args,
-                ) {
+                )? {
                     serde_json::from_value(value).unwrap_or(0)
                 } else {
                     let store = GraphStore::open_read_only(&db_path)
@@ -20705,6 +20783,33 @@ timeout = "20ms"
         .expect_err("a declared but unusable upstream must fail closed");
 
         assert!(format!("{error:#}").contains("refusing direct fallback"));
+    }
+
+    #[test]
+    fn direct_fallback_policy_distinguishes_absent_and_configured_intent() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        assert!(
+            ensure_direct_store_fallback_allowed(&db, None).is_ok(),
+            "record absence preserves ordinary daemon-unavailable fallback"
+        );
+
+        let config = dir.path().join("instance.toml");
+        std::fs::write(&config, valid_local_instance_config(dir.path(), "")).unwrap();
+        nestweaver_daemon::lifecycle::write_last_successful_config(&db, &config).unwrap();
+
+        let configured = ensure_direct_store_fallback_allowed(&db, None)
+            .expect_err("a query failure must not bypass valid persisted configured intent");
+        let configured_message = format!("{configured:#}");
+        assert!(configured_message.contains("persisted daemon config"));
+        assert!(configured_message.contains("refuses to fall back"));
+
+        std::fs::write(&config, "instance_id = [broken").unwrap();
+        let corrupt = ensure_direct_store_fallback_allowed(&db, None)
+            .expect_err("corrupt persisted intent must also fail closed");
+        assert!(format!("{corrupt:#}").contains("persisted daemon config"));
+
+        nestweaver_daemon::lifecycle::remove_last_successful_config(&db).unwrap();
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19148,6 +19148,8 @@ fn run_snapshot(command: SnapshotCommands, _use_daemon: bool) -> anyhow::Result<
                 .collect();
 
             let stamp = nestweaver_engine::Stamp {
+                format_version: nestweaver_engine::SNAPSHOT_FORMAT_VERSION,
+                capabilities: vec![nestweaver_engine::SNAPSHOT_CAPABILITY_EMBEDDINGS.to_string()],
                 instance_id: instance_id.clone(),
                 engine_version: env!("CARGO_PKG_VERSION").to_string(),
                 min_compatible_engine: nestweaver_engine::MIN_SNAPSHOT_READER_VERSION.to_string(),
@@ -19156,6 +19158,7 @@ fn run_snapshot(command: SnapshotCommands, _use_daemon: bool) -> anyhow::Result<
                 schema_hash_effective: effective_hash,
                 embedding_model_id,
                 embedding_dimension: embedding_dim,
+                embedding_count: 0,
                 built_at,
                 repos: repo_stamps,
             };
@@ -19178,13 +19181,15 @@ fn run_snapshot(command: SnapshotCommands, _use_daemon: bool) -> anyhow::Result<
                     .join(format!("snapshot-{instance_id}"))
             });
 
-            nestweaver_engine::build_snapshot(&output_dir, &stamp, &manifest, &db_path)?;
+            let stamp =
+                nestweaver_engine::build_snapshot(&output_dir, &stamp, &manifest, &db_path)?;
 
             println!("Snapshot built successfully in {}", output_dir.display());
             println!("  Instance: {}", stamp.instance_id);
             println!("  Engine: {}", stamp.engine_version);
             println!("  Schema: {}", stamp.schema_hash_effective);
             println!("  Repos: {}", stamp.repos.len());
+            println!("  Embeddings: {}", stamp.embedding_count);
             Ok(EXIT_SUCCESS)
         }
         SnapshotCommands::Verify { path } => {
@@ -19195,6 +19200,7 @@ fn run_snapshot(command: SnapshotCommands, _use_daemon: bool) -> anyhow::Result<
                     println!("  Engine: {}", stamp.engine_version);
                     println!("  Schema: {}", stamp.schema_hash_effective);
                     println!("  Embedding model: {}", stamp.embedding_model_id);
+                    println!("  Embeddings: {}", stamp.embedding_count);
                     println!("  Built: {}", stamp.built_at);
                     println!("  Repos: {}", stamp.repos.len());
                     Ok(EXIT_SUCCESS)

--- a/src/main.rs
+++ b/src/main.rs
@@ -11517,10 +11517,33 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             if config_abs.is_none() && (launchd_owned || live_pidfile) {
                                 let rt = tokio::runtime::Runtime::new()
                                     .context("failed to create tokio runtime")?;
-                                rt.block_on(nestweaver_client::DaemonClient::wait_healthy(
-                                    &db_path_abs,
-                                    nestweaver_client::autostart::daemon_boot_timeout(),
-                                ))?;
+                                let health =
+                                    rt.block_on(nestweaver_client::DaemonClient::wait_healthy(
+                                        &db_path_abs,
+                                        nestweaver_client::autostart::daemon_boot_timeout(),
+                                    ))?;
+                                // A retry after a slow configless launchd boot
+                                // is allowed to finish the pending reset, but
+                                // only when the live binding for the healthy
+                                // PID attests compiled-default provenance. A
+                                // configured incumbent remains a no-op and
+                                // retains its durable intent. Missing,
+                                // malformed, stale, or PID-mismatched bindings
+                                // fail closed instead of clearing intent.
+                                let binding = nestweaver_daemon::lifecycle::
+                                    read_effective_config_binding_for_verified_pid(
+                                        &instance_id,
+                                        health.pid,
+                                    )
+                                    .context(
+                                        "cannot attest the already-running daemon's effective configuration",
+                                    )?;
+                                if matches!(
+                                    binding.effective_config,
+                                    nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::CompiledDefaults
+                                ) {
+                                    finish_manual_default_reset(&db_path_abs, parent_driven_start, &requested_start_config)?;
+                                }
                                 eprintln!("Daemon already running.");
                                 return Ok((EXIT_SUCCESS, None));
                             }
@@ -11650,20 +11673,17 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                             "daemon start cannot confirm that the running launchd agent honors explicit --config",
                                         );
                                     }
-                                    // Deliberately NOT reaping the half-booted
+                                    // Deliberately do not reap the half-booted
                                     // agent: launchd owns its lifecycle and a
-                                    // bootout here would race launchd's next
-                                    // KeepAlive spawn. Report success-with-
-                                    // caveat (exit 0) and point at status+log
-                                    // instead of claiming a failure launchd may
-                                    // still turn into a healthy daemon.
-                                    eprintln!(
-                                        "Daemon is still booting under launchd; check \
-                                         `nestweaver daemon --db {} status` and the logs at {}",
+                                    // bootout here would race its next KeepAlive
+                                    // spawn. The reset is not durable until a
+                                    // live default binding is attested, so do
+                                    // not return a false successful completion.
+                                    return Err(error).context(format!(
+                                        "daemon is still booting under launchd; the default-config reset was not committed. Retry `nestweaver daemon --db {} start` after status becomes healthy. Logs: {}",
                                         db_path.display(),
                                         log_hint
-                                    );
-                                    return Ok((EXIT_SUCCESS, None));
+                                    ));
                                 }
                             }
                         }
@@ -11678,6 +11698,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             std::env::current_exe().context("cannot determine binary path")?;
                         let db_path_abs = abs_for_daemon(&db_path);
                         let config_abs = config.as_deref().map(abs_for_daemon);
+                        let pre_start_pid = nestweaver_client::autostart::read_pid(&pidfile);
                         let mut child = macos_temp_daemon_command(
                             &executable,
                             &db_path_abs,
@@ -11717,7 +11738,6 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                              ({status})"
                                         );
                                     }
-                                    eprintln!("Daemon started.");
                                 } else {
                                     // A concurrent start won the pidfile race.
                                     // Stop and reap this losing child if it has
@@ -11731,12 +11751,22 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                         let _ = child.kill();
                                         let _ = child.wait();
                                     }
-                                    eprintln!("Daemon already running (PID {}).", health.pid);
                                 }
-                                verify_explicit_config_before_start_success(
+                                let ready = wait_for_started_daemon(
                                     &db_path_abs,
-                                    config_abs.as_deref(),
+                                    pre_start_pid,
+                                    &requested_start_config,
                                 )?;
+                                finish_manual_default_reset(
+                                    &db_path_abs,
+                                    parent_driven_start,
+                                    &requested_start_config,
+                                )?;
+                                if ready.pid == child.id() {
+                                    eprintln!("Daemon started.");
+                                } else {
+                                    eprintln!("Daemon already running (PID {}).", ready.pid);
+                                }
                                 Ok((EXIT_SUCCESS, None))
                             }
                             Err(error) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5496,7 +5496,10 @@ async fn restart_live_daemon_preserving_config(
                     "a daemon became connectable while proving cold-start ownership; refusing to overlap it"
                 );
             }
-            let restart_config = nestweaver_client::RestartConfig::for_cold_start(explicit_config)?;
+            let restart_config = nestweaver_client::RestartConfig::for_automatic_cold_start(
+                db_path,
+                explicit_config,
+            )?;
             let executable = std::env::current_exe().context("cannot determine binary path")?;
             let start_args = daemon_restart_start_args(db_path, idle_timeout, &restart_config);
             unowned.release();
@@ -5570,18 +5573,42 @@ fn canonical_repo_dir(repo_path: &std::path::Path) -> anyhow::Result<PathBuf> {
     Ok(canonical)
 }
 
-/// Poll until the daemon's unix socket accepts a connection (proving
-/// run_server survived boot) or `timeout` elapses.
-#[cfg(any(not(target_os = "macos"), test))]
-fn wait_for_daemon_boot(socket: &std::path::Path, timeout: std::time::Duration) -> bool {
-    let start = std::time::Instant::now();
-    while start.elapsed() < timeout {
-        if std::os::unix::net::UnixStream::connect(socket).is_ok() {
-            return true;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(100));
+/// Apply the shared one-budget readiness policy to a directly-started daemon.
+/// This covers connection, health, process-death detection, live pidfile
+/// ownership, and final effective-config attestation.
+fn wait_for_started_daemon(
+    db_path: &std::path::Path,
+    ignore_pid: Option<i32>,
+    expected_config: &nestweaver_client::RestartConfig,
+) -> anyhow::Result<nestweaver_proto::HealthCheckResponse> {
+    let runtime =
+        tokio::runtime::Runtime::new().context("failed to create runtime for daemon readiness")?;
+    runtime.block_on(nestweaver_client::DaemonClient::wait_ready(
+        db_path,
+        nestweaver_client::autostart::daemon_boot_timeout(),
+        ignore_pid,
+        expected_config,
+    ))
+}
+
+/// A manual configless `daemon start` is the explicit reset escape hatch.
+/// Never pre-delete durable intent: clear it only after the replacement has
+/// proved healthy compiled-default provenance.
+fn finish_manual_default_reset(
+    db_path: &std::path::Path,
+    parent_driven_start: bool,
+    expected_config: &nestweaver_client::RestartConfig,
+) -> anyhow::Result<()> {
+    if !parent_driven_start
+        && matches!(
+            expected_config,
+            nestweaver_client::RestartConfig::CompiledDefaults
+        )
+    {
+        nestweaver_daemon::lifecycle::remove_last_successful_config(db_path)
+            .context("clear last successful config after attested manual default start")?;
     }
-    std::os::unix::net::UnixStream::connect(socket).is_ok()
+    Ok(())
 }
 
 /// Build the cold child process used for ephemeral macOS daemons.
@@ -11426,6 +11453,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     // mark only their child command to avoid self-deadlock.
                     let inherited_spawn_lock =
                         std::env::var_os(nestweaver_client::autostart::PARENT_SPAWN_LOCK_FD_ENV);
+                    let parent_driven_start = inherited_spawn_lock.is_some();
                     let mut start_spawn_lock =
                         acquire_daemon_start_spawn_lock(&db_path, inherited_spawn_lock)?;
                     if track_interactions {
@@ -11434,14 +11462,14 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                              Use: nestweaver mcp --track-interactions"
                         );
                     }
-                    if let Some(requested_config) = config.as_deref() {
-                        // Validate before any platform-specific stop/install or
-                        // daemonize mutation. A bad explicit path must leave an
-                        // already-running daemon untouched.
-                        let _ = nestweaver_client::RestartConfig::for_cold_start(Some(
-                            requested_config,
-                        ))?;
-                    }
+                    // Validate before any platform-specific stop/install or
+                    // daemonize mutation. A bad explicit path must leave an
+                    // already-running daemon untouched. `None` intentionally
+                    // means compiled defaults here: manual `daemon start` is
+                    // the reset path, while automatic parents have already
+                    // resolved persisted intent and pass it as `--config`.
+                    let requested_start_config =
+                        nestweaver_client::RestartConfig::for_cold_start(config.as_deref())?;
                     std::fs::create_dir_all(&runtime_dir).with_context(|| {
                         format!("create runtime dir: {}", runtime_dir.display())
                     })?;
@@ -11477,6 +11505,25 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 .ok()
                                 .filter(|v| v.trim().parse::<u32>().is_ok());
                             let config_abs = config.as_deref().map(abs_for_daemon);
+                            let pre_start_pid = nestweaver_client::autostart::read_pid(&pidfile);
+
+                            // A configless manual start is a reset only when it
+                            // actually cold-starts/replaces a daemon. Merely
+                            // observing a launchd/pidfile-owned incumbent is a
+                            // no-op and must not erase configured intent.
+                            let launchd_owned =
+                                nestweaver_daemon::launchd::is_running(&instance_id);
+                            let live_pidfile = pidfile_flock_held(&pidfile);
+                            if config_abs.is_none() && (launchd_owned || live_pidfile) {
+                                let rt = tokio::runtime::Runtime::new()
+                                    .context("failed to create tokio runtime")?;
+                                rt.block_on(nestweaver_client::DaemonClient::wait_healthy(
+                                    &db_path_abs,
+                                    nestweaver_client::autostart::daemon_boot_timeout(),
+                                ))?;
+                                eprintln!("Daemon already running.");
+                                return Ok((EXIT_SUCCESS, None));
+                            }
 
                             // An explicit start against a live incumbent is an
                             // assertion about that daemon, not permission to
@@ -11486,12 +11533,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             // live pidfile with no healthy RPC is likewise not
                             // safe to mutate implicitly.
                             if let Some(requested_config) = config_abs.as_deref() {
-                                let launchd_owned =
-                                    nestweaver_daemon::launchd::is_running(&instance_id);
                                 // The held flock, not a numeric PID plus
                                 // kill(0), is the ownership proof. The latter
                                 // could identify an unrelated recycled PID.
-                                let live_pidfile = pidfile_flock_held(&pidfile);
                                 match verify_explicit_config_before_start_success(
                                     &db_path_abs,
                                     Some(requested_config),
@@ -11587,16 +11631,16 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             // though launchd (KeepAlive.Crashed) kept bringing
                             // the daemon up, leaving the boot racing the user's
                             // next command.
-                            let rt = tokio::runtime::Runtime::new()
-                                .context("failed to create tokio runtime")?;
-                            match rt.block_on(nestweaver_client::DaemonClient::wait_healthy(
-                                &db_path,
-                                std::time::Duration::from_secs(60),
-                            )) {
+                            match wait_for_started_daemon(
+                                &db_path_abs,
+                                pre_start_pid,
+                                &requested_start_config,
+                            ) {
                                 Ok(_) => {
-                                    verify_explicit_config_before_start_success(
-                                        &db_path,
-                                        config.as_deref(),
+                                    finish_manual_default_reset(
+                                        &db_path_abs,
+                                        parent_driven_start,
+                                        &requested_start_config,
                                     )?;
                                     return Ok((EXIT_SUCCESS, None));
                                 }
@@ -11763,6 +11807,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             anyhow::bail!("flock on pidfile failed: {err}");
                         }
 
+                        // We proved this inode is unowned, so any numeric PID
+                        // is stale. Preserve it only as an ignore value for the
+                        // shared readiness policy until the child rewrites the
+                        // pidfile.
+                        let stale_pid = nestweaver_client::autostart::read_pid(&pidfile);
+
                         // We hold the lock — no other daemon is running or
                         // starting. Any PID in the file is stale; daemonize2 will
                         // overwrite it after the double-fork.
@@ -11852,24 +11902,27 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                     );
                                     std::process::exit(EXIT_ERROR);
                                 }
-                                if wait_for_daemon_boot(&socket, std::time::Duration::from_secs(10))
-                                {
-                                    if let Err(error) = verify_explicit_config_before_start_success(
+                                match wait_for_started_daemon(
+                                    &db_path,
+                                    stale_pid,
+                                    &requested_start_config,
+                                )
+                                .and_then(|_| {
+                                    finish_manual_default_reset(
                                         &db_path,
-                                        config.as_deref(),
-                                    ) {
+                                        parent_driven_start,
+                                        &requested_start_config,
+                                    )
+                                }) {
+                                    Ok(()) => {
+                                        eprintln!("Daemon started.");
+                                        std::process::exit(EXIT_SUCCESS);
+                                    }
+                                    Err(error) => {
                                         eprintln!("Error: {error:#}");
                                         std::process::exit(EXIT_ERROR);
                                     }
-                                    eprintln!("Daemon started.");
-                                    std::process::exit(EXIT_SUCCESS);
                                 }
-                                eprintln!(
-                                    "Error: daemon did not start accepting connections within \
-                                     10s — it may have died during boot. Check the logs: {}",
-                                    log_hint
-                                );
-                                std::process::exit(EXIT_ERROR);
                             }
                             daemonize2::Outcome::Parent(Err(e)) => {
                                 anyhow::bail!("Failed to daemonize: {e}");
@@ -20413,28 +20466,6 @@ credential_method = "gh"
             "expected repo_not_found diagnostic, got: {rendered}"
         );
         assert!(!rendered.contains("repo_not_a_directory"), "{rendered}");
-    }
-
-    /// The boot health-check must report a dead/absent daemon as not
-    /// booted (false) and a listening socket as booted (true).
-    #[test]
-    fn wait_for_daemon_boot_detects_listening_socket() {
-        let dir = tempfile::tempdir().unwrap();
-
-        // Nothing listening → false well within the timeout.
-        let absent = dir.path().join("absent.sock");
-        assert!(!wait_for_daemon_boot(
-            &absent,
-            std::time::Duration::from_millis(300)
-        ));
-
-        // A listening unix socket → true.
-        let sock = dir.path().join("live.sock");
-        let _listener = std::os::unix::net::UnixListener::bind(&sock).unwrap();
-        assert!(wait_for_daemon_boot(
-            &sock,
-            std::time::Duration::from_millis(300)
-        ));
     }
 
     /// A full page of search results carries a truncation note;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2201,10 +2201,7 @@ enum Commands {
             help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
         )]
         db: Option<PathBuf>,
-        #[arg(
-            long,
-            help = "Allow the brain_add_source MCP tool to index new paths at runtime"
-        )]
+        #[arg(long, hide = true)]
         allow_mcp_add_sources: bool,
         #[arg(
             long,
@@ -8805,15 +8802,20 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 );
             }
             let db_path = db.unwrap_or_else(default_db_path);
-            if let Some(ref allowed) = tool_allowlist {
-                nestweaver_mcp::tools::set_allowed_tools(allowed.clone());
-            }
             if track_interactions {
                 nestweaver_mcp::tools::set_track_interactions(true);
             }
             // warn=false: run() already emitted the escape-hatch warning once
             // for this invocation — warning again here double-prints it.
             let use_daemon_mcp = resolve_use_daemon(no_daemon, false);
+            nestweaver_mcp::tools::validate_tool_selection(
+                tool_allowlist.as_deref(),
+                lite,
+                !use_daemon_mcp,
+            )?;
+            if let Some(ref allowed) = tool_allowlist {
+                nestweaver_mcp::tools::set_allowed_tools(allowed.clone());
+            }
             if use_daemon_mcp {
                 let rt = tokio::runtime::Runtime::new()
                     .context("create tokio runtime for daemon proxy")?;
@@ -14724,6 +14726,19 @@ fn run_brain(
             });
             let extra_patterns = parse_ignore_flag(&ignore);
             let canonical = abs_for_daemon(&path);
+            // Parse before registration discovery: an invalid timestamp must
+            // not autostart a daemon or touch graph/runtime state.
+            let since_time = since
+                .as_deref()
+                .map(|value| {
+                    parse_iso8601_to_system_time(value).with_context(|| {
+                        format!(
+                            "invalid --since timestamp '{}': expected ISO 8601 (e.g. 2026-05-26T00:00:00Z)",
+                            value
+                        )
+                    })
+                })
+                .transpose()?;
 
             // nw-098: resolve the instance from any EXISTING registration for this
             // root before falling back to flag > config > "default".
@@ -14800,45 +14815,81 @@ fn run_brain(
             // Compute vault UID for recording last_indexed_at.
             let v_uid = nestweaver_schema::vault_uid(&instance_id, &canonical.to_string_lossy());
 
-            if use_daemon && since.is_none() {
-                // Route full refresh through daemon's IndexVault RPC
+            if use_daemon {
                 let rt = tokio::runtime::Runtime::new()?;
                 let mut client = rt.block_on(nestweaver_client::DaemonClient::connect(
                     &db_path,
                     config.as_deref(),
                 ))?;
-                let req = nestweaver_proto::IndexVaultRequest {
-                    // Absolute path: the daemon runs with CWD=/ and would otherwise
-                    // resolve a client-relative vault path against the wrong directory.
-                    vault_path: canonical.to_string_lossy().to_string(),
-                    vault_name: vault_name.clone(),
-                    extra_ignore_patterns: extra_patterns.clone(),
-                    instance_id: instance_id.to_string(),
-                };
-                rt.block_on(async {
-                    let stream = client.inner_mut().index_vault(req).await?.into_inner();
-                    consume_cli_index_progress(stream, |progress| {
-                        let phase_name = match progress.phase {
-                            5 => "Done",
-                            6 => "Error",
-                            _ => "Progress",
-                        };
-                        eprintln!("[{phase_name}] {}", progress.message);
-                    })
-                    .await
-                })?;
+                if let Some(since_time) = since_time {
+                    let since_unix_seconds = since_time
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .context("--since timestamp predates the Unix epoch")?
+                        .as_secs();
+                    let req = nestweaver_proto::RefreshVaultSinceRequest {
+                        vault_path: canonical.to_string_lossy().to_string(),
+                        vault_name: vault_name.clone(),
+                        extra_ignore_patterns: extra_patterns.clone(),
+                        instance_id: instance_id.to_string(),
+                        since_unix_seconds,
+                    };
+                    rt.block_on(async {
+                        let stream = client
+                            .inner_mut()
+                            .refresh_vault_since(req)
+                            .await
+                            .map_err(|status| {
+                                if status.code() == tonic::Code::Unimplemented {
+                                    anyhow::anyhow!(
+                                        "the running daemon does not support incremental vault refresh; upgrade/restart it and retry (refusing full or direct-store fallback)"
+                                    )
+                                } else {
+                                    anyhow::anyhow!(
+                                        "incremental vault refresh RPC failed (refusing direct-store fallback): {status}"
+                                    )
+                                }
+                            })?
+                            .into_inner();
+                        consume_cli_index_progress(stream, |progress| {
+                            let phase_name = match progress.phase {
+                                5 => "Done",
+                                6 => "Error",
+                                _ => "Progress",
+                            };
+                            eprintln!("[{phase_name}] {}", progress.message);
+                        })
+                        .await
+                    })?;
+                } else {
+                    // Route full refresh through daemon's IndexVault RPC.
+                    let req = nestweaver_proto::IndexVaultRequest {
+                        // Absolute path: the daemon runs with CWD=/ and would otherwise
+                        // resolve a client-relative vault path against the wrong directory.
+                        vault_path: canonical.to_string_lossy().to_string(),
+                        vault_name: vault_name.clone(),
+                        extra_ignore_patterns: extra_patterns.clone(),
+                        instance_id: instance_id.to_string(),
+                    };
+                    rt.block_on(async {
+                        let stream = client.inner_mut().index_vault(req).await?.into_inner();
+                        consume_cli_index_progress(stream, |progress| {
+                            let phase_name = match progress.phase {
+                                5 => "Done",
+                                6 => "Error",
+                                _ => "Progress",
+                            };
+                            eprintln!("[{phase_name}] {}", progress.message);
+                        })
+                        .await
+                    })?;
+                }
                 return Ok((EXIT_SUCCESS, None));
             }
 
             if let Some(since_str) = since {
                 // Incremental refresh: only re-index files modified since the
                 // given timestamp.
-                let since_time = parse_iso8601_to_system_time(&since_str).with_context(|| {
-                    format!(
-                        "invalid --since timestamp '{}': expected ISO 8601 (e.g. 2026-05-26T00:00:00Z)",
-                        since_str
-                    )
-                })?;
+                let since_time = since_time.expect("parsed above when --since is present");
                 let result = index_markdown_directory_since_with_ignore(
                     &path,
                     &db_path,
@@ -17664,18 +17715,9 @@ fn resolve_contract_repo_filter(
         return Ok(None);
     };
     let repos = list_repos(store, None)?;
-    // Exact UID match first, then display-name (case-insensitive) match.
-    if let Some(r) = repos.iter().find(|r| r.uid == filter) {
-        return Ok(Some(r.uid.clone()));
-    }
-    let needle = filter.to_lowercase();
-    if let Some(r) = repos
-        .iter()
-        .find(|r| nestweaver_engine::repo_display_name(r).to_lowercase() == needle)
-    {
-        return Ok(Some(r.uid.clone()));
-    }
-    anyhow::bail!("no indexed repo matches --repo '{filter}'")
+    let repo = nestweaver_engine::resolve_repo_selector(&repos, filter)
+        .map_err(|error| anyhow::anyhow!("no indexed repo matches --repo '{filter}': {error}"))?;
+    Ok(Some(repo.uid.clone()))
 }
 
 fn render_contract_list(

--- a/src/main.rs
+++ b/src/main.rs
@@ -5581,11 +5581,25 @@ fn wait_for_started_daemon(
     ignore_pid: Option<i32>,
     expected_config: &nestweaver_client::RestartConfig,
 ) -> anyhow::Result<nestweaver_proto::HealthCheckResponse> {
+    wait_for_started_daemon_with_timeout(
+        db_path,
+        ignore_pid,
+        expected_config,
+        nestweaver_client::autostart::daemon_boot_timeout(),
+    )
+}
+
+fn wait_for_started_daemon_with_timeout(
+    db_path: &std::path::Path,
+    ignore_pid: Option<i32>,
+    expected_config: &nestweaver_client::RestartConfig,
+    timeout: std::time::Duration,
+) -> anyhow::Result<nestweaver_proto::HealthCheckResponse> {
     let runtime =
         tokio::runtime::Runtime::new().context("failed to create runtime for daemon readiness")?;
     runtime.block_on(nestweaver_client::DaemonClient::wait_ready(
         db_path,
-        nestweaver_client::autostart::daemon_boot_timeout(),
+        timeout,
         ignore_pid,
         expected_config,
     ))
@@ -11721,11 +11735,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         eprintln!("  PID file:  {}", pidfile.display());
                         eprintln!("  Socket:    {}", socket.display());
 
+                        let boot_timeout = nestweaver_client::autostart::daemon_boot_timeout();
+                        let boot_started = std::time::Instant::now();
                         match wait_for_macos_temp_daemon(
                             &mut child,
                             &db_path_abs,
                             &pidfile,
-                            std::time::Duration::from_secs(60),
+                            boot_timeout,
                         ) {
                             Ok(health) => {
                                 if health.pid == child.id() {
@@ -11752,10 +11768,17 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                         let _ = child.wait();
                                     }
                                 }
-                                let ready = wait_for_started_daemon(
+                                let remaining = boot_timeout
+                                    .checked_sub(boot_started.elapsed())
+                                    .filter(|remaining| !remaining.is_zero())
+                                    .context(
+                                        "temporary daemon became healthy at the readiness deadline before effective-config attestation completed",
+                                    )?;
+                                let ready = wait_for_started_daemon_with_timeout(
                                     &db_path_abs,
                                     pre_start_pid,
                                     &requested_start_config,
+                                    remaining,
                                 )?;
                                 finish_manual_default_reset(
                                     &db_path_abs,

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -62,6 +62,7 @@ fn mcp_help_hides_deprecated_flag_and_invalid_allowlists_fail_early() {
         .failure()
         .stderr(contains("unknown MCP tool 'context'"));
 
+    drop(nestweaver_store::GraphStore::open_or_create(&db).unwrap());
     let output = nestweaver_cmd()
         .args(["mcp", "--db"])
         .arg(&db)
@@ -2020,7 +2021,7 @@ fn daemon_status_accepts_db_after_subcommand() {
 }
 
 #[test]
-fn cli_snapshot_stamp_has_repos_and_correct_embedding_model() {
+fn cli_snapshot_stamp_has_repos_and_does_not_invent_embedding_model() {
     let dir = tempfile::tempdir().unwrap();
     let repo_dir = dir.path().join("repo");
     let db_path = dir.path().join("test.lbug");
@@ -2107,7 +2108,7 @@ model_id = "sentence-transformers/all-MiniLM-L6-v2"
     std::fs::create_dir_all(dir.path().join("storage")).unwrap();
     std::fs::create_dir_all(dir.path().join("workspace")).unwrap();
 
-    // Build snapshot with --config so embedding_model_id is populated
+    // Build with a config whose model must not override persisted DB truth.
     nestweaver_cmd()
         .args([
             "snapshot",
@@ -2142,17 +2143,22 @@ model_id = "sentence-transformers/all-MiniLM-L6-v2"
         "repo URL '{repo_url}' should reference the indexed repo"
     );
 
-    // Bug 1b: embedding_model_id should come from [embedding], not [inference]
+    // This DB has no vector metadata. The config is compatibility input only;
+    // it must not fabricate an embedding model in the signed stamp.
     let model_id = stamp["embedding_model_id"]
         .as_str()
         .expect("embedding_model_id should be a string");
     assert_eq!(
+        model_id, "",
+        "a DB without embedding metadata must stamp an empty model ID"
+    );
+    assert_ne!(
         model_id, "sentence-transformers/all-MiniLM-L6-v2",
-        "embedding_model_id should come from [embedding].model_id, not [inference].embedding_model"
+        "[embedding].model_id must not override persisted DB truth"
     );
     assert_ne!(
         model_id, "nomic-embed-text",
-        "embedding_model_id should NOT be the inference model"
+        "[inference].embedding_model must not override persisted DB truth"
     );
 }
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -44,6 +44,42 @@ fn cli_help_lists_commands() {
 }
 
 #[test]
+fn mcp_help_hides_deprecated_flag_and_invalid_allowlists_fail_early() {
+    nestweaver_cmd()
+        .args(["mcp", "--help"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("allow-mcp-add-sources").not());
+
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("brain.lbug");
+    nestweaver_cmd()
+        .args(["mcp", "--db"])
+        .arg(&db)
+        .args(["--tools", "context"])
+        .write_stdin("")
+        .assert()
+        .failure()
+        .stderr(contains("unknown MCP tool 'context'"));
+
+    let output = nestweaver_cmd()
+        .args(["mcp", "--db"])
+        .arg(&db)
+        .arg("--allow-mcp-add-sources")
+        .write_stdin("")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stderr
+            .matches("--allow-mcp-add-sources is deprecated")
+            .count(),
+        1
+    );
+}
+
+#[test]
 fn config_validate_accepts_minimal_fixture() {
     let config_path =
         std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/minimal-instance.toml");

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -562,6 +562,72 @@ fn mcp_jsonrpc_envelope_validation_matches_direct_and_daemon_modes() {
 }
 
 #[test]
+fn direct_mcp_fails_closed_on_config_and_exposes_only_read_tools() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_dir = dir.path().join("repo");
+    let db_path = dir.path().join("test.lbug");
+    write_test_repo(&repo_dir);
+
+    let missing_config = dir.path().join("missing.toml");
+    let output = StdCommand::new(bin_path())
+        .args(["mcp", "--no-daemon", "--db"])
+        .arg(&db_path)
+        .arg("--config")
+        .arg(&missing_config)
+        .env("NESTWEAVER_NO_DAEMON", "1")
+        .env("NESTWEAVER_ALLOW_NO_DAEMON", "1")
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty(), "config error polluted MCP stdout");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("canonicalize --config"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !db_path.exists(),
+        "explicit config must fail before graph open"
+    );
+
+    create_db(&repo_dir, &db_path);
+    let input = concat!(
+        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"brain_add_source\",\"arguments\":{\"path\":\"/tmp/never\"}}}\n"
+    );
+    let output = mcp_raw_in_mode(&db_path, input, McpMode::Direct);
+    assert!(output.status.success());
+    let frames = String::from_utf8(output.stdout)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(frames.len(), 2);
+    let tools = frames[0]["result"]["tools"].as_array().unwrap();
+    assert_eq!(tools.len(), 35);
+    for mutator in nestweaver_mcp::http::MUTATING_TOOLS {
+        assert!(
+            tools.iter().all(|tool| tool["name"] != *mutator),
+            "direct tools/list exposed {mutator}"
+        );
+    }
+    assert_eq!(frames[1]["result"]["isError"], true);
+    assert!(
+        frames[1]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("direct read-only mode")
+    );
+
+    let instance = nestweaver_daemon::instance_id_from_db_path(&db_path);
+    assert!(
+        !nestweaver_daemon::pidfile_path(&instance).exists(),
+        "direct mutator rejection must not autostart a daemon"
+    );
+}
+
+#[test]
 fn daemon_start_stop() {
     let dir = tempfile::tempdir().unwrap();
     let repo_dir = dir.path().join("repo");
@@ -4222,4 +4288,45 @@ fn daemon_note_get_returns_frontmatter_and_outline() {
         .unwrap_or_else(|| panic!("daemon note_get must include an outline; got: {note}"));
     let texts: Vec<&str> = outline.iter().filter_map(|h| h["text"].as_str()).collect();
     assert_eq!(texts, ["Hello", "Details"], "outline headings; got: {note}");
+}
+
+/// A normal incremental vault refresh must stay behind the daemon's one-writer
+/// boundary. Before RefreshVaultSince existed, registration discovery
+/// autostarted the daemon and the command then tried to open a second writable
+/// GraphStore, deterministically failing on the database lock.
+#[test]
+fn brain_refresh_since_uses_daemon_owned_writer_and_updates_search() {
+    let dir = tempfile::tempdir().unwrap();
+    let vault_dir = dir.path().join("vault");
+    let db_path = dir.path().join("test.lbug");
+    std::fs::create_dir_all(&vault_dir).unwrap();
+    std::fs::write(vault_dir.join("note.md"), "# Alpha\n\nold text\n").unwrap();
+
+    no_daemon_cmd()
+        .args(["brain", "add"])
+        .arg(&vault_dir)
+        .args(["--db"])
+        .arg(&db_path)
+        .assert()
+        .success();
+
+    let _guard = DaemonGuard::new(&db_path);
+    std::fs::write(vault_dir.join("note.md"), "# Beta Sentinel\n\nnew text\n").unwrap();
+    daemon_cmd()
+        .args(["brain", "refresh"])
+        .arg(&vault_dir)
+        .args(["--db"])
+        .arg(&db_path)
+        .args(["--since", "1970-01-01T00:00:00Z"])
+        .assert()
+        .success()
+        .stderr(contains("[Done] Incremental refresh"))
+        .stderr(predicates::str::contains("Could not set lock").not());
+
+    daemon_cmd()
+        .args(["brain", "search", "Beta Sentinel", "--json", "--db"])
+        .arg(&db_path)
+        .assert()
+        .success()
+        .stdout(contains("Beta Sentinel"));
 }

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -1862,11 +1862,31 @@ credential_method = "gh"
     assert_eq!(read_pid(), pid_overridden);
     assert_eq!(unsafe { libc::kill(pid_overridden, 0) }, 0);
 
-    // Cold restart ignores a stale sidecar. Omitted config is an explicit
-    // compiled-default decision; an explicit path is still validated/chosen.
+    // Automatic cold starts ignore the stale live sidecar but reuse the last
+    // configured daemon that actually reached readiness.
     daemon_action_cmd(&db_path, "stop").assert().success();
-    // A configless query preserves legacy availability when it starts with no
-    // daemon (autostart where possible, direct fallback if connect cannot win).
+    let config_b_contents = std::fs::read_to_string(&config_b).unwrap();
+    std::fs::write(&config_b, "instance_id = [broken").unwrap();
+    daemon_cmd()
+        .args([
+            "brain",
+            "search",
+            "test",
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            contains("persisted daemon config")
+                .and(contains("refuses to fall back"))
+                .and(contains("daemon --db")),
+        );
+    assert!(
+        !nestweaver_daemon::socket_path(&instance_id).exists(),
+        "invalid persisted intent must fail before spawning a daemon"
+    );
+    std::fs::write(&config_b, config_b_contents).unwrap();
     daemon_cmd()
         .args([
             "brain",
@@ -1877,8 +1897,7 @@ credential_method = "gh"
         ])
         .assert()
         .success();
-    // The query may have autostarted a compiled-default daemon; restore the
-    // stopped precondition for the stale-sidecar cold-start case below.
+    assert!(status().contains(&format!("Config: {}", canonical_b.display())));
     daemon_action_cmd(&db_path, "stop").assert().success();
     nestweaver_daemon::lifecycle::write_effective_config_binding(
         &instance_id,
@@ -1891,16 +1910,34 @@ credential_method = "gh"
     )
     .unwrap();
     daemon_action_cmd(&db_path, "restart").assert().success();
-    assert!(status().contains("Config: none"));
-    let pid_defaults = read_pid();
+    assert!(status().contains(&format!("Config: {}", canonical_b.display())));
+    let pid_persisted = read_pid();
     daemon_action_cmd(&db_path, "start")
         .arg("--config")
         .arg(&config_a)
         .assert()
         .failure()
-        .stderr(contains("compiled defaults").and(contains("restart --config")));
-    assert_eq!(read_pid(), pid_defaults);
-    assert_eq!(unsafe { libc::kill(pid_defaults, 0) }, 0);
+        .stderr(contains(canonical_b.display().to_string()).and(contains("restart --config")));
+    assert_eq!(read_pid(), pid_persisted);
+    assert_eq!(unsafe { libc::kill(pid_persisted, 0) }, 0);
+
+    // Merely observing an incumbent with manual configless `start` is a no-op;
+    // it must not erase persisted configured intent.
+    daemon_action_cmd(&db_path, "start").assert().success();
+    assert_eq!(read_pid(), pid_persisted);
+    let persisted = nestweaver_daemon::lifecycle::read_last_successful_config(&db_path).unwrap();
+    assert_eq!(Path::new(&persisted.config_path), canonical_b);
+
+    // Once cold, the same explicit manual invocation is the reset escape
+    // hatch. It bypasses persisted intent and clears it only after the new
+    // default daemon is healthy and attested.
+    daemon_action_cmd(&db_path, "stop").assert().success();
+    daemon_action_cmd(&db_path, "start").assert().success();
+    assert!(status().contains("Config: none"));
+    assert!(matches!(
+        nestweaver_daemon::lifecycle::read_last_successful_config(&db_path),
+        Err(nestweaver_daemon::lifecycle::LastSuccessfulConfigError::Absent { .. })
+    ));
 
     daemon_action_cmd(&db_path, "stop").assert().success();
     daemon_action_cmd(&db_path, "restart")


### PR DESCRIPTION
Closes the validated v4.1.0 end-to-end regression bug hunt. The hunt exercised all 40 MCP tools, direct and daemon stdio transports, HTTP and hybrid routing, daemon lifecycle, CLI surfaces, incremental/full/watch indexing, vault refresh, snapshots, embeddings, contracts, authentication, replicas, and failure recovery. Three independent source audits reproduced and traced every finding on `main` at `76881b8`.

Design and rationale: `Workspaces/NestWeaver/notes/2026-08/decision/validated-v4-1-0-regression-remediation-plan.md`.

## High-priority defects closed

- **Daemon startup intent was PID-bound only.** Graceful idle exit deleted it, so a later configless autostart silently used compiled defaults and could split one database across logical instance IDs. Now a hardened, versioned, persistent last-successful-config record lives under XDG state, keyed by the full SHA-256 identity of the canonical database path. 0700 directory, 0600 no-follow regular file, owner/mode/size/version/fingerprint validation, atomic temp write + fsync + rename + parent fsync. Failed configured startup and failed configless reset cannot clobber the prior record, and live-sidecar cleanup cannot remove it.
- **Direct stdio MCP served compiled defaults on missing/malformed config**, discarding identity, authorization, ranking, and limit assertions. Explicit config is now canonicalized and parsed before locks, sockets, or child startup, and fails closed.
- **Malformed OpenAPI/Protobuf/GraphQL specs parsed as an empty successful plan**, deleting the last good contracts, advancing the repository SHA, and reporting clean drift. Every recognized spec is now strictly parsed as a pre-write phase, before the publication marker and any Repo/File/Symbol mutation. Malformed input leaves the entire prior graph, indexed SHA, generation, and sidecars unchanged and records a per-repo degraded marker. A valid empty spec still yields a successful empty plan.
- **Snapshots omitted the authoritative embedding sidecar** and stamped model identity from caller config rather than persisted database metadata, so verification could bless a replica that had silently lost semantic search. Snapshots are now self-describing (format/capability version, `embedding_count`), complete, and crash-safe: staged into a sibling directory, fsynced, then atomically promoted.
- **Contract UIDs omitted repository ownership**, so identical routes in two repositories collided globally and the second repo got no contracts. Contract node UIDs are now scoped by `repo_uid` plus normalized protocol/verb/path/operation, with a versioned derivation generation and a transactional, idempotent v1→v2 legacy purge that leaves unrefreshed repos explicitly degraded rather than silently wrong.

## Medium-priority defects closed

- Explicit `daemon start` used a private fixed ten-second socket deadline; it now uses the shared configurable, liveness-aware readiness policy with pre-spawn stale-PID `ignore_pid`, process-death detection, gRPC health, and final config attestation under one deadline budget.
- Direct MCP mutators and `brain refresh --since` held the database writer and then tried to autostart a daemon writer, guaranteeing a lock conflict. Mutations now route through the daemon's single writer; direct `--no-daemon` exposes an explicitly read-only surface.
- A distinct `RefreshVaultSince` RPC was added rather than extending `IndexVault`, so an old daemon cannot ignore a new field and silently perform a full refresh. `UNIMPLEMENTED`, deadline, cancellation, and RPC errors fail with upgrade/retry guidance and never fall back to a full refresh or a local writer.
- `brain_diff` advertised repository display-name selection but resolved only URL/path fragments. Repository selection is centralized with precedence: exact UID, Unicode-lowercase exact display name, exact root/canonical URL, then unambiguous substring.
- Cold daemon-proxy startup reported malformed explicit config only as a generic boot timeout; it is now immediate and actionable.

## Low-priority defects closed

- The deprecated `--allow-mcp-add-sources` help text promised behavior the flag no longer controls. It stays parse-compatible for one release, hidden, with a single warning.
- The README's `--tools context,search,symbol` example named no registered MCP tools. Corrected, and `--tools` is now validated against the selected transport surface: unknown, duplicate, empty, `--lite`-disjoint, and direct-unavailable mutator names all fail at startup instead of producing a silent zero-tool server.

## Also closed by follow-up adversarial review

Interactions the original bug hunt did not expose directly:

- incremental vault replacement is one transaction, preserves full wikilink and typed-edge resolver semantics, garbage-collects orphan tags, isolates vaults, handles newly ignored notes, and reads content only for changed or affected sources;
- stable note replacements preserve materialized project membership in both incremental and full vault refreshes, while true deletions remove it;
- configured-default reset completes after slow Linux and launchd startup only when PID-bound effective-config attestation proves compiled defaults are effective;
- the historical public `contract_uid(kind, verb, path, operation_id)` shape helper remains source-compatible while stored Contract nodes use the new repository-scoped identity helper.

## Intentional compatibility changes

- Configless cold autostart reuses persisted configured intent. A successful explicit configless manual start is the reset mechanism.
- Broken persisted config blocks automatic availability instead of silently falling back to defaults.
- Direct MCP advertises 35 read-only tools rather than five unusable mutators.
- Unknown `--tools` allowlist names become errors.
- Contract UIDs change for derived records and require a full reindex. The migration is transactional and self-healing; no user-authored data is migrated in place.
- Embedded legacy snapshots that claim vectors but omit their artifact fail with rebuild guidance. Truly unembedded legacy snapshots remain loadable.

## Deliberately out of scope

Split 3 (per-row skip) of "make contract derivation failure non-destructive and honest" remains open and deferred, per the bug-bash implementation plan. The strict pre-write preflight in this branch supersedes the need for it in the malformed-spec case; the remaining split covers individually invalid rows within an otherwise valid spec.

## Wire compatibility

`proto/nestweaver/daemon/v1/service.proto` changes are purely additive: one new message and one new RPC, no field renumbering or removal.

## Validation

Run locally against this branch head:

- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps`
- `cargo build --locked`
- `cargo run --locked -- config validate examples/minimal-instance.toml`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --locked --workspace --no-fail-fast -- --skip daemon_`
- `cargo test --locked --workspace --no-fail-fast -- daemon_`
- `cargo test --locked -p nestweaver-mcp --features daemon --no-fail-fast`

No production database, daemon, or installed binary was used for mutation or regression tests; all lifecycle tests use isolated HOME/XDG/database roots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
