### PR TITLE
docs(test): make per-crate test runs cover what a workspace run covers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,34 @@
 cargo build                                                 # build all crates
 cargo build --release                                       # release binary
 cargo test                                                  # run all tests
-cargo test -p nestweaver-schema                             # test one crate
+just test-crate nestweaver-schema                           # test one crate — NOT `cargo test -p`
 cargo clippy --workspace --all-targets -- -D warnings       # lint (zero warnings)
 cargo fmt --all -- --check                                  # format check
 cargo fmt --all                                             # format in place
 ```
+
+**Use `just test-crate`, never a bare `cargo test -p <crate>`.** `-p` resolves
+features for that package alone, while a workspace run unifies them across
+dependents. Affected crates therefore run **fewer tests under `-p` and still
+report `ok`**. Measured on `5e9e0f0`, bare `-p` / `--all-features` / `--workspace`:
+
+| crate | `-p` | `--all-features` | `--workspace` |
+| --- | --- | --- | --- |
+| `nestweaver-daemon` | 238 | 264 | 264 |
+| `nestweaver-mcp` | 154 | 180 | 180 |
+
+The recipe uses `--all-features`, not a per-crate feature list, because every
+feature unification can activate on a package is one of that package's own
+features — so `--all-features` is provably a superset and can never cover less.
+Guessing the list is unreliable: `--features embed` looks right and leaves
+`nestweaver-mcp` at 154, since what it actually needs is `daemon`.
+
+Two packages are exempt and run plain: `nestweaver-embed` and the root
+`nestweaver`, whose `metal` feature pulls `objc2` and does not compile on Linux.
+
+Switching between `-p` and `--workspace` also re-resolves features, which
+re-fingerprints the build and forces a full `lbug` C++ rebuild. Pick one shape
+per working tree and keep it.
 
 A clean clone links with no extra linker flags. Only one copy of zstd is in the
 binary: `liblbug.a` vendors it, and Rust code reaches that copy through

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,9 @@ cargo build
 # Install pre-commit hooks (requires pre-commit and Node.js for commitlint)
 pre-commit install
 pre-commit install --hook-type commit-msg
+
+# Task runner used by the recipes below (see `just --list`)
+cargo install just
 ```
 
 Keep `.cargo/config.toml` in place. It forces the Ladybug dependency to build
@@ -121,11 +124,11 @@ cargo fmt --all -- --check                                  # formatting
 ### Useful commands
 
 ```sh
-# Run tests for a single crate
-cargo test -p nestweaver-parser
+# Run tests for a single crate — use the recipe, not bare `cargo test -p`
+just test-crate nestweaver-parser
 
-# Run a specific test
-cargo test -p nestweaver-store -- ranking::tests::pagerank
+# Run a specific test (keep --all-features — see below)
+cargo test -p nestweaver-store --all-features -- ranking::tests::pagerank
 
 # Build release binary
 cargo build --release
@@ -143,6 +146,40 @@ nestweaver list-links --config ./nestweaver-instance.toml
 nestweaver list-features --config ./nestweaver-instance.toml
 nestweaver context --feature <name> --config ./nestweaver-instance.toml --db ./all.lbug
 ```
+
+#### Why `just test-crate` and not `cargo test -p`
+
+A bare `cargo test -p <crate>` resolves features for that package alone, while a
+workspace run unifies them across every dependent. The result is a per-crate run
+that covers less than you assume and still prints `ok`. Measured on `5e9e0f0`:
+
+| crate | `cargo test -p` | `-p --all-features` | `cargo test --workspace` |
+| --- | --- | --- | --- |
+| `nestweaver-daemon` | 238 | **264** | **264** |
+| `nestweaver-mcp` | 154 | **180** | **180** |
+
+This cost two implementers and a reviewer real time during PR #245, each briefly
+treating the gap as a discrepancy in the suite rather than a feature-set
+difference.
+
+`just test-crate` passes `--all-features`. That is deliberate, and not the same
+as naming the features by hand: every feature unification can activate on a
+package is one of that package's own features, so `--all-features` is provably a
+**superset** of the unified set and can never cover less. Hand-maintained lists
+are guesswork — `--features embed` is the obvious guess and leaves
+`nestweaver-mcp` at 154, because what it actually needs is `daemon`
+(`nestweaver-daemon` depends on it as `features = ["daemon"]`).
+
+Two packages are exempt and run plain: `nestweaver-embed` and the root
+`nestweaver`. Both reach `metal = ["candle-core/metal", …]`, which pulls `objc2`
+and fails to compile on Linux.
+
+Without `just` installed, the equivalent is `cargo test -p <crate>
+--all-features` for any crate other than those two.
+
+One consequence worth expecting either way: switching a working tree between
+`-p` and `--workspace` re-resolves features, which re-fingerprints the build and
+forces a full `lbug` C++ rebuild. Pick one shape per tree and stay with it.
 
 ### Code conventions
 

--- a/justfile
+++ b/justfile
@@ -14,9 +14,38 @@ release:
 test:
     cargo test
 
-# Test a specific crate
+# Packages where `--all-features` does not build off macOS. `nestweaver-embed`
+# has `metal = ["candle-core/metal", ...]`, which pulls `objc2` and fails to
+# compile on Linux (measured on 5e9e0f0). The root `nestweaver` package forwards
+# the same feature via `metal = ["nestweaver-embed?/metal"]`, so it inherits the
+# hazard. These fall back to a plain per-crate run.
+no_all_features := "nestweaver nestweaver-embed"
+
+# Why `--all-features` rather than a hand-maintained per-crate feature list:
+# every feature a workspace run can activate on a package is, by definition, one
+# of that package's own features — so `--all-features` is always a SUPERSET of
+# the unified set and can never silently cover less. A hand-maintained list can,
+# and did: `--features embed` alone leaves `nestweaver-mcp` at 154 tests, because
+# what it actually needs is `daemon` (nestweaver-daemon depends on it as
+# `features = ["daemon"]`).
+#
+# Measured on 5e9e0f0 — bare `-p` / `--all-features` / `--workspace`:
+#   nestweaver-daemon   238 / 264 / 264
+#   nestweaver-mcp      154 / 180 / 180
+#
+# Keep the line below as the only comment directly above the recipe: `just
+# --list` uses the immediately-preceding comment as its description.
+
+# Test one crate with the features a workspace run would activate
 test-crate crate:
-    cargo test -p {{crate}}
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ " {{no_all_features}} " == *" {{crate}} "* ]]; then
+        echo "note: {{crate}} cannot take --all-features off macOS (metal/objc2) — running plain" >&2
+        cargo test -p {{crate}}
+    else
+        cargo test -p {{crate}} --all-features
+    fi
 
 # Lint with clippy (zero warnings)
 lint:


### PR DESCRIPTION
Closes the backlog item *`cargo test -p <crate>` silently drops feature-gated tests*.

`cargo test -p <crate>` resolves features for that package alone; a workspace run
unifies them across dependents. Affected crates run fewer tests **and still
report `ok`** — the same shape as the `0 passed; N filtered out` trap. This cost
two implementers and a reviewer real time during PR #245.

Measured on `5e9e0f0`:

| crate | `cargo test -p` | `-p --all-features` | `--workspace` |
| --- | --- | --- | --- |
| `nestweaver-daemon` | 238 | **264** | **264** |
| `nestweaver-mcp` | 154 | **180** | **180** |

## Why `--all-features` and not a per-crate feature list

I wrote the hand-maintained list first and it was wrong. `--features embed` is
the obvious guess — it gives daemon exact parity — and it leaves `nestweaver-mcp`
at **154**, unchanged from bare `-p`, because what mcp actually needs is
`daemon` (`nestweaver-daemon` depends on it as `features = ["daemon"]`).

`--all-features` is correct by construction instead of by maintenance: every
feature unification can activate on a package is one of that package's own
features, so it is always a **superset** of the unified set and can never
silently cover less.

Two packages are exempt and run plain — `nestweaver-embed` and the root
`nestweaver`, which reach `metal = ["candle-core/metal", …]`. That is measured,
not assumed: `cargo check -p nestweaver-embed --all-features` fails compiling
`objc2` on Linux.

## Verification

Both recipe branches were run end to end, not just parsed:

- exempt path — `just test-crate nestweaver-embed` prints the note, runs plain,
  22 passed. Without the exemption this is the invocation that fails on `objc2`.
- `--all-features` path — `just test-crate nestweaver-mcp` → **180 passed**,
  matching the workspace count exactly.

`just --list` output was also checked: an earlier revision buried the recipe
description under a comment block, since `just` takes the immediately-preceding
comment as the doc string.

Docs-only; `cargo fmt --all --check` clean. Also adds `cargo install just` to
Setup — the recipes needed it and no prerequisite mentioned it.