### PR TITLE
fix: index-publication recovery, one copy of zstd, federated honesty fields

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,13 @@
 # cross-platform release builds reproducible. See 6768374, "fix(ci): eliminate
 # zstd link errors and skip daemon tests on Linux".
 LBUG_BUILD_FROM_SOURCE = { value = "1", force = true }
+
+# No linker workaround is needed here, and none should be added. liblbug.a
+# vendors zstd, exports its ZSTD_* symbols, and is linked +whole-archive, so
+# every binary already carries a complete libzstd; Rust code reaches that one
+# copy through `nestweaver_store::zstd`. Adding the `zstd` crate back would pull
+# in zstd-sys, compile a second copy, and make rust-lld reject every link with
+# duplicate symbols. The historical response was to tell the linker to tolerate
+# duplicates, which suppressed the error while leaving two sets of zstd state in
+# the process. `exactly_one_copy_of_zstd_is_linked` in tests/cli_test.rs guards
+# both halves.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,9 +323,9 @@ jobs:
           shared-key: build
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
-      - name: Configure linker for lbug+tantivy zstd coexistence
+      - name: Use mold as the linker
         run: |
-          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
+          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
       - name: Compute native dependency cache key
         id: nativekey
         run: |
@@ -388,9 +388,9 @@ jobs:
           shared-key: build
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
-      - name: Configure linker for lbug+tantivy zstd coexistence
+      - name: Use mold as the linker
         run: |
-          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
+          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
       - name: Compute native dependency cache key
         id: nativekey
         run: |
@@ -435,9 +435,9 @@ jobs:
           shared-key: build
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
-      - name: Configure linker for lbug+tantivy zstd coexistence
+      - name: Use mold as the linker
         run: |
-          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
+          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
       - name: Compute native dependency cache key
         id: nativekey
         run: |
@@ -498,9 +498,9 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
-      - name: Configure linker for lbug+tantivy zstd coexistence
+      - name: Use mold as the linker
         run: |
-          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
+          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
       - name: Compute native dependency cache key
         id: nativekey
         run: |
@@ -638,9 +638,9 @@ jobs:
           cache-dependency-path: crates/nestweaver-web/frontend/package-lock.json
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
-      - name: Configure linker for lbug+tantivy zstd coexistence
+      - name: Use mold as the linker
         run: |
-          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
+          printf '\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-fuse-ld=mold"]\n' >> .cargo/config.toml
       - name: Install frontend dependencies
         working-directory: crates/nestweaver-web/frontend
         run: npm ci

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -127,10 +127,10 @@ jobs:
           cat >> .cargo/config.toml << 'EOF'
 
           [target.x86_64-unknown-linux-gnu]
-          rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]
+          rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 
           [target.aarch64-unknown-linux-gnu]
-          rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition", "-C", "link-arg=-fuse-ld=mold"]
+          rustflags = ["-C", "link-arg=-fuse-ld=mold"]
           EOF
       - uses: actions/setup-node@v7
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,11 +12,12 @@ cargo fmt --all -- --check                                  # format check
 cargo fmt --all                                             # format in place
 ```
 
-On **x86_64 Linux a clean clone cannot link** (duplicate zstd symbols from
-building Ladybug from source alongside Tantivy). The tracked
-`.cargo/config.toml` does NOT carry the fix; CI appends it per job. Append it
-locally and do not commit it — see
-[CONTRIBUTING.md](CONTRIBUTING.md#x86_64-linux-extra-linker-flag-required).
+A clean clone links with no extra linker flags. Only one copy of zstd is in the
+binary: `liblbug.a` vendors it, and Rust code reaches that copy through
+`nestweaver_store::zstd` rather than the `zstd` crate. Do not add a `zstd`
+dependency back — that reintroduces `zstd-sys`, a second complete copy, and the
+duplicate-symbol link failure that `-Wl,--allow-multiple-definition` used to
+suppress.
 
 ## Daemon Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,25 +93,20 @@ initial native build can take several minutes. See
 [INSTALL.md](INSTALL.md#build-from-source) for CMake, C++, OpenSSL, zstd,
 `pkg-config`, and Protocol Buffers prerequisites.
 
-#### x86_64 Linux: extra linker flag required
+#### Only one copy of zstd may be linked
 
-The tracked `.cargo/config.toml` is **not sufficient on x86_64 Linux**.
-Building Ladybug from source and Tantivy in the same binary produces duplicate
-zstd symbols, so linking fails without
-`-Wl,--allow-multiple-definition`. CI appends the stanza to
-`.cargo/config.toml` before every Linux job rather than tracking it, so a clean
-clone cannot link test binaries until you do the same locally:
+`liblbug.a` vendors zstd, exports its symbols, and is linked `+whole-archive`,
+so every binary already contains a complete libzstd. Rust code reaches that copy
+through `nestweaver_store::zstd`.
 
-```sh
-cat >> .cargo/config.toml << 'EOF'
+Do not add the `zstd` crate as a dependency. It pulls in `zstd-sys`, which
+compiles a **second** complete copy, and `rust-lld` — the default linker on
+x86_64 Linux — then refuses to link anything, with dozens of duplicate `ZSTD_*`
+symbols. That is what `-Wl,--allow-multiple-definition` used to suppress; the
+flag never merged the copies, it only silenced the linker and left two sets of
+zstd state in one process.
 
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]
-EOF
-```
-
-Do not commit that stanza. CI additionally passes
-`-C link-arg=-fuse-ld=mold` for speed; `mold` is optional locally.
+CI passes `-C link-arg=-fuse-ld=mold` for speed; `mold` is optional locally.
 
 ### Check suite
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,8 +103,8 @@ Do not add the `zstd` crate as a dependency. It pulls in `zstd-sys`, which
 compiles a **second** complete copy, and `rust-lld` — the default linker on
 x86_64 Linux — then refuses to link anything, with dozens of duplicate `ZSTD_*`
 symbols. That is what `-Wl,--allow-multiple-definition` used to suppress; the
-flag never merged the copies, it only silenced the linker and left two sets of
-zstd state in one process.
+flag never merged the copies, it only told the linker to pick one definition
+silently while the other stayed in the binary.
 
 CI passes `-C link-arg=-fuse-ld=mold` for speed; `mold` is optional locally.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4266,7 +4266,6 @@ dependencies = [
  "walkdir",
  "wiremock",
  "x509-parser",
- "zstd",
 ]
 
 [[package]]
@@ -4444,7 +4443,6 @@ dependencies = [
  "thiserror 2.0.20",
  "toml",
  "tracing",
- "zstd",
 ]
 
 [[package]]
@@ -9012,31 +9010,3 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM rust:1.96-trixie AS builder
 WORKDIR /build
 RUN apt-get update && apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler && rm -rf /var/lib/apt/lists/*
 COPY . .
-RUN RUSTFLAGS="-C link-arg=-Wl,--allow-multiple-definition" cargo build --locked --release --bin nestweaver
+RUN cargo build --locked --release --bin nestweaver
 
 # Runtime stage
 FROM debian:trixie-slim

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -67,18 +67,10 @@ the build uses the Ladybug sources resolved by `Cargo.lock`, rather than a
 prebuilt archive whose hidden ELF symbols cause zstd link errors. Cargo
 vendors the Ladybug sources with the crate.
 
-**x86_64 Linux needs one more linker flag.** Building Ladybug from source
-alongside Tantivy produces duplicate zstd symbols, and the tracked
-`.cargo/config.toml` does not carry the flag that tolerates them — CI appends it
-per job instead. Without it, linking fails on `x86_64-unknown-linux-gnu`:
-
-```sh
-cat >> .cargo/config.toml << 'EOF'
-
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]
-EOF
-```
+No extra linker flags are needed. Exactly one copy of zstd is linked: the one
+Ladybug vendors. Rust code uses it through `nestweaver_store::zstd` instead of
+the `zstd` crate, which would compile a second copy and break the link on
+`x86_64-unknown-linux-gnu`.
 
 If OpenSSL is installed in a non-default location and the linker cannot find
 `ssl` or `crypto`, expose that installation while building:

--- a/README.md
+++ b/README.md
@@ -500,11 +500,16 @@ A local backend is ready only when `selected_device` is `metal` or `cpu` and
 `fallback_used` is `false`; an external backend has no local selected device.
 When semantic retrieval was requested but unavailable, context responses keep
 the graph/PPR/BM25 result and report `"semantic"` in `degraded_components`
-(the only value in that vocabulary today). Caveat: the hybrid/federated merge
-for `brain_context` / `project_context` rebuilds the `connected` response shape
-and currently drops both `semantic_applied` and `degraded_components`, so a
-merged two-tier context answer does not carry them. The direct, daemon, and
-`brain_search` paths do.
+(the only value in that vocabulary today). Every path reports both fields: the
+direct, daemon and `brain_search` paths, and the hybrid/federated merges for
+`brain_search` and for `brain_context` / `project_context`. In a merge,
+`semantic_applied` is the AND across contributing tiers and
+`degraded_components` their deduplicated union; when no tier reports either
+field the merge omits both, so an absent field still means "not reported by any
+tier", never a synthesised `false`. Caveat: `semantic_applied` is one boolean,
+so a merge in which one tier ranked semantically and the other did not reports
+`false` — correct for the merged row set, which contains lexically ranked rows,
+but it does not say which tier was which.
 
 **Performance:** 7ms query embedding (Metal), 37ms (CPU) for all-MiniLM;
 heavier models trade speed for quality. Forward Push PPR replaces power

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -8769,9 +8769,32 @@ pub async fn run_server(
     // hits the cache instead of spending ~350ms rebuilding from the DB.
     {
         let store = state.store.clone();
-        tokio::task::spawn_blocking(move || match store.warm_ppr_cache() {
-            Ok(()) => tracing::info!("PPR adjacency cache warmed"),
-            Err(e) => tracing::warn!("failed to warm PPR cache: {e}"),
+        tokio::task::spawn_blocking(move || {
+            // nw-C1: the daemon is a WRITER. If a prior indexer died between
+            // establishing `<db>.index-dirty` and finalizing, every ranked
+            // query in this database fails closed forever. Reconcile it here,
+            // before warming, so the warm below succeeds and the first PPR
+            // query does not meet the wedge. A live publication is left
+            // strictly alone (see `recover_abandoned_index_publication`).
+            nestweaver_engine::index::recover_abandoned_index_publication_best_effort(&store, true);
+            match store.warm_ppr_cache() {
+                Ok(()) => tracing::info!("PPR adjacency cache warmed"),
+                // nw-C2: this specific failure used to be swallowed as a
+                // generic warn, which is how a permanently wedged database
+                // produced no diagnostic anywhere. Name it.
+                Err(e) if format!("{e}").contains("dirty index publication") => {
+                    let status = store
+                        .db_path()
+                        .map(nestweaver_engine::index_publication::status);
+                    tracing::warn!(
+                        "PPR cache not warmed: an index publication is dirty, so every ranked \
+                         query (brain_context, project_context, investigate) will fail closed \
+                         until it is reconciled. This is an index PUBLICATION marker, not a \
+                         dirty git working tree. status={status:?} error={e}"
+                    );
+                }
+                Err(e) => tracing::warn!("failed to warm PPR cache: {e}"),
+            }
         });
     }
 

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -8770,13 +8770,21 @@ pub async fn run_server(
     {
         let store = state.store.clone();
         tokio::task::spawn_blocking(move || {
-            // nw-C1: the daemon is a WRITER. If a prior indexer died between
-            // establishing `<db>.index-dirty` and finalizing, every ranked
-            // query in this database fails closed forever. Reconcile it here,
-            // before warming, so the warm below succeeds and the first PPR
-            // query does not meet the wedge. A live publication is left
+            // nw-C1: a read-write daemon is a WRITER. If a prior indexer died
+            // between establishing `<db>.index-dirty` and finalizing, every
+            // ranked query in this database fails closed forever. Reconcile it
+            // here, before warming, so the warm below succeeds and the first
+            // PPR query does not meet the wedge. A live publication is left
             // strictly alone (see `recover_abandoned_index_publication`).
-            nestweaver_engine::index::recover_abandoned_index_publication_best_effort(&store, true);
+            //
+            // The gate must mirror how THIS daemon opened the store, exactly
+            // like the neighbouring reconcile passes: a snapshot-replica daemon
+            // opens read-only, and a read-only caller must report the condition
+            // rather than recompute PageRank, persist `.generation`, and delete
+            // the marker out from under whoever holds the write lock.
+            nestweaver_engine::index::recover_abandoned_index_publication_best_effort(
+                &store, !read_only,
+            );
             match store.warm_ppr_cache() {
                 Ok(()) => tracing::info!("PPR adjacency cache warmed"),
                 // nw-C2: this specific failure used to be swallowed as a

--- a/crates/nestweaver-engine/Cargo.toml
+++ b/crates/nestweaver-engine/Cargo.toml
@@ -45,7 +45,6 @@ html2md = "0.2"
 sha2 = { workspace = true }
 tar = "0.4"
 tempfile = "3"
-zstd = "0.13"
 rcgen = "0.14"
 time = "0.3"
 nestweaver-embed = { path = "../nestweaver-embed", optional = true }

--- a/crates/nestweaver-engine/src/backup.rs
+++ b/crates/nestweaver-engine/src/backup.rs
@@ -239,7 +239,7 @@ pub fn package_staged(config: &BackupConfig, staged: StagedBackup) -> anyhow::Re
 /// and recomputes checksums for integrity verification.
 pub fn backup_inspect(archive_path: &Path) -> anyhow::Result<BackupManifest> {
     let file = std::fs::File::open(archive_path)?;
-    let decoder = zstd::Decoder::new(file)?;
+    let decoder = nestweaver_store::zstd::Decoder::new(file)?;
     let mut archive = tar::Archive::new(decoder);
 
     let mut manifest: Option<BackupManifest> = None;
@@ -374,7 +374,7 @@ pub fn backup_restore(config: &RestoreConfig) -> anyhow::Result<RestoreResult> {
     let temp_dir = tempfile::tempdir_in(parent)?;
 
     let file = std::fs::File::open(&config.snapshot_path)?;
-    let decoder = zstd::Decoder::new(file)?;
+    let decoder = nestweaver_store::zstd::Decoder::new(file)?;
     let mut archive = tar::Archive::new(decoder);
     archive.unpack(temp_dir.path())?;
 
@@ -631,7 +631,7 @@ fn package_tar_zstd(staging: &Path, output: &Path) -> anyhow::Result<()> {
         std::fs::create_dir_all(parent)?;
     }
     let file = std::fs::File::create(output)?;
-    let encoder = zstd::Encoder::new(file, 3)?;
+    let encoder = nestweaver_store::zstd::Encoder::new(file, 3)?;
     let mut tar_builder = tar::Builder::new(encoder);
     tar_builder.append_dir_all(".", staging)?;
     let encoder = tar_builder.into_inner()?;

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -1131,8 +1131,10 @@ pub enum IndexPublicationRecovery {
     /// graph, `.pagerank.json` and `.generation` were persisted, and only then
     /// was the marker cleared.
     Recovered {
-        /// The pid of the writer that abandoned the publication.
-        abandoned_writer_pid: i32,
+        /// The pid of the writer that abandoned the publication. `None` when
+        /// the marker carried no attributable writer and an operator forced
+        /// the repair.
+        abandoned_writer_pid: Option<i32>,
         /// The canonical generation now persisted.
         generation: u64,
         /// True when the abandoned publication was left dirty deliberately by
@@ -1184,10 +1186,14 @@ impl IndexPublicationRecovery {
                 generation,
                 was_cancelled_run,
             } => {
+                let who = match abandoned_writer_pid {
+                    Some(pid) => format!("dead writer pid {pid}"),
+                    None => "an unattributable writer (forced repair)".to_string(),
+                };
                 let base = format!(
-                    "recovered an abandoned index publication left by dead writer pid \
-                     {abandoned_writer_pid}: PageRank recomputed against the committed graph, \
-                     graph generation {generation} persisted, marker cleared"
+                    "recovered an abandoned index publication left by {who}: stale PageRank \
+                     sidecar removed and graph generation {generation} persisted before the \
+                     marker was cleared, then PageRank recomputed against the committed graph"
                 );
                 if *was_cancelled_run {
                     format!(
@@ -1216,10 +1222,16 @@ impl IndexPublicationRecovery {
 /// the stale sidecars authoritative again — precisely the silent-wrong-ranks
 /// outcome the guard exists to prevent. Instead it takes the publication lease,
 /// re-establishes ownership of the marker, and routes through
-/// `finalize_committed_index_for_scope_with_io`, so PageRank is recomputed
-/// against the *committed* graph and `.generation` advanced and persisted
-/// **before** the marker is cleared. That ordering is the entire point of the
-/// guard and is not duplicated here.
+/// `finalize_committed_index_for_scope_with_io`.
+///
+/// The ordering that function actually guarantees, stated precisely because it
+/// is easy to overclaim: the **stale `.pagerank.json` is removed** and
+/// `.generation` advanced and persisted BEFORE the marker is cleared; the fresh
+/// PageRank is computed and saved AFTER. So there is a window in which the
+/// publication reads clean with no PageRank sidecar on disk — which is safe,
+/// because an absent sidecar recomputes, whereas a stale one would be trusted.
+/// "Recomputed before the marker clears" would be false. Not duplicated here:
+/// the ordering is the entire point of the guard and lives in one place.
 ///
 /// `read_write` gates recovery exactly as it gates the orphaned-WAL arm of
 /// `open_lbug_with_recovery`: a read-only caller must report the condition, not
@@ -1230,12 +1242,35 @@ pub fn recover_abandoned_index_publication(
     store: &GraphStore,
     read_write: bool,
 ) -> Result<IndexPublicationRecovery, DeletionReconciliationError> {
-    recover_abandoned_index_publication_with_io(store, read_write, &FileSystemIndexEpilogueIo)
+    recover_abandoned_index_publication_with_io(
+        store,
+        read_write,
+        false,
+        &FileSystemIndexEpilogueIo,
+    )
+}
+
+/// Operator-forced recovery: proceeds on the two cases the automatic predicate
+/// must decline — a marker with no attributable writer, and one whose state
+/// cannot be read.
+///
+/// `force` never overrides a writer we can prove is ALIVE, and never overrides
+/// an in-process lease holder; those remain hard declines. What it overrides is
+/// only "cannot prove dead", which is the automatic predicate's conservatism,
+/// not a safety property. The real protection against clobbering a live writer
+/// is that every recovery path holds a read-write `GraphStore`, and lbug's
+/// exclusive write lock means no other process can hold one at the same time;
+/// the pid and lease checks are defence in depth on top of that.
+pub fn force_recover_index_publication(
+    store: &GraphStore,
+) -> Result<IndexPublicationRecovery, DeletionReconciliationError> {
+    recover_abandoned_index_publication_with_io(store, true, true, &FileSystemIndexEpilogueIo)
 }
 
 pub(crate) fn recover_abandoned_index_publication_with_io(
     store: &GraphStore,
     read_write: bool,
+    force: bool,
     io: &dyn IndexEpilogueIo,
 ) -> Result<IndexPublicationRecovery, DeletionReconciliationError> {
     const OPERATION: &str = "recover abandoned index publication";
@@ -1252,28 +1287,56 @@ pub(crate) fn recover_abandoned_index_publication_with_io(
             return Ok(IndexPublicationRecovery::Clean);
         }
         nestweaver_store::index_publication::MarkerState::Undeterminable(detail) => {
-            return Ok(IndexPublicationRecovery::Undeterminable {
-                detail: detail.clone(),
-            });
+            // "Cannot tell" is not "abandoned" — never automatically. An
+            // operator who has looked at the directory can still override.
+            if !(force && read_write) {
+                return Ok(IndexPublicationRecovery::Undeterminable {
+                    detail: detail.clone(),
+                });
+            }
+            tracing::warn!(
+                "forced recovery of an index publication whose marker state could not be \
+                 determined ({detail}); proceeding on explicit operator instruction"
+            );
         }
         nestweaver_store::index_publication::MarkerState::Present(_) => {}
     }
-    let record = state.record().expect("present marker carries a record");
-    let was_cancelled_run = record.is_deliberately_dirty();
-    let Some(pid) = record.writer_pid else {
-        return Ok(IndexPublicationRecovery::WriterUnattributed);
+    let record = state.record();
+    let was_cancelled_run = record.is_some_and(|r| r.is_deliberately_dirty());
+    // `pid` is `None` for an unattributed or undeterminable marker. Automatic
+    // recovery declines; a forced one proceeds.
+    let pid = match record.and_then(|r| r.writer_pid) {
+        Some(pid) => {
+            if crate::index_publication::process_is_alive(pid) {
+                // Never overridden, not even by `force`.
+                return Ok(IndexPublicationRecovery::WriterAlive { pid });
+            }
+            Some(pid)
+        }
+        None => {
+            if !(force && read_write) {
+                return Ok(IndexPublicationRecovery::WriterUnattributed);
+            }
+            None
+        }
     };
-    if crate::index_publication::process_is_alive(pid) {
-        return Ok(IndexPublicationRecovery::WriterAlive { pid });
-    }
     if !read_write {
         // Report, never clear. Same rule, and the same reason, as the
         // read-only arm of `open_lbug_with_recovery`: "a read-only caller
         // quarantining a log out from under a live writer would be a genuine
         // hazard". The MCP server opens the store read-only and can be a
-        // different process from the daemon, so it lands here.
-        return Ok(IndexPublicationRecovery::ReadOnlyStore {
-            abandoned_writer_pid: pid,
+        // different process from the daemon, so it lands here. A read-only
+        // handle also does not hold lbug's exclusive write lock, which is what
+        // actually keeps a live writer safe.
+        return Ok(match pid {
+            Some(pid) => IndexPublicationRecovery::ReadOnlyStore {
+                abandoned_writer_pid: pid,
+            },
+            // Unreachable in practice: a pid-less marker only gets past the
+            // match above when `force && read_write`, and `read_write` is false
+            // here. Written totally rather than unwrapped so it cannot become a
+            // panic if that gating ever changes.
+            None => IndexPublicationRecovery::WriterUnattributed,
         });
     }
 
@@ -1300,12 +1363,21 @@ pub(crate) fn recover_abandoned_index_publication_with_io(
     // publisher in another process could have established a new marker with a
     // live pid; recovering that would clear a marker out from under its writer.
     let confirmed = nestweaver_store::index_publication::read_marker(&db_path);
-    match confirmed.record().and_then(|r| r.writer_pid) {
-        Some(current) if current != pid => {
+    match (confirmed.record().and_then(|r| r.writer_pid), pid) {
+        // A different pid appeared: a fresh publisher established a new marker
+        // between the triage read and here. Recovering it would clear a marker
+        // out from under its writer.
+        (Some(current), Some(original)) if current != original => {
             return Ok(IndexPublicationRecovery::WriterAlive { pid: current });
         }
-        Some(_) => {}
-        None => return Ok(IndexPublicationRecovery::WriterUnattributed),
+        // A forced recovery of a pid-less marker that has since GAINED a pid is
+        // likewise a new publisher; decline if that publisher is alive.
+        (Some(current), None) if crate::index_publication::process_is_alive(current) => {
+            return Ok(IndexPublicationRecovery::WriterAlive { pid: current });
+        }
+        (Some(_), _) => {}
+        (None, Some(_)) => return Ok(IndexPublicationRecovery::WriterUnattributed),
+        (None, None) => {}
     }
 
     // The `u64::MAX` arm. When `.generation` is missing or unparseable while
@@ -1338,12 +1410,37 @@ pub(crate) fn recover_abandoned_index_publication_with_io(
     // Take ownership of the marker (it is rewritten with THIS process's pid and
     // timestamp), then run the ordinary committed-index epilogue.
     let lease = establish_index_publication_marker_on_lease(lease, Some(&db_path), OPERATION, io)?;
+
+    // Re-apply the cancellation reason that `establish_marker` just overwrote.
+    // Without this, a crash DURING recovery loses the attribution: the next
+    // recovery would report an ordinary crash and drop the `index --force`
+    // guidance, which is the exact outcome the stamp exists to preserve.
+    if was_cancelled_run
+        && let Err(error) = io.stamp_marker_reason(
+            &crate::sidecar_path(&db_path, ".index-dirty"),
+            nestweaver_store::index_publication::MARKER_REASON_CANCELLED,
+        )
+    {
+        tracing::warn!(
+            "could not carry the cancellation reason through recovery: {error:#}; \
+             a crash before this recovery completes would report it as a plain crash"
+        );
+    }
+
+    // SCOPE: `unified()`, never `code_only()`. `compute_pagerank` REPLACES the
+    // whole score map, and the canonical sidecar on a brain database is
+    // published unified (`BrainWatcher`), so recovering with a code-only scope
+    // would silently delete every Note/Section/Heading/Tag rank — turning a
+    // recovery into data loss. This also matches the recovered-owner arm in
+    // `index_with_reader_and_write_gate`, which heals "that unknown committed
+    // graph as one unified publication" for the same reason: a recovering owner
+    // cannot prove which slices of the graph the dead owner had touched.
     finalize_committed_index_for_scope_with_io(
         lease,
         Some(&db_path),
         OPERATION,
         io,
-        Some(&nestweaver_store::GraphScope::code_only()),
+        Some(&nestweaver_store::GraphScope::unified()),
         true,
     )?;
 
@@ -5649,6 +5746,40 @@ mod tests {
         .unwrap();
     }
 
+    /// Insert a small NOTE-side graph alongside the code graph, so a recovery
+    /// that ranks with the wrong scope is detectable.
+    fn insert_publication_notes(store: &GraphStore, publisher: &str) {
+        let vault_uid = format!("vault:{publisher}");
+        store
+            .insert_vault(&nestweaver_schema::Vault {
+                uid: vault_uid.clone(),
+                name: format!("vault-{publisher}"),
+                root_path: format!("/tmp/{publisher}"),
+                instance_id: "test".into(),
+            })
+            .unwrap();
+        for n in ["one", "two"] {
+            let uid = format!("note:{publisher}:{n}");
+            store
+                .insert_note(&nestweaver_schema::Note {
+                    uid: uid.clone(),
+                    vault_uid: vault_uid.clone(),
+                    file_path: format!("{n}.md"),
+                    title: n.to_string(),
+                    note_kind: nestweaver_schema::NoteKind::General,
+                    word_count: 10,
+                    content_hash: format!("hash-{publisher}-{n}"),
+                    frontmatter: None,
+                    created_at: None,
+                    modified_at: None,
+                    pagerank_score: None,
+                    embedding: None,
+                })
+                .unwrap();
+            store.insert_vault_note_edge(&vault_uid, &uid).unwrap();
+        }
+    }
+
     /// Leave the database in exactly the state a SIGKILL between marker
     /// establishment and finalize produces: graph committed, `.index-dirty`
     /// present and naming a dead writer, `.pagerank.json` still holding
@@ -5675,6 +5806,7 @@ mod tests {
         )
         .unwrap();
         insert_publication_graph(&store, publisher);
+        insert_publication_notes(&store, publisher);
         // The process dies here: the lease is process-local and simply
         // vanishes, while the marker and both sidecars are durable.
         drop(lease);
@@ -5719,17 +5851,35 @@ mod tests {
             scores.contains_key("sym:publisher-crashed:source"),
             "recovered PageRank must cover the committed graph: {scores:?}"
         );
+        // The sentinel disappearing proves only that SOMETHING was rewritten.
+        // It cannot distinguish a correct unified recompute from one that
+        // silently dropped every note rank, so assert the note side explicitly:
+        // `compute_pagerank` REPLACES the whole map, and the canonical sidecar
+        // on a brain database is unified, so a `code_only()` recovery would be
+        // data loss wearing the shape of a fix.
+        for note in ["note:crashed:one", "note:crashed:two"] {
+            assert!(
+                scores.contains_key(note),
+                "recovery must rank the note side too, not just code: {note} missing from \
+                 {} entries",
+                scores.len()
+            );
+        }
 
         drop(store);
         let reopened = GraphStore::open_or_create(&db_path).unwrap();
         assert!(!reopened.is_index_publication_dirty());
         assert_eq!(reopened.graph_generation(), canonical + 2);
         reopened.load_pagerank_cache(&pagerank_path).unwrap();
+        let persisted = reopened.pagerank_scores();
         assert!(
-            reopened
-                .pagerank_scores()
-                .contains_key("sym:publisher-crashed:source"),
+            persisted.contains_key("sym:publisher-crashed:source"),
             "the persisted PageRank sidecar must reflect the committed graph"
+        );
+        assert!(
+            persisted.contains_key("note:crashed:one")
+                && persisted.contains_key("note:crashed:two"),
+            "and must retain note ranks on disk, not only in memory: {persisted:?}"
         );
     }
 
@@ -5981,6 +6131,92 @@ mod tests {
         );
         assert!(outcome.describe().contains("--force"));
         assert!(!marker_path.exists());
+    }
+
+    #[test]
+    fn force_recovers_an_unattributed_marker_that_auto_heal_must_decline() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
+        {
+            let store = GraphStore::open_or_create(&db_path).unwrap();
+            insert_publication_graph(&store, "forced");
+            insert_publication_notes(&store, "forced");
+        }
+        // The legacy / hand-created marker: present, nothing to attribute.
+        std::fs::write(&marker_path, b"dirty").unwrap();
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        assert_eq!(
+            recover_abandoned_index_publication(&store, true).unwrap(),
+            IndexPublicationRecovery::WriterUnattributed,
+            "auto-heal must still decline what it cannot prove abandoned"
+        );
+        assert!(marker_path.exists());
+
+        let outcome = force_recover_index_publication(&store).unwrap();
+        assert!(outcome.recovered(), "{outcome:?}");
+        assert!(
+            matches!(
+                outcome,
+                IndexPublicationRecovery::Recovered {
+                    abandoned_writer_pid: None,
+                    ..
+                }
+            ),
+            "a forced recovery names no pid because there was none: {outcome:?}"
+        );
+        assert!(!marker_path.exists());
+        assert!(!store.is_index_publication_dirty());
+        let scores = store.pagerank_scores();
+        assert!(scores.contains_key("sym:publisher-forced:source"));
+        assert!(scores.contains_key("note:forced:one"));
+    }
+
+    #[test]
+    fn force_never_overrides_a_live_writer() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        write_marker_with_pid(&marker_path, std::process::id() as i32, None);
+
+        assert_eq!(
+            force_recover_index_publication(&store).unwrap(),
+            IndexPublicationRecovery::WriterAlive {
+                pid: std::process::id() as i32
+            },
+            "--force overrides 'cannot prove dead', never 'provably alive'"
+        );
+        assert!(marker_path.exists());
+    }
+
+    #[test]
+    fn force_recovers_an_undeterminable_marker_only_when_it_can_be_cleared() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
+        {
+            let store = GraphStore::open_or_create(&db_path).unwrap();
+            insert_publication_graph(&store, "undet");
+        }
+        std::fs::create_dir(&marker_path).unwrap();
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        // Auto-heal always declines: "cannot tell" is never "abandoned".
+        assert!(matches!(
+            recover_abandoned_index_publication(&store, true).unwrap(),
+            IndexPublicationRecovery::Undeterminable { .. }
+        ));
+        // Forced, it proceeds — and honestly reports the failure to remove a
+        // directory rather than pretending the publication is clean.
+        let forced = force_recover_index_publication(&store);
+        assert!(
+            forced.is_err(),
+            "clearing a directory-shaped marker must fail loudly: {forced:?}"
+        );
+        assert!(marker_path.exists(), "and must leave it in place");
+        assert!(store.is_index_publication_dirty());
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -635,6 +635,13 @@ fn finalize_code_graph_deletion_with_io(
 pub(crate) trait IndexEpilogueIo {
     fn establish_marker(&self, path: &Path) -> Result<(), anyhow::Error>;
     fn clear_marker(&self, path: &Path) -> Result<(), anyhow::Error>;
+    /// Rewrite an already-established marker with a reason field, so a
+    /// publication left dirty ON PURPOSE is distinguishable from one abandoned
+    /// by a crash. Defaulted so alternate `IndexEpilogueIo` implementations
+    /// (test doubles) inherit the behaviour of the one they wrap.
+    fn stamp_marker_reason(&self, path: &Path, reason: &str) -> Result<(), anyhow::Error> {
+        FileSystemIndexEpilogueIo.stamp_marker_reason_impl(path, reason)
+    }
     fn remove_file(&self, path: &Path) -> std::io::Result<()>;
     fn rename_file(&self, from: &Path, to: &Path) -> std::io::Result<()>;
     fn save_generation(
@@ -653,27 +660,41 @@ pub(crate) trait IndexEpilogueIo {
 
 pub(crate) struct FileSystemIndexEpilogueIo;
 
-impl IndexEpilogueIo for FileSystemIndexEpilogueIo {
-    fn establish_marker(&self, path: &Path) -> Result<(), anyhow::Error> {
+impl FileSystemIndexEpilogueIo {
+    /// Durably (re)write the marker payload. Shared by `establish_marker` and
+    /// `stamp_marker_reason`: the ordering — write, `sync_all`, fsync the
+    /// parent directory — is what makes the marker survive process death, and
+    /// it must not be duplicated with drift.
+    fn write_marker_payload(&self, path: &Path, reason: Option<&str>) -> Result<(), anyhow::Error> {
         let mut file = std::fs::OpenOptions::new()
             .create(true)
             .truncate(true)
             .write(true)
             .open(path)
             .with_context(|| format!("create index publication marker {}", path.display()))?;
-        let marker = format!(
-            "{}:{}\n",
+        let marker = nestweaver_store::index_publication::format_marker_payload(
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
-                .as_nanos()
+                .as_nanos(),
+            reason,
         );
         file.write_all(marker.as_bytes())
             .with_context(|| format!("write index publication marker {}", path.display()))?;
         file.sync_all()
             .with_context(|| format!("sync index publication marker {}", path.display()))?;
         sync_sidecar_parent(path)
+    }
+
+    fn stamp_marker_reason_impl(&self, path: &Path, reason: &str) -> Result<(), anyhow::Error> {
+        self.write_marker_payload(path, Some(reason))
+    }
+}
+
+impl IndexEpilogueIo for FileSystemIndexEpilogueIo {
+    fn establish_marker(&self, path: &Path) -> Result<(), anyhow::Error> {
+        self.write_marker_payload(path, None)
     }
 
     fn clear_marker(&self, path: &Path) -> Result<(), anyhow::Error> {
@@ -786,6 +807,22 @@ pub(crate) fn establish_index_publication_marker_with_io<'a>(
             }],
         )
     })?;
+    establish_index_publication_marker_on_lease(lease, db_path, operation, io)
+}
+
+/// The marker-establishment half of [`establish_index_publication_marker_with_io`],
+/// for callers that already hold the lease.
+///
+/// Abandoned-publication recovery acquires the lease NON-blockingly (a lease
+/// already owned in-process means the publication is not abandoned) and must
+/// repair a fail-closed generation base before preflight can succeed, so it
+/// cannot use the acquire-then-establish entry point.
+pub(crate) fn establish_index_publication_marker_on_lease<'a>(
+    lease: nestweaver_store::IndexPublicationLease<'a>,
+    db_path: Option<&Path>,
+    operation: &str,
+    io: &dyn IndexEpilogueIo,
+) -> Result<nestweaver_store::IndexPublicationLease<'a>, DeletionReconciliationError> {
     let Some(db_path) = db_path else {
         lease.preflight_transient_generation().map_err(|error| {
             DeletionReconciliationError::new(
@@ -858,6 +895,61 @@ pub(crate) fn finalize_committed_index_for_scope_with_io(
 ) -> Result<(), DeletionReconciliationError> {
     let mut failures = Vec::new();
     let store = lease.store();
+
+    // ORDERING, deliberate: when this publication is being left dirty ON
+    // PURPOSE, record that in the marker payload BEFORE any other finalize
+    // I/O, and durably (`sync_all` + parent fsync). This is the earliest point
+    // in the shared finalizer, so the window in which a death leaves an
+    // unlabelled marker is as narrow as the code permits.
+    //
+    // THE WINDOW CANNOT BE CLOSED COMPLETELY, and that is not a defect to fix
+    // later: a run does not LEARN it was cancelled until it polls the flag,
+    // which happens after the commit. There is no earlier instant at which
+    // anything could be stamped, because before that poll the run has nothing
+    // to stamp.
+    //
+    // Why abandoned-publication recovery still auto-heals a deliberately-dirty
+    // publication, rather than refusing to touch anything that might have been
+    // cancelled (nw-C1 / the cancelled-index item's `publish_clean: false`
+    // path). Four points, the last decisive:
+    //
+    //   1. Recovery reconciles ONLY when the recorded writer process is dead,
+    //      so it can never act on a live run.
+    //   2. It asserts only that the SIDECARS NOW MATCH WHAT WAS COMMITTED. It
+    //      never claims the graph is complete. That assertion is equally true
+    //      of a crashed run and a cancelled one.
+    //   3. The stamp therefore changes the MESSAGE, not the ACTION. A run
+    //      killed inside the residual window is reported as a crash — which is
+    //      precisely what it is indistinguishable from at every layer,
+    //      including before this stamp existed.
+    //   4. Refusing to auto-heal "possibly cancelled" publications means
+    //      refusing to auto-heal ANY of them, because we cannot tell them
+    //      apart. That is exactly the wedge this work exists to end: one
+    //      abandoned marker failing every ranked query in the database
+    //      forever, with no way out.
+    //
+    // So the stamp buys honest reporting (a recovered cancelled run repeats
+    // the `index --force` guidance, because its graph really may be
+    // incomplete) without gating recovery on a distinction the system cannot
+    // reliably make.
+    //
+    // Best-effort by construction: a stamp failure leaves the ordinary
+    // `{pid}:{nanos}` payload, which still fails closed and is still
+    // recoverable. Turning a labelling failure into a publication failure
+    // would be strictly worse.
+    if !publish_clean && let Some(db_path) = db_path {
+        let marker_path = crate::sidecar_path(db_path, ".index-dirty");
+        if let Err(error) = io.stamp_marker_reason(
+            &marker_path,
+            nestweaver_store::index_publication::MARKER_REASON_CANCELLED,
+        ) {
+            tracing::warn!(
+                "could not record the cancellation reason in {}: {error:#}; \
+                 the publication stays dirty and recoverable regardless",
+                marker_path.display()
+            );
+        }
+    }
 
     store.invalidate_pagerank();
     let pagerank_safe = if let Some(db_path) = db_path {
@@ -1005,6 +1097,301 @@ pub(crate) fn finalize_committed_index_for_scope_with_io(
         })
     } else {
         Err(DeletionReconciliationError::new(operation, failures))
+    }
+}
+
+// ── Abandoned-publication recovery (nw-C1) ──────────────────────────────────
+
+/// Why recovery did or did not run. Every "did not" arm names its reason: the
+/// operator escape hatch prints these verbatim, and a silent no-op is exactly
+/// the failure mode this work exists to remove.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexPublicationRecovery {
+    /// No marker; nothing to do.
+    Clean,
+    /// The store is in-memory, so there is no marker to reconcile.
+    NotFileBacked,
+    /// The marker's state could not be determined (permissions, I/O error).
+    /// Fails closed: "cannot tell" is not "abandoned".
+    Undeterminable { detail: String },
+    /// The marker records a writer that is still alive. A live publication is
+    /// never recovered out from under its writer.
+    WriterAlive { pid: i32 },
+    /// The marker records no pid we can attribute (an older binary, a
+    /// truncated write, or a hand-created marker). Auto-heal declines; the
+    /// operator escape hatch can still be pointed at it explicitly.
+    WriterUnattributed,
+    /// A live in-process publisher holds the lease, so this publication is
+    /// in flight rather than abandoned.
+    LeaseHeld,
+    /// The publication IS abandoned, but this store is open read-only, so this
+    /// caller must report the condition rather than clear it.
+    ReadOnlyStore { abandoned_writer_pid: i32 },
+    /// Recovery completed: PageRank was recomputed against the committed
+    /// graph, `.pagerank.json` and `.generation` were persisted, and only then
+    /// was the marker cleared.
+    Recovered {
+        /// The pid of the writer that abandoned the publication.
+        abandoned_writer_pid: i32,
+        /// The canonical generation now persisted.
+        generation: u64,
+        /// True when the abandoned publication was left dirty deliberately by
+        /// a committed-after-cancellation run. The graph may be incomplete;
+        /// `nestweaver index --repo <path> --force` is the repair for that,
+        /// and it is a different question from this reconciliation.
+        was_cancelled_run: bool,
+    },
+}
+
+impl IndexPublicationRecovery {
+    /// True when the marker was cleared.
+    pub fn recovered(&self) -> bool {
+        matches!(self, IndexPublicationRecovery::Recovered { .. })
+    }
+
+    /// A single line suitable for a log or for `nestweaver repair` output.
+    pub fn describe(&self) -> String {
+        match self {
+            IndexPublicationRecovery::Clean => {
+                "index publication is clean; nothing to recover".to_string()
+            }
+            IndexPublicationRecovery::NotFileBacked => {
+                "in-memory store has no publication marker to recover".to_string()
+            }
+            IndexPublicationRecovery::Undeterminable { detail } => format!(
+                "index publication marker state could not be determined ({detail}); \
+                 failing closed rather than assuming it was abandoned"
+            ),
+            IndexPublicationRecovery::WriterAlive { pid } => format!(
+                "index publication is in flight; writer pid {pid} is alive — not recovering"
+            ),
+            IndexPublicationRecovery::WriterUnattributed => {
+                "index publication marker records no writer pid; not recovering automatically"
+                    .to_string()
+            }
+            IndexPublicationRecovery::LeaseHeld => {
+                "another publisher in this process holds the publication lease — not recovering"
+                    .to_string()
+            }
+            IndexPublicationRecovery::ReadOnlyStore {
+                abandoned_writer_pid,
+            } => format!(
+                "index publication was abandoned by dead writer pid {abandoned_writer_pid}, but \
+                 this store is open read-only; a writer must perform the repair"
+            ),
+            IndexPublicationRecovery::Recovered {
+                abandoned_writer_pid,
+                generation,
+                was_cancelled_run,
+            } => {
+                let base = format!(
+                    "recovered an abandoned index publication left by dead writer pid \
+                     {abandoned_writer_pid}: PageRank recomputed against the committed graph, \
+                     graph generation {generation} persisted, marker cleared"
+                );
+                if *was_cancelled_run {
+                    format!(
+                        "{base}. That publication was left dirty deliberately by a run that \
+                         committed AFTER cancellation, so the graph itself may be incomplete — \
+                         run `nestweaver index --repo <path> --force` to rebuild it"
+                    )
+                } else {
+                    base
+                }
+            }
+        }
+    }
+}
+
+/// Reconcile an abandoned index publication, in the WRITER only.
+///
+/// The `<db>.index-dirty` marker is durable by design so it survives process
+/// death, and while it exists ranked queries fail closed — correctly, since
+/// `.pagerank.json` and `.generation` may predate the committed graph. What was
+/// missing is the way out. `finalize_committed_index_for_scope_with_io` already
+/// documents the cancelled-commit path as leaving the publication dirty "so the
+/// next open reconciles it"; this function is that reconciliation.
+///
+/// It is a finalize **epilogue, not an `rm`**. Deleting the marker would make
+/// the stale sidecars authoritative again — precisely the silent-wrong-ranks
+/// outcome the guard exists to prevent. Instead it takes the publication lease,
+/// re-establishes ownership of the marker, and routes through
+/// `finalize_committed_index_for_scope_with_io`, so PageRank is recomputed
+/// against the *committed* graph and `.generation` advanced and persisted
+/// **before** the marker is cleared. That ordering is the entire point of the
+/// guard and is not duplicated here.
+///
+/// `read_write` gates recovery exactly as it gates the orphaned-WAL arm of
+/// `open_lbug_with_recovery`: a read-only caller must report the condition, not
+/// mutate the directory to clear it. This is concrete, not theoretical — the
+/// MCP server commonly runs as a separate process from the daemon and opens the
+/// store read-only, so it must never be the process performing repair.
+pub fn recover_abandoned_index_publication(
+    store: &GraphStore,
+    read_write: bool,
+) -> Result<IndexPublicationRecovery, DeletionReconciliationError> {
+    recover_abandoned_index_publication_with_io(store, read_write, &FileSystemIndexEpilogueIo)
+}
+
+pub(crate) fn recover_abandoned_index_publication_with_io(
+    store: &GraphStore,
+    read_write: bool,
+    io: &dyn IndexEpilogueIo,
+) -> Result<IndexPublicationRecovery, DeletionReconciliationError> {
+    const OPERATION: &str = "recover abandoned index publication";
+
+    let Some(db_path) = store.db_path().map(Path::to_path_buf) else {
+        return Ok(IndexPublicationRecovery::NotFileBacked);
+    };
+
+    // Cheap file-derived triage BEFORE touching the lease, so the common
+    // (clean) case costs one `read_to_string` and nothing else.
+    let state = nestweaver_store::index_publication::read_marker(&db_path);
+    match &state {
+        nestweaver_store::index_publication::MarkerState::Absent => {
+            return Ok(IndexPublicationRecovery::Clean);
+        }
+        nestweaver_store::index_publication::MarkerState::Undeterminable(detail) => {
+            return Ok(IndexPublicationRecovery::Undeterminable {
+                detail: detail.clone(),
+            });
+        }
+        nestweaver_store::index_publication::MarkerState::Present(_) => {}
+    }
+    let record = state.record().expect("present marker carries a record");
+    let was_cancelled_run = record.is_deliberately_dirty();
+    let Some(pid) = record.writer_pid else {
+        return Ok(IndexPublicationRecovery::WriterUnattributed);
+    };
+    if crate::index_publication::process_is_alive(pid) {
+        return Ok(IndexPublicationRecovery::WriterAlive { pid });
+    }
+    if !read_write {
+        // Report, never clear. Same rule, and the same reason, as the
+        // read-only arm of `open_lbug_with_recovery`: "a read-only caller
+        // quarantining a log out from under a live writer would be a genuine
+        // hazard". The MCP server opens the store read-only and can be a
+        // different process from the daemon, so it lands here.
+        return Ok(IndexPublicationRecovery::ReadOnlyStore {
+            abandoned_writer_pid: pid,
+        });
+    }
+
+    // Second half of the abandoned predicate: no in-process publisher owns the
+    // lease. Acquired non-blockingly — queueing behind a live publisher would
+    // mean the publication was never abandoned in the first place.
+    let lease = store
+        .try_acquire_index_publication_lease()
+        .map_err(|error| {
+            DeletionReconciliationError::new(
+                OPERATION,
+                vec![DeletionReconciliationFailure {
+                    stage: DeletionReconciliationStage::IndexPublicationMarker,
+                    repo_uid: None,
+                    message: format!("acquire exclusive index publication lease: {error:#}"),
+                }],
+            )
+        })?;
+    let Some(lease) = lease else {
+        return Ok(IndexPublicationRecovery::LeaseHeld);
+    };
+
+    // Re-read under the lease. Between the triage read and here, a fresh
+    // publisher in another process could have established a new marker with a
+    // live pid; recovering that would clear a marker out from under its writer.
+    let confirmed = nestweaver_store::index_publication::read_marker(&db_path);
+    match confirmed.record().and_then(|r| r.writer_pid) {
+        Some(current) if current != pid => {
+            return Ok(IndexPublicationRecovery::WriterAlive { pid: current });
+        }
+        Some(_) => {}
+        None => return Ok(IndexPublicationRecovery::WriterUnattributed),
+    }
+
+    // The `u64::MAX` arm. When `.generation` is missing or unparseable while
+    // the marker is present, the fail-closed load takes `canonical = u64::MAX`,
+    // so `checked_add(2)` overflows in preflight and the publication can NEVER
+    // complete — surfacing as `graph generation exhausted during index
+    // publication`, a DIFFERENT error string. Recovery that ignored this arm
+    // would appear to fix nothing. Re-derive instead of adding to `MAX`.
+    let generation_path = crate::sidecar_path(&db_path, ".generation");
+    if let Some(rederived) = lease
+        .rederive_unavailable_generation_base(&generation_path)
+        .map_err(|error| {
+            DeletionReconciliationError::new(
+                OPERATION,
+                vec![DeletionReconciliationFailure {
+                    stage: DeletionReconciliationStage::GenerationPersistence,
+                    repo_uid: None,
+                    message: format!("re-derive fail-closed generation base: {error:#}"),
+                }],
+            )
+        })?
+    {
+        tracing::warn!(
+            "index publication recovery re-derived an unavailable generation base to \
+             {rederived} because {} was missing or unparseable while the marker was set",
+            generation_path.display()
+        );
+    }
+
+    // Take ownership of the marker (it is rewritten with THIS process's pid and
+    // timestamp), then run the ordinary committed-index epilogue.
+    let lease = establish_index_publication_marker_on_lease(lease, Some(&db_path), OPERATION, io)?;
+    finalize_committed_index_for_scope_with_io(
+        lease,
+        Some(&db_path),
+        OPERATION,
+        io,
+        Some(&nestweaver_store::GraphScope::code_only()),
+        true,
+    )?;
+
+    Ok(IndexPublicationRecovery::Recovered {
+        abandoned_writer_pid: pid,
+        generation: store.graph_generation(),
+        was_cancelled_run,
+    })
+}
+
+/// Open a store READ-WRITE and reconcile any abandoned index publication
+/// before handing it back.
+///
+/// This is the writer-side funnel for auto-heal. Every production writer opens
+/// through it (`index_repo`, the incremental path, the code and vault
+/// watchers); the daemon reconciles separately at startup. Read-only openers —
+/// notably the MCP server, which commonly runs in a different process from the
+/// daemon — deliberately do NOT have an equivalent and must never repair.
+pub fn open_store_for_writing_with_recovery(db_path: &Path) -> Result<GraphStore, anyhow::Error> {
+    let store = GraphStore::open_or_create(db_path)
+        .with_context(|| format!("open/create store at {}", db_path.display()))?;
+    recover_abandoned_index_publication_best_effort(&store, true);
+    Ok(store)
+}
+
+/// Run [`recover_abandoned_index_publication`] and log the outcome, swallowing
+/// errors. For call sites (daemon startup, writer opens) where recovery is a
+/// best-effort improvement and must never be able to fail the caller.
+pub fn recover_abandoned_index_publication_best_effort(
+    store: &GraphStore,
+    read_write: bool,
+) -> Option<IndexPublicationRecovery> {
+    match recover_abandoned_index_publication(store, read_write) {
+        Ok(outcome) => {
+            if outcome.recovered() {
+                tracing::warn!("{}", outcome.describe());
+            } else if !matches!(
+                outcome,
+                IndexPublicationRecovery::Clean | IndexPublicationRecovery::NotFileBacked
+            ) {
+                tracing::info!("{}", outcome.describe());
+            }
+            Some(outcome)
+        }
+        Err(error) => {
+            tracing::warn!("index publication recovery failed: {error:#}");
+            None
+        }
     }
 }
 
@@ -1251,8 +1638,10 @@ pub fn index_directory_with_options(
     force: bool,
     name: Option<&str>,
 ) -> Result<IndexResult, anyhow::Error> {
-    let store = GraphStore::open_or_create(db_path)
-        .with_context(|| format!("failed to open/create GraphStore at {}", db_path.display()))?;
+    // nw-C1: reconcile an abandoned publication before indexing. A crashed
+    // predecessor's `.index-dirty` otherwise wedges every ranked query, and the
+    // fail-closed `u64::MAX` generation base can block this run's own preflight.
+    let store = open_store_for_writing_with_recovery(db_path)?;
     index_directory_with_store(
         &store,
         repo_path,
@@ -3975,8 +4364,11 @@ fn incremental_index_with_name_and_io(
     name: Option<&str>,
     epilogue_io: &dyn IndexEpilogueIo,
 ) -> Result<IncrementalResult, anyhow::Error> {
-    let store = nestweaver_store::GraphStore::open_or_create(db_path)
-        .with_context(|| format!("open/create store at {}", db_path.display()))?;
+    // nw-C1: reconcile BEFORE the `old_sha == new_sha` short-circuit below,
+    // which returns early without ever establishing a marker. Without this, an
+    // idle repo could never clear an abandoned publication however often it was
+    // re-indexed.
+    let store = open_store_for_writing_with_recovery(db_path)?;
 
     let r_uid = nestweaver_schema::repo_uid(instance_id, repo_url);
 
@@ -5225,6 +5617,386 @@ mod tests {
                 evidence: Vec::new(),
             })
             .unwrap();
+    }
+
+    // ── nw-C1: abandoned-publication recovery ───────────────────────────
+
+    /// A pid that is guaranteed not to name a live process: spawn a child,
+    /// wait for it (which reaps the zombie), and return its now-free pid.
+    /// `kill(pid, 0)` then reports ESRCH deterministically.
+    fn reaped_child_pid() -> i32 {
+        let mut child = std::process::Command::new("/bin/true")
+            .spawn()
+            .expect("spawn /bin/true");
+        let pid = child.id() as i32;
+        child.wait().expect("reap /bin/true");
+        assert!(
+            !crate::index_publication::process_is_alive(pid),
+            "a reaped child must not read as alive"
+        );
+        pid
+    }
+
+    fn write_marker_with_pid(marker_path: &Path, pid: i32, reason: Option<&str>) {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::fs::write(
+            marker_path,
+            nestweaver_store::index_publication::format_marker_payload(pid as u32, nanos, reason),
+        )
+        .unwrap();
+    }
+
+    /// Leave the database in exactly the state a SIGKILL between marker
+    /// establishment and finalize produces: graph committed, `.index-dirty`
+    /// present and naming a dead writer, `.pagerank.json` still holding
+    /// pre-crash scores, `.generation` still at the pre-crash canonical value.
+    fn abandon_publication_after_commit(db_path: &Path, publisher: &str) -> (i32, u64) {
+        let generation_path = crate::sidecar_path(db_path, ".generation");
+        let pagerank_path = crate::sidecar_path(db_path, ".pagerank.json");
+        let marker_path = crate::sidecar_path(db_path, ".index-dirty");
+
+        let store = GraphStore::open_or_create(db_path).unwrap();
+        store.bump_graph_generation();
+        store.save_graph_generation(&generation_path).unwrap();
+        let canonical = store.graph_generation();
+        // A PageRank sidecar that predates the commit below. Serving it after
+        // the commit would be the silent-wrong-ranks outcome the guard exists
+        // to prevent, so recovery must overwrite rather than preserve it.
+        std::fs::write(&pagerank_path, r#"{"stale-precrash-score":1.0}"#).unwrap();
+
+        let lease = establish_index_publication_marker_with_io(
+            &store,
+            Some(db_path),
+            "crashing publisher",
+            &FileSystemIndexEpilogueIo,
+        )
+        .unwrap();
+        insert_publication_graph(&store, publisher);
+        // The process dies here: the lease is process-local and simply
+        // vanishes, while the marker and both sidecars are durable.
+        drop(lease);
+        drop(store);
+
+        let pid = reaped_child_pid();
+        write_marker_with_pid(&marker_path, pid, None);
+        (pid, canonical)
+    }
+
+    #[test]
+    fn abandoned_publication_recovers_on_read_write_open_with_no_manual_intervention() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
+        let pagerank_path = crate::sidecar_path(&db_path, ".pagerank.json");
+
+        let (dead_pid, canonical) = abandon_publication_after_commit(&db_path, "crashed");
+        assert!(marker_path.exists(), "the crash must leave the marker set");
+
+        // The whole point: an ordinary read-write open, nothing else.
+        let store = open_store_for_writing_with_recovery(&db_path).unwrap();
+
+        assert!(
+            !marker_path.exists(),
+            "recovery must retire the marker for pid {dead_pid}"
+        );
+        assert!(!store.is_index_publication_dirty());
+        assert_eq!(
+            store.graph_generation(),
+            canonical + 2,
+            "recovery publishes the clean N+2 successor"
+        );
+
+        // PageRank must reflect the COMMITTED graph, not the pre-crash sidecar.
+        let scores = store.pagerank_scores();
+        assert!(
+            !scores.contains_key("stale-precrash-score"),
+            "the pre-crash PageRank sidecar must not survive recovery: {scores:?}"
+        );
+        assert!(
+            scores.contains_key("sym:publisher-crashed:source"),
+            "recovered PageRank must cover the committed graph: {scores:?}"
+        );
+
+        drop(store);
+        let reopened = GraphStore::open_or_create(&db_path).unwrap();
+        assert!(!reopened.is_index_publication_dirty());
+        assert_eq!(reopened.graph_generation(), canonical + 2);
+        reopened.load_pagerank_cache(&pagerank_path).unwrap();
+        assert!(
+            reopened
+                .pagerank_scores()
+                .contains_key("sym:publisher-crashed:source"),
+            "the persisted PageRank sidecar must reflect the committed graph"
+        );
+    }
+
+    #[test]
+    fn a_read_only_open_reports_the_abandoned_publication_and_never_clears_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
+
+        let (dead_pid, _) = abandon_publication_after_commit(&db_path, "readonly");
+
+        let store = GraphStore::open_read_only(&db_path).unwrap();
+        let outcome = recover_abandoned_index_publication(&store, false).unwrap();
+        assert_eq!(
+            outcome,
+            IndexPublicationRecovery::ReadOnlyStore {
+                abandoned_writer_pid: dead_pid
+            },
+            "a read-only caller must report, never repair"
+        );
+        assert!(!outcome.recovered());
+        assert!(
+            marker_path.exists(),
+            "a read-only open must preserve the marker"
+        );
+        assert!(
+            store.is_index_publication_dirty(),
+            "a read-only open must keep failing closed"
+        );
+    }
+
+    #[test]
+    fn a_live_publication_is_never_recovered_out_from_under_its_writer() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
+        let generation_path = crate::sidecar_path(&db_path, ".generation");
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        store.bump_graph_generation();
+        store.save_graph_generation(&generation_path).unwrap();
+
+        let lease = establish_index_publication_marker_with_io(
+            &store,
+            Some(&db_path),
+            "live publisher",
+            &FileSystemIndexEpilogueIo,
+        )
+        .unwrap();
+        let dirty_generation = store.graph_generation();
+
+        // The marker names THIS process, which is alive: liveness alone must
+        // stop recovery, before the lease is even consulted.
+        let outcome = recover_abandoned_index_publication(&store, true).unwrap();
+        assert_eq!(
+            outcome,
+            IndexPublicationRecovery::WriterAlive {
+                pid: std::process::id() as i32
+            }
+        );
+        assert!(marker_path.exists());
+        assert_eq!(store.graph_generation(), dirty_generation);
+
+        // And with a DEAD recorded pid but the lease still held in-process,
+        // the second half of the predicate must decline too.
+        write_marker_with_pid(&marker_path, reaped_child_pid(), None);
+        assert_eq!(
+            recover_abandoned_index_publication(&store, true).unwrap(),
+            IndexPublicationRecovery::LeaseHeld,
+            "a held lease means the publication is in flight, not abandoned"
+        );
+        assert!(marker_path.exists());
+
+        // The live publisher still finishes normally.
+        insert_publication_graph(&store, "live");
+        finalize_committed_index_with_io(
+            lease,
+            Some(&db_path),
+            "live publisher",
+            &FileSystemIndexEpilogueIo,
+            true,
+        )
+        .unwrap();
+        assert!(!marker_path.exists());
+    }
+
+    #[test]
+    fn an_undeterminable_marker_is_reported_not_recovered() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
+        {
+            let _ = GraphStore::open_or_create(&db_path).unwrap();
+        }
+        // A directory where the marker file belongs: `try_exists` succeeds but
+        // the read cannot. `is_index_publication_dirty` is
+        // `try_exists().unwrap_or(true)`, so this reads as permanently dirty by
+        // design — recovery must not mistake it for an abandoned publication.
+        std::fs::create_dir(&marker_path).unwrap();
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        let outcome = recover_abandoned_index_publication(&store, true).unwrap();
+        assert!(
+            matches!(outcome, IndexPublicationRecovery::Undeterminable { .. }),
+            "cannot tell is not abandoned: {outcome:?}"
+        );
+        assert!(marker_path.exists());
+        assert!(store.is_index_publication_dirty());
+    }
+
+    #[test]
+    fn an_unattributed_marker_is_not_auto_recovered() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
+        {
+            let _ = GraphStore::open_or_create(&db_path).unwrap();
+        }
+        // The pre-nw-C1 hand-created marker, and what an older binary's
+        // truncated write leaves behind.
+        std::fs::write(&marker_path, b"dirty").unwrap();
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        assert_eq!(
+            recover_abandoned_index_publication(&store, true).unwrap(),
+            IndexPublicationRecovery::WriterUnattributed
+        );
+        assert!(marker_path.exists());
+    }
+
+    #[test]
+    fn a_dirty_marker_with_a_missing_generation_recovers_instead_of_exhausting() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
+        let generation_path = crate::sidecar_path(&db_path, ".generation");
+
+        {
+            let store = GraphStore::open_or_create(&db_path).unwrap();
+            insert_publication_graph(&store, "nogeneration");
+        }
+        // Marker present, `.generation` absent: the fail-closed load takes
+        // `canonical = u64::MAX`.
+        let dead_pid = reaped_child_pid();
+        write_marker_with_pid(&marker_path, dead_pid, None);
+        assert!(!generation_path.exists());
+
+        // Establish that the second wedge exists, so this test would catch a
+        // recovery that quietly ignored the `u64::MAX` arm.
+        {
+            let store = GraphStore::open_or_create(&db_path).unwrap();
+            assert_eq!(store.graph_generation(), u64::MAX);
+            let error = establish_index_publication_marker_with_io(
+                &store,
+                Some(&db_path),
+                "blocked publisher",
+                &FileSystemIndexEpilogueIo,
+            )
+            .expect_err("preflight must overflow while the base is u64::MAX");
+            assert!(
+                format!("{error}").contains("graph generation exhausted during index publication"),
+                "the second wedge surfaces as a DIFFERENT error string: {error}"
+            );
+        }
+
+        let store = open_store_for_writing_with_recovery(&db_path).unwrap();
+        assert!(
+            !marker_path.exists(),
+            "recovery must re-derive rather than add to u64::MAX"
+        );
+        assert!(!store.is_index_publication_dirty());
+        assert!(generation_path.exists());
+        assert_eq!(
+            store.graph_generation(),
+            2,
+            "re-derivation falls back to the same canonical 0 a clean open would use"
+        );
+        assert!(
+            store
+                .pagerank_scores()
+                .contains_key("sym:publisher-nogeneration:source")
+        );
+    }
+
+    #[test]
+    fn recovery_reports_a_deliberately_dirty_cancelled_publication_distinctly() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
+        let generation_path = crate::sidecar_path(&db_path, ".generation");
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        store.bump_graph_generation();
+        store.save_graph_generation(&generation_path).unwrap();
+
+        let lease = establish_index_publication_marker_with_io(
+            &store,
+            Some(&db_path),
+            "cancelled publisher",
+            &FileSystemIndexEpilogueIo,
+        )
+        .unwrap();
+        insert_publication_graph(&store, "cancelled");
+        // The committed-after-cancellation path: publish_clean = false.
+        finalize_committed_index_for_scope_with_io(
+            lease,
+            Some(&db_path),
+            "cancelled publisher",
+            &FileSystemIndexEpilogueIo,
+            None,
+            false,
+        )
+        .unwrap();
+        assert!(
+            marker_path.exists(),
+            "a cancelled-but-committed run must stay dirty on purpose"
+        );
+        let state = nestweaver_store::index_publication::read_marker(&db_path);
+        assert!(
+            state.record().unwrap().is_deliberately_dirty(),
+            "the deliberate hold must be recorded in the marker payload"
+        );
+
+        // Still owned by a live process → never recovered.
+        assert_eq!(
+            recover_abandoned_index_publication(&store, true).unwrap(),
+            IndexPublicationRecovery::WriterAlive {
+                pid: std::process::id() as i32
+            }
+        );
+        drop(store);
+
+        // Once that writer is gone, the publication IS reconciled — the
+        // sidecars really do predate the commit either way — but the outcome
+        // says so, so the `index --force` guidance is not silently lost.
+        write_marker_with_pid(&marker_path, reaped_child_pid(), Some("cancelled"));
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        let outcome = recover_abandoned_index_publication(&store, true).unwrap();
+        assert!(outcome.recovered());
+        assert!(
+            matches!(
+                outcome,
+                IndexPublicationRecovery::Recovered {
+                    was_cancelled_run: true,
+                    ..
+                }
+            ),
+            "{outcome:?}"
+        );
+        assert!(outcome.describe().contains("--force"));
+        assert!(!marker_path.exists());
+    }
+
+    #[test]
+    fn a_clean_store_reports_clean_and_an_in_memory_store_has_nothing_to_recover() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        assert_eq!(
+            recover_abandoned_index_publication(&store, true).unwrap(),
+            IndexPublicationRecovery::Clean
+        );
+        let memory = GraphStore::in_memory().unwrap();
+        assert_eq!(
+            recover_abandoned_index_publication(&memory, true).unwrap(),
+            IndexPublicationRecovery::NotFileBacked
+        );
     }
 
     /// Liveness deadline for the cross-thread handoffs in the overlapping

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -666,12 +666,6 @@ impl FileSystemIndexEpilogueIo {
     /// parent directory — is what makes the marker survive process death, and
     /// it must not be duplicated with drift.
     fn write_marker_payload(&self, path: &Path, reason: Option<&str>) -> Result<(), anyhow::Error> {
-        let mut file = std::fs::OpenOptions::new()
-            .create(true)
-            .truncate(true)
-            .write(true)
-            .open(path)
-            .with_context(|| format!("create index publication marker {}", path.display()))?;
         let marker = nestweaver_store::index_publication::format_marker_payload(
             std::process::id(),
             std::time::SystemTime::now()
@@ -680,11 +674,23 @@ impl FileSystemIndexEpilogueIo {
                 .as_nanos(),
             reason,
         );
-        file.write_all(marker.as_bytes())
-            .with_context(|| format!("write index publication marker {}", path.display()))?;
-        file.sync_all()
-            .with_context(|| format!("sync index publication marker {}", path.display()))?;
-        sync_sidecar_parent(path)
+        // Temp-file + rename, NOT truncate-in-place. A truncating rewrite makes
+        // the marker briefly zero-byte, and a reader landing in that window
+        // parses no pid and no timestamp — which the wedged predicate now reads
+        // as "unattributable, therefore WEDGED", telling an operator to run
+        // `repair --force` against a publication that is perfectly healthy and
+        // in flight. The window is microseconds and cannot cause data loss
+        // (lbug's write lock stops any forced repair from opening the store),
+        // but a rename removes it entirely: a reader sees the old payload or the
+        // new one, never a partial one.
+        //
+        // `atomic_replace_file` keeps the durability this marker depends on —
+        // it syncs the temp file and the parent directory, so the marker still
+        // survives process death, which is the whole reason it exists.
+        nestweaver_store::durable_sidecar::atomic_replace_file(path, |file| {
+            file.write_all(marker.as_bytes())
+        })
+        .with_context(|| format!("publish index publication marker {}", path.display()))
     }
 
     fn stamp_marker_reason_impl(&self, path: &Path, reason: &str) -> Result<(), anyhow::Error> {
@@ -1227,11 +1233,26 @@ impl IndexPublicationRecovery {
 /// The ordering that function actually guarantees, stated precisely because it
 /// is easy to overclaim: the **stale `.pagerank.json` is removed** and
 /// `.generation` advanced and persisted BEFORE the marker is cleared; the fresh
-/// PageRank is computed and saved AFTER. So there is a window in which the
-/// publication reads clean with no PageRank sidecar on disk — which is safe,
-/// because an absent sidecar recomputes, whereas a stale one would be trusted.
-/// "Recomputed before the marker clears" would be false. Not duplicated here:
-/// the ordering is the entire point of the guard and lives in one place.
+/// PageRank is computed and saved AFTER. "Recomputed before the marker clears"
+/// would be false. Not duplicated here: the ordering is the entire point of the
+/// guard and lives in one place.
+///
+/// That leaves a real window — marker cleared, sidecar not yet written — and it
+/// is **not fully safe**, so do not read the ordering as if it were. Removing
+/// the stale sidecar first is strictly better than leaving it (a stale sidecar
+/// would be trusted; an absent one cannot serve wrong ranks). But a crash
+/// inside the window leaves `.pagerank.json` MISSING with the marker already
+/// gone, and nothing regenerates it: the lazy fallback
+/// (`ranking.rs`, `ensure_pagerank_loaded` → `compute_pagerank_warm_locked`)
+/// ranks `GraphScope::code_only()` and only in memory — it never re-persists,
+/// and on a brain database it never covers the note side at all. The publication
+/// then reports CLEAN, `brain_status` raises no warning, and queries answer from
+/// a code-only in-memory rank forever.
+///
+/// The window predates this recovery path (it is the finalizer's ordering, used
+/// by every publication) and is deliberately left alone here. Making the lazy
+/// path scope-aware and re-persisting is the real fix and is filed separately;
+/// recovery must not paper over it with a second, divergent recompute.
 ///
 /// `read_write` gates recovery exactly as it gates the orphaned-WAL arm of
 /// `open_lbug_with_recovery`: a read-only caller must report the condition, not
@@ -1427,11 +1448,22 @@ pub(crate) fn recover_abandoned_index_publication_with_io(
         );
     }
 
-    // SCOPE: `unified()`, never `code_only()`. `compute_pagerank` REPLACES the
-    // whole score map, and the canonical sidecar on a brain database is
-    // published unified (`BrainWatcher`), so recovering with a code-only scope
-    // would silently delete every Note/Section/Heading/Tag rank — turning a
-    // recovery into data loss. This also matches the recovered-owner arm in
+    // SCOPE: `unified()`, never `code_only()`.
+    //
+    // `compute_pagerank` REPLACES the whole score map rather than merging into
+    // it, so the scope chosen here decides which node kinds survive recovery.
+    //
+    // Which scope the canonical sidecar currently holds is NOT knowable from
+    // here, and it is not always unified: whichever publisher ran last wins.
+    // `nestweaver index` and the code watcher publish `code_only()`; the vault
+    // watcher publishes `unified()`. A fresh `index --repo` followed by
+    // `brain add` leaves a sym-only sidecar on disk.
+    //
+    // `unified()` is right precisely because it is a strict SUPERSET: it can
+    // only ever widen what was published, never narrow it. `code_only()` could
+    // narrow it, and on a database holding both a repo and a vault that means
+    // silently deleting every Note/Section/Heading/Tag rank — a recovery that
+    // destroys data. This matches the recovered-owner arm in
     // `index_with_reader_and_write_gate`, which heals "that unknown committed
     // graph as one unified publication" for the same reason: a recovering owner
     // cannot prove which slices of the graph the dead owner had touched.
@@ -6131,6 +6163,79 @@ mod tests {
         );
         assert!(outcome.describe().contains("--force"));
         assert!(!marker_path.exists());
+    }
+
+    /// A rewrite must never be observable as a partial payload.
+    ///
+    /// With truncate-in-place this fails: a reader stat-ing between `truncate`
+    /// and `write_all` sees a zero-byte marker, which parses to no pid and no
+    /// timestamp — and the wedged predicate reads that as "unattributable,
+    /// therefore WEDGED", telling an operator to force-repair a healthy
+    /// in-flight publication. With temp-file + rename the state is
+    /// unreachable, so a reader only ever sees the old payload or the new one.
+    #[test]
+    fn rewriting_the_marker_is_never_observable_as_a_partial_payload() {
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
+        FileSystemIndexEpilogueIo
+            .establish_marker(&marker_path)
+            .unwrap();
+
+        let stop = AtomicBool::new(false);
+        let observations = AtomicUsize::new(0);
+        let partials = AtomicUsize::new(0);
+
+        std::thread::scope(|scope| {
+            let reader = scope.spawn(|| {
+                while !stop.load(AtomicOrdering::Acquire) {
+                    let state = nestweaver_store::index_publication::read_marker(&db_path);
+                    if let Some(record) = state.record() {
+                        observations.fetch_add(1, AtomicOrdering::Relaxed);
+                        // A present marker written by this process always
+                        // carries a pid. No pid means a torn read.
+                        if record.writer_pid.is_none() {
+                            partials.fetch_add(1, AtomicOrdering::Relaxed);
+                        }
+                    }
+                }
+            });
+            for i in 0..300 {
+                if i % 2 == 0 {
+                    FileSystemIndexEpilogueIo
+                        .establish_marker(&marker_path)
+                        .unwrap();
+                } else {
+                    FileSystemIndexEpilogueIo
+                        .stamp_marker_reason(
+                            &marker_path,
+                            nestweaver_store::index_publication::MARKER_REASON_CANCELLED,
+                        )
+                        .unwrap();
+                }
+            }
+            stop.store(true, AtomicOrdering::Release);
+            reader.join().unwrap();
+        });
+
+        assert!(
+            observations.load(AtomicOrdering::Relaxed) > 0,
+            "the reader must actually have observed the marker"
+        );
+        assert_eq!(
+            partials.load(AtomicOrdering::Relaxed),
+            0,
+            "a marker rewrite must never be observable as a partial payload, or a \
+             healthy in-flight publication is reported WEDGED"
+        );
+        // And the marker is still valid and attributable afterwards.
+        let final_state = nestweaver_store::index_publication::read_marker(&db_path);
+        assert_eq!(
+            final_state.record().unwrap().writer_pid,
+            Some(std::process::id() as i32)
+        );
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/index_publication.rs
+++ b/crates/nestweaver-engine/src/index_publication.rs
@@ -99,17 +99,50 @@ impl IndexPublicationStatus {
             return true;
         }
         match self.writer_alive {
+            // A live writer is a publication in flight, not a wedge.
             Some(true) => false,
+            // A dead writer cannot finish. Wedged regardless of age.
             Some(false) => true,
-            None => self
-                .marker_age_s
-                .is_some_and(|age| Duration::from_secs(age) >= WEDGED_MARKER_AGE),
+            None => match self.marker_age_s {
+                Some(age) => Duration::from_secs(age) >= WEDGED_MARKER_AGE,
+                // Nothing attributable at all: no pid to probe, no timestamp to
+                // age out. A marker written by an older binary, truncated by a
+                // crash, or hand-created with `touch` lands here, and NOTHING
+                // can clear it on its own — auto-heal declines because it
+                // cannot prove the writer is dead. Reporting it as merely
+                // transient would promise a recovery that never arrives, and
+                // would leave every caller paying the bounded wait forever.
+                // Call it wedged so the operator is told to run `repair
+                // --force`, which is the one thing that does resolve it.
+                None => true,
+            },
         }
     }
 
+    /// True when the wedge can only be cleared by an explicit operator
+    /// override — the marker is present but carries no writer we can prove
+    /// dead, so the automatic predicate must decline.
+    pub fn needs_forced_repair(&self) -> bool {
+        self.dirty && (!self.determinable || self.writer_pid.is_none())
+    }
+
     /// The operator escape hatch to name in a wedged-state message.
+    ///
+    /// A marker carrying no writer we can prove dead needs the explicit
+    /// override, so name it. Printing the bare command for a case that is
+    /// guaranteed to decline would send the operator round the same loop the
+    /// automatic predicate already lost.
     pub fn repair_command(db_path: &Path) -> String {
         format!("nestweaver repair --db {}", db_path.display())
+    }
+
+    /// The repair command appropriate to THIS status.
+    pub fn repair_command_for(&self, db_path: &Path) -> String {
+        if self.needs_forced_repair() {
+            format!("nestweaver repair --db {} --force", db_path.display())
+        } else {
+            Self::repair_command(db_path)
+        }
     }
 }
 
@@ -285,6 +318,99 @@ mod tests {
             None,
             "a live writer is never abandoned even with an unowned lease"
         );
+    }
+
+    #[test]
+    fn an_unattributed_marker_is_wedged_not_transient() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        // The legacy / `touch`-created marker: present, but nothing to attribute.
+        std::fs::write(marker_path(&db_path), b"dirty").unwrap();
+        let status = status(&db_path);
+        assert!(status.dirty);
+        assert_eq!(status.writer_pid, None);
+        assert_eq!(status.writer_alive, None);
+        assert_eq!(status.marker_age_s, None);
+        assert!(
+            status.is_wedged(),
+            "an unattributable marker cannot clear itself; reporting it as \
+             transient promises a recovery that never arrives"
+        );
+        assert!(
+            status.needs_forced_repair(),
+            "and the only thing that resolves it is an explicit override"
+        );
+    }
+
+    #[test]
+    fn the_named_repair_command_matches_what_the_case_actually_needs() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+
+        std::fs::write(marker_path(&db_path), b"dirty").unwrap();
+        assert!(
+            status(&db_path)
+                .repair_command_for(&db_path)
+                .ends_with("--force"),
+            "an unattributable marker must be told to use --force"
+        );
+
+        let dead = {
+            let mut c = std::process::Command::new("/bin/true").spawn().unwrap();
+            let pid = c.id() as i32;
+            c.wait().unwrap();
+            pid
+        };
+        std::fs::write(
+            marker_path(&db_path),
+            format_marker_payload(dead as u32, 1, None),
+        )
+        .unwrap();
+        assert!(
+            !status(&db_path)
+                .repair_command_for(&db_path)
+                .ends_with("--force"),
+            "a provably-dead attributed writer needs no override"
+        );
+    }
+
+    #[test]
+    fn an_undeterminable_marker_needs_forced_repair() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let status = status_from(&db_path, MarkerState::Undeterminable("EACCES".into()));
+        assert!(status.is_wedged());
+        assert!(status.needs_forced_repair());
+    }
+
+    #[test]
+    fn an_attributed_live_publication_never_needs_forced_repair() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        std::fs::write(
+            marker_path(&db_path),
+            format_marker_payload(std::process::id(), 1, None),
+        )
+        .unwrap();
+        let status = status(&db_path);
+        assert!(!status.is_wedged());
+        assert!(!status.needs_forced_repair());
+    }
+
+    #[test]
+    fn a_young_timestamped_marker_without_a_pid_is_still_transient() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        // No pid, but a fresh timestamp: age-based classification still applies.
+        std::fs::write(marker_path(&db_path), format!("x:{now}\n")).unwrap();
+        let status = status(&db_path);
+        assert_eq!(status.writer_pid, None);
+        assert!(status.marker_age_s.is_some());
+        assert!(!status.is_wedged(), "a young marker is transient");
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/index_publication.rs
+++ b/crates/nestweaver-engine/src/index_publication.rs
@@ -1,0 +1,304 @@
+//! Liveness-aware view of the `<db>.index-dirty` publication marker, and the
+//! predicate that decides whether a publication is *abandoned*.
+//!
+//! `nestweaver-store` owns the marker's path and payload (see
+//! [`nestweaver_store::index_publication`]) but has no `libc` dependency, so it
+//! deliberately stops short of asking whether the recorded writer pid is still
+//! alive. This module adds that half.
+//!
+//! Two rules govern everything here.
+//!
+//! **A publication is abandoned only when the recorded pid is dead AND the
+//! in-process lease is unowned.** The pid half is cross-process (the writer is
+//! commonly the daemon or a one-shot `nestweaver index`); the lease half closes
+//! the case where the writer is *this* process and simply has not finished yet.
+//! Either half alone is insufficient.
+//!
+//! **"Cannot tell" is not "abandoned".** An `EACCES`/`EIO` on the sidecar
+//! directory reads as permanently dirty by design and is tested that way
+//! (`nestweaver-store/src/db.rs`, `unreadable_index_publication_marker_*`).
+//! Every path here maps an undeterminable marker to "do not recover", never to
+//! "recover".
+
+use std::path::Path;
+use std::time::Duration;
+
+use nestweaver_store::GraphStore;
+use nestweaver_store::index_publication::{MarkerRecord, MarkerState, read_marker};
+
+/// Age past which a dirty publication with an *unattributable* writer is
+/// reported as wedged rather than transient. A publication window is normally
+/// well under a second; anything still dirty after this, with no live writer we
+/// can point at, is a diagnosis worth surfacing.
+pub const WEDGED_MARKER_AGE: Duration = Duration::from_secs(60);
+
+/// Whether `pid` names a live process.
+///
+/// `kill(pid, 0)` performs the permission and existence checks without
+/// delivering a signal — the established idiom in this tree (`src/main.rs`
+/// daemon liveness probes). `EPERM` means the process exists but belongs to
+/// another user, which is still *alive*; only `ESRCH` proves it is gone.
+///
+/// Pid reuse is possible in principle. It is not load-bearing here: a recycled
+/// pid can only make this return `true`, which makes recovery *decline*. The
+/// failure mode is a missed auto-heal, recoverable with `nestweaver repair`,
+/// never a marker cleared out from under a live writer.
+#[cfg(unix)]
+pub fn process_is_alive(pid: i32) -> bool {
+    if pid <= 0 {
+        return false;
+    }
+    if unsafe { libc::kill(pid, 0) } == 0 {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+}
+
+/// Non-unix fallback: we cannot prove the writer is dead, so we never claim it.
+/// Auto-heal declines and the operator escape hatch still applies.
+#[cfg(not(unix))]
+pub fn process_is_alive(_pid: i32) -> bool {
+    true
+}
+
+/// File-derived publication state, suitable for reporting on the direct
+/// (`--no-daemon`) path with no daemon and no writable store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexPublicationStatus {
+    /// True when ranked queries fail closed — present OR undeterminable.
+    pub dirty: bool,
+    /// False when the marker's state could not be determined at all.
+    pub determinable: bool,
+    /// Pid recorded in the marker payload, when it parsed.
+    pub writer_pid: Option<i32>,
+    /// Whether that pid still names a live process. `None` when there is no
+    /// pid to check.
+    pub writer_alive: Option<bool>,
+    /// Seconds since the marker was established, per its own payload.
+    pub marker_age_s: Option<u64>,
+    /// Reason recorded by the writer, when it recorded one (see
+    /// [`nestweaver_store::index_publication::MARKER_REASON_CANCELLED`]).
+    pub writer_reason: Option<String>,
+    /// The marker path, so a message can name the exact file.
+    pub marker_path: String,
+}
+
+impl IndexPublicationStatus {
+    /// A dirty publication that is *not* plausibly in flight: the writer is
+    /// provably dead, or nothing can be attributed to a live writer and the
+    /// marker is older than [`WEDGED_MARKER_AGE`].
+    ///
+    /// An undeterminable marker is reported as wedged (something is wrong and a
+    /// human should look), but see [`abandoned_writer_pid`] — being *wedged* is
+    /// not sufficient to be *recoverable*.
+    pub fn is_wedged(&self) -> bool {
+        if !self.dirty {
+            return false;
+        }
+        if !self.determinable {
+            return true;
+        }
+        match self.writer_alive {
+            Some(true) => false,
+            Some(false) => true,
+            None => self
+                .marker_age_s
+                .is_some_and(|age| Duration::from_secs(age) >= WEDGED_MARKER_AGE),
+        }
+    }
+
+    /// The operator escape hatch to name in a wedged-state message.
+    pub fn repair_command(db_path: &Path) -> String {
+        format!("nestweaver repair --db {}", db_path.display())
+    }
+}
+
+/// Read the marker for `db_path` and decorate it with writer liveness.
+pub fn status(db_path: &Path) -> IndexPublicationStatus {
+    status_from(db_path, read_marker(db_path))
+}
+
+/// [`status`] against an already-read [`MarkerState`], so callers that already
+/// hold one do not re-read the file.
+pub fn status_from(db_path: &Path, state: MarkerState) -> IndexPublicationStatus {
+    let marker_path = nestweaver_store::index_publication::marker_path(db_path)
+        .display()
+        .to_string();
+    match state {
+        MarkerState::Absent => IndexPublicationStatus {
+            dirty: false,
+            determinable: true,
+            writer_pid: None,
+            writer_alive: None,
+            marker_age_s: None,
+            writer_reason: None,
+            marker_path,
+        },
+        MarkerState::Undeterminable(_) => IndexPublicationStatus {
+            dirty: true,
+            determinable: false,
+            writer_pid: None,
+            writer_alive: None,
+            marker_age_s: None,
+            writer_reason: None,
+            marker_path,
+        },
+        MarkerState::Present(record) => IndexPublicationStatus {
+            dirty: true,
+            determinable: true,
+            writer_pid: record.writer_pid,
+            writer_alive: record.writer_pid.map(process_is_alive),
+            marker_age_s: record.age().map(|age| age.as_secs()),
+            writer_reason: record.reason.clone(),
+            marker_path,
+        },
+    }
+}
+
+/// The pid of a writer that is provably gone, when this marker names one.
+///
+/// `None` means "do not recover", for any of four distinct reasons: the marker
+/// is absent, it is undeterminable, it records no pid we can attribute, or the
+/// pid it records is still alive. Only a *present, readable, attributed, dead*
+/// writer qualifies.
+pub fn abandoned_writer_pid(state: &MarkerState) -> Option<i32> {
+    let record: &MarkerRecord = state.record()?;
+    let pid = record.writer_pid?;
+    (!process_is_alive(pid)).then_some(pid)
+}
+
+/// The full abandoned-publication predicate: a dead recorded writer AND an
+/// unowned in-process lease.
+///
+/// The lease half matters when the recorded pid belongs to a process that
+/// exited while *this* process still holds a lease for the same store — and,
+/// more importantly, when the marker was written by a previous incarnation but
+/// a live publisher in this process has already taken over.
+pub fn publication_is_abandoned(store: &GraphStore, state: &MarkerState) -> Option<i32> {
+    let pid = abandoned_writer_pid(state)?;
+    store.index_publication_lease_is_unowned().then_some(pid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nestweaver_store::index_publication::{
+        MARKER_REASON_CANCELLED, format_marker_payload, marker_path,
+    };
+
+    fn present(pid: Option<i32>, reason: Option<&str>) -> MarkerState {
+        MarkerState::Present(MarkerRecord {
+            writer_pid: pid,
+            established_unix_nanos: None,
+            reason: reason.map(str::to_string),
+        })
+    }
+
+    #[test]
+    fn this_process_is_alive() {
+        assert!(process_is_alive(std::process::id() as i32));
+    }
+
+    #[test]
+    fn a_nonpositive_pid_is_never_alive() {
+        assert!(!process_is_alive(0));
+        assert!(!process_is_alive(-1));
+    }
+
+    #[test]
+    fn a_live_writer_is_never_abandoned() {
+        let state = present(Some(std::process::id() as i32), None);
+        assert_eq!(abandoned_writer_pid(&state), None);
+    }
+
+    #[test]
+    fn an_undeterminable_marker_is_never_abandoned_but_is_wedged() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let state = MarkerState::Undeterminable("permission denied".into());
+        assert_eq!(
+            abandoned_writer_pid(&state),
+            None,
+            "cannot tell must never mean abandoned"
+        );
+        let status = status_from(&db_path, state);
+        assert!(status.dirty);
+        assert!(!status.determinable);
+        assert!(status.is_wedged());
+    }
+
+    #[test]
+    fn an_unattributed_marker_is_never_abandoned() {
+        assert_eq!(abandoned_writer_pid(&present(None, None)), None);
+    }
+
+    #[test]
+    fn an_absent_marker_is_clean_and_not_wedged() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let status = status(&db_path);
+        assert!(!status.dirty);
+        assert!(status.determinable);
+        assert!(!status.is_wedged());
+    }
+
+    #[test]
+    fn a_live_writer_reads_as_transient_not_wedged() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        std::fs::write(
+            marker_path(&db_path),
+            format_marker_payload(std::process::id(), 1, None),
+        )
+        .unwrap();
+        let status = status(&db_path);
+        assert_eq!(status.writer_alive, Some(true));
+        assert!(!status.is_wedged(), "a live publication is not wedged");
+    }
+
+    #[test]
+    fn publication_is_abandoned_requires_both_halves() {
+        let store = GraphStore::in_memory().unwrap();
+        let dead = {
+            let mut child = std::process::Command::new("/bin/true").spawn().unwrap();
+            let pid = child.id() as i32;
+            child.wait().unwrap();
+            pid
+        };
+        let dead_state = present(Some(dead), None);
+        assert_eq!(
+            publication_is_abandoned(&store, &dead_state),
+            Some(dead),
+            "dead writer + unowned lease is the abandoned case"
+        );
+
+        let held = store.acquire_index_publication_lease().unwrap();
+        assert_eq!(
+            publication_is_abandoned(&store, &dead_state),
+            None,
+            "a held lease means a live publisher took over in this process"
+        );
+        drop(held);
+
+        assert_eq!(
+            publication_is_abandoned(&store, &present(Some(std::process::id() as i32), None)),
+            None,
+            "a live writer is never abandoned even with an unowned lease"
+        );
+    }
+
+    #[test]
+    fn status_reports_the_cancelled_reason() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        std::fs::write(
+            marker_path(&db_path),
+            format_marker_payload(std::process::id(), 1, Some(MARKER_REASON_CANCELLED)),
+        )
+        .unwrap();
+        assert_eq!(
+            status(&db_path).writer_reason.as_deref(),
+            Some(MARKER_REASON_CANCELLED)
+        );
+    }
+}

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -239,6 +239,7 @@ pub mod html_to_md;
 pub mod hubs;
 pub mod index;
 pub mod index_md;
+pub mod index_publication;
 pub mod interactions;
 pub mod investigate;
 pub mod jobs;

--- a/crates/nestweaver-engine/src/watch_code.rs
+++ b/crates/nestweaver-engine/src/watch_code.rs
@@ -107,10 +107,11 @@ impl CodeWatcher {
     /// Opens its own `GraphStore` from `self.db_path`. For sharing a store
     /// with the web server, use `run_with_store` instead.
     pub fn run(self) -> Result<(), anyhow::Error> {
-        let store = Arc::new(
-            GraphStore::open_or_create(&self.db_path)
-                .with_context(|| format!("open GraphStore at {}", self.db_path.display()))?,
-        );
+        // nw-C1: this watcher is a writer, so it reconciles an abandoned
+        // publication left by a crashed indexer instead of inheriting the wedge.
+        let store = Arc::new(crate::index::open_store_for_writing_with_recovery(
+            &self.db_path,
+        )?);
         self.run_inner(store, None)
     }
 

--- a/crates/nestweaver-engine/src/watcher.rs
+++ b/crates/nestweaver-engine/src/watcher.rs
@@ -241,10 +241,11 @@ impl BrainWatcher {
     /// Opens its own `GraphStore` from `self.db_path`. For sharing a store
     /// with the web server, use `run_with_store` instead.
     pub fn run(self) -> Result<(), anyhow::Error> {
-        let store = Arc::new(
-            GraphStore::open_or_create(&self.db_path)
-                .with_context(|| format!("open GraphStore at {}", self.db_path.display()))?,
-        );
+        // nw-C1: this watcher is a writer, so it reconciles an abandoned
+        // publication left by a crashed indexer instead of inheriting the wedge.
+        let store = Arc::new(crate::index::open_store_for_writing_with_recovery(
+            &self.db_path,
+        )?);
         self.run_inner(store, None)
     }
 

--- a/crates/nestweaver-federation/src/results.rs
+++ b/crates/nestweaver-federation/src/results.rs
@@ -172,6 +172,13 @@ fn push_unique(list: &mut Vec<String>, value: String) {
 /// without them re-creates exactly that ambiguity, so they are merged here
 /// rather than dropped.
 ///
+/// Used by BOTH federated merges: the flat `{ results: [...] }` envelope
+/// ([`merge_json_results`], serving `brain_search`) and the structured
+/// `connected` envelope ([`merge_structured_results`], serving `brain_context`
+/// and `project_context`). Both rebuild their response field by field, so both
+/// have to re-add these deliberately. The rules below are identical for the two
+/// callers; only their *reachability* differs, noted inline where it matters.
+///
 /// Merge rules, and why:
 ///
 /// - `semantic_applied` is **conjunctive (AND across contributing tiers)**. The
@@ -179,21 +186,33 @@ fn push_unique(list: &mut Vec<String>, value: String) {
 ///   only be claimed for the whole answer if it holds for every tier that
 ///   contributed to it. If one tier ran a semantic leg and the other did not,
 ///   part of the merged ranking is purely lexical, and reporting `true` would
-///   overclaim on those rows. `false` is the honest, conservative answer. Today
-///   `brain_search` is keyword/BM25-only everywhere and both tiers report
-///   `false`, making the merge trivial — but the rule is written so it stays
-///   correct the moment a real semantic leg appears on one side.
+///   overclaim on those rows. `false` is the honest, conservative answer. For
+///   `brain_search` the merge is trivial — it is keyword/BM25-only everywhere,
+///   so both tiers report `false` — but for `brain_context` /
+///   `project_context` a real semantic leg exists and either tier can report
+///   `true` on its own.
 ///
 ///   **Known limitation, deliberately accepted:** this collapses two states a
 ///   caller might want to tell apart. "Neither tier ran a semantic leg" and
-///   "local ran one, the server did not" both emit
-///   `semantic_applied: false, degraded_components: []`. A single boolean
-///   cannot carry per-tier provenance, and inventing a vocabulary to encode it
-///   would put values into `degraded_components` that no consumer understands —
-///   the field's documented vocabulary is `"semantic"` (README, docs/server-mode.md)
-///   and agents are told it means retrieval fell back to lexical ranking. If
-///   the mixed case ever becomes reachable and callers need to distinguish it,
-///   it belongs in `_meta` as per-tier provenance, not smuggled into this list.
+///   "local ran one, the server did not" both emit `semantic_applied: false`.
+///   For `brain_search` that mixed state is hypothetical; on the structured
+///   path it is **reachable today** — two independently configured daemons can
+///   differ in whether an embedding model is loaded, so a merged
+///   `brain_context` can genuinely mix a semantically-ranked tier with a
+///   lexical one and will report `false`. The AND is still the correct answer
+///   (a union containing purely lexical rows cannot claim the property for the
+///   whole answer), it is simply less informative than the two-tier truth.
+///
+///   It is NOT encoded here. A single boolean cannot carry per-tier
+///   provenance, and inventing a vocabulary to encode it would put values into
+///   `degraded_components` that no consumer understands — the field's
+///   documented vocabulary is exactly `"semantic"` (README,
+///   docs/server-mode.md, `agent_guide`) and agents are told it means retrieval
+///   fell back to lexical ranking. Note the mixed case is also NOT a
+///   degradation: a tier that never requested a semantic leg did not fall back
+///   from one, so nothing may be added to `degraded_components` on its account.
+///   If callers ever need to distinguish it, it belongs in `_meta` as explicit
+///   per-tier provenance, not smuggled into this list.
 ///
 /// - `degraded_components` is a **deduplicated union**, in local-then-server
 ///   encounter order. Degradation is a property of the merged answer as a
@@ -217,7 +236,10 @@ fn push_unique(list: &mut Vec<String>, value: String) {
 ///   is not reachable today for `brain_search`: both tiers go through
 ///   `dispatch::dispatch_typed_brain_search`, which always emits both keys, and
 ///   proto3 scalars mean an older server decodes to `false`/`[]` rather than to
-///   an absent field. It is defensive, not a supported detection mechanism.
+///   an absent field. The same holds on the structured path
+///   (`dispatch::dispatch_typed_brain_context` /
+///   `dispatch_typed_project_context` insert both keys unconditionally from the
+///   proto response). It is defensive, not a supported detection mechanism.
 ///
 /// - **If no tier reports either field, nothing is emitted.** Inventing
 ///   `semantic_applied: false` out of two silent tiers would destroy the very
@@ -486,6 +508,26 @@ pub fn merge_structured_results(local: &Value, server: &Value) -> Value {
                 result[key] = val.clone();
             }
         }
+        // This envelope is rebuilt key by key above, so anything not re-added
+        // here is silently dropped. `semantic_applied` / `degraded_components`
+        // are merged (not copied) under the same rules as `merge_json_results`
+        // — AND for the boolean, deduplicated union for the list, both omitted
+        // when no tier reported either. See `merge_honesty_fields`.
+        //
+        // Why it matters MORE here than on the `brain_search` path: these two
+        // tools have a real semantic leg, so the fields carry information
+        // rather than being trivially `false`/`[]`, and the mixed case (one
+        // tier ranked semantically, the other lexically — two daemons need not
+        // agree on whether an embedding model is loaded) is reachable in
+        // production. The AND rule collapses that mixed case into `false`,
+        // which is correct-but-lossy: correct because the merged rows include
+        // purely lexical ones, lossy because a caller cannot see which tier
+        // ranked how. Per-tier provenance is deliberately NOT encoded in
+        // `degraded_components` — that field's vocabulary is exactly
+        // `"semantic"` and means "fell back from a requested semantic leg",
+        // which is not what a mixed merge describes. If it is ever needed it
+        // belongs in `_meta`.
+        merge_honesty_fields(local, server, &mut result);
         inject_or_wrap_provenance(&mut result, &["local", "server"], &[]);
         result
     } else {
@@ -1817,6 +1859,117 @@ mod tests {
         let local = json!({"results": [{"uid": "a", "score": 0.9}]});
         let server = json!({"results": [{"uid": "b", "score": 0.8}]});
         let merged = merge_json_results(&local, &server);
+        assert!(merged.get("semantic_applied").is_none());
+        assert!(merged.get("degraded_components").is_none());
+    }
+
+    /// Shape of a `brain_context` / `project_context` response: the structured
+    /// `connected` envelope, which `merge_structured_results` rebuilds field by
+    /// field. Unlike `brain_search` these tools have a real semantic leg, so
+    /// `semantic_applied` can genuinely be `true` on either tier.
+    fn brain_context_tier(uid: &str, semantic_applied: bool, degraded: &[&str]) -> Value {
+        json!({
+            "seeds": [{"uid": format!("seed-{uid}"), "title": "seed"}],
+            "connected": [{"uid": uid, "title": uid, "score": 0.9}],
+            "seeds_expanded": 1,
+            "tokens_used": 100,
+            "token_budget": 4000,
+            "semantic_applied": semantic_applied,
+            "degraded_components": degraded,
+        })
+    }
+
+    #[test]
+    fn merge_structured_carries_honesty_fields() {
+        // The `connected`-schema path (brain_context / project_context) rebuilds
+        // its envelope key by key, so these have to be re-added deliberately —
+        // and they matter MORE here than on brain_search, because these tools
+        // actually have a semantic leg.
+        let merged = merge_structured_results(
+            &brain_context_tier("a", true, &[]),
+            &brain_context_tier("b", true, &[]),
+        );
+        assert_eq!(merged["connected"].as_array().map(Vec::len), Some(2));
+        assert_eq!(
+            merged["semantic_applied"],
+            json!(true),
+            "both tiers applied a semantic leg, so the merged answer did"
+        );
+        assert_eq!(merged["degraded_components"], json!([]));
+    }
+
+    #[test]
+    fn merge_structured_semantic_applied_is_conjunctive() {
+        // Reachable in production on this path: two daemons need not agree on
+        // whether an embedding model is loaded. The merged `connected` array
+        // then contains purely lexical rows, so `true` would overclaim.
+        for (local_semantic, server_semantic) in [(true, false), (false, true)] {
+            let merged = merge_structured_results(
+                &brain_context_tier("a", local_semantic, &[]),
+                &brain_context_tier("b", server_semantic, &[]),
+            );
+            assert_eq!(
+                merged["semantic_applied"],
+                json!(false),
+                "a mixed merge ({local_semantic}/{server_semantic}) must not claim semantic ranking"
+            );
+            // The mixed case is a loss of resolution, NOT a degradation: a tier
+            // that never requested a semantic leg did not fall back from one.
+            // Manufacturing a marker here would put a value into a vocabulary
+            // whose only documented member is "semantic".
+            assert_eq!(
+                merged["degraded_components"],
+                json!([]),
+                "a mixed merge must not invent a degradation marker"
+            );
+        }
+    }
+
+    #[test]
+    fn merge_structured_degraded_components_unions_and_dedupes() {
+        // "semantic" is the only value in the documented vocabulary, and it is
+        // genuinely reachable here: a tier that requested a semantic leg and
+        // could not run it reports it, and that degradation must remain visible
+        // in the merged answer even if the other tier was healthy.
+        let merged = merge_structured_results(
+            &brain_context_tier("a", false, &["semantic"]),
+            &brain_context_tier("b", false, &["semantic"]),
+        );
+        assert_eq!(
+            merged["degraded_components"],
+            json!(["semantic"]),
+            "deduplicated union, not a concatenation"
+        );
+
+        let one_sided = merge_structured_results(
+            &brain_context_tier("a", true, &[]),
+            &brain_context_tier("b", false, &["semantic"]),
+        );
+        assert_eq!(
+            one_sided["degraded_components"],
+            json!(["semantic"]),
+            "a server-side degradation must not be hidden behind a healthy local tier"
+        );
+        assert_eq!(one_sided["semantic_applied"], json!(false));
+    }
+
+    #[test]
+    fn merge_structured_omits_honesty_fields_when_no_tier_reported_them() {
+        // An older server (or a response predating the fields) must not be
+        // upgraded into a manufactured `false`: on a merged response, absence
+        // has to keep meaning "no tier reported".
+        let mut local = brain_context_tier("a", false, &[]);
+        let mut server = brain_context_tier("b", false, &[]);
+        for tier in [&mut local, &mut server] {
+            let obj = tier.as_object_mut().unwrap();
+            obj.remove("semantic_applied");
+            obj.remove("degraded_components");
+        }
+        let merged = merge_structured_results(&local, &server);
+        assert!(
+            merged.get("connected").is_some(),
+            "still a structured merge"
+        );
         assert!(merged.get("semantic_applied").is_none());
         assert!(merged.get("degraded_components").is_none());
     }

--- a/crates/nestweaver-federation/src/results.rs
+++ b/crates/nestweaver-federation/src/results.rs
@@ -231,15 +231,41 @@ fn push_unique(list: &mut Vec<String>, value: String) {
 ///   the safe direction (the alternative silently drops a real degradation), so
 ///   this is intentional, not an oversight.
 ///
+///   `semantic_applied` has the **identical** blind spot, in the same
+///   direction: it too is computed over tiers, not over surviving rows. A
+///   server that returns `connected: []` with `semantic_applied: false`, merged
+///   with a local tier that ranked semantically, yields a merged row set that
+///   is entirely local and entirely semantically ranked — reported as `false`.
+///   Under-claiming is the safe direction for a property (as over-reporting is
+///   for a degradation), so both are accepted rather than fixed by weighting
+///   the fields by surviving-row provenance.
+///
 /// - **A tier that omits `semantic_applied` forces the merged value to
-///   `false`** — we cannot claim a property we were not told about. Note this
-///   is not reachable today for `brain_search`: both tiers go through
-///   `dispatch::dispatch_typed_brain_search`, which always emits both keys, and
-///   proto3 scalars mean an older server decodes to `false`/`[]` rather than to
-///   an absent field. The same holds on the structured path
-///   (`dispatch::dispatch_typed_brain_context` /
-///   `dispatch_typed_project_context` insert both keys unconditionally from the
-///   proto response). It is defensive, not a supported detection mechanism.
+///   `false`** — we cannot claim a property we were not told about.
+///   Reachability differs per tool, and the difference is load-bearing:
+///
+///   - `brain_search` and `brain_context`: **not reachable.** Both go through
+///     `dispatch::dispatch_typed_brain_search` / `dispatch_typed_brain_context`,
+///     which insert both keys unconditionally, and both proto responses carry
+///     them as *typed* fields (`BrainSearchResponse`, `BrainContextResponse`),
+///     so proto3 scalar defaults decode an older server to `false`/`[]` rather
+///     than to an absent field. Here the branch is defensive only, and not a
+///     supported way to detect an old server.
+///
+///   - `project_context`: **reachable.** `ProjectContextResponse` is
+///     `{ string result_json = 1; }` — no typed honesty fields at all — and
+///     `dispatch_typed_project_context` returns the parsed `result_json`
+///     untouched, inserting nothing. Both fields therefore ride *inside* the
+///     JSON, and `tool_project_context` has an early-return envelope for a
+///     project with no members that emits `connected: []` and **neither**
+///     field. A federated `project_context` where one side's project is empty
+///     still enters the structured branch, so the AND below really can see a
+///     silent tier and force `false` even when every surviving row came from a
+///     tier that genuinely applied semantic ranking. That under-claims, which
+///     is the safe direction, but it is a real case and not a hypothetical.
+///     If BOTH tiers are empty projects, `any_reported` is false and neither
+///     field is emitted — worth knowing, because `agent_guide` tells agents
+///     `brain_context` / `project_context` always emit `degraded_components`.
 ///
 /// - **If no tier reports either field, nothing is emitted.** Inventing
 ///   `semantic_applied: false` out of two silent tiers would destroy the very
@@ -1951,6 +1977,42 @@ mod tests {
             "a server-side degradation must not be hidden behind a healthy local tier"
         );
         assert_eq!(one_sided["semantic_applied"], json!(false));
+
+        // Distinct per-tier values, so the assertion can actually tell a union
+        // apart from "whatever the local tier said". A single-element expected
+        // value cannot: it passes identically whether one tier or both reported.
+        //
+        // NOT VOCABULARY. `"reranker"` and `"expansion"` are deliberately
+        // chosen because nothing in this codebase emits them: the merge is a
+        // value-agnostic string union, and inputs no producer can generate are
+        // what prove that, where reusing `"semantic"` twice would not. The
+        // real, complete vocabulary is exactly one value, `"semantic"`, as
+        // stated in `agent_guide`, README.md and docs/server-mode.md — if you
+        // arrived here by grepping `degraded_components` for what values exist,
+        // these two are not among them. (Same convention as the `brain_search`
+        // sibling test `merge_degraded_components_unions_and_dedupes`, which
+        // has used these names since before the structured merge carried these
+        // fields; keeping them aligned beats two conventions in one file.)
+        let distinct = merge_structured_results(
+            &brain_context_tier("a", false, &["semantic"]),
+            &brain_context_tier("b", false, &["reranker"]),
+        );
+        assert_eq!(
+            distinct["degraded_components"],
+            json!(["semantic", "reranker"]),
+            "union of distinct per-tier values, in local-then-server order"
+        );
+
+        // Overlap plus a distinct value: dedup and order together.
+        let overlapping = merge_structured_results(
+            &brain_context_tier("a", false, &["semantic", "reranker"]),
+            &brain_context_tier("b", false, &["reranker", "expansion"]),
+        );
+        assert_eq!(
+            overlapping["degraded_components"],
+            json!(["semantic", "reranker", "expansion"]),
+            "deduplicated, first-seen order preserved across tiers"
+        );
     }
 
     #[test]

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -1373,13 +1373,124 @@ pub fn dispatch_cancellable(
 
     validate_tool_arguments(name, &args)?;
 
-    // F16: serve cacheable read tools from (or populate) the response cache.
-    // Correctness rests on the cache KEY — see `maybe_cached`.
-    if is_cacheable_tool(name) && !cache_bypassed(&args) {
-        return maybe_cached(store, tantivy, name, args, embed_model, cancel, visible);
+    // nw-C2: a query landing inside a normal index-publication window used to
+    // fail outright with an internal-looking assertion string. Wait it out
+    // first — the window is normally well under a second, so this converts the
+    // common case from a hard failure into a latency blip.
+    //
+    // `brain_status` is excluded on purpose: it is the diagnostic that REPORTS
+    // this condition, so it must answer immediately rather than block on it.
+    if name != "brain_status" {
+        wait_out_index_publication(store);
     }
 
-    dispatch_uncached(store, tantivy, name, args, embed_model, cancel, visible)
+    // F16: serve cacheable read tools from (or populate) the response cache.
+    // Correctness rests on the cache KEY — see `maybe_cached`.
+    let result = if is_cacheable_tool(name) && !cache_bypassed(&args) {
+        maybe_cached(store, tantivy, name, args, embed_model, cancel, visible)
+    } else {
+        dispatch_uncached(store, tantivy, name, args, embed_model, cancel, visible)
+    };
+
+    // Tools that do not consult PageRank still succeed during a dirty
+    // publication, so the classification is applied to the ERROR rather than
+    // used to fail early.
+    result.map_err(|error| classify_index_publication_error(store, error))
+}
+
+/// Bounded wait for `NESTWEAVER_INDEX_PUBLICATION_WAIT_MS` (default 3000,
+/// clamped to 30s) before letting a query meet a dirty publication.
+fn index_publication_wait() -> std::time::Duration {
+    std::time::Duration::from_millis(INDEX_PUBLICATION_WAIT_MS.with(|c| c.get()))
+}
+
+/// Poll the marker FILE until the publication is clean or the budget expires.
+///
+/// Two constraints, both deliberate:
+///
+/// * It polls `is_index_publication_dirty`, which is file-based and therefore
+///   genuinely cross-process. `index_publication_lease.available` is an
+///   **in-process** condvar and this reader is commonly in a different process
+///   from the indexing writer, so a condvar-based wait could never fire for it
+///   — and an in-process test of one would pass for the wrong reason.
+/// * It does NOT acquire the publication lease. Acquisition is exclusive and
+///   blocking, so a waiting reader would serialize every other reader behind
+///   the writer, turning a latency blip into a real outage.
+fn wait_out_index_publication(store: &GraphStore) {
+    if !store.is_index_publication_dirty() {
+        return;
+    }
+    let budget = index_publication_wait();
+    if budget.is_zero() {
+        return;
+    }
+    let started = std::time::Instant::now();
+    if store.wait_until_index_publication_clean(budget) {
+        tracing::debug!(
+            "waited {}ms for an in-flight index publication to finish",
+            started.elapsed().as_millis()
+        );
+    }
+}
+
+/// Replace the verbatim `StoreError` string from a fail-closed ranked query
+/// with a message that says whether the condition is TRANSIENT or WEDGED, and
+/// — crucially — that "dirty" here means an index PUBLICATION, not a dirty git
+/// working tree. A user who hit this concluded that NestWeaver is useless while
+/// you work in a repo; that wrong conclusion is itself part of the bug.
+fn classify_index_publication_error(store: &GraphStore, error: anyhow::Error) -> anyhow::Error {
+    // Covers both fail-closed strings: "PageRank unavailable during dirty
+    // index publication" and "graph generation exhausted during index
+    // publication".
+    if !format!("{error:#}").contains("index publication") {
+        return error;
+    }
+    let Some(db_path) = store.db_path().map(std::path::Path::to_path_buf) else {
+        return error;
+    };
+    let status = nestweaver_engine::index_publication::status(&db_path);
+    if !status.dirty {
+        return error;
+    }
+    let writer = match (status.writer_pid, status.writer_alive) {
+        (Some(pid), Some(true)) => format!("writer pid {pid} is running"),
+        (Some(pid), _) => format!("writer pid {pid} is NOT running"),
+        _ => "no writer pid recorded in the marker".to_string(),
+    };
+    let age = status
+        .marker_age_s
+        .map(|s| format!("{s}s"))
+        .unwrap_or_else(|| "unknown".to_string());
+    let waited_ms = index_publication_wait().as_millis();
+    let preamble = "This is an index PUBLICATION window, not a dirty git working tree — \
+                    editing files in a repo does not cause it.";
+    if status.is_wedged() {
+        let repair =
+            nestweaver_engine::index_publication::IndexPublicationStatus::repair_command(&db_path);
+        anyhow!(
+            "index publication WEDGED: ranked queries are failing closed because {} exists \
+             and {writer} (marker age {age}). {preamble} The PageRank and generation sidecars \
+             may predate the committed graph, so serving them would return wrong ranks. \
+             Recover with: {repair}{}",
+            status.marker_path,
+            if status.writer_reason.as_deref()
+                == Some(nestweaver_store::index_publication::MARKER_REASON_CANCELLED)
+            {
+                "  (that publication was left dirty by a run that committed after \
+                 cancellation, so the graph may also be incomplete — follow up with \
+                 `nestweaver index --repo <path> --force`)"
+            } else {
+                ""
+            }
+        )
+    } else {
+        anyhow!(
+            "index publication TRANSIENT: an index publication is in flight ({writer}, marker \
+             age {age}) and did not finish within the {waited_ms}ms wait, so ranked queries are \
+             failing closed. {preamble} Retry shortly; raise \
+             NESTWEAVER_INDEX_PUBLICATION_WAIT_MS to wait longer."
+        )
+    }
 }
 
 /// The actual tool dispatch table, after cache handling.
@@ -2816,7 +2927,7 @@ fn validate_brain_context_kinds(kinds: &[String]) -> Result<(), anyhow::Error> {
 fn tool_schema_brain_context() -> Value {
     json!({
         "name": "brain_context",
-        "description": "Retrieve PPR-ranked structural context from the knowledge graph, seeded by symbol names, note titles, or keywords. Returns mixed-kind results (Symbol, Note, Section, Tag, Heading) within a token budget.\n\nGuidelines:\n- Primary entry point for understanding a topic — use before reading files\n- Seed with specific names (e.g. 'AuthService.validate'), not broad terms\n- Filter with repos, tags, path_prefix, kinds for precision; use response_format 'concise' unless you need full bodies\n\nLimitations:\n- Only searches indexed repos/vaults — check stale_check if results seem stale\n- Ranked by graph proximity, not recency (use recency_weight to add time decay)",
+        "description": "Retrieve PPR-ranked structural context from the knowledge graph, seeded by symbol names, note titles, or keywords. Returns mixed-kind results (Symbol, Note, Section, Tag, Heading) within a token budget.\n\nGuidelines:\n- Primary entry point for understanding a topic — use before reading files\n- Seed with specific names (e.g. 'AuthService.validate'), not broad terms\n- Filter with repos, tags, path_prefix, kinds for precision; use response_format 'concise' unless you need full bodies\n\nLimitations:\n- Only searches indexed repos/vaults — check stale_check if results seem stale\n- Ranked by graph proximity, not recency (use recency_weight to add time decay)\n- May fail with 'index publication TRANSIENT/WEDGED' while an index is being published. This refers to INDEX PUBLICATION, not a dirty git working tree: editing files in a repo does NOT cause it, and NestWeaver is fully usable while you work. TRANSIENT resolves on its own — retry. WEDGED means a prior indexer died mid-publication; run the `nestweaver repair` command named in the error, or check brain_status.index_publication.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -5364,7 +5475,7 @@ fn tool_brain_status(
             .or_default()
             .push(v);
     }
-    let warnings: Vec<Value> = root_to_rows
+    let mut warnings: Vec<Value> = root_to_rows
         .iter()
         .filter(|(_, rows)| rows.len() > 1)
         .map(|(root, rows)| {
@@ -5510,6 +5621,43 @@ fn tool_brain_status(
         db_path.as_deref().map(cache_stats).unwrap_or((0, 0, None));
     let cache_hit_rate_pct = cache_hit_rate.map(|r| (r * 100.0).round() as u64);
 
+    // nw-C2: index-publication state. Unlike the Wave A write-path fields
+    // (`write_queue_depth`, `write_holder`, the embedding `pass_*` set), which
+    // come from the daemon and are therefore absent on the direct
+    // `--no-daemon` and MCP-over-HTTP payloads, this is derived from the marker
+    // FILE and so populates with no daemon running. The user who reported the
+    // wedge was on exactly that direct path.
+    let index_publication = store
+        .db_path()
+        .map(nestweaver_engine::index_publication::status)
+        .map(|status| {
+            let wedged = status.is_wedged();
+            if wedged {
+                warnings.push(json!({
+                    "warning": if status.determinable {
+                        "index publication is wedged: ranked queries (brain_context, \
+                         project_context, investigate) fail closed until it is reconciled. \
+                         This is an index PUBLICATION marker, not a dirty git working tree."
+                    } else {
+                        "index publication marker state cannot be determined (permissions or \
+                         I/O error on the sidecar directory); ranked queries fail closed."
+                    },
+                    "action": nestweaver_engine::index_publication::IndexPublicationStatus
+                        ::repair_command(store.db_path().unwrap_or(std::path::Path::new("<db>"))),
+                }));
+            }
+            json!({
+                "dirty": status.dirty,
+                "determinable": status.determinable,
+                "marker_age_s": status.marker_age_s,
+                "writer_pid": status.writer_pid,
+                "writer_alive": status.writer_alive,
+                "writer_reason": status.writer_reason,
+                "wedged": wedged,
+                "marker_path": status.marker_path,
+            })
+        });
+
     Ok(json!({
         "vaults": vaults_json,
         "vault_count": vaults.len(),
@@ -5540,6 +5688,11 @@ fn tool_brain_status(
         // render an actionable warning without re-deriving it.
         "warnings": warnings,
         "staleness_warnings": staleness_warnings,
+        // File-derived index-publication state; present on the direct
+        // `--no-daemon` path too. `null` for in-memory stores, which have no
+        // marker. `dirty` means an index PUBLICATION is in flight or was
+        // abandoned — it has nothing to do with a dirty git working tree.
+        "index_publication": index_publication,
     }))
 }
 
@@ -7546,7 +7699,7 @@ fn tool_brain_diff(
 fn tool_schema_project_context() -> Value {
     json!({
         "name": "project_context",
-        "description": "Retrieve context for a named project: notes, symbols, and sections ranked by PPR within the project's subgraph, bounded by token budget.\n\nGuidelines:\n- Use when you know the project name — for ad-hoc topics use brain_context with seeds instead\n- Returns a CONCISE orientation by default (~1000 tokens: kind/title/location per node); pass response_format:'detailed' for full metadata (uid + relevance, ~3000 tokens)\n- Narrow with repos, path_prefix, tags/exclude_tags, kinds, since, recency_weight — carry the same filter names over to brain_context when drilling in\n- For composite projects, include_components pulls in sub-project content\n\nLimitations:\n- Requires projects to be defined in the graph (via vault taxonomy or instance config)\n- If you don't know the project name, use brain_search to find it first",
+        "description": "Retrieve context for a named project: notes, symbols, and sections ranked by PPR within the project's subgraph, bounded by token budget.\n\nGuidelines:\n- Use when you know the project name — for ad-hoc topics use brain_context with seeds instead\n- Returns a CONCISE orientation by default (~1000 tokens: kind/title/location per node); pass response_format:'detailed' for full metadata (uid + relevance, ~3000 tokens)\n- Narrow with repos, path_prefix, tags/exclude_tags, kinds, since, recency_weight — carry the same filter names over to brain_context when drilling in\n- For composite projects, include_components pulls in sub-project content\n\nLimitations:\n- Requires projects to be defined in the graph (via vault taxonomy or instance config)\n- If you don't know the project name, use brain_search to find it first\n- May fail with 'index publication TRANSIENT/WEDGED' while an index is being published. This refers to INDEX PUBLICATION, not a dirty git working tree: editing files in a repo does NOT cause it, and NestWeaver is fully usable while you work. TRANSIENT resolves on its own — retry. WEDGED means a prior indexer died mid-publication; run the `nestweaver repair` command named in the error, or check brain_status.index_publication.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -8883,6 +9036,29 @@ thread_local! {
     > = std::cell::RefCell::new(std::collections::HashMap::new());
     // Counts cache misses since last flush; flush to disk every N misses.
     static FLUSH_COUNTER: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+    // nw-C2: bounded wait budget for an in-flight index publication.
+    // Seeded from NESTWEAVER_INDEX_PUBLICATION_WAIT_MS on first use so the
+    // env var is read once per thread rather than per dispatch, and so tests
+    // can override it without racing on process-wide environment mutation.
+    static INDEX_PUBLICATION_WAIT_MS: std::cell::Cell<u64> =
+        std::cell::Cell::new(env_index_publication_wait_ms());
+}
+
+/// Default bounded wait, in milliseconds, from the environment.
+fn env_index_publication_wait_ms() -> u64 {
+    const DEFAULT_MS: u64 = 3_000;
+    const MAX_MS: u64 = 30_000;
+    std::env::var("NESTWEAVER_INDEX_PUBLICATION_WAIT_MS")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_MS)
+        .min(MAX_MS)
+}
+
+/// Override the bounded index-publication wait for this thread. `0` disables
+/// the wait entirely (the pre-nw-C2 behaviour).
+pub fn set_index_publication_wait_ms(ms: u64) {
+    INDEX_PUBLICATION_WAIT_MS.with(|c| c.set(ms.min(30_000)));
 }
 
 pub fn set_current_db_path(path: std::path::PathBuf) {
@@ -10575,6 +10751,11 @@ mod cache_dispatch_tests {
     #[test]
     fn dirty_publication_bypasses_response_cache() {
         reset_session();
+        // This test asserts CACHE behaviour with a permanently dirty marker.
+        // The nw-C2 bounded wait would otherwise spend its whole budget twice
+        // waiting for a publication that never completes; disabling it here
+        // preserves the exact pre-nw-C2 dispatch path the test was written for.
+        set_index_publication_wait_ms(0);
         let (_dir, db_path) = index_on_disk();
         set_current_db_path(db_path.clone());
         fs::write(
@@ -10597,6 +10778,195 @@ mod cache_dispatch_tests {
             RESPONSE_SHAPE_VERSION,
         );
         assert!(cache.is_empty(), "dirty responses must not be retained");
+    }
+
+    // ── nw-C2: index-publication wait, classification, and status ───────
+
+    /// A pid guaranteed not to name a live process: spawn a child and reap it.
+    fn reaped_child_pid() -> i32 {
+        let mut child = std::process::Command::new("/bin/true").spawn().unwrap();
+        let pid = child.id() as i32;
+        child.wait().unwrap();
+        pid
+    }
+
+    fn write_marker(db_path: &std::path::Path, pid: u32, reason: Option<&str>) {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        fs::write(
+            nestweaver_engine::sidecar_path(db_path, ".index-dirty"),
+            nestweaver_store::index_publication::format_marker_payload(pid, nanos, reason),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn a_wedged_publication_error_names_the_marker_the_dead_pid_and_the_repair() {
+        reset_session();
+        let (_dir, db_path) = index_on_disk();
+        set_current_db_path(db_path.clone());
+        let dead = reaped_child_pid();
+        write_marker(&db_path, dead as u32, None);
+        let store = GraphStore::open(&db_path).unwrap();
+
+        let classified = classify_index_publication_error(
+            &store,
+            anyhow!("query error: PageRank unavailable during dirty index publication"),
+        );
+        let message = format!("{classified:#}");
+        assert!(message.contains("WEDGED"), "{message}");
+        assert!(message.contains(&format!("{dead}")), "{message}");
+        assert!(message.contains(".index-dirty"), "{message}");
+        assert!(message.contains("nestweaver repair"), "{message}");
+        assert!(
+            message.contains("not a dirty git working tree"),
+            "the message must correct the wrong conclusion the reporter drew: {message}"
+        );
+    }
+
+    #[test]
+    fn a_live_publication_error_reads_as_transient_and_names_no_repair() {
+        reset_session();
+        let (_dir, db_path) = index_on_disk();
+        set_current_db_path(db_path.clone());
+        write_marker(&db_path, std::process::id(), None);
+        let store = GraphStore::open(&db_path).unwrap();
+
+        let message = format!(
+            "{:#}",
+            classify_index_publication_error(
+                &store,
+                anyhow!("PageRank unavailable during dirty index publication"),
+            )
+        );
+        assert!(message.contains("TRANSIENT"), "{message}");
+        assert!(!message.contains("nestweaver repair"), "{message}");
+        assert!(
+            message.contains("not a dirty git working tree"),
+            "{message}"
+        );
+    }
+
+    #[test]
+    fn a_wedged_cancelled_publication_also_names_index_force() {
+        reset_session();
+        let (_dir, db_path) = index_on_disk();
+        set_current_db_path(db_path.clone());
+        write_marker(&db_path, reaped_child_pid() as u32, Some("cancelled"));
+        let store = GraphStore::open(&db_path).unwrap();
+        let message = format!(
+            "{:#}",
+            classify_index_publication_error(
+                &store,
+                anyhow!("PageRank unavailable during dirty index publication"),
+            )
+        );
+        assert!(message.contains("WEDGED"), "{message}");
+        assert!(message.contains("--force"), "{message}");
+    }
+
+    #[test]
+    fn classification_leaves_unrelated_errors_untouched() {
+        reset_session();
+        let (_dir, db_path) = index_on_disk();
+        set_current_db_path(db_path.clone());
+        write_marker(&db_path, reaped_child_pid() as u32, None);
+        let store = GraphStore::open(&db_path).unwrap();
+        let message = format!(
+            "{:#}",
+            classify_index_publication_error(&store, anyhow!("no such symbol: foo"))
+        );
+        assert_eq!(message, "no such symbol: foo");
+    }
+
+    #[test]
+    fn the_bounded_wait_lets_a_dispatch_through_when_the_marker_clears() {
+        reset_session();
+        set_index_publication_wait_ms(10_000);
+        let (_dir, db_path) = index_on_disk();
+        set_current_db_path(db_path.clone());
+        let marker = nestweaver_engine::sidecar_path(&db_path, ".index-dirty");
+        write_marker(&db_path, std::process::id(), None);
+        let store = GraphStore::open(&db_path).unwrap();
+
+        // The clearer touches ONLY the marker file — it never acquires or
+        // releases the publication lease, so the in-process condvar is never
+        // notified. This is what an out-of-process writer looks like from
+        // here, and it is why the wait must poll the file.
+        let clearer = std::thread::spawn({
+            let marker = marker.clone();
+            move || {
+                std::thread::sleep(std::time::Duration::from_millis(80));
+                fs::remove_file(&marker).unwrap();
+            }
+        });
+
+        let started = std::time::Instant::now();
+        let value = dispatch(&store, None, "hub_nodes", json!({ "limit": 5 }), None).unwrap();
+        clearer.join().unwrap();
+
+        assert!(value.is_object() || value.is_array(), "{value}");
+        assert!(!store.is_index_publication_dirty());
+        assert!(
+            started.elapsed() >= std::time::Duration::from_millis(50),
+            "the dispatch must actually have waited"
+        );
+        assert_eq!(
+            store.index_publication_waiter_count(),
+            0,
+            "a reader must never acquire or queue on the publication lease"
+        );
+        set_index_publication_wait_ms(env_index_publication_wait_ms());
+    }
+
+    #[test]
+    fn brain_status_reports_a_wedged_index_publication_without_a_daemon() {
+        reset_session();
+        set_index_publication_wait_ms(0);
+        let (_dir, db_path) = index_on_disk();
+        set_current_db_path(db_path.clone());
+        let dead = reaped_child_pid();
+        write_marker(&db_path, dead as u32, None);
+        let store = GraphStore::open(&db_path).unwrap();
+
+        // No daemon anywhere in this test: the field is derived from the
+        // marker FILE, which is the whole point — the reporter was on the
+        // direct `--no-daemon` path.
+        let status = dispatch(&store, None, "brain_status", json!({}), None).unwrap();
+        let publication = &status["index_publication"];
+        assert_eq!(publication["dirty"], json!(true));
+        assert_eq!(publication["determinable"], json!(true));
+        assert_eq!(publication["writer_pid"], json!(dead));
+        assert_eq!(publication["writer_alive"], json!(false));
+        assert_eq!(publication["wedged"], json!(true));
+        assert!(
+            publication["marker_path"]
+                .as_str()
+                .unwrap()
+                .ends_with(".index-dirty"),
+            "{publication}"
+        );
+        let warnings = status["warnings"].as_array().unwrap();
+        assert!(
+            warnings.iter().any(|w| w["action"]
+                .as_str()
+                .is_some_and(|a| a.contains("nestweaver repair"))),
+            "a wedged publication must carry an actionable warning: {warnings:?}"
+        );
+        set_index_publication_wait_ms(env_index_publication_wait_ms());
+    }
+
+    #[test]
+    fn brain_status_reports_a_clean_index_publication() {
+        reset_session();
+        let (_dir, db_path) = index_on_disk();
+        set_current_db_path(db_path.clone());
+        let store = GraphStore::open(&db_path).unwrap();
+        let status = dispatch(&store, None, "brain_status", json!({}), None).unwrap();
+        assert_eq!(status["index_publication"]["dirty"], json!(false));
+        assert_eq!(status["index_publication"]["wedged"], json!(false));
     }
 
     #[test]

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -4072,29 +4072,27 @@ fn tool_brain_search(
         //   - `nestweaver-federation/src/results.rs::merge_json_results`,
         //     the hybrid/federated merge. It rebuilds the response from
         //     `wrap_merged_response`, so every field has to be re-added
-        //     deliberately; it now merges these two via
-        //     `merge_honesty_fields` (AND for `semantic_applied`, dedup
-        //     union for `degraded_components`). Honest today.
-        //
-        // Still outstanding, deliberately not changed with this one:
+        //     deliberately; it merges these two via `merge_honesty_fields`
+        //     (AND for `semantic_applied`, dedup union for
+        //     `degraded_components`). Honest today.
         //   - the STRUCTURED branch of `merge_structured_results` (the
         //     `connected`-schema path used by brain_context /
-        //     project_context) rebuilds its response the same way and still
-        //     drops both fields. Note the asymmetry this leaves: brain_search,
-        //     which has no semantic leg and whose fields are trivially
-        //     `false`/`[]`, now carries them through a merge, while the two
-        //     tools that DO have a semantic leg — where the ambiguity actually
-        //     costs the caller something — still lose them.
+        //     project_context), which rebuilds its envelope the same way and
+        //     now calls the SAME `merge_honesty_fields` with the same rules.
+        //     Honest today. It matters more there than here: those tools have
+        //     a real semantic leg, so the fields are not trivially
+        //     `false`/`[]`, and the mixed case (one tier ranked semantically,
+        //     the other lexically) is reachable — the AND rule reports `false`
+        //     for it, which is correct but coarser than the two-tier truth.
+        //     See `merge_honesty_fields` for why that is not encoded in
+        //     `degraded_components`.
         //
-        //     Deferred purely on scope: different tool family, different
-        //     response schema, its own tests. It is NOT blocked on caching.
-        //     `semantic_response_is_degraded` (above) has exactly two call
-        //     sites, both inside `maybe_cached`, reached only from
-        //     `dispatch_cancellable` — the local in-process dispatch, strictly
-        //     upstream of any federated merge. `hybrid.rs` has no response
-        //     cache and never writes merged output back, so nothing downstream
-        //     of the merge reads these values. Closing that gap would be a
-        //     pure reporting change too.
+        // None of this interacts with response caching:
+        // `semantic_response_is_degraded` (above) has exactly two call sites,
+        // both inside `maybe_cached`, reached only from `dispatch_cancellable`
+        // — the local in-process dispatch, strictly upstream of any federated
+        // merge. `hybrid.rs` has no response cache and never writes merged
+        // output back, so nothing downstream of the merge reads these values.
         "semantic_applied": false,
         "degraded_components": [],
     });

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -1381,7 +1381,7 @@ pub fn dispatch_cancellable(
     // `brain_status` is excluded on purpose: it is the diagnostic that REPORTS
     // this condition, so it must answer immediately rather than block on it.
     if name != "brain_status" {
-        wait_out_index_publication(store);
+        wait_out_index_publication(store, cancel);
     }
 
     // F16: serve cacheable read tools from (or populate) the response cache.
@@ -1416,7 +1416,10 @@ fn index_publication_wait() -> std::time::Duration {
 /// * It does NOT acquire the publication lease. Acquisition is exclusive and
 ///   blocking, so a waiting reader would serialize every other reader behind
 ///   the writer, turning a latency blip into a real outage.
-fn wait_out_index_publication(store: &GraphStore) {
+fn wait_out_index_publication(
+    store: &GraphStore,
+    cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
+) {
     if !store.is_index_publication_dirty() {
         return;
     }
@@ -1424,8 +1427,20 @@ fn wait_out_index_publication(store: &GraphStore) {
     if budget.is_zero() {
         return;
     }
+    // Never wait on a publication that cannot complete. A wedged marker names
+    // a writer we can prove is dead (or one we cannot attribute at all), so
+    // waiting buys nothing and charges the full budget to EVERY tool on EVERY
+    // call — including tools that never consult PageRank and would otherwise
+    // have answered in milliseconds. Fail straight through to the classified
+    // WEDGED error, which names the repair.
+    if let Some(db_path) = store.db_path()
+        && nestweaver_engine::index_publication::status(db_path).is_wedged()
+    {
+        return;
+    }
     let started = std::time::Instant::now();
-    if store.wait_until_index_publication_clean(budget) {
+    let cancelled = || cancel.is_some_and(|flag| flag.load(std::sync::atomic::Ordering::Acquire));
+    if store.wait_until_index_publication_clean_interruptible(budget, &cancelled) {
         tracing::debug!(
             "waited {}ms for an in-flight index publication to finish",
             started.elapsed().as_millis()
@@ -1465,8 +1480,7 @@ fn classify_index_publication_error(store: &GraphStore, error: anyhow::Error) ->
     let preamble = "This is an index PUBLICATION window, not a dirty git working tree — \
                     editing files in a repo does not cause it.";
     if status.is_wedged() {
-        let repair =
-            nestweaver_engine::index_publication::IndexPublicationStatus::repair_command(&db_path);
+        let repair = status.repair_command_for(&db_path);
         anyhow!(
             "index publication WEDGED: ranked queries are failing closed because {} exists \
              and {writer} (marker age {age}). {preamble} The PageRank and generation sidecars \
@@ -5642,8 +5656,8 @@ fn tool_brain_status(
                         "index publication marker state cannot be determined (permissions or \
                          I/O error on the sidecar directory); ranked queries fail closed."
                     },
-                    "action": nestweaver_engine::index_publication::IndexPublicationStatus
-                        ::repair_command(store.db_path().unwrap_or(std::path::Path::new("<db>"))),
+                    "action": status.repair_command_for(
+                        store.db_path().unwrap_or(std::path::Path::new("<db>"))),
                 }));
             }
             json!({

--- a/crates/nestweaver-store/Cargo.toml
+++ b/crates/nestweaver-store/Cargo.toml
@@ -24,7 +24,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 rayon = { workspace = true }
-zstd = "0.13"
 rmp-serde = "1"
 csv = "1"
 tempfile = { workspace = true }

--- a/crates/nestweaver-store/build.rs
+++ b/crates/nestweaver-store/build.rs
@@ -104,11 +104,11 @@ fn main() {
     // compiles AND links every one of these third_party libraries. Compiling them
     // here too duplicates each static global — e.g. antlr4's `COMPLETE_CHAR_SET`,
     // whose destructor then runs on a mismatched/duplicated allocation at exit and
-    // aborts the process (`double free or corruption` → SIGABRT) on glibc. It only
-    // works at all today because `--allow-multiple-definition` papers over the
-    // duplicate *symbols* at link time — but that can't prevent the runtime
-    // double-free. This build.rs is ONLY for satisfying the PREBUILT liblbug.a,
-    // which ships these as undefined externals; skip it entirely for source builds.
+    // aborts the process (`double free or corruption` → SIGABRT) on glibc. Note a
+    // linker flag could not have prevented that: tolerating duplicate *symbols*
+    // says nothing about duplicate runtime state. This build.rs is ONLY for
+    // satisfying the PREBUILT liblbug.a, which ships these as undefined
+    // externals; skip it entirely for source builds.
     if std::env::var("LBUG_BUILD_FROM_SOURCE").is_ok() {
         return;
     }

--- a/crates/nestweaver-store/src/cache.rs
+++ b/crates/nestweaver-store/src/cache.rs
@@ -226,7 +226,7 @@ impl ResponseCache {
             return None;
         }
         entry.last_access = now;
-        zstd::decode_all(entry.response.as_slice()).ok()
+        crate::zstd::decode_all(entry.response.as_slice()).ok()
     }
 
     /// Insert (or replace) a response for `key`. `response` is the raw
@@ -240,7 +240,7 @@ impl ResponseCache {
         generation: u64,
         scope_digest: u64,
     ) {
-        let compressed = match zstd::encode_all(response, ZSTD_LEVEL) {
+        let compressed = match crate::zstd::encode_all(response, ZSTD_LEVEL) {
             Ok(c) => c,
             Err(e) => {
                 tracing::warn!("response cache: zstd compress failed: {e}");
@@ -325,7 +325,7 @@ impl ResponseCache {
         };
         let msgpack = rmp_serde::to_vec(&doc)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        let compressed = zstd::encode_all(msgpack.as_slice(), ZSTD_LEVEL)?;
+        let compressed = crate::zstd::encode_all(msgpack.as_slice(), ZSTD_LEVEL)?;
         let mut out = Vec::with_capacity(CACHE_MAGIC.len() + 1 + compressed.len());
         out.extend_from_slice(CACHE_MAGIC);
         out.push(CACHE_VERSION);
@@ -392,7 +392,7 @@ fn decode_cache_bytes(bytes: &[u8]) -> Result<CacheDoc, Box<dyn std::error::Erro
             );
         }
         let payload = &bytes[CACHE_MAGIC.len() + 1..];
-        let decompressed = zstd::decode_all(payload)?;
+        let decompressed = crate::zstd::decode_all(payload)?;
         let doc = rmp_serde::from_slice::<CacheDoc>(&decompressed)?;
         Ok(doc)
     } else {
@@ -690,7 +690,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("t.lbug");
         let key = ResponseCache::key("brain_search", &json!({"query": "q"}));
-        let payload = zstd::encode_all(&b"{\"query\":\"q\"}"[..], ZSTD_LEVEL).unwrap();
+        let payload = crate::zstd::encode_all(&b"{\"query\":\"q\"}"[..], ZSTD_LEVEL).unwrap();
 
         let doc = LegacyCacheDoc {
             entries: vec![LegacyCacheEntry {
@@ -705,7 +705,7 @@ mod tests {
         };
         // Exactly how the old binary encoded it: MessagePack → ZSTD → NWRC.
         let msgpack = rmp_serde::to_vec(&doc).unwrap();
-        let compressed = zstd::encode_all(msgpack.as_slice(), ZSTD_LEVEL).unwrap();
+        let compressed = crate::zstd::encode_all(msgpack.as_slice(), ZSTD_LEVEL).unwrap();
         let mut bytes = Vec::new();
         bytes.extend_from_slice(CACHE_MAGIC);
         bytes.push(CACHE_VERSION);

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -127,6 +127,17 @@ impl IndexPublicationLease<'_> {
         Ok(reserved.generation)
     }
 
+    /// Re-derive an inherited publication base whose N+1/N+2 successors are
+    /// unavailable. See
+    /// [`GraphStore::rederive_unavailable_index_publication_base`].
+    pub fn rederive_unavailable_generation_base(
+        &self,
+        generation_path: &std::path::Path,
+    ) -> Result<Option<u64>, StoreError> {
+        self.store
+            .rederive_unavailable_index_publication_base(self.token, generation_path)
+    }
+
     /// Whether this owner inherited an already-dirty publication.
     pub fn is_recovered(&self) -> bool {
         self.reservation.get() == IndexPublicationReservationState::Recovered
@@ -871,6 +882,37 @@ impl GraphStore {
         })
     }
 
+    /// Acquire the publication lease only if it is free right now.
+    ///
+    /// [`Self::acquire_index_publication_lease`] blocks, which is correct for a
+    /// publisher that must run. Abandoned-publication recovery is opportunistic:
+    /// if a live in-process publisher already owns the lease then the
+    /// publication is by definition not abandoned, and recovery must decline
+    /// rather than queue behind it.
+    pub fn try_acquire_index_publication_lease(
+        &self,
+    ) -> Result<Option<IndexPublicationLease<'_>>, StoreError> {
+        let mut state = self
+            .index_publication_lease
+            .state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if state.owner.is_some() {
+            return Ok(None);
+        }
+        let token = state.next_token;
+        state.next_token = token.checked_add(1).ok_or_else(|| {
+            StoreError::Query("index publication ownership token exhausted".into())
+        })?;
+        state.owner = Some(token);
+        Ok(Some(IndexPublicationLease {
+            store: self,
+            token,
+            reservation: Cell::new(IndexPublicationReservationState::Unreserved),
+            released: false,
+        }))
+    }
+
     /// Current number of publishers or snapshot readers waiting for ownership.
     #[doc(hidden)]
     pub fn index_publication_waiter_count(&self) -> usize {
@@ -935,7 +977,7 @@ impl GraphStore {
     /// While a lease IS held, a live publication is mid-flight and the reservation
     /// must stay fail-closed. This is the live-vs-dead signal the admin path keys
     /// on so a crash can't wedge every future generation bump forever (nw-091).
-    fn index_publication_lease_is_unowned(&self) -> bool {
+    pub fn index_publication_lease_is_unowned(&self) -> bool {
         self.index_publication_lease
             .state
             .lock()
@@ -1042,6 +1084,58 @@ impl GraphStore {
             generation: reserved,
             recovered: false,
         })
+    }
+
+    /// Re-derive a fail-closed publication base whose successors are
+    /// unavailable, so an interrupted publication can be completed at all.
+    ///
+    /// When `.generation` is missing or unparseable *while* the marker is
+    /// present, `load_fail_closed_index_publication_generation` takes
+    /// `canonical = u64::MAX` — deliberately, so nothing can complete a
+    /// publication on top of an unknown canonical value. The cost is that
+    /// `checked_add(2)` then overflows in every preflight and reserve path, so
+    /// the publication can never complete and the user sees a *different*
+    /// error (`graph generation exhausted during index publication`) rather
+    /// than the dirty-publication one. Recovery that ignored this arm would
+    /// appear to fix nothing.
+    ///
+    /// The fix is to re-derive rather than to add to `MAX`. The note that
+    /// specified this work says "re-derive from the database"; there is no
+    /// generation column in the database — the counter's only durable home is
+    /// the `<db>.generation` sidecar — so re-derivation re-reads that sidecar
+    /// and, when it is still unreadable, falls back to `0`. `0` is not a new
+    /// risk: it is exactly what a *clean* open of a store with no `.generation`
+    /// sidecar already uses (`load_graph_generation` leaves the freshly-opened
+    /// `AtomicU64::new(0)` untouched), so recovery lands on the same canonical
+    /// value the clean path would have.
+    ///
+    /// Returns the canonical base in force after the call, or `None` when the
+    /// base did not need re-deriving.
+    fn rederive_unavailable_index_publication_base(
+        &self,
+        token: u64,
+        generation_path: &Path,
+    ) -> Result<Option<u64>, StoreError> {
+        self.validate_index_publication_owner(token)?;
+        let mut base = self
+            .index_publication_generation_base
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let Some(canonical) = *base else {
+            return Ok(None);
+        };
+        if canonical.checked_add(2).is_some() {
+            return Ok(None);
+        }
+        let rederived = std::fs::read_to_string(generation_path)
+            .ok()
+            .and_then(|contents| contents.trim().parse::<u64>().ok())
+            .filter(|value| value.checked_add(2).is_some())
+            .unwrap_or(0);
+        *base = Some(rederived);
+        self.graph_generation
+            .store(rederived.saturating_add(1), Ordering::Release);
+        Ok(Some(rederived))
     }
 
     /// Confirm that a lease acquired for backup/snapshot work did not inherit
@@ -1155,9 +1249,63 @@ impl GraphStore {
     }
 
     fn index_publication_marker_for(db_path: &Path) -> PathBuf {
-        let mut value = db_path.as_os_str().to_owned();
-        value.push(".index-dirty");
-        PathBuf::from(value)
+        crate::index_publication::marker_path(db_path)
+    }
+
+    /// Path of this store's durable publication marker, when it is file-backed.
+    /// In-memory stores have no marker (and nothing to reconcile on a later
+    /// open), so they return `None`.
+    pub fn index_publication_marker_path(&self) -> Option<PathBuf> {
+        self.db_path
+            .as_deref()
+            .map(Self::index_publication_marker_for)
+    }
+
+    /// Three-state read of this store's publication marker. Unlike
+    /// [`Self::is_index_publication_dirty`], which collapses "cannot tell" into
+    /// "dirty", this preserves the distinction recovery depends on.
+    pub fn index_publication_marker_state(&self) -> crate::index_publication::MarkerState {
+        match self.db_path.as_deref() {
+            Some(path) => crate::index_publication::read_marker(path),
+            None => crate::index_publication::MarkerState::Absent,
+        }
+    }
+
+    /// Poll the FILE-BACKED dirty check until the publication is clean or
+    /// `timeout` elapses. Returns true when the publication is clean.
+    ///
+    /// This deliberately polls [`Self::is_index_publication_dirty`] rather than
+    /// waiting on `index_publication_lease.available`. That condition variable
+    /// is **in-process**: the MCP reader commonly runs in a different process
+    /// from the indexing writer and opens the store read-only, so the condvar
+    /// can never fire for it and an in-process test of a condvar-based wait
+    /// would pass for the wrong reason. The marker file is genuinely
+    /// cross-process.
+    ///
+    /// It also deliberately does NOT acquire the publication lease. Acquisition
+    /// is exclusive and blocking, so a waiting reader would serialize every
+    /// other reader behind the writer — turning a latency blip into an outage.
+    pub fn wait_until_index_publication_clean(&self, timeout: std::time::Duration) -> bool {
+        if !self.is_index_publication_dirty() {
+            return true;
+        }
+        if timeout.is_zero() {
+            return false;
+        }
+        let deadline = std::time::Instant::now() + timeout;
+        let mut backoff = std::time::Duration::from_millis(5);
+        let max_backoff = std::time::Duration::from_millis(100);
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                return !self.is_index_publication_dirty();
+            }
+            std::thread::sleep(backoff.min(remaining));
+            if !self.is_index_publication_dirty() {
+                return true;
+            }
+            backoff = (backoff * 2).min(max_backoff);
+        }
     }
 
     /// Path to the `<db>.generation` sidecar. For in-memory stores (no
@@ -2281,6 +2429,13 @@ mod tests {
             !reopened.pagerank_scores().contains_key("stale"),
             "a dirty publication must not load canonical PageRank from before the graph commit"
         );
+        // nw-C1: the same marker is now READ BACK, not merely tested for
+        // existence. An unparseable payload is still `Present` — dirty, but
+        // carrying no writer to attribute the publication to.
+        let state = reopened.index_publication_marker_state();
+        assert!(state.is_dirty());
+        assert_eq!(state.record().unwrap().writer_pid, None);
+        assert!(!reopened.wait_until_index_publication_clean(std::time::Duration::from_millis(30)));
     }
 
     #[test]
@@ -2312,6 +2467,151 @@ mod tests {
             !reopened.pagerank_scores().contains_key("stale"),
             "an unreadable marker must make canonical PageRank non-authoritative"
         );
+        // nw-C1: "cannot tell" must stay distinguishable from "present".
+        // Recovery keys on this: an unreadable marker is never abandoned.
+        let state = reopened.index_publication_marker_state();
+        assert!(
+            matches!(
+                state,
+                crate::index_publication::MarkerState::Undeterminable(_)
+            ),
+            "an unreadable marker must not read as a present, attributable one: {state:?}"
+        );
+        assert!(state.is_dirty());
+        assert!(state.record().is_none());
+    }
+
+    #[test]
+    fn wait_until_index_publication_clean_is_immediate_when_already_clean() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        let started = std::time::Instant::now();
+        assert!(store.wait_until_index_publication_clean(std::time::Duration::from_secs(5)));
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(500),
+            "a clean publication must not consume any of the wait budget"
+        );
+    }
+
+    #[test]
+    fn wait_until_index_publication_clean_times_out_on_a_persistent_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        std::fs::write(crate::index_publication::marker_path(&db_path), b"1:1\n").unwrap();
+        let started = std::time::Instant::now();
+        assert!(!store.wait_until_index_publication_clean(std::time::Duration::from_millis(120)));
+        assert!(started.elapsed() >= std::time::Duration::from_millis(100));
+    }
+
+    #[test]
+    fn wait_until_index_publication_clean_observes_marker_removal_without_the_condvar() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let marker = crate::index_publication::marker_path(&db_path);
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        std::fs::write(&marker, b"1:1\n").unwrap();
+
+        // The remover touches ONLY the file. It never acquires or releases the
+        // publication lease, so `index_publication_lease.available` is never
+        // notified — which is precisely the situation of an out-of-process
+        // writer. A condvar-based wait could not wake here.
+        let remover = std::thread::spawn({
+            let marker = marker.clone();
+            move || {
+                std::thread::sleep(std::time::Duration::from_millis(60));
+                std::fs::remove_file(&marker).unwrap();
+            }
+        });
+        assert!(
+            store.wait_until_index_publication_clean(std::time::Duration::from_secs(10)),
+            "the wait must observe a file-only clean transition"
+        );
+        assert_eq!(
+            store.index_publication_waiter_count(),
+            0,
+            "a waiting reader must never register as a publication-lease waiter"
+        );
+        remover.join().unwrap();
+    }
+
+    #[test]
+    fn try_acquire_index_publication_lease_declines_a_held_lease() {
+        let store = GraphStore::in_memory().unwrap();
+        let held = store.acquire_index_publication_lease().unwrap();
+        assert!(
+            store
+                .try_acquire_index_publication_lease()
+                .unwrap()
+                .is_none(),
+            "a non-blocking acquire must decline rather than queue"
+        );
+        assert!(!store.index_publication_lease_is_unowned());
+        drop(held);
+        assert!(store.index_publication_lease_is_unowned());
+        assert!(
+            store
+                .try_acquire_index_publication_lease()
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn an_unavailable_generation_base_is_rederived_rather_than_added_to() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        // Marker present with NO `.generation` sidecar: the fail-closed load
+        // takes `canonical = u64::MAX`, so `checked_add(2)` overflows and the
+        // publication could never complete.
+        std::fs::write(crate::index_publication::marker_path(&db_path), b"1:1\n").unwrap();
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        assert_eq!(store.graph_generation(), u64::MAX);
+
+        let lease = store.acquire_index_publication_lease().unwrap();
+        assert!(
+            lease.preflight_generation().is_err(),
+            "the u64::MAX arm must block publication before re-derivation"
+        );
+        let generation_path = PathBuf::from(format!("{}.generation", db_path.display()));
+        assert_eq!(
+            lease
+                .rederive_unavailable_generation_base(&generation_path)
+                .unwrap(),
+            Some(0),
+            "an unreadable sidecar re-derives to the same canonical 0 a clean open uses"
+        );
+        assert_eq!(store.graph_generation(), 1);
+        lease.preflight_generation().unwrap();
+        assert_eq!(
+            lease
+                .rederive_unavailable_generation_base(&generation_path)
+                .unwrap(),
+            None,
+            "a usable base is left alone"
+        );
+    }
+
+    #[test]
+    fn rederivation_prefers_a_parseable_generation_sidecar_over_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let generation_path = PathBuf::from(format!("{}.generation", db_path.display()));
+        std::fs::write(crate::index_publication::marker_path(&db_path), b"1:1\n").unwrap();
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        assert_eq!(store.graph_generation(), u64::MAX);
+        // The sidecar appears (or becomes readable) after the fail-closed open.
+        std::fs::write(&generation_path, b"41").unwrap();
+        let lease = store.acquire_index_publication_lease().unwrap();
+        assert_eq!(
+            lease
+                .rederive_unavailable_generation_base(&generation_path)
+                .unwrap(),
+            Some(41)
+        );
+        assert_eq!(store.graph_generation(), 42);
+        assert_eq!(lease.clean_generation().unwrap(), 43);
     }
 
     #[test]

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -1286,10 +1286,24 @@ impl GraphStore {
     /// is exclusive and blocking, so a waiting reader would serialize every
     /// other reader behind the writer — turning a latency blip into an outage.
     pub fn wait_until_index_publication_clean(&self, timeout: std::time::Duration) -> bool {
+        self.wait_until_index_publication_clean_interruptible(timeout, &|| false)
+    }
+
+    /// [`Self::wait_until_index_publication_clean`], but polls `abort` on every
+    /// iteration and gives up early when it returns true.
+    ///
+    /// The MCP dispatch boundary already threads a cancellation flag for query
+    /// timeouts and client disconnects. Without this, a cancelled call would
+    /// still sleep out the whole budget before noticing nobody is listening.
+    pub fn wait_until_index_publication_clean_interruptible(
+        &self,
+        timeout: std::time::Duration,
+        abort: &dyn Fn() -> bool,
+    ) -> bool {
         if !self.is_index_publication_dirty() {
             return true;
         }
-        if timeout.is_zero() {
+        if timeout.is_zero() || abort() {
             return false;
         }
         let deadline = std::time::Instant::now() + timeout;
@@ -1303,6 +1317,9 @@ impl GraphStore {
             std::thread::sleep(backoff.min(remaining));
             if !self.is_index_publication_dirty() {
                 return true;
+            }
+            if abort() {
+                return false;
             }
             backoff = (backoff * 2).min(max_backoff);
         }
@@ -2534,6 +2551,30 @@ mod tests {
             "a waiting reader must never register as a publication-lease waiter"
         );
         remover.join().unwrap();
+    }
+
+    #[test]
+    fn an_interruptible_wait_abandons_the_budget_when_cancelled() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        std::fs::write(crate::index_publication::marker_path(&db_path), b"1:1\n").unwrap();
+        let cancelled = std::sync::atomic::AtomicBool::new(false);
+        let started = std::time::Instant::now();
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                std::thread::sleep(std::time::Duration::from_millis(60));
+                cancelled.store(true, Ordering::Release);
+            });
+            assert!(!store.wait_until_index_publication_clean_interruptible(
+                std::time::Duration::from_secs(30),
+                &|| cancelled.load(Ordering::Acquire)
+            ));
+        });
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(5),
+            "a cancelled wait must not sleep out its whole budget"
+        );
     }
 
     #[test]

--- a/crates/nestweaver-store/src/index_publication.rs
+++ b/crates/nestweaver-store/src/index_publication.rs
@@ -1,0 +1,261 @@
+//! The `<db>.index-dirty` publication marker: its path, its payload, and how
+//! to read that payload back.
+//!
+//! The marker is written durably by the indexing writer (pid + establishment
+//! timestamp, `sync_all`, parent directory fsynced) precisely so it survives
+//! process death. While it exists, canonical `.generation` and `.pagerank.json`
+//! sidecars may predate the committed graph, so ranked queries fail closed.
+//!
+//! Until nw-C1 the payload was written and never read back. This module is the
+//! read side: it turns the marker into a three-state answer — absent, present
+//! (with whatever the payload says), or *undeterminable*.
+//!
+//! **The third state is load-bearing.** [`GraphStore::is_index_publication_dirty`]
+//! is `try_exists().unwrap_or(true)`, so an `EACCES`/`EIO` on the sidecar
+//! directory deliberately reads as permanently dirty. "Cannot tell" is not
+//! "abandoned": recovery must never clear a marker it could not read.
+//!
+//! Liveness of `writer_pid` is intentionally NOT decided here — this crate has
+//! no `libc` dependency. See `nestweaver_engine::index_publication` for the
+//! liveness-aware view built on top of this.
+//!
+//! [`GraphStore::is_index_publication_dirty`]: crate::db::GraphStore::is_index_publication_dirty
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Marker payload reason recorded by a run that committed AFTER cancellation
+/// was requested and therefore left its publication dirty **deliberately**.
+///
+/// See `nestweaver_engine::index::finalize_committed_index_for_scope_with_io`
+/// (`publish_clean: false`). Recovery still reconciles such a publication once
+/// its writer is dead — the sidecars really do predate the commit either way —
+/// but it reports the distinction so the "the graph may be incomplete, run
+/// `index --force`" guidance is not silently lost.
+pub const MARKER_REASON_CANCELLED: &str = "cancelled";
+
+/// Path of the durable publication marker for `db_path`.
+///
+/// Kept as a free function so callers that only have a path (the `repair`
+/// command, `brain_status` on the direct `--no-daemon` path) do not need an
+/// open store to name it.
+pub fn marker_path(db_path: &Path) -> PathBuf {
+    let mut value = db_path.as_os_str().to_owned();
+    value.push(".index-dirty");
+    PathBuf::from(value)
+}
+
+/// What the marker payload records about the writer that established it.
+///
+/// Every field is optional: a marker written by an older binary, truncated by a
+/// crash between `create` and `write_all`, or hand-created by an operator (the
+/// pre-nw-C1 `touch`/`echo` escape hatch) still counts as *present*. A marker
+/// we cannot attribute is never treated as abandoned.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkerRecord {
+    /// The pid recorded by the establishing writer, when the payload parsed.
+    pub writer_pid: Option<i32>,
+    /// Wall-clock establishment time, when the payload parsed.
+    pub established_unix_nanos: Option<u128>,
+    /// Optional reason field (see [`MARKER_REASON_CANCELLED`]). Absent on the
+    /// ordinary `{pid}:{nanos}` payload every writer has always written.
+    pub reason: Option<String>,
+}
+
+impl MarkerRecord {
+    /// How long ago the marker was established, per its own payload.
+    ///
+    /// `None` when the payload carried no timestamp, or when the recorded
+    /// timestamp is in the future (a clock step backwards) — an age we cannot
+    /// compute must not read as "old", because "old" is one of the two
+    /// conditions that classify a publication as wedged.
+    pub fn age(&self) -> Option<Duration> {
+        let established = self.established_unix_nanos?;
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .ok()?
+            .as_nanos();
+        let delta = now.checked_sub(established)?;
+        u64::try_from(delta).ok().map(Duration::from_nanos)
+    }
+
+    /// True when this publication was left dirty on purpose by a
+    /// committed-after-cancellation run.
+    pub fn is_deliberately_dirty(&self) -> bool {
+        self.reason.as_deref() == Some(MARKER_REASON_CANCELLED)
+    }
+}
+
+/// Three-state view of the marker. See the module docs on why "undeterminable"
+/// is distinct from "present".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MarkerState {
+    /// No marker: publication is clean.
+    Absent,
+    /// A marker exists. Payload fields are best-effort.
+    Present(MarkerRecord),
+    /// The marker's state could not be determined (permissions, I/O error, or
+    /// a directory where a file belongs). Fail closed; never recover.
+    Undeterminable(String),
+}
+
+impl MarkerState {
+    /// Whether ranked queries must fail closed. Matches
+    /// [`GraphStore::is_index_publication_dirty`]'s `unwrap_or(true)` exactly.
+    ///
+    /// [`GraphStore::is_index_publication_dirty`]: crate::db::GraphStore::is_index_publication_dirty
+    pub fn is_dirty(&self) -> bool {
+        !matches!(self, MarkerState::Absent)
+    }
+
+    /// The parsed payload, when the marker is present and readable.
+    pub fn record(&self) -> Option<&MarkerRecord> {
+        match self {
+            MarkerState::Present(record) => Some(record),
+            _ => None,
+        }
+    }
+}
+
+/// Serialize a marker payload. The `{pid}:{nanos}` prefix is byte-identical to
+/// what every prior release wrote; `reason` appends a third field that older
+/// readers (which never read the payload at all) cannot be confused by.
+pub fn format_marker_payload(pid: u32, unix_nanos: u128, reason: Option<&str>) -> String {
+    match reason {
+        Some(reason) => format!("{pid}:{unix_nanos}:{reason}\n"),
+        None => format!("{pid}:{unix_nanos}\n"),
+    }
+}
+
+/// Parse a marker payload. Never fails: an unrecognised payload yields a
+/// [`MarkerRecord`] with no attribution, which callers treat as
+/// "present but unattributable" — dirty, but not abandoned.
+pub fn parse_marker_payload(contents: &str) -> MarkerRecord {
+    let trimmed = contents.trim();
+    let mut fields = trimmed.split(':');
+    let writer_pid = fields
+        .next()
+        .and_then(|f| f.trim().parse::<i32>().ok())
+        .filter(|pid| *pid > 0);
+    let established_unix_nanos = fields.next().and_then(|f| f.trim().parse::<u128>().ok());
+    let reason = fields
+        .next()
+        .map(|f| f.trim().to_string())
+        .filter(|r| !r.is_empty());
+    MarkerRecord {
+        writer_pid,
+        established_unix_nanos,
+        reason,
+    }
+}
+
+/// Read the marker for `db_path`.
+///
+/// A `NotFound` is [`MarkerState::Absent`]. Any other I/O error — including the
+/// `EISDIR` produced by the `unreadable_index_publication_marker_*` tests, which
+/// create a *directory* at the marker path — is
+/// [`MarkerState::Undeterminable`], never `Absent`.
+pub fn read_marker(db_path: &Path) -> MarkerState {
+    read_marker_at(&marker_path(db_path))
+}
+
+/// [`read_marker`] against an already-resolved marker path.
+pub fn read_marker_at(path: &Path) -> MarkerState {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => MarkerState::Present(parse_marker_payload(&contents)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            // `read_to_string` reports NotFound only for a genuinely absent
+            // path. Re-confirm through `try_exists` so a racing establish
+            // between the two calls fails closed rather than open.
+            match path.try_exists() {
+                Ok(false) => MarkerState::Absent,
+                Ok(true) => MarkerState::Present(MarkerRecord {
+                    writer_pid: None,
+                    established_unix_nanos: None,
+                    reason: None,
+                }),
+                Err(error) => MarkerState::Undeterminable(error.to_string()),
+            }
+        }
+        Err(error) => MarkerState::Undeterminable(error.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_the_legacy_pid_and_nanos_payload() {
+        let record = parse_marker_payload("4242:1755000000000000000\n");
+        assert_eq!(record.writer_pid, Some(4242));
+        assert_eq!(
+            record.established_unix_nanos,
+            Some(1_755_000_000_000_000_000)
+        );
+        assert_eq!(record.reason, None);
+        assert!(!record.is_deliberately_dirty());
+    }
+
+    #[test]
+    fn parses_the_cancelled_reason_field() {
+        let record = parse_marker_payload(&format_marker_payload(
+            7,
+            1_755_000_000_000_000_000,
+            Some(MARKER_REASON_CANCELLED),
+        ));
+        assert_eq!(record.writer_pid, Some(7));
+        assert!(record.is_deliberately_dirty());
+    }
+
+    #[test]
+    fn an_unparseable_payload_is_present_but_unattributed() {
+        let record = parse_marker_payload("dirty");
+        assert_eq!(record.writer_pid, None);
+        assert_eq!(record.established_unix_nanos, None);
+        assert_eq!(record.age(), None);
+    }
+
+    #[test]
+    fn a_nonpositive_pid_is_not_attribution() {
+        assert_eq!(parse_marker_payload("0:1").writer_pid, None);
+        assert_eq!(parse_marker_payload("-1:1").writer_pid, None);
+    }
+
+    #[test]
+    fn absent_marker_reads_absent_and_not_dirty() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = read_marker(&dir.path().join("test.lbug"));
+        assert_eq!(state, MarkerState::Absent);
+        assert!(!state.is_dirty());
+    }
+
+    #[test]
+    fn a_directory_at_the_marker_path_is_undeterminable_not_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        std::fs::create_dir(marker_path(&db_path)).unwrap();
+        let state = read_marker(&db_path);
+        assert!(
+            matches!(state, MarkerState::Undeterminable(_)),
+            "an unreadable marker must never read as absent: {state:?}"
+        );
+        assert!(state.is_dirty(), "undeterminable must still fail closed");
+        assert!(state.record().is_none());
+    }
+
+    #[test]
+    fn a_future_timestamp_yields_no_age_rather_than_a_stale_one() {
+        let future = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+            + 60_000_000_000;
+        let record = parse_marker_payload(&format_marker_payload(1, future, None));
+        assert_eq!(
+            record.age(),
+            None,
+            "a clock step backwards must not make a young marker look wedged"
+        );
+    }
+}

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -10,6 +10,7 @@ pub mod search;
 pub mod tantivy_index;
 pub mod traverse;
 pub mod write;
+pub mod zstd;
 
 pub use db::{
     EmbeddingIndexReconciliation, EmbeddingSnapshotLease, EmbeddingSnapshotState, GraphStore,

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -3,6 +3,7 @@ pub mod db;
 pub mod durable_sidecar;
 pub mod error;
 pub mod generation;
+pub mod index_publication;
 pub mod ranking;
 pub mod read;
 pub mod regex;

--- a/crates/nestweaver-store/src/zstd.rs
+++ b/crates/nestweaver-store/src/zstd.rs
@@ -15,8 +15,8 @@
 //! complete copy of the same zstd 1.5.7. `rust-lld` — the default linker on
 //! x86_64 Linux — rejects that with duplicate-symbol errors, which is why the
 //! tree carried `-Wl,--allow-multiple-definition`. That flag never merged the
-//! two copies; it just told the linker to pick one and stay quiet, leaving two
-//! sets of zstd state in one process.
+//! two copies; it told the linker to pick one definition silently and left the
+//! other in the binary.
 //!
 //! This module removes the second copy. It declares the handful of stable
 //! public zstd entry points it needs and lets them resolve against the copy
@@ -25,13 +25,28 @@
 //! `zstd` static library that `build.rs` compiles from lbug's vendored sources
 //! in the prebuilt-lbug path. Both paths already emit the link directives.
 //!
+//! What this requires of lbug is narrow but real: it must keep *defining* the
+//! `ZSTD_*` entry points with *global* binding. Note that hiding them — the
+//! stated intent of the `ZSTDLIB_VISIBILITY` line above, which does not
+//! currently do so — would NOT break this: ELF visibility governs dynamic
+//! export, not static resolution, so a hidden-but-global symbol still links.
+//! Only removing the symbols, or localizing them to `STB_LOCAL`, produces a
+//! link error. There is no configuration in which this silently binds to a
+//! different zstd.
+//!
 //! # Format
 //!
-//! This is the same libzstd that produced the existing archives, driven through
-//! the same public API the `zstd` crate uses, so the bytes on disk are
-//! unchanged: `.nwsnap.zst` backups and `NWRC` response-cache sidecars written
-//! by earlier versions still read, and archives written now are still readable
-//! by any standard zstd implementation.
+//! Wire-compatible in both directions, with the same libzstd driven through the
+//! same public API the `zstd` crate used: `.nwsnap.zst` backups and `NWRC`
+//! response-cache sidecars written by earlier versions still read, and what is
+//! written now is readable by any standard zstd implementation.
+//!
+//! The exact bytes are *not* always identical, so do not content-address a
+//! compressed blob across this change. [`encode_all`] uses `ZSTD_compress`,
+//! which records the frame content size in the header; the `zstd` crate's bulk
+//! path did not, so every non-empty one-shot frame differs (and is one byte
+//! longer for small inputs). [`Encoder`] output — the `.nwsnap.zst` path — is
+//! byte-identical.
 
 use std::ffi::{CStr, c_char, c_int, c_uint, c_void};
 use std::io::{self, Read, Write};
@@ -186,6 +201,10 @@ pub struct Encoder<W: Write> {
     stream: NonNull<ZstdStream>,
     writer: Option<W>,
     buffer: Vec<u8>,
+    /// Set after a zstd error. `zstd.h` documents the stream as undefined once
+    /// `ZSTD_compressStream2` fails, and `io::Write` permits a caller to keep
+    /// writing after an error, so refuse instead of touching it.
+    poisoned: bool,
 }
 
 // SAFETY: a `ZSTD_CStream` is owned exclusively by its `Encoder` and carries no
@@ -211,12 +230,18 @@ impl<W: Write> Encoder<W> {
             stream,
             writer: Some(writer),
             buffer,
+            poisoned: false,
         })
     }
 
     /// Drive `ZSTD_compressStream2` over `input` until zstd is done with the
     /// directive, writing every produced byte to the inner writer.
     fn run(&mut self, input: &[u8], end_op: c_int) -> io::Result<()> {
+        if self.poisoned {
+            return Err(io::Error::other(
+                "zstd: compression stream used after an error",
+            ));
+        }
         let mut in_buffer = ZstdInBuffer {
             src: input.as_ptr().cast::<c_void>(),
             size: input.len(),
@@ -230,14 +255,20 @@ impl<W: Write> Encoder<W> {
             };
             // SAFETY: both buffers describe live allocations for the duration
             // of the call, and `self.stream` is a live `ZSTD_CStream`.
-            let remaining = check(unsafe {
+            let remaining = match check(unsafe {
                 ZSTD_compressStream2(
                     self.stream.as_ptr(),
                     &mut out_buffer,
                     &mut in_buffer,
                     end_op,
                 )
-            })?;
+            }) {
+                Ok(remaining) => remaining,
+                Err(error) => {
+                    self.poisoned = true;
+                    return Err(error);
+                }
+            };
             if out_buffer.pos > 0 {
                 let writer = self
                     .writer
@@ -309,6 +340,15 @@ pub struct Decoder<R: Read> {
     /// Bytes of `input[..filled]` already consumed by zstd.
     consumed: usize,
     eof: bool,
+    /// True when the last `ZSTD_decompressStream` returned 0 — "frame
+    /// completely decoded and fully flushed" (`zstd.h`). Starts `false`: input
+    /// that ends before any frame completes is truncated, and must be reported
+    /// as an error rather than as a short-but-successful read.
+    frame_complete: bool,
+    /// Set after a zstd error. `zstd.h` documents the stream as undefined once
+    /// `ZSTD_decompressStream` fails, and `io::Read` permits a caller to call
+    /// `read` again after an error, so refuse instead of touching it.
+    poisoned: bool,
 }
 
 // SAFETY: as for `Encoder` — the `ZSTD_DStream` is exclusively owned and only
@@ -336,25 +376,45 @@ impl<R: Read> Decoder<R> {
             filled: 0,
             consumed: 0,
             eof: false,
+            frame_complete: false,
+            poisoned: false,
         })
+    }
+
+    /// The inner reader is exhausted. Distinguish a clean end-of-stream from a
+    /// truncated one.
+    fn end_of_input(&self) -> io::Result<usize> {
+        if self.frame_complete {
+            Ok(0)
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "zstd: incomplete frame — the compressed input ends mid-frame",
+            ))
+        }
     }
 }
 
 impl<R: Read> Read for Decoder<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.poisoned {
+            return Err(io::Error::other(
+                "zstd: decompression stream used after an error",
+            ));
+        }
         if buf.is_empty() {
             return Ok(0);
         }
         loop {
             if self.consumed == self.filled {
                 if self.eof {
-                    return Ok(0);
+                    return self.end_of_input();
                 }
                 self.filled = self.reader.read(&mut self.input)?;
                 self.consumed = 0;
                 if self.filled == 0 {
                     self.eof = true;
-                    return Ok(0);
+                    return self.end_of_input();
                 }
             }
 
@@ -370,10 +430,20 @@ impl<R: Read> Read for Decoder<R> {
             };
             // SAFETY: both buffers describe live allocations for the duration
             // of the call, and `self.stream` is a live `ZSTD_DStream`.
-            check(unsafe {
+            let remaining = match check(unsafe {
                 ZSTD_decompressStream(self.stream.as_ptr(), &mut out_buffer, &mut in_buffer)
-            })?;
+            }) {
+                Ok(remaining) => remaining,
+                Err(error) => {
+                    self.poisoned = true;
+                    return Err(error);
+                }
+            };
             self.consumed = in_buffer.pos;
+            // 0 means the frame is decoded and flushed; anything else means
+            // zstd is mid-frame and still wants input. Latching it is what lets
+            // `end_of_input` tell a complete stream from a truncated one.
+            self.frame_complete = remaining == 0;
             if out_buffer.pos > 0 {
                 return Ok(out_buffer.pos);
             }
@@ -394,14 +464,37 @@ impl<R: Read> Drop for Decoder<R> {
 mod tests {
     use super::*;
 
-    /// The symbols must resolve against a real libzstd, not merely link. lbug
-    /// vendors 1.5.7 (`lbug-src/third_party/versions.txt`).
+    /// Deterministic, effectively incompressible bytes.
+    ///
+    /// Truncation tests need a frame whose compressed form is larger than the
+    /// tail being cut off. Repetitive filler compresses to a few dozen bytes
+    /// and makes such a test silently vacuous, so generate from an LCG instead.
+    fn incompressible(len: usize) -> Vec<u8> {
+        let mut state = 0x2545_F491_4F6C_DD1Du64;
+        (0..len)
+            .map(|_| {
+                state = state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                (state >> 33) as u8
+            })
+            .collect()
+    }
+
+    /// The symbols must resolve against the libzstd lbug vendors, not merely
+    /// link against something. Pinned exactly rather than as a floor: a loose
+    /// bound would also pass against a stray system libzstd, and the point of
+    /// this test is to prove *which* copy answered.
+    ///
+    /// lbug 0.19.1 vendors 1.5.7 (`lbug-src/third_party/versions.txt`). If an
+    /// lbug bump changes it, update this constant deliberately after checking
+    /// that the entry points this module declares are unchanged.
     #[test]
-    fn links_against_a_real_libzstd() {
-        assert!(
-            version_number() >= 10407,
-            "unexpected libzstd version {}",
-            version_number()
+    fn links_against_the_libzstd_lbug_vendors() {
+        assert_eq!(
+            version_number(),
+            10507,
+            "expected lbug's vendored libzstd 1.5.7"
         );
     }
 
@@ -417,6 +510,79 @@ mod tests {
     fn one_shot_round_trips_empty_input() {
         let compressed = encode_all(b"", 3).unwrap();
         assert_eq!(decode_all(&compressed).unwrap(), Vec::<u8>::new());
+    }
+
+    /// A truncated frame must be an error, never a short success.
+    ///
+    /// This is the failure mode that matters: a `.nwsnap.zst` cut short by an
+    /// interrupted write or a partial copy. Returning `Ok` with fewer bytes
+    /// would let `backup_inspect` report a manifest from a damaged archive, and
+    /// would hand `cache.rs` a silently truncated payload. `tar` and the
+    /// manifest checksums catch *some* of that downstream, but the compression
+    /// layer must signal it in its own right.
+    #[test]
+    fn truncated_frames_are_an_error_not_a_short_read() {
+        // Big enough that dropping a large tail still leaves whole blocks that
+        // decode fine — the case a length-only check would miss.
+        let data = incompressible(2_000_000);
+        let compressed = encode_all(&data, 3).unwrap();
+
+        for cut in [1usize, 50, 5000] {
+            assert!(
+                cut < compressed.len(),
+                "fixture too compressible: {} bytes cannot lose {cut}",
+                compressed.len()
+            );
+            let truncated = &compressed[..compressed.len() - cut];
+            let error = match decode_all(truncated) {
+                Ok(bytes) => panic!(
+                    "truncation by {cut} bytes was accepted, yielding {} bytes",
+                    bytes.len()
+                ),
+                Err(error) => error,
+            };
+            assert_eq!(
+                error.kind(),
+                io::ErrorKind::UnexpectedEof,
+                "truncation by {cut}: {error}"
+            );
+        }
+    }
+
+    /// Empty input is a truncated frame, not an empty stream: zero bytes cannot
+    /// contain a frame header.
+    #[test]
+    fn empty_input_is_an_incomplete_frame() {
+        let error = decode_all(b"").unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof, "{error}");
+    }
+
+    /// `io::Read` allows another `read` after an error. The decoder must keep
+    /// reporting the problem rather than reporting success.
+    #[test]
+    fn a_truncated_decoder_keeps_failing_on_reread() {
+        let compressed = encode_all(&incompressible(100_000), 3).unwrap();
+        let truncated = &compressed[..compressed.len() - 20];
+        let mut decoder = Decoder::new(truncated).unwrap();
+        let mut sink = Vec::new();
+        assert!(decoder.read_to_end(&mut sink).is_err());
+        let mut buf = [0u8; 64];
+        assert!(
+            decoder.read(&mut buf).is_err(),
+            "a second read reported success after a truncated stream"
+        );
+    }
+
+    /// A stream cut mid-frame after a complete earlier frame is still
+    /// truncated: the latch must reset when the next frame starts.
+    #[test]
+    fn truncation_after_a_complete_frame_is_still_an_error() {
+        let mut compressed = encode_all(b"first frame", 3).unwrap();
+        let second = encode_all(&incompressible(100_000), 3).unwrap();
+        assert!(second.len() > 30, "fixture too compressible");
+        compressed.extend_from_slice(&second[..second.len() - 30]);
+        let error = decode_all(&compressed).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof, "{error}");
     }
 
     #[test]

--- a/crates/nestweaver-store/src/zstd.rs
+++ b/crates/nestweaver-store/src/zstd.rs
@@ -1,0 +1,494 @@
+//! Zstandard compression bound to the copy of libzstd that lbug already links.
+//!
+//! # Why this exists instead of the `zstd` crate
+//!
+//! Every NestWeaver binary statically links `liblbug.a` with
+//! `static:+whole-archive` (lbug's own `build.rs`), and that archive *contains*
+//! zstd 1.5.7: lbug's CMake rolls `third_party/zstd` into the merged archive
+//! (`LBUG_STATIC_ARCHIVE_LIBRARIES` in `lbug-src/CMakeLists.txt`) and its
+//! `third_party/zstd/CMakeLists.txt` defines `ZSTDLIB_VISIBILITY` to *nothing*,
+//! so every `ZSTD_*` entry point keeps default visibility and is exported.
+//! `+whole-archive` then forces all of it into the final binary whether or not
+//! anything references it.
+//!
+//! Depending on the `zstd` crate pulled in `zstd-sys`, which compiles a *second*
+//! complete copy of the same zstd 1.5.7. `rust-lld` — the default linker on
+//! x86_64 Linux — rejects that with duplicate-symbol errors, which is why the
+//! tree carried `-Wl,--allow-multiple-definition`. That flag never merged the
+//! two copies; it just told the linker to pick one and stay quiet, leaving two
+//! sets of zstd state in one process.
+//!
+//! This module removes the second copy. It declares the handful of stable
+//! public zstd entry points it needs and lets them resolve against the copy
+//! already present in the binary. There is no `#[link]` attribute on purpose:
+//! the symbols come from `liblbug.a` in the source-build path, and from the
+//! `zstd` static library that `build.rs` compiles from lbug's vendored sources
+//! in the prebuilt-lbug path. Both paths already emit the link directives.
+//!
+//! # Format
+//!
+//! This is the same libzstd that produced the existing archives, driven through
+//! the same public API the `zstd` crate uses, so the bytes on disk are
+//! unchanged: `.nwsnap.zst` backups and `NWRC` response-cache sidecars written
+//! by earlier versions still read, and archives written now are still readable
+//! by any standard zstd implementation.
+
+use std::ffi::{CStr, c_char, c_int, c_uint, c_void};
+use std::io::{self, Read, Write};
+use std::ptr::NonNull;
+
+// --------------------------------------------------------------------------
+// Raw bindings.
+//
+// Only the stable, non-experimental surface of `zstd.h` is declared here: every
+// one of these has been part of libzstd's committed API since 1.4 and none of
+// them requires `ZSTD_STATIC_LINKING_ONLY`.
+// --------------------------------------------------------------------------
+
+/// Opaque `ZSTD_CStream` / `ZSTD_DStream`.
+#[repr(C)]
+struct ZstdStream {
+    _private: [u8; 0],
+}
+
+/// `ZSTD_inBuffer`. `src`/`size` are written by Rust and read by libzstd, never
+/// read back on this side, hence the `dead_code` exemption — the layout is the
+/// contract, not the Rust-side accesses.
+#[repr(C)]
+#[allow(dead_code)]
+struct ZstdInBuffer {
+    src: *const c_void,
+    size: usize,
+    pos: usize,
+}
+
+/// `ZSTD_outBuffer`. See [`ZstdInBuffer`] for why `dead_code` is exempted.
+#[repr(C)]
+#[allow(dead_code)]
+struct ZstdOutBuffer {
+    dst: *mut c_void,
+    size: usize,
+    pos: usize,
+}
+
+/// `ZSTD_EndDirective`.
+const ZSTD_E_CONTINUE: c_int = 0;
+const ZSTD_E_FLUSH: c_int = 1;
+const ZSTD_E_END: c_int = 2;
+
+// The declarations keep libzstd's own names so they match `zstd.h` exactly.
+#[allow(non_snake_case)]
+unsafe extern "C" {
+    fn ZSTD_versionNumber() -> c_uint;
+    fn ZSTD_isError(code: usize) -> c_uint;
+    fn ZSTD_getErrorName(code: usize) -> *const c_char;
+
+    fn ZSTD_compressBound(src_size: usize) -> usize;
+    fn ZSTD_compress(
+        dst: *mut c_void,
+        dst_capacity: usize,
+        src: *const c_void,
+        src_size: usize,
+        compression_level: c_int,
+    ) -> usize;
+
+    fn ZSTD_createCStream() -> *mut ZstdStream;
+    fn ZSTD_freeCStream(zcs: *mut ZstdStream) -> usize;
+    fn ZSTD_initCStream(zcs: *mut ZstdStream, compression_level: c_int) -> usize;
+    fn ZSTD_compressStream2(
+        zcs: *mut ZstdStream,
+        output: *mut ZstdOutBuffer,
+        input: *mut ZstdInBuffer,
+        end_op: c_int,
+    ) -> usize;
+    fn ZSTD_CStreamOutSize() -> usize;
+
+    fn ZSTD_createDStream() -> *mut ZstdStream;
+    fn ZSTD_freeDStream(zds: *mut ZstdStream) -> usize;
+    fn ZSTD_initDStream(zds: *mut ZstdStream) -> usize;
+    fn ZSTD_decompressStream(
+        zds: *mut ZstdStream,
+        output: *mut ZstdOutBuffer,
+        input: *mut ZstdInBuffer,
+    ) -> usize;
+    fn ZSTD_DStreamInSize() -> usize;
+}
+
+/// The libzstd version actually linked into this binary, as `MAJOR*10000 +
+/// MINOR*100 + RELEASE`.
+///
+/// Exposed so a test can assert that the symbols really did resolve against a
+/// real libzstd rather than something that merely linked.
+pub fn version_number() -> u32 {
+    // SAFETY: no arguments, no state, returns a plain integer.
+    unsafe { ZSTD_versionNumber() }
+}
+
+/// Translate a zstd return code into an `io::Error`, or pass it through.
+fn check(code: usize) -> io::Result<usize> {
+    // SAFETY: `ZSTD_isError` reads only the integer it is handed.
+    if unsafe { ZSTD_isError(code) } == 0 {
+        return Ok(code);
+    }
+    // SAFETY: for an error code `ZSTD_getErrorName` returns a pointer to a
+    // static NUL-terminated string with 'static lifetime.
+    let name = unsafe { CStr::from_ptr(ZSTD_getErrorName(code)) };
+    Err(io::Error::other(format!(
+        "zstd: {}",
+        name.to_string_lossy()
+    )))
+}
+
+// --------------------------------------------------------------------------
+// One-shot helpers
+// --------------------------------------------------------------------------
+
+/// Compress `data` into a single zstd frame at `level`.
+pub fn encode_all(data: &[u8], level: i32) -> io::Result<Vec<u8>> {
+    // SAFETY: pure arithmetic on the input length.
+    let capacity = unsafe { ZSTD_compressBound(data.len()) };
+    let mut out = vec![0u8; capacity];
+    // SAFETY: `out` has `capacity` writable bytes and `data` has `data.len()`
+    // readable bytes; both outlive the call.
+    let written = check(unsafe {
+        ZSTD_compress(
+            out.as_mut_ptr().cast::<c_void>(),
+            capacity,
+            data.as_ptr().cast::<c_void>(),
+            data.len(),
+            level as c_int,
+        )
+    })?;
+    out.truncate(written);
+    Ok(out)
+}
+
+/// Decompress every zstd frame in `data`.
+///
+/// Uses the streaming API rather than `ZSTD_decompress` so that frames without
+/// a recorded content size — anything written by [`Encoder`] — decode too.
+pub fn decode_all(data: &[u8]) -> io::Result<Vec<u8>> {
+    let mut out = Vec::new();
+    Decoder::new(data)?.read_to_end(&mut out)?;
+    Ok(out)
+}
+
+// --------------------------------------------------------------------------
+// Streaming compression
+// --------------------------------------------------------------------------
+
+/// A `Write` adapter that zstd-compresses into an inner writer.
+///
+/// Call [`finish`](Self::finish) to terminate the frame; dropping without
+/// finishing leaves a truncated, unreadable frame, exactly as with the `zstd`
+/// crate's encoder.
+pub struct Encoder<W: Write> {
+    stream: NonNull<ZstdStream>,
+    writer: Option<W>,
+    buffer: Vec<u8>,
+}
+
+// SAFETY: a `ZSTD_CStream` is owned exclusively by its `Encoder` and carries no
+// thread-affine state; libzstd only requires that it not be used concurrently,
+// which `&mut self` already guarantees.
+unsafe impl<W: Write + Send> Send for Encoder<W> {}
+
+impl<W: Write> Encoder<W> {
+    /// Create an encoder writing a zstd frame at `level` into `writer`.
+    pub fn new(writer: W, level: i32) -> io::Result<Self> {
+        // SAFETY: allocation only; returns null on failure.
+        let stream = NonNull::new(unsafe { ZSTD_createCStream() })
+            .ok_or_else(|| io::Error::other("zstd: could not allocate a compression stream"))?;
+        // SAFETY: `stream` is a freshly allocated, non-null `ZSTD_CStream`.
+        if let Err(error) = check(unsafe { ZSTD_initCStream(stream.as_ptr(), level as c_int) }) {
+            // SAFETY: `stream` is still owned here and not yet handed out.
+            unsafe { ZSTD_freeCStream(stream.as_ptr()) };
+            return Err(error);
+        }
+        // SAFETY: no arguments; returns the recommended output buffer size.
+        let buffer = vec![0u8; unsafe { ZSTD_CStreamOutSize() }];
+        Ok(Self {
+            stream,
+            writer: Some(writer),
+            buffer,
+        })
+    }
+
+    /// Drive `ZSTD_compressStream2` over `input` until zstd is done with the
+    /// directive, writing every produced byte to the inner writer.
+    fn run(&mut self, input: &[u8], end_op: c_int) -> io::Result<()> {
+        let mut in_buffer = ZstdInBuffer {
+            src: input.as_ptr().cast::<c_void>(),
+            size: input.len(),
+            pos: 0,
+        };
+        loop {
+            let mut out_buffer = ZstdOutBuffer {
+                dst: self.buffer.as_mut_ptr().cast::<c_void>(),
+                size: self.buffer.len(),
+                pos: 0,
+            };
+            // SAFETY: both buffers describe live allocations for the duration
+            // of the call, and `self.stream` is a live `ZSTD_CStream`.
+            let remaining = check(unsafe {
+                ZSTD_compressStream2(
+                    self.stream.as_ptr(),
+                    &mut out_buffer,
+                    &mut in_buffer,
+                    end_op,
+                )
+            })?;
+            if out_buffer.pos > 0 {
+                let writer = self
+                    .writer
+                    .as_mut()
+                    .ok_or_else(|| io::Error::other("zstd: encoder already finished"))?;
+                writer.write_all(&self.buffer[..out_buffer.pos])?;
+            }
+            let done = match end_op {
+                // Feeding input is complete once zstd has consumed all of it.
+                ZSTD_E_CONTINUE => in_buffer.pos == in_buffer.size,
+                // A flush or an end is complete once zstd reports nothing left.
+                _ => remaining == 0,
+            };
+            if done {
+                return Ok(());
+            }
+        }
+    }
+
+    /// Terminate the frame and return the inner writer.
+    pub fn finish(mut self) -> io::Result<W> {
+        self.run(&[], ZSTD_E_END)?;
+        let mut writer = self
+            .writer
+            .take()
+            .ok_or_else(|| io::Error::other("zstd: encoder already finished"))?;
+        writer.flush()?;
+        Ok(writer)
+    }
+}
+
+impl<W: Write> Write for Encoder<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.run(buf, ZSTD_E_CONTINUE)?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.run(&[], ZSTD_E_FLUSH)?;
+        match self.writer.as_mut() {
+            Some(writer) => writer.flush(),
+            None => Err(io::Error::other("zstd: encoder already finished")),
+        }
+    }
+}
+
+impl<W: Write> Drop for Encoder<W> {
+    fn drop(&mut self) {
+        // SAFETY: `self.stream` is live and owned solely by this encoder; it is
+        // never freed anywhere else.
+        unsafe { ZSTD_freeCStream(self.stream.as_ptr()) };
+    }
+}
+
+// --------------------------------------------------------------------------
+// Streaming decompression
+// --------------------------------------------------------------------------
+
+/// A `Read` adapter that zstd-decompresses from an inner reader.
+///
+/// Handles frames with or without a recorded content size, and consumes
+/// consecutive frames as one stream.
+pub struct Decoder<R: Read> {
+    stream: NonNull<ZstdStream>,
+    reader: R,
+    input: Vec<u8>,
+    /// Bytes of `input` that hold data read from `reader`.
+    filled: usize,
+    /// Bytes of `input[..filled]` already consumed by zstd.
+    consumed: usize,
+    eof: bool,
+}
+
+// SAFETY: as for `Encoder` — the `ZSTD_DStream` is exclusively owned and only
+// ever touched behind `&mut self`.
+unsafe impl<R: Read + Send> Send for Decoder<R> {}
+
+impl<R: Read> Decoder<R> {
+    /// Create a decoder reading compressed bytes from `reader`.
+    pub fn new(reader: R) -> io::Result<Self> {
+        // SAFETY: allocation only; returns null on failure.
+        let stream = NonNull::new(unsafe { ZSTD_createDStream() })
+            .ok_or_else(|| io::Error::other("zstd: could not allocate a decompression stream"))?;
+        // SAFETY: `stream` is a freshly allocated, non-null `ZSTD_DStream`.
+        if let Err(error) = check(unsafe { ZSTD_initDStream(stream.as_ptr()) }) {
+            // SAFETY: `stream` is still owned here and not yet handed out.
+            unsafe { ZSTD_freeDStream(stream.as_ptr()) };
+            return Err(error);
+        }
+        // SAFETY: no arguments; returns the recommended input buffer size.
+        let input = vec![0u8; unsafe { ZSTD_DStreamInSize() }];
+        Ok(Self {
+            stream,
+            reader,
+            input,
+            filled: 0,
+            consumed: 0,
+            eof: false,
+        })
+    }
+}
+
+impl<R: Read> Read for Decoder<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        loop {
+            if self.consumed == self.filled {
+                if self.eof {
+                    return Ok(0);
+                }
+                self.filled = self.reader.read(&mut self.input)?;
+                self.consumed = 0;
+                if self.filled == 0 {
+                    self.eof = true;
+                    return Ok(0);
+                }
+            }
+
+            let mut out_buffer = ZstdOutBuffer {
+                dst: buf.as_mut_ptr().cast::<c_void>(),
+                size: buf.len(),
+                pos: 0,
+            };
+            let mut in_buffer = ZstdInBuffer {
+                src: self.input.as_ptr().cast::<c_void>(),
+                size: self.filled,
+                pos: self.consumed,
+            };
+            // SAFETY: both buffers describe live allocations for the duration
+            // of the call, and `self.stream` is a live `ZSTD_DStream`.
+            check(unsafe {
+                ZSTD_decompressStream(self.stream.as_ptr(), &mut out_buffer, &mut in_buffer)
+            })?;
+            self.consumed = in_buffer.pos;
+            if out_buffer.pos > 0 {
+                return Ok(out_buffer.pos);
+            }
+            // zstd produced nothing: it needs more input. Loop and refill.
+        }
+    }
+}
+
+impl<R: Read> Drop for Decoder<R> {
+    fn drop(&mut self) {
+        // SAFETY: `self.stream` is live and owned solely by this decoder; it is
+        // never freed anywhere else.
+        unsafe { ZSTD_freeDStream(self.stream.as_ptr()) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The symbols must resolve against a real libzstd, not merely link. lbug
+    /// vendors 1.5.7 (`lbug-src/third_party/versions.txt`).
+    #[test]
+    fn links_against_a_real_libzstd() {
+        assert!(
+            version_number() >= 10407,
+            "unexpected libzstd version {}",
+            version_number()
+        );
+    }
+
+    #[test]
+    fn one_shot_round_trips() {
+        let data = b"nestweaver".repeat(500);
+        let compressed = encode_all(&data, 3).unwrap();
+        assert!(compressed.len() < data.len());
+        assert_eq!(decode_all(&compressed).unwrap(), data);
+    }
+
+    #[test]
+    fn one_shot_round_trips_empty_input() {
+        let compressed = encode_all(b"", 3).unwrap();
+        assert_eq!(decode_all(&compressed).unwrap(), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn streaming_round_trips_across_many_writes() {
+        // More than one `ZSTD_CStreamOutSize` worth, written in small pieces,
+        // so both the encoder's flush loop and the decoder's refill loop run.
+        let chunk = b"the quick brown fox jumps over the lazy dog\n";
+        let mut expected = Vec::new();
+        let mut encoder = Encoder::new(Vec::new(), 3).unwrap();
+        for _ in 0..20_000 {
+            encoder.write_all(chunk).unwrap();
+            expected.extend_from_slice(chunk);
+        }
+        let compressed = encoder.finish().unwrap();
+        assert!(compressed.len() < expected.len());
+
+        let mut decoded = Vec::new();
+        Decoder::new(compressed.as_slice())
+            .unwrap()
+            .read_to_end(&mut decoded)
+            .unwrap();
+        assert_eq!(decoded, expected);
+    }
+
+    /// A streamed frame records no content size, so a decoder that relied on
+    /// `ZSTD_getFrameContentSize` would fail here.
+    #[test]
+    fn streamed_frames_decode_through_the_one_shot_helper() {
+        let mut encoder = Encoder::new(Vec::new(), 3).unwrap();
+        encoder.write_all(b"streamed payload").unwrap();
+        let compressed = encoder.finish().unwrap();
+        assert_eq!(decode_all(&compressed).unwrap(), b"streamed payload");
+    }
+
+    /// The one-shot and streaming paths must interoperate in both directions,
+    /// because `.nwsnap.zst` archives and `NWRC` sidecars written by earlier
+    /// releases used the `zstd` crate's equivalents of each.
+    #[test]
+    fn one_shot_output_decodes_through_the_streaming_decoder() {
+        let data = b"cross-path payload".repeat(200);
+        let compressed = encode_all(&data, 3).unwrap();
+        let mut decoded = Vec::new();
+        Decoder::new(compressed.as_slice())
+            .unwrap()
+            .read_to_end(&mut decoded)
+            .unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn consecutive_frames_decode_as_one_stream() {
+        let mut compressed = encode_all(b"first", 3).unwrap();
+        compressed.extend_from_slice(&encode_all(b"second", 3).unwrap());
+        assert_eq!(decode_all(&compressed).unwrap(), b"firstsecond");
+    }
+
+    #[test]
+    fn corrupt_input_is_an_error_not_a_panic() {
+        let error = decode_all(b"not a zstd frame at all").unwrap_err();
+        assert!(error.to_string().contains("zstd:"), "{error}");
+    }
+
+    #[test]
+    fn flush_does_not_end_the_frame() {
+        let mut encoder = Encoder::new(Vec::new(), 3).unwrap();
+        encoder.write_all(b"before flush ").unwrap();
+        encoder.flush().unwrap();
+        encoder.write_all(b"after flush").unwrap();
+        let compressed = encoder.finish().unwrap();
+        assert_eq!(
+            decode_all(&compressed).unwrap(),
+            b"before flush after flush"
+        );
+    }
+}

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -538,7 +538,11 @@ alongside the returned rows:
   either field the merge omits both rather than inventing them — so on a merged
   response, absence means "no tier reported", not "`false`".
   `degraded_components` has exactly one value in the current vocabulary,
-  `"semantic"`.
+  `"semantic"`. The structured (`connected`-schema) merge used by
+  `brain_context` / `project_context` applies the same rules. Those tools do
+  have a semantic leg, so a merge there can mix a semantically ranked tier with
+  a lexical one; the AND then reports `false`, which is correct for the merged
+  row set but does not say which tier was which.
 
 For a hybrid merge, NestWeaver reports an exact union only when both local and
 server responses have valid, internally consistent exact-count metadata and

--- a/src/main.rs
+++ b/src/main.rs
@@ -1794,13 +1794,18 @@ enum Commands {
     /// because the PageRank and generation sidecars may predate the committed
     /// graph. This is about index PUBLICATION, not a dirty git working tree.
     ///
-    /// Recovery is not a delete: PageRank is recomputed against the committed
-    /// graph and the generation advanced and persisted BEFORE the marker is
-    /// cleared. A publication whose writer process is still alive is left
-    /// strictly alone, and a marker whose state cannot be read (permissions,
-    /// I/O error) is reported rather than cleared.
+    /// Recovery is not a delete: the stale PageRank sidecar is removed and the
+    /// generation advanced and persisted BEFORE the marker is cleared, then
+    /// PageRank is recomputed against the committed graph. A publication whose
+    /// writer process is still alive is left strictly alone.
+    ///
+    /// Without --force this refuses any marker it cannot prove was abandoned:
+    /// one carrying no writer pid (written by an older release, truncated by a
+    /// crash, or created by hand) and one whose state cannot be read at all.
+    /// --force overrides exactly that conservatism. It never overrides a writer
+    /// that is demonstrably alive.
     #[command(
-        after_help = "Examples:\n  nestweaver repair\n  nestweaver repair --db ~/brain/.nestweaver/brain.lbug\n  nestweaver repair --json\n\nExits 0 when the publication is clean or was recovered, 1 when it is dirty\nand could not be recovered (e.g. a live writer, or an unreadable marker)."
+        after_help = "Examples:\n  nestweaver repair\n  nestweaver repair --db ~/brain/.nestweaver/brain.lbug\n  nestweaver repair --json\n  nestweaver repair --force        # marker carries no usable writer pid\n\nExits 0 when the publication is clean or was recovered, 1 when it is dirty\nand could not be recovered. A live writer is never overridden, even with\n--force; stop that process first."
     )]
     Repair {
         #[arg(
@@ -1812,6 +1817,11 @@ enum Commands {
         json: bool,
         #[arg(long, help = "Report the publication state without clearing anything")]
         dry_run: bool,
+        #[arg(
+            long,
+            help = "Recover a marker that carries no usable writer pid, or whose state cannot be read. Never overrides a live writer."
+        )]
+        force: bool,
     },
     /// Check if the indexed graph is stale by comparing each repo's
     /// indexed SHA against git HEAD. (Same as `brain stale-check`.)
@@ -6493,7 +6503,9 @@ fn repair_outcome_name(
 /// Shipped regardless of auto-heal, because auto-heal deliberately declines in
 /// several safe-but-stuck cases: an unattributed marker (written by an older
 /// binary, or hand-created), an undeterminable one, and any database whose only
-/// writer never runs again. Before this existed, the sole escape was
+/// writer never runs again. The third is served by a plain run; the first two
+/// need `--force`, and this command names that next step instead of exiting
+/// with no remedy. Before this existed, the sole escape was
 /// `rm <db>.index-dirty`, discoverable only by reading the source — and an `rm`
 /// is the *wrong* repair, because it makes sidecars that predate the committed
 /// graph authoritative again.
@@ -6501,6 +6513,7 @@ fn run_repair_index_publication(
     db_path: &std::path::Path,
     json: bool,
     dry_run: bool,
+    force: bool,
 ) -> anyhow::Result<i32> {
     use nestweaver_engine::index_publication as pubstat;
 
@@ -6511,9 +6524,11 @@ fn run_repair_index_publication(
     if status.dirty && !dry_run {
         match nestweaver_store::GraphStore::open(db_path) {
             Ok(store) => {
-                outcome = Some(
-                    nestweaver_engine::index::recover_abandoned_index_publication(&store, true)?,
-                );
+                outcome = Some(if force {
+                    nestweaver_engine::index::force_recover_index_publication(&store)?
+                } else {
+                    nestweaver_engine::index::recover_abandoned_index_publication(&store, true)?
+                });
             }
             Err(error) => {
                 // The write lock is held — almost always by a running daemon,
@@ -6543,6 +6558,8 @@ fn run_repair_index_publication(
             "db": db_path.display().to_string(),
             "marker_path": status.marker_path,
             "dry_run": dry_run,
+            "force": force,
+            "needs_forced_repair": after.needs_forced_repair(),
             "before": {
                 "dirty": status.dirty,
                 "determinable": status.determinable,
@@ -6601,6 +6618,22 @@ fn run_repair_index_publication(
     }
     if after.dirty {
         eprintln!("The publication is still dirty. See the reason above.");
+        // Name the next step. Exiting 1 with no remedy is exactly what left
+        // `rm <db>.index-dirty` as the folk repair in the first place.
+        if !force && after.needs_forced_repair() {
+            eprintln!(
+                "This marker carries no writer this command can prove is gone, so the \
+                 automatic check declined. If no indexer is running for this database, \
+                 re-run with --force:\n    nestweaver repair --db {} --force",
+                db_path.display()
+            );
+        } else if after.writer_alive == Some(true) {
+            eprintln!(
+                "A live writer (pid {}) owns this publication. Wait for it to finish or stop \
+                 that process; --force will not override it.",
+                after.writer_pid.unwrap_or(0)
+            );
+        }
     }
     Ok(exit)
 }
@@ -7366,10 +7399,15 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             Ok((EXIT_SUCCESS, None))
         }
 
-        Commands::Repair { db, json, dry_run } => {
+        Commands::Repair {
+            db,
+            json,
+            dry_run,
+            force,
+        } => {
             let db_path = db.unwrap_or_else(default_db_path);
             require_existing_db(&db_path)?;
-            let code = run_repair_index_publication(&db_path, json, dry_run)?;
+            let code = run_repair_index_publication(&db_path, json, dry_run, force)?;
             Ok((code, None))
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1787,6 +1787,32 @@ enum Commands {
         )]
         db: Option<PathBuf>,
     },
+    /// Reconcile an index publication abandoned by a crashed indexer.
+    ///
+    /// While `<db>.index-dirty` exists, every ranked query in the database
+    /// (brain_context, project_context, investigate) fails closed — correctly,
+    /// because the PageRank and generation sidecars may predate the committed
+    /// graph. This is about index PUBLICATION, not a dirty git working tree.
+    ///
+    /// Recovery is not a delete: PageRank is recomputed against the committed
+    /// graph and the generation advanced and persisted BEFORE the marker is
+    /// cleared. A publication whose writer process is still alive is left
+    /// strictly alone, and a marker whose state cannot be read (permissions,
+    /// I/O error) is reported rather than cleared.
+    #[command(
+        after_help = "Examples:\n  nestweaver repair\n  nestweaver repair --db ~/brain/.nestweaver/brain.lbug\n  nestweaver repair --json\n\nExits 0 when the publication is clean or was recovered, 1 when it is dirty\nand could not be recovered (e.g. a live writer, or an unreadable marker)."
+    )]
+    Repair {
+        #[arg(
+            long,
+            help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
+        )]
+        db: Option<PathBuf>,
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+        #[arg(long, help = "Report the publication state without clearing anything")]
+        dry_run: bool,
+    },
     /// Check if the indexed graph is stale by comparing each repo's
     /// indexed SHA against git HEAD. (Same as `brain stale-check`.)
     /// Exits 1 when any repo is stale or its working tree is missing —
@@ -6444,6 +6470,141 @@ fn require_existing_db(db_path: &std::path::Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Stable machine name for a recovery outcome, for `--json` consumers.
+fn repair_outcome_name(
+    outcome: &nestweaver_engine::index::IndexPublicationRecovery,
+) -> &'static str {
+    use nestweaver_engine::index::IndexPublicationRecovery as R;
+    match outcome {
+        R::Clean => "clean",
+        R::NotFileBacked => "not_file_backed",
+        R::Undeterminable { .. } => "undeterminable",
+        R::WriterAlive { .. } => "writer_alive",
+        R::WriterUnattributed => "writer_unattributed",
+        R::LeaseHeld => "lease_held",
+        R::ReadOnlyStore { .. } => "read_only_store",
+        R::Recovered { .. } => "recovered",
+    }
+}
+
+/// `nestweaver repair` — the operator escape hatch for an abandoned index
+/// publication (nw-C1).
+///
+/// Shipped regardless of auto-heal, because auto-heal deliberately declines in
+/// several safe-but-stuck cases: an unattributed marker (written by an older
+/// binary, or hand-created), an undeterminable one, and any database whose only
+/// writer never runs again. Before this existed, the sole escape was
+/// `rm <db>.index-dirty`, discoverable only by reading the source — and an `rm`
+/// is the *wrong* repair, because it makes sidecars that predate the committed
+/// graph authoritative again.
+fn run_repair_index_publication(
+    db_path: &std::path::Path,
+    json: bool,
+    dry_run: bool,
+) -> anyhow::Result<i32> {
+    use nestweaver_engine::index_publication as pubstat;
+
+    let status = pubstat::status(db_path);
+    let mut outcome: Option<nestweaver_engine::index::IndexPublicationRecovery> = None;
+    let mut open_error: Option<String> = None;
+
+    if status.dirty && !dry_run {
+        match nestweaver_store::GraphStore::open(db_path) {
+            Ok(store) => {
+                outcome = Some(
+                    nestweaver_engine::index::recover_abandoned_index_publication(&store, true)?,
+                );
+            }
+            Err(error) => {
+                // The write lock is held — almost always by a running daemon,
+                // which is itself a writer and reconciles at startup. Say so
+                // instead of emitting a raw store error.
+                open_error = Some(format!(
+                    "could not open {} read-write ({error}). Another process holds the write \
+                     lock; if that is the daemon, restart it (`nestweaver daemon --db {} stop` \
+                     then start) and it will reconcile the publication itself.",
+                    db_path.display(),
+                    db_path.display()
+                ));
+            }
+        }
+    }
+
+    let recovered = outcome.as_ref().is_some_and(|o| o.recovered());
+    let after = pubstat::status(db_path);
+    let exit = if !after.dirty {
+        EXIT_SUCCESS
+    } else {
+        EXIT_ERROR
+    };
+
+    if json {
+        let payload = serde_json::json!({
+            "db": db_path.display().to_string(),
+            "marker_path": status.marker_path,
+            "dry_run": dry_run,
+            "before": {
+                "dirty": status.dirty,
+                "determinable": status.determinable,
+                "writer_pid": status.writer_pid,
+                "writer_alive": status.writer_alive,
+                "marker_age_s": status.marker_age_s,
+                "writer_reason": status.writer_reason,
+                "wedged": status.is_wedged(),
+            },
+            "after": { "dirty": after.dirty },
+            "recovered": recovered,
+            "outcome": outcome.as_ref().map(repair_outcome_name),
+            "message": outcome.as_ref().map(|o| o.describe()),
+            "error": open_error,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(exit);
+    }
+
+    println!("Database: {}", db_path.display());
+    println!("Marker:   {}", status.marker_path);
+    if !status.dirty {
+        println!("Index publication is CLEAN — nothing to repair.");
+        return Ok(exit);
+    }
+    println!(
+        "Index publication is DIRTY (writer_pid={}, writer_alive={}, marker_age={}, wedged={}).",
+        status
+            .writer_pid
+            .map(|p| p.to_string())
+            .unwrap_or_else(|| "unknown".into()),
+        status
+            .writer_alive
+            .map(|a| a.to_string())
+            .unwrap_or_else(|| "unknown".into()),
+        status
+            .marker_age_s
+            .map(|s| format!("{s}s"))
+            .unwrap_or_else(|| "unknown".into()),
+        status.is_wedged(),
+    );
+    println!(
+        "This is an index PUBLICATION marker, not a dirty git working tree — editing files \
+         does not cause it."
+    );
+    if dry_run {
+        println!("--dry-run: nothing was changed.");
+        return Ok(exit);
+    }
+    if let Some(error) = open_error {
+        eprintln!("Error: {error}");
+        return Ok(EXIT_ERROR);
+    }
+    if let Some(outcome) = outcome {
+        println!("{}", outcome.describe());
+    }
+    if after.dirty {
+        eprintln!("The publication is still dirty. See the reason above.");
+    }
+    Ok(exit)
+}
+
 /// Create-operations (`index`, `brain add`) materialize the DB file, so a
 /// `--db` pointing into a not-yet-existing directory must have that
 /// directory created up front — otherwise the store open fails with a bare
@@ -7203,6 +7364,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
             }
             Ok((EXIT_SUCCESS, None))
+        }
+
+        Commands::Repair { db, json, dry_run } => {
+            let db_path = db.unwrap_or_else(default_db_path);
+            require_existing_db(&db_path)?;
+            let code = run_repair_index_publication(&db_path, json, dry_run)?;
+            Ok((code, None))
         }
 
         Commands::PruneStale { db } => {

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -313,6 +313,46 @@ fn source_build_configuration_is_intact_and_reproducible() {
     );
 }
 
+/// Guards the single-copy-of-zstd invariant.
+///
+/// `liblbug.a` vendors zstd, exports its `ZSTD_*` symbols, and is linked
+/// `+whole-archive`, so every binary already contains a complete libzstd. Rust
+/// code reaches it through `nestweaver_store::zstd`.
+///
+/// Adding the `zstd` crate back pulls in `zstd-sys`, which compiles a second
+/// complete copy; `rust-lld` then fails every link with duplicate `ZSTD_*`
+/// symbols. The historical response was `-Wl,--allow-multiple-definition`,
+/// which suppressed the error without merging the copies — two zstd instances
+/// with independent state stayed in the process. Assert both halves here: no
+/// second copy in the tree, and no suppression flag anywhere.
+#[test]
+fn exactly_one_copy_of_zstd_is_linked() {
+    let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    let lockfile = std::fs::read_to_string(repo_root.join("Cargo.lock")).unwrap();
+    assert!(
+        !lockfile.contains("name = \"zstd-sys\""),
+        "zstd-sys is back in the dependency tree; it compiles a second complete \
+         libzstd alongside the one liblbug.a already exports. Use \
+         nestweaver_store::zstd instead of the `zstd` crate."
+    );
+
+    for relative_path in [
+        ".cargo/config.toml",
+        ".github/workflows/ci.yml",
+        ".github/workflows/release-please.yml",
+        "Dockerfile",
+    ] {
+        let contents = std::fs::read_to_string(repo_root.join(relative_path))
+            .unwrap_or_else(|error| panic!("failed to read {relative_path}: {error}"));
+        assert!(
+            !contents.contains("allow-multiple-definition"),
+            "{relative_path} still carries --allow-multiple-definition; it suppresses \
+             duplicate symbols rather than removing the duplicate"
+        );
+    }
+}
+
 #[test]
 fn embedding_docs_match_runtime_contract() {
     let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -322,9 +322,9 @@ fn source_build_configuration_is_intact_and_reproducible() {
 /// Adding the `zstd` crate back pulls in `zstd-sys`, which compiles a second
 /// complete copy; `rust-lld` then fails every link with duplicate `ZSTD_*`
 /// symbols. The historical response was `-Wl,--allow-multiple-definition`,
-/// which suppressed the error without merging the copies — two zstd instances
-/// with independent state stayed in the process. Assert both halves here: no
-/// second copy in the tree, and no suppression flag anywhere.
+/// which suppressed the error without merging the copies — the linker picked
+/// one definition silently and the other stayed in the binary. Assert both
+/// halves here: no second copy in the tree, and no suppression flag anywhere.
 #[test]
 fn exactly_one_copy_of_zstd_is_linked() {
     let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -2397,6 +2397,130 @@ async fn hybrid_brain_search_merge_combines_local_and_server_sources() {
     );
 }
 
+/// MUST-HAVE: the honesty fields survive the STRUCTURED federated merge.
+///
+/// `brain_context` (and `project_context`) go through
+/// `merge_structured_results`, which rebuilds the `connected`-schema envelope
+/// field by field. Every field it does not re-add deliberately is dropped.
+/// Unlike `brain_search`, these tools DO have a semantic leg, so
+/// `semantic_applied` / `degraded_components` carry real information here: a
+/// caller has to be able to tell "the semantic leg ran" from "it did not" from
+/// "this path never reports it". Dropping them in the merge silently converts
+/// the first two into the third.
+///
+/// This runs against the real two-daemon federated path (local UDS daemon +
+/// authenticated gRPC server, `HybridClient` in Merge mode), not a hand-built
+/// literal, and first proves both tiers really contributed by checking that
+/// the merged `connected` payload carries symbols that exist on only one side.
+#[tokio::test]
+async fn hybrid_brain_context_merge_preserves_honesty_fields() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Server side: repo A. `sharedctxfn` is the seed both tiers can resolve;
+    // `serverctxfn` exists ONLY here.
+    let server_repo = dir.path().join("repo_a");
+    let db_server = dir.path().join("server").join("server.lbug");
+    write_repo_files(
+        &server_repo,
+        &[(
+            "main.js",
+            "function serverctxfn(x) { return x; }\n\
+             function sharedctxfn(x) { return serverctxfn(x); }",
+        )],
+    );
+    index_repo(&server_repo, &db_server);
+
+    // Local side: repo B. `localctxfn` exists ONLY here.
+    let local_repo = dir.path().join("repo_b");
+    let db_local = dir.path().join("local").join("local.lbug");
+    write_repo_files(
+        &local_repo,
+        &[(
+            "main.js",
+            "function localctxfn(x) { return x; }\n\
+             function sharedctxfn(x) { return localctxfn(x); }",
+        )],
+    );
+    index_repo(&local_repo, &db_local);
+
+    let server = helpers::server_guard::ServerGuard::start_with_auth(&db_server, HYBRID_TOKEN);
+    let cfg_path = dir.path().join("instance.toml");
+    write_upstream_config(&cfg_path, "server", &server.grpc_addr(), HYBRID_TOKEN);
+    let _local_guard = helpers::server_guard::ServerGuard::start_with_config(&db_local, &cfg_path);
+
+    let local = connect_local(&db_local).await;
+    let upstream = merge_upstream(server.grpc_addr(), HYBRID_TOKEN);
+    let mut hybrid = HybridClient::from_parts(local, vec![upstream]);
+
+    let resp = hybrid
+        .query(
+            "brain_context",
+            &json!({ "seeds": ["sharedctxfn"], "token_budget": 4000 }),
+        )
+        .await
+        .expect("hybrid brain_context merge query");
+
+    // Proof this is the STRUCTURED merge path and that both tiers contributed:
+    // the `connected` schema survived, and it carries a symbol from each side.
+    assert!(
+        resp.get("connected").and_then(Value::as_array).is_some(),
+        "brain_context merge must keep the structured `connected` schema; got {resp}"
+    );
+    let sources = meta_sources(&resp);
+    assert!(
+        sources.iter().any(|s| s == "local") && sources.iter().any(|s| s == "server"),
+        "structured merge must report both sources; got {sources:?} in {resp}"
+    );
+    let payload = resp["connected"].to_string();
+    assert!(
+        payload.contains("serverctxfn"),
+        "merged `connected` must contain the server-only symbol (proof the server \
+         tier contributed to the structured merge); got {resp}"
+    );
+    assert!(
+        payload.contains("localctxfn"),
+        "merged `connected` must contain the local-only symbol; got {resp}"
+    );
+
+    // The honesty fields themselves. Both tiers report them (the daemon's
+    // GetContext response and the local in-process dispatch both always emit
+    // both keys), so the merge must too — an ABSENT field on a merged response
+    // has to keep meaning "no tier reported it / older server", which is a
+    // different statement from `false`.
+    assert!(
+        resp.get("semantic_applied").is_some(),
+        "structured merge must carry `semantic_applied`; dropping it makes a merged \
+         brain_context indistinguishable from a server that never reports it; got {resp}"
+    );
+    assert!(
+        resp.get("degraded_components").is_some(),
+        "structured merge must carry `degraded_components`; got {resp}"
+    );
+
+    // Neither daemon has an embedding model available, so on both tiers the
+    // semantic leg was requested and could not run: each reports
+    // `semantic_applied: false` with `degraded_components: ["semantic"]`.
+    //
+    // That makes this the load-bearing case rather than a trivial one. The AND
+    // across tiers is `false`, and the union is `["semantic"]` — ONE entry, not
+    // two, which proves the merge deduplicates rather than concatenating, and
+    // proves a REAL degradation survives the rebuild of the envelope instead of
+    // being dropped. This is exactly what a caller loses when the structured
+    // merge drops these fields: the merged answer is lexically ranked, and it
+    // has to say so.
+    assert_eq!(
+        resp["semantic_applied"],
+        json!(false),
+        "neither tier applied a semantic leg, so the AND across tiers is false; got {resp}"
+    );
+    assert_eq!(
+        resp["degraded_components"],
+        json!(["semantic"]),
+        "both tiers degraded the semantic component; the merged answer must report it \
+         exactly once (deduplicated union, documented vocabulary); got {resp}"
+    );
+}
+
 /// ATTEMPT: two-tier `blast_radius`. The local daemon indexes a file under
 /// `local/`, the server a file under `server/`. With both paths in
 /// `changed_files`, the two-tier response must carry a populated `local_impact`

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -2501,13 +2501,20 @@ async fn hybrid_brain_context_merge_preserves_honesty_fields() {
     // semantic leg was requested and could not run: each reports
     // `semantic_applied: false` with `degraded_components: ["semantic"]`.
     //
-    // That makes this the load-bearing case rather than a trivial one. The AND
-    // across tiers is `false`, and the union is `["semantic"]` — ONE entry, not
-    // two, which proves the merge deduplicates rather than concatenating, and
-    // proves a REAL degradation survives the rebuild of the envelope instead of
-    // being dropped. This is exactly what a caller loses when the structured
-    // merge drops these fields: the merged answer is lexically ranked, and it
-    // has to say so.
+    // That makes this the load-bearing case rather than a trivial one: a REAL
+    // degradation, produced by two real daemons, has to survive the rebuild of
+    // the envelope instead of being dropped. This is exactly what a caller
+    // loses when the structured merge drops these fields — the merged answer is
+    // lexically ranked, and it has to say so.
+    //
+    // What this assertion does NOT prove: that the union deduplicates. A
+    // one-element `["semantic"]` is the expected output whether both tiers
+    // reported it (the case here, by construction — `weight_semantic` defaults
+    // non-zero and `semantic_requested` does not depend on the store holding
+    // vectors) or only one did. The dedup and union-ordering rules are proven
+    // in `merge_structured_degraded_components_unions_and_dedupes`
+    // (nestweaver-federation), which can drive distinct per-tier inputs
+    // directly; this test proves the fields survive the real federated path.
     assert_eq!(
         resp["semantic_applied"],
         json!(false),


### PR DESCRIPTION
Three independent fixes, each implemented then adversarially reviewed by a
separate agent, repaired, and re-reviewed until clean. Review found a defect in
**every** branch that would have shipped, including two data-integrity bugs and a
data-loss regression introduced by a fix.

## An abandoned index-publication marker permanently wedged every ranked query

`fix/dirty-publication-recovery`

`<db>.index-dirty` is written durably — pid, timestamp, `sync_all`, parent
fsync — so it survives process death by design. While present, ranked queries
fail closed, which is **correct**: `.pagerank.json` and `.generation` may predate
the committed graph, so serving them would silently serve wrong ranks.

The defect was that fail-closed was never paired with a way *out*. There is **one
marker per database**, so a single killed indexer hard-failed every ranked query
for every repo in it. `index.rs` documented that the publication stays dirty "so
the next open reconciles it" — **no such reconciliation existed**. A user hit this
on 2026-08-13: three consecutive MCP calls failing with `PageRank unavailable
during dirty index publication`, recoverable only by `rm <db>.index-dirty`,
discoverable only by reading the source.

Recovery treats a publication as abandoned only when the recorded pid is dead
**and** the lease is unowned, gated to read-write opens, and runs as the finalize
**epilogue rather than an `rm`** — PageRank recomputed and `.generation` persisted
before the marker clears. Also `nestweaver repair [--force]`, a bounded wait that
polls the marker *file* (the lease condvar is in-process and the MCP reader is
often a different process), a TRANSIENT/WEDGED split, and `brain_status`
reporting that says plainly this is an index publication and **not** a dirty git
working tree — the wrong conclusion the reporter drew.

**Review caught a data-loss regression in the fix**: recovery recomputed with
`code_only()` scope while the canonical brain sidecar is **unified**, silently
deleting every Note/Section/Heading/Tag rank. The original evidence could not
detect it — it proved a poisoned sentinel had vanished, not that the entry set
was unchanged *in kind*. Now proven in kind, and the test asserts note UIDs
survive in memory and on disk.

## Two copies of zstd were linked into every binary

`fix/single-zstd`

`liblbug.a` vendors zstd and exports 192 `ZSTD_` symbols; `zstd-sys` built its
own; 173 were defined in both. `rust-lld` refused, and it was masked by
`--allow-multiple-definition`, which does not merge the copies — it silently
picks one.

Root cause is upstream: lbug's CMake *intends* to hide those symbols but writes
`add_compile_definitions(zstd ZSTDLIB_VISIBILITY= ...)`, defining the visibility
macro to nothing, then links `+whole-archive`. The `zstd` crate was also a direct
dependency, reintroducing what `6768374` removed by disabling tantivy's
columnar-zstd.

Dropping the crate and binding the 15 stable libzstd entry points against the
copy already present leaves exactly one. **The workaround is deleted rather than
tracked** — `--allow-multiple-definition` now appears nowhere in the config, the
workflows, or the Dockerfile, and this tree links with `rust-lld` and no flags.

**Review caught a data-integrity defect in the fix**: truncated input decoded as
partial data where the `zstd` crate returned `Err("incomplete frame")`. In a
backup tool that means a `.nwsnap.zst` cut short by an interrupted write reports
a manifest without complaint. Fixed by latching the frame-completion return.

## Federated brain_context/project_context dropped their provenance fields

`fix/structured-merge-honesty`

`merge_structured_results` rebuilt its envelope and never re-added
`semantic_applied`/`degraded_components`, so a federated caller could not tell
"no semantic leg" from "not implemented" from "older server". The asymmetry was
backwards: `brain_search`, which has no semantic leg, carried them; the two tools
that *do* have one did not.

## Verification

- `cargo test --workspace --no-fail-fast`: **3438 passed / 0 failed / 5 ignored**,
  53 suites, exit 0. Baseline on `main` was 3372; **+66 reconciles exactly**
  against 66 added test attributes and **0 removed**.
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --
  -D warnings`: both exit 0.
- **Linked with no linker workaround** — 0 duplicate-symbol errors, which is the
  direct test of the zstd fix's central claim.

## Known gaps, stated rather than implied

- A crash *during* recovery still leaves a clean-reporting publication with no
  PageRank sidecar; the lazy recompute is code-scoped and in-memory. The ordering
  predates this work and the fix is filed as a follow-up.
- The daemon's `!read_only` recovery gate has no test — a correct one-line mirror
  of its neighbours, verified by hand and by review, but nothing pins it.
- `needs_forced_repair()` is broader than its `is_wedged()` guard. Harmless today
  because both consumers gate on `is_wedged()` first.
- The prebuilt-lbug link path is never exercised in-repo, and the
  duplicate-zstd/double-free theory is **not** established — 46/46 daemon tests
  pass, but no failing baseline was built, so that is not evidence of causation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UXMKySLGmPZiQJqaQqhZp
