### PR TITLE
fix(index)!: nanosecond change detection, with the --since, cache-refresh and doc fixes it surfaced

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,7 +312,7 @@ Default database: `./nestweaver.lbug`. Override with `--db <path>` or `NESTWEAVE
 Sidecar files written alongside the database:
 - `<db>.pagerank.json` — PageRank score cache (computed and saved at index time on a full re-index and on incremental updates, loaded on open; a single-flight lazy compute is the fallback for DBs indexed before this or with no sidecar yet)
 - `<db>.manifests.json` — parsed manifest data (package.json, go.mod, Cargo.toml, pyproject.toml, requirements.txt, composer.json, Gemfile, pubspec.yaml, Package.swift, *.csproj, build.gradle.kts, CMakeLists.txt)
-- `<db>.filemeta.json` — per-file mtime/size/hash cache for tiered change detection (skips unchanged files on re-index)
+- `<db>.filemeta.json` — per-file mtime/size/hash cache for tiered change detection (skips unchanged files on re-index). **v3**: the mtime is NANOSECONDS, not seconds — truncating to seconds made same-second edits permanently invisible. Versioned in lockstep with `resolution_cache::CACHE_VERSION`; a stale version is discarded, costing one full re-index rather than risking a mis-classification
 - `<db>.summaries.json` — hierarchical code summaries cache (symbol/file/cluster levels)
 - `<db>.tantivy/` — BM25 full-text search index for notes and sections
 - `<db>.clusters.json` — community/cluster detection output

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ The first build compiles LadybugDB from source and may take several minutes.
 
 | Command | Description |
 |---------|-------------|
-| `index` | Parse and index a repository (auto-detects repo root from `.git`). Use `--name` to set a custom repo name for multi-repo setups. Trigram refresh follows `[indexing] with_trigrams`; with no `--config` the daemon's own setting is inherited. `--with-trigrams` forces it on for one run, `--no-trigrams` off (and conflicts with `--rebuild-trigrams`), `--rebuild-trigrams` forces a full rebuild. |
+| `index` | Parse and index a repository (auto-detects repo root from `.git`). Use `--name` to set a custom repo name for multi-repo setups. Indexing does NOT refresh trigrams implicitly — the daemon's reconcile loop owns that (see `[indexing] trigram_reconcile_interval`). `--with-trigrams` forces an inline refresh for one run (CI, scripted reindex), `--no-trigrams` suppresses it (and conflicts with `--rebuild-trigrams`), `--rebuild-trigrams` forces a full rebuild. The direct `--local` path still refreshes inline, since no daemon exists there to drain for it. |
 | `watch` | Live re-indexing via filesystem watcher with debouncing. Runs daemon-side (no instance config required; unsafe roots are denylisted); `--force` replaces an existing watcher. Incremental reindex preserves CALLS/IMPORTS edges (reverse dependents are re-resolved) and reports per-file failures instead of dying |
 | `context` | Get task-focused context via PPR (supports `--intent` for tuned retrieval) |
 | `search` | Full-text search across indexed symbols and notes |
@@ -243,7 +243,7 @@ The first build compiles LadybugDB from source and may take several minutes.
 | `detect-changes` | Run the MCP-compatible changed-file impact contract directly from the CLI, including risk, gate state, status, and blind spots |
 | `flow-trace` | Trace forward execution flow from a symbol — what it calls, and what those call |
 | `read-symbols` | Read a symbol's source span |
-| `regex-search` | Regex search over indexed text (scope-aware trigram pre-filter; safely scans only missing or stale scopes with `stale_index: true` — refresh with `index --with-trigrams`, or set `[indexing] with_trigrams = true` so indexing keeps the pre-filter fresh automatically) |
+| `regex-search` | Regex search over indexed text (scope-aware trigram pre-filter; safely scans only missing or stale scopes with `stale_index: true` — refresh now with `index --with-trigrams`, or set `[indexing] with_trigrams = true` so the daemon's reconcile loop keeps the pre-filter fresh on `trigram_reconcile_interval`) |
 | `count-patterns` | Count regex matches per pattern |
 | `investigate` | Orient on a topic in one call |
 | `investigate-expand` | Drill into investigate bundle entries — full body plus immediate neighbours |

--- a/crates/nestweaver-engine/src/content_reader.rs
+++ b/crates/nestweaver-engine/src/content_reader.rs
@@ -66,8 +66,24 @@ pub trait ContentReader: Send + Sync {
     fn list_files(&self) -> Result<Vec<PathBuf>>;
 
     /// Return filesystem metadata for change detection.
-    /// For FilesystemReader: `Some((mtime_secs, size_bytes))`.
+    /// For FilesystemReader: `Some((mtime_nanos, size_bytes))`.
     /// For GitBareReader: returns `None` (uses commit SHA instead of mtime).
+    ///
+    /// The timestamp is NANOSECONDS since the Unix epoch, not seconds.
+    ///
+    /// It used to be seconds, and the truncation was the bug (nw-200): every
+    /// edit landing in the same wall-clock second as the one already cached
+    /// compared equal, so the file was classified Unchanged and — because the
+    /// cached value kept matching — stayed misclassified on every later index.
+    /// It never self-healed; only a further mtime change recovered it.
+    ///
+    /// The precision was always there to use. Measured on APFS, five
+    /// consecutive fast writes produced ONE distinct whole second but FIVE
+    /// distinct nanosecond stamps. `SystemTime` carries it; `as_secs()` threw
+    /// it away.
+    ///
+    /// `u64` nanoseconds since 1970 saturate in the year 2554, which is not a
+    /// horizon this cache needs to survive.
     fn file_meta(&self, rel_path: &Path) -> Result<Option<(u64, u64)>>;
 
     /// The root path (for constructing absolute paths in parsers that need them).
@@ -201,12 +217,15 @@ impl ContentReader for FilesystemReader {
     fn file_meta(&self, rel_path: &Path) -> Result<Option<(u64, u64)>> {
         let abs = self.repo_path.join(rel_path);
         let meta = std::fs::metadata(&abs)?;
+        // Nanoseconds, deliberately. See the trait doc: truncating to seconds
+        // here is what made same-second edits permanently invisible (nw-200).
         let mtime = meta
             .modified()
             .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .unwrap_or_default()
-            .as_secs();
+            .as_nanos()
+            .min(u128::from(u64::MAX)) as u64;
         Ok(Some((mtime, meta.len())))
     }
 

--- a/crates/nestweaver-engine/src/content_reader.rs
+++ b/crates/nestweaver-engine/src/content_reader.rs
@@ -66,6 +66,14 @@ pub trait ContentReader: Send + Sync {
     fn list_files(&self) -> Result<Vec<PathBuf>>;
 
     /// Return filesystem metadata for change detection.
+    ///
+    /// NAMED `_nanos` on purpose. The tuple shape `(u64, u64)` is unchanged
+    /// from the seconds-based version, so an external implementation that kept
+    /// returning seconds would still COMPILE — it would write seconds into a
+    /// valid v3 cache and silently retain the same-second miss this release
+    /// exists to fix. Since the sidecar format is already breaking, the rename
+    /// is what forces such an implementation to be looked at rather than
+    /// quietly carried forward.
     /// For FilesystemReader: `Some((mtime_nanos, size_bytes))`.
     /// For GitBareReader: returns `None` (uses commit SHA instead of mtime).
     ///
@@ -77,14 +85,43 @@ pub trait ContentReader: Send + Sync {
     /// cached value kept matching — stayed misclassified on every later index.
     /// It never self-healed; only a further mtime change recovered it.
     ///
-    /// The precision was always there to use. Measured on APFS, five
-    /// consecutive fast writes produced ONE distinct whole second but FIVE
-    /// distinct nanosecond stamps. `SystemTime` carries it; `as_secs()` threw
-    /// it away.
+    /// The precision was always there to use. Measured on APFS, 200 rapid
+    /// writes produced ONE distinct whole second but 200 DISTINCT nanosecond
+    /// stamps (min delta ~33us, zero consecutive collisions). `SystemTime`
+    /// carries it; `as_secs()` threw it away.
+    ///
+    /// HOW MUCH THIS BUYS IS PLATFORM-DEPENDENT — do not read "nanoseconds" as
+    /// "one-nanosecond resolution":
+    ///
+    /// - macOS/APFS: effectively per-write, as measured above.
+    /// - Linux ext4/btrfs/xfs: the VFS stamps mtime from a COARSE clock
+    ///   "updated every jiffy, so any change that happens within that jiffy
+    ///   will end up with the same timestamp" (Documentation/filesystems/
+    ///   multigrain-ts.rst). That is 1-10ms depending on CONFIG_HZ, not 1ns.
+    ///   Multigrain timestamps address it but were reverted before 6.6-rc3 and
+    ///   only landed in 6.13.
+    /// - Coarse or synthetic timestamps (HFS+, ext3, FAT, some network mounts):
+    ///   the sub-second field may be permanently zero, leaving second
+    ///   granularity.
+    ///
+    /// So the ambiguity window narrows from ~1s to ~1 jiffy on Linux and to
+    /// ~per-write on macOS. That is why the size comparison in
+    /// `tiered_change_check` STAYS: on any platform where the sub-second field
+    /// is coarse or absent, size is what still catches size-changing edits.
+    /// Removing it because "we have nanoseconds now" would regress every such
+    /// platform back to the original bug.
+    ///
+    /// Git reaches the opposite conclusion for its own use (`USE_NSEC` is off
+    /// by default, and its Makefile says not to enable it on CEPH/CIFS/NTFS/
+    /// UDF). The difference is the failure mode, not the facts: an erroneous
+    /// sub-second value makes Git report a file dirty, whereas here it only
+    /// sends the file to the Tier 3 content hash, which compares equal and
+    /// returns Unchanged. Over-sensitivity costs a read here; it cannot produce
+    /// a wrong answer.
     ///
     /// `u64` nanoseconds since 1970 saturate in the year 2554, which is not a
     /// horizon this cache needs to survive.
-    fn file_meta(&self, rel_path: &Path) -> Result<Option<(u64, u64)>>;
+    fn file_meta_nanos(&self, rel_path: &Path) -> Result<Option<(u64, u64)>>;
 
     /// The root path (for constructing absolute paths in parsers that need them).
     fn root(&self) -> &Path;
@@ -214,7 +251,7 @@ impl ContentReader for FilesystemReader {
         Ok(files)
     }
 
-    fn file_meta(&self, rel_path: &Path) -> Result<Option<(u64, u64)>> {
+    fn file_meta_nanos(&self, rel_path: &Path) -> Result<Option<(u64, u64)>> {
         let abs = self.repo_path.join(rel_path);
         let meta = std::fs::metadata(&abs)?;
         // Nanoseconds, deliberately. See the trait doc: truncating to seconds
@@ -692,7 +729,7 @@ impl ContentReader for GitBareReader {
         Ok(files)
     }
 
-    fn file_meta(&self, _rel_path: &Path) -> Result<Option<(u64, u64)>> {
+    fn file_meta_nanos(&self, _rel_path: &Path) -> Result<Option<(u64, u64)>> {
         // Bare repos have no filesystem mtime. Return None so callers
         // (tiered_change_check, index_md) use content-hash or always-process paths.
         Ok(None)
@@ -767,11 +804,11 @@ mod tests {
     }
 
     #[test]
-    fn filesystem_reader_file_meta() {
+    fn filesystem_reader_file_meta_nanos() {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("test.rs"), "hello").unwrap();
         let reader = FilesystemReader::new(dir.path());
-        let meta = reader.file_meta(Path::new("test.rs")).unwrap();
+        let meta = reader.file_meta_nanos(Path::new("test.rs")).unwrap();
         assert!(meta.is_some());
         let (mtime, size) = meta.unwrap();
         assert!(mtime > 0);
@@ -782,7 +819,7 @@ mod tests {
     fn filesystem_reader_file_exists_false_for_missing() {
         let dir = TempDir::new().unwrap();
         let reader = FilesystemReader::new(dir.path());
-        let meta = reader.file_meta(Path::new("missing.rs"));
+        let meta = reader.file_meta_nanos(Path::new("missing.rs"));
         assert!(meta.is_err());
     }
 
@@ -947,10 +984,10 @@ mod tests {
     }
 
     #[test]
-    fn git_bare_reader_file_meta() {
+    fn git_bare_reader_file_meta_nanos() {
         let (_tmp, bare, sha) = setup_bare_repo(&[("hello.txt", "world")]);
         let reader = GitBareReader::new(&bare, &sha);
-        let meta = reader.file_meta(Path::new("hello.txt")).unwrap();
+        let meta = reader.file_meta_nanos(Path::new("hello.txt")).unwrap();
         assert!(
             meta.is_none(),
             "GitBareReader should return None (no filesystem mtime)"
@@ -961,7 +998,7 @@ mod tests {
     fn git_bare_reader_file_meta_missing() {
         let (_tmp, bare, sha) = setup_bare_repo(&[("a.txt", "x")]);
         let reader = GitBareReader::new(&bare, &sha);
-        let meta = reader.file_meta(Path::new("missing.txt")).unwrap();
+        let meta = reader.file_meta_nanos(Path::new("missing.txt")).unwrap();
         assert!(
             meta.is_none(),
             "GitBareReader returns None for all paths (no filesystem mtime)"

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -1742,7 +1742,7 @@ fn tiered_change_check(
 
     // file_meta returns None for bare-repo readers (no mtime available).
     // In that case, always fall through to read + hash.
-    let (mtime_nanos, size_bytes) = match reader.file_meta(rel)? {
+    let (mtime_nanos, size_bytes) = match reader.file_meta_nanos(rel)? {
         Some((m, s)) => (m, s),
         None => {
             // No filesystem metadata (e.g. GitBareReader) — read and hash. The
@@ -1801,10 +1801,13 @@ fn tiered_change_check(
         // permanently.
         //
         // The precision was always available and simply discarded — measured on
-        // APFS, five consecutive fast writes gave ONE whole second but FIVE
-        // distinct nanosecond stamps. Keeping it shrinks the ambiguous window
-        // from ~1s to ~1ns, which is the difference between "a fast editor hits
-        // this routinely" and "two writes must land in the same nanosecond".
+        // APFS, 200 rapid writes gave ONE whole second but 200 DISTINCT
+        // nanosecond stamps. How much that buys is PLATFORM-DEPENDENT: on Linux
+        // the VFS stamps mtime from a coarse clock updated once per jiffy, so
+        // the window there narrows to ~1-10ms rather than to ~1ns (see
+        // `ContentReader::file_meta_nanos` for the detail and sources). Either way it
+        // is 100-1000x narrower than one second, which is the difference
+        // between "a fast editor hits this routinely" and "you have to try".
         //
         // Size stays in the check alongside it. That is the standard quick
         // check — rsync transfers when size OR mtime differs, and Git compares
@@ -1813,14 +1816,15 @@ fn tiered_change_check(
         // filesystem with coarser timestamps than APFS, size still catches
         // every size-changing edit.
         //
-        // Git's "racily clean" residue — an edit inside the SAME nanosecond
-        // that also leaves the size identical — is not closed here and cannot
+        // Git's "racily clean" residue — an edit inside the same timestamp tick
+        // that ALSO leaves the size identical — is not closed here and cannot
         // be closed from `cached.mtime_nanos` alone: for an unchanged file it
         // matches by definition, so hashing on match would re-read the whole
         // tree every run. Closing it needs a per-run index timestamp, the way
-        // Git bounds its window by the index file's own mtime. At nanosecond
-        // granularity the window is small enough that this is a theoretical
-        // remainder rather than the routine data loss it was at one second.
+        // Git bounds its window by the index file's own mtime. The residue is
+        // now bounded by the platform tick (per-write on APFS, ~1 jiffy on
+        // Linux) rather than by a full second, which turns routine data loss
+        // into a narrow remainder.
         if cached.mtime_nanos == mtime_nanos && cached.size_bytes == size_bytes {
             return Ok(ChangeVerdict::Unchanged);
         }
@@ -4149,13 +4153,13 @@ fn collect_contract_derivation_inputs(
             continue;
         }
         if reader
-            .file_meta(&rel_path)
+            .file_meta_nanos(&rel_path)
             .context("read contract input metadata")?
             .is_some_and(|(_, size)| size > reader.max_source_file_bytes())
         {
             tracing::debug!(path = %rel_path.display(), "skip oversized contract input before read");
             let observed_bytes = reader
-                .file_meta(&rel_path)
+                .file_meta_nanos(&rel_path)
                 .ok()
                 .flatten()
                 .map(|(_, size)| size)
@@ -4379,7 +4383,7 @@ pub(crate) fn watcher_contract_input_snapshot(
             continue;
         }
         if reader
-            .file_meta(&rel_path)
+            .file_meta_nanos(&rel_path)
             .with_context(|| format!("read watcher contract metadata {}", rel_path.display()))?
             .is_some_and(|(_, size)| size > reader.max_source_file_bytes())
         {
@@ -5550,7 +5554,7 @@ fn prepare_incremental_file(
     }
 
     if let Some((_, observed_bytes)) = reader
-        .file_meta(rel_path)
+        .file_meta_nanos(rel_path)
         .with_context(|| format!("stat {}", abs_path.display()))?
         && observed_bytes > reader.max_source_file_bytes()
     {
@@ -6384,7 +6388,7 @@ mod tests {
             fn list_files(&self) -> anyhow::Result<Vec<PathBuf>> {
                 Ok(vec![PathBuf::from("large.rs")])
             }
-            fn file_meta(&self, _rel_path: &Path) -> anyhow::Result<Option<(u64, u64)>> {
+            fn file_meta_nanos(&self, _rel_path: &Path) -> anyhow::Result<Option<(u64, u64)>> {
                 Ok(None)
             }
             fn root(&self) -> &Path {
@@ -8040,7 +8044,7 @@ function hello(name) { return "Hello " + name; }
             fn list_files(&self) -> anyhow::Result<Vec<PathBuf>> {
                 Ok(vec![PathBuf::from("HugeController.java")])
             }
-            fn file_meta(&self, _rel_path: &Path) -> anyhow::Result<Option<(u64, u64)>> {
+            fn file_meta_nanos(&self, _rel_path: &Path) -> anyhow::Result<Option<(u64, u64)>> {
                 Ok(Some((
                     0,
                     crate::index_limits::DEFAULT_MAX_SOURCE_FILE_BYTES + 1,
@@ -8082,7 +8086,7 @@ function hello(name) { return "Hello " + name; }
             fn list_files(&self) -> anyhow::Result<Vec<PathBuf>> {
                 Ok(vec![PathBuf::from("unreadable.py")])
             }
-            fn file_meta(&self, _rel_path: &Path) -> anyhow::Result<Option<(u64, u64)>> {
+            fn file_meta_nanos(&self, _rel_path: &Path) -> anyhow::Result<Option<(u64, u64)>> {
                 panic!("irrelevant language must be filtered before metadata")
             }
             fn root(&self) -> &Path {
@@ -10685,7 +10689,7 @@ function hello(name) { return "Hello " + name; }
             Ok(Vec::new())
         }
 
-        fn file_meta(&self, _rel_path: &Path) -> Result<Option<(u64, u64)>, anyhow::Error> {
+        fn file_meta_nanos(&self, _rel_path: &Path) -> Result<Option<(u64, u64)>, anyhow::Error> {
             Ok(None)
         }
 
@@ -11862,6 +11866,15 @@ function hello(name) { return "Hello " + name; }
     }
 
     #[test]
+    /// Also the fail-safe that makes unconditional sub-second mtimes safe here
+    /// (nw-200).
+    ///
+    /// Git ships `USE_NSEC` off by default and its Makefile warns against it on
+    /// CEPH/CIFS/NTFS/UDF, because some filesystems report a sub-second field
+    /// that moves when nothing changed. This test is why that caution does not
+    /// transfer: a jittering timestamp lands here, the content hash compares
+    /// equal, and the verdict is Unchanged. Over-sensitivity costs one read; it
+    /// cannot produce a wrong answer.
     fn tiered_check_same_size_different_mtime_falls_through_to_hash() {
         let dir = tempfile::tempdir().unwrap();
         let file_path = dir.path().join("hello.js");
@@ -12050,7 +12063,7 @@ function hello(name) { return "Hello " + name; }
             Ok(vec![PathBuf::from("src/lib.rs")])
         }
 
-        fn file_meta(&self, _rel_path: &Path) -> Result<Option<(u64, u64)>, anyhow::Error> {
+        fn file_meta_nanos(&self, _rel_path: &Path) -> Result<Option<(u64, u64)>, anyhow::Error> {
             Ok(None)
         }
 
@@ -12256,7 +12269,7 @@ function hello(name) { return "Hello " + name; }
     /// A real edit made inside the same whole second as the cached mtime must
     /// still be indexed.
     ///
-    /// `file_meta` truncates timestamps with `as_secs()`, so an mtime-only Tier 1
+    /// `file_meta_nanos` truncates timestamps with `as_secs()`, so an mtime-only Tier 1
     /// check cannot see such an edit — and because the cached mtime then keeps
     /// matching, the file stays misclassified on every LATER index too. It never
     /// self-heals; only a further mtime change recovers it. Verified end to end
@@ -12324,6 +12337,59 @@ function hello(name) { return "Hello " + name; }
             "a same-second edit that changes the file size must still be indexed; \
              an mtime-only Tier 1 check misses it permanently"
         );
+    }
+
+    /// A nanosecond mtime must survive the JSON sidecar EXACTLY.
+    ///
+    /// Nanoseconds since the epoch are ~1.79e18, well above 2^53 — the largest
+    /// integer an IEEE-754 double represents exactly. Any step that routes the
+    /// value through an f64 silently truncates the low ~63ns, and a corrupted
+    /// low digit is indistinguishable from a real edit: the file would be
+    /// re-parsed forever, or worse, compare equal to the wrong thing.
+    ///
+    /// serde_json parses integer literals straight into `u64`, so this holds —
+    /// but it holds by a property of the serializer, not by anything in this
+    /// module, which is exactly the kind of assumption worth pinning.
+    #[test]
+    fn nanosecond_mtimes_round_trip_through_the_sidecar_exactly() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("db.lbug.filemeta.json");
+
+        // A realistic present-day stamp, and the extremes.
+        for mtime_nanos in [1_787_363_596_798_003_519u64, u64::MAX, (1u64 << 53) + 1] {
+            let mut repos = HashMap::new();
+            let mut files = FileMetaCache::new();
+            files.insert(
+                "src/main.rs".to_string(),
+                CachedFileMeta {
+                    mtime_nanos,
+                    size_bytes: 42,
+                    content_hash: "h".to_string(),
+                },
+            );
+            repos.insert("repo:precision".to_string(), files);
+            let sidecar = FileMetaSidecar {
+                version: FILEMETA_VERSION,
+                repos,
+            };
+            save_filemeta_sidecar(&sidecar, &path).unwrap();
+
+            let loaded = load_filemeta_sidecar(&path);
+            let got = loaded.repos["repo:precision"]["src/main.rs"].mtime_nanos;
+            assert_eq!(
+                got, mtime_nanos,
+                "nanosecond mtime must survive the sidecar exactly; a lossy \
+                 round-trip is indistinguishable from a real edit"
+            );
+
+            // And prove the on-disk form is an integer literal, not a float:
+            // `1.787363596798e18` would parse back lossily.
+            let raw = fs::read_to_string(&path).unwrap();
+            assert!(
+                raw.contains(&format!("\"mtime_nanos\":{mtime_nanos}")),
+                "sidecar must store the raw integer, got: {raw}"
+            );
+        }
     }
 
     /// The v2 -> v3 upgrade must FAIL OPEN, not reinterpret.

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -1705,7 +1705,22 @@ fn merge_save_filemeta(
 /// Outcome of the tiered change detection for a single file.
 enum ChangeVerdict {
     /// File is unchanged — skip re-indexing it.
-    Unchanged,
+    Unchanged {
+        /// Set when the stat MOVED but the content hash matched.
+        ///
+        /// Carrying the old entry forward in that case re-reads and re-hashes
+        /// the file on every subsequent index, forever, because the cached
+        /// stat never catches up to what the filesystem reports. That happens
+        /// routinely: a `git checkout` that rewrites identical content, a
+        /// formatter whose output is unchanged, a `touch`, or a filesystem
+        /// whose sub-second field jitters (the case Git names when it ships
+        /// `USE_NSEC` off by default).
+        ///
+        /// Storing the observed stat with the SAME hash makes the next run
+        /// short-circuit at Tier 1. Git does the same thing — it refreshes the
+        /// cached stat when content compares equal.
+        refreshed: Option<CachedFileMeta>,
+    },
     /// File is new or changed — `source` contains the file content and
     /// `content_hash` is the freshly-computed BLAKE3 hex digest.
     Changed {
@@ -1757,7 +1772,9 @@ fn tiered_change_check(
             if let Some(cached) = cache.get(rel_path)
                 && content_hash == cached.content_hash
             {
-                return Ok(ChangeVerdict::Unchanged);
+                // No filesystem stat exists on this path, so there is nothing
+                // to refresh.
+                return Ok(ChangeVerdict::Unchanged { refreshed: None });
             }
             return Ok(ChangeVerdict::Changed {
                 meta: CachedFileMeta {
@@ -1826,7 +1843,7 @@ fn tiered_change_check(
         // Linux) rather than by a full second, which turns routine data loss
         // into a narrow remainder.
         if cached.mtime_nanos == mtime_nanos && cached.size_bytes == size_bytes {
-            return Ok(ChangeVerdict::Unchanged);
+            return Ok(ChangeVerdict::Unchanged { refreshed: None });
         }
 
         // Tier 2: mtime or size changed → fall through to hash check. A
@@ -1841,10 +1858,17 @@ fn tiered_change_check(
         )?;
         let content_hash = content_hash_hex(&source);
         if content_hash == cached.content_hash {
-            // Content identical despite mtime/size change — unchanged for the
-            // graph. No need to re-parse. (The caller will carry forward the
-            // cached entry.)
-            return Ok(ChangeVerdict::Unchanged);
+            // Content identical despite a stat change — unchanged for the
+            // graph, so no re-parse. But hand back the OBSERVED stat: without
+            // it the cached stat never catches up and this file is re-read and
+            // re-hashed on every index from now on.
+            return Ok(ChangeVerdict::Unchanged {
+                refreshed: Some(CachedFileMeta {
+                    mtime_nanos,
+                    size_bytes,
+                    content_hash,
+                }),
+            });
         }
         Ok(ChangeVerdict::Changed {
             meta: CachedFileMeta {
@@ -2701,6 +2725,10 @@ where
     enum ParseOutcome {
         Unchanged {
             rel_path: String,
+            /// Observed stat when it moved but content matched — see
+            /// `ChangeVerdict::Unchanged`. Stored instead of the stale cached
+            /// entry so the next run short-circuits at Tier 1.
+            refreshed: Option<CachedFileMeta>,
         },
         Skipped(SkippedFile),
         /// Transient I/O/parser failure. The full publication must abort;
@@ -2728,6 +2756,7 @@ where
             symbols: Vec<RawSymbol>,
             references: Vec<RawReference>,
             type_bindings: Vec<AstTypeBinding>,
+            refreshed: Option<CachedFileMeta>,
         },
     }
 
@@ -2772,7 +2801,7 @@ where
         // Tiered change detection.
         let (source, content_hash, file_meta) =
             match tiered_change_check(reader, &display_name, cache) {
-                Ok(ChangeVerdict::Unchanged) => {
+                Ok(ChangeVerdict::Unchanged { refreshed }) => {
                     parse_pb.inc(1);
                     // Check parsed cache: if we have cached symbols for this
                     // file's content hash, return CachedParsed so symbols are
@@ -2786,10 +2815,12 @@ where
                             symbols: cached_parse.symbols.clone(),
                             references: cached_parse.references.clone(),
                             type_bindings: cached_parse.type_bindings.clone(),
+                            refreshed,
                         };
                     }
                     return ParseOutcome::Unchanged {
                         rel_path: display_name,
+                        refreshed,
                     };
                 }
                 Ok(ChangeVerdict::Changed {
@@ -2910,13 +2941,18 @@ where
 
     for outcome in outcomes {
         match outcome {
-            ParseOutcome::Unchanged { rel_path } => {
+            ParseOutcome::Unchanged {
+                rel_path,
+                refreshed,
+            } => {
                 present_files.insert(rel_path.clone());
-                // Carry forward the existing cache entry.
-                if let (Some(ref mut new_cache), Some(cached)) =
-                    (new_filemeta.as_deref_mut(), cache.get(&rel_path))
+                // Carry the cache entry forward — but prefer the REFRESHED stat
+                // when the content matched despite a moved mtime/size. Storing
+                // the stale one re-hashes this file on every future index.
+                if let Some(ref mut new_cache) = new_filemeta.as_deref_mut()
+                    && let Some(entry) = refreshed.or_else(|| cache.get(&rel_path).cloned())
                 {
-                    new_cache.insert(rel_path, cached.clone());
+                    new_cache.insert(rel_path, entry);
                 }
                 files_unchanged += 1;
             }
@@ -2925,13 +2961,14 @@ where
                 symbols: raw_symbols,
                 references: raw_references,
                 type_bindings: raw_type_bindings,
+                refreshed,
             } => {
                 present_files.insert(rel_path.clone());
-                // Carry forward the existing filemeta cache entry (file is unchanged).
-                if let (Some(ref mut new_cache), Some(cached)) =
-                    (new_filemeta.as_deref_mut(), cache.get(&rel_path))
+                // Same as above: the refreshed stat wins when present.
+                if let Some(ref mut new_cache) = new_filemeta.as_deref_mut()
+                    && let Some(entry) = refreshed.or_else(|| cache.get(&rel_path).cloned())
                 {
-                    new_cache.insert(rel_path.clone(), cached.clone());
+                    new_cache.insert(rel_path.clone(), entry);
                 }
                 files_unchanged += 1;
                 // Feed cached symbols/references into the resolver so cross-file
@@ -11829,7 +11866,7 @@ function hello(name) { return "Hello " + name; }
                 assert!(meta.size_bytes > 0);
                 assert!(meta.mtime_nanos > 0);
             }
-            ChangeVerdict::Unchanged => panic!("expected Changed for new file"),
+            ChangeVerdict::Unchanged { .. } => panic!("expected Changed for new file"),
         }
     }
 
@@ -11860,7 +11897,7 @@ function hello(name) { return "Hello " + name; }
 
         let reader = crate::content_reader::FilesystemReader::new(dir.path());
         match tiered_change_check(&reader, "hello.js", &cache).unwrap() {
-            ChangeVerdict::Unchanged => {} // expected
+            ChangeVerdict::Unchanged { .. } => {} // expected
             ChangeVerdict::Changed { .. } => panic!("expected Unchanged for same mtime"),
         }
     }
@@ -11897,7 +11934,7 @@ function hello(name) { return "Hello " + name; }
 
         let reader = crate::content_reader::FilesystemReader::new(dir.path());
         match tiered_change_check(&reader, "hello.js", &cache).unwrap() {
-            ChangeVerdict::Unchanged => {} // expected — hash matches, so unchanged
+            ChangeVerdict::Unchanged { .. } => {} // expected — hash matches, so unchanged
             ChangeVerdict::Changed { .. } => panic!("expected Unchanged when hash matches"),
         }
 
@@ -11914,7 +11951,7 @@ function hello(name) { return "Hello " + name; }
 
         match tiered_change_check(&reader, "hello.js", &cache2).unwrap() {
             ChangeVerdict::Changed { .. } => {} // expected — hash differs
-            ChangeVerdict::Unchanged => {
+            ChangeVerdict::Unchanged { .. } => {
                 panic!("expected Changed when hash differs despite same size")
             }
         }
@@ -11948,7 +11985,7 @@ function hello(name) { return "Hello " + name; }
                 assert!(source.contains("return 42"));
                 assert_eq!(content_hash, content_hash_hex(new_content));
             }
-            ChangeVerdict::Unchanged => panic!("expected Changed for different-size file"),
+            ChangeVerdict::Unchanged { .. } => panic!("expected Changed for different-size file"),
         }
     }
 
@@ -12337,6 +12374,82 @@ function hello(name) { return "Hello " + name; }
             "a same-second edit that changes the file size must still be indexed; \
              an mtime-only Tier 1 check misses it permanently"
         );
+    }
+
+    /// A moved stat with identical content must REFRESH the cache, not leave it
+    /// stale.
+    ///
+    /// Carrying the old entry forward means the cached stat never catches up to
+    /// what the filesystem reports, so the file is re-read and re-hashed on
+    /// every index from then on — permanently. This happens routinely: a
+    /// `git checkout` that rewrites identical content, a formatter whose output
+    /// is unchanged, a `touch`, or a filesystem whose sub-second field jitters.
+    #[test]
+    fn a_content_match_after_a_moved_stat_refreshes_the_cached_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("hello.js");
+        let content = "function hello() {}";
+        fs::write(&file_path, content).unwrap();
+
+        let fs_meta = fs::metadata(&file_path).unwrap();
+        let observed_nanos = fs_meta
+            .modified()
+            .unwrap()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+            .min(u128::from(u64::MAX)) as u64;
+        let size_bytes = fs_meta.len();
+        let reader = crate::content_reader::FilesystemReader::new(dir.path());
+
+        // Cache holds a DIFFERENT stat for byte-identical content — the
+        // touch / checkout / jitter shape.
+        let mut cache = FileMetaCache::new();
+        cache.insert(
+            "hello.js".to_string(),
+            CachedFileMeta {
+                mtime_nanos: observed_nanos.wrapping_sub(999_999),
+                size_bytes,
+                content_hash: content_hash_hex(content),
+            },
+        );
+
+        match tiered_change_check(&reader, "hello.js", &cache).unwrap() {
+            ChangeVerdict::Unchanged { refreshed } => {
+                let refreshed = refreshed.expect(
+                    "a content match after a moved stat must hand back the observed stat, \
+                     otherwise the file re-hashes on every future index",
+                );
+                assert_eq!(refreshed.mtime_nanos, observed_nanos);
+                assert_eq!(refreshed.size_bytes, size_bytes);
+                assert_eq!(
+                    refreshed.content_hash,
+                    content_hash_hex(content),
+                    "the hash is unchanged — only the stat advances"
+                );
+            }
+            ChangeVerdict::Changed { .. } => {
+                panic!("identical content must not be reported as a change")
+            }
+        }
+
+        // And the no-op case must NOT claim a refresh.
+        let mut fresh = FileMetaCache::new();
+        fresh.insert(
+            "hello.js".to_string(),
+            CachedFileMeta {
+                mtime_nanos: observed_nanos,
+                size_bytes,
+                content_hash: content_hash_hex(content),
+            },
+        );
+        match tiered_change_check(&reader, "hello.js", &fresh).unwrap() {
+            ChangeVerdict::Unchanged { refreshed } => assert!(
+                refreshed.is_none(),
+                "an untouched file short-circuits at Tier 1 with nothing to refresh"
+            ),
+            ChangeVerdict::Changed { .. } => panic!("expected Unchanged"),
+        }
     }
 
     /// A nanosecond mtime must survive the JSON sidecar EXACTLY.

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -78,7 +78,7 @@ pub struct IndexResult {
 //
 // Sidecar file: `<db>.filemeta.json`
 //
-// On each index run we store (mtime_secs, size_bytes, content_hash) per file.
+// On each index run we store (mtime_nanos, size_bytes, content_hash) per file.
 // Before reading & hashing a file we check:
 //   Tier 1 – mtime unchanged → skip (near-zero cost stat)
 //   Tier 2 – mtime changed but size unchanged → skip (likely identical)
@@ -87,7 +87,12 @@ pub struct IndexResult {
 /// Per-file metadata cached between indexing runs.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CachedFileMeta {
-    pub mtime_secs: u64,
+    /// NANOSECONDS since the Unix epoch, not seconds.
+    ///
+    /// Renamed from `mtime_nanos` deliberately (nw-200): the units changed, and
+    /// a rename makes every call site fail to compile rather than silently
+    /// comparing nanoseconds against a value someone still believes is seconds.
+    pub mtime_nanos: u64,
     pub size_bytes: u64,
     pub content_hash: String,
 }
@@ -95,15 +100,21 @@ pub struct CachedFileMeta {
 /// Map from repo-relative path to cached file metadata.
 pub type FileMetaCache = HashMap<String, CachedFileMeta>;
 
-/// Sidecar format version. v2 = per-repo keying (nw-022). v1 (implicit,
-/// unversioned flat map) fails deserialization and loads as empty — a
-/// deliberate fail-open that costs one full re-index and can never
-/// mis-classify a file.
+/// Sidecar format version. v3 = nanosecond mtimes (nw-200). v2 = per-repo
+/// keying (nw-022). v1 (implicit, unversioned flat map) fails deserialization
+/// and loads as empty — a deliberate fail-open that costs one full re-index and
+/// can never mis-classify a file.
+///
+/// v2 -> v3 MUST be a version bump rather than a silent field reinterpretation:
+/// a v2 entry holds SECONDS in the field v3 reads as NANOSECONDS. Reusing it
+/// would make every cached file compare as changed-by-nine-orders-of-magnitude
+/// on the first run and, worse, would be indistinguishable from a real edit.
+/// Failing the load and re-indexing once is the honest outcome.
 ///
 /// Paired with `resolution_cache::CACHE_VERSION`: bumping one requires
 /// bumping the other (both sidecars must be invalidated together), enforced
 /// by `resolution_cache::tests::cache_version_moves_with_filemeta_version`.
-pub const FILEMETA_VERSION: u32 = 2;
+pub const FILEMETA_VERSION: u32 = 3;
 
 /// On-disk shape of `<db>.filemeta.json`: change-detection metadata keyed by
 /// repo uid, then repo-relative path. Two repos sharing one DB can never
@@ -1731,7 +1742,7 @@ fn tiered_change_check(
 
     // file_meta returns None for bare-repo readers (no mtime available).
     // In that case, always fall through to read + hash.
-    let (mtime_secs, size_bytes) = match reader.file_meta(rel)? {
+    let (mtime_nanos, size_bytes) = match reader.file_meta(rel)? {
         Some((m, s)) => (m, s),
         None => {
             // No filesystem metadata (e.g. GitBareReader) — read and hash. The
@@ -1750,7 +1761,7 @@ fn tiered_change_check(
             }
             return Ok(ChangeVerdict::Changed {
                 meta: CachedFileMeta {
-                    mtime_secs: 0,
+                    mtime_nanos: 0,
                     size_bytes: source.len() as u64,
                     content_hash: content_hash.clone(),
                 },
@@ -1779,29 +1790,38 @@ fn tiered_change_check(
     if let Some(cached) = cache.get(rel_path) {
         // Tier 1: mtime AND size unchanged → skip.
         //
-        // Size is part of this check, not just mtime. `file_meta` truncates the
-        // timestamp to WHOLE SECONDS (`as_secs()`), so every edit landing in the
-        // same second as the one already cached is invisible to an mtime-only
-        // comparison — and because the cached mtime then still matches, the file
-        // stays misclassified on EVERY later index too. It never self-heals; only
-        // a further mtime change recovers it. Reproduced end to end: index a
-        // repo, edit a file inside the same second (size 35 -> 78 bytes), and the
-        // new symbol is absent from the graph permanently.
+        // The timestamp is NANOSECONDS (nw-200). It used to be truncated to
+        // whole seconds, and that truncation was the defect: every edit landing
+        // in the same second as the value already cached compared equal, so the
+        // file was classified Unchanged — and because the cached value kept
+        // matching, it stayed misclassified on EVERY later index. It never
+        // self-healed; only a further mtime change recovered it. Reproduced end
+        // to end through the CLI before the fix: index a repo, edit a file
+        // inside the same second, and the new symbol was absent from the graph
+        // permanently.
         //
-        // Comparing size closes every size-changing edit for free — `size_bytes`
-        // is already in hand from `file_meta`, and a genuinely unchanged file
-        // still short-circuits here with no read. This is the standard quick
-        // check: rsync transfers when size OR mtime differs, and Git compares
-        // `st_size` alongside `st_mtime` precisely because mtime alone is
-        // insufficient (Documentation/technical/racy-git.txt).
+        // The precision was always available and simply discarded — measured on
+        // APFS, five consecutive fast writes gave ONE whole second but FIVE
+        // distinct nanosecond stamps. Keeping it shrinks the ambiguous window
+        // from ~1s to ~1ns, which is the difference between "a fast editor hits
+        // this routinely" and "two writes must land in the same nanosecond".
         //
-        // What remains is Git's "racily clean" case: a same-second edit that
-        // leaves the size identical. Git bounds that window by the INDEX file's
-        // timestamp and re-hashes only entries inside it. The same bound cannot
-        // be had from `cached.mtime_secs` alone — for unchanged files it matches
-        // by definition, so hashing on match would re-read the whole tree every
-        // run. Closing it needs a per-run index timestamp; tracked separately.
-        if cached.mtime_secs == mtime_secs && cached.size_bytes == size_bytes {
+        // Size stays in the check alongside it. That is the standard quick
+        // check — rsync transfers when size OR mtime differs, and Git compares
+        // `st_size` alongside `st_mtime` because mtime alone is insufficient
+        // (Documentation/technical/racy-git.txt). Belt and braces: on a
+        // filesystem with coarser timestamps than APFS, size still catches
+        // every size-changing edit.
+        //
+        // Git's "racily clean" residue — an edit inside the SAME nanosecond
+        // that also leaves the size identical — is not closed here and cannot
+        // be closed from `cached.mtime_nanos` alone: for an unchanged file it
+        // matches by definition, so hashing on match would re-read the whole
+        // tree every run. Closing it needs a per-run index timestamp, the way
+        // Git bounds its window by the index file's own mtime. At nanosecond
+        // granularity the window is small enough that this is a theoretical
+        // remainder rather than the routine data loss it was at one second.
+        if cached.mtime_nanos == mtime_nanos && cached.size_bytes == size_bytes {
             return Ok(ChangeVerdict::Unchanged);
         }
 
@@ -1824,7 +1844,7 @@ fn tiered_change_check(
         }
         Ok(ChangeVerdict::Changed {
             meta: CachedFileMeta {
-                mtime_secs,
+                mtime_nanos,
                 size_bytes,
                 content_hash: content_hash.clone(),
             },
@@ -1841,7 +1861,7 @@ fn tiered_change_check(
         let content_hash = content_hash_hex(&source);
         Ok(ChangeVerdict::Changed {
             meta: CachedFileMeta {
-                mtime_secs,
+                mtime_nanos,
                 size_bytes,
                 content_hash: content_hash.clone(),
             },
@@ -11803,7 +11823,7 @@ function hello(name) { return "Hello " + name; }
                 assert!(source.contains("function hello"));
                 assert!(!content_hash.is_empty());
                 assert!(meta.size_bytes > 0);
-                assert!(meta.mtime_secs > 0);
+                assert!(meta.mtime_nanos > 0);
             }
             ChangeVerdict::Unchanged => panic!("expected Changed for new file"),
         }
@@ -11817,7 +11837,7 @@ function hello(name) { return "Hello " + name; }
         fs::write(&file_path, content).unwrap();
 
         let fs_meta = fs::metadata(&file_path).unwrap();
-        let mtime_secs = fs_meta
+        let mtime_nanos = fs_meta
             .modified()
             .unwrap()
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
@@ -11828,7 +11848,7 @@ function hello(name) { return "Hello " + name; }
         cache.insert(
             "hello.js".to_string(),
             CachedFileMeta {
-                mtime_secs,
+                mtime_nanos,
                 size_bytes: fs_meta.len(),
                 content_hash: content_hash_hex(content),
             },
@@ -11856,7 +11876,7 @@ function hello(name) { return "Hello " + name; }
         cache.insert(
             "hello.js".to_string(),
             CachedFileMeta {
-                mtime_secs: 1, // different from actual mtime
+                mtime_nanos: 1, // different from actual mtime
                 size_bytes: fs_meta.len(),
                 content_hash: content_hash_hex(content),
             },
@@ -11873,7 +11893,7 @@ function hello(name) { return "Hello " + name; }
         cache2.insert(
             "hello.js".to_string(),
             CachedFileMeta {
-                mtime_secs: 1,
+                mtime_nanos: 1,
                 size_bytes: fs_meta.len(),
                 content_hash: content_hash_hex("different content!"),
             },
@@ -11899,7 +11919,7 @@ function hello(name) { return "Hello " + name; }
         cache.insert(
             "hello.js".to_string(),
             CachedFileMeta {
-                mtime_secs: 1,
+                mtime_nanos: 1,
                 size_bytes: 5, // clearly different from actual file
                 content_hash: content_hash_hex("old content"),
             },
@@ -11931,7 +11951,7 @@ function hello(name) { return "Hello " + name; }
             .insert(
                 "main.js".into(),
                 CachedFileMeta {
-                    mtime_secs: 1,
+                    mtime_nanos: 1,
                     size_bytes: 2,
                     content_hash: "h1".into(),
                 },
@@ -11949,7 +11969,7 @@ function hello(name) { return "Hello " + name; }
         let path = dir.path().join("db.lbug.filemeta.json");
         fs::write(
             &path,
-            r#"{"main.js":{"mtime_secs":5,"size_bytes":10,"content_hash":"abc"}}"#,
+            r#"{"main.js":{"mtime_nanos":5,"size_bytes":10,"content_hash":"abc"}}"#,
         )
         .unwrap();
         let loaded = load_filemeta_sidecar(&path);
@@ -11974,9 +11994,15 @@ function hello(name) { return "Hello " + name; }
         // fail-open to empty — full re-index, never a mis-classification.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("db.lbug.filemeta.json");
+        // Derived from the constant, never hardcoded: a literal one-above-current
+        // silently becomes a SAME-version test the moment the version is bumped,
+        // which is exactly what happened at v2 -> v3 (nw-200).
+        let future = FILEMETA_VERSION + 1;
         fs::write(
             &path,
-            r#"{"version":3,"repos":{"repo:test:aaaa":{"main.js":{"mtime_secs":1,"size_bytes":2,"content_hash":"h1"}}}}"#,
+            format!(
+                r#"{{"version":{future},"repos":{{"repo:test:aaaa":{{"main.js":{{"mtime_nanos":1,"size_bytes":2,"content_hash":"h1"}}}}}}}}"#
+            ),
         )
         .unwrap();
         let loaded = load_filemeta_sidecar(&path);
@@ -12000,7 +12026,7 @@ function hello(name) { return "Hello " + name; }
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains(r#""version":2"#),
+                .contains(&format!(r#""version":{FILEMETA_VERSION}"#)),
             "a default-constructed sidecar must serialize with the current version"
         );
         let loaded = load_filemeta_sidecar(&path);
@@ -12193,7 +12219,7 @@ function hello(name) { return "Hello " + name; }
         // Advance the mtime explicitly instead of relying on the two writes
         // straddling a wall-clock second.
         //
-        // `tiered_change_check` Tier 1 is `cached.mtime_secs == mtime_secs ->
+        // `tiered_change_check` Tier 1 is `cached.mtime_nanos == mtime_nanos ->
         // Unchanged`, at WHOLE-SECOND granularity and short-circuiting before
         // any content hash. When both writes land in the same second the edit
         // is classified unchanged, nothing is re-indexed, no scope is dirtied,
@@ -12297,6 +12323,108 @@ function hello(name) { return "Hello " + name; }
             1,
             "a same-second edit that changes the file size must still be indexed; \
              an mtime-only Tier 1 check misses it permanently"
+        );
+    }
+
+    /// The v2 -> v3 upgrade must FAIL OPEN, not reinterpret.
+    ///
+    /// A v2 entry stores SECONDS in the field v3 reads as NANOSECONDS. Silently
+    /// reusing it would compare a real timestamp against one nine orders of
+    /// magnitude smaller — every file would look changed on the first run, and
+    /// a genuinely stale entry would be indistinguishable from a real edit. The
+    /// version bump makes the load fail and the cache come back empty, which
+    /// costs one full re-index and can never mis-classify a file.
+    #[test]
+    fn a_v2_sidecar_is_discarded_rather_than_reinterpreted_as_nanoseconds() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("upgrade.lbug");
+        let sidecar_path = crate::sidecar_path(&db_path, ".filemeta.json");
+
+        // A v2 sidecar whose mtime field holds SECONDS, as v2 wrote it.
+        let legacy = serde_json::json!({
+            "version": 2,
+            "repos": {
+                "repo:legacy": {
+                    "src/main.js": {
+                        "mtime_nanos": 1_500_000,
+                        "size_bytes": 18,
+                        "content_hash": "deadbeef"
+                    }
+                }
+            }
+        });
+        fs::write(&sidecar_path, serde_json::to_string(&legacy).unwrap()).unwrap();
+
+        let loaded = load_filemeta_sidecar(&sidecar_path);
+        assert_eq!(
+            loaded.version, FILEMETA_VERSION,
+            "a stale sidecar must be replaced with a current-version one"
+        );
+        assert!(
+            loaded.repos.is_empty(),
+            "a v2 sidecar must be discarded, not carried forward with seconds in \
+             a nanoseconds field: {:?}",
+            loaded.repos
+        );
+    }
+
+    /// nw-200: a same-second edit that leaves the file size IDENTICAL must
+    /// still be indexed.
+    ///
+    /// This is the half the size comparison cannot catch. With second-
+    /// granularity timestamps it was routine silent data loss: the edit
+    /// compared equal on both mtime and size, the file was classified
+    /// Unchanged, and because the cached value kept matching it stayed wrong on
+    /// every later index — recovered only by a further mtime change.
+    ///
+    /// Keeping nanoseconds closes it. Both writes here are pinned to the same
+    /// WHOLE SECOND but different nanoseconds, which is exactly what a fast
+    /// editor produces (measured on APFS: five consecutive writes, one whole
+    /// second, five distinct nanosecond stamps).
+    #[test]
+    fn same_second_same_size_edit_is_not_missed() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("same-nanos.lbug");
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        let file = repo.join("main.js");
+
+        // Same second, different nanosecond — the realistic fast-edit shape.
+        let base_secs = 1_500_000u64;
+        let pin = |path: &std::path::Path, nanos: u32| {
+            let handle = fs::OpenOptions::new().write(true).open(path).unwrap();
+            let when =
+                std::time::SystemTime::UNIX_EPOCH + std::time::Duration::new(base_secs, nanos);
+            handle
+                .set_times(fs::FileTimes::new().set_modified(when))
+                .unwrap();
+        };
+
+        // Byte-for-byte identical LENGTH, different content: `aaa` -> `bbb`.
+        fs::write(&file, "function aaa() {}\n").unwrap();
+        pin(&file, 1_000);
+        incremental_index_with_name(&repo, &db_path, "test", "https://example.com/nanos", None)
+            .unwrap();
+
+        fs::write(&file, "function bbb() {}\n").unwrap();
+        pin(&file, 2_000);
+        assert_eq!(
+            fs::metadata(&file).unwrap().len(),
+            18,
+            "the two revisions must be the same size for this test to mean anything"
+        );
+        incremental_index_with_name(&repo, &db_path, "test", "https://example.com/nanos", None)
+            .unwrap();
+
+        let store = GraphStore::open_read_only(&db_path).unwrap();
+        let found = store
+            .regex_search("function bbb", None, None, None, None)
+            .unwrap();
+        assert_eq!(
+            found.results.len(),
+            1,
+            "a same-second, same-size edit must still be indexed; second-granularity \
+             timestamps missed it permanently"
         );
     }
 

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -460,15 +460,32 @@ fn index_markdown_since_with_reader(
         .map(|note| note.uid.clone())
         .collect::<std::collections::HashSet<_>>();
 
-    // NANOSECONDS, to match `ContentReader::file_meta` (nw-200). Both sides of
-    // the comparison below must use the same unit; leaving this in seconds
-    // while the reader returns nanoseconds would make every file look newer
-    // than `since` and silently disable the filter entirely.
+    // NANOSECONDS, to match `ContentReader::file_meta_nanos` (nw-200) — but FLOORED
+    // TO THE SECOND first.
+    //
+    // Both sides must share a unit, and naively converting `since` to exact
+    // nanoseconds is not enough: a filesystem whose mtime granularity is
+    // coarser than the caller's clock stamps a write performed AFTER `since`
+    // with a value slightly BEFORE it. On Linux the VFS stamps mtime from a
+    // clock "updated every jiffy" (Documentation/filesystems/multigrain-ts.rst),
+    // so a note written microseconds after `since` can carry an mtime up to a
+    // jiffy earlier and be silently skipped — the exact miss this filter exists
+    // to prevent.
+    //
+    // Flooring restores the previous behaviour, where BOTH sides were truncated
+    // to whole seconds and anything written within `since`'s second compared
+    // greater-or-equal. The error is deliberately one-sided: flooring can only
+    // ever include a few extra notes, which costs a re-parse, and can never
+    // exclude one that was genuinely written after the threshold.
+    //
+    // The file CACHE keeps full nanosecond precision — that is what closes the
+    // same-second edit bug. This coarsening applies only to the `--since`
+    // threshold, where inclusiveness beats sharpness.
     let since_nanos = since
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
-        .as_nanos()
-        .min(u128::from(u64::MAX)) as u64;
+        .as_secs()
+        .saturating_mul(1_000_000_000);
 
     let all_files = reader.list_files()?;
 
@@ -499,7 +516,7 @@ fn index_markdown_since_with_reader(
 
         // Parse changed files now. Unchanged sources are read later only when
         // the affected-source closure shows their outgoing links may change.
-        let changed = match reader.file_meta(&rel_path) {
+        let changed = match reader.file_meta_nanos(&rel_path) {
             Ok(Some((mtime_nanos, file_size))) => {
                 if file_size > MAX_NOTE_SIZE_BYTES {
                     if existing_note_uids.contains(&n_uid) {
@@ -1410,7 +1427,7 @@ where
         }
 
         // Size guard.
-        if let Ok(Some((_, size))) = reader.file_meta(&rel_path)
+        if let Ok(Some((_, size))) = reader.file_meta_nanos(&rel_path)
             && size > MAX_NOTE_SIZE_BYTES
         {
             skipped.push(SkippedFile {
@@ -1498,7 +1515,7 @@ where
                 ));
             }
         };
-        // `file_meta` is unavailable for bare Git readers. Enforce the note
+        // `file_meta_nanos` is unavailable for bare Git readers. Enforce the note
         // policy again on the returned content so any reader implementation
         // remains policy-correct even when it cannot preflight metadata.
         if source.len() as u64 > MAX_NOTE_SIZE_BYTES {
@@ -3261,7 +3278,7 @@ sub b body
             fn list_files(&self) -> anyhow::Result<Vec<PathBuf>> {
                 Ok(vec![PathBuf::from("notes/test.md")])
             }
-            fn file_meta(&self, _rel_path: &Path) -> anyhow::Result<Option<(u64, u64)>> {
+            fn file_meta_nanos(&self, _rel_path: &Path) -> anyhow::Result<Option<(u64, u64)>> {
                 Ok(None)
             }
             fn root(&self) -> &Path {
@@ -3275,7 +3292,7 @@ sub b body
         let reader = MockBareReader;
         let files = reader.list_files().unwrap();
         assert_eq!(files.len(), 1);
-        let meta = reader.file_meta(&files[0]).unwrap();
+        let meta = reader.file_meta_nanos(&files[0]).unwrap();
         assert!(meta.is_none());
         let content = reader.read_file(&files[0]).unwrap();
         assert!(content.contains("# Test Note"));
@@ -3609,6 +3626,48 @@ sub b body
     /// The incremental (`--since`) refresh path must advance AND persist
     /// the graph generation, so a later process (or the daemon) observes the
     /// bump and distrusts the stale trigram postings.
+    #[test]
+    fn since_threshold_still_matches_a_coarse_granularity_mtime() {
+        // A filesystem whose mtime granularity is coarser than the caller's
+        // clock stamps a write performed AFTER `since` with a value slightly
+        // BEFORE it. On Linux the VFS stamps mtime from a clock updated once
+        // per jiffy, so this is the normal case there, not an exotic one — and
+        // it is invisible on APFS, where mtimes are per-write precise.
+        //
+        // Comparing exact nanoseconds on both sides silently skipped such a
+        // note. Flooring the threshold to the second restores the inclusive
+        // window the seconds-based comparison always had.
+        let (_dir, root) = make_vault(&[("a.md", "# A\n\nalpha body\n")]);
+        let db_path = root.join("brain.lbug");
+        index_markdown_directory(&root, &db_path, "default", "v").unwrap();
+
+        let note = root.join("a.md");
+        fs::write(&note, "# A\n\nbeta body rewritten\n").unwrap();
+
+        // `since` is captured with full precision AFTER the write...
+        let since = std::time::SystemTime::now();
+        // ...and the filesystem reports the write floored to its second, i.e.
+        // BEFORE `since`. Exactly the coarse-granularity case.
+        let coarse = std::time::UNIX_EPOCH
+            + std::time::Duration::from_secs(
+                since
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+            );
+        let handle = fs::OpenOptions::new().write(true).open(&note).unwrap();
+        handle
+            .set_times(fs::FileTimes::new().set_modified(coarse))
+            .unwrap();
+
+        let res = index_markdown_directory_since(&root, &db_path, "default", "v", since).unwrap();
+        assert_eq!(
+            res.notes_updated, 1,
+            "a note written after `since` must not be skipped because the \
+             filesystem reported its mtime at coarser granularity"
+        );
+    }
+
     #[test]
     fn since_refresh_advances_and_persists_generation_on_in_place_edit() {
         let (_dir, root) = make_vault(&[("a.md", "# A\n\nalpha body\n")]);
@@ -3967,8 +4026,8 @@ sub b body
             fn list_files(&self) -> anyhow::Result<Vec<PathBuf>> {
                 self.inner.list_files()
             }
-            fn file_meta(&self, rel_path: &Path) -> anyhow::Result<Option<(u64, u64)>> {
-                self.inner.file_meta(rel_path)
+            fn file_meta_nanos(&self, rel_path: &Path) -> anyhow::Result<Option<(u64, u64)>> {
+                self.inner.file_meta_nanos(rel_path)
             }
             fn root(&self) -> &Path {
                 self.inner.root()

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -460,10 +460,15 @@ fn index_markdown_since_with_reader(
         .map(|note| note.uid.clone())
         .collect::<std::collections::HashSet<_>>();
 
-    let since_secs = since
+    // NANOSECONDS, to match `ContentReader::file_meta` (nw-200). Both sides of
+    // the comparison below must use the same unit; leaving this in seconds
+    // while the reader returns nanoseconds would make every file look newer
+    // than `since` and silently disable the filter entirely.
+    let since_nanos = since
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
-        .as_secs();
+        .as_nanos()
+        .min(u128::from(u64::MAX)) as u64;
 
     let all_files = reader.list_files()?;
 
@@ -495,7 +500,7 @@ fn index_markdown_since_with_reader(
         // Parse changed files now. Unchanged sources are read later only when
         // the affected-source closure shows their outgoing links may change.
         let changed = match reader.file_meta(&rel_path) {
-            Ok(Some((mtime_secs, file_size))) => {
+            Ok(Some((mtime_nanos, file_size))) => {
                 if file_size > MAX_NOTE_SIZE_BYTES {
                     if existing_note_uids.contains(&n_uid) {
                         return Err(anyhow::anyhow!(
@@ -505,7 +510,7 @@ fn index_markdown_since_with_reader(
                     tracing::warn!("skipping oversized file: {}", rel_path_str);
                     continue;
                 }
-                mtime_secs >= since_secs
+                mtime_nanos >= since_nanos
             }
             Ok(None) => true, // bare repo: no mtime, process unconditionally
             Err(error) => {

--- a/crates/nestweaver-engine/src/resolution_cache.rs
+++ b/crates/nestweaver-engine/src/resolution_cache.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 /// Paired with `index::FILEMETA_VERSION`: bumping one requires bumping the
 /// other (both sidecars must be invalidated together), enforced by
 /// `tests::cache_version_moves_with_filemeta_version`.
-const CACHE_VERSION: u32 = 2;
+const CACHE_VERSION: u32 = 3;
 
 /// Maximum number of transitive reverse-dependency hops expanded when deciding
 /// which files to re-resolve after a change. Shared by the local cache-based

--- a/crates/nestweaver-engine/tests/edge_duplication_sidecar.rs
+++ b/crates/nestweaver-engine/tests/edge_duplication_sidecar.rs
@@ -129,7 +129,7 @@ fn sidecar_deleted_with_one_changed_file_keeps_edge_multiplicities() {
     sane_baseline(&baseline);
 
     // Change helper.js without changing its symbol or edge set (comment only).
-    // The sleep guarantees an mtime_secs delta so tiered change detection
+    // The sleep guarantees an mtime delta so tiered change detection
     // cannot skip the file as mtime-identical.
     std::thread::sleep(std::time::Duration::from_millis(1100));
     std::fs::write(

--- a/crates/nestweaver-engine/tests/index_cancellation.rs
+++ b/crates/nestweaver-engine/tests/index_cancellation.rs
@@ -104,8 +104,8 @@ impl ContentReader for CountingReader {
     fn list_files(&self) -> anyhow::Result<Vec<PathBuf>> {
         self.inner.list_files()
     }
-    fn file_meta(&self, rel_path: &Path) -> anyhow::Result<Option<(u64, u64)>> {
-        self.inner.file_meta(rel_path)
+    fn file_meta_nanos(&self, rel_path: &Path) -> anyhow::Result<Option<(u64, u64)>> {
+        self.inner.file_meta_nanos(rel_path)
     }
     fn root(&self) -> &Path {
         self.inner.root()

--- a/crates/nestweaver-engine/tests/remove_repo_sidecar.rs
+++ b/crates/nestweaver-engine/tests/remove_repo_sidecar.rs
@@ -133,7 +133,7 @@ fn slice_drop_is_uid_scoped() {
     a_files.insert(
         "a.js".into(),
         CachedFileMeta {
-            mtime_secs: 1,
+            mtime_nanos: 1,
             size_bytes: 2,
             content_hash: "ha".into(),
         },
@@ -142,7 +142,7 @@ fn slice_drop_is_uid_scoped() {
     b_files.insert(
         "b.js".into(),
         CachedFileMeta {
-            mtime_secs: 3,
+            mtime_nanos: 3,
             size_bytes: 4,
             content_hash: "hb".into(),
         },

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -12064,7 +12064,7 @@ mod cache_dispatch_tests {
         s.repos.entry("repo:t:aaaa".into()).or_default().insert(
             "main.js".into(),
             nestweaver_engine::CachedFileMeta {
-                mtime_secs: 1,
+                mtime_nanos: 1,
                 size_bytes: 1,
                 content_hash: "h".into(),
             },
@@ -12077,7 +12077,7 @@ mod cache_dispatch_tests {
         s.repos.entry("repo:t:bbbb".into()).or_default().insert(
             "main.js".into(),
             nestweaver_engine::CachedFileMeta {
-                mtime_secs: 1,
+                mtime_nanos: 1,
                 size_bytes: 1,
                 content_hash: "h".into(),
             },

--- a/docs/guide/instance-config.md
+++ b/docs/guide/instance-config.md
@@ -257,6 +257,37 @@ nestweaver embed --db "$DB" --local --model-id "$MODEL" --cache-dir "$CACHE" --f
 nestweaver daemon --db "$DB" start --config "$CONFIG"
 ```
 
+#### `[ranking]` — Retrieval ranking policy
+
+```toml
+[ranking]
+track_interactions = false   # default
+enable_prf = false           # default
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `track_interactions` | `false` | Record MCP interaction telemetry to the `<db>.interactions.json` sidecar, which feeds usage-based ranking. Local-only: UIDs and timestamps, no content. The CLI `--track-interactions` / `--no-track-interactions` flags override it per invocation; passing neither inherits this value. |
+| `enable_prf` | `false` | Pseudo-relevance-feedback query expansion on BM25 searches. The CLI `--prf` flag and MCP `prf: true` override per call. |
+| `dampen` / `boost` | — | Path-glob priors on result relevance. |
+| `test_path_patterns` | built-in list | Substrings that deboost test/fixture paths in symbol-name ranking. |
+| `git_activity_weight` | `1.2` | Weight of the git-activity recency rescale on `pagerank_score`. Applies only when a `<db>.gitactivity.json` sidecar exists. |
+
+`track_interactions` lives here rather than existing only as a CLI flag because
+it is a durable per-brain policy, and `nestweaver setup` regenerates every
+`.mcp.json` it manages — so a flag hand-added to a generated config was dropped
+on the next setup run, leaving the feature unreachable through the supported
+install path. Setting it here reaches every generated registration at once.
+
+Note this is not only telemetry: the recorded scores feed PPR personalization,
+so enabling it changes retrieval output. The blend is deliberately capped (an
+exploration floor limits interaction history to a small fraction of the
+personalization mass, with sublinear scoring, time decay, and invalidation on
+content change), but treat it as a ranking change rather than pure logging.
+
+For a generated MCP registration to see any of this, it must be started with
+`--config`. `nestweaver setup` emits that automatically.
+
 #### `[git]`
 
 How to authenticate git operations.
@@ -437,6 +468,58 @@ redefine core properties).
 extra_node_properties = { Symbol = { team_owner = "string", deprecated = "bool" } }
 ```
 
+### Change detection
+
+Indexing skips a file when its cached metadata proves it has not changed. That
+check compares the file's **modification time in nanoseconds** and its **size**;
+only when one of those moves is the file read and content-hashed.
+
+Both parts matter, and neither is redundant:
+
+- **Nanoseconds.** The timestamp used to be truncated to whole seconds, so any
+  edit landing in the same second as the cached value compared equal and the
+  file was classified unchanged. Because the cached value then kept matching, it
+  stayed misclassified on every later index — it never self-healed; only a
+  further mtime change recovered it.
+- **Size.** How much sub-second precision you actually get is platform-
+  dependent. On macOS/APFS it is effectively per-write (measured: 200 rapid
+  writes, 200 distinct stamps). On Linux the VFS stamps mtime from a clock
+  updated once per jiffy, so the granularity there is ~1–10ms depending on
+  `CONFIG_HZ`, not 1ns. On filesystems with no sub-second field at all (HFS+,
+  ext3, FAT, some network mounts) it stays whole seconds. Size is what still
+  catches size-changing edits on every one of those.
+
+What remains uncovered is an edit inside a single timestamp tick that also
+leaves the size byte-for-byte identical — Git's "racily clean" case. Bounding it
+completely requires a per-run index timestamp, the way Git bounds its window by
+the index file's own mtime.
+
+An over-sensitive timestamp is safe here. If a filesystem reports a sub-second
+value that moves when nothing changed, the file falls through to the content
+hash, compares equal, and is reported unchanged — it costs a read, not a wrong
+answer. (This is why Git's caution about `USE_NSEC` on CEPH/CIFS/NTFS/UDF does
+not transfer: there, an erroneous value makes Git report a file dirty.) The
+observed stat is then written back, so the file is not re-hashed on every
+subsequent index.
+
+#### Upgrading
+
+The change-detection sidecar (`<db>.filemeta.json`) is versioned, and the
+nanosecond change moves it to **v3**. A v2 entry stores seconds in the field v3
+reads as nanoseconds, so it is **discarded rather than reinterpreted** —
+reusing it would be indistinguishable from a real edit.
+
+**The first index after upgrading is therefore a full re-index of every existing
+database.** This is a deliberate fail-open: it costs one re-index and can never
+mis-classify a file. `resolution_cache::CACHE_VERSION` is bumped in lockstep for
+the same reason. Embeddings are keyed separately and are **not** invalidated, so
+no re-embed is required.
+
+Integrators implementing `ContentReader` should note the trait method is now
+`file_meta_nanos` and must return nanoseconds. It was renamed because the tuple
+shape did not change: an implementation still returning seconds would otherwise
+compile, write seconds into a valid v3 cache, and silently keep the bug.
+
 ### `[indexing]` (optional)
 
 Source code and Markdown notes have independent size policies. Source files
@@ -465,10 +548,9 @@ instead of relying on the flag being remembered on every run:
 with_trigrams = true
 ```
 
-This applies everywhere sources are indexed — `nestweaver index`, the daemon's
-`IndexRepo`, and its background reindex, which previously never touched
-trigrams at all, so postings went stale as the graph moved and later
-`regex-search` calls silently paid for a full scan.
+`with_trigrams` is the master switch for whether trigram acceleration is
+maintained at all. **It no longer means "refresh during indexing."** Maintenance
+is owned by a reconcile loop in the daemon; see below.
 
 Defaults to `false`, preserving the opt-in storage cost. Precedence for one-off
 runs:
@@ -492,6 +574,45 @@ inherits for the same reason — it has no flags with which to state a policy.
 A refresh failure never fails an otherwise successful index: a stale posting
 table is detected and bypassed at query time, so the cost is a slower
 `regex-search`, not a wrong one.
+
+##### Who refreshes trigrams
+
+The daemon runs a **reconcile loop** that drains pending trigram work on an
+interval. Writers do not refresh; they only enqueue.
+
+```toml
+[indexing]
+with_trigrams = true
+trigram_reconcile_interval = "30s"   # default; "0" disables the loop
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `trigram_reconcile_interval` | `"30s"` | How often the daemon drains pending trigram work. Humanized duration (`"30s"`, `"5m"`); a bare `"0"` disables the loop. Gated on `with_trigrams`. An unparseable value fails config loading rather than silently disabling maintenance. |
+
+This is why the loop exists rather than each writer refreshing. Invalidation was
+already universal and transactional — the store's own write path marks a scope
+dirty inside the mutating transaction, so no caller can forget. What was missing
+was anything that *drained* that queue: the refresh ran only as a side effect of
+two write handlers, so the vault-refresh path and both file watchers enqueued
+work nobody picked up, and their scopes stayed dirty until an unrelated repo
+index happened to run. That is a transactional outbox with no relay, and a
+level-triggered design invoked edge-triggered.
+
+Consequences worth knowing:
+
+- **An index no longer refreshes trigrams implicitly.** Explicit intent still
+  wins: `index --with-trigrams` and `--rebuild-trigrams` refresh inline, which
+  is what CI and scripted reindex want. `--no-trigrams` still forces none.
+- **The direct (`--local` / `--no-daemon`) path still refreshes inline**, because
+  no daemon exists there to drain for it.
+- **The file watchers need no trigram handling at all.** They mutate, the
+  mutation enqueues, the loop drains. Refreshing per watcher batch would run a
+  punishing duty cycle: refresh cost is dominated by fixed overhead (measured
+  ~918ms for 2 changed nodes) while the watcher debounces into ~2s batches.
+- Inspect the current state with `regex-search --json`, which reports
+  `ready_scopes`, `dirty_scopes`, `error_scopes`, `stale_index` and
+  `scanned_fallback`.
 
 ## Manifest Parsing (automatic)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2505,9 +2505,11 @@ enum Commands {
         name: Option<String>,
         #[arg(
             long = "with-trigrams",
-            help = "Refresh trigram postings for changed repo/vault scopes for THIS run, \
-                    whatever the config says. Set `[indexing] with_trigrams = true` to \
-                    enable it permanently (opt-in storage cost)"
+            help = "Refresh trigram postings INLINE for this run, whatever the config \
+                    says. Use it when the index must be current before the command \
+                    returns (CI, scripted reindex). Ongoing maintenance does not need \
+                    it: with `[indexing] with_trigrams = true` the daemon's reconcile \
+                    loop drains pending work every `trigram_reconcile_interval`"
         )]
         with_trigrams: bool,
         #[arg(
@@ -2517,8 +2519,10 @@ enum Commands {
             // --no-trigrams is a contradiction. It used to be accepted and
             // silently no-op, reporting success with no refresh performed.
             conflicts_with = "rebuild_trigrams",
-            help = "Skip the trigram refresh even when `[indexing] with_trigrams = true` \
-                    is set in the config"
+            help = "Skip the inline trigram refresh for this run. An index does not \
+                    refresh implicitly any more — the daemon's reconcile loop owns \
+                    maintenance — so this suppresses an otherwise-requested inline \
+                    refresh, not the loop"
         )]
         no_trigrams: bool,
         #[arg(
@@ -8421,6 +8425,8 @@ fn no_daemon_allowed() -> bool {
 /// "both set" is last-wins rather than an error. The explicit-off branch is
 /// still checked first so that ordering can never resolve to on-by-accident.
 /// `daemon gc` — sweep orphaned daemon runtime state.
+///
+/// `--db` / `NESTWEAVER_DB` are accepted and IGNORED: the sweep is global.
 ///
 /// Deliberately takes NO database path. It sweeps orphaned launch agents and
 /// orphaned per-instance directories under all three roots, sparing live

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1165,7 +1165,8 @@ fn generate_copilot_instructions() -> String {
     - Don't grep indexed repos — use `brain_search`\n\
     - Don't read entire files — use `read_symbols`\n\n\
     ## Interaction Memory\n\n\
-    When the MCP server is started with `--track-interactions`, NestWeaver learns from agent \
+    Set `[ranking] track_interactions = true` in your instance config (or start the MCP \
+    server with `--track-interactions`) and NestWeaver learns from agent \
     query patterns to improve retrieval ranking over time. Opt-in, local-only, records UIDs \
     and timestamps only — no content is captured. Use `interactions status` to view memory stats \
     and `interactions clear` to wipe interaction data.\n",

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -710,6 +710,34 @@ fn flatten_diagnostic(bytes: &[u8]) -> String {
         .join(" ")
 }
 
+/// Drop the semantic-availability note before comparing direct and daemon output.
+///
+/// That note is a DELIBERATE difference between the two paths, not an accident:
+/// the direct path passes no embedding model, so `semantic_applied` is always
+/// false there and the note always prints, while the daemon prints it only when
+/// its own embedding state says semantic retrieval was unavailable. nw-120 added
+/// it precisely so a reader can tell which path produced a ranking.
+///
+/// Asserting byte-equality across that note therefore tests the daemon's
+/// embedding-probe state, not renderer parity. The probe is cached and
+/// time-bounded, so the assertion passed only while the fixture happened to
+/// leave the daemon without semantic too — a flake confirmed on main, not
+/// introduced here.
+///
+/// Strip the note and keep everything else strict: renderer parity is what this
+/// suite is for, and the note has its own coverage below.
+fn strip_semantic_note(bytes: &[u8]) -> String {
+    redact_bundle_ids(bytes)
+        .lines()
+        .filter(|line| {
+            !line
+                .trim_start()
+                .starts_with("note: semantic retrieval unavailable")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Replace generated bundle IDs with a fixed placeholder.
 ///
 /// `investigate` mints a fresh `bndl_<hex>` per invocation, so its stdout is
@@ -752,9 +780,18 @@ fn parity_investigate_human_direct_vs_daemon() {
         "investigate (human): exit code diverged"
     );
     assert_eq!(
-        redact_bundle_ids(&direct.stdout),
-        redact_bundle_ids(&daemon.stdout),
+        strip_semantic_note(&direct.stdout),
+        strip_semantic_note(&daemon.stdout),
         "investigate (human): stdout diverged between direct and daemon mode"
+    );
+
+    // The note itself is still pinned, on the path whose behaviour is
+    // deterministic: the direct path passes no embedding model, so it must
+    // always disclose that the ranking was lexical.
+    let direct_text = String::from_utf8_lossy(&direct.stdout);
+    assert!(
+        direct_text.contains("note: semantic retrieval unavailable"),
+        "the direct path has no embedding model and must say so; got: {direct_text}"
     );
 }
 


### PR DESCRIPTION
Closes nw-200 — the residual half of the change-detection gap — and closes two stability items plus a documentation audit found while validating it.

## The defect

`ContentReader::file_meta` truncated the timestamp with `as_secs()`, discarding precision the filesystem already provides. Any edit landing in the cached second compared equal, so the file was classified `Unchanged` — and because the cached value kept matching, it stayed misclassified on **every later index**. It never self-healed; only a further mtime change recovered it.

6.4.1 fixed the half where the edit **changes the file size**. This closes the rest: a same-second edit that leaves the size byte-for-byte identical — Git's ["racily clean"](https://git-scm.com/docs/racy-git) case.

## How much this actually buys — stated per platform

An earlier revision of this PR claimed "~1s to ~1ns". That is true on APFS and **false on Linux**, and the description was corrected:

| Platform | Ambiguity window |
|---|---|
| macOS / APFS | effectively per-write (measured: 200 rapid writes, 200 distinct stamps, min delta ~33µs) |
| Linux ext4/btrfs/xfs | ~1 jiffy (1–10ms by `CONFIG_HZ`) — the VFS stamps mtime from a clock *"updated every jiffy, so any change that happens within that jiffy will end up with the same timestamp"* ([kernel docs](https://docs.kernel.org/filesystems/multigrain-ts.html)). Multigrain timestamps were reverted before 6.6-rc3 and landed in 6.13. |
| HFS+, ext3, FAT, some network mounts | unchanged — no sub-second field |

**This is why the size comparison stays** in Tier 1. On any platform where the sub-second field is coarse or absent, size is what still catches size-changing edits. Removing it "because we have nanoseconds now" would regress those platforms to the original bug.

## Why Git's caution does not transfer

Git ships `USE_NSEC` **off by default** and its Makefile warns against enabling it on CEPH/CIFS/NTFS/UDF, because some filesystems report a sub-second field that moves when nothing changed.

The difference is the failure mode, not the facts. There, an erroneous value makes Git report a file **dirty**. Here it only routes the file to the Tier 3 content hash, which compares equal and returns `Unchanged` — over-sensitivity costs a read, never a wrong answer. The existing test proving that is now labelled as the fail-safe it is.

## Two review findings, both real

**`--since` could silently MISS files.** Comparing exact nanoseconds on both sides assumed the filesystem stamps mtime at least as precisely as the caller's clock. On Linux it does not, so a note written microseconds *after* `since` could carry an mtime a jiffy *earlier* and be skipped. The seconds version never had this problem, because both sides were truncated identically. The threshold is now floored to the second — a one-sided error that can only over-include. **The cache keeps full nanosecond precision**; only the threshold is coarsened.

This was invisible on macOS and every local test passed. The regression test simulates the coarse case and is mutation-checked.

**External `ContentReader` impls were not forced to migrate.** The tuple `(u64, u64)` was unchanged, so an implementation still returning seconds would compile and write seconds into a valid v3 cache. Renamed `file_meta` → `file_meta_nanos`.

## Two stability fixes

**A moved stat with identical content left the cache stale.** The caller carried the old entry forward, so the cached stat never caught up and the file was re-read and re-hashed on *every* subsequent index — permanently. Routine in practice: a `git checkout` rewriting identical content, a formatter, a `touch`, a jittering mount. `ChangeVerdict::Unchanged` now carries a refreshed stat; only the stat advances, the hash is unchanged. Git does the same.

**`parity_investigate_human_direct_vs_daemon` was flaky.** It asserted byte-equal stdout across a note the product *deliberately* differentiates. Confirmed pre-existing — untouched main failed the identical test on run 4 of 5. The note is stripped before comparison and keeps its own assertion on the deterministic path. Previous failure rate ~1 in 3–5; now 6 consecutive clean runs.

## ⚠ Breaking: one full re-index

The `<db>.filemeta.json` sidecar moves to **v3**, with `resolution_cache::CACHE_VERSION` bumped in lockstep as its pairing test requires. A v2 entry stores **seconds** in the field v3 reads as **nanoseconds**, so it is **discarded rather than reinterpreted** — reusing it would be indistinguishable from a real edit.

**The first index after upgrading is a full re-index for every existing database.** That is the documented fail-open: it costs one re-index and can never mis-classify a file. **Embeddings are keyed separately and are not invalidated.**

## Documentation

The audit found statements left inaccurate by work that already merged, not just by this PR:

- `[indexing] trigram_reconcile_interval` and `[ranking] track_interactions` were **undocumented despite shipping** — there was no `[ranking]` section at all, so the setting was unreachable from the docs, which is the exact problem that item was about.
- The trigram section still claimed indexing refreshes via `IndexRepo`; the README said the same in two rows. Corrected.
- `index --with-trigrams` / `--no-trigrams` help described config-driven index-time refresh. Rewritten.
- `daemon gc --help` now states `--db` is accepted and **ignored**.
- The generated Copilot guidance told agents to start the MCP server with `--track-interactions` — the flag `setup` cannot emit. It now names the config setting first. Verified by generating the artifact.
- New "Change detection" and "Upgrading" sections covering the platform table, the remaining racily-clean case, and the full re-index.

## Verification

`--locked --release --workspace --lib` **3203 passed / 0 failed** on three consecutive runs; daemon_test 52, cli_test 97, ownership 3; parity_test 17 on six consecutive runs. Clippy `-D warnings` and fmt clean.

Every new guard mutation-checked:

| Guard | Mutation | Result |
|---|---|---|
| same-second same-size edit | revert to `as_secs()` | fails |
| v2 sidecar discarded | revert the version bump | fails, showing seconds in a nanoseconds field |
| `--since` coarse granularity | revert the floor | fails with `notes_updated = 0` |
| cached stat refreshed | revert the refresh | fails with "re-hashes on every future index" |
| JSON precision | — | pins that ~1.79e18 (above 2^53) survives exactly |

**Caveat worth stating:** all local validation is macOS. The `--since` bug was invisible here and only reproducible by simulating coarse granularity — CI's Linux jobs are the real test.

## Release note

This re-targets the pending release from 6.4.1 to a major. The release notes should state that the first index after upgrade is a full re-index.
