### PR TITLE
fix(cli): forward every brain status warning to text output

### DIFF
--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -5475,11 +5475,24 @@ fn tool_brain_status(
         })
         .collect();
 
+    // nw-C2: index-publication state, read ONCE from the store's own path
+    // and shared between the warnings builder and the `index_publication`
+    // block below, so the two can never disagree about which database they
+    // describe (thread-local vs store path) or race a marker cleared between
+    // two reads. Unlike the Wave A write-path fields (`write_queue_depth`,
+    // `write_holder`, the embedding `pass_*` set), which come from the daemon
+    // and are therefore absent on the direct `--no-daemon` and MCP-over-HTTP
+    // payloads, this is derived from the marker FILE and so populates with no
+    // daemon running. The user who reported the wedge was on exactly that
+    // direct path.
+    let publication_status = store
+        .db_path()
+        .map(nestweaver_engine::index_publication::status);
     // Structured warnings (duplicate-root collisions, wedged index
-    // publication) come from the shared helper so the CLI's direct
+    // publication) come from the shared builder so the CLI's direct
     // (`--no-daemon`) path forwards the SAME array instead of re-deriving a
     // subset locally.
-    let warnings = brain_status_warnings(store, db_path.as_deref());
+    let warnings = brain_status_warnings_for(store, store.db_path(), publication_status.as_ref());
     let repos_json: Vec<Value> = repos
         .iter()
         .map(|r| json!({ "url": r.url, "sha": r.indexed_sha }))
@@ -5553,28 +5566,21 @@ fn tool_brain_status(
         db_path.as_deref().map(cache_stats).unwrap_or((0, 0, None));
     let cache_hit_rate_pct = cache_hit_rate.map(|r| (r * 100.0).round() as u64);
 
-    // nw-C2: index-publication state. Unlike the Wave A write-path fields
-    // (`write_queue_depth`, `write_holder`, the embedding `pass_*` set), which
-    // come from the daemon and are therefore absent on the direct
-    // `--no-daemon` and MCP-over-HTTP payloads, this is derived from the marker
-    // FILE and so populates with no daemon running. The user who reported the
-    // wedge was on exactly that direct path. The matching
-    // `index_publication_wedged` warning is pushed by `brain_status_warnings`.
-    let index_publication = store
-        .db_path()
-        .map(nestweaver_engine::index_publication::status)
-        .map(|status| {
-            json!({
-                "dirty": status.dirty,
-                "determinable": status.determinable,
-                "marker_age_s": status.marker_age_s,
-                "writer_pid": status.writer_pid,
-                "writer_alive": status.writer_alive,
-                "writer_reason": status.writer_reason,
-                "wedged": status.is_wedged(),
-                "marker_path": status.marker_path,
-            })
-        });
+    // The `index_publication` payload reuses the single status read taken
+    // above; the matching `index_publication_wedged` warning is pushed by
+    // `brain_status_warnings_for` from that same read.
+    let index_publication = publication_status.as_ref().map(|status| {
+        json!({
+            "dirty": status.dirty,
+            "determinable": status.determinable,
+            "marker_age_s": status.marker_age_s,
+            "writer_pid": status.writer_pid,
+            "writer_alive": status.writer_alive,
+            "writer_reason": status.writer_reason,
+            "wedged": status.is_wedged(),
+            "marker_path": status.marker_path,
+        })
+    });
 
     Ok(json!({
         "vaults": vaults_json,
@@ -5623,6 +5629,20 @@ fn tool_brain_status(
 /// a wedged publication at all. Every entry carries a `kind` so renderers
 /// can special-case a shape and still forward the rest generically.
 pub fn brain_status_warnings(store: &GraphStore, db_path: Option<&std::path::Path>) -> Vec<Value> {
+    let db_path = db_path.or_else(|| store.db_path());
+    let publication = db_path.map(nestweaver_engine::index_publication::status);
+    brain_status_warnings_for(store, db_path, publication.as_ref())
+}
+
+/// Core of [`brain_status_warnings`] with the index-publication status
+/// already read, so `tool_brain_status` can share ONE marker read — against
+/// ONE db path — between the wedge warning and its `index_publication`
+/// block. `db_path` and `publication` must describe the same database.
+fn brain_status_warnings_for(
+    store: &GraphStore,
+    db_path: Option<&std::path::Path>,
+    publication: Option<&nestweaver_engine::index_publication::IndexPublicationStatus>,
+) -> Vec<Value> {
     // Detect duplicate-root collisions. The CLI's local (non-daemon) path
     // emits these warnings to stderr; forward them through the JSON-RPC
     // response so daemon-routed callers and `--json` consumers see the
@@ -5711,23 +5731,21 @@ pub fn brain_status_warnings(store: &GraphStore, db_path: Option<&std::path::Pat
     // this populates with no daemon running — the user who reported the
     // wedge was on exactly that direct path. `kind` makes the entry
     // addressable for renderers that special-case warning shapes.
-    let publication_db_path = db_path.or_else(|| store.db_path());
-    if let Some(p) = publication_db_path {
-        let status = nestweaver_engine::index_publication::status(p);
-        if status.is_wedged() {
-            warnings.push(json!({
-                "kind": "index_publication_wedged",
-                "warning": if status.determinable {
-                    "index publication is wedged: ranked queries (brain_context, \
-                     project_context, investigate) fail closed until it is reconciled. \
-                     This is an index PUBLICATION marker, not a dirty git working tree."
-                } else {
-                    "index publication marker state cannot be determined (permissions or \
-                     I/O error on the sidecar directory); ranked queries fail closed."
-                },
-                "action": status.repair_command_for(p),
-            }));
-        }
+    if let (Some(p), Some(status)) = (db_path, publication)
+        && status.is_wedged()
+    {
+        warnings.push(json!({
+            "kind": "index_publication_wedged",
+            "warning": if status.determinable {
+                "index publication is wedged: ranked queries (brain_context, \
+                 project_context, investigate) fail closed until it is reconciled. \
+                 This is an index PUBLICATION marker, not a dirty git working tree."
+            } else {
+                "index publication marker state cannot be determined (permissions or \
+                 I/O error on the sidecar directory); ranked queries fail closed."
+            },
+            "action": status.repair_command_for(p),
+        }));
     }
 
     warnings

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -5475,91 +5475,11 @@ fn tool_brain_status(
         })
         .collect();
 
-    // Detect duplicate-root collisions. The CLI's local (non-daemon) path
-    // emits these warnings to stderr; forward them through the JSON-RPC
-    // response so daemon-routed callers and `--json` consumers see the
-    // same diagnostic.
-    let mut root_to_rows: std::collections::HashMap<&str, Vec<&nestweaver_schema::Vault>> =
-        std::collections::HashMap::new();
-    for v in &vaults {
-        root_to_rows
-            .entry(v.root_path.as_str())
-            .or_default()
-            .push(v);
-    }
-    let mut warnings: Vec<Value> = root_to_rows
-        .iter()
-        .filter(|(_, rows)| rows.len() > 1)
-        .map(|(root, rows)| {
-            // Pair each row with its note count so we can both render the
-            // entries and pick the keeper for the remediation hint.
-            let rows_with_counts: Vec<(&&nestweaver_schema::Vault, usize)> = rows
-                .iter()
-                .map(|v| {
-                    (
-                        v,
-                        store.list_notes(Some(&v.uid)).unwrap_or_default().len(),
-                    )
-                })
-                .collect();
-            let entries: Vec<Value> = rows_with_counts
-                .iter()
-                .map(|(v, n)| {
-                    json!({
-                        "uid": v.uid,
-                        "instance_id": v.instance_id,
-                        "name": v.name,
-                        "note_count": n,
-                    })
-                })
-                .collect();
-
-            // Suggest a concrete merge command. The keeper is the row with
-            // the highest note_count (most data); ties break on the
-            // lexicographically smallest instance_id so the suggestion is
-            // deterministic. Emit one command per non-keeper row so callers
-            // collapse all ghosts into the canonical instance.
-            let keeper = rows_with_counts
-                .iter()
-                .max_by(|a, b| {
-                    a.1.cmp(&b.1)
-                        .then_with(|| b.0.instance_id.cmp(&a.0.instance_id))
-                })
-                .map(|(v, _)| v);
-            let (remediation_commands, remediation_hint) = match keeper {
-                Some(keeper_v) => {
-                    let cmds: Vec<String> = rows_with_counts
-                        .iter()
-                        .filter(|(v, _)| v.instance_id != keeper_v.instance_id)
-                        .map(|(v, _)| {
-                            format!(
-                                "nestweaver instance merge --from {} --to {}",
-                                v.instance_id, keeper_v.instance_id,
-                            )
-                        })
-                        .collect();
-                    let hint = format!(
-                        "Multiple instance_ids share this vault root. Keep '{}' (has the most data) and merge the others into it using the commands below. Take a snapshot of {} first.",
-                        keeper_v.instance_id,
-                        db_path
-                            .as_deref()
-                            .and_then(|p| p.to_str())
-                            .unwrap_or("the database"),
-                    );
-                    (cmds, hint)
-                }
-                None => (Vec::new(), String::new()),
-            };
-
-            json!({
-                "kind": "duplicate_vault_root",
-                "root_path": root,
-                "entries": entries,
-                "remediation_commands": remediation_commands,
-                "remediation_hint": remediation_hint,
-            })
-        })
-        .collect();
+    // Structured warnings (duplicate-root collisions, wedged index
+    // publication) come from the shared helper so the CLI's direct
+    // (`--no-daemon`) path forwards the SAME array instead of re-deriving a
+    // subset locally.
+    let warnings = brain_status_warnings(store, db_path.as_deref());
     let repos_json: Vec<Value> = repos
         .iter()
         .map(|r| json!({ "url": r.url, "sha": r.indexed_sha }))
@@ -5638,26 +5558,12 @@ fn tool_brain_status(
     // come from the daemon and are therefore absent on the direct
     // `--no-daemon` and MCP-over-HTTP payloads, this is derived from the marker
     // FILE and so populates with no daemon running. The user who reported the
-    // wedge was on exactly that direct path.
+    // wedge was on exactly that direct path. The matching
+    // `index_publication_wedged` warning is pushed by `brain_status_warnings`.
     let index_publication = store
         .db_path()
         .map(nestweaver_engine::index_publication::status)
         .map(|status| {
-            let wedged = status.is_wedged();
-            if wedged {
-                warnings.push(json!({
-                    "warning": if status.determinable {
-                        "index publication is wedged: ranked queries (brain_context, \
-                         project_context, investigate) fail closed until it is reconciled. \
-                         This is an index PUBLICATION marker, not a dirty git working tree."
-                    } else {
-                        "index publication marker state cannot be determined (permissions or \
-                         I/O error on the sidecar directory); ranked queries fail closed."
-                    },
-                    "action": status.repair_command_for(
-                        store.db_path().unwrap_or(std::path::Path::new("<db>"))),
-                }));
-            }
             json!({
                 "dirty": status.dirty,
                 "determinable": status.determinable,
@@ -5665,7 +5571,7 @@ fn tool_brain_status(
                 "writer_pid": status.writer_pid,
                 "writer_alive": status.writer_alive,
                 "writer_reason": status.writer_reason,
-                "wedged": wedged,
+                "wedged": status.is_wedged(),
                 "marker_path": status.marker_path,
             })
         });
@@ -5706,6 +5612,125 @@ fn tool_brain_status(
         // abandoned — it has nothing to do with a dirty git working tree.
         "index_publication": index_publication,
     }))
+}
+
+/// Build the `warnings` array for `brain_status` from the store's current
+/// state: duplicate-vault-root collisions and a wedged index publication.
+///
+/// Shared by `tool_brain_status` and the CLI's direct (`--no-daemon`) text
+/// path so both forward the SAME warnings — the direct path previously
+/// re-derived only the duplicate-root subset locally and could never report
+/// a wedged publication at all. Every entry carries a `kind` so renderers
+/// can special-case a shape and still forward the rest generically.
+pub fn brain_status_warnings(store: &GraphStore, db_path: Option<&std::path::Path>) -> Vec<Value> {
+    // Detect duplicate-root collisions. The CLI's local (non-daemon) path
+    // emits these warnings to stderr; forward them through the JSON-RPC
+    // response so daemon-routed callers and `--json` consumers see the
+    // same diagnostic.
+    let vaults = store.list_vaults(None).unwrap_or_default();
+    let mut root_to_rows: std::collections::HashMap<&str, Vec<&nestweaver_schema::Vault>> =
+        std::collections::HashMap::new();
+    for v in &vaults {
+        root_to_rows
+            .entry(v.root_path.as_str())
+            .or_default()
+            .push(v);
+    }
+    let mut warnings: Vec<Value> = root_to_rows
+        .iter()
+        .filter(|(_, rows)| rows.len() > 1)
+        .map(|(root, rows)| {
+            // Pair each row with its note count so we can both render the
+            // entries and pick the keeper for the remediation hint.
+            let rows_with_counts: Vec<(&&nestweaver_schema::Vault, usize)> = rows
+                .iter()
+                .map(|v| {
+                    (
+                        v,
+                        store.list_notes(Some(&v.uid)).unwrap_or_default().len(),
+                    )
+                })
+                .collect();
+            let entries: Vec<Value> = rows_with_counts
+                .iter()
+                .map(|(v, n)| {
+                    json!({
+                        "uid": v.uid,
+                        "instance_id": v.instance_id,
+                        "name": v.name,
+                        "note_count": n,
+                    })
+                })
+                .collect();
+
+            // Suggest a concrete merge command. The keeper is the row with
+            // the highest note_count (most data); ties break on the
+            // lexicographically smallest instance_id so the suggestion is
+            // deterministic. Emit one command per non-keeper row so callers
+            // collapse all ghosts into the canonical instance.
+            let keeper = rows_with_counts
+                .iter()
+                .max_by(|a, b| {
+                    a.1.cmp(&b.1)
+                        .then_with(|| b.0.instance_id.cmp(&a.0.instance_id))
+                })
+                .map(|(v, _)| v);
+            let (remediation_commands, remediation_hint) = match keeper {
+                Some(keeper_v) => {
+                    let cmds: Vec<String> = rows_with_counts
+                        .iter()
+                        .filter(|(v, _)| v.instance_id != keeper_v.instance_id)
+                        .map(|(v, _)| {
+                            format!(
+                                "nestweaver instance merge --from {} --to {}",
+                                v.instance_id, keeper_v.instance_id,
+                            )
+                        })
+                        .collect();
+                    let hint = format!(
+                        "Multiple instance_ids share this vault root. Keep '{}' (has the most data) and merge the others into it using the commands below. Take a snapshot of {} first.",
+                        keeper_v.instance_id,
+                        db_path.and_then(|p| p.to_str()).unwrap_or("the database"),
+                    );
+                    (cmds, hint)
+                }
+                None => (Vec::new(), String::new()),
+            };
+
+            json!({
+                "kind": "duplicate_vault_root",
+                "root_path": root,
+                "entries": entries,
+                "remediation_commands": remediation_commands,
+                "remediation_hint": remediation_hint,
+            })
+        })
+        .collect();
+
+    // nw-C2: a wedged index publication. Derived from the marker FILE, so
+    // this populates with no daemon running — the user who reported the
+    // wedge was on exactly that direct path. `kind` makes the entry
+    // addressable for renderers that special-case warning shapes.
+    let publication_db_path = db_path.or_else(|| store.db_path());
+    if let Some(p) = publication_db_path {
+        let status = nestweaver_engine::index_publication::status(p);
+        if status.is_wedged() {
+            warnings.push(json!({
+                "kind": "index_publication_wedged",
+                "warning": if status.determinable {
+                    "index publication is wedged: ranked queries (brain_context, \
+                     project_context, investigate) fail closed until it is reconciled. \
+                     This is an index PUBLICATION marker, not a dirty git working tree."
+                } else {
+                    "index publication marker state cannot be determined (permissions or \
+                     I/O error on the sidecar directory); ranked queries fail closed."
+                },
+                "action": status.repair_command_for(p),
+            }));
+        }
+    }
+
+    warnings
 }
 
 // ── 6. brain_add_source ─────────────────────────────────────────────────────
@@ -10962,10 +10987,13 @@ mod cache_dispatch_tests {
         );
         let warnings = status["warnings"].as_array().unwrap();
         assert!(
-            warnings.iter().any(|w| w["action"]
-                .as_str()
-                .is_some_and(|a| a.contains("nestweaver repair"))),
-            "a wedged publication must carry an actionable warning: {warnings:?}"
+            warnings
+                .iter()
+                .any(|w| w["kind"] == "index_publication_wedged"
+                    && w["action"]
+                        .as_str()
+                        .is_some_and(|a| a.contains("nestweaver repair"))),
+            "a wedged publication must carry a `kind`-addressable, actionable warning: {warnings:?}"
         );
         set_index_publication_wait_ms(env_index_publication_wait_ms());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1528,6 +1528,24 @@ fn format_brain_status_warnings(warnings: &[serde_json::Value]) -> String {
     out
 }
 
+/// The one-line index-publication state for the `brain status` text body.
+///
+/// The "(see warning)" pointer is printed ONLY when a warning actually
+/// follows: `brain_status_warnings` pushes the `index_publication_wedged`
+/// entry only for a wedged publication, so a dirty-but-not-wedged state —
+/// routine during active indexing, when the writer is still alive — gets an
+/// informational line with no pointer and no overstatement.
+fn format_index_publication_line(dirty: bool, wedged: bool) -> Option<&'static str> {
+    if !dirty {
+        return None;
+    }
+    if wedged {
+        Some("  Index publication: wedged — ranked queries fail closed (see warning)")
+    } else {
+        Some("  Index publication: in flight — ranked queries fail closed until the writer commits")
+    }
+}
+
 #[cfg(test)]
 mod brain_status_warning_tests {
     use super::*;
@@ -1590,6 +1608,50 @@ mod brain_status_warning_tests {
         assert!(out.contains("keep a"), "{out:?}");
         assert!(
             out.contains("nestweaver instance merge --from b --to a"),
+            "{out:?}"
+        );
+    }
+
+    #[test]
+    fn clean_publication_prints_no_status_line() {
+        assert_eq!(format_index_publication_line(false, false), None);
+    }
+
+    #[test]
+    fn in_flight_publication_line_does_not_point_at_a_warning() {
+        // Dirty-but-not-wedged is the ROUTINE state during active indexing
+        // (live writer). The warnings builder pushes nothing for it, so the
+        // line must not promise a "(see warning)" that never follows.
+        let line = format_index_publication_line(true, false)
+            .expect("a dirty publication gets a status line");
+        assert!(
+            !line.contains("(see warning)"),
+            "no warning follows an in-flight publication; the line must not point at one: {line:?}"
+        );
+        assert!(
+            !line.contains("wedged"),
+            "an in-flight publication must not be overstated as wedged: {line:?}"
+        );
+    }
+
+    #[test]
+    fn wedged_publication_line_points_at_a_warning_that_follows() {
+        // The wedged one-liner promises a warning — pin that the warning
+        // renderer really does emit the matching entry with its repair
+        // command, so the pointer can never dangle.
+        let line = format_index_publication_line(true, true)
+            .expect("a wedged publication gets a status line");
+        assert!(line.contains("wedged"), "{line:?}");
+        assert!(line.contains("(see warning)"), "{line:?}");
+        let warnings = vec![serde_json::json!({
+            "kind": "index_publication_wedged",
+            "warning": "index publication is wedged: ranked queries fail closed",
+            "action": "nestweaver repair --db /tmp/x.lbug --force",
+        })];
+        let out = format_brain_status_warnings(&warnings);
+        assert!(out.contains("index publication is wedged"), "{out:?}");
+        assert!(
+            out.contains("nestweaver repair --db /tmp/x.lbug --force"),
             "{out:?}"
         );
     }
@@ -15928,19 +15990,16 @@ fn run_brain(
                     println!("  Tags:      {tags}");
                     println!("  Wikilinks: {wikilinks}");
                     println!("  Repos:     {repo_count}");
-                    // One-line publication state when dirty — the full
-                    // diagnosis and repair command ride in the warning below.
-                    if let Some(publication) = value.get("index_publication")
-                        && publication["dirty"].as_bool().unwrap_or(false)
-                    {
-                        let state = if publication["wedged"].as_bool().unwrap_or(false) {
-                            "wedged"
-                        } else {
-                            "dirty"
-                        };
-                        println!(
-                            "  Index publication: {state} — ranked queries fail closed (see warning)"
-                        );
+                    // One-line publication state when dirty — the "(see
+                    // warning)" pointer is only printed when a warning
+                    // actually follows (wedged), not for a routine in-flight
+                    // publication.
+                    if let Some(publication) = value.get("index_publication") {
+                        let dirty = publication["dirty"].as_bool().unwrap_or(false);
+                        let wedged = publication["wedged"].as_bool().unwrap_or(false);
+                        if let Some(line) = format_index_publication_line(dirty, wedged) {
+                            println!("{line}");
+                        }
                     }
                     if let Some(embedding) = value.get("embedding_status") {
                         println!("Embedding:");
@@ -16176,18 +16235,13 @@ fn run_brain(
                 println!("  Wikilinks: {wikilink_count}");
                 println!("  Repos:     {}", repos.len());
                 // One-line publication state when dirty, mirroring the
-                // daemon-routed path — the full diagnosis and repair command
-                // ride in the warning forwarded below.
+                // daemon-routed path — the "(see warning)" pointer only when
+                // a warning actually follows (wedged).
                 let publication = nestweaver_engine::index_publication::status(db_path);
-                if publication.dirty {
-                    let state = if publication.is_wedged() {
-                        "wedged"
-                    } else {
-                        "dirty"
-                    };
-                    println!(
-                        "  Index publication: {state} — ranked queries fail closed (see warning)"
-                    );
+                if let Some(line) =
+                    format_index_publication_line(publication.dirty, publication.is_wedged())
+                {
+                    println!("{line}");
                 }
                 // nw-121: the daemon prints an `Embedding:` block here and this
                 // path printed nothing at all — same command, same database,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1454,6 +1454,147 @@ fn embedding_status_from_json(value: &serde_json::Value) -> nestweaver_proto::Em
     }
 }
 
+/// Render `brain_status` warnings for the text output. Both the daemon-routed
+/// and the direct (`--no-daemon`) paths forward the tool's `warnings` array
+/// through this one renderer so the two cannot drift apart.
+///
+/// `duplicate_vault_root` keeps its rich rendering (per-entry instances plus
+/// remediation commands). Every OTHER kind is forwarded generically — the
+/// `warning` text, plus the `action` when present — because the previous
+/// renderer matched only that one kind and silently dropped everything else,
+/// which is how a wedged index publication produced no text output at all.
+fn format_brain_status_warnings(warnings: &[serde_json::Value]) -> String {
+    let mut out = String::new();
+    for w in warnings {
+        let kind = w["kind"].as_str().unwrap_or("");
+        if kind == "duplicate_vault_root" {
+            let root = w["root_path"].as_str().unwrap_or("?");
+            let entries = w["entries"].as_array().cloned().unwrap_or_default();
+            out.push_str(&format!(
+                "Warning: {} vault entries share root path {}:\n",
+                entries.len(),
+                root
+            ));
+            for e in &entries {
+                let name = e["name"].as_str().unwrap_or("?");
+                let instance = e["instance_id"].as_str().unwrap_or("?");
+                let uid = e["uid"].as_str().unwrap_or("?");
+                let n = e["note_count"].as_u64().unwrap_or(0);
+                out.push_str(&format!(
+                    "    - {name} [instance: {instance}] uid={uid} ({n} notes)\n"
+                ));
+            }
+            out.push_str(
+                "  This usually means brain add was run with different --instance values.\n",
+            );
+            // Prefer the targeted remediation produced by tool_brain_status
+            // when present, fall back to the generic three-option guidance
+            // for older daemon binaries.
+            let cmds = w["remediation_commands"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default();
+            let hint = w["remediation_hint"].as_str().unwrap_or("");
+            if !cmds.is_empty() {
+                if !hint.is_empty() {
+                    out.push_str(&format!("  {hint}\n"));
+                }
+                out.push_str("  Run:\n");
+                for c in &cmds {
+                    if let Some(s) = c.as_str() {
+                        out.push_str(&format!("      {s}\n"));
+                    }
+                }
+            } else {
+                out.push_str(&format!(
+                    "  Fix one row precisely with:\n      nestweaver brain remove --instance <instance-id>\n  \
+                     Or sweep all rows at this path:\n      nestweaver brain remove {root}\n  \
+                     Or consolidate under one instance:\n      nestweaver instance merge --from <old-id> --to <correct-id>\n"
+                ));
+            }
+        } else {
+            // Generic forwarding: a warning kind this binary does not know —
+            // emitted by a newer daemon, or any future tool-side warning —
+            // must still reach the user verbatim rather than be dropped.
+            match w["warning"].as_str() {
+                Some(msg) => out.push_str(&format!("Warning: {msg}\n")),
+                None => out.push_str(&format!("Warning: {w}\n")),
+            }
+            if let Some(action) = w["action"].as_str() {
+                out.push_str(&format!("  Run: {action}\n"));
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod brain_status_warning_tests {
+    use super::*;
+
+    #[test]
+    fn unrecognised_warning_kind_is_forwarded_not_dropped() {
+        // A synthetic kind no released binary renders specially: the generic
+        // path must still surface the warning text and action verbatim.
+        let warnings = vec![serde_json::json!({
+            "kind": "synthetic_future_kind",
+            "warning": "synthetic condition this CLI predates",
+            "action": "run `nestweaver synthetic-repair`",
+        })];
+        let out = format_brain_status_warnings(&warnings);
+        assert!(
+            out.contains("synthetic condition this CLI predates"),
+            "an unrecognised warning kind must still reach text output: {out:?}"
+        );
+        assert!(
+            out.contains("run `nestweaver synthetic-repair`"),
+            "the warning's action must be rendered too: {out:?}"
+        );
+    }
+
+    #[test]
+    fn warning_without_a_kind_field_is_forwarded() {
+        // The wedged-publication shape emitted by daemons predating the
+        // `kind` field: {"warning", "action"} only. It must still render,
+        // including the repair command.
+        let warnings = vec![serde_json::json!({
+            "warning": "index publication is wedged: ranked queries fail closed",
+            "action": "nestweaver repair --db /tmp/x.lbug --force",
+        })];
+        let out = format_brain_status_warnings(&warnings);
+        assert!(out.contains("index publication is wedged"), "{out:?}");
+        assert!(
+            out.contains("nestweaver repair --db /tmp/x.lbug --force"),
+            "{out:?}"
+        );
+    }
+
+    #[test]
+    fn duplicate_vault_root_keeps_its_rich_rendering() {
+        let warnings = vec![serde_json::json!({
+            "kind": "duplicate_vault_root",
+            "root_path": "/vault",
+            "entries": [
+                {"name": "v", "instance_id": "a", "uid": "u1", "note_count": 3},
+                {"name": "v", "instance_id": "b", "uid": "u2", "note_count": 0},
+            ],
+            "remediation_commands": ["nestweaver instance merge --from b --to a"],
+            "remediation_hint": "keep a",
+        })];
+        let out = format_brain_status_warnings(&warnings);
+        assert!(
+            out.contains("2 vault entries share root path /vault"),
+            "{out:?}"
+        );
+        assert!(out.contains("uid=u1"), "{out:?}");
+        assert!(out.contains("keep a"), "{out:?}");
+        assert!(
+            out.contains("nestweaver instance merge --from b --to a"),
+            "{out:?}"
+        );
+    }
+}
+
 fn format_effective_config(config: Option<&nestweaver_proto::EffectiveConfig>) -> String {
     use nestweaver_proto::effective_config::Source;
 
@@ -15787,6 +15928,20 @@ fn run_brain(
                     println!("  Tags:      {tags}");
                     println!("  Wikilinks: {wikilinks}");
                     println!("  Repos:     {repo_count}");
+                    // One-line publication state when dirty — the full
+                    // diagnosis and repair command ride in the warning below.
+                    if let Some(publication) = value.get("index_publication")
+                        && publication["dirty"].as_bool().unwrap_or(false)
+                    {
+                        let state = if publication["wedged"].as_bool().unwrap_or(false) {
+                            "wedged"
+                        } else {
+                            "dirty"
+                        };
+                        println!(
+                            "  Index publication: {state} — ranked queries fail closed (see warning)"
+                        );
+                    }
                     if let Some(embedding) = value.get("embedding_status") {
                         println!("Embedding:");
                         println!(
@@ -15817,59 +15972,11 @@ fn run_brain(
                         }
                     }
                     // Forward structured warnings from the MCP response —
-                    // e.g. duplicate-vault-root collisions. Previously these
-                    // were only emitted on the local (non-daemon) code path.
+                    // duplicate-vault-root collisions, a wedged index
+                    // publication, and any kind this binary predates —
+                    // through the shared renderer so nothing is dropped.
                     if let Some(warnings) = value.get("warnings").and_then(|v| v.as_array()) {
-                        for w in warnings {
-                            let kind = w["kind"].as_str().unwrap_or("");
-                            if kind == "duplicate_vault_root" {
-                                let root = w["root_path"].as_str().unwrap_or("?");
-                                let entries = w["entries"].as_array().cloned().unwrap_or_default();
-                                eprintln!(
-                                    "Warning: {} vault entries share root path {}:",
-                                    entries.len(),
-                                    root
-                                );
-                                for e in &entries {
-                                    let name = e["name"].as_str().unwrap_or("?");
-                                    let instance = e["instance_id"].as_str().unwrap_or("?");
-                                    let uid = e["uid"].as_str().unwrap_or("?");
-                                    let n = e["note_count"].as_u64().unwrap_or(0);
-                                    eprintln!(
-                                        "    - {name} [instance: {instance}] uid={uid} ({n} notes)"
-                                    );
-                                }
-                                eprintln!(
-                                    "  This usually means brain add was run with different --instance values."
-                                );
-                                // Prefer the targeted remediation produced
-                                // by tool_brain_status when present, fall
-                                // back to the generic three-option guidance
-                                // for older daemon binaries.
-                                let cmds = w["remediation_commands"]
-                                    .as_array()
-                                    .cloned()
-                                    .unwrap_or_default();
-                                let hint = w["remediation_hint"].as_str().unwrap_or("");
-                                if !cmds.is_empty() {
-                                    if !hint.is_empty() {
-                                        eprintln!("  {hint}");
-                                    }
-                                    eprintln!("  Run:");
-                                    for c in &cmds {
-                                        if let Some(s) = c.as_str() {
-                                            eprintln!("      {s}");
-                                        }
-                                    }
-                                } else {
-                                    eprintln!(
-                                        "  Fix one row precisely with:\n      nestweaver brain remove --instance <instance-id>\n  \
-                                         Or sweep all rows at this path:\n      nestweaver brain remove {root}\n  \
-                                         Or consolidate under one instance:\n      nestweaver instance merge --from <old-id> --to <correct-id>"
-                                    );
-                                }
-                            }
-                        }
+                        eprint!("{}", format_brain_status_warnings(warnings));
                     }
                     // ── Upstream server info ─────────────────────────────
                     let upstream_configs = nestweaver_client::discovery::discover_upstreams(
@@ -16068,6 +16175,20 @@ fn run_brain(
                 println!("  Tags:      {tag_count}");
                 println!("  Wikilinks: {wikilink_count}");
                 println!("  Repos:     {}", repos.len());
+                // One-line publication state when dirty, mirroring the
+                // daemon-routed path — the full diagnosis and repair command
+                // ride in the warning forwarded below.
+                let publication = nestweaver_engine::index_publication::status(db_path);
+                if publication.dirty {
+                    let state = if publication.is_wedged() {
+                        "wedged"
+                    } else {
+                        "dirty"
+                    };
+                    println!(
+                        "  Index publication: {state} — ranked queries fail closed (see warning)"
+                    );
+                }
                 // nw-121: the daemon prints an `Embedding:` block here and this
                 // path printed nothing at all — same command, same database,
                 // silently different answer. An omitted section reads as "no
@@ -16106,45 +16227,14 @@ fn run_brain(
                 }
             }
 
-            // Warn when multiple vault UIDs map to the same canonical root
-            // path — usually caused by brain add with mismatched --instance
-            // or missing --config. This produces phantom 0-note vault rows.
-            // Each entry surfaces name + instance_id + uid so the user can
-            // target `brain remove --instance <id>` precisely.
-            let mut root_to_vaults: std::collections::HashMap<
-                &str,
-                Vec<&nestweaver_schema::Vault>,
-            > = std::collections::HashMap::new();
-            for v in &vaults {
-                root_to_vaults
-                    .entry(v.root_path.as_str())
-                    .or_default()
-                    .push(v);
-            }
-            for (root, rows) in &root_to_vaults {
-                if rows.len() > 1 {
-                    eprintln!(
-                        "Warning: {} vault entries share root path {}:",
-                        rows.len(),
-                        root
-                    );
-                    for v in rows {
-                        let n = store.list_notes(Some(&v.uid)).unwrap_or_default().len();
-                        eprintln!(
-                            "    - {} [instance: {}] uid={} ({} notes)",
-                            v.name, v.instance_id, v.uid, n
-                        );
-                    }
-                    eprintln!(
-                        "  This usually means brain add was run with different --instance values."
-                    );
-                    eprintln!(
-                        "  Fix one row precisely with:\n      nestweaver brain remove --instance <instance-id>\n  \
-                         Or sweep all rows at this path:\n      nestweaver brain remove {root}\n  \
-                         Or consolidate under one instance:\n      nestweaver instance merge --from <old-id> --to <correct-id>",
-                    );
-                }
-            }
+            // Forward the SAME structured warnings the daemon-routed path
+            // renders — duplicate-vault-root collisions, a wedged index
+            // publication, and any kind this binary predates — through the
+            // shared builder + renderer. The previous locally-derived block
+            // only ever reported duplicate roots, so a wedged publication
+            // produced no text output on this path at all.
+            let warnings = nestweaver_mcp::tools::brain_status_warnings(&store, Some(db_path));
+            eprint!("{}", format_brain_status_warnings(&warnings));
 
             Ok((EXIT_SUCCESS, None))
         }


### PR DESCRIPTION
## Problem

`nestweaver brain status` text output rendered only warnings with `kind == "duplicate_vault_root"` and silently dropped everything else. A database wedged with an `.index-dirty` marker reported **nothing** in text output while `--json` carried the wedged state and the exact repair command — the warning was computed, carried across the wire, and thrown away at the last step. Any future warning kind would be dropped by default. The `--no-daemon` text path didn't consult the `warnings` array at all, re-deriving a duplicate-root warning locally.

## Fix

- New `format_brain_status_warnings` renderer: `duplicate_vault_root` keeps its rich rendering; every other warning is forwarded generically (`Warning:` + `Run:` lines) instead of dropped.
- The wedged-publication warning now carries `kind: "index_publication_wedged"` (no other consumer switches on `kind`; grep-verified).
- The `--no-daemon` text path now builds warnings through the same `brain_status_warnings` builder and renders through the same function as the daemon path — one warning source, one renderer.
- `tool_brain_status` reads the publication status **once** from `store.db_path()` and shares that read between the warnings and the `index_publication` payload (previously two independent derivations with a thread-local seam and a TOCTOU window).
- New one-line `Index publication:` status in text output: `wedged … (see warning)` only when the warning actually follows; a dirty-but-in-flight publication (live writer) prints an honest `in flight — ranked queries fail closed until the writer commits` with no dangling pointer.

`--json` output is unchanged except the item-requested `kind` field on the wedged warning.

## Tests

- Renderer tests proven to fail pre-fix (unrecognized kind and kind-less warning were both dropped, output `""`).
- Tests pin the one-liner against warning presence: clean → no line; in-flight → no `(see warning)` pointer; wedged → pointer AND the rendered warning with repair command.
- Demonstrated live on a scratch DB in all three publication states, on both the daemon and `--no-daemon` paths, with correct `repair` vs `repair --force` commands per marker type.
- `just test-crate nestweaver-mcp`: 180 passed; root bin tests: 163 passed; fmt and clippy clean.

Backlog item: `brain-status-text-output-drops-every-warning-but-one` (MEDIUM).