### PR TITLE
test(engine): reconcile refresh-failure tests with dirty-fail-closed ranking reads

### DIFF
--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -9351,7 +9351,13 @@ function hello(name) { return "Hello " + name; }
             error.failures[0].stage,
             DeletionReconciliationStage::PageRankCompute
         );
-        assert!(!store.pagerank_scores().unwrap().contains_key("stale"));
+        // The rank path now fails CLOSED while the publication is dirty —
+        // Err(RankingUnavailable), and the failed read itself invalidates the
+        // stale cache. Observing ranks requires reconciling first.
+        assert!(matches!(
+            store.pagerank_scores(),
+            Err(nestweaver_store::StoreError::RankingUnavailable)
+        ));
         assert!(!pagerank_path.exists());
         assert!(store.graph_generation() > generation_before);
         // The failed refresh BLOCKS marker retirement: the publication stays
@@ -9370,6 +9376,17 @@ function hello(name) { return "Hello " + name; }
                 .unwrap()
                 > generation_before
         );
+
+        // After reconciliation the healed ranks must not contain the stale score.
+        let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
+        write_marker_with_pid(&marker_path, reaped_child_pid(), None);
+        let outcome = recover_abandoned_index_publication(&store, true).unwrap();
+        assert!(
+            outcome.recovered(),
+            "the dirty publication must reconcile: {}",
+            outcome.describe()
+        );
+        assert!(!store.pagerank_scores().unwrap().contains_key("stale"));
     }
 
     #[test]
@@ -9405,9 +9422,29 @@ function hello(name) { return "Hello " + name; }
             error.failures[0].stage,
             DeletionReconciliationStage::PageRankPersistence
         );
-        assert!(!store.pagerank_scores().unwrap().contains_key("stale"));
+        // Same contract as the compute-failure sibling: dirty reads fail
+        // closed, the marker survives, and reconciling the publication must
+        // not restore the stale score.
+        assert!(matches!(
+            store.pagerank_scores(),
+            Err(nestweaver_store::StoreError::RankingUnavailable)
+        ));
         assert!(!pagerank_path.exists());
         assert!(store.graph_generation() > generation_before);
+
+        let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
+        assert!(
+            marker_path.exists(),
+            "a failed PageRank refresh must leave the publication dirty"
+        );
+        write_marker_with_pid(&marker_path, reaped_child_pid(), None);
+        let outcome = recover_abandoned_index_publication(&store, true).unwrap();
+        assert!(
+            outcome.recovered(),
+            "the dirty publication must reconcile: {}",
+            outcome.describe()
+        );
+        assert!(!store.pagerank_scores().unwrap().contains_key("stale"));
     }
 
     /// Leave the database in exactly the state a SIGKILL inside the finalizer
@@ -10031,13 +10068,18 @@ function hello(name) { return "Hello " + name; }
                     "the stale PageRank sidecar must be retired before the write gate is released"
                 );
                 assert!(self.store.graph_generation() > self.generation_before);
-                assert_eq!(
-                    fs::read_to_string(&self.generation_path)
-                        .unwrap()
-                        .trim()
-                        .parse::<u64>()
-                        .unwrap(),
-                    self.store.graph_generation(),
+                // A failed refresh blocks marker retirement, so the in-memory
+                // generation stays at the dirty reservation while the durable
+                // file already holds the clean successor. What this guard pins
+                // is that the generation is DURABLE and advanced before the
+                // write gate is released — not that the two agree.
+                let persisted = fs::read_to_string(&self.generation_path)
+                    .unwrap()
+                    .trim()
+                    .parse::<u64>()
+                    .unwrap();
+                assert!(
+                    persisted > self.generation_before,
                     "the graph generation must be durable before the write gate is released"
                 );
                 self.dropped.store(true, Ordering::SeqCst);
@@ -10096,7 +10138,13 @@ function hello(name) { return "Hello " + name; }
             store.symbols_in_file("old.js").unwrap().is_empty(),
             "the server replacement transaction must commit before PageRank fails"
         );
-        assert!(!store.pagerank_scores().unwrap().contains_key("stale"));
+        // The publication stays dirty after the failed refresh, so the rank
+        // path fails closed — and the failed read itself invalidates the live
+        // stale cache.
+        assert!(matches!(
+            store.pagerank_scores(),
+            Err(nestweaver_store::StoreError::RankingUnavailable)
+        ));
         assert!(dropped.load(Ordering::SeqCst));
     }
 


### PR DESCRIPTION
Main broke (3 engine tests) on the semantic interaction between #261 (failed PageRank refresh leaves the marker set — publication stays dirty) and #262 (ranking reads fail closed with `Err(StoreError::RankingUnavailable)` during a dirty publication). CI: 1081 passed / 3 failed. All three failures were test expectations predating the combination; no production behavior was wrong, so only tests changed.

Reproduced RED on clean main (`981ed16`) before fixing — identical signatures to CI:
- `pagerank_compute_failure_...`: `Result::unwrap()` on `Err(RankingUnavailable)` (index.rs:9354)
- `pagerank_save_failure_...`: same (index.rs:9408)
- `server_full_compute_failure_...`: generation assert left 4 right 3 (index.rs:10034)

## Per-test reconciliation

- **`pagerank_compute_failure_is_returned_after_mandatory_commit_publication`** pinned "the committed graph invalidates the live stale PageRank cache" by reading ranks after the failed refresh. Under the combined semantics a dirty read MUST error — that is the new contract and #261's own design — so the test now asserts `Err(RankingUnavailable)` (the failed read itself invalidates the stale cache), keeps the marker-present and advanced-durable-generation assertions, then reconciles the deliberately dirty publication (dead-pid marker rewrite + `recover_abandoned_index_publication`) and asserts the healed ranks do not contain the stale score.
- **`pagerank_save_failure_is_returned_without_restoring_stale_persisted_ranks`**: same shape, plus it now also pins that the marker survives a failed save (blocked retirement).
- **`server_full_compute_failure_finalizes_before_releasing_write_gate`** pinned "generation durable before the write gate is released" as file == in-memory. With retirement blocked on the failed compute, the durable file holds the clean successor (4) while in-memory holds the dirty reservation (3) — both advanced, next open reconciles. The guard now asserts the persisted generation is advanced (`> generation_before`) before gate release, which is the property the test exists to pin; the body asserts the dirty rank read fails closed.

## Verification

- RED on clean main: 3/3 fail with the CI signatures (log captured before any edit)
- GREEN after: `cargo test -p nestweaver-engine --lib -- pagerank kill_ reader_in_refresh dirty` — 37 passed / 0 failed (includes all three fixed tests plus the kill_* fault-injection and dirty-publication tests)
- `cargo test -p nestweaver-store --lib ranking` — 39 passed / 0 failed
- `cargo fmt --all` clean; `cargo clippy -p nestweaver-engine --all-targets -- -D warnings` clean

Full workspace suite left to CI.

🤖 Generated with [Kimi Code](https://github.com/MoonshotAI/kimi-code)