### PR TITLE
fix: harden database routing, watchers, and graph replacement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,7 @@ nestweaver export --format msgpack       # graph snapshot for WASM engine
 
 # Markdown brain (`.brainignore` for glob exclusion patterns; `--ignore` flag for ad-hoc)
 nestweaver brain add ~/Documents/Obsidian/MyVault
-nestweaver brain add ~/vault --config ./instance.toml  # uses config's instance_id and db_path
+nestweaver brain add ~/vault --config ./instance.toml  # uses config's instance_id and db field
 nestweaver brain search "architecture"   # searches code symbols AND vault notes
 nestweaver brain context "MyProject"     # unified code + notes context
 nestweaver brain status                  # vault counts, per-vault staleness

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4240,7 +4240,6 @@ dependencies = [
  "nestweaver-storage",
  "nestweaver-store",
  "notify",
- "notify-debouncer-mini",
  "openapiv3",
  "prost-types",
  "protox-parse",
@@ -4530,18 +4529,6 @@ dependencies = [
  "notify-types",
  "walkdir",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "notify-debouncer-mini"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17849edfaabd9a5fef1c606d99cfc615a8e99f7ac4366406d86c7942a3184cf2"
-dependencies = [
- "log",
- "notify",
- "notify-types",
- "tempfile",
 ]
 
 [[package]]

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -278,6 +278,27 @@ impl Drop for ConnectionGuard {
     }
 }
 
+/// Compose shutdown admission and the process-wide writer gate in the only
+/// safe order. Long-lived services receive this factory and acquire a lease at
+/// their actual mutation boundary instead of pinning the daemon while idle or
+/// performing remote/read-only planning.
+fn daemon_mutation_lease_factory(
+    state: Arc<DaemonState>,
+) -> nestweaver_engine::WatchMutationLeaseFactory {
+    Arc::new(move |label| {
+        let guard = ConnectionGuard::write(&state).map_err(|status| {
+            if status.code() == tonic::Code::Unavailable {
+                anyhow::Error::new(nestweaver_engine::WatchMutationRefused)
+                    .context(status.message().to_string())
+            } else {
+                anyhow::anyhow!(status.to_string())
+            }
+        })?;
+        let write = state.write_gate.blocking_lock(label);
+        Ok(Box::new((guard, write)))
+    })
+}
+
 /// The process-wide write gate. Homed in `nestweaver-engine` because the
 /// daemon is not the only writer: the worker pool and the web admin API take
 /// the same lock, and every one of them must stamp the holder so
@@ -1657,23 +1678,21 @@ impl DaemonService {
     /// watcher batch.  Returns `None` when the `embed` feature is disabled or
     /// the model is not yet loaded.
     ///
-    /// The embed writes run **inline** on the watcher thread. That thread holds
-    /// `write_mutex` + a `ConnectionGuard::write` for the watcher's whole run
-    /// (see `watch_vault`/`watch_code` wiring) and invokes this callback within
-    /// that hold, so executing the `add_embedding`/`flush_embedding_index`
-    /// writes here keeps them under the same write gate every other daemon
-    /// mutation uses:
+    /// The embed writes run **inline** on the watcher thread. The engine keeps
+    /// the batch's mutation lease live through this callback, so executing the
+    /// `add_embedding`/`flush_embedding_index` writes here keeps them under the
+    /// same write gate every other daemon mutation uses:
     ///  - **backup-safe:** the write runs while the watcher holds `write_mutex`,
     ///    so a backup's `.embeddings` sidecar copy (which also takes
     ///    `write_mutex` in `stage_backup_from_store`) cannot run concurrently,
     ///    and no detached task outlives the lock to race the copy;
     ///  - **drain-visible:** the write completes before the watcher thread drops
-    ///    its `ConnectionGuard::write`, so `active_writes` stays > 0 until the
+    ///    its batch `ConnectionGuard::write`, so `active_writes` stays > 0 until the
     ///    embed finishes and the shutdown drain waits for it.
     ///
     /// It must NOT be moved to a detached `spawn_blocking` task: that escapes
     /// both guarantees. It also must NOT re-acquire `write_mutex` itself — the
-    /// watcher thread already holds it for the whole run, so a fresh
+    /// watcher thread already holds it for the batch, so a fresh
     /// `blocking_lock()` here would deadlock. Inheriting the existing hold is
     /// the correct single-writer discipline.
     #[cfg(feature = "embed")]
@@ -3537,7 +3556,7 @@ impl NestWeaverDaemon for DaemonService {
         // daemon holding a shutdown handle for a `BrainWatcher` dropped on the
         // very next line, on behalf of a request that was rejected: state
         // mutated by a refused RPC.
-        let guard = ConnectionGuard::write(&self.state)?;
+        let admission_guard = ConnectionGuard::write(&self.state)?;
 
         // register_watcher holds the lock across check + store (TOCTOU-safe).
         let watcher_id = match register_watcher(&self.state, shutdown_handle, false) {
@@ -3551,8 +3570,12 @@ impl NestWeaverDaemon for DaemonService {
             }
             Err(e) => return Err(e),
         };
-        let write_lock = self.state.write_gate.clone();
+        // Registration is admitted as one short mutation. The endless service
+        // must not remain an active write while it is merely waiting for files.
+        drop(admission_guard);
         let state = self.state.clone();
+        let mutation_factory = daemon_mutation_lease_factory(self.state.clone());
+        watcher = watcher.with_mutation_lease_factory(mutation_factory);
         let store = self.state.store.clone();
         let on_change = Self::make_embed_on_change(
             self.state.embedding_runtime.clone(),
@@ -3560,8 +3583,6 @@ impl NestWeaverDaemon for DaemonService {
         );
 
         tokio::task::spawn_blocking(move || {
-            let _write_lock = write_lock.blocking_lock("watch_vault");
-            let _guard = guard;
             tracing::info!(vault = %vault_path.display(), "watcher thread started");
 
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -3623,7 +3644,7 @@ impl NestWeaverDaemon for DaemonService {
 
         let db_path = self.state.db_path.clone();
 
-        let watcher = nestweaver_engine::CodeWatcher::new(&db_path, &repo_path, &instance_id);
+        let mut watcher = nestweaver_engine::CodeWatcher::new(&db_path, &repo_path, &instance_id);
         let shutdown_handle = watcher.shutdown_handle();
 
         // Refuse BEFORE registering — and here the ordering matters more than in
@@ -3633,7 +3654,7 @@ impl NestWeaverDaemon for DaemonService {
         // it, leaving no watcher at all plus a registration pointing at a
         // dropped `CodeWatcher`. Destroying live state on behalf of a rejected
         // request is not something a refusal is allowed to do.
-        let guard = ConnectionGuard::write(&self.state)?;
+        let admission_guard = ConnectionGuard::write(&self.state)?;
 
         // register_watcher holds the lock across check + store (TOCTOU-safe).
         // With `force`, an already-running watcher (e.g. orphaned by a
@@ -3651,8 +3672,10 @@ impl NestWeaverDaemon for DaemonService {
             }
             Err(e) => return Err(e),
         };
-        let write_lock = self.state.write_gate.clone();
+        drop(admission_guard);
         let state = self.state.clone();
+        let mutation_factory = daemon_mutation_lease_factory(self.state.clone());
+        watcher = watcher.with_mutation_lease_factory(mutation_factory);
         let store = self.state.store.clone();
         let on_change = Self::make_embed_on_change(
             self.state.embedding_runtime.clone(),
@@ -3660,8 +3683,6 @@ impl NestWeaverDaemon for DaemonService {
         );
 
         tokio::task::spawn_blocking(move || {
-            let _write_lock = write_lock.blocking_lock("watch_code");
-            let _guard = guard;
             tracing::info!(repo = %repo_path.display(), "code watcher thread started");
 
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -4558,50 +4579,53 @@ impl NestWeaverDaemon for DaemonService {
         let config_path = PathBuf::from(&req.config_path);
         let instance_id =
             resolve_effective_instance_id(&req.instance_id, &self.state.data_instance_id)?;
+        // Configuration I/O and parsing do not mutate the graph and must not
+        // occupy the sole writer while a slow filesystem is being read.
+        let instance_config =
+            nestweaver_engine::InstanceConfig::from_file(&config_path).map_err(|error| {
+                Status::invalid_argument(format!(
+                    "failed to load instance config {}: {error:#}",
+                    config_path.display()
+                ))
+            })?;
         let state = self.state.clone();
 
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<IndexProgress, Status>>(16);
 
-        let guard = ConnectionGuard::write(&self.state)?;
-        let write_lock = self.state.write_gate.clone();
+        let base_mutation_factory = daemon_mutation_lease_factory(self.state.clone());
+        let writing_tx = tx.clone();
+        let project_total = instance_config.projects.len() as u64;
+        let mutation_factory: nestweaver_engine::WatchMutationLeaseFactory =
+            Arc::new(move |label| {
+                let lease = base_mutation_factory(label)?;
+                let _ = writing_tx.blocking_send(Ok(IndexProgress {
+                    phase: Phase::Writing as i32,
+                    message: "Applying the planned project graph in one transaction".to_string(),
+                    files_processed: 0,
+                    files_total: project_total,
+                    symbols_found: 0,
+                }));
+                Ok(lease)
+            });
         tokio::task::spawn_blocking(move || {
-            let _write_lock = write_lock.blocking_lock("materialize_projects");
-            let _guard = guard;
             let _ = tx.blocking_send(Ok(IndexProgress {
                 phase: Phase::Discovering as i32,
-                message: format!("Loading instance config from {}", config_path.display()),
+                message: format!(
+                    "Loaded {} configured project(s) from {}",
+                    instance_config.projects.len(),
+                    config_path.display()
+                ),
                 files_processed: 0,
-                files_total: 0,
+                files_total: instance_config.projects.len() as u64,
                 symbols_found: 0,
             }));
 
-            let instance_config = match nestweaver_engine::InstanceConfig::from_file(&config_path) {
-                Ok(c) => c,
-                Err(e) => {
-                    let _ = tx.blocking_send(Ok(IndexProgress {
-                        phase: Phase::Error as i32,
-                        message: format!("Failed to load instance config: {e:#}"),
-                        files_processed: 0,
-                        files_total: 0,
-                        symbols_found: 0,
-                    }));
-                    return;
-                }
-            };
-
-            let _ = tx.blocking_send(Ok(IndexProgress {
-                phase: Phase::Writing as i32,
-                message: format!("Materializing projects for instance {}", instance_id),
-                files_processed: 0,
-                files_total: 0,
-                symbols_found: 0,
-            }));
-
-            match nestweaver_engine::materialize_projects(
+            match nestweaver_engine::materialize_projects_with_lease(
                 &state.store,
                 &instance_config,
                 &instance_id,
                 &state.db_path,
+                Some(mutation_factory),
             ) {
                 Ok(result) => {
                     let _ = tx.blocking_send(Ok(IndexProgress {
@@ -4623,7 +4647,7 @@ impl NestWeaverDaemon for DaemonService {
                         phase: Phase::Error as i32,
                         message: format!("MaterializeProjects failed: {e:#}"),
                         files_processed: 0,
-                        files_total: 0,
+                        files_total: instance_config.projects.len() as u64,
                         symbols_found: 0,
                     }));
                 }
@@ -14727,14 +14751,14 @@ mod startup_helper_tests {
     }
 
     /// The watcher's embed-on-change callback must perform its `add_embedding`
-    /// writes under the write gate the watcher thread holds (`write_mutex` +
+    /// writes under the current batch lease (`write_mutex` +
     /// `ConnectionGuard::write`), not on a detached fire-and-forget task that
-    /// escapes it. Escaping the gate (a) races a backup's sidecar copy and
+    /// escapes it. Escaping the lease (a) races a backup's sidecar copy and
     /// (b) is invisible to the shutdown drain (`active_writes`).
     ///
-    /// This mirrors the `watch_vault`/`watch_code` wiring (server.rs ~863-872):
-    /// the watcher thread takes `write_mutex.blocking_lock()` + a write guard
-    /// for its whole run and calls the callback inline within that hold.
+    /// This mirrors the `watch_vault`/`watch_code` wiring: the engine acquires
+    /// one composite lease for a mutation batch and calls the callback inline
+    /// before dropping it. An idle watcher owns no lease.
     #[cfg(feature = "embed")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn watcher_embed_holds_write_gate() {
@@ -14787,15 +14811,27 @@ mod startup_helper_tests {
         let cb = DaemonService::make_embed_on_change(embedding_runtime, store.clone())
             .expect("embed callback should be present when a model is loaded");
 
-        // Mirror the watcher thread: hold write_mutex + bump active_writes for
-        // the callback's whole run, exactly as watch_vault/watch_code do.
-        let wm = write_mutex.clone();
+        struct ActiveWriteProbe(Arc<AtomicU32>);
+        impl Drop for ActiveWriteProbe {
+            fn drop(&mut self) {
+                self.0.fetch_sub(1, Ordering::Relaxed);
+            }
+        }
+
+        // Mirror the batch factory: admission/counting first, then the gate,
+        // returned as one opaque RAII value.
+        let gate = WriteGate::from_mutex(write_mutex.clone());
         let aw = active_writes.clone();
+        let factory: nestweaver_engine::WatchMutationLeaseFactory = Arc::new(move |label| {
+            aw.fetch_add(1, Ordering::Relaxed);
+            let guard = ActiveWriteProbe(aw.clone());
+            let write = gate.blocking_lock(label);
+            Ok(Box::new((guard, write)))
+        });
         let handle = tokio::task::spawn_blocking(move || {
-            let _write_lock = wm.blocking_lock();
-            aw.fetch_add(1, Ordering::Relaxed); // == ConnectionGuard::write
+            let lease = factory("watch_vault_batch").unwrap();
             cb();
-            aw.fetch_sub(1, Ordering::Relaxed); // == guard drop on watcher exit
+            drop(lease);
         });
 
         // Wait for the embed write to run (or fail the test if it never does).
@@ -14817,6 +14853,15 @@ mod startup_helper_tests {
         assert!(
             store.has_embedding(&sym_uid),
             "callback should have embedded the pending symbol"
+        );
+        assert_eq!(
+            active_writes.load(Ordering::Relaxed),
+            0,
+            "the batch lease must release active_writes after the callback"
+        );
+        assert!(
+            write_mutex.try_lock().is_ok(),
+            "the batch lease must release the writer gate while the watcher is idle"
         );
     }
 
@@ -16839,6 +16884,64 @@ external_model = "unavailable-test-model"
         state.active_writes.store(0, Ordering::Relaxed);
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn idle_vault_watcher_releases_the_write_lease() {
+        let state = test_state_with_writer();
+        let service = DaemonService {
+            state: Arc::clone(&state),
+        };
+        let vault = tempfile::tempdir().unwrap();
+        std::fs::write(vault.path().join("seed.md"), "# Seed\n").unwrap();
+
+        let response = service
+            .watch_vault(tonic::Request::new(nestweaver_proto::WatchVaultRequest {
+                vault_path: vault.path().to_string_lossy().into_owned(),
+                vault_name: "test-vault".to_string(),
+                instance_id: String::new(),
+                extra_ignore_patterns: Vec::new(),
+            }))
+            .await
+            .expect("WatchVault RPC")
+            .into_inner();
+        assert!(response.ok, "watcher failed to start: {}", response.message);
+
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            loop {
+                if state.active_writes.load(Ordering::Relaxed) == 0
+                    && state.write_gate.holder_snapshot().is_none()
+                    && !state.store.list_vaults(None).unwrap().is_empty()
+                {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("WatchVault must release its startup batch lease while idle");
+
+        let independent = ConnectionGuard::write(&state).expect("independent write admission");
+        let gate = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            state.write_gate.lock("idle_watcher_probe"),
+        )
+        .await
+        .expect("independent write must not block behind idle WatchVault");
+        drop(gate);
+        drop(independent);
+
+        stop_active_watcher(&state);
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if state.watcher_stop.lock().unwrap().is_none() {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("stopped WatchVault must clear its registration");
+    }
+
     /// The link nothing else covers: that a REAL SIGTERM routes into the drain
     /// rather than broadcasting.
     ///
@@ -17964,6 +18067,38 @@ mod watcher_e2e_tests {
             .expect("watch_code")
             .into_inner();
         assert!(r1.ok, "first watch must start: {}", r1.message);
+
+        // Wait for the cold snapshot to finish, then prove the long-lived idle
+        // service owns neither the writer gate nor a queued write. Before the
+        // batch-lease fix this permanently reported `watch_code` here.
+        let idle_status = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            loop {
+                let status = client
+                    .brain_status(nestweaver_proto::BrainStatusRequest {})
+                    .await
+                    .expect("brain status while watcher is idle")
+                    .into_inner();
+                if status.repo_count > 0 && status.write_holder.is_empty() {
+                    break status;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("watcher must release the writer gate after its initial batch");
+        assert_eq!(idle_status.write_queue_depth, 0);
+
+        // A second mutation must reach the server and finish while the watcher
+        // is idle, rather than queueing behind the watcher session forever.
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            client.remove_repo(nestweaver_proto::RemoveRepoRequest {
+                repo_uid: "repo:does-not-exist".to_string(),
+            }),
+        )
+        .await
+        .expect("an independent write must not block behind an idle watcher")
+        .expect("remove_repo RPC should return a normal response");
 
         // Simulated orphan: the first "CLI" never calls StopWatch.
         let r2 = client

--- a/crates/nestweaver-engine/Cargo.toml
+++ b/crates/nestweaver-engine/Cargo.toml
@@ -33,7 +33,6 @@ walkdir = "2"
 ignore = "0.4"
 indicatif = "0.18"
 notify = "8"
-notify-debouncer-mini = { version = "0.7", default-features = false }
 rand = "0.10"
 rusqlite = { workspace = true }
 libc = "0.2"

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -395,7 +395,10 @@ pub use process::{
     AffectedProcess, AffectedSymbol, ChangeImpact, ProcessMember, ProcessResult, RiskLevel,
     detect_changes_impact, trace_processes,
 };
-pub use project::{ProjectMaterializationResult, detect_implicit_projects, materialize_projects};
+pub use project::{
+    ProjectMaterializationResult, detect_implicit_projects, materialize_projects,
+    materialize_projects_with_lease,
+};
 pub use pull::*;
 pub use query::{
     BrainContextResult, BrainNode, ContextNode, ContextResult, CrossRepoLink, EmbedModelProvider,
@@ -426,7 +429,10 @@ pub use summaries::{
     merge_and_save_summaries, render_text, save_summaries, truncate_to_budget,
 };
 pub use watch_code::CodeWatcher;
-pub use watcher::{BrainWatcher, ShutdownHandle, UpdateOutcome};
+pub use watcher::{
+    BrainWatcher, ShutdownHandle, UpdateOutcome, WatchMutationLease, WatchMutationLeaseFactory,
+    WatchMutationRefused,
+};
 pub use write_gate::{WriteGate, WriteLease};
 
 #[cfg(test)]

--- a/crates/nestweaver-engine/src/project.rs
+++ b/crates/nestweaver-engine/src/project.rs
@@ -64,6 +64,18 @@ pub fn materialize_projects(
     instance_id: &str,
     db_path: &Path,
 ) -> Result<ProjectMaterializationResult, anyhow::Error> {
+    materialize_projects_with_lease(store, config, instance_id, db_path, None)
+}
+
+/// Materialize configured projects, acquiring an optional external writer
+/// lease only after remote wiki sources have been fetched and validated.
+pub fn materialize_projects_with_lease(
+    store: &GraphStore,
+    config: &InstanceConfig,
+    instance_id: &str,
+    db_path: &Path,
+    mutation_lease_factory: Option<crate::watcher::WatchMutationLeaseFactory>,
+) -> Result<ProjectMaterializationResult, anyhow::Error> {
     let mut ext_store = load_extensions(db_path);
 
     // Reject duplicate project names up front: two entries with the same name
@@ -79,119 +91,229 @@ pub fn materialize_projects(
         }
     }
 
-    // Clean existing project edges before re-materializing (idempotent).
-    for project_config in &config.projects {
-        let uid = project_uid(instance_id, &project_config.name);
-        store.delete_project_edges(&uid)?;
+    // Remote MCP calls are planning, not graph mutation. Fetch every source
+    // before acquiring the daemon's sole-writer lease so a slow or wedged wiki
+    // server cannot block unrelated writes.
+    let mut prepared_wiki_results = HashMap::new();
+    let mut mcp_clients: HashMap<String, Option<McpClient>> = HashMap::new();
+    let mut total_wiki_fetch_errors = 0usize;
+    for project_cfg in &config.projects {
+        for ws in &project_cfg.wiki_sources {
+            let Some(server_config) = config
+                .mcp_servers
+                .iter()
+                .find(|server| server.name == ws.mcp_server)
+            else {
+                tracing::warn!(
+                    project = project_cfg.name,
+                    mcp_server = ws.mcp_server,
+                    "MCP server not found in config, skipping wiki source"
+                );
+                continue;
+            };
+            let timeout = std::time::Duration::from_secs(server_config.timeout_secs.unwrap_or(30));
+            let client_slot = mcp_clients.entry(ws.mcp_server.clone()).or_insert_with(|| {
+                match McpClient::spawn_with_timeout(
+                    &server_config.command,
+                    &server_config.args,
+                    &server_config.env,
+                    timeout,
+                ) {
+                    Ok(client) => Some(client),
+                    Err(error) => {
+                        tracing::warn!(
+                            mcp_server = ws.mcp_server,
+                            error = %error,
+                            "failed to spawn MCP server, skipping wiki sources for this server"
+                        );
+                        None
+                    }
+                }
+            });
+            let Some(client) = client_slot.as_mut() else {
+                continue;
+            };
+            if client.is_poisoned() {
+                tracing::debug!(label = ws.label, "skipping — MCP client is poisoned");
+                total_wiki_fetch_errors += 1;
+                continue;
+            }
+            match client.call_tool(&ws.tool, serde_json::json!(ws.args)) {
+                Ok(result) => {
+                    prepared_wiki_results.insert(
+                        (
+                            project_cfg.name.clone(),
+                            ws.mcp_server.clone(),
+                            ws.tool.clone(),
+                            ws.label.clone(),
+                        ),
+                        result,
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        label = ws.label,
+                        tool = ws.tool,
+                        error = %error,
+                        "MCP tool call failed, skipping wiki source"
+                    );
+                    total_wiki_fetch_errors += 1;
+                }
+            }
+        }
+    }
+    drop(mcp_clients);
+
+    let mut prepared_wiki_contents = HashMap::new();
+    for (key, result) in prepared_wiki_results {
+        let content = result.content;
+        if content.is_empty() {
+            tracing::warn!(label = key.3, "MCP tool returned empty content");
+            total_wiki_fetch_errors += 1;
+            continue;
+        }
+        if result.is_error || looks_like_fetch_error(&content) {
+            let preview: String = content.chars().take(120).collect();
+            tracing::warn!(label = key.3, "wiki fetch failed: {preview}");
+            total_wiki_fetch_errors += 1;
+            continue;
+        }
+        prepared_wiki_contents.insert(key, maybe_convert_html_to_markdown(&content));
     }
 
-    let mut projects_created = 0usize;
-    let mut total_note_edges = 0usize;
-    let mut total_symbol_edges = 0usize;
-    let mut total_component_edges = 0usize;
-    let mut total_wiki_notes_ingested = 0usize;
-    let mut total_wiki_fetch_errors = 0usize;
+    let _mutation_lease = mutation_lease_factory
+        .as_ref()
+        .map(|factory| factory("materialize_projects"))
+        .transpose()?;
+
+    // Plan every local graph relationship before deleting anything. Repository
+    // and note inventories are stable for this materialization pass and are
+    // intentionally loaded once rather than once per project/repo.
+    let all_notes = store.list_notes(None)?;
+    let all_repos = store.list_repos(None)?;
+    let mut symbols_by_repo: HashMap<String, Vec<String>> = HashMap::new();
+    let mut projects = Vec::with_capacity(config.projects.len());
+    let mut note_edges: Vec<(String, String)> = Vec::new();
+    let mut symbol_edges: Vec<(String, String)> = Vec::new();
+    let mut component_edges: Vec<(String, String)> = Vec::new();
+    let mut parent_edges: Vec<(String, String)> = Vec::new();
 
     for project_cfg in &config.projects {
         let uid = project_uid(instance_id, &project_cfg.name);
-
-        // 1. Create the Project node.
-        let project = Project {
+        projects.push(Project {
             uid: uid.clone(),
             name: project_cfg.name.clone(),
             summary: project_cfg.description.clone(),
             instance_id: instance_id.to_string(),
-        };
-        store.upsert_project(&project)?;
-        projects_created += 1;
+        });
 
-        // 2. Vault-folder → note edges.
         if let Some(folder) = &project_cfg.vault_folder {
-            let all_notes = store.list_notes(None)?;
             let prefix = if folder.ends_with('/') {
                 folder.clone()
             } else {
                 format!("{folder}/")
             };
-            let edges: Vec<(&str, &str)> = all_notes
-                .iter()
-                .filter(|n| n.file_path.starts_with(&prefix) || n.file_path == *folder)
-                .map(|n| (uid.as_str(), n.uid.as_str()))
-                .collect();
-            let count = edges.len();
-            if !edges.is_empty() {
-                store.batch_insert_project_note_edges(&edges)?;
-            }
-            total_note_edges += count;
+            note_edges.extend(
+                all_notes
+                    .iter()
+                    .filter(|note| note.file_path.starts_with(&prefix) || note.file_path == *folder)
+                    .map(|note| (uid.clone(), note.uid.clone())),
+            );
         }
 
-        // 3. Repo names → symbol edges.
-        if !project_cfg.repos.is_empty() {
-            let all_repos = store.list_repos(None)?;
-            let mut symbol_uids: Vec<String> = Vec::new();
-
-            for repo_name in &project_cfg.repos {
-                // Resolve the project's declared repo name to one or more DB
-                // repos. Match order:
-                //   a) DB Repo.name override matches (e.g. `--name redrock`),
-                //   b) URL-derived display name matches,
-                //   c) an `[[repos]]` config entry whose `name = repo_name`
-                //      points at a URL that an indexed repo carries — covers
-                //      the case where the repo was indexed under its URL
-                //      basename but the config aliases it to a friendlier
-                //      name (e.g. redrock ↔ web-application),
-                //   d) URL substring match (legacy fallback).
-                let cfg_url_for_name: Option<&str> = config
-                    .repos
-                    .iter()
-                    .find(|rc| rc.name.as_deref() == Some(repo_name.as_str()))
-                    .map(|rc| rc.url.as_str());
-
-                let matched: Vec<_> = all_repos
-                    .iter()
-                    .filter(|r| {
-                        repo_display_name(r) == *repo_name
-                            || cfg_url_for_name.is_some_and(|u| {
-                                r.url.trim_end_matches('/') == u.trim_end_matches('/')
-                            })
-                            || r.url.contains(repo_name.as_str())
-                    })
-                    .collect();
-
-                for repo in matched {
-                    let syms = store.symbol_lite_by_repo(&repo.uid)?;
-                    symbol_uids.extend(syms.into_iter().map(|(sym_uid, _, _)| sym_uid));
+        // A transient wiki fetch failure must not erase the last successfully
+        // materialized membership. Successful sources are re-linked after
+        // their Note replacement below; failed sources preserve an existing
+        // Note edge if that Note is still present.
+        for ws in &project_cfg.wiki_sources {
+            let key = (
+                project_cfg.name.clone(),
+                ws.mcp_server.clone(),
+                ws.tool.clone(),
+                ws.label.clone(),
+            );
+            if !prepared_wiki_contents.contains_key(&key) {
+                let wiki_note_uid = note_uid(
+                    &format!("wiki:{}", ws.mcp_server),
+                    &format!("{}/{}", ws.tool, ws.label),
+                );
+                if all_notes.iter().any(|note| note.uid == wiki_note_uid) {
+                    note_edges.push((uid.clone(), wiki_note_uid));
                 }
             }
-
-            // Deduplicate — a project may declare two aliases that resolve to
-            // the same DB repo, and (s)-[:PROJECT_INCLUDES_SYMBOL]->(p)
-            // tolerates only one edge per pair.
-            symbol_uids.sort();
-            symbol_uids.dedup();
-
-            let count = symbol_uids.len();
-            if !symbol_uids.is_empty() {
-                store.batch_insert_project_symbol_edges(&uid, &symbol_uids, 1.0)?;
-            }
-            total_symbol_edges += count;
         }
 
-        // 4. Component edges (parent → child + child → parent).
+        let mut project_symbol_uids = Vec::new();
+        for repo_name in &project_cfg.repos {
+            let cfg_url_for_name = config
+                .repos
+                .iter()
+                .find(|repo| repo.name.as_deref() == Some(repo_name.as_str()))
+                .map(|repo| repo.url.as_str());
+            for repo in all_repos.iter().filter(|repo| {
+                repo_display_name(repo) == *repo_name
+                    || cfg_url_for_name.is_some_and(|url| {
+                        repo.url.trim_end_matches('/') == url.trim_end_matches('/')
+                    })
+                    || repo.url.contains(repo_name.as_str())
+            }) {
+                let repo_symbols = match symbols_by_repo.get(&repo.uid) {
+                    Some(symbols) => symbols,
+                    None => {
+                        let symbols = store
+                            .symbol_lite_by_repo(&repo.uid)?
+                            .into_iter()
+                            .map(|(symbol_uid, _, _)| symbol_uid)
+                            .collect();
+                        symbols_by_repo.insert(repo.uid.clone(), symbols);
+                        symbols_by_repo
+                            .get(&repo.uid)
+                            .expect("just inserted repository symbol inventory")
+                    }
+                };
+                project_symbol_uids.extend(repo_symbols.iter().cloned());
+            }
+        }
+        project_symbol_uids.sort();
+        project_symbol_uids.dedup();
+        symbol_edges.extend(
+            project_symbol_uids
+                .into_iter()
+                .map(|symbol_uid| (uid.clone(), symbol_uid)),
+        );
+
         for component_name in &project_cfg.components {
             let child_uid = project_uid(instance_id, component_name);
-            store.insert_project_component_edge(&uid, &child_uid, 1.0)?;
-            store.insert_project_parent_edge(&child_uid, &uid, 1.0)?;
-            total_component_edges += 1;
+            component_edges.push((uid.clone(), child_uid.clone()));
+            parent_edges.push((child_uid, uid.clone()));
         }
-
-        // 4b. Parent declaration (symmetric with components, declared from child side).
         if let Some(parent_name) = &project_cfg.parent {
             let parent_uid = project_uid(instance_id, parent_name);
-            store.insert_project_component_edge(&parent_uid, &uid, 1.0)?;
-            store.insert_project_parent_edge(&uid, &parent_uid, 1.0)?;
-            total_component_edges += 1;
+            component_edges.push((parent_uid.clone(), uid.clone()));
+            parent_edges.push((uid.clone(), parent_uid));
         }
+    }
+
+    // One transaction replaces the complete configured Project subgraph.
+    // Relationship COPY turns the 139k-edge hot path from one execute per edge
+    // into four bounded bulk loads, and rollback preserves the old graph if
+    // any replacement step fails.
+    store.replace_materialized_projects(
+        &projects,
+        &note_edges,
+        &symbol_edges,
+        &component_edges,
+        &parent_edges,
+    )?;
+
+    let projects_created = projects.len();
+    let total_note_edges = note_edges.len();
+    let total_symbol_edges = symbol_edges.len();
+    let total_component_edges = component_edges.len();
+    let mut total_wiki_notes_ingested = 0usize;
+
+    for project_cfg in &config.projects {
+        let uid = project_uid(instance_id, &project_cfg.name);
 
         // 5. Store external_refs in the extension sidecar.
         if !project_cfg.external_refs.is_empty() {
@@ -233,227 +355,151 @@ pub fn materialize_projects(
             );
         }
 
-        // 7. Process wiki sources via MCP client calls.
-        //    Reuse clients across sources from the same MCP server to avoid
-        //    spawning/killing the server process for every wiki page.
-        let mut mcp_clients: HashMap<String, Option<McpClient>> = HashMap::new();
-
+        // 7. Apply the wiki content fetched before the mutation lease.
         for ws in &project_cfg.wiki_sources {
-            let server_config = config.mcp_servers.iter().find(|s| s.name == ws.mcp_server);
-
-            let Some(server_config) = server_config else {
-                tracing::warn!(
-                    project = project_cfg.name,
-                    mcp_server = ws.mcp_server,
-                    "MCP server not found in config, skipping wiki source"
-                );
+            let key = (
+                project_cfg.name.clone(),
+                ws.mcp_server.clone(),
+                ws.tool.clone(),
+                ws.label.clone(),
+            );
+            let Some(content) = prepared_wiki_contents.remove(&key) else {
                 continue;
             };
-
-            // Get or spawn client for this MCP server.
-            let timeout = std::time::Duration::from_secs(server_config.timeout_secs.unwrap_or(30));
-            let client_slot = mcp_clients.entry(ws.mcp_server.clone()).or_insert_with(|| {
-                match McpClient::spawn_with_timeout(
-                    &server_config.command,
-                    &server_config.args,
-                    &server_config.env,
-                    timeout,
-                ) {
-                    Ok(c) => Some(c),
-                    Err(e) => {
-                        tracing::warn!(
-                            mcp_server = ws.mcp_server,
-                            error = %e,
-                            "failed to spawn MCP server, skipping wiki sources for this server"
-                        );
-                        None
-                    }
-                }
-            });
-
-            let Some(client) = client_slot.as_mut() else {
-                continue; // Server failed to spawn — skip all sources for it
-            };
-
-            if client.is_poisoned() {
-                tracing::debug!(label = ws.label, "skipping — MCP client is poisoned");
-                total_wiki_fetch_errors += 1;
-                continue;
-            }
-
             {
-                match client.call_tool(&ws.tool, serde_json::json!(ws.args)) {
-                    Ok(tool_result) => {
-                        let content = tool_result.content;
+                // Create a Note from the wiki content.
+                let wiki_note_uid = note_uid(
+                    &format!("wiki:{}", ws.mcp_server),
+                    &format!("{}/{}", ws.tool, ws.label),
+                );
 
-                        if content.is_empty() {
-                            tracing::warn!(label = ws.label, "MCP tool returned empty content");
-                            continue;
-                        }
+                let note = Note {
+                    uid: wiki_note_uid.clone(),
+                    vault_uid: format!("wiki:{}", ws.mcp_server),
+                    file_path: format!("{}/{}", ws.tool, ws.label),
+                    title: ws.label.clone(),
+                    note_kind: NoteKind::General,
+                    word_count: content.split_whitespace().count() as u32,
+                    content_hash: truncated_hash(&content),
+                    frontmatter: None,
+                    created_at: None,
+                    modified_at: None,
+                    pagerank_score: None,
+                    embedding: None,
+                };
 
-                        // Detect error responses: either the MCP server
-                        // flagged `isError: true`, or the content looks like
-                        // an error message (e.g. TLS/certificate failures).
-                        if tool_result.is_error || looks_like_fetch_error(&content) {
-                            let preview: String = content.chars().take(120).collect();
-                            tracing::warn!(label = ws.label, "wiki fetch failed: {preview}");
-                            total_wiki_fetch_errors += 1;
-                            continue;
-                        }
+                if let Err(e) = store.upsert_note(&note) {
+                    tracing::warn!(
+                        label = ws.label,
+                        error = %e,
+                        "failed to upsert wiki note"
+                    );
+                    continue;
+                }
 
-                        // Wiki PRDs from Confluence arrive as HTML storage
-                        // format. Convert to markdown so comrak produces
-                        // proper Heading / Section nodes instead of a single
-                        // plaintext blob.
-                        let content = maybe_convert_html_to_markdown(&content);
+                // Decompose the wiki note into headings and sections.
+                if let Ok(parsed) = nestweaver_parser::parse_markdown(
+                    &format!("{}/{}", ws.tool, ws.label),
+                    &content,
+                ) {
+                    // Build heading UIDs so sections can reference them.
+                    let heading_uids: Vec<String> = parsed
+                        .headings
+                        .iter()
+                        .map(|h| heading_uid(&wiki_note_uid, &h.slug, h.start_line))
+                        .collect();
 
-                        // Create a Note from the wiki content.
-                        let wiki_note_uid = note_uid(
-                            &format!("wiki:{}", ws.mcp_server),
-                            &format!("{}/{}", ws.tool, ws.label),
-                        );
-
-                        let note = Note {
-                            uid: wiki_note_uid.clone(),
-                            vault_uid: format!("wiki:{}", ws.mcp_server),
-                            file_path: format!("{}/{}", ws.tool, ws.label),
-                            title: ws.label.clone(),
-                            note_kind: NoteKind::General,
-                            word_count: content.split_whitespace().count() as u32,
-                            content_hash: truncated_hash(&content),
-                            frontmatter: None,
-                            created_at: None,
-                            modified_at: None,
-                            pagerank_score: None,
+                    let headings: Vec<Heading> = parsed
+                        .headings
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, h)| Heading {
+                            uid: heading_uids[idx].clone(),
+                            note_uid: wiki_note_uid.clone(),
+                            level: h.level,
+                            text: h.text.clone(),
+                            slug: h.slug.clone(),
+                            start_line: h.start_line,
+                            end_line: h.end_line,
+                            content_hash: truncated_hash(&h.text),
                             embedding: None,
-                        };
+                        })
+                        .collect();
 
-                        if let Err(e) = store.upsert_note(&note) {
+                    if !headings.is_empty() {
+                        if let Err(e) = store.batch_insert_headings(&headings) {
                             tracing::warn!(
                                 label = ws.label,
                                 error = %e,
-                                "failed to upsert wiki note"
+                                "failed to insert wiki note headings"
                             );
-                            continue;
-                        }
-
-                        // Decompose the wiki note into headings and sections.
-                        if let Ok(parsed) = nestweaver_parser::parse_markdown(
-                            &format!("{}/{}", ws.tool, ws.label),
-                            &content,
-                        ) {
-                            // Build heading UIDs so sections can reference them.
-                            let heading_uids: Vec<String> = parsed
-                                .headings
+                        } else {
+                            let nh_edges: Vec<(&str, &str)> = heading_uids
                                 .iter()
-                                .map(|h| heading_uid(&wiki_note_uid, &h.slug, h.start_line))
+                                .map(|h| (wiki_note_uid.as_str(), h.as_str()))
                                 .collect();
-
-                            let headings: Vec<Heading> = parsed
-                                .headings
-                                .iter()
-                                .enumerate()
-                                .map(|(idx, h)| Heading {
-                                    uid: heading_uids[idx].clone(),
-                                    note_uid: wiki_note_uid.clone(),
-                                    level: h.level,
-                                    text: h.text.clone(),
-                                    slug: h.slug.clone(),
-                                    start_line: h.start_line,
-                                    end_line: h.end_line,
-                                    content_hash: truncated_hash(&h.text),
-                                    embedding: None,
-                                })
-                                .collect();
-
-                            if !headings.is_empty() {
-                                if let Err(e) = store.batch_insert_headings(&headings) {
-                                    tracing::warn!(
-                                        label = ws.label,
-                                        error = %e,
-                                        "failed to insert wiki note headings"
-                                    );
-                                } else {
-                                    let nh_edges: Vec<(&str, &str)> = heading_uids
-                                        .iter()
-                                        .map(|h| (wiki_note_uid.as_str(), h.as_str()))
-                                        .collect();
-                                    let _ = store.batch_insert_note_heading_edges(&nh_edges);
-                                }
-                            }
-
-                            let sections: Vec<Section> = parsed
-                                .sections
-                                .iter()
-                                .map(|sec| {
-                                    let text_hash = truncated_hash(&sec.text);
-                                    let s_uid =
-                                        section_uid(&wiki_note_uid, sec.start_line, &text_hash);
-                                    let heading_link =
-                                        sec.heading_idx.and_then(|i| heading_uids.get(i)).cloned();
-                                    let word_count =
-                                        u32::try_from(sec.text.split_whitespace().count())
-                                            .unwrap_or(u32::MAX);
-                                    Section {
-                                        uid: s_uid,
-                                        note_uid: wiki_note_uid.clone(),
-                                        heading_uid: heading_link,
-                                        start_line: sec.start_line,
-                                        end_line: sec.end_line,
-                                        text_hash,
-                                        text_content: sec.text.clone(),
-                                        word_count,
-                                        pagerank_score: None,
-                                    }
-                                })
-                                .collect();
-
-                            if !sections.is_empty() {
-                                if let Err(e) = store.batch_upsert_sections(&sections) {
-                                    tracing::warn!(
-                                        label = ws.label,
-                                        error = %e,
-                                        "failed to upsert wiki note sections"
-                                    );
-                                } else {
-                                    let ns_edges: Vec<(&str, &str)> = sections
-                                        .iter()
-                                        .map(|s| (wiki_note_uid.as_str(), s.uid.as_str()))
-                                        .collect();
-                                    let _ = store.batch_insert_note_section_edges(&ns_edges);
-                                }
-                            }
+                            let _ = store.batch_insert_note_heading_edges(&nh_edges);
                         }
-
-                        let edge = (uid.as_str(), wiki_note_uid.as_str());
-                        if let Err(e) = store.batch_insert_project_note_edges(&[edge]) {
-                            tracing::warn!(
-                                label = ws.label,
-                                error = %e,
-                                "failed to link wiki note to project"
-                            );
-                        }
-
-                        total_wiki_notes_ingested += 1;
-                        tracing::info!(
-                            label = ws.label,
-                            project = project_cfg.name,
-                            "ingested wiki source"
-                        );
                     }
-                    Err(e) => {
-                        tracing::warn!(
-                            label = ws.label,
-                            tool = ws.tool,
-                            error = %e,
-                            "MCP tool call failed, skipping wiki source"
-                        );
-                        total_wiki_fetch_errors += 1;
+
+                    let sections: Vec<Section> = parsed
+                        .sections
+                        .iter()
+                        .map(|sec| {
+                            let text_hash = truncated_hash(&sec.text);
+                            let s_uid = section_uid(&wiki_note_uid, sec.start_line, &text_hash);
+                            let heading_link =
+                                sec.heading_idx.and_then(|i| heading_uids.get(i)).cloned();
+                            let word_count = u32::try_from(sec.text.split_whitespace().count())
+                                .unwrap_or(u32::MAX);
+                            Section {
+                                uid: s_uid,
+                                note_uid: wiki_note_uid.clone(),
+                                heading_uid: heading_link,
+                                start_line: sec.start_line,
+                                end_line: sec.end_line,
+                                text_hash,
+                                text_content: sec.text.clone(),
+                                word_count,
+                                pagerank_score: None,
+                            }
+                        })
+                        .collect();
+
+                    if !sections.is_empty() {
+                        if let Err(e) = store.batch_upsert_sections(&sections) {
+                            tracing::warn!(
+                                label = ws.label,
+                                error = %e,
+                                "failed to upsert wiki note sections"
+                            );
+                        } else {
+                            let ns_edges: Vec<(&str, &str)> = sections
+                                .iter()
+                                .map(|s| (wiki_note_uid.as_str(), s.uid.as_str()))
+                                .collect();
+                            let _ = store.batch_insert_note_section_edges(&ns_edges);
+                        }
                     }
                 }
+
+                let edge = (uid.as_str(), wiki_note_uid.as_str());
+                if let Err(e) = store.batch_insert_project_note_edges(&[edge]) {
+                    tracing::warn!(
+                        label = ws.label,
+                        error = %e,
+                        "failed to link wiki note to project"
+                    );
+                }
+
+                total_wiki_notes_ingested += 1;
+                tracing::info!(
+                    label = ws.label,
+                    project = project_cfg.name,
+                    "ingested wiki source"
+                );
             }
         }
-        // MCP clients are dropped here when mcp_clients goes out of scope.
     }
 
     // Persist the extension sidecar once after all projects are processed.
@@ -593,6 +639,86 @@ components = ["child-b"]
         assert!(
             err.to_string().contains("\"dup\""),
             "error must name the duplicate project, got: {err}"
+        );
+    }
+
+    #[test]
+    fn failed_wiki_fetch_preserves_the_last_materialized_membership() {
+        use nestweaver_schema::{Note, NoteKind, Project, note_uid, project_uid};
+
+        let toml = r#"
+instance_id = "test-instance"
+
+[snapshot_storage]
+backend = "local"
+path = "/tmp/snapshots"
+
+[workspace]
+backend = "local"
+path = "/tmp/workspace"
+
+[inference]
+endpoint = "http://localhost:8080"
+embedding_model = "text-embedding-3-small"
+summary_model = "gpt-4o-mini"
+
+[git]
+credential_method = "ssh"
+
+[[projects]]
+name = "stable"
+
+[[projects.wiki_sources]]
+label = "Architecture"
+mcp_server = "missing-server"
+tool = "get_page"
+args = { page = "123" }
+"#;
+        let config = crate::config::InstanceConfig::from_toml_str(toml).unwrap();
+        let store = nestweaver_store::GraphStore::in_memory().unwrap();
+        let project_uid = project_uid("test-instance", "stable");
+        let wiki_note_uid = note_uid("wiki:missing-server", "get_page/Architecture");
+        store
+            .insert_project(&Project {
+                uid: project_uid.clone(),
+                name: "stable".to_string(),
+                summary: None,
+                instance_id: "test-instance".to_string(),
+            })
+            .unwrap();
+        store
+            .insert_note(&Note {
+                uid: wiki_note_uid.clone(),
+                vault_uid: "wiki:missing-server".to_string(),
+                file_path: "get_page/Architecture".to_string(),
+                title: "Architecture".to_string(),
+                note_kind: NoteKind::General,
+                word_count: 1,
+                content_hash: "last-good".to_string(),
+                frontmatter: None,
+                created_at: None,
+                modified_at: None,
+                pagerank_score: None,
+                embedding: None,
+            })
+            .unwrap();
+        store
+            .batch_insert_project_note_edges(&[(&project_uid, &wiki_note_uid)])
+            .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        super::materialize_projects(
+            &store,
+            &config,
+            "test-instance",
+            &dir.path().join("brain.lbug"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            store.list_project_note_uids(&project_uid).unwrap(),
+            vec![wiki_note_uid],
+            "a transient remote failure must preserve the last good wiki membership"
         );
     }
 

--- a/crates/nestweaver-engine/src/watch_code.rs
+++ b/crates/nestweaver-engine/src/watch_code.rs
@@ -20,12 +20,14 @@ use std::time::{Duration, Instant};
 use anyhow::Context;
 use nestweaver_parser::detect_language;
 use nestweaver_store::{GraphScope, GraphStore};
-use notify::RecursiveMode;
-use notify_debouncer_mini::{DebouncedEvent, new_debouncer};
+use notify::{Event, RecursiveMode, Watcher};
 
 use crate::content_reader::ContentReader;
 use crate::index::{is_minified_or_bundled, path_in_skip_dir};
-use crate::watcher::ShutdownHandle;
+use crate::watcher::{
+    RawWatchResult, ShutdownHandle, WatchMutationLease, WatchMutationLeaseFactory,
+    WatchMutationRefused, WatchReceive, event_kind_can_mutate, receive_debounced_paths,
+};
 
 /// Live file-watcher for a code repository. Construct via `new`, then
 /// call `run` — it blocks until `stop()` is signalled or the watcher
@@ -35,6 +37,10 @@ pub struct CodeWatcher {
     repo_root: PathBuf,
     instance_id: String,
     stop_flag: Arc<AtomicBool>,
+    mutation_lease_factory: Option<WatchMutationLeaseFactory>,
+    debounce: Duration,
+    #[cfg(test)]
+    ready_signal: Option<std::sync::mpsc::Sender<()>>,
 }
 
 #[derive(Debug)]
@@ -92,7 +98,40 @@ impl CodeWatcher {
             repo_root,
             instance_id: instance_id.into(),
             stop_flag: Arc::new(AtomicBool::new(false)),
+            mutation_lease_factory: None,
+            debounce: Duration::from_secs(2),
+            #[cfg(test)]
+            ready_signal: None,
         }
+    }
+
+    /// Install an external RAII lease acquired once around each published
+    /// mutation batch, including the inline after-change callback.
+    pub fn with_mutation_lease_factory(mut self, factory: WatchMutationLeaseFactory) -> Self {
+        self.mutation_lease_factory = Some(factory);
+        self
+    }
+
+    #[cfg(test)]
+    fn with_debounce_ms(mut self, debounce_ms: u64) -> Self {
+        self.debounce = Duration::from_millis(debounce_ms);
+        self
+    }
+
+    #[cfg(test)]
+    fn with_ready_signal(mut self, ready: std::sync::mpsc::Sender<()>) -> Self {
+        self.ready_signal = Some(ready);
+        self
+    }
+
+    fn acquire_mutation_lease(
+        &self,
+        label: &'static str,
+    ) -> Result<Option<Box<dyn WatchMutationLease>>, anyhow::Error> {
+        self.mutation_lease_factory
+            .as_ref()
+            .map(|factory| factory(label))
+            .transpose()
     }
 
     /// Returns a handle that can request graceful shutdown from another
@@ -136,18 +175,25 @@ impl CodeWatcher {
         // Register before inspecting or cold-indexing the tree. Events that
         // race the initial snapshot are queued by the debouncer and replayed
         // below, closing the former scan-then-watch lost-event window.
-        let (tx, rx) = std::sync::mpsc::channel::<DebounceResult>();
-        let mut debouncer = new_debouncer(
-            Duration::from_secs(2),
-            move |res: Result<Vec<DebouncedEvent>, notify::Error>| {
-                let _ = tx.send(res);
-            },
-        )
-        .context("init code debouncer")?;
-        debouncer
-            .watcher()
+        let (tx, rx) = std::sync::mpsc::channel::<RawWatchResult>();
+        let mut watcher =
+            notify::recommended_watcher(move |result: Result<Event, notify::Error>| match result {
+                Ok(event) if event_kind_can_mutate(&event.kind) => {
+                    let _ = tx.send(Ok(event.paths));
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    let _ = tx.send(Err(error));
+                }
+            })
+            .context("init code filesystem watcher")?;
+        watcher
             .watch(&self.repo_root, RecursiveMode::Recursive)
             .with_context(|| format!("watch {}", self.repo_root.display()))?;
+        #[cfg(test)]
+        if let Some(ready) = &self.ready_signal {
+            let _ = ready.send(());
+        }
 
         // Identity decision (see `resolve_watch_identity`): adopt an existing
         // `file://` graph rather than re-identifying+pruning, so a watch-first
@@ -170,6 +216,21 @@ impl CodeWatcher {
                     .filter(|path| !path_in_skip_dir(path))
                     .filter(|path| !is_minified_or_bundled(path))
                     .collect();
+                let _mutation_lease = match self.acquire_mutation_lease("watch_code_initial") {
+                    Ok(lease) => lease,
+                    Err(error) if error.downcast_ref::<WatchMutationRefused>().is_some() => {
+                        tracing::info!("CodeWatcher startup refused during shutdown; exiting");
+                        return Ok(());
+                    }
+                    Err(error) => {
+                        return Err(error.context("acquire code watcher startup lease"));
+                    }
+                };
+                // Another admitted writer may have completed the authoritative
+                // snapshot while this watcher waited for the gate.
+                if store.lookup_repo(&r_uid)?.is_some() {
+                    break;
+                }
                 match self.process_batch_and_notify(
                     &store,
                     &r_uid,
@@ -224,9 +285,9 @@ impl CodeWatcher {
             let batch = if !replay_batch.is_empty() {
                 std::mem::take(&mut replay_batch)
             } else {
-                match rx.recv_timeout(Duration::from_millis(250)) {
-                    Ok(Ok(events)) => events,
-                    Ok(Err(err)) => {
+                match receive_debounced_paths(&rx, self.debounce, &self.stop_flag) {
+                    WatchReceive::Batch(paths) => paths,
+                    WatchReceive::NotifyError(err) => {
                         if !self.repo_root.exists() {
                             tracing::error!(
                                 repo = %self.repo_root.display(),
@@ -240,7 +301,7 @@ impl CodeWatcher {
                         tracing::warn!("notify error: {err}");
                         continue;
                     }
-                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    WatchReceive::Timeout => {
                         if !self.repo_root.exists() {
                             tracing::error!(
                                 repo = %self.repo_root.display(),
@@ -253,8 +314,12 @@ impl CodeWatcher {
                         }
                         continue;
                     }
-                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                    WatchReceive::Disconnected => {
                         tracing::warn!("code debouncer disconnected; exiting");
+                        return Ok(());
+                    }
+                    WatchReceive::Stop => {
+                        tracing::info!("CodeWatcher stop requested; exiting");
                         return Ok(());
                     }
                 }
@@ -263,8 +328,8 @@ impl CodeWatcher {
             // Deduplicate paths within the batch — the debouncer may
             // fire multiple events for the same file.
             let mut unique_paths: HashSet<PathBuf> = HashSet::new();
-            for event in &batch {
-                unique_paths.insert(event.path.clone());
+            for path in batch {
+                unique_paths.insert(path);
             }
 
             // Contract specs are first-class watcher inputs even though they
@@ -282,6 +347,14 @@ impl CodeWatcher {
                 continue;
             }
 
+            let _mutation_lease = match self.acquire_mutation_lease("watch_code_batch") {
+                Ok(lease) => lease,
+                Err(error) if error.downcast_ref::<WatchMutationRefused>().is_some() => {
+                    tracing::info!("CodeWatcher batch refused during shutdown; exiting");
+                    return Ok(());
+                }
+                Err(error) => return Err(error.context("acquire code watcher batch lease")),
+            };
             let start = Instant::now();
             let outcome = self.process_batch_and_notify(
                 &store,
@@ -568,10 +641,7 @@ impl CodeWatcher {
     }
 }
 
-/// The debouncer callback type.
-type DebounceResult = Result<Vec<DebouncedEvent>, notify::Error>;
-
-fn drain_queued_events(rx: &std::sync::mpsc::Receiver<DebounceResult>) -> Vec<DebouncedEvent> {
+fn drain_queued_events(rx: &std::sync::mpsc::Receiver<RawWatchResult>) -> Vec<PathBuf> {
     let mut events = Vec::new();
     loop {
         match rx.try_recv() {
@@ -938,20 +1008,13 @@ mod tests {
     #[test]
     fn startup_event_drain_replays_every_queued_batch() {
         let (tx, rx) = std::sync::mpsc::channel();
-        tx.send(Ok(vec![DebouncedEvent::new(
-            PathBuf::from("openapi.yaml"),
-            notify_debouncer_mini::DebouncedEventKind::Any,
-        )]))
-        .unwrap();
-        tx.send(Ok(vec![DebouncedEvent::new(
-            PathBuf::from("ItemsController.java"),
-            notify_debouncer_mini::DebouncedEventKind::Any,
-        )]))
-        .unwrap();
+        tx.send(Ok(vec![PathBuf::from("openapi.yaml")])).unwrap();
+        tx.send(Ok(vec![PathBuf::from("ItemsController.java")]))
+            .unwrap();
         let replay = drain_queued_events(&rx);
         assert_eq!(replay.len(), 2);
-        assert_eq!(replay[0].path, PathBuf::from("openapi.yaml"));
-        assert_eq!(replay[1].path, PathBuf::from("ItemsController.java"));
+        assert_eq!(replay[0], PathBuf::from("openapi.yaml"));
+        assert_eq!(replay[1], PathBuf::from("ItemsController.java"));
     }
 
     /// Index a small JS fixture repo (a.js ← b.js ← c.js) into an in-memory
@@ -1569,6 +1632,63 @@ mod tests {
         assert!(is_minified_or_bundled(Path::new("main.chunk.js")));
         assert!(!is_minified_or_bundled(Path::new("app.js")));
         assert!(!is_minified_or_bundled(Path::new("src/main.rs")));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn one_code_edit_settles_after_one_hot_batch() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::thread;
+
+        let dir = tempfile::tempdir().unwrap();
+        let repo_root = dir.path().join("repo");
+        std::fs::create_dir_all(&repo_root).unwrap();
+        let source_path = repo_root.join("service.js");
+        std::fs::write(&source_path, "export function alpha() { return 1; }\n").unwrap();
+        let root = std::fs::canonicalize(repo_root).unwrap();
+        let repo_url = format!("file://{}", root.display());
+        let db_path = dir.path().join("watch.lbug");
+        crate::index::index_directory(&root, &db_path, "test", &repo_url, "sha-1").unwrap();
+        let store = Arc::new(GraphStore::open_or_create(&db_path).unwrap());
+        let notifications = Arc::new(AtomicUsize::new(0));
+        let callback_count = notifications.clone();
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+        let watcher = CodeWatcher::new(&db_path, &root, "test")
+            .with_debounce_ms(100)
+            .with_ready_signal(ready_tx);
+        let stop = watcher.shutdown_handle();
+        let handle = thread::spawn(move || {
+            watcher.run_with_store(
+                store,
+                Some(Box::new(move || {
+                    callback_count.fetch_add(1, Ordering::SeqCst);
+                })),
+            )
+        });
+        ready_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("code watcher should start");
+        thread::sleep(Duration::from_millis(100));
+
+        std::fs::write(&source_path, "export function alpha() { return 2; }\n").unwrap();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while notifications.load(Ordering::SeqCst) < 1 && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(25));
+        }
+        assert_eq!(
+            notifications.load(Ordering::SeqCst),
+            1,
+            "the real edit must publish one code batch"
+        );
+        thread::sleep(Duration::from_millis(1200));
+        assert_eq!(
+            notifications.load(Ordering::SeqCst),
+            1,
+            "parser reads must not feed another code watcher batch"
+        );
+
+        stop.stop();
+        handle.join().unwrap().unwrap();
     }
 
     /// Regression (data loss on watch-first over a legacy DB): a repo whose

--- a/crates/nestweaver-engine/src/watcher.rs
+++ b/crates/nestweaver-engine/src/watcher.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use globset::GlobSet;
@@ -26,8 +26,26 @@ use nestweaver_schema::{
     Heading, Note, Section, Tag, Vault, heading_uid, note_uid, section_uid, tag_uid, vault_uid,
 };
 use nestweaver_store::{GraphScope, GraphStore, TantivyIndex};
-use notify::RecursiveMode;
-use notify_debouncer_mini::{DebouncedEvent, DebouncedEventKind, new_debouncer};
+use notify::event::{MetadataKind, ModifyKind};
+use notify::{Event, EventKind, RecursiveMode, Watcher};
+
+/// Opaque caller-owned protection held for one watcher mutation window.
+///
+/// Daemon callers use this to compose their shutdown admission guard and
+/// single-writer gate. Direct callers omit the factory because opening the
+/// store already gives them exclusive writer ownership.
+pub trait WatchMutationLease: Send {}
+
+impl<T: Send> WatchMutationLease for T {}
+
+pub type WatchMutationLeaseFactory =
+    Arc<dyn Fn(&'static str) -> Result<Box<dyn WatchMutationLease>, anyhow::Error> + Send + Sync>;
+
+/// A batch was refused because daemon shutdown has begun. Watchers treat this
+/// as a normal stop, not as graph corruption or a retryable filesystem error.
+#[derive(Debug, thiserror::Error)]
+#[error("watcher mutation refused because daemon shutdown has started")]
+pub struct WatchMutationRefused;
 
 /// Manifest filenames whose changes should trigger a manifest cache refresh.
 const MANIFEST_FILES: &[&str] = &[
@@ -101,13 +119,13 @@ pub struct BrainWatcher {
     /// Pre-opened TantivyIndex from the caller (e.g. daemon). When set,
     /// `run_inner` uses this instead of opening its own from `tantivy_path`.
     external_tantivy: Option<Arc<TantivyIndex>>,
+    mutation_lease_factory: Option<WatchMutationLeaseFactory>,
     #[cfg(test)]
     ready_signal: Option<std::sync::mpsc::Sender<()>>,
 }
 
 impl BrainWatcher {
-    fn event_targets_graph(&self, event: &DebouncedEvent) -> bool {
-        let path = &event.path;
+    fn event_targets_graph(&self, path: &Path) -> bool {
         if !is_markdown(path) || path_in_skip_dir(path) {
             return false;
         }
@@ -174,6 +192,7 @@ impl BrainWatcher {
             debounce_ms: 200,
             ignore_set,
             external_tantivy: None,
+            mutation_lease_factory: None,
             #[cfg(test)]
             ready_signal: None,
         }
@@ -202,6 +221,32 @@ impl BrainWatcher {
     pub fn with_external_tantivy(mut self, tantivy: Arc<TantivyIndex>) -> Self {
         self.external_tantivy = Some(tantivy);
         self
+    }
+
+    /// Install an external RAII lease acquired once around each mutation
+    /// window. The returned object remains live through the inline callback.
+    pub fn with_mutation_lease_factory(mut self, factory: WatchMutationLeaseFactory) -> Self {
+        self.mutation_lease_factory = Some(factory);
+        self
+    }
+
+    fn acquire_mutation_lease(
+        &self,
+        label: &'static str,
+    ) -> Result<Option<Box<dyn WatchMutationLease>>, anyhow::Error> {
+        self.mutation_lease_factory
+            .as_ref()
+            .map(|factory| factory(label))
+            .transpose()
+    }
+
+    fn event_targets_manifest(&self, path: &Path) -> bool {
+        self.manifests_path.is_some()
+            && path.exists()
+            && path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| MANIFEST_FILES.contains(&name))
     }
 
     /// Set the debounce interval for filesystem events.
@@ -290,6 +335,14 @@ impl BrainWatcher {
         // Make sure the Vault node exists — first-time runs (no prior
         // `brain add`) still get a working graph.
         let v_uid = vault_uid(&self.instance_id, &self.vault_root.to_string_lossy());
+        let _initial_mutation_lease = match self.acquire_mutation_lease("watch_vault_initial") {
+            Ok(lease) => lease,
+            Err(error) if error.downcast_ref::<WatchMutationRefused>().is_some() => {
+                tracing::info!("BrainWatcher startup refused during shutdown; exiting");
+                return Ok(());
+            }
+            Err(error) => return Err(error.context("acquire brain watcher startup lease")),
+        };
         let initial_publication = self.establish_graph_publication_with_io(
             &store,
             &crate::index::FileSystemIndexEpilogueIo,
@@ -319,18 +372,22 @@ impl BrainWatcher {
                 )));
             }
         }
+        drop(_initial_mutation_lease);
 
         // Channel from the debouncer into our loop.
-        let (tx, rx) = std::sync::mpsc::channel::<DebounceResult>();
-        let mut debouncer = new_debouncer(
-            Duration::from_millis(self.debounce_ms),
-            move |res: Result<Vec<DebouncedEvent>, notify::Error>| {
-                let _ = tx.send(res);
-            },
-        )
-        .with_context(|| "init debouncer")?;
-        debouncer
-            .watcher()
+        let (tx, rx) = std::sync::mpsc::channel::<RawWatchResult>();
+        let mut watcher =
+            notify::recommended_watcher(move |result: Result<Event, notify::Error>| match result {
+                Ok(event) if event_kind_can_mutate(&event.kind) => {
+                    let _ = tx.send(Ok(event.paths));
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    let _ = tx.send(Err(error));
+                }
+            })
+            .with_context(|| "init filesystem watcher")?;
+        watcher
             .watch(&self.vault_root, RecursiveMode::Recursive)
             .with_context(|| format!("watch {}", self.vault_root.display()))?;
         #[cfg(test)]
@@ -351,9 +408,13 @@ impl BrainWatcher {
                 tracing::info!("BrainWatcher stop requested; exiting");
                 return Ok(());
             }
-            let batch = match rx.recv_timeout(Duration::from_millis(250)) {
-                Ok(Ok(events)) => events,
-                Ok(Err(err)) => {
+            let batch = match receive_debounced_paths(
+                &rx,
+                Duration::from_millis(self.debounce_ms),
+                &self.stop_flag,
+            ) {
+                WatchReceive::Batch(paths) => paths,
+                WatchReceive::NotifyError(err) => {
                     if !self.vault_root.exists() {
                         tracing::error!(
                             vault = %self.vault_root.display(),
@@ -367,7 +428,7 @@ impl BrainWatcher {
                     tracing::warn!("notify error: {err}");
                     continue;
                 }
-                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                WatchReceive::Timeout => {
                     // Periodic liveness check: detect vault directory
                     // disappearance even when `notify` is silent (e.g.
                     // when the directory's inode is replaced via a
@@ -385,13 +446,38 @@ impl BrainWatcher {
                     }
                     continue;
                 }
-                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                WatchReceive::Disconnected => {
                     tracing::warn!("debouncer disconnected; exiting");
+                    return Ok(());
+                }
+                WatchReceive::Stop => {
+                    tracing::info!("BrainWatcher stop requested; exiting");
                     return Ok(());
                 }
             };
 
-            let graph_batch = batch.iter().any(|event| self.event_targets_graph(event));
+            let mut unique_paths = batch;
+            unique_paths.sort();
+            unique_paths.dedup();
+            let graph_batch = unique_paths
+                .iter()
+                .any(|path| self.event_targets_graph(path));
+            let mutation_batch = graph_batch
+                || unique_paths
+                    .iter()
+                    .any(|path| self.event_targets_manifest(path));
+            let _mutation_lease = if mutation_batch {
+                match self.acquire_mutation_lease("watch_vault_batch") {
+                    Ok(lease) => lease,
+                    Err(error) if error.downcast_ref::<WatchMutationRefused>().is_some() => {
+                        tracing::info!("BrainWatcher batch refused during shutdown; exiting");
+                        return Ok(());
+                    }
+                    Err(error) => return Err(error.context("acquire brain watcher batch lease")),
+                }
+            } else {
+                None
+            };
             let publication = if graph_batch {
                 // Establish the fail-closed marker before handle_event can
                 // cascade-delete a note and then fail during read or parse.
@@ -423,12 +509,12 @@ impl BrainWatcher {
             }
 
             let mut batch_failures = Vec::new();
-            for event in batch {
+            for path in unique_paths {
                 match self.handle_event(
                     &store,
                     tantivy.as_deref(),
                     &v_uid,
-                    event,
+                    path,
                     symbol_index.as_ref(),
                     &mut title_forward,
                     &mut title_reverse,
@@ -486,13 +572,11 @@ impl BrainWatcher {
         store: &GraphStore,
         tantivy: Option<&TantivyIndex>,
         v_uid: &str,
-        event: DebouncedEvent,
+        path: PathBuf,
         symbol_index: Option<&crate::cross_domain::SymbolIndex>,
         title_forward: &mut HashMap<String, Vec<String>>,
         title_reverse: &mut HashMap<String, String>,
     ) -> Result<UpdateOutcome, anyhow::Error> {
-        let path = event.path;
-
         // Check for manifest file changes and refresh the sidecar cache.
         // This check runs before the markdown filter so manifest files are
         // never silently dropped as "not markdown".
@@ -600,8 +684,8 @@ impl BrainWatcher {
         }
 
         // Inspect the filesystem to distinguish modify/create vs delete.
-        // notify-debouncer-mini collapses related events into a single
-        // DebouncedEvent of kind Any; we always re-stat the path.
+        // Raw notify event kinds were filtered before debouncing; re-stat the
+        // path because rename/remove delivery varies by backend.
         let file_exists = path.exists();
 
         // Step 1: always cascade-delete the existing graph data for this
@@ -631,7 +715,6 @@ impl BrainWatcher {
             &path,
             &rel_path,
             &parsed,
-            event.kind,
             title_forward,
         )?;
 
@@ -737,8 +820,74 @@ impl ShutdownHandle {
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
-/// The debouncer's callback receives `Result<Vec<DebouncedEvent>, notify::Error>`.
-type DebounceResult = Result<Vec<DebouncedEvent>, notify::Error>;
+/// Raw watcher messages preserve notify's event classification. Access-only
+/// events are discarded in the callback before they can extend a debounce
+/// window, acquire a daemon writer lease, or feed back from parser reads.
+pub(crate) type RawWatchResult = Result<Vec<PathBuf>, notify::Error>;
+
+pub(crate) enum WatchReceive {
+    Batch(Vec<PathBuf>),
+    NotifyError(notify::Error),
+    Timeout,
+    Disconnected,
+    Stop,
+}
+
+pub(crate) fn event_kind_can_mutate(kind: &EventKind) -> bool {
+    match kind {
+        EventKind::Access(_) => false,
+        EventKind::Modify(ModifyKind::Metadata(
+            MetadataKind::AccessTime
+            | MetadataKind::Permissions
+            | MetadataKind::Ownership
+            | MetadataKind::Extended,
+        )) => false,
+        EventKind::Any
+        | EventKind::Create(_)
+        | EventKind::Modify(_)
+        | EventKind::Remove(_)
+        | EventKind::Other => true,
+    }
+}
+
+pub(crate) fn receive_debounced_paths(
+    rx: &std::sync::mpsc::Receiver<RawWatchResult>,
+    quiet_period: Duration,
+    stop_flag: &AtomicBool,
+) -> WatchReceive {
+    let mut paths = match rx.recv_timeout(Duration::from_millis(250)) {
+        Ok(Ok(paths)) => paths,
+        Ok(Err(error)) => return WatchReceive::NotifyError(error),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => return WatchReceive::Timeout,
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            return WatchReceive::Disconnected;
+        }
+    };
+    let mut quiet_deadline = Instant::now() + quiet_period;
+    loop {
+        if stop_flag.load(Ordering::Relaxed) {
+            return WatchReceive::Stop;
+        }
+        let now = Instant::now();
+        if now >= quiet_deadline {
+            return WatchReceive::Batch(paths);
+        }
+        let wait = quiet_deadline
+            .saturating_duration_since(now)
+            .min(Duration::from_millis(250));
+        match rx.recv_timeout(wait) {
+            Ok(Ok(mut more_paths)) => {
+                paths.append(&mut more_paths);
+                quiet_deadline = Instant::now() + quiet_period;
+            }
+            Ok(Err(error)) => return WatchReceive::NotifyError(error),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                return WatchReceive::Disconnected;
+            }
+        }
+    }
+}
 
 fn log_outcome(outcome: &UpdateOutcome) {
     match outcome {
@@ -807,7 +956,6 @@ fn reinsert_note(
     path: &Path,
     rel_path: &str,
     parsed: &ParsedNote,
-    _event_kind: DebouncedEventKind,
     title_lookup: &HashMap<String, Vec<String>>,
 ) -> Result<(usize, usize, usize, usize), anyhow::Error> {
     // ── Note + VAULT_HAS_NOTE ───────────────────────────────────────────
@@ -1210,7 +1358,7 @@ mod tests {
                 &store,
                 None,
                 "vlt:test",
-                DebouncedEvent::new(root.join("package.json"), DebouncedEventKind::Any),
+                root.join("package.json"),
                 None,
                 &mut HashMap::new(),
                 &mut HashMap::new(),
@@ -1235,6 +1383,81 @@ mod tests {
         assert!(path_in_skip_dir(p));
         let p = Path::new("/x/vault/notes/regular.md");
         assert!(!path_in_skip_dir(p));
+    }
+
+    #[test]
+    fn raw_event_filter_rejects_access_and_non_content_metadata() {
+        use notify::event::{AccessKind, DataChange, MetadataKind, ModifyKind, RenameMode};
+
+        assert!(!event_kind_can_mutate(&EventKind::Access(AccessKind::Read)));
+        assert!(!event_kind_can_mutate(&EventKind::Modify(
+            ModifyKind::Metadata(MetadataKind::AccessTime)
+        )));
+        assert!(!event_kind_can_mutate(&EventKind::Modify(
+            ModifyKind::Metadata(MetadataKind::Permissions)
+        )));
+        assert!(event_kind_can_mutate(&EventKind::Modify(
+            ModifyKind::Metadata(MetadataKind::WriteTime)
+        )));
+        assert!(event_kind_can_mutate(&EventKind::Modify(ModifyKind::Data(
+            DataChange::Content
+        ))));
+        assert!(event_kind_can_mutate(&EventKind::Modify(ModifyKind::Name(
+            RenameMode::Both
+        ))));
+        assert!(event_kind_can_mutate(&EventKind::Any));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn one_vault_edit_settles_after_one_hot_batch() {
+        use std::sync::atomic::AtomicUsize;
+        use std::time::Instant;
+
+        let _guard = serial_watcher_test();
+        let (_dir, root) = make_vault(&[("note.md", "# Original\n\nbody\n")]);
+        let db_dir = tempfile::tempdir().unwrap();
+        let db_path = db_dir.path().join("brain.lbug");
+        crate::index_md::index_markdown_directory(&root, &db_path, "default", "test").unwrap();
+        let store = Arc::new(GraphStore::open_or_create(&db_path).unwrap());
+        let notifications = Arc::new(AtomicUsize::new(0));
+        let callback_count = notifications.clone();
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+        let watcher =
+            BrainWatcher::new(&db_path, &root, "default", "test").with_ready_signal(ready_tx);
+        let stop = watcher.shutdown_handle();
+        let handle = thread::spawn(move || {
+            watcher.run_with_store(
+                store,
+                Some(Box::new(move || {
+                    callback_count.fetch_add(1, Ordering::SeqCst);
+                })),
+            )
+        });
+        ready_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("watcher should start");
+        assert_eq!(notifications.load(Ordering::SeqCst), 1);
+
+        fs::write(root.join("note.md"), "# Updated\n\nchanged once\n").unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while notifications.load(Ordering::SeqCst) < 2 && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(25));
+        }
+        assert_eq!(
+            notifications.load(Ordering::SeqCst),
+            2,
+            "the real edit must publish one hot batch"
+        );
+        thread::sleep(Duration::from_millis(1200));
+        assert_eq!(
+            notifications.load(Ordering::SeqCst),
+            2,
+            "parser reads must not feed another watcher batch"
+        );
+
+        stop.stop();
+        handle.join().unwrap().unwrap();
     }
 
     // Integration-style tests below exercise the live event loop. They

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -32,6 +32,37 @@ use crate::error::StoreError;
 /// this module must use it.
 const COPY_CSV_OPTS: &str = "(PARALLEL=FALSE, DELIM=',', QUOTE='\"', ESCAPE='\"', HEADER=false)";
 
+fn unique_uid_set<'a>(
+    entity: &str,
+    uids: impl IntoIterator<Item = &'a str>,
+) -> Result<std::collections::HashSet<&'a str>, StoreError> {
+    let mut unique = std::collections::HashSet::new();
+    for uid in uids {
+        if !unique.insert(uid) {
+            return Err(StoreError::Query(format!(
+                "duplicate {entity} uid in replacement input: {uid}"
+            )));
+        }
+    }
+    Ok(unique)
+}
+
+fn validate_edge_pairs(
+    relationship: &str,
+    edges: &[(&str, &str)],
+    valid_sources: &std::collections::HashSet<&str>,
+    valid_targets: &std::collections::HashSet<&str>,
+) -> Result<(), StoreError> {
+    for (source, target) in edges {
+        if !valid_sources.contains(*source) || !valid_targets.contains(*target) {
+            return Err(StoreError::Query(format!(
+                "{relationship} endpoint is outside replacement input: {source} -> {target}"
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// `Meta.key` prefix for the per-repo contract-derivation failure marker.
 ///
 /// The full key is `<prefix><repo_uid>`. Contract derivation is best-effort at
@@ -593,6 +624,25 @@ fn write_edge_pair_csv(edges: &[(&str, &str)], path: &Path) -> Result<(), StoreE
     }
     wtr.flush()
         .map_err(|e| StoreError::Query(format!("flush edge csv: {e}")))?;
+    Ok(())
+}
+
+/// Write relationship rows `(from_pk, to_pk, confidence)` to a CSV file.
+fn write_project_edge_csv(
+    edges: &[(String, String)],
+    confidence: f32,
+    path: &Path,
+) -> Result<(), StoreError> {
+    let f = std::fs::File::create(path)
+        .map_err(|e| StoreError::Query(format!("create project edge csv: {e}")))?;
+    let mut wtr = csv::WriterBuilder::new().has_headers(false).from_writer(f);
+    let confidence = confidence.to_string();
+    for (from_pk, to_pk) in edges {
+        wtr.write_record([from_pk, to_pk, &confidence])
+            .map_err(|e| StoreError::Query(format!("write project edge row: {e}")))?;
+    }
+    wtr.flush()
+        .map_err(|e| StoreError::Query(format!("flush project edge csv: {e}")))?;
     Ok(())
 }
 
@@ -1202,6 +1252,15 @@ impl GraphStore {
         services: &[Service],
         service_symbol_edges: &[(&str, &str)],
     ) -> Result<(usize, usize), StoreError> {
+        Self::validate_bulk_reindex_input(
+            repo_uid,
+            files,
+            symbols,
+            repo_file_edges,
+            file_symbol_edges,
+            services,
+            service_symbol_edges,
+        )?;
         let conn = self.begin_transaction()?;
 
         // Delete old data within the transaction.
@@ -1221,6 +1280,71 @@ impl GraphStore {
 
         self.commit_transaction(&conn)?;
         Ok(counts)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn validate_bulk_reindex_input(
+        repo_uid: &str,
+        files: &[File],
+        symbols: &[Symbol],
+        repo_file_edges: &[(&str, &str)],
+        file_symbol_edges: &[(&str, &str)],
+        services: &[Service],
+        service_symbol_edges: &[(&str, &str)],
+    ) -> Result<(), StoreError> {
+        let file_uids = unique_uid_set("File", files.iter().map(|file| file.uid.as_str()))?;
+        let symbol_uids =
+            unique_uid_set("Symbol", symbols.iter().map(|symbol| symbol.uid.as_str()))?;
+        let service_uids = unique_uid_set(
+            "Service",
+            services.iter().map(|service| service.uid.as_str()),
+        )?;
+        for file in files {
+            if file.repo_uid != repo_uid {
+                return Err(StoreError::Query(format!(
+                    "File {} belongs to {}, expected {repo_uid}",
+                    file.uid, file.repo_uid
+                )));
+            }
+        }
+        for symbol in symbols {
+            if symbol.repo_uid != repo_uid {
+                return Err(StoreError::Query(format!(
+                    "Symbol {} belongs to {}, expected {repo_uid}",
+                    symbol.uid, symbol.repo_uid
+                )));
+            }
+        }
+        for service in services {
+            if service.repo_uid != repo_uid {
+                return Err(StoreError::Query(format!(
+                    "Service {} belongs to {}, expected {repo_uid}",
+                    service.uid, service.repo_uid
+                )));
+            }
+        }
+        for (source, target) in repo_file_edges {
+            if *source != repo_uid || !file_uids.contains(*target) {
+                return Err(StoreError::Query(format!(
+                    "REPO_HAS_FILE endpoint is outside replacement input: {source} -> {target}"
+                )));
+            }
+        }
+        for (source, target) in file_symbol_edges {
+            if !file_uids.contains(*source) || !symbol_uids.contains(*target) {
+                return Err(StoreError::Query(format!(
+                    "FILE_HAS_SYMBOL endpoint is outside replacement input: {source} -> {target}"
+                )));
+            }
+        }
+        for (source, target) in service_symbol_edges {
+            if !service_uids.contains(*source) || !symbol_uids.contains(*target) {
+                return Err(StoreError::Query(format!(
+                    "SERVICE_HAS_SYMBOL endpoint is outside replacement input: {source} -> {target}"
+                )));
+            }
+        }
+        Ok(())
     }
 
     /// Wrap all markdown vault inserts in a single transaction.
@@ -1345,6 +1469,22 @@ impl GraphStore {
         wikilink_to_note_edges: &[(&str, &str, f32, &str, &str)],
         wikilink_to_heading_edges: &[(&str, &str, f32, &str, &str)],
     ) -> Result<usize, StoreError> {
+        Self::validate_bulk_vault_reindex_input(
+            vault,
+            notes,
+            headings,
+            sections,
+            vault_note_edges,
+            note_heading_edges,
+            note_section_edges,
+            heading_section_edges,
+            heading_parent_edges,
+            tags,
+            note_tag_edges,
+            section_tag_edges,
+            wikilink_to_note_edges,
+            wikilink_to_heading_edges,
+        )?;
         // Project membership is derived outside the vault hierarchy, but the
         // authoritative vault replacement DETACH-deletes every old Note.
         // Preserve membership for stable note UIDs that survive the refresh;
@@ -1407,6 +1547,117 @@ impl GraphStore {
 
         self.commit_transaction(&conn)?;
         Ok(deleted)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn validate_bulk_vault_reindex_input(
+        vault: &Vault,
+        notes: &[Note],
+        headings: &[Heading],
+        sections: &[Section],
+        vault_note_edges: &[(&str, &str)],
+        note_heading_edges: &[(&str, &str)],
+        note_section_edges: &[(&str, &str)],
+        heading_section_edges: &[(&str, &str)],
+        heading_parent_edges: &[(&str, &str)],
+        tags: &[Tag],
+        note_tag_edges: &[(&str, &str)],
+        section_tag_edges: &[(&str, &str)],
+        wikilink_to_note_edges: &[(&str, &str, f32, &str, &str)],
+        wikilink_to_heading_edges: &[(&str, &str, f32, &str, &str)],
+    ) -> Result<(), StoreError> {
+        let note_uids = unique_uid_set("Note", notes.iter().map(|note| note.uid.as_str()))?;
+        let heading_uids = unique_uid_set(
+            "Heading",
+            headings.iter().map(|heading| heading.uid.as_str()),
+        )?;
+        let section_uids = unique_uid_set(
+            "Section",
+            sections.iter().map(|section| section.uid.as_str()),
+        )?;
+        let tag_uids = unique_uid_set("Tag", tags.iter().map(|tag| tag.uid.as_str()))?;
+        for note in notes {
+            if note.vault_uid != vault.uid {
+                return Err(StoreError::Query(format!(
+                    "Note {} belongs to {}, expected {}",
+                    note.uid, note.vault_uid, vault.uid
+                )));
+            }
+        }
+        for heading in headings {
+            if !note_uids.contains(heading.note_uid.as_str()) {
+                return Err(StoreError::Query(format!(
+                    "Heading {} references Note {} outside replacement input",
+                    heading.uid, heading.note_uid
+                )));
+            }
+        }
+        for section in sections {
+            if !note_uids.contains(section.note_uid.as_str())
+                || section
+                    .heading_uid
+                    .as_deref()
+                    .is_some_and(|uid| !heading_uids.contains(uid))
+            {
+                return Err(StoreError::Query(format!(
+                    "Section {} references an endpoint outside replacement input",
+                    section.uid
+                )));
+            }
+        }
+        for (source, target) in vault_note_edges {
+            if *source != vault.uid || !note_uids.contains(*target) {
+                return Err(StoreError::Query(format!(
+                    "VAULT_HAS_NOTE endpoint is outside replacement input: {source} -> {target}"
+                )));
+            }
+        }
+        validate_edge_pairs(
+            "NOTE_HAS_HEADING",
+            note_heading_edges,
+            &note_uids,
+            &heading_uids,
+        )?;
+        validate_edge_pairs(
+            "NOTE_HAS_SECTION",
+            note_section_edges,
+            &note_uids,
+            &section_uids,
+        )?;
+        validate_edge_pairs(
+            "HEADING_HAS_SECTION",
+            heading_section_edges,
+            &heading_uids,
+            &section_uids,
+        )?;
+        validate_edge_pairs(
+            "HEADING_PARENT",
+            heading_parent_edges,
+            &heading_uids,
+            &heading_uids,
+        )?;
+        validate_edge_pairs("NOTE_TAGGED_WITH", note_tag_edges, &note_uids, &tag_uids)?;
+        validate_edge_pairs(
+            "SECTION_TAGGED_WITH",
+            section_tag_edges,
+            &section_uids,
+            &tag_uids,
+        )?;
+        for (source, _, _, _, _) in wikilink_to_note_edges {
+            if !section_uids.contains(*source) {
+                return Err(StoreError::Query(format!(
+                    "WIKILINK_TO_NOTE source Section is outside replacement input: {source}"
+                )));
+            }
+        }
+        for (source, _, _, _, _) in wikilink_to_heading_edges {
+            if !section_uids.contains(*source) {
+                return Err(StoreError::Query(format!(
+                    "WIKILINK_TO_HEADING source Section is outside replacement input: {source}"
+                )));
+            }
+        }
+        Ok(())
     }
 
     pub fn batch_insert_edges(&self, edges: &[ResolvedEdge]) -> Result<(), StoreError> {
@@ -1986,9 +2237,30 @@ impl GraphStore {
 
     pub fn insert_project(&self, project: &Project) -> Result<(), StoreError> {
         let conn = self.conn()?;
+        Self::insert_project_on(&conn, project)
+    }
+
+    fn insert_project_on(conn: &lbug::Connection<'_>, project: &Project) -> Result<(), StoreError> {
         exec_params(
-            &conn,
+            conn,
             "CREATE (:Project {uid: $uid, name: $name, summary: $summary, instance_id: $iid})",
+            vec![
+                ("uid", lbug::Value::String(project.uid.clone())),
+                ("name", lbug::Value::String(project.name.clone())),
+                (
+                    "summary",
+                    lbug::Value::String(project.summary.clone().unwrap_or_default()),
+                ),
+                ("iid", lbug::Value::String(project.instance_id.clone())),
+            ],
+        )
+    }
+
+    fn merge_project_on(conn: &lbug::Connection<'_>, project: &Project) -> Result<(), StoreError> {
+        exec_params(
+            conn,
+            "MERGE (p:Project {uid: $uid}) \
+             SET p.name = $name, p.summary = $summary, p.instance_id = $iid",
             vec![
                 ("uid", lbug::Value::String(project.uid.clone())),
                 ("name", lbug::Value::String(project.name.clone())),
@@ -4654,23 +4926,11 @@ impl GraphStore {
         conn: &lbug::Connection<'_>,
         edges: &[(&str, &str)],
     ) -> Result<(), StoreError> {
-        let mut stmt = conn
-            .prepare(
-                "MATCH (p:Project {uid: $pid}), (n:Note {uid: $nid}) \
-                 CREATE (p)-[:PROJECT_INCLUDES_NOTE {confidence: 1.0}]->(n)",
-            )
-            .map_err(|e| StoreError::Query(format!("prepare: {e}")))?;
-        for (project_uid, note_uid) in edges {
-            conn.execute(
-                &mut stmt,
-                vec![
-                    ("pid", lbug::Value::String(project_uid.to_string())),
-                    ("nid", lbug::Value::String(note_uid.to_string())),
-                ],
-            )
-            .map_err(|e| StoreError::Query(format!("execute: {e}")))?;
-        }
-        Ok(())
+        let owned = edges
+            .iter()
+            .map(|(from, to)| ((*from).to_string(), (*to).to_string()))
+            .collect::<Vec<_>>();
+        Self::copy_project_edges_on(conn, "PROJECT_INCLUDES_NOTE", &owned, 1.0)
     }
 
     pub fn batch_insert_project_symbol_edges(
@@ -4680,22 +4940,353 @@ impl GraphStore {
         confidence: f32,
     ) -> Result<(), StoreError> {
         let conn = self.conn()?;
-        let mut stmt = conn
-            .prepare(
-                "MATCH (p:Project {uid: $pid}), (s:Symbol {uid: $sid}) \
-                 CREATE (p)-[:PROJECT_INCLUDES_SYMBOL {confidence: $conf}]->(s)",
-            )
-            .map_err(|e| StoreError::Query(format!("prepare: {e}")))?;
-        for sym_uid in symbol_uids {
-            conn.execute(
-                &mut stmt,
+        let edges = symbol_uids
+            .iter()
+            .map(|symbol_uid| (project_uid.to_string(), symbol_uid.clone()))
+            .collect::<Vec<_>>();
+        Self::copy_project_edges_on(&conn, "PROJECT_INCLUDES_SYMBOL", &edges, confidence)
+    }
+
+    fn copy_project_edges_on(
+        conn: &lbug::Connection<'_>,
+        relationship: &'static str,
+        edges: &[(String, String)],
+        confidence: f32,
+    ) -> Result<(), StoreError> {
+        if edges.is_empty() {
+            return Ok(());
+        }
+        let tmp_dir =
+            tempfile::tempdir().map_err(|e| StoreError::Query(format!("tempdir: {e}")))?;
+        let csv_path = tmp_dir.path().join(format!("{relationship}.csv"));
+        write_project_edge_csv(edges, confidence, &csv_path)?;
+        let csv_str = csv_path.display().to_string().replace('\\', "/");
+        conn.query(&format!(
+            "COPY {relationship} FROM '{csv_str}' {COPY_CSV_OPTS}"
+        ))
+        .map_err(|e| StoreError::Query(format!("COPY {relationship}: {e}")))?;
+        Ok(())
+    }
+
+    /// Atomically replace all explicitly configured Project nodes and their
+    /// membership relationships. Planning is deliberately performed by the
+    /// engine before this call, so a lookup or remote-source failure cannot
+    /// erase the previously published project graph.
+    pub fn replace_materialized_projects(
+        &self,
+        projects: &[Project],
+        note_edges: &[(String, String)],
+        symbol_edges: &[(String, String)],
+        component_edges: &[(String, String)],
+        parent_edges: &[(String, String)],
+    ) -> Result<(), StoreError> {
+        let target_uids = projects
+            .iter()
+            .map(|project| project.uid.as_str())
+            .collect::<std::collections::HashSet<_>>();
+        for (relationship, edges) in [
+            ("PROJECT_INCLUDES_NOTE", note_edges),
+            ("PROJECT_INCLUDES_SYMBOL", symbol_edges),
+        ] {
+            if let Some((source, _)) = edges
+                .iter()
+                .find(|(source, _)| !target_uids.contains(source.as_str()))
+            {
+                return Err(StoreError::Query(format!(
+                    "{relationship} source Project {source} is not configured"
+                )));
+            }
+        }
+        for (relationship, edges) in [
+            ("PROJECT_HAS_COMPONENT", component_edges),
+            ("PROJECT_HAS_PARENT", parent_edges),
+        ] {
+            if let Some((source, _)) = edges
+                .iter()
+                .find(|(source, _)| !target_uids.contains(source.as_str()))
+            {
+                return Err(StoreError::Query(format!(
+                    "{relationship} source Project {source} is not configured"
+                )));
+            }
+            if let Some((_, target)) = edges
+                .iter()
+                .find(|(_, target)| !target_uids.contains(target.as_str()))
+            {
+                return Err(StoreError::Query(format!(
+                    "{relationship} target Project {target} is not configured"
+                )));
+            }
+        }
+
+        let existing = self.list_projects()?;
+        let target_names = projects
+            .iter()
+            .map(|project| project.name.to_lowercase())
+            .collect::<std::collections::HashSet<_>>();
+        let stale_uids = existing
+            .iter()
+            .filter(|project| {
+                target_names.contains(&project.name.to_lowercase())
+                    && !target_uids.contains(project.uid.as_str())
+            })
+            .map(|project| project.uid.clone())
+            .collect::<Vec<_>>();
+
+        self.replace_materialized_projects_transaction(
+            projects,
+            note_edges,
+            symbol_edges,
+            component_edges,
+            parent_edges,
+            &stale_uids,
+            true,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn replace_materialized_projects_transaction(
+        &self,
+        projects: &[Project],
+        note_edges: &[(String, String)],
+        symbol_edges: &[(String, String)],
+        component_edges: &[(String, String)],
+        parent_edges: &[(String, String)],
+        stale_uids: &[String],
+        recover_on_failure: bool,
+    ) -> Result<(), StoreError> {
+        let existing_note_edges = self.list_project_edge_pairs("PROJECT_INCLUDES_NOTE")?;
+        let existing_symbol_edges = self.list_project_edge_pairs("PROJECT_INCLUDES_SYMBOL")?;
+        let existing_component_edges = self.list_project_edge_pairs("PROJECT_HAS_COMPONENT")?;
+        let existing_parent_edges = self.list_project_edge_pairs("PROJECT_HAS_PARENT")?;
+        let desired_note_edges = note_edges
+            .iter()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
+        let desired_symbol_edges = symbol_edges
+            .iter()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
+        let desired_component_edges = component_edges
+            .iter()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
+        let desired_parent_edges = parent_edges
+            .iter()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
+        let affected_sources = projects
+            .iter()
+            .map(|project| project.uid.as_str())
+            .chain(stale_uids.iter().map(String::as_str))
+            .collect::<std::collections::HashSet<_>>();
+        let stale_targets = stale_uids
+            .iter()
+            .map(String::as_str)
+            .collect::<std::collections::HashSet<_>>();
+        let existing_projects = self.list_projects()?;
+        let existing_project_uids = existing_projects
+            .iter()
+            .map(|project| project.uid.clone())
+            .collect::<std::collections::HashSet<_>>();
+
+        let note_additions = desired_note_edges
+            .difference(&existing_note_edges)
+            .cloned()
+            .collect::<Vec<_>>();
+        let symbol_additions = desired_symbol_edges
+            .difference(&existing_symbol_edges)
+            .cloned()
+            .collect::<Vec<_>>();
+        let component_additions = desired_component_edges
+            .difference(&existing_component_edges)
+            .cloned()
+            .collect::<Vec<_>>();
+        let parent_additions = desired_parent_edges
+            .difference(&existing_parent_edges)
+            .cloned()
+            .collect::<Vec<_>>();
+        let obsolete_note_edges = existing_note_edges
+            .iter()
+            .filter(|edge| {
+                affected_sources.contains(edge.0.as_str()) && !desired_note_edges.contains(*edge)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        let obsolete_symbol_edges = existing_symbol_edges
+            .iter()
+            .filter(|edge| {
+                affected_sources.contains(edge.0.as_str()) && !desired_symbol_edges.contains(*edge)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        let obsolete_component_edges = existing_component_edges
+            .iter()
+            .filter(|edge| {
+                (affected_sources.contains(edge.0.as_str())
+                    || stale_targets.contains(edge.1.as_str()))
+                    && !desired_component_edges.contains(*edge)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        let obsolete_parent_edges = existing_parent_edges
+            .iter()
+            .filter(|edge| {
+                (affected_sources.contains(edge.0.as_str())
+                    || stale_targets.contains(edge.1.as_str()))
+                    && !desired_parent_edges.contains(*edge)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let conn = self.begin_transaction()?;
+        let mutation = (|| {
+            for project in projects
+                .iter()
+                .filter(|project| !existing_project_uids.contains(&project.uid))
+            {
+                Self::insert_project_on(&conn, project)?;
+            }
+            // Create every missing edge before deleting any old edge. A COPY
+            // endpoint failure therefore rolls back only additive work; it
+            // never relies on LadybugDB to resurrect detached relationships.
+            Self::copy_project_edges_on(&conn, "PROJECT_INCLUDES_NOTE", &note_additions, 1.0)?;
+            Self::copy_project_edges_on(&conn, "PROJECT_INCLUDES_SYMBOL", &symbol_additions, 1.0)?;
+            Self::copy_project_edges_on(&conn, "PROJECT_HAS_COMPONENT", &component_additions, 1.0)?;
+            Self::copy_project_edges_on(&conn, "PROJECT_HAS_PARENT", &parent_additions, 1.0)?;
+            for project in projects
+                .iter()
+                .filter(|project| existing_project_uids.contains(&project.uid))
+            {
+                Self::merge_project_on(&conn, project)?;
+            }
+            Self::delete_project_edge_pairs_on(
+                &conn,
+                "PROJECT_INCLUDES_NOTE",
+                "Note",
+                &obsolete_note_edges,
+            )?;
+            Self::delete_project_edge_pairs_on(
+                &conn,
+                "PROJECT_INCLUDES_SYMBOL",
+                "Symbol",
+                &obsolete_symbol_edges,
+            )?;
+            Self::delete_project_edge_pairs_on(
+                &conn,
+                "PROJECT_HAS_COMPONENT",
+                "Project",
+                &obsolete_component_edges,
+            )?;
+            Self::delete_project_edge_pairs_on(
+                &conn,
+                "PROJECT_HAS_PARENT",
+                "Project",
+                &obsolete_parent_edges,
+            )?;
+            for uid in stale_uids {
+                exec_params(
+                    &conn,
+                    "MATCH (p:Project {uid: $uid}) DELETE p",
+                    vec![("uid", lbug::Value::String(uid.clone()))],
+                )?;
+            }
+            Ok(())
+        })();
+        let publication = match mutation {
+            Ok(()) => self.commit_transaction(&conn).map_err(|error| {
+                StoreError::Query(format!("Project materialization commit: {error}"))
+            }),
+            Err(error) => Err(error),
+        };
+        let Err(error) = publication else {
+            return Ok(());
+        };
+        let primary = Self::rollback_project_transaction(&conn, error, "Project materialization");
+        if !recover_on_failure {
+            return Err(primary);
+        }
+
+        let snapshot_note_edges = existing_note_edges.into_iter().collect::<Vec<_>>();
+        let snapshot_symbol_edges = existing_symbol_edges.into_iter().collect::<Vec<_>>();
+        let snapshot_component_edges = existing_component_edges.into_iter().collect::<Vec<_>>();
+        let snapshot_parent_edges = existing_parent_edges.into_iter().collect::<Vec<_>>();
+        let snapshot_uids = existing_projects
+            .iter()
+            .map(|project| project.uid.as_str())
+            .collect::<std::collections::HashSet<_>>();
+        let introduced_uids = self
+            .list_projects()?
+            .into_iter()
+            .filter(|project| !snapshot_uids.contains(project.uid.as_str()))
+            .map(|project| project.uid)
+            .collect::<Vec<_>>();
+        match self.replace_materialized_projects_transaction(
+            &existing_projects,
+            &snapshot_note_edges,
+            &snapshot_symbol_edges,
+            &snapshot_component_edges,
+            &snapshot_parent_edges,
+            &introduced_uids,
+            false,
+        ) {
+            Ok(()) => Err(primary),
+            Err(recovery) => Err(StoreError::Query(format!(
+                "{primary}; Project materialization recovery failed: {recovery}"
+            ))),
+        }
+    }
+
+    fn list_project_edge_pairs(
+        &self,
+        relationship: &'static str,
+    ) -> Result<std::collections::HashSet<(String, String)>, StoreError> {
+        let conn = self.conn()?;
+        let rows = conn
+            .query(&format!(
+                "MATCH (p:Project)-[:{relationship}]->(target) RETURN p.uid, target.uid"
+            ))
+            .map_err(|error| StoreError::Query(format!("list {relationship}: {error}")))?;
+        rows.map(|row| {
+            let source = match row.first() {
+                Some(lbug::Value::String(value)) => value.clone(),
+                _ => {
+                    return Err(StoreError::Query(format!(
+                        "list {relationship}: malformed source uid"
+                    )));
+                }
+            };
+            let target = match row.get(1) {
+                Some(lbug::Value::String(value)) => value.clone(),
+                _ => {
+                    return Err(StoreError::Query(format!(
+                        "list {relationship}: malformed target uid"
+                    )));
+                }
+            };
+            Ok((source, target))
+        })
+        .collect()
+    }
+
+    fn delete_project_edge_pairs_on(
+        conn: &lbug::Connection<'_>,
+        relationship: &'static str,
+        target_label: &'static str,
+        edges: &[(String, String)],
+    ) -> Result<(), StoreError> {
+        for (source, target) in edges {
+            exec_params(
+                conn,
+                &format!(
+                    "MATCH (p:Project {{uid: $source}})-[r:{relationship}]->\
+                     (target:{target_label} {{uid: $target}}) DELETE r"
+                ),
                 vec![
-                    ("pid", lbug::Value::String(project_uid.to_string())),
-                    ("sid", lbug::Value::String(sym_uid.clone())),
-                    ("conf", lbug::Value::Double(confidence as f64)),
+                    ("source", lbug::Value::String(source.clone())),
+                    ("target", lbug::Value::String(target.clone())),
                 ],
-            )
-            .map_err(|e| StoreError::Query(format!("execute: {e}")))?;
+            )?;
         }
         Ok(())
     }
@@ -5211,6 +5802,16 @@ impl GraphStore {
     ) -> StoreError {
         match conn.query("ROLLBACK") {
             Ok(_) => error,
+            Err(rollback_error)
+                if rollback_error
+                    .to_string()
+                    .contains("No active transaction for ROLLBACK") =>
+            {
+                // LadybugDB automatically rolls back and clears a manual
+                // transaction when a statement throws. The explicit rollback
+                // is therefore idempotent from NestWeaver's perspective.
+                error
+            }
             Err(rollback_error) => StoreError::Query(format!(
                 "{error}; {operation} rollback failed: {rollback_error}"
             )),
@@ -8993,5 +9594,462 @@ mod tests {
             .unwrap()
             .collect();
         assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn materialized_project_replacement_bulk_loads_every_relationship_kind() {
+        use nestweaver_schema::{Note, NoteKind, Project};
+
+        let store = GraphStore::in_memory().unwrap();
+        let projects = vec![
+            Project {
+                uid: "proj:test:parent".to_string(),
+                name: "parent".to_string(),
+                summary: Some("new parent".to_string()),
+                instance_id: "test".to_string(),
+            },
+            Project {
+                uid: "proj:test:child".to_string(),
+                name: "child".to_string(),
+                summary: None,
+                instance_id: "test".to_string(),
+            },
+        ];
+        store
+            .insert_note(&Note {
+                uid: "note:project-bulk".to_string(),
+                vault_uid: "vault:test".to_string(),
+                file_path: "Projects/parent.md".to_string(),
+                title: "Parent".to_string(),
+                note_kind: NoteKind::General,
+                word_count: 1,
+                content_hash: "note-hash".to_string(),
+                frontmatter: None,
+                created_at: None,
+                modified_at: None,
+                pagerank_score: None,
+                embedding: None,
+            })
+            .unwrap();
+        let symbol_uid = "sym:project-bulk".to_string();
+        store
+            .insert_symbol(&Symbol {
+                uid: symbol_uid.clone(),
+                name: "project_bulk".to_string(),
+                kind: nestweaver_schema::SymbolKind::Function,
+                repo_uid: "repo:project-bulk".to_string(),
+                file_path: "src/lib.rs".to_string(),
+                start_line: 1,
+                end_line: 1,
+                signature: "fn project_bulk()".to_string(),
+                summary: None,
+                content_hash: "symbol-hash".to_string(),
+                embedding: None,
+                pagerank_score: None,
+                is_entry_point: false,
+                entry_point_kind: None,
+                visibility: nestweaver_schema::Visibility::Public,
+                type_info: None,
+                framework_hint: None,
+                canonical_id: None,
+            })
+            .unwrap();
+
+        store
+            .replace_materialized_projects(
+                &projects,
+                &[(
+                    "proj:test:parent".to_string(),
+                    "note:project-bulk".to_string(),
+                )],
+                &[("proj:test:parent".to_string(), symbol_uid)],
+                &[(
+                    "proj:test:parent".to_string(),
+                    "proj:test:child".to_string(),
+                )],
+                &[(
+                    "proj:test:child".to_string(),
+                    "proj:test:parent".to_string(),
+                )],
+            )
+            .unwrap();
+
+        assert_eq!(
+            store.list_project_note_uids("proj:test:parent").unwrap(),
+            vec!["note:project-bulk".to_string()]
+        );
+        assert_eq!(
+            store
+                .list_project_component_uids("proj:test:parent")
+                .unwrap(),
+            vec!["proj:test:child".to_string()]
+        );
+        let conn = store.conn().unwrap();
+        for relationship in ["PROJECT_INCLUDES_SYMBOL", "PROJECT_HAS_PARENT"] {
+            let count = conn
+                .query(&format!("MATCH ()-[r:{relationship}]->() RETURN count(r)"))
+                .unwrap()
+                .filter_map(|row| match row.first() {
+                    Some(lbug::Value::Int64(value)) => Some(*value),
+                    _ => None,
+                })
+                .next()
+                .unwrap_or_default();
+            assert_eq!(count, 1, "{relationship} bulk COPY lost an edge");
+        }
+    }
+
+    #[test]
+    fn disk_backed_late_project_copy_failure_restores_previous_graph() {
+        use nestweaver_schema::{Note, NoteKind, Project};
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("project-rollback.lbug");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        let old = Project {
+            uid: "proj:test:stable".to_string(),
+            name: "stable".to_string(),
+            summary: Some("old summary".to_string()),
+            instance_id: "test".to_string(),
+        };
+        store.insert_project(&old).unwrap();
+        store
+            .insert_note(&Note {
+                uid: "note:stable".to_string(),
+                vault_uid: "vault:test".to_string(),
+                file_path: "stable.md".to_string(),
+                title: "Stable".to_string(),
+                note_kind: NoteKind::General,
+                word_count: 1,
+                content_hash: "stable".to_string(),
+                frontmatter: None,
+                created_at: None,
+                modified_at: None,
+                pagerank_score: None,
+                embedding: None,
+            })
+            .unwrap();
+        store
+            .insert_note(&Note {
+                uid: "note:new".to_string(),
+                vault_uid: "vault:test".to_string(),
+                file_path: "new.md".to_string(),
+                title: "New".to_string(),
+                note_kind: NoteKind::General,
+                word_count: 1,
+                content_hash: "new".to_string(),
+                frontmatter: None,
+                created_at: None,
+                modified_at: None,
+                pagerank_score: None,
+                embedding: None,
+            })
+            .unwrap();
+        let symbol_uid = "sym:project-rollback".to_string();
+        store
+            .insert_symbol(&Symbol {
+                uid: symbol_uid.clone(),
+                name: "project_rollback".to_string(),
+                kind: nestweaver_schema::SymbolKind::Function,
+                repo_uid: "repo:project-rollback".to_string(),
+                file_path: "src/lib.rs".to_string(),
+                start_line: 1,
+                end_line: 1,
+                signature: "fn project_rollback()".to_string(),
+                summary: None,
+                content_hash: "symbol-hash".to_string(),
+                embedding: None,
+                pagerank_score: None,
+                is_entry_point: false,
+                entry_point_kind: None,
+                visibility: nestweaver_schema::Visibility::Public,
+                type_info: None,
+                framework_hint: None,
+                canonical_id: None,
+            })
+            .unwrap();
+        store
+            .batch_insert_project_note_edges(&[("proj:test:stable", "note:stable")])
+            .unwrap();
+
+        let mut replacement = old.clone();
+        replacement.summary = Some("new summary".to_string());
+        let result = store.replace_materialized_projects_transaction(
+            &[replacement],
+            &[("proj:test:stable".to_string(), "note:new".to_string())],
+            &[("proj:test:stable".to_string(), symbol_uid)],
+            &[(
+                "proj:test:stable".to_string(),
+                "proj:test:missing".to_string(),
+            )],
+            &[],
+            &[],
+            true,
+        );
+        let error = result.expect_err("the late component COPY must fail");
+        assert!(error.to_string().contains("PROJECT_HAS_COMPONENT"));
+        assert!(
+            !error.to_string().contains("rollback failed"),
+            "automatic rollback should not be misreported: {error}"
+        );
+        drop(store);
+
+        let reopened = GraphStore::open_or_create(&db_path).unwrap();
+        let restored = reopened
+            .list_projects()
+            .unwrap()
+            .into_iter()
+            .find(|project| project.uid == old.uid)
+            .expect("rollback must restore the previous Project node");
+        assert_eq!(restored.summary, old.summary);
+        assert_eq!(
+            reopened.list_project_note_uids(&old.uid).unwrap(),
+            vec!["note:stable".to_string()],
+            "disk-backed rollback must restore previous membership and remove partial replacement"
+        );
+    }
+
+    #[test]
+    fn undeclared_project_endpoint_fails_before_materialization_mutates() {
+        use nestweaver_schema::{Note, NoteKind, Project};
+
+        let store = GraphStore::in_memory().unwrap();
+        let project = Project {
+            uid: "proj:test:stable".to_string(),
+            name: "stable".to_string(),
+            summary: Some("old summary".to_string()),
+            instance_id: "test".to_string(),
+        };
+        store.insert_project(&project).unwrap();
+        store
+            .insert_note(&Note {
+                uid: "note:stable".to_string(),
+                vault_uid: "vault:test".to_string(),
+                file_path: "stable.md".to_string(),
+                title: "Stable".to_string(),
+                note_kind: NoteKind::General,
+                word_count: 1,
+                content_hash: "stable".to_string(),
+                frontmatter: None,
+                created_at: None,
+                modified_at: None,
+                pagerank_score: None,
+                embedding: None,
+            })
+            .unwrap();
+        store
+            .batch_insert_project_note_edges(&[("proj:test:stable", "note:stable")])
+            .unwrap();
+
+        let error = store
+            .replace_materialized_projects(
+                std::slice::from_ref(&project),
+                &[],
+                &[],
+                &[(project.uid.clone(), "proj:test:not-configured".to_string())],
+                &[],
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("is not configured"));
+        assert_eq!(
+            store.list_project_note_uids(&project.uid).unwrap(),
+            vec!["note:stable".to_string()]
+        );
+    }
+
+    #[test]
+    fn duplicate_repo_input_fails_before_previous_graph_is_deleted() {
+        use nestweaver_schema::{File, Repo, Service, SymbolKind, Visibility};
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("repo-rollback.lbug");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        let repo_uid = "repo:test:rollback";
+        store
+            .insert_repo(&Repo {
+                uid: repo_uid.to_string(),
+                url: "file:///repo-rollback".to_string(),
+                indexed_sha: "old".to_string(),
+                staleness_commits_behind: 0,
+                instance_id: "test".to_string(),
+                name: Some("rollback".to_string()),
+                root_path: Some("/repo-rollback".to_string()),
+            })
+            .unwrap();
+        let old_file = File {
+            uid: "file:repo-rollback:old".to_string(),
+            path: "src/old.rs".to_string(),
+            repo_uid: repo_uid.to_string(),
+            content_hash: "old-file".to_string(),
+        };
+        let old_symbol = Symbol {
+            uid: "sym:repo-rollback:old".to_string(),
+            name: "old_symbol".to_string(),
+            kind: SymbolKind::Function,
+            repo_uid: repo_uid.to_string(),
+            file_path: old_file.path.clone(),
+            start_line: 1,
+            end_line: 1,
+            signature: "fn old_symbol()".to_string(),
+            summary: None,
+            content_hash: "old-symbol".to_string(),
+            embedding: None,
+            pagerank_score: None,
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Public,
+            type_info: None,
+            framework_hint: None,
+            canonical_id: None,
+        };
+        store
+            .bulk_index_write(
+                std::slice::from_ref(&old_file),
+                std::slice::from_ref(&old_symbol),
+                &[(repo_uid, old_file.uid.as_str())],
+                &[(old_file.uid.as_str(), old_symbol.uid.as_str())],
+                &[],
+                &[],
+            )
+            .unwrap();
+
+        let new_file = File {
+            uid: "file:repo-rollback:new".to_string(),
+            path: "src/new.rs".to_string(),
+            repo_uid: repo_uid.to_string(),
+            content_hash: "new-file".to_string(),
+        };
+        let new_symbol = Symbol {
+            uid: "sym:repo-rollback:new".to_string(),
+            name: "new_symbol".to_string(),
+            kind: SymbolKind::Function,
+            repo_uid: repo_uid.to_string(),
+            file_path: new_file.path.clone(),
+            start_line: 1,
+            end_line: 1,
+            signature: "fn new_symbol()".to_string(),
+            summary: None,
+            content_hash: "new-symbol".to_string(),
+            embedding: None,
+            pagerank_score: None,
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Public,
+            type_info: None,
+            framework_hint: None,
+            canonical_id: None,
+        };
+        let duplicate_service = Service {
+            uid: "svc:repo-rollback:duplicate".to_string(),
+            name: "duplicate".to_string(),
+            repo_uid: repo_uid.to_string(),
+            summary: None,
+            summary_hash: None,
+            embedding: None,
+        };
+        let result = store.bulk_reindex_write(
+            repo_uid,
+            std::slice::from_ref(&new_file),
+            std::slice::from_ref(&new_symbol),
+            &[(repo_uid, new_file.uid.as_str())],
+            &[(new_file.uid.as_str(), new_symbol.uid.as_str())],
+            &[duplicate_service.clone(), duplicate_service],
+            &[],
+        );
+        let error = result.expect_err("duplicate Service uid must fail preflight");
+        assert!(error.to_string().contains("duplicate Service uid"));
+        drop(store);
+
+        let reopened = GraphStore::open_or_create(&db_path).unwrap();
+        let conn = reopened.conn().unwrap();
+        let count = conn
+            .query(&format!(
+                "MATCH (f:File {{uid: '{}'}})-[:FILE_HAS_SYMBOL]->\
+                 (s:Symbol {{uid: '{}'}}) RETURN count(s)",
+                old_file.uid, old_symbol.uid
+            ))
+            .unwrap()
+            .filter_map(|row| match row.first() {
+                Some(lbug::Value::Int64(value)) => Some(*value),
+                _ => None,
+            })
+            .next()
+            .unwrap_or_default();
+        assert_eq!(count, 1, "failed repo reindex must preserve the old graph");
+    }
+
+    #[test]
+    fn malformed_vault_replacement_fails_before_previous_graph_is_deleted() {
+        use nestweaver_schema::{Note, NoteKind, Vault};
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("vault-preflight.lbug");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        let vault = Vault {
+            uid: "vault:test:preflight".to_string(),
+            name: "preflight".to_string(),
+            root_path: "/vault-preflight".to_string(),
+            instance_id: "test".to_string(),
+        };
+        let old_note = Note {
+            uid: "note:vault-preflight:old".to_string(),
+            vault_uid: vault.uid.clone(),
+            file_path: "old.md".to_string(),
+            title: "Old".to_string(),
+            note_kind: NoteKind::General,
+            word_count: 1,
+            content_hash: "old".to_string(),
+            frontmatter: None,
+            created_at: None,
+            modified_at: None,
+            pagerank_score: None,
+            embedding: None,
+        };
+        store.insert_vault(&vault).unwrap();
+        store.insert_note(&old_note).unwrap();
+        store
+            .insert_vault_note_edge(&vault.uid, &old_note.uid)
+            .unwrap();
+
+        let mut replacement = old_note.clone();
+        replacement.title = "Replacement".to_string();
+        let error = store
+            .bulk_vault_reindex_write(
+                &vault,
+                true,
+                &[replacement.clone(), replacement],
+                &[],
+                &[],
+                &[(vault.uid.as_str(), old_note.uid.as_str())],
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("duplicate Note uid"));
+        drop(store);
+
+        let reopened = GraphStore::open_or_create(&db_path).unwrap();
+        let conn = reopened.conn().unwrap();
+        let count = conn
+            .query(&format!(
+                "MATCH (v:Vault {{uid: '{}'}})-[:VAULT_HAS_NOTE]->\
+                 (n:Note {{uid: '{}'}}) RETURN count(n)",
+                vault.uid, old_note.uid
+            ))
+            .unwrap()
+            .filter_map(|row| match row.first() {
+                Some(lbug::Value::Int64(value)) => Some(*value),
+                _ => None,
+            })
+            .next()
+            .unwrap_or_default();
+        assert_eq!(count, 1, "vault preflight failure must preserve old graph");
     }
 }

--- a/docs/guide/instance-config.md
+++ b/docs/guide/instance-config.md
@@ -59,6 +59,18 @@ A unique name for this instance. Used in UIDs and registry.
 instance_id = "my-project"
 ```
 
+#### `db` (optional)
+
+Selects the graph database for commands invoked with `--config`, so callers do
+not also need `--db`.
+
+```toml
+db = "/path/to/brain.lbug"
+```
+
+An explicit `--db` takes precedence. When `db` is absent, NestWeaver uses
+`NESTWEAVER_DB` and then `./nestweaver.lbug`.
+
 #### `[snapshot_storage]`
 
 Where snapshots are stored for distribution.

--- a/examples/minimal-instance.toml
+++ b/examples/minimal-instance.toml
@@ -3,6 +3,8 @@
 #   nestweaver config validate examples/minimal-instance.toml
 
 instance_id = "minimal-example"
+# Optional: lets `--config` select the database.
+# db = "./nestweaver.lbug"
 
 [snapshot_storage]
 backend = "local"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3888,7 +3888,7 @@ enum BrainCommands {
         db: Option<PathBuf>,
         #[arg(
             long,
-            help = "Path to instance config (TOML) — uses its instance_id and db_path"
+            help = "Path to instance config (TOML) — uses its instance_id and db field"
         )]
         config: Option<PathBuf>,
         #[arg(long, help = "Additional glob patterns to ignore (comma-separated)")]
@@ -3973,7 +3973,7 @@ enum BrainCommands {
         db: Option<PathBuf>,
         #[arg(
             long,
-            help = "Path to instance config (TOML) — uses its instance_id and db_path"
+            help = "Path to instance config (TOML) — uses its instance_id and db field"
         )]
         config: Option<PathBuf>,
         #[arg(
@@ -4845,7 +4845,7 @@ fn default_db_path() -> PathBuf {
     }
 }
 
-/// Resolve the DB path for a read command, honoring `--config`.
+/// Resolve the DB path for a command that accepts `--config`.
 ///
 /// Precedence: an explicit `--db` always wins; otherwise the instance
 /// config's `db` field (when `--config` is given and declares one); otherwise
@@ -5398,14 +5398,31 @@ fn uninstall_pre_push_hook(cwd: &Path) -> anyhow::Result<i32> {
     Ok(EXIT_SUCCESS)
 }
 
-fn resolve_index_db_path(db: Option<PathBuf>, repo_root: &Path) -> PathBuf {
+/// Resolve the DB path for repository-scoped commands (`index` and code
+/// `watch`) while preserving their repository-local final fallback.
+///
+/// Precedence intentionally matches [`resolve_db_with_config`]: an explicit
+/// `--db`, then the explicit config's `db`, then `NESTWEAVER_DB`, and finally
+/// `<repo>/nestweaver.lbug`.
+fn resolve_index_db_path(
+    db: Option<PathBuf>,
+    config: Option<&Path>,
+    repo_root: &Path,
+) -> anyhow::Result<PathBuf> {
     if let Some(explicit) = db {
-        return explicit;
+        return Ok(explicit);
+    }
+    if let Some(cfg_path) = config {
+        let cfg = nestweaver_engine::InstanceConfig::from_file(cfg_path)
+            .with_context(|| format!("loading --config {}", cfg_path.display()))?;
+        if let Some(db) = cfg.db_path() {
+            return Ok(db);
+        }
     }
     if let Ok(env_db) = std::env::var("NESTWEAVER_DB") {
-        return PathBuf::from(env_db);
+        return Ok(PathBuf::from(env_db));
     }
-    repo_root.join("nestweaver.lbug")
+    Ok(repo_root.join("nestweaver.lbug"))
 }
 
 /// nw-023: first-index auto-setup, gated to "human at a TTY standing in the
@@ -8062,7 +8079,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
         } => {
             // nw-087: read-only command — fail `db_not_found` on a
             // missing --db before any daemon/store connect could create one.
-            let db_path = db.clone().unwrap_or_else(default_db_path);
+            let db_path = resolve_db_with_config(db, config_opt.as_deref())?;
             require_existing_db(&db_path)?;
             // ── daemon guard ──────────────────────────────────────
             if use_daemon {
@@ -8105,7 +8122,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
             }
 
-            let store = open_store(db.as_deref())?;
+            let store = open_store(Some(&db_path))?;
             let repos = list_repos(&store, instance.as_deref())?;
 
             if json {
@@ -8729,6 +8746,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             json,
             db,
         } => {
+            let db_path = resolve_db_with_config(db, config.as_deref())?;
             let parsed_intent: Option<QueryIntent> = intent
                 .as_deref()
                 .map(|s| s.parse())
@@ -8749,8 +8767,6 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         .as_ref()
                         .and_then(|fs| fs.iter().find(|f| f.name == *feature_name))
                     {
-                        let db_default = default_db_path();
-                        let db_path = db.as_deref().unwrap_or(&db_default);
                         let hybrid_args = serde_json::json!({
                             "seeds": fc.entry_points,
                             "token_budget": token_budget.unwrap_or(0),
@@ -8760,7 +8776,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         });
                         if let Some(result_json) = try_hybrid_json_rpc_checked(
                             use_daemon,
-                            db_path,
+                            &db_path,
                             config.as_deref(),
                             "brain_context",
                             hybrid_args,
@@ -8788,7 +8804,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     }
                 }
 
-                let store = open_store(db.as_deref())?;
+                let store = open_store(Some(&db_path))?;
                 let instance_config = nestweaver_engine::InstanceConfig::from_file(config_path)?;
                 let feature_config = instance_config
                     .features
@@ -8846,8 +8862,6 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // pattern.
             let effective_limit = limit.unwrap_or(30);
             if use_daemon {
-                let db_default = default_db_path();
-                let db_path = db.as_deref().unwrap_or(&db_default);
                 let hybrid_args = serde_json::json!({
                     "seeds": seeds.clone(),
                     "token_budget": token_budget.unwrap_or(0),
@@ -8856,7 +8870,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 });
                 if let Some(result_json) = try_hybrid_json_rpc_checked(
                     use_daemon,
-                    db_path,
+                    &db_path,
                     config.as_deref(),
                     "brain_context",
                     hybrid_args,
@@ -8883,7 +8897,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             }
 
             // ── Local fallback (daemon unavailable) ──────────────────
-            let store = open_store(db.as_deref())?;
+            let store = open_store(Some(&db_path))?;
             match build_context_with_intent(&store, &seeds, parsed_intent, limit) {
                 Ok(mut result) => {
                     if let Some(budget) = token_budget {
@@ -8979,9 +8993,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             json,
             config: config_opt,
         } => {
+            let db_path = resolve_db_with_config(db, config_opt.as_deref())?;
             // ── daemon guard ──────────────────────────────────────
             if use_daemon {
-                let db_path = db.clone().unwrap_or_else(default_db_path);
                 let args = serde_json::json!({});
                 if let Some(value) = try_hybrid_json_rpc_checked(
                     true,
@@ -9074,11 +9088,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
             }
 
-            let db_default = default_db_path();
-            let db_path = db.as_deref().unwrap_or(&db_default);
-            let store = open_store(Some(db_path))?;
+            let store = open_store(Some(&db_path))?;
             let manifests =
-                nestweaver_engine::load_manifest_cache_for_db(db_path).unwrap_or_default();
+                nestweaver_engine::load_manifest_cache_for_db(&db_path).unwrap_or_default();
             let suggestions = suggest_links(&store, &manifests)?;
 
             if json {
@@ -9153,7 +9165,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             format,
             rules_from,
         } => {
-            let db_path = db.unwrap_or_else(default_db_path);
+            let db_path = resolve_db_with_config(db, config.as_deref())?;
 
             // ── daemon guard (JSON pass-through) ─────────────────
             // Try the daemon first regardless of --output / --rules-from
@@ -9322,7 +9334,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             db,
             config,
         } => {
-            let db_path = db.unwrap_or_else(default_db_path);
+            let db_path = resolve_db_with_config(db, config.as_deref())?;
             require_existing_db(&db_path)?;
 
             // ── hybrid guard (routes through local + upstream) ────
@@ -9426,7 +9438,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             db,
             config: config_opt,
         } => {
-            let db_path = db.unwrap_or_else(default_db_path);
+            let db_path = resolve_db_with_config(db, config_opt.as_deref())?;
 
             // ── daemon guard ──────────────────────────────────────
             if use_daemon {
@@ -9649,7 +9661,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             db,
             config: config_opt,
         } => {
-            let db_path = db.unwrap_or_else(default_db_path);
+            let db_path = resolve_db_with_config(db, config_opt.as_deref())?;
 
             // ── daemon guard ──────────────────────────────────────
             // The daemon `clusters` tool truncates each community's
@@ -10708,7 +10720,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 );
                 return Ok((EXIT_ERROR, None));
             }
-            let db_path = resolve_index_db_path(db, &repo_path);
+            let db_path = resolve_index_db_path(db, config.as_deref(), &repo_path)?;
             // nw-019: --instance flag > config's instance_id > "default"
             // (mirrors `brain watch`/`brain add`; without this, `watch --config X`
             // with no --instance stamps symbols under "default" even with the
@@ -10903,7 +10915,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                      remove it from your MCP config"
                 );
             }
-            let db_path = db.unwrap_or_else(default_db_path);
+            let db_path = resolve_db_with_config(db, config.as_deref())?;
             if track_interactions {
                 nestweaver_mcp::tools::set_track_interactions(true);
             }
@@ -10967,7 +10979,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             no_open,
             watch,
         } => {
-            let db_path = db.unwrap_or_else(default_db_path);
+            let db_path = resolve_db_with_config(db, config.as_deref())?;
 
             let daemon_connection = if use_daemon {
                 match tokio::runtime::Runtime::new() {
@@ -11150,12 +11162,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             db,
             config,
         } => {
+            let db_path = resolve_db_with_config(db, config.as_deref())?;
             let cfg = load_instance_config_opt(config.as_deref());
             let limit = resolve_limit(limit, cfg.as_ref(), 10);
 
             // ── daemon guard ──────────────────────────────────────
             if use_daemon {
-                let db_path = db.clone().unwrap_or_else(default_db_path);
                 let args = serde_json::json!({ "query": query, "limit": limit });
                 if let Some(value) = try_hybrid_json_rpc_checked(
                     true,
@@ -11196,7 +11208,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
             }
 
-            let store = open_store(db.as_deref())?;
+            let store = open_store(Some(&db_path))?;
             let candidates = search_symbols(&store, &query, limit)?;
 
             if json {
@@ -11228,9 +11240,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             db,
             config,
         } => {
+            let db_path = resolve_db_with_config(db, config.as_deref())?;
             // ── daemon guard ──────────────────────────────────────
             if use_daemon {
-                let db_path = db.clone().unwrap_or_else(default_db_path);
                 let mut args = serde_json::json!({ "pattern": pattern });
                 if let Some(ref pp) = path_prefix {
                     args["path_prefix"] = serde_json::json!(pp);
@@ -11304,7 +11316,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
             }
 
-            let store = open_store(db.as_deref())?;
+            let store = open_store(Some(&db_path))?;
             let res = store
                 .regex_search(
                     &pattern,
@@ -11362,9 +11374,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             db,
             config,
         } => {
+            let db_path = resolve_db_with_config(db, config.as_deref())?;
             // ── daemon guard ──────────────────────────────────────
             if use_daemon {
-                let db_path = db.clone().unwrap_or_else(default_db_path);
                 let mut args = serde_json::json!({ "patterns": patterns });
                 if let Some(ref pp) = path_prefix {
                     args["path_prefix"] = serde_json::json!(pp);
@@ -11415,7 +11427,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
             }
 
-            let store = open_store(db.as_deref())?;
+            let store = open_store(Some(&db_path))?;
             let counts = store
                 .count_patterns(&patterns, path_prefix.as_deref(), kinds.as_deref())
                 .context("count_patterns")?;
@@ -11450,9 +11462,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             db,
             config,
         } => {
+            let db_path = resolve_db_with_config(db, config.as_deref())?;
             // ── daemon guard ──────────────────────────────────────
             if use_daemon {
-                let db_path = db.clone().unwrap_or_else(default_db_path);
                 let args =
                     read_symbols_rpc_args(&targets, neighbors, token_budget, root.as_deref());
                 if let Some(value) = try_hybrid_json_rpc_checked(
@@ -11467,7 +11479,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
             }
 
-            let store = open_store(db.as_deref())?;
+            let store = open_store(Some(&db_path))?;
             let root = root.unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
             let reader = nestweaver_engine::content_reader::FilesystemReader::new(&root);
             let res = nestweaver_engine::read_symbols::read_symbols(
@@ -12189,6 +12201,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             config: config_opt,
             ..
         } => {
+            let db_path = resolve_db_with_config(db, config_opt.as_deref())?;
             // ── daemon guard ──────────────────────────────────────
             // The daemon brain_impact tool doesn't apply a --repo filter, so when the user
             // scopes to a repo we fall through to the direct path (resolve_uid_with_repo_filter),
@@ -12200,8 +12213,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // honored and surfaced. Same for a non-default --confidence: the daemon tool
             // hardcodes 0.0, so an explicit filter must take the direct path or it would be
             // silently ignored.
+            // Keep the daemon eligibility guard separate from the RPC result:
+            // collapsing them would reindent this large response-rendering block
+            // and obscure the small database-resolution change in this patch.
+            #[allow(clippy::collapsible_if)]
             if use_daemon && repo_filter.is_none() && min_score.is_none() && confidence <= 0.0 {
-                let db_path = db.clone().unwrap_or_else(default_db_path);
                 if let Some(value) = try_hybrid_json_rpc_checked(
                     true,
                     &db_path,
@@ -12350,9 +12366,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             let total = value.get("total").and_then(|v| v.as_u64());
                             if !out.quiet {
                                 match total {
-                                    Some(t) if t > count as u64 => println!(
-                                        "Impact of '{name_or_uid}' ({count} of {t} nodes):"
-                                    ),
+                                    Some(t) if t > count as u64 => {
+                                        println!(
+                                            "Impact of '{name_or_uid}' ({count} of {t} nodes):"
+                                        )
+                                    }
                                     _ => println!("Impact of '{name_or_uid}' ({count} nodes):"),
                                 }
                             }
@@ -12399,7 +12417,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
             }
 
-            let store = open_store(db.as_deref())?;
+            let store = open_store(Some(&db_path))?;
 
             // Resolve the symbol UID first (may be a name).
             match resolve_uid_with_repo_filter(&store, &name_or_uid, repo_filter.as_deref())? {
@@ -12556,28 +12574,34 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // defined" — and the text path suggested adding [[projects]] to a
             // config, an actively wrong remedy. 17 of 18 comparable commands
             // already exit 1 here; this was the outlier.
-            let resolved_db = db.clone().unwrap_or_else(default_db_path);
+            let resolved_db = resolve_db_with_config(db, config.as_deref())?;
             require_existing_db(&resolved_db)?;
 
             // ── daemon guard ──────────────────────────────────────
             let materialized: Vec<nestweaver_schema::Project> = if use_daemon {
                 let db_path = resolved_db.clone();
                 let args = serde_json::json!({});
-                try_hybrid_json_rpc(true, &db_path, None, "list_projects", args)?
-                    .and_then(|v| serde_json::from_value(unwrap_hybrid_payload(v)).ok())
-                    .unwrap_or_else(|| {
-                        // Daemon unreachable / RPC failed — fall back to a direct read, but
-                        // never panic on a bad --db path; warn and return empty on error.
-                        match open_store(db.as_deref()) {
-                            Ok(store) => store.list_projects().unwrap_or_default(),
-                            Err(e) => {
-                                eprintln!("Warning: could not open store: {e}");
-                                Vec::new()
-                            }
+                try_hybrid_json_rpc_checked(
+                    true,
+                    &db_path,
+                    config.as_deref(),
+                    "list_projects",
+                    args,
+                )?
+                .and_then(|v| serde_json::from_value(unwrap_hybrid_payload(v)).ok())
+                .unwrap_or_else(|| {
+                    // Daemon unreachable / RPC failed — fall back to a direct read, but
+                    // never panic on a bad --db path; warn and return empty on error.
+                    match open_store(Some(&resolved_db)) {
+                        Ok(store) => store.list_projects().unwrap_or_default(),
+                        Err(e) => {
+                            eprintln!("Warning: could not open store: {e}");
+                            Vec::new()
                         }
-                    })
+                    }
+                })
             } else {
-                let store = open_store(db.as_deref())?;
+                let store = open_store(Some(&resolved_db))?;
                 store.list_projects().map_err(|e| anyhow::anyhow!(e))?
             };
 
@@ -12662,7 +12686,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // server-mode-remainder-decisions); --detailed opts into the full record.
             let response_format = if detailed { "detailed" } else { "concise" };
             let token_budget = token_budget.unwrap_or(if detailed { 3000 } else { 1000 });
-            let db_path = db.unwrap_or_else(default_db_path);
+            let db_path = resolve_db_with_config(db, config.as_deref())?;
 
             if let Some(value) = try_hybrid_json_rpc_checked(
                 use_daemon,
@@ -13162,7 +13186,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let instance_config = nestweaver_engine::InstanceConfig::from_file(config_path)
                 .with_context(|| format!("failed to load config from {}", config_path.display()))?;
             let instance_id = &instance_config.instance_id;
-            let db_path = db.unwrap_or_else(default_db_path);
+            let db_path = resolve_db_with_config(db, Some(config_path))?;
 
             if cli.no_daemon {
                 eprintln!(
@@ -13275,7 +13299,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // Failing fast here also turns a typo'd/nonexistent path into a clear error
             // instead of a confusing no-op.
             let repo_path = canonical_repo_dir(&repo_path)?;
-            let db_path = resolve_index_db_path(db, &repo_path);
+            let db_path = resolve_index_db_path(db, config.as_deref(), &repo_path)?;
             // Create-operation: a --db in a not-yet-existing directory must
             // not fail with a bare OS error on either the daemon or the
             // direct path — create the parent directories up front.
@@ -17236,7 +17260,7 @@ fn run_brain(
                 eprintln!("Error: --refresh-wiki-hours requires --config");
                 return Ok((EXIT_ERROR, None));
             }
-            let db_path = db.unwrap_or_else(default_db_path);
+            let db_path = resolve_db_with_config(db, config.as_deref())?;
             if !path.exists() || !path.is_dir() {
                 eprintln!("Error: vault path is not a directory: {}", path.display());
                 return Ok((EXIT_ERROR, None));
@@ -19501,6 +19525,83 @@ mod cli_help_contract_tests {
     #[test]
     fn cli_definition_is_internally_consistent() {
         on_big_stack(|| Cli::command().debug_assert());
+    }
+
+    /// Keep the database-binding surface executable. Any new command exposing
+    /// both flags must extend the behavioral config-DB matrix rather than
+    /// silently inheriting an unrelated fallback.
+    #[test]
+    fn config_aware_database_command_inventory_is_explicit() {
+        let paths = on_big_stack(|| {
+            let root = Cli::command();
+            let mut found = Vec::new();
+            let mut queue = vec![(&root, String::new())];
+            while let Some((command, parent)) = queue.pop() {
+                let path = if parent.is_empty() {
+                    command.get_name().to_string()
+                } else {
+                    format!("{parent} {}", command.get_name())
+                };
+                let has_db = command.get_arguments().any(|arg| arg.get_id() == "db");
+                let has_config = command.get_arguments().any(|arg| arg.get_id() == "config");
+                if has_db && has_config {
+                    found.push(path.clone());
+                }
+                queue.extend(command.get_subcommands().map(|child| (child, path.clone())));
+            }
+            found.sort();
+            found
+        });
+
+        let expected = [
+            "nestweaver backup save",
+            "nestweaver blast-radius",
+            "nestweaver brain add",
+            "nestweaver brain broken-links",
+            "nestweaver brain context",
+            "nestweaver brain doc-stats",
+            "nestweaver brain orphans",
+            "nestweaver brain refresh",
+            "nestweaver brain search",
+            "nestweaver brain status",
+            "nestweaver brain tag-graph",
+            "nestweaver brain topic-clusters",
+            "nestweaver brain watch",
+            "nestweaver bridges",
+            "nestweaver clusters",
+            "nestweaver context",
+            "nestweaver count-patterns",
+            "nestweaver flow-trace",
+            "nestweaver generate-guide",
+            "nestweaver hubs",
+            "nestweaver impact",
+            "nestweaver index",
+            "nestweaver list-links",
+            "nestweaver list-projects",
+            "nestweaver list-repos",
+            "nestweaver materialize-projects",
+            "nestweaver mcp",
+            "nestweaver memory consolidate",
+            "nestweaver memory lint",
+            "nestweaver memory related",
+            "nestweaver project-context",
+            "nestweaver ranking explain",
+            "nestweaver ranking rank",
+            "nestweaver read-symbols",
+            "nestweaver regex-search",
+            "nestweaver search",
+            "nestweaver server backup save",
+            "nestweaver snapshot build",
+            "nestweaver suggest-links",
+            "nestweaver ui",
+            "nestweaver watch",
+        ]
+        .map(str::to_string)
+        .to_vec();
+        assert_eq!(
+            paths, expected,
+            "the --db + --config command inventory changed; update the config-DB behavior matrix"
+        );
     }
 }
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -218,6 +218,214 @@ url = "{}"
 }
 
 #[test]
+fn commands_honor_database_declared_by_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("configured.lbug");
+    let store = nestweaver_store::GraphStore::open_or_create(&db_path).unwrap();
+    store
+        .insert_project(&nestweaver_schema::Project {
+            uid: "proj:config-db:configured-project".to_string(),
+            name: "configured-project".to_string(),
+            summary: None,
+            instance_id: "config-db".to_string(),
+        })
+        .unwrap();
+    drop(store);
+
+    let config_path = dir.path().join("instance.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"instance_id = "config-db"
+db = "{}"
+repos = []
+
+[snapshot_storage]
+backend = "local"
+path = "/tmp/nestweaver/config-db/snapshots"
+
+[workspace]
+backend = "local"
+path = "/tmp/nestweaver/config-db/workspace"
+
+[inference]
+endpoint = "http://localhost:11434"
+embedding_model = "nomic-embed-text"
+summary_model = "qwen2.5-coder:7b"
+
+[git]
+credential_method = "gh"
+"#,
+            toml_basic_string(&db_path),
+        ),
+    )
+    .unwrap();
+
+    // Run away from both the configured DB and the repository so the default
+    // `./nestweaver.lbug` cannot accidentally make either assertion pass.
+    let unrelated_cwd = dir.path().join("unrelated-cwd");
+    std::fs::create_dir(&unrelated_cwd).unwrap();
+
+    for args in [
+        &["list-repos", "--json"][..],
+        &["search", "configured-project", "--json"][..],
+        &["regex-search", "configured-project", "--json"][..],
+        &["count-patterns", "configured-project", "--json"][..],
+        &["suggest-links", "--json"][..],
+        &["generate-guide", "--format", "agents-md"][..],
+        &["hubs", "--json"][..],
+        &["bridges", "--json"][..],
+        &["clusters", "--json"][..],
+        &["brain", "status", "--json"][..],
+    ] {
+        nestweaver_cmd()
+            .current_dir(&unrelated_cwd)
+            .env_remove("NESTWEAVER_DB")
+            .args(args)
+            .arg("--config")
+            .arg(&config_path)
+            .assert()
+            .success();
+    }
+
+    for args in [
+        &["context", "definitely-not-present"][..],
+        &["impact", "definitely-not-present"][..],
+        &["read-symbols", "definitely-not-present"][..],
+    ] {
+        nestweaver_cmd()
+            .current_dir(&unrelated_cwd)
+            .env_remove("NESTWEAVER_DB")
+            .args(args)
+            .arg("--config")
+            .arg(&config_path)
+            .assert()
+            .code(2)
+            .stderr(contains("Database not found").not());
+    }
+
+    nestweaver_cmd()
+        .current_dir(&unrelated_cwd)
+        .env_remove("NESTWEAVER_DB")
+        .args(["mcp", "--config"])
+        .arg(&config_path)
+        .write_stdin("")
+        .assert()
+        .success();
+
+    nestweaver_cmd()
+        .current_dir(&unrelated_cwd)
+        .env_remove("NESTWEAVER_DB")
+        .args(["list-projects", "--config"])
+        .arg(&config_path)
+        .arg("--json")
+        .assert()
+        .success()
+        .stdout(contains("configured-project"));
+
+    let env_db_path = dir.path().join("environment.lbug");
+    let env_store = nestweaver_store::GraphStore::open_or_create(&env_db_path).unwrap();
+    env_store
+        .insert_project(&nestweaver_schema::Project {
+            uid: "proj:config-db:environment-project".to_string(),
+            name: "environment-project".to_string(),
+            summary: None,
+            instance_id: "config-db".to_string(),
+        })
+        .unwrap();
+    drop(env_store);
+    let explicit_db_path = dir.path().join("explicit.lbug");
+    let explicit_store = nestweaver_store::GraphStore::open_or_create(&explicit_db_path).unwrap();
+    explicit_store
+        .insert_project(&nestweaver_schema::Project {
+            uid: "proj:config-db:explicit-project".to_string(),
+            name: "explicit-project".to_string(),
+            summary: None,
+            instance_id: "config-db".to_string(),
+        })
+        .unwrap();
+    drop(explicit_store);
+
+    // --db > config.db > NESTWEAVER_DB > fallback.
+    nestweaver_cmd()
+        .current_dir(&unrelated_cwd)
+        .env("NESTWEAVER_DB", &env_db_path)
+        .args(["list-projects", "--config"])
+        .arg(&config_path)
+        .arg("--json")
+        .assert()
+        .success()
+        .stdout(contains("configured-project"))
+        .stdout(contains("environment-project").not());
+    nestweaver_cmd()
+        .current_dir(&unrelated_cwd)
+        .env("NESTWEAVER_DB", &env_db_path)
+        .args(["list-projects", "--db"])
+        .arg(&explicit_db_path)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--json")
+        .assert()
+        .success()
+        .stdout(contains("explicit-project"))
+        .stdout(contains("configured-project").not());
+    nestweaver_cmd()
+        .current_dir(&unrelated_cwd)
+        .env("NESTWEAVER_DB", &env_db_path)
+        .args(["list-projects", "--json"])
+        .assert()
+        .success()
+        .stdout(contains("environment-project"));
+
+    let invalid_config = dir.path().join("invalid.toml");
+    std::fs::write(&invalid_config, "this is not valid = [toml").unwrap();
+    nestweaver_cmd()
+        .current_dir(&unrelated_cwd)
+        .env("NESTWEAVER_DB", &env_db_path)
+        .args(["list-projects", "--config"])
+        .arg(&invalid_config)
+        .arg("--json")
+        .assert()
+        .failure()
+        .stderr(contains("loading --config"));
+
+    nestweaver_cmd()
+        .current_dir(&unrelated_cwd)
+        .env_remove("NESTWEAVER_DB")
+        .args(["project-context", "configured-project", "--config"])
+        .arg(&config_path)
+        .assert()
+        .success()
+        .stdout(contains("has no associated notes or symbols"));
+
+    // Repository-scoped commands have a different final fallback
+    // (`<repo>/nestweaver.lbug`), so cover their shared resolver explicitly.
+    // `index` is finite; code `watch` uses the same resolver before entering
+    // its long-running service loop.
+    let repo = unrelated_cwd.join("configured-repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    std::fs::write(repo.join("main.js"), "export function configuredDb() {}\n").unwrap();
+    nestweaver_cmd()
+        .current_dir(&unrelated_cwd)
+        .env_remove("NESTWEAVER_DB")
+        .args(["index", "--repo"])
+        .arg(&repo)
+        .arg("--config")
+        .arg(&config_path)
+        .assert()
+        .success();
+    assert!(
+        !repo.join("nestweaver.lbug").exists(),
+        "index must not create its repository-local fallback when config.db is set"
+    );
+    let configured = nestweaver_store::GraphStore::open(&db_path).unwrap();
+    assert!(
+        !configured.list_repos(None).unwrap().is_empty(),
+        "the indexed repository must land in config.db"
+    );
+}
+
+#[test]
 fn installation_docs_only_claim_live_channels() {
     let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let mut docs = vec![


### PR DESCRIPTION
## What changed

- honor the database declared by an instance config across config-aware CLI commands
- preserve the existing graph when bulk repository, vault, or project replacement input is invalid or a late project relationship load fails
- replace access-blind watcher debouncing with mutation-event filtering so one file edit settles after one hot batch
- scope daemon writer leases to watcher startup and mutation batches instead of the entire watcher lifetime
- materialize the planned project graph in one guarded operation while preserving prior remote membership on fetch failure

## Why

Release regression testing exposed three user-visible blockers: config-aware commands could silently query the fallback database, idle watchers could monopolize the writer gate and real edits could trigger self-feedback loops, and a late project relationship failure could destroy previously committed memberships.

## Impact

The CLI now consistently targets the configured brain database, idle and settled watchers release the writer gate, and failed graph replacement operations retain the last known-good graph. This restores live vault/code watching without wedging the daemon and makes project materialization failure-safe.

## Root causes

- database resolution was implemented command-by-command and many config-aware paths ignored the config `db` field
- `notify-debouncer-mini` discarded raw event kinds, causing watcher reads to feed access events back into new batches; daemon leases were also held at watcher-session scope
- LadybugDB rollback restores detached project nodes but does not reliably restore their prior relationships after a failing late COPY

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- manual isolated config-routing matrix across CLI, daemon, MCP, UI, backup, snapshot, and indexing paths
- manual isolated vault/code watcher lifecycle and one-edit settling tests
- manual disk-backed project materialization failure/reopen test

