### PR TITLE
fix(index)!: stop a parseable-to-parseable rename failing the whole incremental index

### DIFF
--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -5208,22 +5208,37 @@ fn incremental_index_with_name_and_io(
                 let from_str = from.to_string_lossy();
                 let to_str = to.to_string_lossy();
 
-                if is_parseable(to) && !path_in_skip_dir(to) {
-                    // Update symbol file_path references.
-                    nestweaver_store::GraphStore::update_symbol_file_paths_on(
-                        &txn, &r_uid, &from_str, &to_str,
-                    )
-                    .with_context(|| {
-                        format!("update_symbol_file_paths {} -> {}", from_str, to_str)
-                    })?;
-                } else {
-                    // Destination is not parseable — just delete the old symbols.
-                    let removed = nestweaver_store::GraphStore::delete_symbols_in_file_on(
-                        &txn, &r_uid, &from_str,
-                    )
-                    .with_context(|| format!("delete_symbols_in_file {}", from_str))?;
-                    result.symbols_removed += removed;
-                }
+                // The old path's symbols are dead in BOTH cases, so delete them
+                // unconditionally rather than branching.
+                //
+                // `symbol_uid` hashes the file path, so a rename re-keys every
+                // symbol in the file — nothing at `from` can survive, whether
+                // or not the destination is parseable. The parseable branch
+                // used to call `update_symbol_file_paths_on` instead, which
+                // carried the rows across by rewriting `file_path` while
+                // KEEPING the old-path-derived UID. Those rows were then
+                // deleted two statements below and re-created from the parse,
+                // so the re-key preserved nothing.
+                //
+                // It was also actively harmful: its per-row CREATE
+                // (`insert_symbol_with_conn_static`) preceded the bulk
+                // `COPY Symbol` of the re-insert in the SAME transaction, and
+                // the copied nodes were then invisible to the following
+                // `COPY FILE_HAS_SYMBOL`:
+                //
+                //   COPY FILE_HAS_SYMBOL: Unable to find primary key value
+                //   sym:<repo>:<hash(after.js)>:<hash(name)>:<line>
+                //
+                // which failed the WHOLE incremental index for any repo where
+                // git reported a rename between parseable paths. DELETE-then-
+                // COPY is fine — the Modified arm has always done exactly that
+                // — so the per-row CREATE is the ingredient that breaks it. Do
+                // not reintroduce one on a table this transaction COPYs into.
+                let removed = nestweaver_store::GraphStore::delete_symbols_in_file_on(
+                    &txn, &r_uid, &from_str,
+                )
+                .with_context(|| format!("delete_symbols_in_file {}", from_str))?;
+                result.symbols_removed += removed;
 
                 // Re-key the File node: delete old, insert new.
                 let old_f_uid = nestweaver_schema::file_uid(&r_uid, &from_str);
@@ -5466,20 +5481,37 @@ where
                 let from_str = from.to_string_lossy();
                 let to_str = to.to_string_lossy();
 
-                if is_parseable(to) && !path_in_skip_dir(to) {
-                    nestweaver_store::GraphStore::update_symbol_file_paths_on(
-                        &txn, &r_uid, &from_str, &to_str,
-                    )
-                    .with_context(|| {
-                        format!("update_symbol_file_paths {} -> {}", from_str, to_str)
-                    })?;
-                } else {
-                    let removed = nestweaver_store::GraphStore::delete_symbols_in_file_on(
-                        &txn, &r_uid, &from_str,
-                    )
-                    .with_context(|| format!("delete_symbols_in_file {}", from_str))?;
-                    result.symbols_removed += removed;
-                }
+                // The old path's symbols are dead in BOTH cases, so delete them
+                // unconditionally rather than branching.
+                //
+                // `symbol_uid` hashes the file path, so a rename re-keys every
+                // symbol in the file — nothing at `from` can survive, whether
+                // or not the destination is parseable. The parseable branch
+                // used to call `update_symbol_file_paths_on` instead, which
+                // carried the rows across by rewriting `file_path` while
+                // KEEPING the old-path-derived UID. Those rows were then
+                // deleted two statements below and re-created from the parse,
+                // so the re-key preserved nothing.
+                //
+                // It was also actively harmful: its per-row CREATE
+                // (`insert_symbol_with_conn_static`) preceded the bulk
+                // `COPY Symbol` of the re-insert in the SAME transaction, and
+                // the copied nodes were then invisible to the following
+                // `COPY FILE_HAS_SYMBOL`:
+                //
+                //   COPY FILE_HAS_SYMBOL: Unable to find primary key value
+                //   sym:<repo>:<hash(after.js)>:<hash(name)>:<line>
+                //
+                // which failed the WHOLE incremental index for any repo where
+                // git reported a rename between parseable paths. DELETE-then-
+                // COPY is fine — the Modified arm has always done exactly that
+                // — so the per-row CREATE is the ingredient that breaks it. Do
+                // not reintroduce one on a table this transaction COPYs into.
+                let removed = nestweaver_store::GraphStore::delete_symbols_in_file_on(
+                    &txn, &r_uid, &from_str,
+                )
+                .with_context(|| format!("delete_symbols_in_file {}", from_str))?;
+                result.symbols_removed += removed;
 
                 let old_f_uid = nestweaver_schema::file_uid(&r_uid, &from_str);
                 nestweaver_store::GraphStore::delete_file_node_on(&txn, &old_f_uid)
@@ -9626,6 +9658,93 @@ function hello(name) { return "Hello " + name; }
         assert!(
             !clusters_path.exists(),
             "node-UID-keyed cluster output must be invalidated after deletion"
+        );
+    }
+
+    /// nw-206. A rename between two parseable paths must not fail the
+    /// incremental index. It used to fail ALL of it, on an ordinary `git mv`:
+    ///
+    ///   batch_insert_file_symbol_edges after.js: query error:
+    ///   COPY FILE_HAS_SYMBOL: Unable to find primary key value sym:…
+    ///
+    /// The rename arms had no test at all, which is how two independent bugs
+    /// shipped behind each other on this path.
+    ///
+    /// Asserts on the resulting GRAPH STATE, not merely that the call returned
+    /// Ok: the first attempt at this fix stopped the error while leaving stale
+    /// symbols at the old path, turning a loud failure into silent bad data.
+    #[test]
+    fn incremental_index_survives_a_rename_between_parseable_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(
+            repo.join("before.js"),
+            "function moved() { return 'moved'; }",
+        )
+        .unwrap();
+
+        let git = |args: &[&str]| -> String {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            String::from_utf8(output.stdout).unwrap().trim().to_string()
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "NestWeaver Test"]);
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "initial"]);
+
+        let repo_url = "https://example.com/nw-206-rename";
+        index_directory(
+            &repo,
+            &db_path,
+            "test",
+            repo_url,
+            &git(&["rev-parse", "HEAD"]),
+        )
+        .unwrap();
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        let old_uid = store
+            .symbols_in_file("before.js")
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+            .uid;
+        drop(store);
+
+        fs::rename(repo.join("before.js"), repo.join("after.js")).unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "rename before.js -> after.js"]);
+
+        incremental_index(&repo, &db_path, "test", repo_url)
+            .expect("a rename between parseable paths must not fail the incremental index");
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        let moved = store.symbols_in_file("after.js").unwrap();
+        assert_eq!(
+            moved.len(),
+            1,
+            "the renamed file's symbol must be present at its new path"
+        );
+        assert_ne!(
+            moved[0].uid, old_uid,
+            "a rename re-keys the symbol, so the new UID must differ from the old"
+        );
+        assert!(
+            store.symbols_in_file("before.js").unwrap().is_empty(),
+            "no symbol may remain at the old path"
         );
     }
 

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -3963,58 +3963,22 @@ impl GraphStore {
         )
     }
 
-    /// Update `file_path` on every Symbol belonging to `repo_uid` that
-    /// currently has `old_path`.  LadybugDB does not support `SET`, so each
-    /// symbol is deleted and re-created with the new path while preserving all
-    /// other fields.
-    pub fn update_symbol_file_paths(
-        &self,
-        repo_uid: &str,
-        old_path: &str,
-        new_path: &str,
-    ) -> Result<(), StoreError> {
-        let conn = self.conn()?;
-        Self::update_symbol_file_paths_on(&conn, repo_uid, old_path, new_path)
-    }
-
-    /// Update symbol file paths using an externally-provided connection (for transaction batching).
-    pub fn update_symbol_file_paths_on(
-        conn: &lbug::Connection<'_>,
-        repo_uid: &str,
-        old_path: &str,
-        new_path: &str,
-    ) -> Result<(), StoreError> {
-        use crate::read::row_to_symbol;
-
-        let rows: Vec<_> = {
-            let r = conn
-                .query(&format!(
-                    "MATCH (s:Symbol) WHERE s.repo_uid = '{}' AND s.file_path = '{}' RETURN \
-                     s.uid, s.name, s.kind, s.repo_uid, s.file_path, s.start_line, \
-                     s.signature, s.summary, s.content_hash, s.pagerank_score",
-                    repo_uid.replace('\'', "''"),
-                    old_path.replace('\'', "''"),
-                ))
-                .map_err(|e| StoreError::Query(format!("query symbols: {e}")))?;
-            r.collect()
-        };
-
-        for row in rows {
-            let mut sym = row_to_symbol(&row)?;
-            let old_uid = sym.uid.clone();
-            sym.file_path = new_path.to_string();
-
-            exec_params(
-                conn,
-                "MATCH (s:Symbol {uid: $uid}) DETACH DELETE s",
-                vec![("uid", lbug::Value::String(old_uid))],
-            )?;
-
-            Self::insert_symbol_with_conn_static(conn, &sym)?;
-        }
-
-        Ok(())
-    }
+    // `update_symbol_file_paths` / `_on` were REMOVED here, not merely orphaned.
+    // They rewrote a Symbol's `file_path` while KEEPING its UID — but
+    // `symbol_uid` hashes the file path, so every row they produced had a UID
+    // that disagreed with its own `file_path`, an inconsistency nothing
+    // downstream expected. Their only callers were the incremental index's two
+    // rename arms, where the rows were deleted two statements later and
+    // re-created from the parse, so they preserved nothing; and their per-row
+    // CREATE poisoned the bulk `COPY Symbol` that followed in the same
+    // transaction, failing the whole incremental index on any parseable rename.
+    // A rename re-keys symbols: delete and re-insert them.
+    //
+    // They also carried a second, independent bug that this removal moots: the
+    // RETURN list omitted `s.end_line` while `row_to_symbol` reads by POSITION,
+    // shifting every column from index 6 on, so the parse hit `signature` where
+    // it expected an Int64 and the function errored for any symbol that had
+    // one. That error is what shielded the COPY failure above from view.
 
     /// Update the `indexed_sha` field of a Repo node.
     pub fn update_repo_sha(&self, repo_uid: &str, new_sha: &str) -> Result<(), StoreError> {


### PR DESCRIPTION
## The bug

`git mv a.js b.js` followed by `nestweaver index` fails the **entire** incremental run:

```
batch_insert_file_symbol_edges after.js: query error:
COPY FILE_HAS_SYMBOL: Query execution failed: Copy exception:
Unable to find primary key value sym:<repo>:<hash(after.js)>:<hash>:<line>
```

An ordinary git operation, so the blast radius is wide. Users experience it as "incremental index broke" with no hint that a rename caused it.

Found while adding rename coverage during an unrelated review. **The rename arms had no test at all**, which is how two independent bugs shipped behind each other here.

## Root cause

Established by instrumenting the transaction rather than by reading it. `update_symbol_file_paths_on` carried a renamed file's symbols across by rewriting `file_path` while **keeping the old-path-derived UID**. Two consequences:

1. **It preserved nothing.** The rows it wrote were deleted two statements later by `delete_symbols_in_file_on(to)` and re-created from the freshly parsed file. The instrumented run shows the delete removing exactly the UIDs the re-key had just written.
2. **It was actively harmful.** Its per-row `CREATE` preceded the bulk `COPY Symbol` of the re-insert in the *same transaction*, after which the copied nodes were invisible to the following `COPY FILE_HAS_SYMBOL`.

`DELETE`-then-`COPY` is fine — the `Modified` arm has always done exactly that — which isolates the per-row `CREATE` as the ingredient that breaks it.

## The fix

`symbol_uid` hashes the file path, so a rename re-keys every symbol and **nothing at the old path can survive**, whether or not the destination is parseable. The branch is therefore gone: the old path's symbols are deleted unconditionally, and a parseable destination additionally deletes and re-inserts there. Simpler than what it replaces.

`update_symbol_file_paths` / `_on` are **removed** rather than left orphaned. Every row they produced had a UID that disagreed with its own `file_path` — dead *and* actively wrong is a removal, not a deprecation.

### A second bug the removal moots

Their `RETURN` list omitted `s.end_line` while `row_to_symbol` reads by **position**, shifting every column from index 6 on — so the parse hit `signature` where it wanted an `Int64` and the function errored for any symbol that had one. That error fires *first* and is what shielded the `COPY` failure from view. Recorded in a comment at the removal site so the history explains why a bug was "fixed" by deletion.

## Testing

`incremental_index_survives_a_rename_between_parseable_paths` asserts on the resulting **graph state**, not merely that the call returned `Ok`.

That distinction earned its keep: a first attempt at this fix removed the re-key outright, which stopped the error while leaving **stale symbols at the old path** — a loud failure traded for silent bad data. Only the state assertion caught it.

Mutation-checked against pristine `main`, where it fails on the column-order error above.

- `cargo test --locked --release --workspace --lib --no-fail-fast` → **3204 passed, 0 failed**
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean

## Breaking change

`GraphStore::update_symbol_file_paths` and `update_symbol_file_paths_on` are removed. A rename re-keys symbols; delete and re-insert them instead.