### PR TITLE
fix(engine): fold the is_wedged gate into needs_forced_repair + pin the read-only boot gate

### DIFF
--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -8581,8 +8581,13 @@ async fn load_embedding_model(state: &std::sync::Arc<DaemonState>) {
 /// neighbouring reconcile passes: a snapshot-replica daemon opens read-only,
 /// and a read-only caller must report the condition rather than recompute
 /// PageRank, persist `.generation`, and delete the marker out from under
-/// whoever holds the write lock. This is pinned by
-/// `read_only_boot_reconciliation_leaves_the_publication_untouched_on_disk`.
+/// whoever holds the write lock. Both directions of the gate are pinned:
+/// `read_only_boot_reconciliation_leaves_the_publication_untouched_on_disk`
+/// (must NOT recover on a read-only boot) and
+/// `read_write_boot_reconciliation_recovers_the_abandoned_publication` (MUST
+/// recover on a read-write boot), with
+/// `read_write_daemon_boot_recovers_the_abandoned_publication` pinning the
+/// call-site binding end to end.
 fn reconcile_index_publication_before_ppr_warm(store: &GraphStore, read_only: bool) {
     nestweaver_engine::index::recover_abandoned_index_publication_best_effort(store, !read_only);
     match store.warm_ppr_cache() {
@@ -17546,6 +17551,107 @@ mod boot_reconciliation_tests {
         pid
     }
 
+    /// A minimal code graph, so a recovery's PageRank recompute has
+    /// observable content (mirrors the engine fixture's shape).
+    fn insert_publication_graph(store: &GraphStore) {
+        let repo_uid = "repo:boot".to_string();
+        let file_uid = "file:boot".to_string();
+        store
+            .insert_repo(&nestweaver_schema::Repo {
+                uid: repo_uid.clone(),
+                url: "https://example.test/boot".into(),
+                indexed_sha: "boot".into(),
+                staleness_commits_behind: 0,
+                instance_id: "test".into(),
+                name: None,
+                root_path: None,
+            })
+            .unwrap();
+        store
+            .insert_file(&nestweaver_schema::File {
+                uid: file_uid.clone(),
+                path: "src/boot.rs".into(),
+                repo_uid: repo_uid.clone(),
+                content_hash: "hash-boot".into(),
+            })
+            .unwrap();
+        store.insert_repo_file_edge(&repo_uid, &file_uid).unwrap();
+        for (uid, name) in [
+            ("sym:boot:source", "boot_source"),
+            ("sym:boot:target", "boot_target"),
+        ] {
+            store
+                .insert_symbol(&nestweaver_schema::Symbol {
+                    uid: uid.into(),
+                    name: name.into(),
+                    kind: nestweaver_schema::SymbolKind::Function,
+                    repo_uid: repo_uid.clone(),
+                    file_path: "src/boot.rs".into(),
+                    start_line: 1,
+                    end_line: 2,
+                    signature: "fn boot()".into(),
+                    summary: None,
+                    content_hash: format!("hash-{uid}"),
+                    embedding: None,
+                    pagerank_score: None,
+                    is_entry_point: false,
+                    entry_point_kind: None,
+                    visibility: nestweaver_schema::Visibility::Inferred,
+                    type_info: None,
+                    framework_hint: None,
+                    canonical_id: None,
+                })
+                .unwrap();
+            store.insert_file_symbol_edge(&file_uid, uid).unwrap();
+        }
+        store
+            .insert_edge(&nestweaver_schema::ResolvedEdge {
+                source_uid: "sym:boot:source".into(),
+                target_uid: "sym:boot:target".into(),
+                edge_type: nestweaver_schema::EdgeType::Calls,
+                confidence: 1.0,
+                link_type: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
+    }
+
+    /// Leave `db_path` in exactly the state a SIGKILL between marker
+    /// establishment and finalize produces: graph committed, `.index-dirty`
+    /// present and naming a dead writer, `.pagerank.json` still holding
+    /// pre-crash scores, `.generation` still at the pre-crash canonical value.
+    /// Returns the dead writer's pid and the canonical generation.
+    fn abandoned_publication_fixture(db_path: &std::path::Path) -> (i32, u64) {
+        let generation_path = nestweaver_engine::sidecar_path(db_path, ".generation");
+        let pagerank_path = nestweaver_engine::sidecar_path(db_path, ".pagerank.json");
+        let marker_path = nestweaver_engine::sidecar_path(db_path, ".index-dirty");
+
+        let canonical = {
+            let store = GraphStore::open_or_create(db_path).unwrap();
+            store.bump_graph_generation();
+            store.save_graph_generation(&generation_path).unwrap();
+            let canonical = store.graph_generation();
+            insert_publication_graph(&store);
+            canonical
+        };
+        std::fs::write(&pagerank_path, br#"{"stale-precrash-score":1.0}"#).unwrap();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dead_pid = reaped_child_pid();
+        std::fs::write(
+            &marker_path,
+            nestweaver_store::index_publication::format_marker_payload(
+                dead_pid as u32,
+                nanos,
+                None,
+            ),
+        )
+        .unwrap();
+        (dead_pid, canonical)
+    }
+
     /// The daemon-level pin for the `!read_only` recovery gate (nw-C1): a
     /// read-only replica's boot reconciliation must REPORT an abandoned
     /// publication, never repair it. Asserted ON DISK: the marker,
@@ -17572,30 +17678,7 @@ mod boot_reconciliation_tests {
         let marker_path = nestweaver_engine::sidecar_path(&db_path, ".index-dirty");
         let generation_path = nestweaver_engine::sidecar_path(&db_path, ".generation");
         let pagerank_path = nestweaver_engine::sidecar_path(&db_path, ".pagerank.json");
-
-        // The state a SIGKILL between marker establishment and finalize
-        // leaves: a committed database with a durable generation, a PageRank
-        // sidecar that predates the last commit, and a marker naming a dead
-        // writer.
-        {
-            let store = GraphStore::open_or_create(&db_path).unwrap();
-            store.bump_graph_generation();
-            store.save_graph_generation(&generation_path).unwrap();
-        }
-        std::fs::write(&pagerank_path, br#"{"stale-precrash-score":1.0}"#).unwrap();
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        std::fs::write(
-            &marker_path,
-            nestweaver_store::index_publication::format_marker_payload(
-                reaped_child_pid() as u32,
-                nanos,
-                None,
-            ),
-        )
-        .unwrap();
+        abandoned_publication_fixture(&db_path);
 
         let before_marker = std::fs::read(&marker_path).unwrap();
         let before_generation = std::fs::read(&generation_path).unwrap();
@@ -17625,6 +17708,167 @@ mod boot_reconciliation_tests {
             store.is_index_publication_dirty(),
             "a read-only boot must keep failing closed, not clear the condition"
         );
+    }
+
+    /// The other half of the gate (nw-C1): a READ-WRITE daemon's boot
+    /// reconciliation must actually recover — a gate pinned only in the
+    /// "decline" direction could be flipped to never recover at all
+    /// (`!read_only` → `false`) with no test failing. Asserted against the
+    /// recovery contract: the marker is retired, the clean N+2 generation is
+    /// published, and the recomputed ranks cover the committed graph.
+    #[test]
+    fn read_write_boot_reconciliation_recovers_the_abandoned_publication() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("writer.lbug");
+        let marker_path = nestweaver_engine::sidecar_path(&db_path, ".index-dirty");
+        let pagerank_path = nestweaver_engine::sidecar_path(&db_path, ".pagerank.json");
+        let (_dead_pid, canonical) = abandoned_publication_fixture(&db_path);
+
+        // Open exactly as the read-write boot does, then run the boot
+        // reconciliation with the same `read_only` the boot computes.
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        reconcile_index_publication_before_ppr_warm(&store, false);
+
+        assert!(
+            !marker_path.exists(),
+            "a read-write boot must retire the abandoned marker"
+        );
+        assert!(!store.is_index_publication_dirty());
+        assert_eq!(
+            store.graph_generation(),
+            canonical + 2,
+            "recovery publishes the clean N+2 successor"
+        );
+        let scores = store.pagerank_scores();
+        assert!(
+            scores.contains_key("sym:boot:source") && scores.contains_key("sym:boot:target"),
+            "recovered PageRank must cover the committed graph: {scores:?}"
+        );
+        assert!(
+            !std::fs::read_to_string(&pagerank_path)
+                .unwrap()
+                .contains("stale-precrash-score"),
+            "recovery must rewrite the pre-crash PageRank sidecar"
+        );
+    }
+
+    /// The end-to-end pin for the CALL SITE (nw-C1): a full read-write daemon
+    /// boot on a database carrying the crash state must recover the abandoned
+    /// publication with no RPC and no operator action. The two function-level
+    /// tests above call `reconcile_index_publication_before_ppr_warm` with
+    /// literal arguments, so neither can see a flipped binding at the boot
+    /// call site (`read_only` → `!read_only` there passes `true` on a
+    /// read-write boot, silently disabling writer-boot recovery); this test
+    /// boots the real server and observes the marker's retirement on disk.
+    // Holding a std MutexGuard across await points is deliberate here: the
+    // guard only ever blocks sibling TEST threads that swap env vars (they
+    // take the same lock), never async tasks in this runtime — a tokio Mutex
+    // would buy nothing.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn read_write_daemon_boot_recovers_the_abandoned_publication() {
+        // Resolve env-dependent paths (socket, pidfile, log/runtime dirs) for
+        // the daemon's whole lifetime under the same lock the sibling e2e
+        // tests hold while swapping XDG vars.
+        let _env_guard = lifecycle::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("brain.lbug");
+        let marker_path = nestweaver_engine::sidecar_path(&db_path, ".index-dirty");
+        let pagerank_path = nestweaver_engine::sidecar_path(&db_path, ".pagerank.json");
+        let (_dead_pid, canonical) = abandoned_publication_fixture(&db_path);
+
+        let db_for_server = db_path.clone();
+        let server =
+            tokio::spawn(async move { run_server(&db_for_server, None, None, None).await });
+
+        let instance_id = lifecycle::instance_id_from_db_path(&db_path);
+        let sock = lifecycle::socket_path(&instance_id);
+
+        // Wait for the daemon's socket to accept connections.
+        let mut client = None;
+        for _ in 0..100 {
+            if sock.exists()
+                && let Ok(c) = connect_uds(&sock).await
+            {
+                client = Some(c);
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        let mut client = client.expect("daemon socket did not come up within 10s");
+
+        // The boot reconciliation needs no RPC: it runs on a blocking thread
+        // during startup and must retire the marker on its own.
+        let mut retired = false;
+        for _ in 0..300 {
+            if !marker_path.exists() {
+                retired = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        assert!(
+            retired,
+            "a read-write daemon boot must recover the abandoned publication \
+             (retire the marker) within 30s of startup"
+        );
+
+        client
+            .shutdown(nestweaver_proto::ShutdownRequest {})
+            .await
+            .expect("shutdown RPC");
+        let finished = tokio::time::timeout(std::time::Duration::from_secs(30), server)
+            .await
+            .expect("daemon must exit promptly");
+        finished
+            .expect("server task panicked")
+            .expect("run_server error");
+
+        // The recovery contract, verified against the reopened database.
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        assert!(!store.is_index_publication_dirty());
+        assert_eq!(
+            store.graph_generation(),
+            canonical + 2,
+            "recovery publishes the clean N+2 successor"
+        );
+        store.load_pagerank_cache(&pagerank_path).unwrap();
+        let scores = store.pagerank_scores();
+        assert!(
+            scores.contains_key("sym:boot:source") && scores.contains_key("sym:boot:target"),
+            "persisted ranks must cover the committed graph: {scores:?}"
+        );
+        drop(store);
+
+        // Belt-and-suspenders cleanup; a temp-DB daemon sweeps these itself.
+        let _ = std::fs::remove_dir_all(lifecycle::log_dir(&instance_id));
+        let _ = std::fs::remove_dir_all(lifecycle::runtime_dir(&instance_id));
+    }
+
+    async fn connect_uds(
+        sock: &std::path::Path,
+    ) -> Result<
+        nestweaver_proto::nest_weaver_daemon_client::NestWeaverDaemonClient<
+            tonic::transport::Channel,
+        >,
+        (),
+    > {
+        let path = sock.to_path_buf();
+        let channel = tonic::transport::Endpoint::try_from("http://[::]:50051")
+            .map_err(|_| ())?
+            .connect_timeout(std::time::Duration::from_secs(5))
+            .connect_with_connector(tower::service_fn(move |_: tonic::transport::Uri| {
+                let path = path.clone();
+                async move {
+                    let stream = tokio::net::UnixStream::connect(path).await?;
+                    Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(stream))
+                }
+            }))
+            .await
+            .map_err(|_| ())?;
+        Ok(nestweaver_proto::nest_weaver_daemon_client::NestWeaverDaemonClient::new(channel))
     }
 }
 

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -8567,6 +8567,44 @@ async fn load_embedding_model(state: &std::sync::Arc<DaemonState>) {
     }
 }
 
+/// Boot-time index-publication reconciliation, run on a blocking thread just
+/// before the PPR cache warm.
+///
+/// nw-C1: a read-write daemon is a WRITER. If a prior indexer died between
+/// establishing `<db>.index-dirty` and finalizing, every ranked query in this
+/// database fails closed forever. Reconcile it here, before warming, so the
+/// warm below succeeds and the first PPR query does not meet the wedge. A live
+/// publication is left strictly alone (see
+/// `recover_abandoned_index_publication`).
+///
+/// The gate must mirror how THIS daemon opened the store, exactly like the
+/// neighbouring reconcile passes: a snapshot-replica daemon opens read-only,
+/// and a read-only caller must report the condition rather than recompute
+/// PageRank, persist `.generation`, and delete the marker out from under
+/// whoever holds the write lock. This is pinned by
+/// `read_only_boot_reconciliation_leaves_the_publication_untouched_on_disk`.
+fn reconcile_index_publication_before_ppr_warm(store: &GraphStore, read_only: bool) {
+    nestweaver_engine::index::recover_abandoned_index_publication_best_effort(store, !read_only);
+    match store.warm_ppr_cache() {
+        Ok(()) => tracing::info!("PPR adjacency cache warmed"),
+        // nw-C2: this specific failure used to be swallowed as a generic warn,
+        // which is how a permanently wedged database produced no diagnostic
+        // anywhere. Name it.
+        Err(e) if format!("{e}").contains("dirty index publication") => {
+            let status = store
+                .db_path()
+                .map(nestweaver_engine::index_publication::status);
+            tracing::warn!(
+                "PPR cache not warmed: an index publication is dirty, so every ranked \
+                 query (brain_context, project_context, investigate) will fail closed \
+                 until it is reconciled. This is an index PUBLICATION marker, not a \
+                 dirty git working tree. status={status:?} error={e}"
+            );
+        }
+        Err(e) => tracing::warn!("failed to warm PPR cache: {e}"),
+    }
+}
+
 pub async fn run_server(
     db_path: &Path,
     mut idle_timeout: Option<Duration>,
@@ -9011,39 +9049,7 @@ pub async fn run_server(
     {
         let store = state.store.clone();
         tokio::task::spawn_blocking(move || {
-            // nw-C1: a read-write daemon is a WRITER. If a prior indexer died
-            // between establishing `<db>.index-dirty` and finalizing, every
-            // ranked query in this database fails closed forever. Reconcile it
-            // here, before warming, so the warm below succeeds and the first
-            // PPR query does not meet the wedge. A live publication is left
-            // strictly alone (see `recover_abandoned_index_publication`).
-            //
-            // The gate must mirror how THIS daemon opened the store, exactly
-            // like the neighbouring reconcile passes: a snapshot-replica daemon
-            // opens read-only, and a read-only caller must report the condition
-            // rather than recompute PageRank, persist `.generation`, and delete
-            // the marker out from under whoever holds the write lock.
-            nestweaver_engine::index::recover_abandoned_index_publication_best_effort(
-                &store, !read_only,
-            );
-            match store.warm_ppr_cache() {
-                Ok(()) => tracing::info!("PPR adjacency cache warmed"),
-                // nw-C2: this specific failure used to be swallowed as a
-                // generic warn, which is how a permanently wedged database
-                // produced no diagnostic anywhere. Name it.
-                Err(e) if format!("{e}").contains("dirty index publication") => {
-                    let status = store
-                        .db_path()
-                        .map(nestweaver_engine::index_publication::status);
-                    tracing::warn!(
-                        "PPR cache not warmed: an index publication is dirty, so every ranked \
-                         query (brain_context, project_context, investigate) will fail closed \
-                         until it is reconciled. This is an index PUBLICATION marker, not a \
-                         dirty git working tree. status={status:?} error={e}"
-                    );
-                }
-                Err(e) => tracing::warn!("failed to warm PPR cache: {e}"),
-            }
+            reconcile_index_publication_before_ppr_warm(&store, read_only)
         });
     }
 
@@ -17517,6 +17523,108 @@ external_model = "unavailable-test-model"
         assert!(!replica_mounts_admin_api(true, false));
         assert!(replica_mounts_admin_api(false, true));
         assert!(!replica_mounts_admin_api(false, false));
+    }
+}
+
+#[cfg(test)]
+mod boot_reconciliation_tests {
+    use super::*;
+
+    /// A pid guaranteed not to name a live process: spawn a child, wait for it
+    /// (reaping the zombie), and return its now-free pid, so `kill(pid, 0)`
+    /// reports ESRCH deterministically.
+    fn reaped_child_pid() -> i32 {
+        let mut child = std::process::Command::new("/bin/true")
+            .spawn()
+            .expect("spawn /bin/true");
+        let pid = child.id() as i32;
+        child.wait().expect("reap /bin/true");
+        assert!(
+            !nestweaver_engine::index_publication::process_is_alive(pid),
+            "a reaped child must not read as alive"
+        );
+        pid
+    }
+
+    /// The daemon-level pin for the `!read_only` recovery gate (nw-C1): a
+    /// read-only replica's boot reconciliation must REPORT an abandoned
+    /// publication, never repair it. Asserted ON DISK: the marker,
+    /// `.generation`, and `.pagerank.json` are byte-for-byte untouched.
+    ///
+    /// Why this drives `reconcile_index_publication_before_ppr_warm` directly
+    /// rather than booting a full replica end to end: a replica's working copy
+    /// is rebuilt from the snapshot on every boot, and `materialize_snapshot`
+    /// relocates only the graph file and its known sidecars — any marker file
+    /// in the snapshot is discarded, so no marker can ride a snapshot into the
+    /// boot path deterministically. What CAN be pinned deterministically is
+    /// the exact boot path itself: the store here is opened exactly the way
+    /// the replica boot opens it (`GraphStore::open_read_only`), against a
+    /// database left in exactly the crash state (committed graph, dead-writer
+    /// marker, pre-crash sidecars), and the function under test is the exact
+    /// code the boot runs, passed the same `read_only` the boot computes.
+    /// Flipping the `!read_only` argument inside it to `true` fails this test;
+    /// the engine-level tests cannot see that flip, because they call the
+    /// engine function with an explicit literal.
+    #[test]
+    fn read_only_boot_reconciliation_leaves_the_publication_untouched_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("replica.lbug");
+        let marker_path = nestweaver_engine::sidecar_path(&db_path, ".index-dirty");
+        let generation_path = nestweaver_engine::sidecar_path(&db_path, ".generation");
+        let pagerank_path = nestweaver_engine::sidecar_path(&db_path, ".pagerank.json");
+
+        // The state a SIGKILL between marker establishment and finalize
+        // leaves: a committed database with a durable generation, a PageRank
+        // sidecar that predates the last commit, and a marker naming a dead
+        // writer.
+        {
+            let store = GraphStore::open_or_create(&db_path).unwrap();
+            store.bump_graph_generation();
+            store.save_graph_generation(&generation_path).unwrap();
+        }
+        std::fs::write(&pagerank_path, br#"{"stale-precrash-score":1.0}"#).unwrap();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::fs::write(
+            &marker_path,
+            nestweaver_store::index_publication::format_marker_payload(
+                reaped_child_pid() as u32,
+                nanos,
+                None,
+            ),
+        )
+        .unwrap();
+
+        let before_marker = std::fs::read(&marker_path).unwrap();
+        let before_generation = std::fs::read(&generation_path).unwrap();
+        let before_pagerank = std::fs::read(&pagerank_path).unwrap();
+
+        // Open exactly as the snapshot-replica boot does, then run the boot
+        // reconciliation with the same `read_only` the boot computes.
+        let store = GraphStore::open_read_only(&db_path).unwrap();
+        reconcile_index_publication_before_ppr_warm(&store, true);
+
+        assert_eq!(
+            std::fs::read(&marker_path).unwrap(),
+            before_marker,
+            "a read-only boot must not rewrite or delete the marker"
+        );
+        assert_eq!(
+            std::fs::read(&generation_path).unwrap(),
+            before_generation,
+            "a read-only boot must not persist a recomputed .generation"
+        );
+        assert_eq!(
+            std::fs::read(&pagerank_path).unwrap(),
+            before_pagerank,
+            "a read-only boot must not rewrite the PageRank sidecar"
+        );
+        assert!(
+            store.is_index_publication_dirty(),
+            "a read-only boot must keep failing closed, not clear the condition"
+        );
     }
 }
 

--- a/crates/nestweaver-engine/src/index_publication.rs
+++ b/crates/nestweaver-engine/src/index_publication.rs
@@ -122,8 +122,15 @@ impl IndexPublicationStatus {
     /// True when the wedge can only be cleared by an explicit operator
     /// override — the marker is present but carries no writer we can prove
     /// dead, so the automatic predicate must decline.
+    ///
+    /// The [`is_wedged`](Self::is_wedged) gate is INTRINSIC, not something each
+    /// call site must remember: a young, timestamped, pid-less marker is a
+    /// publication in flight, not a wedge, and it does not need repair at all —
+    /// so it must never produce a `repair --force` suggestion, even for a
+    /// caller that reaches for [`repair_command_for`](Self::repair_command_for)
+    /// without checking `is_wedged()` first.
     pub fn needs_forced_repair(&self) -> bool {
-        self.dirty && (!self.determinable || self.writer_pid.is_none())
+        self.is_wedged() && (!self.determinable || self.writer_pid.is_none())
     }
 
     /// The operator escape hatch to name in a wedged-state message.
@@ -411,6 +418,53 @@ mod tests {
         assert_eq!(status.writer_pid, None);
         assert!(status.marker_age_s.is_some());
         assert!(!status.is_wedged(), "a young marker is transient");
+    }
+
+    #[test]
+    fn a_transient_publication_is_never_told_to_force_repair() {
+        // The third-consumer trap: a caller of `repair_command_for` that does
+        // NOT gate on `is_wedged()` first must still never print `--force` at
+        // a publication that is simply in flight — here a young, timestamped,
+        // pid-less marker, which `is_wedged()` classifies as transient.
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::fs::write(marker_path(&db_path), format!("x:{now}\n")).unwrap();
+        let status = status(&db_path);
+        assert_eq!(status.writer_pid, None);
+        assert!(status.marker_age_s.is_some());
+        assert!(!status.is_wedged(), "a young marker is transient");
+        assert!(
+            !status.needs_forced_repair(),
+            "a transient publication does not need repair at all, forced or otherwise"
+        );
+        assert!(
+            !status.repair_command_for(&db_path).ends_with("--force"),
+            "an ungated consumer must not be handed --force for a transient publication"
+        );
+    }
+
+    #[test]
+    fn an_aged_out_pidless_marker_still_needs_forced_repair() {
+        // The narrowing must not go too far: once the same pid-less marker is
+        // older than WEDGED_MARKER_AGE it IS wedged, and the explicit override
+        // remains the only thing that resolves it.
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let old = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+            - (WEDGED_MARKER_AGE + Duration::from_secs(60)).as_nanos();
+        std::fs::write(marker_path(&db_path), format!("x:{old}\n")).unwrap();
+        let status = status(&db_path);
+        assert_eq!(status.writer_pid, None);
+        assert!(status.is_wedged(), "an aged-out pid-less marker is wedged");
+        assert!(status.needs_forced_repair());
+        assert!(status.repair_command_for(&db_path).ends_with("--force"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Two daemon-lifecycle guards that are correct today but unpinned or over-broad:

1. **The daemon's `!read_only` boot recovery gate had no daemon-level test.** Daemon startup passes `!read_only` into index-publication recovery; the engine callee is covered, but nothing pinned the caller's argument — flipping it to `true` (letting a **read-only snapshot replica** recompute PageRank, persist `.generation`, and delete the marker) broke no test.
2. **`needs_forced_repair()` was broader than its guard** — age-blind `dirty && (!determinable || writer_pid.is_none())`, true for a young, timestamped, pid-less marker that `is_wedged()` correctly classifies as transient. Harmless only because both `repair_command_for` consumers gate on `is_wedged()` first; a third consumer without the gate would print `repair --force` at an operator whose publication is simply in flight.

## Fix

- `needs_forced_repair()` now folds the gate in: `self.is_wedged() && (!determinable || writer_pid.is_none())`. Both existing consumers already gate, so nothing reachable changes today — but a future ungated consumer can no longer get `--force` for a transient publication (the gate is intrinsic, not something each call site must remember). Also removes a stale "re-run with --force" hint on an ungated repair-advice path. `is_wedged()` implies `dirty`, so the only behavioral divergence is exactly the intended young-transient case; undeterminable markers (always wedged) still get `--force`.
- The boot recovery+warm block is extracted into `reconcile_index_publication_before_ppr_warm(store, read_only)` and pinned at daemon level in **both directions**: a read-only open leaves marker/`.generation`/`.pagerank.json` byte-for-byte untouched on disk (flipping the gate to `true` fails this test — proven), and a read-write boot MUST recover (function-level test plus a full `run_server`-over-UDS e2e that polls marker retirement and verifies the recovery contract on reopen). Flip matrix verified empirically; the one uncoverable mutation (call-site `read_only` → `false`, replica boots only — `materialize_snapshot` discards markers, so no deterministic replica-boot test exists) is disclosed in the test docs.

## Tests

- Transient publication never told to force repair (proven RED against the unfixed predicate); aged-out pid-less marker still gets `--force` (pins over-narrowing).
- daemon 280, engine 1082+15, mcp 182, root bins 369; fmt/clippy clean.

Backlog item: `two-daemon-lifecycle-guards-are-broader-or-thinner-than-they-look` (LOW). Adversarial review: APPROVE, plus one repair round closing the call-site seam.