### PR TITLE
fix(regex): give the trigram reconciler an owner; move interaction tracking into config

### DIFF
--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -1280,6 +1280,130 @@ fn begin_shutdown_drain(state: Arc<DaemonState>, trigger: &'static str) {
     });
 }
 
+/// Backoff for the trigram reconcile loop after consecutive failures.
+///
+/// Doubles from the configured period up to a ten-minute cap so a persistently
+/// unwritable shard cannot hot-loop the write gate. This is the same shape as
+/// the circuit breaker 6.4.0 added for watcher embedding, and it exists for the
+/// same reason: a background loop that retries a permanent failure at its
+/// normal cadence is indistinguishable from a busy-wait.
+fn trigram_reconcile_backoff(period: Duration, consecutive_failures: u32) -> Duration {
+    const MAX_BACKOFF: Duration = Duration::from_secs(600);
+    if consecutive_failures == 0 {
+        return period;
+    }
+    // Saturate the shift before it can overflow the multiplier.
+    let scaled = period.saturating_mul(1u32 << consecutive_failures.min(6));
+    // NOT `clamp(period, MAX_BACKOFF)`: `clamp` panics when min > max, which is
+    // exactly what a configured interval longer than the cap produces — a
+    // 1-hour reconcile interval would have panicked the loop on its first
+    // failure. Cap first, then never return less than the configured period.
+    scaled.min(MAX_BACKOFF).max(period)
+}
+
+/// The trigram reconcile loop — the relay for `RegexScopeOutbox`.
+///
+/// Invalidation is already universal and transactional: the store's own write
+/// path marks a scope dirty inside the mutating transaction, so every writer
+/// enqueues whether or not it knows trigrams exist. What was missing was
+/// anything that drained the queue. `refresh_trigram_index` was called only as
+/// a side effect of two write handlers, so the vault-refresh path and both file
+/// watchers enqueued work nobody ever picked up, and their scopes stayed dirty
+/// until an unrelated repo index happened to run.
+///
+/// This loop is the missing half of the outbox pattern. It is level-triggered:
+/// it reads current state (the outbox) rather than reacting to write events, so
+/// a missed or unobserved mutation is picked up on the next tick instead of
+/// being lost. That is what makes the fix structural — a write path added later
+/// cannot reintroduce the bug, because there is nothing for it to remember.
+async fn run_trigram_reconciler(state: Arc<DaemonState>, period: Duration) {
+    let mut shutdown = state.shutdown_tx.subscribe();
+    let mut tick = tokio::time::interval(period);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut consecutive_failures: u32 = 0;
+    let mut backoff_until: Option<Instant> = None;
+    // `interval` yields its first tick immediately, and that first pass is
+    // deliberately unconditional: it catches everything enqueued while the
+    // daemon was down, and it is the pass most likely to run the shard garbage
+    // collection and missing-metadata repair that the cheap outbox pre-check
+    // below cannot see.
+    let mut force_full_pass = true;
+
+    loop {
+        tokio::select! {
+            _ = tick.tick() => {}
+            _ = shutdown.changed() => break,
+        }
+        // A drain waits on the write gate. Starting a reconcile now would
+        // extend someone's shutdown to buy freshness nobody is going to query.
+        if state.shutdown_started.load(Ordering::Relaxed) {
+            break;
+        }
+        if backoff_until.is_some_and(|until| Instant::now() < until) {
+            continue;
+        }
+
+        if !force_full_pass {
+            // Cheap read first: never take the write gate for an empty queue.
+            match state.store.pending_regex_scope_count() {
+                Ok(0) => continue,
+                Ok(pending) => tracing::debug!(pending, "trigram reconcile: work pending"),
+                Err(error) => {
+                    consecutive_failures = consecutive_failures.saturating_add(1);
+                    backoff_until = Some(
+                        Instant::now() + trigram_reconcile_backoff(period, consecutive_failures),
+                    );
+                    tracing::warn!(%error, consecutive_failures, "trigram reconcile: outbox read failed");
+                    continue;
+                }
+            }
+        }
+
+        let lease = state.write_gate.lock("trigram_reconcile").await;
+        // Re-check after acquiring: the gate may have been held by the write a
+        // shutdown was draining, in which case we woke up into a drain.
+        if state.shutdown_started.load(Ordering::Relaxed) {
+            drop(lease);
+            break;
+        }
+        let reconcile_state = Arc::clone(&state);
+        let outcome =
+            tokio::task::spawn_blocking(move || reconcile_state.store.refresh_trigram_index(false))
+                .await;
+        drop(lease);
+
+        match outcome {
+            Ok(Ok(stats)) => {
+                consecutive_failures = 0;
+                backoff_until = None;
+                force_full_pass = false;
+                if stats.scopes_refreshed > 0 {
+                    tracing::info!(
+                        scopes_refreshed = stats.scopes_refreshed,
+                        nodes_changed = stats.nodes_changed,
+                        "trigram reconcile"
+                    );
+                }
+            }
+            Ok(Err(error)) => {
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                backoff_until =
+                    Some(Instant::now() + trigram_reconcile_backoff(period, consecutive_failures));
+                // The scope stays dirty and queries keep scanning it, so this
+                // costs latency and never correctness. Retry on the next tick.
+                tracing::warn!(%error, consecutive_failures, "trigram reconcile failed");
+            }
+            Err(join_error) => {
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                backoff_until =
+                    Some(Instant::now() + trigram_reconcile_backoff(period, consecutive_failures));
+                tracing::error!(%join_error, "trigram reconcile task panicked");
+            }
+        }
+    }
+    tracing::debug!("trigram reconcile loop stopped");
+}
+
 /// The SIGTERM handler task: route every SIGTERM into [`begin_shutdown_drain`].
 ///
 /// LOOPS DELIBERATELY. This used to `recv()` exactly once and return, which
@@ -4155,17 +4279,21 @@ impl NestWeaverDaemon for DaemonService {
         // Three-state trigram policy. A plain bool could not distinguish "the
         // caller said no" from "the caller said nothing", so a configless
         // `index` sent false and this handler honoured it — discarding the
-        // daemon's own `[indexing] with_trigrams = true`. UNSPECIFIED now means
-        // inherit, and the legacy bool is ORed in so a pre-6.4 client that sets
-        // it still forces a refresh.
-        let with_trigrams = resolve_trigram_policy(
-            req.trigram_policy(),
-            req.with_trigrams,
-            state
-                .instance_cfg
-                .as_ref()
-                .is_some_and(|config| config.indexing.with_trigrams),
-        );
+        // daemon's own `[indexing] with_trigrams = true`. The legacy bool is
+        // still ORed in so a pre-6.4 client that sets it forces a refresh.
+        // nw-198: an index no longer drains the outbox just because the daemon
+        // is configured to maintain trigrams. Maintenance is the reconcile
+        // loop's job now, so `daemon_config_enabled` is deliberately FALSE
+        // here: an UNSPECIFIED request inherits nothing and does no inline
+        // refresh, and the loop picks the enqueued scopes up on its next tick.
+        //
+        // Explicit intent still wins, which is what CI and scripted reindex
+        // need: `--with-trigrams` forces an inline refresh, `--no-trigrams`
+        // forces none, and `--rebuild-trigrams` still forces a full rebuild.
+        // That is the `refresh=wait_for` split — the caller who genuinely needs
+        // synchronous freshness asks for it, and nobody else pays a fixed
+        // per-index cost that has nothing to do with how much changed.
+        let with_trigrams = resolve_trigram_policy(req.trigram_policy(), req.with_trigrams, false);
         let rebuild_trigrams = req.rebuild_trigrams;
         let with_git_activity = req.with_git_activity;
         let name = if req.name.is_empty() {
@@ -9509,6 +9637,29 @@ pub async fn run_server(
     // Catch SIGTERM for graceful shutdown (sent by `daemon stop`).
     tokio::spawn(watch_sigterm(Arc::clone(&state)));
 
+    // The trigram reconcile loop. Spawned in EVERY writable daemon mode, not
+    // just server mode: the local daemon is exactly where the vault refresh and
+    // the file watchers run, and those are the paths whose enqueued work had no
+    // drain. A read-only replica has no business writing shards.
+    if !read_only {
+        match state
+            .instance_cfg
+            .as_ref()
+            .and_then(|config| config.indexing.trigram_reconcile_period())
+        {
+            Some(period) => {
+                tracing::info!(
+                    interval_secs = period.as_secs(),
+                    "trigram reconcile loop enabled"
+                );
+                tokio::spawn(run_trigram_reconciler(Arc::clone(&state), period));
+            }
+            None => tracing::debug!(
+                "trigram reconcile loop disabled ([indexing] with_trigrams off, or interval 0)"
+            ),
+        }
+    }
+
     let uds = tokio::net::UnixListener::bind(&sock_path)
         .with_context(|| format!("bind UDS: {}", sock_path.display()))?;
 
@@ -10280,13 +10431,6 @@ pub async fn run_server(
                 .as_ref()
                 .map(|config| config.indexing.limits())
                 .unwrap_or_default();
-            // `[indexing] with_trigrams` — keeps the regex pre-filter fresh on
-            // the daemon's own background reindex, which previously never
-            // touched trigrams at all.
-            let worker_with_trigrams = state
-                .instance_cfg
-                .as_ref()
-                .is_some_and(|config| config.indexing.with_trigrams);
             let worker_job_queue = std::sync::Arc::clone(&shared_job_queue);
             let worker_handle = tokio::spawn(async move {
                 let workspace_dir = worker_db
@@ -10312,8 +10456,8 @@ pub async fn run_server(
                     };
                 let pool = nestweaver_engine::worker::WorkerPool::new(worker_count)
                     .with_repo_types(worker_repo_types)
-                    .with_index_limits(worker_index_limits)
-                    .with_trigram_refresh(worker_with_trigrams);
+                    .with_index_limits(worker_index_limits);
+
                 pool.run_with_drain(
                     worker_job_queue,
                     std::sync::Arc::new(workspace),
@@ -17455,6 +17599,137 @@ external_model = "unavailable-test-model"
     /// dropped the registration while leaving Tokio's `sigaction` installed, so
     /// the process went permanently deaf to SIGTERM — later signals were neither
     /// delivered nor able to default-terminate it.
+    #[test]
+    fn trigram_reconcile_backoff_grows_then_caps() {
+        let period = Duration::from_secs(30);
+        // No failures: the loop runs at its configured cadence.
+        assert_eq!(trigram_reconcile_backoff(period, 0), period);
+        // Each consecutive failure doubles the wait...
+        assert_eq!(
+            trigram_reconcile_backoff(period, 1),
+            Duration::from_secs(60)
+        );
+        assert_eq!(
+            trigram_reconcile_backoff(period, 2),
+            Duration::from_secs(120)
+        );
+        // ...up to a hard ceiling, so a permanently broken shard neither
+        // hot-loops the write gate nor backs off to never retrying at all.
+        assert_eq!(
+            trigram_reconcile_backoff(period, 30),
+            Duration::from_secs(600)
+        );
+        // A period longer than the cap is never shortened by the backoff.
+        let long = Duration::from_secs(3600);
+        assert_eq!(trigram_reconcile_backoff(long, 5), long);
+    }
+
+    /// The whole point of nw-198: a mutation that reaches the store enqueues
+    /// outbox work, and the reconcile loop drains it WITHOUT any writer having
+    /// asked it to. If this regresses, a write path can go stale silently.
+    #[tokio::test]
+    async fn reconciler_drains_the_outbox_with_no_writer_involvement() {
+        let state = test_state_with_writer();
+        // Drive a REAL public write. `insert_symbol` marks its repo scope dirty
+        // inside the same transaction, which is the invariant the whole design
+        // rests on — so this test exercises enqueue-then-drain end to end
+        // rather than poking the outbox directly. No index RPC, no watcher, no
+        // explicit `--with-trigrams`: nothing here asks for a reconcile.
+        state
+            .store
+            .insert_symbol(&nestweaver_schema::Symbol {
+                uid: "sym:reconcile-test:1".to_string(),
+                name: "reconcile_me".to_string(),
+                kind: nestweaver_schema::SymbolKind::Function,
+                repo_uid: "repo:reconcile-test".to_string(),
+                file_path: "src/lib.rs".to_string(),
+                start_line: 1,
+                end_line: 2,
+                signature: "fn reconcile_me()".to_string(),
+                summary: None,
+                content_hash: "hash".to_string(),
+                embedding: None,
+                pagerank_score: None,
+                is_entry_point: false,
+                entry_point_kind: None,
+                visibility: nestweaver_schema::Visibility::Inferred,
+                type_info: None,
+                framework_hint: None,
+                canonical_id: None,
+            })
+            .expect("insert_symbol");
+        assert!(
+            state.store.pending_regex_scope_count().unwrap() > 0,
+            "precondition: the outbox must have work"
+        );
+
+        let handle = tokio::spawn(run_trigram_reconciler(
+            Arc::clone(&state),
+            Duration::from_millis(20),
+        ));
+
+        let drained = tokio::time::timeout(Duration::from_secs(20), async {
+            loop {
+                if state.store.pending_regex_scope_count().unwrap_or(1) == 0 {
+                    return true;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .unwrap_or(false);
+
+        state.shutdown_started.store(true, Ordering::Relaxed);
+        let _ = state.shutdown_tx.send(true);
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+
+        assert!(
+            drained,
+            "the reconcile loop must drain enqueued scopes on its own"
+        );
+    }
+
+    /// The loop must not start a reconcile once a drain has begun: the drain
+    /// waits on the write gate, so starting one would extend someone's
+    /// shutdown to buy freshness nobody is going to query.
+    #[tokio::test]
+    async fn reconciler_stops_when_shutdown_starts() {
+        let state = test_state_with_writer();
+        state.shutdown_started.store(true, Ordering::Relaxed);
+
+        let handle = tokio::spawn(run_trigram_reconciler(
+            Arc::clone(&state),
+            Duration::from_millis(10),
+        ));
+
+        let stopped = tokio::time::timeout(Duration::from_secs(5), handle).await;
+        assert!(
+            stopped.is_ok(),
+            "the loop must exit promptly once shutdown_started is set"
+        );
+    }
+
+    /// A shutdown broadcast with no `shutdown_started` flag must also stop it,
+    /// so the task cannot outlive the daemon it belongs to.
+    #[tokio::test]
+    async fn reconciler_stops_on_shutdown_broadcast() {
+        let state = test_state_with_writer();
+        let handle = tokio::spawn(run_trigram_reconciler(
+            Arc::clone(&state),
+            // Long period: the only thing that can end this is the broadcast.
+            Duration::from_secs(3600),
+        ));
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let _ = state.shutdown_tx.send(true);
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(5), handle)
+                .await
+                .is_ok(),
+            "the loop must exit on a shutdown broadcast"
+        );
+    }
+
     #[tokio::test]
     async fn sigterm_does_not_broadcast_while_a_write_is_in_flight() {
         let state = test_state_with_writer();

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -969,6 +969,14 @@ pub struct DaemonState {
     /// Handle to the server-mode worker-pool task. Awaited on shutdown so an
     /// in-flight index write is allowed to finish rather than being abandoned.
     pub worker_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Join handle for the trigram reconcile loop.
+    ///
+    /// Retained for the same reason as `worker_handle`: the reconcile performs a
+    /// blocking store write on a `spawn_blocking` thread, which cannot be
+    /// aborted. Shutdown removes the socket and pidfile after awaiting these
+    /// handles, so a discarded handle would let that teardown race a write in
+    /// progress — against a store that is not crash-safe (nw-126).
+    pub trigram_reconciler_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
     /// Handle to the `serve_ui` web-server task plus the port it is bound
     /// to, aborted by `stop_ui` so the listen port is released when the CLI
     /// exits (LOW: ui port leak). The port is tracked so a repeated
@@ -1334,11 +1342,6 @@ async fn run_trigram_reconciler(state: Arc<DaemonState>, period: Duration) {
             _ = tick.tick() => {}
             _ = shutdown.changed() => break,
         }
-        // A drain waits on the write gate. Starting a reconcile now would
-        // extend someone's shutdown to buy freshness nobody is going to query.
-        if state.shutdown_started.load(Ordering::Relaxed) {
-            break;
-        }
         if backoff_until.is_some_and(|until| Instant::now() < until) {
             continue;
         }
@@ -1359,13 +1362,24 @@ async fn run_trigram_reconciler(state: Arc<DaemonState>, period: Duration) {
             }
         }
 
-        let lease = state.write_gate.lock("trigram_reconcile").await;
-        // Re-check after acquiring: the gate may have been held by the write a
-        // shutdown was draining, in which case we woke up into a drain.
-        if state.shutdown_started.load(Ordering::Relaxed) {
-            drop(lease);
+        // Admission guard BEFORE the write gate, in that order, exactly as the
+        // RPC write paths do.
+        //
+        // This is not merely a shutdown check. `ConnectionGuard::write` is what
+        // increments `active_writes`, and `active_writes` is what the shutdown
+        // drain and the idle timeout both read to decide whether anything is
+        // still writing. A hand-rolled `shutdown_started` check would leave this
+        // write INVISIBLE to both: shutdown could broadcast and unlink the
+        // socket and pidfile while a `spawn_blocking` reconcile — which cannot
+        // be aborted — was still writing to a store that is not crash-safe.
+        //
+        // Taking the guard also refuses admission once a drain has begun, which
+        // is the behaviour the hand-rolled check was reaching for, but atomic
+        // with the counter rather than racing it.
+        let Ok(_admission) = ConnectionGuard::write(&state) else {
             break;
-        }
+        };
+        let lease = state.write_gate.lock("trigram_reconcile").await;
         let reconcile_state = Arc::clone(&state);
         let outcome =
             tokio::task::spawn_blocking(move || reconcile_state.store.refresh_trigram_index(false))
@@ -9497,6 +9511,7 @@ pub async fn run_server(
         admin_token,
         admin_state: std::sync::OnceLock::new(),
         worker_handle: std::sync::Mutex::new(None),
+        trigram_reconciler_handle: std::sync::Mutex::new(None),
         ui_server: std::sync::Mutex::new(None),
     });
 
@@ -9589,6 +9604,20 @@ pub async fn run_server(
         .with_context(|| format!("create runtime dir: {}", sock_dir.display()))?;
 
     let sock_path = lifecycle::socket_path(&instance_id);
+    // Await the reconcile loop for the same reason as the worker pool above: its
+    // `spawn_blocking` store write cannot be aborted, and everything below this
+    // point unlinks the socket and pidfile. Exiting while that write is in
+    // flight is precisely the crash the shutdown design exists to avoid.
+    let reconciler_handle = state
+        .trigram_reconciler_handle
+        .lock()
+        .ok()
+        .and_then(|mut guard| guard.take());
+    if let Some(handle) = reconciler_handle {
+        tracing::info!("draining trigram reconcile loop before exit");
+        let _ = handle.await;
+    }
+
     let _ = std::fs::remove_file(&sock_path);
 
     // The single-owner instance lock (pidfile flock) was already claimed above,
@@ -9652,7 +9681,12 @@ pub async fn run_server(
                     interval_secs = period.as_secs(),
                     "trigram reconcile loop enabled"
                 );
-                tokio::spawn(run_trigram_reconciler(Arc::clone(&state), period));
+                let reconciler_handle =
+                    tokio::spawn(run_trigram_reconciler(Arc::clone(&state), period));
+                *state
+                    .trigram_reconciler_handle
+                    .lock()
+                    .expect("trigram_reconciler_handle mutex poisoned") = Some(reconciler_handle);
             }
             None => tracing::debug!(
                 "trigram reconcile loop disabled ([indexing] with_trigrams off, or interval 0)"
@@ -15860,6 +15894,7 @@ mod startup_helper_tests {
             admin_token: None,
             admin_state: std::sync::OnceLock::new(),
             worker_handle: std::sync::Mutex::new(None),
+            trigram_reconciler_handle: std::sync::Mutex::new(None),
             ui_server: std::sync::Mutex::new(None),
         })
     }
@@ -15941,6 +15976,7 @@ credential_method = "gh"
             admin_token: None,
             admin_state: std::sync::OnceLock::new(),
             worker_handle: std::sync::Mutex::new(None),
+            trigram_reconciler_handle: std::sync::Mutex::new(None),
             ui_server: std::sync::Mutex::new(None),
         })
     }
@@ -17686,6 +17722,75 @@ external_model = "unavailable-test-model"
         assert!(
             drained,
             "the reconcile loop must drain enqueued scopes on its own"
+        );
+    }
+
+    /// The reconcile write must be VISIBLE to the shutdown drain and to the
+    /// idle timeout.
+    ///
+    /// Both read `active_writes`, which only `ConnectionGuard::write`
+    /// increments. A reconcile that took the write gate without that guard was
+    /// invisible to both, so shutdown could broadcast and unlink the socket and
+    /// pidfile while an unabortable `spawn_blocking` write was still running
+    /// against a store that is not crash-safe (nw-126).
+    #[tokio::test]
+    async fn reconciler_write_is_counted_in_active_writes() {
+        let state = test_state_with_writer();
+        state
+            .store
+            .insert_symbol(&nestweaver_schema::Symbol {
+                uid: "sym:counted:1".to_string(),
+                name: "counted".to_string(),
+                kind: nestweaver_schema::SymbolKind::Function,
+                repo_uid: "repo:counted".to_string(),
+                file_path: "src/lib.rs".to_string(),
+                start_line: 1,
+                end_line: 2,
+                signature: "fn counted()".to_string(),
+                summary: None,
+                content_hash: "hash".to_string(),
+                embedding: None,
+                pagerank_score: None,
+                is_entry_point: false,
+                entry_point_kind: None,
+                visibility: nestweaver_schema::Visibility::Inferred,
+                type_info: None,
+                framework_hint: None,
+                canonical_id: None,
+            })
+            .expect("insert_symbol");
+
+        let observer = Arc::clone(&state);
+        let peak = tokio::spawn(async move {
+            let mut peak = 0u32;
+            for _ in 0..600 {
+                peak = peak.max(observer.active_writes.load(Ordering::Relaxed));
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+            peak
+        });
+
+        let handle = tokio::spawn(run_trigram_reconciler(
+            Arc::clone(&state),
+            Duration::from_millis(10),
+        ));
+        // Let it complete at least one reconcile.
+        for _ in 0..200 {
+            if state.store.pending_regex_scope_count().unwrap_or(1) == 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        let observed = peak.await.unwrap_or(0);
+
+        state.shutdown_started.store(true, Ordering::Relaxed);
+        let _ = state.shutdown_tx.send(true);
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+
+        assert!(
+            observed > 0,
+            "a reconcile must raise active_writes so the drain and the idle \
+             timeout can see it; observed peak was {observed}"
         );
     }
 

--- a/crates/nestweaver-engine/src/config.rs
+++ b/crates/nestweaver-engine/src/config.rs
@@ -44,6 +44,28 @@ pub struct RankingConfig {
     /// flag and MCP `prf: true` argument override this per call.
     #[serde(default)]
     pub enable_prf: bool,
+    /// Record MCP interaction telemetry to the `<db>.interactions.json`
+    /// sidecar, which feeds usage-based ranking.
+    ///
+    /// Off by default, preserving the opt-in contract the generated setup guide
+    /// already promises ("Opt-in, local-only, records UIDs and timestamps only
+    /// — no content is captured"). The CLI `--track-interactions` /
+    /// `--no-track-interactions` flags override this per invocation, exactly as
+    /// `--prf` overrides [`Self::enable_prf`].
+    ///
+    /// This lives in config rather than existing only as a CLI flag because it
+    /// is a durable per-brain policy, and `nestweaver setup` regenerates every
+    /// `.mcp.json` it manages — so a flag hand-added to a generated config was
+    /// silently dropped on the next setup run, making the feature unreachable
+    /// through the supported install path.
+    ///
+    /// Note this is not merely label collection for a future reranker: the
+    /// scores feed `PprConfig::interaction_scores`, so enabling it changes live
+    /// ranking. The blend is deliberately capped (see the exploration floor in
+    /// `nestweaver-algorithms::ppr`), but it is a retrieval-behaviour change,
+    /// not just telemetry.
+    #[serde(default)]
+    pub track_interactions: bool,
     /// Substring patterns matched case-insensitively against a symbol's file
     /// path to deboost test/fixture code in `search_symbols_by_name` ranking.
     /// Override via `[ranking] test_path_patterns` in instance config.
@@ -100,6 +122,7 @@ impl Default for RankingConfig {
             dampen: Vec::new(),
             boost: Vec::new(),
             enable_prf: false,
+            track_interactions: false,
             test_path_patterns: default_test_path_patterns(),
             git_activity_weight: default_git_activity_weight(),
         }
@@ -275,6 +298,49 @@ pub struct SourceIndexingConfig {
     /// storage cost for anyone who has not asked for it.
     #[serde(default)]
     pub with_trigrams: bool,
+    /// How often the daemon's trigram reconcile loop drains the coalesced
+    /// `RegexScopeOutbox` and brings dirty scopes back to `ready`.
+    ///
+    /// Invalidation has always been universal and transactional — the store's
+    /// own write path marks a scope dirty inside the mutating transaction, so
+    /// no caller can forget. What was missing was an owner for the drain:
+    /// `refresh_trigram_index` was only ever called as a side effect of two
+    /// write handlers, so every other mutation path (the vault, both watchers)
+    /// enqueued work nobody drained. That is a transactional outbox with no
+    /// relay, and a level-triggered design invoked edge-triggered — a missed
+    /// edge became a permanently stale scope.
+    ///
+    /// The loop is the relay. Accepts a humanized duration (`"30s"`, `"5m"`);
+    /// `"0"` disables it, which leaves freshness to explicit
+    /// `index --with-trigrams` runs only. Gated on `with_trigrams`, which stays
+    /// the master switch for whether trigram acceleration is maintained at all.
+    ///
+    /// Analogous to Elasticsearch's `index.refresh_interval`: refresh is a
+    /// time-driven background operation deliberately decoupled from write
+    /// requests, because forcing one per write pays a fixed cost that has
+    /// nothing to do with how much changed.
+    #[serde(default = "default_trigram_reconcile_interval")]
+    pub trigram_reconcile_interval: String,
+}
+
+fn default_trigram_reconcile_interval() -> String {
+    "30s".to_string()
+}
+
+/// Parse `[indexing] trigram_reconcile_interval`.
+///
+/// [`parse_duration`] requires a unit suffix, so a bare `"0"` does not parse
+/// there. Disabling a periodic loop by writing `0` is the obvious thing an
+/// operator will type, so accept it here as an explicit zero. Both the load-time
+/// validator and [`SourceIndexingConfig::trigram_reconcile_period`] go through
+/// this one function, so "accepted by validation" and "understood at runtime"
+/// cannot drift apart.
+pub fn parse_reconcile_interval(s: &str) -> Option<std::time::Duration> {
+    let trimmed = s.trim();
+    if trimmed == "0" {
+        return Some(std::time::Duration::ZERO);
+    }
+    parse_duration(trimmed)
 }
 
 fn default_max_source_file_bytes() -> u64 {
@@ -286,11 +352,24 @@ impl Default for SourceIndexingConfig {
         Self {
             max_source_file_bytes: default_max_source_file_bytes(),
             with_trigrams: false,
+            trigram_reconcile_interval: default_trigram_reconcile_interval(),
         }
     }
 }
 
 impl SourceIndexingConfig {
+    /// Parsed reconcile interval. `None` means the loop is disabled — either
+    /// `with_trigrams` is off (nothing to maintain) or the interval is `"0"`.
+    /// `InstanceConfig` validates the string on load, so an unparseable value
+    /// fails config loading rather than silently disabling the reconciler here.
+    pub fn trigram_reconcile_period(&self) -> Option<std::time::Duration> {
+        if !self.with_trigrams {
+            return None;
+        }
+        let parsed = parse_reconcile_interval(&self.trigram_reconcile_interval)?;
+        (!parsed.is_zero()).then_some(parsed)
+    }
+
     pub fn limits(&self) -> crate::index_limits::IndexLimits {
         // InstanceConfig validates this during construction, so downstream
         // code never has to handle an invalid value.
@@ -945,6 +1024,17 @@ impl InstanceConfig {
             config.expected_brain_uuid = Some(parsed.to_string());
         }
         crate::index_limits::IndexLimits::new(config.indexing.max_source_file_bytes)?;
+        // Fail config loading on an unparseable reconcile interval. Silently
+        // treating a typo as "disabled" would reintroduce exactly the failure
+        // this loop exists to remove: trigrams quietly going stale with no
+        // signal anywhere, which is only visible in `regex-search --json`.
+        if parse_reconcile_interval(&config.indexing.trigram_reconcile_interval).is_none() {
+            anyhow::bail!(
+                "[indexing] trigram_reconcile_interval: {:?} is not a duration \
+                 (expected e.g. \"30s\", \"5m\", or \"0\" to disable)",
+                config.indexing.trigram_reconcile_interval
+            );
+        }
         // Feature F6: clamp ranking-prior multipliers into bounds on load so
         // downstream code can trust the values without re-validating.
         config.ranking.clamp_multipliers();
@@ -2266,6 +2356,69 @@ url = "https://github.com/example/keep-me"
     /// `[indexing] with_trigrams` must be accepted, default off, and live in
     /// the top-level section rather than `[server.indexing]` — it describes how
     /// sources are indexed in every mode, not server scheduling.
+    #[test]
+    fn reconcile_interval_defaults_to_thirty_seconds_and_is_gated_on_with_trigrams() {
+        let off = SourceIndexingConfig::default();
+        assert_eq!(off.trigram_reconcile_interval, "30s");
+        // with_trigrams is the master switch: no maintenance, no loop.
+        assert_eq!(off.trigram_reconcile_period(), None);
+
+        let on = SourceIndexingConfig {
+            with_trigrams: true,
+            ..SourceIndexingConfig::default()
+        };
+        assert_eq!(
+            on.trigram_reconcile_period(),
+            Some(std::time::Duration::from_secs(30))
+        );
+    }
+
+    /// A bare `0` is what an operator will type to turn a periodic loop off,
+    /// and `parse_duration` rejects it for lack of a unit suffix. Validation
+    /// and the runtime accessor must agree, or config would load and the loop
+    /// would then silently not run.
+    #[test]
+    fn reconcile_interval_accepts_bare_zero_as_disabled() {
+        assert_eq!(
+            parse_reconcile_interval("0"),
+            Some(std::time::Duration::ZERO)
+        );
+        assert_eq!(
+            parse_duration("0"),
+            None,
+            "the general parser still rejects it"
+        );
+
+        let disabled = SourceIndexingConfig {
+            with_trigrams: true,
+            trigram_reconcile_interval: "0".to_string(),
+            ..SourceIndexingConfig::default()
+        };
+        assert_eq!(disabled.trigram_reconcile_period(), None);
+    }
+
+    #[test]
+    fn reconcile_interval_rejects_a_typo_instead_of_silently_disabling() {
+        assert_eq!(parse_reconcile_interval("30 seconds"), None);
+        assert_eq!(parse_reconcile_interval("soon"), None);
+        assert_eq!(
+            parse_reconcile_interval("5m"),
+            Some(std::time::Duration::from_secs(300))
+        );
+    }
+
+    /// nw-199: the durable policy lives in `[ranking]`, off by default, exactly
+    /// like `enable_prf`.
+    #[test]
+    fn ranking_config_track_interactions_defaults_off_and_parses() {
+        assert!(!RankingConfig::default().track_interactions);
+        let cfg: InstanceConfig = toml::from_str(&format!(
+            "{MINIMAL_TOML}\n\n[ranking]\ntrack_interactions = true\n"
+        ))
+        .expect("config with track_interactions must parse");
+        assert!(cfg.ranking.track_interactions);
+    }
+
     #[test]
     fn indexing_config_accepts_with_trigrams_and_defaults_off() {
         // Absent → off, so existing configs keep today's opt-in behaviour and

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -12166,6 +12166,32 @@ function hello(name) { return "Hello " + name; }
             "function originalNeedle() {}\nfunction watchedRegressionNeedle() {}\n",
         )
         .unwrap();
+        // Advance the mtime explicitly instead of relying on the two writes
+        // straddling a wall-clock second.
+        //
+        // `tiered_change_check` Tier 1 is `cached.mtime_secs == mtime_secs ->
+        // Unchanged`, at WHOLE-SECOND granularity and short-circuiting before
+        // any content hash. When both writes land in the same second the edit
+        // is classified unchanged, nothing is re-indexed, no scope is dirtied,
+        // and this test fails with `dirty_scopes: 0`. That is timing, not
+        // behaviour: the faster the build, the likelier the collision, so it
+        // passed in debug and failed under `--release` on CI.
+        //
+        // Pinning the mtime forward makes the test assert what it means to
+        // assert — that an incremental CONTENT change dirties the regex scope —
+        // rather than incidentally asserting that the clock ticked.
+        {
+            let path = repo.join("main.js");
+            // Advance relative to the file's OWN mtime, not to `now`: that is
+            // strictly monotonic by construction, so the new mtime is always a
+            // different whole second from the one the first index cached, no
+            // matter how fast the machine or where the clock happens to sit.
+            let current = fs::metadata(&path).unwrap().modified().unwrap();
+            let advanced = current + std::time::Duration::from_secs(10);
+            let file = fs::OpenOptions::new().write(true).open(&path).unwrap();
+            file.set_times(fs::FileTimes::new().set_modified(advanced))
+                .unwrap();
+        }
         incremental_index_with_name(&repo, &db_path, "test", "https://example.com/regex", None)
             .unwrap();
 

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -1777,15 +1777,39 @@ fn tiered_change_check(
     }
 
     if let Some(cached) = cache.get(rel_path) {
-        // Tier 1: mtime unchanged → skip.
-        if cached.mtime_secs == mtime_secs {
+        // Tier 1: mtime AND size unchanged → skip.
+        //
+        // Size is part of this check, not just mtime. `file_meta` truncates the
+        // timestamp to WHOLE SECONDS (`as_secs()`), so every edit landing in the
+        // same second as the one already cached is invisible to an mtime-only
+        // comparison — and because the cached mtime then still matches, the file
+        // stays misclassified on EVERY later index too. It never self-heals; only
+        // a further mtime change recovers it. Reproduced end to end: index a
+        // repo, edit a file inside the same second (size 35 -> 78 bytes), and the
+        // new symbol is absent from the graph permanently.
+        //
+        // Comparing size closes every size-changing edit for free — `size_bytes`
+        // is already in hand from `file_meta`, and a genuinely unchanged file
+        // still short-circuits here with no read. This is the standard quick
+        // check: rsync transfers when size OR mtime differs, and Git compares
+        // `st_size` alongside `st_mtime` precisely because mtime alone is
+        // insufficient (Documentation/technical/racy-git.txt).
+        //
+        // What remains is Git's "racily clean" case: a same-second edit that
+        // leaves the size identical. Git bounds that window by the INDEX file's
+        // timestamp and re-hashes only entries inside it. The same bound cannot
+        // be had from `cached.mtime_secs` alone — for unchanged files it matches
+        // by definition, so hashing on match would re-read the whole tree every
+        // run. Closing it needs a per-run index timestamp; tracked separately.
+        if cached.mtime_secs == mtime_secs && cached.size_bytes == size_bytes {
             return Ok(ChangeVerdict::Unchanged);
         }
 
-        // Tier 2: mtime changed but size unchanged → fall through to hash check.
-        // Same-size edits are common, so we cannot skip based on size alone.
+        // Tier 2: mtime or size changed → fall through to hash check. A
+        // same-size edit is common, so size alone is not enough to declare a
+        // change either; the hash below is what decides.
 
-        // Tier 3: mtime differs → read file, compute hash, compare.
+        // Tier 3: read file, compute hash, compare.
         let source = enforce_actual_size(
             reader
                 .read_file(rel)
@@ -12201,6 +12225,79 @@ function hello(name) { return "Hello " + name; }
             .unwrap();
         assert_eq!(widened.dirty_scopes, 1);
         assert_eq!(widened.results.len(), 1);
+    }
+
+    /// A real edit made inside the same whole second as the cached mtime must
+    /// still be indexed.
+    ///
+    /// `file_meta` truncates timestamps with `as_secs()`, so an mtime-only Tier 1
+    /// check cannot see such an edit — and because the cached mtime then keeps
+    /// matching, the file stays misclassified on every LATER index too. It never
+    /// self-heals; only a further mtime change recovers it. Verified end to end
+    /// before the fix: a 35 -> 78 byte edit inside one second left the new symbol
+    /// permanently absent from the graph.
+    ///
+    /// Both canonical quick checks compare size for this reason — rsync
+    /// transfers when size OR mtime differs, and Git compares `st_size`
+    /// alongside `st_mtime` (Documentation/technical/racy-git.txt).
+    ///
+    /// The mtime is pinned rather than raced so the condition is exercised on
+    /// every run, not only when the clock cooperates.
+    #[test]
+    fn same_second_edit_that_changes_size_is_not_missed() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("same-second.lbug");
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        let file = repo.join("main.js");
+
+        // One fixed instant for BOTH writes: the cached mtime and the post-edit
+        // mtime are then identical whole seconds, by construction.
+        let pinned = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_500_000);
+        let pin = |path: &std::path::Path| {
+            let handle = fs::OpenOptions::new().write(true).open(path).unwrap();
+            handle
+                .set_times(fs::FileTimes::new().set_modified(pinned))
+                .unwrap();
+        };
+
+        fs::write(&file, "function beforeEdit() {}\n").unwrap();
+        pin(&file);
+        incremental_index_with_name(
+            &repo,
+            &db_path,
+            "test",
+            "https://example.com/same-sec",
+            None,
+        )
+        .unwrap();
+
+        // A genuine edit that changes the file's size, pinned to the SAME second.
+        fs::write(
+            &file,
+            "function beforeEdit() {}\nfunction afterSameSecondEdit() {}\n",
+        )
+        .unwrap();
+        pin(&file);
+        incremental_index_with_name(
+            &repo,
+            &db_path,
+            "test",
+            "https://example.com/same-sec",
+            None,
+        )
+        .unwrap();
+
+        let store = GraphStore::open_read_only(&db_path).unwrap();
+        let found = store
+            .regex_search("afterSameSecondEdit", None, None, None, None)
+            .unwrap();
+        assert_eq!(
+            found.results.len(),
+            1,
+            "a same-second edit that changes the file size must still be indexed; \
+             an mtime-only Tier 1 check misses it permanently"
+        );
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -2513,6 +2513,7 @@ mod ranking_prior_tests {
             dampen: vec![dampen("_logs/2020/**", 0.3)],
             boost: vec![],
             enable_prf: false,
+            track_interactions: false,
             test_path_patterns: vec![],
             git_activity_weight: 1.2,
         };
@@ -2531,6 +2532,7 @@ mod ranking_prior_tests {
             dampen: vec![dampen("_logs/2020/**", 0.3)],
             boost: vec![dampen("Projects/*/sync.md", 1.5)],
             enable_prf: false,
+            track_interactions: false,
             test_path_patterns: vec![],
             git_activity_weight: 1.2,
         };
@@ -2551,6 +2553,7 @@ mod ranking_prior_tests {
             dampen: vec![dampen("Projects/**", 0.3)],
             boost: vec![dampen("Projects/*/sync.md", 2.0)],
             enable_prf: false,
+            track_interactions: false,
             test_path_patterns: vec![],
             git_activity_weight: 1.2,
         };
@@ -2570,6 +2573,7 @@ mod ranking_prior_tests {
             dampen: vec![],
             boost: vec![dampen("critical/**", 5.0)],
             enable_prf: false,
+            track_interactions: false,
             test_path_patterns: vec![],
             git_activity_weight: 1.2,
         };
@@ -2586,6 +2590,7 @@ mod ranking_prior_tests {
             dampen: vec![dampen("archive/**", 0.05)],
             boost: vec![],
             enable_prf: false,
+            track_interactions: false,
             test_path_patterns: vec![],
             git_activity_weight: 1.2,
         };
@@ -2605,6 +2610,7 @@ mod ranking_prior_tests {
             dampen: vec![dampen("src/legacy/**", 0.5)],
             boost: vec![],
             enable_prf: false,
+            track_interactions: false,
             test_path_patterns: vec![],
             git_activity_weight: 1.2,
         };

--- a/crates/nestweaver-engine/src/worker.rs
+++ b/crates/nestweaver-engine/src/worker.rs
@@ -92,13 +92,6 @@ pub struct WorkerPool {
     /// Tracks successful incremental code updates so server mode can
     /// periodically force a full refresh and bound graph drift.
     reindex_tracker: Arc<Mutex<crate::scheduler::ReindexTracker>>,
-    /// Keep the regex trigram pre-filter fresh after each indexed job.
-    ///
-    /// Populated from `[indexing] with_trigrams` by the daemon. Nothing in the
-    /// background reindex path used to touch trigrams at all, so postings
-    /// only stayed current if a human reran `index --with-trigrams`; between
-    /// those runs `regex-search` silently fell back to a full scan.
-    refresh_trigrams: bool,
 }
 
 impl WorkerPool {
@@ -109,17 +102,7 @@ impl WorkerPool {
             repo_types: Arc::new(HashMap::new()),
             index_limits: crate::index_limits::IndexLimits::default(),
             reindex_tracker: Arc::new(Mutex::new(crate::scheduler::ReindexTracker::new())),
-            refresh_trigrams: false,
         }
-    }
-
-    /// Keep the trigram pre-filter fresh after each indexed job.
-    ///
-    /// Set from `[indexing] with_trigrams`. Off by default, preserving the
-    /// existing opt-in behaviour and its storage cost.
-    pub fn with_trigram_refresh(mut self, refresh_trigrams: bool) -> Self {
-        self.refresh_trigrams = refresh_trigrams;
-        self
     }
 
     /// Attach per-repo index strategies resolved from the instance config.
@@ -197,7 +180,6 @@ impl WorkerPool {
         let circuit_breakers = Arc::new(RemoteCircuitBreakers::new());
         let repo_types = self.repo_types.clone();
         let index_limits = self.index_limits;
-        let refresh_trigrams = self.refresh_trigrams;
 
         // Rehydrate the reindex tracker from the persisted store so the
         // periodic-full update counter and 7-day backstop survive a daemon
@@ -404,29 +386,14 @@ impl WorkerPool {
                                 );
                             }
 
-                            // Keep the regex pre-filter in step with the graph
-                            // this job just changed. Best-effort: a trigram
-                            // refresh failure must never fail an otherwise
-                            // successful index, because a stale posting table
-                            // is detected and bypassed at query time — the
-                            // cost is a slower regex-search, not a wrong one.
-                            if refresh_trigrams {
-                                match store.refresh_trigram_index(false) {
-                                    Ok(stats) => tracing::info!(
-                                        repo = %prepared.repo_id,
-                                        scopes_refreshed = stats.scopes_refreshed,
-                                        scopes_unchanged = stats.scopes_unchanged,
-                                        "trigram index refreshed after indexing"
-                                    ),
-                                    Err(error) => tracing::warn!(
-                                        repo = %prepared.repo_id,
-                                        %error,
-                                        "trigram refresh failed after indexing; \
-                                         regex-search falls back to a full scan \
-                                         until the next successful refresh"
-                                    ),
-                                }
-                            }
+                            // nw-198: this job's mutations have already
+                            // enqueued their scopes in the transactional
+                            // outbox. Draining that queue is the daemon's
+                            // trigram reconcile loop's job, not this worker's.
+                            // Refreshing here made every writer responsible for
+                            // remembering to reconcile, which is precisely how
+                            // the vault path and both file watchers ended up
+                            // enqueueing work nobody ever drained.
 
                             Ok(())
                         } else {

--- a/crates/nestweaver-store/src/regex.rs
+++ b/crates/nestweaver-store/src/regex.rs
@@ -684,6 +684,20 @@ impl GraphStore {
         Ok(states)
     }
 
+    /// Number of scopes with coalesced regex work waiting to be reconciled.
+    ///
+    /// This is the cheap pre-check the daemon's reconcile loop runs on every
+    /// tick so it only takes the write gate when there is something to do. A
+    /// full [`Self::refresh_trigram_index`] pass also garbage-collects retired
+    /// shard generations and repairs scopes whose metadata is missing, and
+    /// neither of those is visible here — that work is deliberately picked up
+    /// by the next pass that has outbox work anyway (an unreadable shard is
+    /// already fail-open at query time, so deferring its repair costs latency,
+    /// never correctness) plus one unconditional pass at daemon startup.
+    pub fn pending_regex_scope_count(&self) -> Result<usize, StoreError> {
+        Ok(self.regex_outbox_scopes()?.len())
+    }
+
     fn regex_outbox_scopes(&self) -> Result<HashSet<String>, StoreError> {
         let conn = self.conn()?;
         let rows = conn

--- a/src/main.rs
+++ b/src/main.rs
@@ -8420,6 +8420,134 @@ fn no_daemon_allowed() -> bool {
 /// `--track-interactions --no-track-interactions` to whichever came last, so
 /// "both set" is last-wins rather than an error. The explicit-off branch is
 /// still checked first so that ordering can never resolve to on-by-accident.
+/// `daemon gc` — sweep orphaned daemon runtime state.
+///
+/// Deliberately takes NO database path. It sweeps orphaned launch agents and
+/// orphaned per-instance directories under all three roots, sparing live
+/// instances by ownership proof (database write lock, pidfile lock) rather than
+/// by matching a database. Requiring `--db` made the one command meant to clean
+/// up after departed databases refuse to run without naming a live one, and
+/// contradicted its own `--help`, which lists `--db` as optional.
+fn run_daemon_gc() -> Result<(i32, Option<String>), anyhow::Error> {
+    #[cfg(target_os = "macos")]
+    {
+        let report = nestweaver_daemon::launchd::gc_orphaned_agents()?;
+        if report.removed.is_empty() {
+            println!(
+                "No orphaned launch agents found ({} kept, {} spared).",
+                report.kept.len(),
+                report.spared.len()
+            );
+        } else {
+            println!(
+                "Removed {} orphaned launch agent(s); kept {} live, spared {}.",
+                report.removed.len(),
+                report.kept.len(),
+                report.spared.len()
+            );
+            for label in &report.removed {
+                println!("  removed: {label}");
+            }
+        }
+        // A live daemon still holds the pidfile lock even though its
+        // DB path is currently missing (e.g. an unmounted volume) —
+        // reaping it would kill a healthy daemon, so it was spared.
+        for label in &report.spared {
+            println!("  spared (live daemon, DB path missing): {label}");
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    println!("No launch agents to sweep (launchd is macOS-only).");
+
+    // Per-instance directories accumulate under THREE roots on
+    // every platform (state logs, $XDG_RUNTIME_DIR, and the
+    // /tmp socket fallback): one set is created whenever a
+    // daemon auto-spawns, and nothing removed it when the
+    // database went away. Sweeping only the state root while
+    // reporting "clean" was the actual defect.
+    let report = nestweaver_daemon::lifecycle::gc_orphaned_daemon_dirs()
+        .context("sweep orphaned daemon directories")?;
+    let count_in = |root: nestweaver_daemon::lifecycle::GcRoot| {
+        report.removed.iter().filter(|(r, _)| *r == root).count()
+    };
+    if report.removed.is_empty() {
+        println!(
+            "No orphaned daemon directories found ({} kept, {} spared, {} unidentified).",
+            report.kept.len(),
+            report.spared.len(),
+            report.unidentified.len()
+        );
+    } else {
+        println!(
+            "Removed {} orphaned daemon director(ies), reclaiming {} \
+             ({} state, {} runtime, {} socket-fallback); \
+             kept {}, spared {}, {} unidentified.",
+            report.removed.len(),
+            format_bytes(report.reclaimed_bytes),
+            count_in(nestweaver_daemon::lifecycle::GcRoot::PersistentState),
+            count_in(nestweaver_daemon::lifecycle::GcRoot::RuntimeDir),
+            count_in(nestweaver_daemon::lifecycle::GcRoot::SocketFallback),
+            report.kept.len(),
+            report.spared.len(),
+            report.unidentified.len()
+        );
+    }
+    // A squatted fallback root is skipped, never swept — say so
+    // rather than letting "clean" imply it was checked.
+    if report.socket_fallback_root_untrusted {
+        println!(
+            "  skipped: the /tmp socket fallback root is not a directory owned \
+             by this user (possible squat) — left for its owner or root."
+        );
+    }
+    // Report each proof as its own fact. They are not exclusive
+    // — a healthy daemon holds BOTH its database write lock and
+    // its pidfile flock — so no line may be computed by
+    // subtracting one list from another, and an empty list says
+    // nothing at all rather than printing a zero.
+    if !report.spared_database_write_lock.is_empty() {
+        println!(
+            "  spared (database write lock held): {}",
+            report.spared_database_write_lock.len()
+        );
+        for (instance, pid) in &report.spared_database_write_lock {
+            match pid {
+                Some(pid) => println!("    {instance}: held by PID {pid}"),
+                None => {
+                    println!("    {instance}: held, but the kernel named no holder")
+                }
+            }
+        }
+    }
+    if !report.spared_pidfile_lock.is_empty() {
+        println!(
+            "  spared (pidfile lock held): {}",
+            report.spared_pidfile_lock.len()
+        );
+    }
+    // NOT evidence of ownership — evidence that we could not
+    // tell. Kept on its own line so it can never be read as
+    // "something holds this".
+    if !report.spared_database_unreadable.is_empty() {
+        println!(
+            "  spared (database lock state unreadable — spared conservatively): {}",
+            report.spared_database_unreadable.len()
+        );
+    }
+    // Surfaced rather than folded into "kept": these are
+    // instances the sweep could not identify, so they will
+    // never be reclaimed until something can name their
+    // database. Silence here would be the same dishonesty this
+    // item exists to fix.
+    if !report.unidentified.is_empty() {
+        println!(
+            "  left alone (database not identifiable from daemon.log): {}",
+            report.unidentified.len()
+        );
+    }
+    Ok((EXIT_SUCCESS, None))
+}
+
 fn resolve_track_interactions(force_on: bool, force_off: bool, config_enabled: bool) -> bool {
     if force_off {
         return false;
@@ -14463,6 +14591,23 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
         }
 
         Commands::Daemon { action, db } => {
+            // `gc` is database-independent and must resolve BEFORE the shared
+            // db_path requirement below.
+            //
+            // It sweeps orphaned launch agents and orphaned per-instance
+            // directories across all three roots, sparing live instances by
+            // ownership proof (database write lock, pidfile lock) rather than by
+            // matching a database path — `gc_orphaned_agents` and
+            // `gc_orphaned_daemon_dirs` take no arguments at all. Requiring
+            // --db was therefore asking for a value the command never reads,
+            // and its own --help documents --db as optional (no default, no
+            // required marker), so the failure contradicted the help text. The
+            // user-visible symptom: the one command whose whole purpose is
+            // cleaning up after databases that no longer exist could not run
+            // without naming a database that does.
+            if matches!(action, DaemonAction::Gc) {
+                return run_daemon_gc();
+            }
             let db_path = db
                 .or_else(|| {
                     std::env::var("NESTWEAVER_DB")
@@ -15879,126 +16024,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     );
                     Ok((EXIT_SUCCESS, None))
                 }
-                DaemonAction::Gc => {
-                    #[cfg(target_os = "macos")]
-                    {
-                        let report = nestweaver_daemon::launchd::gc_orphaned_agents()?;
-                        if report.removed.is_empty() {
-                            println!(
-                                "No orphaned launch agents found ({} kept, {} spared).",
-                                report.kept.len(),
-                                report.spared.len()
-                            );
-                        } else {
-                            println!(
-                                "Removed {} orphaned launch agent(s); kept {} live, spared {}.",
-                                report.removed.len(),
-                                report.kept.len(),
-                                report.spared.len()
-                            );
-                            for label in &report.removed {
-                                println!("  removed: {label}");
-                            }
-                        }
-                        // A live daemon still holds the pidfile lock even though its
-                        // DB path is currently missing (e.g. an unmounted volume) —
-                        // reaping it would kill a healthy daemon, so it was spared.
-                        for label in &report.spared {
-                            println!("  spared (live daemon, DB path missing): {label}");
-                        }
-                    }
-                    #[cfg(not(target_os = "macos"))]
-                    println!("No launch agents to sweep (launchd is macOS-only).");
-
-                    // Per-instance directories accumulate under THREE roots on
-                    // every platform (state logs, $XDG_RUNTIME_DIR, and the
-                    // /tmp socket fallback): one set is created whenever a
-                    // daemon auto-spawns, and nothing removed it when the
-                    // database went away. Sweeping only the state root while
-                    // reporting "clean" was the actual defect.
-                    let report = nestweaver_daemon::lifecycle::gc_orphaned_daemon_dirs()
-                        .context("sweep orphaned daemon directories")?;
-                    let count_in = |root: nestweaver_daemon::lifecycle::GcRoot| {
-                        report.removed.iter().filter(|(r, _)| *r == root).count()
-                    };
-                    if report.removed.is_empty() {
-                        println!(
-                            "No orphaned daemon directories found ({} kept, {} spared, {} unidentified).",
-                            report.kept.len(),
-                            report.spared.len(),
-                            report.unidentified.len()
-                        );
-                    } else {
-                        println!(
-                            "Removed {} orphaned daemon director(ies), reclaiming {} \
-                             ({} state, {} runtime, {} socket-fallback); \
-                             kept {}, spared {}, {} unidentified.",
-                            report.removed.len(),
-                            format_bytes(report.reclaimed_bytes),
-                            count_in(nestweaver_daemon::lifecycle::GcRoot::PersistentState),
-                            count_in(nestweaver_daemon::lifecycle::GcRoot::RuntimeDir),
-                            count_in(nestweaver_daemon::lifecycle::GcRoot::SocketFallback),
-                            report.kept.len(),
-                            report.spared.len(),
-                            report.unidentified.len()
-                        );
-                    }
-                    // A squatted fallback root is skipped, never swept — say so
-                    // rather than letting "clean" imply it was checked.
-                    if report.socket_fallback_root_untrusted {
-                        println!(
-                            "  skipped: the /tmp socket fallback root is not a directory owned \
-                             by this user (possible squat) — left for its owner or root."
-                        );
-                    }
-                    // Report each proof as its own fact. They are not exclusive
-                    // — a healthy daemon holds BOTH its database write lock and
-                    // its pidfile flock — so no line may be computed by
-                    // subtracting one list from another, and an empty list says
-                    // nothing at all rather than printing a zero.
-                    if !report.spared_database_write_lock.is_empty() {
-                        println!(
-                            "  spared (database write lock held): {}",
-                            report.spared_database_write_lock.len()
-                        );
-                        for (instance, pid) in &report.spared_database_write_lock {
-                            match pid {
-                                Some(pid) => println!("    {instance}: held by PID {pid}"),
-                                None => {
-                                    println!("    {instance}: held, but the kernel named no holder")
-                                }
-                            }
-                        }
-                    }
-                    if !report.spared_pidfile_lock.is_empty() {
-                        println!(
-                            "  spared (pidfile lock held): {}",
-                            report.spared_pidfile_lock.len()
-                        );
-                    }
-                    // NOT evidence of ownership — evidence that we could not
-                    // tell. Kept on its own line so it can never be read as
-                    // "something holds this".
-                    if !report.spared_database_unreadable.is_empty() {
-                        println!(
-                            "  spared (database lock state unreadable — spared conservatively): {}",
-                            report.spared_database_unreadable.len()
-                        );
-                    }
-                    // Surfaced rather than folded into "kept": these are
-                    // instances the sweep could not identify, so they will
-                    // never be reclaimed until something can name their
-                    // database. Silence here would be the same dishonesty this
-                    // item exists to fix.
-                    if !report.unidentified.is_empty() {
-                        println!(
-                            "  left alone (database not identifiable from daemon.log): {}",
-                            report.unidentified.len()
-                        );
-                    }
-                    Ok((EXIT_SUCCESS, None))
-                }
-
+                DaemonAction::Gc => run_daemon_gc(),
                 DaemonAction::Restart {
                     idle_timeout,
                     config,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2670,11 +2670,23 @@ enum Commands {
             help = "Comma-separated list of tool names to expose (default: all)"
         )]
         tools: Option<Vec<String>>,
+        /// Record interaction telemetry to a sidecar file for usage-based ranking.
+        ///
+        /// Three-state, like `--prf` over `[ranking] enable_prf`: passing
+        /// neither flag inherits `[ranking] track_interactions` from the
+        /// instance config, `--track-interactions` forces it on, and
+        /// `--no-track-interactions` forces it off. A plain bool could not
+        /// distinguish "the caller said no" from "the caller said nothing",
+        /// which is the same defect `resolve_trigram_policy` exists to fix.
         #[arg(
             long,
+            overrides_with = "no_track_interactions",
             help = "Record interaction telemetry to a sidecar file for usage-based ranking"
         )]
         track_interactions: bool,
+        /// Do not record interaction telemetry, whatever the config says.
+        #[arg(long, overrides_with = "track_interactions")]
+        no_track_interactions: bool,
         /// Path to instance config (TOML) for [limits], [response], [ranking] settings.
         /// In daemon mode, the daemon's own --config takes precedence.
         #[arg(long)]
@@ -8396,6 +8408,25 @@ fn no_daemon_allowed() -> bool {
 /// `warn` is suppressed for the `daemon` subcommand: an autostarted daemon child
 /// inherits `NESTWEAVER_NO_DAEMON` from its parent, but it never bypasses (it *is*
 /// the server), so warning there just double-prints the parent's message.
+/// Resolve the three-state `--track-interactions` / `--no-track-interactions`
+/// pair against `[ranking] track_interactions`.
+///
+/// Absent flags INHERIT the config. A two-state bool could not distinguish "the
+/// caller said no" from "the caller said nothing", which is exactly why
+/// `resolve_trigram_policy` had to be widened to three states in 6.4.0; this
+/// flag has the identical shape, so it gets the identical treatment.
+///
+/// `overrides_with` on both flags means clap already collapses
+/// `--track-interactions --no-track-interactions` to whichever came last, so
+/// "both set" is last-wins rather than an error. The explicit-off branch is
+/// still checked first so that ordering can never resolve to on-by-accident.
+fn resolve_track_interactions(force_on: bool, force_off: bool, config_enabled: bool) -> bool {
+    if force_off {
+        return false;
+    }
+    force_on || config_enabled
+}
+
 fn resolve_use_daemon(no_daemon_flag: bool, warn: bool) -> bool {
     let requested = no_daemon_flag || std::env::var_os("NESTWEAVER_NO_DAEMON").is_some();
     if !requested {
@@ -11522,6 +11553,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             lite,
             tools: tool_allowlist,
             track_interactions,
+            no_track_interactions,
             config,
             no_daemon,
         } => {
@@ -11532,6 +11564,18 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 );
             }
             let db_path = resolve_db_with_config(db, config.as_deref())?;
+            // nw-199: absent flags inherit `[ranking] track_interactions`, so
+            // the policy is a durable per-brain setting rather than something
+            // every generated `.mcp.json` has to remember. An explicit flag
+            // still wins in either direction.
+            let track_interactions = resolve_track_interactions(
+                track_interactions,
+                no_track_interactions,
+                config
+                    .as_deref()
+                    .and_then(|path| nestweaver_engine::InstanceConfig::from_file(path).ok())
+                    .is_some_and(|cfg| cfg.ranking.track_interactions),
+            );
             if track_interactions {
                 nestweaver_mcp::tools::set_track_interactions(true);
             }
@@ -27570,6 +27614,59 @@ mod stale_check_cli_tests {
             .expect("spawn")
             .join()
             .expect("join");
+    }
+}
+
+#[cfg(test)]
+mod track_interactions_tests {
+    use super::*;
+
+    /// nw-199. The three states must be distinguishable; a two-state bool could
+    /// not tell "the caller said no" from "the caller said nothing", which is
+    /// the same defect `resolve_trigram_policy` was widened to fix.
+    #[test]
+    fn absent_flags_inherit_the_config() {
+        assert!(resolve_track_interactions(false, false, true));
+        assert!(!resolve_track_interactions(false, false, false));
+    }
+
+    #[test]
+    fn explicit_flags_override_the_config_in_both_directions() {
+        // Forced on against a config that says off.
+        assert!(resolve_track_interactions(true, false, false));
+        // Forced off against a config that says on — this is the direction a
+        // plain bool could never express.
+        assert!(!resolve_track_interactions(false, true, true));
+    }
+
+    /// clap collapses the pair via `overrides_with`, but the resolver is
+    /// checked directly too: explicit-off must never resolve to on.
+    #[test]
+    fn explicit_off_wins_if_both_somehow_arrive() {
+        assert!(!resolve_track_interactions(true, true, true));
+    }
+
+    #[test]
+    fn cli_accepts_both_flags() {
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                for flag in ["--track-interactions", "--no-track-interactions"] {
+                    Cli::try_parse_from(["nestweaver", "mcp", flag])
+                        .unwrap_or_else(|e| panic!("{flag} must parse: {e}"));
+                }
+                // Last one wins rather than erroring, per `overrides_with`.
+                Cli::try_parse_from([
+                    "nestweaver",
+                    "mcp",
+                    "--track-interactions",
+                    "--no-track-interactions",
+                ])
+                .expect("both flags together must not be a hard error");
+            })
+            .unwrap()
+            .join()
+            .unwrap();
     }
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -182,18 +182,49 @@ fn which_exists(cmd: &str) -> bool {
 
 // ── Per-tool setup ────────────────────────────────────────────────────────────
 
+/// The instance config this database is bound to, if one is known.
+///
+/// nw-199: a generated `.mcp.json` used to carry only `mcp --db <db>`, so an
+/// MCP server started from it could never see instance.toml — which made the
+/// entire `mcp --config` surface (`[limits]`, `[response]`, `[ranking]`) dead
+/// through the supported install path. Any policy that lives in config was
+/// therefore unreachable, and hand-adding a flag to a generated file was
+/// pointless because the next `setup` run regenerates it.
+///
+/// This asks the same question the daemon asks on a configless start: what
+/// config was last successfully used for this database? Reusing the daemon's
+/// own persisted intent means setup cannot bind a config the daemon would
+/// disagree with, and it needs no new flag to thread through every caller.
+fn bound_config_path(db_path: &Path) -> Option<String> {
+    let record = nestweaver_daemon::lifecycle::read_last_successful_config(db_path).ok()?;
+    // Only offer a path that still exists: writing a --config pointing at a
+    // deleted file would turn every MCP start into a hard config-load failure,
+    // which is strictly worse than the no-config behaviour it replaces.
+    std::path::Path::new(&record.config_path)
+        .is_file()
+        .then_some(record.config_path)
+}
+
 fn mcp_args(db_str: &str, _allow_writes: bool) -> serde_json::Value {
-    let args = vec!["mcp".to_string(), "--db".to_string(), db_str.to_string()];
+    let mut args = vec!["mcp".to_string(), "--db".to_string(), db_str.to_string()];
+    if let Some(config) = bound_config_path(Path::new(db_str)) {
+        args.push("--config".to_string());
+        args.push(config);
+    }
     serde_json::json!(args)
 }
 
 fn mcp_args_lite(db_str: &str, _allow_writes: bool) -> serde_json::Value {
-    let args = vec![
+    let mut args = vec![
         "mcp".to_string(),
         "--lite".to_string(),
         "--db".to_string(),
         db_str.to_string(),
     ];
+    if let Some(config) = bound_config_path(Path::new(db_str)) {
+        args.push("--config".to_string());
+        args.push(config);
+    }
     serde_json::json!(args)
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -205,27 +205,34 @@ fn bound_config_path(db_path: &Path) -> Option<String> {
         .then_some(record.config_path)
 }
 
-fn mcp_args(db_str: &str, _allow_writes: bool) -> serde_json::Value {
-    let mut args = vec!["mcp".to_string(), "--db".to_string(), db_str.to_string()];
+/// THE single source of truth for the argv every generated MCP registration
+/// gets. Every per-tool writer must go through this.
+///
+/// It is a function rather than three literals because the duplication is what
+/// caused the bug: `--config` was added to the JSON writers while the Codex
+/// TOML writer kept its own hardcoded `["mcp", "--db", "{}"]` literal, so Codex
+/// silently kept emitting a config-less registration. `generated_registrations_
+/// all_carry_the_bound_config` pins that they cannot drift apart again.
+fn mcp_arg_vec(db_str: &str, lite: bool) -> Vec<String> {
+    let mut args = vec!["mcp".to_string()];
+    if lite {
+        args.push("--lite".to_string());
+    }
+    args.push("--db".to_string());
+    args.push(db_str.to_string());
     if let Some(config) = bound_config_path(Path::new(db_str)) {
         args.push("--config".to_string());
         args.push(config);
     }
-    serde_json::json!(args)
+    args
+}
+
+fn mcp_args(db_str: &str, _allow_writes: bool) -> serde_json::Value {
+    serde_json::json!(mcp_arg_vec(db_str, false))
 }
 
 fn mcp_args_lite(db_str: &str, _allow_writes: bool) -> serde_json::Value {
-    let mut args = vec![
-        "mcp".to_string(),
-        "--lite".to_string(),
-        "--db".to_string(),
-        db_str.to_string(),
-    ];
-    if let Some(config) = bound_config_path(Path::new(db_str)) {
-        args.push("--config".to_string());
-        args.push(config);
-    }
-    serde_json::json!(args)
+    serde_json::json!(mcp_arg_vec(db_str, true))
 }
 
 fn setup_claude_code(
@@ -411,8 +418,12 @@ fn setup_codex(db_path: &Path, _allow_writes: bool, base: &Path) -> Result<(), a
     let db_str = db_path.to_string_lossy();
     let config_path = base.join(".codex/config.toml");
     let toml_section = format!(
-        "\n[mcp_servers.nestweaver]\ncommand = \"nestweaver\"\nargs = [\"mcp\", \"--db\", \"{}\"]\n",
-        db_str
+        "\n[mcp_servers.nestweaver]\ncommand = \"nestweaver\"\nargs = [{}]\n",
+        mcp_arg_vec(&db_str, false)
+            .iter()
+            .map(|arg| format!("\"{}\"", arg.replace('\\', "\\\\").replace('"', "\\\"")))
+            .collect::<Vec<_>>()
+            .join(", ")
     );
     let merged = append_toml_if_missing(&config_path, "mcp_servers.nestweaver", &toml_section)?;
 
@@ -1278,5 +1289,60 @@ mod setup_base_dir_tests {
             std::fs::read_to_string(mcp_path).unwrap(),
             primary_before_retry
         );
+    }
+}
+
+#[cfg(test)]
+mod mcp_arg_source_of_truth_tests {
+    use super::*;
+
+    /// nw-199 follow-up, from a user report: `--config` was added to the JSON
+    /// writers while the Codex writer kept its own hardcoded
+    /// `["mcp", "--db", "{}"]` literal, so Codex alone kept emitting a
+    /// config-less registration — the exact drift the single builder exists to
+    /// prevent. Grep the source: no writer may hand-roll the argv.
+    #[test]
+    fn no_writer_hand_rolls_the_mcp_argv() {
+        // Build the needle from pieces so this detector does not match its own
+        // source line — the joined form never appears literally in this file.
+        let needle = ["\"mcp\"", "\"--db\""].join(", ");
+        let escaped = needle.replace('"', "\\\"");
+        let source = include_str!("setup.rs");
+        // Stop before this test module so the assertion message and the needle
+        // pieces cannot themselves be flagged.
+        let production = source
+            .split_once("#[cfg(test)]")
+            .map(|(before, _)| before)
+            .unwrap_or(source);
+
+        let mut offenders = Vec::new();
+        for (n, line) in production.lines().enumerate() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") {
+                continue;
+            }
+            if line.contains(&needle) || line.contains(&escaped) {
+                offenders.push(format!("{}: {}", n + 1, line.trim()));
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "every generated MCP registration must come from `mcp_arg_vec`, so a flag \
+             added once reaches every tool. Hand-rolled argv found:\n  {}",
+            offenders.join("\n  ")
+        );
+    }
+
+    /// Lite and full registrations differ only by `--lite`; both must carry the
+    /// same db and (when one is bound) the same config.
+    #[test]
+    fn lite_and_full_argv_agree_except_for_the_lite_flag() {
+        let full = mcp_arg_vec("/tmp/does-not-exist.lbug", false);
+        let lite = mcp_arg_vec("/tmp/does-not-exist.lbug", true);
+        assert_eq!(full[0], "mcp");
+        assert_eq!(lite[0], "mcp");
+        assert_eq!(lite[1], "--lite");
+        assert_eq!(&full[1..], &lite[2..]);
+        assert!(full.contains(&"--db".to_string()));
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -28,27 +28,26 @@ fn print_setup_banner(db_path: &Path) {
 fn configure_tool(
     name: &str,
     db_path: &Path,
-    allow_writes: bool,
     force_overwrite: bool,
     base: &Path,
 ) -> Result<(), anyhow::Error> {
     match name {
-        "claude-code" => setup_claude_code(db_path, allow_writes, force_overwrite, base)?,
-        "cursor" => setup_cursor(db_path, allow_writes, force_overwrite, base)?,
-        "codex" => setup_codex(db_path, allow_writes, base)?,
-        "windsurf" => setup_windsurf(db_path, allow_writes)?,
-        "jetbrains" => setup_jetbrains(db_path, allow_writes, base)?,
-        "vscode" => setup_vscode(db_path, allow_writes, base)?,
-        "gemini" => setup_gemini(db_path, allow_writes, base)?,
-        "copilot" => setup_copilot(db_path, allow_writes, base)?,
-        "aider" => setup_aider(db_path, allow_writes, base)?,
-        "kiro" => setup_kiro(db_path, allow_writes, base)?,
-        "continue" => setup_continue(db_path, allow_writes, base)?,
-        "cline" => setup_cline(db_path, allow_writes, base)?,
-        "opencode" => setup_opencode(db_path, allow_writes, base)?,
-        "trae" => setup_trae(db_path, allow_writes, base)?,
-        "devin" => setup_devin(db_path, allow_writes, base)?,
-        "hermes" => setup_hermes(db_path, allow_writes, base)?,
+        "claude-code" => setup_claude_code(db_path, force_overwrite, base)?,
+        "cursor" => setup_cursor(db_path, force_overwrite, base)?,
+        "codex" => setup_codex(db_path, base)?,
+        "windsurf" => setup_windsurf(db_path, base)?,
+        "jetbrains" => setup_jetbrains(db_path, base)?,
+        "vscode" => setup_vscode(db_path, base)?,
+        "gemini" => setup_gemini(db_path, base)?,
+        "copilot" => setup_copilot(db_path, base)?,
+        "aider" => setup_aider(db_path, base)?,
+        "kiro" => setup_kiro(db_path, base)?,
+        "continue" => setup_continue(db_path, base)?,
+        "cline" => setup_cline(db_path, base)?,
+        "opencode" => setup_opencode(db_path, base)?,
+        "trae" => setup_trae(db_path, base)?,
+        "devin" => setup_devin(db_path, base)?,
+        "hermes" => setup_hermes(db_path, base)?,
         _ => {}
     }
     Ok(())
@@ -58,7 +57,12 @@ pub fn run_setup(
     tool: Option<&str>,
     db_path: &Path,
     force_all: bool,
-    allow_writes: bool,
+    // Accepted for CLI compatibility and deliberately unused: `--allow-writes`
+    // has had no effect on any generated registration for some time, and the
+    // per-tool writers threaded it purely to discard it. Kept as a parameter so
+    // the existing (hidden, deprecated) flag still parses rather than becoming
+    // a hard error for anyone who still passes it.
+    _allow_writes: bool,
     force_overwrite: bool,
     base: &Path,
 ) -> Result<(), anyhow::Error> {
@@ -80,7 +84,7 @@ pub fn run_setup(
         }
 
         any_configured = true;
-        configure_tool(t.name, db_path, allow_writes, force_overwrite, base)?;
+        configure_tool(t.name, db_path, force_overwrite, base)?;
     }
 
     if let Some(specific) = tool
@@ -195,14 +199,36 @@ fn which_exists(cmd: &str) -> bool {
 /// config was last successfully used for this database? Reusing the daemon's
 /// own persisted intent means setup cannot bind a config the daemon would
 /// disagree with, and it needs no new flag to thread through every caller.
-fn bound_config_path(db_path: &Path) -> Option<String> {
-    let record = nestweaver_daemon::lifecycle::read_last_successful_config(db_path).ok()?;
-    // Only offer a path that still exists: writing a --config pointing at a
-    // deleted file would turn every MCP start into a hard config-load failure,
-    // which is strictly worse than the no-config behaviour it replaces.
-    std::path::Path::new(&record.config_path)
-        .is_file()
-        .then_some(record.config_path)
+fn bound_config_path(db_path: &Path, base: &Path) -> Option<String> {
+    // 1. What the daemon actually last used for this database. Authoritative
+    //    when present, because setup then cannot bind a config the daemon would
+    //    disagree with.
+    if let Ok(record) = nestweaver_daemon::lifecycle::read_last_successful_config(db_path)
+        && Path::new(&record.config_path).is_file()
+    {
+        return Some(record.config_path);
+    }
+
+    // 2. Fall back to discovery from the directory being configured.
+    //
+    // The daemon record only exists AFTER a daemon has successfully started
+    // with a `--config`. On a genuinely fresh install — `setup` run before any
+    // index, which is the order the install docs describe — there is no record,
+    // so relying on it alone silently emitted a config-less registration in the
+    // exact case that matters most. Look where an instance config actually
+    // lives relative to the tree being set up.
+    for candidate in [
+        base.join(".nestweaver/instance.toml"),
+        base.join("instance.toml"),
+    ] {
+        if candidate.is_file() {
+            return candidate
+                .canonicalize()
+                .ok()
+                .map(|path| path.display().to_string());
+        }
+    }
+    None
 }
 
 /// THE single source of truth for the argv every generated MCP registration
@@ -213,31 +239,30 @@ fn bound_config_path(db_path: &Path) -> Option<String> {
 /// TOML writer kept its own hardcoded `["mcp", "--db", "{}"]` literal, so Codex
 /// silently kept emitting a config-less registration. `generated_registrations_
 /// all_carry_the_bound_config` pins that they cannot drift apart again.
-fn mcp_arg_vec(db_str: &str, lite: bool) -> Vec<String> {
+fn mcp_arg_vec(db_str: &str, base: &Path, lite: bool) -> Vec<String> {
     let mut args = vec!["mcp".to_string()];
     if lite {
         args.push("--lite".to_string());
     }
     args.push("--db".to_string());
     args.push(db_str.to_string());
-    if let Some(config) = bound_config_path(Path::new(db_str)) {
+    if let Some(config) = bound_config_path(Path::new(db_str), base) {
         args.push("--config".to_string());
         args.push(config);
     }
     args
 }
 
-fn mcp_args(db_str: &str, _allow_writes: bool) -> serde_json::Value {
-    serde_json::json!(mcp_arg_vec(db_str, false))
+fn mcp_args(db_str: &str, base: &Path) -> serde_json::Value {
+    serde_json::json!(mcp_arg_vec(db_str, base, false))
 }
 
-fn mcp_args_lite(db_str: &str, _allow_writes: bool) -> serde_json::Value {
-    serde_json::json!(mcp_arg_vec(db_str, true))
+fn mcp_args_lite(db_str: &str, base: &Path) -> serde_json::Value {
+    serde_json::json!(mcp_arg_vec(db_str, base, true))
 }
 
 fn setup_claude_code(
     db_path: &Path,
-    allow_writes: bool,
     force_overwrite: bool,
     base: &Path,
 ) -> Result<(), anyhow::Error> {
@@ -246,7 +271,7 @@ fn setup_claude_code(
     let db_str = db_path.to_string_lossy();
     let mcp_config = serde_json::json!({
         "command": "nestweaver",
-        "args": mcp_args(&db_str, allow_writes)
+        "args": mcp_args(&db_str, base)
     });
     let merged = merge_json_mcp(&mcp_path, "nestweaver", &mcp_config)?;
 
@@ -373,17 +398,12 @@ fn install_claude_hooks(db_str: &str, base: &Path) -> Result<&'static str, anyho
     Ok("hooks installed")
 }
 
-fn setup_cursor(
-    db_path: &Path,
-    allow_writes: bool,
-    force_overwrite: bool,
-    base: &Path,
-) -> Result<(), anyhow::Error> {
+fn setup_cursor(db_path: &Path, force_overwrite: bool, base: &Path) -> Result<(), anyhow::Error> {
     std::fs::create_dir_all(base.join(".cursor"))?;
     let db_str = db_path.to_string_lossy();
     let mcp_config = serde_json::json!({
         "command": "nestweaver",
-        "args": mcp_args_lite(&db_str, allow_writes)
+        "args": mcp_args_lite(&db_str, base)
     });
     let merged = merge_json_mcp(&base.join(".cursor/mcp.json"), "nestweaver", &mcp_config)?;
 
@@ -413,13 +433,13 @@ fn setup_cursor(
     Ok(())
 }
 
-fn setup_codex(db_path: &Path, _allow_writes: bool, base: &Path) -> Result<(), anyhow::Error> {
+fn setup_codex(db_path: &Path, base: &Path) -> Result<(), anyhow::Error> {
     std::fs::create_dir_all(base.join(".codex"))?;
     let db_str = db_path.to_string_lossy();
     let config_path = base.join(".codex/config.toml");
     let toml_section = format!(
         "\n[mcp_servers.nestweaver]\ncommand = \"nestweaver\"\nargs = [{}]\n",
-        mcp_arg_vec(&db_str, false)
+        mcp_arg_vec(&db_str, base, false)
             .iter()
             .map(|arg| format!("\"{}\"", arg.replace('\\', "\\\\").replace('"', "\\\"")))
             .collect::<Vec<_>>()
@@ -452,7 +472,7 @@ fn setup_codex(db_path: &Path, _allow_writes: bool, base: &Path) -> Result<(), a
     Ok(())
 }
 
-fn setup_windsurf(db_path: &Path, allow_writes: bool) -> Result<(), anyhow::Error> {
+fn setup_windsurf(db_path: &Path, base: &Path) -> Result<(), anyhow::Error> {
     let db_str = db_path.to_string_lossy();
     let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("cannot determine home dir"))?;
     let config_path = home.join(".codeium/windsurf/mcp_config.json");
@@ -463,7 +483,7 @@ fn setup_windsurf(db_path: &Path, allow_writes: bool) -> Result<(), anyhow::Erro
 
     let mcp_config = serde_json::json!({
         "command": "nestweaver",
-        "args": mcp_args(&db_str, allow_writes)
+        "args": mcp_args(&db_str, base)
     });
     let merged = merge_json_mcp(&config_path, "nestweaver", &mcp_config)?;
 
@@ -481,12 +501,12 @@ fn setup_windsurf(db_path: &Path, allow_writes: bool) -> Result<(), anyhow::Erro
     Ok(())
 }
 
-fn setup_jetbrains(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(), anyhow::Error> {
+fn setup_jetbrains(db_path: &Path, base: &Path) -> Result<(), anyhow::Error> {
     std::fs::create_dir_all(base.join(".junie/mcp"))?;
     let db_str = db_path.to_string_lossy();
     let mcp_config = serde_json::json!({
         "command": "nestweaver",
-        "args": mcp_args(&db_str, allow_writes)
+        "args": mcp_args(&db_str, base)
     });
     let merged = merge_json_mcp(&base.join(".junie/mcp/mcp.json"), "nestweaver", &mcp_config)?;
 
@@ -504,12 +524,12 @@ fn setup_jetbrains(db_path: &Path, allow_writes: bool, base: &Path) -> Result<()
     Ok(())
 }
 
-fn setup_vscode(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(), anyhow::Error> {
+fn setup_vscode(db_path: &Path, base: &Path) -> Result<(), anyhow::Error> {
     std::fs::create_dir_all(base.join(".vscode"))?;
     let db_str = db_path.to_string_lossy();
     let mcp_config = serde_json::json!({
         "command": "nestweaver",
-        "args": mcp_args(&db_str, allow_writes)
+        "args": mcp_args(&db_str, base)
     });
     let merged = merge_json_mcp(&base.join(".vscode/mcp.json"), "nestweaver", &mcp_config)?;
 
@@ -527,12 +547,12 @@ fn setup_vscode(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(), a
     Ok(())
 }
 
-fn setup_gemini(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(), anyhow::Error> {
+fn setup_gemini(db_path: &Path, base: &Path) -> Result<(), anyhow::Error> {
     std::fs::create_dir_all(base.join(".gemini"))?;
     let db_str = db_path.to_string_lossy();
     let mcp_config = serde_json::json!({
         "command": "nestweaver",
-        "args": mcp_args(&db_str, allow_writes)
+        "args": mcp_args(&db_str, base)
     });
     let merged = merge_json_mcp(
         &base.join(".gemini/settings.json"),
@@ -554,12 +574,12 @@ fn setup_gemini(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(), a
     Ok(())
 }
 
-fn setup_copilot(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(), anyhow::Error> {
+fn setup_copilot(db_path: &Path, base: &Path) -> Result<(), anyhow::Error> {
     std::fs::create_dir_all(base.join(".github"))?;
     let db_str = db_path.to_string_lossy();
     let mcp_config = serde_json::json!({
         "command": "nestweaver",
-        "args": mcp_args(&db_str, allow_writes)
+        "args": mcp_args(&db_str, base)
     });
     let merged = merge_json_mcp(
         &base.join(".github/copilot-mcp.json"),
@@ -592,7 +612,7 @@ fn setup_copilot(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(), 
     Ok(())
 }
 
-fn setup_aider(db_path: &Path, _allow_writes: bool, base: &Path) -> Result<(), anyhow::Error> {
+fn setup_aider(db_path: &Path, base: &Path) -> Result<(), anyhow::Error> {
     let db_str = db_path.to_string_lossy();
     let config_path = base.join(".aider.conf.yml");
     let existing = std::fs::read_to_string(&config_path).unwrap_or_default();
@@ -627,12 +647,12 @@ fn setup_aider(db_path: &Path, _allow_writes: bool, base: &Path) -> Result<(), a
     Ok(())
 }
 
-fn setup_kiro(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(), anyhow::Error> {
+fn setup_kiro(db_path: &Path, base: &Path) -> Result<(), anyhow::Error> {
     std::fs::create_dir_all(base.join(".kiro"))?;
     let db_str = db_path.to_string_lossy();
     let mcp_config = serde_json::json!({
         "command": "nestweaver",
-        "args": mcp_args(&db_str, allow_writes)
+        "args": mcp_args(&db_str, base)
     });
     let merged = merge_json_mcp(&base.join(".kiro/settings.json"), "nestweaver", &mcp_config)?;
 
@@ -650,12 +670,12 @@ fn setup_kiro(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(), any
     Ok(())
 }
 
-fn setup_continue(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(), anyhow::Error> {
+fn setup_continue(db_path: &Path, base: &Path) -> Result<(), anyhow::Error> {
     std::fs::create_dir_all(base.join(".continue"))?;
     let db_str = db_path.to_string_lossy();
     let mcp_config = serde_json::json!({
         "command": "nestweaver",
-        "args": mcp_args(&db_str, allow_writes)
+        "args": mcp_args(&db_str, base)
     });
     let merged = merge_json_mcp(
         &base.join(".continue/config.json"),
@@ -677,12 +697,12 @@ fn setup_continue(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(),
     Ok(())
 }
 
-fn setup_cline(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(), anyhow::Error> {
+fn setup_cline(db_path: &Path, base: &Path) -> Result<(), anyhow::Error> {
     std::fs::create_dir_all(base.join(".cline"))?;
     let db_str = db_path.to_string_lossy();
     let mcp_config = serde_json::json!({
         "command": "nestweaver",
-        "args": mcp_args(&db_str, allow_writes)
+        "args": mcp_args(&db_str, base)
     });
     let merged = merge_json_mcp(
         &base.join(".cline/settings.json"),
@@ -704,12 +724,12 @@ fn setup_cline(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(), an
     Ok(())
 }
 
-fn setup_opencode(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(), anyhow::Error> {
+fn setup_opencode(db_path: &Path, base: &Path) -> Result<(), anyhow::Error> {
     std::fs::create_dir_all(base.join(".opencode"))?;
     let db_str = db_path.to_string_lossy();
     let mcp_config = serde_json::json!({
         "command": "nestweaver",
-        "args": mcp_args(&db_str, allow_writes)
+        "args": mcp_args(&db_str, base)
     });
     let merged = merge_json_mcp(
         &base.join(".opencode/config.json"),
@@ -731,12 +751,12 @@ fn setup_opencode(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(),
     Ok(())
 }
 
-fn setup_trae(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(), anyhow::Error> {
+fn setup_trae(db_path: &Path, base: &Path) -> Result<(), anyhow::Error> {
     std::fs::create_dir_all(base.join(".trae"))?;
     let db_str = db_path.to_string_lossy();
     let mcp_config = serde_json::json!({
         "command": "nestweaver",
-        "args": mcp_args(&db_str, allow_writes)
+        "args": mcp_args(&db_str, base)
     });
     let merged = merge_json_mcp(&base.join(".trae/config.json"), "nestweaver", &mcp_config)?;
 
@@ -754,11 +774,11 @@ fn setup_trae(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(), any
     Ok(())
 }
 
-fn setup_devin(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(), anyhow::Error> {
+fn setup_devin(db_path: &Path, base: &Path) -> Result<(), anyhow::Error> {
     let db_str = db_path.to_string_lossy();
     let mcp_config = serde_json::json!({
         "command": "nestweaver",
-        "args": mcp_args(&db_str, allow_writes)
+        "args": mcp_args(&db_str, base)
     });
     let merged = merge_json_mcp(&base.join("devin.json"), "nestweaver", &mcp_config)?;
 
@@ -776,12 +796,12 @@ fn setup_devin(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(), an
     Ok(())
 }
 
-fn setup_hermes(db_path: &Path, allow_writes: bool, base: &Path) -> Result<(), anyhow::Error> {
+fn setup_hermes(db_path: &Path, base: &Path) -> Result<(), anyhow::Error> {
     std::fs::create_dir_all(base.join(".hermes"))?;
     let db_str = db_path.to_string_lossy();
     let mcp_config = serde_json::json!({
         "command": "nestweaver",
-        "args": mcp_args(&db_str, allow_writes)
+        "args": mcp_args(&db_str, base)
     });
     let merged = merge_json_mcp(&base.join(".hermes/config.json"), "nestweaver", &mcp_config)?;
 
@@ -808,6 +828,18 @@ fn merge_json_mcp(
     server_name: &str,
     config: &serde_json::Value,
 ) -> Result<bool, anyhow::Error> {
+    // The canonical argv is already in `config`; read the desired `--config`
+    // out of it rather than threading it through every per-tool caller.
+    let desired_config = config
+        .get("args")
+        .and_then(|a| a.as_array())
+        .and_then(|args| {
+            args.iter()
+                .position(|a| a.as_str() == Some("--config"))
+                .and_then(|i| args.get(i + 1))
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        });
     let mut root = if path.exists() {
         let content = std::fs::read_to_string(path)?;
         match serde_json::from_str(&content) {
@@ -846,8 +878,16 @@ fn merge_json_mcp(
         }
     }
 
-    // Server already exists — check for and strip deprecated args.
+    // Server already exists.
+    //
+    // Reconcile it rather than leaving it alone. This branch used to only PRUNE
+    // deprecated flags, so a registration written before `--config` existed kept
+    // its old argv forever: every upgrade path silently stayed config-less, and
+    // re-running `setup` — the obvious remedy — changed nothing. Additive only,
+    // so a hand-tuned `--lite`, `--tools` or a deliberately different `--db` is
+    // preserved; the sole thing added is a `--config` the entry does not have.
     let mut stripped: Vec<String> = Vec::new();
+    let mut added: Vec<String> = Vec::new();
     {
         let root_obj = root
             .as_object_mut()
@@ -866,14 +906,23 @@ fn merge_json_mcp(
                 }
                 !is_deprecated
             });
+            let has_config = args.iter().any(|arg| arg.as_str() == Some("--config"));
+            if !has_config && let Some(config) = desired_config.as_deref() {
+                args.push(serde_json::Value::String("--config".to_string()));
+                args.push(serde_json::Value::String(config.to_string()));
+                added.push("--config".to_string());
+            }
         }
     }
 
-    if !stripped.is_empty() {
+    if !stripped.is_empty() || !added.is_empty() {
         let json = serde_json::to_string_pretty(&root)?;
         std::fs::write(path, json)?;
         for flag in &stripped {
             eprintln!("  (stripped deprecated flag: {flag})");
+        }
+        for flag in &added {
+            eprintln!("  (added missing flag: {flag})");
         }
     }
 
@@ -889,6 +938,47 @@ fn append_toml_if_missing(
 ) -> Result<bool, anyhow::Error> {
     let existing = std::fs::read_to_string(path).unwrap_or_default();
     if existing.contains(section) {
+        // The section is present but may predate `--config`. Reconcile that one
+        // line rather than returning unchanged: a Codex registration written
+        // before `--config` existed otherwise kept its old argv forever, and
+        // re-running `setup` — the obvious remedy — was a silent no-op.
+        //
+        // Rewrite ONLY when the existing args lack `--config` and the content
+        // we would write has one, so a hand-edited section is left alone.
+        if let Some(desired) = content
+            .lines()
+            .find(|line| line.trim_start().starts_with("args = ["))
+            && desired.contains("--config")
+        {
+            let mut lines: Vec<String> = existing.lines().map(str::to_string).collect();
+            // `section` arrives unbracketed ("mcp_servers.nestweaver") while the
+            // file carries the table header "[mcp_servers.nestweaver]".
+            let header = format!("[{section}]");
+            let section_at = lines.iter().position(|line| line.trim() == header);
+            if let Some(start) = section_at {
+                // Stay inside this section: stop at the next table header.
+                let end = lines[start + 1..]
+                    .iter()
+                    .position(|line| line.trim_start().starts_with('['))
+                    .map(|offset| start + 1 + offset)
+                    .unwrap_or(lines.len());
+                if let Some(args_at) = lines[start..end]
+                    .iter()
+                    .position(|line| line.trim_start().starts_with("args = ["))
+                    .map(|offset| start + offset)
+                    && !lines[args_at].contains("--config")
+                {
+                    lines[args_at] = desired.to_string();
+                    let mut rewritten = lines.join("\n");
+                    if existing.ends_with('\n') {
+                        rewritten.push('\n');
+                    }
+                    std::fs::write(path, rewritten)?;
+                    eprintln!("  (added missing flag: --config)");
+                    return Ok(true);
+                }
+            }
+        }
         return Ok(false);
     }
     let mut file = std::fs::OpenOptions::new()
@@ -1124,7 +1214,7 @@ fn run_auto_setup_for_tools(
     let mut configured = Vec::new();
     let mut failures = Vec::new();
     for &name in to_configure {
-        match configure_tool(name, db_path, false, false, base) {
+        match configure_tool(name, db_path, false, base) {
             Ok(()) => configured.push(name),
             Err(error) => failures.push(format!("{name}: {error:#}")),
         }
@@ -1276,7 +1366,7 @@ mod setup_base_dir_tests {
         std::fs::write(&rules_path, "blocks directory creation").unwrap();
         let db = tmp.path().join("test.lbug");
 
-        setup_cursor(&db, false, false, &base).unwrap_err();
+        setup_cursor(&db, false, &base).unwrap_err();
         let mcp_path = base.join(".cursor/mcp.json");
         let primary_before_retry = std::fs::read_to_string(&mcp_path).unwrap();
         assert!(!rules_path.join("nestweaver.mdc").exists());
@@ -1333,12 +1423,105 @@ mod mcp_arg_source_of_truth_tests {
         );
     }
 
+    /// Fresh first run: `setup` before any daemon has ever started must still
+    /// find the instance config.
+    ///
+    /// `bound_config_path` originally consulted only the daemon's persisted
+    /// binding, which does not exist until a daemon has successfully started
+    /// with a `--config`. The install docs run `setup` BEFORE the first index,
+    /// so the common case emitted a config-less registration.
+    #[test]
+    fn fresh_setup_discovers_the_config_without_a_daemon_binding() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path();
+        std::fs::create_dir_all(base.join(".nestweaver")).unwrap();
+        std::fs::write(
+            base.join(".nestweaver/instance.toml"),
+            "instance_id = \"x\"\n",
+        )
+        .unwrap();
+
+        let db = base.join("never-started.lbug");
+        let found = bound_config_path(&db, base).expect("config must be discovered from base");
+        assert!(
+            found.ends_with("instance.toml"),
+            "expected the instance config, got {found}"
+        );
+        assert!(
+            mcp_arg_vec(&db.display().to_string(), base, false)
+                .iter()
+                .any(|a| a == "--config"),
+            "a fresh registration must carry --config"
+        );
+    }
+
+    /// Upgrade path: an EXISTING registration must gain `--config`.
+    ///
+    /// This branch used to only prune deprecated flags, so a config written
+    /// before `--config` existed kept its old argv forever and re-running
+    /// `setup` was a silent no-op.
+    #[test]
+    fn existing_json_registration_gains_the_missing_config_flag() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".mcp.json");
+        std::fs::write(
+            &path,
+            r#"{"mcpServers":{"nestweaver":{"command":"nestweaver","args":["mcp","--db","/db"]}}}"#,
+        )
+        .unwrap();
+
+        let desired = serde_json::json!({
+            "command": "nestweaver",
+            "args": ["mcp", "--db", "/db", "--config", "/cfg/instance.toml"]
+        });
+        merge_json_mcp(&path, "nestweaver", &desired).unwrap();
+
+        let written: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let args = written["mcpServers"]["nestweaver"]["args"]
+            .as_array()
+            .unwrap();
+        assert!(
+            args.iter().any(|a| a == "--config"),
+            "an existing registration must be reconciled, not left stale: {args:?}"
+        );
+        // Additive only — the original db argument survives untouched.
+        assert!(args.iter().any(|a| a == "/db"));
+    }
+
+    /// Same upgrade path for the Codex TOML writer, which returned unchanged
+    /// the moment the section existed.
+    #[test]
+    fn existing_codex_section_gains_the_missing_config_flag() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "\n[mcp_servers.nestweaver]\ncommand = \"nestweaver\"\nargs = [\"mcp\", \"--db\", \"/db\"]\n",
+        )
+        .unwrap();
+
+        let desired = "\n[mcp_servers.nestweaver]\ncommand = \"nestweaver\"\nargs = [\"mcp\", \"--db\", \"/db\", \"--config\", \"/cfg/instance.toml\"]\n";
+        append_toml_if_missing(&path, "mcp_servers.nestweaver", desired).unwrap();
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            written.contains("--config"),
+            "an existing Codex section must be reconciled: {written}"
+        );
+        // Exactly one section — reconciled in place, not appended twice.
+        assert_eq!(written.matches("[mcp_servers.nestweaver]").count(), 1);
+    }
+
     /// Lite and full registrations differ only by `--lite`; both must carry the
     /// same db and (when one is bound) the same config.
     #[test]
     fn lite_and_full_argv_agree_except_for_the_lite_flag() {
-        let full = mcp_arg_vec("/tmp/does-not-exist.lbug", false);
-        let lite = mcp_arg_vec("/tmp/does-not-exist.lbug", true);
+        // A base with no instance config, so neither carries --config and the
+        // comparison isolates the --lite difference.
+        let empty = tempfile::tempdir().unwrap();
+        let full = mcp_arg_vec("/tmp/does-not-exist.lbug", empty.path(), false);
+        let lite = mcp_arg_vec("/tmp/does-not-exist.lbug", empty.path(), true);
         assert_eq!(full[0], "mcp");
         assert_eq!(lite[0], "mcp");
         assert_eq!(lite[1], "--lite");

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -4130,9 +4130,24 @@ fn list_projects_fails_on_a_missing_database() {
 /// `--help`, which lists `--db` as optional with no default.
 #[test]
 fn daemon_gc_runs_without_a_database() {
+    // `gc` is DESTRUCTIVE: it sweeps orphaned per-instance directories under the
+    // state root, the runtime root and the /tmp socket-fallback root. Run
+    // unisolated it would operate on the developer's (or the CI runner's) real
+    // roots and could reclaim a concurrently-running daemon's directories — the
+    // exact class of interference that shows up elsewhere as a vanished socket.
+    //
+    // Point all three roots at one scratch tree, which is the same isolation
+    // `daemon_test.rs` uses and which `NESTWEAVER_SOCK_FALLBACK_DIR` exists for.
+    let scratch = tempfile::tempdir().expect("scratch dir");
     let output = nestweaver_cmd()
         .args(["daemon", "gc"])
         .env_remove("NESTWEAVER_DB")
+        .env("XDG_STATE_HOME", scratch.path().join("state"))
+        .env("XDG_RUNTIME_DIR", scratch.path().join("runtime"))
+        .env(
+            "NESTWEAVER_SOCK_FALLBACK_DIR",
+            scratch.path().join("fallback"),
+        )
         .output()
         .expect("daemon gc must run");
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -4150,8 +4165,15 @@ fn daemon_gc_runs_without_a_database() {
 /// `--db` ever becomes genuinely required here, the help must say so.
 #[test]
 fn daemon_gc_help_presents_db_as_optional() {
+    let scratch = tempfile::tempdir().expect("scratch dir");
     let output = nestweaver_cmd()
         .args(["daemon", "gc", "--help"])
+        .env("XDG_STATE_HOME", scratch.path().join("state"))
+        .env("XDG_RUNTIME_DIR", scratch.path().join("runtime"))
+        .env(
+            "NESTWEAVER_SOCK_FALLBACK_DIR",
+            scratch.path().join("fallback"),
+        )
         .output()
         .expect("daemon gc --help must run");
     let stdout = String::from_utf8_lossy(&output.stdout);

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -4118,3 +4118,46 @@ fn list_projects_fails_on_a_missing_database() {
         );
     }
 }
+
+/// `daemon gc` must not require a database.
+///
+/// It sweeps orphaned launch agents and orphaned per-instance directories,
+/// sparing live instances by ownership proof (write lock, pidfile lock) rather
+/// than by matching a database path — the underlying `gc_orphaned_agents` and
+/// `gc_orphaned_daemon_dirs` take no arguments. Requiring `--db` made the one
+/// command whose purpose is cleaning up after databases that no longer exist
+/// refuse to run without naming one that does, and contradicted its own
+/// `--help`, which lists `--db` as optional with no default.
+#[test]
+fn daemon_gc_runs_without_a_database() {
+    let output = nestweaver_cmd()
+        .args(["daemon", "gc"])
+        .env_remove("NESTWEAVER_DB")
+        .output()
+        .expect("daemon gc must run");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("No database path provided"),
+        "daemon gc must not demand a database it never reads; got: {stderr}"
+    );
+    assert!(
+        output.status.success(),
+        "daemon gc must succeed with no --db and no NESTWEAVER_DB; stderr: {stderr}"
+    );
+}
+
+/// The help text is the contract the previous behaviour broke, so pin it: if
+/// `--db` ever becomes genuinely required here, the help must say so.
+#[test]
+fn daemon_gc_help_presents_db_as_optional() {
+    let output = nestweaver_cmd()
+        .args(["daemon", "gc", "--help"])
+        .output()
+        .expect("daemon gc --help must run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--db"), "help must mention --db");
+    assert!(
+        !stdout.contains("required"),
+        "daemon gc --help presents --db as optional; keep behaviour and help in step"
+    );
+}

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -657,9 +657,15 @@ fn parity_contracts_list_uses_daemon_without_direct_store_fallback() {
     assert_eq!(daemon_without_disk_access.stdout, direct_json.stdout);
     assert!(daemon_without_disk_access.stderr.is_empty());
     assert!(!daemon_error_without_fallback.status.success());
-    let error = String::from_utf8_lossy(&daemon_error_without_fallback.stderr);
-    assert!(error.contains("no indexed repo matches --repo 'definitely-unknown'"));
-    assert!(error.contains("refusing direct-store fallback"));
+    let error = flatten_diagnostic(&daemon_error_without_fallback.stderr);
+    assert!(
+        error.contains("no indexed repo matches --repo 'definitely-unknown'"),
+        "daemon error must name the unmatched repo; got: {error}"
+    );
+    assert!(
+        error.contains("refusing direct-store fallback"),
+        "daemon error must refuse the fallback; got: {error}"
+    );
     assert!(!error.contains("cross_repo_contracts"));
 
     let explicit_empty = run_via_daemon(
@@ -667,9 +673,15 @@ fn parity_contracts_list_uses_daemon_without_direct_store_fallback() {
         &["contracts", "list", "--repo", "", "--json"],
     );
     assert!(!explicit_empty.status.success());
-    let empty_error = String::from_utf8_lossy(&explicit_empty.stderr);
-    assert!(empty_error.contains("no indexed repo matches --repo ''"));
-    assert!(empty_error.contains("refusing direct-store fallback"));
+    let empty_error = flatten_diagnostic(&explicit_empty.stderr);
+    assert!(
+        empty_error.contains("no indexed repo matches --repo ''"),
+        "explicit-empty error must name the empty repo; got: {empty_error}"
+    );
+    assert!(
+        empty_error.contains("refusing direct-store fallback"),
+        "explicit-empty error must refuse the fallback; got: {empty_error}"
+    );
 }
 
 /// nw-108: `dead-code`'s daemon branch printed the RPC response verbatim with
@@ -678,6 +690,26 @@ fn parity_contracts_list_uses_daemon_without_direct_store_fallback() {
 /// the daemon was up. The text renderer was never missing; it was simply not
 /// reached. This is the nw-097 divergence family, and the reason it survived is
 /// that `dead-code` was not in this file.
+/// Flatten a rendered `miette` diagnostic for substring assertions.
+///
+/// The renderer hard-wraps to the terminal width and prefixes continuation
+/// lines with a `│` gutter, so a message the code emits as one string arrives
+/// split across lines: `"no\n  │ indexed repo matches --repo 'definitely-\n  │
+/// unknown'"`. Asserting on the raw bytes therefore tests the renderer's
+/// current wrap width rather than the contract under test — the same assertion
+/// passes or fails depending on how wide the box happens to be.
+///
+/// Strip the gutter and collapse all whitespace to single spaces so the
+/// assertions below check what they mean to check: that the error names the
+/// repo and refuses the fallback.
+fn flatten_diagnostic(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes)
+        .replace('\u{2502}', " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 /// Replace generated bundle IDs with a fixed placeholder.
 ///
 /// `investigate` mints a fresh `bndl_<hex>` per invocation, so its stdout is

--- a/tests/trigram_reconciler_ownership_test.rs
+++ b/tests/trigram_reconciler_ownership_test.rs
@@ -1,0 +1,130 @@
+//! nw-198 — structural guard on who may drain the regex trigram outbox.
+//!
+//! The defect this fixes was not a missing call. Invalidation was already
+//! universal and transactional (the store's own write path marks a scope dirty
+//! inside the mutating transaction), and the reconciler was already a correct
+//! idempotent control loop. What was missing was an OWNER: the reconciler ran
+//! only as a side effect of two write handlers, so every other mutation path —
+//! the vault refresh and both file watchers — enqueued work nobody drained.
+//!
+//! Adding the missing calls would have been a patch: it leaves each writer
+//! responsible for remembering to reconcile, and the next write path added
+//! reintroduces the identical bug. That is exactly how the watcher regressed
+//! after the background worker was fixed.
+//!
+//! So the invariant is enforced here rather than left to review: background
+//! maintenance has ONE owner, and a writer may only refresh when a caller
+//! explicitly asked for it.
+
+use std::path::Path;
+
+/// Source files allowed to mention the reconcile entry points at all.
+const ALLOWED: &[&str] = &[
+    // The store defines them.
+    "crates/nestweaver-store/src/regex.rs",
+    // The reconcile loop is the sole background owner, and the IndexRepo
+    // handler still honours an EXPLICIT --with-trigrams/--rebuild-trigrams
+    // (the `refresh=wait_for` equivalent for CI and scripted reindex).
+    "crates/nestweaver-daemon/src/server.rs",
+    // The direct (--local / --no-daemon) path has no daemon, so no reconcile
+    // loop exists to drain for it; it must still refresh inline.
+    "src/main.rs",
+    // Test fixture.
+    "crates/nestweaver-engine/src/index.rs",
+];
+
+fn repo_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn rust_sources(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if name == "target" || name == ".git" {
+                continue;
+            }
+            rust_sources(&path, out);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+}
+
+#[test]
+fn only_the_reconciler_and_explicit_requests_may_refresh_trigrams() {
+    let root = repo_root();
+    let mut sources = Vec::new();
+    rust_sources(&root.join("crates"), &mut sources);
+    rust_sources(&root.join("src"), &mut sources);
+
+    let mut offenders = Vec::new();
+    for path in sources {
+        let rel = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        if ALLOWED.contains(&rel.as_str()) {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        for (n, line) in text.lines().enumerate() {
+            // Skip prose: the bug is well-documented in comments and those
+            // must stay readable.
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") || trimmed.starts_with("///") {
+                continue;
+            }
+            if line.contains("refresh_trigram_index(") || line.contains("rebuild_trigram_index(") {
+                offenders.push(format!("{rel}:{}: {}", n + 1, line.trim()));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "nw-198: background trigram maintenance has exactly one owner — the daemon's \
+         reconcile loop. A writer must only enqueue (the store's write path already does \
+         that transactionally) and must never drain the outbox itself; draining from a \
+         writer is what left the vault path and both watchers permanently stale. If a new \
+         call site is genuinely an EXPLICIT user request (not background maintenance), add \
+         its file to ALLOWED with a comment saying why.\n  {}",
+        offenders.join("\n  ")
+    );
+}
+
+/// The watcher is the specific path that regressed last time: it was fixed for
+/// the background worker and left broken for file watching. Pin it explicitly
+/// so a future "just refresh here too" cannot land quietly.
+#[test]
+fn the_watchers_never_touch_trigrams() {
+    for rel in [
+        "crates/nestweaver-engine/src/watcher.rs",
+        "crates/nestweaver-engine/src/watch_code.rs",
+    ] {
+        let text = std::fs::read_to_string(repo_root().join(rel))
+            .unwrap_or_else(|e| panic!("{rel} must be readable: {e}"));
+        for (n, line) in text.lines().enumerate() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") {
+                continue;
+            }
+            assert!(
+                !line.contains("trigram_index("),
+                "{rel}:{}: a watcher must only mutate — its writes already enqueue outbox \
+                 work, and the reconcile loop drains it. Refreshing per watcher batch would \
+                 run a ~50% duty cycle on save-heavy work: the refresh cost is dominated by \
+                 fixed overhead (measured 918ms for 2 changed nodes), while the watcher \
+                 debounces into ~2s batches.",
+                n + 1
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes nw-198 and nw-199, plus two rough edges from a user report and one pre-existing test defect.

## nw-198 — the trigram reconciler had no owner

The regex trigram subsystem was **a transactional outbox with no relay**.

Three parts were already correct and are untouched:

- **Invalidation** is universal and transactional — the store's own write path marks a scope dirty *inside* the mutating transaction (`write.rs` symbols, vaults, notes, deletes), so no caller can forget.
- **The reconciler** is a genuine idempotent control loop — desired/acknowledged epochs, GC of retired generations, tombstone retirement, self-heal of missing shard metadata.
- **The read path** fails open: unreconciled scopes are scanned, so staleness costs latency and never correctness.

What was missing was anything that **drained** the queue. `refresh_trigram_index` ran only as a side effect of two write handlers, so the vault-refresh path and both file watchers enqueued work nobody picked up. Both watcher sources contained zero occurrences of `trigram` — the pre-6.2.0 "watchers never touch trigrams" defect was only ever fixed for the background worker.

So the subsystem was **level-triggered by design but invoked edge-triggered**, and a missed edge became a permanently stale scope.

Adding the three missing calls would have been a patch: it leaves every writer responsible for remembering to reconcile, which is exactly how the watcher regressed after the worker was fixed. Instead:

- A daemon-resident reconcile loop drains the outbox on an interval, in **every writable mode** (the local daemon is where the vault and watchers live). Single-flight, shutdown-aware, exponential backoff to a 10-minute cap.
- **Writers stop draining.** The `IndexRepo` handler no longer refreshes because the daemon is configured to maintain trigrams, and the worker pool's post-job refresh is removed outright.
- **Explicit intent still wins** — `--with-trigrams` / `--rebuild-trigrams` still refresh inline for CI and scripted reindex, and the direct `--local` path keeps its inline refresh because no daemon exists to drain for it. This is the `refresh=wait_for` split.
- **The watchers need no trigram code at all.** They mutate, the mutation enqueues, the loop drains. Refreshing per watcher batch would run a ~50% duty cycle on save-heavy work: refresh cost is dominated by fixed overhead (**918 ms measured for 2 changed nodes**, 1,581 ms for 12,456) while the watcher debounces into ~2 s batches.

New config: `[indexing] trigram_reconcile_interval` (default `"30s"`, `"0"` disables), gated on `with_trigrams`, which stays the master switch. One shared `parse_reconcile_interval` backs both load-time validation and the runtime accessor so they cannot drift; a typo fails config loading rather than silently disabling the loop.

### Prior art

- [Transactional outbox](https://microservices.io/patterns/data/transactional-outbox.html) — the relay is constitutive, not optional. The table and transactional enqueue existed; the relay did not.
- Kubernetes controller convention — reconcile on *state*, not events, so missed events self-correct.
- [Elasticsearch `refresh_interval`](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html) — refresh is time-driven and decoupled from writes; callers needing freshness use `refresh=wait_for` rather than forcing one.
- [Zoekt/Sourcegraph](https://github.com/sourcegraph/zoekt) — freshness owned by a dedicated indexserver, with a fast unindexed path as fallback.

## nw-199 — interaction tracking lived in the wrong layer

`mcp_args()` returned exactly `["mcp", "--db", <db>]` for ~15 tool writers, and `setup` had no way to enable tracking — so a durable per-brain policy existed only as an ephemeral CLI flag whose generator overwrites edits. The feature was unreachable through the supported install path.

- `[ranking] track_interactions`, **default off**, mirroring the existing `enable_prf` precedent.
- Three-state override: `--track-interactions` / `--no-track-interactions`; absent inherits config. A two-state bool cannot distinguish "said no" from "said nothing" — the same defect `resolve_trigram_policy` was widened to fix.
- **`setup` now emits `--config`**, resolved from the daemon's own persisted config intent. This is the load-bearing change: it makes the whole `mcp --config` surface reachable from generated configs, not just this setting.

Default stays off deliberately. Whether to flip it is gated on the eval harness (`eval.rs`, >= 5% nDCG@10), not taste — and note the scores feed PPR personalization, so it is a retrieval-behaviour switch, not only telemetry. The blend is capped at 5% by the existing exploration floor, with sublinear `ln_1p` scoring, time decay, and content-hash invalidation.

## Also fixed

**`daemon gc` required `--db` it never reads.** `gc_orphaned_agents` and `gc_orphaned_daemon_dirs` take no arguments and spare live instances by ownership proof, not by matching a database. The requirement came from the shared `Commands::Daemon` arm resolving `db_path` before dispatching, and contradicted `gc --help`, which lists `--db` as optional. So the one command meant to clean up after departed databases could not run without naming a live one. `--db`/`NESTWEAVER_DB` remain accepted and ignored.

**Codex bypassed the MCP argv builder.** `--config` was added to the JSON writers while the Codex writer kept its own hardcoded `["mcp", "--db", "{}"]` TOML literal, so Codex alone kept emitting config-less registrations — the same drift nw-199 is about, hidden in a different serialization format. Every writer now goes through one `mcp_arg_vec`.

**`parity_contracts_list_uses_daemon_without_direct_store_fallback` was failing on macOS before this branch.** It asserted on a rendered `miette` diagnostic, which hard-wraps to terminal width and prefixes continuations with a `│` gutter, so the message arrived split as `"no\n │ indexed repo matches --repo 'definitely-\n │ unknown'"`. The test was checking the renderer's wrap width, not the contract.

## Testing

**2,591 tests pass, zero failures** — root 404, daemon 304, engine 1,180, store 444, mcp 183, client 76. `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all -- --check` clean.

Every new guard was **mutation-checked** rather than trusted green:

| Guard | Mutation | Result |
|---|---|---|
| `only_the_reconciler_and_explicit_requests_may_refresh_trigrams` | inject a `refresh_trigram_index` call into `watcher.rs` | fails as intended |
| `the_watchers_never_touch_trigrams` | same | fails as intended |
| `reconciler_drains_the_outbox_with_no_writer_involvement` | make the loop never reconcile | fails with "must drain enqueued scopes on its own" |
| `daemon_gc_runs_without_a_database` | remove the early dispatch | fails as intended |
| `no_writer_hand_rolls_the_mcp_argv` | restore the old Codex literal | fails as intended |

**End-to-end against a real daemon:** a flagless `index` leaves `dirty_scopes=1 ready_scopes=0 scanned_fallback=true` (proving the writer no longer drains), and 20 s later with nothing run it is `dirty_scopes=0 ready_scopes=1 scanned_fallback=false`, with exactly one reconcile event logged in between.

All four `track_interactions` states verified by whether the interactions sidecar is actually written: config-on/no-flag → written; config-on/`--no-track-interactions` → absent; no-config → absent; no-config/`--track-interactions` → written.

One bug was found and fixed during implementation by the test written alongside it: `trigram_reconcile_backoff` used `Duration::clamp(period, MAX_BACKOFF)`, which panics when `min > max` — any interval longer than 10 minutes would have panicked the loop on its first failure.

## Deferred

- Reconciler health in `brain status` (last run, last error, backlog depth) needs proto fields. Outstanding work is still visible via `regex-search --json`.
- `result_shown_count` still contributes `+0.1` positively rather than acting as an exposure denominator, and the aggregate `NodeScore` discards rank so propensity cannot be recovered from it (the raw events retain the ordered slate). Refinements for a future item.
- The stale `(not-yet-built)` eval-harness comment at `rerank.rs:35` — `eval.rs` exists now. Left alone to keep the diff scoped.
