### PR TITLE
fix(store): fail ranking queries closed during dirty index publication

### DIFF
--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -3847,7 +3847,12 @@ impl NestWeaverDaemon for DaemonService {
         {
             let store = state.store.clone();
             tokio::task::spawn_blocking(move || {
-                store.ensure_pagerank_loaded();
+                // Best-effort: a dirty index publication refuses the warm
+                // (ranking queries fail closed until the publication
+                // completes — see the ranking.rs module contract).
+                if let Err(error) = store.ensure_pagerank_loaded() {
+                    tracing::debug!("PageRank pre-warm skipped: {error}");
+                }
             });
         }
 
@@ -12716,7 +12721,7 @@ mod startup_helper_tests {
             "deleted repo sidecar slice survived merge error"
         );
         assert!(!pagerank_path.exists(), "stale PageRank sidecar survived");
-        let scores_after = state.store.pagerank_scores();
+        let scores_after = state.store.pagerank_scores().unwrap();
         assert!(state.store.pagerank_generation() > pagerank_generation);
         assert!(
             !scores_after.contains_key("repo:old:first"),
@@ -12774,7 +12779,13 @@ mod startup_helper_tests {
         assert_eq!(error.code(), tonic::Code::Internal);
         assert!(state.store.graph_generation() > graph_generation);
         assert!(!pagerank_path.exists());
-        assert!(!state.store.pagerank_scores().contains_key("rank-sentinel"));
+        assert!(
+            !state
+                .store
+                .pagerank_scores()
+                .unwrap()
+                .contains_key("rank-sentinel")
+        );
         assert!(state.store.pagerank_generation() > pagerank_generation);
         assert_eq!(
             reconciliations, 0,
@@ -13005,7 +13016,7 @@ mod startup_helper_tests {
         );
         assert!(state.store.graph_generation() > graph_generation);
         assert!(!pagerank_path.exists(), "stale PageRank sidecar survived");
-        let scores_after = state.store.pagerank_scores();
+        let scores_after = state.store.pagerank_scores().unwrap();
         assert!(state.store.pagerank_generation() > pagerank_generation);
         assert!(!scores_after.contains_key(repo_uid));
         assert_eq!(
@@ -13052,7 +13063,7 @@ mod startup_helper_tests {
         );
         assert!(state.store.graph_generation() > graph_generation);
         assert!(!pagerank_path.exists(), "stale PageRank sidecar survived");
-        let scores_after = state.store.pagerank_scores();
+        let scores_after = state.store.pagerank_scores().unwrap();
         assert!(state.store.pagerank_generation() > pagerank_generation);
         assert!(!scores_after.contains_key(repo_uid));
         assert_eq!(
@@ -13075,7 +13086,7 @@ mod startup_helper_tests {
         let pagerank_path = nestweaver_engine::sidecar_path(&state.db_path, ".pagerank.json");
         std::fs::write(&pagerank_path, r#"{"repo:test:pagerank":1.0}"#).unwrap();
         state.store.load_pagerank_cache(&pagerank_path).unwrap();
-        let before_scores = state.store.pagerank_scores();
+        let before_scores = state.store.pagerank_scores().unwrap();
         let before_generation = state.store.pagerank_generation();
         assert!(
             before_scores.contains_key("repo:test:pagerank"),
@@ -13089,7 +13100,7 @@ mod startup_helper_tests {
             .unwrap();
         delete_repo_cascade(&state.store, &repo).unwrap();
         finalize_code_graph_deletion(&state, &[repo.uid]);
-        let after_scores = state.store.pagerank_scores();
+        let after_scores = state.store.pagerank_scores().unwrap();
 
         assert!(state.store.pagerank_generation() > before_generation);
         assert!(!after_scores.contains_key("repo:test:pagerank"));
@@ -13237,7 +13248,7 @@ mod startup_helper_tests {
             u64::MAX.to_string()
         );
         assert!(!pagerank_path.exists());
-        assert!(state.store.pagerank_scores().is_empty());
+        assert!(state.store.pagerank_scores().unwrap().is_empty());
         assert!(state.store.pagerank_generation() > pagerank_generation);
     }
 
@@ -13278,7 +13289,13 @@ mod startup_helper_tests {
         assert_eq!(response.project_name, "Durable remove");
         assert!(state.store.graph_generation() > generation_before);
         assert!(!pagerank_path.exists());
-        assert!(!state.store.pagerank_scores().contains_key(project_uid));
+        assert!(
+            !state
+                .store
+                .pagerank_scores()
+                .unwrap()
+                .contains_key(project_uid)
+        );
         assert!(!state.store.has_embedding(project_uid));
         let extensions = nestweaver_engine::load_extensions(&state.db_path);
         assert!(
@@ -13305,7 +13322,12 @@ mod startup_helper_tests {
         assert_eq!(reopened.graph_generation(), expected_generation);
         assert!(!reopened.has_embedding(project_uid));
         reopened.load_pagerank_cache(&pagerank_path).unwrap();
-        assert!(!reopened.pagerank_scores().contains_key(project_uid));
+        assert!(
+            !reopened
+                .pagerank_scores()
+                .unwrap()
+                .contains_key(project_uid)
+        );
     }
 
     #[test]
@@ -13396,7 +13418,13 @@ mod startup_helper_tests {
         assert!(!state.store.project_exists(project_uid).unwrap());
         assert!(state.store.graph_generation() > generation_before);
         assert!(!pagerank_path.exists());
-        assert!(!state.store.pagerank_scores().contains_key(project_uid));
+        assert!(
+            !state
+                .store
+                .pagerank_scores()
+                .unwrap()
+                .contains_key(project_uid)
+        );
         assert!(!state.store.has_embedding(project_uid));
         assert!(
             nestweaver_engine::get_all_properties(
@@ -13425,7 +13453,12 @@ mod startup_helper_tests {
         assert_eq!(reopened.graph_generation(), expected_generation);
         assert!(!reopened.has_embedding(project_uid));
         reopened.load_pagerank_cache(&pagerank_path).unwrap();
-        assert!(!reopened.pagerank_scores().contains_key(project_uid));
+        assert!(
+            !reopened
+                .pagerank_scores()
+                .unwrap()
+                .contains_key(project_uid)
+        );
         assert!(
             nestweaver_engine::get_all_properties(
                 &nestweaver_engine::load_extensions(&db_path),
@@ -14001,7 +14034,13 @@ mod startup_helper_tests {
                 .is_empty_for_repo(repo_uid)
         );
         assert!(!pagerank_path.exists());
-        assert!(!state.store.pagerank_scores().contains_key(&file_uid));
+        assert!(
+            !state
+                .store
+                .pagerank_scores()
+                .unwrap()
+                .contains_key(&file_uid)
+        );
         assert!(
             !tantivy
                 .search("late_remove_search_sentinel", 10)
@@ -17596,7 +17635,7 @@ mod boot_reconciliation_tests {
             canonical + 2,
             "recovery publishes the clean N+2 successor"
         );
-        let scores = store.pagerank_scores();
+        let scores = store.pagerank_scores().unwrap();
         assert!(
             scores.contains_key("sym:boot:source") && scores.contains_key("sym:boot:target"),
             "recovered PageRank must cover the committed graph: {scores:?}"
@@ -17692,7 +17731,7 @@ mod boot_reconciliation_tests {
             "recovery publishes the clean N+2 successor"
         );
         store.load_pagerank_cache(&pagerank_path).unwrap();
-        let scores = store.pagerank_scores();
+        let scores = store.pagerank_scores().unwrap();
         assert!(
             scores.contains_key("sym:boot:source") && scores.contains_key("sym:boot:target"),
             "persisted ranks must cover the committed graph: {scores:?}"

--- a/crates/nestweaver-engine/src/agent_guide.rs
+++ b/crates/nestweaver-engine/src/agent_guide.rs
@@ -107,8 +107,19 @@ pub fn generate_guide_with_tools(
             out.push_str(&map);
             out.push_str("\n```\n\n");
         }
-        Err(_) => {
-            out.push_str("No symbols indexed yet.\n\n");
+        Err(error) => {
+            // A dirty index publication fails the map closed (the ranking.rs
+            // module contract): say so instead of the affirmative-but-false
+            // "No symbols indexed yet." Any other failure keeps that wording.
+            if let Some(nestweaver_store::StoreError::RankingUnavailable) =
+                error.downcast_ref::<nestweaver_store::StoreError>()
+            {
+                out.push_str(
+                    "Repo map temporarily unavailable — index publication in progress.\n\n",
+                );
+            } else {
+                out.push_str("No symbols indexed yet.\n\n");
+            }
         }
     }
 
@@ -1026,6 +1037,29 @@ pub fn generate_agents_md_with_rules(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A dirty index publication fails `generate_repo_map` closed (the
+    /// ranking.rs module contract): the guide must say the map is temporarily
+    /// unavailable, not claim "No symbols indexed yet." — an affirmative
+    /// false statement about the graph.
+    #[test]
+    fn guide_repo_map_reports_unavailable_during_dirty_publication() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let store = nestweaver_store::GraphStore::open_or_create(&db_path).unwrap();
+        std::fs::write(format!("{}.index-dirty", db_path.display()), b"dirty").unwrap();
+
+        let guide = generate_guide(&store, None).unwrap();
+
+        assert!(
+            guide.contains("Repo map temporarily unavailable"),
+            "the dirty window must read as transient, not empty: {guide}"
+        );
+        assert!(
+            !guide.contains("No symbols indexed yet."),
+            "a dirty window must not claim the graph is empty: {guide}"
+        );
+    }
 
     #[test]
     fn generate_guide_produces_valid_markdown() {

--- a/crates/nestweaver-engine/src/blast_radius.rs
+++ b/crates/nestweaver-engine/src/blast_radius.rs
@@ -497,9 +497,14 @@ pub fn analyze_blast_radius(
     // high-centrality threshold in Step 4; 0 means no cache was available.
     let mut ranks_len: usize = 0;
     if !changed_symbols.is_empty() {
-        store.ensure_pagerank_loaded();
-        let ranks = store.pagerank_scores();
-        if !ranks.is_empty() {
+        // Ranking fails closed during a dirty index publication (the
+        // ranking.rs module contract); the centrality risk boost is advisory,
+        // so an unavailable cache degrades to no boost rather than failing
+        // the analysis.
+        let _ = store.ensure_pagerank_loaded();
+        if let Ok(ranks) = store.pagerank_scores()
+            && !ranks.is_empty()
+        {
             ranks_len = ranks.len();
             for cs in &mut changed_symbols {
                 if let Some(r) = ranks.get(&cs.uid) {
@@ -2871,7 +2876,7 @@ mod tests {
                 })
                 .unwrap();
         }
-        store.ensure_pagerank_loaded();
+        store.ensure_pagerank_loaded().unwrap();
         let result = analyze_blast_radius(
             &store,
             &[PathBuf::from("src/hub.rs")],

--- a/crates/nestweaver-engine/src/export.rs
+++ b/crates/nestweaver-engine/src/export.rs
@@ -88,7 +88,9 @@ pub fn export_cypher(store: &GraphStore, writer: &mut dyn Write) -> anyhow::Resu
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     // The `pagerank_score` column is never populated; the real scores
     // live in the store's PageRank cache (same source `hubs` reads).
-    let pagerank = store.pagerank_scores();
+    let pagerank = store
+        .pagerank_scores()
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
     for sym in &symbols {
         let pr = pagerank
             .get(&sym.uid)
@@ -242,7 +244,9 @@ pub fn export_graphml(store: &GraphStore, writer: &mut dyn Write) -> anyhow::Res
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     // The `pagerank_score` column is never populated; the real scores
     // live in the store's PageRank cache (same source `hubs` reads).
-    let pagerank = store.pagerank_scores();
+    let pagerank = store
+        .pagerank_scores()
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
     for sym in &symbols {
         let pr = pagerank
             .get(&sym.uid)
@@ -336,7 +340,9 @@ pub fn export_mermaid(
     // column is never populated; rank by the store's PageRank cache (the same
     // source `hubs` reads), falling back to the column for stores without a
     // computed cache.
-    let pagerank = store.pagerank_scores();
+    let pagerank = store
+        .pagerank_scores()
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
     let mut ranked = symbols;
     ranked.sort_by(|a, b| {
         let pa = pagerank
@@ -601,7 +607,7 @@ mod tests {
         // The `pagerank_score` column is never populated in production;
         // export must carry the store's computed PageRank cache values.
         let store = ranked_store();
-        let scores = store.pagerank_scores();
+        let scores = store.pagerank_scores().unwrap();
         assert!(
             scores.contains_key("sym-b"),
             "cache should compute scores on demand"
@@ -636,7 +642,7 @@ mod tests {
         // but sym-b has two inbound CALLS edges, so the computed PageRank
         // must rank it first.
         let store = ranked_store();
-        let scores = store.pagerank_scores();
+        let scores = store.pagerank_scores().unwrap();
         assert!(
             scores["sym-b"] > scores["sym-a"],
             "callee must outrank caller: {scores:?}"

--- a/crates/nestweaver-engine/src/hubs.rs
+++ b/crates/nestweaver-engine/src/hubs.rs
@@ -65,8 +65,11 @@ pub fn find_hub_nodes(store: &GraphStore, top_n: usize) -> Result<Vec<HubNode>> 
         }
     }
 
-    // Read PageRank scores from the in-memory cache.
-    let pr_scores: HashMap<String, f64> = store.pagerank_scores();
+    // Read PageRank scores from the in-memory cache. Fails closed during a
+    // dirty index publication (the ranking.rs module contract): hub ranking
+    // must not silently treat every symbol as score 0.
+    let pr_scores: HashMap<String, f64> =
+        store.pagerank_scores().map_err(|e| anyhow::anyhow!(e))?;
 
     // Feature F12: when git-activity recency scores are loaded, demote dormant
     // code at read time. We apply the same clamped multiplier the store uses in

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -5874,7 +5874,7 @@ mod tests {
         );
 
         // PageRank must reflect the COMMITTED graph, not the pre-crash sidecar.
-        let scores = store.pagerank_scores();
+        let scores = store.pagerank_scores().unwrap();
         assert!(
             !scores.contains_key("stale-precrash-score"),
             "the pre-crash PageRank sidecar must not survive recovery: {scores:?}"
@@ -5903,7 +5903,7 @@ mod tests {
         assert!(!reopened.is_index_publication_dirty());
         assert_eq!(reopened.graph_generation(), canonical + 2);
         reopened.load_pagerank_cache(&pagerank_path).unwrap();
-        let persisted = reopened.pagerank_scores();
+        let persisted = reopened.pagerank_scores().unwrap();
         assert!(
             persisted.contains_key("sym:publisher-crashed:source"),
             "the persisted PageRank sidecar must reflect the committed graph"
@@ -6092,6 +6092,7 @@ mod tests {
         assert!(
             store
                 .pagerank_scores()
+                .unwrap()
                 .contains_key("sym:publisher-nogeneration:source")
         );
     }
@@ -6273,7 +6274,7 @@ mod tests {
         );
         assert!(!marker_path.exists());
         assert!(!store.is_index_publication_dirty());
-        let scores = store.pagerank_scores();
+        let scores = store.pagerank_scores().unwrap();
         assert!(scores.contains_key("sym:publisher-forced:source"));
         assert!(scores.contains_key("note:forced:one"));
     }
@@ -6454,7 +6455,7 @@ mod tests {
             store.graph_generation()
         );
         assert!(pagerank_path.exists());
-        let expected_scores = store.pagerank_scores();
+        let expected_scores = store.pagerank_scores().unwrap();
         assert_eq!(expected_scores.len(), 4);
         for uid in [
             "sym:publisher-a:source",
@@ -6505,7 +6506,7 @@ mod tests {
             vec!["sym:publisher-b:target".to_string()]
         );
         reopened.load_pagerank_cache(&pagerank_path).unwrap();
-        assert_eq!(reopened.pagerank_scores(), expected_scores);
+        assert_eq!(reopened.pagerank_scores().unwrap(), expected_scores);
         assert_eq!(reopened.graph_generation(), generation_after_a + 2);
     }
 
@@ -6629,7 +6630,7 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
-        assert!(reopened.pagerank_scores().is_empty());
+        assert!(reopened.pagerank_scores().is_err());
     }
 
     #[test]
@@ -6674,7 +6675,7 @@ mod tests {
 
         assert!(!marker_path.exists());
         assert_eq!(store.graph_generation(), canonical_generation + 2);
-        let expected_scores = store.pagerank_scores();
+        let expected_scores = store.pagerank_scores().unwrap();
         assert_eq!(expected_scores.len(), 2);
         drop(store);
 
@@ -6686,7 +6687,7 @@ mod tests {
                 .is_ok()
         );
         reopened.load_pagerank_cache(&pagerank_path).unwrap();
-        assert_eq!(reopened.pagerank_scores(), expected_scores);
+        assert_eq!(reopened.pagerank_scores().unwrap(), expected_scores);
     }
 
     #[test]
@@ -8994,7 +8995,7 @@ function hello(name) { return "Hello " + name; }
             "persisted PageRank invalidation must run after earlier failures"
         );
         assert!(
-            !store.pagerank_scores().contains_key("deleted"),
+            !store.pagerank_scores().unwrap().contains_key("deleted"),
             "live PageRank invalidation must discard the primed stale score"
         );
         assert!(store.pagerank_generation() > pagerank_generation);
@@ -9118,7 +9119,7 @@ function hello(name) { return "Hello " + name; }
             "precondition: the replacement graph transaction must commit before filemeta fails"
         );
         assert!(
-            !store.pagerank_scores().contains_key("stale"),
+            !store.pagerank_scores().unwrap().contains_key("stale"),
             "the committed graph must invalidate the live stale PageRank cache"
         );
         let persisted: HashMap<String, f64> =
@@ -9247,7 +9248,7 @@ function hello(name) { return "Hello " + name; }
             error.failures[0].stage,
             DeletionReconciliationStage::PageRankCompute
         );
-        assert!(!store.pagerank_scores().contains_key("stale"));
+        assert!(!store.pagerank_scores().unwrap().contains_key("stale"));
         assert!(!pagerank_path.exists());
         assert!(store.graph_generation() > generation_before);
         assert_eq!(
@@ -9293,7 +9294,7 @@ function hello(name) { return "Hello " + name; }
             error.failures[0].stage,
             DeletionReconciliationStage::PageRankPersistence
         );
-        assert!(!store.pagerank_scores().contains_key("stale"));
+        assert!(!store.pagerank_scores().unwrap().contains_key("stale"));
         assert!(!pagerank_path.exists());
         assert!(store.graph_generation() > generation_before);
     }
@@ -9331,7 +9332,7 @@ function hello(name) { return "Hello " + name; }
             error.failures[0].stage,
             DeletionReconciliationStage::PersistedPageRank
         );
-        assert!(!store.pagerank_scores().contains_key("stale"));
+        assert!(!store.pagerank_scores().unwrap().contains_key("stale"));
         assert!(!pagerank_path.exists());
         assert!(quarantine_path(&pagerank_path).exists());
         assert!(store.graph_generation() > generation_before);
@@ -9399,7 +9400,7 @@ function hello(name) { return "Hello " + name; }
         let reopened = GraphStore::open_or_create(&db_path).unwrap();
         assert_ne!(reopened.graph_generation(), canonical_generation);
         reopened.load_pagerank_cache(&pagerank_path).unwrap();
-        assert!(!reopened.pagerank_scores().contains_key("stale"));
+        assert!(reopened.pagerank_scores().is_err());
     }
 
     #[test]
@@ -9448,7 +9449,7 @@ function hello(name) { return "Hello " + name; }
         let reopened = GraphStore::open_or_create(&db_path).unwrap();
         assert_ne!(reopened.graph_generation(), stale_generation);
         reopened.load_pagerank_cache(&pagerank_path).unwrap();
-        assert!(!reopened.pagerank_scores().contains_key("stale"));
+        assert!(reopened.pagerank_scores().is_err());
     }
 
     #[test]
@@ -9491,7 +9492,7 @@ function hello(name) { return "Hello " + name; }
             "dirty recovery must reserve canonical generation 7's successor"
         );
         recovering.load_pagerank_cache(&pagerank_path).unwrap();
-        assert!(!recovering.pagerank_scores().contains_key("stale"));
+        assert!(recovering.pagerank_scores().is_err());
         let mut cache =
             nestweaver_store::cache::ResponseCache::open(&db_path, 1, RESPONSE_SHAPE_FIXTURE);
         assert!(
@@ -9537,7 +9538,7 @@ function hello(name) { return "Hello " + name; }
         assert_eq!(clean.graph_generation(), 9);
         assert!(clean.graph_generation() > 8);
         clean.load_pagerank_cache(&pagerank_path).unwrap();
-        assert!(!clean.pagerank_scores().contains_key("stale"));
+        assert!(!clean.pagerank_scores().unwrap().contains_key("stale"));
         let mut cache =
             nestweaver_store::cache::ResponseCache::open(&db_path, 1, RESPONSE_SHAPE_FIXTURE);
         assert!(
@@ -9648,7 +9649,7 @@ function hello(name) { return "Hello " + name; }
             .next()
             .unwrap()
             .uid;
-        assert!(store.pagerank_scores().contains_key(&removed_uid));
+        assert!(store.pagerank_scores().unwrap().contains_key(&removed_uid));
 
         let reader = EmptyReader {
             root: dir.path().join("empty-reader"),
@@ -9667,7 +9668,7 @@ function hello(name) { return "Hello " + name; }
 
         assert_eq!(result.files_deleted, 1);
         assert!(
-            !store.pagerank_scores().contains_key(&removed_uid),
+            !store.pagerank_scores().unwrap().contains_key(&removed_uid),
             "the live server store must not serve the deleted symbol's stale score"
         );
         let persisted: HashMap<String, f64> =
@@ -9679,7 +9680,10 @@ function hello(name) { return "Hello " + name; }
         let reopened = GraphStore::open_or_create(&db_path).unwrap();
         reopened.load_pagerank_cache(&pagerank_path).unwrap();
         assert!(
-            !reopened.pagerank_scores().contains_key(&removed_uid),
+            !reopened
+                .pagerank_scores()
+                .unwrap()
+                .contains_key(&removed_uid),
             "a reopened store must not reload the deleted symbol's stale score"
         );
     }
@@ -9771,7 +9775,7 @@ function hello(name) { return "Hello " + name; }
             store.symbols_in_file("old.js").unwrap().is_empty(),
             "the server replacement transaction must commit before PageRank fails"
         );
-        assert!(!store.pagerank_scores().contains_key("stale"));
+        assert!(!store.pagerank_scores().unwrap().contains_key("stale"));
         assert!(dropped.load(Ordering::SeqCst));
     }
 
@@ -10451,7 +10455,7 @@ function hello(name) { return "Hello " + name; }
                 .any(|symbol| symbol.name == "after"),
             "the incremental transaction must be committed before PageRank fails"
         );
-        assert!(!store.pagerank_scores().contains_key("stale"));
+        assert!(store.pagerank_scores().is_err());
         assert!(!pagerank_path.exists());
         assert!(store.graph_generation() > generation_before);
     }
@@ -10522,7 +10526,7 @@ function hello(name) { return "Hello " + name; }
                 .any(|symbol| symbol.name == "replacement"),
             "the forced fallback must atomically install the replacement graph"
         );
-        assert!(!store.pagerank_scores().contains_key("stale"));
+        assert!(store.pagerank_scores().is_err());
         assert!(!pagerank_path.exists());
         assert!(store.graph_generation() > generation_before);
     }

--- a/crates/nestweaver-engine/src/watch_code.rs
+++ b/crates/nestweaver-engine/src/watch_code.rs
@@ -918,7 +918,7 @@ mod tests {
         let reopened = GraphStore::open_or_create(&db_path).unwrap();
         assert_ne!(reopened.graph_generation(), stale_generation);
         reopened.load_pagerank_cache(&pagerank_path).unwrap();
-        assert!(!reopened.pagerank_scores().contains_key("stale"));
+        assert!(reopened.pagerank_scores().is_err());
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/watcher.rs
+++ b/crates/nestweaver-engine/src/watcher.rs
@@ -1183,7 +1183,7 @@ mod tests {
         let reopened = GraphStore::open_or_create(&db_path).unwrap();
         assert_ne!(reopened.graph_generation(), stale_generation);
         reopened.load_pagerank_cache(&pagerank_path).unwrap();
-        assert!(!reopened.pagerank_scores().contains_key("stale"));
+        assert!(reopened.pagerank_scores().is_err());
     }
 
     #[test]

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -10938,10 +10938,14 @@ mod cache_dispatch_tests {
         )
         .unwrap();
         let store = GraphStore::open(&db_path).unwrap();
-        let args = json!({ "limit": 5 });
+        // Dispatch a cacheable NON-ranking tool: hub_nodes (this test's
+        // original dispatch) now fails closed during a dirty window under
+        // the ranking.rs fail-closed contract, while the response-cache
+        // bypass this test exists to pin applies to every cacheable tool.
+        let args = json!({ "pattern": "fn" });
 
-        let _ = dispatch(&store, None, "hub_nodes", args.clone(), None).unwrap();
-        let _ = dispatch(&store, None, "hub_nodes", args, None).unwrap();
+        let _ = dispatch(&store, None, "regex_search", args.clone(), None).unwrap();
+        let _ = dispatch(&store, None, "regex_search", args, None).unwrap();
         flush_response_cache();
 
         assert_eq!(CACHE_HITS.with(|c| c.get()), 0);
@@ -10987,7 +10991,7 @@ mod cache_dispatch_tests {
 
         let classified = classify_index_publication_error(
             &store,
-            anyhow!("query error: PageRank unavailable during dirty index publication"),
+            anyhow!("PageRank unavailable during dirty index publication"),
         );
         let message = format!("{classified:#}");
         assert!(message.contains("WEDGED"), "{message}");

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -2443,7 +2443,7 @@ mod tests {
         );
         reopened.load_pagerank_cache(&pagerank_path).unwrap();
         assert!(
-            !reopened.pagerank_scores().contains_key("stale"),
+            reopened.pagerank_scores().is_err(),
             "a dirty publication must not load canonical PageRank from before the graph commit"
         );
         // nw-C1: the same marker is now READ BACK, not merely tested for
@@ -2481,7 +2481,7 @@ mod tests {
         );
         reopened.load_pagerank_cache(&pagerank_path).unwrap();
         assert!(
-            !reopened.pagerank_scores().contains_key("stale"),
+            reopened.pagerank_scores().is_err(),
             "an unreadable marker must make canonical PageRank non-authoritative"
         );
         // nw-C1: "cannot tell" must stay distinguishable from "present".

--- a/crates/nestweaver-store/src/durable_sidecar.rs
+++ b/crates/nestweaver-store/src/durable_sidecar.rs
@@ -517,7 +517,7 @@ mod tests {
 
         let reopened = GraphStore::open_or_create(&db_path).unwrap();
         reopened.load_pagerank_cache(&pagerank_path).unwrap();
-        assert_eq!(reopened.pagerank_scores().get("old"), Some(&1.0));
+        assert_eq!(reopened.pagerank_scores().unwrap().get("old"), Some(&1.0));
     }
 
     #[test]
@@ -557,14 +557,14 @@ mod tests {
             let store = GraphStore::open_or_create(&db_path).unwrap();
             std::fs::write(&pagerank_path, r#"{"stale":1.0}"#).unwrap();
             store.load_pagerank_cache(&pagerank_path).unwrap();
-            assert!(store.pagerank_scores().contains_key("stale"));
+            assert!(store.pagerank_scores().unwrap().contains_key("stale"));
         }
 
         assert!(remove_file_durable_if_exists(&pagerank_path).unwrap());
 
         let reopened = GraphStore::open_or_create(&db_path).unwrap();
         reopened.load_pagerank_cache(&pagerank_path).unwrap();
-        assert!(!reopened.pagerank_scores().contains_key("stale"));
+        assert!(!reopened.pagerank_scores().unwrap().contains_key("stale"));
         assert!(!pagerank_path.exists());
     }
 }

--- a/crates/nestweaver-store/src/error.rs
+++ b/crates/nestweaver-store/src/error.rs
@@ -29,6 +29,14 @@ pub enum StoreError {
     Database(String),
     #[error("query error: {0}")]
     Query(String),
+    /// A ranking query was refused while an index publication is in flight:
+    /// the ranking caches may describe a graph that no longer exists, so the
+    /// query fails closed rather than answering with a successful-looking
+    /// empty result (see the `ranking` module-header contract). Transient —
+    /// callers should surface it as "temporarily unavailable", never as an
+    /// empty graph.
+    #[error("PageRank unavailable during dirty index publication")]
+    RankingUnavailable,
     #[error("not found")]
     NotFound,
     #[error("presentation limit {limit} exceeds maximum {max}")]
@@ -57,6 +65,7 @@ impl StoreError {
                     || lower.contains("constraint")
             }
             StoreError::NotFound
+            | StoreError::RankingUnavailable
             | StoreError::PresentationLimitExceeded { .. }
             | StoreError::Cancelled(_)
             | StoreError::CorruptValue { .. } => false,

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -1,3 +1,25 @@
+//! PageRank and personalized-PageRank ranking over the graph: computation,
+//! the in-memory caches, and the `.pagerank.json` sidecar.
+//!
+//! # Dirty-publication contract
+//!
+//! While an index publication is in flight (the `<db>.index-dirty` marker
+//! exists — see `crate::index_publication`), the ranking caches may describe
+//! a graph that no longer exists. Every guard site in this module calls
+//! `invalidate_ranking_caches_locked` first, so cache correctness is uniform.
+//! The return contract is uniform by policy:
+//!
+//! - **Query paths fail closed.** `compute_pagerank`, `personalized_pagerank*`,
+//!   `symbols_by_pagerank`, `pagerank_scores`, `ensure_pagerank_loaded`, and
+//!   `warm_ppr_cache` return
+//!   `Err(StoreError::Query("PageRank unavailable during dirty index publication"))`.
+//!   A publication window must never be mistaken for an empty graph, so no
+//!   query path answers with a successful-looking empty result.
+//! - **Sidecar load/save no-op.** `save_pagerank_cache` and
+//!   `load_pagerank_cache` return `Ok(())` without touching the cache or the
+//!   disk: refusing to persist or load during the window is a no-op by
+//!   nature, not a degraded answer.
+
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -996,6 +1018,8 @@ impl GraphStore {
     /// Scores are read from the in-memory cache populated by `compute_pagerank`.
     /// If the cache is empty it is computed lazily on first access.
     /// If `limit` is `None`, all symbols are returned.
+    /// Fails closed with `Err` during a dirty index publication (see the
+    /// module-header contract).
     pub fn symbols_by_pagerank(&self, limit: Option<usize>) -> Result<Vec<Symbol>, StoreError> {
         let _flight = self
             .pagerank_compute_lock
@@ -1003,9 +1027,11 @@ impl GraphStore {
             .unwrap_or_else(|error| error.into_inner());
         if self.is_index_publication_dirty() {
             self.invalidate_ranking_caches_locked();
-            return Ok(Vec::new());
+            return Err(StoreError::Query(
+                "PageRank unavailable during dirty index publication".into(),
+            ));
         }
-        self.ensure_pagerank_loaded_locked();
+        self.ensure_pagerank_loaded_locked()?;
         let scores = self
             .pagerank_cache
             .lock()
@@ -1122,21 +1148,26 @@ impl GraphStore {
     /// Returns an empty map if PageRank has not been computed yet or the
     /// cache is not loaded. Used by downstream crates (engine) that need
     /// per-UID score lookups without loading full Symbol objects.
-    pub fn pagerank_scores(&self) -> HashMap<String, f64> {
+    /// Fails closed with `Err` during a dirty index publication (see the
+    /// module-header contract).
+    pub fn pagerank_scores(&self) -> Result<HashMap<String, f64>, StoreError> {
         let _flight = self
             .pagerank_compute_lock
             .lock()
             .unwrap_or_else(|error| error.into_inner());
         if self.is_index_publication_dirty() {
             self.invalidate_ranking_caches_locked();
-            return HashMap::new();
+            return Err(StoreError::Query(
+                "PageRank unavailable during dirty index publication".into(),
+            ));
         }
-        self.ensure_pagerank_loaded_locked();
-        self.pagerank_cache
+        self.ensure_pagerank_loaded_locked()?;
+        Ok(self
+            .pagerank_cache
             .lock()
             .ok()
             .and_then(|guard| guard.clone())
-            .unwrap_or_default()
+            .unwrap_or_default())
     }
 
     /// Ensure the in-memory PageRank cache is populated.
@@ -1144,30 +1175,35 @@ impl GraphStore {
     /// If the cache is already loaded (from a sidecar file or a previous
     /// computation), this is a no-op.  Otherwise it computes PageRank on
     /// demand so callers never see an empty cache after a fresh index.
-    pub fn ensure_pagerank_loaded(&self) {
+    /// Fails closed with `Err` during a dirty index publication (see the
+    /// module-header contract).
+    pub fn ensure_pagerank_loaded(&self) -> Result<(), StoreError> {
         let _flight = self
             .pagerank_compute_lock
             .lock()
             .unwrap_or_else(|error| error.into_inner());
-        self.ensure_pagerank_loaded_locked();
+        self.ensure_pagerank_loaded_locked()
     }
 
-    fn ensure_pagerank_loaded_locked(&self) {
+    fn ensure_pagerank_loaded_locked(&self) -> Result<(), StoreError> {
         if self.is_index_publication_dirty() {
             self.invalidate_ranking_caches_locked();
-            return;
+            return Err(StoreError::Query(
+                "PageRank unavailable during dirty index publication".into(),
+            ));
         }
         let loaded = |cache: &std::sync::Mutex<Option<HashMap<String, f64>>>| {
             cache.lock().map(|c| c.is_some()).unwrap_or(false)
         };
         if loaded(&self.pagerank_cache) {
-            return;
+            return Ok(());
         }
         tracing::info!("PageRank cache empty — computing lazily (single-flight)");
         if let Err(e) = self.compute_pagerank_warm_locked(0.85, 20, &GraphScope::code_only(), None)
         {
             tracing::warn!("lazy PageRank computation failed: {e}");
         }
+        Ok(())
     }
 
     /// Pre-build the PPR adjacency cache for the unified graph scope.
@@ -1280,7 +1316,7 @@ mod tests {
             let b = barrier.clone();
             handles.push(std::thread::spawn(move || {
                 b.wait();
-                s.ensure_pagerank_loaded();
+                s.ensure_pagerank_loaded().unwrap();
             }));
         }
         for h in handles {
@@ -1305,7 +1341,7 @@ mod tests {
         store
             .compute_pagerank(0.85, 20, &GraphScope::code_only())
             .unwrap();
-        assert!(store.pagerank_scores().contains_key("A"));
+        assert!(store.pagerank_scores().unwrap().contains_key("A"));
         let clean_pagerank_generation = store.pagerank_generation();
 
         let publication = store.acquire_index_publication_lease().unwrap();
@@ -1317,14 +1353,20 @@ mod tests {
             })
             .unwrap();
 
+        // The module-header contract: every ranking QUERY path fails closed
+        // during the window — none may answer with a successful-looking
+        // empty result that a caller could mistake for an empty graph.
         assert!(
-            store.pagerank_scores().is_empty(),
+            store.pagerank_scores().is_err(),
             "dirty publication must not serve ranks computed while clean"
         );
-        assert_eq!(
-            store.pagerank_generation(),
-            clean_pagerank_generation,
-            "dirty lazy access must not compute PageRank"
+        assert!(
+            store.symbols_by_pagerank(None).is_err(),
+            "dirty publication must not answer a ranked list query as an empty list"
+        );
+        assert!(
+            store.ensure_pagerank_loaded().is_err(),
+            "dirty publication must refuse the lazy load/compute"
         );
         assert!(
             store
@@ -1332,12 +1374,38 @@ mod tests {
                 .is_err(),
             "explicit PageRank computation must fail closed while dirty"
         );
+        assert!(
+            store
+                .personalized_pagerank(&["A".to_string()], 0.85, 20, &GraphScope::code_only())
+                .is_err(),
+            "PPR queries must fail closed while dirty"
+        );
+        assert!(
+            store.warm_ppr_cache().is_err(),
+            "PPR cache warming must fail closed while dirty"
+        );
+        assert_eq!(
+            store.pagerank_generation(),
+            clean_pagerank_generation,
+            "dirty lazy access must not compute PageRank"
+        );
+
+        // The sidecar pair stays a no-op: refusing to persist or load during
+        // the window is not a degraded answer.
         store.save_pagerank_cache(&pagerank_path).unwrap();
         assert!(
             !pagerank_path.exists(),
             "dirty PageRank state must never be persisted"
         );
-        assert!(store.pagerank_scores().is_empty());
+        store.load_pagerank_cache(&pagerank_path).unwrap();
+        assert!(
+            store
+                .pagerank_cache
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .is_none(),
+            "dirty sidecar load must not populate the cache"
+        );
         assert_eq!(store.pagerank_generation(), clean_pagerank_generation);
 
         let clean_generation = publication.clean_generation().unwrap();
@@ -1361,7 +1429,7 @@ mod tests {
             "dirty-window ranks must not survive clean publication"
         );
         assert_eq!(store.pagerank_generation(), clean_pagerank_generation);
-        assert!(store.pagerank_scores().contains_key("A"));
+        assert!(store.pagerank_scores().unwrap().contains_key("A"));
         assert_eq!(
             store.pagerank_generation(),
             clean_pagerank_generation + 1,
@@ -1402,7 +1470,7 @@ mod tests {
             .compute_pagerank(0.85, 20, &GraphScope::code_only())
             .unwrap();
         let gen_before = store.pagerank_generation();
-        let scores_before = store.pagerank_scores();
+        let scores_before = store.pagerank_scores().unwrap();
         assert!(
             scores_before.contains_key("D") && scores_before.contains_key("E"),
             "repo-2 symbols should be ranked before the deletion"
@@ -1420,7 +1488,7 @@ mod tests {
         );
 
         // A rank query triggers the single-flight recompute over the reduced graph.
-        let scores_after = store.pagerank_scores();
+        let scores_after = store.pagerank_scores().unwrap();
         let gen_after = store.pagerank_generation();
 
         // Primary assertion: a recompute happened (invalidation fired).
@@ -1487,7 +1555,7 @@ mod tests {
         store
             .compute_pagerank(0.85, 20, &GraphScope::code_only())
             .unwrap();
-        assert!(store.pagerank_scores().contains_key("A"));
+        assert!(store.pagerank_scores().unwrap().contains_key("A"));
 
         assert_eq!(
             store
@@ -1500,7 +1568,7 @@ mod tests {
             .unwrap();
 
         assert!(
-            store.pagerank_scores().is_empty(),
+            store.pagerank_scores().unwrap().is_empty(),
             "an empty graph must replace previously cached scores with an empty cache"
         );
     }

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -11,14 +11,15 @@
 //!
 //! - **Query paths fail closed.** `compute_pagerank`, `personalized_pagerank*`,
 //!   `symbols_by_pagerank`, `pagerank_scores`, `ensure_pagerank_loaded`, and
-//!   `warm_ppr_cache` return
-//!   `Err(StoreError::Query("PageRank unavailable during dirty index publication"))`.
-//!   A publication window must never be mistaken for an empty graph, so no
-//!   query path answers with a successful-looking empty result.
+//!   `warm_ppr_cache` return `Err(StoreError::RankingUnavailable)` ("PageRank
+//!   unavailable during dirty index publication"). A publication window must
+//!   never be mistaken for an empty graph, so no query path answers with a
+//!   successful-looking empty result.
 //! - **Sidecar load/save no-op.** `save_pagerank_cache` and
-//!   `load_pagerank_cache` return `Ok(())` without touching the cache or the
-//!   disk: refusing to persist or load during the window is a no-op by
-//!   nature, not a degraded answer.
+//!   `load_pagerank_cache` return `Ok(())` without reading or writing sidecar
+//!   data (the caches are still invalidated, as at every guard site):
+//!   refusing to persist or load during the window is a no-op by nature, not
+//!   a degraded answer.
 
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -599,9 +600,7 @@ impl GraphStore {
     ) -> Result<(), StoreError> {
         if self.is_index_publication_dirty() {
             self.invalidate_ranking_caches_locked();
-            return Err(StoreError::Query(
-                "PageRank unavailable during dirty index publication".into(),
-            ));
+            return Err(StoreError::RankingUnavailable);
         }
         let (uids, _uid_to_idx, incoming, out_weight) = self.load_ppr_graph(scope, None)?;
         let n = uids.len();
@@ -682,9 +681,7 @@ impl GraphStore {
 
         if self.is_index_publication_dirty() {
             self.invalidate_ranking_caches_locked();
-            return Err(StoreError::Query(
-                "PageRank unavailable during dirty index publication".into(),
-            ));
+            return Err(StoreError::RankingUnavailable);
         }
 
         // 5. Store scores in the in-memory cache (no DB write-back needed).
@@ -886,9 +883,7 @@ impl GraphStore {
             .unwrap_or_else(|error| error.into_inner());
         if self.is_index_publication_dirty() {
             self.invalidate_ranking_caches_locked();
-            return Err(StoreError::Query(
-                "PageRank unavailable during dirty index publication".into(),
-            ));
+            return Err(StoreError::RankingUnavailable);
         }
         let effective_damping = intent.map_or(damping, |i| i.damping());
 
@@ -1027,9 +1022,7 @@ impl GraphStore {
             .unwrap_or_else(|error| error.into_inner());
         if self.is_index_publication_dirty() {
             self.invalidate_ranking_caches_locked();
-            return Err(StoreError::Query(
-                "PageRank unavailable during dirty index publication".into(),
-            ));
+            return Err(StoreError::RankingUnavailable);
         }
         self.ensure_pagerank_loaded_locked()?;
         let scores = self
@@ -1157,9 +1150,7 @@ impl GraphStore {
             .unwrap_or_else(|error| error.into_inner());
         if self.is_index_publication_dirty() {
             self.invalidate_ranking_caches_locked();
-            return Err(StoreError::Query(
-                "PageRank unavailable during dirty index publication".into(),
-            ));
+            return Err(StoreError::RankingUnavailable);
         }
         self.ensure_pagerank_loaded_locked()?;
         Ok(self
@@ -1188,9 +1179,7 @@ impl GraphStore {
     fn ensure_pagerank_loaded_locked(&self) -> Result<(), StoreError> {
         if self.is_index_publication_dirty() {
             self.invalidate_ranking_caches_locked();
-            return Err(StoreError::Query(
-                "PageRank unavailable during dirty index publication".into(),
-            ));
+            return Err(StoreError::RankingUnavailable);
         }
         let loaded = |cache: &std::sync::Mutex<Option<HashMap<String, f64>>>| {
             cache.lock().map(|c| c.is_some()).unwrap_or(false)
@@ -1220,9 +1209,7 @@ impl GraphStore {
             .unwrap_or_else(|error| error.into_inner());
         if self.is_index_publication_dirty() {
             self.invalidate_ranking_caches_locked();
-            return Err(StoreError::Query(
-                "PageRank unavailable during dirty index publication".into(),
-            ));
+            return Err(StoreError::RankingUnavailable);
         }
         let scope = GraphScope::unified();
         self.load_ppr_graph(&scope, None)?;
@@ -1357,7 +1344,7 @@ mod tests {
         // during the window — none may answer with a successful-looking
         // empty result that a caller could mistake for an empty graph.
         assert!(
-            store.pagerank_scores().is_err(),
+            matches!(store.pagerank_scores(), Err(StoreError::RankingUnavailable)),
             "dirty publication must not serve ranks computed while clean"
         );
         assert!(

--- a/crates/nestweaver-web/src/error.rs
+++ b/crates/nestweaver-web/src/error.rs
@@ -28,6 +28,29 @@ impl ApiError {
             message: msg.into(),
         }
     }
+
+    pub fn unavailable(msg: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            message: msg.into(),
+        }
+    }
+
+    /// Classify a failed ranking query. During a dirty index publication the
+    /// store fails ranking closed (see the `nestweaver-store` ranking module
+    /// contract): that refusal is transient, so it maps to 503 "ranking
+    /// unavailable" — never to a successful-looking empty result. Any other
+    /// store error maps to 500 as usual.
+    pub fn from_ranking(
+        store: &nestweaver_store::GraphStore,
+        err: nestweaver_store::StoreError,
+    ) -> Self {
+        if store.is_index_publication_dirty() {
+            Self::unavailable("ranking temporarily unavailable — index publication in progress")
+        } else {
+            Self::from(err)
+        }
+    }
 }
 
 impl IntoResponse for ApiError {

--- a/crates/nestweaver-web/src/error.rs
+++ b/crates/nestweaver-web/src/error.rs
@@ -36,20 +36,23 @@ impl ApiError {
         }
     }
 
-    /// Classify a failed ranking query. During a dirty index publication the
-    /// store fails ranking closed (see the `nestweaver-store` ranking module
-    /// contract): that refusal is transient, so it maps to 503 "ranking
-    /// unavailable" — never to a successful-looking empty result. Any other
-    /// store error maps to 500 as usual.
-    pub fn from_ranking(
-        store: &nestweaver_store::GraphStore,
-        err: nestweaver_store::StoreError,
-    ) -> Self {
-        if store.is_index_publication_dirty() {
-            Self::unavailable("ranking temporarily unavailable — index publication in progress")
-        } else {
-            Self::from(err)
+    /// Classify a failed ranking query. A dirty-publication refusal
+    /// (`StoreError::RankingUnavailable` — the store fails ranking closed;
+    /// see the `nestweaver-store` ranking module contract) is transient, so
+    /// it maps to 503 "ranking unavailable" — never to a successful-looking
+    /// empty result. Any other error maps to 500 as usual. The error itself
+    /// is classified (not a re-check of the dirty flag), so an unrelated
+    /// failure during a publication window is still reported as 500.
+    pub fn from_ranking(err: anyhow::Error) -> Self {
+        if let Some(nestweaver_store::StoreError::RankingUnavailable) =
+            err.downcast_ref::<nestweaver_store::StoreError>()
+        {
+            tracing::info!(error = %err, "ranking query refused: index publication in flight");
+            return Self::unavailable(
+                "ranking temporarily unavailable — index publication in progress",
+            );
         }
+        Self::from(err)
     }
 }
 

--- a/crates/nestweaver-web/src/routes/admin.rs
+++ b/crates/nestweaver-web/src/routes/admin.rs
@@ -2000,7 +2000,12 @@ url = "https://github.com/example/existing"
             .next()
             .unwrap()
             .uid;
-        assert!(store.pagerank_scores().contains_key(&removed_symbol_uid));
+        assert!(
+            store
+                .pagerank_scores()
+                .unwrap()
+                .contains_key(&removed_symbol_uid)
+        );
         assert!(store.add_embedding(&removed_symbol_uid, vec![1.0, 0.0]));
         store.flush_embedding_index().unwrap();
 
@@ -2117,7 +2122,10 @@ url = "https://github.com/example/existing"
             "admin deletion must remove the persisted PageRank cache"
         );
         assert!(
-            !store.pagerank_scores().contains_key(&removed_symbol_uid),
+            !store
+                .pagerank_scores()
+                .unwrap()
+                .contains_key(&removed_symbol_uid),
             "admin deletion must invalidate the live PageRank cache"
         );
         assert!(
@@ -2240,7 +2248,7 @@ url = "https://github.com/example/existing"
                 .is_empty_for_repo(repo_uid)
         );
         assert!(!pagerank_path.exists());
-        assert!(!store.pagerank_scores().contains_key(&file_uid));
+        assert!(!store.pagerank_scores().unwrap().contains_key(&file_uid));
         assert!(
             !tantivy
                 .search("web_late_remove_search_sentinel", 10)

--- a/crates/nestweaver-web/src/routes/overview.rs
+++ b/crates/nestweaver-web/src/routes/overview.rs
@@ -221,7 +221,13 @@ fn overview_scope_data(
             let projects = state.store.list_projects()?;
             let repos = nestweaver_engine::list_repos(&state.store, None)?;
             let services = nestweaver_engine::list_services(&state.store, None)?;
-            let top_symbols = state.store.symbols_by_pagerank(Some(limit))?;
+            // A dirty index publication fails ranking closed: surface 503 so
+            // the UI says "ranking unavailable" instead of rendering an
+            // overview with an empty landmark list.
+            let top_symbols = state
+                .store
+                .symbols_by_pagerank(Some(limit))
+                .map_err(|e| ApiError::from_ranking(&state.store, e))?;
             let vaults = state.store.list_vaults(None)?;
             let notes = state.store.list_notes_lite(None)?;
             let counts = OverviewCounts {
@@ -420,4 +426,44 @@ fn repo_label(repo: &nestweaver_schema::Repo) -> String {
         .filter(|segment| !segment.is_empty())
         .unwrap_or(&repo.uid)
         .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+
+    use super::*;
+
+    /// Same contract as the top-symbols route: a dirty index publication must
+    /// surface as 503 "ranking unavailable", not as a 200 overview with an
+    /// empty landmark list (the `ranking.rs` dirty-publication contract).
+    #[tokio::test]
+    async fn overview_reports_ranking_unavailable_during_dirty_publication() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("brain.lbug");
+        let store = nestweaver_store::GraphStore::open_or_create(&db_path).unwrap();
+        std::fs::write(format!("{}.index-dirty", db_path.display()), b"dirty").unwrap();
+        let state = AppState::new(store, None, db_path);
+
+        let error = match overview(
+            State(state),
+            Query(OverviewParams {
+                limit: None,
+                workspace: None,
+                scope: None,
+            }),
+        )
+        .await
+        {
+            Ok(_) => panic!("a dirty publication must not render a successful overview"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.status, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(
+            error.message.contains("ranking"),
+            "the error must name ranking as unavailable: {}",
+            error.message
+        );
+    }
 }

--- a/crates/nestweaver-web/src/routes/overview.rs
+++ b/crates/nestweaver-web/src/routes/overview.rs
@@ -227,7 +227,7 @@ fn overview_scope_data(
             let top_symbols = state
                 .store
                 .symbols_by_pagerank(Some(limit))
-                .map_err(|e| ApiError::from_ranking(&state.store, e))?;
+                .map_err(|e| ApiError::from_ranking(e.into()))?;
             let vaults = state.store.list_vaults(None)?;
             let notes = state.store.list_notes_lite(None)?;
             let counts = OverviewCounts {

--- a/crates/nestweaver-web/src/routes/repos.rs
+++ b/crates/nestweaver-web/src/routes/repos.rs
@@ -37,7 +37,10 @@ pub async fn repo_map(
     // if a (re)compute fired.
     let state2 = state.clone();
     with_rank_event(&state, move || {
-        let map = nestweaver_engine::generate_repo_map(&state2.store, budget)?;
+        // Same contract as the ranked routes: a dirty index publication fails
+        // the repo map closed — surface 503 "ranking unavailable", not a 500.
+        let map = nestweaver_engine::generate_repo_map(&state2.store, budget)
+            .map_err(ApiError::from_ranking)?;
         Ok(Json(json!({ "map": map })).into_response())
     })
     .await
@@ -65,6 +68,30 @@ pub async fn suggest_links(State(state): State<Arc<AppState>>) -> Result<Respons
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The repo-map route follows the same contract as the ranked routes: a
+    /// dirty index publication surfaces as 503 "ranking unavailable", not a
+    /// 500 and not a successful empty map.
+    #[tokio::test]
+    async fn repo_map_reports_ranking_unavailable_during_dirty_publication() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("brain.lbug");
+        let store = nestweaver_store::GraphStore::open_or_create(&db_path).unwrap();
+        std::fs::write(format!("{}.index-dirty", db_path.display()), b"dirty").unwrap();
+        let state = AppState::new(store, None, db_path);
+
+        let error = match repo_map(State(state), Query(RepoMapParams { budget: None })).await {
+            Ok(_) => panic!("a dirty publication must not render a successful repo map"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.status, axum::http::StatusCode::SERVICE_UNAVAILABLE);
+        assert!(
+            error.message.contains("ranking"),
+            "the error must name ranking as unavailable: {}",
+            error.message
+        );
+    }
 
     #[tokio::test]
     async fn suggest_links_migrates_and_reads_a_legacy_only_manifest_sidecar() {

--- a/crates/nestweaver-web/src/routes/symbols.rs
+++ b/crates/nestweaver-web/src/routes/symbols.rs
@@ -77,9 +77,44 @@ pub async fn symbols_top(
     // so run it off the async runtime and emit `pagerank:recomputed` if it fired.
     let state2 = state.clone();
     with_rank_event(&state, move || {
-        let symbols = state2.store.symbols_by_pagerank(Some(limit))?;
+        // A dirty index publication fails ranking closed: surface 503 so the
+        // UI says "ranking unavailable" instead of rendering an empty list.
+        let symbols = state2
+            .store
+            .symbols_by_pagerank(Some(limit))
+            .map_err(|e| ApiError::from_ranking(&state2.store, e))?;
         let json = serde_json::to_value(&symbols)?;
         Ok(Json(json).into_response())
     })
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// During a dirty index publication the top-symbols route must say
+    /// "ranking unavailable" (503), never answer 200 with an empty list — an
+    /// empty list is indistinguishable from a graph with no ranked symbols
+    /// (the `ranking.rs` dirty-publication contract).
+    #[tokio::test]
+    async fn symbols_top_reports_ranking_unavailable_during_dirty_publication() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("brain.lbug");
+        let store = nestweaver_store::GraphStore::open_or_create(&db_path).unwrap();
+        std::fs::write(format!("{}.index-dirty", db_path.display()), b"dirty").unwrap();
+        let state = AppState::new(store, None, db_path);
+
+        let error = match symbols_top(State(state), Query(TopParams { limit: None })).await {
+            Ok(_) => panic!("a dirty publication must not render a successful top-symbols list"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.status, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(
+            error.message.contains("ranking"),
+            "the error must name ranking as unavailable: {}",
+            error.message
+        );
+    }
 }

--- a/crates/nestweaver-web/src/routes/symbols.rs
+++ b/crates/nestweaver-web/src/routes/symbols.rs
@@ -82,7 +82,7 @@ pub async fn symbols_top(
         let symbols = state2
             .store
             .symbols_by_pagerank(Some(limit))
-            .map_err(|e| ApiError::from_ranking(&state2.store, e))?;
+            .map_err(|e| ApiError::from_ranking(e.into()))?;
         let json = serde_json::to_value(&symbols)?;
         Ok(Json(json).into_response())
     })

--- a/src/main.rs
+++ b/src/main.rs
@@ -10894,7 +10894,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 {
                     let store = state.store.clone();
                     rt.spawn_blocking(move || {
-                        store.ensure_pagerank_loaded();
+                        // Best-effort: a dirty index publication refuses the
+                        // warm (ranking queries fail closed until the
+                        // publication completes — see the ranking.rs module
+                        // contract).
+                        if let Err(error) = store.ensure_pagerank_loaded() {
+                            tracing::debug!("PageRank pre-warm skipped: {error}");
+                        }
                     });
                 }
 
@@ -15472,6 +15478,7 @@ fn run_ranking(
                 .map_err(|e| anyhow::anyhow!(e))?;
             let base_pagerank = store
                 .pagerank_scores()
+                .map_err(|e| anyhow::anyhow!(e))?
                 .get(&resolved)
                 .copied()
                 .unwrap_or(0.0);


### PR DESCRIPTION
## Summary

Implements the backlog item **"Ranking guard sites disagree on empty versus error"** (Option A): every ranking *query* site in `crates/nestweaver-store/src/ranking.rs` now fails with `Err(StoreError::Query("PageRank unavailable during dirty index publication"))` during a dirty publication, so no caller can mistake a publication window for an empty graph. The contract is stated once in the module header.

## Changes

- **store/ranking.rs**: the three silent query sites now fail closed — `symbols_by_pagerank` (was `Ok(vec![])`), `pagerank_scores` (was empty map; now returns `Result`), `ensure_pagerank_loaded_locked` (was silent return; now `Result`). The two sidecar no-ops (`save_`/`load_pagerank_cache`) and all non-ranking cache-bypass sites are unchanged, per the item's Scope section.
- **web**: `symbols_top` and `overview` map the refusal via new `ApiError::from_ranking` to **503 "ranking temporarily unavailable — index publication in progress"** (matching the degraded-mode 503 convention) instead of rendering an empty list — "no ranked symbols" (200 + empty list) is now distinguishable from "ranking unavailable" (503).
- **engine**: `hubs` and `export` propagate; `blast_radius` degrades its advisory centrality boost explicitly (`if let Ok`, same "no boost" semantics as a cold cache); `query::generate_repo_map` already propagated.
- **daemon/CLI**: the two PageRank pre-warms log-and-skip at debug level; the CLI rank-explain path propagates with `anyhow` per local convention.
- **tests**: extended `dirty_publication_blocks_pagerank_load_compute_save_and_serving` to assert the contract at **every** guard site (all six query paths error; sidecar pair no-ops; generation untouched); tests that enshrined the old empty-during-dirty behavior now assert `is_err()`; two new web route tests pin the 503.

## RED / GREEN

- **RED**: with the old empty-returns temporarily restored at the three query sites, the extended contract test fails: `dirty publication must not serve ranks computed while clean`.
- **GREEN**: `cargo test -p nestweaver-store` filters `ranking`/`dirty`/`sidecar`/`pagerank` — 63 passed, 0 failed; web route tests — 2 new tests pass; targeted engine tests for every flipped assertion site pass (two initially-misclassified dirty-context sites in `index.rs` were caught by these runs and corrected to `is_err()`).
- `cargo fmt` clean; scoped `clippy --all-targets -- -D warnings` clean for store/web/engine/daemon/root; `cargo check --all-targets --all-features` clean for engine + daemon.
- Full crate suites left to CI.

## Round-2 review follow-up

- `dirty_publication_bypasses_response_cache` (mcp) now dispatches `regex_search` (cacheable, non-ranking) instead of `hub_nodes`, which fails closed by design under the new contract; the cache-bypass assertions are unchanged.
- Correction to the round-1 commit message: the `RankingUnavailable` variant's Display drops the `"query error: "` prefix the `Query(...)` payload used to render, so the text is NOT byte-identical — only the substring mcp's classifier matches ("PageRank unavailable during dirty index publication") is unchanged. The wedged-classification fixture at tools.rs now feeds the current bare format.
- mcp targeted tests green: `publication` 7/7, `dirty` 2/2 (classification tests included in the publication filter); clippy `-D warnings` clean on nestweaver-mcp; fmt clean.
