### PR TITLE
Post-v4.1.1 Waves 1–2: daemon config intent, state-dir gc, RunAtLoad, bench harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,6 +353,12 @@ jobs:
         run: cargo build --locked
       - name: Validate canonical instance config
         run: cargo run --locked -- config validate examples/minimal-instance.toml
+      - name: Type-check benchmarks
+        # Bench targets are built by neither `cargo build` nor `cargo test`, so
+        # nothing here compiled them until this step existed and they rotted
+        # unnoticed. `check --benches` catches a bench that stops compiling
+        # without paying for a full release-profile `bench --no-run`.
+        run: cargo check --locked --benches
       - name: Tests
         # --workspace is REQUIRED: the root manifest is both [package] and
         # [workspace], so `cargo test` without it runs ONLY the root package's

--- a/benches/brain_benchmarks.rs
+++ b/benches/brain_benchmarks.rs
@@ -26,21 +26,15 @@
 //! Results from a representative run are recorded in
 //! docs/architecture/project-brain.md Appendix C.
 
-#[cfg(not(test))]
 use std::path::PathBuf;
 
-#[cfg(not(test))]
 use criterion::{Criterion, criterion_group, criterion_main};
-#[cfg(not(test))]
 use nestweaver_engine::{HybridSearchConfig, build_brain_context_hybrid, index_markdown_directory};
-#[cfg(not(test))]
 use nestweaver_store::{GraphScope, GraphStore, TantivyIndex};
-#[cfg(not(test))]
 use tempfile::tempdir;
 
 /// Number of notes to generate. Pulled from env so larger runs don't
 /// require a recompile.
-#[cfg(not(test))]
 fn bench_notes() -> usize {
     std::env::var("BENCH_NOTES")
         .ok()
@@ -52,7 +46,6 @@ fn bench_notes() -> usize {
 /// preamble, frontmatter with a tag and a type, and ~3 wikilinks to
 /// other notes — roughly the density of a real PKM vault per the
 /// architecture doc.
-#[cfg(not(test))]
 fn synth_vault(n: usize) -> (tempfile::TempDir, PathBuf) {
     let dir = tempdir().unwrap();
     let root = dir.path().join("vault");
@@ -102,7 +95,6 @@ fn synth_vault(n: usize) -> (tempfile::TempDir, PathBuf) {
 
 // ── bench: cold_index ──────────────────────────────────────────────────────
 
-#[cfg(not(test))]
 fn bench_cold_index(c: &mut Criterion) {
     let n = bench_notes();
     let mut group = c.benchmark_group("cold_index");
@@ -126,7 +118,6 @@ fn bench_cold_index(c: &mut Criterion) {
 
 // ── bench: brain_context_query (after warm-up index + PPR) ─────────────────
 
-#[cfg(not(test))]
 fn bench_brain_context_query(c: &mut Criterion) {
     let n = bench_notes();
     let (_dir, root) = synth_vault(n);
@@ -160,7 +151,6 @@ fn bench_brain_context_query(c: &mut Criterion) {
 
 // ── bench: tantivy_search ──────────────────────────────────────────────────
 
-#[cfg(not(test))]
 fn bench_tantivy_search(c: &mut Criterion) {
     let n = bench_notes();
     let (_dir, root) = synth_vault(n);
@@ -180,7 +170,6 @@ fn bench_tantivy_search(c: &mut Criterion) {
 
 // ── bench: ppr_compute (unified scope) ─────────────────────────────────────
 
-#[cfg(not(test))]
 fn bench_ppr_compute(c: &mut Criterion) {
     let n = bench_notes();
     let (_dir, root) = synth_vault(n);
@@ -201,7 +190,6 @@ fn bench_ppr_compute(c: &mut Criterion) {
     group.finish();
 }
 
-#[cfg(not(test))]
 criterion_group!(
     benches,
     bench_cold_index,
@@ -209,8 +197,4 @@ criterion_group!(
     bench_tantivy_search,
     bench_ppr_compute,
 );
-#[cfg(not(test))]
 criterion_main!(benches);
-
-#[cfg(test)]
-fn main() {}

--- a/benches/embed_latency.rs
+++ b/benches/embed_latency.rs
@@ -1,4 +1,3 @@
-#[cfg(not(test))]
 fn main() {
     #[cfg(feature = "embed")]
     {
@@ -49,6 +48,3 @@ fn main() {
         eprintln!("Benchmark requires --features embed");
     }
 }
-
-#[cfg(test)]
-fn main() {}

--- a/benches/index_benchmarks.rs
+++ b/benches/index_benchmarks.rs
@@ -12,22 +12,15 @@
 //! Scaling:
 //!   BENCH_FILES=500 cargo bench --bench index_benchmarks
 
-#[cfg(not(test))]
 use std::path::PathBuf;
-#[cfg(not(test))]
 use std::sync::Once;
 
-#[cfg(not(test))]
 use criterion::{Criterion, criterion_group, criterion_main};
-#[cfg(not(test))]
 use nestweaver_engine::index_directory_with_options;
-#[cfg(not(test))]
 use tempfile::tempdir;
 
-#[cfg(not(test))]
 static INIT_TRACING: Once = Once::new();
 
-#[cfg(not(test))]
 fn init_tracing() {
     INIT_TRACING.call_once(|| {
         use tracing_subscriber::fmt::format::FmtSpan;
@@ -43,7 +36,6 @@ fn init_tracing() {
 }
 
 /// Number of TypeScript files to generate. Pull from env to avoid recompile.
-#[cfg(not(test))]
 fn bench_files() -> usize {
     std::env::var("BENCH_FILES")
         .ok()
@@ -56,7 +48,6 @@ fn bench_files() -> usize {
 /// Each file exports a class with a constructor and two methods that call each
 /// other, producing a realistic symbol + reference density. Files in `src/`
 /// have varying subdirectories to exercise service-node grouping.
-#[cfg(not(test))]
 fn synth_ts_repo(n: usize) -> (tempfile::TempDir, PathBuf) {
     let dir = tempdir().unwrap();
     let root = dir.path().join("repo");
@@ -112,7 +103,6 @@ export function create{i}(n: number): Item{i} {{
 
 // ── bench: cold_index ─────────────────────────────────────────────────────
 
-#[cfg(not(test))]
 fn bench_cold_index(c: &mut Criterion) {
     init_tracing();
     let n = bench_files();
@@ -148,7 +138,6 @@ fn bench_cold_index(c: &mut Criterion) {
 
 // ── bench: warm_noop ──────────────────────────────────────────────────────
 
-#[cfg(not(test))]
 fn bench_warm_noop(c: &mut Criterion) {
     init_tracing();
     let n = bench_files();
@@ -194,10 +183,5 @@ fn bench_warm_noop(c: &mut Criterion) {
     group.finish();
 }
 
-#[cfg(not(test))]
 criterion_group!(benches, bench_cold_index, bench_warm_noop);
-#[cfg(not(test))]
 criterion_main!(benches);
-
-#[cfg(test)]
-fn main() {}

--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -78,7 +78,7 @@ impl RestartConfig {
                 anyhow::bail!(
                     "cannot honor persisted daemon configuration for {}: {error}. \
                      To deliberately reset this database to compiled defaults, run \
-                     `nestweaver daemon --db {} start`",
+                     `nestweaver daemon --db {} start --reset`",
                     db_path.display(),
                     db_path.display()
                 );
@@ -87,7 +87,7 @@ impl RestartConfig {
         let recorded = PathBuf::from(&record.config_path);
         let canonical = validate_restart_config(&recorded).with_context(|| {
             format!(
-                "persisted daemon config {} for {} is no longer usable; automatic startup refuses to fall back to compiled defaults. To deliberately reset, run `nestweaver daemon --db {} start`",
+                "persisted daemon config {} for {} is no longer usable; automatic startup refuses to fall back to compiled defaults. To deliberately reset, run `nestweaver daemon --db {} start --reset`",
                 recorded.display(),
                 db_path.display(),
                 db_path.display()
@@ -95,7 +95,7 @@ impl RestartConfig {
         })?;
         anyhow::ensure!(
             canonical == recorded,
-            "persisted daemon config path is not canonical: {}. To deliberately reset, run `nestweaver daemon --db {} start`",
+            "persisted daemon config path is not canonical: {}. To deliberately reset, run `nestweaver daemon --db {} start --reset`",
             recorded.display(),
             db_path.display()
         );

--- a/crates/nestweaver-daemon/src/launchd.rs
+++ b/crates/nestweaver-daemon/src/launchd.rs
@@ -231,11 +231,16 @@ pub fn generate_plist(
         log_path,
         index_cpu_percent,
         None,
+        false,
     )
 }
 
 /// Render a per-instance launch agent, optionally forwarding an absolute
 /// instance configuration path to the foreground `daemon run` process.
+///
+/// `start_at_login` emits `RunAtLoad`. Without it launchd *registers* the agent
+/// at login but never starts it — `install_and_start` compensates with an
+/// explicit `kickstart`, which covers install time but not reboot.
 pub fn generate_plist_with_config(
     instance_id: &str,
     binary_path: &Path,
@@ -243,6 +248,7 @@ pub fn generate_plist_with_config(
     log_path: &Path,
     index_cpu_percent: Option<&str>,
     config_path: Option<&Path>,
+    start_at_login: bool,
 ) -> String {
     let label = xml_escape(&lifecycle::launchd_label(instance_id));
     let binary = xml_escape(&binary_path.display().to_string());
@@ -266,6 +272,14 @@ pub fn generate_plist_with_config(
             )
         }
         None => String::new(),
+    };
+
+    // Opt-in. Omitted entirely rather than emitted as `<false/>` so a plist
+    // from a machine that never opted in is byte-identical to the old output.
+    let run_at_load = if start_at_login {
+        "    <key>RunAtLoad</key>\n    <true/>\n"
+    } else {
+        ""
     };
 
     format!(
@@ -299,7 +313,7 @@ pub fn generate_plist_with_config(
     <true/>
     <key>ProcessType</key>
     <string>Interactive</string>
-{env_block}</dict>
+{run_at_load}{env_block}</dict>
 </plist>
 "#
     )
@@ -480,6 +494,7 @@ mod tests {
             Path::new("/tmp/log"),
             None,
             Some(Path::new("/Users/k/dev/repo/nestweaver-instance.toml")),
+            false,
         );
         assert!(
             plist.contains(
@@ -494,6 +509,64 @@ mod tests {
         );
     }
 
+    /// `RunAtLoad` is what makes the agent *start* at login rather than merely
+    /// register. It is opt-in, and when off the key must be absent entirely —
+    /// not `<false/>` — so plists on machines that never opted in are unchanged.
+    #[test]
+    fn plist_omits_run_at_load_unless_start_at_login_is_set() {
+        let plist = generate_plist_with_config(
+            "abc123",
+            Path::new("/usr/local/bin/nestweaver"),
+            Path::new("/Users/k/dev/repo/brain.lbug"),
+            Path::new("/tmp/log"),
+            None,
+            None,
+            false,
+        );
+        assert!(!plist.contains("RunAtLoad"), "{plist}");
+        // The 5-arg convenience wrapper must not silently opt a caller in.
+        let default_plist = generate_plist(
+            "abc123",
+            Path::new("/usr/local/bin/nestweaver"),
+            Path::new("/Users/k/dev/repo/brain.lbug"),
+            Path::new("/tmp/log"),
+            None,
+        );
+        assert!(!default_plist.contains("RunAtLoad"), "{default_plist}");
+    }
+
+    #[test]
+    fn plist_emits_run_at_load_when_start_at_login_is_set() {
+        let plist = generate_plist_with_config(
+            "abc123",
+            Path::new("/usr/local/bin/nestweaver"),
+            Path::new("/Users/k/dev/repo/brain.lbug"),
+            Path::new("/tmp/log"),
+            Some("45"),
+            Some(Path::new("/Users/k/dev/repo/nestweaver-instance.toml")),
+            true,
+        );
+        assert!(
+            plist.contains("<key>RunAtLoad</key>\n    <true/>"),
+            "{plist}"
+        );
+        // RunAtLoad must sit as a sibling of the other top-level keys, not
+        // inside the EnvironmentVariables dict it is rendered next to.
+        assert!(
+            plist.contains(
+                "<key>ProcessType</key>\n    <string>Interactive</string>\n    \
+                 <key>RunAtLoad</key>\n    <true/>\n    <key>EnvironmentVariables</key>"
+            ),
+            "{plist}"
+        );
+        // Coexists with the other dynamic blocks without disturbing them.
+        assert_eq!(
+            parse_db_path_from_plist(&plist),
+            Some(PathBuf::from("/Users/k/dev/repo/brain.lbug"))
+        );
+        assert!(plist.contains("<string>--config</string>"), "{plist}");
+    }
+
     #[test]
     fn plist_escapes_all_dynamic_strings_and_round_trips_db_path() {
         let metacharacters = r#"& < > " '"#;
@@ -504,8 +577,15 @@ mod tests {
         let log = PathBuf::from(format!("/Users/k/Logs {metacharacters}/daemon.log"));
         let cpu = format!("cpu-{metacharacters}");
 
-        let plist =
-            generate_plist_with_config(&instance_id, &binary, &db, &log, Some(&cpu), Some(&config));
+        let plist = generate_plist_with_config(
+            &instance_id,
+            &binary,
+            &db,
+            &log,
+            Some(&cpu),
+            Some(&config),
+            false,
+        );
         let escaped = "&amp; &lt; &gt; &quot; &apos;";
 
         for expected in [
@@ -534,8 +614,15 @@ mod tests {
         let config = PathBuf::from(format!("/Users/k/Config {metacharacters}/instance.toml"));
         let log = PathBuf::from(format!("/Users/k/Logs {metacharacters}/daemon.log"));
         let cpu = format!("cpu-{metacharacters}");
-        let plist =
-            generate_plist_with_config(&instance_id, &binary, &db, &log, Some(&cpu), Some(&config));
+        let plist = generate_plist_with_config(
+            &instance_id,
+            &binary,
+            &db,
+            &log,
+            Some(&cpu),
+            Some(&config),
+            false,
+        );
         let dir = tempfile::tempdir().unwrap();
         let plist_path = dir.path().join("special-values.plist");
         std::fs::write(&plist_path, &plist).unwrap();
@@ -590,6 +677,52 @@ mod tests {
         assert_eq!(
             decoded["EnvironmentVariables"]["NESTWEAVER_INDEX_CPU_PERCENT"],
             serde_json::json!(cpu)
+        );
+        assert_eq!(decoded.get("RunAtLoad"), None);
+    }
+
+    /// launchd, not just the XML parser, has to accept `RunAtLoad` where we put
+    /// it. A structural string assertion cannot prove the key decodes as a
+    /// top-level boolean rather than landing inside a neighboring dict.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn plist_with_run_at_load_decodes_as_a_top_level_boolean() {
+        let plist = generate_plist_with_config(
+            "abc123",
+            Path::new("/usr/local/bin/nestweaver"),
+            Path::new("/Users/k/dev/repo/brain.lbug"),
+            Path::new("/tmp/log"),
+            Some("45"),
+            Some(Path::new("/Users/k/dev/repo/nestweaver-instance.toml")),
+            true,
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let plist_path = dir.path().join("run-at-load.plist");
+        std::fs::write(&plist_path, &plist).unwrap();
+
+        let lint = Command::new("plutil")
+            .arg("-lint")
+            .arg(&plist_path)
+            .output()
+            .expect("plutil must be available on macOS");
+        assert!(
+            lint.status.success(),
+            "plutil rejected generated plist:\n{}",
+            String::from_utf8_lossy(&lint.stderr)
+        );
+
+        let json = Command::new("plutil")
+            .args(["-convert", "json", "-o", "-"])
+            .arg(&plist_path)
+            .output()
+            .expect("plutil must decode generated plist");
+        let decoded: serde_json::Value =
+            serde_json::from_slice(&json.stdout).expect("plutil must emit JSON");
+        assert_eq!(decoded["RunAtLoad"], serde_json::json!(true));
+        // Still a sibling of, not swallowed by, the env dict.
+        assert_eq!(
+            decoded["EnvironmentVariables"]["NESTWEAVER_INDEX_CPU_PERCENT"],
+            serde_json::json!("45")
         );
     }
 

--- a/crates/nestweaver-daemon/src/launchd.rs
+++ b/crates/nestweaver-daemon/src/launchd.rs
@@ -12,22 +12,10 @@ fn launchd_agents_dir() -> PathBuf {
         .join("LaunchAgents")
 }
 
-/// True if `db_path` lives under a temporary directory (`/tmp`, `/private/tmp`,
-/// `/var/folders`, or `$TMPDIR`). Daemons for temp DBs are ephemeral (tests,
-/// throwaway repros) and must never receive a persistent launchd agent — that
-/// was the source of the leaked, crash-looping `io.kehl.nestweaver.*` agents.
-pub fn is_temp_db_path(db_path: &Path) -> bool {
-    let mut bases: Vec<PathBuf> = vec![
-        PathBuf::from("/tmp"),
-        PathBuf::from("/private/tmp"),
-        PathBuf::from("/var/folders"),
-        PathBuf::from("/private/var/folders"),
-    ];
-    if let Some(t) = std::env::var_os("TMPDIR") {
-        bases.push(PathBuf::from(t));
-    }
-    bases.iter().any(|b| db_path.starts_with(b))
-}
+/// Re-exported so this module's callers (and `main.rs`) keep a stable path.
+/// The predicate itself lives in `lifecycle` because it is not
+/// launchd-specific and this module is macOS-gated.
+pub use crate::lifecycle::is_temp_db_path;
 
 /// Escape a dynamic value for use as XML character data in a plist `<string>`.
 fn xml_escape(value: &str) -> String {

--- a/crates/nestweaver-daemon/src/lifecycle.rs
+++ b/crates/nestweaver-daemon/src/lifecycle.rs
@@ -1244,6 +1244,209 @@ pub fn log_hint(instance_id: &str) -> String {
     )
 }
 
+/// True if `db_path` lives under a temporary directory (`/tmp`, `/private/tmp`,
+/// `/var/folders`, or `$TMPDIR`). Daemons for temp DBs are ephemeral (tests,
+/// throwaway repros): they must never receive a persistent launchd agent, and
+/// their state directories are always reclaimable.
+///
+/// Lives here rather than in `launchd` because the predicate is not
+/// launchd-specific and `launchd` is macOS-gated, while state directories
+/// accumulate on every platform.
+pub fn is_temp_db_path(db_path: &Path) -> bool {
+    let mut bases: Vec<PathBuf> = vec![
+        PathBuf::from("/tmp"),
+        PathBuf::from("/private/tmp"),
+        PathBuf::from("/var/folders"),
+        PathBuf::from("/private/var/folders"),
+    ];
+    if let Some(t) = std::env::var_os("TMPDIR") {
+        bases.push(PathBuf::from(t));
+    }
+    bases.iter().any(|b| db_path.starts_with(b))
+}
+
+/// Outcome of a [`gc_orphaned_state_dirs`] pass.
+#[derive(Debug, Default)]
+pub struct StateDirGcReport {
+    /// Instance directories deleted (database gone or under a temp dir).
+    pub removed: Vec<String>,
+    /// Bytes reclaimed by those deletions.
+    pub reclaimed_bytes: u64,
+    /// Directories whose database still exists.
+    pub kept: Vec<String>,
+    /// Directories spared because a live daemon still holds the pidfile lock.
+    pub spared: Vec<String>,
+    /// Directories left alone because their database could not be identified.
+    /// Not an error: unidentifiable means undeletable, by design.
+    pub unidentified: Vec<String>,
+}
+
+/// Is a live daemon holding `instance_id`'s pidfile lock?
+///
+/// The daemon opens the DB *before* taking the pidfile `flock(LOCK_EX)` and
+/// holds it for its whole lifetime, so a held lock means a healthy daemon.
+/// Fails toward `true` (spare) on any error we cannot interpret.
+#[cfg(unix)]
+fn instance_daemon_is_live(instance_id: &str) -> bool {
+    let pidfile = pidfile_path(instance_id);
+    let file = match std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&pidfile)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return false,
+        Err(_) => return true,
+    };
+    use std::os::unix::io::AsRawFd;
+    let fd = file.as_raw_fd();
+    if unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        return std::io::Error::last_os_error().kind() == std::io::ErrorKind::WouldBlock;
+    }
+    unsafe {
+        libc::flock(fd, libc::LOCK_UN);
+    }
+    false
+}
+
+#[cfg(not(unix))]
+fn instance_daemon_is_live(_instance_id: &str) -> bool {
+    true
+}
+
+/// A daemon instance directory is named by the 8-hex instance id.
+///
+/// This is the **allowlist** the state sweep is built on. `config-intent/` is a
+/// sibling under the same root holding the persisted startup intent, and its
+/// own children are 64-hex database fingerprints — so neither that directory
+/// nor its contents can ever match this shape. Deleting `config-intent/` is the
+/// catastrophic failure here (it has happened once for real, via a hand-written
+/// `find … -exec rm -rf`), and structural exclusion is what prevents it. Never
+/// replace this with a denylist of known-bad names.
+fn is_instance_dir_name(name: &str) -> bool {
+    name.len() == 8
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_digit() || b.is_ascii_lowercase() && b <= b'f')
+}
+
+/// Recover the database path a daemon instance was serving, from the first line
+/// its startup wrote to `daemon.log`:
+///
+/// ```text
+/// [daemon] starting for /path/to/brain.lbug (instance repo-1a2b3c4d)
+/// ```
+///
+/// The instance id is a one-way hash of the database path, so this log line is
+/// the only record tying an existing directory back to its database. Returns
+/// `None` when the line is absent or unparseable, which makes the directory
+/// unidentifiable and therefore undeletable.
+fn db_path_from_daemon_log(log: &str) -> Option<PathBuf> {
+    let line = log
+        .lines()
+        .find(|line| line.starts_with("[daemon] starting for "))?;
+    let rest = line.strip_prefix("[daemon] starting for ")?;
+    // A database path may itself contain " (instance ", so anchor on the LAST
+    // occurrence — the suffix this line format always ends with.
+    let end = rest.rfind(" (instance ")?;
+    let path = &rest[..end];
+    if path.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(path))
+}
+
+fn directory_size_bytes(dir: &Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    entries
+        .flatten()
+        .map(|entry| match entry.file_type() {
+            Ok(file_type) if file_type.is_dir() => directory_size_bytes(&entry.path()),
+            Ok(file_type) if file_type.is_file() => {
+                entry.metadata().map(|meta| meta.len()).unwrap_or(0)
+            }
+            _ => 0,
+        })
+        .sum()
+}
+
+/// Reclaim daemon state directories whose database is gone or was temporary.
+///
+/// The state directory is keyed by a hash of `--db` and created whenever a
+/// daemon auto-spawns. Because writes are daemon-routed, nearly any write-path
+/// test spawns one against its temp database, and nothing removed the directory
+/// when that database went away — 8,525 directories / 547 MB accumulated on one
+/// machine in about a month, exactly one of them live, while `daemon gc`
+/// reported "clean".
+///
+/// Fail-closed at every step. A directory is deleted only when its name matches
+/// the instance-id shape, its database was positively identified, that database
+/// is temporary or missing, and no live daemon holds its pidfile lock. Anything
+/// unreadable, unparseable, or ambiguous is kept.
+pub fn gc_orphaned_state_dirs() -> std::io::Result<StateDirGcReport> {
+    let root = persistent_state_root();
+    let mut report = StateDirGcReport::default();
+
+    let entries = match std::fs::read_dir(&root) {
+        Ok(entries) => entries,
+        // No state root yet is a clean machine, not a failure.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(report),
+        Err(error) => return Err(error),
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        // Allowlist first, before reading anything inside.
+        if !is_instance_dir_name(name) {
+            continue;
+        }
+        // symlink_metadata: never follow a symlink out of the state root.
+        match std::fs::symlink_metadata(&path) {
+            Ok(meta) if meta.file_type().is_dir() => {}
+            _ => continue,
+        }
+
+        let log = std::fs::read_to_string(path.join("daemon.log")).unwrap_or_default();
+        let Some(db_path) = db_path_from_daemon_log(&log) else {
+            report.unidentified.push(name.to_string());
+            continue;
+        };
+
+        if instance_daemon_is_live(name) {
+            report.spared.push(name.to_string());
+            continue;
+        }
+
+        if !(is_temp_db_path(&db_path) || !db_path.exists()) {
+            report.kept.push(name.to_string());
+            continue;
+        }
+
+        let size = directory_size_bytes(&path);
+        match std::fs::remove_dir_all(&path) {
+            Ok(()) => {
+                report.reclaimed_bytes += size;
+                report.removed.push(name.to_string());
+            }
+            // A directory that vanished under us needs no reporting; anything
+            // else stays visible as still present rather than silently counted.
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(_) => report.kept.push(name.to_string()),
+        }
+    }
+
+    report.removed.sort();
+    report.kept.sort();
+    report.spared.sort();
+    report.unidentified.sort();
+    Ok(report)
+}
+
 /// Launchd service label for the given instance.
 pub fn launchd_label(instance_id: &str) -> String {
     format!("io.kehl.nestweaver.{instance_id}")
@@ -2078,5 +2281,206 @@ mod tests {
             hint.contains(&log_dir("test1234").display().to_string()),
             "hint must name the directory holding both files: {hint}"
         );
+    }
+
+    /// Set BOTH XDG roots under one ENV_LOCK acquisition. Nesting
+    /// `with_xdg_state` inside `with_xdg_runtime` would deadlock: ENV_LOCK is a
+    /// plain std Mutex and is not reentrant.
+    fn with_xdg_state_and_runtime<T>(state: &Path, runtime: &Path, test: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let previous_state = std::env::var_os("XDG_STATE_HOME");
+        let previous_runtime = std::env::var_os("XDG_RUNTIME_DIR");
+        unsafe {
+            std::env::set_var("XDG_STATE_HOME", state);
+            std::env::set_var("XDG_RUNTIME_DIR", runtime);
+        }
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(test));
+        unsafe {
+            match previous_state {
+                Some(value) => std::env::set_var("XDG_STATE_HOME", value),
+                None => std::env::remove_var("XDG_STATE_HOME"),
+            }
+            match previous_runtime {
+                Some(value) => std::env::set_var("XDG_RUNTIME_DIR", value),
+                None => std::env::remove_var("XDG_RUNTIME_DIR"),
+            }
+        }
+        match result {
+            Ok(value) => value,
+            Err(panic) => std::panic::resume_unwind(panic),
+        }
+    }
+
+    /// Write a state directory as a real daemon boot would leave it.
+    fn seed_state_dir(instance: &str, db_path: &str) {
+        let dir = log_dir(instance);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("daemon.log"),
+            format!("[daemon] starting for {db_path} (instance label-{instance})\nDone: 2 notes\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn instance_dir_allowlist_admits_only_the_instance_id_shape() {
+        assert!(is_instance_dir_name("05c1b2b6"));
+        assert!(is_instance_dir_name("ffffffff"));
+        assert!(is_instance_dir_name("00000000"));
+        // The catastrophic one: the persisted-intent directory and its 64-hex
+        // database-fingerprint children must be structurally inexpressible.
+        assert!(!is_instance_dir_name("config-intent"));
+        assert!(!is_instance_dir_name(
+            "11f099ee842b018cde34fa942a9b537735ed79ee24a6e31fe59b00315ebee205"
+        ));
+        // Near misses.
+        assert!(
+            !is_instance_dir_name("05C1B2B6"),
+            "uppercase is not our shape"
+        );
+        assert!(!is_instance_dir_name("05c1b2b"), "7 chars");
+        assert!(!is_instance_dir_name("05c1b2b6a"), "9 chars");
+        assert!(!is_instance_dir_name("05c1b2g6"), "g is not hex");
+        assert!(!is_instance_dir_name(""));
+        assert!(!is_instance_dir_name(".."));
+    }
+
+    #[test]
+    fn db_path_is_recovered_from_the_daemon_log_boot_line() {
+        assert_eq!(
+            db_path_from_daemon_log(
+                "[daemon] starting for /tmp/x/test.lbug (instance x-05c1b2b6)\nDone: 2 notes\n"
+            ),
+            Some(PathBuf::from("/tmp/x/test.lbug"))
+        );
+        // A database path may itself contain the delimiter; the LAST occurrence
+        // is the real one.
+        assert_eq!(
+            db_path_from_daemon_log(
+                "[daemon] starting for /tmp/a (instance b)/t.lbug (instance x-05c1b2b6)\n"
+            ),
+            Some(PathBuf::from("/tmp/a (instance b)/t.lbug"))
+        );
+        // Unidentifiable inputs yield None, which makes a directory undeletable.
+        assert_eq!(db_path_from_daemon_log(""), None);
+        assert_eq!(db_path_from_daemon_log("Done: 2 notes\n"), None);
+        assert_eq!(
+            db_path_from_daemon_log("[daemon] starting for /tmp/x.lbug\n"),
+            None
+        );
+        assert_eq!(
+            db_path_from_daemon_log("[daemon] starting for  (instance x)\n"),
+            None
+        );
+    }
+
+    /// The regression guard the hazard section calls non-optional: a populated
+    /// `config-intent/` must survive `gc`. A hand-written `find … -exec rm -rf`
+    /// once deleted it for real, leaving the daemon with no persisted intent.
+    #[test]
+    fn gc_state_dirs_never_touches_config_intent() {
+        let state = tempfile::tempdir().unwrap();
+        let runtime = tempfile::tempdir().unwrap();
+        with_xdg_state_and_runtime(state.path(), runtime.path(), || {
+            let db = PathBuf::from("/tmp/gone-forever-12345/test.lbug");
+            let intent_dir = last_successful_config_dir(&db);
+            std::fs::create_dir_all(&intent_dir).unwrap();
+            let intent_file = intent_dir.join("last-successful-config.json");
+            std::fs::write(&intent_file, r#"{"version":1}"#).unwrap();
+
+            // An unambiguous orphan sits beside it so the sweep is not a no-op:
+            // a test that deletes nothing would "protect" config-intent trivially.
+            seed_state_dir("05c1b2b6", "/tmp/gone-forever-12345/test.lbug");
+
+            let report = gc_orphaned_state_dirs().unwrap();
+
+            assert_eq!(report.removed, vec!["05c1b2b6".to_string()]);
+            assert!(
+                intent_file.exists(),
+                "config-intent must survive gc — deleting it reproduces the \
+                 missing-intent failure this sweep is supposed to avoid"
+            );
+            assert_eq!(
+                std::fs::read_to_string(&intent_file).unwrap(),
+                r#"{"version":1}"#
+            );
+        });
+    }
+
+    #[test]
+    fn gc_state_dirs_reaps_orphans_keeps_live_databases_and_reports_unidentified() {
+        let state = tempfile::tempdir().unwrap();
+        let runtime = tempfile::tempdir().unwrap();
+        with_xdg_state_and_runtime(state.path(), runtime.path(), || {
+            // Reaped: database path is gone.
+            seed_state_dir("aaaaaaaa", "/nonexistent-root-98765/brain.lbug");
+            // Reaped: temp database, whether or not it still exists.
+            seed_state_dir("bbbbbbbb", "/tmp/ephemeral-54321/test.lbug");
+            // Kept: the database still exists at a NON-temp path. It must be
+            // outside any tempdir — a `tempfile::tempdir()` lives under /tmp, so
+            // the temp rule would reap it and this case would prove nothing.
+            // The sweep only calls `.exists()`, so any stable real file serves.
+            let live_db = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+            assert!(live_db.exists() && !is_temp_db_path(&live_db));
+            seed_state_dir("cccccccc", live_db.to_str().unwrap());
+            // Kept and REPORTED: no boot line, so the database cannot be named.
+            let unknown = log_dir("dddddddd");
+            std::fs::create_dir_all(&unknown).unwrap();
+            std::fs::write(unknown.join("daemon.log"), "rotated away\n").unwrap();
+
+            let report = gc_orphaned_state_dirs().unwrap();
+
+            assert_eq!(
+                report.removed,
+                vec!["aaaaaaaa".to_string(), "bbbbbbbb".to_string()]
+            );
+            assert_eq!(report.kept, vec!["cccccccc".to_string()]);
+            assert_eq!(report.unidentified, vec!["dddddddd".to_string()]);
+            assert!(
+                report.reclaimed_bytes > 0,
+                "reclaimed bytes must be reported"
+            );
+            assert!(!log_dir("aaaaaaaa").exists());
+            assert!(!log_dir("bbbbbbbb").exists());
+            assert!(
+                log_dir("cccccccc").exists(),
+                "a live database keeps its logs"
+            );
+            assert!(unknown.exists(), "unidentifiable means undeletable");
+        });
+    }
+
+    /// Never reap a live daemon's directory, even when its database path is
+    /// gone — an unmounted volume must not cost a healthy daemon its logs.
+    #[cfg(unix)]
+    #[test]
+    fn gc_state_dirs_spares_a_directory_whose_daemon_holds_the_pidfile_lock() {
+        use std::os::unix::io::AsRawFd;
+        let state = tempfile::tempdir().unwrap();
+        let runtime = tempfile::tempdir().unwrap();
+        with_xdg_state_and_runtime(state.path(), runtime.path(), || {
+            seed_state_dir("eeeeeeee", "/nonexistent-root-24680/brain.lbug");
+            let pidfile = pidfile_path("eeeeeeee");
+            std::fs::create_dir_all(pidfile.parent().unwrap()).unwrap();
+            std::fs::write(&pidfile, "12345\n").unwrap();
+            let held = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&pidfile)
+                .unwrap();
+            // A separate file description, so the sweep's LOCK_NB attempt
+            // genuinely contends the way another process would.
+            assert_eq!(unsafe { libc::flock(held.as_raw_fd(), libc::LOCK_EX) }, 0);
+
+            let report = gc_orphaned_state_dirs().unwrap();
+
+            assert_eq!(report.spared, vec!["eeeeeeee".to_string()]);
+            assert!(report.removed.is_empty());
+            assert!(log_dir("eeeeeeee").exists());
+
+            unsafe {
+                libc::flock(held.as_raw_fd(), libc::LOCK_UN);
+            }
+        });
     }
 }

--- a/crates/nestweaver-engine/src/config.rs
+++ b/crates/nestweaver-engine/src/config.rs
@@ -222,6 +222,9 @@ pub struct InstanceConfig {
     /// Server-mode configuration (`[server]`).
     #[serde(default)]
     pub server: ServerConfig,
+    /// Daemon lifecycle policy (`[daemon]`).
+    #[serde(default)]
+    pub daemon: DaemonConfig,
     /// Local embedding model and hybrid-search blend configuration (`[embedding]`).
     #[serde(default)]
     pub embedding: EmbeddingConfig,
@@ -711,6 +714,20 @@ pub struct ServerConfig {
     pub indexing: IndexingConfig,
 }
 
+/// `[daemon]` — daemon lifecycle policy.
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct DaemonConfig {
+    /// Emit `RunAtLoad` into the generated macOS launch agent, so the daemon
+    /// is *started* at login and not merely registered.
+    ///
+    /// Opt-in rather than defaulted on: `RunAtLoad` boots a daemon that loads
+    /// an embedding model at every login, including for sessions that never
+    /// touch NestWeaver. The one-hour idle exit bounds that cost but does not
+    /// remove it, so the choice belongs to the operator.
+    #[serde(default)]
+    pub start_at_login: bool,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct IndexingConfig {
     #[serde(default = "default_workers")]
@@ -1157,6 +1174,26 @@ credential_method = "ssh"
 [[repos]]
 url = "https://github.com/example/repo"
 "#;
+
+    #[test]
+    fn daemon_start_at_login_is_opt_in_and_absent_by_default() {
+        // No `[daemon]` section at all — the overwhelmingly common case, and
+        // the one that must not start booting a daemon at every login.
+        let default = InstanceConfig::from_toml_str(MINIMAL_TOML)
+            .expect("minimal config must parse without a [daemon] section");
+        assert!(!default.daemon.start_at_login);
+
+        // Section present but the key omitted.
+        let empty_section =
+            InstanceConfig::from_toml_str(&format!("{MINIMAL_TOML}\n[daemon]\n")).unwrap();
+        assert!(!empty_section.daemon.start_at_login);
+
+        let opted_in = InstanceConfig::from_toml_str(&format!(
+            "{MINIMAL_TOML}\n[daemon]\nstart_at_login = true\n"
+        ))
+        .expect("[daemon] start_at_login must be an accepted key");
+        assert!(opted_in.daemon.start_at_login);
+    }
 
     #[test]
     fn shipped_instance_configs_parse() {

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -2926,29 +2926,63 @@ where
         let contract_txn = store
             .begin_transaction()
             .context("begin full contract derivation transaction")?;
-        let contracts_derived =
-            match apply_contract_derivation_on(&contract_txn, &r_uid, &contract_plan) {
-                Ok(count) => count,
-                Err(error) => {
-                    drop(contract_txn);
-                    if let Err(marker_error) =
-                        store.set_contract_derivation_failed(&r_uid, &error.to_string())
-                    {
-                        tracing::warn!(
-                            "recording contract derivation failure failed: {marker_error}"
-                        );
-                    }
-                    return Err(error).context("apply full contract derivation");
-                }
-            };
-        store
-            .commit_transaction(&contract_txn)
-            .context("commit full contract derivation transaction")?;
+        // This transaction opens AFTER symbols, edges, and MEMBER_OF have
+        // already committed in their own transactions. Returning Err from here
+        // therefore reported a failed index over a fully written graph — the
+        // same "committed work reported as a failure" defect as a cancelled
+        // index, reached by a different door.
+        //
+        // Degrade instead of failing the run. The preflight parse phase
+        // (`prepare_contract_derivation`, before the write guard) still rejects
+        // a malformed spec with no graph mutation at all, so this path is only
+        // reached when the graph is already durable and the *contracts* alone
+        // could not be applied. Dropping the transaction leaves the previously
+        // derived contract graph intact, exactly as split 1 guaranteed.
+        //
+        // `set_contract_derivation_failed` already marks the repo and split 2
+        // already taught every consumer to read it, so a degraded-but-successful
+        // result reuses that vocabulary end to end rather than inventing a
+        // second way to say the same thing.
+        //
+        // The two incremental paths deliberately keep returning Err: their
+        // contract apply shares one transaction with their symbol writes and
+        // SHA update, so a failure there rolls the entire change back and
+        // commits nothing. Failing is honest for them; it is not honest here.
+        let contract_apply =
+            apply_contract_derivation_checked(&contract_txn, &r_uid, &contract_plan).and_then(
+                |count| {
+                    store
+                        .commit_transaction(&contract_txn)
+                        .context("commit full contract derivation transaction")?;
+                    Ok(count)
+                },
+            );
         drop(contract_txn);
-        if let Err(error) = store.clear_contract_derivation_failed(&r_uid) {
-            tracing::warn!("clearing contract derivation marker failed: {error}");
-        }
-        let contracts_status = crate::blast_radius::AnalysisStatus::Complete;
+        let (contracts_derived, contracts_status) = match contract_apply {
+            Ok(count) => {
+                if let Err(error) = store.clear_contract_derivation_failed(&r_uid) {
+                    tracing::warn!("clearing contract derivation marker failed: {error}");
+                }
+                (count, crate::blast_radius::AnalysisStatus::Complete)
+            }
+            Err(error) => {
+                if let Err(marker_error) =
+                    store.set_contract_derivation_failed(&r_uid, &error.to_string())
+                {
+                    tracing::warn!("recording contract derivation failure failed: {marker_error}");
+                }
+                // error!, not warn!: the index succeeds, so this line is the
+                // only place the failure is loud. The previous behavior at
+                // least surfaced a non-zero exit.
+                tracing::error!(
+                    error = %format!("{error:#}"),
+                    repo = %r_uid,
+                    "contract derivation failed; the graph is committed and this \
+                     repository is reported as degraded rather than failing the index"
+                );
+                (0, crate::blast_radius::AnalysisStatus::Degraded)
+            }
+        };
         tracing::info!(
             spec_files = spec_files.len(),
             handler_files = handler_files.len(),
@@ -3781,6 +3815,38 @@ fn prepare_contract_derivation(
         input_hashes,
         observed_input_hashes: std::collections::BTreeMap::new(),
     })
+}
+
+// Test seam for the post-write contract-apply failure path.
+//
+// Both production triggers were fixed (UID dedup and CSV dialect, #229) and the
+// strict preflight now rejects a malformed spec before any write, so there is no
+// longer a way to reach the degradation branch from a fixture. Without a seam
+// that branch would ship untested, which is the situation this whole item exists
+// to complain about.
+#[cfg(test)]
+thread_local! {
+    static FAIL_CONTRACT_APPLY: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Arm a one-shot injected failure for the next post-write contract apply.
+#[cfg(test)]
+pub(crate) fn fail_next_contract_apply() {
+    FAIL_CONTRACT_APPLY.with(|cell| cell.set(true));
+}
+
+/// [`apply_contract_derivation_on`], consulting the test seam first. A plain
+/// passthrough in non-test builds.
+fn apply_contract_derivation_checked(
+    conn: &nestweaver_store::DbConnection<'_>,
+    r_uid: &str,
+    plan: &ContractDerivationPlan,
+) -> Result<usize, anyhow::Error> {
+    #[cfg(test)]
+    if FAIL_CONTRACT_APPLY.with(|cell| cell.replace(false)) {
+        anyhow::bail!("injected post-write contract apply failure");
+    }
+    apply_contract_derivation_on(conn, r_uid, plan)
 }
 
 /// Replace one repo's derived contract graph on an existing transaction.
@@ -6814,6 +6880,84 @@ function hello(name) { return "Hello " + name; }
              }\n",
         )
         .unwrap();
+    }
+
+    /// A post-write contract-apply failure must DEGRADE, not fail the index.
+    ///
+    /// The preflight parse phase runs before the write guard, so a malformed
+    /// spec is rejected with no graph mutation at all (covered by
+    /// `degraded_contract_derivation_is_not_reported_clean`). This branch is
+    /// the other one: the graph has already committed in earlier transactions
+    /// and only the contracts could not be applied. Returning Err there
+    /// reported a failed index over a fully written graph — committed work
+    /// reported as a failure.
+    ///
+    /// The two incremental paths deliberately still fail: their contract apply
+    /// shares one transaction with their symbol writes and SHA update, so a
+    /// failure rolls the whole change back and commits nothing.
+    #[test]
+    fn post_write_contract_apply_failure_degrades_instead_of_failing_the_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("repo");
+        write_shared_route_repo(&src);
+
+        let store = GraphStore::in_memory().unwrap();
+        fail_next_contract_apply();
+        let result = reindex_into(&store, &src, "abc123")
+            .expect("a post-write contract failure must not fail the whole index");
+
+        // The index succeeded and says so honestly.
+        assert_eq!(
+            result.contracts_status,
+            crate::blast_radius::AnalysisStatus::Degraded,
+            "a failed contract apply must report degraded, not complete"
+        );
+        assert_eq!(
+            result.contracts_derived, 0,
+            "no contracts were applied, so none may be claimed"
+        );
+        // The work that DID commit is still there — that is the whole point of
+        // not failing the run.
+        assert!(
+            result.symbols_count > 0,
+            "symbols committed before the contract phase must survive"
+        );
+
+        let repo_uid = store
+            .list_repos(None)
+            .unwrap()
+            .into_iter()
+            .next()
+            .expect("the repo row must have been written")
+            .uid;
+
+        // Every downstream consumer must see the degradation, using split 2's
+        // vocabulary rather than a second way of saying the same thing.
+        let report = crate::contracts::drift_for_store(&store, Some(&repo_uid)).unwrap();
+        assert!(!report.is_clean(), "a degraded repo must not report clean");
+        assert_eq!(
+            report.contracts_status,
+            crate::blast_radius::AnalysisStatus::Degraded
+        );
+        assert_eq!(report.degraded_repos, vec![repo_uid.clone()]);
+        let envelope = crate::contracts::drift_envelope(report, 50);
+        assert_eq!(envelope["clean"], serde_json::json!(false));
+        assert_eq!(envelope["contracts_status"], serde_json::json!("degraded"));
+
+        // A later healthy index clears the marker: degradation is a state, not
+        // a permanent stain.
+        let healthy = reindex_into(&store, &src, "def456").expect("healthy reindex must succeed");
+        assert_eq!(
+            healthy.contracts_status,
+            crate::blast_radius::AnalysisStatus::Complete
+        );
+        assert!(healthy.contracts_derived > 0);
+        assert!(
+            crate::contracts::drift_for_store(&store, Some(&repo_uid))
+                .unwrap()
+                .is_clean(),
+            "a successful re-index must clear the degradation marker"
+        );
     }
 
     /// A malformed recognized spec fails before graph/SHA publication, retains

--- a/crates/nestweaver-engine/src/snapshot.rs
+++ b/crates/nestweaver-engine/src/snapshot.rs
@@ -807,6 +807,12 @@ pub fn schema_hashes(cfg: Option<&crate::config::InstanceConfig>) -> (String, St
 mod tests {
     use super::*;
 
+    /// The last engine release before the v2 snapshot floor was raised. A
+    /// historical fact, so it is correctly a literal — unlike the *current*
+    /// reader, which must track `MIN_SNAPSHOT_READER_VERSION` or these tests
+    /// break at every release that raises the floor.
+    const PRE_V2_READER: &str = "4.1.0";
+
     fn make_stamp(
         engine_version: &str,
         min_compatible: &str,
@@ -1169,8 +1175,14 @@ mod tests {
         verify_snapshot(&snap_dir).unwrap();
 
         let work = dir.path().join("work");
-        let materialized =
-            materialize_snapshot_with_config(&snap_dir, &work, "4.1.0", None, None).unwrap();
+        let materialized = materialize_snapshot_with_config(
+            &snap_dir,
+            &work,
+            MIN_SNAPSHOT_READER_VERSION,
+            None,
+            None,
+        )
+        .unwrap();
         let replica = nestweaver_store::GraphStore::open_read_only(&materialized).unwrap();
         assert_eq!(replica.embedding_count(), 2);
         assert_eq!(replica.embedding_dimension().unwrap(), 3);
@@ -1194,10 +1206,15 @@ mod tests {
         assert_eq!(stamp.format_version, SNAPSHOT_FORMAT_VERSION);
         assert_eq!(stamp.min_compatible_engine, MIN_SNAPSHOT_READER_VERSION);
         assert!(
-            !semver_ge("4.1.0", &stamp.min_compatible_engine),
-            "the last pre-v2 reader must reject the raised compatibility floor"
+            !semver_ge(PRE_V2_READER, &stamp.min_compatible_engine),
+            "the last pre-v2 reader must sit below the raised compatibility floor"
         );
-        load_snapshot_with_config(&snap_dir, "4.1.0", None, None)
+        // Assert the fence actually FENCES. Previously this test only checked
+        // the semver relation and then expected the same old reader to load,
+        // which is self-contradictory the moment the floor rises past it.
+        load_snapshot_with_config(&snap_dir, PRE_V2_READER, None, None)
+            .expect_err("a pre-v2 reader must be refused by the raised floor");
+        load_snapshot_with_config(&snap_dir, MIN_SNAPSHOT_READER_VERSION, None, None)
             .expect("the v2-capable reader must accept the v2 snapshot it wrote");
     }
 
@@ -1214,7 +1231,16 @@ mod tests {
         std::fs::write(work.join("sentinel"), b"old replica").unwrap();
         std::fs::write(snap_dir.join(GRAPH_FILE), b"tampered").unwrap();
 
-        assert!(materialize_snapshot_with_config(&snap_dir, &work, "4.1.0", None, None).is_err());
+        assert!(
+            materialize_snapshot_with_config(
+                &snap_dir,
+                &work,
+                MIN_SNAPSHOT_READER_VERSION,
+                None,
+                None
+            )
+            .is_err()
+        );
         assert_eq!(
             std::fs::read(work.join("sentinel")).unwrap(),
             b"old replica"
@@ -1241,7 +1267,7 @@ mod tests {
         let error = materialize_snapshot_with_config_and_hook(
             &snap_dir,
             &work,
-            "4.1.0",
+            MIN_SNAPSHOT_READER_VERSION,
             None,
             None,
             || std::fs::write(snap_dir.join(GRAPH_FILE), b"changed after verification").unwrap(),
@@ -1293,21 +1319,28 @@ mod tests {
         let db = make_test_db(dir.path());
         let core = make_stamp("4.1.0", "0.11.0", "core-effective", "");
         build_snapshot(&core_dir, &core, &make_manifest(), &db).unwrap();
-        load_snapshot_with_config(&core_dir, "4.1.0", None, None).unwrap();
+        load_snapshot_with_config(&core_dir, MIN_SNAPSHOT_READER_VERSION, None, None).unwrap();
 
         let extension_dir = dir.path().join("extension");
         let mut extension = core;
         extension.schema_hash_extensions = "extension-hash".to_string();
         extension.schema_hash_effective = "extension-effective".to_string();
         build_snapshot(&extension_dir, &extension, &make_manifest(), &db).unwrap();
-        let error = load_snapshot_with_config(&extension_dir, "4.1.0", None, None).unwrap_err();
+        let error =
+            load_snapshot_with_config(&extension_dir, MIN_SNAPSHOT_READER_VERSION, None, None)
+                .unwrap_err();
         assert!(
             error
                 .to_string()
                 .contains("requires the matching instance config")
         );
-        load_snapshot_with_config(&extension_dir, "4.1.0", Some("extension-effective"), None)
-            .unwrap();
+        load_snapshot_with_config(
+            &extension_dir,
+            MIN_SNAPSHOT_READER_VERSION,
+            Some("extension-effective"),
+            None,
+        )
+        .unwrap();
     }
 
     #[test]

--- a/docs/guide/instance-config.md
+++ b/docs/guide/instance-config.md
@@ -250,6 +250,30 @@ pin_sha = "abc123"    # optional: pin to a specific commit
 
 ### Optional sections
 
+#### `[daemon]` — Daemon lifecycle policy
+
+```toml
+[daemon]
+# macOS only. Emit RunAtLoad into the generated launch agent so the daemon
+# is *started* at login, not merely registered. Off by default.
+start_at_login = false  # default
+```
+
+Without `RunAtLoad`, launchd registers the agent at login but never starts it.
+`nestweaver daemon start` compensates with an explicit `launchctl kickstart`,
+which covers install time but **not a reboot** — after restarting, the daemon
+comes back only if something else starts it (typically the desktop app running
+as a login item). If you use the CLI or MCP without the app, enable this.
+
+It is opt-in rather than on by default because `RunAtLoad` boots a daemon that
+loads an embedding model at *every* login, including sessions that never touch
+NestWeaver. The one-hour idle exit bounds that cost but does not remove it.
+
+The setting is read from the config the launch agent will run with, so it only
+takes effect on a `daemon start` that was passed a `--config` (directly or via
+persisted config intent). Do not hand-edit the generated plist: every
+`daemon start` overwrites it with generated content.
+
 #### `[pr_impact]` — Pre-push / CI strict-gate policy
 
 Controls what `nestweaver pr-impact --strict` (and the strict `hooks --install

--- a/src/main.rs
+++ b/src/main.rs
@@ -3181,6 +3181,15 @@ enum DaemonAction {
         /// parity to the direct-disk CLI path.
         #[arg(long)]
         config: Option<PathBuf>,
+        /// Reset this database to compiled defaults, discarding the persisted
+        /// startup-intent record.
+        ///
+        /// Without this flag a configless start REUSES the last configuration
+        /// that reached readiness, so the app and a hand-typed `daemon start`
+        /// no longer silently drop to compiled defaults. Reset is an explicit
+        /// request rather than the accidental default.
+        #[arg(long, conflicts_with = "config")]
+        reset: bool,
         /// Hidden: redirect users who pass this flag here to the correct command.
         #[arg(long, hide = true)]
         track_interactions: bool,
@@ -11472,6 +11481,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 DaemonAction::Start {
                     idle_timeout,
                     config,
+                    reset,
                     track_interactions,
                 } => {
                     // Serialize every direct start from incumbent preflight
@@ -11491,12 +11501,51 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     }
                     // Validate before any platform-specific stop/install or
                     // daemonize mutation. A bad explicit path must leave an
-                    // already-running daemon untouched. `None` intentionally
-                    // means compiled defaults here: manual `daemon start` is
-                    // the reset path, while automatic parents have already
-                    // resolved persisted intent and pass it as `--config`.
-                    let requested_start_config =
-                        nestweaver_client::RestartConfig::for_cold_start(config.as_deref())?;
+                    // already-running daemon untouched.
+                    //
+                    // A configless start now REUSES the persisted intent rather
+                    // than meaning "compiled defaults". Resolving here — not
+                    // only in the client-side autostart wrapper — is what makes
+                    // the invariant hold at the boundary, so the desktop app's
+                    // bare `daemon start` and a hand-typed one behave alike.
+                    // Reset survives as `--reset`, an explicit request.
+                    let requested_start_config = if reset {
+                        // `--reset` conflicts with `--config` at the clap layer,
+                        // so this is unambiguously "compiled defaults".
+                        nestweaver_client::RestartConfig::CompiledDefaults
+                    } else {
+                        nestweaver_client::RestartConfig::for_automatic_cold_start(
+                            &db_path,
+                            config.as_deref(),
+                        )?
+                    };
+                    // Discard the record BEFORE spawning, not after attestation.
+                    // The child `daemon run` resolves intent itself, so a record
+                    // still on disk when it boots would make it come up
+                    // configured while this parent cleared the record behind it
+                    // — a reset that resets nothing this boot and everything the
+                    // next. An explicit `--reset` is exactly the case where
+                    // losing the record is the requested outcome, so the
+                    // post-attestation caution that protects an accidental
+                    // configless start does not apply.
+                    if reset {
+                        nestweaver_daemon::lifecycle::remove_last_successful_config(&db_path)
+                            .context("discard persisted startup intent for --reset")?;
+                    }
+                    // The config the child actually boots with. Everything that
+                    // SPAWNS or PERSISTS uses this; the incumbent-assertion
+                    // checks below deliberately keep using the explicit CLI arg,
+                    // because "I passed --config X" is a claim about the running
+                    // daemon and a reused record is not such a claim.
+                    //
+                    // Spawning with the raw arg instead is a real failure, not a
+                    // tidiness point: the parent captures `requested_start_config`
+                    // and attests the child against it, so a child booted from
+                    // `None` comes up CompiledDefaults and the start dies with
+                    // "replacement daemon effective config ... does not match
+                    // captured restart config".
+                    let effective_config: Option<PathBuf> =
+                        requested_start_config.as_path().map(PathBuf::from);
                     std::fs::create_dir_all(&runtime_dir).with_context(|| {
                         format!("create runtime dir: {}", runtime_dir.display())
                     })?;
@@ -11532,6 +11581,10 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 .ok()
                                 .filter(|v| v.trim().parse::<u32>().is_ok());
                             let config_abs = config.as_deref().map(abs_for_daemon);
+                            // The resolved config the agent will boot with —
+                            // may come from the persisted record, not the CLI.
+                            let effective_config_abs =
+                                effective_config.as_deref().map(abs_for_daemon);
                             let pre_start_pid = nestweaver_client::autostart::read_pid(&pidfile);
 
                             // A configless manual start is a reset only when it
@@ -11595,8 +11648,49 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                         return Ok((EXIT_SUCCESS, None));
                                     }
                                     Err(error) if launchd_owned || live_pidfile => {
-                                        return Err(error).context(
-                                            "refusing to stop a launchd/pidfile-owned incumbent before explicit --config provenance is verified",
+                                        // Self-heal. An incumbent attesting
+                                        // CompiledDefaults provenance IS the bad
+                                        // state this item exists to fix, and
+                                        // refusing here is what made it sticky:
+                                        // recovery needed a manual `daemon stop`
+                                        // first. Displace it instead.
+                                        //
+                                        // Everything else still refuses. A
+                                        // configured incumbent is someone else's
+                                        // deliberate state, and provenance we
+                                        // cannot read is not permission to kill
+                                        // — both fail closed, so any error or
+                                        // missing binding leaves it untouched.
+                                        let incumbent_is_compiled_defaults = (|| {
+                                            let rt = tokio::runtime::Runtime::new().ok()?;
+                                            let health = rt
+                                                .block_on(
+                                                    nestweaver_client::DaemonClient::wait_healthy(
+                                                        &db_path_abs,
+                                                        nestweaver_client::autostart::daemon_boot_timeout(),
+                                                    ),
+                                                )
+                                                .ok()?;
+                                            let binding = nestweaver_daemon::lifecycle::
+                                                read_effective_config_binding_for_verified_pid(
+                                                    &instance_id,
+                                                    health.pid,
+                                                )
+                                                .ok()?;
+                                            Some(matches!(
+                                                binding.effective_config,
+                                                nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::CompiledDefaults
+                                            ))
+                                        })()
+                                        .unwrap_or(false);
+
+                                        if !incumbent_is_compiled_defaults {
+                                            return Err(error).context(
+                                                "refusing to stop a launchd/pidfile-owned incumbent before explicit --config provenance is verified",
+                                            );
+                                        }
+                                        eprintln!(
+                                            "Replacing a compiled-defaults daemon with the requested configuration."
                                         );
                                     }
                                     Err(_) => {
@@ -11612,7 +11706,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 &db_path_abs,
                                 &log_file,
                                 index_cpu_percent.as_deref(),
-                                config_abs.as_deref(),
+                                effective_config_abs.as_deref(),
                             );
 
                             // Clean up any existing agent or fork-based daemon
@@ -11724,7 +11818,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         let executable =
                             std::env::current_exe().context("cannot determine binary path")?;
                         let db_path_abs = abs_for_daemon(&db_path);
-                        let config_abs = config.as_deref().map(abs_for_daemon);
+                        let config_abs = effective_config.as_deref().map(abs_for_daemon);
                         let pre_start_pid = nestweaver_client::autostart::read_pid(&pidfile);
                         let mut child = macos_temp_daemon_command(
                             &executable,
@@ -11975,7 +12069,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 };
                                 let rt = tokio::runtime::Runtime::new()
                                     .expect("failed to create tokio runtime");
-                                let config_path = config.clone();
+                                let config_path = effective_config.clone();
                                 rt.block_on(async {
                                     if let Err(e) = nestweaver_daemon::run_server(
                                         &db_path,
@@ -12112,11 +12206,33 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     } else {
                         None
                     };
+                    // The foreground process launchd executes. A plist written
+                    // before this change — or by any caller that did not resolve
+                    // intent — carries no `--config`, and with RunAtLoad this is
+                    // now the primary path at login. Resolving here means the
+                    // record is honored even when nothing rewrote the plist.
+                    //
+                    // No `--reset` twin: `daemon start --reset` discards the
+                    // record, after which there is nothing here to honor. That
+                    // keeps reset expressible in exactly one place.
+                    let effective_config =
+                        nestweaver_client::RestartConfig::for_automatic_cold_start(
+                            &db_path,
+                            config.as_deref(),
+                        )?;
+                    if config.is_none()
+                        && let Some(resolved) = effective_config.as_path()
+                    {
+                        tracing::info!(
+                            config = %resolved.display(),
+                            "honoring persisted startup intent (no --config supplied)"
+                        );
+                    }
                     rt.block_on(async {
                         nestweaver_daemon::run_server(
                             &db_path,
                             idle,
-                            config.as_deref(),
+                            effective_config.as_path(),
                             server_opts,
                         )
                         .await
@@ -13360,7 +13476,7 @@ fn ensure_direct_store_fallback_allowed(
     match nestweaver_client::RestartConfig::for_automatic_cold_start(db_path, None)? {
         nestweaver_client::RestartConfig::CompiledDefaults => Ok(()),
         nestweaver_client::RestartConfig::Configured(config) => anyhow::bail!(
-            "persisted daemon config {} for {} cannot be honored by the direct store, which refuses to fall back. Retry the daemon or deliberately reset with `nestweaver daemon --db {} start`",
+            "persisted daemon config {} for {} cannot be honored by the direct store, which refuses to fall back. Retry the daemon or deliberately reset with `nestweaver daemon --db {} start --reset`",
             config.display(),
             db_path.display(),
             db_path.display()
@@ -22100,6 +22216,67 @@ mod cli_bounds_tests {
                         assert!(Cli::try_parse_from(&argv).is_ok(), "{argv:?} must parse");
                     }
                 }
+            })
+            .expect("spawn")
+            .join()
+            .expect("join");
+    }
+
+    /// `daemon start --reset` is the ONLY way to ask for compiled defaults now
+    /// that a configless start reuses persisted intent. `--reset --config` is
+    /// a contradiction — "reset to defaults" and "use this config" cannot both
+    /// hold — and must be rejected at parse time rather than silently resolved
+    /// in favor of one of them.
+    #[test]
+    fn daemon_start_reset_is_parseable_and_conflicts_with_config() {
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                let base = ["nestweaver", "daemon", "--db", "/tmp/x.lbug", "start"];
+
+                let plain = Cli::try_parse_from(base).expect("bare start must parse");
+                assert!(matches!(
+                    plain.command,
+                    Commands::Daemon {
+                        action: DaemonAction::Start {
+                            reset: false,
+                            config: None,
+                            ..
+                        },
+                        ..
+                    }
+                ));
+
+                let mut reset_argv = base.to_vec();
+                reset_argv.push("--reset");
+                let reset = Cli::try_parse_from(&reset_argv).expect("--reset must parse");
+                assert!(matches!(
+                    reset.command,
+                    Commands::Daemon {
+                        action: DaemonAction::Start {
+                            reset: true,
+                            config: None,
+                            ..
+                        },
+                        ..
+                    }
+                ));
+
+                let mut both = base.to_vec();
+                both.extend(["--reset", "--config", "/tmp/instance.toml"]);
+                assert!(
+                    Cli::try_parse_from(&both).is_err(),
+                    "--reset with --config is contradictory and must be rejected"
+                );
+
+                // The reverse order must be rejected too — conflict rules are
+                // not order-sensitive, and a user could type either.
+                let mut both_reversed = base.to_vec();
+                both_reversed.extend(["--config", "/tmp/instance.toml", "--reset"]);
+                assert!(
+                    Cli::try_parse_from(&both_reversed).is_err(),
+                    "--config with --reset is contradictory and must be rejected"
+                );
             })
             .expect("spawn")
             .join()

--- a/src/main.rs
+++ b/src/main.rs
@@ -11532,6 +11532,29 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 .ok()
                                 .filter(|v| v.trim().parse::<u32>().is_ok());
                             let config_abs = config.as_deref().map(abs_for_daemon);
+                            // Without RunAtLoad launchd only *registers* the
+                            // agent at login; `install_and_start` kickstarts it
+                            // here, but nothing does after a reboot. Opt in via
+                            // `[daemon] start_at_login` in the very config this
+                            // agent will run with — a configless start has
+                            // nowhere to express the intent, so it stays off.
+                            // Already parsed once by `for_cold_start`, so this
+                            // re-read cannot be the first place a bad config is
+                            // noticed; it still fails closed if it were.
+                            let start_at_login = match config_abs.as_deref() {
+                                Some(path) => {
+                                    nestweaver_engine::InstanceConfig::from_file(path)
+                                        .with_context(|| {
+                                            format!(
+                                                "read [daemon] start_at_login from {}",
+                                                path.display()
+                                            )
+                                        })?
+                                        .daemon
+                                        .start_at_login
+                                }
+                                None => false,
+                            };
                             let pre_start_pid = nestweaver_client::autostart::read_pid(&pidfile);
 
                             // A configless manual start is a reset only when it
@@ -11613,6 +11636,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 &log_file,
                                 index_cpu_percent.as_deref(),
                                 config_abs.as_deref(),
+                                start_at_login,
                             );
 
                             // Clean up any existing agent or fork-based daemon

--- a/src/main.rs
+++ b/src/main.rs
@@ -12447,7 +12447,49 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         }
                     }
                     #[cfg(not(target_os = "macos"))]
-                    println!("daemon gc is a no-op here (launchd is macOS-only).");
+                    println!("No launch agents to sweep (launchd is macOS-only).");
+
+                    // State directories accumulate on EVERY platform: one is
+                    // created whenever a daemon auto-spawns, and nothing removed
+                    // it when the database went away. Reporting "clean" while
+                    // thousands sat beside the agents was the actual defect.
+                    let state = nestweaver_daemon::lifecycle::gc_orphaned_state_dirs()
+                        .context("sweep orphaned daemon state directories")?;
+                    if state.removed.is_empty() {
+                        println!(
+                            "No orphaned state directories found ({} kept, {} spared, {} unidentified).",
+                            state.kept.len(),
+                            state.spared.len(),
+                            state.unidentified.len()
+                        );
+                    } else {
+                        println!(
+                            "Removed {} orphaned state director(ies), reclaiming {}; \
+                             kept {}, spared {}, {} unidentified.",
+                            state.removed.len(),
+                            format_bytes(state.reclaimed_bytes),
+                            state.kept.len(),
+                            state.spared.len(),
+                            state.unidentified.len()
+                        );
+                    }
+                    if !state.spared.is_empty() {
+                        println!(
+                            "  spared (live daemon holds the pidfile lock): {}",
+                            state.spared.len()
+                        );
+                    }
+                    // Surfaced rather than folded into "kept": these are
+                    // directories the sweep could not identify, so they will
+                    // never be reclaimed until something can name their
+                    // database. Silence here would be the same dishonesty this
+                    // item exists to fix.
+                    if !state.unidentified.is_empty() {
+                        println!(
+                            "  left alone (database not identifiable from daemon.log): {}",
+                            state.unidentified.len()
+                        );
+                    }
                     Ok((EXIT_SUCCESS, None))
                 }
 

--- a/tests/bench_gating_test.rs
+++ b/tests/bench_gating_test.rs
@@ -1,0 +1,84 @@
+//! Guard: bench targets must not gate their bodies behind `cfg(not(test))`.
+//!
+//! Cargo compiles `harness = false` bench targets **with `--cfg test`**, so the
+//! `#[cfg(not(test))]` + `#[cfg(test)] fn main() {}` idiom compiles the real
+//! body out and runs the stub instead. Three of the four benches did exactly
+//! that: they exited 0 having measured nothing, and `just bench` reported a
+//! clean run. `test = false` does not prevent it — the behavior is cargo's.
+//!
+//! A silent no-op that presents as a passing benchmark run is worse than having
+//! no benchmark, because it launders the absence of a measurement into apparent
+//! success. This test fails if the idiom returns.
+
+use std::path::Path;
+
+/// Every `.rs` file under `benches/`, as (filename, contents).
+fn bench_sources() -> Vec<(String, String)> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("benches");
+    let mut sources: Vec<(String, String)> = std::fs::read_dir(&dir)
+        .expect("benches/ must exist")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "rs"))
+        .map(|path| {
+            let name = path.file_name().unwrap().to_string_lossy().into_owned();
+            let body = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            (name, body)
+        })
+        .collect();
+    sources.sort();
+    assert!(
+        !sources.is_empty(),
+        "benches/ contained no .rs files — this guard would silently pass"
+    );
+    sources
+}
+
+#[test]
+fn no_bench_gates_its_body_behind_cfg_not_test() {
+    let mut offenders = Vec::new();
+    for (name, body) in bench_sources() {
+        for (index, line) in body.lines().enumerate() {
+            // Match the ATTRIBUTE, not prose: remove_repo_benchmarks.rs
+            // documents this very idiom in its `//!` header, and that
+            // explanation must stay.
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("#[cfg(not(test))]") || trimmed.starts_with("#[cfg(test)]") {
+                offenders.push(format!("{name}:{}: {}", index + 1, line.trim()));
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "bench targets must not use cfg(test) gating — cargo compiles \
+         `harness = false` benches with `--cfg test`, so these compile to \
+         empty stubs that report success having measured nothing:\n  {}",
+        offenders.join("\n  ")
+    );
+}
+
+/// The stub `main` is the visible half of the same defect: with the gating
+/// removed but an empty `fn main() {}` left behind, the bench still measures
+/// nothing.
+#[test]
+fn no_bench_defines_an_empty_main() {
+    let mut offenders = Vec::new();
+    for (name, body) in bench_sources() {
+        // Strip comments before matching: remove_repo_benchmarks.rs quotes
+        // `#[cfg(test)] fn main() {}` verbatim in its header to explain the
+        // defect, and that prose is not an offense.
+        let code: String = body
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        if code.replace([' ', '\n'], "").contains("fnmain(){}") {
+            offenders.push(name);
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "these benches define an empty `fn main() {{}}` and measure nothing: {offenders:?}"
+    );
+}

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -1482,6 +1482,119 @@ fn daemon_crash_recovery() {
         .stdout(contains("running").and(contains("PID")));
 }
 
+/// A configless `daemon start` must REUSE the last configuration that reached
+/// readiness instead of silently resetting to compiled defaults.
+///
+/// This is the boundary invariant. Before it, "preserve config across cold
+/// starts" was a property of the client-side autostart wrapper only: the
+/// desktop app issues a bare `daemon start`, so it booted a compiled-defaults
+/// daemon whose `data_instance_id` collapsed to the database-path hash.
+/// Project-scoped queries then returned nothing while plain search still looked
+/// fine — a silent failure reported as success.
+///
+/// Reset stays available, but only as an explicit `--reset`.
+#[cfg(target_os = "linux")]
+#[test]
+fn daemon_configless_start_reuses_persisted_config_intent_until_reset() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_dir = dir.path().join("repo");
+    let db_path = dir.path().join("intent-boundary").join("test.lbug");
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+    write_test_repo(&repo_dir);
+    create_db(&repo_dir, &db_path);
+    let _guard = DaemonGuard::new(&db_path);
+
+    let config = dir.path().join("pinned.toml");
+    std::fs::write(
+        &config,
+        format!(
+            r#"
+instance_id = "intent-boundary"
+repos = []
+
+[snapshot_storage]
+backend = "local"
+path = "{}"
+
+[workspace]
+backend = "local"
+path = "{}"
+
+[inference]
+endpoint = "http://localhost:11434"
+embedding_model = "nomic-embed-text"
+summary_model = "qwen2.5-coder:7b"
+
+[git]
+credential_method = "gh"
+"#,
+            dir.path().join("snapshots").display(),
+            dir.path().join("workspace").display()
+        ),
+    )
+    .unwrap();
+    let canonical = std::fs::canonicalize(&config).unwrap();
+
+    let status = || {
+        let output = daemon_action_cmd(&db_path, "status").output().unwrap();
+        assert!(output.status.success(), "status failed: {output:?}");
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    };
+    let intent_record = nestweaver_daemon::lifecycle::last_successful_config_path(&db_path);
+
+    // Establish the intent: one configured start that reaches readiness.
+    daemon_action_cmd(&db_path, "start")
+        .arg("--config")
+        .arg(&config)
+        .assert()
+        .success();
+    assert!(
+        status().contains(&format!("Config: {}", canonical.display())),
+        "configured start must report its config"
+    );
+    assert!(
+        intent_record.exists(),
+        "a configured start that reached readiness must persist its intent"
+    );
+    stop_daemon(&db_path);
+
+    // The regression this item exists to fix: a bare start — exactly what the
+    // desktop app issues — must come back configured, not defaulted.
+    daemon_action_cmd(&db_path, "start").assert().success();
+    assert!(
+        status().contains(&format!("Config: {}", canonical.display())),
+        "a configless start must reuse persisted intent rather than reset to \
+         compiled defaults — got: {}",
+        status()
+    );
+    stop_daemon(&db_path);
+
+    // Reset remains possible, but only when asked for explicitly.
+    daemon_action_cmd(&db_path, "start")
+        .arg("--reset")
+        .assert()
+        .success();
+    let after_reset = status();
+    assert!(
+        !after_reset.contains(&format!("Config: {}", canonical.display())),
+        "--reset must drop the pinned config — got: {after_reset}"
+    );
+    assert!(
+        !intent_record.exists(),
+        "--reset must discard the persisted intent record"
+    );
+    stop_daemon(&db_path);
+
+    // And the reset must STICK. With the record gone there is nothing left to
+    // honor, so the next bare start stays on compiled defaults rather than
+    // resurrecting the old config.
+    daemon_action_cmd(&db_path, "start").assert().success();
+    assert!(
+        !status().contains(&format!("Config: {}", canonical.display())),
+        "a reset must not be undone by the next configless start"
+    );
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn daemon_restart_preserves_and_overrides_live_effective_config_without_early_shutdown() {
@@ -1928,11 +2041,20 @@ credential_method = "gh"
     let persisted = nestweaver_daemon::lifecycle::read_last_successful_config(&db_path).unwrap();
     assert_eq!(Path::new(&persisted.config_path), canonical_b);
 
-    // Once cold, the same explicit manual invocation is the reset escape
-    // hatch. It bypasses persisted intent and clears it only after the new
-    // default daemon is healthy and attested.
+    // Once cold, reset is still the escape hatch — but it is now an explicit
+    // `--reset` rather than a bare `start`. A configless start reuses persisted
+    // intent at the daemon boundary (see
+    // `daemon_configless_start_reuses_persisted_config_intent_until_reset`),
+    // because the desktop app issues exactly that command and was silently
+    // resetting configured databases to compiled defaults. Making a bare start
+    // reuse intent is the fix; it forces reset to become something a user asks
+    // for. Intent is still cleared only after the new default daemon is
+    // healthy and attested.
     daemon_action_cmd(&db_path, "stop").assert().success();
-    daemon_action_cmd(&db_path, "start").assert().success();
+    daemon_action_cmd(&db_path, "start")
+        .arg("--reset")
+        .assert()
+        .success();
     assert!(status().contains("Config: none"));
     assert!(matches!(
         nestweaver_daemon::lifecycle::read_last_successful_config(&db_path),


### PR DESCRIPTION
Consolidates the four post-v4.1.1 backlog items from Waves 1 and 2. Each was
developed and verified on its own branch, then merged here so CI runs once.

| Commit | Item |
| --- | --- |
| `1080cc8` | Emit `RunAtLoad` in the generated launch agent, opt-in |
| `46c621f` | Un-stub three benches that measured nothing |
| `23af6bf` | Honor persisted config intent at the daemon boundary |
| `bcd8307` | Sweep orphaned daemon state directories |

Ordering is a real dependency chain, not preference: `RunAtLoad` is what makes
login a race, so it precedes the config-intent fix; the gc allowlist had to be
written against settled config-intent semantics, so it follows it.

## What each one fixes

**`RunAtLoad`** — the generated plist had no `RunAtLoad`, so launchd *registered*
the agent at login but never started it. `install_and_start` compensated with an
explicit `kickstart`, which covers install time but not a reboot. Hand-edits
didn't survive, because every `daemon start` overwrites the plist. Gated on an
opt-in `[daemon] start_at_login`; when off the key is omitted entirely rather
than written as `<false/>`, so untouched machines get a byte-identical plist.

**Bench harness** — cargo compiles `harness = false` benches with `--cfg test`,
so the `#[cfg(not(test))]` + stub-`main` idiom compiled the real bodies out.
Three of four targets exited 0 having measured nothing and `just bench` reported
a clean run. Index performance, embed latency, and remove-repo fix ordering have
all been unmeasurable without anyone being told.

**Config intent at the boundary** — "preserve config across cold starts" was a
property of the client-side autostart wrapper, not of the daemon. The desktop
app launches with a bare `daemon start`, which mapped straight to compiled
defaults. `data_instance_id` then collapsed to the database-path hash, so
project-scoped queries returned nothing while plain search still looked fine.
A configless start now reuses persisted intent; reset moves to `--reset`.

**State-dir gc** — `daemon gc` swept only launch agents. On one machine it
reported "No orphaned launch agents found (1 kept, 0 spared)" while 8,524
orphaned state directories sat beside it (547 MB in about a month). A garbage
collector that reports clean when it is not is the defect, more than the disk.

## Notes for review

- **`daemon start` semantics change.** A configless start no longer resets to
  compiled defaults; it reuses the last configuration that reached readiness.
  Reset is now `daemon start --reset`, declared `conflicts_with = "config"`.
  Four error messages advising a bare `start` to reset were updated.
- **One existing test was changed, not just fixed.**
  `daemon_restart_preserves_and_overrides_live_effective_config_without_early_shutdown`
  asserted a bare `start` was the reset escape hatch — the behavior this
  replaces. Its neighbouring assertion, that merely *observing* an incumbent must
  not erase intent, still passes unchanged.
- **The merge needed a semantic resolution, not a mechanical one.**
  `start_at_login` is read from the *effective* config rather than the CLI arg.
  Reading the explicit arg would drop `RunAtLoad` on exactly the bare
  `daemon start` the app issues — the opt-in would appear to work and then stop
  surviving reboots.
- **`gc`'s allowlist is structural.** Instance dirs are 8-hex; `config-intent/`'s
  children are 64-hex fingerprints, so that directory cannot express the accepted
  shape. Deleting it has happened once for real via a hand-written
  `find … -exec rm -rf`. Please don't relax this into a denylist.
- **`is_temp_db_path` moved** from `launchd` (macOS-gated) to `lifecycle`, since
  state dirs accumulate on every platform. Its test now runs on Linux too.

## Verification

- Full daemon suite green (46 tests) on the config-intent branch.
- `gc` verified against a real accumulation: 48 entries → 2, 46 swept,
  `config-intent` intact with all 10 records readable, live daemon spared.
- Bench targets now do real work: 4 criterion benches, real indexing
  (900 symbols / 600 edges), embed latency avg 196.8ms, remove-repo 7.9×.
  These are **first baselines, not comparisons** — no trustworthy pre-fix
  numbers exist from the three stubbed targets.
- New guards: CI `cargo check --benches`, plus a regression test that fails if
  the gating idiom returns. Both negative-tested by reintroducing the defect.

## What this PR does NOT prove

Two things have **never executed anywhere** and land here for the first time,
both because a Linux build compiles none of the launchd surface
(`nestweaver-daemon/src/lib.rs:4` gates the module):

1. The `plutil` plist tests, and reboot survival with `RunAtLoad`.
2. The config-intent **self-heal** — an explicit `--config` displacing an
   incumbent that attests `CompiledDefaults`.

Both are type-checked only (verified by temporarily un-gating locally). The
Cold Metal job is the first place they actually run, so please weight its
result accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZafS4yodRXCyKGi7FsymG