### PR TITLE
fix(cli): keep the UI port answering across a daemon outage

### DIFF
--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -4074,10 +4074,14 @@ impl NestWeaverDaemon for DaemonService {
         // is tracked so `stop_ui` can abort it and release the listen port
         // (LOW: ui port leak).
         let handle = tokio::spawn(async move {
-            if let Err(e) =
-                nestweaver_web::start_server_with_router(web_router, port, open_browser).await
-            {
-                tracing::error!("UI server error: {e}");
+            match nestweaver_web::start_server_with_router(web_router, port, open_browser).await {
+                // No graceful shutdown is wired up here (stop_ui aborts the
+                // task), so a clean return means the listener is gone while
+                // the daemon looks healthy — never let that pass silently.
+                Ok(()) => tracing::error!(
+                    "UI server on port {port} exited without an error — the port is no longer bound"
+                ),
+                Err(e) => tracing::error!("UI server error: {e}"),
             }
         });
         {

--- a/crates/nestweaver-web/src/lib.rs
+++ b/crates/nestweaver-web/src/lib.rs
@@ -280,6 +280,54 @@ pub async fn start_server(
     start_server_with_router(app, port, open_browser).await
 }
 
+/// Degraded-mode page served while the daemon that owns the graph is down.
+/// The UI process keeps its port bound across a daemon outage and answers
+/// every route with this, so a browser or the menubar app sees the outage
+/// instead of a dead socket.
+const DEGRADED_PAGE: &str = "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>NestWeaver — daemon unavailable</title>\n</head>\n<body>\n<h1>The NestWeaver daemon is down</h1>\n<p>The graph daemon is unreachable, so the UI cannot serve graph data right now. The UI is still running and resumes full service automatically once the daemon returns — no restart needed.</p>\n</body>\n</html>\n";
+
+async fn degraded_response(request: Request) -> Response {
+    let path = request.uri().path();
+    // API routes stay machine-readable in degraded mode too.
+    if path == "/api" || path.starts_with("/api/") {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            [(http::header::CONTENT_TYPE, "application/json")],
+            r#"{"error":"daemon_unavailable","message":"The NestWeaver daemon is down; the UI is serving a degraded page and resumes full service once the daemon returns."}"#,
+        )
+            .into_response();
+    }
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        [(http::header::CONTENT_TYPE, "text/html; charset=utf-8")],
+        DEGRADED_PAGE,
+    )
+        .into_response()
+}
+
+/// Router served while the daemon is unreachable: every route reports the
+/// outage. The status is `503`, not `200`, so health checks and supervisors
+/// see the truth; browsers still render the page body.
+pub fn degraded_router() -> Router {
+    Router::new().fallback(get(degraded_response))
+}
+
+/// Serve [`degraded_router`] on `port` until `shutdown` resolves. Returning
+/// `Ok` therefore always means a requested shutdown; a bind or serve failure
+/// is the `Err` case and carries the underlying cause.
+pub async fn start_degraded_server(
+    port: u16,
+    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+) -> anyhow::Result<()> {
+    let addr = format!("127.0.0.1:{port}");
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    tracing::warn!("nestweaver-web serving degraded daemon-down page on http://{addr}");
+    axum::serve(listener, degraded_router().into_make_service())
+        .with_graceful_shutdown(shutdown)
+        .await?;
+    Ok(())
+}
+
 /// Start the web UI server with a pre-built router.
 ///
 /// This allows callers (e.g. the daemon's `serve_ui` RPC) to customise the
@@ -359,5 +407,54 @@ mod frontend_assets_tests {
         let response = spa_fallback(request).await;
 
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}
+
+#[cfg(test)]
+mod degraded_tests {
+    use super::*;
+
+    /// The degraded page must plainly name the daemon outage and answer 503,
+    /// so a port probe never mistakes it for a healthy UI.
+    #[tokio::test]
+    async fn degraded_page_names_the_daemon_outage() {
+        let request = Request::builder()
+            .uri("/")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let response = degraded_response(request).await;
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = std::str::from_utf8(&body).unwrap();
+        assert!(
+            text.contains("daemon is down"),
+            "degraded page must say the daemon is down: {text}"
+        );
+    }
+
+    /// API consumers get a machine-readable 503, not an HTML page.
+    #[tokio::test]
+    async fn degraded_api_response_is_machine_readable() {
+        let request = Request::builder()
+            .uri("/api/v1/health")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let response = degraded_response(request).await;
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            response.headers().get(http::header::CONTENT_TYPE).unwrap(),
+            "application/json"
+        );
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = std::str::from_utf8(&body).unwrap();
+        assert!(text.contains("daemon_unavailable"), "body: {text}");
     }
 }

--- a/crates/nestweaver-web/src/lib.rs
+++ b/crates/nestweaver-web/src/lib.rs
@@ -12,7 +12,7 @@ use axum::{
     extract::Request,
     http::{self, StatusCode},
     response::{IntoResponse, Response},
-    routing::{delete, get, post, put},
+    routing::{any, delete, get, post, put},
 };
 use rust_embed::RustEmbed;
 
@@ -305,11 +305,13 @@ async fn degraded_response(request: Request) -> Response {
         .into_response()
 }
 
-/// Router served while the daemon is unreachable: every route reports the
-/// outage. The status is `503`, not `200`, so health checks and supervisors
-/// see the truth; browsers still render the page body.
+/// Router served while the daemon is unreachable: every route, on every
+/// method, reports the outage. The status is `503`, not `200`, so health
+/// checks and supervisors see the truth; browsers still render the page
+/// body. `any` (not `get`) so the real UI's POST routes (/api/v1/context,
+/// /api/v1/llm/query, exports) get the same 503 instead of a bare 405.
 pub fn degraded_router() -> Router {
-    Router::new().fallback(get(degraded_response))
+    Router::new().fallback(any(degraded_response))
 }
 
 /// Serve [`degraded_router`] on `port` until `shutdown` resolves. Returning
@@ -451,6 +453,29 @@ mod degraded_tests {
             response.headers().get(http::header::CONTENT_TYPE).unwrap(),
             "application/json"
         );
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = std::str::from_utf8(&body).unwrap();
+        assert!(text.contains("daemon_unavailable"), "body: {text}");
+    }
+
+    /// The real UI has POST routes (/api/v1/context, /api/v1/llm/query,
+    /// exports); in degraded mode those must get the same 503 outage
+    /// response, not a bare 405 from a GET-only fallback.
+    #[tokio::test]
+    async fn degraded_router_answers_non_get_methods() {
+        use tower::ServiceExt;
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/v1/context")
+            .body(axum::body::Body::from("{}"))
+            .unwrap();
+
+        let response = degraded_router().oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
             .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5631,6 +5631,208 @@ fn daemon_process_running_for_db(db_path: &std::path::Path) -> bool {
         .unwrap_or(false)
 }
 
+/// How often `nestweaver ui` polls the daemon that owns its listener.
+const UI_DAEMON_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Bound on one daemon health probe from the UI supervision loop, so a wedged
+/// socket cannot stall Ctrl-C handling on the client defaults (5s connect /
+/// 10s RPC).
+const UI_DAEMON_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// A degraded "daemon is down" web server holding the UI port while the
+/// daemon is unreachable.
+struct DegradedUiServer {
+    stop: tokio::sync::oneshot::Sender<()>,
+    task: tokio::task::JoinHandle<anyhow::Result<()>>,
+}
+
+impl DegradedUiServer {
+    fn spawn(rt: &tokio::runtime::Runtime, port: u16) -> Self {
+        let (stop, wait) = tokio::sync::oneshot::channel::<()>();
+        let task = rt.spawn(async move {
+            nestweaver_web::start_degraded_server(port, async move {
+                let _ = wait.await;
+            })
+            .await
+        });
+        Self { stop, task }
+    }
+
+    /// Stop serving and wait for the listen socket to be released, so the
+    /// daemon can re-bind the port via `serve_ui`.
+    fn shutdown(self, rt: &tokio::runtime::Runtime) -> anyhow::Result<()> {
+        let _ = self.stop.send(());
+        match rt.block_on(self.task) {
+            Ok(result) => result,
+            Err(join_error) => Err(anyhow::anyhow!(
+                "degraded UI server task failed: {join_error}"
+            )),
+        }
+    }
+}
+
+/// Probe the daemon that serves the UI. `Err` carries why the daemon is
+/// considered down (socket gone, connect failed, RPC failed, timed out).
+fn ui_daemon_health_probe(
+    rt: &tokio::runtime::Runtime,
+    db_path: &std::path::Path,
+) -> anyhow::Result<()> {
+    rt.block_on(async {
+        tokio::time::timeout(UI_DAEMON_PROBE_TIMEOUT, async {
+            let mut probe = nestweaver_client::DaemonClient::connect_existing(db_path).await?;
+            probe.health_check().await?;
+            anyhow::Ok(())
+        })
+        .await
+        .context("daemon health probe timed out")?
+    })
+}
+
+/// Supervise the daemon-served web UI until Ctrl-C.
+///
+/// The UI's listening socket is owned by the daemon process (`serve_ui`
+/// spawns the axum server there), so a daemon death unbinds the port while
+/// this process would otherwise sit in `ctrlc_rx.recv()` — alive, silent,
+/// and serving nothing. While running, this polls the daemon; on loss it
+/// logs the cause at error level, takes over the port with a degraded
+/// "daemon is down" page, and keeps answering. On the daemon's return it
+/// re-resolves the connection (the startup client is never reused after an
+/// outage), hands the port back via a fresh `serve_ui`, and resumes full
+/// service — no app restart.
+///
+/// `client` is replaced with the re-resolved client on recovery. Returns
+/// whether the daemon was up at exit, so the caller knows whether a
+/// `stop_ui` is meaningful.
+fn supervise_ui_daemon(
+    rt: &tokio::runtime::Runtime,
+    db_path: &std::path::Path,
+    port: u16,
+    watch: bool,
+    watch_repo_path: &str,
+    ctrlc_rx: &std::sync::mpsc::Receiver<()>,
+    client: &mut nestweaver_client::DaemonClient,
+) -> bool {
+    let mut daemon_up = true;
+    let mut degraded: Option<DegradedUiServer> = None;
+    // Two consecutive probe failures before an outage is declared: a busy
+    // daemon can exceed the probe timeout without being down, and degrading
+    // against a LIVE daemon means grabbing (and failing to bind) a port it
+    // still owns.
+    let mut probe_failures = 0u32;
+
+    loop {
+        match ctrlc_rx.recv_timeout(UI_DAEMON_POLL_INTERVAL) {
+            Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+        }
+
+        if daemon_up {
+            match ui_daemon_health_probe(rt, db_path) {
+                Ok(()) => probe_failures = 0,
+                Err(error) => {
+                    probe_failures += 1;
+                    if probe_failures == 1 {
+                        tracing::warn!(
+                            port,
+                            "daemon health probe failed ({error:#}); probing again before declaring an outage"
+                        );
+                    } else {
+                        tracing::error!(
+                            port,
+                            "daemon lost ({error:#}); its UI listener died with it — \
+                             serving a degraded daemon-down page until the daemon returns"
+                        );
+                        eprintln!(
+                            "Error: daemon lost ({error:#}); the UI is degraded on http://127.0.0.1:{port} until the daemon returns"
+                        );
+                        probe_failures = 0;
+                        daemon_up = false;
+                    }
+                }
+            }
+        }
+
+        if !daemon_up {
+            // Reap a finished degraded server (e.g. a bind failure) so the
+            // failure is logged and serving is retried — never silent.
+            if degraded
+                .as_ref()
+                .is_some_and(|active| active.task.is_finished())
+                && let Some(active) = degraded.take()
+            {
+                match active.shutdown(rt) {
+                    Ok(()) => tracing::error!(
+                        port,
+                        "degraded UI server exited by itself while the daemon is down — restarting it"
+                    ),
+                    Err(error) => {
+                        tracing::error!(port, "degraded UI server failed: {error:#} — retrying")
+                    }
+                }
+            }
+
+            // Re-resolve the daemon connection; the startup client is dead.
+            if let Ok(mut candidate) =
+                rt.block_on(nestweaver_client::DaemonClient::connect_existing(db_path))
+                && rt.block_on(candidate.health_check()).is_ok()
+            {
+                // Hand the port back: release it BEFORE the daemon re-binds
+                // (serve_ui reports port_in_use otherwise).
+                if let Some(active) = degraded.take()
+                    && let Err(error) = active.shutdown(rt)
+                {
+                    tracing::warn!("degraded UI server did not shut down cleanly: {error:#}");
+                }
+                // No browser re-open on recovery — an outage must not pop
+                // windows. watch/watch_repo_path mirror the startup request.
+                match rt.block_on(candidate.serve_ui(
+                    port,
+                    false,
+                    watch,
+                    watch_repo_path,
+                    "default",
+                )) {
+                    Ok(resp) if resp.ok => {
+                        tracing::info!(
+                            port,
+                            "daemon restored — full UI service resumed on :{port}"
+                        );
+                        eprintln!(
+                            "Daemon restored — full UI service resumed on http://127.0.0.1:{port}"
+                        );
+                        *client = candidate;
+                        daemon_up = true;
+                    }
+                    Ok(resp) => {
+                        tracing::error!(
+                            port,
+                            error = %resp.error,
+                            "daemon is back but refused to resume the UI: {}",
+                            resp.message
+                        );
+                        eprintln!(
+                            "Error: daemon is back but could not resume the UI on :{port}: {}",
+                            resp.message
+                        );
+                    }
+                    Err(error) => {
+                        tracing::error!(port, "daemon is back but serve_ui failed: {error:#}");
+                    }
+                }
+            }
+
+            if !daemon_up && degraded.is_none() {
+                degraded = Some(DegradedUiServer::spawn(rt, port));
+            }
+        }
+    }
+
+    if let Some(active) = degraded.take() {
+        let _ = active.shutdown(rt);
+    }
+    daemon_up
+}
+
 /// Which PID, if any, `daemon stop` is allowed to signal.
 ///
 /// ONLY the pidfile PID and the socket peer are candidates. The database write
@@ -10476,14 +10678,29 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         let _ = ctrlc_handler(move || {
                             let _ = tx.send(());
                         });
-                        let _ = rx.recv();
+                        // The listener lives in the daemon process; supervise
+                        // it so a daemon outage degrades the UI instead of
+                        // leaving a healthy-looking shell with a dead port.
+                        let daemon_up_at_exit = supervise_ui_daemon(
+                            &rt,
+                            &db_path,
+                            port,
+                            watch,
+                            &watch_repo_path,
+                            &rx,
+                            &mut client,
+                        );
                         // Tell the daemon to stop serving so
                         // the listen port is released when the CLI exits.
-                        match rt.block_on(client.stop_ui()) {
-                            Ok(resp) if resp.ok => eprintln!("UI server stopped."),
-                            Ok(resp) => eprintln!("note: {}", resp.message),
-                            Err(e) => {
-                                eprintln!("warning: failed to stop UI server cleanly: {e:#}")
+                        // Meaningless while the daemon is down — the degraded
+                        // server was already shut down by supervise_ui_daemon.
+                        if daemon_up_at_exit {
+                            match rt.block_on(client.stop_ui()) {
+                                Ok(resp) if resp.ok => eprintln!("UI server stopped."),
+                                Ok(resp) => eprintln!("note: {}", resp.message),
+                                Err(e) => {
+                                    eprintln!("warning: failed to stop UI server cleanly: {e:#}")
+                                }
                             }
                         }
                     }
@@ -10528,7 +10745,16 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     });
                 }
 
+                // A returned serve future means the listener is gone; never
+                // survive that silently as a healthy-looking shell with a
+                // dead port. An Err propagates with its cause; a bare Ok is
+                // abnormal (no graceful shutdown is wired here) and is
+                // reported the same way — error log, non-zero exit.
                 rt.block_on(nestweaver_web::start_server(state, port, !no_open))?;
+                eprintln!(
+                    "Error: UI server on port {port} exited without an error — the port is no longer bound"
+                );
+                return Ok((EXIT_ERROR, None));
             }
 
             Ok((EXIT_SUCCESS, None))

--- a/src/main.rs
+++ b/src/main.rs
@@ -5639,6 +5639,20 @@ const UI_DAEMON_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_s
 /// 10s RPC).
 const UI_DAEMON_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
+/// Bound on one `serve_ui` RPC from the supervision loop. The RPC has no
+/// client-side deadline of its own, so a daemon that accepts but wedges
+/// would otherwise hang the loop (and Ctrl-C with it) — potentially with
+/// the degraded server already shut down.
+const UI_SERVE_RPC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Bound on the TCP connect that checks whether the UI port is serving.
+const UI_PORT_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// How long the supervision loop waits for the degraded server to drain
+/// before aborting it; a slow-trickling client must not stall recovery
+/// (or Ctrl-C) forever.
+const DEGRADED_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
 /// A degraded "daemon is down" web server holding the UI port while the
 /// daemon is unreachable.
 struct DegradedUiServer {
@@ -5658,15 +5672,26 @@ impl DegradedUiServer {
         Self { stop, task }
     }
 
-    /// Stop serving and wait for the listen socket to be released, so the
-    /// daemon can re-bind the port via `serve_ui`.
+    /// Stop serving and wait — bounded — for the listen socket to be
+    /// released, so the daemon can re-bind the port via `serve_ui`. If the
+    /// graceful drain outlasts [`DEGRADED_SHUTDOWN_TIMEOUT`] (a slow client
+    /// holding a connection open), the task is aborted to force the release.
     fn shutdown(self, rt: &tokio::runtime::Runtime) -> anyhow::Result<()> {
         let _ = self.stop.send(());
-        match rt.block_on(self.task) {
-            Ok(result) => result,
-            Err(join_error) => Err(anyhow::anyhow!(
+        let mut task = self.task;
+        match rt
+            .block_on(async { tokio::time::timeout(DEGRADED_SHUTDOWN_TIMEOUT, &mut task).await })
+        {
+            Ok(Ok(result)) => result,
+            Ok(Err(join_error)) => Err(anyhow::anyhow!(
                 "degraded UI server task failed: {join_error}"
             )),
+            Err(_) => {
+                task.abort();
+                Err(anyhow::anyhow!(
+                    "degraded UI server did not stop within {DEGRADED_SHUTDOWN_TIMEOUT:?} — aborted"
+                ))
+            }
         }
     }
 }
@@ -5688,6 +5713,38 @@ fn ui_daemon_health_probe(
     })
 }
 
+/// Is anything accepting connections on the UI port? A healthy daemon does
+/// not prove the UI is served: `serve_ui` pre-checks the port with a
+/// throwaway bind, so the spawned server task can lose the real bind race
+/// with nothing but a daemon-side log to show for it.
+fn ui_port_serving(port: u16) -> bool {
+    std::net::TcpStream::connect_timeout(
+        &std::net::SocketAddr::from(([127, 0, 0, 1], port)),
+        UI_PORT_PROBE_TIMEOUT,
+    )
+    .is_ok()
+}
+
+/// Issue `serve_ui` with a bounded wait (see [`UI_SERVE_RPC_TIMEOUT`]).
+/// `open_browser` is always false — a supervision retry must never pop
+/// windows. `watch`/`watch_repo_path` mirror the startup request.
+fn ui_serve_request(
+    rt: &tokio::runtime::Runtime,
+    client: &mut nestweaver_client::DaemonClient,
+    port: u16,
+    watch: bool,
+    watch_repo_path: &str,
+) -> anyhow::Result<nestweaver_proto::ServeUiResponse> {
+    rt.block_on(async {
+        tokio::time::timeout(
+            UI_SERVE_RPC_TIMEOUT,
+            client.serve_ui(port, false, watch, watch_repo_path, "default"),
+        )
+        .await
+        .context("serve_ui RPC timed out")?
+    })
+}
+
 /// Supervise the daemon-served web UI until Ctrl-C.
 ///
 /// The UI's listening socket is owned by the daemon process (`serve_ui`
@@ -5699,6 +5756,12 @@ fn ui_daemon_health_probe(
 /// re-resolves the connection (the startup client is never reused after an
 /// outage), hands the port back via a fresh `serve_ui`, and resumes full
 /// service — no app restart.
+///
+/// Two honesty rules beyond that happy path: recovery is only declared when
+/// the daemon serves OUR port (an "already running" response naming another
+/// port keeps the degraded page and is logged as-is), and while the daemon
+/// is up the port itself is probed — a daemon that outlives its UI task is
+/// re-issued `serve_ui`, never trusted silently.
 ///
 /// `client` is replaced with the re-resolved client on recovery. Returns
 /// whether the daemon was up at exit, so the caller knows whether a
@@ -5719,6 +5782,12 @@ fn supervise_ui_daemon(
     // against a LIVE daemon means grabbing (and failing to bind) a port it
     // still owns.
     let mut probe_failures = 0u32;
+    // Same two-strike rule for the port probe (the daemon's server task can
+    // take a moment to bind after a fresh serve_ui).
+    let mut port_failures = 0u32;
+    // The "daemon serves a different UI port" state is logged once per
+    // distinct port, not on every poll.
+    let mut mismatch_logged_for: Option<u16> = None;
 
     loop {
         match ctrlc_rx.recv_timeout(UI_DAEMON_POLL_INTERVAL) {
@@ -5728,7 +5797,43 @@ fn supervise_ui_daemon(
 
         if daemon_up {
             match ui_daemon_health_probe(rt, db_path) {
-                Ok(()) => probe_failures = 0,
+                Ok(()) => {
+                    probe_failures = 0;
+                    // A healthy daemon does not prove the UI port is served
+                    // (its server task can have died independently), so probe
+                    // the port itself. The daemon still owns the port here,
+                    // so a dead port is repaired by re-issuing serve_ui —
+                    // never by binding the degraded server over a live daemon.
+                    if ui_port_serving(port) {
+                        port_failures = 0;
+                    } else {
+                        port_failures += 1;
+                        if port_failures >= 2 {
+                            port_failures = 0;
+                            tracing::error!(
+                                port,
+                                "daemon is healthy but the UI port is not serving — re-issuing serve_ui"
+                            );
+                            eprintln!(
+                                "Error: daemon is healthy but http://127.0.0.1:{port} is not serving — asking the daemon to re-serve it"
+                            );
+                            match ui_serve_request(rt, client, port, watch, watch_repo_path) {
+                                Ok(resp) if resp.ok => {
+                                    tracing::info!(port, "serve_ui re-issued: {}", resp.message)
+                                }
+                                Ok(resp) => tracing::error!(
+                                    port,
+                                    error = %resp.error,
+                                    "serve_ui re-issue refused: {}",
+                                    resp.message
+                                ),
+                                Err(error) => {
+                                    tracing::error!(port, "serve_ui re-issue failed: {error:#}")
+                                }
+                            }
+                        }
+                    }
+                }
                 Err(error) => {
                     probe_failures += 1;
                     if probe_failures == 1 {
@@ -5746,6 +5851,7 @@ fn supervise_ui_daemon(
                             "Error: daemon lost ({error:#}); the UI is degraded on http://127.0.0.1:{port} until the daemon returns"
                         );
                         probe_failures = 0;
+                        mismatch_logged_for = None;
                         daemon_up = false;
                     }
                 }
@@ -5776,31 +5882,123 @@ fn supervise_ui_daemon(
                 rt.block_on(nestweaver_client::DaemonClient::connect_existing(db_path))
                 && rt.block_on(candidate.health_check()).is_ok()
             {
-                // Hand the port back: release it BEFORE the daemon re-binds
-                // (serve_ui reports port_in_use otherwise).
-                if let Some(active) = degraded.take()
-                    && let Err(error) = active.shutdown(rt)
-                {
-                    tracing::warn!("degraded UI server did not shut down cleanly: {error:#}");
-                }
-                // No browser re-open on recovery — an outage must not pop
-                // windows. watch/watch_repo_path mirror the startup request.
-                match rt.block_on(candidate.serve_ui(
-                    port,
-                    false,
-                    watch,
-                    watch_repo_path,
-                    "default",
-                )) {
+                // Ask BEFORE releasing the degraded port: while we hold it
+                // the daemon cannot bind, so ok:true here can only mean it
+                // ALREADY serves a UI — possibly a different port, if
+                // another `ui` command ran during the outage. Recovery is
+                // only declared when the daemon serves OUR port. watch=false
+                // on this probe: the "already running" arm would otherwise
+                // start a duplicate watcher on every poll.
+                match ui_serve_request(rt, &mut candidate, port, false, watch_repo_path) {
+                    Ok(resp)
+                        if resp.ok && resp.message.starts_with("UI server already running") =>
+                    {
+                        // Mirror the startup path: trust the ACTUAL port the
+                        // daemon reports, not the one we asked for.
+                        let actual_port = if resp.port != 0 {
+                            resp.port as u16
+                        } else {
+                            port
+                        };
+                        if actual_port == port {
+                            // The daemon already serves OUR port (the outage
+                            // was a false positive, or another ui bound it
+                            // while we were down).
+                            if let Some(active) = degraded.take()
+                                && let Err(error) = active.shutdown(rt)
+                            {
+                                tracing::warn!(
+                                    "degraded UI server did not shut down cleanly: {error:#}"
+                                );
+                            }
+                            tracing::info!(
+                                port,
+                                "daemon restored — full UI service resumed on :{port}"
+                            );
+                            eprintln!(
+                                "Daemon restored — full UI service resumed on http://127.0.0.1:{port}"
+                            );
+                            *client = candidate;
+                            mismatch_logged_for = None;
+                            daemon_up = true;
+                        } else if mismatch_logged_for != Some(actual_port) {
+                            // Honest state: the daemon took a different UI
+                            // request during the outage. Keep the degraded
+                            // page on OUR port rather than claiming a
+                            // recovery :port does not have.
+                            tracing::error!(
+                                port,
+                                actual_port,
+                                "daemon is back but serves the UI on :{actual_port}, not :{port} — keeping the degraded page"
+                            );
+                            eprintln!(
+                                "Error: daemon is back but serves the UI on http://127.0.0.1:{actual_port} — :{port} stays degraded"
+                            );
+                            mismatch_logged_for = Some(actual_port);
+                        }
+                    }
+                    Ok(resp) if !resp.ok && resp.error == "port_in_use" => {
+                        // Expected while our degraded server holds the port:
+                        // release it, then re-issue so the daemon binds
+                        // fresh (with the real watch setting).
+                        if let Some(active) = degraded.take()
+                            && let Err(error) = active.shutdown(rt)
+                        {
+                            tracing::warn!(
+                                "degraded UI server did not shut down cleanly: {error:#}"
+                            );
+                        }
+                        match ui_serve_request(rt, &mut candidate, port, watch, watch_repo_path) {
+                            Ok(resp) if resp.ok => {
+                                tracing::info!(
+                                    port,
+                                    "daemon restored — full UI service resumed on :{port}"
+                                );
+                                eprintln!(
+                                    "Daemon restored — full UI service resumed on http://127.0.0.1:{port}"
+                                );
+                                *client = candidate;
+                                mismatch_logged_for = None;
+                                daemon_up = true;
+                            }
+                            Ok(resp) => {
+                                tracing::error!(
+                                    port,
+                                    error = %resp.error,
+                                    "daemon is back but refused to resume the UI: {}",
+                                    resp.message
+                                );
+                                eprintln!(
+                                    "Error: daemon is back but could not resume the UI on :{port}: {}",
+                                    resp.message
+                                );
+                            }
+                            Err(error) => {
+                                tracing::error!(
+                                    port,
+                                    "daemon is back but serve_ui failed: {error:#}"
+                                );
+                            }
+                        }
+                    }
                     Ok(resp) if resp.ok => {
-                        tracing::info!(
+                        // A fresh-start claim while our degraded server still
+                        // holds the port — the daemon could not have bound
+                        // it. Hand over and let the port probe in the up
+                        // state verify; do NOT claim "resumed" on trust.
+                        if let Some(active) = degraded.take()
+                            && let Err(error) = active.shutdown(rt)
+                        {
+                            tracing::warn!(
+                                "degraded UI server did not shut down cleanly: {error:#}"
+                            );
+                        }
+                        tracing::warn!(
                             port,
-                            "daemon restored — full UI service resumed on :{port}"
-                        );
-                        eprintln!(
-                            "Daemon restored — full UI service resumed on http://127.0.0.1:{port}"
+                            "daemon claims the UI started on :{port} while the degraded server still held it — verifying via the port probe"
                         );
                         *client = candidate;
+                        mismatch_logged_for = None;
                         daemon_up = true;
                     }
                     Ok(resp) => {

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -1469,6 +1469,87 @@ fn wait_until(deadline: Duration, mut probe: impl FnMut() -> bool) -> bool {
     false
 }
 
+/// Guard that SIGINTs (then SIGKILLs) the UI child on drop, so no test
+/// failure path leaks a process holding a port.
+struct UiChildGuard(std::process::Child);
+
+impl UiChildGuard {
+    fn is_alive(&mut self) -> bool {
+        self.0.try_wait().ok().flatten().is_none()
+    }
+
+    /// SIGINT and wait for a graceful exit (SIGKILL as the last resort).
+    fn stop(mut self) {
+        let _ = unsafe { libc::kill(self.0.id() as i32, libc::SIGINT) };
+        for _ in 0..25 {
+            if self.0.try_wait().ok().flatten().is_some() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+        let _ = self.0.kill();
+    }
+}
+
+impl Drop for UiChildGuard {
+    fn drop(&mut self) {
+        let _ = unsafe { libc::kill(self.0.id() as i32, libc::SIGINT) };
+        for _ in 0..25 {
+            if self.0.try_wait().ok().flatten().is_some() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+        let _ = self.0.kill();
+    }
+}
+
+/// Spawn `nestweaver ui --no-open --port <port> --db <db>` with the daemon
+/// path enabled, stderr captured to `stderr_file` for log assertions (a
+/// silent failure is half of the defect these tests pin down).
+fn spawn_ui(db_path: &Path, port: u16, stderr_file: std::fs::File) -> UiChildGuard {
+    let ui = StdCommand::new(bin_path())
+        .args([
+            "ui",
+            "--no-open",
+            "--port",
+            &port.to_string(),
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .env_remove("NESTWEAVER_NO_DAEMON")
+        .env_remove("NESTWEAVER_DAEMON_PIDFILE_LOCK_HELD")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(stderr_file))
+        .spawn()
+        .expect("failed to spawn nestweaver ui");
+    UiChildGuard(ui)
+}
+
+/// SIGKILL the daemon for this DB via its pidfile; returns the killed PID.
+fn sigkill_daemon(db_path: &Path) -> i32 {
+    let instance_id = nestweaver_daemon::instance_id_from_db_path(db_path);
+    let pidfile = nestweaver_daemon::pidfile_path(&instance_id);
+    let pid: i32 = std::fs::read_to_string(&pidfile)
+        .expect("pidfile should exist")
+        .trim()
+        .parse()
+        .expect("pidfile should contain a PID");
+    unsafe {
+        libc::kill(pid, libc::SIGKILL);
+    }
+    pid
+}
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
 /// Reproduction for the UI/daemon outage defect: a running `ui` must keep
 /// its port answering across a daemon outage — degraded while the daemon is
 /// down, full service again once the daemon returns, with no app restart —
@@ -1485,48 +1566,9 @@ fn ui_survives_daemon_outage_and_recovers() {
     let _guard = DaemonGuard::new(&db_path);
     start_daemon(&db_path);
 
-    // A port nothing else holds.
-    let port = std::net::TcpListener::bind("127.0.0.1:0")
-        .unwrap()
-        .local_addr()
-        .unwrap()
-        .port();
-
-    // Spawn `ui` as a long-running child, stderr captured for the log
-    // assertion (a silent failure is the defect's second half).
+    let port = free_port();
     let ui_stderr = std::fs::File::create(dir.path().join("ui-stderr.log")).unwrap();
-    let ui = StdCommand::new(bin_path())
-        .args([
-            "ui",
-            "--no-open",
-            "--port",
-            &port.to_string(),
-            "--db",
-            &db_path.display().to_string(),
-        ])
-        .env_remove("NESTWEAVER_NO_DAEMON")
-        .env_remove("NESTWEAVER_DAEMON_PIDFILE_LOCK_HELD")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::from(ui_stderr))
-        .spawn()
-        .expect("failed to spawn nestweaver ui");
-
-    // Cleanup on any panic path: the UI child must not leak.
-    struct UiChildGuard(std::process::Child);
-    impl Drop for UiChildGuard {
-        fn drop(&mut self) {
-            let _ = unsafe { libc::kill(self.0.id() as i32, libc::SIGINT) };
-            for _ in 0..25 {
-                if self.0.try_wait().ok().flatten().is_some() {
-                    return;
-                }
-                std::thread::sleep(Duration::from_millis(200));
-            }
-            let _ = self.0.kill();
-        }
-    }
-    let mut ui = UiChildGuard(ui);
+    let mut ui = spawn_ui(&db_path, port, ui_stderr);
 
     // 1. Full service while the daemon is up.
     assert!(
@@ -1537,16 +1579,7 @@ fn ui_survives_daemon_outage_and_recovers() {
     );
 
     // 2. Kill the daemon with SIGKILL.
-    let instance_id = nestweaver_daemon::instance_id_from_db_path(&db_path);
-    let pidfile = nestweaver_daemon::pidfile_path(&instance_id);
-    let pid: i32 = std::fs::read_to_string(&pidfile)
-        .expect("pidfile should exist")
-        .trim()
-        .parse()
-        .expect("pidfile should contain a PID");
-    unsafe {
-        libc::kill(pid, libc::SIGKILL);
-    }
+    sigkill_daemon(&db_path);
 
     // 3. The port must keep answering with a degraded page that names the
     //    daemon outage — never listening-dead-but-alive.
@@ -1561,7 +1594,7 @@ fn ui_survives_daemon_outage_and_recovers() {
          (503 naming the daemon outage), not a dead socket"
     );
     assert!(
-        ui.0.try_wait().ok().flatten().is_none(),
+        ui.is_alive(),
         "the UI process must survive the daemon outage"
     );
 
@@ -1584,8 +1617,96 @@ fn ui_survives_daemon_outage_and_recovers() {
         "restoring the daemon must restore full UI service without an app restart"
     );
     assert!(
-        ui.0.try_wait().ok().flatten().is_none(),
+        ui.is_alive(),
         "the UI process must still be the original one (no restart)"
+    );
+}
+
+/// While the UI is degraded on its port, a SECOND `ui` command binding the
+/// daemon to a DIFFERENT port must not be reported as recovery: the
+/// degraded page stays, the log names the port the daemon actually serves,
+/// and once the other UI exits the original port recovers for real.
+#[test]
+fn ui_different_port_ui_during_outage_stays_degraded_then_recovers() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_dir = dir.path().join("repo");
+    let db_path = dir.path().join("ui-outage-mismatch").join("test.lbug");
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+    write_test_repo(&repo_dir);
+    create_db(&repo_dir, &db_path);
+
+    let _guard = DaemonGuard::new(&db_path);
+    start_daemon(&db_path);
+
+    let port_a = free_port();
+    let port_b = free_port();
+    let ui_a_stderr = std::fs::File::create(dir.path().join("ui-a-stderr.log")).unwrap();
+    let mut ui_a = spawn_ui(&db_path, port_a, ui_a_stderr);
+
+    assert!(
+        wait_until(Duration::from_secs(60), || {
+            matches!(ui_http_get(port_a, "/api/v1/health"), Some((200, _)))
+        }),
+        "UI on :{port_a} never reached http=200 with the daemon up"
+    );
+
+    // Kill the daemon; :port_a goes degraded.
+    sigkill_daemon(&db_path);
+    assert!(
+        wait_until(Duration::from_secs(30), || {
+            matches!(ui_http_get(port_a, "/"), Some((503, _)))
+        }),
+        "after killing the daemon :{port_a} must serve the degraded page"
+    );
+
+    // Freeze ui_a's supervision so a second `ui` deterministically wins the
+    // race to the restored daemon (its degraded server keeps the port bound
+    // while stopped; only accept() stalls).
+    let ui_a_pid = ui_a.0.id() as i32;
+    unsafe {
+        libc::kill(ui_a_pid, libc::SIGSTOP);
+    }
+    start_daemon(&db_path);
+    let ui_b_stderr = std::fs::File::create(dir.path().join("ui-b-stderr.log")).unwrap();
+    let ui_b = spawn_ui(&db_path, port_b, ui_b_stderr);
+    assert!(
+        wait_until(Duration::from_secs(60), || {
+            matches!(ui_http_get(port_b, "/api/v1/health"), Some((200, _)))
+        }),
+        "second UI on :{port_b} never reached http=200"
+    );
+
+    // Unfreeze: the next poll must discover the daemon serving :port_b and
+    // keep :port_a degraded, honestly — never claim "resumed" on :port_a.
+    unsafe {
+        libc::kill(ui_a_pid, libc::SIGCONT);
+    }
+    assert!(
+        wait_until(Duration::from_secs(30), || {
+            let log =
+                std::fs::read_to_string(dir.path().join("ui-a-stderr.log")).unwrap_or_default();
+            log.contains(&format!("http://127.0.0.1:{port_b}")) && log.contains("stays degraded")
+        }),
+        "ui_a must log that the daemon serves :{port_b} and that :{port_a} stays degraded"
+    );
+    assert!(
+        matches!(ui_http_get(port_a, "/"), Some((503, _))),
+        ":{port_a} must still serve the degraded page while the daemon serves :{port_b}"
+    );
+    assert!(ui_a.is_alive(), "ui_a must survive the mismatch");
+
+    // Stop the second UI: its stop_ui releases the daemon's UI on :port_b.
+    // The original UI's port must now recover for real.
+    ui_b.stop();
+    assert!(
+        wait_until(Duration::from_secs(60), || {
+            matches!(ui_http_get(port_a, "/api/v1/health"), Some((200, _)))
+        }),
+        ":{port_a} must recover once the daemon no longer serves :{port_b}"
+    );
+    assert!(
+        ui_a.is_alive(),
+        "ui_a must still be the original process (no restart)"
     );
 }
 

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -1435,6 +1435,160 @@ export function transportcountneedle_three() { return impacttarget(); }
     }
 }
 
+/// Minimal HTTP/1.0 GET against the loopback UI port. Returns the status
+/// code and the raw response text, or `None` when nothing is listening.
+fn ui_http_get(port: u16, path: &str) -> Option<(u16, String)> {
+    use std::io::{Read, Write};
+
+    let mut stream = std::net::TcpStream::connect(("127.0.0.1", port)).ok()?;
+    stream.set_read_timeout(Some(Duration::from_secs(2))).ok()?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(2)))
+        .ok()?;
+    write!(
+        stream,
+        "GET {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n"
+    )
+    .ok()?;
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).ok()?;
+    let text = String::from_utf8_lossy(&buf).into_owned();
+    let status: u16 = text.split_whitespace().nth(1)?.parse().ok()?;
+    Some((status, text))
+}
+
+/// Poll `probe` until it returns true or the deadline elapses.
+fn wait_until(deadline: Duration, mut probe: impl FnMut() -> bool) -> bool {
+    let start = std::time::Instant::now();
+    while start.elapsed() < deadline {
+        if probe() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    false
+}
+
+/// Reproduction for the UI/daemon outage defect: a running `ui` must keep
+/// its port answering across a daemon outage — degraded while the daemon is
+/// down, full service again once the daemon returns, with no app restart —
+/// and must log the failure instead of surviving silently with a dead port.
+#[test]
+fn ui_survives_daemon_outage_and_recovers() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_dir = dir.path().join("repo");
+    let db_path = dir.path().join("ui-outage").join("test.lbug");
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+    write_test_repo(&repo_dir);
+    create_db(&repo_dir, &db_path);
+
+    let _guard = DaemonGuard::new(&db_path);
+    start_daemon(&db_path);
+
+    // A port nothing else holds.
+    let port = std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+
+    // Spawn `ui` as a long-running child, stderr captured for the log
+    // assertion (a silent failure is the defect's second half).
+    let ui_stderr = std::fs::File::create(dir.path().join("ui-stderr.log")).unwrap();
+    let ui = StdCommand::new(bin_path())
+        .args([
+            "ui",
+            "--no-open",
+            "--port",
+            &port.to_string(),
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .env_remove("NESTWEAVER_NO_DAEMON")
+        .env_remove("NESTWEAVER_DAEMON_PIDFILE_LOCK_HELD")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(ui_stderr))
+        .spawn()
+        .expect("failed to spawn nestweaver ui");
+
+    // Cleanup on any panic path: the UI child must not leak.
+    struct UiChildGuard(std::process::Child);
+    impl Drop for UiChildGuard {
+        fn drop(&mut self) {
+            let _ = unsafe { libc::kill(self.0.id() as i32, libc::SIGINT) };
+            for _ in 0..25 {
+                if self.0.try_wait().ok().flatten().is_some() {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(200));
+            }
+            let _ = self.0.kill();
+        }
+    }
+    let mut ui = UiChildGuard(ui);
+
+    // 1. Full service while the daemon is up.
+    assert!(
+        wait_until(Duration::from_secs(60), || {
+            matches!(ui_http_get(port, "/api/v1/health"), Some((200, _)))
+        }),
+        "UI never reached http=200 with the daemon up"
+    );
+
+    // 2. Kill the daemon with SIGKILL.
+    let instance_id = nestweaver_daemon::instance_id_from_db_path(&db_path);
+    let pidfile = nestweaver_daemon::pidfile_path(&instance_id);
+    let pid: i32 = std::fs::read_to_string(&pidfile)
+        .expect("pidfile should exist")
+        .trim()
+        .parse()
+        .expect("pidfile should contain a PID");
+    unsafe {
+        libc::kill(pid, libc::SIGKILL);
+    }
+
+    // 3. The port must keep answering with a degraded page that names the
+    //    daemon outage — never listening-dead-but-alive.
+    assert!(
+        wait_until(Duration::from_secs(30), || {
+            match ui_http_get(port, "/") {
+                Some((status, body)) => status == 503 && body.to_lowercase().contains("daemon"),
+                None => false,
+            }
+        }),
+        "after killing the daemon the UI port must serve a degraded page \
+         (503 naming the daemon outage), not a dead socket"
+    );
+    assert!(
+        ui.0.try_wait().ok().flatten().is_none(),
+        "the UI process must survive the daemon outage"
+    );
+
+    // 3b. The failure must be logged, not silent.
+    let stderr_log = std::fs::read_to_string(dir.path().join("ui-stderr.log")).unwrap();
+    assert!(
+        stderr_log.to_lowercase().contains("daemon")
+            && (stderr_log.contains("error")
+                || stderr_log.to_lowercase().contains("down")
+                || stderr_log.to_lowercase().contains("lost")),
+        "the daemon outage must be logged at error level with its cause; got:\n{stderr_log}"
+    );
+
+    // 4. Restore the daemon: full service must resume with no app restart.
+    start_daemon(&db_path);
+    assert!(
+        wait_until(Duration::from_secs(60), || {
+            matches!(ui_http_get(port, "/api/v1/health"), Some((200, _)))
+        }),
+        "restoring the daemon must restore full UI service without an app restart"
+    );
+    assert!(
+        ui.0.try_wait().ok().flatten().is_none(),
+        "the UI process must still be the original one (no restart)"
+    );
+}
+
 #[test]
 fn daemon_crash_recovery() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Problem

`nestweaver ui` with the daemon up serves http=200, but the listening socket is owned **by the daemon** (the UI CLI sends a `ServeUi` RPC; the daemon runs the axum server in-process). `kill -9` the daemon and the kernel tears down its sockets: the UI process stays alive parked in a Ctrl-C wait, the port is dead, **nothing is logged anywhere**, and a restored daemon never rebinds. The menubar app looks healthy while the UI is unreachable — a silent-failure class defect. (Instrumentation disproved the initial hypothesis that `axum::serve` returns; the socket owner itself dies.)

## Fix — survive degraded (contract chosen per the backlog item's recommendation: the menubar app cannot see a dead port)

- New `supervise_ui_daemon()` replaces the bare Ctrl-C park. It health-probes the daemon once a second (fresh `connect_existing` each time — the startup client is never reused — two consecutive failures required so a busy-but-alive daemon isn't mis-declared).
- On daemon loss: logs at error level with the underlying cause, binds the port itself, and serves a degraded page — 503 on every route and every method (HTML "daemon is down" for browsers, `{"error":"daemon_unavailable"}` for `/api/*`). 503 so supervisors and the menubar app see the truth.
- On daemon return: re-resolves the connection, shuts the degraded server down (bounded, then abort), and re-issues `serve_ui` — full service resumes under the same UI process, no app restart, no browser re-open. Recovery is only **declared** after verifying the daemon actually serves **our** port (the "already running on port X" handshake mirrors the startup path; a different port keeps the degraded server and error-logs the truth).
- While the daemon is up, the probe also watches the port itself: a healthy daemon with a dead UI port (e.g. the serve_ui pre-check/bind TOCTOU) triggers an error-logged, bounded re-issue — never a degraded bind over a live daemon, never silence.
- All waits in the outage path are bounded (5s RPC timeout, 2s degraded shutdown then abort); Ctrl-C stays responsive in both states.
- The daemon's UI task now error-logs a clean return of the server (previously only `Err`); the direct/`--no-daemon` path (which owns its own socket — verified not the same shape) now logs and exits non-zero if its serve future returns, instead of silently exiting 0.

## Tests

- `ui_survives_daemon_outage_and_recovers`: automates the acceptance sequence — 200 → SIGKILL daemon → 503 degraded page + error-level log + process alive → daemon restored → 200 under the same UI process. **Proven to fail pre-fix** (33.8s dead port).
- `ui_different_port_ui_during_outage_stays_degraded_then_recovers`: a second `ui` binding the restored daemon to a different port no longer produces a false "resumed" — the original port stays degraded, loudly, then recovers once the port is free.
- Degraded-router unit tests incl. POST; daemon_test 48/48 serial, nestweaver-web 104, nestweaver-daemon 268; fmt/clippy clean.

Honest caveat: "the port stays bound" is a fast handover, not literal continuity — the daemon owns the socket while up, so there is a ≤~3s window between daemon death and the degraded page answering. Steady state is never listening-dead-but-alive.

Backlog item: `ui-stops-listening-when-the-daemon-goes-away-and-never-rebinds` (MEDIUM). Two adversarial review rounds.