### PR TITLE
build: track the x86_64-linux linker workaround so a clean clone links

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -24,5 +24,11 @@ LBUG_BUILD_FROM_SOURCE = { value = "1", force = true }
 #
 # Note -DZSTD_DISABLE_ASM does NOT substitute for this: it disables the Huffman
 # assembly, which is 2 of lbug's 192 ZSTD_ symbols, not the 190 that collide.
+# mold is deliberately NOT set here: CI installs it, a contributor may not have
+# it, and a missing linker is a worse first experience than a slower one. CI
+# overrides both targets via CARGO_TARGET_<TRIPLE>_RUSTFLAGS to add it.
 [target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]
+
+[target.aarch64-unknown-linux-gnu]
 rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,24 @@
 # cross-platform release builds reproducible. See 6768374, "fix(ci): eliminate
 # zstd link errors and skip daemon tests on Linux".
 LBUG_BUILD_FROM_SOURCE = { value = "1", force = true }
+
+# WORKAROUND, not a fix. Two complete copies of zstd are linked into every
+# binary: liblbug.a statically vendors it and exports 192 ZSTD_ symbols, and
+# zstd-sys builds its own. rust-lld — the default linker here — refuses with 43
+# duplicate symbols, so a clean clone cannot link a single test binary without
+# this. CI appends the same flag in every Linux job; tracking it means a fresh
+# clone works the way CI does.
+#
+# This does NOT merge the two copies — the linker silently picks one. Two zstd
+# instances with independent state in one process is the same shape as the
+# double-free at process exit that 6768374 attributes to lbug's +whole-archive,
+# and which is why daemon_ tests are skipped on Linux. Removing the duplicate is
+# the real fix: `zstd` is a DIRECT dependency of nestweaver-engine and
+# nestweaver-store, so 6768374's removal of tantivy's columnar-zstd-compression
+# no longer keeps zstd-sys out of the tree. Drop that dependency or point both
+# consumers at a shared system zstd, then delete this block.
+#
+# Note -DZSTD_DISABLE_ASM does NOT substitute for this: it disables the Huffman
+# assembly, which is 2 of lbug's 192 ZSTD_ symbols, not the 190 that collide.
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ env:
   RUST_BACKTRACE: 1
   LBUG_BUILD_FROM_SOURCE: "1"
   CFLAGS: "-DZSTD_DISABLE_ASM"
+  # Adds mold on top of the --allow-multiple-definition already tracked in
+  # .cargo/config.toml. Set as an env override rather than appended to that
+  # file: a second [target.x86_64-unknown-linux-gnu] table is a TOML duplicate
+  # key and fails the build outright.
+  CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-Wl,--allow-multiple-definition -C link-arg=-fuse-ld=mold"
 
 jobs:
   # Detect what actually changed so we don't recompile the entire Rust
@@ -323,9 +328,6 @@ jobs:
           shared-key: build
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
-      - name: Configure linker for lbug+tantivy zstd coexistence
-        run: |
-          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
       - name: Compute native dependency cache key
         id: nativekey
         run: |
@@ -388,9 +390,6 @@ jobs:
           shared-key: build
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
-      - name: Configure linker for lbug+tantivy zstd coexistence
-        run: |
-          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
       - name: Compute native dependency cache key
         id: nativekey
         run: |
@@ -435,9 +434,6 @@ jobs:
           shared-key: build
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
-      - name: Configure linker for lbug+tantivy zstd coexistence
-        run: |
-          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
       - name: Compute native dependency cache key
         id: nativekey
         run: |
@@ -498,9 +494,6 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
-      - name: Configure linker for lbug+tantivy zstd coexistence
-        run: |
-          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
       - name: Compute native dependency cache key
         id: nativekey
         run: |
@@ -638,9 +631,6 @@ jobs:
           cache-dependency-path: crates/nestweaver-web/frontend/package-lock.json
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
-      - name: Configure linker for lbug+tantivy zstd coexistence
-        run: |
-          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
       - name: Install frontend dependencies
         working-directory: crates/nestweaver-web/frontend
         run: npm ci

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -121,17 +121,12 @@ jobs:
               ;;
           esac
           echo "MACOSX_DEPLOYMENT_TARGET=$DEPLOYMENT_TARGET" >> "$GITHUB_ENV"
-      - name: Configure linker (Linux)
+      - name: Add mold to the tracked linker flags (Linux)
         if: runner.os == 'Linux'
         run: |
-          cat >> .cargo/config.toml << 'EOF'
-
-          [target.x86_64-unknown-linux-gnu]
-          rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]
-
-          [target.aarch64-unknown-linux-gnu]
-          rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]
-          EOF
+          F="-C link-arg=-Wl,--allow-multiple-definition -C link-arg=-fuse-ld=mold"
+          echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS=$F" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS=$F" >> "$GITHUB_ENV"
       - uses: actions/setup-node@v7
         with:
           node-version: 24


### PR DESCRIPTION
Without this flag a fresh clone cannot link a single test binary on
x86_64 Linux:

    rust-lld: error: duplicate symbol: ZSTD_createCCtx
                     duplicate symbol: ZSTD_compressBound
                     ... 43 unique symbols, 0 of 38 test binaries linked
    between liblbug.a and libzstd_sys-*.rlib

CI already appends the identical flag in every Linux job, so this only
moves an existing requirement into the tracked config where a contributor
gets it automatically. Three separate contributors rediscovered this the
hard way; it was masked by an uncommitted local edit.

The comment records what the flag is and is not. It is a suppression, not
a fix: two complete copies of zstd are linked into every binary because
`zstd` is a direct dependency of nestweaver-engine and nestweaver-store,
which reintroduced what 6768374 removed by disabling tantivy's
columnar-zstd-compression. Getting to one copy is the real fix and would
let this block be deleted.

Also records that -DZSTD_DISABLE_ASM is not a substitute — it disables the
Huffman assembly, 2 of lbug's 192 ZSTD_ symbols, not the 190 that collide.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012UXMKySLGmPZiQJqaQqhZp