### PR TITLE
fix(daemon)!: drain on shutdown with listeners up, refusing new writes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,20 +25,43 @@ that owns the LadybugDB write lock. The daemon auto-starts on the first CLI
 invocation and self-terminates after an idle timeout. The client auto-restarts
 the daemon on version mismatch.
 
-**Two different shutdown paths.** The graceful drain loop runs ONLY for the gRPC
-`Shutdown` RPC. `nestweaver daemon stop` sends SIGTERM, whose handler broadcasts
-shutdown immediately — no drain loop, no ceiling, no progress warnings — so
-`NESTWEAVER_DRAIN_TIMEOUT_SECS` does not govern `daemon stop` at all. It only
-derives that command's SIGKILL grace (see the table below). Because the
-broadcast closes every listener at once, reads are down for the entire stop
-grace, not just at the end of it.
+**One shutdown path.** Both operator-initiated routes — the gRPC `Shutdown` RPC
+(`daemon restart`) and SIGTERM (`daemon stop`) — go through
+`begin_shutdown_drain` in `crates/nestweaver-daemon/src/server.rs`, which runs
+the same drain loop and emits the same messages. Neither broadcasts shutdown up
+front, so **listeners stay up and reads keep being served while writes drain**.
+An idle daemon still exits immediately: the drain tests its counters before its
+first sleep. `NESTWEAVER_DRAIN_TIMEOUT_SECS` governs both routes.
 
-On the `Shutdown`-RPC path, `NESTWEAVER_DRAIN_TIMEOUT_SECS` (default 660s) means
-two different things depending on what is still in flight. While a WRITE RPC is
-running it is a reporting threshold, not a kill switch — those run on
+**Nothing escalates automatically.** `daemon stop` waits up to the stop grace and
+then, if the daemon is still draining, **reports and stands down** — it leaves
+the daemon running and serving reads, and exits non-zero. It does not SIGKILL.
+Automatic escalation was the defect: nothing in the process can abort a
+`spawn_blocking` write, and the graph store is not crash-safe, so an automatic
+SIGKILL performed on a timer exactly the crash declined at the drain ceiling on
+nw-126 evidence (a SIGKILLed daemon left a stale 42-byte WAL that made a live
+5.6 GB database look absent). Ending an in-flight write is an explicit operator
+act: `nestweaver daemon stop --force`, or `kill -9 <pid>`.
+
+**Under a process supervisor none of that is a guarantee.** The unbounded drain
+describes what this process does with SIGTERM; a supervisor that SIGKILLs on its
+own timer still does, and nothing here can prevent it. The repo ships **no
+systemd unit** — on Linux `daemon start` spawns a bare detached process
+supervised by nothing, and that is the case this change fully fixes. The macOS
+launchd plist now sets `ExitTimeOut` to the drain ceiling + 30 (the key was
+absent, so launchd applied its 20s default), and `docker-compose.yml`'s
+`stop_grace_period` is raised to match — but both remain hard deadlines that
+SIGKILL a draining daemon. **The interactive case is fixed; the supervised case
+remains exposed until the graph store is crash-safe.** See
+`docs/guide/daemon-shutdown.md`.
+
+`NESTWEAVER_DRAIN_TIMEOUT_SECS` (default 660s) still means two different things
+depending on what is still in flight. While a WRITE RPC is running it is a
+reporting threshold, not a kill switch — those run on
 `spawn_blocking` threads that cannot be aborted, so past the ceiling the daemon
-keeps waiting, keeps serving reads, and logs what it is waiting on; SIGKILL is
-the only thing that ends a stuck write. While only an INDEX job is in flight it
+keeps waiting, keeps serving reads, and logs what it is waiting on; an operator
+SIGKILL (`daemon stop --force` or `kill -9`) is the only thing that ends a stuck
+write, and nothing does it automatically. While only an INDEX job is in flight it
 is a real deadline: the daemon signals shutdown at the ceiling — which closes
 every listener and STOPS READ SERVICE — because the worker's `indexing_active`
 flag cannot clear once the pool is drained with a non-empty queue, so waiting on
@@ -70,8 +93,8 @@ by an error message the tool can print, so they belong somewhere findable.
 |----------|---------|---------|
 | `NESTWEAVER_DAEMON_BOOT_TIMEOUT_SECS` | 30 | How long a client waits for the daemon to bind its socket. Raise it on a slow cold start; the boot-failure message names it. Boot phase timings (`boot_ms`, `store_open_ms`, `extension_reconcile_ms`, `unattributed_ms`) are logged at bind so a slow boot is diagnosable rather than guessed at. |
 | `NESTWEAVER_INDEX_TIMEOUT_SECS` | 1800 | Overall ceiling for one index. On expiry the daemon requests cancellation and reports a non-terminal warning naming this variable. Cancellation is COOPERATIVE and only observed up to the pre-write boundary, so the final stream event says whether the run aborted before writing or committed anyway (committed-after-cancellation names `index --force` as the repair). |
-| `NESTWEAVER_DRAIN_TIMEOUT_SECS` | 660 | Drain ceiling for the gRPC `Shutdown` RPC — NOT for `daemon stop`, whose SIGTERM skips the drain entirely. With an in-flight write RPC it is NOT a deadline: the daemon cannot abort one, so past this point it keeps waiting, keeps serving most reads (`embed`/`plan_embed` excepted — they take the write gate), logs the in-flight count, and names SIGKILL as the only escape. With only an index job in flight it IS a deadline: the daemon signals shutdown at the ceiling, which stops read service, because `indexing_active` cannot clear once the worker pool is drained with a non-empty queue. Also derives `NESTWEAVER_STOP_GRACE_SECS` and the client's owner-release wait (ceiling + 5s). |
-| `NESTWEAVER_STOP_GRACE_SECS` | drain ceiling + 30 (690) | How long `daemon stop` waits after SIGTERM before escalating to SIGKILL. Unset, it is derived from `NESTWEAVER_DRAIN_TIMEOUT_SECS` + 30s rather than a fixed value a real index would blow past. Unlike the drain ceiling this IS a deadline: a write still running when it expires is SIGKILLed. SIGTERM closes every listener immediately, so reads are down for the whole window, not just at the end. |
+| `NESTWEAVER_DRAIN_TIMEOUT_SECS` | 660 | Drain ceiling for BOTH shutdown routes — the gRPC `Shutdown` RPC (`daemon restart`) and SIGTERM (`daemon stop`), which share one drain. With an in-flight write it is NOT a deadline: the daemon cannot abort one, so past this point it keeps waiting, keeps serving most reads (`embed`/`plan_embed` excepted — they take the write gate), logs the in-flight count, and names `daemon stop --force` / `kill -9` as the escapes. With only an index job in flight it IS a deadline: the daemon signals shutdown at the ceiling, which stops read service, because `indexing_active` cannot clear once the worker pool is drained with a non-empty queue. Also derives `NESTWEAVER_STOP_GRACE_SECS`, the launchd plist's `ExitTimeOut` (ceiling + 30), and the client's owner-release wait (ceiling + 5s). |
+| `NESTWEAVER_STOP_GRACE_SECS` | drain ceiling + 30 (690) | How long `daemon stop` waits for the daemon to exit. This is NOT a kill deadline: when it expires with the daemon still draining, `daemon stop` reports what is happening, leaves the daemon running and serving reads, and exits non-zero. It does not SIGKILL — see the daemon-architecture section for why an automatic escalation was the defect. Listeners stay up for the whole window, so waiting is not an outage. `daemon stop --force` ignores this variable and uses a short fixed 10s window before SIGKILL, abandoning any in-flight write. |
 | `NESTWEAVER_INDEX_CPU_PERCENT` | 50 | Index CPU duty cycle, percent of one core (1–99; `0` or `>=100` disables). Also see the launchd note below. |
 | `NESTWEAVER_ALLOW_NO_DAEMON` | unset | Opt-in required to honour `--no-daemon` / `NESTWEAVER_NO_DAEMON` outside CI. Without it the bypass is REFUSED, because it circumvents the single-writer lock. Not for normal use. |
 | `NESTWEAVER_LBUG_MAX_THREADS` | 1 | Engine thread-pool size. `1` closes the nw-073 eviction-vs-read race; raise only if you measure a query-latency cost. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,13 +54,22 @@ migration paths (pre-SHA-256 instance IDs; pre-v0.26.2 `$TMPDIR` sockets) and
 neither is on the `daemon stop` route, but "nothing escalates automatically" is
 true of `daemon stop` only, not of the binary as a whole.
 
-**The drain is monotone.** Once shutdown starts, `ConnectionGuard::write`
-refuses new writes with `UNAVAILABLE`. This is not a nicety: because listeners
-now stay up by design, without it a webhook feed, watcher, MCP client or agent
-loop could start a new write minutes into a drain and reset the drain's exit
-condition indefinitely — leaving `--force`/`kill -9` as the only way out, which
-would make the unsafe kill *more* likely on a busy daemon, not less. Reads are
-deliberately not gated.
+**The drain is monotone over the gRPC surface.** Once shutdown starts,
+`ConnectionGuard::write` refuses new writes with `UNAVAILABLE`. This is not a
+nicety: because listeners now stay up by design, without it a webhook feed,
+watcher, MCP client or agent loop could start a new write minutes into a drain
+and reset the drain's exit condition indefinitely — leaving `--force`/`kill -9`
+as the only way out, which would make the unsafe kill *more* likely on a busy
+daemon, not less. Reads are deliberately not gated, and every gated RPC takes the
+guard BEFORE the write gate so a refusal is immediate rather than queued behind
+the in-flight write.
+
+The claim is scoped to gRPC on purpose. The **web admin** routes
+(`nestweaver-web/src/routes/admin.rs`) take the write gate but no
+`ConnectionGuard::write`, and `AdminState` is never handed `shutdown_started`, so
+they can neither be refused nor consult the flag. They are also invisible to the
+drain's exit condition, which means the drain neither waits for them nor is
+extended by them. Pre-existing, not introduced or fixed here.
 
 **Under a process supervisor none of that is a guarantee.** The unbounded drain
 describes what this process does with SIGTERM; a supervisor that SIGKILLs on its

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,9 +33,10 @@ front, so **listeners stay up and reads keep being served while writes drain**.
 An idle daemon still exits immediately: the drain tests its counters before its
 first sleep. `NESTWEAVER_DRAIN_TIMEOUT_SECS` governs both routes.
 
-**Nothing escalates automatically.** `daemon stop` waits up to the stop grace and
-then, if the daemon is still draining, **reports and stands down** — it leaves
-the daemon running and serving reads, and exits non-zero. It does not SIGKILL.
+**`daemon stop` does not escalate automatically.** It waits up to the stop grace
+and then, if the daemon is still draining, **reports and stands down** — it
+leaves the daemon running, re-probes the socket so its claim about read service
+is observed rather than assumed, and exits non-zero. It does not SIGKILL.
 Automatic escalation was the defect: nothing in the process can abort a
 `spawn_blocking` write, and the graph store is not crash-safe, so an automatic
 SIGKILL performed on a timer exactly the crash declined at the drain ceiling on
@@ -43,14 +44,32 @@ nw-126 evidence (a SIGKILLed daemon left a stale 42-byte WAL that made a live
 5.6 GB database look absent). Ending an in-flight write is an explicit operator
 act: `nestweaver daemon stop --force`, or `kill -9 <pid>`.
 
+**Two client-side paths still do escalate, and this change did not touch them.**
+`nestweaver_daemon::lifecycle::stop_legacy_hash_daemon` and the legacy
+`$TMPDIR`-path cleanup in `nestweaver-client/src/autostart.rs` both do
+SIGTERM → 2s → SIGKILL when autostart finds a *legacy* daemon holding the DB
+write lock. Two seconds is far inside a drain, so either can SIGKILL a daemon
+that is draining correctly — the nw-126 crash, on a 2-second fuse. Both are
+migration paths (pre-SHA-256 instance IDs; pre-v0.26.2 `$TMPDIR` sockets) and
+neither is on the `daemon stop` route, but "nothing escalates automatically" is
+true of `daemon stop` only, not of the binary as a whole.
+
+**The drain is monotone.** Once shutdown starts, `ConnectionGuard::write`
+refuses new writes with `UNAVAILABLE`. This is not a nicety: because listeners
+now stay up by design, without it a webhook feed, watcher, MCP client or agent
+loop could start a new write minutes into a drain and reset the drain's exit
+condition indefinitely — leaving `--force`/`kill -9` as the only way out, which
+would make the unsafe kill *more* likely on a busy daemon, not less. Reads are
+deliberately not gated.
+
 **Under a process supervisor none of that is a guarantee.** The unbounded drain
 describes what this process does with SIGTERM; a supervisor that SIGKILLs on its
 own timer still does, and nothing here can prevent it. The repo ships **no
 systemd unit** — on Linux `daemon start` spawns a bare detached process
 supervised by nothing, and that is the case this change fully fixes. The macOS
-launchd plist now sets `ExitTimeOut` to the drain ceiling + 30 (the key was
+launchd plist now sets `ExitTimeOut` to the drain ceiling + 60 (the key was
 absent, so launchd applied its 20s default), and `docker-compose.yml`'s
-`stop_grace_period` is raised to match — but both remain hard deadlines that
+`stop_grace_period` is raised to 720s — but both remain hard deadlines that
 SIGKILL a draining daemon. **The interactive case is fixed; the supervised case
 remains exposed until the graph store is crash-safe.** See
 `docs/guide/daemon-shutdown.md`.
@@ -93,8 +112,8 @@ by an error message the tool can print, so they belong somewhere findable.
 |----------|---------|---------|
 | `NESTWEAVER_DAEMON_BOOT_TIMEOUT_SECS` | 30 | How long a client waits for the daemon to bind its socket. Raise it on a slow cold start; the boot-failure message names it. Boot phase timings (`boot_ms`, `store_open_ms`, `extension_reconcile_ms`, `unattributed_ms`) are logged at bind so a slow boot is diagnosable rather than guessed at. |
 | `NESTWEAVER_INDEX_TIMEOUT_SECS` | 1800 | Overall ceiling for one index. On expiry the daemon requests cancellation and reports a non-terminal warning naming this variable. Cancellation is COOPERATIVE and only observed up to the pre-write boundary, so the final stream event says whether the run aborted before writing or committed anyway (committed-after-cancellation names `index --force` as the repair). |
-| `NESTWEAVER_DRAIN_TIMEOUT_SECS` | 660 | Drain ceiling for BOTH shutdown routes — the gRPC `Shutdown` RPC (`daemon restart`) and SIGTERM (`daemon stop`), which share one drain. With an in-flight write it is NOT a deadline: the daemon cannot abort one, so past this point it keeps waiting, keeps serving most reads (`embed`/`plan_embed` excepted — they take the write gate), logs the in-flight count, and names `daemon stop --force` / `kill -9` as the escapes. With only an index job in flight it IS a deadline: the daemon signals shutdown at the ceiling, which stops read service, because `indexing_active` cannot clear once the worker pool is drained with a non-empty queue. Also derives `NESTWEAVER_STOP_GRACE_SECS`, the launchd plist's `ExitTimeOut` (ceiling + 30), and the client's owner-release wait (ceiling + 5s). |
-| `NESTWEAVER_STOP_GRACE_SECS` | drain ceiling + 30 (690) | How long `daemon stop` waits for the daemon to exit. This is NOT a kill deadline: when it expires with the daemon still draining, `daemon stop` reports what is happening, leaves the daemon running and serving reads, and exits non-zero. It does not SIGKILL — see the daemon-architecture section for why an automatic escalation was the defect. Listeners stay up for the whole window, so waiting is not an outage. `daemon stop --force` ignores this variable and uses a short fixed 10s window before SIGKILL, abandoning any in-flight write. |
+| `NESTWEAVER_DRAIN_TIMEOUT_SECS` | 660 | Drain ceiling for BOTH shutdown routes — the gRPC `Shutdown` RPC (`daemon restart`) and SIGTERM (`daemon stop`), which share one drain. With an in-flight write it is NOT a deadline: the daemon cannot abort one, so past this point it keeps waiting, keeps serving most reads (`embed`/`plan_embed` excepted — they take the write gate), logs the in-flight count, and names `daemon stop --force` / `kill -9` as the escapes. With only an index job in flight it IS a deadline: the daemon signals shutdown at the ceiling, which stops read service, because `indexing_active` cannot clear once the worker pool is drained with a non-empty queue. Also derives `NESTWEAVER_STOP_GRACE_SECS`, the launchd plist's `ExitTimeOut` (ceiling + 60 — deliberately later than the stop grace, so the CLI gives up watching before launchd kills), and the client's owner-release wait (ceiling + 5s). |
+| `NESTWEAVER_STOP_GRACE_SECS` | drain ceiling + 30 (690) | How long `daemon stop` waits for the daemon to exit. This is NOT a kill deadline: when it expires with the daemon still draining, `daemon stop` re-probes the socket, reports what it observed, leaves the daemon running, and exits non-zero. It does not SIGKILL — see the daemon-architecture section for why an automatic escalation was the defect. Listeners stay up for the whole window in a write drain, so waiting is not an outage (individual reads can still stall for seconds while a write commits); in an index-only drain the ceiling broadcast closes them 30s before this expires, and the message says so. `daemon stop --force` ignores this variable and uses a short fixed 10s window before SIGKILL, abandoning any in-flight write. |
 | `NESTWEAVER_INDEX_CPU_PERCENT` | 50 | Index CPU duty cycle, percent of one core (1–99; `0` or `>=100` disables). Also see the launchd note below. |
 | `NESTWEAVER_ALLOW_NO_DAEMON` | unset | Opt-in required to honour `--no-daemon` / `NESTWEAVER_NO_DAEMON` outside CI. Without it the bypass is REFUSED, because it circumvents the single-writer lock. Not for normal use. |
 | `NESTWEAVER_LBUG_MAX_THREADS` | 1 | Engine thread-pool size. `1` closes the nw-073 eviction-vs-read race; raise only if you measure a query-latency cost. |

--- a/README.md
+++ b/README.md
@@ -484,10 +484,12 @@ that daemon first or, when the configured daemon backend is already ready, drop
 both direct-path flags.
 
 **Stopping.** `nestweaver daemon stop` drains in-flight writes with every
-listener still up, so reads keep working while it drains, and an idle daemon
-exits immediately. It never SIGKILLs on its own — if a write is still running it
-reports and leaves the daemon up; `daemon stop --force` or `kill -9` end it
-anyway, abandoning that write. Under a process supervisor (systemd
+listener still up, so reads keep working while it drains (individual reads can
+still stall for seconds while a write commits), and an idle daemon exits
+immediately. New writes are refused with `UNAVAILABLE` once shutdown starts, so
+the drain always finishes. It never SIGKILLs on its own — if a write is still
+running it reports what it observed and leaves the daemon up; `daemon stop
+--force` or `kill -9` end it anyway, abandoning that write. Under a process supervisor (systemd
 `TimeoutStopSec`, launchd `ExitTimeOut`, Docker `stop_grace_period`) the
 supervisor's own timer still applies. See the
 [Daemon Shutdown Guide](docs/guide/daemon-shutdown.md).

--- a/README.md
+++ b/README.md
@@ -486,8 +486,9 @@ both direct-path flags.
 **Stopping.** `nestweaver daemon stop` drains in-flight writes with every
 listener still up, so reads keep working while it drains (individual reads can
 still stall for seconds while a write commits), and an idle daemon exits
-immediately. New writes are refused with `UNAVAILABLE` once shutdown starts, so
-the drain always finishes. It never SIGKILLs on its own — if a write is still
+immediately. New writes over the gRPC surface are refused with `UNAVAILABLE`
+once shutdown starts, so the drain always finishes (the web admin routes are
+outside that gate — see CLAUDE.md). It never SIGKILLs on its own — if a write is still
 running it reports what it observed and leaves the daemon up; `daemon stop
 --force` or `kill -9` end it anyway, abandoning that write. Under a process supervisor (systemd
 `TimeoutStopSec`, launchd `ExitTimeOut`, Docker `stop_grace_period`) the

--- a/README.md
+++ b/README.md
@@ -483,6 +483,15 @@ model/backend switch requires `--force`. The direct path
 that daemon first or, when the configured daemon backend is already ready, drop
 both direct-path flags.
 
+**Stopping.** `nestweaver daemon stop` drains in-flight writes with every
+listener still up, so reads keep working while it drains, and an idle daemon
+exits immediately. It never SIGKILLs on its own — if a write is still running it
+reports and leaves the daemon up; `daemon stop --force` or `kill -9` end it
+anyway, abandoning that write. Under a process supervisor (systemd
+`TimeoutStopSec`, launchd `ExitTimeOut`, Docker `stop_grace_period`) the
+supervisor's own timer still applies. See the
+[Daemon Shutdown Guide](docs/guide/daemon-shutdown.md).
+
 **Readiness and diagnostics.** On macOS, background start/autostart uses launchd
 to own a foreground daemon process; `daemon run` stays in the invoking
 foreground. Neither path forks or self-daemonizes. Readiness is published only

--- a/crates/nestweaver-daemon/src/launchd.rs
+++ b/crates/nestweaver-daemon/src/launchd.rs
@@ -223,10 +223,20 @@ pub fn generate_plist(
     )
 }
 
-/// Buffer added to the drain ceiling to derive the plist's `ExitTimeOut`,
-/// mirroring `STOP_GRACE_BUFFER_SECS` in the CLI so launchd's SIGKILL deadline
-/// and `daemon stop`'s wait cannot drift apart.
-const LAUNCHD_EXIT_TIMEOUT_BUFFER_SECS: u64 = 30;
+/// Buffer added to the drain ceiling to derive the plist's `ExitTimeOut`.
+///
+/// DELIBERATELY LARGER than the CLI's `STOP_GRACE_BUFFER_SECS` (30), and the
+/// gap is load-bearing rather than cosmetic. Both are derived from the same
+/// drain ceiling, so making them equal made the two deadlines land at the same
+/// instant: `daemon stop` would give up watching at ceiling+30 and print "it is
+/// still running and still serving reads" about a process launchd had SIGKILLed
+/// at ceiling+30. Keeping launchd's deadline strictly later means the CLI's
+/// report is about a process that is still alive whenever launchd is the
+/// supervisor.
+///
+/// It does not make the drain safe under launchd — a write still running at
+/// `ExitTimeOut` is still SIGKILLed. It makes the CLI stop lying about it.
+const LAUNCHD_EXIT_TIMEOUT_BUFFER_SECS: u64 = 60;
 
 /// Render a per-instance launch agent, optionally forwarding an absolute
 /// instance configuration path to the foreground `daemon run` process.
@@ -243,6 +253,38 @@ pub fn generate_plist_with_config(
     config_path: Option<&Path>,
     start_at_login: bool,
 ) -> String {
+    // The ceiling is read from the environment exactly once, here, and passed
+    // down explicitly. Keeping the read out of the renderer is what lets the
+    // ceiling/ExitTimeOut/baked-env relationship be tested without a test
+    // mutating process-wide env — which would race the other plist tests under
+    // cargo's parallel execution.
+    render_plist(
+        instance_id,
+        binary_path,
+        db_path,
+        log_path,
+        index_cpu_percent,
+        config_path,
+        start_at_login,
+        nestweaver_schema::drain_ceiling_from_env(),
+        std::env::var("NESTWEAVER_DRAIN_TIMEOUT_SECS").is_ok(),
+    )
+}
+
+/// Pure renderer. `drain_ceiling` and `ceiling_was_overridden` are supplied by
+/// the caller rather than read here — see `generate_plist_with_config`.
+#[allow(clippy::too_many_arguments)]
+fn render_plist(
+    instance_id: &str,
+    binary_path: &Path,
+    db_path: &Path,
+    log_path: &Path,
+    index_cpu_percent: Option<&str>,
+    config_path: Option<&Path>,
+    start_at_login: bool,
+    drain_ceiling: u64,
+    ceiling_was_overridden: bool,
+) -> String {
     let label = xml_escape(&lifecycle::launchd_label(instance_id));
     let binary = xml_escape(&binary_path.display().to_string());
     let db = xml_escape(&db_path.display().to_string());
@@ -254,20 +296,9 @@ pub fn generate_plist_with_config(
         })
         .unwrap_or_default();
 
-    // launchd jobs don't inherit the invoking shell's environment, so the
-    // index CPU-throttle knob is baked into the plist when it was set (and
-    // validated) at install time. Value is validated numeric by the caller.
-    let env_block = match index_cpu_percent {
-        Some(v) => {
-            let value = xml_escape(v.trim());
-            format!(
-                "    <key>EnvironmentVariables</key>\n    <dict>\n        <key>NESTWEAVER_INDEX_CPU_PERCENT</key>\n        <string>{value}</string>\n    </dict>\n"
-            )
-        }
-        None => String::new(),
-    };
-
-    // How long launchd waits after SIGTERM before SIGKILLing us.
+    // How long launchd waits after SIGTERM before SIGKILLing us. See
+    // `LAUNCHD_EXIT_TIMEOUT_BUFFER_SECS` for why the buffer is larger than the
+    // CLI's.
     //
     // This key was previously ABSENT, so launchd applied its 20-second default
     // — a hard SIGKILL 20s into a drain that routinely runs for minutes. That
@@ -276,17 +307,53 @@ pub fn generate_plist_with_config(
     // what the daemon or `daemon stop` did, because it is launchd's timer and
     // not ours.
     //
-    // Pinned to the same budget `daemon stop` uses (drain ceiling + buffer) so
-    // the supervised macOS path and the interactive path cannot drift.
-    //
     // This does NOT make the drain guarantee absolute under launchd: a write
     // still running at `exit_timeout` is still SIGKILLed, by launchd, outside
-    // our control. It moves the deadline from "20s, always fires" to "the same
-    // deadline the operator already reasons about". launchd does treat `0` as
-    // infinity, but a job that can refuse to die forever is a wedged logout and
-    // a worse failure than a bounded one, so it is not used here.
-    let exit_timeout = nestweaver_schema::drain_ceiling_from_env()
-        .saturating_add(LAUNCHD_EXIT_TIMEOUT_BUFFER_SECS);
+    // our control. It moves the deadline from "20s, always fires" to a bound
+    // derived from the ceiling the operator already reasons about. launchd does
+    // treat `0` as infinity, but a job that can refuse to die forever is a
+    // wedged logout and a worse failure than a bounded one, so it is not used.
+    let exit_timeout = drain_ceiling.saturating_add(LAUNCHD_EXIT_TIMEOUT_BUFFER_SECS);
+
+    // launchd jobs don't inherit the invoking shell's environment, so anything
+    // the daemon needs at runtime has to be baked in here.
+    //
+    // NESTWEAVER_DRAIN_TIMEOUT_SECS is baked in for a specific reason:
+    // `exit_timeout` above is computed from the ceiling as seen by THIS
+    // process — the CLI running `daemon start`. Without baking it, the daemon
+    // launchd starts would not inherit it and would run the 660s default while
+    // the plist carried a deadline derived from whatever the installing shell
+    // happened to export. `NESTWEAVER_DRAIN_TIMEOUT_SECS=60 nestweaver daemon
+    // start` produced ExitTimeOut=120 against a daemon draining to 660s — a
+    // supervisor deadline SHORTER than the drain it is supposed to outlast,
+    // which is the original 20s bug in a new disguise. Baking it makes the
+    // plist internally consistent: the daemon and its `ExitTimeOut` read the
+    // same number.
+    //
+    // Baked ONLY when the var is actually set. When it is unset both this
+    // process and the daemon fall back to the same compiled default, so the
+    // plist stays byte-identical to the pre-`ExitTimeOut` output for the
+    // machines that never set it — the property `plist_omits_environment_...`
+    // guards. There is no divergence to fix in that case; the divergence only
+    // exists when someone exported a value that the daemon would not inherit.
+    let mut env_entries: Vec<(&str, String)> = Vec::new();
+    if ceiling_was_overridden {
+        env_entries.push(("NESTWEAVER_DRAIN_TIMEOUT_SECS", drain_ceiling.to_string()));
+    }
+    // Index CPU-throttle knob, baked when it was set (and validated) at install
+    // time. Value is validated numeric by the caller.
+    if let Some(v) = index_cpu_percent {
+        env_entries.push(("NESTWEAVER_INDEX_CPU_PERCENT", xml_escape(v.trim())));
+    }
+    let env_block = if env_entries.is_empty() {
+        String::new()
+    } else {
+        let entries = env_entries
+            .iter()
+            .map(|(k, v)| format!("        <key>{k}</key>\n        <string>{v}</string>\n"))
+            .collect::<String>();
+        format!("    <key>EnvironmentVariables</key>\n    <dict>\n{entries}    </dict>\n")
+    };
 
     // Opt-in. Omitted entirely rather than emitted as `<false/>` so a plist
     // from a machine that never opted in is byte-identical to the old output.
@@ -509,6 +576,53 @@ mod tests {
         assert!(
             expected > 20,
             "the whole point is to beat launchd's 20s default"
+        );
+        // The CLI's own `STOP_GRACE_BUFFER_SECS` is 30 and lives in `src/main.rs`,
+        // which this crate cannot reference — so it is pinned by value here.
+        // These two were equal, which put both deadlines at the same instant and
+        // let `daemon stop` print "still running and still serving reads" about
+        // a process launchd had just SIGKILLed. The CLI must give up watching
+        // STRICTLY BEFORE launchd kills.
+        assert!(
+            LAUNCHD_EXIT_TIMEOUT_BUFFER_SECS > 30,
+            "launchd's deadline must be strictly later than the CLI's stop grace \
+             (STOP_GRACE_BUFFER_SECS = 30 in src/main.rs), or the CLI reports on \
+             a process that is already dead"
+        );
+    }
+
+    /// `ExitTimeOut` is computed from the ceiling as seen by the CLI process
+    /// running `daemon start`, but launchd jobs inherit no shell environment —
+    /// so without baking the variable in, the daemon launchd starts runs a
+    /// DIFFERENT ceiling from the one its own SIGKILL deadline was derived
+    /// from. `NESTWEAVER_DRAIN_TIMEOUT_SECS=60` gave `ExitTimeOut=120` against a
+    /// daemon draining to 660s: a supervisor deadline shorter than the drain it
+    /// exists to outlast, which is the original 20s bug wearing a new hat.
+    #[test]
+    fn plist_bakes_the_drain_ceiling_it_derived_exit_timeout_from() {
+        let plist = render_plist(
+            "abc123",
+            Path::new("/usr/local/bin/nestweaver"),
+            Path::new("/Users/k/dev/repo/brain.lbug"),
+            Path::new("/tmp/log"),
+            None,
+            None,
+            false,
+            60,
+            true,
+        );
+
+        assert!(
+            plist.contains("<key>NESTWEAVER_DRAIN_TIMEOUT_SECS</key>\n        <string>60</string>"),
+            "the ceiling ExitTimeOut was derived from must be baked in, or the \
+             daemon will not run it: {plist}"
+        );
+        assert!(
+            plist.contains(&format!(
+                "<key>ExitTimeOut</key>\n    <integer>{}</integer>",
+                60 + LAUNCHD_EXIT_TIMEOUT_BUFFER_SECS
+            )),
+            "and the deadline must match that same ceiling: {plist}"
         );
     }
 

--- a/crates/nestweaver-daemon/src/launchd.rs
+++ b/crates/nestweaver-daemon/src/launchd.rs
@@ -223,6 +223,11 @@ pub fn generate_plist(
     )
 }
 
+/// Buffer added to the drain ceiling to derive the plist's `ExitTimeOut`,
+/// mirroring `STOP_GRACE_BUFFER_SECS` in the CLI so launchd's SIGKILL deadline
+/// and `daemon stop`'s wait cannot drift apart.
+const LAUNCHD_EXIT_TIMEOUT_BUFFER_SECS: u64 = 30;
+
 /// Render a per-instance launch agent, optionally forwarding an absolute
 /// instance configuration path to the foreground `daemon run` process.
 ///
@@ -262,6 +267,27 @@ pub fn generate_plist_with_config(
         None => String::new(),
     };
 
+    // How long launchd waits after SIGTERM before SIGKILLing us.
+    //
+    // This key was previously ABSENT, so launchd applied its 20-second default
+    // — a hard SIGKILL 20s into a drain that routinely runs for minutes. That
+    // is the nw-126 crash (a SIGKILLed daemon left a stale WAL that made a live
+    // database look absent) on a 20-second fuse, and it fired regardless of
+    // what the daemon or `daemon stop` did, because it is launchd's timer and
+    // not ours.
+    //
+    // Pinned to the same budget `daemon stop` uses (drain ceiling + buffer) so
+    // the supervised macOS path and the interactive path cannot drift.
+    //
+    // This does NOT make the drain guarantee absolute under launchd: a write
+    // still running at `exit_timeout` is still SIGKILLed, by launchd, outside
+    // our control. It moves the deadline from "20s, always fires" to "the same
+    // deadline the operator already reasons about". launchd does treat `0` as
+    // infinity, but a job that can refuse to die forever is a wedged logout and
+    // a worse failure than a bounded one, so it is not used here.
+    let exit_timeout = nestweaver_schema::drain_ceiling_from_env()
+        .saturating_add(LAUNCHD_EXIT_TIMEOUT_BUFFER_SECS);
+
     // Opt-in. Omitted entirely rather than emitted as `<false/>` so a plist
     // from a machine that never opted in is byte-identical to the old output.
     let run_at_load = if start_at_login {
@@ -297,6 +323,8 @@ pub fn generate_plist_with_config(
     </dict>
     <key>ThrottleInterval</key>
     <integer>10</integer>
+    <key>ExitTimeOut</key>
+    <integer>{exit_timeout}</integer>
     <key>LowPriorityIO</key>
     <true/>
     <key>ProcessType</key>
@@ -449,6 +477,39 @@ mod tests {
         );
         // No EnvironmentVariables block without the CPU knob.
         assert!(!plist.contains("EnvironmentVariables"), "{plist}");
+    }
+
+    /// Without this key launchd applied its own 20s default: a hard SIGKILL 20
+    /// seconds into a drain that routinely runs for minutes, on launchd's timer
+    /// rather than ours. That is the nw-126 crash on a short fuse, and it fired
+    /// no matter what `daemon stop` or the SIGTERM drain did.
+    ///
+    /// The value must track the drain ceiling so the supervised macOS path and
+    /// the interactive `daemon stop` path cannot drift apart. This does not
+    /// make the drain unbounded under launchd — a write still running at the
+    /// timeout is still SIGKILLed, by launchd, outside this process's control.
+    #[test]
+    fn plist_sets_exit_timeout_from_the_drain_ceiling() {
+        let plist = generate_plist(
+            "abc123",
+            Path::new("/usr/local/bin/nestweaver"),
+            Path::new("/Users/k/dev/repo/brain.lbug"),
+            Path::new("/tmp/log"),
+            None,
+        );
+        let expected = nestweaver_schema::drain_ceiling_from_env()
+            .saturating_add(LAUNCHD_EXIT_TIMEOUT_BUFFER_SECS);
+        assert!(
+            plist.contains(&format!(
+                "<key>ExitTimeOut</key>\n    <integer>{expected}</integer>"
+            )),
+            "ExitTimeOut must be present and derived from the drain ceiling, \
+             not left to launchd's 20s default: {plist}"
+        );
+        assert!(
+            expected > 20,
+            "the whole point is to beat launchd's 20s default"
+        );
     }
 
     #[test]

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -1177,12 +1177,13 @@ async fn run_shutdown_drain(state: Arc<DaemonState>, ceiling: u64) {
                 "drain ceiling ({ceiling}s) exceeded — still waiting on {writes} \
                  in-flight write(s){}; the daemon CANNOT abort them and is NOT \
                  shutting down. Most reads are still served — `embed` and \
-                 `plan_embed` are not, they take the same write gate. To end it \
-                 now: `kill -9 {pid}`, which abandons the in-flight write. Prefer \
-                 that over `nestweaver daemon stop`: its SIGTERM closes every \
-                 listener immediately, so reads stay down for the whole stop \
-                 grace (default: ceiling + 30s) before it escalates to SIGKILL \
-                 anyway",
+                 `plan_embed` are not, they take the same write gate. This is \
+                 the same drain whether you sent SIGTERM (`nestweaver daemon \
+                 stop`) or the Shutdown RPC (`nestweaver daemon restart`); \
+                 neither escalates on its own. To end it now — abandoning the \
+                 in-flight write, which the graph store may not survive cleanly \
+                 (nw-126) — run `nestweaver daemon stop --force` or `kill -9 \
+                 {pid}`",
                 // Hedged: `indexing_active` is a flag, not a proof of work. It
                 // can stay set after the worker pool is drained, so claiming a
                 // running index job here would be the same kind of overclaim
@@ -1217,6 +1218,89 @@ async fn run_shutdown_drain(state: Arc<DaemonState>, ceiling: u64) {
     }
 
     let _ = state.shutdown_tx.send(true);
+}
+
+/// The ONE way a shutdown starts in this process.
+///
+/// Both operator-initiated shutdown routes go through here — the gRPC
+/// `Shutdown` RPC (`daemon restart`) and the SIGTERM handler (`daemon stop`) —
+/// so there is a single drain implementation and a single set of honest drain
+/// messages. Before this existed, SIGTERM broadcast shutdown immediately: every
+/// UDS/TCP/MCP listener closed at once, so read service died the instant the
+/// signal landed, while the in-flight `spawn_blocking` write it could not abort
+/// kept the process alive anyway. The outage bought nothing — reads do not take
+/// `write_mutex` (`embed`/`plan_embed` are the sole exceptions), so killing read
+/// service neither sped the write up nor protected anything — and the drain
+/// reporting written for the RPC path was unreachable from the command
+/// operators actually type.
+///
+/// The fast path is unchanged in cost: [`run_shutdown_drain`] tests the
+/// counters at the top of its first iteration and breaks immediately when
+/// nothing is in flight, so a SIGTERM on an idle daemon still broadcasts and
+/// exits without waiting.
+///
+/// This function deliberately does NOT terminate anything. Nothing here can
+/// abort a `spawn_blocking` write, and the graph store is not crash-safe (see
+/// nw-126: a SIGKILLed daemon left a stale 42-byte WAL that made a live 5.6 GB
+/// database look absent). Ending a genuinely in-flight write is the operator's
+/// explicit act — `nestweaver daemon stop --force`, or the `kill -9` the drain
+/// log names — never an automatic escalation.
+///
+/// `trigger` names the route for the log only; behaviour is identical either
+/// way, which is the point.
+fn begin_shutdown_drain(state: Arc<DaemonState>, trigger: &'static str) {
+    // T6.2: mark the pool drained BEFORE the drain wait loop so the worker
+    // stops claiming NEW jobs immediately and only finishes in-flight work.
+    // Without this the worker keeps claiming new jobs during the drain, so
+    // under continuous webhook enqueue `indexing_active` never clears and
+    // shutdown burns the full drain ceiling doing work it will abandon.
+    state.drained.store(true, Ordering::Relaxed);
+
+    // Once-only guard on the drain task. A second trigger (a Shutdown RPC after
+    // a SIGTERM, or two Shutdown RPCs) must not spawn a second
+    // `run_shutdown_drain`: the two would duplicate every drain warning for as
+    // long as the write runs — visible in the incident log as two interleaved
+    // 90%/ceiling report streams — and race the broadcast.
+    //
+    // This MUST NOT key off `drained`. That flag is shared with `AdminState`,
+    // and `POST /admin/api/drain` sets it as routine maintenance; keying the
+    // guard off it would make every Shutdown RPC after any admin drain a silent
+    // no-op that never stops the watcher, never drains and never broadcasts,
+    // leaving `daemon restart` unable to stop the daemon until someone found
+    // `POST /admin/api/resume`.
+    // SEMANTIC CHANGE, deliberate: SIGTERM used to take this path
+    // UNCONDITIONALLY — it stored `shutdown_started` without checking, stopped
+    // the watcher, and broadcast, even if a `Shutdown` RPC had already begun
+    // draining. Now a SIGTERM arriving behind an in-progress drain is a no-op
+    // and does NOT force a broadcast.
+    //
+    // That is the point: forcing the broadcast is precisely what tore down every
+    // listener mid-drain. An operator who runs `daemon restart` and then
+    // `daemon stop` now gets one drain that keeps serving reads, and the CLI
+    // reports honestly instead of the second signal cutting the first one short.
+    if state.shutdown_started.swap(true, Ordering::Relaxed) {
+        tracing::info!(
+            trigger,
+            "shutdown already in progress — not starting a second drain"
+        );
+        return;
+    }
+
+    // Stop any active watcher BEFORE the drain wait — an orphaned watcher's
+    // blocking thread would otherwise pin shutdown (Tokio's runtime drop waits
+    // for blocking threads) until someone kills the process.
+    //
+    // Consequence of the guard above: only the FIRST trigger stops the watcher,
+    // so a watcher registered after a drain began is not stopped here. That hole
+    // is closed on the exit path — the belt-and-suspenders `stop_active_watcher`
+    // after `uds_serve` returns runs before the worker await and before runtime
+    // drop, so such a watcher still cannot pin process exit. Verified by
+    // inspection of the call ordering, not by test.
+    stop_active_watcher(&state);
+
+    tokio::spawn(async move {
+        run_shutdown_drain(state, nestweaver_schema::drain_ceiling_from_env()).await;
+    });
 }
 
 /// Register a watcher's shutdown handle, returning its registration id (the
@@ -3342,39 +3426,10 @@ impl NestWeaverDaemon for DaemonService {
         }
         tracing::info!("shutdown requested via gRPC — draining active writes");
 
-        // T6.2: mark the pool drained BEFORE the drain wait loop so the worker
-        // stops claiming NEW jobs immediately and only finishes in-flight work.
-        // Without this the worker keeps claiming new jobs during the drain, so
-        // under continuous webhook enqueue `indexing_active` never clears and
-        // shutdown burns the full drain ceiling doing work it will abandon.
-        self.state.drained.store(true, Ordering::Relaxed);
-
-        // Once-only guard on the drain task. A second Shutdown must not spawn a
-        // second `run_shutdown_drain`: the two would duplicate every drain
-        // warning for as long as the write runs — visible in the incident log
-        // as two interleaved 90%/ceiling report streams — and race the
-        // broadcast.
-        //
-        // This MUST NOT key off `drained`. That flag is shared with
-        // `AdminState`, and `POST /admin/api/drain` sets it as routine
-        // maintenance; keying the guard off it would make every Shutdown RPC
-        // after any admin drain a silent no-op that never stops the watcher,
-        // never drains and never broadcasts, leaving `daemon restart` unable to
-        // stop the daemon until someone found `POST /admin/api/resume`.
-        if self.state.shutdown_started.swap(true, Ordering::Relaxed) {
-            tracing::info!("shutdown already in progress — not starting a second drain");
-            return Ok(Response::new(ShutdownResponse { ok: true }));
-        }
-
-        // Stop any active watcher BEFORE the drain wait — an orphaned
-        // watcher's blocking thread would otherwise pin shutdown until the
-        // client's SIGKILL.
-        stop_active_watcher(&self.state);
-
-        let state = self.state.clone();
-        tokio::spawn(async move {
-            run_shutdown_drain(state, nestweaver_schema::drain_ceiling_from_env()).await;
-        });
+        // Same entry point SIGTERM uses — one drain, one message. See
+        // [`begin_shutdown_drain`] for the drained-flag ordering, the once-only
+        // guard, and why neither route escalates on its own.
+        begin_shutdown_drain(self.state.clone(), "grpc_shutdown");
 
         Ok(Response::new(ShutdownResponse { ok: true }))
     }
@@ -8867,29 +8922,27 @@ pub async fn run_server(
     }
 
     // Catch SIGTERM for graceful shutdown (sent by `daemon stop`).
+    //
+    // SIGTERM runs the SAME drain as the gRPC `Shutdown` RPC. It does not
+    // broadcast shutdown up front: listeners stay up and reads keep being
+    // served while writes drain, and the operator gets the drain's honest
+    // reporting. An idle daemon still exits immediately — the drain breaks on
+    // its first counter check. See [`begin_shutdown_drain`].
+    //
+    // SUPERVISORS: this only governs what THIS process does with the signal. A
+    // process supervisor that SIGKILLs on its own timer (systemd's
+    // `TimeoutStopSec`, default 90s; launchd's `ExitTimeOut`) still does so,
+    // and nothing here can prevent it. The unbounded-drain guarantee holds for
+    // interactive `daemon stop`; under a supervisor it holds only for as long
+    // as that supervisor's stop timeout allows.
     {
-        let tx = shutdown_tx.clone();
-        let drained = Arc::clone(&state.drained);
         let state = Arc::clone(&state);
         tokio::spawn(async move {
             let mut sig = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
                 .expect("register SIGTERM handler");
             sig.recv().await;
-            tracing::info!("received SIGTERM — shutting down");
-            // T6.2: stop the worker claiming new jobs BEFORE broadcasting
-            // shutdown, mirroring the gRPC Shutdown handler. In-flight jobs
-            // still drain via the worker loop's JoinSet; only NEW claims stop.
-            drained.store(true, Ordering::Relaxed);
-            // SIGTERM broadcasts immediately below, so a Shutdown RPC arriving
-            // after it has nothing left to drain — claim the guard so it does
-            // not start a drain loop behind an already-broadcast shutdown.
-            state.shutdown_started.store(true, Ordering::Relaxed);
-            // Stop any active watcher too — its `spawn_blocking` thread
-            // would otherwise outlive the broadcast and pin process exit
-            // (Tokio's runtime drop waits for blocking threads) until the
-            // client's stop grace elapses and it SIGKILLs us.
-            stop_active_watcher(&state);
-            let _ = tx.send(true);
+            tracing::info!("received SIGTERM — draining before shutdown");
+            begin_shutdown_drain(state, "sigterm");
         });
     }
 
@@ -16361,11 +16414,157 @@ external_model = "unavailable-test-model"
              write gate and are exactly what an operator reaches for during an embed \
              incident, so the line must say so: {text}"
         );
+        // ── The assertion that used to live here ─────────────────────────
+        //
+        // Was:
+        //     assert!(text.contains("reads stay down"), ...)
+        //
+        // Its PURPOSE was disclosure: the ceiling line recommends `kill -9`, so
+        // it must not steer an operator away from `daemon stop` without naming
+        // what `daemon stop` costs. At the time that cost was real — SIGTERM
+        // broadcast shutdown immediately and ended read service for the whole
+        // stop grace.
+        //
+        // That cost no longer exists: SIGTERM now runs THIS drain with every
+        // listener up. Keeping the assertion literally would force the message
+        // to keep asserting a falsehood — the same overclaim this test family
+        // exists to prevent, merely inverted.
+        //
+        // So the PURPOSE is preserved and the premise is replaced. The four
+        // assertions below are deliberately not a weaker substitute for the one
+        // removed:
+        //
+        //  1. the negative guard is NEW coverage that did not exist before. It
+        //     couples the message to the SIGTERM implementation in both
+        //     directions: revert SIGTERM to broadcasting and leave the message
+        //     alone, or vice versa, and this fails.
+        //  2. the "same drain" assertion positively pins the unification claim,
+        //     so the block cannot pass vacuously on an empty or broken log
+        //     capture (and five other positive assertions above share `text`,
+        //     which fail first if capture breaks at all).
+        //  3./4. `--force` and "neither escalates" pin the new contract — the
+        //     supported escape and the no-auto-kill promise — which is the
+        //     direct analogue of the old "name the cost of the alternative".
         assert!(
-            text.contains("reads stay down"),
-            "the line must not recommend `daemon stop` without saying its SIGTERM \
-             closes every listener and ends read service for the stop grace: {text}"
+            !text.contains("reads stay down"),
+            "SIGTERM now runs this same drain with listeners up — the line must \
+             not still warn that `daemon stop` ends read service: {text}"
         );
+        assert!(
+            text.contains("the same drain whether you sent SIGTERM"),
+            "the line must positively state that both routes share this drain — \
+             that unification is the change, and a negative assertion alone \
+             could pass on an empty log: {text}"
+        );
+        assert!(
+            text.contains("--force"),
+            "the operator needs the supported explicit escape named, not only \
+             `kill -9`: {text}"
+        );
+        assert!(
+            text.contains("neither escalates on its own"),
+            "the whole point of the unified drain is that no path auto-kills — \
+             the line must say so: {text}"
+        );
+    }
+
+    /// The fast path must stay fast. Routing SIGTERM through the drain would be
+    /// a bad trade if it turned every ordinary stop into a slow one: the drain
+    /// tests its counters at the top of its FIRST iteration and breaks before
+    /// the first sleep, so an idle daemon still broadcasts essentially at once.
+    ///
+    /// The bound is deliberately tight (250ms against a 500ms poll interval):
+    /// anything that made the fast path take a poll cycle would fail this.
+    #[tokio::test]
+    async fn begin_shutdown_drain_broadcasts_at_once_when_nothing_is_in_flight() {
+        let state = test_state_with_writer();
+        let mut shutdown_rx = state.shutdown_tx.subscribe();
+        assert_eq!(state.active_writes.load(Ordering::Relaxed), 0);
+
+        let started = tokio::time::Instant::now();
+        begin_shutdown_drain(Arc::clone(&state), "test");
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), shutdown_rx.changed())
+            .await
+            .expect("an idle daemon must broadcast shutdown immediately")
+            .expect("shutdown channel closed");
+        assert!(*shutdown_rx.borrow());
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(250),
+            "the idle fast path must not cost a drain poll cycle: took {:?}",
+            started.elapsed()
+        );
+        assert!(
+            state.drained.load(Ordering::Relaxed),
+            "the worker must stop claiming new jobs on every shutdown route"
+        );
+    }
+
+    /// The contract change, at the unit level: a SIGTERM-triggered shutdown must
+    /// NOT broadcast while a write is in flight.
+    ///
+    /// The broadcast is what closes the UDS/TCP/MCP listeners. Before this,
+    /// SIGTERM broadcast up front, so read service died instantly while the
+    /// unabortable `spawn_blocking` write kept the process alive anyway — pure
+    /// cost, since reads do not take `write_mutex`. `begin_shutdown_drain` is
+    /// the shared entry point both SIGTERM and the `Shutdown` RPC now use, so
+    /// asserting on it asserts on both.
+    #[tokio::test]
+    async fn begin_shutdown_drain_keeps_listeners_up_until_the_write_finishes() {
+        let state = test_state_with_writer();
+        let mut shutdown_rx = state.shutdown_tx.subscribe();
+        state.active_writes.store(1, Ordering::Relaxed);
+
+        begin_shutdown_drain(Arc::clone(&state), "sigterm");
+
+        // Long enough to cover several 500ms drain polls.
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(2_000),
+                shutdown_rx.changed()
+            )
+            .await
+            .is_err(),
+            "shutdown must NOT be broadcast while a write is in flight — that \
+             broadcast is exactly what took read service down"
+        );
+
+        // ...and when the write does finish, shutdown still completes cleanly
+        // rather than leaving a half-dead process behind.
+        state.active_writes.store(0, Ordering::Relaxed);
+        tokio::time::timeout(std::time::Duration::from_secs(10), shutdown_rx.changed())
+            .await
+            .expect("the drain must complete once the write finishes")
+            .expect("shutdown channel closed");
+        assert!(*shutdown_rx.borrow());
+    }
+
+    /// One drain, not two. SIGTERM and a `Shutdown` RPC racing (an operator who
+    /// runs `daemon stop` and then `daemon restart`, or a supervisor doing both)
+    /// must not produce two drain loops interleaving duplicate warnings and
+    /// racing the broadcast.
+    #[tokio::test]
+    async fn a_second_shutdown_trigger_does_not_start_a_second_drain() {
+        let state = test_state_with_writer();
+        state.active_writes.store(1, Ordering::Relaxed);
+
+        let logs = CapturedLogs::new();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(logs.clone())
+            .with_ansi(false)
+            .finish();
+        let _log_guard = tracing::subscriber::set_default(subscriber);
+
+        begin_shutdown_drain(Arc::clone(&state), "sigterm");
+        begin_shutdown_drain(Arc::clone(&state), "grpc_shutdown");
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let text = logs.text();
+        assert!(
+            text.contains("shutdown already in progress"),
+            "the second trigger must be refused by the once-only guard: {text}"
+        );
+        state.active_writes.store(0, Ordering::Relaxed);
     }
 
     /// `drained` is NOT shutdown-private: the same `Arc` is handed to

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -223,12 +223,52 @@ impl ConnectionGuard {
         }
     }
 
-    fn write(state: &DaemonState) -> Self {
+    /// Admit a write, or refuse it because shutdown has begun.
+    ///
+    /// THIS REFUSAL IS WHAT MAKES THE DRAIN TERMINATE. `active_writes` is the
+    /// drain's exit condition and this constructor is its ONLY incrementer (the
+    /// web admin crate holds the same `Arc` but never adds to it), so gating
+    /// here — and only here — makes the count monotonically non-increasing once
+    /// shutdown starts.
+    ///
+    /// Without it the drain is not merely slow, it is not guaranteed to
+    /// terminate at all. The old SIGTERM broadcast closed every listener, which
+    /// made new writes impossible as a side effect of the outage. Draining with
+    /// listeners UP removes that outage — and, without this gate, removes the
+    /// accidental protection with it: a webhook feed, a watcher, an MCP client
+    /// or an agent loop can start a NEW write eight minutes into a drain and
+    /// reset the exit condition. `daemon stop` would then wait its whole grace,
+    /// report, and exit non-zero; re-running it would do nothing (the once-guard
+    /// swallows the second trigger); and the only remaining way out would be
+    /// `--force` or `kill -9` — the exact nw-126 crash this whole change exists
+    /// to avoid. On a busy daemon that would have made the unsafe kill MORE
+    /// likely, not less.
+    ///
+    /// `UNAVAILABLE` is the correct code: the daemon is going away, the request
+    /// was not applied, and the operation is safe to retry against whatever
+    /// serves the database next. Clients already treat it as retryable.
+    ///
+    /// Reads are deliberately NOT gated. They neither hold the write gate nor
+    /// extend the drain, and continuing to serve them for the whole drain is
+    /// the point of this design.
+    fn write(state: &DaemonState) -> Result<Self, Status> {
+        // Ordering: this load pairs with the `swap` in `begin_shutdown_drain`.
+        // `Relaxed` matches every other access to this flag; the race window it
+        // leaves is one already-admitted write, which the drain then waits for
+        // exactly as it would have anyway. What must not happen — an unbounded
+        // stream of new writes — is closed regardless of ordering.
+        if state.shutdown_started.load(Ordering::Relaxed) {
+            return Err(Status::unavailable(
+                "daemon is shutting down and is not accepting new writes; it is \
+                 finishing the writes already in flight and still serving reads. \
+                 Retry against the daemon that starts next.",
+            ));
+        }
         state.active_writes.fetch_add(1, Ordering::Relaxed);
         state.idle_notify.notify_one();
-        Self {
+        Ok(Self {
             counter: Arc::clone(&state.active_writes),
-        }
+        })
     }
 }
 
@@ -1176,8 +1216,11 @@ async fn run_shutdown_drain(state: Arc<DaemonState>, ceiling: u64) {
                 pid,
                 "drain ceiling ({ceiling}s) exceeded — still waiting on {writes} \
                  in-flight write(s){}; the daemon CANNOT abort them and is NOT \
-                 shutting down. Most reads are still served — `embed` and \
-                 `plan_embed` are not, they take the same write gate. This is \
+                 shutting down. NEW writes are already being refused with \
+                 UNAVAILABLE, so this count only falls. Most reads are still \
+                 served, though they can stall for seconds while a write \
+                 commits — `embed` and `plan_embed` are not served at all, they \
+                 take the same write gate. This is \
                  the same drain whether you sent SIGTERM (`nestweaver daemon \
                  stop`) or the Shutdown RPC (`nestweaver daemon restart`); \
                  neither escalates on its own. To end it now — abandoning the \
@@ -1301,6 +1344,51 @@ fn begin_shutdown_drain(state: Arc<DaemonState>, trigger: &'static str) {
     tokio::spawn(async move {
         run_shutdown_drain(state, nestweaver_schema::drain_ceiling_from_env()).await;
     });
+}
+
+/// The SIGTERM handler task: route every SIGTERM into [`begin_shutdown_drain`].
+///
+/// LOOPS DELIBERATELY. This used to `recv()` exactly once and return, which
+/// dropped the `Signal` registration — and because Tokio leaves its
+/// process-wide `sigaction` installed, later SIGTERMs were then neither
+/// delivered to anything nor allowed to default-terminate the process. The
+/// daemon went permanently DEAF to SIGTERM after the first one: a supervisor
+/// that re-sends got nothing, and `begin_shutdown_drain`'s "shutdown already in
+/// progress" branch — documented as the behaviour of a second `daemon stop` —
+/// was unreachable from a signal at all.
+///
+/// Looping restores it. The second and later signals are cheap: the once-guard
+/// inside `begin_shutdown_drain` refuses them and logs, so a supervisor's
+/// repeated SIGTERMs neither start a second drain nor cut the first one short.
+/// It does NOT close the late-watcher hole documented on `begin_shutdown_drain`:
+/// the once-guard returns before `stop_active_watcher` is reached, so a second
+/// signal still does not stop a watcher registered after the drain began. That
+/// hole stays closed where it already was, on the exit path.
+///
+/// Hoisted out of `run_server` so it can be unit-tested with a real signal —
+/// see `sigterm_does_not_broadcast_while_a_write_is_in_flight`.
+///
+/// SUPERVISORS: this only governs what THIS process does with the signal. A
+/// process supervisor that SIGKILLs on its own timer (systemd's
+/// `TimeoutStopSec`, default 90s; launchd's `ExitTimeOut`) still does so, and
+/// nothing here can prevent it. The unbounded-drain guarantee holds for
+/// interactive `daemon stop`; under a supervisor it holds only for as long as
+/// that supervisor's stop timeout allows.
+async fn watch_sigterm(state: Arc<DaemonState>) {
+    let mut sig = match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+        Ok(sig) => sig,
+        Err(error) => {
+            // Previously `.expect(...)`, which panicked a spawned task — the
+            // panic is swallowed by the JoinHandle nobody awaits, so the daemon
+            // would have run on with no SIGTERM handling and no diagnostic.
+            tracing::error!(%error, "could not register SIGTERM handler — `daemon stop` will not drain");
+            return;
+        }
+    };
+    while sig.recv().await.is_some() {
+        tracing::info!("received SIGTERM — draining before shutdown");
+        begin_shutdown_drain(Arc::clone(&state), "sigterm");
+    }
 }
 
 /// Register a watcher's shutdown handle, returning its registration id (the
@@ -3470,7 +3558,7 @@ impl NestWeaverDaemon for DaemonService {
         // lock on drop/panic — there is no persistent quiesce flag to leak.
         let staged = {
             let _write_lock = self.state.write_gate.lock("backup").await;
-            let _guard = ConnectionGuard::write(&self.state);
+            let _guard = ConnectionGuard::write(&self.state)?;
             let store = self.state.store.clone();
             let cfg = config.clone();
             tracing::info!("backup: staging under write lock");
@@ -3579,7 +3667,7 @@ impl NestWeaverDaemon for DaemonService {
             Err(e) => return Err(e),
         };
 
-        let guard = ConnectionGuard::write(&self.state);
+        let guard = ConnectionGuard::write(&self.state)?;
         let write_lock = self.state.write_gate.clone();
         let state = self.state.clone();
         let store = self.state.store.clone();
@@ -3672,7 +3760,7 @@ impl NestWeaverDaemon for DaemonService {
             Err(e) => return Err(e),
         };
 
-        let guard = ConnectionGuard::write(&self.state);
+        let guard = ConnectionGuard::write(&self.state)?;
         let write_lock = self.state.write_gate.clone();
         let state = self.state.clone();
         let store = self.state.store.clone();
@@ -4066,7 +4154,7 @@ impl NestWeaverDaemon for DaemonService {
 
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<IndexProgress, Status>>(16);
 
-        let guard = ConnectionGuard::write(&self.state);
+        let guard = ConnectionGuard::write(&self.state)?;
         let write_lock = self.state.write_gate.clone();
 
         // Cooperative cancellation for the otherwise-uncancelable spawn_blocking
@@ -4365,7 +4453,7 @@ impl NestWeaverDaemon for DaemonService {
 
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<IndexProgress, Status>>(16);
 
-        let guard = ConnectionGuard::write(&self.state);
+        let guard = ConnectionGuard::write(&self.state)?;
         let write_lock = self.state.write_gate.clone();
         tokio::task::spawn_blocking(move || {
             let _write_lock = write_lock.blocking_lock("index_vault");
@@ -4469,7 +4557,7 @@ impl NestWeaverDaemon for DaemonService {
         let state = self.state.clone();
 
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<IndexProgress, Status>>(16);
-        let guard = ConnectionGuard::write(&self.state);
+        let guard = ConnectionGuard::write(&self.state)?;
         let write_lock = self.state.write_gate.clone();
         tokio::task::spawn_blocking(move || {
             let _write_lock = write_lock.blocking_lock("refresh_vault_since");
@@ -4575,7 +4663,7 @@ impl NestWeaverDaemon for DaemonService {
 
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<IndexProgress, Status>>(16);
 
-        let guard = ConnectionGuard::write(&self.state);
+        let guard = ConnectionGuard::write(&self.state)?;
         let write_lock = self.state.write_gate.clone();
         tokio::task::spawn_blocking(move || {
             let _write_lock = write_lock.blocking_lock("materialize_projects");
@@ -4658,7 +4746,7 @@ impl NestWeaverDaemon for DaemonService {
             return Err(Status::permission_denied("admin token required"));
         }
         let _write_lock = self.state.write_gate.lock("remove_vault").await;
-        let _guard = ConnectionGuard::write(&self.state);
+        let _guard = ConnectionGuard::write(&self.state)?;
 
         let req = request.into_inner();
         let state = self.state.clone();
@@ -4684,7 +4772,7 @@ impl NestWeaverDaemon for DaemonService {
             return Err(Status::permission_denied("admin token required"));
         }
         let _write_lock = self.state.write_gate.lock("remove_repo").await;
-        let _guard = ConnectionGuard::write(&self.state);
+        let _guard = ConnectionGuard::write(&self.state)?;
 
         let req = request.into_inner();
         let state = self.state.clone();
@@ -4722,7 +4810,7 @@ impl NestWeaverDaemon for DaemonService {
             return Err(Status::permission_denied("admin token required"));
         }
         let _write_lock = self.state.write_gate.lock("remove_project").await;
-        let _guard = ConnectionGuard::write(&self.state);
+        let _guard = ConnectionGuard::write(&self.state)?;
 
         let req = request.into_inner();
         let state = self.state.clone();
@@ -4754,7 +4842,7 @@ impl NestWeaverDaemon for DaemonService {
             return Err(Status::permission_denied("admin token required"));
         }
         let _write_lock = self.state.write_gate.lock("prune_stale").await;
-        let _guard = ConnectionGuard::write(&self.state);
+        let _guard = ConnectionGuard::write(&self.state)?;
 
         let _req = request.into_inner();
         let state = self.state.clone();
@@ -4797,7 +4885,7 @@ impl NestWeaverDaemon for DaemonService {
             ));
         }
         let _write_lock = self.state.write_gate.lock("merge_instance").await;
-        let _guard = ConnectionGuard::write(&self.state);
+        let _guard = ConnectionGuard::write(&self.state)?;
 
         let state = self.state.clone();
 
@@ -4859,7 +4947,7 @@ impl NestWeaverDaemon for DaemonService {
 
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<IndexProgress, Status>>(16);
 
-        let guard = ConnectionGuard::write(&self.state);
+        let guard = ConnectionGuard::write(&self.state)?;
         let write_lock = self.state.write_gate.clone();
         tokio::task::spawn_blocking(move || {
             let _write_lock = write_lock.blocking_lock("purge_instance");
@@ -4941,7 +5029,7 @@ impl NestWeaverDaemon for DaemonService {
         // drain / idle timeout via `active_writes` — mirroring `prune_stale`
         // and `purge_instance`.
         let _write_lock = self.state.write_gate.lock("reindex_search").await;
-        let _guard = ConnectionGuard::write(&self.state);
+        let _guard = ConnectionGuard::write(&self.state)?;
 
         let state = self.state.clone();
         #[allow(clippy::result_large_err)]
@@ -5788,7 +5876,7 @@ impl NestWeaverDaemon for DaemonService {
         // updates (last-writer-wins). This is the single gated write path: the
         // MCP `tool_set_extension` routes here rather than mutating directly.
         let _write_lock = self.state.write_gate.lock("set_extension").await;
-        let _guard = ConnectionGuard::write(&self.state);
+        let _guard = ConnectionGuard::write(&self.state)?;
 
         let req = r.into_inner();
         let db_path = self.state.db_path.clone();
@@ -6367,7 +6455,7 @@ impl NestWeaverDaemon for DaemonService {
             return Err(Status::permission_denied("admin token required"));
         }
         let _write_lock = self.state.write_gate.lock("embed").await;
-        let _guard = ConnectionGuard::write(&self.state);
+        let _guard = ConnectionGuard::write(&self.state)?;
 
         #[cfg(not(feature = "embed"))]
         {
@@ -8922,29 +9010,7 @@ pub async fn run_server(
     }
 
     // Catch SIGTERM for graceful shutdown (sent by `daemon stop`).
-    //
-    // SIGTERM runs the SAME drain as the gRPC `Shutdown` RPC. It does not
-    // broadcast shutdown up front: listeners stay up and reads keep being
-    // served while writes drain, and the operator gets the drain's honest
-    // reporting. An idle daemon still exits immediately — the drain breaks on
-    // its first counter check. See [`begin_shutdown_drain`].
-    //
-    // SUPERVISORS: this only governs what THIS process does with the signal. A
-    // process supervisor that SIGKILLs on its own timer (systemd's
-    // `TimeoutStopSec`, default 90s; launchd's `ExitTimeOut`) still does so,
-    // and nothing here can prevent it. The unbounded-drain guarantee holds for
-    // interactive `daemon stop`; under a supervisor it holds only for as long
-    // as that supervisor's stop timeout allows.
-    {
-        let state = Arc::clone(&state);
-        tokio::spawn(async move {
-            let mut sig = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-                .expect("register SIGTERM handler");
-            sig.recv().await;
-            tracing::info!("received SIGTERM — draining before shutdown");
-            begin_shutdown_drain(state, "sigterm");
-        });
-    }
+    tokio::spawn(watch_sigterm(Arc::clone(&state)));
 
     let uds = tokio::net::UnixListener::bind(&sock_path)
         .with_context(|| format!("bind UDS: {}", sock_path.display()))?;
@@ -16466,6 +16532,25 @@ external_model = "unavailable-test-model"
             "the whole point of the unified drain is that no path auto-kills — \
              the line must say so: {text}"
         );
+        // Without the write gate this line would be inviting an operator to
+        // wait out a count that a webhook feed or agent loop can push back up
+        // indefinitely. The refusal is what makes "it only falls" true, and an
+        // operator deciding whether to wait or to `--force` needs to know it.
+        assert!(
+            text.contains("NEW writes are already being refused")
+                && text.contains("this count only falls"),
+            "the line tells the operator to wait; it must therefore say that the \
+             count is monotone, which is only true because new writes are \
+             refused: {text}"
+        );
+        // Transcript evidence (and the control run) showed reads stalling for
+        // seconds around a write commit. "Reads are served" without that
+        // qualifier is the same overclaim class this test family polices.
+        assert!(
+            text.contains("stall for seconds"),
+            "read service during a drain is not latency-free — a bare \"reads are \
+             served\" overclaims: {text}"
+        );
     }
 
     /// The fast path must stay fast. Routing SIGTERM through the drain would be
@@ -16565,6 +16650,149 @@ external_model = "unavailable-test-model"
             "the second trigger must be refused by the once-only guard: {text}"
         );
         state.active_writes.store(0, Ordering::Relaxed);
+    }
+
+    /// The drain must be MONOTONE, or it is not guaranteed to terminate.
+    ///
+    /// `active_writes` is the drain's exit condition. Draining with listeners up
+    /// means clients can still reach the daemon, so without a gate a webhook
+    /// feed, watcher, MCP client or agent loop can start a NEW write minutes
+    /// into a drain and push the count back up — indefinitely. The old SIGTERM
+    /// broadcast prevented that only as a side effect of the outage it caused;
+    /// removing the outage removes that accidental protection too.
+    ///
+    /// The consequence of getting this wrong is not a slow stop, it is the
+    /// unsafe one: stop waits its whole grace, reports, exits non-zero, a re-run
+    /// is swallowed by the once-guard, and the only remaining exit is `--force`
+    /// or `kill -9` — the nw-126 crash this change exists to avoid. On a busy
+    /// daemon that would make the unsafe kill MORE likely, not less.
+    #[tokio::test]
+    async fn writes_are_refused_once_shutdown_has_started() {
+        let state = test_state_with_writer();
+
+        // Before shutdown: admitted, and counted.
+        let guard = ConnectionGuard::write(&state).expect("writes are admitted normally");
+        assert_eq!(state.active_writes.load(Ordering::Relaxed), 1);
+        drop(guard);
+        assert_eq!(state.active_writes.load(Ordering::Relaxed), 0);
+
+        // A write in flight when shutdown begins, exactly as in the incident.
+        let in_flight = ConnectionGuard::write(&state).expect("writes are admitted normally");
+        assert_eq!(state.active_writes.load(Ordering::Relaxed), 1);
+        begin_shutdown_drain(Arc::clone(&state), "sigterm");
+
+        let refused = ConnectionGuard::write(&state)
+            .err()
+            .expect("a NEW write must be refused once shutdown has started");
+        assert_eq!(
+            refused.code(),
+            tonic::Code::Unavailable,
+            "the daemon is going away and the request was not applied, so this \
+             must be the retryable code clients already handle: {refused:?}"
+        );
+        assert!(
+            refused.message().contains("shutting down"),
+            "the refusal must say why, or a client cannot tell it from a real \
+             failure: {}",
+            refused.message()
+        );
+        assert_eq!(
+            state.active_writes.load(Ordering::Relaxed),
+            1,
+            "a REFUSED write must not increment the drain's exit condition — \
+             incrementing before refusing would be the same unbounded drain with \
+             extra steps"
+        );
+
+        // Reads are deliberately still admitted: they do not extend the drain,
+        // and serving them throughout is the point of the whole design.
+        let read = ConnectionGuard::read(&state);
+        assert_eq!(state.active_reads.load(Ordering::Relaxed), 1);
+        drop(read);
+
+        drop(in_flight);
+    }
+
+    /// The link nothing else covers: that a REAL SIGTERM routes into the drain
+    /// rather than broadcasting.
+    ///
+    /// Every other test here calls `begin_shutdown_drain` directly, so all of
+    /// them still pass if the signal handler is reverted to broadcasting — the
+    /// gap that was disclosed rather than closed. This raises an actual SIGTERM
+    /// at itself and asserts on the outcome.
+    ///
+    /// Also pins the loop: the handler used to `recv()` once and return, which
+    /// dropped the registration while leaving Tokio's `sigaction` installed, so
+    /// the process went permanently deaf to SIGTERM — later signals were neither
+    /// delivered nor able to default-terminate it.
+    #[tokio::test]
+    async fn sigterm_does_not_broadcast_while_a_write_is_in_flight() {
+        let state = test_state_with_writer();
+        let mut shutdown_rx = state.shutdown_tx.subscribe();
+        state.active_writes.store(1, Ordering::Relaxed);
+
+        let logs = CapturedLogs::new();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(logs.clone())
+            .with_ansi(false)
+            .finish();
+        let _log_guard = tracing::subscriber::set_default(subscriber);
+
+        let handler = tokio::spawn(watch_sigterm(Arc::clone(&state)));
+        // Let the handler install its registration before signalling. Raising
+        // SIGTERM before `signal()` returns would, with Tokio's default
+        // disposition not yet replaced, terminate the test process.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        unsafe { libc::raise(libc::SIGTERM) };
+
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(2_000),
+                shutdown_rx.changed()
+            )
+            .await
+            .is_err(),
+            "SIGTERM must run the drain, not broadcast: the broadcast is what \
+             closes every UDS/TCP/MCP listener and is what took read service \
+             down the instant the signal landed"
+        );
+        assert!(
+            logs.text()
+                .contains("received SIGTERM — draining before shutdown"),
+            "the signal must actually have been delivered, or this test passes \
+             vacuously on a signal that never arrived: {}",
+            logs.text()
+        );
+
+        // Second signal: the handler must still be listening. Before the loop
+        // this was silently swallowed forever.
+        unsafe { libc::raise(libc::SIGTERM) };
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        assert_eq!(
+            logs.text()
+                .matches("received SIGTERM — draining before shutdown")
+                .count(),
+            2,
+            "a second SIGTERM must still be received — the handler used to stop \
+             listening after the first, leaving supervisors that re-send with no \
+             effect at all: {}",
+            logs.text()
+        );
+        assert!(
+            logs.text().contains("shutdown already in progress"),
+            "and it must be refused by the once-guard rather than starting a \
+             second drain: {}",
+            logs.text()
+        );
+
+        // The write finishing still completes shutdown cleanly.
+        state.active_writes.store(0, Ordering::Relaxed);
+        tokio::time::timeout(std::time::Duration::from_secs(10), shutdown_rx.changed())
+            .await
+            .expect("the drain must complete once the write finishes")
+            .expect("shutdown channel closed");
+        handler.abort();
     }
 
     /// `drained` is NOT shutdown-private: the same `Arc` is handed to

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -1219,8 +1219,10 @@ async fn run_shutdown_drain(state: Arc<DaemonState>, ceiling: u64) {
                  shutting down. NEW writes are already being refused with \
                  UNAVAILABLE, so this count only falls. Most reads are still \
                  served, though they can stall for seconds while a write \
-                 commits — `embed` and `plan_embed` are not served at all, they \
-                 take the same write gate. This is \
+                 commits. `embed` takes the write gate AND the write guard, so \
+                 it is refused outright; `plan_embed` takes the gate but counts \
+                 as a read, so it is not refused — it BLOCKS until the \
+                 in-flight write releases the gate. This is \
                  the same drain whether you sent SIGTERM (`nestweaver daemon \
                  stop`) or the Shutdown RPC (`nestweaver daemon restart`); \
                  neither escalates on its own. To end it now — abandoning the \
@@ -1333,12 +1335,19 @@ fn begin_shutdown_drain(state: Arc<DaemonState>, trigger: &'static str) {
     // blocking thread would otherwise pin shutdown (Tokio's runtime drop waits
     // for blocking threads) until someone kills the process.
     //
-    // Consequence of the guard above: only the FIRST trigger stops the watcher,
-    // so a watcher registered after a drain began is not stopped here. That hole
-    // is closed on the exit path — the belt-and-suspenders `stop_active_watcher`
-    // after `uds_serve` returns runs before the worker await and before runtime
-    // drop, so such a watcher still cannot pin process exit. Verified by
-    // inspection of the call ordering, not by test.
+    // Consequence of the guard above: only the FIRST trigger stops the watcher.
+    // A watcher registered after a drain began would therefore not be stopped
+    // here — but no such watcher can exist via the RPC route any more. This
+    // function sets `shutdown_started` at the guard above, and
+    // `watch_vault`/`watch_code` now take `ConnectionGuard::write` BEFORE
+    // `register_watcher`, so every registration attempt after this point is
+    // refused with UNAVAILABLE and no watcher thread is ever spawned. The write
+    // gate closed this hole as a side effect of making the drain monotone.
+    //
+    // The belt-and-suspenders `stop_active_watcher` after `uds_serve` returns is
+    // kept regardless: it runs before the worker await and before runtime drop,
+    // so anything registered by a path not covered above still cannot pin
+    // process exit. Verified by inspection of the call ordering, not by test.
     stop_active_watcher(&state);
 
     tokio::spawn(async move {
@@ -1360,10 +1369,13 @@ fn begin_shutdown_drain(state: Arc<DaemonState>, trigger: &'static str) {
 /// Looping restores it. The second and later signals are cheap: the once-guard
 /// inside `begin_shutdown_drain` refuses them and logs, so a supervisor's
 /// repeated SIGTERMs neither start a second drain nor cut the first one short.
-/// It does NOT close the late-watcher hole documented on `begin_shutdown_drain`:
-/// the once-guard returns before `stop_active_watcher` is reached, so a second
-/// signal still does not stop a watcher registered after the drain began. That
-/// hole stays closed where it already was, on the exit path.
+/// The loop itself does not stop a late-registered watcher — the once-guard
+/// returns before `stop_active_watcher` is reached — but that no longer matters
+/// for the RPC route: `watch_vault`/`watch_code` now take
+/// `ConnectionGuard::write` BEFORE `register_watcher`, so once `shutdown_started`
+/// is set no new watcher can be registered at all. A watcher already running
+/// when the drain began is stopped by the first trigger, and the belt-and-braces
+/// `stop_active_watcher` on the exit path still covers anything else.
 ///
 /// Hoisted out of `run_server` so it can be unit-tested with a real signal —
 /// see `sigterm_does_not_broadcast_while_a_write_is_in_flight`.
@@ -3557,8 +3569,13 @@ impl NestWeaverDaemon for DaemonService {
         // no writer touches the files mid-copy, and the RAII guard releases the
         // lock on drop/panic — there is no persistent quiesce flag to leak.
         let staged = {
-            let _write_lock = self.state.write_gate.lock("backup").await;
+            // Guard BEFORE the write gate: during a drain the gate is held by the
+            // in-flight write for as long as it runs, so taking it first meant this
+            // request queued for minutes and only then learned it was refused. A
+            // client with a deadline saw DEADLINE_EXCEEDED instead of the
+            // explanatory UNAVAILABLE, which defeats the point of the message.
             let _guard = ConnectionGuard::write(&self.state)?;
+            let _write_lock = self.state.write_gate.lock("backup").await;
             let store = self.state.store.clone();
             let cfg = config.clone();
             tracing::info!("backup: staging under write lock");
@@ -3654,6 +3671,15 @@ impl NestWeaverDaemon for DaemonService {
 
         let shutdown_handle = watcher.shutdown_handle();
 
+        // Refuse BEFORE registering. `register_watcher` mutates
+        // `state.watcher_stop`, and the only thing that clears it is
+        // `clear_watcher_registration` inside the spawned thread below — which
+        // never runs if the guard refuses. Registering first therefore left the
+        // daemon holding a shutdown handle for a `BrainWatcher` dropped on the
+        // very next line, on behalf of a request that was rejected: state
+        // mutated by a refused RPC.
+        let guard = ConnectionGuard::write(&self.state)?;
+
         // register_watcher holds the lock across check + store (TOCTOU-safe).
         let watcher_id = match register_watcher(&self.state, shutdown_handle, false) {
             Ok(id) => id,
@@ -3666,8 +3692,6 @@ impl NestWeaverDaemon for DaemonService {
             }
             Err(e) => return Err(e),
         };
-
-        let guard = ConnectionGuard::write(&self.state)?;
         let write_lock = self.state.write_gate.clone();
         let state = self.state.clone();
         let store = self.state.store.clone();
@@ -3743,6 +3767,15 @@ impl NestWeaverDaemon for DaemonService {
         let watcher = nestweaver_engine::CodeWatcher::new(&db_path, &repo_path, &instance_id);
         let shutdown_handle = watcher.shutdown_handle();
 
+        // Refuse BEFORE registering — and here the ordering matters more than in
+        // `watch_vault`, because `force` is passed through. With the guard
+        // second, `nestweaver watch --force` during a drain would STOP THE
+        // RUNNING INCUMBENT WATCHER and then refuse the request that replaced
+        // it, leaving no watcher at all plus a registration pointing at a
+        // dropped `CodeWatcher`. Destroying live state on behalf of a rejected
+        // request is not something a refusal is allowed to do.
+        let guard = ConnectionGuard::write(&self.state)?;
+
         // register_watcher holds the lock across check + store (TOCTOU-safe).
         // With `force`, an already-running watcher (e.g. orphaned by a
         // kill -9'd `watch` CLI) is stopped and replaced instead of
@@ -3759,8 +3792,6 @@ impl NestWeaverDaemon for DaemonService {
             }
             Err(e) => return Err(e),
         };
-
-        let guard = ConnectionGuard::write(&self.state)?;
         let write_lock = self.state.write_gate.clone();
         let state = self.state.clone();
         let store = self.state.store.clone();
@@ -4745,8 +4776,13 @@ impl NestWeaverDaemon for DaemonService {
         {
             return Err(Status::permission_denied("admin token required"));
         }
-        let _write_lock = self.state.write_gate.lock("remove_vault").await;
+        // Guard BEFORE the write gate: during a drain the gate is held by the
+        // in-flight write for as long as it runs, so taking it first meant this
+        // request queued for minutes and only then learned it was refused. A
+        // client with a deadline saw DEADLINE_EXCEEDED instead of the
+        // explanatory UNAVAILABLE, which defeats the point of the message.
         let _guard = ConnectionGuard::write(&self.state)?;
+        let _write_lock = self.state.write_gate.lock("remove_vault").await;
 
         let req = request.into_inner();
         let state = self.state.clone();
@@ -4771,8 +4807,13 @@ impl NestWeaverDaemon for DaemonService {
         {
             return Err(Status::permission_denied("admin token required"));
         }
-        let _write_lock = self.state.write_gate.lock("remove_repo").await;
+        // Guard BEFORE the write gate: during a drain the gate is held by the
+        // in-flight write for as long as it runs, so taking it first meant this
+        // request queued for minutes and only then learned it was refused. A
+        // client with a deadline saw DEADLINE_EXCEEDED instead of the
+        // explanatory UNAVAILABLE, which defeats the point of the message.
         let _guard = ConnectionGuard::write(&self.state)?;
+        let _write_lock = self.state.write_gate.lock("remove_repo").await;
 
         let req = request.into_inner();
         let state = self.state.clone();
@@ -4809,8 +4850,13 @@ impl NestWeaverDaemon for DaemonService {
         {
             return Err(Status::permission_denied("admin token required"));
         }
-        let _write_lock = self.state.write_gate.lock("remove_project").await;
+        // Guard BEFORE the write gate: during a drain the gate is held by the
+        // in-flight write for as long as it runs, so taking it first meant this
+        // request queued for minutes and only then learned it was refused. A
+        // client with a deadline saw DEADLINE_EXCEEDED instead of the
+        // explanatory UNAVAILABLE, which defeats the point of the message.
         let _guard = ConnectionGuard::write(&self.state)?;
+        let _write_lock = self.state.write_gate.lock("remove_project").await;
 
         let req = request.into_inner();
         let state = self.state.clone();
@@ -4841,8 +4887,13 @@ impl NestWeaverDaemon for DaemonService {
         {
             return Err(Status::permission_denied("admin token required"));
         }
-        let _write_lock = self.state.write_gate.lock("prune_stale").await;
+        // Guard BEFORE the write gate: during a drain the gate is held by the
+        // in-flight write for as long as it runs, so taking it first meant this
+        // request queued for minutes and only then learned it was refused. A
+        // client with a deadline saw DEADLINE_EXCEEDED instead of the
+        // explanatory UNAVAILABLE, which defeats the point of the message.
         let _guard = ConnectionGuard::write(&self.state)?;
+        let _write_lock = self.state.write_gate.lock("prune_stale").await;
 
         let _req = request.into_inner();
         let state = self.state.clone();
@@ -4884,8 +4935,13 @@ impl NestWeaverDaemon for DaemonService {
                 "source and target instance IDs must differ",
             ));
         }
-        let _write_lock = self.state.write_gate.lock("merge_instance").await;
+        // Guard BEFORE the write gate: during a drain the gate is held by the
+        // in-flight write for as long as it runs, so taking it first meant this
+        // request queued for minutes and only then learned it was refused. A
+        // client with a deadline saw DEADLINE_EXCEEDED instead of the
+        // explanatory UNAVAILABLE, which defeats the point of the message.
         let _guard = ConnectionGuard::write(&self.state)?;
+        let _write_lock = self.state.write_gate.lock("merge_instance").await;
 
         let state = self.state.clone();
 
@@ -5028,8 +5084,13 @@ impl NestWeaverDaemon for DaemonService {
         // (which copies under the same lock) and is visible to the shutdown
         // drain / idle timeout via `active_writes` — mirroring `prune_stale`
         // and `purge_instance`.
-        let _write_lock = self.state.write_gate.lock("reindex_search").await;
+        // Guard BEFORE the write gate: during a drain the gate is held by the
+        // in-flight write for as long as it runs, so taking it first meant this
+        // request queued for minutes and only then learned it was refused. A
+        // client with a deadline saw DEADLINE_EXCEEDED instead of the
+        // explanatory UNAVAILABLE, which defeats the point of the message.
         let _guard = ConnectionGuard::write(&self.state)?;
+        let _write_lock = self.state.write_gate.lock("reindex_search").await;
 
         let state = self.state.clone();
         #[allow(clippy::result_large_err)]
@@ -5875,8 +5936,13 @@ impl NestWeaverDaemon for DaemonService {
         // shutdown drain / idle timeout, and two concurrent callers cannot lose
         // updates (last-writer-wins). This is the single gated write path: the
         // MCP `tool_set_extension` routes here rather than mutating directly.
-        let _write_lock = self.state.write_gate.lock("set_extension").await;
+        // Guard BEFORE the write gate: during a drain the gate is held by the
+        // in-flight write for as long as it runs, so taking it first meant this
+        // request queued for minutes and only then learned it was refused. A
+        // client with a deadline saw DEADLINE_EXCEEDED instead of the
+        // explanatory UNAVAILABLE, which defeats the point of the message.
         let _guard = ConnectionGuard::write(&self.state)?;
+        let _write_lock = self.state.write_gate.lock("set_extension").await;
 
         let req = r.into_inner();
         let db_path = self.state.db_path.clone();
@@ -6454,8 +6520,13 @@ impl NestWeaverDaemon for DaemonService {
         {
             return Err(Status::permission_denied("admin token required"));
         }
-        let _write_lock = self.state.write_gate.lock("embed").await;
+        // Guard BEFORE the write gate: during a drain the gate is held by the
+        // in-flight write for as long as it runs, so taking it first meant this
+        // request queued for minutes and only then learned it was refused. A
+        // client with a deadline saw DEADLINE_EXCEEDED instead of the
+        // explanatory UNAVAILABLE, which defeats the point of the message.
         let _guard = ConnectionGuard::write(&self.state)?;
+        let _write_lock = self.state.write_gate.lock("embed").await;
 
         #[cfg(not(feature = "embed"))]
         {
@@ -16711,6 +16782,76 @@ external_model = "unavailable-test-model"
         drop(read);
 
         drop(in_flight);
+    }
+
+    /// A refused request must not leave state behind.
+    ///
+    /// `watch_vault`/`watch_code` used to call `register_watcher` first and take
+    /// the write guard second. During a drain that registered a shutdown handle
+    /// for a watcher that was then dropped when the guard refused, and nothing
+    /// ever cleared it — `clear_watcher_registration` only runs inside the
+    /// thread that never spawned. Every later watch session in that process
+    /// would then be told "a watcher is already running".
+    ///
+    /// `watch_code` was the worse of the two because it forwards `force`:
+    /// `nestweaver watch --force` mid-drain would STOP the running incumbent
+    /// watcher and then refuse the request that was meant to replace it,
+    /// destroying live state on behalf of a rejected call.
+    #[tokio::test]
+    async fn a_refused_watch_leaves_no_watcher_registration() {
+        let state = test_state_with_writer();
+        let service = DaemonService {
+            state: Arc::clone(&state),
+        };
+        // A real directory: `watch_code` rejects a non-existent repo path long
+        // before it reaches the guard, so a fake path would make this test pass
+        // for the wrong reason.
+        let repo_dir = tempfile::tempdir().unwrap();
+        let repo_path = repo_dir.path().to_string_lossy().into_owned();
+
+        // A watcher registered before shutdown, standing in for the incumbent
+        // that `--force` would otherwise tear down.
+        let incumbent =
+            nestweaver_engine::CodeWatcher::new(&state.db_path, repo_dir.path(), "test-instance");
+        register_watcher(&state, incumbent.shutdown_handle(), false)
+            .expect("the incumbent registers before shutdown");
+
+        state.active_writes.store(1, Ordering::Relaxed);
+        begin_shutdown_drain(Arc::clone(&state), "sigterm");
+
+        for force in [false, true] {
+            let refusal = service
+                .watch_code(tonic::Request::new(nestweaver_proto::WatchCodeRequest {
+                    repo_path: repo_path.clone(),
+                    instance_id: String::new(),
+                    force,
+                }))
+                .await
+                .err()
+                .unwrap_or_else(|| panic!("watch_code(force={force}) must be refused"));
+            assert_eq!(refusal.code(), tonic::Code::Unavailable, "{refusal:?}");
+        }
+
+        // `begin_shutdown_drain` legitimately stops and clears the incumbent —
+        // that is the drain doing its job. What must NOT happen is a refused
+        // call putting something back. With the guard after `register_watcher`,
+        // both passes above would have stored a fresh handle for a `CodeWatcher`
+        // dropped moments later, so this slot would be `Some` again and every
+        // later watch session in the process would be told one is already
+        // running.
+        let registered = state
+            .watcher_stop
+            .lock()
+            .expect("watcher_stop lock")
+            .is_some();
+        assert!(
+            !registered,
+            "a refused watch must not register a watcher it never started — the \
+             slot is left holding a handle to a dropped watcher and nothing ever \
+             clears it"
+        );
+
+        state.active_writes.store(0, Ordering::Relaxed);
     }
 
     /// The link nothing else covers: that a REAL SIGTERM routes into the drain

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,17 @@ services:
         "--config", "/etc/nestweaver/instance.toml"
       ]
     restart: unless-stopped
-    stop_grace_period: 30s
+    # Docker sends SIGTERM, which runs the daemon's graceful drain with every
+    # listener still up, then SIGKILLs at this deadline. 30s sat far below the
+    # 660s drain ceiling, so `docker compose stop` during a large index reliably
+    # SIGKILLed the daemon mid-write — the nw-126 stale-WAL crash, on a 30s fuse.
+    #
+    # Matched to the drain ceiling + 30s, the same budget `nestweaver daemon
+    # stop` uses. This is still a HARD DEADLINE that Docker enforces and the
+    # daemon cannot extend: a write running at 690s is SIGKILLed anyway. Raise
+    # it (and NESTWEAVER_DRAIN_TIMEOUT_SECS with it) if your indexes run longer.
+    # See docs/guide/daemon-shutdown.md.
+    stop_grace_period: 690s
 
 volumes:
   nestweaver-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,12 +50,15 @@ services:
     # 660s drain ceiling, so `docker compose stop` during a large index reliably
     # SIGKILLed the daemon mid-write — the nw-126 stale-WAL crash, on a 30s fuse.
     #
-    # Matched to the drain ceiling + 30s, the same budget `nestweaver daemon
-    # stop` uses. This is still a HARD DEADLINE that Docker enforces and the
-    # daemon cannot extend: a write running at 690s is SIGKILLed anyway. Raise
-    # it (and NESTWEAVER_DRAIN_TIMEOUT_SECS with it) if your indexes run longer.
-    # See docs/guide/daemon-shutdown.md.
-    stop_grace_period: 690s
+    # Drain ceiling + 60s. Deliberately LONGER than `nestweaver daemon stop`'s
+    # own ceiling + 30s window (and matching the launchd ExitTimeOut) so the
+    # supervisor's kill always lands after the CLI has given up watching, never
+    # during it — otherwise `daemon stop` inside the container could report "still
+    # running" about a process Docker had just killed. This is still a HARD
+    # DEADLINE that Docker enforces and the daemon cannot extend: a write running
+    # at 720s is SIGKILLed anyway. Raise it (and NESTWEAVER_DRAIN_TIMEOUT_SECS
+    # with it) if your indexes run longer. See docs/guide/daemon-shutdown.md.
+    stop_grace_period: 720s
 
 volumes:
   nestweaver-data:

--- a/docs/guide/daemon-shutdown.md
+++ b/docs/guide/daemon-shutdown.md
@@ -8,7 +8,10 @@ supervisor is in the picture.
 
 - Both `daemon stop` (SIGTERM) and `daemon restart` (gRPC `Shutdown` RPC) run
   the **same drain**, with **listeners still up**. Reads keep being served while
-  writes drain.
+  writes drain — though an individual read can stall for seconds while a write
+  commits, which is pre-existing store behaviour and not caused by the drain.
+- **New writes are refused** (`UNAVAILABLE`) once shutdown starts, so the drain
+  is monotone and is guaranteed to finish. Reads are not gated.
 - An idle daemon exits **immediately**. Nothing about this makes a normal stop
   slower.
 - If a write is still in flight when the stop grace expires, `daemon stop`
@@ -18,8 +21,10 @@ supervisor is in the picture.
   `kill -9 <pid>`. Both abandon the write.
 - **Under a process supervisor, the supervisor's own timer wins.** Nothing in
   this codebase can prevent that.
+- **Autostart's two legacy-daemon cleanup paths still SIGKILL on a 2s timer.**
+  See "What still escalates" below.
 
-## Why nothing escalates automatically
+## Why `daemon stop` does not escalate automatically
 
 Daemon writes run on `spawn_blocking` threads. Tokio cannot cancel them, so
 there is no mechanism in the process to abort an in-flight write — the shutdown
@@ -36,33 +41,64 @@ performed, automatically and on a timer, exactly the unsafe act that was
 deliberately refused elsewhere. That escalation is gone. Killing a daemon
 mid-write is a decision with a known cost, so it is now an explicit operator act.
 
+## What still escalates
+
+Two paths in the **client's autostart**, both untouched by this change, do
+SIGTERM → wait 2s → SIGKILL when they find a *legacy* daemon holding the DB
+write lock:
+
+- `nestweaver_daemon::lifecycle::stop_legacy_hash_daemon` — daemons whose
+  instance ID predates the SHA-256 upgrade.
+- the `$TMPDIR`-path cleanup in `nestweaver-client/src/autostart.rs` — daemons
+  at the pre-v0.26.2 socket location.
+
+Two seconds is far inside a normal drain, so either can SIGKILL a daemon that is
+draining exactly as designed. Neither is reachable from `daemon stop`; both are
+migration paths that run when a *new* daemon is starting. They are listed here
+because "nothing escalates automatically" would otherwise be an overclaim.
+
 ## What `daemon stop` prints
 
 While waiting, every 60s:
 
 ```
-  still draining after 120s — the daemon is still serving reads; check its log
-  for the in-flight count
+  still draining after 120s — new writes are being refused; check the daemon
+  log for what it is waiting on
 ```
 
-If the grace expires with a write still running:
+If the grace expires with work still in flight and the daemon still reachable:
 
 ```
 Daemon (PID 4242) is STILL DRAINING after 690s and was NOT stopped.
-It is still running and still serving reads — an in-flight write cannot be
-aborted (`spawn_blocking` work is not cancellable), so it has to finish.
+It is still running and still answering on its socket — reads are still served,
+though they can stall for seconds while a write commits. Work that cannot be
+aborted (`spawn_blocking` is not cancellable) has to finish.
 Nothing was killed: the graph store is not crash-safe, and a SIGKILL here is
 what left a stale WAL making a live database look absent (nw-126).
 Options:
-  - wait: the daemon exits on its own when the write completes (no re-run
-    needed; the SIGTERM drain is already in progress)
-  - end it now, abandoning that write: `nestweaver daemon stop --force`, or
+  - wait: the daemon exits on its own when the work completes (no re-run
+    needed; the SIGTERM drain is already in progress, and new writes are being
+    refused)
+  - end it now, abandoning that work: `nestweaver daemon stop --force`, or
     `kill -9 4242`
-Check the daemon log for the in-flight write count.
+Check the daemon log for what it is waiting on.
 ```
 
-Exit status is non-zero: the operator asked for the daemon to stop and it has
-not stopped.
+The command **re-probes the socket** immediately before printing, and says so
+honestly when the answer is bad. In the index-only drain (`active_writes == 0`
+with `indexing_active` set) the daemon broadcasts at the ceiling — 660s — which
+closes every listener, while this command's grace runs to 690s. In that window
+the daemon is alive but unreachable, and the message says:
+
+```
+It is still running but is NO LONGER answering on its socket: the drain reached
+its ceiling with no in-flight write and broadcast shutdown, which closes every
+listener, and the process is now finishing unabortable work with nothing being
+served. Reads are DOWN.
+```
+
+Exit status is non-zero in both cases: the operator asked for the daemon to stop
+and it has not stopped.
 
 ## What is still served during a drain
 
@@ -71,12 +107,21 @@ during a write drain bought nothing and was pure cost. The exceptions are
 `embed` and `plan_embed`: they take the same write gate and block until the
 in-flight write completes.
 
+"Served" is not "fast". A read can stall for **seconds** while a write commits —
+measured at up to 15s under load. This is store-level contention, not something
+the drain introduces: a control run indexing the same repo with **no shutdown at
+all** produced the same stalls at the same magnitude. Do not read "reads keep
+working" as a latency guarantee.
+
+New **writes** during a drain are refused outright with `UNAVAILABLE` — see the
+short version above for why that refusal is what makes the drain terminate.
+
 ## Timeouts
 
 | Knob | Default | What it is |
 |---|---|---|
 | `NESTWEAVER_DRAIN_TIMEOUT_SECS` | 660 | Drain ceiling. With a write in flight this is a **reporting** threshold, not a deadline. With only an index job in flight it **is** a deadline (see CLAUDE.md for why). |
-| `NESTWEAVER_STOP_GRACE_SECS` | ceiling + 30 (690) | How long `daemon stop` waits before reporting and standing down. **Not** a kill deadline. |
+| `NESTWEAVER_STOP_GRACE_SECS` | ceiling + 30 (690) | How long `daemon stop` waits before reporting and standing down. **Not** a kill deadline. Deliberately shorter than the launchd `ExitTimeOut` below, so the CLI reports before launchd kills rather than after. |
 | `daemon stop --force` | 10s, fixed | SIGTERM, brief wait for a clean exit, then SIGKILL. Ignores the two variables above — an operator using `--force` should not have to wait 11 minutes first. |
 
 ## Process supervisors — read this before assuming a guarantee
@@ -122,7 +167,7 @@ into a drain**, on launchd's timer, regardless of anything `daemon stop` or the
 SIGTERM handler did — a far tighter guillotine than the systemd default, present
 in every macOS install, and not previously known.
 
-The plist now sets `ExitTimeOut` to the drain ceiling + 30. **Re-run
+The plist now sets `ExitTimeOut` to the drain ceiling + 60 — strictly later than `daemon stop`'s own ceiling + 30 window, so the CLI can never report "still running" about a process launchd has just killed. When `NESTWEAVER_DRAIN_TIMEOUT_SECS` is set at install time it is baked into the plist's `EnvironmentVariables`, because launchd jobs inherit no shell environment and the daemon would otherwise run a different ceiling from the one its own kill deadline was derived from. **Re-run
 `nestweaver daemon start` to regenerate an existing plist** — an
 already-installed agent keeps the old 20s behaviour until regenerated.
 
@@ -143,7 +188,9 @@ logout, so it is not used.
 ### Docker / Compose — **partially fixed**
 
 `docker-compose.yml` previously set `stop_grace_period: 30s`, the tightest
-deadline in the repo, against a 660s drain ceiling. It is now 690s. The
+deadline in the repo, against a 660s drain ceiling. It is now 720s — ceiling +
+60, the same budget as the launchd `ExitTimeOut` and deliberately later than
+`daemon stop`'s ceiling + 30 window. The
 `Dockerfile` sets no `STOPSIGNAL`, so Docker's default SIGTERM is correct and
 reaches the drain. If you run the image outside the shipped compose file, set
 `--stop-timeout` / `stop_grace_period` yourself; Docker's default is **10

--- a/docs/guide/daemon-shutdown.md
+++ b/docs/guide/daemon-shutdown.md
@@ -1,0 +1,158 @@
+# Daemon shutdown
+
+How `nestweaver daemon stop` and `nestweaver daemon restart` behave, what they
+guarantee, and — importantly — what they cannot guarantee when a process
+supervisor is in the picture.
+
+## The short version
+
+- Both `daemon stop` (SIGTERM) and `daemon restart` (gRPC `Shutdown` RPC) run
+  the **same drain**, with **listeners still up**. Reads keep being served while
+  writes drain.
+- An idle daemon exits **immediately**. Nothing about this makes a normal stop
+  slower.
+- If a write is still in flight when the stop grace expires, `daemon stop`
+  **reports and stands down**. It leaves the daemon running and exits non-zero.
+  It does **not** SIGKILL.
+- To end an in-flight write anyway: `nestweaver daemon stop --force`, or
+  `kill -9 <pid>`. Both abandon the write.
+- **Under a process supervisor, the supervisor's own timer wins.** Nothing in
+  this codebase can prevent that.
+
+## Why nothing escalates automatically
+
+Daemon writes run on `spawn_blocking` threads. Tokio cannot cancel them, so
+there is no mechanism in the process to abort an in-flight write — the shutdown
+broadcast only stops listeners *accepting*, it cannot preempt work already
+running. The drain therefore waits, and says so.
+
+The graph store is **not crash-safe**. In nw-126 a SIGKILLed daemon left a stale
+42-byte WAL that made a live 5.6 GB database look absent. That evidence is why
+the drain ceiling is a reporting threshold rather than a kill switch.
+
+`daemon stop` used to contradict that: after SIGTERM it polled for the stop
+grace and then SIGKILLed regardless. So the command operators actually reach for
+performed, automatically and on a timer, exactly the unsafe act that was
+deliberately refused elsewhere. That escalation is gone. Killing a daemon
+mid-write is a decision with a known cost, so it is now an explicit operator act.
+
+## What `daemon stop` prints
+
+While waiting, every 60s:
+
+```
+  still draining after 120s — the daemon is still serving reads; check its log
+  for the in-flight count
+```
+
+If the grace expires with a write still running:
+
+```
+Daemon (PID 4242) is STILL DRAINING after 690s and was NOT stopped.
+It is still running and still serving reads — an in-flight write cannot be
+aborted (`spawn_blocking` work is not cancellable), so it has to finish.
+Nothing was killed: the graph store is not crash-safe, and a SIGKILL here is
+what left a stale WAL making a live database look absent (nw-126).
+Options:
+  - wait: the daemon exits on its own when the write completes (no re-run
+    needed; the SIGTERM drain is already in progress)
+  - end it now, abandoning that write: `nestweaver daemon stop --force`, or
+    `kill -9 4242`
+Check the daemon log for the in-flight write count.
+```
+
+Exit status is non-zero: the operator asked for the daemon to stop and it has
+not stopped.
+
+## What is still served during a drain
+
+Most reads. Reads do not take the write gate — which is why killing read service
+during a write drain bought nothing and was pure cost. The exceptions are
+`embed` and `plan_embed`: they take the same write gate and block until the
+in-flight write completes.
+
+## Timeouts
+
+| Knob | Default | What it is |
+|---|---|---|
+| `NESTWEAVER_DRAIN_TIMEOUT_SECS` | 660 | Drain ceiling. With a write in flight this is a **reporting** threshold, not a deadline. With only an index job in flight it **is** a deadline (see CLAUDE.md for why). |
+| `NESTWEAVER_STOP_GRACE_SECS` | ceiling + 30 (690) | How long `daemon stop` waits before reporting and standing down. **Not** a kill deadline. |
+| `daemon stop --force` | 10s, fixed | SIGTERM, brief wait for a clean exit, then SIGKILL. Ignores the two variables above — an operator using `--force` should not have to wait 11 minutes first. |
+
+## Process supervisors — read this before assuming a guarantee
+
+Everything above describes what **this process** does with SIGTERM. A supervisor
+that SIGKILLs on its own timer still does so, at its own deadline, and the
+daemon cannot extend or refuse it. Concretely:
+
+### Linux, `daemon start` — **fully fixed**
+
+This repo ships **no systemd unit** and no service-installer command. On Linux
+`nestweaver daemon start` spawns a bare detached process supervised by nothing.
+There is no external timer, so the drain really is unbounded and `daemon stop`
+really does refuse to kill. This is the case the change fixes completely.
+
+### Linux, your own systemd unit — **exposed unless you configure it**
+
+If you wrote a unit yourself, systemd's `TimeoutStopSec` defaults to **90
+seconds**, after which it sends SIGKILL. That is well inside a normal index, so
+`systemctl stop` will crash the daemon mid-write regardless of anything here.
+Set it to at least the drain ceiling plus a buffer:
+
+```ini
+[Service]
+ExecStart=/usr/local/bin/nestweaver daemon --db /var/lib/nestweaver/brain.lbug run
+# Must exceed NESTWEAVER_DRAIN_TIMEOUT_SECS (default 660) or systemd SIGKILLs
+# a draining daemon mid-write. `infinity` removes the deadline entirely at the
+# cost of a stop that can hang; 690s matches `nestweaver daemon stop`.
+TimeoutStopSec=690
+KillSignal=SIGTERM
+Restart=on-failure
+```
+
+Even so, this is a **hard deadline** systemd enforces. It moves the exposure
+window; it does not remove it.
+
+### macOS, launchd — **was the tightest exposure of all; now partially fixed**
+
+`daemon start` on macOS installs a launch agent. The generated plist set **no
+`ExitTimeOut` at all**, so launchd applied its **20-second** default. Against a
+660s drain ceiling that means macOS has been SIGKILLing the daemon **20 seconds
+into a drain**, on launchd's timer, regardless of anything `daemon stop` or the
+SIGTERM handler did — a far tighter guillotine than the systemd default, present
+in every macOS install, and not previously known.
+
+The plist now sets `ExitTimeOut` to the drain ceiling + 30. **Re-run
+`nestweaver daemon start` to regenerate an existing plist** — an
+already-installed agent keeps the old 20s behaviour until regenerated.
+
+> **Unverified.** `crates/nestweaver-daemon/src/lib.rs` declares the module as
+> `#[cfg(target_os = "macos")] pub mod launchd;`, so none of this compiles on
+> Linux: `cargo check --all-targets`, `cargo clippy` and
+> `cargo test -p nestweaver-daemon` all pass on Linux without ever type-checking
+> the `ExitTimeOut` change, and `plist_sets_exit_timeout_from_the_drain_ceiling`
+> does not appear in the Linux test list at all. Neither the code nor its test
+> has been executed anywhere yet. The change is correct by inspection only and
+> needs CI's Cold Metal (macOS) job before this section describes observed
+> behaviour.
+
+Still a hard deadline: a write running at `ExitTimeOut` is SIGKILLed by launchd.
+launchd treats `0` as infinity, but a job that can refuse to die is a wedged
+logout, so it is not used.
+
+### Docker / Compose — **partially fixed**
+
+`docker-compose.yml` previously set `stop_grace_period: 30s`, the tightest
+deadline in the repo, against a 660s drain ceiling. It is now 690s. The
+`Dockerfile` sets no `STOPSIGNAL`, so Docker's default SIGTERM is correct and
+reaches the drain. If you run the image outside the shipped compose file, set
+`--stop-timeout` / `stop_grace_period` yourself; Docker's default is **10
+seconds**.
+
+### Honest summary
+
+**The interactive case is fixed. The supervised case remains exposed until the
+graph store is crash-safe.** Widening supervisor timeouts moves the deadline out
+to where a legitimate drain usually fits; it does not make the kill safe, and a
+drain longer than the configured timeout still ends in the nw-126 crash. The
+real fix is crash safety in the store, not a larger number here.

--- a/docs/guide/daemon-shutdown.md
+++ b/docs/guide/daemon-shutdown.md
@@ -11,7 +11,9 @@ supervisor is in the picture.
   writes drain — though an individual read can stall for seconds while a write
   commits, which is pre-existing store behaviour and not caused by the drain.
 - **New writes are refused** (`UNAVAILABLE`) once shutdown starts, so the drain
-  is monotone and is guaranteed to finish. Reads are not gated.
+  is monotone and is guaranteed to finish. Reads are not gated. This covers the
+  gRPC surface; the web admin routes take the write gate but are outside this
+  guard and are invisible to the drain either way.
 - An idle daemon exits **immediately**. Nothing about this makes a normal stop
   slower.
 - If a write is still in flight when the stop grace expires, `daemon stop`

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -827,10 +827,11 @@ services:
       ]
     restart: unless-stopped
     # Must exceed the drain ceiling (NESTWEAVER_DRAIN_TIMEOUT_SECS, default
-    # 660s) or `docker compose stop` SIGKILLs the daemon mid-write. Docker
-    # enforces this deadline; the daemon cannot extend it. See
-    # docs/guide/daemon-shutdown.md.
-    stop_grace_period: 690s
+    # 660s) or `docker compose stop` SIGKILLs the daemon mid-write, and should
+    # exceed `daemon stop`'s own ceiling + 30s window so the kill never lands
+    # while the CLI is still reporting. Docker enforces this deadline; the
+    # daemon cannot extend it. See docs/guide/daemon-shutdown.md.
+    stop_grace_period: 720s
 
 volumes:
   nestweaver-data:

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -826,7 +826,11 @@ services:
         "--config", "/etc/nestweaver/instance.toml"
       ]
     restart: unless-stopped
-    stop_grace_period: 30s
+    # Must exceed the drain ceiling (NESTWEAVER_DRAIN_TIMEOUT_SECS, default
+    # 660s) or `docker compose stop` SIGKILLs the daemon mid-write. Docker
+    # enforces this deadline; the daemon cannot extend it. See
+    # docs/guide/daemon-shutdown.md.
+    stop_grace_period: 690s
 
 volumes:
   nestweaver-data:

--- a/src/main.rs
+++ b/src/main.rs
@@ -4484,7 +4484,7 @@ const FORCE_STOP_GRACE_SECS: u64 = 10;
 const STOP_WAIT_NOTICE_SECS: u64 = 60;
 
 /// What `daemon stop` prints when the grace expires with the daemon still
-/// draining — and, critically, still alive and still serving reads.
+/// draining — still alive, and, if `serving_reads`, still reachable.
 ///
 /// Kept as a function so its content is unit-testable without a live daemon:
 /// this message IS the contract change. Before it, the CLI silently escalated
@@ -4492,19 +4492,41 @@ const STOP_WAIT_NOTICE_SECS: u64 = 60;
 /// to perform (nw-126: a SIGKILLed daemon left a stale 42-byte WAL that made a
 /// live 5.6 GB database look absent). It must name what happened, that the
 /// daemon is still usable, and both explicit ways to end it.
-fn stop_still_draining_message(pid: i32, waited_secs: u64) -> String {
+///
+/// `serving_reads` is OBSERVED, not assumed — the caller re-probes the socket
+/// immediately before printing. The first version of this message asserted
+/// "still serving reads" unconditionally, which is false in the index-only
+/// drain: with `active_writes == 0 && indexing_active`, `run_shutdown_drain`
+/// breaks and BROADCASTS at the ceiling, closing every listener at 660s, while
+/// this command's grace is 690s — so at report time the daemon could have had
+/// no listeners for thirty seconds. That is exactly the overclaim class this
+/// change exists to remove, so it must not be reintroduced by the command
+/// announcing the fix.
+///
+/// The in-flight-write sentence is hedged for the same reason: in an index-only
+/// drain there is no write to be unable to abort.
+fn stop_still_draining_message(pid: i32, waited_secs: u64, serving_reads: bool) -> String {
+    let state_line = if serving_reads {
+        "It is still running and still answering on its socket — reads are still served, \
+         though they can stall for seconds while a write commits. Work that cannot be \
+         aborted (`spawn_blocking` is not cancellable) has to finish."
+    } else {
+        "It is still running but is NO LONGER answering on its socket: the drain reached \
+         its ceiling with no in-flight write and broadcast shutdown, which closes every \
+         listener, and the process is now finishing unabortable work with nothing being \
+         served. Reads are DOWN."
+    };
     format!(
         "Daemon (PID {pid}) is STILL DRAINING after {waited_secs}s and was NOT stopped.\n\
-         It is still running and still serving reads — an in-flight write cannot be \
-         aborted (`spawn_blocking` work is not cancellable), so it has to finish.\n\
+         {state_line}\n\
          Nothing was killed: the graph store is not crash-safe, and a SIGKILL here is \
          what left a stale WAL making a live database look absent (nw-126).\n\
          Options:\n  \
-           - wait: the daemon exits on its own when the write completes (no re-run needed; \
-         the SIGTERM drain is already in progress)\n  \
-           - end it now, abandoning that write: `nestweaver daemon stop --force`, or \
+           - wait: the daemon exits on its own when the work completes (no re-run needed; \
+         the SIGTERM drain is already in progress, and new writes are being refused)\n  \
+           - end it now, abandoning that work: `nestweaver daemon stop --force`, or \
          `kill -9 {pid}`\n\
-         Check the daemon log for the in-flight write count."
+         Check the daemon log for what it is waiting on."
     )
 }
 
@@ -13543,15 +13565,17 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         }
                         // Keep the operator informed during a long drain rather
                         // than showing a silent terminal for eleven minutes.
-                        // The daemon is still serving reads throughout; this
-                        // line is what makes that visible.
+                        // Says "still reachable" rather than "still serving
+                        // reads" because it is not re-probing the socket here —
+                        // the final report does, and only it makes a claim about
+                        // read service.
                         if !force
                             && waited_ms > 0
                             && waited_ms.is_multiple_of(STOP_WAIT_NOTICE_SECS * 1000)
                         {
                             eprintln!(
-                                "  still draining after {}s — the daemon is still serving \
-                                 reads; check its log for the in-flight count",
+                                "  still draining after {}s — new writes are being refused; \
+                                 check the daemon log for what it is waiting on",
                                 waited_ms / 1000
                             );
                         }
@@ -13580,7 +13604,18 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         // state the identity cross-check above exists to
                         // prevent — and strand the clients that are still being
                         // served reads while the write drains.
-                        eprintln!("{}", stop_still_draining_message(pid, grace_secs));
+                        // OBSERVE whether reads are still being served rather
+                        // than asserting it. The index-only drain broadcasts at
+                        // the ceiling, which closes every listener 30s before
+                        // this grace expires — claiming "still serving reads"
+                        // there would be the same overclaim this change removes.
+                        // A socket that refuses connections, or one now owned by
+                        // a different PID, both mean "not this daemon's reads".
+                        let serving_reads = daemon_socket_reported_pid(&socket) == Some(pid);
+                        eprintln!(
+                            "{}",
+                            stop_still_draining_message(pid, grace_secs, serving_reads)
+                        );
                         return Ok((EXIT_ERROR, None));
                     }
 
@@ -22660,7 +22695,7 @@ mod stop_grace_tests {
     /// explicit escapes are named.
     #[test]
     fn still_draining_message_reports_instead_of_claiming_a_kill() {
-        let msg = stop_still_draining_message(4242, 690);
+        let msg = stop_still_draining_message(4242, 690, true);
 
         assert!(msg.contains("4242"), "{msg}");
         assert!(msg.contains("690s"), "{msg}");
@@ -22669,9 +22704,25 @@ mod stop_grace_tests {
             "the command must not imply success it did not achieve: {msg}"
         );
         assert!(
-            msg.contains("still serving reads"),
+            msg.contains("reads are still served"),
             "the reason waiting is now acceptable is that this is not an \
              outage — the message must say so: {msg}"
+        );
+        // Transcripts (and a control run with no shutdown at all) showed reads
+        // stalling for seconds around a write commit. "Reads are served" with no
+        // latency qualifier is an overclaim of exactly the kind this message
+        // exists to stop making.
+        assert!(
+            msg.contains("stall for seconds"),
+            "read service during a drain is not latency-free and the message \
+             must not imply it is: {msg}"
+        );
+        // The advice is "wait". That is only sound if the thing being waited on
+        // cannot be pushed back up by other clients.
+        assert!(
+            msg.contains("new writes are being refused"),
+            "telling an operator to wait requires telling them the drain is \
+             monotone: {msg}"
         );
         assert!(
             msg.contains("--force"),
@@ -22691,6 +22742,56 @@ mod stop_grace_tests {
         assert!(
             !msg.contains("sending SIGKILL"),
             "this path must not kill anything: {msg}"
+        );
+    }
+
+    /// The index-only drain is the case the first version of this message got
+    /// wrong. With `active_writes == 0 && indexing_active`, `run_shutdown_drain`
+    /// breaks and BROADCASTS at the ceiling — which closes every listener at
+    /// 660s, while this command's grace runs to 690s. So there is a real window
+    /// in which the daemon is alive, unreachable, and the command was announcing
+    /// "still serving reads" about it.
+    ///
+    /// The caller re-probes the socket and passes what it observed. Both
+    /// branches are asserted here because the honest branch is the whole point:
+    /// a message that could only ever say the reassuring thing would not be
+    /// reporting, it would be guessing.
+    #[test]
+    fn still_draining_message_does_not_claim_reads_when_the_socket_is_gone() {
+        let msg = stop_still_draining_message(4242, 690, false);
+
+        assert!(
+            msg.contains("NO LONGER answering on its socket") && msg.contains("Reads are DOWN"),
+            "when the listeners are gone the message must say so plainly: {msg}"
+        );
+        assert!(
+            !msg.contains("reads are still served"),
+            "this is the overclaim the branch exists to prevent: {msg}"
+        );
+        // Still not a kill, and still names both escapes — the reporting
+        // contract does not weaken just because the news is worse.
+        assert!(msg.contains("was NOT stopped"), "{msg}");
+        assert!(
+            msg.contains("--force") && msg.contains("kill -9 4242"),
+            "{msg}"
+        );
+        assert!(
+            !msg.contains("sending SIGKILL"),
+            "this path must not kill anything: {msg}"
+        );
+        // The message must not diagnose a write that is not there. It may
+        // mention the absence of one (and does); what it must not do is assert
+        // one exists, which is what the original unconditional wording — "an
+        // in-flight write cannot be aborted ... so it has to finish" — did.
+        assert!(
+            !msg.contains("an in-flight write cannot be aborted"),
+            "an index-only drain has no in-flight write; diagnosing one would be \
+             a fabrication: {msg}"
+        );
+        assert!(
+            msg.contains("no in-flight write"),
+            "and it should say positively what it did observe, so the operator \
+             knows which drain branch they are in: {msg}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3331,24 +3331,40 @@ enum DaemonAction {
         #[arg(long, hide = true)]
         track_interactions: bool,
     },
-    /// Stop the running daemon.
+    /// Stop the running daemon, draining in-flight writes first.
     ///
-    /// Sends SIGTERM, which broadcasts shutdown IMMEDIATELY — every listener
-    /// closes at once, so read service stops right away rather than at the end
-    /// of a drain. This path does NOT run the graceful drain loop that the gRPC
-    /// Shutdown RPC uses; NESTWEAVER_DRAIN_TIMEOUT_SECS does not apply here. The
-    /// process lingers only until in-flight `spawn_blocking` writes finish,
-    /// during which it is unreachable.
+    /// Sends SIGTERM, which runs the SAME graceful drain as the gRPC Shutdown
+    /// RPC used by `daemon restart`: listeners stay UP, so reads keep being
+    /// served while writes drain (`embed`/`plan_embed` excepted — they take the
+    /// write gate). An idle daemon exits immediately.
     ///
-    /// Escalates to SIGKILL after the stop grace (NESTWEAVER_STOP_GRACE_SECS,
-    /// else NESTWEAVER_DRAIN_TIMEOUT_SECS + 30s; 690s by default), so a write
-    /// still running at that point IS killed.
+    /// Waits up to the stop grace (NESTWEAVER_STOP_GRACE_SECS, else
+    /// NESTWEAVER_DRAIN_TIMEOUT_SECS + 30s; 690s by default) for exit. If the
+    /// daemon is STILL draining then, this command does NOT kill it: it reports
+    /// what is in flight and exits non-zero, leaving the daemon serving reads.
+    /// Nothing in the process can abort a `spawn_blocking` write, and the graph
+    /// store is not crash-safe (nw-126), so abandoning one is an explicit
+    /// operator decision — `--force`, or `kill -9`.
+    ///
+    /// NOTE: under a process supervisor (systemd `TimeoutStopSec`, default 90s;
+    /// launchd `ExitTimeOut`) the supervisor's own timer still SIGKILLs
+    /// regardless of any of this. See docs/guide/daemon-shutdown.md.
     ///
     /// Refuses to signal a process that only holds the database write lock
     /// unless its /proc cmdline proves it is a daemon for this DB —
     /// `embed --local`, `index`, and `--no-daemon` runs hold the same lock.
     /// That cmdline recovery path is Linux-only.
-    Stop,
+    Stop {
+        /// Escalate to SIGKILL if the daemon has not exited shortly after
+        /// SIGTERM, abandoning any in-flight write.
+        ///
+        /// This is the known-unsafe act: a SIGKILLed daemon has left a stale
+        /// WAL that made a live 5.6 GB database look absent (nw-126). It exists
+        /// so an operator who has decided to accept that can say so explicitly,
+        /// rather than having the tool decide it for them on a timer.
+        #[arg(long)]
+        force: bool,
+    },
     /// Show daemon status.
     ///
     /// Reports one of three states: running (reachable), not running, or
@@ -4447,29 +4463,76 @@ enum InteractionCommands {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /// Safety buffer added on top of the drain ceiling so the daemon has room to
-/// flush WAL and unwind after a drain that ran to the full ceiling, before the
-/// CLI escalates to SIGKILL.
+/// flush WAL and unwind after a drain that ran to the full ceiling, before
+/// `daemon stop` gives up watching and reports.
+///
+/// Mirrored by `LAUNCHD_EXIT_TIMEOUT_BUFFER_SECS` in `nestweaver-daemon`, which
+/// derives the launchd plist's `ExitTimeOut` the same way. Unlike this one,
+/// that IS a kill deadline — launchd enforces it.
 const STOP_GRACE_BUFFER_SECS: u64 = 30;
 
-/// Resolve how long `daemon stop` waits after SIGTERM before escalating to
-/// SIGKILL.
+/// How long `daemon stop --force` waits for a clean exit before SIGKILL.
+///
+/// Deliberately short and NOT derived from the drain ceiling. `--force` is the
+/// operator saying "end it now, I accept losing the in-flight write"; making
+/// them wait the 690s default first would make the flag useless for the only
+/// case it exists to serve. Long enough that a daemon which was about to exit
+/// cleanly still gets to.
+const FORCE_STOP_GRACE_SECS: u64 = 10;
+
+/// How often `daemon stop` prints a "still draining" line while waiting.
+const STOP_WAIT_NOTICE_SECS: u64 = 60;
+
+/// What `daemon stop` prints when the grace expires with the daemon still
+/// draining — and, critically, still alive and still serving reads.
+///
+/// Kept as a function so its content is unit-testable without a live daemon:
+/// this message IS the contract change. Before it, the CLI silently escalated
+/// to SIGKILL here, performing the crash the drain ceiling deliberately refuses
+/// to perform (nw-126: a SIGKILLed daemon left a stale 42-byte WAL that made a
+/// live 5.6 GB database look absent). It must name what happened, that the
+/// daemon is still usable, and both explicit ways to end it.
+fn stop_still_draining_message(pid: i32, waited_secs: u64) -> String {
+    format!(
+        "Daemon (PID {pid}) is STILL DRAINING after {waited_secs}s and was NOT stopped.\n\
+         It is still running and still serving reads — an in-flight write cannot be \
+         aborted (`spawn_blocking` work is not cancellable), so it has to finish.\n\
+         Nothing was killed: the graph store is not crash-safe, and a SIGKILL here is \
+         what left a stale WAL making a live database look absent (nw-126).\n\
+         Options:\n  \
+           - wait: the daemon exits on its own when the write completes (no re-run needed; \
+         the SIGTERM drain is already in progress)\n  \
+           - end it now, abandoning that write: `nestweaver daemon stop --force`, or \
+         `kill -9 {pid}`\n\
+         Check the daemon log for the in-flight write count."
+    )
+}
+
+/// Resolve how long `daemon stop` waits for the daemon to exit after SIGTERM.
 ///
 /// T6.2 reconciliation: a legitimate large in-flight index can run far longer
-/// than the old fixed 60s default, so a 60s grace could SIGKILL mid-write of a
-/// non-atomic sidecar. When `NESTWEAVER_STOP_GRACE_SECS` is unset we derive the
-/// grace from the drain ceiling (plus a small buffer) so the two can't drift.
-/// An explicit `NESTWEAVER_STOP_GRACE_SECS` always wins.
+/// than the old fixed 60s default. When `NESTWEAVER_STOP_GRACE_SECS` is unset we
+/// derive the grace from the drain ceiling (plus a small buffer) so the two
+/// can't drift. An explicit `NESTWEAVER_STOP_GRACE_SECS` always wins.
 ///
-/// A1 correction to that reconciliation: this grace is now a real DEADLINE, not
-/// a guarantee that stop never kills a legitimately draining daemon. The
-/// daemon's write drain is NOT bounded by `NESTWEAVER_DRAIN_TIMEOUT_SECS` —
-/// nothing can abort a `spawn_blocking` write, so past the ceiling the daemon
-/// keeps waiting and keeps serving reads rather than claiming a shutdown it
-/// cannot perform. A write still running when this grace expires WILL be
-/// SIGKILLed. That is the intended contract for an explicit `daemon stop`: the
-/// operator asked for the daemon to go away and the escalation is what makes
-/// that true. Operators who want to wait a stuck write out instead should leave
-/// the daemon alone (reads keep working) rather than raising this value.
+/// This is NOT a kill deadline. It used to be — the CLI SIGKILLed here — and
+/// that was the defect: nothing can abort a `spawn_blocking` write, the graph
+/// store is not crash-safe, and an automatic SIGKILL performed on a timer
+/// exactly the crash declined at the drain ceiling on nw-126 evidence. When this
+/// grace expires with a write still in flight, `daemon stop` now reports (see
+/// [`stop_still_draining_message`]), leaves the daemon running and serving
+/// reads, and exits non-zero. Killing it is the operator's explicit act:
+/// `daemon stop --force` (which uses [`FORCE_STOP_GRACE_SECS`] instead of this)
+/// or `kill -9`.
+///
+/// Since SIGTERM now runs the daemon's drain with every listener still UP,
+/// waiting out this grace is no longer an outage — which is what makes
+/// "report instead of kill" a usable default rather than a hang.
+///
+/// Raising this value only lengthens how long the command watches. It has no
+/// effect on a supervisor's own stop timeout (systemd `TimeoutStopSec`, launchd
+/// `ExitTimeOut`, Docker `stop_grace_period`), which still SIGKILLs on its own
+/// schedule — see docs/guide/daemon-shutdown.md.
 ///
 /// `stop_env` / `drain_env` are the raw env-var strings (passed in so this is
 /// unit-testable without touching process env).
@@ -13282,7 +13345,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     Ok((EXIT_SUCCESS, None))
                 }
 
-                DaemonAction::Stop => {
+                DaemonAction::Stop { force } => {
                     // Try launchd first on macOS — but do NOT declare success
                     // yet: a detached auto-spawned daemon may still be serving
                     // this DB outside launchd's control (e.g. a stale launchd
@@ -13441,27 +13504,33 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         libc::kill(pid, libc::SIGTERM);
                     }
 
-                    // Poll for graceful exit. The daemon drains in-flight index
-                    // writes before exiting (a `spawn_blocking` write cannot be
-                    // aborted), which can take longer than a couple of seconds for
-                    // a large repo — so the grace window must exceed the max write
-                    // duration or `daemon stop` would SIGKILL mid-write. By
-                    // default we derive the grace from NESTWEAVER_DRAIN_TIMEOUT_SECS
-                    // (default 660s) rather than a fixed 60s that a real index
-                    // blows past. Override with NESTWEAVER_STOP_GRACE_SECS.
+                    // How long to wait for a clean exit before giving up.
                     //
-                    // A1: this is a deadline, not a promise. The daemon's write
-                    // drain is deliberately unbounded (a spawn_blocking write
-                    // cannot be aborted), so a write still running when the grace
-                    // expires IS SIGKILLed — see resolve_stop_grace_secs.
-                    let grace_secs = resolve_stop_grace_secs(
-                        std::env::var("NESTWEAVER_STOP_GRACE_SECS").ok().as_deref(),
-                        std::env::var("NESTWEAVER_DRAIN_TIMEOUT_SECS")
-                            .ok()
-                            .as_deref(),
-                    );
+                    // SIGTERM now runs the daemon's graceful drain with every
+                    // listener still UP, so waiting here is not an outage: the
+                    // daemon keeps serving reads for the whole window. The
+                    // window still tracks the drain ceiling by default so the
+                    // two cannot drift — see resolve_stop_grace_secs.
+                    //
+                    // `--force` is the operator saying "end it now, I accept
+                    // losing the in-flight write". It still SIGTERMs first and
+                    // still prefers a clean exit, but only briefly: waiting the
+                    // full 690s would make the flag useless for the case it
+                    // exists to serve.
+                    let grace_secs = if force {
+                        FORCE_STOP_GRACE_SECS
+                    } else {
+                        resolve_stop_grace_secs(
+                            std::env::var("NESTWEAVER_STOP_GRACE_SECS").ok().as_deref(),
+                            std::env::var("NESTWEAVER_DRAIN_TIMEOUT_SECS")
+                                .ok()
+                                .as_deref(),
+                        )
+                    };
+                    let mut waited_ms: u64 = 0;
                     for _ in 0..(grace_secs * 10) {
                         std::thread::sleep(std::time::Duration::from_millis(100));
+                        waited_ms += 100;
                         if unsafe { libc::kill(pid, 0) } != 0 {
                             eprintln!("Daemon stopped.");
                             report_runtime_cleanup(&remove_unowned_daemon_runtime(
@@ -13472,11 +13541,56 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             ));
                             return Ok((EXIT_SUCCESS, None));
                         }
+                        // Keep the operator informed during a long drain rather
+                        // than showing a silent terminal for eleven minutes.
+                        // The daemon is still serving reads throughout; this
+                        // line is what makes that visible.
+                        if !force
+                            && waited_ms > 0
+                            && waited_ms.is_multiple_of(STOP_WAIT_NOTICE_SECS * 1000)
+                        {
+                            eprintln!(
+                                "  still draining after {}s — the daemon is still serving \
+                                 reads; check its log for the in-flight count",
+                                waited_ms / 1000
+                            );
+                        }
                     }
 
-                    // Force kill only after the full grace window elapses — the
-                    // daemon was still draining and did not exit in time.
-                    eprintln!("Daemon did not exit within {grace_secs}s; sending SIGKILL...");
+                    if !force {
+                        // The defect this replaced: an automatic SIGKILL here.
+                        //
+                        // That escalation performed, on a timer, exactly the act
+                        // investigated and DECLINED at the drain ceiling — a
+                        // SIGKILLed daemon left a stale 42-byte WAL that made a
+                        // live 5.6 GB database look absent (nw-126). The graph
+                        // store is not crash-safe, so the tool must not choose
+                        // that for the operator. It reports and stands down; the
+                        // daemon stays up and keeps serving reads.
+                        //
+                        // Non-zero exit: the operator asked for the daemon to
+                        // stop and it has not stopped. Reporting success here
+                        // would be the same class of overclaim.
+                        //
+                        // DELIBERATELY no `remove_unowned_daemon_runtime` here.
+                        // Every other exit from this arm runs it because the
+                        // daemon is gone; on this path it is ALIVE and still
+                        // owns its pidfile, socket and config binding. Sweeping
+                        // them would delete a live daemon's socket — the exact
+                        // state the identity cross-check above exists to
+                        // prevent — and strand the clients that are still being
+                        // served reads while the write drains.
+                        eprintln!("{}", stop_still_draining_message(pid, grace_secs));
+                        return Ok((EXIT_ERROR, None));
+                    }
+
+                    // --force only. The operator asked for this explicitly.
+                    eprintln!(
+                        "Daemon did not exit within {grace_secs}s; --force given, sending \
+                         SIGKILL. Any in-flight write is abandoned — if the database looks \
+                         empty or absent afterwards, that is nw-126 (stale WAL), not data \
+                         loss."
+                    );
                     unsafe {
                         libc::kill(pid, libc::SIGKILL);
                     }
@@ -22535,6 +22649,80 @@ mod server_status_tests {
 #[cfg(test)]
 mod stop_grace_tests {
     use super::*;
+
+    /// The contract change, stated as a test on the message that carries it.
+    ///
+    /// `daemon stop` used to SIGKILL here. That escalation performed on a timer
+    /// exactly the act declined at the drain ceiling on nw-126 evidence — a
+    /// SIGKILLed daemon left a stale WAL that made a live database look absent.
+    /// The command now reports and stands down, so the message has to carry the
+    /// whole truth: nothing was killed, the daemon is still usable, and both
+    /// explicit escapes are named.
+    #[test]
+    fn still_draining_message_reports_instead_of_claiming_a_kill() {
+        let msg = stop_still_draining_message(4242, 690);
+
+        assert!(msg.contains("4242"), "{msg}");
+        assert!(msg.contains("690s"), "{msg}");
+        assert!(
+            msg.contains("was NOT stopped"),
+            "the command must not imply success it did not achieve: {msg}"
+        );
+        assert!(
+            msg.contains("still serving reads"),
+            "the reason waiting is now acceptable is that this is not an \
+             outage — the message must say so: {msg}"
+        );
+        assert!(
+            msg.contains("--force"),
+            "the supported explicit escape must be named: {msg}"
+        );
+        assert!(
+            msg.contains("kill -9 4242"),
+            "the escape hatch the daemon log already names must be repeated \
+             here, with the pid filled in: {msg}"
+        );
+        assert!(
+            msg.contains("nw-126"),
+            "the reason nothing was killed must be traceable: {msg}"
+        );
+        // The failure mode this replaced. If any future edit reintroduces an
+        // automatic kill, this message would have to change with it.
+        assert!(
+            !msg.contains("sending SIGKILL"),
+            "this path must not kill anything: {msg}"
+        );
+    }
+
+    /// `--force` must not inherit the 690s default. An operator reaching for it
+    /// has already accepted losing the in-flight write; making them wait eleven
+    /// minutes first would make the flag useless for its only purpose.
+    #[test]
+    fn force_grace_is_short_and_independent_of_the_drain_ceiling() {
+        // Both bounds are on a constant, so they are asserted at compile time —
+        // clippy::assertions_on_constants would otherwise reject a runtime
+        // `assert!` here, and a const block is the stronger form anyway: a
+        // future edit that widened `FORCE_STOP_GRACE_SECS` would fail to build
+        // rather than fail a test someone could ignore.
+        const {
+            assert!(
+                FORCE_STOP_GRACE_SECS < 60,
+                "--force must terminate promptly"
+            )
+        };
+        const {
+            assert!(
+                FORCE_STOP_GRACE_SECS > 0,
+                "a daemon that was about to exit cleanly should still get to"
+            )
+        };
+        // This one is genuinely runtime: `resolve_stop_grace_secs` reads the
+        // default drain ceiling, so the relationship it pins cannot be a const.
+        assert!(
+            FORCE_STOP_GRACE_SECS < resolve_stop_grace_secs(None, None),
+            "--force must be strictly faster than the patient path"
+        );
+    }
 
     /// An explicit `NESTWEAVER_STOP_GRACE_SECS` always wins, regardless of the
     /// drain ceiling — operators keep a hard override.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4466,9 +4466,15 @@ enum InteractionCommands {
 /// flush WAL and unwind after a drain that ran to the full ceiling, before
 /// `daemon stop` gives up watching and reports.
 ///
-/// Mirrored by `LAUNCHD_EXIT_TIMEOUT_BUFFER_SECS` in `nestweaver-daemon`, which
-/// derives the launchd plist's `ExitTimeOut` the same way. Unlike this one,
-/// that IS a kill deadline — launchd enforces it.
+/// DELIBERATELY SMALLER than `LAUNCHD_EXIT_TIMEOUT_BUFFER_SECS` (60) in
+/// `nestweaver-daemon`, which derives the launchd plist's `ExitTimeOut` from the
+/// same drain ceiling. The two used to be equal, and that was a defect: both
+/// deadlines landed at the same instant, so this command could print "still
+/// running and still serving reads" about a process launchd had just SIGKILLed.
+/// The gap is the point — this side must give up watching STRICTLY BEFORE the
+/// supervisor kills. Unlike this one, launchd's IS a kill deadline, and it
+/// enforces it. Docker's `stop_grace_period` (720s) is set with the same
+/// ordering in mind.
 const STOP_GRACE_BUFFER_SECS: u64 = 30;
 
 /// How long `daemon stop --force` waits for a clean exit before SIGKILL.
@@ -4503,18 +4509,28 @@ const STOP_WAIT_NOTICE_SECS: u64 = 60;
 /// change exists to remove, so it must not be reintroduced by the command
 /// announcing the fix.
 ///
-/// The in-flight-write sentence is hedged for the same reason: in an index-only
-/// drain there is no write to be unable to abort.
+/// THE NEGATIVE BRANCH REPORTS THE OBSERVATION, NOT A CAUSE. All the caller
+/// knows is that one `connect()` did not answer. The index-only ceiling
+/// broadcast is the *likely* explanation and is named as such, but it is not
+/// the only one: ECONNREFUSED while the process is mid-exit, `EMFILE`/`ENFILE`
+/// in this CLI process, a socket already swept by `daemon gc`, or a full listen
+/// backlog all produce the same failed connect — including 690s into a WRITE
+/// drain, where "no in-flight write" would be flatly false. Stating a
+/// fabricated diagnosis confidently is the same defect as the overclaim this
+/// branch exists to fix, merely inverted, so the wording stays hedged and the
+/// write-specific sentence is omitted rather than negated.
 fn stop_still_draining_message(pid: i32, waited_secs: u64, serving_reads: bool) -> String {
     let state_line = if serving_reads {
         "It is still running and still answering on its socket — reads are still served, \
          though they can stall for seconds while a write commits. Work that cannot be \
          aborted (`spawn_blocking` is not cancellable) has to finish."
     } else {
-        "It is still running but is NO LONGER answering on its socket: the drain reached \
-         its ceiling with no in-flight write and broadcast shutdown, which closes every \
-         listener, and the process is now finishing unabortable work with nothing being \
-         served. Reads are DOWN."
+        "It is still running, but its socket did not answer just now, so reads may be \
+         DOWN. The likeliest cause is the index-only drain: with nothing in the write \
+         queue the daemon broadcasts at the drain ceiling, which closes every listener \
+         while the process keeps finishing unabortable work. This probe cannot tell that \
+         apart from a socket already cleaned up, a refused connection during exit, or a \
+         local file-descriptor limit — check the daemon log before concluding."
     };
     format!(
         "Daemon (PID {pid}) is STILL DRAINING after {waited_secs}s and was NOT stopped.\n\
@@ -13604,13 +13620,38 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         // state the identity cross-check above exists to
                         // prevent — and strand the clients that are still being
                         // served reads while the write drains.
-                        // OBSERVE whether reads are still being served rather
-                        // than asserting it. The index-only drain broadcasts at
-                        // the ceiling, which closes every listener 30s before
-                        // this grace expires — claiming "still serving reads"
-                        // there would be the same overclaim this change removes.
-                        // A socket that refuses connections, or one now owned by
-                        // a different PID, both mean "not this daemon's reads".
+                        // LIVENESS RE-CHECK before claiming anything. Up to
+                        // 100ms passed since the wait loop's last probe, and a
+                        // daemon that finished draining inside that window
+                        // stopped exactly as asked. Without this the socket
+                        // probe below would find nothing listening and the CLI
+                        // would announce "STILL DRAINING … Reads are DOWN" about
+                        // a clean stop, return EXIT_ERROR, and — because this
+                        // arm deliberately skips the runtime sweep — strand the
+                        // dead daemon's pidfile and socket. Reporting a success
+                        // as the most alarming failure available is the same
+                        // overclaim class, pointing the other way.
+                        if unsafe { libc::kill(pid, 0) } != 0 {
+                            eprintln!("Daemon stopped.");
+                            report_runtime_cleanup(&remove_unowned_daemon_runtime(
+                                &db_path,
+                                &pidfile,
+                                &socket,
+                                &nestweaver_daemon::effective_config_binding_path(&instance_id),
+                            ));
+                            return Ok((EXIT_SUCCESS, None));
+                        }
+
+                        // OBSERVE whether the socket answers; do NOT infer why.
+                        // The index-only drain broadcasts at the ceiling, which
+                        // closes every listener 30s before this grace expires,
+                        // so "still serving reads" cannot be asserted — but a
+                        // failed connect does not prove that particular cause
+                        // either (ECONNREFUSED mid-exit, EMFILE in this process,
+                        // a socket swept by `daemon gc`, a full listen backlog).
+                        // The message therefore reports the observation and
+                        // hedges the cause. A socket owned by a different PID is
+                        // likewise not this daemon's read service.
                         let serving_reads = daemon_socket_reported_pid(&socket) == Some(pid);
                         eprintln!(
                             "{}",
@@ -22756,17 +22797,42 @@ mod stop_grace_tests {
     /// branches are asserted here because the honest branch is the whole point:
     /// a message that could only ever say the reassuring thing would not be
     /// reporting, it would be guessing.
+    ///
+    /// It must not overcorrect either. A failed `connect()` is one observation
+    /// with several possible causes, so this test pins that the message reports
+    /// the observation and HEDGES the cause. An earlier version asserted the
+    /// fixed string "no in-flight write", which locked in a diagnosis the probe
+    /// cannot support — the branch's own defect class, inverted.
     #[test]
     fn still_draining_message_does_not_claim_reads_when_the_socket_is_gone() {
         let msg = stop_still_draining_message(4242, 690, false);
 
         assert!(
-            msg.contains("NO LONGER answering on its socket") && msg.contains("Reads are DOWN"),
-            "when the listeners are gone the message must say so plainly: {msg}"
+            msg.contains("socket did not answer"),
+            "the message must report what was actually observed — one failed \
+             connect: {msg}"
+        );
+        assert!(
+            msg.contains("reads may be") && msg.contains("DOWN"),
+            "and must not leave the operator thinking read service is fine: {msg}"
         );
         assert!(
             !msg.contains("reads are still served"),
             "this is the overclaim the branch exists to prevent: {msg}"
+        );
+        // The hedge is the point. A single failed connect is also produced by
+        // ECONNREFUSED mid-exit, EMFILE in this process, a socket swept by
+        // `daemon gc`, or a full backlog — including during a WRITE drain,
+        // where a confident "no in-flight write" would be flatly wrong.
+        assert!(
+            msg.contains("likeliest cause") && msg.contains("cannot tell that apart"),
+            "the message must present the index-only drain as the likely cause, \
+             not as an established fact: {msg}"
+        );
+        assert!(
+            !msg.contains("no in-flight write"),
+            "the probe cannot observe whether a write is in flight, so it must \
+             not state it either way: {msg}"
         );
         // Still not a kill, and still names both escapes — the reporting
         // contract does not weaken just because the news is worse.
@@ -22779,19 +22845,13 @@ mod stop_grace_tests {
             !msg.contains("sending SIGKILL"),
             "this path must not kill anything: {msg}"
         );
-        // The message must not diagnose a write that is not there. It may
-        // mention the absence of one (and does); what it must not do is assert
-        // one exists, which is what the original unconditional wording — "an
-        // in-flight write cannot be aborted ... so it has to finish" — did.
+        // The message must not diagnose a write it cannot see. The original
+        // unconditional wording — "an in-flight write cannot be aborted ... so
+        // it has to finish" — asserted one exists on every path.
         assert!(
             !msg.contains("an in-flight write cannot be aborted"),
-            "an index-only drain has no in-flight write; diagnosing one would be \
-             a fabrication: {msg}"
-        );
-        assert!(
-            msg.contains("no in-flight write"),
-            "and it should say positively what it did observe, so the operator \
-             knows which drain branch they are in: {msg}"
+            "this branch cannot know whether a write is in flight; diagnosing \
+             one would be a fabrication: {msg}"
         );
     }
 


### PR DESCRIPTION
`daemon stop` and SIGTERM now drain with listeners up: reads keep working through
a shutdown, and nothing SIGKILLs on a timer. Both routes enter through a single
`begin_shutdown_drain(state, trigger)`.

**Three adversarial review rounds.** The first found the change *did not
terminate*, and the record is worth keeping because the gap was in the
specification, not the implementation: "drain with listeners up" requires "refuse
new writes once shutdown starts", and only the first half was ever specified.

## What review caught, and how it was closed

**The drain admitted new writes.** `shutdown_started` had exactly one reader; no
RPC handler consulted it. Because listeners stay up by design, a client could
start a fresh write mid-drain and reset the exit condition — proven with a
`nestweaver index` accepted and committed **eight minutes into a drain**.
Combined with the SIGTERM defect below, that left `kill -9` as the only exit: the
nw-126 crash this change exists to prevent, made *more* likely on a busy daemon.

`ConnectionGuard::write` now returns `Result<Self, Status>` and refuses with
`UNAVAILABLE` **before** incrementing. 16 call sites take `?`.

**SIGTERM was swallowed after the first.** The handler `recv()`d once and
returned, dropping the `Signal` while Tokio's process-wide handler stayed
installed — later SIGTERMs were neither delivered nor allowed to
default-terminate. Three signals produced one log line and a live daemon. Now
`while sig.recv().await.is_some()`.

Also fixed: `stop_still_draining_message` claimed "still serving reads"
unconditionally, false in the index-only drain; `read_write` was hardcoded `true`
at daemon startup; and a second undisclosed SIGTERM→2s→SIGKILL site at
`lifecycle.rs stop_legacy_hash_daemon` made "nothing escalates automatically" an
overclaim.

## The refusal had to be hoisted above the write gate

Otherwise a refused call still blocked on `write_gate.lock()` first. Structure
alone cannot demonstrate that, so it was mutation-checked by timing:

| ordering | `prune-stale` during a drain |
| --- | --- |
| lock first | **95.49s** |
| guard first | **0.04s** |

Nine production sites now guard before locking. Two lock-first sites remain and
are correct: `plan_embed` takes a `ConnectionGuard::read` and is legitimately
*blocked* rather than refused, and one is a test fixture.

## The most valuable finding is unrelated to the change

The macOS launch agent set **no `ExitTimeOut`**, so launchd applied its 20-second
default against a 660-second drain ceiling — SIGKILLing the daemon 20 seconds
into a drain, on every Mac, today. `NESTWEAVER_DRAIN_TIMEOUT_SECS` is now baked
into the plist so the two cannot diverge.

**This is `#[cfg(target_os = "macos")]` and has never been compiled, type-checked
or run anywhere**, including its tests. Cold Metal is the only job that can
verify it, and it is the main reason this PR is open.

## Verification

Linux: fmt clean, clippy clean, `nestweaver-daemon` 238 passed, `--bin
nestweaver` 157 passed. Full workspace gate run by the integrator.

Two test defects were caught by the implementer before review: one used a
non-existent repo path that `watch_code` rejects long before the guard (it would
have passed for the wrong reason), and one asserted that a refused `--force`
leaves the incumbent watcher running — it should not, since `begin_shutdown_drain`
legitimately stops it. The real property is that a refused call must not
*repopulate* the slot.

## BREAKING CHANGE

Write RPCs return `UNAVAILABLE` once a shutdown drain has started, instead of
being accepted. `daemon stop` may take up to the drain ceiling (default 21
minutes) rather than returning promptly, and no longer escalates to SIGKILL on a
timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UXMKySLGmPZiQJqaQqhZp
