### PR TITLE
fix: harden publication and query lifecycle regressions

### DIFF
--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -493,12 +493,83 @@ fn adoption_lock_verdict(
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RestartRequest {
+    AutomaticReplacement,
+    ExplicitCommand,
+}
+
+fn restart_ownership_allowed(
+    owner: nestweaver_daemon::lifecycle::DaemonLifecycleOwner,
+    request: RestartRequest,
+    verified_platform_supervisor: bool,
+) -> bool {
+    owner == nestweaver_daemon::lifecycle::DaemonLifecycleOwner::NestweaverManaged
+        || (request == RestartRequest::ExplicitCommand && verified_platform_supervisor)
+}
+
+#[cfg(target_os = "macos")]
+fn launchd_supervisor_matches(db_path: &Path, instance_id: &str) -> bool {
+    if !nestweaver_daemon::launchd::is_running(instance_id) {
+        return false;
+    }
+    let plist = nestweaver_daemon::lifecycle::launchd_plist_path(instance_id);
+    let Ok(contents) = std::fs::read_to_string(plist) else {
+        return false;
+    };
+    let Some(plist_db) = nestweaver_daemon::launchd::parse_db_path_from_plist(&contents) else {
+        return false;
+    };
+    nestweaver_daemon::lifecycle::canonical_db_path(&plist_db)
+        == nestweaver_daemon::lifecycle::canonical_db_path(db_path)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn launchd_supervisor_matches(_db_path: &Path, _instance_id: &str) -> bool {
+    false
+}
+
 /// Capture trustworthy live daemon ownership and configuration before any
-/// shutdown request. Callers must not shut down when this returns an error.
+/// automatic version-replacement shutdown request. Callers must not shut down
+/// when this returns an error.
 pub fn prepare_restart(
     db_path: &Path,
     health: &nestweaver_proto::HealthCheckResponse,
     explicit_config: Option<&Path>,
+) -> Result<PreparedRestart> {
+    prepare_restart_for(
+        db_path,
+        health,
+        explicit_config,
+        RestartRequest::AutomaticReplacement,
+    )
+}
+
+/// Prepare a user-requested `daemon restart`.
+///
+/// Automatic replacement remains limited to NestWeaver-managed detached
+/// daemons. An explicit command may also restart a daemon whose launchd job and
+/// plist are both verified to target this exact database; the restart command
+/// preserves that supervisor route instead of replacing it with a detached
+/// process.
+pub fn prepare_explicit_restart(
+    db_path: &Path,
+    health: &nestweaver_proto::HealthCheckResponse,
+    explicit_config: Option<&Path>,
+) -> Result<PreparedRestart> {
+    prepare_restart_for(
+        db_path,
+        health,
+        explicit_config,
+        RestartRequest::ExplicitCommand,
+    )
+}
+
+fn prepare_restart_for(
+    db_path: &Path,
+    health: &nestweaver_proto::HealthCheckResponse,
+    explicit_config: Option<&Path>,
+    request: RestartRequest,
 ) -> Result<PreparedRestart> {
     let instance_id = nestweaver_daemon::lifecycle::instance_id_from_db_path(db_path);
     let prepared = (|| {
@@ -508,12 +579,23 @@ pub fn prepare_restart(
             health.instance_id
         );
         let pidfile = open_verified_live_pidfile(&instance_id, health.pid)?;
-        let config = select_restart_config(explicit_config, || {
-            nestweaver_daemon::lifecycle::read_effective_config_binding_for_verified_pid(
-                &instance_id,
-                health.pid,
-            )
-        })?;
+        let binding = nestweaver_daemon::lifecycle::read_effective_config_binding_for_verified_pid(
+            &instance_id,
+            health.pid,
+        )?;
+        let verified_platform_supervisor = launchd_supervisor_matches(db_path, &instance_id);
+        anyhow::ensure!(
+            restart_ownership_allowed(
+                binding.lifecycle_owner,
+                request,
+                verified_platform_supervisor
+            ),
+            "daemon PID {} is supervisor-managed, foreground, or has unknown lifecycle ownership; refusing to shut it down and replace it with a detached process. Restart it through its supervisor (for systemd: `systemctl --user restart nestweaver`; for launchd: `launchctl kickstart -k gui/$(id -u)/{}`), or stop it and run `nestweaver daemon --db {} start`",
+            health.pid,
+            nestweaver_daemon::lifecycle::launchd_label(&instance_id),
+            db_path.display()
+        );
+        let config = select_restart_config(explicit_config, || Ok(binding))?;
         Ok(PreparedRestart {
             config,
             daemon_pid: health.pid,
@@ -530,8 +612,10 @@ fn restart_prepare_result<T>(db_path: &Path, prepared: Result<T>) -> Result<T> {
     prepared.with_context(|| {
         format!(
             "refusing automatic daemon restart because its live configuration and ownership could not be verified. \
-             The daemon has not been shut down. Re-run this command with --config <path>, or restart it manually \
-             with `nestweaver daemon --db {} restart --config <path>`",
+             The daemon has not been shut down. Restart it through its supervisor. If it is intentionally \
+             NestWeaver-managed, run `nestweaver daemon --db {} stop`, verify that it exits, then run \
+             `nestweaver daemon --db {} start --config <path>`",
+            db_path.display(),
             db_path.display()
         )
     })
@@ -1651,7 +1735,10 @@ credential_method = "gh"
             ),
         )
         .unwrap_err();
-        assert!(format!("{old_daemon:#}").contains("restart it manually"));
+        assert!(
+            format!("{old_daemon:#}").contains("Restart it through its supervisor"),
+            "{old_daemon:#}"
+        );
     }
 
     #[test]
@@ -2161,6 +2248,79 @@ credential_method = "gh"
             let _ =
                 fs::remove_dir_all(nestweaver_daemon::lifecycle::runtime_dir(&self.instance_id));
         }
+    }
+
+    #[test]
+    fn version_replacement_requires_verified_nestweaver_ownership() {
+        use std::os::fd::AsRawFd;
+
+        let dir = tempfile::tempdir().unwrap();
+        let fixture = RuntimeDirFixture::new(&dir);
+        let pid = std::process::id();
+        fs::write(&fixture.pidfile, format!("{pid}\n")).unwrap();
+        let owner = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&fixture.pidfile)
+            .unwrap();
+        assert_eq!(unsafe { libc::flock(owner.as_raw_fd(), libc::LOCK_EX) }, 0);
+        let health = health_for(pid, &fixture.instance_id);
+
+        let external = nestweaver_daemon::lifecycle::EffectiveConfigBinding::new(
+            pid,
+            nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::CompiledDefaults,
+        );
+        nestweaver_daemon::lifecycle::write_effective_config_binding(
+            &fixture.instance_id,
+            &external,
+        )
+        .unwrap();
+        let refusal = prepare_restart(&fixture.db, &health, None).unwrap_err();
+        assert!(
+            format!("{refusal:#}").contains("refusing to shut it down"),
+            "{refusal:#}"
+        );
+
+        let autostart =
+            nestweaver_daemon::lifecycle::EffectiveConfigBinding::new_with_lifecycle_owner(
+                pid,
+                nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::CompiledDefaults,
+                nestweaver_daemon::lifecycle::DaemonLifecycleOwner::NestweaverManaged,
+            );
+        nestweaver_daemon::lifecycle::write_effective_config_binding(
+            &fixture.instance_id,
+            &autostart,
+        )
+        .unwrap();
+        let prepared = prepare_restart(&fixture.db, &health, None)
+            .expect("a live, attested NestWeaver-managed owner may be replaced");
+        assert_eq!(prepared.daemon_pid, pid);
+    }
+
+    #[test]
+    fn only_an_explicit_command_may_use_verified_platform_supervisor_ownership() {
+        use nestweaver_daemon::lifecycle::DaemonLifecycleOwner;
+
+        assert!(restart_ownership_allowed(
+            DaemonLifecycleOwner::NestweaverManaged,
+            RestartRequest::AutomaticReplacement,
+            false,
+        ));
+        assert!(!restart_ownership_allowed(
+            DaemonLifecycleOwner::ExternalOrUnknown,
+            RestartRequest::AutomaticReplacement,
+            true,
+        ));
+        assert!(restart_ownership_allowed(
+            DaemonLifecycleOwner::ExternalOrUnknown,
+            RestartRequest::ExplicitCommand,
+            true,
+        ));
+        assert!(!restart_ownership_allowed(
+            DaemonLifecycleOwner::ExternalOrUnknown,
+            RestartRequest::ExplicitCommand,
+            false,
+        ));
     }
 
     #[test]

--- a/crates/nestweaver-daemon/src/lifecycle.rs
+++ b/crates/nestweaver-daemon/src/lifecycle.rs
@@ -14,6 +14,24 @@ static EFFECTIVE_CONFIG_TEMP_SEQUENCE: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 static LAST_SUCCESSFUL_CONFIG_TEMP_SEQUENCE: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
+/// Process-local proof that this daemon was started through NestWeaver's
+/// managed `daemon start` path. Unlike an environment variable, an external
+/// supervisor cannot accidentally inherit or forge this marker. The command
+/// sets it only after acquiring or validating the locked spawn descriptor.
+static VERIFIED_NESTWEAVER_MANAGED_START: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+pub fn mark_verified_nestweaver_managed_start() {
+    VERIFIED_NESTWEAVER_MANAGED_START.store(true, std::sync::atomic::Ordering::Release);
+}
+
+pub fn clear_verified_nestweaver_managed_start() {
+    VERIFIED_NESTWEAVER_MANAGED_START.store(false, std::sync::atomic::Ordering::Release);
+}
+
+pub fn is_verified_nestweaver_managed_start() -> bool {
+    VERIFIED_NESTWEAVER_MANAGED_START.load(std::sync::atomic::Ordering::Acquire)
+}
 
 /// Process-wide lock serializing every test that swaps OR durably reads the
 /// XDG/socket-fallback env vars. Defined at module level (not inside the
@@ -259,6 +277,20 @@ pub enum EffectiveConfigBindingSource {
     CompiledDefaults,
 }
 
+/// The authority responsible for keeping a daemon alive.
+///
+/// Only `NestweaverManaged` authorizes in-client version replacement. This
+/// covers manual and automatic `daemon start`, both of which prove the spawn
+/// lock before forking. Foreground and supervisor-owned daemons must be
+/// restarted by their owner so a detached process cannot escape it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DaemonLifecycleOwner {
+    NestweaverManaged,
+    #[default]
+    ExternalOrUnknown,
+}
+
 /// Versioned daemon-owned live binding between an instance, PID, and its
 /// effective configuration. This record is meaningful only while `pid` still
 /// identifies the daemon holding the corresponding pidfile lock.
@@ -267,14 +299,29 @@ pub struct EffectiveConfigBinding {
     pub version: u32,
     pub pid: u32,
     pub effective_config: EffectiveConfigBindingSource,
+    #[serde(default)]
+    pub lifecycle_owner: DaemonLifecycleOwner,
 }
 
 impl EffectiveConfigBinding {
     pub fn new(pid: u32, effective_config: EffectiveConfigBindingSource) -> Self {
+        Self::new_with_lifecycle_owner(
+            pid,
+            effective_config,
+            DaemonLifecycleOwner::ExternalOrUnknown,
+        )
+    }
+
+    pub fn new_with_lifecycle_owner(
+        pid: u32,
+        effective_config: EffectiveConfigBindingSource,
+        lifecycle_owner: DaemonLifecycleOwner,
+    ) -> Self {
         Self {
             version: EFFECTIVE_CONFIG_BINDING_VERSION,
             pid,
             effective_config,
+            lifecycle_owner,
         }
     }
 }
@@ -2278,7 +2325,10 @@ pub fn legacy_instance_id_from_db_path(db_path: &Path) -> String {
 pub fn stop_legacy_hash_daemon(db_path: &Path) {
     let new_id = instance_id_from_db_path(db_path);
     let old_id = legacy_instance_id_from_db_path(db_path);
-    retire_daemon_under_old_identity(&old_id, &new_id, "hash algorithm upgrade");
+    if let Err(error) = retire_daemon_under_old_identity(&old_id, &new_id, "hash algorithm upgrade")
+    {
+        tracing::warn!(%error, "could not retire daemon under the legacy hash identity");
+    }
 }
 
 /// Stop a daemon bound to the pre-anchoring, SELECTED-SLOT instance id.
@@ -2296,18 +2346,40 @@ pub fn stop_legacy_hash_daemon(db_path: &Path) {
 /// over resolves to its own base path and returns immediately, and an
 /// unreadable CURRENT is not a reason to fail a daemon start.
 pub fn stop_selected_slot_identity_daemon(db_path: &Path) {
-    let anchor = nestweaver_engine::publication::instance_anchor_database(db_path);
-    let Ok(selected) = nestweaver_engine::publication::resolve_selected_database(&anchor) else {
-        return;
-    };
-    // No publication in play — the pre-fix id equals the new one.
-    if selected == anchor {
-        return;
+    if let Err(error) = retire_selected_slot_identity_daemon(db_path) {
+        tracing::warn!(%error, "could not retire daemon under the selected-slot identity");
     }
+}
+
+/// Fallible selected-slot migration for direct lifecycle commands. Unlike the
+/// best-effort autostart compatibility hook, this refuses to let a command
+/// claim success while a verified old owner is still draining or its identity
+/// cannot be proved safely.
+pub fn retire_selected_slot_identity_daemon(db_path: &Path) -> anyhow::Result<()> {
+    let Some(old_id) = selected_slot_identity_instance_id(db_path) else {
+        return Ok(());
+    };
+    let new_id = instance_id_from_db_path(db_path);
+    retire_daemon_under_old_identity(&old_id, &new_id, "publication identity anchoring")
+}
+
+/// Return the pre-anchoring selected-slot identity when a publication is
+/// active. This read-only probe lets direct lifecycle commands report the same
+/// legacy owner that autostart migrates instead of claiming no daemon exists.
+pub fn selected_slot_identity_instance_id(db_path: &Path) -> Option<String> {
+    let anchor = nestweaver_engine::publication::instance_anchor_database(db_path);
+    let root = nestweaver_engine::publication::default_publication_root(&anchor);
+    let current = nestweaver_engine::publication::read_current(&root).ok()??;
+    // Identity recovery must not open or validate the selected graph: a corrupt
+    // slot is exactly when an operator most needs `daemon stop` to find its
+    // runtime owner.
+    let selected = nestweaver_engine::publication::slot_path(&root, &current.publication_uuid)
+        .ok()?
+        .join(nestweaver_engine::publication::PUBLICATION_GRAPH_FILE);
     let new_id = instance_id_from_db_path(&anchor);
     // The pre-fix identity: the SELECTED path, hashed WITHOUT the anchor step.
     let old_id = instance_id_from_canonical_path(&canonical_db_path(&selected));
-    retire_daemon_under_old_identity(&old_id, &new_id, "publication identity anchoring");
+    (old_id != new_id).then_some(old_id)
 }
 
 /// The pid of a daemon still running under the pre-anchoring, selected-slot
@@ -2339,12 +2411,16 @@ pub fn selected_slot_identity_daemon_pid(db_path: &Path) -> Option<i32> {
 /// Stop and clean up a daemon left behind under a superseded instance id.
 ///
 /// Shared by every identity migration so a new one cannot get the shutdown
-/// sequence subtly wrong: SIGTERM, bounded wait, SIGKILL, unload the launchd
-/// plist, then remove the runtime artifacts.
-fn retire_daemon_under_old_identity(old_id: &str, new_id: &str, reason: &str) {
+/// sequence subtly wrong: verified SIGTERM, bounded drain, unload the launchd
+/// plist, then remove runtime artifacts only after ownership is released.
+fn retire_daemon_under_old_identity(
+    old_id: &str,
+    new_id: &str,
+    reason: &str,
+) -> anyhow::Result<()> {
     // If the ids happen to coincide, nothing to migrate.
     if new_id == old_id {
-        return;
+        return Ok(());
     }
     let old_id = old_id.to_string();
     let new_id = new_id.to_string();
@@ -2354,14 +2430,46 @@ fn retire_daemon_under_old_identity(old_id: &str, new_id: &str, reason: &str) {
     let old_rt_dir = runtime_dir(&old_id);
 
     if !old_pid_path.exists() && !old_sock_path.exists() && !old_binding_path.exists() {
-        return;
+        return Ok(());
     }
 
-    // Try to read the PID and stop the old daemon gracefully.
-    if let Ok(content) = std::fs::read_to_string(&old_pid_path)
-        && let Ok(pid) = content.trim().parse::<i32>()
-        && pid > 0
-    {
+    // Prefer kernel socket-peer identity; fall back to a pidfile only when its
+    // exact inode is still flock-owned and the daemon-owned live binding names
+    // the same PID. A numeric pidfile alone may be stale/recycled and never
+    // authorizes a signal.
+    let socket_pid = std::os::unix::net::UnixStream::connect(&old_sock_path)
+        .ok()
+        .and_then(|stream| unix_socket_peer_pid(&stream));
+    let pidfile_pid = std::fs::read_to_string(&old_pid_path)
+        .ok()
+        .and_then(|content| content.trim().parse::<i32>().ok())
+        .filter(|pid| *pid > 0);
+    let pidfile_owned = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&old_pid_path)
+        .ok()
+        .is_some_and(|file| {
+            let acquired = unsafe {
+                libc::flock(
+                    std::os::fd::AsRawFd::as_raw_fd(&file),
+                    libc::LOCK_EX | libc::LOCK_NB,
+                ) == 0
+            };
+            if acquired {
+                unsafe {
+                    libc::flock(std::os::fd::AsRawFd::as_raw_fd(&file), libc::LOCK_UN);
+                }
+            }
+            !acquired
+        });
+    let bound_pid = pidfile_pid.filter(|pid| {
+        pidfile_owned
+            && read_effective_config_binding_for_verified_pid(&old_id, *pid as u32).is_ok()
+    });
+    let verified_pid = socket_pid.or(bound_pid);
+
+    if let Some(pid) = verified_pid {
         let alive = unsafe { libc::kill(pid, 0) == 0 };
         if alive {
             tracing::info!(
@@ -2383,16 +2491,15 @@ fn retire_daemon_under_old_identity(old_id: &str, new_id: &str, reason: &str) {
                 std::thread::sleep(std::time::Duration::from_millis(100));
             }
             if unsafe { libc::kill(pid, 0) == 0 } {
-                tracing::warn!(
-                    pid,
-                    "daemon under the superseded identity did not exit after SIGTERM, sending SIGKILL"
+                anyhow::bail!(
+                    "daemon PID {pid} under superseded identity {old_id} is still draining after SIGTERM; its runtime ownership was left intact"
                 );
-                unsafe {
-                    libc::kill(pid, libc::SIGKILL);
-                }
-                std::thread::sleep(std::time::Duration::from_millis(200));
             }
         }
+    } else if socket_pid.is_some() || pidfile_owned {
+        anyhow::bail!(
+            "superseded daemon runtime {old_id} is owned but its PID identity could not be verified during {reason}; refusing to signal or clean it"
+        );
     }
 
     // Unload the old launchd plist on macOS if it exists.
@@ -2415,6 +2522,7 @@ fn retire_daemon_under_old_identity(old_id: &str, new_id: &str, reason: &str) {
     let _ = std::fs::remove_file(&old_pid_path);
     let _ = std::fs::remove_file(&old_binding_path);
     let _ = std::fs::remove_dir(&old_rt_dir);
+    Ok(())
 }
 
 #[cfg(test)]
@@ -2507,6 +2615,39 @@ mod tests {
             instance_id_from_canonical_path(&canonical_db_path(base)),
             anchored
         );
+    }
+
+    #[test]
+    fn direct_lifecycle_probe_finds_selected_slot_identity_without_opening_graph() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("brain.lbug");
+        let root = nestweaver_engine::publication::default_publication_root(&base);
+        std::fs::create_dir_all(&root).unwrap();
+        let identity = nestweaver_store::PublicationIdentity {
+            brain_uuid: "11111111-1111-4111-8111-111111111111".to_string(),
+            publication_uuid: "22222222-2222-4222-8222-222222222222".to_string(),
+        };
+        let pointer = nestweaver_engine::publication::CurrentPublicationPointer::new(
+            &identity,
+            None,
+            "a".repeat(64),
+        )
+        .unwrap();
+        std::fs::write(
+            nestweaver_engine::publication::current_pointer_path(&root),
+            serde_json::to_vec(&pointer).unwrap(),
+        )
+        .unwrap();
+
+        let selected = nestweaver_engine::publication::slot_path(&root, &identity.publication_uuid)
+            .unwrap()
+            .join(nestweaver_engine::publication::PUBLICATION_GRAPH_FILE);
+        let expected = instance_id_from_canonical_path(&canonical_db_path(&selected));
+        assert_eq!(
+            selected_slot_identity_instance_id(&base).as_deref(),
+            Some(expected.as_str())
+        );
+        assert!(!selected.exists(), "the probe must not require the graph");
     }
 
     #[test]
@@ -3005,7 +3146,7 @@ mod tests {
             let binding_path = effective_config_binding_path(old_id);
             assert!(binding_path.exists(), "fixture must seed the old binding");
 
-            retire_daemon_under_old_identity(old_id, new_id, "test migration");
+            retire_daemon_under_old_identity(old_id, new_id, "test migration").unwrap();
 
             assert!(
                 !binding_path.exists(),
@@ -3030,7 +3171,7 @@ mod tests {
             write_effective_config_binding(id, &binding).unwrap();
             let binding_path = effective_config_binding_path(id);
 
-            retire_daemon_under_old_identity(id, id, "same identity");
+            retire_daemon_under_old_identity(id, id, "same identity").unwrap();
 
             assert!(
                 binding_path.exists(),

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -8904,7 +8904,25 @@ pub async fn run_server(
     if let Some(parent) = db_path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    let db_path = lifecycle::canonical_db_path(db_path);
+    let requested_db_path = lifecycle::canonical_db_path(db_path);
+    let base_db_path = nestweaver_engine::publication::instance_anchor_database(&requested_db_path);
+    let publication_root = nestweaver_engine::publication::default_publication_root(&base_db_path);
+    // Serialize CURRENT resolution plus GraphStore open with rollback/prune/CAS.
+    // Once the graph's write lock is held, a rollback owner can observe this
+    // daemon through the pidfile and refuse; releasing earlier would reopen the
+    // check-to-open race that leaves a daemon serving an abandoned slot.
+    let snapshot_replica = server_opts
+        .as_ref()
+        .and_then(|options| options.snapshot.as_ref())
+        .is_some();
+    let publication_root_lock = (!snapshot_replica)
+        .then(|| nestweaver_engine::publication::PublicationRootLock::acquire(&publication_root))
+        .transpose()?;
+    let db_path = if snapshot_replica {
+        requested_db_path
+    } else {
+        nestweaver_engine::publication::resolve_selected_database(&base_db_path)?
+    };
 
     let instance_id = lifecycle::instance_id_from_db_path(&db_path);
     let instance_label = lifecycle::instance_label_from_db_path(&db_path);
@@ -9085,6 +9103,7 @@ pub async fn run_server(
             }
         }
     };
+    drop(publication_root_lock);
     if let Some(config) = instance_cfg.as_ref() {
         config.assert_expected_brain(&store).with_context(|| {
             format!(
@@ -9147,9 +9166,15 @@ pub async fn run_server(
     // unreadable, or malformed input is fatal in both UDS and network server
     // modes; otherwise a restart-time file race could silently demote the
     // instance to compiled-default identity and authorization.
-    let live_binding = lifecycle::EffectiveConfigBinding::new(
+    let lifecycle_owner = if lifecycle::is_verified_nestweaver_managed_start() {
+        lifecycle::DaemonLifecycleOwner::NestweaverManaged
+    } else {
+        lifecycle::DaemonLifecycleOwner::ExternalOrUnknown
+    };
+    let live_binding = lifecycle::EffectiveConfigBinding::new_with_lifecycle_owner(
         std::process::id(),
         live_binding_source(&effective_config),
+        lifecycle_owner,
     );
     lifecycle::write_effective_config_binding(&instance_id, &live_binding).with_context(|| {
         format!("publish effective-config binding for daemon instance {instance_id}")

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -5201,6 +5201,8 @@ fn incremental_index_with_name_and_io(
     // If we crash before commit, the next run replays from the old SHA.
     nestweaver_store::GraphStore::update_repo_sha_on(&txn, &r_uid, &new_sha)
         .with_context(|| "update_repo_sha")?;
+    nestweaver_store::GraphStore::mark_regex_scope_dirty_on(&txn, &r_uid, false)
+        .with_context(|| "mark incremental regex scope dirty")?;
 
     store
         .commit_transaction(&txn)
@@ -5452,6 +5454,8 @@ where
 
     nestweaver_store::GraphStore::update_repo_sha_on(&txn, &r_uid, new_sha)
         .with_context(|| "update_repo_sha")?;
+    nestweaver_store::GraphStore::mark_regex_scope_dirty_on(&txn, &r_uid, false)
+        .with_context(|| "mark server incremental regex scope dirty")?;
     store
         .commit_transaction(&txn)
         .with_context(|| "commit incremental transaction")?;
@@ -9580,7 +9584,7 @@ function hello(name) { return "Hello " + name; }
         assert!(store.add_embedding(&survivor_symbol_uid, vec![0.8, 0.6]));
         store.flush_embedding_index().unwrap();
         assert_eq!(
-            store.vector_search(&[1.0, 0.0], 1).unwrap()[0].0,
+            store.try_vector_search(&[1.0, 0.0], 1).unwrap()[0].0,
             removed_symbol_uid,
             "precondition: stale vector must displace the live result"
         );
@@ -9598,13 +9602,13 @@ function hello(name) { return "Hello " + name; }
         )
         .unwrap();
 
-        let live_results = store.vector_search(&[1.0, 0.0], 1).unwrap();
+        let live_results = store.try_vector_search(&[1.0, 0.0], 1).unwrap();
         assert_eq!(live_results[0].0, survivor_symbol_uid);
         assert!(!store.has_embedding(&removed_symbol_uid));
         assert!(store.has_embedding(&survivor_symbol_uid));
 
         let reopened = GraphStore::open_or_create(&db_path).unwrap();
-        let persisted_results = reopened.vector_search(&[1.0, 0.0], 1).unwrap();
+        let persisted_results = reopened.try_vector_search(&[1.0, 0.0], 1).unwrap();
         assert_eq!(persisted_results[0].0, survivor_symbol_uid);
         assert!(!reopened.has_embedding(&removed_symbol_uid));
         assert!(reopened.has_embedding(&survivor_symbol_uid));
@@ -12135,6 +12139,42 @@ function hello(name) { return "Hello " + name; }
             json.as_object().map(|o| !o.is_empty()).unwrap_or(false),
             "sidecar must contain scores"
         );
+    }
+
+    #[test]
+    fn incremental_code_change_dirties_regex_scope_and_widens_without_losing_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("regex-dirty.lbug");
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(repo.join("main.js"), "function originalNeedle() {}\n").unwrap();
+
+        incremental_index_with_name(&repo, &db_path, "test", "https://example.com/regex", None)
+            .unwrap();
+        {
+            let store = GraphStore::open_or_create(&db_path).unwrap();
+            store.refresh_trigram_index(true).unwrap();
+            let clean = store
+                .regex_search("originalNeedle", None, None, None, None)
+                .unwrap();
+            assert_eq!(clean.dirty_scopes, 0);
+            assert_eq!(clean.results.len(), 1);
+        }
+
+        fs::write(
+            repo.join("main.js"),
+            "function originalNeedle() {}\nfunction watchedRegressionNeedle() {}\n",
+        )
+        .unwrap();
+        incremental_index_with_name(&repo, &db_path, "test", "https://example.com/regex", None)
+            .unwrap();
+
+        let store = GraphStore::open_read_only(&db_path).unwrap();
+        let widened = store
+            .regex_search("watchedRegressionNeedle", None, None, None, None)
+            .unwrap();
+        assert_eq!(widened.dirty_scopes, 1);
+        assert_eq!(widened.results.len(), 1);
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/publication.rs
+++ b/crates/nestweaver-engine/src/publication.rs
@@ -642,8 +642,6 @@ pub fn default_publication_root(db_path: &Path) -> PathBuf {
     crate::sidecar_path(db_path, ".publications")
 }
 
-/// Resolve the retained incumbent graph used to authorize activation rollback
-/// without consulting or opening the newly selected publication. `None`
 /// Cross-process exclusion for one publication root.
 ///
 /// The `IndexPublicationLease` is an in-process coordinator — a `Mutex` plus a
@@ -1109,6 +1107,20 @@ pub fn rollback_current(
     lease: &nestweaver_store::IndexPublicationLease<'_>,
     expected_current: &str,
 ) -> anyhow::Result<Option<CurrentPublicationPointer>> {
+    let root_lock = PublicationRootLock::acquire(publication_root)?;
+    rollback_current_under_lock(publication_root, lease, expected_current, &root_lock)
+}
+
+/// Roll back while the caller holds publication-root ownership across an
+/// external quiescence proof and this selector mutation. Daemon startup takes
+/// the same lock while resolving/opening CURRENT, closing the check-to-CAS
+/// race without coupling the engine to process-lifecycle implementation.
+pub fn rollback_current_under_lock(
+    publication_root: &Path,
+    lease: &nestweaver_store::IndexPublicationLease<'_>,
+    expected_current: &str,
+    _root_lock: &PublicationRootLock,
+) -> anyhow::Result<Option<CurrentPublicationPointer>> {
     lease
         .ensure_clean_for_snapshot()
         .map_err(|error| anyhow::anyhow!("refusing CURRENT rollback from dirty graph: {error}"))?;
@@ -1361,6 +1373,27 @@ mod tests {
                 .is_none()
         );
         assert_eq!(resolve_selected_database(&base).unwrap(), base);
+        lease.release().unwrap();
+    }
+
+    #[test]
+    fn rollback_under_an_existing_root_lock_does_not_reacquire_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("brain.lbug");
+        let store = nestweaver_store::GraphStore::create(&base).unwrap();
+        let incumbent = store.publication_identity().unwrap().unwrap();
+        let target = incumbent.next_publication().unwrap();
+        let pointer = write_resolvable_slot(&base, &target);
+        let root = default_publication_root(&base);
+        let root_lock = PublicationRootLock::acquire(&root).unwrap();
+        let lease = store.acquire_index_publication_lease().unwrap();
+
+        assert!(
+            rollback_current_under_lock(&root, &lease, &pointer.publication_uuid, &root_lock,)
+                .unwrap()
+                .is_none()
+        );
+        assert!(read_current(&root).unwrap().is_none());
         lease.release().unwrap();
     }
 

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -3455,7 +3455,7 @@ mod semantic_leg_tests {
         {
             let store = GraphStore::open(&db).unwrap();
             assert!(
-                store.vector_search(&[0.0; 4], 1).is_err(),
+                store.try_vector_search(&[0.0; 4], 1).is_err(),
                 "a corrupt artifact must fail closed"
             );
             assert!(
@@ -3473,7 +3473,7 @@ mod semantic_leg_tests {
         // Reopen: the artifact must now be valid and semantic search must work.
         let store = GraphStore::open(&db).unwrap();
         let hits = store
-            .vector_search(&[1.0, 0.0, 0.0, 0.0], 1)
+            .try_vector_search(&[1.0, 0.0, 0.0, 0.0], 1)
             .expect("a repaired artifact must serve semantic search");
         assert_eq!(
             hits.first().map(|(uid, _)| uid.as_str()),

--- a/crates/nestweaver-engine/src/snapshot.rs
+++ b/crates/nestweaver-engine/src/snapshot.rs
@@ -1908,7 +1908,7 @@ mod tests {
         assert_eq!(replica.embedding_count(), 2);
         assert_eq!(replica.embedding_dimension().unwrap(), 3);
         assert_eq!(
-            replica.vector_search(&[1.0, 0.0, 0.0], 1).unwrap()[0].0,
+            replica.try_vector_search(&[1.0, 0.0, 0.0], 1).unwrap()[0].0,
             "sym:a"
         );
     }

--- a/crates/nestweaver-engine/src/summaries.rs
+++ b/crates/nestweaver-engine/src/summaries.rs
@@ -170,9 +170,9 @@ pub struct SymbolSummaries {
     pub capped: bool,
 }
 
-/// Symbol-level summaries with the `target` filter pushed DOWN before the
-/// expensive per-symbol caller/callee queries, and a hard cap so an untargeted
-/// call over a large graph can't hang.
+/// Symbol-level summaries with the `target` filter pushed down before batched
+/// caller/callee retrieval, and a hard cap so an untargeted call over a large
+/// graph can't hang.
 ///
 /// - `target = Some(t)`: only symbols whose name or uid contains `t`
 ///   (case-insensitive) are summarized. The cap does not apply — a targeted
@@ -215,14 +215,20 @@ pub fn generate_symbol_summaries_bounded(
         capped = true;
     }
 
+    let selected_uids = symbols
+        .iter()
+        .map(|symbol| symbol.uid.clone())
+        .collect::<Vec<_>>();
+    let adjacency = store
+        .summary_adjacency_by_uid(&selected_uids)
+        .map_err(|error| anyhow::anyhow!("summary adjacency batch: {error}"))?;
     let mut summaries = Vec::with_capacity(symbols.len());
 
     for sym in &symbols {
-        let callers = store.callers_of(&sym.uid).unwrap_or_default();
-        let callees = store.callees_of(&sym.uid).unwrap_or_default();
-
-        let caller_names: Vec<&str> = callers.iter().map(|c| c.name.as_str()).collect();
-        let callee_names: Vec<&str> = callees.iter().map(|c| c.name.as_str()).collect();
+        let (caller_names, callee_names) = adjacency
+            .get(&sym.uid)
+            .map(|(callers, callees)| (callers.as_slice(), callees.as_slice()))
+            .unwrap_or_default();
 
         let content = format!(
             "{kind} {sig} | callers: [{callers}] | callees: [{callees}] | file: {file}:{line}",
@@ -784,6 +790,58 @@ mod tests {
         assert!(summaries[0].content.contains("src/main.js:10"));
         assert_eq!(summaries[0].level, SummaryLevel::Symbol);
         assert!(summaries[0].token_estimate > 0);
+    }
+
+    #[test]
+    fn symbol_summaries_batch_callers_and_callees_without_losing_semantics() {
+        use nestweaver_schema::{EdgeType, ResolvedEdge};
+
+        let store = GraphStore::in_memory().unwrap();
+        let make_symbol = |uid: &str, name: &str| nestweaver_schema::Symbol {
+            uid: uid.to_string(),
+            name: name.to_string(),
+            kind: nestweaver_schema::SymbolKind::Function,
+            repo_uid: "repo:test".to_string(),
+            file_path: "src/lib.rs".to_string(),
+            start_line: 1,
+            end_line: 1,
+            signature: format!("fn {name}()"),
+            summary: None,
+            content_hash: uid.to_string(),
+            embedding: None,
+            pagerank_score: None,
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: nestweaver_schema::Visibility::Inferred,
+            type_info: None,
+            framework_hint: None,
+            canonical_id: None,
+        };
+        for symbol in [
+            make_symbol("caller", "caller_fn"),
+            make_symbol("target", "target_fn"),
+            make_symbol("callee", "callee_fn"),
+        ] {
+            store.insert_symbol(&symbol).unwrap();
+        }
+        for (source_uid, target_uid) in [("caller", "target"), ("target", "callee")] {
+            store
+                .insert_edge(&ResolvedEdge {
+                    source_uid: source_uid.to_string(),
+                    target_uid: target_uid.to_string(),
+                    edge_type: EdgeType::Calls,
+                    confidence: 1.0,
+                    link_type: None,
+                    evidence: Vec::new(),
+                })
+                .unwrap();
+        }
+
+        let output = generate_symbol_summaries_bounded(&store, Some("target_fn"), 10).unwrap();
+        assert_eq!(output.summaries.len(), 1);
+        let content = &output.summaries[0].content;
+        assert!(content.contains("callers: [caller_fn]"), "{content}");
+        assert!(content.contains("callees: [callee_fn]"), "{content}");
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/watch_code.rs
+++ b/crates/nestweaver-engine/src/watch_code.rs
@@ -655,6 +655,9 @@ impl CodeWatcher {
             return Err(error).context("apply watcher contract derivation");
         }
 
+        nestweaver_store::GraphStore::mark_regex_scope_dirty_on(&txn, r_uid, false)
+            .context("mark watched regex scope dirty")?;
+
         store
             .commit_transaction(&txn)
             .context("commit code watcher batch transaction")?;

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -1543,7 +1543,7 @@ fn dispatch_uncached(
         "blast_radius" => tool_blast_radius(store, args, cancel, visible),
         "get_summary" => tool_get_summary(store, args),
         "read_symbols" => tool_read_symbols(store, args),
-        "regex_search" => tool_regex_search(store, args),
+        "regex_search" => tool_regex_search(store, args, cancel),
         "count_patterns" => tool_count_patterns(store, args),
         "brain_broken_links" => tool_brain_broken_links(store, args),
         "brain_orphan_documents" => tool_brain_orphan_documents(store, args),
@@ -2445,7 +2445,11 @@ fn validate_regex_kinds(kinds: Option<&[String]>) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-fn tool_regex_search(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error> {
+fn tool_regex_search(
+    store: &GraphStore,
+    args: Value,
+    cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
+) -> Result<Value, anyhow::Error> {
     let pattern = args
         .get("pattern")
         .or_else(|| args.get("query"))
@@ -2470,7 +2474,14 @@ fn tool_regex_search(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
     let max_millis = args.get("max_millis").and_then(|v| v.as_u64());
 
     let res = store
-        .regex_search(pattern, path_prefix, kinds.as_deref(), limit, max_millis)
+        .regex_search_cancellable(
+            pattern,
+            path_prefix,
+            kinds.as_deref(),
+            limit,
+            max_millis,
+            cancel,
+        )
         .map_err(|e| anyhow!("regex_search: {e}"))?;
     // nw-097: the note now rides on RegexSearchResult itself, attached by the
     // store, so the CLI and daemon paths carry it too. This tool used to bolt it
@@ -3904,21 +3915,20 @@ fn tool_brain_search(
         let matched_entities = groups.len();
         // Parity with the Tantivy path: detailed note rows carry their vault
         // (resolved from the note list already fetched above).
-        let note_vaults: HashMap<&str, &str> = notes
+        let note_sources: HashMap<&str, (&str, &str)> = notes
             .iter()
-            .map(|n| (n.uid.as_str(), n.vault_uid.as_str()))
+            .map(|n| (n.uid.as_str(), (n.vault_uid.as_str(), n.file_path.as_str())))
             .collect();
         let rows: Vec<Value> = note_order
             .iter()
             .take(limit)
             .filter_map(|nuid| groups.get(nuid))
             .map(|g| {
-                if concise {
+                let mut row = if concise {
                     json!({
                         "uid": g.note_uid,
                         "kind": grouped_row_kind(&g.note_uid),
                         "title": g.best_title,
-                        "matched_headings": g.matched_headings,
                     })
                 } else {
                     json!({
@@ -3926,10 +3936,21 @@ fn tool_brain_search(
                         "kind": grouped_row_kind(&g.note_uid),
                         "title": g.best_title,
                         "score": g.best_score,
-                        "vault_uid": note_vaults.get(g.note_uid.as_str()).copied().unwrap_or_default(),
-                        "matched_headings": g.matched_headings,
                     })
+                };
+                if let Some((vault_uid, file_path)) = note_sources.get(g.note_uid.as_str()).copied()
+                {
+                    if !vault_uid.is_empty() {
+                        row["vault_uid"] = json!(vault_uid);
+                    }
+                    if !file_path.is_empty() {
+                        row["location"] = json!(file_path);
+                    }
                 }
+                if !g.matched_headings.is_empty() {
+                    row["matched_headings"] = json!(g.matched_headings);
+                }
+                row
             })
             .collect();
 
@@ -4371,12 +4392,11 @@ fn group_search_hits_by_note(
         .take(limit)
         .filter_map(|nuid| groups.get(nuid))
         .map(|g| {
-            if concise {
+            let mut row = if concise {
                 json!({
                     "uid": g.note_uid,
                     "kind": grouped_row_kind(&g.note_uid),
                     "title": g.best_title,
-                    "matched_headings": g.matched_headings,
                 })
             } else {
                 json!({
@@ -4384,11 +4404,18 @@ fn group_search_hits_by_note(
                     "kind": grouped_row_kind(&g.note_uid),
                     "title": g.best_title,
                     "score": g.best_score,
-                    "location": g.file_path,
-                    "vault_uid": g.vault_uid,
-                    "matched_headings": g.matched_headings,
                 })
+            };
+            if !g.file_path.is_empty() {
+                row["location"] = json!(g.file_path);
             }
+            if !g.vault_uid.is_empty() {
+                row["vault_uid"] = json!(g.vault_uid);
+            }
+            if !g.matched_headings.is_empty() {
+                row["matched_headings"] = json!(g.matched_headings);
+            }
+            row
         })
         .collect();
     Ok(GroupedNoteResults { rows, total })
@@ -5056,6 +5083,35 @@ mod brain_search_total_contract_tests {
             grouped.rows[0]["matched_headings"],
             json!(["Shared", "Other"])
         );
+    }
+
+    #[test]
+    fn local_brain_search_omits_empty_optional_arrays_like_daemon_route() {
+        let store = GraphStore::in_memory().unwrap();
+        store
+            .insert_note(&note("note:title-only", "Titleonlyneedle"))
+            .unwrap();
+        let hit = nestweaver_store::SearchHit {
+            uid: "note:title-only".to_string(),
+            kind: "note".to_string(),
+            title: "Titleonlyneedle".to_string(),
+            vault_uid: "vlt:test".to_string(),
+            note_uid: "note:title-only".to_string(),
+            score: 1.0,
+        };
+
+        for concise in [false, true] {
+            let grouped = group_search_hits_by_note(
+                &store,
+                std::slice::from_ref(&hit),
+                SearchTotal::exact(1),
+                10,
+                concise,
+            )
+            .unwrap();
+            assert!(grouped.rows[0].get("matched_headings").is_none());
+            assert_eq!(grouped.rows[0]["vault_uid"], "vlt:test");
+        }
     }
 
     #[test]
@@ -12398,9 +12454,13 @@ mod arg_alias_tests {
         // A bogus kind used to filter out every candidate and return empty
         // results; now it is an error naming the advertised kinds.
         let store = GraphStore::in_memory().unwrap();
-        let err = tool_regex_search(&store, json!({ "pattern": "x", "kinds": ["Function"] }))
-            .unwrap_err()
-            .to_string();
+        let err = tool_regex_search(
+            &store,
+            json!({ "pattern": "x", "kinds": ["Function"] }),
+            None,
+        )
+        .unwrap_err()
+        .to_string();
         assert!(
             err.contains("unknown kind 'Function'") && err.contains("Section, Note, Symbol"),
             "{err}"
@@ -12414,6 +12474,7 @@ mod arg_alias_tests {
         tool_regex_search(
             &store,
             json!({ "pattern": "x", "kinds": ["section", "NOTE"] }),
+            None,
         )
         .expect("case-insensitive advertised kinds must be accepted");
     }
@@ -12469,7 +12530,9 @@ mod arg_alias_tests {
         // is a scan-cost lever, not a query.
         let store = GraphStore::in_memory().unwrap();
         for args in [json!({ "pattern": "" }), json!({ "pattern": "   " })] {
-            let err = tool_regex_search(&store, args).unwrap_err().to_string();
+            let err = tool_regex_search(&store, args, None)
+                .unwrap_err()
+                .to_string();
             assert!(err.contains("empty pattern"), "{err}");
         }
     }

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -2006,16 +2006,20 @@ impl GraphStore {
 
     /// Perform a vector similarity search over the embedding index.
     /// Returns `(uid, cosine_similarity)` pairs sorted descending.
-    /// Returns `Err` for a corrupt embedding artifact.
     ///
-    /// This used to `.expect()`, which was sound while `Cancelled` was the only
-    /// possible error and `cancel = None` made it unreachable. Adding
-    /// `EmbeddingArtifactCorrupt` broke that invariant: the publication startup
-    /// smoke calls this, so a corrupt artifact would PANIC there instead of
-    /// failing the smoke — bypassing the automatic rollback that a failed smoke
-    /// exists to trigger. Every other check in that smoke propagates with `?`;
-    /// this one now does too.
-    pub fn vector_search(
+    /// Retained for source compatibility. New code should use
+    /// [`try_vector_search`](Self::try_vector_search) so artifact errors do not
+    /// become panics.
+    #[deprecated(note = "use try_vector_search so corrupt embedding artifacts are handled")]
+    pub fn vector_search(&self, query_embedding: &[f32], limit: usize) -> Vec<(String, f64)> {
+        self.try_vector_search(query_embedding, limit)
+            .expect("legacy vector_search cannot represent embedding artifact errors")
+    }
+
+    /// Fallible vector search that preserves corruption and I/O errors.
+    /// Publication startup smoke uses this path so corrupt artifacts trigger
+    /// rollback instead of unwinding past it.
+    pub fn try_vector_search(
         &self,
         query_embedding: &[f32],
         limit: usize,
@@ -3534,6 +3538,28 @@ mod tests {
 
         let error = store.flush_embedding_index().unwrap_err();
         assert!(error.to_string().contains("not a regular file"));
+    }
+
+    #[test]
+    fn graph_vector_search_returns_corrupt_artifact_error_without_panicking() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        store.set_embedding_metadata("test-model", 2).unwrap();
+        assert!(store.add_embedding("symbol:live", vec![1.0, 0.0]));
+        store.flush_embedding_index().unwrap();
+        let embedding_path = store.embedding_sidecar_path().unwrap();
+        drop(store);
+
+        let mut bytes = std::fs::read(&embedding_path).unwrap();
+        *bytes.last_mut().unwrap() ^= 0xff;
+        std::fs::write(&embedding_path, bytes).unwrap();
+
+        let reopened = GraphStore::open_read_only(&db_path).unwrap();
+        assert!(matches!(
+            reopened.try_vector_search(&[1.0, 0.0], 1),
+            Err(StoreError::EmbeddingArtifactCorrupt)
+        ));
     }
 
     #[test]

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use lbug::Value;
 use nestweaver_schema::{
@@ -27,6 +27,9 @@ pub type TypedEdge = (String, String, String, f64, String);
 
 /// Combined symbols and edges for clustering algorithms.
 pub type CodeGraph = (Vec<SymbolBasic>, Vec<CodeEdge>);
+
+/// Caller and callee names keyed by symbol UID for batched summary rendering.
+pub type SummaryAdjacency = HashMap<String, (Vec<String>, Vec<String>)>;
 
 /// A single inbound wikilink to a target Note — the source side of the edge.
 #[derive(Debug, Clone, Serialize)]
@@ -598,6 +601,78 @@ impl GraphStore {
             .execute(&mut stmt, vec![("uid", Value::String(uid.to_string()))])
             .map_err(|e| StoreError::Query(format!("execute: {e}")))?;
         result.map(|row| row_to_symbol(&row)).collect()
+    }
+
+    /// Fetch caller and callee names for many symbols with a constant number
+    /// of query plans.
+    ///
+    /// Summary generation only needs names, not fully hydrated symbols. This
+    /// avoids issuing one inbound query plus three outbound queries per symbol
+    /// while retaining the same CALLS/IMPORTS/CROSS_REPO_LINK semantics as
+    /// [`callers_of`](Self::callers_of) and [`callees_of`](Self::callees_of).
+    pub fn summary_adjacency_by_uid(
+        &self,
+        uids: &[String],
+    ) -> Result<SummaryAdjacency, StoreError> {
+        let mut adjacency = HashMap::with_capacity(uids.len());
+        for uid in uids {
+            adjacency
+                .entry(uid.clone())
+                .or_insert_with(|| (Vec::new(), Vec::new()));
+        }
+        if uids.is_empty() {
+            return Ok(adjacency);
+        }
+
+        let in_list = uids
+            .iter()
+            .map(|uid| format!("'{}'", uid.replace('\'', "''")))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let conn = self.conn()?;
+
+        let callers_query = format!(
+            "UNWIND [{in_list}] AS want_uid \
+             MATCH (caller:Symbol)-[:CALLS]->(target:Symbol {{uid: want_uid}}) \
+             RETURN target.uid, caller.name"
+        );
+        let callers = conn
+            .query(&callers_query)
+            .map_err(|error| StoreError::Query(format!("summary callers batch: {error}")))?;
+        for row in callers {
+            let uid = extract_string(&row, 0)?;
+            let name = extract_string(&row, 1)?;
+            if let Some((names, _)) = adjacency.get_mut(&uid) {
+                names.push(name);
+            }
+        }
+
+        for edge_type in ["CALLS", "IMPORTS", "CROSS_REPO_LINK"] {
+            let callees_query = format!(
+                "UNWIND [{in_list}] AS want_uid \
+                 MATCH (source:Symbol {{uid: want_uid}})-[:{edge_type}]->(target:Symbol) \
+                 RETURN source.uid, target.name"
+            );
+            let callees = conn.query(&callees_query).map_err(|error| {
+                StoreError::Query(format!("summary {edge_type} batch: {error}"))
+            })?;
+            for row in callees {
+                let uid = extract_string(&row, 0)?;
+                let name = extract_string(&row, 1)?;
+                if let Some((_, names)) = adjacency.get_mut(&uid)
+                    && !names.contains(&name)
+                {
+                    names.push(name);
+                }
+            }
+        }
+
+        for (callers, callees) in adjacency.values_mut() {
+            callers.sort();
+            callers.dedup();
+            callees.sort();
+        }
+        Ok(adjacency)
     }
 
     /// Returns the set of service UIDs that have at least one caller whose

--- a/crates/nestweaver-store/src/regex.rs
+++ b/crates/nestweaver-store/src/regex.rs
@@ -24,7 +24,7 @@ use regex_syntax::hir::literal::Extractor;
 use serde::{Deserialize, Serialize};
 
 use crate::db::GraphStore;
-use crate::error::StoreError;
+use crate::error::{CancelReason, StoreError};
 use crate::regex_index::{
     REGEX_INDEX_SCHEMA_VERSION, REGEX_TOKENIZER_FINGERPRINT, RegexIndex, RegexShardDocument,
     RegexShardMetadata,
@@ -43,6 +43,11 @@ pub const CANDIDATE_CAP: usize = 200_000;
 
 /// Default wall-clock budget for a single search, in milliseconds.
 pub const DEFAULT_MAX_MILLIS: u64 = 2000;
+
+/// Do not start a graph-hydration phase when less than this budget remains.
+/// Ladybug queries cannot be interrupted mid-call, so admission control keeps
+/// tiny deadlines from launching work that is already certain to outlive them.
+const PHASE_ADMISSION_MILLIS: u64 = 5;
 
 /// Maximum accepted regex pattern length, in bytes. A longer pattern is rejected
 /// before compilation so an untrusted client cannot force a large compile just
@@ -255,6 +260,12 @@ struct Candidate {
     start_line: u32,
 }
 
+#[derive(Clone, Copy)]
+struct CandidateLimits<'a> {
+    cancel: Option<&'a std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    max_candidates: usize,
+}
+
 #[derive(Debug, Clone)]
 struct RegexGraphScopeState {
     desired_epoch: u64,
@@ -376,7 +387,7 @@ impl GraphStore {
         Ok(self.refresh_trigram_index(false)?.postings_added)
     }
 
-    /// Force a one-time full rebuild using the stable v2 schema.
+    /// Force a one-time full rebuild using the current regex-v3 schema.
     pub fn rebuild_trigram_index(&self) -> Result<TrigramRefreshStats, StoreError> {
         self.refresh_trigram_index(true)
     }
@@ -497,7 +508,19 @@ impl GraphStore {
                 }
             };
             let one_scope = HashSet::from([scope_uid.clone()]);
-            let mut candidates = self.collect_candidates_for_scopes(&one_scope, None, None)?;
+            let mut candidates = self
+                .collect_candidates_for_scopes(
+                    &one_scope,
+                    None,
+                    None,
+                    Instant::now(),
+                    u64::MAX,
+                    CandidateLimits {
+                        cancel: None,
+                        max_candidates: usize::MAX,
+                    },
+                )?
+                .0;
             candidates.sort_by(|left, right| left.uid.cmp(&right.uid));
             let digest = candidate_digest(&candidates);
             let prior = existing.get(&scope_uid);
@@ -710,7 +733,19 @@ impl GraphStore {
         &self,
         path_prefix: Option<&str>,
         kinds: Option<&[String]>,
-    ) -> Result<Vec<Candidate>, StoreError> {
+        start: Instant,
+        deadline_ms: u64,
+        limits: CandidateLimits<'_>,
+    ) -> Result<(Vec<Candidate>, Option<RegexTruncationReason>), StoreError> {
+        let interrupted = || -> Result<bool, StoreError> {
+            if limits
+                .cancel
+                .is_some_and(|flag| flag.load(Ordering::Acquire))
+            {
+                return Err(StoreError::Cancelled(CancelReason::Timeout));
+            }
+            Ok(elapsed_millis(start) >= deadline_ms)
+        };
         let want_kind = |k: &str| -> bool {
             match kinds {
                 None => true,
@@ -724,11 +759,17 @@ impl GraphStore {
         // file_path for the location, so build a note_uid -> path map once.
         if want_kind("Section") {
             let notes = self.list_notes(None)?;
+            if interrupted()? {
+                return Ok((out, Some(RegexTruncationReason::Deadline)));
+            }
             let note_path: HashMap<String, (String, String)> = notes
                 .into_iter()
                 .map(|n| (n.uid, (n.file_path, n.vault_uid)))
                 .collect();
             for s in self.list_all_sections()? {
+                if interrupted()? {
+                    return Ok((out, Some(RegexTruncationReason::Deadline)));
+                }
                 if s.text_content.is_empty() {
                     continue;
                 }
@@ -738,6 +779,9 @@ impl GraphStore {
                     && !path.starts_with(prefix)
                 {
                     continue;
+                }
+                if out.len() >= limits.max_candidates {
+                    return Ok((out, Some(RegexTruncationReason::CandidateCap)));
                 }
                 out.push(Candidate {
                     uid: s.uid,
@@ -759,6 +803,9 @@ impl GraphStore {
         // Notes — index the title (the section body carries the rest).
         if want_kind("Note") {
             for n in self.list_notes(None)? {
+                if interrupted()? {
+                    return Ok((out, Some(RegexTruncationReason::Deadline)));
+                }
                 if n.title.is_empty() {
                     continue;
                 }
@@ -766,6 +813,9 @@ impl GraphStore {
                     && !n.file_path.starts_with(prefix)
                 {
                     continue;
+                }
+                if out.len() >= limits.max_candidates {
+                    return Ok((out, Some(RegexTruncationReason::CandidateCap)));
                 }
                 out.push(Candidate {
                     uid: n.uid,
@@ -784,6 +834,9 @@ impl GraphStore {
         // Symbols — signature text.
         if want_kind("Symbol") {
             for sym in self.list_all_symbols()? {
+                if interrupted()? {
+                    return Ok((out, Some(RegexTruncationReason::Deadline)));
+                }
                 if sym.signature.is_empty() {
                     continue;
                 }
@@ -793,6 +846,9 @@ impl GraphStore {
                     continue;
                 }
                 let location = format!("{}:{}", sym.file_path, sym.start_line);
+                if out.len() >= limits.max_candidates {
+                    return Ok((out, Some(RegexTruncationReason::CandidateCap)));
+                }
                 out.push(Candidate {
                     uid: sym.uid,
                     scope_uid: sym.repo_uid,
@@ -806,7 +862,10 @@ impl GraphStore {
             }
         }
 
-        Ok(out)
+        Ok((
+            out,
+            interrupted()?.then_some(RegexTruncationReason::Deadline),
+        ))
     }
 
     /// Collect fallback/rebuild text only for explicitly selected source
@@ -816,7 +875,19 @@ impl GraphStore {
         scopes: &HashSet<String>,
         path_prefix: Option<&str>,
         kinds: Option<&[String]>,
-    ) -> Result<Vec<Candidate>, StoreError> {
+        start: Instant,
+        deadline_ms: u64,
+        limits: CandidateLimits<'_>,
+    ) -> Result<(Vec<Candidate>, Option<RegexTruncationReason>), StoreError> {
+        let interrupted = || -> Result<bool, StoreError> {
+            if limits
+                .cancel
+                .is_some_and(|flag| flag.load(Ordering::Acquire))
+            {
+                return Err(StoreError::Cancelled(CancelReason::Timeout));
+            }
+            Ok(elapsed_millis(start) >= deadline_ms)
+        };
         let want_kind = |kind: &str| {
             kinds.is_none_or(|values| values.iter().any(|value| value.eq_ignore_ascii_case(kind)))
         };
@@ -828,12 +899,21 @@ impl GraphStore {
         ordered.sort();
         let mut candidates = Vec::new();
         for scope_uid in ordered {
+            if interrupted()? {
+                return Ok((candidates, Some(RegexTruncationReason::Deadline)));
+            }
             if want_kind("Symbol") {
                 for symbol in self.lookup_symbols_by_repo(&scope_uid)? {
+                    if interrupted()? {
+                        return Ok((candidates, Some(RegexTruncationReason::Deadline)));
+                    }
                     if symbol.signature.is_empty()
                         || path_prefix.is_some_and(|prefix| !symbol.file_path.starts_with(prefix))
                     {
                         continue;
+                    }
+                    if candidates.len() >= limits.max_candidates {
+                        return Ok((candidates, Some(RegexTruncationReason::CandidateCap)));
                     }
                     candidates.push(Candidate {
                         uid: symbol.uid,
@@ -848,16 +928,25 @@ impl GraphStore {
                 }
             }
             let notes = self.list_notes(Some(&scope_uid))?;
+            if interrupted()? {
+                return Ok((candidates, Some(RegexTruncationReason::Deadline)));
+            }
             let note_paths: HashMap<_, _> = notes
                 .iter()
                 .map(|note| (note.uid.clone(), note.file_path.clone()))
                 .collect();
             if want_kind("Note") {
                 for note in notes {
+                    if interrupted()? {
+                        return Ok((candidates, Some(RegexTruncationReason::Deadline)));
+                    }
                     if note.title.is_empty()
                         || path_prefix.is_some_and(|prefix| !note.file_path.starts_with(prefix))
                     {
                         continue;
+                    }
+                    if candidates.len() >= limits.max_candidates {
+                        return Ok((candidates, Some(RegexTruncationReason::CandidateCap)));
                     }
                     candidates.push(Candidate {
                         uid: note.uid,
@@ -894,6 +983,9 @@ impl GraphStore {
                 // this scope's notes in memory.
                 let sections = self.list_all_sections()?;
                 for section in sections {
+                    if interrupted()? {
+                        return Ok((candidates, Some(RegexTruncationReason::Deadline)));
+                    }
                     if !note_paths.contains_key(&section.note_uid) {
                         continue;
                     }
@@ -906,6 +998,9 @@ impl GraphStore {
                         .unwrap_or_default();
                     if path_prefix.is_some_and(|prefix| !path.starts_with(prefix)) {
                         continue;
+                    }
+                    if candidates.len() >= limits.max_candidates {
+                        return Ok((candidates, Some(RegexTruncationReason::CandidateCap)));
                     }
                     candidates.push(Candidate {
                         uid: section.uid,
@@ -924,7 +1019,10 @@ impl GraphStore {
                 }
             }
         }
-        Ok(candidates)
+        Ok((
+            candidates,
+            interrupted()?.then_some(RegexTruncationReason::Deadline),
+        ))
     }
 
     /// Hydrate only derived-index hits, in bounded primary-key batches.
@@ -933,7 +1031,19 @@ impl GraphStore {
         uids: &HashSet<String>,
         path_prefix: Option<&str>,
         kinds: Option<&[String]>,
-    ) -> Result<Vec<Candidate>, StoreError> {
+        start: Instant,
+        deadline_ms: u64,
+        limits: CandidateLimits<'_>,
+    ) -> Result<(Vec<Candidate>, Option<RegexTruncationReason>), StoreError> {
+        let interrupted = || -> Result<bool, StoreError> {
+            if limits
+                .cancel
+                .is_some_and(|flag| flag.load(Ordering::Acquire))
+            {
+                return Err(StoreError::Cancelled(CancelReason::Timeout));
+            }
+            Ok(elapsed_millis(start) >= deadline_ms)
+        };
         let want_kind = |kind: &str| {
             kinds.is_none_or(|values| values.iter().any(|value| value.eq_ignore_ascii_case(kind)))
         };
@@ -941,55 +1051,86 @@ impl GraphStore {
         ordered.sort();
         let mut candidates = Vec::new();
         if want_kind("Symbol") {
-            for symbol in self.lookup_symbols_by_uids(&ordered)? {
-                if symbol.signature.is_empty()
-                    || path_prefix.is_some_and(|prefix| !symbol.file_path.starts_with(prefix))
-                {
-                    continue;
+            for chunk in ordered.chunks(256) {
+                if interrupted()? {
+                    return Ok((candidates, Some(RegexTruncationReason::Deadline)));
                 }
-                candidates.push(Candidate {
-                    uid: symbol.uid,
-                    scope_uid: symbol.repo_uid,
-                    text_hash: text_hash(&symbol.signature),
-                    kind: "Symbol".to_string(),
-                    title: symbol.name,
-                    location: format!("{}:{}", symbol.file_path, symbol.start_line),
-                    text: symbol.signature,
-                    start_line: symbol.start_line,
-                });
+                for symbol in self.lookup_symbols_by_uids(chunk)? {
+                    if symbol.signature.is_empty()
+                        || path_prefix.is_some_and(|prefix| !symbol.file_path.starts_with(prefix))
+                    {
+                        continue;
+                    }
+                    if candidates.len() >= limits.max_candidates {
+                        return Ok((candidates, Some(RegexTruncationReason::CandidateCap)));
+                    }
+                    candidates.push(Candidate {
+                        uid: symbol.uid,
+                        scope_uid: symbol.repo_uid,
+                        text_hash: text_hash(&symbol.signature),
+                        kind: "Symbol".to_string(),
+                        title: symbol.name,
+                        location: format!("{}:{}", symbol.file_path, symbol.start_line),
+                        text: symbol.signature,
+                        start_line: symbol.start_line,
+                    });
+                }
             }
         }
         if want_kind("Note") {
-            for note in self.lookup_notes_by_uids(&ordered)? {
-                if note.title.is_empty()
-                    || path_prefix.is_some_and(|prefix| !note.file_path.starts_with(prefix))
-                {
-                    continue;
+            for chunk in ordered.chunks(256) {
+                if interrupted()? {
+                    return Ok((candidates, Some(RegexTruncationReason::Deadline)));
                 }
-                candidates.push(Candidate {
-                    uid: note.uid,
-                    scope_uid: note.vault_uid,
-                    text_hash: text_hash(&note.title),
-                    kind: "Note".to_string(),
-                    title: note.title.clone(),
-                    location: note.file_path,
-                    text: note.title,
-                    start_line: 1,
-                });
+                for note in self.lookup_notes_by_uids(chunk)? {
+                    if note.title.is_empty()
+                        || path_prefix.is_some_and(|prefix| !note.file_path.starts_with(prefix))
+                    {
+                        continue;
+                    }
+                    if candidates.len() >= limits.max_candidates {
+                        return Ok((candidates, Some(RegexTruncationReason::CandidateCap)));
+                    }
+                    candidates.push(Candidate {
+                        uid: note.uid,
+                        scope_uid: note.vault_uid,
+                        text_hash: text_hash(&note.title),
+                        kind: "Note".to_string(),
+                        title: note.title.clone(),
+                        location: note.file_path,
+                        text: note.title,
+                        start_line: 1,
+                    });
+                }
             }
         }
         if want_kind("Section") {
-            let sections = self.lookup_sections_by_uids(&ordered)?;
+            let mut sections = Vec::new();
+            for chunk in ordered.chunks(256) {
+                if interrupted()? {
+                    return Ok((candidates, Some(RegexTruncationReason::Deadline)));
+                }
+                sections.extend(self.lookup_sections_by_uids(chunk)?);
+            }
             let note_uids: Vec<_> = sections
                 .iter()
                 .map(|section| section.note_uid.clone())
                 .collect();
-            let note_paths: HashMap<_, _> = self
-                .lookup_notes_by_uids(&note_uids)?
-                .into_iter()
-                .map(|note| (note.uid, (note.file_path, note.vault_uid)))
-                .collect();
+            let mut note_paths = HashMap::new();
+            for chunk in note_uids.chunks(256) {
+                if interrupted()? {
+                    return Ok((candidates, Some(RegexTruncationReason::Deadline)));
+                }
+                note_paths.extend(
+                    self.lookup_notes_by_uids(chunk)?
+                        .into_iter()
+                        .map(|note| (note.uid, (note.file_path, note.vault_uid))),
+                );
+            }
             for section in sections {
+                if interrupted()? {
+                    return Ok((candidates, Some(RegexTruncationReason::Deadline)));
+                }
                 if section.text_content.is_empty() {
                     continue;
                 }
@@ -999,6 +1140,9 @@ impl GraphStore {
                     .unwrap_or_default();
                 if path_prefix.is_some_and(|prefix| !path.starts_with(prefix)) {
                     continue;
+                }
+                if candidates.len() >= limits.max_candidates {
+                    return Ok((candidates, Some(RegexTruncationReason::CandidateCap)));
                 }
                 candidates.push(Candidate {
                     uid: section.uid,
@@ -1016,21 +1160,40 @@ impl GraphStore {
                 });
             }
         }
-        Ok(candidates)
+        Ok((
+            candidates,
+            interrupted()?.then_some(RegexTruncationReason::Deadline),
+        ))
     }
 
     fn regex_v3_candidate_uids(
         &self,
         clauses: &[HashSet<String>],
-    ) -> Result<TrigramPrefilterPlan, StoreError> {
+        start: Instant,
+        deadline_ms: u64,
+        cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    ) -> Result<Option<TrigramPrefilterPlan>, StoreError> {
+        let interrupted = || -> Result<bool, StoreError> {
+            if cancel.is_some_and(|flag| flag.load(Ordering::Acquire)) {
+                return Err(StoreError::Cancelled(CancelReason::Timeout));
+            }
+            Ok(elapsed_millis(start) >= deadline_ms)
+        };
+        if interrupted()? {
+            return Ok(None);
+        }
         let Some(root) = self.regex_sidecar_root() else {
-            return Ok(TrigramPrefilterPlan {
+            let dirty_scopes = self.active_regex_scopes()?;
+            if interrupted()? {
+                return Ok(None);
+            }
+            return Ok(Some(TrigramPrefilterPlan {
                 matching_ready_uids: HashSet::new(),
                 ready_scopes: HashSet::new(),
-                dirty_scopes: self.active_regex_scopes()?,
+                dirty_scopes,
                 error_scopes: HashSet::new(),
                 has_index: false,
-            });
+            }));
         };
         let index = RegexIndex::with_reader_pool(root, self.regex_reader_pool.clone());
         let identity = self.publication_identity()?.ok_or_else(|| {
@@ -1044,6 +1207,9 @@ impl GraphStore {
         let mut error_scopes = HashSet::new();
         let mut matching_ready_uids = HashSet::new();
         for scope_uid in active_scopes {
+            if interrupted()? {
+                return Ok(None);
+            }
             let Some(state) = states.get(&scope_uid) else {
                 dirty_scopes.insert(scope_uid);
                 continue;
@@ -1104,13 +1270,20 @@ impl GraphStore {
         } else if dirty_scopes.is_empty() {
             TRIGRAM_STALE_WARNED.store(false, Ordering::Relaxed);
         }
-        Ok(TrigramPrefilterPlan {
+        // A single shard lookup may consume the remaining budget. Re-check
+        // before handing a seemingly usable plan to hydration; otherwise a
+        // one-scope corpus can overrun during planning and still launch the
+        // most expensive phase.
+        if interrupted()? {
+            return Ok(None);
+        }
+        Ok(Some(TrigramPrefilterPlan {
             matching_ready_uids,
             ready_scopes,
             dirty_scopes,
             error_scopes,
             has_index,
-        })
+        }))
     }
 
     /// First-party regex search over indexed text with an optional trigram
@@ -1128,6 +1301,22 @@ impl GraphStore {
         limit: Option<usize>,
         max_millis: Option<u64>,
     ) -> Result<RegexSearchResult, StoreError> {
+        self.regex_search_cancellable(pattern, path_prefix, kinds, limit, max_millis, None)
+    }
+
+    /// Regex search with cooperative cancellation across every phase.
+    /// Internal `max_millis` exhaustion returns an honestly truncated result;
+    /// an RPC/client cancellation returns `StoreError::Cancelled` so it cannot
+    /// be cached or mistaken for a complete empty answer.
+    pub fn regex_search_cancellable(
+        &self,
+        pattern: &str,
+        path_prefix: Option<&str>,
+        kinds: Option<&[String]>,
+        limit: Option<usize>,
+        max_millis: Option<u64>,
+        cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    ) -> Result<RegexSearchResult, StoreError> {
         if let Some(l) = limit
             && l > SEARCH_PRESENTATION_LIMIT_MAX
         {
@@ -1139,13 +1328,28 @@ impl GraphStore {
         let deadline_ms = max_millis.unwrap_or(DEFAULT_MAX_MILLIS);
         let start = Instant::now();
         let limit = limit.unwrap_or(usize::MAX);
+        let check_cancel = || {
+            if cancel.is_some_and(|flag| flag.load(Ordering::Acquire)) {
+                Err(StoreError::Cancelled(CancelReason::Timeout))
+            } else {
+                Ok(())
+            }
+        };
+        check_cancel()?;
 
         let planning_started = Instant::now();
         let clauses = required_trigram_clauses(pattern);
-        let plan = match &clauses {
-            Some(clauses) => Some(self.regex_v3_candidate_uids(clauses)?),
-            None => None,
+        let (plan, mut planning_deadline) = match &clauses {
+            Some(clauses) => {
+                match self.regex_v3_candidate_uids(clauses, start, deadline_ms, cancel)? {
+                    Some(plan) => (Some(plan), false),
+                    None => (None, true),
+                }
+            }
+            None => (None, elapsed_millis(start) >= deadline_ms),
         };
+        planning_deadline |=
+            elapsed_millis(start).saturating_add(PHASE_ADMISSION_MILLIS) >= deadline_ms;
         let planning_ms = elapsed_millis(planning_started);
         let scanned_fallback = plan
             .as_ref()
@@ -1160,19 +1364,63 @@ impl GraphStore {
             .as_ref()
             .map_or(0, |plan| plan.matching_ready_uids.len());
 
+        check_cancel()?;
         let hydration_started = Instant::now();
-        let (mut candidates, hydrated_candidates) = match &plan {
-            Some(plan) => {
-                let mut candidates =
-                    self.collect_candidates_for_scopes(&plan.dirty_scopes, path_prefix, kinds)?;
-                let hydrated =
-                    self.load_candidates_by_uid(&plan.matching_ready_uids, path_prefix, kinds)?;
-                let hydrated_candidates = hydrated.len();
-                candidates.extend(hydrated);
-                (candidates, hydrated_candidates)
+        let mut hydration_stop = None;
+        let (mut candidates, hydrated_candidates) = if planning_deadline {
+            (Vec::new(), 0)
+        } else {
+            match &plan {
+                Some(plan) => {
+                    let (mut candidates, fallback_stop) = self.collect_candidates_for_scopes(
+                        &plan.dirty_scopes,
+                        path_prefix,
+                        kinds,
+                        start,
+                        deadline_ms,
+                        CandidateLimits {
+                            cancel,
+                            max_candidates: CANDIDATE_CAP,
+                        },
+                    )?;
+                    let (mut hydrated, hydrated_stop) = self.load_candidates_by_uid(
+                        &plan.matching_ready_uids,
+                        path_prefix,
+                        kinds,
+                        start,
+                        deadline_ms,
+                        CandidateLimits {
+                            cancel,
+                            max_candidates: CANDIDATE_CAP,
+                        },
+                    )?;
+                    hydration_stop = fallback_stop.or(hydrated_stop);
+                    let remaining = CANDIDATE_CAP.saturating_sub(candidates.len());
+                    if hydrated.len() > remaining {
+                        hydrated.truncate(remaining);
+                        hydration_stop = Some(RegexTruncationReason::CandidateCap);
+                    }
+                    let hydrated_candidates = hydrated.len();
+                    candidates.extend(hydrated);
+                    (candidates, hydrated_candidates)
+                }
+                None => {
+                    let (candidates, stop) = self.collect_candidates(
+                        path_prefix,
+                        kinds,
+                        start,
+                        deadline_ms,
+                        CandidateLimits {
+                            cancel,
+                            max_candidates: CANDIDATE_CAP,
+                        },
+                    )?;
+                    hydration_stop = stop;
+                    (candidates, 0)
+                }
             }
-            None => (self.collect_candidates(path_prefix, kinds)?, 0),
         };
+        check_cancel()?;
         candidates.sort_by(|left, right| left.uid.cmp(&right.uid));
         let hydration_ms = elapsed_millis(hydration_started);
 
@@ -1181,12 +1429,21 @@ impl GraphStore {
         // ONLY when the scan actually stops early, so `truncated:true` with an
         // empty `results` now genuinely means "incomplete scan" rather than
         // "the match was ordered past a 5000 cap and never scanned" (nw-076).
-        let mut truncated = false;
-        let mut truncation_reason = None;
+        let elapsed_deadline = elapsed_millis(start) >= deadline_ms;
+        let mut truncated = planning_deadline || hydration_stop.is_some() || elapsed_deadline;
+        let mut truncation_reason = if planning_deadline || elapsed_deadline {
+            Some(RegexTruncationReason::Deadline)
+        } else {
+            hydration_stop
+        };
         let mut results = Vec::new();
         let mut scanned_candidates = 0usize;
         let verification_started = Instant::now();
         for (i, c) in candidates.iter().enumerate() {
+            check_cancel()?;
+            if truncated {
+                break;
+            }
             if start.elapsed().as_millis() as u64 > deadline_ms {
                 truncated = true;
                 truncation_reason = Some(RegexTruncationReason::Deadline);
@@ -1287,7 +1544,7 @@ impl GraphStore {
             let planning_started = Instant::now();
             let clauses = required_trigram_clauses(pattern);
             let plan = match &clauses {
-                Some(clauses) => Some(self.regex_v3_candidate_uids(clauses)?),
+                Some(clauses) => self.regex_v3_candidate_uids(clauses, started, u64::MAX, None)?,
                 None => None,
             };
             let planning_ms = elapsed_millis(planning_started);
@@ -1301,15 +1558,50 @@ impl GraphStore {
             let hydration_started = Instant::now();
             let (candidates, hydrated_candidates) = match &plan {
                 Some(plan) => {
-                    let mut candidates =
-                        self.collect_candidates_for_scopes(&plan.dirty_scopes, path_prefix, kinds)?;
-                    let hydrated =
-                        self.load_candidates_by_uid(&plan.matching_ready_uids, path_prefix, kinds)?;
+                    let mut candidates = self
+                        .collect_candidates_for_scopes(
+                            &plan.dirty_scopes,
+                            path_prefix,
+                            kinds,
+                            started,
+                            u64::MAX,
+                            CandidateLimits {
+                                cancel: None,
+                                max_candidates: usize::MAX,
+                            },
+                        )?
+                        .0;
+                    let hydrated = self
+                        .load_candidates_by_uid(
+                            &plan.matching_ready_uids,
+                            path_prefix,
+                            kinds,
+                            started,
+                            u64::MAX,
+                            CandidateLimits {
+                                cancel: None,
+                                max_candidates: usize::MAX,
+                            },
+                        )?
+                        .0;
                     let hydrated_candidates = hydrated.len();
                     candidates.extend(hydrated);
                     (candidates, hydrated_candidates)
                 }
-                None => (self.collect_candidates(path_prefix, kinds)?, 0),
+                None => (
+                    self.collect_candidates(
+                        path_prefix,
+                        kinds,
+                        started,
+                        u64::MAX,
+                        CandidateLimits {
+                            cancel: None,
+                            max_candidates: usize::MAX,
+                        },
+                    )?
+                    .0,
+                    0,
+                ),
             };
             let hydration_ms = elapsed_millis(hydration_started);
             let verification_started = Instant::now();
@@ -1382,6 +1674,8 @@ fn line_and_snippet(text: &str, match_start: usize) -> (u32, String) {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     /// nw-097: an empty result that is empty only because the scan budget ran
     /// out must SAY so. Previously the MCP tool attached this note itself, so a
     /// CLI `--json` caller received `{"results": [], "truncated": true}` with
@@ -1406,6 +1700,33 @@ mod tests {
         }
         .with_scan_budget_note();
         assert_eq!(r.note.as_deref(), Some(SCAN_BUDGET_NOTE));
+    }
+
+    #[test]
+    fn regex_deadline_stops_before_candidate_hydration() {
+        let store = GraphStore::in_memory().unwrap();
+        populate_store(&store);
+        let result = store
+            .regex_search("authenticateUser", None, None, None, Some(0))
+            .unwrap();
+        assert!(result.truncated);
+        assert_eq!(
+            result.truncation_reason,
+            Some(RegexTruncationReason::Deadline)
+        );
+        assert_eq!(result.hydrated_candidates, 0);
+        assert_eq!(result.scanned_candidates, 0);
+    }
+
+    #[test]
+    fn regex_external_cancellation_is_an_error_not_an_empty_result() {
+        let store = GraphStore::in_memory().unwrap();
+        populate_store(&store);
+        let cancel = Arc::new(AtomicBool::new(true));
+        let error = store
+            .regex_search_cancellable("authenticateUser", None, None, None, None, Some(&cancel))
+            .unwrap_err();
+        assert!(error.is_cancelled(), "{error}");
     }
 
     /// A genuinely exhaustive empty search HAS established that nothing matches,

--- a/crates/nestweaver-store/src/search.rs
+++ b/crates/nestweaver-store/src/search.rs
@@ -1133,9 +1133,19 @@ impl EmbeddingIndex {
     ///
     /// Uses rayon for parallel iteration and assumes stored embeddings are
     /// L2-normalized, so cosine similarity reduces to dot-product / query_norm.
+    #[deprecated(note = "use try_vector_search so corrupt embedding artifacts are handled")]
     pub fn vector_search(&self, query_vec: &[f32], limit: usize) -> Vec<(String, f64)> {
+        self.try_vector_search(query_vec, limit)
+            .expect("legacy vector_search cannot represent embedding artifact errors")
+    }
+
+    /// Fallible vector search that preserves corruption and I/O errors.
+    pub fn try_vector_search(
+        &self,
+        query_vec: &[f32],
+        limit: usize,
+    ) -> Result<Vec<(String, f64)>, StoreError> {
         self.vector_search_cancellable(query_vec, limit, None)
-            .expect("vector_search with cancel=None cannot be cancelled")
     }
 
     /// Like [`vector_search`], but cooperatively bails when `cancel` trips (a
@@ -2188,7 +2198,7 @@ mod tests {
         idx.embeddings
             .insert("sym:wrongdim".to_string(), vec![1.0_f32, 0.0]);
         let query = vec![1.0_f32, 0.0, 0.0];
-        let results = idx.vector_search(&query, 10);
+        let results = idx.try_vector_search(&query, 10).unwrap();
         // The matching-dim vector scores ~1.0; the mismatched one is absent.
         let right = results.iter().find(|(u, _)| u == "sym:right").unwrap();
         assert!((right.1 - 1.0).abs() < 1e-6, "got {}", right.1);
@@ -2262,7 +2272,7 @@ mod tests {
         assert!(idx.add("b", vec![0.9, 0.1, 0.0], false));
         assert!(idx.add("c", vec![0.0, 0.0, 1.0], false));
 
-        let results = idx.vector_search(&[1.0, 0.0, 0.0], 2);
+        let results = idx.try_vector_search(&[1.0, 0.0, 0.0], 2).unwrap();
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].0, "a");
         assert_eq!(results[1].0, "b");
@@ -2274,7 +2284,7 @@ mod tests {
         for i in 0..10 {
             assert!(idx.add(&format!("sym:{i}"), vec![i as f32, 0.0], false));
         }
-        let results = idx.vector_search(&[1.0, 0.0], 3);
+        let results = idx.try_vector_search(&[1.0, 0.0], 3).unwrap();
         assert_eq!(results.len(), 3);
     }
 
@@ -2291,7 +2301,7 @@ mod tests {
 
         let loaded = EmbeddingIndex::load(&path).unwrap();
         assert_eq!(loaded.len(), 1);
-        let results = loaded.vector_search(&v, 1);
+        let results = loaded.try_vector_search(&v, 1).unwrap();
         assert_eq!(results[0].0, "sym:test");
         assert!((results[0].1 - 1.0).abs() < 1e-5);
     }
@@ -2442,6 +2452,13 @@ mod tests {
                 Err(StoreError::EmbeddingArtifactCorrupt)
             ),
             "the cancellable path must fail closed too"
+        );
+        assert!(
+            matches!(
+                corrupt.try_vector_search(&[0.1, 0.2, 0.3], 10),
+                Err(StoreError::EmbeddingArtifactCorrupt)
+            ),
+            "the convenience path must propagate corruption too"
         );
 
         // The write path stays fail-closed: republishing an unverified base
@@ -2761,8 +2778,11 @@ mod tests {
                 .then_with(|| left.0.cmp(&right.0))
         });
         oracle.truncate(3);
-        assert_eq!(index.vector_search(&query, 3), oracle);
-        assert_eq!(index.vector_search(&query, 0), Vec::<(String, f64)>::new());
+        assert_eq!(index.try_vector_search(&query, 3).unwrap(), oracle);
+        assert_eq!(
+            index.try_vector_search(&query, 0).unwrap(),
+            Vec::<(String, f64)>::new()
+        );
     }
 
     #[test]

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -1248,7 +1248,11 @@ impl GraphStore {
         Ok(())
     }
 
-    fn mark_regex_scope_dirty_on(
+    /// Advance a regex scope's desired epoch in the caller's transaction.
+    ///
+    /// Bulk and incremental writers must use this variant so the graph
+    /// mutation and its derived-index invalidation commit atomically.
+    pub fn mark_regex_scope_dirty_on(
         conn: &lbug::Connection<'_>,
         scope_uid: &str,
         tombstone: bool,

--- a/docs/guide/daemon-shutdown.md
+++ b/docs/guide/daemon-shutdown.md
@@ -138,6 +138,13 @@ Everything above describes what **this process** does with SIGTERM. A supervisor
 that SIGKILLs on its own timer still does so, at its own deadline, and the
 daemon cannot extend or refuse it. Concretely:
 
+Daemon startup also records lifecycle ownership. A process forked by
+`nestweaver daemon start` is NestWeaver-managed and may be replaced
+automatically after a client/server version mismatch. A foreground,
+systemd-owned, launchd-owned, or older daemon with unknown provenance is never
+shut down and replaced by a detached process; the client fails before shutdown
+and names the supervisor/manual restart commands instead.
+
 ### Linux, `daemon start` — **fully fixed**
 
 This repo ships **no systemd unit** and no service-installer command. On Linux

--- a/docs/guide/publication-rebuild.md
+++ b/docs/guide/publication-rebuild.md
@@ -21,6 +21,11 @@ revalidates the inputs before the atomic switch. Interaction history is copied
 only for stable graph UIDs that still exist; the sealed preservation receipt
 reports captured, imported, and deliberately pruned counts and checksums.
 
+`--no-embed` is intentionally incompatible with `publication rebuild` and is
+rejected before an operation or slot is created. A publication is a complete,
+validated release unit; use an ordinary non-publication index when an
+embedding-free development graph is required.
+
 The command prints its operation UUID immediately. A failure or interruption
 leaves the incumbent selected. Inspect and resume the same staging work with:
 
@@ -88,6 +93,11 @@ switching back to the abandoned publication; a later successful activation
 establishes a new one-step predecessor. Keep the predecessor until the new
 release has passed normal workload verification and a fresh backup has been
 taken.
+
+Rollback proves the currently selected graph is quiescent before changing
+`CURRENT`; an idle predecessor alone is not sufficient. Selector changes and
+destructive slot pruning also share a publication-root filesystem lock, so
+separate processes cannot select and reclaim the same slot concurrently.
 
 ## Failure behavior
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2518,7 +2518,7 @@ enum Commands {
         no_trigrams: bool,
         #[arg(
             long = "rebuild-trigrams",
-            help = "Force a full v2 trigram rebuild instead of refreshing changed scopes"
+            help = "Force a full regex-v3 trigram rebuild instead of refreshing changed scopes"
         )]
         rebuild_trigrams: bool,
         #[arg(
@@ -4710,7 +4710,10 @@ enum SnapshotCommands {
 
 #[derive(Subcommand)]
 enum PublicationCommands {
-    /// Build, validate, and optionally activate a fresh publication from every indexed source
+    /// Build, validate, and optionally activate a complete fresh publication.
+    ///
+    /// Includes embeddings by contract; the global --no-embed flag is rejected
+    /// before any operation or slot is created.
     Rebuild {
         #[arg(
             long,
@@ -7440,14 +7443,15 @@ async fn restart_verified_live_under_lock(
     let locked_health = client.health_check().await.context(
         "could not revalidate live daemon after acquiring restart transaction lock; no shutdown was attempted",
     )?;
-    let prepared = nestweaver_client::prepare_restart(db_path, &locked_health, explicit_config)
-        .and_then(|prepared| {
+    let prepared =
+        nestweaver_client::prepare_explicit_restart(db_path, &locked_health, explicit_config)
+            .and_then(|prepared| {
             anyhow::ensure!(
                 prepared.config() == &expected_config,
                 "daemon effective config changed while waiting for the restart transaction lock; no shutdown was attempted"
             );
             Ok(prepared)
-        });
+            });
     drop(original);
 
     // Capture the incumbent's OWN effective config while it is still live, so
@@ -7608,8 +7612,11 @@ async fn restart_live_daemon_preserving_config(
     match nestweaver_client::DaemonClient::connect_existing(db_path).await {
         Ok(mut client) => {
             let original_health = client.health_check().await?;
-            let original =
-                nestweaver_client::prepare_restart(db_path, &original_health, explicit_config)?;
+            let original = nestweaver_client::prepare_explicit_restart(
+                db_path,
+                &original_health,
+                explicit_config,
+            )?;
             let expected_config = original.config().clone();
             let spawn_lock =
                 nestweaver_client::autostart::SpawnLock::acquire_async(db_path).await?;
@@ -7632,7 +7639,7 @@ async fn restart_live_daemon_preserving_config(
             {
                 let health = winner.health_check().await?;
                 let original =
-                    nestweaver_client::prepare_restart(db_path, &health, explicit_config)?;
+                    nestweaver_client::prepare_explicit_restart(db_path, &health, explicit_config)?;
                 let expected_config = original.config().clone();
                 return restart_verified_live_under_lock(
                     db_path,
@@ -10493,7 +10500,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
         Commands::Contracts { command } => run_contracts(command, use_daemon),
 
         Commands::Snapshot { command } => run_snapshot(command, use_daemon).map(|c| (c, None)),
-        Commands::Publication { command } => run_publication(command).map(|c| (c, None)),
+        Commands::Publication { command } => run_publication(command, no_embed).map(|c| (c, None)),
         Commands::Backup { command } => run_backup(command).map(|c| (c, None)),
         Commands::Instance { command } => run_instance(command).map(|c| (c, None)),
         Commands::Config { command } => run_config(command),
@@ -14392,20 +14399,19 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 .ok_or_else(|| {
                     anyhow::anyhow!("No database path provided. Use --db or set NESTWEAVER_DB.")
                 })?;
-            // nw-145 migration: these commands derive the ANCHORED identity
-            // directly, so on their own they cannot see a daemon that 6.3.0
-            // bound to the SELECTED-SLOT identity — `start` would fail to take
-            // the write lock it still holds, and `stop` would report nothing to
-            // stop. Autostart already retires it; the explicit commands have to
-            // as well, or the two disagree about which daemon exists.
-            //
-            // `status` is deliberately excluded: it is a read-only command and
-            // must not kill anything. It reports the orphan instead, below.
+            let selected_slot_legacy_id =
+                nestweaver_daemon::lifecycle::selected_slot_identity_instance_id(&db_path);
             if matches!(
-                action,
-                DaemonAction::Start { .. } | DaemonAction::Stop { .. }
+                &action,
+                DaemonAction::Start { .. }
+                    | DaemonAction::Stop { .. }
+                    | DaemonAction::Restart { .. }
             ) {
-                nestweaver_daemon::lifecycle::stop_selected_slot_identity_daemon(&db_path);
+                // Direct lifecycle commands must perform the same v6.3.0
+                // selected-slot identity migration as client autostart. Do it
+                // before resolving the anchored runtime paths so an invisible
+                // old daemon cannot retain the database lock.
+                nestweaver_daemon::lifecycle::retire_selected_slot_identity_daemon(&db_path)?;
             }
             // Don't pre-canonicalize — instance_id_from_db_path handles it
             // internally with consistent fallback for non-existent files.
@@ -14435,6 +14441,10 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     let inherited_spawn_lock =
                         std::env::var_os(nestweaver_client::autostart::PARENT_SPAWN_LOCK_FD_ENV);
                     let parent_driven_start = inherited_spawn_lock.is_some();
+                    // Never trust an ambient ownership hint. Re-publish it only
+                    // after `acquire_daemon_start_spawn_lock` verifies the exact
+                    // inherited locked descriptor below.
+                    nestweaver_daemon::lifecycle::clear_verified_nestweaver_managed_start();
                     // Held for its RAII effect on every platform; explicitly
                     // `.take()`n after daemonize only under
                     // `#[cfg(not(target_os = "macos"))]` below, so on macOS it
@@ -14444,6 +14454,14 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     #[cfg_attr(target_os = "macos", allow(unused_mut, unused_variables))]
                     let mut start_spawn_lock =
                         acquire_daemon_start_spawn_lock(&db_path, inherited_spawn_lock)?;
+                    // Every successful `daemon start` owns a verified spawn
+                    // lock, whether invoked manually or by client autostart.
+                    // The non-macOS fork inherits this process-local marker;
+                    // launchd starts a fresh supervised process and therefore
+                    // deliberately does not inherit it.
+                    if start_spawn_lock.is_some() {
+                        nestweaver_daemon::lifecycle::mark_verified_nestweaver_managed_start();
+                    }
                     if track_interactions {
                         eprintln!(
                             "note: --track-interactions is an MCP flag, not a daemon flag. \
@@ -14867,14 +14885,17 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         let db_path_abs = abs_for_daemon(&db_path);
                         let config_abs = effective_config.as_deref().map(abs_for_daemon);
                         let pre_start_pid = nestweaver_client::autostart::read_pid(&pidfile);
-                        let mut child = macos_temp_daemon_command(
+                        let mut child_command = macos_temp_daemon_command(
                             &executable,
                             &db_path_abs,
                             config_abs.as_deref(),
                             idle_timeout,
-                        )
-                        .spawn()
-                        .with_context(|| {
+                        );
+                        start_spawn_lock
+                            .as_ref()
+                            .context("temporary daemon start lost its verified spawn lock")?
+                            .configure_child_handoff(&mut child_command)?;
+                        let mut child = child_command.spawn().with_context(|| {
                             format!(
                                 "spawn temporary daemon process for {}",
                                 db_path_abs.display()
@@ -15242,6 +15263,25 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     acme_email,
                     acme_production,
                 } => {
+                    // A temporary macOS daemon is a fresh `daemon run` exec,
+                    // so the process-local ownership marker from `daemon
+                    // start` cannot cross the boundary. Accept ownership only
+                    // through the exact inherited, locked spawn-file
+                    // description; an ambient environment value without that
+                    // OS proof fails validation. launchd children receive no
+                    // handoff and remain explicitly supervisor-owned.
+                    nestweaver_daemon::lifecycle::clear_verified_nestweaver_managed_start();
+                    if let Some(inherited_fd) =
+                        std::env::var_os(nestweaver_client::autostart::PARENT_SPAWN_LOCK_FD_ENV)
+                    {
+                        let verified =
+                            acquire_daemon_start_spawn_lock(&db_path, Some(inherited_fd))?
+                                .context(
+                                    "daemon run did not retain its verified parent spawn lock",
+                                )?;
+                        nestweaver_daemon::lifecycle::mark_verified_nestweaver_managed_start();
+                        verified.close_in_forked_child_without_unlock();
+                    }
                     if snapshot.is_some() && !server {
                         anyhow::bail!(
                             "--snapshot requires --server (a replica serves reads over TCP)"
@@ -15648,6 +15688,24 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
 
                 DaemonAction::Status => {
+                    if daemon_socket_reported_pid(&socket).is_none()
+                        && !pidfile_flock_held(&pidfile)
+                        && let Some(old_id) = selected_slot_legacy_id.as_deref()
+                    {
+                        let old_socket = nestweaver_daemon::socket_path(old_id);
+                        if let Some(pid) = daemon_socket_reported_pid(&old_socket) {
+                            println!(
+                                "Daemon is running under the superseded selected-slot identity (PID {pid})"
+                            );
+                            println!("  DB:     {}", db_path.display());
+                            println!("  Socket: {}", old_socket.display());
+                            println!(
+                                "  Action: run `nestweaver daemon --db {} stop`, then start it again to migrate the runtime identity",
+                                db_path.display()
+                            );
+                            return Ok((EXIT_SUCCESS, None));
+                        }
+                    }
                     // Check launchd first on macOS
                     #[cfg(target_os = "macos")]
                     if nestweaver_daemon::launchd::is_running(&instance_id) {
@@ -20998,22 +21056,31 @@ fn render_project_context_daemon_response(
 }
 
 fn print_brain_context_json(result: &BrainContextResult, limit: usize) -> anyhow::Result<()> {
+    let resp = brain_context_json_value(result, limit);
+    println!("{}", serde_json::to_string_pretty(&resp)?);
+    Ok(())
+}
+
+fn brain_context_json_value(result: &BrainContextResult, limit: usize) -> serde_json::Value {
     let mut resp = serde_json::json!({
         "seeds_expanded": result.seeds.len(),
         "connected": result.connected.iter().take(limit).collect::<Vec<_>>(),
+        "semantic_applied": result.semantic_applied,
+        "degraded_components": result.degraded_components,
     });
 
     if !result.unresolved_seeds.is_empty() {
         resp["unresolved_seeds"] = serde_json::json!(result.unresolved_seeds);
+    }
+    if result.semantic_seed_count > 0 {
+        resp["semantic_seed_count"] = serde_json::json!(result.semantic_seed_count);
     }
 
     // Feature F7: surface PRF-mined expansion terms for auditing.
     if !result.expansion_terms.is_empty() {
         resp["expansion_terms"] = serde_json::json!(result.expansion_terms);
     }
-
-    println!("{}", serde_json::to_string_pretty(&resp)?);
-    Ok(())
+    resp
 }
 
 /// Render the `project-context` JSON for the local (--no-daemon) path with
@@ -21031,6 +21098,29 @@ fn print_project_context_json(
     external_refs: &serde_json::Value,
     concise: bool,
 ) -> anyhow::Result<()> {
+    let resp = project_context_json_value(
+        project,
+        result,
+        limit,
+        tokens_used,
+        token_budget,
+        external_refs,
+        concise,
+    );
+    println!("{}", serde_json::to_string_pretty(&resp)?);
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn project_context_json_value(
+    project: &nestweaver_schema::Project,
+    result: &BrainContextResult,
+    limit: usize,
+    tokens_used: usize,
+    token_budget: usize,
+    external_refs: &serde_json::Value,
+    concise: bool,
+) -> serde_json::Value {
     // Match the daemon/MCP `project_context` node shape EXACTLY (tools.rs render_node): concise
     // = {kind,title,location}; detailed adds uid + relevance. Without this the --no-daemon path
     // emitted full nodes regardless of response_format, diverging from the daemon path.
@@ -21056,9 +21146,14 @@ fn print_project_context_json(
         "connected": connected,
         "tokens_used": tokens_used,
         "token_budget": token_budget,
+        "semantic_applied": result.semantic_applied,
+        "degraded_components": result.degraded_components,
     });
     if !result.unresolved_seeds.is_empty() {
         resp["unresolved_seeds"] = serde_json::json!(result.unresolved_seeds);
+    }
+    if result.semantic_seed_count > 0 {
+        resp["semantic_seed_count"] = serde_json::json!(result.semantic_seed_count);
     }
     if !result.expansion_terms.is_empty() {
         resp["expansion_terms"] = serde_json::json!(result.expansion_terms);
@@ -21066,8 +21161,60 @@ fn print_project_context_json(
     if !external_refs.is_null() {
         resp["external_refs"] = external_refs.clone();
     }
-    println!("{}", serde_json::to_string_pretty(&resp)?);
-    Ok(())
+    resp
+}
+
+#[cfg(test)]
+mod context_json_renderer_tests {
+    use super::*;
+
+    fn degraded_context() -> BrainContextResult {
+        BrainContextResult {
+            seeds: Vec::new(),
+            connected: Vec::new(),
+            unresolved_seeds: vec!["missing".to_string()],
+            expansion_terms: Vec::new(),
+            semantic_applied: false,
+            semantic_seed_count: 0,
+            degraded_components: vec!["semantic".to_string()],
+        }
+    }
+
+    #[test]
+    fn direct_brain_context_never_drops_semantic_honesty() {
+        let value = brain_context_json_value(&degraded_context(), 30);
+        assert_eq!(value["semantic_applied"], false);
+        assert_eq!(
+            value["degraded_components"],
+            serde_json::json!(["semantic"])
+        );
+        assert_eq!(value["unresolved_seeds"], serde_json::json!(["missing"]));
+    }
+
+    #[test]
+    fn direct_project_context_never_drops_semantic_honesty() {
+        let project = nestweaver_schema::Project {
+            uid: "project:test".to_string(),
+            name: "test".to_string(),
+            summary: None,
+            instance_id: "default".to_string(),
+        };
+        let value = project_context_json_value(
+            &project,
+            &degraded_context(),
+            30,
+            0,
+            1_000,
+            &serde_json::Value::Null,
+            false,
+        );
+        assert_eq!(value["semantic_applied"], false);
+        assert_eq!(
+            value["degraded_components"],
+            serde_json::json!(["semantic"])
+        );
+        assert_eq!(value["project_uid"], "project:test");
+    }
 }
 
 /// Generate embeddings for symbols, notes, and/or headings.
@@ -22962,6 +23109,16 @@ fn ensure_no_live_daemon_for_snapshot_build(db_path: &Path) -> anyhow::Result<()
     };
     daemon_check?;
 
+    // A pidfile is advisory runtime metadata and may be unlinked underneath a
+    // live daemon. The database lock is the durable ownership proof that
+    // survives that incident state. Rollback, prune, rebuild, and snapshot
+    // creation all require a quiescent graph, so only a provably free lock is
+    // safe; an indeterminate probe fails closed.
+    ensure_database_write_lock_quiesced(
+        db_path,
+        nestweaver_daemon::lifecycle::db_write_lock(db_path),
+    )?;
+
     // Standalone `code watch` and `brain watch` processes do not own a daemon
     // pidfile. They publish their PID in `<db>.lock`; apply the same fail-closed
     // quiescence check so snapshot build cannot race those writers either.
@@ -22989,6 +23146,32 @@ fn ensure_no_live_daemon_for_snapshot_build(db_path: &Path) -> anyhow::Result<()
             Ok(_) => Ok(()),
         },
     }
+}
+
+fn ensure_database_write_lock_quiesced(
+    db_path: &Path,
+    observed: nestweaver_daemon::lifecycle::DbWriteLock,
+) -> anyhow::Result<()> {
+    match observed {
+        nestweaver_daemon::lifecycle::DbWriteLock::Free => {}
+        nestweaver_daemon::lifecycle::DbWriteLock::Held { pid } => {
+            let owner = pid
+                .map(|value| format!(" by pid {value}"))
+                .unwrap_or_default();
+            anyhow::bail!(
+                "the database write lock for {} is held{owner} — refusing an operation that \
+                 requires a quiescent graph. Stop the daemon or writer and retry.",
+                db_path.display(),
+            );
+        }
+        nestweaver_daemon::lifecycle::DbWriteLock::Unknown => anyhow::bail!(
+            "the database write-lock state for {} could not be determined — refusing an \
+             operation that requires a quiescent graph. Stop the daemon or writer, verify the \
+             database is readable, and retry.",
+            db_path.display(),
+        ),
+    }
+    Ok(())
 }
 
 /// Run the MCP stdio server using HybridClient for query routing.
@@ -23262,7 +23445,7 @@ fn format_bytes(bytes: u64) -> String {
 // `snapshot build` never routes through a daemon: it guards for a quiesced DB
 // and reads the store directly (autospawning a RW daemon would trip that
 // guard). `verify`/`push` operate on snapshot artifacts, not the live DB.
-fn run_publication(command: PublicationCommands) -> anyhow::Result<i32> {
+fn run_publication(command: PublicationCommands, no_embed: bool) -> anyhow::Result<i32> {
     fn root(root: Option<PathBuf>, db: Option<PathBuf>) -> anyhow::Result<PathBuf> {
         if root.is_some() && db.is_some() {
             anyhow::bail!("pass either --root or --db, not both");
@@ -23286,14 +23469,21 @@ fn run_publication(command: PublicationCommands) -> anyhow::Result<i32> {
             batch_size,
             no_activate,
             json,
-        } => run_publication_rebuild(
-            db,
-            &config,
-            operation.as_deref(),
-            batch_size,
-            !no_activate,
-            json,
-        ),
+        } => {
+            if no_embed {
+                anyhow::bail!(
+                    "--no-embed is incompatible with `publication rebuild`: a complete publication must contain a validated embedding artifact; rerun without --no-embed"
+                );
+            }
+            run_publication_rebuild(
+                db,
+                &config,
+                operation.as_deref(),
+                batch_size,
+                !no_activate,
+                json,
+            )
+        }
         PublicationCommands::Status {
             operation,
             root: explicit_root,
@@ -23503,11 +23693,25 @@ fn run_publication(command: PublicationCommands) -> anyhow::Result<i32> {
         PublicationCommands::Rollback { db, config, json } => {
             let (base_db, cfg) = resolve_base_db_with_config(db, config.as_deref())?;
             let root = nestweaver_engine::publication::default_publication_root(&base_db);
-            // Serialize against rebuild / discard / prune. Taken BEFORE reading
-            // CURRENT so the pointer this rollback acts on cannot move under it.
-            let _root_lock = nestweaver_engine::publication::PublicationRootLock::acquire(&root)?;
+            // Hold selector ownership across the active-daemon proof and CAS.
+            // Daemon startup takes the same lock while resolving/opening
+            // CURRENT, so it cannot slip into the abandoned slot between the
+            // check and rollback.
+            let root_lock = nestweaver_engine::publication::PublicationRootLock::acquire(&root)?;
             let current = nestweaver_engine::publication::read_current(&root)?
                 .ok_or_else(|| anyhow::anyhow!("no selected publication to roll back"))?;
+            // Derive the active slot path from the already validated selector
+            // without opening the graph. Rollback is the recovery path for a
+            // publication whose graph cannot be opened, so resolving it through
+            // `resolve_selected_database` here would make that exact failure
+            // impossible to recover from.
+            let selected_db =
+                nestweaver_engine::publication::slot_path(&root, &current.publication_uuid)?
+                    .join(nestweaver_engine::publication::PUBLICATION_GRAPH_FILE);
+            // Quiesce the graph that is serving requests before moving the
+            // selector away from it. Checking only the predecessor proves
+            // nothing about a live daemon still serving the abandoned slot.
+            ensure_no_live_daemon_for_snapshot_build(&selected_db)?;
             let predecessor_db = nestweaver_engine::publication::retained_predecessor_database(
                 &base_db,
                 current.expected_previous_publication_uuid.as_deref(),
@@ -23520,10 +23724,11 @@ fn run_publication(command: PublicationCommands) -> anyhow::Result<i32> {
                 cfg.assert_expected_brain(&store)?;
             }
             let lease = store.acquire_index_publication_lease()?;
-            let selected = nestweaver_engine::publication::rollback_current(
+            let selected = nestweaver_engine::publication::rollback_current_under_lock(
                 &root,
                 &lease,
                 &current.publication_uuid,
+                &root_lock,
             )?;
             lease.release()?;
             if json {
@@ -23569,7 +23774,7 @@ fn run_publication_rebuild(
     // Serialize against rollback / discard / prune on this root. Held for the
     // whole rebuild — including the cutover — so no concurrent operation can
     // reclaim or reselect a slot this one is building.
-    let _root_lock =
+    let root_lock =
         nestweaver_engine::publication::PublicationRootLock::acquire(&publication_root)?;
     let incumbent_db = nestweaver_engine::publication::resolve_selected_database(&base_db)?;
     if !incumbent_db.exists() {
@@ -24017,10 +24222,12 @@ fn run_publication_rebuild(
                                 )
                             },
                         )?;
-                        let rollback = nestweaver_engine::publication::rollback_current(
+                        let rollback =
+                            nestweaver_engine::publication::rollback_current_under_lock(
                             &publication_root,
                             &rollback_lease,
                             &state.plan.target_publication_uuid,
+                            &root_lock,
                         );
                         let release = rollback_lease.release();
                         return match (rollback, release) {
@@ -24221,9 +24428,7 @@ fn publication_startup_smoke(
     text_index.search("nestweaver", 1)?;
     store.regex_search("(?s).", None, None, Some(1), Some(1_000))?;
     if let Some(dimension) = store.embedding_index_dimension() {
-        // Propagate, do not swallow: a corrupt embedding artifact must FAIL
-        // this smoke so the caller rolls back, not surface as a panic.
-        store.vector_search(&vec![0.0; dimension], 1)?;
+        store.try_vector_search(&vec![0.0; dimension], 1)?;
     }
     Ok(())
 }
@@ -25484,6 +25689,30 @@ mod snapshot_build_guard_tests {
         std::fs::remove_file(&pidfile).unwrap();
         ensure_no_live_daemon_for_snapshot_build(&db)
             .expect("build permitted when no daemon is live");
+    }
+
+    #[test]
+    fn quiescence_requires_a_provably_free_database_write_lock() {
+        let db = PathBuf::from("/tmp/nestweaver-quiescence-contract.lbug");
+        ensure_database_write_lock_quiesced(&db, nestweaver_daemon::lifecycle::DbWriteLock::Free)
+            .expect("a provably free database is quiescent");
+
+        let held = ensure_database_write_lock_quiesced(
+            &db,
+            nestweaver_daemon::lifecycle::DbWriteLock::Held { pid: Some(42) },
+        )
+        .expect_err("a held database lock must block rollback and snapshot operations");
+        assert!(held.to_string().contains("pid 42"), "err was: {held}");
+
+        let unknown = ensure_database_write_lock_quiesced(
+            &db,
+            nestweaver_daemon::lifecycle::DbWriteLock::Unknown,
+        )
+        .expect_err("an indeterminate database lock must fail closed");
+        assert!(
+            unknown.to_string().contains("could not be determined"),
+            "err was: {unknown}"
+        );
     }
 
     /// A present-but-garbage pidfile must FAIL CLOSED: we can't confirm the

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -44,6 +44,39 @@ fn cli_help_lists_commands() {
 }
 
 #[test]
+fn publication_rebuild_rejects_no_embed_before_config_or_operation_setup() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("brain.lbug");
+    let missing_config = dir.path().join("missing.toml");
+
+    nestweaver_cmd()
+        .arg("--no-embed")
+        .args(["publication", "rebuild", "--config"])
+        .arg(&missing_config)
+        .arg("--db")
+        .arg(&db)
+        .assert()
+        .failure()
+        .stderr(contains(
+            "--no-embed is incompatible with `publication rebuild`",
+        ));
+
+    assert!(!db.exists());
+    assert!(!nestweaver_engine::publication::default_publication_root(&db).exists());
+
+    // The global flag is irrelevant to read-only publication commands. This
+    // guards against attaching the validation to the wrong match arm.
+    let root = dir.path().join("empty-publications");
+    std::fs::create_dir_all(&root).unwrap();
+    nestweaver_cmd()
+        .arg("--no-embed")
+        .args(["publication", "status", "--root"])
+        .arg(&root)
+        .assert()
+        .success();
+}
+
+#[test]
 fn mcp_help_hides_deprecated_flag_and_invalid_allowlists_fail_early() {
     nestweaver_cmd()
         .args(["mcp", "--help"])

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -2489,8 +2489,30 @@ credential_method = "gh"
     assert_eq!(read_pid(), pid_preserved);
     assert_eq!(unsafe { libc::kill(pid_preserved, 0) }, 0);
 
-    // Explicit config bypasses the corrupt provenance value but still uses
-    // the already-verified live PID/pidfile ownership evidence.
+    // An explicit config resolves configuration intent, but it cannot prove
+    // lifecycle ownership. Corrupt provenance therefore fails before shutdown
+    // even when the operator supplies a config: otherwise a supervisor-owned
+    // daemon could be replaced by a detached process.
+    daemon_action_cmd(&db_path, "restart")
+        .arg("--config")
+        .arg(&config_b)
+        .assert()
+        .failure()
+        .stderr(contains("ownership could not be verified"));
+    assert_eq!(read_pid(), pid_preserved);
+    assert_eq!(unsafe { libc::kill(pid_preserved, 0) }, 0);
+
+    nestweaver_daemon::lifecycle::write_effective_config_binding(
+        &instance_id,
+        &nestweaver_daemon::lifecycle::EffectiveConfigBinding::new_with_lifecycle_owner(
+            pid_preserved as u32,
+            nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::Configured {
+                path: canonical_a.to_str().unwrap().to_string(),
+            },
+            nestweaver_daemon::lifecycle::DaemonLifecycleOwner::NestweaverManaged,
+        ),
+    )
+    .unwrap();
     daemon_action_cmd(&db_path, "restart")
         .arg("--config")
         .arg(&config_b)
@@ -4615,6 +4637,7 @@ fn first_search_uid(db_path: &Path, query: &str) -> String {
         .filter(|results| results.is_array())
         .unwrap_or(&payload);
     rows.as_array()
+        .or_else(|| rows.get("results").and_then(serde_json::Value::as_array))
         .and_then(|arr| arr.first())
         .and_then(|row| row["uid"].as_str())
         .unwrap_or_else(|| panic!("search for '{query}' must return at least one uid: {payload}"))


### PR DESCRIPTION
## Summary

- fixes all ten validated critical-path findings from the PR #272 bug hunt across publication lifecycle, regex correctness and deadlines, semantic recovery, incremental indexing, summaries, daemon identity, and JSON honesty
- preserves the public vector-search API while adding a fallible internal path for corrupt embedding artifacts
- hardens the final review findings: corrupt-slot rollback recovery, root-lock reuse during automatic rollback, database-write-lock quiescence, and supervisor-aware explicit macOS restart

## Manual verification

- corrupt selected-slot rollback recovers to the base graph without opening the failed graph
- live selected-slot daemons and independent graph writers block rollback; rollback succeeds after every writer exits
- root-scoped prune works without creating or opening an unrelated graph and fails fast under lock contention
- watcher edits dirty only the changed regex scope and matches are preserved through graph-scan widening
- candidate-cap saturation widens instead of dropping matches; deadline truncation is explicit
- corrupt embedding payloads return a typed checksum error; semantic JSON reports applied/degraded state honestly
- explicit foreground supervisor ownership refuses replacement before shutdown; launchd authorization requires a running exact-plist database match

## Automated verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- nestweaver-store: 444 passed
- nestweaver-engine: 1,178 passed, 4 platform-timing tests ignored
- nestweaver-daemon: 289 passed
- nestweaver-client: 76 passed
- nestweaver-mcp: 183 passed
- root: 180 unit + 4 bare-index + 2 bench-gating + 5 CI integration + 95 CLI + 53 daemon integration + 17 parity + 36 server tests passed

Targets the original audit branch so PR #272 can be re-reviewed with these fixes before merging to main.