### PR TITLE
feat(index): harden source coverage and trigram refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2821,9 +2821,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4174,6 +4174,7 @@ dependencies = [
  "nestweaver-embed",
  "nestweaver-engine",
  "nestweaver-mcp",
+ "nestweaver-parser",
  "nestweaver-proto",
  "nestweaver-schema",
  "nestweaver-store",
@@ -4424,6 +4425,7 @@ name = "nestweaver-store"
 version = "6.1.1"
 dependencies = [
  "anyhow",
+ "blake3",
  "cc",
  "csv",
  "lbug",

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ The first build compiles LadybugDB from source and may take several minutes.
 | `blast-radius` | Assess blast radius for a set of changed files; reports `gate_state`/`status` and blind spots, and never reports `ok` for a truncated traversal |
 | `flow-trace` | Trace forward execution flow from a symbol — what it calls, and what those call |
 | `read-symbols` | Read a symbol's source span |
-| `regex-search` | Regex search over indexed text (trigram pre-filter; falls back to a full scan with `stale_index: true` when the trigram index is stale — re-run `index --with-trigrams`) |
+| `regex-search` | Regex search over indexed text (scope-aware trigram pre-filter; safely scans only missing or stale scopes with `stale_index: true` — refresh with `index --with-trigrams`) |
 | `count-patterns` | Count regex matches per pattern |
 | `investigate` | Orient on a topic in one call |
 | `investigate-expand` | Drill into investigate bundle entries — full body plus immediate neighbours |

--- a/crates/nestweaver-daemon/Cargo.toml
+++ b/crates/nestweaver-daemon/Cargo.toml
@@ -11,6 +11,7 @@ nestweaver-proto = { workspace = true }
 nestweaver-engine = { workspace = true }
 nestweaver-store = { workspace = true }
 nestweaver-schema = { workspace = true }
+nestweaver-parser = { workspace = true }
 nestweaver-mcp = { workspace = true, features = ["daemon"] }
 nestweaver-web = { workspace = true }
 nestweaver-embed = { workspace = true, optional = true }

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -1063,6 +1063,7 @@ fn index_done_message(
     edges_count: usize,
     repo_path: &std::path::Path,
     cancelled: bool,
+    skipped_count: usize,
 ) -> String {
     if cancelled {
         format!(
@@ -1075,11 +1076,46 @@ fn index_done_message(
             edges_count,
             repo_path.display()
         )
+    } else if skipped_count > 0 {
+        format!(
+            "Done — DEGRADED — {} files, {} symbols, {} edges; {} eligible file(s) skipped",
+            files_count, symbols_count, edges_count, skipped_count
+        )
     } else {
         format!(
             "Done — {} files, {} symbols, {} edges",
             files_count, symbols_count, edges_count
         )
+    }
+}
+
+fn index_skip_details(skipped: &[nestweaver_parser::SkippedFile]) -> Vec<IndexSkipDetail> {
+    skipped
+        .iter()
+        .map(|file| IndexSkipDetail {
+            path: file.path.clone(),
+            reason_code: serde_json::to_value(file.reason_code)
+                .ok()
+                .and_then(|value| value.as_str().map(str::to_owned))
+                .unwrap_or_else(|| "other".to_string()),
+            detail: file.reason.clone(),
+            observed_bytes: file.observed_bytes,
+            limit_bytes: file.limit_bytes,
+        })
+        .collect()
+}
+
+fn trigram_refresh_detail(stats: &nestweaver_store::TrigramRefreshStats) -> TrigramRefreshDetail {
+    TrigramRefreshDetail {
+        scopes_refreshed: stats.scopes_refreshed as u64,
+        scopes_unchanged: stats.scopes_unchanged as u64,
+        nodes_added: stats.nodes_added as u64,
+        nodes_changed: stats.nodes_changed as u64,
+        nodes_deleted: stats.nodes_deleted as u64,
+        postings_added: stats.postings_added as u64,
+        postings_deleted: stats.postings_deleted as u64,
+        migrated_legacy_index: stats.migrated_legacy_index,
+        elapsed_ms: stats.elapsed_ms,
     }
 }
 
@@ -1089,7 +1125,7 @@ mod index_done_message_tests {
 
     #[test]
     fn cancelled_variant_reports_commit_and_names_repair() {
-        let message = index_done_message(12, 340, 1500, std::path::Path::new("/tmp/repo"), true);
+        let message = index_done_message(12, 340, 1500, std::path::Path::new("/tmp/repo"), true, 0);
         assert!(message.contains("COMMITTED"), "{message}");
         assert!(
             message.contains("nestweaver index --repo /tmp/repo --force"),
@@ -1102,8 +1138,17 @@ mod index_done_message_tests {
 
     #[test]
     fn uncancelled_variant_is_the_plain_done_line() {
-        let message = index_done_message(12, 340, 1500, std::path::Path::new("/tmp/repo"), false);
+        let message =
+            index_done_message(12, 340, 1500, std::path::Path::new("/tmp/repo"), false, 0);
         assert_eq!(message, "Done — 12 files, 340 symbols, 1500 edges");
+    }
+
+    #[test]
+    fn skipped_files_make_done_explicitly_degraded() {
+        let message =
+            index_done_message(12, 340, 1500, std::path::Path::new("/tmp/repo"), false, 2);
+        assert!(message.contains("DEGRADED"), "{message}");
+        assert!(message.contains("2 eligible file(s) skipped"), "{message}");
     }
 }
 
@@ -3644,7 +3689,14 @@ impl NestWeaverDaemon for DaemonService {
 
         let db_path = self.state.db_path.clone();
 
-        let mut watcher = nestweaver_engine::CodeWatcher::new(&db_path, &repo_path, &instance_id);
+        let limits = self
+            .state
+            .instance_cfg
+            .as_ref()
+            .map(|config| config.indexing.limits())
+            .unwrap_or_default();
+        let mut watcher = nestweaver_engine::CodeWatcher::new(&db_path, &repo_path, &instance_id)
+            .with_limits(limits);
         let shutdown_handle = watcher.shutdown_handle();
 
         // Refuse BEFORE registering — and here the ordering matters more than in
@@ -3900,13 +3952,19 @@ impl NestWeaverDaemon for DaemonService {
                     let watch_repo = std::path::PathBuf::from(&req.watch_repo_path);
                     let watch_store = state.store.clone();
                     let watch_instance = watch_instance.clone();
+                    let watch_limits = state
+                        .instance_cfg
+                        .as_ref()
+                        .map(|config| config.indexing.limits())
+                        .unwrap_or_default();
 
                     tokio::task::spawn_blocking(move || {
                         let watcher = nestweaver_engine::CodeWatcher::new(
                             &watch_db,
                             &watch_repo,
                             &watch_instance,
-                        );
+                        )
+                        .with_limits(watch_limits);
                         if let Err(e) = watcher.run_with_store(watch_store, None) {
                             tracing::error!("CodeWatcher failed: {e}");
                         }
@@ -3983,10 +4041,16 @@ impl NestWeaverDaemon for DaemonService {
             let watch_db = state.db_path.clone();
             let watch_repo = std::path::PathBuf::from(&req.watch_repo_path);
             let watch_store = state.store.clone();
+            let watch_limits = state
+                .instance_cfg
+                .as_ref()
+                .map(|config| config.indexing.limits())
+                .unwrap_or_default();
 
             tokio::task::spawn_blocking(move || {
                 let watcher =
-                    nestweaver_engine::CodeWatcher::new(&watch_db, &watch_repo, &watch_instance);
+                    nestweaver_engine::CodeWatcher::new(&watch_db, &watch_repo, &watch_instance)
+                        .with_limits(watch_limits);
                 if let Err(e) = watcher.run_with_store(watch_store, None) {
                     tracing::error!("CodeWatcher failed: {e}");
                 }
@@ -4063,6 +4127,7 @@ impl NestWeaverDaemon for DaemonService {
         let state = self.state.clone();
         let force = req.force;
         let with_trigrams = req.with_trigrams;
+        let rebuild_trigrams = req.rebuild_trigrams;
         let with_git_activity = req.with_git_activity;
         let name = if req.name.is_empty() {
             None
@@ -4071,6 +4136,16 @@ impl NestWeaverDaemon for DaemonService {
         };
         let effective_instance =
             resolve_effective_instance_id(&req.instance_id, &state.data_instance_id)?;
+        let index_limits = if req.max_source_file_bytes == 0 {
+            state
+                .instance_cfg
+                .as_ref()
+                .map(|config| config.indexing.limits())
+                .unwrap_or_default()
+        } else {
+            nestweaver_engine::index_limits::IndexLimits::new(req.max_source_file_bytes)
+                .map_err(|error| Status::invalid_argument(error.to_string()))?
+        };
 
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<IndexProgress, Status>>(16);
 
@@ -4178,9 +4253,10 @@ impl NestWeaverDaemon for DaemonService {
                 files_processed: 0,
                 files_total: 0,
                 symbols_found: 0,
+                ..Default::default()
             }));
 
-            match nestweaver_engine::index_directory_with_store_cancellable(
+            match nestweaver_engine::index::index_directory_with_store_cancellable_and_limits(
                 &state.store,
                 &repo_path,
                 &state.db_path,
@@ -4192,8 +4268,16 @@ impl NestWeaverDaemon for DaemonService {
                 force,
                 name.as_deref(),
                 &cancel_for_index,
+                index_limits,
             ) {
                 Ok(result) => {
+                    let skipped_count = result.skipped_files.len();
+                    let skipped_files = index_skip_details(&result.skipped_files);
+                    let coverage_status = if skipped_count == 0 {
+                        CoverageStatus::Complete as i32
+                    } else {
+                        CoverageStatus::Degraded as i32
+                    };
                     let _ = tx.blocking_send(Ok(IndexProgress {
                         phase: Phase::Writing as i32,
                         message: format!(
@@ -4203,6 +4287,10 @@ impl NestWeaverDaemon for DaemonService {
                         files_processed: result.files_count as u64,
                         files_total: result.files_count as u64,
                         symbols_found: result.symbols_count as u64,
+                        skipped_count: skipped_count as u64,
+                        skipped_files: skipped_files.clone(),
+                        coverage_status,
+                        trigram_refresh: None,
                     }));
 
                     // PageRank is deferred to first query (lazy evaluation
@@ -4230,10 +4318,15 @@ impl NestWeaverDaemon for DaemonService {
                                 result.edges_count,
                                 &repo_path,
                                 true,
+                                skipped_count,
                             ),
                             files_processed: result.files_count as u64,
                             files_total: result.files_count as u64,
                             symbols_found: result.symbols_count as u64,
+                            skipped_count: skipped_count as u64,
+                            skipped_files: skipped_files.clone(),
+                            coverage_status,
+                            trigram_refresh: None,
                         }));
                         return;
                     }
@@ -4300,20 +4393,45 @@ impl NestWeaverDaemon for DaemonService {
                     }
 
                     // Trigram index.
+                    let mut trigram_refresh = None;
                     if with_trigrams {
                         let _ = tx.blocking_send(Ok(IndexProgress {
-                            message: "Building trigram index...".to_string(),
+                            message: "Refreshing trigram index...".to_string(),
                             ..Default::default()
                         }));
-                        match state.store.build_trigram_index() {
-                            Ok(postings) => {
-                                tracing::info!(postings, "trigram index built");
+                        let refresh = if rebuild_trigrams {
+                            state.store.rebuild_trigram_index()
+                        } else {
+                            state.store.refresh_trigram_index(false)
+                        };
+                        match refresh {
+                            Ok(stats) => {
+                                tracing::info!(?stats, "trigram index refreshed");
+                                trigram_refresh = Some(trigram_refresh_detail(&stats));
                                 let _ = tx.blocking_send(Ok(IndexProgress {
-                                    message: format!("Trigram index built ({postings} postings)."),
+                                    message: format!(
+                                        "Trigram refresh: {} scope(s) refreshed, {} unchanged; {} node(s) changed; {} posting(s) added, {} deleted in {} ms{}.",
+                                        stats.scopes_refreshed,
+                                        stats.scopes_unchanged,
+                                        stats.nodes_added + stats.nodes_changed + stats.nodes_deleted,
+                                        stats.postings_added,
+                                        stats.postings_deleted,
+                                        stats.elapsed_ms,
+                                        if stats.migrated_legacy_index { "; migrated legacy v1 index" } else { "" },
+                                    ),
                                     ..Default::default()
                                 }));
                             }
-                            Err(e) => tracing::warn!("trigram index build failed: {e}"),
+                            Err(e) => {
+                                let _ = tx.blocking_send(Ok(IndexProgress {
+                                    phase: Phase::Error as i32,
+                                    message: format!(
+                                        "Code index committed, but requested trigram refresh failed: {e}"
+                                    ),
+                                    ..Default::default()
+                                }));
+                                return;
+                            }
                         }
                     }
 
@@ -4329,10 +4447,15 @@ impl NestWeaverDaemon for DaemonService {
                             result.edges_count,
                             &repo_path,
                             cancel_for_index.load(std::sync::atomic::Ordering::Acquire),
+                            skipped_count,
                         ),
                         files_processed: result.files_count as u64,
                         files_total: result.files_count as u64,
                         symbols_found: result.symbols_count as u64,
+                        skipped_count: skipped_count as u64,
+                        skipped_files,
+                        coverage_status,
+                        trigram_refresh,
                     }));
                 }
                 Err(e) => {
@@ -4342,6 +4465,7 @@ impl NestWeaverDaemon for DaemonService {
                         files_processed: 0,
                         files_total: 0,
                         symbols_found: 0,
+                        ..Default::default()
                     }));
                 }
             }
@@ -4384,6 +4508,7 @@ impl NestWeaverDaemon for DaemonService {
                 files_processed: 0,
                 files_total: 0,
                 symbols_found: 0,
+                ..Default::default()
             }));
 
             let index_result =
@@ -4398,6 +4523,13 @@ impl NestWeaverDaemon for DaemonService {
 
             match index_result {
                 Ok(result) => {
+                    let skipped_files = index_skip_details(&result.index.skipped);
+                    let skipped_count = skipped_files.len();
+                    let coverage_status = if skipped_count == 0 {
+                        CoverageStatus::Complete as i32
+                    } else {
+                        CoverageStatus::Degraded as i32
+                    };
                     let _ = tx.blocking_send(Ok(IndexProgress {
                         phase: Phase::Writing as i32,
                         message: format!(
@@ -4409,6 +4541,10 @@ impl NestWeaverDaemon for DaemonService {
                         files_processed: result.index.notes_count as u64,
                         files_total: result.index.notes_count as u64,
                         symbols_found: result.index.headings_count as u64,
+                        skipped_count: skipped_count as u64,
+                        skipped_files: skipped_files.clone(),
+                        coverage_status,
+                        trigram_refresh: None,
                     }));
 
                     // Rebuild Tantivy search index so BM25 search reflects
@@ -4435,6 +4571,10 @@ impl NestWeaverDaemon for DaemonService {
                         files_processed: result.index.notes_count as u64,
                         files_total: result.index.notes_count as u64,
                         symbols_found: result.index.headings_count as u64,
+                        skipped_count: skipped_count as u64,
+                        skipped_files,
+                        coverage_status,
+                        trigram_refresh: None,
                     }));
                 }
                 Err(e) => {
@@ -4444,6 +4584,7 @@ impl NestWeaverDaemon for DaemonService {
                         files_processed: 0,
                         files_total: 0,
                         symbols_found: 0,
+                        ..Default::default()
                     }));
                 }
             }
@@ -4492,6 +4633,7 @@ impl NestWeaverDaemon for DaemonService {
                 files_processed: 0,
                 files_total: 0,
                 symbols_found: 0,
+                ..Default::default()
             }));
 
             match nestweaver_engine::index_markdown_directory_since_with_store_and_ignore(
@@ -4515,6 +4657,7 @@ impl NestWeaverDaemon for DaemonService {
                                 files_processed: result.files_checked as u64,
                                 files_total: result.files_checked as u64,
                                 symbols_found: result.headings_count as u64,
+                                ..Default::default()
                             }));
                         return;
                     }
@@ -4545,6 +4688,7 @@ impl NestWeaverDaemon for DaemonService {
                         files_processed: result.files_checked as u64,
                         files_total: result.files_checked as u64,
                         symbols_found: result.headings_count as u64,
+                        ..Default::default()
                     }));
                 }
                 Err(error) => {
@@ -4554,6 +4698,7 @@ impl NestWeaverDaemon for DaemonService {
                         files_processed: 0,
                         files_total: 0,
                         symbols_found: 0,
+                        ..Default::default()
                     }));
                 }
             }
@@ -4604,6 +4749,7 @@ impl NestWeaverDaemon for DaemonService {
                     files_processed: 0,
                     files_total: project_total,
                     symbols_found: 0,
+                    ..Default::default()
                 }));
                 Ok(lease)
             });
@@ -4618,6 +4764,7 @@ impl NestWeaverDaemon for DaemonService {
                 files_processed: 0,
                 files_total: instance_config.projects.len() as u64,
                 symbols_found: 0,
+                ..Default::default()
             }));
 
             match nestweaver_engine::materialize_projects_with_lease(
@@ -4640,6 +4787,7 @@ impl NestWeaverDaemon for DaemonService {
                         files_processed: result.projects_created as u64,
                         files_total: result.projects_created as u64,
                         symbols_found: result.symbol_edges as u64,
+                        ..Default::default()
                     }));
                 }
                 Err(e) => {
@@ -4649,6 +4797,7 @@ impl NestWeaverDaemon for DaemonService {
                         files_processed: 0,
                         files_total: instance_config.projects.len() as u64,
                         symbols_found: 0,
+                        ..Default::default()
                     }));
                 }
             }
@@ -4906,6 +5055,7 @@ impl NestWeaverDaemon for DaemonService {
                 files_processed: 0,
                 files_total: 0,
                 symbols_found: 0,
+                ..Default::default()
             }));
 
             match run_purge_instance_with(
@@ -4934,6 +5084,7 @@ impl NestWeaverDaemon for DaemonService {
                         files_processed: (result.repos + result.vaults) as u64,
                         files_total: (result.repos + result.vaults) as u64,
                         symbols_found: result.symbols as u64,
+                        ..Default::default()
                     }));
                 }
                 Err(e) => {
@@ -4943,6 +5094,7 @@ impl NestWeaverDaemon for DaemonService {
                         files_processed: 0,
                         files_total: 0,
                         symbols_found: 0,
+                        ..Default::default()
                     }));
                 }
             }
@@ -9801,6 +9953,11 @@ pub async fn run_server(
                 .as_ref()
                 .map(|c| build_repo_types(&c.repos))
                 .unwrap_or_default();
+            let worker_index_limits = state
+                .instance_cfg
+                .as_ref()
+                .map(|config| config.indexing.limits())
+                .unwrap_or_default();
             let worker_job_queue = std::sync::Arc::clone(&shared_job_queue);
             let worker_handle = tokio::spawn(async move {
                 let workspace_dir = worker_db
@@ -9825,7 +9982,8 @@ pub async fn run_server(
                         }
                     };
                 let pool = nestweaver_engine::worker::WorkerPool::new(worker_count)
-                    .with_repo_types(worker_repo_types);
+                    .with_repo_types(worker_repo_types)
+                    .with_index_limits(worker_index_limits);
                 pool.run_with_drain(
                     worker_job_queue,
                     std::sync::Arc::new(workspace),

--- a/crates/nestweaver-engine/src/config.rs
+++ b/crates/nestweaver-engine/src/config.rs
@@ -219,6 +219,10 @@ pub struct InstanceConfig {
     /// Default pagination limits for tool responses (`[limits]`).
     #[serde(default)]
     pub limits: LimitsConfig,
+    /// Source-code indexing policy (`[indexing]`). Kept separate from
+    /// `[server.indexing]`, which controls worker/poll scheduling.
+    #[serde(default)]
+    pub indexing: SourceIndexingConfig,
     /// Server-mode configuration (`[server]`).
     #[serde(default)]
     pub server: ServerConfig,
@@ -244,6 +248,33 @@ pub struct InstanceConfig {
     /// heuristic. See [`PrImpactConfig`].
     #[serde(default)]
     pub pr_impact: Option<PrImpactConfig>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct SourceIndexingConfig {
+    #[serde(default = "default_max_source_file_bytes")]
+    pub max_source_file_bytes: u64,
+}
+
+fn default_max_source_file_bytes() -> u64 {
+    crate::index_limits::DEFAULT_MAX_SOURCE_FILE_BYTES
+}
+
+impl Default for SourceIndexingConfig {
+    fn default() -> Self {
+        Self {
+            max_source_file_bytes: default_max_source_file_bytes(),
+        }
+    }
+}
+
+impl SourceIndexingConfig {
+    pub fn limits(&self) -> crate::index_limits::IndexLimits {
+        // InstanceConfig validates this during construction, so downstream
+        // code never has to handle an invalid value.
+        crate::index_limits::IndexLimits::new(self.max_source_file_bytes)
+            .expect("validated source indexing limit")
+    }
 }
 
 /// Pre-push / CI strict-gate policy (`[pr_impact]`).
@@ -863,6 +894,7 @@ impl InstanceConfig {
         // `sym:repo:<instance>:<hash>:…` uids where a colon is ambiguous for
         // any split-on-colon consumer.
         validate_instance_id(&config.instance_id)?;
+        crate::index_limits::IndexLimits::new(config.indexing.max_source_file_bytes)?;
         // Feature F6: clamp ranking-prior multipliers into bounds on load so
         // downstream code can trust the values without re-validating.
         config.ranking.clamp_multipliers();
@@ -1193,6 +1225,29 @@ url = "https://github.com/example/repo"
         ))
         .expect("[daemon] start_at_login must be an accepted key");
         assert!(opted_in.daemon.start_at_login);
+    }
+
+    #[test]
+    fn source_indexing_limit_defaults_and_validates_bounds() {
+        let default = InstanceConfig::from_toml_str(MINIMAL_TOML).unwrap();
+        assert_eq!(
+            default.indexing.max_source_file_bytes,
+            crate::index_limits::DEFAULT_MAX_SOURCE_FILE_BYTES
+        );
+
+        let configured = InstanceConfig::from_toml_str(&format!(
+            "{MINIMAL_TOML}\n[indexing]\nmax_source_file_bytes = 8388608\n"
+        ))
+        .unwrap();
+        assert_eq!(configured.indexing.max_source_file_bytes, 8 * 1024 * 1024);
+
+        for invalid in [0, 512, crate::index_limits::HARD_MAX_SOURCE_FILE_BYTES + 1] {
+            let error = InstanceConfig::from_toml_str(&format!(
+                "{MINIMAL_TOML}\n[indexing]\nmax_source_file_bytes = {invalid}\n"
+            ))
+            .unwrap_err();
+            assert!(error.to_string().contains("max_source_file_bytes"));
+        }
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/content_reader.rs
+++ b/crates/nestweaver-engine/src/content_reader.rs
@@ -12,7 +12,16 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 
 use crate::git_cmd::{apply_git_isolation, git_net_timeout, run_git_with_timeout};
-use crate::index_md::MAX_FILE_SIZE_BYTES;
+use crate::index_limits::{DEFAULT_MAX_SOURCE_FILE_BYTES, IndexLimits};
+
+/// A source was rejected from metadata/object headers before allocation.
+#[derive(Debug, thiserror::Error)]
+#[error("source {path} is too large ({observed_bytes} bytes exceeds the {limit_bytes}-byte limit)")]
+pub struct SourceTooLarge {
+    pub path: String,
+    pub observed_bytes: u64,
+    pub limit_bytes: u64,
+}
 
 /// Maximum time to wait for a single `git cat-file --batch` response.
 ///
@@ -54,17 +63,31 @@ pub trait ContentReader: Send + Sync {
 
     /// An identifier for the content version (HEAD SHA for git, "local" for filesystem).
     fn version_id(&self) -> &str;
+
+    /// Validated source-code input ceiling for this reader.
+    fn max_source_file_bytes(&self) -> u64 {
+        DEFAULT_MAX_SOURCE_FILE_BYTES
+    }
 }
 
 /// Local filesystem reader — wraps the existing `ignore::WalkBuilder` + `fs::read_to_string`.
 pub struct FilesystemReader {
     repo_path: PathBuf,
+    limits: IndexLimits,
 }
 
 impl FilesystemReader {
     pub fn new(repo_path: &Path) -> Self {
         Self {
             repo_path: repo_path.to_path_buf(),
+            limits: IndexLimits::default(),
+        }
+    }
+
+    pub fn with_limits(repo_path: &Path, limits: IndexLimits) -> Self {
+        Self {
+            repo_path: repo_path.to_path_buf(),
+            limits,
         }
     }
 }
@@ -72,7 +95,35 @@ impl FilesystemReader {
 impl ContentReader for FilesystemReader {
     fn read_file(&self, rel_path: &Path) -> Result<String> {
         let abs = self.repo_path.join(rel_path);
-        std::fs::read_to_string(&abs).map_err(|e| anyhow::anyhow!("read {}: {e}", abs.display()))
+        let observed_bytes = std::fs::metadata(&abs)
+            .map_err(|e| anyhow::anyhow!("stat {}: {e}", abs.display()))?
+            .len();
+        if observed_bytes > self.limits.max_source_file_bytes() {
+            return Err(SourceTooLarge {
+                path: rel_path.display().to_string(),
+                observed_bytes,
+                limit_bytes: self.limits.max_source_file_bytes(),
+            }
+            .into());
+        }
+        // Bound the actual read as well as the metadata preflight so a file
+        // that grows between stat and read cannot force an unbounded allocation.
+        let file = std::fs::File::open(&abs)
+            .map_err(|e| anyhow::anyhow!("open {}: {e}", abs.display()))?;
+        let mut bounded = file.take(self.limits.max_source_file_bytes() + 1);
+        let mut source = String::new();
+        bounded
+            .read_to_string(&mut source)
+            .map_err(|e| anyhow::anyhow!("read {}: {e}", abs.display()))?;
+        if source.len() as u64 > self.limits.max_source_file_bytes() {
+            return Err(SourceTooLarge {
+                path: rel_path.display().to_string(),
+                observed_bytes: observed_bytes.max(source.len() as u64),
+                limit_bytes: self.limits.max_source_file_bytes(),
+            }
+            .into());
+        }
+        Ok(source)
     }
 
     fn list_files(&self) -> Result<Vec<PathBuf>> {
@@ -132,6 +183,10 @@ impl ContentReader for FilesystemReader {
     fn version_id(&self) -> &str {
         "local"
     }
+
+    fn max_source_file_bytes(&self) -> u64 {
+        self.limits.max_source_file_bytes()
+    }
 }
 
 /// One object resolved from the `git cat-file --batch` stream.
@@ -140,10 +195,10 @@ enum BatchObject {
     Found(Vec<u8>),
     /// Git reported `<spec> missing` — no such object/path at this revision.
     Missing,
-    /// The object's git-reported size exceeded [`MAX_FILE_SIZE_BYTES`]. Its bytes
+    /// The object's git-reported size exceeded the reader's source limit. Its bytes
     /// were read-and-discarded (never materialized) to keep the stream framed;
     /// the caller skips the file, mirroring the filesystem oversized-file guard.
-    TooLarge,
+    TooLarge(u64),
 }
 
 /// Read and discard exactly `n` bytes from `r` using a small fixed buffer, so an
@@ -181,7 +236,7 @@ struct CatFileBatch {
 impl CatFileBatch {
     /// Spawn `git -C <bare_path> cat-file --batch` with piped stdin/stdout, plus
     /// a dedicated reader thread that owns stdout and parses framed responses.
-    fn spawn(bare_path: &Path) -> Result<Self> {
+    fn spawn(bare_path: &Path, max_source_file_bytes: u64) -> Result<Self> {
         // The pooled batch process is long-lived with an interactive stdin/stdout
         // protocol, so it can't go through `run_git_with_timeout` (which nulls
         // stdin and drains stdout to EOF). Its read deadline is enforced per
@@ -216,7 +271,7 @@ impl CatFileBatch {
         let (tx, rx) = mpsc::channel();
         let reader = std::thread::Builder::new()
             .name("cat-file-batch-reader".to_string())
-            .spawn(move || read_loop(BufReader::new(stdout), tx))
+            .spawn(move || read_loop(BufReader::new(stdout), tx, max_source_file_bytes))
             .context("failed to spawn cat-file --batch reader thread")?;
 
         Ok(Self {
@@ -274,9 +329,13 @@ impl CatFileBatch {
 /// Reader-thread loop: parse framed `cat-file --batch` responses from `stdout`
 /// and forward each to `tx` in request order. Stops on the first parse/I/O error
 /// (the stream is then desynced or closed) or once the receiver is dropped.
-fn read_loop(mut stdout: BufReader<ChildStdout>, tx: mpsc::Sender<Result<BatchObject>>) {
+fn read_loop(
+    mut stdout: BufReader<ChildStdout>,
+    tx: mpsc::Sender<Result<BatchObject>>,
+    max_source_file_bytes: u64,
+) {
     loop {
-        let result = read_one(&mut stdout);
+        let result = read_one(&mut stdout, max_source_file_bytes);
         let is_err = result.is_err();
         if tx.send(result).is_err() {
             // Receiver gone (the batch was discarded) — nothing left to do.
@@ -291,9 +350,12 @@ fn read_loop(mut stdout: BufReader<ChildStdout>, tx: mpsc::Sender<Result<BatchOb
 
 /// Parse exactly one framed response: `<oid> <type> <size>\n` then `<size>`
 /// content bytes and a trailing newline, or `<spec> missing\n`. Blobs over
-/// [`MAX_FILE_SIZE_BYTES`] are read-and-discarded (not allocated) and reported
+/// `max_source_file_bytes` are read-and-discarded (not allocated) and reported
 /// as [`BatchObject::TooLarge`].
-fn read_one(stdout: &mut BufReader<ChildStdout>) -> Result<BatchObject> {
+fn read_one(
+    stdout: &mut BufReader<ChildStdout>,
+    max_source_file_bytes: u64,
+) -> Result<BatchObject> {
     // Read the header: "<oid> <type> <size>\n" or "<spec> missing\n".
     let mut header = String::new();
     let n = stdout
@@ -319,9 +381,9 @@ fn read_one(stdout: &mut BufReader<ChildStdout>) -> Result<BatchObject> {
     // accident- or attacker-sized blob would be allocated whole via vec![0u8;
     // size]. Discard exactly `size` bytes plus the trailing newline to keep the
     // stream framed, but never materialize the blob.
-    if size as u64 > MAX_FILE_SIZE_BYTES {
+    if size as u64 > max_source_file_bytes {
         discard_exact(stdout, size + 1).context("discard oversized cat-file --batch object")?;
-        return Ok(BatchObject::TooLarge);
+        return Ok(BatchObject::TooLarge(size as u64));
     }
 
     // Read exactly `size` bytes of content, then consume the trailing newline.
@@ -360,6 +422,7 @@ impl Drop for CatFileBatch {
 pub struct GitBareReader {
     bare_path: PathBuf,
     sha: String,
+    limits: IndexLimits,
     /// Lazily-spawned pooled `cat-file --batch` process. `None` until the first
     /// read; reset to `None` if the process dies so the next read re-spawns.
     batch: Mutex<Option<CatFileBatch>>,
@@ -370,12 +433,27 @@ impl GitBareReader {
         Self {
             bare_path: bare_path.to_path_buf(),
             sha: sha.to_string(),
+            limits: IndexLimits::default(),
+            batch: Mutex::new(None),
+        }
+    }
+
+    pub fn with_limits(bare_path: &Path, sha: &str, limits: IndexLimits) -> Self {
+        Self {
+            bare_path: bare_path.to_path_buf(),
+            sha: sha.to_string(),
+            limits,
             batch: Mutex::new(None),
         }
     }
 
     /// Resolve HEAD of the bare repo to a full SHA.
     pub fn from_head(bare_path: &Path) -> Result<Self> {
+        Self::from_head_with_limits(bare_path, IndexLimits::default())
+    }
+
+    /// Resolve HEAD while applying the configured source-file limit.
+    pub fn from_head_with_limits(bare_path: &Path, limits: IndexLimits) -> Result<Self> {
         let mut cmd = Command::new("git");
         cmd.args(["-C", &bare_path.display().to_string(), "rev-parse", "HEAD"]);
         let output = run_git_with_timeout(cmd, git_net_timeout())
@@ -390,7 +468,7 @@ impl GitBareReader {
             .context("non-utf8 SHA")?
             .trim()
             .to_string();
-        Ok(Self::new(bare_path, &sha))
+        Ok(Self::with_limits(bare_path, &sha, limits))
     }
 
     /// One-shot fallback read used when the pooled `cat-file --batch` process is
@@ -410,21 +488,31 @@ impl GitBareReader {
             "-s",
             &spec,
         ]);
-        if let Ok(out) = run_git_with_timeout(size_cmd, git_net_timeout())
-            && out.status.success()
-            && let Ok(size) = String::from_utf8_lossy(&out.stdout).trim().parse::<u64>()
-            && size > MAX_FILE_SIZE_BYTES
-        {
+        let size_output = run_git_with_timeout(size_cmd, git_net_timeout())
+            .with_context(|| format!("failed to preflight object size for {spec}"))?;
+        if !size_output.status.success() {
+            anyhow::bail!(
+                "git cat-file -s {} failed: {}",
+                spec,
+                String::from_utf8_lossy(&size_output.stderr).trim()
+            );
+        }
+        let size = String::from_utf8_lossy(&size_output.stdout)
+            .trim()
+            .parse::<u64>()
+            .with_context(|| format!("invalid git object size for {spec}"))?;
+        if size > self.limits.max_source_file_bytes() {
             tracing::warn!(
                 "skipping oversized blob {} (exceeds {} bytes) via git show",
                 rel_path.display(),
-                MAX_FILE_SIZE_BYTES
+                self.limits.max_source_file_bytes()
             );
-            anyhow::bail!(
-                "blob too large, skipped: {} exceeds {} bytes",
-                rel_path.display(),
-                MAX_FILE_SIZE_BYTES
-            );
+            return Err(SourceTooLarge {
+                path: rel_path.display().to_string(),
+                observed_bytes: size,
+                limit_bytes: self.limits.max_source_file_bytes(),
+            }
+            .into());
         }
         let mut cmd = Command::new("git");
         cmd.args(["-C", &self.bare_path.display().to_string(), "show", &spec]);
@@ -448,7 +536,7 @@ impl ContentReader for GitBareReader {
 
         // Lazily spawn the pooled batch process on the first read.
         if guard.is_none() {
-            match CatFileBatch::spawn(&self.bare_path) {
+            match CatFileBatch::spawn(&self.bare_path, self.limits.max_source_file_bytes()) {
                 Ok(batch) => *guard = Some(batch),
                 Err(err) => {
                     tracing::warn!(
@@ -470,7 +558,7 @@ impl ContentReader for GitBareReader {
                 self.sha,
                 self.bare_path.display()
             ),
-            Ok(BatchObject::TooLarge) => {
+            Ok(BatchObject::TooLarge(observed_bytes)) => {
                 // Mirror the filesystem oversized-file skip: the blob was already
                 // read-and-discarded (never materialized) so the stream stays
                 // framed. Do NOT fall back to `git show` — that would re-read the
@@ -479,13 +567,14 @@ impl ContentReader for GitBareReader {
                 tracing::warn!(
                     "skipping oversized blob {} (exceeds {} bytes)",
                     rel_path.display(),
-                    MAX_FILE_SIZE_BYTES
+                    self.limits.max_source_file_bytes()
                 );
-                anyhow::bail!(
-                    "blob too large, skipped: {} exceeds {} bytes",
-                    rel_path.display(),
-                    MAX_FILE_SIZE_BYTES
-                )
+                Err(SourceTooLarge {
+                    path: rel_path.display().to_string(),
+                    observed_bytes,
+                    limit_bytes: self.limits.max_source_file_bytes(),
+                }
+                .into())
             }
             Err(err) => {
                 // The batch process likely died — discard it (so the next read
@@ -563,6 +652,10 @@ impl ContentReader for GitBareReader {
     fn version_id(&self) -> &str {
         &self.sha
     }
+
+    fn max_source_file_bytes(&self) -> u64 {
+        self.limits.max_source_file_bytes()
+    }
 }
 
 #[cfg(test)]
@@ -584,6 +677,22 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let reader = FilesystemReader::new(dir.path());
         assert!(reader.read_file(Path::new("nope.rs")).is_err());
+    }
+
+    #[test]
+    fn filesystem_reader_enforces_configured_source_limit_boundaries() {
+        let dir = TempDir::new().unwrap();
+        let limit = crate::index_limits::MIN_MAX_SOURCE_FILE_BYTES;
+        std::fs::write(dir.path().join("below.rs"), vec![b'x'; limit as usize - 1]).unwrap();
+        std::fs::write(dir.path().join("at.rs"), vec![b'x'; limit as usize]).unwrap();
+        std::fs::write(dir.path().join("above.rs"), vec![b'x'; limit as usize + 1]).unwrap();
+        let reader = FilesystemReader::with_limits(dir.path(), IndexLimits::new(limit).unwrap());
+        assert!(reader.read_file(Path::new("below.rs")).is_ok());
+        assert!(reader.read_file(Path::new("at.rs")).is_ok());
+        let error = reader.read_file(Path::new("above.rs")).unwrap_err();
+        let oversized = error.downcast_ref::<SourceTooLarge>().unwrap();
+        assert_eq!(oversized.observed_bytes, limit + 1);
+        assert_eq!(oversized.limit_bytes, limit);
     }
 
     #[test]
@@ -1102,13 +1211,14 @@ mod tests {
 
     // ---------- FIX 2: oversized blob cap on bare clones ----------
 
-    /// A blob whose git-reported size exceeds MAX_FILE_SIZE_BYTES must be skipped
+    /// A blob whose git-reported size exceeds the configured source limit must be skipped
     /// without being materialized, and the batch stream must stay framed so later
     /// valid reads through the same reader still succeed.
     #[test]
     fn git_bare_reader_skips_oversized_blob_and_keeps_stream_usable() {
         // Just over the cap; setup_bare_repo borrows &str so build it first.
-        let big = "x".repeat(MAX_FILE_SIZE_BYTES as usize + 1_000);
+        let limit = DEFAULT_MAX_SOURCE_FILE_BYTES;
+        let big = "x".repeat(limit as usize + 1_000);
         let (_tmp, bare, sha) = setup_bare_repo(&[
             ("small.txt", "tiny"),
             ("big.txt", big.as_str()),
@@ -1140,5 +1250,21 @@ mod tests {
             "still here"
         );
         assert_eq!(reader.read_file(Path::new("small.txt")).unwrap(), "tiny");
+    }
+
+    #[test]
+    fn git_show_fallback_enforces_the_same_object_size_limit() {
+        let limit = crate::index_limits::MIN_MAX_SOURCE_FILE_BYTES;
+        let big = "x".repeat(limit as usize + 1);
+        let (_tmp, bare, sha) = setup_bare_repo(&[("big.rs", big.as_str())]);
+        let reader = GitBareReader::with_limits(
+            &bare,
+            &sha,
+            IndexLimits::new(limit).expect("test limit is valid"),
+        );
+        let error = reader.read_file_via_show(Path::new("big.rs")).unwrap_err();
+        let oversized = error.downcast_ref::<SourceTooLarge>().unwrap();
+        assert_eq!(oversized.observed_bytes, limit + 1);
+        assert_eq!(oversized.limit_bytes, limit);
     }
 }

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -6,7 +6,8 @@ use std::time::Instant;
 use anyhow::Context;
 use indicatif::{ProgressBar, ProgressStyle};
 use nestweaver_parser::{
-    AstTypeBinding, RawReference, RawSymbol, SkippedFile, detect_language, parse_source,
+    AstTypeBinding, RawReference, RawSymbol, SkipReasonCode, SkippedFile, detect_language,
+    parse_source,
 };
 use nestweaver_resolver::{discover_workspace_context_with, resolve_references_with_context};
 use nestweaver_schema::{
@@ -24,6 +25,7 @@ type ContractDerivationInputs = (
     Vec<PathBuf>,
     Vec<HandlerFileData>,
     Vec<nestweaver_schema::Symbol>,
+    Vec<SkippedFile>,
 );
 pub(crate) type PreparedFileData = HashMap<String, (Vec<RawSymbol>, Vec<RawReference>)>;
 
@@ -1678,6 +1680,19 @@ fn tiered_change_check(
     cache: &FileMetaCache,
 ) -> Result<ChangeVerdict, anyhow::Error> {
     let rel = Path::new(rel_path);
+    let enforce_actual_size = |source: String| -> Result<String, anyhow::Error> {
+        let observed_bytes = source.len() as u64;
+        let limit_bytes = reader.max_source_file_bytes();
+        if observed_bytes > limit_bytes {
+            return Err(crate::content_reader::SourceTooLarge {
+                path: rel_path.to_string(),
+                observed_bytes,
+                limit_bytes,
+            }
+            .into());
+        }
+        Ok(source)
+    };
 
     // file_meta returns None for bare-repo readers (no mtime available).
     // In that case, always fall through to read + hash.
@@ -1687,9 +1702,11 @@ fn tiered_change_check(
             // No filesystem metadata (e.g. GitBareReader) — read and hash. The
             // bare-clone reader enforces the size cap inside its own read_file
             // (oversized blobs return Err), so a huge file is skipped there.
-            let source = reader
-                .read_file(rel)
-                .with_context(|| format!("read {rel_path}"))?;
+            let source = enforce_actual_size(
+                reader
+                    .read_file(rel)
+                    .with_context(|| format!("read {rel_path}"))?,
+            )?;
             let content_hash = content_hash_hex(&source);
             if let Some(cached) = cache.get(rel_path)
                 && content_hash == cached.content_hash
@@ -1714,11 +1731,14 @@ fn tiered_change_check(
     // generated bundle that minified-detection misses) was read whole and handed
     // to tree-sitter, exhausting memory. `size_bytes` is already in hand from
     // file_meta, so the guard is free; the caller turns this Err into a skip.
-    if size_bytes > crate::index_md::MAX_FILE_SIZE_BYTES {
-        anyhow::bail!(
-            "file exceeds size limit ({size_bytes} > {} bytes), skipping",
-            crate::index_md::MAX_FILE_SIZE_BYTES
-        );
+    let max_source_file_bytes = reader.max_source_file_bytes();
+    if size_bytes > max_source_file_bytes {
+        return Err(crate::content_reader::SourceTooLarge {
+            path: rel_path.to_string(),
+            observed_bytes: size_bytes,
+            limit_bytes: max_source_file_bytes,
+        }
+        .into());
     }
 
     if let Some(cached) = cache.get(rel_path) {
@@ -1731,9 +1751,11 @@ fn tiered_change_check(
         // Same-size edits are common, so we cannot skip based on size alone.
 
         // Tier 3: mtime differs → read file, compute hash, compare.
-        let source = reader
-            .read_file(rel)
-            .with_context(|| format!("read {rel_path}"))?;
+        let source = enforce_actual_size(
+            reader
+                .read_file(rel)
+                .with_context(|| format!("read {rel_path}"))?,
+        )?;
         let content_hash = content_hash_hex(&source);
         if content_hash == cached.content_hash {
             // Content identical despite mtime/size change — unchanged for the
@@ -1752,9 +1774,11 @@ fn tiered_change_check(
         })
     } else {
         // No cache entry → file is new, read and hash it.
-        let source = reader
-            .read_file(rel)
-            .with_context(|| format!("read {rel_path}"))?;
+        let source = enforce_actual_size(
+            reader
+                .read_file(rel)
+                .with_context(|| format!("read {rel_path}"))?,
+        )?;
         let content_hash = content_hash_hex(&source);
         Ok(ChangeVerdict::Changed {
             meta: CachedFileMeta {
@@ -1845,11 +1869,35 @@ pub fn index_directory_with_options(
     force: bool,
     name: Option<&str>,
 ) -> Result<IndexResult, anyhow::Error> {
+    index_directory_with_options_and_limits(
+        repo_path,
+        db_path,
+        instance_id,
+        repo_url,
+        indexed_sha,
+        force,
+        name,
+        crate::index_limits::IndexLimits::default(),
+    )
+}
+
+/// Index a directory with an explicit validated source-input ceiling.
+#[allow(clippy::too_many_arguments)]
+pub fn index_directory_with_options_and_limits(
+    repo_path: &Path,
+    db_path: &Path,
+    instance_id: &str,
+    repo_url: &str,
+    indexed_sha: &str,
+    force: bool,
+    name: Option<&str>,
+    limits: crate::index_limits::IndexLimits,
+) -> Result<IndexResult, anyhow::Error> {
     // nw-C1: reconcile an abandoned publication before indexing. A crashed
     // predecessor's `.index-dirty` otherwise wedges every ranked query, and the
     // fail-closed `u64::MAX` generation base can block this run's own preflight.
     let store = open_store_for_writing_with_recovery(db_path)?;
-    index_directory_with_store(
+    index_directory_with_store_and_limits(
         &store,
         repo_path,
         db_path,
@@ -1858,6 +1906,7 @@ pub fn index_directory_with_options(
         indexed_sha,
         force,
         name,
+        limits,
     )
 }
 
@@ -1875,6 +1924,31 @@ pub fn index_directory_with_store(
     force: bool,
     name: Option<&str>,
 ) -> Result<IndexResult, anyhow::Error> {
+    index_directory_with_store_and_limits(
+        store,
+        repo_path,
+        db_path,
+        instance_id,
+        repo_url,
+        indexed_sha,
+        force,
+        name,
+        crate::index_limits::IndexLimits::default(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn index_directory_with_store_and_limits(
+    store: &GraphStore,
+    repo_path: &Path,
+    db_path: &Path,
+    instance_id: &str,
+    repo_url: &str,
+    indexed_sha: &str,
+    force: bool,
+    name: Option<&str>,
+    limits: crate::index_limits::IndexLimits,
+) -> Result<IndexResult, anyhow::Error> {
     index_directory_with_store_inner(
         store,
         repo_path,
@@ -1884,6 +1958,7 @@ pub fn index_directory_with_store(
         indexed_sha,
         force,
         name,
+        limits,
         None,
     )
 }
@@ -1906,6 +1981,33 @@ pub fn index_directory_with_store_cancellable(
     name: Option<&str>,
     cancel: &std::sync::Arc<std::sync::atomic::AtomicBool>,
 ) -> Result<IndexResult, anyhow::Error> {
+    index_directory_with_store_cancellable_and_limits(
+        store,
+        repo_path,
+        db_path,
+        instance_id,
+        repo_url,
+        indexed_sha,
+        force,
+        name,
+        cancel,
+        crate::index_limits::IndexLimits::default(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn index_directory_with_store_cancellable_and_limits(
+    store: &GraphStore,
+    repo_path: &Path,
+    db_path: &Path,
+    instance_id: &str,
+    repo_url: &str,
+    indexed_sha: &str,
+    force: bool,
+    name: Option<&str>,
+    cancel: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    limits: crate::index_limits::IndexLimits,
+) -> Result<IndexResult, anyhow::Error> {
     index_directory_with_store_inner(
         store,
         repo_path,
@@ -1915,6 +2017,7 @@ pub fn index_directory_with_store_cancellable(
         indexed_sha,
         force,
         name,
+        limits,
         Some(cancel),
     )
 }
@@ -1929,6 +2032,7 @@ fn index_directory_with_store_inner(
     indexed_sha: &str,
     force: bool,
     name: Option<&str>,
+    limits: crate::index_limits::IndexLimits,
     cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
 ) -> Result<IndexResult, anyhow::Error> {
     let filemeta_path = crate::sidecar_path(db_path, ".filemeta.json");
@@ -1942,7 +2046,7 @@ fn index_directory_with_store_inner(
     let resolution_deps_path = crate::sidecar_path(db_path, ".resolution_deps.bin");
     let mut resolution_deps = crate::resolution_cache::ResolutionDeps::load(&resolution_deps_path);
 
-    let reader = crate::content_reader::FilesystemReader::new(repo_path);
+    let reader = crate::content_reader::FilesystemReader::with_limits(repo_path, limits);
     // Local filesystem index: the working tree location is `repo_path`.
     // Persisted as `root_path` on the Repo node so consumers never derive
     // a disk path from the identity `url`.
@@ -2438,6 +2542,7 @@ where
     scan_pb.set_message("Scanning files...");
 
     let mut file_entries: Vec<(PathBuf, Language)> = Vec::new();
+    let mut scan_skipped_files: Vec<SkippedFile> = Vec::new();
     // F2.1: spec files (OpenAPI/Swagger/proto/GraphQL) collected separately —
     // most have no detected source language so they fall outside `file_entries`.
     let mut spec_files: Vec<PathBuf> = Vec::new();
@@ -2463,6 +2568,11 @@ where
 
         // Skip minified/bundled files — they produce noise in the graph.
         if is_minified_or_bundled(&path) {
+            scan_skipped_files.push(SkippedFile::new(
+                rel_path.to_string_lossy().into_owned(),
+                SkipReasonCode::Ignored,
+                "minified or generated bundle policy",
+            ));
             continue;
         }
 
@@ -2505,6 +2615,10 @@ where
             rel_path: String,
         },
         Skipped(SkippedFile),
+        /// Transient I/O/parser failure. The full publication must abort;
+        /// treating this as a policy skip could replace a complete incumbent
+        /// graph with an incomplete one.
+        Failed(String),
         Parsed {
             rel_path: String,
             lang: Language,
@@ -2560,10 +2674,11 @@ where
         // `index --force` as the repair.
         if cancel.is_some_and(|c| c.load(std::sync::atomic::Ordering::Relaxed)) {
             parse_pb.inc(1);
-            return ParseOutcome::Skipped(SkippedFile {
-                path: display_name,
-                reason: "index cancelled".to_string(),
-            });
+            return ParseOutcome::Skipped(SkippedFile::new(
+                display_name,
+                SkipReasonCode::Cancelled,
+                "index cancelled",
+            ));
         }
 
         // Tiered change detection.
@@ -2596,10 +2711,16 @@ where
                 }) => (source, content_hash, meta),
                 Err(err) => {
                     parse_pb.inc(1);
-                    return ParseOutcome::Skipped(SkippedFile {
-                        path: path.to_string_lossy().into_owned(),
-                        reason: format!("stat/read error: {err}"),
-                    });
+                    if let Some(oversized) =
+                        err.downcast_ref::<crate::content_reader::SourceTooLarge>()
+                    {
+                        return ParseOutcome::Skipped(SkippedFile::oversized(
+                            display_name,
+                            oversized.observed_bytes,
+                            oversized.limit_bytes,
+                        ));
+                    }
+                    return ParseOutcome::Failed(format!("stat/read {}: {err}", path.display()));
                 }
             };
 
@@ -2636,10 +2757,7 @@ where
             }
             Err(err) => {
                 parse_pb.inc(1);
-                ParseOutcome::Skipped(SkippedFile {
-                    path: path.to_string_lossy().into_owned(),
-                    reason: err.to_string(),
-                })
+                ParseOutcome::Failed(format!("parse {}: {err}", path.display()))
             }
         }
     };
@@ -2666,6 +2784,12 @@ where
     if cancel.is_some_and(|c| c.load(std::sync::atomic::Ordering::Acquire)) {
         anyhow::bail!("index cancelled");
     }
+    if let Some(error) = outcomes.iter().find_map(|outcome| match outcome {
+        ParseOutcome::Failed(error) => Some(error),
+        _ => None,
+    }) {
+        anyhow::bail!("source indexing failed before publication: {error}");
+    }
 
     // ── Sequential collection of parallel results ────────────────────────
     let _phase_collect_span = tracing::info_span!("index_phase_collect").entered();
@@ -2685,7 +2809,7 @@ where
     let mut files_deleted = 0usize;
     let mut symbols_deleted = 0usize;
     let mut symbols_count = 0usize;
-    let mut skipped_files: Vec<SkippedFile> = Vec::new();
+    let mut skipped_files: Vec<SkippedFile> = scan_skipped_files;
     let mut actually_changed_files: std::collections::HashSet<String> =
         std::collections::HashSet::new();
     // Every file still present in the working tree this index, regardless of
@@ -2733,6 +2857,7 @@ where
             ParseOutcome::Skipped(sf) => {
                 skipped_files.push(sf);
             }
+            ParseOutcome::Failed(_) => unreachable!("failures are rejected before collection"),
             ParseOutcome::Parsed {
                 rel_path,
                 lang,
@@ -2950,6 +3075,14 @@ where
             return Err(error).context("prepare strict contract derivation");
         }
     };
+    skipped_files.extend(contract_plan.skipped_files.iter().cloned());
+    skipped_files.sort_by(|left, right| {
+        left.path
+            .cmp(&right.path)
+            .then_with(|| left.reason_code.cmp(&right.reason_code))
+    });
+    skipped_files
+        .dedup_by(|left, right| left.path == right.path && left.reason_code == right.reason_code);
 
     // Last cancellation observation point. Bailing in this window needs no
     // teardown: the marker call below is what creates `.index-dirty` and
@@ -3867,6 +4000,7 @@ fn collect_contract_derivation_inputs(
     let mut spec_files = Vec::new();
     let mut handler_files = Vec::new();
     let mut all_symbols = Vec::new();
+    let mut skipped_files = Vec::new();
     let repo_path = reader.root();
     let discovered_files = reader
         .list_files()
@@ -3910,13 +4044,39 @@ fn collect_contract_derivation_inputs(
         if reader
             .file_meta(&rel_path)
             .context("read contract input metadata")?
-            .is_some_and(|(_, size)| size > crate::index_md::MAX_FILE_SIZE_BYTES)
+            .is_some_and(|(_, size)| size > reader.max_source_file_bytes())
         {
             tracing::debug!(path = %rel_path.display(), "skip oversized contract input before read");
+            let observed_bytes = reader
+                .file_meta(&rel_path)
+                .ok()
+                .flatten()
+                .map(|(_, size)| size)
+                .unwrap_or(reader.max_source_file_bytes() + 1);
+            skipped_files.push(SkippedFile::oversized(
+                rel_path.to_string_lossy().into_owned(),
+                observed_bytes,
+                reader.max_source_file_bytes(),
+            ));
             continue;
         }
         let source = match reader.read_file(&rel_path) {
             Ok(source) => source,
+            Err(error)
+                if error
+                    .downcast_ref::<crate::content_reader::SourceTooLarge>()
+                    .is_some() =>
+            {
+                let oversized = error
+                    .downcast_ref::<crate::content_reader::SourceTooLarge>()
+                    .expect("guarded above");
+                skipped_files.push(SkippedFile::oversized(
+                    rel_path.to_string_lossy().into_owned(),
+                    oversized.observed_bytes,
+                    oversized.limit_bytes,
+                ));
+                continue;
+            }
             Err(error) if strict => {
                 return Err(error).with_context(|| {
                     format!("read contract handler candidate {}", rel_path.display())
@@ -3927,8 +4087,13 @@ fn collect_contract_derivation_inputs(
                 continue;
             }
         };
-        if source.len() as u64 > crate::index_md::MAX_FILE_SIZE_BYTES {
+        if source.len() as u64 > reader.max_source_file_bytes() {
             tracing::debug!(path = %rel_path.display(), "skip oversized contract input");
+            skipped_files.push(SkippedFile::oversized(
+                rel_path.to_string_lossy().into_owned(),
+                source.len() as u64,
+                reader.max_source_file_bytes(),
+            ));
             continue;
         }
         let controller_candidate = match lang {
@@ -4052,7 +4217,7 @@ fn collect_contract_derivation_inputs(
 
     spec_files.sort();
     handler_files.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
-    Ok((spec_files, handler_files, all_symbols))
+    Ok((spec_files, handler_files, all_symbols, skipped_files))
 }
 
 fn prepare_incremental_contract_derivation(
@@ -4060,16 +4225,18 @@ fn prepare_incremental_contract_derivation(
     r_uid: &str,
     repo_url: &str,
 ) -> Result<ContractDerivationPlan, anyhow::Error> {
-    let (spec_files, handler_files, all_symbols) =
+    let (spec_files, handler_files, all_symbols, skipped_files) =
         collect_contract_derivation_inputs(reader, r_uid, repo_url, true)?;
-    prepare_contract_derivation(
+    let mut plan = prepare_contract_derivation(
         reader,
         r_uid,
         &spec_files,
         &handler_files,
         &all_symbols,
         true,
-    )
+    )?;
+    plan.skipped_files.extend(skipped_files);
+    Ok(plan)
 }
 
 pub(crate) fn prepare_watcher_contract_derivation(
@@ -4107,14 +4274,14 @@ pub(crate) fn watcher_contract_input_snapshot(
         if reader
             .file_meta(&rel_path)
             .with_context(|| format!("read watcher contract metadata {}", rel_path.display()))?
-            .is_some_and(|(_, size)| size > crate::index_md::MAX_FILE_SIZE_BYTES)
+            .is_some_and(|(_, size)| size > reader.max_source_file_bytes())
         {
             continue;
         }
         let source = reader
             .read_file(&rel_path)
             .with_context(|| format!("read watcher contract input {}", rel_path.display()))?;
-        if source.len() as u64 > crate::index_md::MAX_FILE_SIZE_BYTES {
+        if source.len() as u64 > reader.max_source_file_bytes() {
             continue;
         }
         let candidate = if is_spec {
@@ -4154,7 +4321,7 @@ where
     let before = watcher_contract_input_snapshot(reader)?;
     before_plan();
     let observed = watcher_contract_input_snapshot(reader)?;
-    let (spec_files, handler_files, all_symbols) =
+    let (spec_files, handler_files, all_symbols, skipped_files) =
         collect_contract_derivation_inputs(reader, r_uid, repo_url, true)?;
     let mut plan = prepare_contract_derivation(
         reader,
@@ -4164,6 +4331,7 @@ where
         &all_symbols,
         true,
     )?;
+    plan.skipped_files.extend(skipped_files);
     after_plan();
     let after = watcher_contract_input_snapshot(reader)?;
     let plan_reads_match_observed = plan
@@ -4212,6 +4380,7 @@ pub(crate) struct ContractDerivationPlan {
     edges: Vec<nestweaver_schema::ResolvedEdge>,
     pub(crate) input_hashes: std::collections::BTreeMap<String, String>,
     pub(crate) observed_input_hashes: std::collections::BTreeMap<String, String>,
+    pub(crate) skipped_files: Vec<SkippedFile>,
 }
 
 /// Prepare contract rows and implementation edges without mutating the graph.
@@ -4229,6 +4398,7 @@ fn prepare_contract_derivation(
     // 1. Declared contracts from specs.
     let mut all_contracts = ContractSet::new();
     let mut input_hashes = std::collections::BTreeMap::new();
+    let mut skipped_files = Vec::new();
     // (contract_uid, "<package>.<Service>/<Rpc>") for every declared gRPC method.
     let mut declared_grpc: Vec<(String, String)> = Vec::new();
     let repo_path = reader.root();
@@ -4240,6 +4410,21 @@ fn prepare_contract_derivation(
             .into_owned();
         let source = match reader.read_file(Path::new(&rel)) {
             Ok(s) => s,
+            Err(error)
+                if error
+                    .downcast_ref::<crate::content_reader::SourceTooLarge>()
+                    .is_some() =>
+            {
+                let oversized = error
+                    .downcast_ref::<crate::content_reader::SourceTooLarge>()
+                    .expect("guarded above");
+                skipped_files.push(SkippedFile::oversized(
+                    rel,
+                    oversized.observed_bytes,
+                    oversized.limit_bytes,
+                ));
+                continue;
+            }
             Err(error) if strict => {
                 return Err(error).with_context(|| format!("read watched contract spec {rel}"));
             }
@@ -4248,6 +4433,14 @@ fn prepare_contract_derivation(
                 continue;
             }
         };
+        if source.len() as u64 > reader.max_source_file_bytes() {
+            skipped_files.push(SkippedFile::oversized(
+                rel,
+                source.len() as u64,
+                reader.max_source_file_bytes(),
+            ));
+            continue;
+        }
         let parsed_specs = if strict {
             input_hashes.insert(rel.clone(), crate::hash::blake3_hex(&source));
             crate::contracts::parse_spec_file_strict(&rel, &source)
@@ -4410,6 +4603,7 @@ fn prepare_contract_derivation(
         edges,
         input_hashes,
         observed_input_hashes: std::collections::BTreeMap::new(),
+        skipped_files,
     })
 }
 
@@ -4520,9 +4714,36 @@ pub struct IncrementalResult {
     pub files_deleted: usize,
     pub files_renamed: usize,
     pub files_skipped: usize,
+    pub skipped_files: Vec<SkippedFile>,
     pub symbols_added: usize,
     pub symbols_removed: usize,
     pub fell_back_to_full: bool,
+}
+
+enum IncrementalFileOutcome {
+    Indexed(usize),
+    PolicySkipped(SkippedFile),
+}
+
+fn record_incremental_file_outcome(
+    result: &mut IncrementalResult,
+    outcome: IncrementalFileOutcome,
+) -> bool {
+    match outcome {
+        IncrementalFileOutcome::Indexed(symbols) => {
+            result.symbols_added += symbols;
+            true
+        }
+        IncrementalFileOutcome::PolicySkipped(skipped) => {
+            if !result.skipped_files.iter().any(|existing| {
+                existing.path == skipped.path && existing.reason_code == skipped.reason_code
+            }) {
+                result.files_skipped += 1;
+                result.skipped_files.push(skipped);
+            }
+            false
+        }
+    }
 }
 
 /// Incrementally re-index a repository using git diff.
@@ -4553,12 +4774,31 @@ pub fn incremental_index_with_name(
     repo_url: &str,
     name: Option<&str>,
 ) -> Result<IncrementalResult, anyhow::Error> {
+    incremental_index_with_name_and_limits(
+        repo_path,
+        db_path,
+        instance_id,
+        repo_url,
+        name,
+        crate::index_limits::IndexLimits::default(),
+    )
+}
+
+pub fn incremental_index_with_name_and_limits(
+    repo_path: &Path,
+    db_path: &Path,
+    instance_id: &str,
+    repo_url: &str,
+    name: Option<&str>,
+    limits: crate::index_limits::IndexLimits,
+) -> Result<IncrementalResult, anyhow::Error> {
     incremental_index_with_name_and_io(
         repo_path,
         db_path,
         instance_id,
         repo_url,
         name,
+        limits,
         &FileSystemIndexEpilogueIo,
     )
 }
@@ -4569,6 +4809,7 @@ fn incremental_index_with_name_and_io(
     instance_id: &str,
     repo_url: &str,
     name: Option<&str>,
+    limits: crate::index_limits::IndexLimits,
     epilogue_io: &dyn IndexEpilogueIo,
 ) -> Result<IncrementalResult, anyhow::Error> {
     // nw-C1: reconcile BEFORE the `old_sha == new_sha` short-circuit below,
@@ -4598,6 +4839,7 @@ fn incremental_index_with_name_and_io(
                     new_sha: "local",
                     name,
                     force: false,
+                    limits,
                     epilogue_io,
                 },
             );
@@ -4618,6 +4860,7 @@ fn incremental_index_with_name_and_io(
                     new_sha: &new_sha,
                     name,
                     force: false,
+                    limits,
                     epilogue_io,
                 },
             );
@@ -4653,6 +4896,7 @@ fn incremental_index_with_name_and_io(
                 // Force the core path so bulk_reindex_write deletes the old
                 // graph and installs its replacement in one transaction.
                 force: true,
+                limits,
                 epilogue_io,
             },
         );
@@ -4677,6 +4921,7 @@ fn incremental_index_with_name_and_io(
                 // Force the core path so bulk_reindex_write deletes the old
                 // graph and installs its replacement in one transaction.
                 force: true,
+                limits,
                 epilogue_io,
             },
         );
@@ -4699,7 +4944,7 @@ fn incremental_index_with_name_and_io(
         "processing incremental changes"
     );
 
-    let reader = crate::content_reader::FilesystemReader::new(repo_path);
+    let reader = crate::content_reader::FilesystemReader::with_limits(repo_path, limits);
     let mut result = IncrementalResult::default();
 
     // nw-008 Phase 0 — transitive reverse-dependents from the LIVE graph, BEFORE
@@ -4717,6 +4962,12 @@ fn incremental_index_with_name_and_io(
             return Err(error).context("prepare incremental contract derivation");
         }
     };
+    result
+        .skipped_files
+        .extend(contract_plan.skipped_files.iter().cloned());
+    result.files_skipped += contract_plan.skipped_files.len();
+    let prepared_files =
+        prepare_incremental_files(&reader, &changes).context("prepare incremental source files")?;
 
     let publication = establish_index_publication_marker_with_io(
         &store,
@@ -4737,33 +4988,61 @@ fn incremental_index_with_name_and_io(
         match change {
             crate::git_diff::FileChange::Added(rel_path) => {
                 if path_in_skip_dir(rel_path) || !is_parseable(rel_path) {
-                    result.files_skipped += 1;
                     continue;
                 }
-                let added = process_added_or_modified_file_txn(
-                    &reader, rel_path, &r_uid, repo_url, &store, &txn,
-                )?;
-                result.symbols_added += added;
-                result.files_added += 1;
+                match prepared_files
+                    .get(rel_path.to_string_lossy().as_ref())
+                    .expect("parseable added file was prepared")
+                {
+                    PreparedIncrementalOutcome::Ready(prepared) => {
+                        let outcome = write_prepared_incremental_file_txn(
+                            &reader, prepared, &r_uid, repo_url, &store, &txn,
+                        )?;
+                        if record_incremental_file_outcome(&mut result, outcome) {
+                            result.files_added += 1;
+                        }
+                    }
+                    PreparedIncrementalOutcome::PolicySkipped(skipped) => {
+                        record_incremental_file_outcome(
+                            &mut result,
+                            IncrementalFileOutcome::PolicySkipped(skipped.clone()),
+                        );
+                    }
+                }
             }
             crate::git_diff::FileChange::Modified(rel_path) => {
                 if path_in_skip_dir(rel_path) || !is_parseable(rel_path) {
-                    result.files_skipped += 1;
                     continue;
                 }
-                // Remove old symbols first.
+                let prepared = prepared_files
+                    .get(rel_path.to_string_lossy().as_ref())
+                    .expect("parseable modified file was prepared");
+                // A policy exclusion intentionally removes stale incumbent
+                // coverage. Transient failures never reach this transaction.
                 let rel_str = rel_path.to_string_lossy();
                 let removed =
                     nestweaver_store::GraphStore::delete_symbols_in_file_on(&txn, &r_uid, &rel_str)
                         .with_context(|| format!("delete_symbols_in_file {}", rel_str))?;
                 result.symbols_removed += removed;
-
-                // Re-parse and insert.
-                let added = process_added_or_modified_file_txn(
-                    &reader, rel_path, &r_uid, repo_url, &store, &txn,
-                )?;
-                result.symbols_added += added;
-                result.files_modified += 1;
+                match prepared {
+                    PreparedIncrementalOutcome::Ready(prepared) => {
+                        let outcome = write_prepared_incremental_file_txn(
+                            &reader, prepared, &r_uid, repo_url, &store, &txn,
+                        )?;
+                        if record_incremental_file_outcome(&mut result, outcome) {
+                            result.files_modified += 1;
+                        }
+                    }
+                    PreparedIncrementalOutcome::PolicySkipped(skipped) => {
+                        let file_uid = nestweaver_schema::file_uid(&r_uid, &rel_str);
+                        nestweaver_store::GraphStore::delete_file_node_on(&txn, &file_uid)
+                            .with_context(|| format!("delete policy-skipped file {rel_str}"))?;
+                        record_incremental_file_outcome(
+                            &mut result,
+                            IncrementalFileOutcome::PolicySkipped(skipped.clone()),
+                        );
+                    }
+                }
             }
             crate::git_diff::FileChange::Deleted(rel_path) => {
                 let rel_str = rel_path.to_string_lossy();
@@ -4811,10 +5090,23 @@ fn incremental_index_with_name_and_io(
                     .with_context(|| "delete_symbols_in_file (rename to)")?;
                     result.symbols_removed += removed2;
 
-                    let added = process_added_or_modified_file_txn(
-                        &reader, to, &r_uid, repo_url, &store, &txn,
-                    )?;
-                    result.symbols_added += added;
+                    match prepared_files
+                        .get(to_str.as_ref())
+                        .expect("parseable renamed file was prepared")
+                    {
+                        PreparedIncrementalOutcome::Ready(prepared) => {
+                            let outcome = write_prepared_incremental_file_txn(
+                                &reader, prepared, &r_uid, repo_url, &store, &txn,
+                            )?;
+                            record_incremental_file_outcome(&mut result, outcome);
+                        }
+                        PreparedIncrementalOutcome::PolicySkipped(skipped) => {
+                            record_incremental_file_outcome(
+                                &mut result,
+                                IncrementalFileOutcome::PolicySkipped(skipped.clone()),
+                            );
+                        }
+                    }
                 }
 
                 result.files_renamed += 1;
@@ -4919,6 +5211,8 @@ where
     let (changed_files, removed_files) = partition_changed_removed(&changes);
     let rdeps = collect_reverse_dep_files(store, &r_uid, &changed_files, &removed_files);
     let contract_plan_result = prepare_incremental_contract_derivation(reader, &r_uid, repo_url);
+    let prepared_files = prepare_incremental_files(reader, &changes)
+        .context("prepare server incremental source files")?;
 
     let _write_guard = acquire_write_guard()?;
     let contract_plan = match contract_plan_result {
@@ -4942,36 +5236,69 @@ where
         .begin_transaction()
         .with_context(|| "begin incremental transaction")?;
     let mut result = IncrementalResult::default();
+    result
+        .skipped_files
+        .extend(contract_plan.skipped_files.iter().cloned());
+    result.files_skipped += contract_plan.skipped_files.len();
 
     for change in &changes {
         match change {
             crate::git_diff::FileChange::Added(rel_path) => {
                 if path_in_skip_dir(rel_path) || !is_parseable(rel_path) {
-                    result.files_skipped += 1;
                     continue;
                 }
-                let added = process_added_or_modified_file_txn(
-                    reader, rel_path, &r_uid, repo_url, store, &txn,
-                )?;
-                result.symbols_added += added;
-                result.files_added += 1;
+                match prepared_files
+                    .get(rel_path.to_string_lossy().as_ref())
+                    .expect("parseable added file was prepared")
+                {
+                    PreparedIncrementalOutcome::Ready(prepared) => {
+                        let outcome = write_prepared_incremental_file_txn(
+                            reader, prepared, &r_uid, repo_url, store, &txn,
+                        )?;
+                        if record_incremental_file_outcome(&mut result, outcome) {
+                            result.files_added += 1;
+                        }
+                    }
+                    PreparedIncrementalOutcome::PolicySkipped(skipped) => {
+                        record_incremental_file_outcome(
+                            &mut result,
+                            IncrementalFileOutcome::PolicySkipped(skipped.clone()),
+                        );
+                    }
+                }
             }
             crate::git_diff::FileChange::Modified(rel_path) => {
                 if path_in_skip_dir(rel_path) || !is_parseable(rel_path) {
-                    result.files_skipped += 1;
                     continue;
                 }
+                let prepared = prepared_files
+                    .get(rel_path.to_string_lossy().as_ref())
+                    .expect("parseable modified file was prepared");
                 let rel_str = rel_path.to_string_lossy();
                 let removed =
                     nestweaver_store::GraphStore::delete_symbols_in_file_on(&txn, &r_uid, &rel_str)
                         .with_context(|| format!("delete_symbols_in_file {}", rel_str))?;
                 result.symbols_removed += removed;
 
-                let added = process_added_or_modified_file_txn(
-                    reader, rel_path, &r_uid, repo_url, store, &txn,
-                )?;
-                result.symbols_added += added;
-                result.files_modified += 1;
+                match prepared {
+                    PreparedIncrementalOutcome::Ready(prepared) => {
+                        let outcome = write_prepared_incremental_file_txn(
+                            reader, prepared, &r_uid, repo_url, store, &txn,
+                        )?;
+                        if record_incremental_file_outcome(&mut result, outcome) {
+                            result.files_modified += 1;
+                        }
+                    }
+                    PreparedIncrementalOutcome::PolicySkipped(skipped) => {
+                        let file_uid = nestweaver_schema::file_uid(&r_uid, &rel_str);
+                        nestweaver_store::GraphStore::delete_file_node_on(&txn, &file_uid)
+                            .with_context(|| format!("delete policy-skipped file {rel_str}"))?;
+                        record_incremental_file_outcome(
+                            &mut result,
+                            IncrementalFileOutcome::PolicySkipped(skipped.clone()),
+                        );
+                    }
+                }
             }
             crate::git_diff::FileChange::Deleted(rel_path) => {
                 let rel_str = rel_path.to_string_lossy();
@@ -5015,10 +5342,23 @@ where
                     .with_context(|| "delete_symbols_in_file (rename to)")?;
                     result.symbols_removed += removed2;
 
-                    let added = process_added_or_modified_file_txn(
-                        reader, to, &r_uid, repo_url, store, &txn,
-                    )?;
-                    result.symbols_added += added;
+                    match prepared_files
+                        .get(to_str.as_ref())
+                        .expect("parseable renamed file was prepared")
+                    {
+                        PreparedIncrementalOutcome::Ready(prepared) => {
+                            let outcome = write_prepared_incremental_file_txn(
+                                reader, prepared, &r_uid, repo_url, store, &txn,
+                            )?;
+                            record_incremental_file_outcome(&mut result, outcome);
+                        }
+                        PreparedIncrementalOutcome::PolicySkipped(skipped) => {
+                            record_incremental_file_outcome(
+                                &mut result,
+                                IncrementalFileOutcome::PolicySkipped(skipped.clone()),
+                            );
+                        }
+                    }
                 }
 
                 result.files_renamed += 1;
@@ -5068,41 +5408,114 @@ where
     Ok(result)
 }
 
-/// Like [`process_added_or_modified_file`] but uses an externally-provided
-/// transaction connection for all store writes, ensuring atomicity.
-fn process_added_or_modified_file_txn(
+struct PreparedIncrementalFile {
+    abs_path: std::path::PathBuf,
+    rel_str: String,
+    source: String,
+    parsed: nestweaver_parser::ParsedFile,
+}
+
+enum PreparedIncrementalOutcome {
+    Ready(PreparedIncrementalFile),
+    PolicySkipped(SkippedFile),
+}
+
+/// Read and parse before opening the write transaction. This ordering is the
+/// rollback guarantee: a transient read/parser failure cannot occur after an
+/// incumbent file's nodes or relationships have been detached.
+fn prepare_incremental_file(
     reader: &dyn crate::content_reader::ContentReader,
     rel_path: &std::path::Path,
+) -> Result<PreparedIncrementalOutcome, anyhow::Error> {
+    let abs_path = reader.root().join(rel_path);
+    let rel_str = rel_path.to_string_lossy().into_owned();
+
+    if is_minified_or_bundled(&abs_path) {
+        return Ok(PreparedIncrementalOutcome::PolicySkipped(SkippedFile::new(
+            rel_str,
+            SkipReasonCode::Ignored,
+            "minified or generated bundle policy",
+        )));
+    }
+
+    if let Some((_, observed_bytes)) = reader
+        .file_meta(rel_path)
+        .with_context(|| format!("stat {}", abs_path.display()))?
+        && observed_bytes > reader.max_source_file_bytes()
+    {
+        return Ok(PreparedIncrementalOutcome::PolicySkipped(
+            SkippedFile::oversized(rel_str, observed_bytes, reader.max_source_file_bytes()),
+        ));
+    }
+    let source = match reader.read_file(rel_path) {
+        Ok(source) => source,
+        Err(error) => {
+            if let Some(oversized) = error.downcast_ref::<crate::content_reader::SourceTooLarge>() {
+                return Ok(PreparedIncrementalOutcome::PolicySkipped(
+                    SkippedFile::oversized(
+                        rel_str,
+                        oversized.observed_bytes,
+                        oversized.limit_bytes,
+                    ),
+                ));
+            }
+            return Err(error).with_context(|| format!("read {}", abs_path.display()));
+        }
+    };
+    let parsed = nestweaver_parser::parse_source(&abs_path, &source)
+        .with_context(|| format!("parse {}", abs_path.display()))?;
+    Ok(PreparedIncrementalOutcome::Ready(PreparedIncrementalFile {
+        abs_path,
+        rel_str,
+        source,
+        parsed,
+    }))
+}
+
+fn prepare_incremental_files(
+    reader: &dyn crate::content_reader::ContentReader,
+    changes: &[crate::git_diff::FileChange],
+) -> Result<HashMap<String, PreparedIncrementalOutcome>, anyhow::Error> {
+    let mut prepared = HashMap::new();
+    for change in changes {
+        let path = match change {
+            crate::git_diff::FileChange::Added(path)
+            | crate::git_diff::FileChange::Modified(path) => Some(path),
+            crate::git_diff::FileChange::Renamed { to, .. } => Some(to),
+            crate::git_diff::FileChange::Deleted(_) => None,
+        };
+        let Some(path) = path else { continue };
+        if path_in_skip_dir(path) || !is_parseable(path) {
+            continue;
+        }
+        prepared.insert(
+            path.to_string_lossy().into_owned(),
+            prepare_incremental_file(reader, path)?,
+        );
+    }
+    Ok(prepared)
+}
+
+/// Write one already-read and parsed file through the shared transaction.
+fn write_prepared_incremental_file_txn(
+    reader: &dyn crate::content_reader::ContentReader,
+    prepared: &PreparedIncrementalFile,
     r_uid: &str,
     repo_url: &str,
     _store: &nestweaver_store::GraphStore,
     conn: &nestweaver_store::DbConnection<'_>,
-) -> Result<usize, anyhow::Error> {
+) -> Result<IncrementalFileOutcome, anyhow::Error> {
     use nestweaver_parser::{RawReference, RawSymbol};
     use nestweaver_resolver::{discover_workspace_context_with, resolve_references_with_context};
     use nestweaver_schema::{File, Symbol, canonical_symbol_id, file_uid, symbol_uid};
 
-    let abs_path = reader.root().join(rel_path);
-    let rel_str = rel_path.to_string_lossy().into_owned();
+    let abs_path = &prepared.abs_path;
+    let rel_str = &prepared.rel_str;
+    let source = &prepared.source;
+    let parsed = &prepared.parsed;
 
-    let source = match reader.read_file(rel_path) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!(path = %abs_path.display(), "read error: {e}; skipping");
-            return Ok(0);
-        }
-    };
-
-    let parsed = match nestweaver_parser::parse_source(&abs_path, &source) {
-        Ok(p) => p,
-        Err(e) => {
-            tracing::warn!(path = %abs_path.display(), "parse error: {e}; skipping");
-            return Ok(0);
-        }
-    };
-
-    let content_hash = content_hash_hex(&source);
-    let f_uid = file_uid(r_uid, &rel_str);
+    let content_hash = content_hash_hex(source);
+    let f_uid = file_uid(r_uid, rel_str);
 
     // Insert the File node via the transaction connection.
     let file = File {
@@ -5120,9 +5533,9 @@ fn process_added_or_modified_file_txn(
     let mut file_sym_pairs: Vec<(String, String)> = Vec::new();
 
     for raw_sym in &parsed.symbols {
-        let s_uid = symbol_uid(r_uid, &rel_str, &raw_sym.name, raw_sym.start_line);
+        let s_uid = symbol_uid(r_uid, rel_str, &raw_sym.name, raw_sym.start_line);
         let scope_str = raw_sym.scope_chain.as_deref().unwrap_or("");
-        let canonical = canonical_symbol_id(repo_url, &rel_str, &raw_sym.name, scope_str);
+        let canonical = canonical_symbol_id(repo_url, rel_str, &raw_sym.name, scope_str);
         let sym = Symbol {
             uid: s_uid.clone(),
             name: raw_sym.name.clone(),
@@ -5160,7 +5573,7 @@ fn process_added_or_modified_file_txn(
         .with_context(|| format!("batch_insert_file_symbol_edges {}", rel_str))?;
 
     // Resolve cross-file edges within this file only (single-file scope).
-    let lang = nestweaver_parser::detect_language(&abs_path)
+    let lang = nestweaver_parser::detect_language(abs_path)
         .unwrap_or(nestweaver_schema::Language::JavaScript);
 
     let workspace_ctx = if matches!(
@@ -5196,7 +5609,7 @@ fn process_added_or_modified_file_txn(
             .with_context(|| format!("batch_insert_edges {}", rel_str))?;
     }
 
-    Ok(sym_count)
+    Ok(IncrementalFileOutcome::Indexed(sym_count))
 }
 
 /// Split a set of file changes into the parseable files that still exist after
@@ -5627,6 +6040,7 @@ struct FullIndexFallback<'a> {
     new_sha: &'a str,
     name: Option<&'a str>,
     force: bool,
+    limits: crate::index_limits::IndexLimits,
     epilogue_io: &'a dyn IndexEpilogueIo,
 }
 
@@ -5642,6 +6056,7 @@ fn full_index_fallback(
         new_sha,
         name,
         force,
+        limits,
         epilogue_io,
     } = request;
     // Load filemeta sidecar for tiered change detection even in fallback.
@@ -5663,7 +6078,7 @@ fn full_index_fallback(
     let resolution_deps_path = crate::sidecar_path(db_path, ".resolution_deps.bin");
     let mut resolution_deps = crate::resolution_cache::ResolutionDeps::load(&resolution_deps_path);
 
-    let reader = crate::content_reader::FilesystemReader::new(repo_path);
+    let reader = crate::content_reader::FilesystemReader::with_limits(repo_path, limits);
     let local_root = repo_path.display().to_string();
     // nw-022: capture a re-identified legacy file:// uid so its filemeta
     // slice is dropped below, mirroring index_directory_with_store_inner.
@@ -5729,6 +6144,9 @@ fn full_index_fallback(
     // surviving nodes' ranks even though files_count is zero.
     Ok(IncrementalResult {
         fell_back_to_full: true,
+        files_added: result.files_count,
+        files_skipped: result.skipped_files.len(),
+        skipped_files: result.skipped_files,
         symbols_added: result.symbols_count,
         files_deleted: result.files_deleted,
         symbols_removed: result.symbols_deleted,
@@ -5752,6 +6170,113 @@ mod tests {
     /// works; these tests hold it fixed so shape versioning is not the variable
     /// under test.
     const RESPONSE_SHAPE_FIXTURE: u64 = 0xE1691E;
+
+    #[test]
+    fn default_source_limit_indexes_nestweaver_sized_rust_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(repo.join("src")).unwrap();
+        let mut source = String::from("pub fn large_file_marker() -> usize { 42 }\n");
+        source.push_str(&"// representative source padding\n".repeat(40_000));
+        assert!(source.len() > 1_048_576 && source.len() < 2_097_152);
+        fs::write(repo.join("src/main.rs"), source).unwrap();
+        let db = dir.path().join("graph.lbug");
+        let result = index_directory_with_options_and_limits(
+            &repo,
+            &db,
+            "test",
+            "https://example.test/large-rust",
+            "fixture",
+            true,
+            None,
+            crate::index_limits::IndexLimits::default(),
+        )
+        .unwrap();
+        assert!(
+            result.skipped_files.is_empty(),
+            "{:?}",
+            result.skipped_files
+        );
+        assert!(result.symbols_count >= 1);
+        let store = GraphStore::open_or_create(&db).unwrap();
+        assert!(
+            store
+                .list_all_symbols()
+                .unwrap()
+                .iter()
+                .any(|symbol| symbol.name == "large_file_marker")
+        );
+    }
+
+    #[test]
+    fn sparse_generated_file_is_policy_skipped_by_metadata_preflight() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        let file = fs::File::create(repo.join("bundle.js")).unwrap();
+        file.set_len(200 * 1024 * 1024).unwrap();
+        let db = dir.path().join("graph.lbug");
+        let result = index_directory_with_options_and_limits(
+            &repo,
+            &db,
+            "test",
+            "https://example.test/sparse",
+            "fixture",
+            true,
+            None,
+            crate::index_limits::IndexLimits::default(),
+        )
+        .unwrap();
+        assert_eq!(result.skipped_files.len(), 1);
+        assert_eq!(
+            result.skipped_files[0].reason_code,
+            nestweaver_parser::SkipReasonCode::Oversized
+        );
+        assert_eq!(
+            result.skipped_files[0].observed_bytes,
+            Some(200 * 1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn metadata_free_reader_cannot_bypass_the_actual_source_size_limit() {
+        struct MetadataFreeReader {
+            root: PathBuf,
+        }
+        impl crate::content_reader::ContentReader for MetadataFreeReader {
+            fn read_file(&self, _rel_path: &Path) -> anyhow::Result<String> {
+                Ok("x".repeat(1025))
+            }
+            fn list_files(&self) -> anyhow::Result<Vec<PathBuf>> {
+                Ok(vec![PathBuf::from("large.rs")])
+            }
+            fn file_meta(&self, _rel_path: &Path) -> anyhow::Result<Option<(u64, u64)>> {
+                Ok(None)
+            }
+            fn root(&self) -> &Path {
+                &self.root
+            }
+            fn version_id(&self) -> &str {
+                "metadata-free"
+            }
+            fn max_source_file_bytes(&self) -> u64 {
+                1024
+            }
+        }
+
+        let reader = MetadataFreeReader {
+            root: PathBuf::from("/unused"),
+        };
+        let error = match tiered_change_check(&reader, "large.rs", &FileMetaCache::new()) {
+            Err(error) => error,
+            Ok(_) => panic!("metadata-free oversized content must be rejected"),
+        };
+        let oversized = error
+            .downcast_ref::<crate::content_reader::SourceTooLarge>()
+            .expect("actual returned content must be bounded even without metadata");
+        assert_eq!(oversized.observed_bytes, 1025);
+        assert_eq!(oversized.limit_bytes, 1024);
+    }
 
     fn owned_contract_uid(repo_uid: &str, bare_shape: &str) -> String {
         format!(
@@ -7346,6 +7871,7 @@ function hello(name) { return "Hello " + name; }
             edges: Vec::new(),
             input_hashes: std::collections::BTreeMap::new(),
             observed_input_hashes: std::collections::BTreeMap::new(),
+            skipped_files: Vec::new(),
         };
         let transaction = store.begin_transaction().unwrap();
         apply_contract_derivation_on(&transaction, repo_a, &plan).unwrap();
@@ -7374,7 +7900,10 @@ function hello(name) { return "Hello " + name; }
                 Ok(vec![PathBuf::from("HugeController.java")])
             }
             fn file_meta(&self, _rel_path: &Path) -> anyhow::Result<Option<(u64, u64)>> {
-                Ok(Some((0, crate::index_md::MAX_FILE_SIZE_BYTES + 1)))
+                Ok(Some((
+                    0,
+                    crate::index_limits::DEFAULT_MAX_SOURCE_FILE_BYTES + 1,
+                )))
             }
             fn root(&self) -> &Path {
                 &self.root
@@ -7387,7 +7916,7 @@ function hello(name) { return "Hello " + name; }
         let reader = OversizeReader {
             root: PathBuf::from("/unused"),
         };
-        let (specs, handlers, symbols) = collect_contract_derivation_inputs(
+        let (specs, handlers, symbols, skipped) = collect_contract_derivation_inputs(
             &reader,
             "repo:test:oversize",
             "https://example.com/oversize",
@@ -7397,6 +7926,7 @@ function hello(name) { return "Hello " + name; }
         assert!(specs.is_empty());
         assert!(handlers.is_empty());
         assert!(symbols.is_empty());
+        assert_eq!(skipped.len(), 1);
     }
 
     #[test]
@@ -7425,7 +7955,7 @@ function hello(name) { return "Hello " + name; }
         let reader = IrrelevantReader {
             root: PathBuf::from("/unused"),
         };
-        let (specs, handlers, symbols) = collect_contract_derivation_inputs(
+        let (specs, handlers, symbols, skipped) = collect_contract_derivation_inputs(
             &reader,
             "repo:test:irrelevant",
             "https://example.com/irrelevant",
@@ -7435,6 +7965,7 @@ function hello(name) { return "Hello " + name; }
         assert!(specs.is_empty());
         assert!(handlers.is_empty());
         assert!(symbols.is_empty());
+        assert!(skipped.is_empty());
     }
 
     #[test]
@@ -7942,6 +8473,7 @@ function hello(name) { return "Hello " + name; }
             edges: Vec::new(),
             input_hashes: std::collections::BTreeMap::new(),
             observed_input_hashes: std::collections::BTreeMap::new(),
+            skipped_files: Vec::new(),
         };
         let transaction = store.begin_transaction().unwrap();
         let err = apply_contract_derivation_on(&transaction, &repo_uid, &invalid_plan)
@@ -10704,6 +11236,170 @@ function hello(name) { return "Hello " + name; }
         );
     }
 
+    #[test]
+    fn incremental_policy_skip_removes_stale_symbols_and_reports_degraded() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        let db_path = dir.path().join("test.lbug");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(repo.join("main.rs"), "pub fn incumbent() {}\n").unwrap();
+        let git = |args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .unwrap();
+            assert!(output.status.success(), "git {args:?} failed");
+            String::from_utf8(output.stdout).unwrap().trim().to_string()
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "NestWeaver Test"]);
+        git(&["add", "main.rs"]);
+        git(&["commit", "-q", "-m", "initial"]);
+        let old_sha = git(&["rev-parse", "HEAD"]);
+        let repo_url = "https://example.com/policy-crossing";
+        index_directory(&repo, &db_path, "test", repo_url, &old_sha).unwrap();
+
+        let oversized = format!("pub fn replacement() {{}}\n{}", "// pad\n".repeat(200));
+        assert!(oversized.len() > crate::index_limits::MIN_MAX_SOURCE_FILE_BYTES as usize);
+        fs::write(repo.join("main.rs"), oversized).unwrap();
+        git(&["add", "main.rs"]);
+        git(&["commit", "-q", "-m", "grow"]);
+        let new_sha = git(&["rev-parse", "HEAD"]);
+
+        let result = incremental_index_with_name_and_limits(
+            &repo,
+            &db_path,
+            "test",
+            repo_url,
+            None,
+            crate::index_limits::IndexLimits::new(crate::index_limits::MIN_MAX_SOURCE_FILE_BYTES)
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(result.skipped_files.len(), 1);
+        assert_eq!(
+            result.skipped_files[0].reason_code,
+            SkipReasonCode::Oversized
+        );
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        assert!(store.symbols_in_file("main.rs").unwrap().is_empty());
+        let r_uid = nestweaver_schema::repo_uid("test", repo_url);
+        assert_eq!(
+            store.lookup_repo(&r_uid).unwrap().unwrap().indexed_sha,
+            new_sha
+        );
+    }
+
+    #[test]
+    fn incremental_unsupported_file_change_is_not_degraded_coverage() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        let db_path = dir.path().join("test.lbug");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(repo.join("main.rs"), "pub fn covered() {}\n").unwrap();
+        fs::write(repo.join("README.md"), "first\n").unwrap();
+        let git = |args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .unwrap();
+            assert!(output.status.success(), "git {args:?} failed");
+            String::from_utf8(output.stdout).unwrap().trim().to_string()
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "NestWeaver Test"]);
+        git(&["add", "."]);
+        git(&["commit", "-q", "-m", "initial"]);
+        let old_sha = git(&["rev-parse", "HEAD"]);
+        let repo_url = "https://example.com/unsupported-change";
+        index_directory(&repo, &db_path, "test", repo_url, &old_sha).unwrap();
+
+        fs::write(repo.join("README.md"), "second\n").unwrap();
+        git(&["add", "README.md"]);
+        git(&["commit", "-q", "-m", "docs"]);
+        let result = incremental_index_with_name_and_limits(
+            &repo,
+            &db_path,
+            "test",
+            repo_url,
+            None,
+            crate::index_limits::IndexLimits::default(),
+        )
+        .unwrap();
+        assert!(result.skipped_files.is_empty());
+        assert_eq!(result.files_skipped, 0);
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        assert!(
+            store
+                .symbols_in_file("main.rs")
+                .unwrap()
+                .iter()
+                .any(|symbol| symbol.name == "covered")
+        );
+    }
+
+    #[test]
+    fn incremental_transient_read_failure_preserves_graph_and_sha() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        let db_path = dir.path().join("test.lbug");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(repo.join("main.rs"), "pub fn incumbent() {}\n").unwrap();
+        let git = |args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .unwrap();
+            assert!(output.status.success(), "git {args:?} failed");
+            String::from_utf8(output.stdout).unwrap().trim().to_string()
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "NestWeaver Test"]);
+        git(&["add", "main.rs"]);
+        git(&["commit", "-q", "-m", "initial"]);
+        let old_sha = git(&["rev-parse", "HEAD"]);
+        let repo_url = "https://example.com/transient-read";
+        index_directory(&repo, &db_path, "test", repo_url, &old_sha).unwrap();
+
+        fs::write(repo.join("main.rs"), [0xff, 0xfe, 0xfd]).unwrap();
+        git(&["add", "main.rs"]);
+        git(&["commit", "-q", "-m", "invalid-utf8"]);
+        let error = incremental_index_with_name_and_limits(
+            &repo,
+            &db_path,
+            "test",
+            repo_url,
+            None,
+            crate::index_limits::IndexLimits::default(),
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("prepare incremental source files")
+        );
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        assert!(
+            store
+                .symbols_in_file("main.rs")
+                .unwrap()
+                .iter()
+                .any(|symbol| symbol.name == "incumbent")
+        );
+        let r_uid = nestweaver_schema::repo_uid("test", repo_url);
+        assert_eq!(
+            store.lookup_repo(&r_uid).unwrap().unwrap().indexed_sha,
+            old_sha
+        );
+    }
+
     /// An empty indexed_sha (Repo row created but SHA never committed) must
     /// explicitly take the full-index path rather than relying on
     /// `is_ancestor("")` returning false downstream.
@@ -10805,6 +11501,7 @@ function hello(name) { return "Hello " + name; }
             "test",
             repo_url,
             None,
+            crate::index_limits::IndexLimits::default(),
             &InjectedIndexEpilogueIo {
                 fail_generation: true,
                 fail_compute: true,
@@ -10875,6 +11572,7 @@ function hello(name) { return "Hello " + name; }
             "test",
             repo_url,
             None,
+            crate::index_limits::IndexLimits::default(),
             &InjectedIndexEpilogueIo {
                 fail_generation: true,
                 fail_compute: true,

--- a/crates/nestweaver-engine/src/index_limits.rs
+++ b/crates/nestweaver-engine/src/index_limits.rs
@@ -1,0 +1,63 @@
+//! Bounded input policy for source-code indexing.
+//!
+//! Markdown notes intentionally keep their independent 1 MiB policy in
+//! `index_md`; source inputs use this configurable parser-safety ceiling.
+
+/// Default maximum source file size: 2 MiB.
+pub const DEFAULT_MAX_SOURCE_FILE_BYTES: u64 = 2 * 1024 * 1024;
+
+/// Smallest accepted configured source limit: 1 KiB.
+pub const MIN_MAX_SOURCE_FILE_BYTES: u64 = 1024;
+
+/// Non-configurable safety ceiling: 64 MiB.
+pub const HARD_MAX_SOURCE_FILE_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Validated source-indexing limits shared by every reader/indexing path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexLimits {
+    max_source_file_bytes: u64,
+}
+
+impl IndexLimits {
+    pub fn new(max_source_file_bytes: u64) -> Result<Self, anyhow::Error> {
+        if max_source_file_bytes < MIN_MAX_SOURCE_FILE_BYTES {
+            anyhow::bail!(
+                "[indexing].max_source_file_bytes must be at least {MIN_MAX_SOURCE_FILE_BYTES} bytes (got {max_source_file_bytes})"
+            );
+        }
+        if max_source_file_bytes > HARD_MAX_SOURCE_FILE_BYTES {
+            anyhow::bail!(
+                "[indexing].max_source_file_bytes must not exceed the hard ceiling of {HARD_MAX_SOURCE_FILE_BYTES} bytes (got {max_source_file_bytes})"
+            );
+        }
+        Ok(Self {
+            max_source_file_bytes,
+        })
+    }
+
+    pub const fn max_source_file_bytes(self) -> u64 {
+        self.max_source_file_bytes
+    }
+}
+
+impl Default for IndexLimits {
+    fn default() -> Self {
+        Self {
+            max_source_file_bytes: DEFAULT_MAX_SOURCE_FILE_BYTES,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_limit_bounds_are_rejected_not_clamped() {
+        assert!(IndexLimits::new(0).is_err());
+        assert!(IndexLimits::new(MIN_MAX_SOURCE_FILE_BYTES - 1).is_err());
+        assert!(IndexLimits::new(MIN_MAX_SOURCE_FILE_BYTES).is_ok());
+        assert!(IndexLimits::new(HARD_MAX_SOURCE_FILE_BYTES).is_ok());
+        assert!(IndexLimits::new(HARD_MAX_SOURCE_FILE_BYTES + 1).is_err());
+    }
+}

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -14,7 +14,8 @@ use anyhow::Context;
 use globset::GlobSet;
 use indicatif::{ProgressBar, ProgressStyle};
 use nestweaver_parser::{
-    ParsedNote, RawTag, RawWikilink, SkippedFile, TagSource, is_markdown, parse_markdown,
+    ParsedNote, RawTag, RawWikilink, SkipReasonCode, SkippedFile, TagSource, is_markdown,
+    parse_markdown,
 };
 use nestweaver_schema::{
     EdgeType, Heading, Note, Repo, ResolvedEdge, Section, Tag, Vault, heading_uid, note_uid,
@@ -47,7 +48,7 @@ pub struct MarkdownRefreshResult {
 
 /// Canonical full-refresh summary shared by direct CLI and daemon progress.
 pub fn format_markdown_refresh_summary(result: &MarkdownRefreshResult) -> String {
-    format!(
+    let mut summary = format!(
         "Refreshed vault '{}': dropped {} stale note(s), reindexed {} note(s), \
          {} heading(s), {} section(s), {} tag(s), {} wikilink(s) ({} unresolved).",
         result.index.vault_name,
@@ -58,7 +59,14 @@ pub fn format_markdown_refresh_summary(result: &MarkdownRefreshResult) -> String
         result.index.tags_count,
         result.index.wikilinks_resolved,
         result.index.wikilinks_unresolved,
-    )
+    );
+    if !result.index.skipped.is_empty() {
+        summary.push_str(&format!(
+            " Coverage DEGRADED: {} note file(s) skipped.",
+            result.index.skipped.len()
+        ));
+    }
+    summary
 }
 
 /// Directory names skipped when walking a vault. Includes `.obsidian` (config),
@@ -97,7 +105,12 @@ fn path_has_vault_skip_dir(rel_path: &Path) -> bool {
 /// logged warning. Architecture doc §9.7 specifies 1 MB; multi-MB markdown
 /// is almost always machine-generated (pasted logs, exported data dumps)
 /// and parsing them takes seconds while tanking ranking quality.
-pub(crate) const MAX_FILE_SIZE_BYTES: u64 = 1024 * 1024; // 1 MB
+pub(crate) const MAX_NOTE_SIZE_BYTES: u64 = 1024 * 1024; // 1 MiB
+
+fn note_reader_limits() -> crate::index_limits::IndexLimits {
+    crate::index_limits::IndexLimits::new(MAX_NOTE_SIZE_BYTES)
+        .expect("note size policy is within source-reader safety bounds")
+}
 
 /// Index a markdown vault into a persistent `GraphStore` at `db_path`.
 ///
@@ -187,7 +200,8 @@ pub fn index_markdown_directory_with_store_and_deletion_count(
     extra_ignore_patterns: &[String],
 ) -> Result<MarkdownRefreshResult, anyhow::Error> {
     let canonical = std::fs::canonicalize(vault_root).unwrap_or_else(|_| vault_root.to_path_buf());
-    let reader = crate::content_reader::FilesystemReader::new(&canonical);
+    let reader =
+        crate::content_reader::FilesystemReader::with_limits(&canonical, note_reader_limits());
     let ignore_set = crate::brainignore::load_brain_ignore(&canonical, extra_ignore_patterns);
     let result = index_into_store(&reader, store, instance_id, vault_name, &ignore_set)?;
 
@@ -235,7 +249,8 @@ pub fn index_markdown_directory_in_memory(
 ) -> Result<(MarkdownIndexResult, GraphStore), anyhow::Error> {
     let store = GraphStore::in_memory().context("create in-memory GraphStore")?;
     let canonical = std::fs::canonicalize(vault_root).unwrap_or_else(|_| vault_root.to_path_buf());
-    let reader = crate::content_reader::FilesystemReader::new(&canonical);
+    let reader =
+        crate::content_reader::FilesystemReader::with_limits(&canonical, note_reader_limits());
     let ignore_set = crate::brainignore::load_brain_ignore(&canonical, &[]);
     let result = index_into_store(&reader, &store, instance_id, vault_name, &ignore_set)?;
     Ok((result.index, store))
@@ -418,7 +433,8 @@ pub fn index_markdown_directory_since_with_store_and_ignore(
     extra_ignore_patterns: &[String],
 ) -> Result<MarkdownSinceResult, anyhow::Error> {
     let canonical = std::fs::canonicalize(vault_root).unwrap_or_else(|_| vault_root.to_path_buf());
-    let reader = crate::content_reader::FilesystemReader::new(&canonical);
+    let reader =
+        crate::content_reader::FilesystemReader::with_limits(&canonical, note_reader_limits());
     let ignore_set = crate::brainignore::load_brain_ignore(&canonical, extra_ignore_patterns);
     index_markdown_since_with_reader(store, &reader, instance_id, vault_name, since, &ignore_set)
 }
@@ -480,7 +496,7 @@ fn index_markdown_since_with_reader(
         // the affected-source closure shows their outgoing links may change.
         let changed = match reader.file_meta(&rel_path) {
             Ok(Some((mtime_secs, file_size))) => {
-                if file_size > MAX_FILE_SIZE_BYTES {
+                if file_size > MAX_NOTE_SIZE_BYTES {
                     if existing_note_uids.contains(&n_uid) {
                         return Err(anyhow::anyhow!(
                             "cannot safely rebuild wikilinks for oversized indexed note {rel_path_str}"
@@ -1380,20 +1396,24 @@ where
         let rel_str = rel_path.to_string_lossy();
         if crate::brainignore::is_ignored(&rel_str, ignore_set) {
             tracing::debug!("brainignore: skipping {}", rel_str);
-            skipped.push(SkippedFile {
-                path: rel_str.into_owned(),
-                reason: "matched .brainignore pattern".to_string(),
-            });
+            skipped.push(SkippedFile::new(
+                rel_str.into_owned(),
+                SkipReasonCode::Ignored,
+                "matched .brainignore pattern",
+            ));
             continue;
         }
 
         // Size guard.
         if let Ok(Some((_, size))) = reader.file_meta(&rel_path)
-            && size > MAX_FILE_SIZE_BYTES
+            && size > MAX_NOTE_SIZE_BYTES
         {
             skipped.push(SkippedFile {
                 path: rel_str.into_owned(),
-                reason: format!("file exceeds {} bytes", MAX_FILE_SIZE_BYTES),
+                reason: format!("file exceeds {} bytes", MAX_NOTE_SIZE_BYTES),
+                reason_code: SkipReasonCode::Oversized,
+                observed_bytes: Some(size),
+                limit_bytes: Some(MAX_NOTE_SIZE_BYTES),
             });
             continue;
         }
@@ -1456,21 +1476,46 @@ where
             Ok(s) => s,
             Err(err) => {
                 parse_pb.inc(1);
-                return NoteOutcome::Skipped(SkippedFile {
-                    path: rel_path,
-                    reason: format!("read error: {err}"),
-                });
+                if let Some(oversized) = err.downcast_ref::<crate::content_reader::SourceTooLarge>()
+                {
+                    return NoteOutcome::Skipped(SkippedFile {
+                        path: rel_path,
+                        reason: format!("file exceeds {} bytes", MAX_NOTE_SIZE_BYTES),
+                        reason_code: SkipReasonCode::Oversized,
+                        observed_bytes: Some(oversized.observed_bytes),
+                        limit_bytes: Some(MAX_NOTE_SIZE_BYTES),
+                    });
+                }
+                return NoteOutcome::Skipped(SkippedFile::new(
+                    rel_path,
+                    SkipReasonCode::ReadError,
+                    format!("read error: {err}"),
+                ));
             }
         };
+        // `file_meta` is unavailable for bare Git readers. Enforce the note
+        // policy again on the returned content so any reader implementation
+        // remains policy-correct even when it cannot preflight metadata.
+        if source.len() as u64 > MAX_NOTE_SIZE_BYTES {
+            parse_pb.inc(1);
+            return NoteOutcome::Skipped(SkippedFile {
+                path: rel_path,
+                reason: format!("file exceeds {} bytes", MAX_NOTE_SIZE_BYTES),
+                reason_code: SkipReasonCode::Oversized,
+                observed_bytes: Some(source.len() as u64),
+                limit_bytes: Some(MAX_NOTE_SIZE_BYTES),
+            });
+        }
 
         let parsed: ParsedNote = match parse_markdown(&rel_path, &source) {
             Ok(p) => p,
             Err(err) => {
                 parse_pb.inc(1);
-                return NoteOutcome::Skipped(SkippedFile {
-                    path: rel_path.clone(),
-                    reason: err.to_string(),
-                });
+                return NoteOutcome::Skipped(SkippedFile::new(
+                    rel_path.clone(),
+                    SkipReasonCode::ParseError,
+                    err.to_string(),
+                ));
             }
         };
 
@@ -2687,6 +2732,33 @@ sub b body
 
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "x").unwrap();
         assert_eq!(result.notes_count, 1);
+    }
+
+    #[test]
+    fn note_size_policy_remains_one_mib_at_exact_boundaries() {
+        let note = |title: &str, size: usize| {
+            let prefix = format!("# {title}\n\n");
+            format!("{prefix}{}", "x".repeat(size - prefix.len()))
+        };
+        let below = note("Below", MAX_NOTE_SIZE_BYTES as usize - 1);
+        let at = note("At", MAX_NOTE_SIZE_BYTES as usize);
+        let above = note("Above", MAX_NOTE_SIZE_BYTES as usize + 1);
+        let (_dir, root) = make_vault(&[
+            ("below.md", below.as_str()),
+            ("at.md", at.as_str()),
+            ("above.md", above.as_str()),
+        ]);
+
+        let (result, _) = index_markdown_directory_in_memory(&root, "default", "limits").unwrap();
+        assert_eq!(result.notes_count, 2, "limit - 1 and limit are indexed");
+        assert_eq!(result.skipped.len(), 1);
+        assert_eq!(result.skipped[0].path, "above.md");
+        assert_eq!(result.skipped[0].reason_code, SkipReasonCode::Oversized);
+        assert_eq!(
+            result.skipped[0].observed_bytes,
+            Some(MAX_NOTE_SIZE_BYTES + 1)
+        );
+        assert_eq!(result.skipped[0].limit_bytes, Some(MAX_NOTE_SIZE_BYTES));
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -239,6 +239,7 @@ pub mod hash;
 pub mod html_to_md;
 pub mod hubs;
 pub mod index;
+pub mod index_limits;
 pub mod index_md;
 pub mod index_publication;
 pub mod interactions;

--- a/crates/nestweaver-engine/src/watch_code.rs
+++ b/crates/nestweaver-engine/src/watch_code.rs
@@ -39,6 +39,7 @@ pub struct CodeWatcher {
     stop_flag: Arc<AtomicBool>,
     mutation_lease_factory: Option<WatchMutationLeaseFactory>,
     debounce: Duration,
+    limits: crate::index_limits::IndexLimits,
     #[cfg(test)]
     ready_signal: Option<std::sync::mpsc::Sender<()>>,
 }
@@ -100,9 +101,15 @@ impl CodeWatcher {
             stop_flag: Arc::new(AtomicBool::new(false)),
             mutation_lease_factory: None,
             debounce: Duration::from_secs(2),
+            limits: crate::index_limits::IndexLimits::default(),
             #[cfg(test)]
             ready_signal: None,
         }
+    }
+
+    pub fn with_limits(mut self, limits: crate::index_limits::IndexLimits) -> Self {
+        self.limits = limits;
+        self
     }
 
     /// Install an external RAII lease acquired once around each published
@@ -206,7 +213,10 @@ impl CodeWatcher {
         // contract snapshot through the exact same atomic batch seam.
         if store.lookup_repo(&r_uid)?.is_none() {
             loop {
-                let reader = crate::content_reader::FilesystemReader::new(&self.repo_root);
+                let reader = crate::content_reader::FilesystemReader::with_limits(
+                    &self.repo_root,
+                    self.limits,
+                );
                 let initial_paths: Vec<PathBuf> = reader
                     .list_files()
                     .context("list files for initial watcher snapshot")?
@@ -214,7 +224,6 @@ impl CodeWatcher {
                     .map(|path| self.repo_root.join(path))
                     .filter(|path| is_watcher_input(path))
                     .filter(|path| !path_in_skip_dir(path))
-                    .filter(|path| !is_minified_or_bundled(path))
                     .collect();
                 let _mutation_lease = match self.acquire_mutation_lease("watch_code_initial") {
                     Ok(lease) => lease,
@@ -340,7 +349,6 @@ impl CodeWatcher {
                 .into_iter()
                 .filter(|p| !path_in_skip_dir(p))
                 .filter(|p| is_watcher_input(p))
-                .filter(|p| !is_minified_or_bundled(p))
                 .collect();
 
             if relevant.is_empty() {
@@ -421,12 +429,21 @@ impl CodeWatcher {
         F: FnOnce(),
     {
         let insert_initial_repo = store.lookup_repo(r_uid)?.is_none();
-        let reader = crate::content_reader::FilesystemReader::new(&self.repo_root);
+        let reader =
+            crate::content_reader::FilesystemReader::with_limits(&self.repo_root, self.limits);
         let contract_plan =
             match crate::index::prepare_watcher_contract_derivation(&reader, r_uid, repo_url) {
                 Ok(plan) => plan,
                 Err(reason) => return Ok(WatchBatchOutcome::Skipped { reason }),
             };
+        for skipped in &contract_plan.skipped_files {
+            tracing::warn!(
+                path = %skipped.path,
+                reason = ?skipped.reason_code,
+                detail = %skipped.reason,
+                "watcher published degraded coverage for a policy-skipped contract input"
+            );
+        }
         after_plan();
         let mut prepared_paths = Vec::new();
         let mut changed: HashSet<String> = HashSet::new();
@@ -443,13 +460,35 @@ impl CodeWatcher {
                 }
             };
             let rel_str = rel_path.to_string_lossy().into_owned();
+            if is_minified_or_bundled(path) {
+                tracing::warn!(
+                    path = %rel_path.display(),
+                    "watched source is policy-skipped as minified/generated; removing stale graph coverage"
+                );
+                removed.insert(rel_str.clone());
+                prepared_paths.push(PreparedPath::Delete { rel_path: rel_str });
+                continue;
+            }
             match std::fs::metadata(path) {
                 Ok(metadata) if metadata.is_file() => {
-                    let prepared =
-                        match prepare_code_file(&self.repo_root, rel_path, r_uid, repo_url) {
-                            Ok(prepared) => prepared,
-                            Err(reason) => return Ok(WatchBatchOutcome::Skipped { reason }),
-                        };
+                    let prepared = match prepare_code_file(&reader, rel_path, r_uid, repo_url) {
+                        Ok(prepared) => prepared,
+                        Err(reason)
+                            if reason
+                                .downcast_ref::<crate::content_reader::SourceTooLarge>()
+                                .is_some() =>
+                        {
+                            tracing::warn!(
+                                path = %rel_path.display(),
+                                %reason,
+                                "watched source is policy-skipped; removing stale graph coverage"
+                            );
+                            removed.insert(rel_str.clone());
+                            prepared_paths.push(PreparedPath::Delete { rel_path: rel_str });
+                            continue;
+                        }
+                        Err(reason) => return Ok(WatchBatchOutcome::Skipped { reason }),
+                    };
                     if contract_plan
                         .input_hashes
                         .get(&rel_str)
@@ -726,7 +765,7 @@ struct PreparedCodeFile {
 /// the read/delete/re-read race that could otherwise erase a transiently
 /// malformed half-save.
 fn prepare_code_file(
-    repo_root: &Path,
+    reader: &crate::content_reader::FilesystemReader,
     rel_path: &Path,
     r_uid: &str,
     repo_url: &str,
@@ -735,10 +774,11 @@ fn prepare_code_file(
     use nestweaver_resolver::{discover_workspace_context, resolve_references_with_context};
     use nestweaver_schema::{File, Symbol, canonical_symbol_id, file_uid, symbol_uid};
 
-    let abs_path = repo_root.join(rel_path);
+    let abs_path = reader.root().join(rel_path);
     let rel_str = rel_path.to_string_lossy().into_owned();
 
-    let source = std::fs::read_to_string(&abs_path)
+    let source = reader
+        .read_file(rel_path)
         .with_context(|| format!("read watched source {}", abs_path.display()))?;
     let parsed = parse_source(&abs_path, &source)
         .with_context(|| format!("parse watched source {}", abs_path.display()))?;
@@ -838,7 +878,7 @@ fn prepare_code_file(
             | nestweaver_schema::Language::Svelte
             | nestweaver_schema::Language::Astro
     ) {
-        discover_workspace_context(repo_root)
+        discover_workspace_context(reader.root())
     } else {
         Default::default()
     };
@@ -1095,6 +1135,33 @@ mod tests {
                 &crate::index::FileSystemIndexEpilogueIo,
             )
             .unwrap()
+    }
+
+    #[test]
+    fn watch_rename_into_minified_policy_removes_stale_symbols() {
+        let dir = tempfile::tempdir().unwrap();
+        let (store, r_uid, canonical_root) = index_fixture_repo(&dir);
+        let old_path = canonical_root.join("src/a.js");
+        let minified_path = canonical_root.join("src/a.min.js");
+        std::fs::rename(&old_path, &minified_path).unwrap();
+        let watcher = CodeWatcher::new(dir.path().join("graph.lbug"), &canonical_root, "test");
+
+        let outcome = process_fixture_batch(
+            &watcher,
+            &store,
+            &r_uid,
+            &canonical_root,
+            &[old_path, minified_path],
+        );
+        assert!(matches!(outcome, WatchBatchOutcome::Published { .. }));
+        assert!(
+            store
+                .lookup_symbols_by_repo(&r_uid)
+                .unwrap()
+                .iter()
+                .all(|symbol| symbol.name != "helper"),
+            "a policy-excluded rename must not leave stale source coverage"
+        );
     }
 
     /// Regression (CRITICAL — edge loss across watch reindex): a watcher

--- a/crates/nestweaver-engine/src/worker.rs
+++ b/crates/nestweaver-engine/src/worker.rs
@@ -88,6 +88,7 @@ pub struct WorkerPool {
     /// Populated from the instance config by the daemon; empty by default, so
     /// an unconfigured pool indexes everything as code (the prior behaviour).
     repo_types: Arc<HashMap<String, RepoType>>,
+    index_limits: crate::index_limits::IndexLimits,
     /// Tracks successful incremental code updates so server mode can
     /// periodically force a full refresh and bound graph drift.
     reindex_tracker: Arc<Mutex<crate::scheduler::ReindexTracker>>,
@@ -99,6 +100,7 @@ impl WorkerPool {
             concurrency,
             semaphore: Arc::new(Semaphore::new(concurrency)),
             repo_types: Arc::new(HashMap::new()),
+            index_limits: crate::index_limits::IndexLimits::default(),
             reindex_tracker: Arc::new(Mutex::new(crate::scheduler::ReindexTracker::new())),
         }
     }
@@ -110,6 +112,12 @@ impl WorkerPool {
     /// supplying the full set is also fine.
     pub fn with_repo_types(mut self, repo_types: HashMap<String, RepoType>) -> Self {
         self.repo_types = Arc::new(repo_types);
+        self
+    }
+
+    /// Apply the configured source-file safety limit to bare-repository reads.
+    pub fn with_index_limits(mut self, limits: crate::index_limits::IndexLimits) -> Self {
+        self.index_limits = limits;
         self
     }
 
@@ -171,6 +179,7 @@ impl WorkerPool {
     ) {
         let circuit_breakers = Arc::new(RemoteCircuitBreakers::new());
         let repo_types = self.repo_types.clone();
+        let index_limits = self.index_limits;
 
         // Rehydrate the reindex tracker from the persisted store so the
         // periodic-full update counter and 7-day backstop survive a daemon
@@ -340,11 +349,12 @@ impl WorkerPool {
                                 false
                             };
 
-                            let outcome = commit_prepared_job_with_reindex_decision(
+                            let outcome = commit_prepared_job_with_reindex_decision_and_limits(
                                 &prepared,
                                 &store,
                                 &instance_id,
                                 force_full_reindex,
+                                index_limits,
                                 move || {
                                     // Acquire the write lock. A backup in progress holds this lock
                                     // while it copies files, so this simply waits until the backup
@@ -630,6 +640,31 @@ enum ReindexOutcome {
     Incremental,
 }
 
+fn report_degraded_worker_coverage(
+    repo_url: &str,
+    skipped_files: &[nestweaver_parser::SkippedFile],
+) {
+    if skipped_files.is_empty() {
+        return;
+    }
+    tracing::warn!(
+        repo = %repo_url,
+        skipped_count = skipped_files.len(),
+        "server worker published degraded source coverage"
+    );
+    for skipped in skipped_files {
+        tracing::warn!(
+            repo = %repo_url,
+            path = %skipped.path,
+            reason = ?skipped.reason_code,
+            observed_bytes = skipped.observed_bytes,
+            limit_bytes = skipped.limit_bytes,
+            detail = %skipped.reason,
+            "server worker policy-skipped an eligible source file"
+        );
+    }
+}
+
 fn current_file_count(
     store: &nestweaver_store::GraphStore,
     instance_id: &str,
@@ -691,11 +726,33 @@ fn persist_reindex_outcome(
     }
 }
 
+#[cfg(test)]
 fn commit_prepared_job_with_reindex_decision<G, F>(
     prepared: &PreparedIndexJob,
     store: &nestweaver_store::GraphStore,
     instance_id: &str,
     force_full_reindex: bool,
+    acquire_write_guard: F,
+) -> Result<ReindexOutcome, anyhow::Error>
+where
+    F: FnOnce() -> Result<G, anyhow::Error>,
+{
+    commit_prepared_job_with_reindex_decision_and_limits(
+        prepared,
+        store,
+        instance_id,
+        force_full_reindex,
+        crate::index_limits::IndexLimits::default(),
+        acquire_write_guard,
+    )
+}
+
+fn commit_prepared_job_with_reindex_decision_and_limits<G, F>(
+    prepared: &PreparedIndexJob,
+    store: &nestweaver_store::GraphStore,
+    instance_id: &str,
+    force_full_reindex: bool,
+    limits: crate::index_limits::IndexLimits,
     acquire_write_guard: F,
 ) -> Result<ReindexOutcome, anyhow::Error>
 where
@@ -732,8 +789,17 @@ where
     }
 
     // Build a reader over the bare clone at the new SHA.
-    let reader =
-        crate::content_reader::GitBareReader::new(&prepared.bare_path, &prepared.remote_sha);
+    let reader_limits = if prepared.repo_type == RepoType::Vault {
+        crate::index_limits::IndexLimits::new(crate::index_md::MAX_NOTE_SIZE_BYTES)
+            .expect("note size policy is within source-reader safety bounds")
+    } else {
+        limits
+    };
+    let reader = crate::content_reader::GitBareReader::with_limits(
+        &prepared.bare_path,
+        &prepared.remote_sha,
+        reader_limits,
+    );
 
     match prepared.repo_type {
         RepoType::Vault => {
@@ -799,6 +865,7 @@ where
                     &prepared.remote_sha,
                     acquire_write_guard,
                 )?;
+                report_degraded_worker_coverage(&prepared.repo_url, &result.skipped_files);
                 if result.fell_back_to_full {
                     Ok(ReindexOutcome::Full)
                 } else {
@@ -815,7 +882,7 @@ where
                 // self-committing delete before the parse phase re-opens the
                 // empty-repo window (a concurrent reader or Backup RPC would see
                 // zero symbols for the whole scan+parse span).
-                crate::index_with_reader_and_write_gate(
+                let result = crate::index_with_reader_and_write_gate(
                     &reader,
                     store,
                     instance_id,
@@ -825,6 +892,7 @@ where
                     None,
                     acquire_write_guard,
                 )?;
+                report_degraded_worker_coverage(&prepared.repo_url, &result.skipped_files);
                 Ok(ReindexOutcome::Full)
             }
         }

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -33,7 +33,7 @@ use serde_json::{Value, json};
 // In non-daemon builds, brain_add_source and set_extension write directly using
 // these primitives; in daemon builds those writes route through the daemon.
 #[cfg(not(feature = "daemon"))]
-use nestweaver_engine::{index_directory, index_markdown_directory, save_extensions, set_property};
+use nestweaver_engine::{index_markdown_directory, save_extensions, set_property};
 
 // ── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -2132,7 +2132,10 @@ fn tool_read_symbols(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
         match bare_result {
             Some(res) => serde_json::to_value(res)?,
             None => {
-                let reader = nestweaver_engine::content_reader::FilesystemReader::new(&root);
+                let reader = nestweaver_engine::content_reader::FilesystemReader::with_limits(
+                    &root,
+                    configured_index_limits(),
+                );
                 let res = nestweaver_engine::read_symbols::read_symbols(
                     store,
                     &targets,
@@ -2144,7 +2147,10 @@ fn tool_read_symbols(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
             }
         }
     } else {
-        let reader = nestweaver_engine::content_reader::FilesystemReader::new(&root);
+        let reader = nestweaver_engine::content_reader::FilesystemReader::with_limits(
+            &root,
+            configured_index_limits(),
+        );
         let res = nestweaver_engine::read_symbols::read_symbols(
             store,
             &targets,
@@ -2300,6 +2306,9 @@ fn bare_reader_for_repo(
     workspace_root: &std::path::Path,
     repo_uid: &str,
 ) -> Option<nestweaver_engine::content_reader::GitBareReader> {
+    let limits = current_instance_config()
+        .map(|config| config.indexing.limits())
+        .unwrap_or_default();
     let repo = store.lookup_repo(repo_uid).ok().flatten()?;
     // The bare clone is named solely from the URL by `ensure_clone` (it never
     // sees the explicit repo name), so resolve the on-disk dir the same way —
@@ -2314,12 +2323,16 @@ fn bare_reader_for_repo(
     // fetched past it. Fall back to HEAD only when no server sha is recorded
     // (local repos store "local" or an empty sha).
     if repo.indexed_sha.is_empty() || repo.indexed_sha == "local" {
-        nestweaver_engine::content_reader::GitBareReader::from_head(&bare_path).ok()
+        nestweaver_engine::content_reader::GitBareReader::from_head_with_limits(&bare_path, limits)
+            .ok()
     } else {
-        Some(nestweaver_engine::content_reader::GitBareReader::new(
-            &bare_path,
-            &repo.indexed_sha,
-        ))
+        Some(
+            nestweaver_engine::content_reader::GitBareReader::with_limits(
+                &bare_path,
+                &repo.indexed_sha,
+                limits,
+            ),
+        )
     }
 }
 
@@ -6017,7 +6030,9 @@ fn tool_brain_add_source(store: &GraphStore, args: Value) -> Result<Value, anyho
                 "tags": result.tags_count,
                 "wikilinks_resolved": result.wikilinks_resolved,
                 "wikilinks_unresolved": result.wikilinks_unresolved,
+                "coverage_status": if result.skipped.is_empty() { "complete" } else { "degraded" },
                 "skipped_count": result.skipped.len(),
+                "skipped_files": result.skipped,
             }));
         }
 
@@ -6028,15 +6043,26 @@ fn tool_brain_add_source(store: &GraphStore, args: Value) -> Result<Value, anyho
             // file:// URL. The engine persists the disk location as
             // `root_path` on the Repo node.
             let url = nestweaver_engine::mint_repo_identity(path);
-            let result =
-                index_directory(path, &db_path, "default", &url, "local").context("index repo")?;
+            let result = nestweaver_engine::index::index_directory_with_options_and_limits(
+                path,
+                &db_path,
+                "default",
+                &url,
+                "local",
+                false,
+                None,
+                configured_index_limits(),
+            )
+            .context("index repo")?;
             return Ok(json!({
                 "kind": "repo",
                 "url": url,
                 "files": result.files_count,
                 "symbols": result.symbols_count,
                 "edges": result.edges_count,
+                "coverage_status": if result.skipped_files.is_empty() { "complete" } else { "degraded" },
                 "skipped_count": result.skipped_files.len(),
+                "skipped_files": result.skipped_files,
             }));
         }
 
@@ -9262,6 +9288,12 @@ fn configured_result_limit() -> usize {
         .unwrap_or(DEFAULT_RESULT_LIMIT)
 }
 
+fn configured_index_limits() -> nestweaver_engine::index_limits::IndexLimits {
+    current_instance_config()
+        .map(|config| config.indexing.limits())
+        .unwrap_or_default()
+}
+
 /// Read the configured `[response]` settings, falling back to defaults if no
 /// instance config is installed for this dispatch context.
 fn configured_response() -> nestweaver_engine::ResponseConfig {
@@ -9854,7 +9886,7 @@ impl DaemonIndexSource {
     }
 }
 
-#[cfg(feature = "daemon")]
+#[cfg(all(test, feature = "daemon"))]
 async fn consume_daemon_index_progress<S>(
     source: DaemonIndexSource,
     mut stream: S,
@@ -9862,9 +9894,28 @@ async fn consume_daemon_index_progress<S>(
 where
     S: tokio_stream::Stream<Item = Result<nestweaver_proto::IndexProgress, tonic::Status>> + Unpin,
 {
-    nestweaver_proto::consume_index_progress(&mut stream, |_| {})
-        .await
-        .map_err(|error| anyhow::anyhow!("{} index failed: {error}", source.label()))
+    Ok(consume_daemon_index_progress_detailed(source, &mut stream)
+        .await?
+        .0)
+}
+
+#[cfg(feature = "daemon")]
+async fn consume_daemon_index_progress_detailed<S>(
+    source: DaemonIndexSource,
+    mut stream: S,
+) -> Result<(String, Option<nestweaver_proto::IndexProgress>), anyhow::Error>
+where
+    S: tokio_stream::Stream<Item = Result<nestweaver_proto::IndexProgress, tonic::Status>> + Unpin,
+{
+    let mut terminal = None;
+    let message = nestweaver_proto::consume_index_progress(&mut stream, |progress| {
+        if progress.phase == nestweaver_proto::Phase::Done as i32 {
+            terminal = Some(progress.clone());
+        }
+    })
+    .await
+    .map_err(|error| anyhow::anyhow!("{} index failed: {error}", source.label()))?;
+    Ok((message, terminal))
 }
 
 /// Heuristic vault detector for `brain_add_source`: true when markdown files are
@@ -9997,12 +10048,22 @@ fn dispatch_add_source_via_daemon(
                 .await
                 .map_err(|s| anyhow::anyhow!("gRPC error: {}", s.message()))?
                 .into_inner();
-            let last_msg = consume_daemon_index_progress(DaemonIndexSource::Vault, stream).await?;
+            let (last_msg, terminal) =
+                consume_daemon_index_progress_detailed(DaemonIndexSource::Vault, stream).await?;
             Ok(serde_json::json!({
                 "status": "indexed",
                 "path": path,
                 "type": "vault",
                 "message": last_msg,
+                "coverage_status": terminal.as_ref().map(|progress| if progress.coverage_status == nestweaver_proto::CoverageStatus::Degraded as i32 { "degraded" } else { "complete" }),
+                "skipped_count": terminal.as_ref().map_or(0, |progress| progress.skipped_count),
+                "skipped_files": terminal.as_ref().map(|progress| progress.skipped_files.iter().map(|file| serde_json::json!({
+                    "path": file.path,
+                    "reason_code": file.reason_code,
+                    "detail": file.detail,
+                    "observed_bytes": file.observed_bytes,
+                    "limit_bytes": file.limit_bytes,
+                })).collect::<Vec<_>>()).unwrap_or_default(),
             }))
         } else {
             let req = tonic::Request::new(nestweaver_proto::IndexRepoRequest {
@@ -10014,6 +10075,10 @@ fn dispatch_add_source_via_daemon(
                 force: false,
                 with_trigrams: false,
                 with_git_activity: false,
+                rebuild_trigrams: false,
+                max_source_file_bytes: current_instance_config()
+                    .map(|config| config.indexing.limits().max_source_file_bytes())
+                    .unwrap_or(0),
                 // nw-019: no explicit instance here — let the daemon decide
                 // (config's logical name, else runtime hash).
                 instance_id: String::new(),
@@ -10023,12 +10088,22 @@ fn dispatch_add_source_via_daemon(
                 .await
                 .map_err(|s| anyhow::anyhow!("gRPC error: {}", s.message()))?
                 .into_inner();
-            let last_msg = consume_daemon_index_progress(DaemonIndexSource::Repo, stream).await?;
+            let (last_msg, terminal) =
+                consume_daemon_index_progress_detailed(DaemonIndexSource::Repo, stream).await?;
             Ok(serde_json::json!({
                 "status": "indexed",
                 "path": path,
                 "type": "repo",
                 "message": last_msg,
+                "coverage_status": terminal.as_ref().map(|progress| if progress.coverage_status == nestweaver_proto::CoverageStatus::Degraded as i32 { "degraded" } else { "complete" }),
+                "skipped_count": terminal.as_ref().map_or(0, |progress| progress.skipped_count),
+                "skipped_files": terminal.as_ref().map(|progress| progress.skipped_files.iter().map(|file| serde_json::json!({
+                    "path": file.path,
+                    "reason_code": file.reason_code,
+                    "detail": file.detail,
+                    "observed_bytes": file.observed_bytes,
+                    "limit_bytes": file.limit_bytes,
+                })).collect::<Vec<_>>()).unwrap_or_default(),
             }))
         }
     })

--- a/crates/nestweaver-parser/src/lib.rs
+++ b/crates/nestweaver-parser/src/lib.rs
@@ -27,6 +27,6 @@ pub use markdown::{
 pub use mermaid::{MermaidDiagram, MermaidEdge, MermaidNode, parse_mermaid};
 pub use parse::{
     AstBindingKind, AstTypeBinding, ParseError, ParseResult, ParsedFile, RawReference, RawSymbol,
-    ReferenceKind, SkippedFile, parse_batch, parse_source,
+    ReferenceKind, SkipReasonCode, SkippedFile, parse_batch, parse_source,
 };
 pub use registry::{LanguageParser, ParserRegistry};

--- a/crates/nestweaver-parser/src/parse.rs
+++ b/crates/nestweaver-parser/src/parse.rs
@@ -179,10 +179,67 @@ pub struct ParsedFile {
     pub type_bindings: Vec<AstTypeBinding>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SkipReasonCode {
+    Ignored,
+    Unsupported,
+    Oversized,
+    ReadError,
+    ParseError,
+    Cancelled,
+    #[default]
+    Other,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SkippedFile {
     pub path: String,
     pub reason: String,
+    #[serde(default)]
+    pub reason_code: SkipReasonCode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit_bytes: Option<u64>,
+}
+
+impl SkippedFile {
+    pub fn new(
+        path: impl Into<String>,
+        reason_code: SkipReasonCode,
+        reason: impl Into<String>,
+    ) -> Self {
+        let mut reason = reason.into();
+        const MAX_SKIP_DETAIL_BYTES: usize = 1024;
+        if reason.len() > MAX_SKIP_DETAIL_BYTES {
+            let mut end = MAX_SKIP_DETAIL_BYTES;
+            while end > 0 && !reason.is_char_boundary(end) {
+                end -= 1;
+            }
+            reason.truncate(end);
+            reason.push('…');
+        }
+        Self {
+            path: path.into(),
+            reason,
+            reason_code,
+            observed_bytes: None,
+            limit_bytes: None,
+        }
+    }
+
+    pub fn oversized(path: impl Into<String>, observed_bytes: u64, limit_bytes: u64) -> Self {
+        Self {
+            path: path.into(),
+            reason: format!(
+                "file exceeds source size limit ({observed_bytes} > {limit_bytes} bytes)"
+            ),
+            reason_code: SkipReasonCode::Oversized,
+            observed_bytes: Some(observed_bytes),
+            limit_bytes: Some(limit_bytes),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1399,10 +1456,11 @@ pub fn parse_batch(files: &[(&Path, &str)]) -> ParseResult {
             Err(e) => {
                 let path_str = path.to_string_lossy().into_owned();
                 tracing::warn!(path = %path_str, error = %e, "skipping file due to parse error");
-                result.skipped.push(SkippedFile {
-                    path: path_str,
-                    reason: e.to_string(),
-                });
+                result.skipped.push(SkippedFile::new(
+                    path_str,
+                    SkipReasonCode::ParseError,
+                    e.to_string(),
+                ));
             }
         }
     }

--- a/crates/nestweaver-store/Cargo.toml
+++ b/crates/nestweaver-store/Cargo.toml
@@ -23,6 +23,7 @@ tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
+blake3 = { workspace = true }
 rayon = { workspace = true }
 rmp-serde = "1"
 csv = "1"

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -250,6 +250,10 @@ pub struct GraphStore {
     /// or edges added/removed). Lets the web UI and other consumers detect
     /// when their view of the graph is stale without diffing the full graph.
     pub(crate) graph_generation: AtomicU64,
+    /// Generation/digest-keyed trigram scope trust verdict. The digest keeps
+    /// raw/import mutations that do not bump the in-process generation from
+    /// reusing a narrower stale verdict.
+    pub(crate) trigram_scope_cache: Mutex<Option<crate::regex::TrigramScopeCache>>,
     /// Last canonical generation while an index publication is dirty. A
     /// present value means `graph_generation` is either its dirty N+1
     /// reservation or the prepared clean N+2 publication. Keeping this
@@ -505,6 +509,7 @@ impl GraphStore {
             pagerank_generation: AtomicU64::new(0),
             pagerank_compute_lock: Mutex::new(()),
             graph_generation: AtomicU64::new(0),
+            trigram_scope_cache: Mutex::new(None),
             index_publication_generation_base: Mutex::new(None),
             index_publication_lease: IndexPublicationLeaseCoordinator::default(),
             interaction_cache: Mutex::new(None),
@@ -537,6 +542,7 @@ impl GraphStore {
             pagerank_generation: AtomicU64::new(0),
             pagerank_compute_lock: Mutex::new(()),
             graph_generation: AtomicU64::new(0),
+            trigram_scope_cache: Mutex::new(None),
             index_publication_generation_base: Mutex::new(None),
             index_publication_lease: IndexPublicationLeaseCoordinator::default(),
             interaction_cache: Mutex::new(None),
@@ -570,6 +576,7 @@ impl GraphStore {
             pagerank_generation: AtomicU64::new(0),
             pagerank_compute_lock: Mutex::new(()),
             graph_generation: AtomicU64::new(0),
+            trigram_scope_cache: Mutex::new(None),
             index_publication_generation_base: Mutex::new(None),
             index_publication_lease: IndexPublicationLeaseCoordinator::default(),
             interaction_cache: Mutex::new(None),
@@ -626,6 +633,7 @@ impl GraphStore {
             pagerank_generation: AtomicU64::new(0),
             pagerank_compute_lock: Mutex::new(()),
             graph_generation: AtomicU64::new(0),
+            trigram_scope_cache: Mutex::new(None),
             index_publication_generation_base: Mutex::new(None),
             index_publication_lease: IndexPublicationLeaseCoordinator::default(),
             interaction_cache: Mutex::new(None),
@@ -2120,6 +2128,29 @@ impl GraphStore {
                 uid STRING, \
                 trigram STRING, \
                 node_uid STRING, \
+                scope_uid STRING, \
+                PRIMARY KEY(uid))",
+        )
+        .map_err(|e| StoreError::Query(e.to_string()))?;
+        // Forward migration for posting tables created before scoped trigram
+        // maintenance. Legacy rows retain the empty default and are replaced
+        // by the first v2 refresh.
+        let _ = conn.query("ALTER TABLE TrigramPosting ADD scope_uid STRING DEFAULT ''");
+        conn.query(
+            "CREATE NODE TABLE IF NOT EXISTS TrigramDocument(\
+                uid STRING, \
+                scope_uid STRING, \
+                text_hash STRING, \
+                PRIMARY KEY(uid))",
+        )
+        .map_err(|e| StoreError::Query(e.to_string()))?;
+        conn.query(
+            "CREATE NODE TABLE IF NOT EXISTS TrigramScope(\
+                uid STRING, \
+                status STRING, \
+                candidate_count INT64, \
+                candidate_digest STRING, \
+                indexed_generation INT64, \
                 PRIMARY KEY(uid))",
         )
         .map_err(|e| StoreError::Query(e.to_string()))?;

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -33,6 +33,7 @@ pub use read::{
 };
 pub use regex::{
     CANDIDATE_CAP, DEFAULT_MAX_MILLIS, FileCount, PatternCount, RegexMatch, RegexSearchResult,
+    TrigramRefreshStats,
 };
 pub use search::{
     EMBED_CHECKPOINT_INTERVAL, EmbeddingFlushCheckpoint, EmbeddingIndex, SearchResult,

--- a/crates/nestweaver-store/src/regex.rs
+++ b/crates/nestweaver-store/src/regex.rs
@@ -10,13 +10,13 @@
 //! The trigram posting table is purely an optimization. Correctness never
 //! depends on it: when no posting table exists (the `index --with-trigrams`
 //! flag was not used), when the pattern yields no usable literal trigrams
-//! (e.g. `.{4,}`), or when the posting table is *stale* (the graph changed
-//! since it was built), we fall back to scanning every candidate
-//! node's text and running the compiled regex against it. The trigram
+//! (e.g. `.{4,}`), or for any repository/vault scope whose manifest is stale,
+//! we fall back to scanning that scope's candidate text and running the
+//! compiled regex against it. Ready scopes remain prefiltered. The trigram
 //! pre-filter only ever *narrows* the candidate set — we always confirm with
 //! the real regex.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
@@ -46,11 +46,9 @@ pub const DEFAULT_MAX_MILLIS: u64 = 2000;
 /// by sending a huge pattern.
 pub const MAX_PATTERN_BYTES: usize = 4096;
 
-/// `Meta` table key under which `build_trigram_index` records provenance for
-/// the posting table as `"<graph_generation>:<candidate_node_count>"`. A
-/// reader compares both values against the current graph; any drift means the
-/// postings no longer reflect the indexed text and the pre-filter must not be
-/// used.
+/// Legacy global provenance key. Its presence identifies the v1 positional
+/// posting schema; the first v2 refresh migrates it atomically to stable,
+/// scope-owned postings.
 const TRIGRAM_INDEX_META_KEY: &str = "trigram_index";
 
 /// One-shot latch so the stale-index warning is printed once per process
@@ -103,16 +101,26 @@ pub struct RegexSearchResult {
     pub results: Vec<RegexMatch>,
     /// True when the candidate cap or time budget was hit and results are partial.
     pub truncated: bool,
-    /// True when the trigram pre-filter could not be used and we scanned all
-    /// candidate text directly (either no posting table, or no usable literals).
+    /// True when any candidate scope was scanned directly (no usable literal,
+    /// no posting table, or a mixed query containing dirty scopes).
     pub scanned_fallback: bool,
-    /// True when a trigram posting table EXISTS but was bypassed because it is
-    /// stale (the graph changed since it was built). This lets callers
+    /// True when persisted trigram postings exist but at least one scope was
+    /// distrusted and scanned. This lets callers
     /// surface staleness in-band: on the daemon path the once-per-process
     /// stderr warning is invisible. Implies `scanned_fallback` when the
     /// pattern has usable literals; always false when no index was ever built.
     #[serde(default)]
     pub stale_index: bool,
+    /// Number of repository/vault scopes safely narrowed by trigram postings.
+    #[serde(default)]
+    pub ready_scopes: usize,
+    /// Number of scopes scanned directly because their postings were absent,
+    /// stale, or mid-refresh. Correctness is preserved per scope.
+    #[serde(default)]
+    pub dirty_scopes: usize,
+    /// Candidate nodes actually evaluated by the real regex.
+    #[serde(default)]
+    pub scanned_candidates: usize,
     /// Human-readable explanation when an empty result is NOT a definitive
     /// "no matches exist".
     ///
@@ -163,11 +171,38 @@ pub struct PatternCount {
     /// was counted via a full scan. Lets callers surface staleness in-band on
     /// the daemon path, where the stderr warning is invisible.
     pub stale_index: bool,
+    #[serde(default)]
+    pub ready_scopes: usize,
+    #[serde(default)]
+    pub dirty_scopes: usize,
+    #[serde(default)]
+    pub scanned_candidates: usize,
+}
+
+/// Work performed by an incremental trigram refresh.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrigramRefreshStats {
+    pub scopes_refreshed: usize,
+    pub scopes_unchanged: usize,
+    pub nodes_added: usize,
+    pub nodes_changed: usize,
+    pub nodes_deleted: usize,
+    pub postings_added: usize,
+    pub postings_deleted: usize,
+    pub migrated_legacy_index: bool,
+    #[serde(default)]
+    pub elapsed_ms: u64,
 }
 
 /// A unit of indexed text plus its node metadata. Internal to this module.
+#[derive(Clone)]
 struct Candidate {
     uid: String,
+    /// Repository UID for symbols, vault UID for notes and sections.
+    scope_uid: String,
+    /// Content-derived identity used to determine whether this node's
+    /// postings need to change.
+    text_hash: String,
     kind: String,
     title: String,
     location: String,
@@ -176,6 +211,72 @@ struct Candidate {
     /// Used to translate a match's line *within* `text` into a file line.
     /// `1` when the node has no meaningful file offset (e.g. Note titles).
     start_line: u32,
+}
+
+#[derive(Clone)]
+struct TrigramScopeState {
+    status: String,
+    candidate_count: usize,
+    candidate_digest: String,
+}
+
+struct TrigramDocumentState {
+    scope_uid: String,
+    text_hash: String,
+}
+
+struct TrigramPrefilterPlan {
+    matching_ready_uids: HashSet<String>,
+    ready_scopes: HashSet<String>,
+    dirty_scopes: HashSet<String>,
+    has_index: bool,
+}
+
+#[derive(Clone)]
+pub(crate) struct TrigramScopeCache {
+    generation: u64,
+    corpus_digest: String,
+    ready_scopes: HashSet<String>,
+    dirty_scopes: HashSet<String>,
+    has_index: bool,
+}
+
+fn text_hash(text: &str) -> String {
+    blake3::hash(text.as_bytes()).to_hex().to_string()
+}
+
+fn candidate_digest(candidates: &[Candidate]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    for candidate in candidates {
+        hasher.update(candidate.uid.as_bytes());
+        hasher.update(&[0]);
+        hasher.update(candidate.text_hash.as_bytes());
+        hasher.update(&[0xff]);
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+fn stable_posting_uid(trigram: &str, node_uid: &str) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(trigram.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(node_uid.as_bytes());
+    format!("tg:v2:{}", hasher.finalize().to_hex())
+}
+
+fn widened_scan_plan(
+    ready_scopes: &HashSet<String>,
+    dirty_scopes: &HashSet<String>,
+    has_index: bool,
+) -> TrigramPrefilterPlan {
+    let mut all_dirty = dirty_scopes.clone();
+    all_dirty.extend(ready_scopes.iter().cloned());
+    TrigramPrefilterPlan {
+        matching_ready_uids: HashSet::new(),
+        ready_scopes: HashSet::new(),
+        dirty_scopes: all_dirty,
+        has_index,
+    }
 }
 
 /// Lowercase 3-grams of `s`, deduplicated. Operates on Unicode scalar values
@@ -266,176 +367,422 @@ impl GraphStore {
         }
     }
 
-    /// Build (or rebuild) the trigram posting table over all indexed text:
-    /// `Section.text_content`, `Note.title`, and `Symbol.signature`.
-    ///
-    /// Idempotent: clears any existing postings first. Opt-in — only called by
-    /// `index --with-trigrams`. Returns the number of (trigram, uid) postings
-    /// written.
+    /// Incrementally refresh trigram postings over all indexed text. Existing
+    /// callers keep the historical return value (postings written), while
+    /// [`GraphStore::refresh_trigram_index`] exposes detailed work metrics.
     pub fn build_trigram_index(&self) -> Result<usize, StoreError> {
-        let setup_conn = self.conn()?;
-        // Mark the index as mid-build BEFORE touching the postings. An
-        // interrupted rebuild (crash/kill between the clear below and the
-        // provenance write at the end) would otherwise leave the OLD
-        // provenance in place — matching the current generation and looking
-        // "fresh" while the posting table is empty or partial, silently
-        // dropping regex matches. "building" is unparseable by
-        // `trigram_index_meta`, so any interrupted build reads as stale and
-        // falls back to a full scan. Written on its own auto-committed
-        // connection so it survives the build transaction rolling back.
-        Self::write_trigram_meta(&setup_conn, "building")?;
+        Ok(self.refresh_trigram_index(false)?.postings_added)
+    }
 
+    /// Force a one-time full rebuild using the stable v2 schema.
+    pub fn rebuild_trigram_index(&self) -> Result<TrigramRefreshStats, StoreError> {
+        self.refresh_trigram_index(true)
+    }
+
+    /// Refresh only scopes whose deterministic candidate digest changed. A
+    /// scope is published `building` before mutation, then `ready` in the same
+    /// transaction as its postings and document manifest. Search trusts ready
+    /// scopes and scans only dirty scopes, so an interruption cannot lose
+    /// matches outside (or inside) the failed scope.
+    pub fn refresh_trigram_index(
+        &self,
+        force_full: bool,
+    ) -> Result<TrigramRefreshStats, StoreError> {
+        let refresh_started = Instant::now();
+        *self
+            .trigram_scope_cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
         let candidates = self.collect_candidates(None, None)?;
-
-        // Accumulate distinct (trigram, uid) pairs. A node contributes each of
-        // its distinct trigrams once.
-        let mut postings: Vec<(String, String)> = Vec::new();
-        for c in &candidates {
-            for tg in trigrams(&c.text) {
-                postings.push((tg, c.uid.clone()));
+        let mut desired: BTreeMap<String, Vec<Candidate>> = BTreeMap::new();
+        for candidate in candidates {
+            // Unknown ownership is never publishable as trusted. Search keeps
+            // these candidates in the empty dirty scope and scans them.
+            if candidate.scope_uid.is_empty() {
+                continue;
             }
+            desired
+                .entry(candidate.scope_uid.clone())
+                .or_default()
+                .push(candidate);
+        }
+        for values in desired.values_mut() {
+            values.sort_by(|a, b| a.uid.cmp(&b.uid));
         }
 
-        // Clear + rebuild + provenance in ONE explicit transaction: per-
-        // statement auto-commit made every posting its own WAL flush, which
-        // is fsync-bound and impractically slow at monorepo scale (20+
-        // minutes on a ~25 MB DB). A single transaction flushes once. It
-        // also makes interruption all-or-nothing: a crashed build rolls
-        // back, leaving the durable "building" marker above to report the
-        // index as stale.
-        let conn = self.begin_transaction()?;
-        let build = (|| -> Result<usize, StoreError> {
-            // Clear existing postings so a rebuild reflects the current graph.
+        let conn = self.conn()?;
+        // Positional v1 IDs (`tg:<number>`) sort before versioned v2 IDs
+        // (`tg:v2:<hash>`), so checking the first UID detects legacy rows
+        // without scanning and materializing a potentially 12.9M-row table.
+        let has_legacy_uid = conn
+            .query("MATCH (t:TrigramPosting) RETURN t.uid ORDER BY t.uid LIMIT 1")
+            .ok()
+            .and_then(|rows| rows.into_iter().next())
+            .and_then(|row| row.first().cloned())
+            .is_some_and(|value| match value {
+                Value::String(uid) => !uid.starts_with("tg:v2:"),
+                _ => true,
+            });
+        let legacy = has_legacy_uid
+            || conn
+                .query("MATCH (t:TrigramPosting) WHERE t.scope_uid = '' RETURN t.uid LIMIT 1")
+                .map(|rows| rows.count() > 0)
+                .unwrap_or(false)
+            || conn
+                .query(&format!(
+                    "MATCH (m:Meta {{key: '{TRIGRAM_INDEX_META_KEY}'}}) RETURN m.value LIMIT 1"
+                ))
+                .map(|rows| rows.count() > 0)
+                .unwrap_or(false);
+        let mut stats = TrigramRefreshStats {
+            migrated_legacy_index: legacy,
+            ..Default::default()
+        };
+        if force_full || legacy {
+            // Fail closed before any destructive full-rebuild statement. If
+            // the process dies between the table clears below, every former
+            // v2 scope remains visibly `building` and search scans it instead
+            // of trusting a partially cleared posting set.
+            for (scope_uid, scope) in self.read_trigram_scopes()? {
+                Self::write_trigram_scope(
+                    &conn,
+                    &scope_uid,
+                    "building",
+                    scope.candidate_count,
+                    &scope.candidate_digest,
+                    self.graph_generation(),
+                )?;
+            }
+            // A concurrent query can populate the cache in the interval
+            // between the initial invalidation and the first durable
+            // `building` marker. Invalidate again after every incumbent scope
+            // is fail-closed and before deleting any postings, so a forced
+            // rebuild (whose candidate corpus may be unchanged) cannot leave a
+            // cached `ready` verdict trusting partial data after failure.
+            *self
+                .trigram_scope_cache
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+            stats.postings_deleted = conn
+                .query("MATCH (t:TrigramPosting) RETURN count(t)")
+                .ok()
+                .and_then(|rows| rows.into_iter().next())
+                .and_then(|row| row.first().cloned())
+                .and_then(|value| match value {
+                    Value::Int64(count) => Some(count.max(0) as usize),
+                    _ => None,
+                })
+                .unwrap_or(0);
             conn.query("MATCH (t:TrigramPosting) DETACH DELETE t")
                 .map_err(|e| StoreError::Query(format!("clear trigram postings: {e}")))?;
-
-            let mut stmt = conn
-                .prepare("CREATE (:TrigramPosting {uid: $puid, trigram: $tg, node_uid: $nuid})")
-                .map_err(|e| StoreError::Query(format!("prepare trigram insert: {e}")))?;
-            for (i, (tg, nuid)) in postings.iter().enumerate() {
-                // Synthetic primary key: index-stamped to stay unique.
-                let puid = format!("tg:{i}");
-                conn.execute(
-                    &mut stmt,
-                    vec![
-                        ("puid", Value::String(puid)),
-                        ("tg", Value::String(tg.clone())),
-                        ("nuid", Value::String(nuid.clone())),
-                    ],
-                )
-                .map_err(|e| StoreError::Query(format!("insert trigram: {e}")))?;
-            }
-
-            // Record provenance so a later reader can detect that the posting
-            // table no longer reflects the graph (nodes added/edited after this
-            // build) and fall back to a full scan instead of silently missing
-            // matches. Overwrites the "building" marker written at the
-            // start of this rebuild.
-            let meta_value = format!("{}:{}", self.graph_generation(), candidates.len());
-            Self::write_trigram_meta(&conn, &meta_value)?;
-            Ok(postings.len())
-        })();
-        match build {
-            Ok(n) => {
-                self.commit_transaction(&conn)?;
-                Ok(n)
-            }
-            Err(e) => {
-                let _ = self.rollback_transaction(&conn);
-                Err(e)
-            }
+            conn.query("MATCH (d:TrigramDocument) DETACH DELETE d")
+                .map_err(|e| StoreError::Query(format!("clear trigram documents: {e}")))?;
+            // Keep the durable `building` rows written above. Missing scope
+            // state is also fail-closed, but retaining the marker makes an
+            // interrupted rebuild directly observable and lets each scope's
+            // update transaction publish `ready` atomically.
+            let _ = conn.query(&format!(
+                "MATCH (m:Meta {{key: '{TRIGRAM_INDEX_META_KEY}'}}) DETACH DELETE m"
+            ));
         }
-    }
 
-    /// Upsert the trigram-index provenance singleton in the `Meta` table
-    /// (same delete+insert pattern as the other `Meta` singletons).
-    fn write_trigram_meta(conn: &lbug::Connection<'_>, value: &str) -> Result<(), StoreError> {
-        let mut del = conn
-            .prepare("MATCH (m:Meta {key: $k}) DETACH DELETE m")
-            .map_err(|e| StoreError::Query(format!("prepare trigram meta delete: {e}")))?;
-        conn.execute(
-            &mut del,
-            vec![("k", Value::String(TRIGRAM_INDEX_META_KEY.to_string()))],
-        )
-        .map_err(|e| StoreError::Query(format!("clear trigram meta: {e}")))?;
-        let mut ins = conn
-            .prepare("CREATE (:Meta {key: $k, value: $v})")
-            .map_err(|e| StoreError::Query(format!("prepare trigram meta insert: {e}")))?;
-        conn.execute(
-            &mut ins,
-            vec![
-                ("k", Value::String(TRIGRAM_INDEX_META_KEY.to_string())),
-                ("v", Value::String(value.to_string())),
-            ],
-        )
-        .map_err(|e| StoreError::Query(format!("write trigram meta: {e}")))?;
-        Ok(())
-    }
+        let existing_scopes = self.read_trigram_scopes()?;
+        let mut all_scope_uids: HashSet<String> = desired.keys().cloned().collect();
+        all_scope_uids.extend(existing_scopes.keys().cloned());
+        let existing_docs = self.read_trigram_documents()?;
+        let desired_scope_by_uid: HashMap<String, String> = desired
+            .values()
+            .flatten()
+            .map(|candidate| (candidate.uid.clone(), candidate.scope_uid.clone()))
+            .collect();
 
-    /// Read the provenance recorded by [`GraphStore::build_trigram_index`].
-    /// Returns `None` when the `Meta` table or key is absent (postings built
-    /// before provenance tracking) or the value is unparseable.
-    fn trigram_index_meta(&self) -> Option<(u64, u64)> {
-        let conn = self.conn().ok()?;
-        let mut stmt = conn
-            .prepare("MATCH (m:Meta {key: $k}) RETURN m.value")
-            .ok()?;
-        let result = conn
-            .execute(
-                &mut stmt,
-                vec![("k", Value::String(TRIGRAM_INDEX_META_KEY.to_string()))],
-            )
-            .ok()?;
-        for row in result {
-            if let Some(Value::String(value)) = row.first() {
-                let (generation, count) = value.split_once(':')?;
-                return Some((generation.parse().ok()?, count.parse().ok()?));
+        let mut scope_uids: Vec<String> = all_scope_uids.into_iter().collect();
+        scope_uids.sort();
+        for scope_uid in scope_uids {
+            let scope_candidates = desired.get(&scope_uid).map(Vec::as_slice).unwrap_or(&[]);
+            let digest = candidate_digest(scope_candidates);
+            let unchanged = !force_full
+                && !legacy
+                && existing_scopes.get(&scope_uid).is_some_and(|scope| {
+                    scope.status == "ready"
+                        && scope.candidate_count == scope_candidates.len()
+                        && scope.candidate_digest == digest
+                });
+            if unchanged {
+                stats.scopes_unchanged += 1;
+                continue;
             }
-        }
-        None
-    }
 
-    /// Number of text-bearing candidate nodes (Sections with body text, Notes
-    /// with a title, Symbols with a signature) — the same set
-    /// `collect_candidates(None, None)` would yield, counted cheaply.
-    fn searchable_candidate_count(&self) -> Result<u64, StoreError> {
-        let conn = self.conn()?;
-        let mut total = 0u64;
-        for query in [
-            "MATCH (s:Section) WHERE s.text_content <> '' RETURN count(s)",
-            "MATCH (n:Note) WHERE n.title <> '' RETURN count(n)",
-            "MATCH (s:Symbol) WHERE s.signature <> '' RETURN count(s)",
-        ] {
-            let result = conn
-                .query(query)
-                .map_err(|e| StoreError::Query(format!("candidate count: {e}")))?;
-            for row in result {
-                if let Some(Value::Int64(n)) = row.first() {
-                    total += (*n).max(0) as u64;
+            Self::write_trigram_scope(
+                &conn,
+                &scope_uid,
+                "building",
+                scope_candidates.len(),
+                &digest,
+                self.graph_generation(),
+            )?;
+
+            let old_for_scope: HashMap<String, String> = existing_docs
+                .iter()
+                .filter(|(_, doc)| doc.scope_uid == scope_uid)
+                .map(|(uid, doc)| (uid.clone(), doc.text_hash.clone()))
+                .collect();
+            let deleted: Vec<String> = old_for_scope
+                .keys()
+                // A node that moved scopes is deleted and reinserted by its
+                // destination scope. Treating it as deleted by the source
+                // scope is order-dependent: if the destination ran first,
+                // the source would erase the newly published postings.
+                .filter(|uid| !desired_scope_by_uid.contains_key(uid.as_str()))
+                .cloned()
+                .collect();
+            let changed: Vec<&Candidate> = scope_candidates
+                .iter()
+                .filter(|candidate| {
+                    old_for_scope
+                        .get(&candidate.uid)
+                        .is_none_or(|hash| hash != &candidate.text_hash)
+                })
+                .collect();
+
+            let txn = self.begin_transaction()?;
+            let update = (|| -> Result<(usize, usize), StoreError> {
+                let mut postings_deleted = 0usize;
+                for uid in deleted
+                    .iter()
+                    .chain(changed.iter().map(|candidate| &candidate.uid))
+                {
+                    postings_deleted += Self::delete_trigram_document(&txn, uid)?;
+                }
+                let mut postings_added = 0usize;
+                let mut insert_posting = txn
+                    .prepare("CREATE (:TrigramPosting {uid: $uid, trigram: $trigram, node_uid: $node_uid, scope_uid: $scope_uid})")
+                    .map_err(|e| StoreError::Query(format!("prepare trigram insert: {e}")))?;
+                for candidate in &changed {
+                    Self::insert_trigram_document(&txn, candidate)?;
+                    for trigram in trigrams(&candidate.text) {
+                        let posting_uid = stable_posting_uid(&trigram, &candidate.uid);
+                        txn.execute(
+                            &mut insert_posting,
+                            vec![
+                                ("uid", Value::String(posting_uid.clone())),
+                                ("trigram", Value::String(trigram)),
+                                ("node_uid", Value::String(candidate.uid.clone())),
+                                ("scope_uid", Value::String(scope_uid.clone())),
+                            ],
+                        )
+                        .map_err(|e| {
+                            StoreError::Query(format!(
+                                "insert stable trigram posting {posting_uid} (collision or duplicate): {e}"
+                            ))
+                        })?;
+                        postings_added += 1;
+                    }
+                }
+                if scope_candidates.is_empty() {
+                    let mut delete_scope = txn
+                        .prepare("MATCH (s:TrigramScope {uid: $uid}) DETACH DELETE s")
+                        .map_err(|e| {
+                            StoreError::Query(format!("prepare empty trigram scope delete: {e}"))
+                        })?;
+                    txn.execute(
+                        &mut delete_scope,
+                        vec![("uid", Value::String(scope_uid.clone()))],
+                    )
+                    .map_err(|e| StoreError::Query(format!("delete empty trigram scope: {e}")))?;
+                } else {
+                    Self::write_trigram_scope(
+                        &txn,
+                        &scope_uid,
+                        "ready",
+                        scope_candidates.len(),
+                        &digest,
+                        self.graph_generation(),
+                    )?;
+                }
+                Ok((postings_added, postings_deleted))
+            })();
+            match update {
+                Ok((added, deleted_postings)) => {
+                    self.commit_transaction(&txn)?;
+                    stats.scopes_refreshed += 1;
+                    stats.postings_added += added;
+                    stats.postings_deleted += deleted_postings;
+                    stats.nodes_deleted += deleted.len();
+                    for candidate in changed {
+                        if existing_docs.contains_key(&candidate.uid) {
+                            stats.nodes_changed += 1;
+                        } else {
+                            stats.nodes_added += 1;
+                        }
+                    }
+                }
+                Err(error) => {
+                    let _ = self.rollback_transaction(&txn);
+                    return Err(error);
                 }
             }
         }
-        Ok(total)
+        *self
+            .trigram_scope_cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        stats.elapsed_ms = refresh_started.elapsed().as_millis().min(u64::MAX as u128) as u64;
+        Ok(stats)
     }
 
-    /// True when the posting table exists but was built against a different
-    /// graph state: the graph generation advanced (any mutation, e.g. an
-    /// in-place edit) or the candidate-node count drifted (nodes added or
-    /// removed) since `index --with-trigrams` ran. Postings without
-    /// provenance (built by an older version) cannot be trusted and count as
-    /// stale.
-    fn trigram_index_is_stale(&self) -> bool {
-        let Some((indexed_generation, indexed_count)) = self.trigram_index_meta() else {
-            return true;
+    fn write_trigram_scope(
+        conn: &lbug::Connection<'_>,
+        uid: &str,
+        status: &str,
+        candidate_count: usize,
+        candidate_digest: &str,
+        indexed_generation: u64,
+    ) -> Result<(), StoreError> {
+        let mut delete = conn
+            .prepare("MATCH (s:TrigramScope {uid: $uid}) DETACH DELETE s")
+            .map_err(|e| StoreError::Query(format!("prepare trigram scope delete: {e}")))?;
+        conn.execute(&mut delete, vec![("uid", Value::String(uid.to_string()))])
+            .map_err(|e| StoreError::Query(format!("delete trigram scope: {e}")))?;
+        let mut insert = conn
+            .prepare("CREATE (:TrigramScope {uid: $uid, status: $status, candidate_count: $count, candidate_digest: $digest, indexed_generation: $generation})")
+            .map_err(|e| StoreError::Query(format!("prepare trigram scope insert: {e}")))?;
+        conn.execute(
+            &mut insert,
+            vec![
+                ("uid", Value::String(uid.to_string())),
+                ("status", Value::String(status.to_string())),
+                ("count", Value::Int64(candidate_count as i64)),
+                ("digest", Value::String(candidate_digest.to_string())),
+                (
+                    "generation",
+                    Value::Int64(indexed_generation.min(i64::MAX as u64) as i64),
+                ),
+            ],
+        )
+        .map_err(|e| StoreError::Query(format!("write trigram scope: {e}")))?;
+        Ok(())
+    }
+
+    fn delete_trigram_document(
+        conn: &lbug::Connection<'_>,
+        node_uid: &str,
+    ) -> Result<usize, StoreError> {
+        let mut count = conn
+            .prepare("MATCH (t:TrigramPosting {node_uid: $uid}) RETURN count(t)")
+            .map_err(|e| StoreError::Query(format!("prepare trigram posting count: {e}")))?;
+        let rows = conn
+            .execute(
+                &mut count,
+                vec![("uid", Value::String(node_uid.to_string()))],
+            )
+            .map_err(|e| StoreError::Query(format!("count trigram postings: {e}")))?;
+        let posting_count = rows
+            .into_iter()
+            .next()
+            .and_then(|row| row.first().cloned())
+            .and_then(|value| match value {
+                Value::Int64(count) => Some(count.max(0) as usize),
+                _ => None,
+            })
+            .unwrap_or(0);
+        let mut delete_postings = conn
+            .prepare("MATCH (t:TrigramPosting {node_uid: $uid}) DETACH DELETE t")
+            .map_err(|e| StoreError::Query(format!("prepare trigram posting delete: {e}")))?;
+        conn.execute(
+            &mut delete_postings,
+            vec![("uid", Value::String(node_uid.to_string()))],
+        )
+        .map_err(|e| StoreError::Query(format!("delete trigram postings: {e}")))?;
+        let mut delete_doc = conn
+            .prepare("MATCH (d:TrigramDocument {uid: $uid}) DETACH DELETE d")
+            .map_err(|e| StoreError::Query(format!("prepare trigram document delete: {e}")))?;
+        conn.execute(
+            &mut delete_doc,
+            vec![("uid", Value::String(node_uid.to_string()))],
+        )
+        .map_err(|e| StoreError::Query(format!("delete trigram document: {e}")))?;
+        Ok(posting_count)
+    }
+
+    fn insert_trigram_document(
+        conn: &lbug::Connection<'_>,
+        candidate: &Candidate,
+    ) -> Result<(), StoreError> {
+        let mut insert = conn
+            .prepare("CREATE (:TrigramDocument {uid: $uid, scope_uid: $scope_uid, text_hash: $text_hash})")
+            .map_err(|e| StoreError::Query(format!("prepare trigram document insert: {e}")))?;
+        conn.execute(
+            &mut insert,
+            vec![
+                ("uid", Value::String(candidate.uid.clone())),
+                ("scope_uid", Value::String(candidate.scope_uid.clone())),
+                ("text_hash", Value::String(candidate.text_hash.clone())),
+            ],
+        )
+        .map_err(|e| StoreError::Query(format!("insert trigram document: {e}")))?;
+        Ok(())
+    }
+
+    fn read_trigram_scopes(&self) -> Result<HashMap<String, TrigramScopeState>, StoreError> {
+        let conn = match self.conn() {
+            Ok(conn) => conn,
+            Err(_) => return Ok(HashMap::new()),
         };
-        if indexed_generation != self.graph_generation() {
-            return true;
+        let rows = match conn.query(
+            "MATCH (s:TrigramScope) RETURN s.uid, s.status, s.candidate_count, s.candidate_digest",
+        ) {
+            Ok(rows) => rows,
+            // A read-only process can open a v1 database before a writer has
+            // run the schema migration. Missing/unreadable scope state means
+            // trust nothing and scan, never fail the correctness path.
+            Err(_) => return Ok(HashMap::new()),
+        };
+        let mut scopes = HashMap::new();
+        for row in rows {
+            if let [
+                Value::String(uid),
+                Value::String(status),
+                Value::Int64(count),
+                Value::String(digest),
+            ] = row.as_slice()
+            {
+                scopes.insert(
+                    uid.clone(),
+                    TrigramScopeState {
+                        status: status.clone(),
+                        candidate_count: (*count).max(0) as usize,
+                        candidate_digest: digest.clone(),
+                    },
+                );
+            }
         }
-        match self.searchable_candidate_count() {
-            Ok(count) => count != indexed_count,
-            // On a read error, distrust the index (safe direction).
-            Err(_) => true,
+        Ok(scopes)
+    }
+
+    fn read_trigram_documents(&self) -> Result<HashMap<String, TrigramDocumentState>, StoreError> {
+        let conn = self.conn()?;
+        let rows = conn
+            .query("MATCH (d:TrigramDocument) RETURN d.uid, d.scope_uid, d.text_hash")
+            .map_err(|e| StoreError::Query(format!("read trigram documents: {e}")))?;
+        let mut docs = HashMap::new();
+        for row in rows {
+            if let [
+                Value::String(uid),
+                Value::String(scope_uid),
+                Value::String(text_hash),
+            ] = row.as_slice()
+            {
+                docs.insert(
+                    uid.clone(),
+                    TrigramDocumentState {
+                        scope_uid: scope_uid.clone(),
+                        text_hash: text_hash.clone(),
+                    },
+                );
+            }
         }
+        Ok(docs)
     }
 
     /// Collect all searchable candidate nodes (Sections, Notes, Symbols),
@@ -459,13 +806,15 @@ impl GraphStore {
         // file_path for the location, so build a note_uid -> path map once.
         if want_kind("Section") {
             let notes = self.list_notes(None)?;
-            let note_path: HashMap<String, String> =
-                notes.into_iter().map(|n| (n.uid, n.file_path)).collect();
+            let note_path: HashMap<String, (String, String)> = notes
+                .into_iter()
+                .map(|n| (n.uid, (n.file_path, n.vault_uid)))
+                .collect();
             for s in self.list_all_sections()? {
                 if s.text_content.is_empty() {
                     continue;
                 }
-                let path = note_path.get(&s.note_uid).cloned().unwrap_or_default();
+                let (path, scope_uid) = note_path.get(&s.note_uid).cloned().unwrap_or_default();
                 let location = format!("{path}:{}", s.start_line);
                 if let Some(prefix) = path_prefix
                     && !path.starts_with(prefix)
@@ -474,6 +823,12 @@ impl GraphStore {
                 }
                 out.push(Candidate {
                     uid: s.uid,
+                    scope_uid,
+                    text_hash: if s.text_hash.is_empty() {
+                        text_hash(&s.text_content)
+                    } else {
+                        s.text_hash
+                    },
                     kind: "Section".to_string(),
                     title: String::new(),
                     location,
@@ -496,6 +851,8 @@ impl GraphStore {
                 }
                 out.push(Candidate {
                     uid: n.uid,
+                    scope_uid: n.vault_uid,
+                    text_hash: text_hash(&n.title),
                     kind: "Note".to_string(),
                     title: n.title.clone(),
                     location: n.file_path,
@@ -520,6 +877,8 @@ impl GraphStore {
                 let location = format!("{}:{}", sym.file_path, sym.start_line);
                 out.push(Candidate {
                     uid: sym.uid,
+                    scope_uid: sym.repo_uid,
+                    text_hash: text_hash(&sym.signature),
                     kind: "Symbol".to_string(),
                     title: sym.name,
                     location,
@@ -547,52 +906,137 @@ impl GraphStore {
     fn trigram_candidate_uids(
         &self,
         clauses: &[HashSet<String>],
-    ) -> Result<(Option<HashSet<String>>, bool), StoreError> {
-        if !self.has_trigram_index() {
-            return Ok((None, false));
+        all_candidates: &[Candidate],
+    ) -> Result<TrigramPrefilterPlan, StoreError> {
+        let mut by_scope: BTreeMap<String, Vec<Candidate>> = BTreeMap::new();
+        for candidate in all_candidates {
+            by_scope
+                .entry(candidate.scope_uid.clone())
+                .or_default()
+                .push(candidate.clone());
         }
-        if self.trigram_index_is_stale() {
-            // Correctness first: a stale pre-filter can drop real matches
-            // (nodes added after the build are invisible to it), so fall back
-            // to a full scan and say so once on stderr.
-            if !TRIGRAM_STALE_WARNED.swap(true, Ordering::Relaxed) {
-                eprintln!(
-                    "warning: trigram index is stale (graph changed since it was built); \
-                     falling back to full scan — rerun `index --with-trigrams` to restore the pre-filter"
-                );
+        for values in by_scope.values_mut() {
+            values.sort_by(|a, b| a.uid.cmp(&b.uid));
+        }
+        let mut corpus_hasher = blake3::Hasher::new();
+        for (scope_uid, candidates) in &by_scope {
+            corpus_hasher.update(scope_uid.as_bytes());
+            corpus_hasher.update(&[0]);
+            corpus_hasher.update(candidate_digest(candidates).as_bytes());
+            corpus_hasher.update(&[0xff]);
+        }
+        let corpus_digest = corpus_hasher.finalize().to_hex().to_string();
+        let generation = self.graph_generation();
+        let cached = self
+            .trigram_scope_cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+            .filter(|cache| cache.generation == generation && cache.corpus_digest == corpus_digest);
+        let (ready_scopes, dirty_scopes, has_index) = if let Some(cache) = cached {
+            (cache.ready_scopes, cache.dirty_scopes, cache.has_index)
+        } else {
+            let stored_scopes = self.read_trigram_scopes()?;
+            let has_index = self.has_trigram_index() || !stored_scopes.is_empty();
+            let mut ready_scopes = HashSet::new();
+            let mut dirty_scopes = HashSet::new();
+            for (scope_uid, candidates) in &by_scope {
+                let digest = candidate_digest(candidates);
+                if stored_scopes.get(scope_uid).is_some_and(|scope| {
+                    scope.status == "ready"
+                        && scope.candidate_count == candidates.len()
+                        && scope.candidate_digest == digest
+                }) {
+                    ready_scopes.insert(scope_uid.clone());
+                } else {
+                    dirty_scopes.insert(scope_uid.clone());
+                }
             }
-            return Ok((None, true));
+            for scope_uid in stored_scopes.keys() {
+                if !ready_scopes.contains(scope_uid) && !dirty_scopes.contains(scope_uid) {
+                    dirty_scopes.insert(scope_uid.clone());
+                }
+            }
+            *self
+                .trigram_scope_cache
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(TrigramScopeCache {
+                generation,
+                corpus_digest,
+                ready_scopes: ready_scopes.clone(),
+                dirty_scopes: dirty_scopes.clone(),
+                has_index,
+            });
+            (ready_scopes, dirty_scopes, has_index)
+        };
+
+        if has_index
+            && !dirty_scopes.is_empty()
+            && !TRIGRAM_STALE_WARNED.swap(true, Ordering::Relaxed)
+        {
+            eprintln!(
+                "warning: {} trigram scope(s) are stale; scanning only those scopes — rerun `index --with-trigrams` to refresh them",
+                dirty_scopes.len()
+            );
+        } else if dirty_scopes.is_empty() {
+            TRIGRAM_STALE_WARNED.store(false, Ordering::Relaxed);
         }
-        // A fresh index was observed: re-arm the one-shot warning latch so a
-        // long-lived process can warn again after a rebuild + restale.
-        TRIGRAM_STALE_WARNED.store(false, Ordering::Relaxed);
-        let conn = self.conn()?;
+
+        if ready_scopes.is_empty() {
+            return Ok(TrigramPrefilterPlan {
+                matching_ready_uids: HashSet::new(),
+                ready_scopes,
+                dirty_scopes,
+                has_index,
+            });
+        }
+
+        let conn = match self.conn() {
+            Ok(conn) => conn,
+            Err(_) => {
+                return Ok(widened_scan_plan(&ready_scopes, &dirty_scopes, has_index));
+            }
+        };
         let mut acc: Option<HashSet<String>> = None;
         for clause in clauses {
-            let mut clause_uids: HashSet<String> = HashSet::new();
+            let mut clause_uids = HashSet::new();
             for tg in clause {
-                let mut stmt = conn
-                    .prepare("MATCH (t:TrigramPosting {trigram: $tg}) RETURN t.node_uid")
-                    .map_err(|e| StoreError::Query(format!("prepare trigram lookup: {e}")))?;
-                let result = conn
-                    .execute(&mut stmt, vec![("tg", Value::String(tg.clone()))])
-                    .map_err(|e| StoreError::Query(format!("trigram lookup: {e}")))?;
-                for row in result {
-                    if let Some(Value::String(uid)) = row.first() {
+                let mut stmt = match conn.prepare(
+                    "MATCH (t:TrigramPosting {trigram: $tg}) RETURN t.node_uid, t.scope_uid",
+                ) {
+                    Ok(stmt) => stmt,
+                    Err(_) => {
+                        return Ok(widened_scan_plan(&ready_scopes, &dirty_scopes, has_index));
+                    }
+                };
+                let rows = match conn.execute(&mut stmt, vec![("tg", Value::String(tg.clone()))]) {
+                    Ok(rows) => rows,
+                    Err(_) => {
+                        return Ok(widened_scan_plan(&ready_scopes, &dirty_scopes, has_index));
+                    }
+                };
+                for row in rows {
+                    if let [Value::String(uid), Value::String(scope_uid)] = row.as_slice()
+                        && ready_scopes.contains(scope_uid)
+                    {
                         clause_uids.insert(uid.clone());
                     }
                 }
             }
             acc = Some(match acc {
                 None => clause_uids,
-                Some(prev) => prev.intersection(&clause_uids).cloned().collect(),
+                Some(previous) => previous.intersection(&clause_uids).cloned().collect(),
             });
-            // Early out: an empty intersection can never grow.
-            if acc.as_ref().is_some_and(|s| s.is_empty()) {
+            if acc.as_ref().is_some_and(HashSet::is_empty) {
                 break;
             }
         }
-        Ok((acc, false))
+        Ok(TrigramPrefilterPlan {
+            matching_ready_uids: acc.unwrap_or_default(),
+            ready_scopes,
+            dirty_scopes,
+            has_index,
+        })
     }
 
     /// First-party regex search over indexed text with an optional trigram
@@ -622,20 +1066,31 @@ impl GraphStore {
         let start = Instant::now();
         let limit = limit.unwrap_or(usize::MAX);
 
-        // Decide whether a trigram pre-filter is possible. A pattern with no
-        // usable literals never consults the index, so it reports no staleness.
+        // Validate scope manifests against the complete corpus before applying
+        // request filters. A path/kind subset must never make a healthy scope
+        // appear stale merely because candidates were intentionally omitted.
+        let all_candidates = self.collect_candidates(None, None)?;
         let clauses = required_trigram_clauses(pattern);
-        let (prefilter_uids, stale_index) = match &clauses {
-            Some(c) => self.trigram_candidate_uids(c)?,
-            None => (None, false),
+        let plan = match &clauses {
+            Some(clauses) => Some(self.trigram_candidate_uids(clauses, &all_candidates)?),
+            None => None,
         };
-        // scanned_fallback: we did NOT narrow via trigrams (no literals, or no
-        // posting table built).
-        let scanned_fallback = prefilter_uids.is_none();
+        let scanned_fallback = plan
+            .as_ref()
+            .is_none_or(|plan| !plan.dirty_scopes.is_empty());
+        let stale_index = plan
+            .as_ref()
+            .is_some_and(|plan| plan.has_index && !plan.dirty_scopes.is_empty());
+        let ready_scopes = plan.as_ref().map_or(0, |plan| plan.ready_scopes.len());
+        let dirty_scopes = plan.as_ref().map_or(0, |plan| plan.dirty_scopes.len());
 
         let mut candidates = self.collect_candidates(path_prefix, kinds)?;
-        if let Some(ref uids) = prefilter_uids {
-            candidates.retain(|c| uids.contains(&c.uid));
+        if let Some(plan) = &plan {
+            candidates.retain(|candidate| {
+                plan.dirty_scopes.contains(&candidate.scope_uid)
+                    || (plan.ready_scopes.contains(&candidate.scope_uid)
+                        && plan.matching_ready_uids.contains(&candidate.uid))
+            });
         }
 
         // Scan the full candidate set, bounded by the wall-clock deadline (and a
@@ -645,11 +1100,13 @@ impl GraphStore {
         // "the match was ordered past a 5000 cap and never scanned" (nw-076).
         let mut truncated = false;
         let mut results = Vec::new();
+        let mut scanned_candidates = 0usize;
         for (i, c) in candidates.iter().enumerate() {
             if start.elapsed().as_millis() as u64 > deadline_ms || i >= CANDIDATE_CAP {
                 truncated = true;
                 break;
             }
+            scanned_candidates += 1;
             if let Some(m) = re.find(&c.text) {
                 // Check the limit BEFORE pushing: with `--limit 0` the caller
                 // asked for no results, so even the first match must not be
@@ -697,6 +1154,9 @@ impl GraphStore {
             truncated,
             scanned_fallback,
             stale_index,
+            ready_scopes,
+            dirty_scopes,
+            scanned_candidates,
             note: None,
         }
         .with_scan_budget_note())
@@ -712,8 +1172,11 @@ impl GraphStore {
         path_prefix: Option<&str>,
         kinds: Option<&[String]>,
     ) -> Result<Vec<PatternCount>, StoreError> {
-        // Collect candidates once and reuse across patterns.
-        let all_candidates = self.collect_candidates(path_prefix, kinds)?;
+        // Scope trust is always verified against the complete corpus. Request
+        // filters select results only; they must not make omitted candidates
+        // look like scope drift and disable otherwise healthy postings.
+        let corpus_candidates = self.collect_candidates(None, None)?;
+        let filtered_candidates = self.collect_candidates(path_prefix, kinds)?;
 
         let mut out = Vec::new();
         for pattern in patterns {
@@ -721,19 +1184,27 @@ impl GraphStore {
 
             // Optional trigram narrowing.
             let clauses = required_trigram_clauses(pattern);
-            let (prefilter_uids, stale_index) = match &clauses {
-                Some(c) => self.trigram_candidate_uids(c)?,
-                None => (None, false),
+            let plan = match &clauses {
+                Some(clauses) => Some(self.trigram_candidate_uids(clauses, &corpus_candidates)?),
+                None => None,
             };
+            let stale_index = plan
+                .as_ref()
+                .is_some_and(|plan| plan.has_index && !plan.dirty_scopes.is_empty());
 
             let mut per_file: HashMap<String, u64> = HashMap::new();
             let mut total: u64 = 0;
-            for c in &all_candidates {
-                if let Some(ref uids) = prefilter_uids
-                    && !uids.contains(&c.uid)
-                {
-                    continue;
+            let mut scanned_candidates = 0usize;
+            for c in &filtered_candidates {
+                if let Some(plan) = &plan {
+                    let should_scan = plan.dirty_scopes.contains(&c.scope_uid)
+                        || (plan.ready_scopes.contains(&c.scope_uid)
+                            && plan.matching_ready_uids.contains(&c.uid));
+                    if !should_scan {
+                        continue;
+                    }
                 }
+                scanned_candidates += 1;
                 if re.is_match(&c.text) {
                     total += 1;
                     let file = file_of(&c.location);
@@ -755,6 +1226,9 @@ impl GraphStore {
                 files_matched,
                 top_files,
                 stale_index,
+                ready_scopes: plan.as_ref().map_or(0, |plan| plan.ready_scopes.len()),
+                dirty_scopes: plan.as_ref().map_or(0, |plan| plan.dirty_scopes.len()),
+                scanned_candidates,
             });
         }
         Ok(out)
@@ -794,6 +1268,9 @@ mod tests {
             truncated: true,
             scanned_fallback: false,
             stale_index: false,
+            ready_scopes: 0,
+            dirty_scopes: 0,
+            scanned_candidates: 0,
             note: None,
         }
         .with_scan_budget_note();
@@ -809,6 +1286,9 @@ mod tests {
             truncated: false,
             scanned_fallback: false,
             stale_index: false,
+            ready_scopes: 0,
+            dirty_scopes: 0,
+            scanned_candidates: 0,
             note: None,
         }
         .with_scan_budget_note();
@@ -832,6 +1312,9 @@ mod tests {
             truncated: true,
             scanned_fallback: false,
             stale_index: false,
+            ready_scopes: 0,
+            dirty_scopes: 0,
+            scanned_candidates: 0,
             note: None,
         }
         .with_scan_budget_note();
@@ -991,6 +1474,23 @@ mod tests {
             .unwrap();
         assert_eq!(counts_ci[0].total_matches, 2);
         assert_eq!(counts_ci[0].files_matched, 2);
+    }
+
+    #[test]
+    fn count_filters_do_not_make_complete_scopes_look_stale() {
+        let store = store_with_text();
+        store.build_trigram_index().unwrap();
+        let counts = store
+            .count_patterns(
+                &["authenticateUser".to_string()],
+                Some("src/"),
+                Some(&["Symbol".to_string()]),
+            )
+            .unwrap();
+        assert_eq!(counts[0].total_matches, 1);
+        assert!(!counts[0].stale_index);
+        assert_eq!(counts[0].dirty_scopes, 0);
+        assert_eq!(counts[0].scanned_candidates, 1);
     }
 
     #[test]
@@ -1295,10 +1795,138 @@ mod tests {
         );
     }
 
-    /// A generation bump without a count change (e.g. an in-place edit
-    /// through the engine) must also mark the index stale.
     #[test]
-    fn generation_bump_marks_trigram_index_stale() {
+    fn stable_posting_ids_are_order_independent_and_tuple_sensitive() {
+        let first = stable_posting_uid("abc", "sym:one");
+        assert_eq!(first, stable_posting_uid("abc", "sym:one"));
+        assert_ne!(first, stable_posting_uid("abd", "sym:one"));
+        assert_ne!(first, stable_posting_uid("abc", "sym:two"));
+        assert!(first.starts_with("tg:v2:"));
+    }
+
+    #[test]
+    fn legacy_positional_postings_migrate_to_scoped_v2_once() {
+        let store = store_with_text();
+        let conn = store.conn().unwrap();
+        conn.query("CREATE (:TrigramPosting {uid: 'tg:0', trigram: 'aut', node_uid: 'sym:1', scope_uid: ''})")
+            .unwrap();
+        conn.query("CREATE (:Meta {key: 'trigram_index', value: '1:1'})")
+            .unwrap();
+
+        let migration = store.refresh_trigram_index(false).unwrap();
+        assert!(migration.migrated_legacy_index);
+        assert!(migration.scopes_refreshed >= 2);
+        let legacy = conn
+            .query("MATCH (t:TrigramPosting) WHERE t.scope_uid = '' RETURN count(t)")
+            .unwrap()
+            .next()
+            .and_then(|row| row.first().cloned());
+        assert_eq!(legacy, Some(Value::Int64(0)));
+        let second = store.refresh_trigram_index(false).unwrap();
+        assert!(!second.migrated_legacy_index);
+        assert_eq!(second.scopes_refreshed, 0);
+    }
+
+    #[test]
+    fn dirty_repo_is_scanned_while_unrelated_scopes_keep_prefiltering() {
+        let _latch_guard = LATCH_TEST_LOCK.lock().unwrap();
+        let store = store_with_text();
+        let symbol = |uid: &str, repo_uid: &str, signature: &str| Symbol {
+            uid: uid.into(),
+            name: uid.into(),
+            kind: SymbolKind::Function,
+            repo_uid: repo_uid.into(),
+            file_path: format!("src/{uid}.rs"),
+            start_line: 1,
+            end_line: 1,
+            signature: signature.into(),
+            summary: None,
+            content_hash: text_hash(signature),
+            embedding: None,
+            pagerank_score: None,
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Inferred,
+            type_info: None,
+            framework_hint: None,
+            canonical_id: None,
+        };
+        store
+            .insert_symbol(&symbol("sym:repo2", "repo:2", "fn sharedScopeMarker()"))
+            .unwrap();
+        let first = store.refresh_trigram_index(false).unwrap();
+        assert!(first.scopes_refreshed >= 3, "repo 1, repo 2, and vault");
+
+        // Only repo:1 changes after publication.
+        store
+            .insert_symbol(&symbol("sym:repo1:new", "repo:1", "fn sharedScopeMarker()"))
+            .unwrap();
+        let result = store
+            .regex_search("sharedScopeMarker", None, None, None, None)
+            .unwrap();
+        let uids: HashSet<_> = result.results.iter().map(|hit| hit.uid.as_str()).collect();
+        assert!(uids.contains("sym:repo2"), "ready repo uses postings");
+        assert!(uids.contains("sym:repo1:new"), "dirty repo is scanned");
+        assert!(
+            result.scanned_fallback,
+            "mixed query includes a scoped scan"
+        );
+        assert!(result.stale_index);
+        assert!(result.ready_scopes >= 2);
+        assert_eq!(result.dirty_scopes, 1);
+
+        let refresh = store.refresh_trigram_index(false).unwrap();
+        assert_eq!(refresh.scopes_refreshed, 1);
+        assert!(refresh.scopes_unchanged >= 2);
+        assert_eq!(refresh.nodes_added, 1);
+        let unchanged = store.refresh_trigram_index(false).unwrap();
+        assert_eq!(unchanged.scopes_refreshed, 0);
+        assert_eq!(unchanged.postings_added, 0);
+        assert!(unchanged.scopes_unchanged >= 3);
+    }
+
+    #[test]
+    fn moving_a_node_to_an_earlier_scope_cannot_erase_new_postings() {
+        let store = store_with_text();
+        store.refresh_trigram_index(false).unwrap();
+
+        // `repo:0` sorts before the incumbent `repo:1`. This exercises the
+        // dangerous order where the destination publishes first and the
+        // source scope is cleaned afterward.
+        store
+            .conn()
+            .unwrap()
+            .query("MATCH (s:Symbol {uid: 'sym:1'}) SET s.repo_uid = 'repo:0'")
+            .unwrap();
+        let refresh = store.refresh_trigram_index(false).unwrap();
+        assert_eq!(refresh.nodes_changed, 1);
+        assert_eq!(refresh.nodes_deleted, 0);
+
+        let result = store
+            .regex_search("authenticateUser", None, None, None, None)
+            .unwrap();
+        assert!(
+            result.results.iter().any(|hit| hit.uid == "sym:1"),
+            "the moved symbol must remain reachable through its new postings"
+        );
+        assert!(
+            !result.scanned_fallback,
+            "both source cleanup and destination publication completed"
+        );
+        let scoped_postings = store
+            .conn()
+            .unwrap()
+            .query("MATCH (t:TrigramPosting {node_uid: 'sym:1'}) RETURN DISTINCT t.scope_uid")
+            .unwrap()
+            .filter_map(|row| row.first().cloned())
+            .collect::<Vec<_>>();
+        assert_eq!(scoped_postings, vec![Value::String("repo:0".to_string())]);
+    }
+
+    /// A generation bump with identical searchable digests must not cause any
+    /// scope to lose trust or rewrite postings.
+    #[test]
+    fn generation_bump_with_identical_digests_keeps_scopes_ready() {
         let _latch_guard = LATCH_TEST_LOCK.lock().unwrap();
         let store = store_with_text();
         store.build_trigram_index().unwrap();
@@ -1306,27 +1934,26 @@ mod tests {
         let res = store
             .regex_search("authenticateUser", None, None, None, None)
             .unwrap();
-        assert!(
-            res.scanned_fallback,
-            "a generation bump must stale the index"
-        );
+        assert!(!res.scanned_fallback);
+        assert!(!res.stale_index);
         assert!(
             !res.results.is_empty(),
             "the fallback scan still returns correct results"
         );
     }
 
-    /// Postings built before provenance tracking (no `Meta` key) cannot
-    /// be trusted — treat them as stale and scan.
+    /// Postings without v2 scope state cannot be trusted.
     #[test]
-    fn trigram_index_without_provenance_is_treated_as_stale() {
+    fn trigram_index_without_scope_state_is_treated_as_stale() {
         let _latch_guard = LATCH_TEST_LOCK.lock().unwrap();
         let store = store_with_text();
         store.build_trigram_index().unwrap();
-        // Simulate a legacy index: drop the provenance row.
+        // Simulate a partially migrated/legacy index: keep postings but drop
+        // the v2 trust records.
         let conn = store.conn().unwrap();
-        conn.query("MATCH (m:Meta {key: 'trigram_index'}) DETACH DELETE m")
+        conn.query("MATCH (s:TrigramScope) DETACH DELETE s")
             .unwrap();
+        *store.trigram_scope_cache.lock().unwrap() = None;
         let res = store
             .regex_search("authenticateUser", None, None, None, None)
             .unwrap();
@@ -1362,8 +1989,29 @@ mod tests {
         assert!(!res.scanned_fallback);
         assert!(!res.stale_index, "fresh index → not stale");
 
-        // Graph drifts (in-place-edit style generation bump): stale.
-        store.bump_graph_generation();
+        // Searchable content drifts in the repository scope: stale.
+        store
+            .insert_symbol(&Symbol {
+                uid: "sym:drift".into(),
+                name: "drift".into(),
+                kind: SymbolKind::Function,
+                repo_uid: "repo:1".into(),
+                file_path: "src/drift.rs".into(),
+                start_line: 1,
+                end_line: 1,
+                signature: "fn drift()".into(),
+                summary: None,
+                content_hash: "drift".into(),
+                embedding: None,
+                pagerank_score: None,
+                is_entry_point: false,
+                entry_point_kind: None,
+                visibility: Visibility::Inferred,
+                type_info: None,
+                framework_hint: None,
+                canonical_id: None,
+            })
+            .unwrap();
         let res = store
             .regex_search("authenticateUser", None, None, None, None)
             .unwrap();

--- a/docs/guide/instance-config.md
+++ b/docs/guide/instance-config.md
@@ -410,6 +410,27 @@ redefine core properties).
 extra_node_properties = { Symbol = { team_owner = "string", deprecated = "bool" } }
 ```
 
+### `[indexing]` (optional)
+
+Source code and Markdown notes have independent size policies. Source files
+default to 2 MiB and can be raised for repositories with unusually large,
+legitimate files:
+
+```toml
+[indexing]
+max_source_file_bytes = 8388608 # 8 MiB
+```
+
+The accepted range is 1 KiB through a fixed 64 MiB safety ceiling; invalid
+values fail config loading rather than being clamped. Markdown notes retain
+their separate 1 MiB policy. Every policy skip is reported by `nestweaver
+index`; use `--json` for a typed terminal result or `--fail-on-skip` when CI
+must reject degraded coverage.
+
+`index --with-trigrams` incrementally refreshes only changed repository/vault
+scopes. Use `--rebuild-trigrams` with it for a one-time full v2 migration or
+repair.
+
 ## Manifest Parsing (automatic)
 
 When you run `nestweaver index`, NestWeaver automatically reads the manifest

--- a/examples/nestweaver-instance.toml
+++ b/examples/nestweaver-instance.toml
@@ -164,6 +164,11 @@ components = ["device-onboarding", "user-auth"]
 stoplist_extend = ["Platform", "Service", "Manager"]
 min_symbol_name_length = 4
 
+# Source-code parser safety limit. Markdown notes keep their independent 1 MiB
+# policy. Values must be between 1 KiB and the fixed 64 MiB hard ceiling.
+[indexing]
+max_source_file_bytes = 2097152
+
 # ── MCP servers (for wiki source ingestion) ──────────────────────────────
 #
 # Declare external MCP servers that NestWeaver can call to fetch content

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -34,6 +34,10 @@ message IndexRepoRequest {
   bool with_trigrams = 4;
   bool with_git_activity = 5;
   string instance_id = 6;  // nw-019: logical instance for the indexed data. Empty = daemon decides (config name, else runtime hash).
+  bool rebuild_trigrams = 7;
+  // Validated client policy. Zero asks the daemon to use its configured/default
+  // value; non-zero must remain within the daemon's hard safety bounds.
+  uint64 max_source_file_bytes = 8;
 }
 
 message IndexVaultRequest {
@@ -110,6 +114,36 @@ message IndexProgress {
   uint64 files_processed = 3;
   uint64 files_total = 4;
   uint64 symbols_found = 5;
+  uint64 skipped_count = 6;
+  repeated IndexSkipDetail skipped_files = 7;
+  CoverageStatus coverage_status = 8;
+  TrigramRefreshDetail trigram_refresh = 9;
+}
+
+enum CoverageStatus {
+  COVERAGE_STATUS_UNSPECIFIED = 0;
+  COMPLETE = 1;
+  DEGRADED = 2;
+}
+
+message IndexSkipDetail {
+  string path = 1;
+  string reason_code = 2;
+  string detail = 3;
+  optional uint64 observed_bytes = 4;
+  optional uint64 limit_bytes = 5;
+}
+
+message TrigramRefreshDetail {
+  uint64 scopes_refreshed = 1;
+  uint64 scopes_unchanged = 2;
+  uint64 nodes_added = 3;
+  uint64 nodes_changed = 4;
+  uint64 nodes_deleted = 5;
+  uint64 postings_added = 6;
+  uint64 postings_deleted = 7;
+  bool migrated_legacy_index = 8;
+  uint64 elapsed_ms = 9;
 }
 
 // ─── Write RPCs ─────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,8 +101,7 @@ use nestweaver_engine::{
     export_graphml, export_in_memory_graph, export_mermaid, filter_by_target, find_bridge_nodes,
     find_hub_nodes, generate_agents_md_with_rules, generate_claude_md_with_rules,
     generate_cursor_rule_with_rules, generate_guide_with_tools, generate_repo_map,
-    generate_summaries, get_last_indexed_at, incremental_index_with_name,
-    index_directory_with_options, index_markdown_directory_since_with_ignore,
+    generate_summaries, get_last_indexed_at, index_markdown_directory_since_with_ignore,
     index_markdown_directory_with_ignore, index_markdown_directory_with_ignore_and_deletion_count,
     list_repos, list_services, load_alias_sidecar, load_clusters, load_extensions, lookup_symbol,
     record_last_indexed_at, render_text, save_clusters, save_cochange_sidecar, save_summaries,
@@ -2449,10 +2448,16 @@ enum Commands {
         name: Option<String>,
         #[arg(
             long = "with-trigrams",
-            help = "Build a trigram posting table over indexed text to accelerate `regex-search` \
-                    (opt-in storage cost)"
+            help = "Incrementally refresh trigram postings for changed repo/vault scopes to \
+                    accelerate `regex-search` (opt-in storage cost)"
         )]
         with_trigrams: bool,
+        #[arg(
+            long = "rebuild-trigrams",
+            requires = "with_trigrams",
+            help = "Force a full v2 trigram rebuild instead of refreshing changed scopes"
+        )]
+        rebuild_trigrams: bool,
         #[arg(
             long = "with-git-activity",
             help = "Feature F12: mine git history and write a <db>.gitactivity.json recency \
@@ -2465,6 +2470,12 @@ enum Commands {
                     opt-out for --with-git-activity"
         )]
         config: Option<PathBuf>,
+        /// Emit one terminal machine-readable result on stdout; progress remains on stderr.
+        #[arg(long)]
+        json: bool,
+        /// Return a non-zero exit status when eligible files were policy-skipped.
+        #[arg(long)]
+        fail_on_skip: bool,
         /// Configure detected AI tool integrations at the indexed repo root after
         /// indexing (bypasses the TTY/cwd auto-setup gate).
         #[arg(long)]
@@ -10721,6 +10732,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 return Ok((EXIT_ERROR, None));
             }
             let db_path = resolve_index_db_path(db, config.as_deref(), &repo_path)?;
+            let index_limits = match config.as_deref() {
+                Some(path) => nestweaver_engine::InstanceConfig::from_file(path)
+                    .with_context(|| format!("failed to load config from {}", path.display()))?
+                    .indexing
+                    .limits(),
+                None => nestweaver_engine::index_limits::IndexLimits::default(),
+            };
             // nw-019: --instance flag > config's instance_id > "default"
             // (mirrors `brain watch`/`brain add`; without this, `watch --config X`
             // with no --instance stamps symbols under "default" even with the
@@ -10812,7 +10830,8 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             }
 
             // Fallback: run watcher directly.
-            let watcher = CodeWatcher::new(&db_path, &repo_path, &instance_id);
+            let watcher =
+                CodeWatcher::new(&db_path, &repo_path, &instance_id).with_limits(index_limits);
             let stop = watcher.shutdown_handle();
 
             let lock_path = {
@@ -11272,6 +11291,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 truncated: false,
                                 scanned_fallback: false,
                                 stale_index: false,
+                                ready_scopes: 0,
+                                dirty_scopes: 0,
+                                scanned_candidates: 0,
                                 note: None,
                             }
                         });
@@ -11481,7 +11503,15 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
 
             let store = open_store(Some(&db_path))?;
             let root = root.unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
-            let reader = nestweaver_engine::content_reader::FilesystemReader::new(&root);
+            let limits = match config.as_deref() {
+                Some(path) => nestweaver_engine::InstanceConfig::from_file(path)
+                    .with_context(|| format!("failed to load config from {}", path.display()))?
+                    .indexing
+                    .limits(),
+                None => nestweaver_engine::index_limits::IndexLimits::default(),
+            };
+            let reader =
+                nestweaver_engine::content_reader::FilesystemReader::with_limits(&root, limits);
             let res = nestweaver_engine::read_symbols::read_symbols(
                 &store,
                 &targets,
@@ -13285,8 +13315,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             force,
             name,
             with_trigrams,
+            rebuild_trigrams,
             with_git_activity,
             config,
+            json,
+            fail_on_skip,
             setup,
         } => {
             let repo_path = match repo {
@@ -13300,6 +13333,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // instead of a confusing no-op.
             let repo_path = canonical_repo_dir(&repo_path)?;
             let db_path = resolve_index_db_path(db, config.as_deref(), &repo_path)?;
+            let index_limits = match config.as_deref() {
+                Some(path) => nestweaver_engine::InstanceConfig::from_file(path)
+                    .with_context(|| format!("failed to load config from {}", path.display()))?
+                    .indexing
+                    .limits(),
+                None => nestweaver_engine::index_limits::IndexLimits::default(),
+            };
             // Create-operation: a --db in a not-yet-existing directory must
             // not fail with a bare OS error on either the daemon or the
             // direct path — create the parent directories up front.
@@ -13328,12 +13368,21 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     force,
                     with_trigrams,
                     with_git_activity,
+                    rebuild_trigrams,
+                    // Zero preserves an already-running daemon's configured
+                    // policy when this invocation did not name a config.
+                    max_source_file_bytes: if config.is_some() {
+                        index_limits.max_source_file_bytes()
+                    } else {
+                        0
+                    },
                     // nw-019: thread an explicit `--instance` through the RPC so it
                     // overrides the daemon's default; empty lets the daemon decide.
                     instance_id: instance.clone().unwrap_or_default(),
                 };
 
                 let index_result = rt.block_on(async {
+                    let mut terminal_progress = None;
                     // A3: `index_repo` serialises behind the daemon write lock.
                     // Blocked behind a long embed it used to print nothing at
                     // all, which read as a hang. This adds a periodic notice
@@ -13347,7 +13396,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         },
                     );
                     let stream = client.inner_mut().index_repo(req).await?.into_inner();
-                    consume_cli_index_progress(stream, |progress| {
+                    let message = consume_cli_index_progress(stream, |progress| {
                         let phase_name = match progress.phase {
                             0 => "Discovering",
                             1 => "Parsing",
@@ -13359,21 +13408,95 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             _ => "Unknown",
                         };
                         eprintln!("[{phase_name}] {}", progress.message);
+                        if progress.phase == nestweaver_proto::Phase::Done as i32 {
+                            terminal_progress = Some(progress.clone());
+                        }
                     })
-                    .await
+                    .await?;
+                    Ok::<_, anyhow::Error>((message, terminal_progress))
                 });
 
                 // Logical failures arrive in-band. Empty, truncated, malformed,
                 // and transport-failed streams must also skip auto-setup.
-                if let Err(error) = index_result {
-                    out.status(&format!("Index failed: {error}"));
-                    return Ok((EXIT_ERROR, None));
+                let (_message, terminal) = match index_result {
+                    Ok(result) => result,
+                    Err(error) => {
+                        out.status(&format!("Index failed: {error}"));
+                        return Ok((EXIT_ERROR, None));
+                    }
+                };
+                let terminal = terminal.ok_or_else(|| {
+                    anyhow::anyhow!("index completed without a terminal progress payload")
+                })?;
+                if json {
+                    let skipped: Vec<_> = terminal
+                        .skipped_files
+                        .iter()
+                        .map(|file| {
+                            serde_json::json!({
+                                "path": file.path,
+                                "reason_code": file.reason_code,
+                                "detail": file.detail,
+                                "observed_bytes": file.observed_bytes,
+                                "limit_bytes": file.limit_bytes,
+                            })
+                        })
+                        .collect();
+                    let trigram_refresh = terminal.trigram_refresh.as_ref().map(|stats| {
+                        serde_json::json!({
+                            "scopes_refreshed": stats.scopes_refreshed,
+                            "scopes_unchanged": stats.scopes_unchanged,
+                            "nodes_added": stats.nodes_added,
+                            "nodes_changed": stats.nodes_changed,
+                            "nodes_deleted": stats.nodes_deleted,
+                            "postings_added": stats.postings_added,
+                            "postings_deleted": stats.postings_deleted,
+                            "migrated_legacy_index": stats.migrated_legacy_index,
+                            "elapsed_ms": stats.elapsed_ms,
+                        })
+                    });
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "coverage_status": if terminal.coverage_status
+                                == nestweaver_proto::CoverageStatus::Degraded as i32
+                            {
+                                "degraded"
+                            } else {
+                                "complete"
+                            },
+                            "files_processed": terminal.files_processed,
+                            "symbols_found": terminal.symbols_found,
+                            "skipped_count": terminal.skipped_count,
+                            "skipped_files": skipped,
+                            "trigram_refresh": trigram_refresh,
+                            "message": terminal.message,
+                        }))?
+                    );
+                } else if terminal.skipped_count > 0 {
+                    out.status(&format!(
+                        "Skipped {} eligible file(s):",
+                        terminal.skipped_count
+                    ));
+                    for file in &terminal.skipped_files {
+                        out.status(&format!(
+                            "  {} — {}: {}",
+                            file.path, file.reason_code, file.detail
+                        ));
+                    }
                 }
 
                 // nw-023: setup is client-side (config files + marker, no DB access); give
                 // daemon-mode users the same gated first-index convenience as the direct path.
                 maybe_run_auto_setup(&db_path, &repo_path, out, setup);
-                return Ok((EXIT_SUCCESS, None));
+                return Ok((
+                    if fail_on_skip && terminal.skipped_count > 0 {
+                        EXIT_ERROR
+                    } else {
+                        EXIT_SUCCESS
+                    },
+                    None,
+                ));
             }
 
             // nw-047: resolve `--instance` > config `instance_id` > "default"
@@ -13413,10 +13536,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 .unwrap_or_else(|| "local".to_string());
 
             let (files_count, symbols_count, edges_count);
+            let skipped_files;
 
             if force {
                 // Full re-index requested explicitly.
-                let result = index_directory_with_options(
+                let result = nestweaver_engine::index::index_directory_with_options_and_limits(
                     &repo_path,
                     &db_path,
                     &instance_id,
@@ -13424,6 +13548,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     &indexed_sha,
                     true,
                     name.as_deref(),
+                    index_limits,
                 )
                 .context("index_directory")?;
 
@@ -13431,31 +13556,30 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 symbols_count = result.symbols_count;
                 edges_count = result.edges_count;
 
-                println!(
-                    "Indexed {} file(s), {} symbol(s), {} edge(s).",
-                    files_count, symbols_count, edges_count
-                );
-
-                if !result.skipped_files.is_empty() {
-                    out.status(&format!("Skipped {} file(s):", result.skipped_files.len()));
-                    for sf in &result.skipped_files {
-                        out.status(&format!("  {} — {}", sf.path, sf.reason));
-                    }
+                if !json {
+                    println!(
+                        "Indexed {} file(s), {} symbol(s), {} edge(s).",
+                        files_count, symbols_count, edges_count
+                    );
                 }
+
+                skipped_files = result.skipped_files;
             } else {
                 // Incremental index (falls back to full when no prior index exists).
-                let inc = incremental_index_with_name(
+                let inc = nestweaver_engine::index::incremental_index_with_name_and_limits(
                     &repo_path,
                     &db_path,
                     &instance_id,
                     &repo_url,
                     name.as_deref(),
+                    index_limits,
                 )
                 .context("incremental_index")?;
 
                 files_count = inc.files_added + inc.files_modified;
                 symbols_count = inc.symbols_added;
                 edges_count = 0; // not tracked separately in incremental
+                skipped_files = inc.skipped_files.clone();
 
                 if inc.fell_back_to_full {
                     out.status(
@@ -13473,6 +13597,19 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     out.status(&format!(
                         "Incremental: {} symbol(s) added, {} symbol(s) removed.",
                         inc.symbols_added, inc.symbols_removed,
+                    ));
+                }
+            }
+
+            if !json && !skipped_files.is_empty() {
+                out.status(&format!(
+                    "Done — DEGRADED — skipped {} eligible file(s):",
+                    skipped_files.len()
+                ));
+                for file in &skipped_files {
+                    out.status(&format!(
+                        "  {} — {:?}: {}",
+                        file.path, file.reason_code, file.reason
                     ));
                 }
             }
@@ -13538,20 +13675,51 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
             }
 
+            let mut trigram_refresh_stats = None;
             if with_trigrams {
-                out.status("Building trigram index...");
+                out.status("Refreshing trigram index...");
                 let store = GraphStore::open(&db_path)
                     .with_context(|| format!("failed to open database at {}", db_path.display()))?;
-                let postings = store
-                    .build_trigram_index()
-                    .with_context(|| "build_trigram_index")?;
-                out.status(&format!("Trigram index built ({postings} postings)."));
+                let stats = if rebuild_trigrams {
+                    store.rebuild_trigram_index()
+                } else {
+                    store.refresh_trigram_index(false)
+                }
+                .with_context(|| "refresh_trigram_index")?;
+                out.status(&format!(
+                    "Trigram refresh: {} scope(s) refreshed, {} unchanged; {} node(s) added, {} changed, {} deleted; {} posting(s) added, {} deleted in {} ms{}.",
+                    stats.scopes_refreshed,
+                    stats.scopes_unchanged,
+                    stats.nodes_added,
+                    stats.nodes_changed,
+                    stats.nodes_deleted,
+                    stats.postings_added,
+                    stats.postings_deleted,
+                    stats.elapsed_ms,
+                    if stats.migrated_legacy_index { "; migrated legacy v1 index" } else { "" },
+                ));
+                trigram_refresh_stats = Some(stats);
             }
 
             // Auto-setup AI tool integrations on first index of this repo.
             // Uses a marker sidecar so it only fires once per db, not on every
             // incremental re-index. Non-fatal — a failure here never aborts the index.
             maybe_run_auto_setup(&db_path, &repo_path, out, setup);
+
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "coverage_status": if skipped_files.is_empty() { "complete" } else { "degraded" },
+                        "files_processed": files_count,
+                        "symbols_found": symbols_count,
+                        "edges_found": edges_count,
+                        "skipped_count": skipped_files.len(),
+                        "skipped_files": skipped_files,
+                        "trigram_refresh": trigram_refresh_stats,
+                    }))?
+                );
+            }
 
             let stats = format!(
                 "{} files, {} symbols, {} edges in {}",
@@ -13561,7 +13729,14 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 format_elapsed(t0.elapsed())
             );
 
-            Ok((EXIT_SUCCESS, Some(stats)))
+            Ok((
+                if fail_on_skip && !skipped_files.is_empty() {
+                    EXIT_ERROR
+                } else {
+                    EXIT_SUCCESS
+                },
+                Some(stats),
+            ))
         }
 
         Commands::Daemon { action, db } => {
@@ -16298,6 +16473,18 @@ fn pattern_count_from_tool_json(
             .get("stale_index")
             .and_then(|v| v.as_bool())
             .unwrap_or(false),
+        ready_scopes: c
+            .get("ready_scopes")
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0) as usize,
+        dirty_scopes: c
+            .get("dirty_scopes")
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0) as usize,
+        scanned_candidates: c
+            .get("scanned_candidates")
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0) as usize,
     })
 }
 
@@ -16306,7 +16493,7 @@ fn pattern_count_from_tool_json(
 /// the signal in-band via the `stale_index` field instead.
 fn print_stale_index_note() {
     println!(
-        "(trigram index is stale — results came from a full scan; reindex with `index --with-trigrams`)"
+        "(one or more trigram scopes are stale — only dirty scopes were scanned; refresh with `index --with-trigrams`)"
     );
 }
 
@@ -23550,7 +23737,7 @@ credential_method = "gh"
     }
 
     /// A `count_patterns` tool payload entry rebuilds into the direct
-    /// path's `PatternCount` — field order byte-identical, `stale_index`
+    /// path's `PatternCount` — field order byte-identical, compatibility fields
     /// defaulted for pre-field daemons.
     #[test]
     fn pattern_count_from_tool_json_rebuilds_direct_struct() {
@@ -23567,6 +23754,9 @@ credential_method = "gh"
         assert_eq!(c.total_matches, 4);
         assert_eq!(c.files_matched, 2);
         assert!(c.stale_index);
+        assert_eq!(c.ready_scopes, 0);
+        assert_eq!(c.dirty_scopes, 0);
+        assert_eq!(c.scanned_candidates, 0);
         assert_eq!(c.top_files.len(), 2);
         assert_eq!(c.top_files[0].path, "src/a.rs");
         assert_eq!(c.top_files[0].count, 3);
@@ -23575,7 +23765,7 @@ credential_method = "gh"
         let serialized = serde_json::to_string(&c).unwrap();
         assert_eq!(
             serialized,
-            r#"{"pattern":"foo","total_matches":4,"files_matched":2,"top_files":[{"path":"src/a.rs","count":3},{"path":"src/b.rs","count":1}],"stale_index":true}"#
+            r#"{"pattern":"foo","total_matches":4,"files_matched":2,"top_files":[{"path":"src/a.rs","count":3},{"path":"src/b.rs","count":1}],"stale_index":true,"ready_scopes":0,"dirty_scopes":0,"scanned_candidates":0}"#
         );
 
         // A pre-`stale_index` daemon payload still rebuilds (default false).
@@ -23587,6 +23777,9 @@ credential_method = "gh"
         });
         let c = pattern_count_from_tool_json(&old).expect("old payload must rebuild");
         assert!(!c.stale_index);
+        assert_eq!(c.ready_scopes, 0);
+        assert_eq!(c.dirty_scopes, 0);
+        assert_eq!(c.scanned_candidates, 0);
 
         // Malformed entries are skipped (None), not panicked on.
         assert!(pattern_count_from_tool_json(&serde_json::json!({"pattern": 1})).is_none());

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -2831,6 +2831,79 @@ credential_method = "gh"
     config_path
 }
 
+#[test]
+fn index_json_reports_degraded_source_coverage_and_fail_on_skip_is_strict() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    let mut source = String::from("pub fn oversized_marker() {}\n");
+    source.push_str(&"// padding\n".repeat(200));
+    assert!(source.len() > 1024);
+    std::fs::write(repo.join("main.rs"), source).unwrap();
+
+    let config = nw047_valid_config(dir.path(), "coverage-test");
+    let mut config_body = std::fs::read_to_string(&config).unwrap();
+    config_body.push_str("\n[indexing]\nmax_source_file_bytes = 1024\n");
+    std::fs::write(&config, config_body).unwrap();
+
+    let run = |db: &std::path::Path, fail_on_skip: bool| {
+        let mut command = nestweaver_cmd();
+        command
+            .args(["index", "--repo"])
+            .arg(&repo)
+            .arg("--db")
+            .arg(db)
+            .arg("--config")
+            .arg(&config)
+            .args(["--force", "--json"]);
+        if fail_on_skip {
+            command.arg("--fail-on-skip");
+        }
+        command.output().unwrap()
+    };
+
+    let best_effort = run(&dir.path().join("best-effort.lbug"), false);
+    assert!(best_effort.status.success(), "{best_effort:?}");
+    let payload: serde_json::Value = serde_json::from_slice(&best_effort.stdout).unwrap();
+    assert_eq!(payload["coverage_status"], "degraded");
+    assert_eq!(payload["skipped_count"], 1);
+    assert_eq!(payload["skipped_files"][0]["path"], "main.rs");
+    assert_eq!(payload["skipped_files"][0]["reason_code"], "oversized");
+    assert_eq!(payload["skipped_files"][0]["limit_bytes"], 1024);
+
+    let strict = run(&dir.path().join("strict.lbug"), true);
+    assert!(!strict.status.success());
+    let strict_payload: serde_json::Value = serde_json::from_slice(&strict.stdout).unwrap();
+    assert_eq!(strict_payload["coverage_status"], "degraded");
+    assert_eq!(strict_payload["skipped_count"], 1);
+}
+
+#[test]
+fn invalid_source_limit_fails_before_database_creation() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    std::fs::write(repo.join("main.rs"), "pub fn marker() {}\n").unwrap();
+    let config = nw047_valid_config(dir.path(), "invalid-limit");
+    let mut config_body = std::fs::read_to_string(&config).unwrap();
+    config_body.push_str("\n[indexing]\nmax_source_file_bytes = 512\n");
+    std::fs::write(&config, config_body).unwrap();
+    let db = dir.path().join("must-not-exist").join("brain.lbug");
+
+    nestweaver_cmd()
+        .args(["index", "--repo"])
+        .arg(&repo)
+        .arg("--db")
+        .arg(&db)
+        .arg("--config")
+        .arg(&config)
+        .assert()
+        .failure()
+        .stderr(contains("max_source_file_bytes"));
+    assert!(!db.exists());
+    assert!(!db.parent().unwrap().exists());
+}
+
 fn nw047_repo_instances(db_path: &std::path::Path) -> Vec<String> {
     let output = nestweaver_cmd()
         .args(["list-repos", "--json", "--db"])


### PR DESCRIPTION
## Summary

- separate the fixed 1 MiB Markdown policy from a configurable source-code ceiling
- report oversized/minified source skips through CLI, JSON, MCP, daemon progress, and strict `--fail-on-skip`
- replace positional trigram postings with stable content-derived IDs and per-document/per-scope provenance
- refresh only changed trigram scopes while safely scanning dirty scopes and migrating legacy indexes

## Why

The Markdown size limit was being reused as a source-code OOM guard, silently excluding legitimate files such as NestWeaver's own `main.rs`. Trigram provenance was global and posting identities were positional, so any graph mutation invalidated and rewrote the complete index.

## Impact

Source coverage is now explicit and configurable without weakening the Markdown policy. Regex queries preserve no-false-negative behavior while unchanged repositories retain ready trigram postings. Legacy indexes migrate automatically, and interrupted or dirty scopes fall back to direct scanning.

## Validation

- `cargo test -p nestweaver-engine -- --test-threads=1` — 1,103 unit tests and 17 integration tests passed; four platform-timing tests ignored as designed
- `cargo test --workspace --exclude nestweaver-engine -- --test-threads=1` — all remaining workspace tests and doc tests passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check -p nestweaver-mcp --no-default-features`
- affected crates compiled with all features; normal workspace check passed
- `cargo fmt --all -- --check`
- `git diff --check`
- manual self-index: 472 files, 17,455 symbols, including the previously skipped `main.rs`
- manual two-repository trigram validation covered unchanged-scope reuse and mixed ready/dirty search fallback
