### PR TITLE
fix(daemon): distinguish a live index job from a stuck flag in the drain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,14 +113,22 @@ reporting threshold, not a kill switch — those run on
 `spawn_blocking` threads that cannot be aborted, so past the ceiling the daemon
 keeps waiting, keeps serving reads, and logs what it is waiting on; an operator
 SIGKILL (`daemon stop --force` or `kill -9`) is the only thing that ends a stuck
-write, and nothing does it automatically. While only an INDEX job is in flight it
-is a real deadline: the daemon signals shutdown at the ceiling — which closes
-every listener and STOPS READ SERVICE — because the worker's `indexing_active`
-flag cannot clear once the pool is drained with a non-empty queue, so waiting on
-it would hang forever. Note the inversion: the unbounded write branch preserves
-reads, while the bounded index branch is the one that ends them. During a write
-drain MOST reads keep being served — `embed` and `plan_embed` are the exception,
-they take the same write gate and block until the write finishes.
+write, and nothing does it automatically. A genuinely running INDEX job is
+treated the same way: the drain consults the worker pool's own in-flight
+counter (`DaemonState::indexing_in_flight`, shared into the worker's
+`IndexingStatus` so the worker — not the flag — is the authority on whether a
+job is running), and a job that is genuinely in flight past the ceiling gets
+the same unbounded wait with reads still served. The ceiling is a real deadline
+only for a STUCK flag: `indexing_active` set with no worker job in flight,
+which cannot clear once the pool is drained with a non-empty queue, so waiting
+on it would hang forever — there the daemon signals shutdown at the ceiling,
+which closes every listener and stops read service. One honest limit: a job
+that is in-flight but truly wedged is indistinguishable from a slow one, so it
+gets the unbounded wait — the same operator escape (`daemon stop --force` /
+`kill -9`) applies, and reads stay up in the meantime, which the old bounded
+branch could not say. During a write drain MOST reads keep being served —
+`embed` and `plan_embed` are the exception, they take the same write gate and
+block until the write finishes.
 Indexing is CPU-throttled to a rolling 5s duty-cycle window so a saturated
 daemon stays under macOS CPU-violation limits; tune with
 `NESTWEAVER_INDEX_CPU_PERCENT` (percent of one core, 1–99, default 50; `0` or
@@ -145,8 +153,8 @@ by an error message the tool can print, so they belong somewhere findable.
 |----------|---------|---------|
 | `NESTWEAVER_DAEMON_BOOT_TIMEOUT_SECS` | 30 | How long a client waits for the daemon to bind its socket. Raise it on a slow cold start; the boot-failure message names it. Boot phase timings (`boot_ms`, `store_open_ms`, `extension_reconcile_ms`, `unattributed_ms`) are logged at bind so a slow boot is diagnosable rather than guessed at. |
 | `NESTWEAVER_INDEX_TIMEOUT_SECS` | 1800 | Overall ceiling for one index. On expiry the daemon requests cancellation and reports a non-terminal warning naming this variable. Cancellation is COOPERATIVE and only observed up to the pre-write boundary, so the final stream event says whether the run aborted before writing or committed anyway (committed-after-cancellation names `index --force` as the repair). |
-| `NESTWEAVER_DRAIN_TIMEOUT_SECS` | 660 | Drain ceiling for BOTH shutdown routes — the gRPC `Shutdown` RPC (`daemon restart`) and SIGTERM (`daemon stop`), which share one drain. With an in-flight write it is NOT a deadline: the daemon cannot abort one, so past this point it keeps waiting, keeps serving most reads (`embed`/`plan_embed` excepted — they take the write gate), logs the in-flight count, and names `daemon stop --force` / `kill -9` as the escapes. With only an index job in flight it IS a deadline: the daemon signals shutdown at the ceiling, which stops read service, because `indexing_active` cannot clear once the worker pool is drained with a non-empty queue. Also derives `NESTWEAVER_STOP_GRACE_SECS`, the launchd plist's `ExitTimeOut` (ceiling + 60 — deliberately later than the stop grace, so the CLI gives up watching before launchd kills), and the client's owner-release wait (ceiling + 5s). |
-| `NESTWEAVER_STOP_GRACE_SECS` | drain ceiling + 30 (690) | How long `daemon stop` waits for the daemon to exit. This is NOT a kill deadline: when it expires with the daemon still draining, `daemon stop` re-probes the socket, reports what it observed, leaves the daemon running, and exits non-zero. It does not SIGKILL — see the daemon-architecture section for why an automatic escalation was the defect. Listeners stay up for the whole window in a write drain, so waiting is not an outage (individual reads can still stall for seconds while a write commits); in an index-only drain the ceiling broadcast closes them 30s before this expires, and the message says so. `daemon stop --force` ignores this variable and uses a short fixed 10s window before SIGKILL, abandoning any in-flight write. |
+| `NESTWEAVER_DRAIN_TIMEOUT_SECS` | 660 | Drain ceiling for BOTH shutdown routes — the gRPC `Shutdown` RPC (`daemon restart`) and SIGTERM (`daemon stop`), which share one drain. With an in-flight write OR a genuinely running index job (the drain reads the worker pool's own in-flight counter, not the `indexing_active` flag) it is NOT a deadline: the daemon cannot abort either, so past this point it keeps waiting, keeps serving most reads (`embed`/`plan_embed` excepted — they take the write gate), logs the in-flight count, and names `daemon stop --force` / `kill -9` as the escapes. With only a STUCK `indexing_active` flag (set, but no worker job in flight) it IS a deadline: the daemon signals shutdown at the ceiling, which stops read service, because that flag cannot clear once the worker pool is drained with a non-empty queue. Also derives `NESTWEAVER_STOP_GRACE_SECS`, the launchd plist's `ExitTimeOut` (ceiling + 60 — deliberately later than the stop grace, so the CLI gives up watching before launchd kills), and the client's owner-release wait (ceiling + 5s). |
+| `NESTWEAVER_STOP_GRACE_SECS` | drain ceiling + 30 (690) | How long `daemon stop` waits for the daemon to exit. This is NOT a kill deadline: when it expires with the daemon still draining, `daemon stop` re-probes the socket, reports what it observed, leaves the daemon running, and exits non-zero. It does not SIGKILL — see the daemon-architecture section for why an automatic escalation was the defect. Listeners stay up for the whole window in a write drain (and in a genuinely-running-index drain), so waiting is not an outage (individual reads can still stall for seconds while a write commits); only in a stuck-flag index drain does the ceiling broadcast close them 30s before this expires, and the message says so. `daemon stop --force` ignores this variable and uses a short fixed 10s window before SIGKILL, abandoning any in-flight write. |
 | `NESTWEAVER_INDEX_CPU_PERCENT` | 50 | Index CPU duty cycle, percent of one core (1–99; `0` or `>=100` disables). Also see the launchd note below. |
 | `NESTWEAVER_ALLOW_NO_DAEMON` | unset | Opt-in required to honour `--no-daemon` / `NESTWEAVER_NO_DAEMON` outside CI. Without it the bypass is REFUSED, because it circumvents the single-writer lock. Not for normal use. |
 | `NESTWEAVER_LBUG_MAX_THREADS` | 1 | Engine thread-pool size. `1` closes the nw-073 eviction-vs-read race; raise only if you measure a query-latency cost. |

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -909,6 +909,13 @@ pub struct DaemonState {
     pub indexing_repo: Arc<tokio::sync::RwLock<String>>,
     /// Number of pending + running jobs in the server-side job queue.
     pub indexing_queue_depth: Arc<AtomicU32>,
+    /// The worker pool's own count of index jobs still running (claimed, not
+    /// yet finished). Shared into the worker's `IndexingStatus` so the WORKER
+    /// — not the `indexing_active` flag — is the authority on whether a job
+    /// genuinely exists; the shutdown drain reads it to tell a running job
+    /// (unbounded wait, reads stay served) from a stuck flag (bounded by the
+    /// drain ceiling).
+    pub indexing_in_flight: Arc<AtomicU32>,
     /// Brain-status documents served by this daemon process. A daemon-side
     /// witness counter: a client that adopted this daemon after its pidfile
     /// was unlinked proves the answer really came from the daemon (the
@@ -1095,180 +1102,26 @@ fn stop_active_watcher(state: &DaemonState) {
     }
 }
 
-/// Minimum spacing between repeats of the over-ceiling drain warning. The
-/// ceiling itself sets the cadence; this floor stops a tiny
-/// `NESTWEAVER_DRAIN_TIMEOUT_SECS` from turning the log into a spinner.
-const DRAIN_OVER_CEILING_REPORT_FLOOR_SECS: u64 = 60;
-
 /// Wait for in-flight writes and indexing to finish, then broadcast shutdown.
 ///
-/// `ceiling` (`NESTWEAVER_DRAIN_TIMEOUT_SECS`) is a REPORTING threshold, not a
-/// kill switch, and this function must not pretend otherwise. Nothing in this
-/// process can abort an in-flight write: daemon writes run on `spawn_blocking`
-/// threads Tokio cannot cancel (see the "`spawn_blocking` work cannot be
-/// aborted" note on the exit path), and the shutdown broadcast this function
-/// ends with only stops listeners ACCEPTING — it cannot preempt work already
-/// running.
-///
-/// So the loop keeps waiting past the ceiling and says so. It used to log
-/// "drain timeout reached — forcing shutdown" and break, which was false twice
-/// over:
-///
-///  - nothing was forced. The broadcast does not abort the write, the process
-///    stayed alive holding the DB write lock, and only an operator's SIGKILL
-///    ever ended it; and
-///  - broadcasting shutdown there tore down every listener while the process
-///    lived on, which is how a stuck WRITE drain also took READS down. Almost
-///    no read needs the write gate (`ConnectionGuard::read` does not take
-///    `write_mutex`), so they were not blocked by the drain itself — they died
-///    because the UDS/TCP/MCP acceptors had already been shut down by that
-///    premature broadcast, and every new `daemon status` / MCP / CLI read
-///    connection was refused for as long as the write ran.
-///
-/// Waiting instead keeps the daemon readable until the operator escalates —
-/// and if the write does finish, shutdown still completes cleanly rather than
-/// leaving a half-dead process behind. "Readable" is not absolute: `embed` and
-/// `plan_embed` take `write_mutex` themselves, so they stay blocked for the
-/// duration of the stuck write, and the ceiling message says so.
-///
-/// The unbounded wait applies to in-flight WRITES ONLY. `indexing_active` on
-/// its own stays bounded by the ceiling — see the comment on that branch for
-/// why waiting on it forever would be a hang rather than a safeguard.
+/// The loop itself is [`nestweaver_engine::drain::run_drain`], fed with the
+/// daemon's shared counters; it lives next to the worker pool so the drain's
+/// indexing behaviour can be tested against a real worker-pool index, which
+/// this crate's tests cannot drive (they link the engine without its
+/// `cfg(test)` `file://` clone allowance). The doc comment on `run_drain`
+/// covers why the ceiling is a reporting threshold for in-flight writes and a
+/// real deadline for a stuck `indexing_active` flag.
 async fn run_shutdown_drain(state: Arc<DaemonState>, ceiling: u64) {
-    let ceiling_at = std::time::Duration::from_secs(ceiling);
-    let half = std::time::Duration::from_secs(ceiling / 2);
-    let ninety = std::time::Duration::from_secs(ceiling * 9 / 10);
-    let repeat_every =
-        std::time::Duration::from_secs(ceiling.max(DRAIN_OVER_CEILING_REPORT_FLOOR_SECS));
-    let start = tokio::time::Instant::now();
-    let mut warned_half = false;
-    let mut warned_ninety = false;
-    // When the next over-ceiling report is due: first at the ceiling itself,
-    // then every `repeat_every` after that.
-    let mut next_over_ceiling_report = ceiling_at;
-
-    loop {
-        let writes = state.active_writes.load(Ordering::Relaxed);
-        // Index jobs bump `indexing_active`, not `active_writes`, so the
-        // drain must wait on both — otherwise a shutdown could proceed
-        // while the worker is mid-write.
-        let indexing = state.indexing_active.load(Ordering::Relaxed);
-        if writes == 0 && !indexing {
-            tracing::info!("no active writes or indexing — shutting down");
-            break;
-        }
-
-        let elapsed = start.elapsed();
-
-        if writes == 0 {
-            // Indexing-only wait: BOUNDED, deliberately.
-            //
-            // Only an in-flight write earns an unbounded wait — it holds the DB
-            // write lock, runs on a `spawn_blocking` thread nothing can cancel,
-            // and abandoning it is the operator's call. `indexing_active` is
-            // different: waiting on it forever is a hang, not a safeguard.
-            //
-            // `indexing_active` is cleared in exactly two places in
-            // `nestweaver-engine`'s worker loop, and with `drained` set (which
-            // the Shutdown handler does before this runs) BOTH are unreachable
-            // while the job queue is non-empty: the idle branch is skipped
-            // because the drained check `continue`s before a job is ever
-            // claimed, and the post-job branch clears only when pending +
-            // running + in-flight all reach zero. A server-mode daemon told to
-            // shut down with work still queued — the "continuous webhook
-            // enqueue" case the Shutdown handler already calls out — would
-            // never exit at all.
-            //
-            // The broadcast below is precisely what unblocks it: the worker
-            // loop observes shutdown and breaks. That is the pre-existing,
-            // working behaviour for this path, so it is kept intact.
-            //
-            // This branch DOES have a cost, and the message says so rather than
-            // letting the daemon do the dishonest thing quietly. Broadcasting
-            // stops every listener accepting, so read service ends here — and
-            // worker-pool index jobs bump `indexing_active` rather than
-            // `active_writes`, so if the flag is set because a job really is
-            // running, that unabortable `spawn_blocking` write keeps the process
-            // alive with nothing being served. That is the original incident,
-            // surviving in the server-mode index path. It is not a regression
-            // (`main` behaves identically) and it cannot be fixed from here: the
-            // worker's `in_flight` counter lives inside `IndexingStatus` and is
-            // never shared into `DaemonState`, so this loop cannot tell a stuck
-            // flag from a running job. Tracked as a follow-up alongside the
-            // SIGTERM broadcast; both come from the same root cause, that the
-            // broadcast is the only shutdown primitive and it is all-or-nothing.
-            if elapsed >= ceiling_at {
-                tracing::warn!(
-                    indexing_active = indexing,
-                    waited_secs = elapsed.as_secs(),
-                    "drain ceiling ({ceiling}s) reached with no in-flight writes — \
-                     signalling shutdown. The index worker stops after its current \
-                     job; anything still queued is left for the next start. NOTE: \
-                     this closes every listener, so reads stop being served now — \
-                     and if an index job is genuinely still running, it cannot be \
-                     aborted, so the process may stay alive without serving \
-                     anything until it finishes. `kill -9` ends it sooner, \
-                     abandoning that job's write"
-                );
-                break;
-            }
-        } else if elapsed >= next_over_ceiling_report {
-            next_over_ceiling_report = elapsed + repeat_every;
-            let pid = std::process::id();
-            tracing::warn!(
-                active_writes = writes,
-                indexing_active = indexing,
-                waited_secs = elapsed.as_secs(),
-                pid,
-                "drain ceiling ({ceiling}s) exceeded — still waiting on {writes} \
-                 in-flight write(s){}; the daemon CANNOT abort them and is NOT \
-                 shutting down. NEW writes are already being refused with \
-                 UNAVAILABLE, so this count only falls. Most reads are still \
-                 served, though they can stall for seconds while a write \
-                 commits. `embed` takes the write gate AND the write guard, so \
-                 it is refused outright; `plan_embed` takes the gate but counts \
-                 as a read, so it is not refused — it BLOCKS until the \
-                 in-flight write releases the gate. This is \
-                 the same drain whether you sent SIGTERM (`nestweaver daemon \
-                 stop`) or the Shutdown RPC (`nestweaver daemon restart`); \
-                 neither escalates on its own. To end it now — abandoning the \
-                 in-flight write, which the graph store may not survive cleanly \
-                 (nw-126) — run `nestweaver daemon stop --force` or `kill -9 \
-                 {pid}`",
-                // Hedged: `indexing_active` is a flag, not a proof of work. It
-                // can stay set after the worker pool is drained, so claiming a
-                // running index job here would be the same kind of overclaim
-                // this line exists to stop making.
-                if indexing {
-                    " (indexing_active is also set)"
-                } else {
-                    ""
-                },
-            );
-        }
-
-        // Past the ceiling these are noise — the reports above have taken over.
-        if elapsed < ceiling_at {
-            if !warned_half && elapsed >= half {
-                tracing::warn!(
-                    active_writes = writes,
-                    "drain at 50% of ceiling ({ceiling}s)"
-                );
-                warned_half = true;
-            }
-            if !warned_ninety && elapsed >= ninety {
-                tracing::warn!(
-                    active_writes = writes,
-                    "drain at 90% of ceiling ({ceiling}s)"
-                );
-                warned_ninety = true;
-            }
-        }
-
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-    }
-
-    let _ = state.shutdown_tx.send(true);
+    nestweaver_engine::drain::run_drain(
+        nestweaver_engine::drain::DrainSignals {
+            active_writes: Arc::clone(&state.active_writes),
+            indexing_active: Arc::clone(&state.indexing_active),
+            indexing_in_flight: Arc::clone(&state.indexing_in_flight),
+            shutdown_tx: state.shutdown_tx.clone(),
+        },
+        ceiling,
+    )
+    .await;
 }
 
 /// The ONE way a shutdown starts in this process.
@@ -8961,6 +8814,7 @@ pub async fn run_server(
         indexing_active: Arc::new(AtomicBool::new(false)),
         indexing_repo: Arc::new(tokio::sync::RwLock::new(String::new())),
         indexing_queue_depth: Arc::new(AtomicU32::new(0)),
+        indexing_in_flight: Arc::new(AtomicU32::new(0)),
         requests_served: AtomicU64::new(0),
         safeguards,
         rate_limiters: rate_limiters.clone(),
@@ -9897,6 +9751,7 @@ pub async fn run_server(
                 Arc::clone(&state.indexing_active),
                 state.indexing_repo.clone(),
                 Arc::clone(&state.indexing_queue_depth),
+                Arc::clone(&state.indexing_in_flight),
             );
             // Map each declared repo to its index strategy so vault repos index
             // as markdown instead of code. Keyed by the same canonical repo id
@@ -15247,6 +15102,7 @@ mod startup_helper_tests {
             indexing_active: Arc::new(AtomicBool::new(false)),
             indexing_repo: Arc::new(tokio::sync::RwLock::new(String::new())),
             indexing_queue_depth: Arc::new(AtomicU32::new(0)),
+            indexing_in_flight: Arc::new(AtomicU32::new(0)),
             requests_served: AtomicU64::new(0),
             safeguards: QuerySafeguards::default_server(),
             rate_limiters: None,
@@ -15327,6 +15183,7 @@ credential_method = "gh"
             indexing_active: Arc::new(AtomicBool::new(false)),
             indexing_repo: Arc::new(tokio::sync::RwLock::new(String::new())),
             indexing_queue_depth: Arc::new(AtomicU32::new(0)),
+            indexing_in_flight: Arc::new(AtomicU32::new(0)),
             requests_served: AtomicU64::new(0),
             safeguards: QuerySafeguards::default_server(),
             rate_limiters: None,

--- a/crates/nestweaver-engine/src/drain.rs
+++ b/crates/nestweaver-engine/src/drain.rs
@@ -15,6 +15,22 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 /// The counters and the shutdown channel the drain loop reads. Every field is
 /// a shared handle: the daemon clones its own `Arc`s in, so the loop observes
 /// the same values the RPC handlers and the worker pool mutate.
+///
+/// CONSUMER CONTRACT. This loop only OBSERVES and reports; the guarantees its
+/// log messages assert belong to the consumer, and [`run_drain`] cannot
+/// enforce them:
+///
+///  - "NEW writes are already being refused with UNAVAILABLE" — the consumer
+///    must refuse new writes before and for the whole drain (the daemon does
+///    this via `ConnectionGuard::write`, and `begin_shutdown_drain` sets
+///    `drained` before spawning this loop). Without that, fresh work can
+///    extend the wait indefinitely while the log claims it cannot.
+///  - The `embed` / `plan_embed` write-gate behaviour the write-branch report
+///    describes is the daemon's RPC-gating design, not something this loop
+///    does.
+///  - The operator commands named in the messages (`nestweaver daemon stop
+///    [--force]`, `kill -9`) are the daemon's CLI; a different consumer must
+///    substitute its own escalation path rather than inherit these strings.
 pub struct DrainSignals {
     /// In-flight write RPCs. A write holds the DB write lock on an
     /// unabortable `spawn_blocking` thread, so while any are running the wait

--- a/crates/nestweaver-engine/src/drain.rs
+++ b/crates/nestweaver-engine/src/drain.rs
@@ -1,0 +1,406 @@
+//! The shutdown drain: wait for in-flight writes and indexing to finish, then
+//! broadcast shutdown.
+//!
+//! This module holds the drain LOOP; the daemon owns the triggers (the gRPC
+//! `Shutdown` RPC and the SIGTERM handler) and the state the loop reads. It
+//! lives here, next to the worker pool, because the drain's exit condition is
+//! about work the worker publishes — a unit test in this crate can drive a
+//! real worker-pool index against the real drain, which the daemon crate
+//! cannot (its tests link this crate without the `cfg(test)` `file://` clone
+//! allowance, so no daemon test can run a real index job).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+/// The counters and the shutdown channel the drain loop reads. Every field is
+/// a shared handle: the daemon clones its own `Arc`s in, so the loop observes
+/// the same values the RPC handlers and the worker pool mutate.
+pub struct DrainSignals {
+    /// In-flight write RPCs. A write holds the DB write lock on an
+    /// unabortable `spawn_blocking` thread, so while any are running the wait
+    /// is unbounded.
+    pub active_writes: Arc<AtomicU32>,
+    /// The worker pool's `indexing_active` flag. A flag, not a proof of work:
+    /// it cannot clear once the pool is drained with a non-empty queue.
+    pub indexing_active: Arc<AtomicBool>,
+    /// The worker pool's OWN count of spawned index jobs still running —
+    /// incremented when a job is claimed, decremented only when its task
+    /// finishes (commit included). Unlike the flag, this is a proof of work:
+    /// it is how the drain tells a genuinely running index job (unbounded
+    /// wait, like a write) from a stuck `indexing_active` flag (bounded by
+    /// the ceiling).
+    pub indexing_in_flight: Arc<AtomicU32>,
+    /// The channel the drain broadcasts on when the wait ends. Every listener
+    /// accepts until this fires, so the broadcast is what ends read service.
+    pub shutdown_tx: tokio::sync::watch::Sender<bool>,
+}
+
+/// Minimum spacing between repeats of the over-ceiling drain warning. The
+/// ceiling itself sets the cadence; this floor stops a tiny
+/// `NESTWEAVER_DRAIN_TIMEOUT_SECS` from turning the log into a spinner.
+const DRAIN_OVER_CEILING_REPORT_FLOOR_SECS: u64 = 60;
+
+/// Wait for in-flight writes and indexing to finish, then broadcast shutdown.
+///
+/// `ceiling` (`NESTWEAVER_DRAIN_TIMEOUT_SECS`) is a REPORTING threshold, not a
+/// kill switch, and this function must not pretend otherwise. Nothing in this
+/// process can abort an in-flight write: daemon writes run on `spawn_blocking`
+/// threads Tokio cannot cancel (see the "`spawn_blocking` work cannot be
+/// aborted" note on the daemon's exit path), and the shutdown broadcast this
+/// function ends with only stops listeners ACCEPTING — it cannot preempt work
+/// already running.
+///
+/// So the loop keeps waiting past the ceiling and says so. It used to log
+/// "drain timeout reached — forcing shutdown" and break, which was false twice
+/// over:
+///
+///  - nothing was forced. The broadcast does not abort the write, the process
+///    stayed alive holding the DB write lock, and only an operator's SIGKILL
+///    ever ended it; and
+///  - broadcasting shutdown there tore down every listener while the process
+///    lived on, which is how a stuck WRITE drain also took READS down. Almost
+///    no read needs the write gate (the daemon's `ConnectionGuard::read` does
+///    not take `write_mutex`), so they were not blocked by the drain itself —
+///    they died because the UDS/TCP/MCP acceptors had already been shut down
+///    by that premature broadcast, and every new `daemon status` / MCP / CLI
+///    read connection was refused for as long as the write ran.
+///
+/// Waiting instead keeps the daemon readable until the operator escalates —
+/// and if the write does finish, shutdown still completes cleanly rather than
+/// leaving a half-dead process behind. "Readable" is not absolute: `embed` and
+/// `plan_embed` take `write_mutex` themselves, so they stay blocked for the
+/// duration of the stuck write, and the ceiling message says so.
+///
+/// The unbounded wait applies to work that is GENUINELY in flight: writes,
+/// and index jobs the worker pool's own in-flight counter says are running.
+/// `indexing_active` on its own — the flag set with no job in flight — stays
+/// bounded by the ceiling: see the comment on that branch for why waiting on
+/// a stuck flag forever would be a hang rather than a safeguard.
+///
+/// What the in-flight counter can and cannot detect: it proves a job's task
+/// has not finished, not that the job is making progress. A job that is
+/// in-flight but truly wedged is indistinguishable from a slow one, so it
+/// earns the same unbounded wait a stuck write gets — reads stay served, the
+/// over-ceiling report keeps naming the operator escapes (`daemon stop
+/// --force` / `kill -9`), and nothing escalates automatically. That is
+/// strictly better than the old bounded branch, which broadcast at the
+/// ceiling and left the same wedged job running with NOTHING being served.
+pub async fn run_drain(signals: DrainSignals, ceiling: u64) {
+    let ceiling_at = std::time::Duration::from_secs(ceiling);
+    let half = std::time::Duration::from_secs(ceiling / 2);
+    let ninety = std::time::Duration::from_secs(ceiling * 9 / 10);
+    let repeat_every =
+        std::time::Duration::from_secs(ceiling.max(DRAIN_OVER_CEILING_REPORT_FLOOR_SECS));
+    let start = tokio::time::Instant::now();
+    let mut warned_half = false;
+    let mut warned_ninety = false;
+    // When the next over-ceiling report is due: first at the ceiling itself,
+    // then every `repeat_every` after that.
+    let mut next_over_ceiling_report = ceiling_at;
+
+    loop {
+        let writes = signals.active_writes.load(Ordering::Relaxed);
+        // Index jobs bump `indexing_active`, not `active_writes`, so the
+        // drain must wait on both — otherwise a shutdown could proceed
+        // while the worker is mid-write.
+        let indexing = signals.indexing_active.load(Ordering::Relaxed);
+        // The worker pool's own count of claimed jobs still running. This —
+        // not the flag — is the authority on whether an index job genuinely
+        // exists: it is incremented on claim and decremented only when the
+        // job's task finishes, so it cannot outlive the work the way the
+        // flag can.
+        let in_flight = signals.indexing_in_flight.load(Ordering::Relaxed);
+        if writes == 0 && !indexing && in_flight == 0 {
+            tracing::info!("no active writes or indexing — shutting down");
+            break;
+        }
+
+        let elapsed = start.elapsed();
+
+        if writes == 0 && in_flight == 0 {
+            // Stuck-flag wait: BOUNDED, deliberately.
+            //
+            // Only work that is genuinely in flight earns an unbounded wait —
+            // it holds the DB write lock on a `spawn_blocking` thread nothing
+            // can cancel, and abandoning it is the operator's call. This
+            // branch is the opposite case: the flag is set but the worker
+            // pool reports ZERO jobs in flight, so there is no running work
+            // to wait for, and waiting on the flag forever is a hang, not a
+            // safeguard.
+            //
+            // `indexing_active` is cleared in exactly two places in the worker
+            // loop, and with `drained` set (which the daemon's Shutdown handler
+            // does before this runs) BOTH are unreachable while the job queue
+            // is non-empty: the idle branch is skipped because the drained
+            // check `continue`s before a job is ever claimed, and the post-job
+            // branch clears only when pending + running + in-flight all reach
+            // zero. A server-mode daemon told to shut down with work still
+            // queued — the "continuous webhook enqueue" case the Shutdown
+            // handler already calls out — would never exit at all.
+            //
+            // The broadcast below is precisely what unblocks it: the worker
+            // loop observes shutdown and breaks. That is the pre-existing,
+            // working behaviour for this path, so it is kept intact — and the
+            // message says what it costs (read service ends here) rather than
+            // letting the daemon do it quietly.
+            if elapsed >= ceiling_at {
+                tracing::warn!(
+                    indexing_active = indexing,
+                    indexing_in_flight = in_flight,
+                    waited_secs = elapsed.as_secs(),
+                    "drain ceiling ({ceiling}s) reached with no in-flight writes \
+                     and no index job actually running — `indexing_active` is \
+                     set but the worker pool reports zero jobs in flight, so \
+                     the flag is stale (work is queued that the drained pool \
+                     will not claim). Signalling shutdown so the worker loop \
+                     breaks; anything still queued is left for the next start. \
+                     NOTE: this closes every listener, so reads stop being \
+                     served now"
+                );
+                break;
+            }
+        } else if elapsed >= next_over_ceiling_report {
+            next_over_ceiling_report = elapsed + repeat_every;
+            let pid = std::process::id();
+            if writes > 0 {
+                tracing::warn!(
+                    active_writes = writes,
+                    indexing_active = indexing,
+                    waited_secs = elapsed.as_secs(),
+                    pid,
+                    "drain ceiling ({ceiling}s) exceeded — still waiting on {writes} \
+                     in-flight write(s){}; the daemon CANNOT abort them and is NOT \
+                     shutting down. NEW writes are already being refused with \
+                     UNAVAILABLE, so this count only falls. Most reads are still \
+                     served, though they can stall for seconds while a write \
+                     commits. `embed` takes the write gate AND the write guard, so \
+                     it is refused outright; `plan_embed` takes the gate but counts \
+                     as a read, so it is not refused — it BLOCKS until the \
+                     in-flight write releases the gate. This is \
+                     the same drain whether you sent SIGTERM (`nestweaver daemon \
+                     stop`) or the Shutdown RPC (`nestweaver daemon restart`); \
+                     neither escalates on its own. To end it now — abandoning the \
+                     in-flight write, which the graph store may not survive cleanly \
+                     (nw-126) — run `nestweaver daemon stop --force` or `kill -9 \
+                     {pid}`",
+                    // The in-flight counter, not the flag, says whether an index
+                    // job is really running alongside the write.
+                    if in_flight > 0 {
+                        " (an index job is also genuinely in flight)"
+                    } else if indexing {
+                        " (indexing_active is also set, but no index job is in flight — the flag is stale)"
+                    } else {
+                        ""
+                    },
+                );
+            } else {
+                tracing::warn!(
+                    indexing_in_flight = in_flight,
+                    waited_secs = elapsed.as_secs(),
+                    pid,
+                    "drain ceiling ({ceiling}s) exceeded — an index job is genuinely \
+                     still running (the worker pool reports {in_flight} job(s) in \
+                     flight — its own counter, not the flag); the daemon CANNOT \
+                     abort it and is NOT shutting down. NEW writes are already \
+                     being refused with UNAVAILABLE, and reads keep being served, \
+                     though they can stall while the job's write commits. This is \
+                     the same drain whether you sent SIGTERM (`nestweaver daemon \
+                     stop`) or the Shutdown RPC (`nestweaver daemon restart`); \
+                     neither escalates on its own. If the job is wedged rather \
+                     than slow, ending it — abandoning its write, which the graph \
+                     store may not survive cleanly (nw-126) — is the operator's \
+                     call: `nestweaver daemon stop --force` or `kill -9 {pid}`"
+                );
+            }
+        }
+
+        // Past the ceiling these are noise — the reports above have taken over.
+        if elapsed < ceiling_at {
+            if !warned_half && elapsed >= half {
+                tracing::warn!(
+                    active_writes = writes,
+                    "drain at 50% of ceiling ({ceiling}s)"
+                );
+                warned_half = true;
+            }
+            if !warned_ninety && elapsed >= ninety {
+                tracing::warn!(
+                    active_writes = writes,
+                    "drain at 90% of ceiling ({ceiling}s)"
+                );
+                warned_ninety = true;
+            }
+        }
+
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+
+    let _ = signals.shutdown_tx.send(true);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Create a tiny git repo at `dir` with `files` committed, as the `file://`
+    /// fetch source for a real worker-pool index job (allowed here by the
+    /// `cfg(test)` clone allowance in `bare_clone`).
+    fn create_source_repo(dir: &std::path::Path, files: &[(&str, &str)]) {
+        std::fs::create_dir_all(dir).unwrap();
+        let git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(dir)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?}: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        git(&["init"]);
+        git(&["config", "user.email", "test@test.com"]);
+        git(&["config", "user.name", "Test"]);
+        for (path, content) in files {
+            let full = dir.join(path);
+            if let Some(parent) = full.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(&full, content).unwrap();
+        }
+        git(&["add", "."]);
+        git(&["commit", "-m", "init"]);
+    }
+
+    /// A GENUINELY RUNNING index job past the drain ceiling must not cost read
+    /// service. The drain historically consulted only `indexing_active` — a
+    /// flag that can outlive the work — so at the ceiling it broadcast shutdown
+    /// (closing every listener, ending reads) even while a real worker-pool job
+    /// was mid-commit, because it could not tell a live job from a stuck flag.
+    ///
+    /// This drives a REAL worker-pool index (real `JobQueue`, real bare-clone
+    /// fetch, real commit into a real store) and holds the job in flight past
+    /// the ceiling by holding the write gate: the worker's commit blocks in
+    /// `blocking_lock("worker_commit")`, which is exactly a job that is
+    /// running, not a flag that is stuck. Past the ceiling the drain must NOT
+    /// have broadcast — the broadcast is what closes the listeners, so its
+    /// absence IS "reads are still served". Once the gate is released the job
+    /// finishes and the drain must complete and broadcast.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn drain_with_genuinely_running_index_keeps_serving_reads_past_ceiling() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let src = tmp.path().join("source");
+        create_source_repo(
+            &src,
+            &[("lib.rs", "pub fn add(a: i32, b: i32) -> i32 { a + b }")],
+        );
+        let url = format!("file://{}", src.display());
+
+        // A real job queue with one repo to index.
+        let queue = crate::jobs::JobQueue::open(&tmp.path().join("jobs.db")).unwrap();
+        queue
+            .upsert(
+                "live-index-repo",
+                &url,
+                crate::jobs::JobTrigger::Unindexed,
+                None,
+            )
+            .unwrap();
+        let queue = Arc::new(Mutex::new(queue));
+        let workspace = Arc::new(
+            crate::bare_clone::BareCloneWorkspace::new(&tmp.path().join("workspace")).unwrap(),
+        );
+        let store = Arc::new(nestweaver_store::GraphStore::in_memory().unwrap());
+
+        // The drain reads the worker's own status handles — the same Arcs the
+        // worker mutates, wired exactly as the daemon wires them.
+        let status = crate::worker::IndexingStatus::new();
+        let write_gate = crate::write_gate::WriteGate::new();
+        let drained = Arc::new(AtomicBool::new(false));
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let mut worker_shutdown = shutdown_tx.subscribe();
+        let signals = DrainSignals {
+            active_writes: Arc::new(AtomicU32::new(0)),
+            indexing_active: Arc::clone(&status.active),
+            indexing_in_flight: Arc::clone(&status.in_flight),
+            shutdown_tx,
+        };
+
+        let pool = crate::worker::WorkerPool::new(1);
+        let worker_queue = Arc::clone(&queue);
+        let worker_workspace = Arc::clone(&workspace);
+        let worker_store = Arc::clone(&store);
+        let worker_status = status.clone();
+        let worker_drained = Arc::clone(&drained);
+        let worker_gate = write_gate.clone();
+        let worker = tokio::spawn(async move {
+            pool.run_with_drain(
+                worker_queue,
+                worker_workspace,
+                worker_store,
+                "test".to_string(),
+                &mut worker_shutdown,
+                Some(worker_status),
+                Some(worker_drained),
+                Some(worker_gate),
+            )
+            .await;
+        });
+
+        // Hold the write gate so the job's commit phase blocks: the job is
+        // genuinely running — claimed, fetched, parsed, and waiting to write —
+        // for exactly as long as this lease is held.
+        let held = write_gate.lock("test_holds_gate").await;
+
+        // Wait until the worker's commit is actually blocked on the gate —
+        // observable proof a job is in flight, not merely a flag set.
+        let blocked = tokio::time::timeout(std::time::Duration::from_secs(30), async {
+            while write_gate.waiting() == 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        })
+        .await;
+        assert!(
+            blocked.is_ok(),
+            "the worker must reach its commit phase and block on the write gate"
+        );
+        assert!(
+            status.active.load(Ordering::Relaxed),
+            "precondition: the indexing flag is set for a real job"
+        );
+
+        // Start the drain with a 1s ceiling, as the daemon's Shutdown handler
+        // does (it sets `drained` first, then runs the drain).
+        drained.store(true, Ordering::Relaxed);
+        let drain = tokio::spawn(run_drain(signals, 1));
+
+        // Well past the ceiling, with the job still genuinely in flight, the
+        // drain must NOT have broadcast: the broadcast closes every listener,
+        // so its absence is what "reads are still served" means.
+        tokio::time::sleep(std::time::Duration::from_millis(2_500)).await;
+        assert!(
+            !*shutdown_rx.borrow(),
+            "a genuinely running index job past the ceiling must not end read \
+             service: the drain broadcast (which closes every listener) fired \
+             anyway, because the drain cannot tell a live job from a stuck flag"
+        );
+
+        // Release the gate: the job commits, the flag clears, and the drain
+        // must then complete and broadcast.
+        drop(held);
+        tokio::time::timeout(std::time::Duration::from_secs(30), drain)
+            .await
+            .expect("the drain must complete once the index job finishes")
+            .expect("drain task panicked");
+        assert!(
+            *shutdown_rx.borrow(),
+            "once the job really finishes the drain must still shut down cleanly"
+        );
+        tokio::time::timeout(std::time::Duration::from_secs(30), worker)
+            .await
+            .expect("the worker must exit after the shutdown broadcast")
+            .expect("worker task panicked");
+    }
+}

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -224,6 +224,7 @@ pub mod cpu_throttle;
 pub mod cross_domain;
 pub mod dead_code;
 pub mod diff_impact;
+pub mod drain;
 pub mod embedding;
 pub mod eval;
 pub mod export;

--- a/crates/nestweaver-engine/src/worker.rs
+++ b/crates/nestweaver-engine/src/worker.rs
@@ -51,16 +51,21 @@ impl IndexingStatus {
     }
 
     /// Create from existing Arc fields (e.g. shared with DaemonState).
+    ///
+    /// `in_flight` must be the caller's own handle too — the daemon's shutdown
+    /// drain reads it to tell a genuinely running index job from a stuck
+    /// `active` flag, so a fresh counter here would hide real work from it.
     pub fn from_arcs(
         active: Arc<AtomicBool>,
         current_repo: Arc<tokio::sync::RwLock<String>>,
         queue_depth: Arc<AtomicU32>,
+        in_flight: Arc<AtomicU32>,
     ) -> Self {
         Self {
             active,
             current_repo,
             queue_depth,
-            in_flight: Arc::new(AtomicU32::new(0)),
+            in_flight,
         }
     }
 }

--- a/docs/guide/daemon-shutdown.md
+++ b/docs/guide/daemon-shutdown.md
@@ -87,10 +87,12 @@ Check the daemon log for what it is waiting on.
 ```
 
 The command **re-probes the socket** immediately before printing, and says so
-honestly when the answer is bad. In the index-only drain (`active_writes == 0`
-with `indexing_active` set) the daemon broadcasts at the ceiling — 660s — which
-closes every listener, while this command's grace runs to 690s. In that window
-the daemon is alive but unreachable, and the message says:
+honestly when the answer is bad. In a stuck-flag index drain (`active_writes ==
+0` with `indexing_active` set but no worker job actually in flight — the flag
+cannot clear once the pool is drained with a non-empty queue) the daemon
+broadcasts at the ceiling — 660s — which closes every listener, while this
+command's grace runs to 690s. In that window the daemon is alive but
+unreachable, and the message says:
 
 ```
 It is still running but is NO LONGER answering on its socket: the drain reached
@@ -122,7 +124,7 @@ short version above for why that refusal is what makes the drain terminate.
 
 | Knob | Default | What it is |
 |---|---|---|
-| `NESTWEAVER_DRAIN_TIMEOUT_SECS` | 660 | Drain ceiling. With a write in flight this is a **reporting** threshold, not a deadline. With only an index job in flight it **is** a deadline (see CLAUDE.md for why). |
+| `NESTWEAVER_DRAIN_TIMEOUT_SECS` | 660 | Drain ceiling. With a write in flight — or a genuinely running index job (the drain reads the worker pool's own in-flight counter) — this is a **reporting** threshold, not a deadline. With only a stuck `indexing_active` flag (no job in flight) it **is** a deadline (see CLAUDE.md for why). |
 | `NESTWEAVER_STOP_GRACE_SECS` | ceiling + 30 (690) | How long `daemon stop` waits before reporting and standing down. **Not** a kill deadline. Deliberately shorter than the launchd `ExitTimeOut` below, so the CLI reports before launchd kills rather than after. |
 | `daemon stop --force` | 10s, fixed | SIGTERM, brief wait for a clean exit, then SIGKILL. Ignores the two variables above — an operator using `--force` should not have to wait 11 minutes first. |
 

--- a/docs/guide/daemon-shutdown.md
+++ b/docs/guide/daemon-shutdown.md
@@ -95,10 +95,14 @@ command's grace runs to 690s. In that window the daemon is alive but
 unreachable, and the message says:
 
 ```
-It is still running but is NO LONGER answering on its socket: the drain reached
-its ceiling with no in-flight write and broadcast shutdown, which closes every
-listener, and the process is now finishing unabortable work with nothing being
-served. Reads are DOWN.
+It is still running, but its socket did not answer just now, so reads may be
+DOWN. The likeliest cause is a stuck-flag index drain: with nothing in the
+write queue and the worker pool idle, the daemon broadcasts at the drain
+ceiling, which closes every listener (a genuinely running index job keeps
+them up, like a write — the broadcast is only for a flag that outlived its
+work). This probe cannot tell that apart from a socket already cleaned up,
+a refused connection during exit, or a local file-descriptor limit — check
+the daemon log before concluding.
 ```
 
 Exit status is non-zero in both cases: the operator asked for the daemon to stop

--- a/src/main.rs
+++ b/src/main.rs
@@ -4740,16 +4740,19 @@ const STOP_WAIT_NOTICE_SECS: u64 = 60;
 ///
 /// `serving_reads` is OBSERVED, not assumed — the caller re-probes the socket
 /// immediately before printing. The first version of this message asserted
-/// "still serving reads" unconditionally, which is false in the index-only
-/// drain: with `active_writes == 0 && indexing_active`, `run_shutdown_drain`
-/// breaks and BROADCASTS at the ceiling, closing every listener at 660s, while
-/// this command's grace is 690s — so at report time the daemon could have had
-/// no listeners for thirty seconds. That is exactly the overclaim class this
-/// change exists to remove, so it must not be reintroduced by the command
-/// announcing the fix.
+/// "still serving reads" unconditionally, which is false in the stuck-flag
+/// index drain: with `active_writes == 0`, `indexing_active` set, and the
+/// worker pool reporting ZERO jobs in flight (the flag cannot clear once the
+/// pool is drained with a non-empty queue), the drain breaks and BROADCASTS at
+/// the ceiling, closing every listener at 660s, while this command's grace is
+/// 690s — so at report time the daemon could have had no listeners for thirty
+/// seconds. A GENUINELY RUNNING index job is not this case: like an in-flight
+/// write, it keeps the listeners up past the ceiling, so reads stay served.
+/// That is exactly the overclaim class this change exists to remove, so it
+/// must not be reintroduced by the command announcing the fix.
 ///
 /// THE NEGATIVE BRANCH REPORTS THE OBSERVATION, NOT A CAUSE. All the caller
-/// knows is that one `connect()` did not answer. The index-only ceiling
+/// knows is that one `connect()` did not answer. The stuck-flag ceiling
 /// broadcast is the *likely* explanation and is named as such, but it is not
 /// the only one: ECONNREFUSED while the process is mid-exit, `EMFILE`/`ENFILE`
 /// in this CLI process, a socket already swept by `daemon gc`, or a full listen
@@ -4765,11 +4768,13 @@ fn stop_still_draining_message(pid: i32, waited_secs: u64, serving_reads: bool) 
          aborted (`spawn_blocking` is not cancellable) has to finish."
     } else {
         "It is still running, but its socket did not answer just now, so reads may be \
-         DOWN. The likeliest cause is the index-only drain: with nothing in the write \
-         queue the daemon broadcasts at the drain ceiling, which closes every listener \
-         while the process keeps finishing unabortable work. This probe cannot tell that \
-         apart from a socket already cleaned up, a refused connection during exit, or a \
-         local file-descriptor limit — check the daemon log before concluding."
+         DOWN. The likeliest cause is a stuck-flag index drain: with nothing in the \
+         write queue and the worker pool idle, the daemon broadcasts at the drain \
+         ceiling, which closes every listener (a genuinely running index job keeps \
+         them up, like a write — the broadcast is only for a flag that outlived its \
+         work). This probe cannot tell that apart from a socket already cleaned up, \
+         a refused connection during exit, or a local file-descriptor limit — check \
+         the daemon log before concluding."
     };
     format!(
         "Daemon (PID {pid}) is STILL DRAINING after {waited_secs}s and was NOT stopped.\n\
@@ -14419,10 +14424,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         }
 
                         // OBSERVE whether the socket answers; do NOT infer why.
-                        // The index-only drain broadcasts at the ceiling, which
-                        // closes every listener 30s before this grace expires,
-                        // so "still serving reads" cannot be asserted — but a
-                        // failed connect does not prove that particular cause
+                        // A stuck-flag index drain (`indexing_active` set with
+                        // the worker pool reporting zero jobs in flight)
+                        // broadcasts at the ceiling, which closes every
+                        // listener 30s before this grace expires, so "still
+                        // serving reads" cannot be asserted — but a failed
+                        // connect does not prove that particular cause
                         // either (ECONNREFUSED mid-exit, EMFILE in this process,
                         // a socket swept by `daemon gc`, a full listen backlog).
                         // The message therefore reports the observation and
@@ -23499,12 +23506,15 @@ mod stop_grace_tests {
         );
     }
 
-    /// The index-only drain is the case the first version of this message got
-    /// wrong. With `active_writes == 0 && indexing_active`, `run_shutdown_drain`
-    /// breaks and BROADCASTS at the ceiling — which closes every listener at
-    /// 660s, while this command's grace runs to 690s. So there is a real window
-    /// in which the daemon is alive, unreachable, and the command was announcing
-    /// "still serving reads" about it.
+    /// The stuck-flag index drain is the case the first version of this message
+    /// got wrong. With `active_writes == 0`, `indexing_active` set, and the
+    /// worker pool reporting zero jobs in flight, the drain breaks and
+    /// BROADCASTS at the ceiling — which closes every listener at 660s, while
+    /// this command's grace runs to 690s. So there is a real window in which
+    /// the daemon is alive, unreachable, and the command was announcing "still
+    /// serving reads" about it. (A genuinely running index job keeps the
+    /// listeners up past the ceiling, so the broadcast case is provably a
+    /// stuck flag.)
     ///
     /// The caller re-probes the socket and passes what it observed. Both
     /// branches are asserted here because the honest branch is the whole point:


### PR DESCRIPTION
## Problem

Re-scoped residual of the shutdown-broadcast item (Symptom 1 landed in PR #250): the drain could not distinguish a **stuck `indexing_active` flag** from a genuinely running index job, because the worker pool's `in_flight` counter lived inside `IndexingStatus` and was never shared into `DaemonState`. A genuinely running long index job past the drain ceiling took the bounded branch — the daemon broadcast shutdown and **dropped reads** while the write continued, on the assumption the flag might be stale.

## Fix

- The worker's own `in_flight` counter (`Arc<AtomicU32`, incremented on job claim, decremented only when the job's task finishes — commit included) is now shared into `DaemonState::indexing_in_flight`; `IndexingStatus::from_arcs` takes it instead of minting a private one.
- The drain loop consults it: exit requires `writes == 0 && !indexing && in_flight == 0`; the bounded-at-ceiling branch now only fires when `writes == 0 && in_flight == 0` — **provably** a stuck flag. A job with `in_flight > 0` past the ceiling gets the same unbounded wait as a write, with a periodic report naming `daemon stop --force` / `kill -9`. A wedged-but-in-flight job is documented as indistinguishable from a slow one: it earns the unbounded wait, reads stay served, nothing escalates automatically.
- The 15-line "cannot be fixed from here" residual comment is deleted (the condition no longer exists). New jobs can be enqueued during a drain but never claimed (`drained` is set before the loop spawns), so the ceiling race is closed by construction.
- The drain loop moved from `server.rs` to `crates/nestweaver-engine/src/drain.rs` (`run_drain(DrainSignals { … })`) with `run_shutdown_drain` as a thin adapter — required because the acceptance test must drive a **real** worker-pool index, and the SSRF guard's `file://` clone allowance is `#[cfg(test)]`-only, so no daemon-crate test can run one (proven empirically). No dependency inversion: drain.rs imports only std/tokio/tracing. A `CONSUMER CONTRACT` doc on `DrainSignals` states which message claims belong to the consumer.
- The `daemon stop` "still draining" message and drain docs (CLAUDE.md, daemon-shutdown.md) now describe the stuck-flag-only ceiling broadcast.

## Tests

- Acceptance test `drain_with_genuinely_running_index_keeps_serving_reads_past_ceiling`: real WorkerPool + JobQueue + bare-clone fetch + real commit, job held in flight via the write gate, asserts **no broadcast** 2.5s past a 1s ceiling and clean drain completion after release. **Proven RED against the unfixed loop** (failed at exactly that assertion), GREEN post-fix.
- engine 1081/1081, daemon 269/269 (all pre-existing drain/ceiling tests pass against the adapter), fmt/clippy clean.

Backlog item: `the-shutdown-broadcast-is-the-only-shutdown-primitive` (MEDIUM, re-scoped). Adversarial review: APPROVE, plus a doc-honesty repair round.