### PR TITLE
fix(embeddings)!: tombstone deleted nodes so dead vectors stop being scored

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,13 @@ jobs:
       # Scoped to the WORKSPACE, not just the daemon: the class recurred in a
       # second crate precisely because the gate was per-crate. --lib keeps this
       # to unit tests; the ubuntu job still carries integration coverage.
+      # nw-205: --no-fail-fast. Without it a failure in one crate ABORTS the
+      # remaining crates, and the job reports a single non-zero exit that reads
+      # like a verdict on the whole workspace while later crates were never run
+      # at all. That is how a daemon-crate flake hid the store and engine
+      # suites entirely. Every other test job here already passes it.
       - name: Workspace unit tests (macOS portability gate)
-        run: cargo test --locked --release --workspace --lib
+        run: cargo test --locked --release --workspace --lib --no-fail-fast
       # The --lib gate above did not cover INTEGRATION tests, and two of them
       # were failing on macOS the whole time: one #[cfg(target_os = "macos")]
       # test Linux CI can never run, and one gc test that passes on Linux but

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,7 +277,7 @@ nestweaver mcp --track-interactions --db ./nestweaver.lbug    # enable usage tra
 nestweaver interactions status --db ./nestweaver.lbug          # show memory stats
 nestweaver interactions clear --db ./nestweaver.lbug           # wipe interaction data
 
-# MCP server (40 tools, or 6 in lite mode for Cursor)
+# MCP server (41 tools, or 6 in lite mode for Cursor)
 nestweaver mcp --db ./nestweaver.lbug
 nestweaver mcp --lite --db ./nestweaver.lbug                          # 6 core tools only
 nestweaver mcp --tools context,search,symbol --db ./nestweaver.lbug   # allowlist specific tools

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Personalized PageRank with per-edge-type weights (CALLS, IMPORTS, USES, ACCESSES
 </td>
 <td width="50%" valign="top">
 
-**40-Tool MCP Server**<br>
+**41-Tool MCP Server**<br>
 Model Context Protocol tools for AI agents. Drop-in for any MCP client, lite mode for Cursor. Daemon architecture enables concurrent access from multiple AI tools without lock contention.
 
 </td>
@@ -344,7 +344,7 @@ The regex-v3/embedding-v2 upgrade requires this one-time full rebuild. See the
 
 | Command | Description |
 |---------|-------------|
-| `mcp` | Start the MCP server (40 tools, or 6 in lite mode; auto-starts daemon) |
+| `mcp` | Start the MCP server (41 tools, or 6 in lite mode; auto-starts daemon) |
 | `daemon` | Manage the background daemon (`start`, `stop`, `status`, `restart`; `run --server` for server mode) |
 | `connect` | Connect to an upstream NestWeaver server (federated read/impact) |
 | `server` | Server management utilities (`init-tls`, `backup`, `status`) |
@@ -363,6 +363,7 @@ The regex-v3/embedding-v2 upgrade requires this one-time full rebuild. See the
 | `remove-repo` | Remove an indexed repository and all its data (symbols, files, services, contracts) from the graph |
 | `remove-project` | Remove a materialized project and its edges from the graph |
 | `prune-stale` | Remove repos and vaults whose source directories no longer exist on disk |
+| `compact-embeddings` | Reclaim embedding vectors left behind by deleted nodes (`--dry-run`, `--json`); no model load |
 | `list-services` | List all detected services |
 | `service-summary` | Display a summary of a specific service |
 | `admin` | Subagent guidance instructions |
@@ -643,7 +644,7 @@ CLI commands (`search`, `brain search`, `brain context`) also respect this setti
 
 ## MCP Server
 
-NestWeaver exposes 40 tools via the [Model Context Protocol](https://modelcontextprotocol.io), giving any MCP-compatible AI agent structured access to your codebase graph without reading source files directly.
+NestWeaver exposes 41 tools via the [Model Context Protocol](https://modelcontextprotocol.io), giving any MCP-compatible AI agent structured access to your codebase graph without reading source files directly.
 
 ```sh
 nestweaver mcp --db ./nestweaver.lbug
@@ -652,7 +653,7 @@ NESTWEAVER_NO_DAEMON=1 nestweaver mcp --no-daemon --db ./nestweaver.lbug   # rea
 ```
 
 Direct mode advertises 35 read-only tools and rejects mutations before
-dispatch. Daemon-backed stdio exposes all 40 tools. `--tools` names are exact,
+dispatch. Daemon-backed stdio exposes all 41 tools. `--tools` names are exact,
 case-sensitive registry names; unknown, duplicate, empty, or transport-
 unavailable names fail at startup instead of silently producing an empty tool
 surface.
@@ -665,7 +666,7 @@ nestweaver daemon stop --db ./nestweaver.lbug     # stop the daemon manually
 pgrep -af "nestweaver daemon"                     # find running daemons (Linux)
 ```
 
-40 tools including type-aware context retrieval, confidence-weighted impact analysis (`impact_score` shows how strongly changes propagate), investigation bundles, co-change detection, dead code analysis, community detection, and vault/notes integration. Use `--tools` to expose only the tools you need. The `--tools`/`--lite` allowlists are enforced on every transport (local stdio, daemon proxy, hybrid, and MCP-over-HTTP), and tool schemas validate their arguments — numeric bounds (e.g. `token_budget` 1–16000, `depth`/`max_depth` 1–15) are enforced and unknown argument names are rejected instead of silently ignored.
+41 tools including type-aware context retrieval, confidence-weighted impact analysis (`impact_score` shows how strongly changes propagate), investigation bundles, co-change detection, dead code analysis, community detection, and vault/notes integration. Use `--tools` to expose only the tools you need. The `--tools`/`--lite` allowlists are enforced on every transport (local stdio, daemon proxy, hybrid, and MCP-over-HTTP), and tool schemas validate their arguments — numeric bounds (e.g. `token_budget` 1–16000, `depth`/`max_depth` 1–15) are enforced and unknown argument names are rejected instead of silently ignored.
 
 ### Key capabilities
 

--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -1279,6 +1279,24 @@ impl DaemonClient {
         Ok(resp.into_inner())
     }
 
+    /// Reclaim embedding vectors left behind by deleted graph nodes (nw-204).
+    ///
+    /// `dry_run` reports occupancy without writing. Note that a dry run can
+    /// only see what is ALREADY tombstoned; orphans that were never tombstoned
+    /// are discovered by the reconcile a real run performs, so a dry run's
+    /// count is a floor rather than a total.
+    pub async fn compact_embeddings(
+        &mut self,
+        dry_run: bool,
+    ) -> Result<nestweaver_proto::CompactEmbeddingsResponse> {
+        let resp = self
+            .inner
+            .compact_embeddings(nestweaver_proto::CompactEmbeddingsRequest { dry_run })
+            .await
+            .context("compact_embeddings RPC failed")?;
+        Ok(resp.into_inner())
+    }
+
     /// Merge one instance's data into another.
     pub async fn merge_instance(
         &mut self,

--- a/crates/nestweaver-daemon/src/lifecycle.rs
+++ b/crates/nestweaver-daemon/src/lifecycle.rs
@@ -2674,6 +2674,17 @@ mod tests {
             "a cutover to a new slot must not rename the daemon"
         );
 
+        // nw-205: the two `socket_path` calls below each resolve the XDG roots
+        // independently, so a sibling test swapping XDG_STATE_HOME /
+        // XDG_RUNTIME_DIR between them makes the SAME instance id render under
+        // two different roots and this assertion fail — the observed symptom
+        // being `~/.local/state/...` on one side and a test tempdir on the
+        // other. `instance_id_from_db_path` is a pure hash of the path and
+        // needs no lock; only the path rendering reads the environment. Same
+        // defect and same fix as `log_hint_names_the_dated_tracing_file_not_just_stderr`
+        // below: the writers already take ENV_LOCK, this reader did not.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+
         // The same anchoring applies to every derived local-state path.
         assert_eq!(
             socket_path(&instance_id_from_db_path(&after)),

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -714,6 +714,7 @@ fn effective_embedding_state(
 fn embedding_status_proto(
     status: &EmbeddingRuntimeStatus,
     progress: &EmbedProgressSnapshot,
+    occupancy: nestweaver_store::EmbeddingIndexOccupancy,
 ) -> nestweaver_proto::EmbeddingStatus {
     nestweaver_proto::EmbeddingStatus {
         state: effective_embedding_state(status, progress),
@@ -729,12 +730,16 @@ fn embedding_status_proto(
         pass_total: progress.total,
         pass_started_at: progress.started_at,
         pass_scope: progress.scope.clone(),
+        index_live: occupancy.live as u64,
+        index_tombstoned: occupancy.tombstoned as u64,
+        index_stored: occupancy.stored as u64,
     }
 }
 
 fn embedding_status_json(
     status: &EmbeddingRuntimeStatus,
     progress: &EmbedProgressSnapshot,
+    occupancy: nestweaver_store::EmbeddingIndexOccupancy,
 ) -> serde_json::Value {
     serde_json::json!({
         "state": effective_embedding_state(status, progress),
@@ -750,6 +755,9 @@ fn embedding_status_json(
         "pass_total": progress.total,
         "pass_started_at": progress.started_at,
         "pass_scope": progress.scope,
+        "index_live": occupancy.live,
+        "index_tombstoned": occupancy.tombstoned,
+        "index_stored": occupancy.stored,
     })
 }
 
@@ -1416,6 +1424,120 @@ async fn run_trigram_reconciler(state: Arc<DaemonState>, period: Duration) {
         }
     }
     tracing::debug!("trigram reconcile loop stopped");
+}
+
+/// How often the embedding backstop checks for orphaned vectors.
+///
+/// Not configurable and not tied to the trigram interval: this is a safety net,
+/// not a feature. Five minutes is far below any rate at which orphans become a
+/// problem, and each tick is O(1) unless the graph generation actually moved.
+const EMBEDDING_RECONCILE_INTERVAL: Duration = Duration::from_secs(300);
+
+/// nw-204 backstop: reconcile the embedding index against the live graph, and
+/// compact it once enough of it is dead.
+///
+/// The targeted tombstoning on the index and watcher paths is the primary fix
+/// and handles the common case at O(deleted). This exists because that
+/// guarantee is only as good as every delete path remembering to report what it
+/// removed — which is exactly the assumption that failed and produced the
+/// original bug. Level-triggered: it reads current state rather than reacting
+/// to events, so a delete path added later cannot reintroduce the leak, because
+/// there is nothing for it to remember to call. It is also the ONLY thing that
+/// covers Note and Heading vectors, which the targeted path does not.
+///
+/// OWNS ITS OWN LOOP, deliberately. The first cut rode the trigram reconciler
+/// to save a task — but that loop only spawns when `[indexing] with_trigrams`
+/// is on, and that defaults to OFF. The backstop would therefore have been
+/// absent on almost every real daemon while its doc comment claimed a
+/// structural guarantee. A safety net may not depend on an unrelated opt-in.
+async fn run_embedding_reconciler(state: Arc<DaemonState>, period: Duration) {
+    let mut shutdown = state.shutdown_tx.subscribe();
+    let mut tick = tokio::time::interval(period);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut last_generation: Option<u64> = None;
+    let mut consecutive_failures: u32 = 0;
+    let mut backoff_until: Option<Instant> = None;
+
+    loop {
+        tokio::select! {
+            _ = tick.tick() => {}
+            _ = shutdown.changed() => break,
+        }
+        if backoff_until.is_some_and(|until| Instant::now() < until) {
+            continue;
+        }
+
+        // Cheap gates first, before the write gate and before anything O(graph).
+        // The generation advances on every mutating publication, so an unchanged
+        // one proves there is nothing new to reconcile.
+        let generation = state.store.graph_generation();
+        if last_generation == Some(generation) {
+            continue;
+        }
+        // A brain with no vectors at all has nothing to reconcile, and the
+        // liveness scan below is three full-table queries. This check is O(1)
+        // in the base because occupancy reads maintained counts.
+        if state.store.embedding_index_occupancy().stored == 0 {
+            last_generation = Some(generation);
+            continue;
+        }
+
+        let Ok(_admission) = ConnectionGuard::write(&state) else {
+            break;
+        };
+        let lease = state.write_gate.lock("embedding_reconcile").await;
+        let reconcile_state = Arc::clone(&state);
+        let outcome = tokio::task::spawn_blocking(move || {
+            let removed = reconcile_state.store.reconcile_embedding_index()?;
+            // Compaction is deliberately here and NOT in `flush_embedding_index`:
+            // the watcher flushes on every save, and compaction rewrites the
+            // whole base.
+            let compacted = if reconcile_state.store.should_compact_embeddings() {
+                reconcile_state.store.compact_embedding_index()?;
+                true
+            } else {
+                false
+            };
+            Ok::<_, nestweaver_store::StoreError>((removed, compacted))
+        })
+        .await;
+        drop(lease);
+
+        match outcome {
+            Ok(Ok((removed, compacted))) => {
+                consecutive_failures = 0;
+                backoff_until = None;
+                // Only advance the watermark on success, so a failed pass is
+                // retried rather than skipped.
+                last_generation = Some(generation);
+                if removed > 0 || compacted {
+                    tracing::info!(
+                        removed,
+                        compacted,
+                        generation,
+                        "embedding reconcile: reclaimed vectors for deleted nodes"
+                    );
+                }
+            }
+            Ok(Err(error)) => {
+                // Backoff matters more here than for trigrams: a permanent
+                // failure (vectors present but no pipeline-v2 metadata, say)
+                // would otherwise repeat a full graph scan under the write gate
+                // every tick forever, with a warning each time.
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                backoff_until =
+                    Some(Instant::now() + trigram_reconcile_backoff(period, consecutive_failures));
+                tracing::warn!(%error, consecutive_failures, generation, "embedding reconcile failed");
+            }
+            Err(join_error) => {
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                backoff_until =
+                    Some(Instant::now() + trigram_reconcile_backoff(period, consecutive_failures));
+                tracing::error!(%join_error, "embedding reconcile task panicked");
+            }
+        }
+    }
+    tracing::debug!("embedding reconcile loop stopped");
 }
 
 /// The SIGTERM handler task: route every SIGTERM into [`begin_shutdown_drain`].
@@ -5140,6 +5262,90 @@ impl NestWeaverDaemon for DaemonService {
         result.map(Response::new)
     }
 
+    /// nw-204. Reclaim embedding vectors for nodes that no longer exist.
+    ///
+    /// Routed through the daemon like every other write: it takes the same
+    /// admission guard and write gate, so it cannot race an index, a watcher
+    /// batch, or the reconcile loop against a store that is not crash-safe.
+    /// An operator running this on a live brain is exactly when a concurrent
+    /// write is most likely, which is why it is an RPC rather than a
+    /// direct-store command.
+    async fn compact_embeddings(
+        &self,
+        request: Request<CompactEmbeddingsRequest>,
+    ) -> Result<Response<CompactEmbeddingsResponse>, Status> {
+        if let Some(crate::auth::IsAdmin(false)) | None =
+            request.extensions().get::<crate::auth::IsAdmin>()
+        {
+            return Err(Status::permission_denied("admin token required"));
+        }
+        let dry_run = request.into_inner().dry_run;
+        let state = self.state.clone();
+
+        // A dry run writes NOTHING, so it must not take the write gate: doing so
+        // would let a purely informational query block indexing and the watcher,
+        // and be refused outright during a drain. The real run takes the guard
+        // BEFORE the gate, matching every other write RPC — during a drain the
+        // gate is held for as long as the in-flight write runs, so taking it
+        // first would queue this behind a write it is about to be refused after.
+        let _write_scope = if dry_run {
+            None
+        } else {
+            let guard = ConnectionGuard::write(&self.state)?;
+            let lease = self.state.write_gate.lock("compact_embeddings").await;
+            Some((guard, lease))
+        };
+
+        let response = tokio::task::spawn_blocking(move || {
+            let sidecar = nestweaver_engine::sidecar_path(&state.db_path, ".embeddings.bin");
+            let bytes_of = |path: &std::path::Path| {
+                std::fs::metadata(path).map(|meta| meta.len()).unwrap_or(0)
+            };
+
+            let before = state.store.embedding_index_occupancy();
+            let bytes_before = bytes_of(&sidecar);
+
+            if dry_run {
+                return Ok::<_, nestweaver_store::StoreError>(CompactEmbeddingsResponse {
+                    stored_before: before.stored as u64,
+                    tombstoned_before: before.tombstoned as u64,
+                    stored_after: before.stored as u64,
+                    live_after: before.live as u64,
+                    reclaimed: 0,
+                    bytes_before,
+                    bytes_after: bytes_before,
+                    dry_run: true,
+                });
+            }
+
+            // Reconcile FIRST, always. Compaction rewrites the base without
+            // tombstoned rows, so running it alone on a brain whose orphans
+            // were never tombstoned reclaims exactly nothing — which is the
+            // state every pre-fix brain is in.
+            let reclaimed = state.store.reconcile_embedding_index()?;
+            if state.store.embedding_index_occupancy().tombstoned > 0 {
+                state.store.compact_embedding_index()?;
+            }
+
+            let after = state.store.embedding_index_occupancy();
+            Ok(CompactEmbeddingsResponse {
+                stored_before: before.stored as u64,
+                tombstoned_before: before.tombstoned as u64,
+                stored_after: after.stored as u64,
+                live_after: after.live as u64,
+                reclaimed: reclaimed as u64,
+                bytes_before,
+                bytes_after: bytes_of(&sidecar),
+                dry_run: false,
+            })
+        })
+        .await
+        .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?
+        .map_err(|e| Status::internal(format!("compact embeddings failed: {e}")))?;
+
+        Ok(Response::new(response))
+    }
+
     async fn merge_instance(
         &self,
         request: Request<MergeInstanceRequest>,
@@ -5757,6 +5963,7 @@ impl NestWeaverDaemon for DaemonService {
         let embedding_status = embedding_status_proto(
             &self.state.embedding_runtime.status(),
             &self.state.embed_progress.snapshot(),
+            self.state.store.embedding_index_occupancy(),
         );
         let write_queue_depth = self.state.write_gate.waiting() as i32;
         let (write_holder, write_holder_seconds) = self
@@ -5871,8 +6078,11 @@ impl NestWeaverDaemon for DaemonService {
             value["write_holder"] = serde_json::json!(write_holder);
             value["write_holder_seconds"] = serde_json::json!(write_holder_seconds);
             let embedding_status = self.state.embedding_runtime.status();
-            value["embedding_status"] =
-                embedding_status_json(&embedding_status, &self.state.embed_progress.snapshot());
+            value["embedding_status"] = embedding_status_json(
+                &embedding_status,
+                &self.state.embed_progress.snapshot(),
+                self.state.store.embedding_index_occupancy(),
+            );
             // Daemon-side witness counter in the `cache` block (the
             // `hit_rate_pct` session-counter precedent): an adopted client
             // proves the answer came from THIS daemon because the counter
@@ -9678,6 +9888,21 @@ pub async fn run_server(
                 "trigram reconcile loop disabled ([indexing] with_trigrams off, or interval 0)"
             ),
         }
+    }
+
+    // nw-204: the embedding backstop, spawned in EVERY writable daemon mode.
+    // Unlike the trigram reconciler above it is NOT gated on an instance config
+    // or on an opt-in feature flag — orphaned vectors accumulate on any brain
+    // that deletes nodes, which is all of them.
+    if !read_only {
+        tracing::info!(
+            interval_secs = EMBEDDING_RECONCILE_INTERVAL.as_secs(),
+            "embedding reconcile loop enabled"
+        );
+        tokio::spawn(run_embedding_reconciler(
+            Arc::clone(&state),
+            EMBEDDING_RECONCILE_INTERVAL,
+        ));
     }
 
     let uds = tokio::net::UnixListener::bind(&sock_path)
@@ -14801,6 +15026,7 @@ mod startup_helper_tests {
                 "brain_memory_consolidate",
                 "set_extension",
                 "prune_stale",
+                "compact_embeddings",
             ]
         );
         // The daemon's gate is this exact const, not a copy.

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -3315,11 +3315,20 @@ where
         //     from seeing zero symbols while the CPU-heavy service-grouping work
         //     runs between delete and insert.
         let force_reindex = existing_repo.is_some() && files_unchanged == 0;
+        // nw-204: this whole-store re-index path deletes symbols too, and used
+        // to discard the fact entirely. Accumulate what it removed so the
+        // epilogue can tombstone the embeddings of symbols that do not come
+        // back — the same treatment the incremental and watcher paths get.
+        let mut reindex_deleted_uids: Vec<String> = Vec::new();
+        let mut reindex_deleted_files: Vec<String> = Vec::new();
         if !force_reindex && existing_repo.is_some() {
             // Incremental: only delete the specific files we're about to re-insert.
             for file in &all_files {
                 // Remove old symbols belonging to this file.
-                let _ = store.delete_symbols_in_file(&r_uid, &file.path);
+                if let Ok(removed) = store.delete_symbols_in_file(&r_uid, &file.path) {
+                    reindex_deleted_uids.extend(removed);
+                    reindex_deleted_files.push(file.path.clone());
+                }
                 // Remove old File node.
                 let _ = store.delete_file_node(&file.uid);
             }
@@ -3332,7 +3341,10 @@ where
             if let Ok(stored_files) = store.list_files_by_repo(&r_uid) {
                 for (f_uid, path) in &stored_files {
                     if !present_files.contains(path) {
-                        let _ = store.delete_symbols_in_file(&r_uid, path);
+                        if let Ok(removed) = store.delete_symbols_in_file(&r_uid, path) {
+                            reindex_deleted_uids.extend(removed);
+                            reindex_deleted_files.push(path.clone());
+                        }
                         let _ = store.delete_file_node(f_uid);
                         // nw-055 (P1b): a vanished file is a genuine deletion. Count
                         // it so the index-time PageRank guard fires on a delete-only
@@ -3427,6 +3439,19 @@ where
             symbols_written = all_symbols.len(),
             services_written = all_services.len(),
             "phase write complete"
+        );
+
+        // nw-204: the symbols are back in the graph now, so the liveness
+        // difference is meaningful — nearly every UID deleted above has just
+        // been re-inserted unchanged, and only the genuine disappearances
+        // should lose their vectors. Running this before the write would
+        // tombstone the entire repo.
+        tombstone_deleted_symbol_embeddings_after_commit(
+            store,
+            &r_uid,
+            &reindex_deleted_files,
+            &reindex_deleted_uids,
+            "full index over existing store",
         );
         drop(_phase_write_span);
 
@@ -4854,6 +4879,46 @@ pub(crate) fn path_in_skip_dir(path: &Path) -> bool {
     })
 }
 
+/// nw-204: tombstone the embeddings of symbols an index run actually removed.
+///
+/// Every whole-graph delete path already reconciles the embedding index, but
+/// the ordinary index epilogue did not — and that is where most node deletions
+/// happen. An untombstoned vector is not merely wasted disk: the vector scan
+/// filters on the tombstone set, so a missing tombstone means the dead vector
+/// is SCORED and can consume a top-k slot a live result would have held.
+///
+/// Deliberately BEST-EFFORT. The graph mutation is already committed and
+/// durable at this point; failing the whole index over sidecar hygiene would
+/// turn a recoverable degradation into a hard failure. The periodic reconcile
+/// on the daemon is the designed backstop, and `brain_status` reports the
+/// resulting occupancy gap, so a failure here is visible rather than silent.
+pub(crate) fn tombstone_deleted_symbol_embeddings_after_commit(
+    store: &nestweaver_store::GraphStore,
+    repo_uid: &str,
+    touched_files: &[String],
+    deleted_symbol_uids: &[String],
+    operation: &str,
+) {
+    if deleted_symbol_uids.is_empty() {
+        return;
+    }
+    match store.tombstone_deleted_symbol_embeddings(repo_uid, touched_files, deleted_symbol_uids) {
+        Ok(0) => {}
+        Ok(removed) => tracing::info!(
+            removed,
+            candidates = deleted_symbol_uids.len(),
+            operation,
+            "tombstoned embeddings for deleted symbols"
+        ),
+        Err(error) => tracing::warn!(
+            %error,
+            operation,
+            "embedding tombstoning failed; dead vectors stay searchable until the \
+             periodic reconcile repairs it (see `brain status` occupancy)"
+        ),
+    }
+}
+
 /// Result returned by `incremental_index`.
 #[derive(Debug, Default)]
 pub struct IncrementalResult {
@@ -4865,6 +4930,18 @@ pub struct IncrementalResult {
     pub skipped_files: Vec<SkippedFile>,
     pub symbols_added: usize,
     pub symbols_removed: usize,
+    /// UIDs of every Symbol deleted during the run — the RAW delete set, which
+    /// routinely contains UIDs the same run re-inserted unchanged (a modified
+    /// file has its symbols deleted and rewritten). nw-204: the epilogue
+    /// differences this against the post-commit graph to tombstone the
+    /// embeddings of symbols that really did disappear. Never tombstone from
+    /// this list directly.
+    pub deleted_symbol_uids: Vec<String>,
+    /// Every file path `deleted_symbol_uids` came from. Paired with that list
+    /// so the post-commit liveness check can be scoped to exactly what this run
+    /// touched instead of scanning the whole repo — the watcher runs this on
+    /// every save.
+    pub deleted_symbol_files: Vec<String>,
     pub fell_back_to_full: bool,
 }
 
@@ -5171,7 +5248,9 @@ fn incremental_index_with_name_and_io(
                 let removed =
                     nestweaver_store::GraphStore::delete_symbols_in_file_on(&txn, &r_uid, &rel_str)
                         .with_context(|| format!("delete_symbols_in_file {}", rel_str))?;
-                result.symbols_removed += removed;
+                result.symbols_removed += removed.len();
+                result.deleted_symbol_uids.extend(removed);
+                result.deleted_symbol_files.push(rel_str.to_string());
                 match prepared {
                     PreparedIncrementalOutcome::Ready(prepared) => {
                         let outcome = write_prepared_incremental_file_txn(
@@ -5197,7 +5276,9 @@ fn incremental_index_with_name_and_io(
                 let removed =
                     nestweaver_store::GraphStore::delete_symbols_in_file_on(&txn, &r_uid, &rel_str)
                         .with_context(|| format!("delete_symbols_in_file {}", rel_str))?;
-                result.symbols_removed += removed;
+                result.symbols_removed += removed.len();
+                result.deleted_symbol_uids.extend(removed);
+                result.deleted_symbol_files.push(rel_str.to_string());
 
                 let f_uid = nestweaver_schema::file_uid(&r_uid, &rel_str);
                 nestweaver_store::GraphStore::delete_file_node_on(&txn, &f_uid)
@@ -5208,8 +5289,8 @@ fn incremental_index_with_name_and_io(
                 let from_str = from.to_string_lossy();
                 let to_str = to.to_string_lossy();
 
-                // The old path's symbols are dead in BOTH cases, so delete them
-                // unconditionally rather than branching.
+                // nw-206: the old path's symbols are dead in BOTH cases, so
+                // delete them unconditionally rather than branching.
                 //
                 // `symbol_uid` hashes the file path, so a rename re-keys every
                 // symbol in the file — nothing at `from` can survive, whether
@@ -5217,8 +5298,8 @@ fn incremental_index_with_name_and_io(
                 // used to call `update_symbol_file_paths_on` instead, which
                 // carried the rows across by rewriting `file_path` while
                 // KEEPING the old-path-derived UID. Those rows were then
-                // deleted two statements below and re-created from the parse,
-                // so the re-key preserved nothing.
+                // deleted two statements later and re-created from the parse,
+                // so the re-key accomplished nothing.
                 //
                 // It was also actively harmful: its per-row CREATE
                 // (`insert_symbol_with_conn_static`) preceded the bulk
@@ -5232,13 +5313,15 @@ fn incremental_index_with_name_and_io(
                 // which failed the WHOLE incremental index for any repo where
                 // git reported a rename between parseable paths. DELETE-then-
                 // COPY is fine — the Modified arm has always done exactly that
-                // — so the per-row CREATE is the ingredient that breaks it. Do
-                // not reintroduce one on a table this transaction COPYs into.
+                // — so the per-row CREATE is the ingredient that breaks it.
+                // Do not reintroduce one on a table this transaction COPYs into.
                 let removed = nestweaver_store::GraphStore::delete_symbols_in_file_on(
                     &txn, &r_uid, &from_str,
                 )
                 .with_context(|| format!("delete_symbols_in_file {}", from_str))?;
-                result.symbols_removed += removed;
+                result.symbols_removed += removed.len();
+                result.deleted_symbol_uids.extend(removed);
+                result.deleted_symbol_files.push(from_str.to_string());
 
                 // Re-key the File node: delete old, insert new.
                 let old_f_uid = nestweaver_schema::file_uid(&r_uid, &from_str);
@@ -5251,7 +5334,9 @@ fn incremental_index_with_name_and_io(
                         &txn, &r_uid, &to_str,
                     )
                     .with_context(|| "delete_symbols_in_file (rename to)")?;
-                    result.symbols_removed += removed2;
+                    result.symbols_removed += removed2.len();
+                    result.deleted_symbol_uids.extend(removed2);
+                    result.deleted_symbol_files.push(to_str.to_string());
 
                     match prepared_files
                         .get(to_str.as_ref())
@@ -5311,6 +5396,17 @@ fn incremental_index_with_name_and_io(
     if let Err(error) = store.clear_contract_derivation_failed(&r_uid) {
         tracing::warn!("clearing contract derivation marker failed: {error}");
     }
+
+    // AFTER the commit, never before: a modified file has its symbols deleted
+    // and re-inserted under the same UIDs, so the pre-commit graph would report
+    // the whole file as dead and tombstone live vectors.
+    tombstone_deleted_symbol_embeddings_after_commit(
+        &store,
+        &r_uid,
+        &result.deleted_symbol_files,
+        &result.deleted_symbol_uids,
+        "incremental index",
+    );
 
     finalize_committed_index_with_io(
         publication,
@@ -5443,7 +5539,9 @@ where
                 let removed =
                     nestweaver_store::GraphStore::delete_symbols_in_file_on(&txn, &r_uid, &rel_str)
                         .with_context(|| format!("delete_symbols_in_file {}", rel_str))?;
-                result.symbols_removed += removed;
+                result.symbols_removed += removed.len();
+                result.deleted_symbol_uids.extend(removed);
+                result.deleted_symbol_files.push(rel_str.to_string());
 
                 match prepared {
                     PreparedIncrementalOutcome::Ready(prepared) => {
@@ -5470,7 +5568,9 @@ where
                 let removed =
                     nestweaver_store::GraphStore::delete_symbols_in_file_on(&txn, &r_uid, &rel_str)
                         .with_context(|| format!("delete_symbols_in_file {}", rel_str))?;
-                result.symbols_removed += removed;
+                result.symbols_removed += removed.len();
+                result.deleted_symbol_uids.extend(removed);
+                result.deleted_symbol_files.push(rel_str.to_string());
 
                 let f_uid = nestweaver_schema::file_uid(&r_uid, &rel_str);
                 nestweaver_store::GraphStore::delete_file_node_on(&txn, &f_uid)
@@ -5481,8 +5581,8 @@ where
                 let from_str = from.to_string_lossy();
                 let to_str = to.to_string_lossy();
 
-                // The old path's symbols are dead in BOTH cases, so delete them
-                // unconditionally rather than branching.
+                // nw-206: the old path's symbols are dead in BOTH cases, so
+                // delete them unconditionally rather than branching.
                 //
                 // `symbol_uid` hashes the file path, so a rename re-keys every
                 // symbol in the file — nothing at `from` can survive, whether
@@ -5490,8 +5590,8 @@ where
                 // used to call `update_symbol_file_paths_on` instead, which
                 // carried the rows across by rewriting `file_path` while
                 // KEEPING the old-path-derived UID. Those rows were then
-                // deleted two statements below and re-created from the parse,
-                // so the re-key preserved nothing.
+                // deleted two statements later and re-created from the parse,
+                // so the re-key accomplished nothing.
                 //
                 // It was also actively harmful: its per-row CREATE
                 // (`insert_symbol_with_conn_static`) preceded the bulk
@@ -5505,13 +5605,15 @@ where
                 // which failed the WHOLE incremental index for any repo where
                 // git reported a rename between parseable paths. DELETE-then-
                 // COPY is fine — the Modified arm has always done exactly that
-                // — so the per-row CREATE is the ingredient that breaks it. Do
-                // not reintroduce one on a table this transaction COPYs into.
+                // — so the per-row CREATE is the ingredient that breaks it.
+                // Do not reintroduce one on a table this transaction COPYs into.
                 let removed = nestweaver_store::GraphStore::delete_symbols_in_file_on(
                     &txn, &r_uid, &from_str,
                 )
                 .with_context(|| format!("delete_symbols_in_file {}", from_str))?;
-                result.symbols_removed += removed;
+                result.symbols_removed += removed.len();
+                result.deleted_symbol_uids.extend(removed);
+                result.deleted_symbol_files.push(from_str.to_string());
 
                 let old_f_uid = nestweaver_schema::file_uid(&r_uid, &from_str);
                 nestweaver_store::GraphStore::delete_file_node_on(&txn, &old_f_uid)
@@ -5522,7 +5624,9 @@ where
                         &txn, &r_uid, &to_str,
                     )
                     .with_context(|| "delete_symbols_in_file (rename to)")?;
-                    result.symbols_removed += removed2;
+                    result.symbols_removed += removed2.len();
+                    result.deleted_symbol_uids.extend(removed2);
+                    result.deleted_symbol_files.push(to_str.to_string());
 
                     match prepared_files
                         .get(to_str.as_ref())
@@ -5580,6 +5684,15 @@ where
     if let Err(error) = store.clear_contract_derivation_failed(&r_uid) {
         tracing::warn!("clearing contract derivation marker failed: {error}");
     }
+
+    // See the note at the sibling call site: this must follow the commit.
+    tombstone_deleted_symbol_embeddings_after_commit(
+        store,
+        &r_uid,
+        &result.deleted_symbol_files,
+        &result.deleted_symbol_uids,
+        "server incremental index",
+    );
 
     finalize_committed_index_with_io(
         publication,
@@ -9661,18 +9774,129 @@ function hello(name) { return "Hello " + name; }
         );
     }
 
-    /// nw-206. A rename between two parseable paths must not fail the
-    /// incremental index. It used to fail ALL of it, on an ordinary `git mv`:
+    /// nw-204. The acceptance criterion that matters, and the one the original
+    /// backlog item did NOT have: assert on SEARCH RESULTS, not on the vector
+    /// count or the file size. Compaction alone satisfies "the count drops and
+    /// the file shrinks" while leaving the recall bug completely intact —
+    /// dead vectors stay scored, and one outranking a live result silently eats
+    /// a top-k slot.
     ///
-    ///   batch_insert_file_symbol_edges after.js: query error:
-    ///   COPY FILE_HAS_SYMBOL: Unable to find primary key value sym:…
+    /// Drives the INCREMENTAL INDEX path specifically. Repo removal already
+    /// reconciled correctly before this fix; the epilogue for an ordinary
+    /// re-index did not, which is where ~52% of a real brain's index went dead.
+    #[test]
+    fn incremental_index_stops_deleted_symbols_from_being_returned_by_vector_search() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(
+            repo.join("doomed.js"),
+            "function doomed() { return 'doomed'; }",
+        )
+        .unwrap();
+        fs::write(
+            repo.join("survivor.js"),
+            "function survivor() { return 'survivor'; }",
+        )
+        .unwrap();
+
+        let git = |args: &[&str]| -> String {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            String::from_utf8(output.stdout).unwrap().trim().to_string()
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "NestWeaver Test"]);
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "initial"]);
+
+        let repo_url = "https://example.com/nw-204-incremental";
+        index_directory(
+            &repo,
+            &db_path,
+            "test",
+            repo_url,
+            &git(&["rev-parse", "HEAD"]),
+        )
+        .unwrap();
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        let doomed_uid = store
+            .symbols_in_file("doomed.js")
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+            .uid;
+        let survivor_uid = store
+            .symbols_in_file("survivor.js")
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+            .uid;
+        store.set_embedding_metadata("test-model", 2).unwrap();
+        // The doomed vector is the NEAREST neighbour of the probe, so if it is
+        // still scored after deletion it necessarily displaces the survivor.
+        assert!(store.add_embedding(&doomed_uid, vec![1.0, 0.0]));
+        assert!(store.add_embedding(&survivor_uid, vec![0.8, 0.6]));
+        store.flush_embedding_index().unwrap();
+        assert_eq!(
+            store.try_vector_search(&[1.0, 0.0], 1).unwrap()[0].0,
+            doomed_uid,
+            "precondition: the doomed vector must outrank the survivor"
+        );
+        drop(store);
+
+        fs::remove_file(repo.join("doomed.js")).unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "delete doomed.js"]);
+        let result = incremental_index(&repo, &db_path, "test", repo_url).unwrap();
+        assert!(
+            !result.fell_back_to_full,
+            "this must exercise the incremental path, not a full re-index"
+        );
+        assert!(
+            result.symbols_removed > 0,
+            "precondition: the run must have deleted symbols"
+        );
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        // THE assertion. Not "the count dropped" — what a caller actually sees.
+        let hits = store.try_vector_search(&[1.0, 0.0], 2).unwrap();
+        assert!(
+            !hits.iter().any(|(uid, _)| uid == &doomed_uid),
+            "a deleted symbol must not be returned by vector search; got {hits:?}"
+        );
+        assert_eq!(
+            hits.first().map(|(uid, _)| uid.as_str()),
+            Some(survivor_uid.as_str()),
+            "the live symbol must take the top-k slot the dead vector held"
+        );
+        assert!(!store.has_embedding(&doomed_uid));
+        assert!(
+            store.has_embedding(&survivor_uid),
+            "an untouched file's embedding must survive the re-index"
+        );
+    }
+
+    /// nw-206. A parseable-to-parseable rename must not fail the incremental
+    /// index — it used to fail ALL of it, on an ordinary `git mv`.
     ///
-    /// The rename arms had no test at all, which is how two independent bugs
-    /// shipped behind each other on this path.
-    ///
-    /// Asserts on the resulting GRAPH STATE, not merely that the call returned
-    /// Ok: the first attempt at this fix stopped the error while leaving stale
-    /// symbols at the old path, turning a loud failure into silent bad data.
+    /// Also the nw-204 coverage for the rename arm that pushes `to_str` into
+    /// the touched-file set: the destination's re-inserted symbol must KEEP its
+    /// place in the graph while the old path's UID disappears. That arm was
+    /// untestable until the failure below was fixed.
     #[test]
     fn incremental_index_survives_a_rename_between_parseable_paths() {
         let dir = tempfile::tempdir().unwrap();
@@ -9722,12 +9946,20 @@ function hello(name) { return "Hello " + name; }
             .next()
             .unwrap()
             .uid;
+        // nw-204: give the pre-rename symbol a vector, so this also proves the
+        // dead UID stops being scored rather than merely leaving the graph.
+        store.set_embedding_metadata("test-model", 2).unwrap();
+        assert!(store.add_embedding(&old_uid, vec![1.0, 0.0]));
+        store.flush_embedding_index().unwrap();
         drop(store);
 
         fs::rename(repo.join("before.js"), repo.join("after.js")).unwrap();
         git(&["add", "-A"]);
         git(&["commit", "-q", "-m", "rename before.js -> after.js"]);
 
+        // THE assertion: this used to return
+        // `batch_insert_file_symbol_edges after.js: … Unable to find primary
+        // key value sym:…`, taking the entire incremental run with it.
         incremental_index(&repo, &db_path, "test", repo_url)
             .expect("a rename between parseable paths must not fail the incremental index");
 
@@ -9740,11 +9972,202 @@ function hello(name) { return "Hello " + name; }
         );
         assert_ne!(
             moved[0].uid, old_uid,
-            "a rename re-keys the symbol, so the new UID must differ from the old"
+            "a rename re-keys the symbol, so the new UID must differ"
         );
         assert!(
             store.symbols_in_file("before.js").unwrap().is_empty(),
             "no symbol may remain at the old path"
+        );
+        assert!(
+            !store.has_embedding(&old_uid),
+            "the pre-rename UID is dead and its vector must not survive"
+        );
+    }
+
+    /// nw-204. Covers the rename arm that deletes without re-inserting: when a
+    /// file is renamed to a NON-parseable path, its symbols are dropped for
+    /// good, so their vectors must stop being scored. This is the arm that
+    /// pushes `from_str` into the touched-file set.
+    ///
+    /// The sibling arm — a parseable-to-parseable rename, which pushes `to_str`
+    /// — is covered by `incremental_index_survives_a_rename_between_parseable_paths`
+    /// above, which was only possible once nw-206 was fixed.
+    #[test]
+    fn incremental_index_tombstones_symbols_a_rename_drops_for_good() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(
+            repo.join("doomed.js"),
+            "function doomed() { return 'doomed'; }",
+        )
+        .unwrap();
+        fs::write(
+            repo.join("anchor.js"),
+            "function anchor() { return 'anchor'; }",
+        )
+        .unwrap();
+
+        let git = |args: &[&str]| -> String {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            String::from_utf8(output.stdout).unwrap().trim().to_string()
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "NestWeaver Test"]);
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "initial"]);
+
+        let repo_url = "https://example.com/nw-204-rename-drop";
+        index_directory(
+            &repo,
+            &db_path,
+            "test",
+            repo_url,
+            &git(&["rev-parse", "HEAD"]),
+        )
+        .unwrap();
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        let doomed_uid = store
+            .symbols_in_file("doomed.js")
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+            .uid;
+        let anchor_uid = store
+            .symbols_in_file("anchor.js")
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+            .uid;
+        store.set_embedding_metadata("test-model", 2).unwrap();
+        // The doomed vector is the probe's nearest neighbour, so a regression
+        // necessarily displaces the survivor rather than merely lingering.
+        assert!(store.add_embedding(&doomed_uid, vec![1.0, 0.0]));
+        assert!(store.add_embedding(&anchor_uid, vec![0.8, 0.6]));
+        store.flush_embedding_index().unwrap();
+        assert_eq!(
+            store.try_vector_search(&[1.0, 0.0], 1).unwrap()[0].0,
+            doomed_uid,
+            "precondition: the doomed vector must outrank the survivor"
+        );
+        drop(store);
+
+        // Rename to a non-parseable extension: the symbols are gone for good.
+        fs::rename(repo.join("doomed.js"), repo.join("doomed.txt")).unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "rename doomed.js -> doomed.txt"]);
+        incremental_index(&repo, &db_path, "test", repo_url).unwrap();
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        let hits = store.try_vector_search(&[1.0, 0.0], 2).unwrap();
+        assert!(
+            !hits.iter().any(|(uid, _)| uid == &doomed_uid),
+            "a symbol dropped by a rename must not be returned by vector search; got {hits:?}"
+        );
+        assert_eq!(
+            hits.first().map(|(uid, _)| uid.as_str()),
+            Some(anchor_uid.as_str()),
+            "the live symbol must take the top-k slot the dead vector held"
+        );
+        assert!(
+            store.has_embedding(&anchor_uid),
+            "a rename elsewhere must not disturb an untouched file's embedding"
+        );
+    }
+
+    /// nw-204 regression guard. A modified file has ALL its symbols deleted and
+    /// then re-inserted under the same UIDs, so tombstoning the raw delete list
+    /// would drop live vectors — a far worse bug than the orphans being fixed.
+    /// This is the test that fails if the liveness difference is ever removed.
+    #[test]
+    fn incremental_index_keeps_embeddings_for_symbols_a_modified_file_reinserts() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(
+            repo.join("stable.js"),
+            "function kept() { return 1; }\nfunction doomed() { return 2; }\n",
+        )
+        .unwrap();
+
+        let git = |args: &[&str]| -> String {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            String::from_utf8(output.stdout).unwrap().trim().to_string()
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "NestWeaver Test"]);
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "initial"]);
+
+        let repo_url = "https://example.com/nw-204-reinsert";
+        index_directory(
+            &repo,
+            &db_path,
+            "test",
+            repo_url,
+            &git(&["rev-parse", "HEAD"]),
+        )
+        .unwrap();
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        let symbols = store.symbols_in_file("stable.js").unwrap();
+        let kept_uid = symbols
+            .iter()
+            .find(|s| s.name == "kept")
+            .expect("kept symbol")
+            .uid
+            .clone();
+        store.set_embedding_metadata("test-model", 2).unwrap();
+        assert!(store.add_embedding(&kept_uid, vec![1.0, 0.0]));
+        store.flush_embedding_index().unwrap();
+        drop(store);
+
+        // Remove only `doomed`, leaving `kept` byte-identical. The re-index
+        // deletes both symbols and re-inserts `kept` under its original UID.
+        fs::write(repo.join("stable.js"), "function kept() { return 1; }\n").unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "drop doomed"]);
+        let result = incremental_index(&repo, &db_path, "test", repo_url).unwrap();
+        assert!(
+            result.deleted_symbol_uids.contains(&kept_uid),
+            "precondition: the raw delete list must include the re-inserted symbol, \
+             otherwise this test is not exercising the liveness filter"
+        );
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        assert!(
+            store.has_embedding(&kept_uid),
+            "a symbol the same run re-inserted must keep its embedding"
+        );
+        assert_eq!(
+            store.try_vector_search(&[1.0, 0.0], 1).unwrap()[0].0,
+            kept_uid,
+            "the surviving symbol must still be reachable by vector search"
         );
     }
 

--- a/crates/nestweaver-engine/src/watch_code.rs
+++ b/crates/nestweaver-engine/src/watch_code.rs
@@ -601,29 +601,38 @@ impl CodeWatcher {
         }
 
         let mut files_processed = 0usize;
+        // nw-204: every symbol UID this batch removes, so the epilogue can
+        // tombstone the ones that do not come back. Both arms delete — a
+        // Replace deletes the file's symbols before re-inserting them.
+        let mut deleted_symbol_uids: Vec<String> = Vec::new();
+        let mut deleted_symbol_files: Vec<String> = Vec::new();
         for prepared_path in &prepared_paths {
             match prepared_path {
                 PreparedPath::Replace(prepared) => {
-                    let symbols = apply_prepared_code_file(&txn, r_uid, prepared)
+                    let (symbols, removed) = apply_prepared_code_file(&txn, r_uid, prepared)
                         .with_context(|| format!("apply watched file {}", prepared.rel_path))?;
+                    deleted_symbol_uids.extend(removed);
+                    deleted_symbol_files.push(prepared.rel_path.clone());
                     tracing::debug!(path = %prepared.rel_path, symbols, "re-indexed file");
                     files_processed += 1;
                 }
                 PreparedPath::Delete { rel_path } => {
-                    let removed_count = nestweaver_store::GraphStore::delete_symbols_in_file_on(
+                    let removed = nestweaver_store::GraphStore::delete_symbols_in_file_on(
                         &txn, r_uid, rel_path,
                     )
                     .with_context(|| format!("delete symbols for removed file {rel_path}"))?;
                     let f_uid = nestweaver_schema::file_uid(r_uid, rel_path);
                     nestweaver_store::GraphStore::delete_file_node_on(&txn, &f_uid)
                         .with_context(|| format!("delete removed File node {rel_path}"))?;
-                    if removed_count > 0 {
+                    if !removed.is_empty() {
                         tracing::debug!(
                             path = %rel_path,
-                            removed = removed_count,
+                            removed = removed.len(),
                             "deleted symbols for removed file"
                         );
                     }
+                    deleted_symbol_uids.extend(removed);
+                    deleted_symbol_files.push(rel_path.clone());
                     files_processed += 1;
                 }
             }
@@ -665,6 +674,15 @@ impl CodeWatcher {
         if let Err(error) = store.clear_contract_derivation_failed(r_uid) {
             tracing::warn!("clearing watcher contract derivation marker failed: {error}");
         }
+        // After the commit: a Replace deletes and re-inserts the same UIDs, so
+        // the pre-commit graph would report a whole saved file as dead.
+        crate::index::tombstone_deleted_symbol_embeddings_after_commit(
+            store,
+            r_uid,
+            &deleted_symbol_files,
+            &deleted_symbol_uids,
+            "code watcher batch",
+        );
         self.finalize_graph_publication_with_io(publication, epilogue_io)
             .map_err(anyhow::Error::from)?;
         Ok(WatchBatchOutcome::Published { files_processed })
@@ -915,12 +933,22 @@ fn prepare_code_file(
     })
 }
 
+/// Apply one prepared file, returning `(symbols_inserted, deleted_symbol_uids)`.
+///
+/// nw-204: the delete list matters as much as the insert count here. This is
+/// the watcher's per-save path, so it is the single most frequent producer of
+/// orphaned embedding vectors in a long-lived brain — every save that removes
+/// or renames a symbol leaves one behind. The list is RAW (a re-index rewrites
+/// most symbols under their original UIDs); the post-commit liveness filter in
+/// `GraphStore::tombstone_deleted_symbol_embeddings` decides what is actually
+/// dead.
 fn apply_prepared_code_file(
     txn: &nestweaver_store::DbConnection<'_>,
     r_uid: &str,
     prepared: &PreparedCodeFile,
-) -> Result<usize, anyhow::Error> {
-    nestweaver_store::GraphStore::delete_symbols_in_file_on(txn, r_uid, &prepared.rel_path)?;
+) -> Result<(usize, Vec<String>), anyhow::Error> {
+    let deleted_symbol_uids =
+        nestweaver_store::GraphStore::delete_symbols_in_file_on(txn, r_uid, &prepared.rel_path)?;
     let old_file_uid = nestweaver_schema::file_uid(r_uid, &prepared.rel_path);
     nestweaver_store::GraphStore::delete_file_node_on(txn, &old_file_uid)?;
     nestweaver_store::GraphStore::insert_file_on(txn, &prepared.file)?;
@@ -935,7 +963,7 @@ fn apply_prepared_code_file(
     if !prepared.resolved_edges.is_empty() {
         nestweaver_store::GraphStore::batch_insert_edges_on(txn, &prepared.resolved_edges)?;
     }
-    Ok(prepared.symbols.len())
+    Ok((prepared.symbols.len(), deleted_symbol_uids))
 }
 
 fn reject_recovered_publication(

--- a/crates/nestweaver-mcp/src/http.rs
+++ b/crates/nestweaver-mcp/src/http.rs
@@ -42,6 +42,9 @@ pub const MUTATING_TOOLS: &[&str] = &[
     "brain_memory_consolidate",
     "set_extension",
     "prune_stale",
+    // Rewrites the embedding artifact through the daemon's write gate. A
+    // read-only endpoint must neither advertise nor dispatch it.
+    "compact_embeddings",
 ];
 
 const SERVER_NAME: &str = "nestweaver-brain";
@@ -1222,6 +1225,7 @@ mod tests {
                 "brain_memory_consolidate",
                 "set_extension",
                 "prune_stale",
+                "compact_embeddings",
             ]
         );
         let unique: std::collections::HashSet<_> = MUTATING_TOOLS.iter().collect();
@@ -1269,6 +1273,7 @@ mod tests {
                 "value": true,
             }),
             "prune_stale" => json!({}),
+            "compact_embeddings" => json!({ "dry_run": true }),
             other => panic!("missing schema-valid mutating fixture for {other}"),
         }
     }

--- a/crates/nestweaver-mcp/src/lib.rs
+++ b/crates/nestweaver-mcp/src/lib.rs
@@ -933,7 +933,7 @@ mod tests {
                 ] {
                     assert!(names.contains(&expected), "missing tool: {expected}");
                 }
-                assert_eq!(tools.len(), 40, "expected 40 tools, got {}", tools.len());
+                assert_eq!(tools.len(), 41, "expected 41 tools, got {}", tools.len());
                 // Every tool has a description leading with usage guidance.
                 for tool in tools {
                     let desc = tool["description"].as_str().expect("description");

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -159,6 +159,7 @@ fn all_tool_schemas() -> Vec<Value> {
         tool_schema_brain_add_source(),
         tool_schema_brain_remove_source(),
         tool_schema_prune_stale(),
+        tool_schema_compact_embeddings(),
         tool_schema_cross_repo_contracts(),
         tool_schema_brain_impact(),
         tool_schema_brain_guide(),
@@ -489,7 +490,7 @@ mod tool_schema_validation_tests {
     }
 
     #[test]
-    fn registry_contains_exactly_the_40_advertised_unique_names() {
+    fn registry_contains_exactly_the_41_advertised_unique_names() {
         let expected: BTreeSet<&str> = [
             "affected_tests",
             "backlinks",
@@ -512,6 +513,7 @@ mod tool_schema_validation_tests {
             "brain_topic_clusters",
             "bridge_nodes",
             "clusters",
+            "compact_embeddings",
             "contract_drift",
             "count_patterns",
             "cross_repo_contracts",
@@ -538,8 +540,8 @@ mod tool_schema_validation_tests {
         let schemas = all_tool_schemas();
         assert_eq!(
             schemas.len(),
-            40,
-            "registry must contain exactly 40 schemas"
+            41,
+            "registry must contain exactly 41 schemas"
         );
         let names: BTreeSet<&str> = schemas
             .iter()
@@ -1261,6 +1263,7 @@ pub fn tool_doc_entries() -> Vec<(String, String, String, Vec<String>)> {
         ("brain_add_source", "Status & maintenance"),
         ("brain_remove_source", "Status & maintenance"),
         ("prune_stale", "Status & maintenance"),
+        ("compact_embeddings", "Status & maintenance"),
         ("get_summary", "Status & maintenance"),
         ("read_symbols", "Code search"),
         ("regex_search", "Code search"),
@@ -1526,6 +1529,7 @@ fn dispatch_uncached(
         "brain_add_source" => tool_brain_add_source(store, args),
         "brain_remove_source" => tool_brain_remove_source(store, args),
         "prune_stale" => tool_prune_stale(store),
+        "compact_embeddings" => tool_compact_embeddings(store, args),
         "cross_repo_contracts" => tool_cross_repo_contracts(store, args),
         "brain_impact" => tool_brain_impact(store, args, cancel, visible),
         "brain_guide" => tool_brain_guide(store, args),
@@ -6390,6 +6394,65 @@ fn tool_prune_stale(store: &GraphStore) -> Result<Value, anyhow::Error> {
     {
         let _ = store;
         Err(anyhow!("prune_stale requires daemon mode"))
+    }
+}
+
+// ── 6d. compact_embeddings ──────────────────────────────────────────────────
+
+fn tool_schema_compact_embeddings() -> Value {
+    json!({
+        "name": "compact_embeddings",
+        "description": "Reclaim embedding vectors left behind by deleted graph nodes, then rewrite the sidecar without them. Does NOT load the embedding model and does NOT re-embed anything.\n\nGuidelines:\n- Two reasons to run it. Disk is the obvious one. The other is result quality: the vector scan skips tombstoned rows, so a dead vector that was never tombstoned is still SCORED, and one outranking a live result silently consumes a top-k slot in semantic search.\n- Ongoing tombstoning is automatic. Use this on a brain that accumulated orphans before that existed, or to force the reclaim rather than waiting for the ratio threshold.\n- Check `brain_status` first: its `index_tombstoned` / `index_stored` fields show whether there is anything to reclaim.\n\nReading the response:\n- `reclaimed` is the number of dead vectors removed; `stored_before` / `stored_after` and `bytes_before` / `bytes_after` bracket the change.\n- `dry_run: true` reports only what is ALREADY tombstoned. Orphans that were never tombstoned are invisible to a dry run and are found by the reconcile a real run performs, so a dry run is a FLOOR, not a total.\n\nLimitations:\n- Requires daemon mode: it is a write, and rewriting the artifact outside the daemon's write gate can race an index or watcher batch.\n- Reclaims nothing on a brain with no deletions, which is the correct outcome, not a failure.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "dry_run": {
+                    "type": "boolean",
+                    "description": "Report occupancy without writing anything. Defaults to false.",
+                    "default": false
+                }
+            },
+            "required": [],
+            "additionalProperties": false
+        }
+    })
+}
+
+fn tool_compact_embeddings(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error> {
+    #[cfg(feature = "daemon")]
+    {
+        let dry_run = args
+            .get("dry_run")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        let db_path = current_db_path(store)?;
+        let db_path_buf = std::path::PathBuf::from(&db_path);
+        let rt = tokio::runtime::Runtime::new()
+            .map_err(|e| anyhow::anyhow!("failed to create tokio runtime: {e}"))?;
+        let sock_path = inline_ensure_daemon(&db_path_buf)
+            .map_err(|e| anyhow::anyhow!("failed to start daemon: {e}"))?;
+        let mut client = rt.block_on(inline_connect_daemon(&sock_path))?;
+        let resp = rt
+            .block_on(
+                client.compact_embeddings(nestweaver_proto::CompactEmbeddingsRequest { dry_run }),
+            )
+            .map_err(|e| anyhow!("compact_embeddings RPC failed: {e}"))?;
+        let inner = resp.into_inner();
+        Ok(json!({
+            "dry_run": inner.dry_run,
+            "reclaimed": inner.reclaimed,
+            "live": inner.live_after,
+            "stored_before": inner.stored_before,
+            "stored_after": inner.stored_after,
+            "tombstoned_before": inner.tombstoned_before,
+            "bytes_before": inner.bytes_before,
+            "bytes_after": inner.bytes_after
+        }))
+    }
+    #[cfg(not(feature = "daemon"))]
+    {
+        let _ = (store, args);
+        Err(anyhow!("compact_embeddings requires daemon mode"))
     }
 }
 

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -7,6 +7,39 @@ use std::sync::{Arc, Condvar, Mutex};
 use crate::error::StoreError;
 use crate::ranking::QueryIntent;
 
+/// Dead fraction at which the embedding base is worth rewriting. 20% matches
+/// the threshold shape used by segment-merge reclaim in Lucene and by Milvus's
+/// automatic compaction.
+const EMBEDDING_COMPACT_TOMBSTONE_RATIO: f64 = 0.20;
+
+/// Absolute floor for ratio-triggered compaction. Below this the ratio is noisy
+/// and the reclaim is not worth a rewrite.
+const EMBEDDING_COMPACT_MIN_TOMBSTONES: usize = 1_000;
+
+/// Occupancy of the embedding sidecar: what a query can match, what is
+/// tombstoned but still on disk, and what the base physically stores.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EmbeddingIndexOccupancy {
+    /// Vectors a query can actually match.
+    pub live: usize,
+    /// Base rows hidden by tombstones — reclaimable by compaction.
+    pub tombstoned: usize,
+    /// `live + tombstoned`: what the artifact physically holds.
+    pub stored: usize,
+}
+
+impl EmbeddingIndexOccupancy {
+    /// Fraction of stored vectors that are dead, in `0.0..=1.0`. Zero for an
+    /// empty index — an index with nothing in it is not "100% dead", and
+    /// reporting it that way would trip every ratio threshold on a fresh brain.
+    pub fn tombstone_ratio(&self) -> f64 {
+        if self.stored == 0 {
+            return 0.0;
+        }
+        self.tombstoned as f64 / self.stored as f64
+    }
+}
+
 /// Typed results for the two durable embedding reconciliation sub-stages.
 /// Legacy retirement is not attempted until canonical persistence succeeds.
 #[derive(Debug)]
@@ -1836,7 +1869,13 @@ impl GraphStore {
             .embedding_index
             .lock()
             .unwrap_or_else(|error| error.into_inner());
-        if index.is_empty() {
+        // NOT `is_empty()`, which is `len() == 0` and counts only LIVE vectors.
+        // An index whose rows are ALL tombstoned reports itself empty, so the
+        // old guard returned early on the MAXIMUM-reclaim case and left every
+        // dead row on disk permanently — a brain that removed all its repos
+        // could never reclaim its sidecar. Compaction has work whenever there
+        // is anything to write or anything to drop.
+        if index.is_empty() && index.tombstoned_len() == 0 {
             return Ok(());
         }
         let Some(path) = self.embedding_sidecar_path() else {
@@ -1950,6 +1989,126 @@ impl GraphStore {
             _guard: idx,
         })
     }
+    /// Tombstone embeddings for symbols an index run deleted from one repo,
+    /// and persist the result.
+    ///
+    /// This is the targeted counterpart to [`reconcile_embedding_index`], and
+    /// the fix for nw-204: every whole-graph delete path (repo removal, prune,
+    /// purge, merge, vault removal) already reconciles, but the ordinary
+    /// index-publication epilogue did not — and that is where the vast
+    /// majority of node deletions actually happen (a file deleted, a file
+    /// re-parsed into fewer symbols, a scope or size-cap change). Untombstoned
+    /// vectors are not merely wasted disk: `vector_search_cancellable` filters
+    /// on `deleted_base_uids`, so a UID missing from that set is SCORED, and a
+    /// dead vector outranking a live one silently consumes a top-k slot.
+    ///
+    /// `deleted_uids` is the raw delete list, which is deliberately allowed to
+    /// contain UIDs that are still live: an incremental re-index deletes a
+    /// file's symbols and re-inserts most of them under the same UIDs. This
+    /// function re-reads the live symbols of `touched_files` from the
+    /// POST-COMMIT graph and tombstones only the difference, so callers cannot
+    /// cause live vectors to be dropped by passing the delete list verbatim.
+    /// Call it AFTER the index transaction commits; calling it mid-transaction
+    /// would see the deletions but not the re-inserts and would tombstone the
+    /// whole file.
+    ///
+    /// `touched_files` MUST cover every file `deleted_uids` came from, or a
+    /// still-live symbol in an unlisted file would be read as dead. Scoping to
+    /// those files rather than the whole repo is what keeps this affordable on
+    /// the watcher's per-save path; see `symbol_uids_for_files`.
+    ///
+    /// Returns the number of vectors removed.
+    ///
+    /// [`reconcile_embedding_index`]: Self::reconcile_embedding_index
+    pub fn tombstone_deleted_symbol_embeddings(
+        &self,
+        repo_uid: &str,
+        touched_files: &[String],
+        deleted_uids: &[String],
+    ) -> Result<usize, StoreError> {
+        if deleted_uids.is_empty() {
+            return Ok(0);
+        }
+        let live = self.symbol_uids_for_files(repo_uid, touched_files)?;
+        let dead: Vec<String> = deleted_uids
+            .iter()
+            .filter(|uid| !live.contains(uid.as_str()))
+            .cloned()
+            .collect();
+        if dead.is_empty() {
+            return Ok(0);
+        }
+        let removed = {
+            let mut idx = self
+                .embedding_index
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            idx.tombstone_uids(&dead)
+        };
+        // Nothing was actually held for those UIDs (deleted before an embed
+        // pass ever reached them, or already tombstoned). Flushing would
+        // rewrite the sidecar for no change, so leave the artifact and its
+        // journal untouched. This is also what keeps the common watcher save —
+        // a file whose symbols were never embedded — off the disk entirely.
+        if removed == 0 {
+            return Ok(0);
+        }
+        self.flush_embedding_index()?;
+        Ok(removed)
+    }
+
+    /// Whether the embedding sidecar carries enough dead weight to be worth
+    /// rewriting.
+    ///
+    /// Ratio-triggered, matching the Lucene/Elasticsearch and Milvus shape:
+    /// reclaim on deleted-fraction rather than on ceremony or a manual command,
+    /// because the cost of carrying tombstones grows monotonically and nobody
+    /// runs hygiene commands on a schedule.
+    ///
+    /// DELIBERATELY NOT CONSULTED BY `flush_embedding_index`. The per-save
+    /// watcher path flushes, and compaction rewrites the entire base — on a
+    /// real brain that is over a gigabyte. Firing THIS trigger from a flush
+    /// would put a multi-hundred-millisecond rewrite inside a file save. The
+    /// daemon's reconcile loop is the intended caller: writers enqueue, the
+    /// relay drains.
+    ///
+    /// PRECISION, because the weaker claim is the true one: this removes the
+    /// RATIO trigger from the save path, not every rewrite. `flush_embedding_index`
+    /// still compacts when the JOURNAL crosses its size/record threshold, and
+    /// that can now be reached by tombstone deltas as well as upserts. That
+    /// trigger is what bounds journal growth, so removing it would trade a
+    /// bounded latency spike for an unbounded file — a worse deal. The
+    /// worst case on a save is therefore one base rewrite per ~10k journal
+    /// records, not one per threshold-crossing delete.
+    ///
+    /// The absolute floor keeps a nearly-empty index from rewriting itself
+    /// over a handful of vectors, where the ratio is noisy and the reclaim is
+    /// worth nothing.
+    pub fn should_compact_embeddings(&self) -> bool {
+        let occupancy = self.embedding_index_occupancy();
+        occupancy.tombstoned >= EMBEDDING_COMPACT_MIN_TOMBSTONES
+            && occupancy.tombstone_ratio() >= EMBEDDING_COMPACT_TOMBSTONE_RATIO
+    }
+
+    /// Live, tombstoned, and stored vector counts for the embedding sidecar.
+    ///
+    /// `stored` is what the base file physically holds, `live` is what a query
+    /// can actually match, and `tombstoned` is the reclaimable difference.
+    /// Surfacing all three is deliberate: a 52%-dead index reported itself as
+    /// "ready" for weeks because status had no way to express the gap.
+    pub fn embedding_index_occupancy(&self) -> EmbeddingIndexOccupancy {
+        let idx = self
+            .embedding_index
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let (live, tombstoned, stored) = idx.occupancy();
+        EmbeddingIndexOccupancy {
+            live,
+            tombstoned,
+            stored,
+        }
+    }
+
     /// Remove embeddings for graph nodes that no longer exist, update the
     /// live index, and persist the repaired binary sidecar.
     ///
@@ -3508,6 +3667,55 @@ mod tests {
         );
     }
 
+    /// nw-204. The ordering invariant `compact-embeddings` depends on:
+    /// compaction alone reclaims NOTHING when the orphans were never
+    /// tombstoned, which is the state of every brain that predates the fix —
+    /// exactly the brains the command exists for. Reconcile must run first.
+    ///
+    /// Without this, dropping or reordering the reconcile would leave a
+    /// command that exits 0, prints a reclaim summary, and does nothing.
+    #[test]
+    fn compaction_reclaims_nothing_until_orphans_are_tombstoned() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        store.set_embedding_metadata("test-model", 2).unwrap();
+        // No graph nodes are inserted, so both vectors are orphans — but
+        // nothing has tombstoned them yet.
+        assert!(store.add_embedding("symbol:orphan-a", vec![1.0, 0.0]));
+        assert!(store.add_embedding("symbol:orphan-b", vec![0.0, 1.0]));
+        store.flush_embedding_index().unwrap();
+
+        let before = store.embedding_index_occupancy();
+        assert_eq!(before.stored, 2);
+        assert_eq!(
+            before.tombstoned, 0,
+            "precondition: the orphans must be untombstoned, as on a pre-fix brain"
+        );
+
+        // Compaction on its own.
+        store.compact_embedding_index().unwrap();
+        let after_compact_only = store.embedding_index_occupancy();
+        assert_eq!(
+            after_compact_only.stored, 2,
+            "compaction alone must not reclaim untombstoned orphans"
+        );
+
+        // Reconcile first, then compact — the order the command uses.
+        assert_eq!(store.reconcile_embedding_index().unwrap(), 2);
+        store.compact_embedding_index().unwrap();
+        let after = store.embedding_index_occupancy();
+        // Also pins the all-dead case, which this test originally caught:
+        // `compact_embedding_index` guarded on `is_empty()`, i.e. `len() == 0`,
+        // which counts only LIVE vectors — so an index whose rows were ALL
+        // tombstoned reported itself empty and returned early on the maximum-
+        // reclaim case, stranding every dead row on disk.
+        assert_eq!(after.stored, 0);
+        assert_eq!(after.tombstoned, 0, "compaction must clear the tombstones");
+        assert!(!store.has_embedding("symbol:orphan-a"));
+        assert!(!store.has_embedding("symbol:orphan-b"));
+    }
+
     #[test]
     fn embedding_reconciliation_persists_deletion_of_the_last_vector() {
         let dir = tempfile::tempdir().unwrap();
@@ -3523,6 +3731,33 @@ mod tests {
 
         let reopened = GraphStore::open_or_create(&db_path).unwrap();
         assert!(!reopened.has_embedding("symbol:stale"));
+    }
+
+    /// nw-204. An empty index must report a 0.0 tombstone ratio, not 100% dead.
+    /// Reporting `0/0` as fully dead would trip the compaction threshold on
+    /// every fresh brain and make status alarm about nothing.
+    #[test]
+    fn tombstone_ratio_is_zero_for_an_empty_index() {
+        let empty = EmbeddingIndexOccupancy {
+            live: 0,
+            tombstoned: 0,
+            stored: 0,
+        };
+        assert_eq!(empty.tombstone_ratio(), 0.0);
+
+        let healthy = EmbeddingIndexOccupancy {
+            live: 100,
+            tombstoned: 0,
+            stored: 100,
+        };
+        assert_eq!(healthy.tombstone_ratio(), 0.0);
+
+        let half_dead = EmbeddingIndexOccupancy {
+            live: 50,
+            tombstoned: 50,
+            stored: 100,
+        };
+        assert_eq!(half_dead.tombstone_ratio(), 0.5);
     }
 
     #[test]

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -16,8 +16,8 @@ pub mod write;
 pub mod zstd;
 
 pub use db::{
-    EmbeddingIndexReconciliation, EmbeddingSnapshotLease, EmbeddingSnapshotState, GraphStore,
-    IndexPublicationLease, PublicationIdentity,
+    EmbeddingIndexOccupancy, EmbeddingIndexReconciliation, EmbeddingSnapshotLease,
+    EmbeddingSnapshotState, GraphStore, IndexPublicationLease, PublicationIdentity,
 };
 pub use error::{CancelReason, StoreError};
 
@@ -1343,7 +1343,10 @@ mod tests {
         let deleted = store
             .delete_symbols_in_file("repo-del-1", "src/a.rs")
             .unwrap();
-        assert_eq!(deleted, 1);
+        // nw-204: the UIDs themselves are the contract now — the epilogue
+        // tombstones embeddings by them, so returning the right count with the
+        // wrong identities would be silently useless.
+        assert_eq!(deleted, vec!["sym-del-a".to_string()]);
 
         // sym-a should be gone; sym-b should remain.
         let err = store.lookup_symbol("sym-del-a").unwrap_err();

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -1970,7 +1970,8 @@ mod tests {
         assert_eq!(
             store
                 .delete_symbols_in_file("repo-1", "src/lib.rs")
-                .unwrap(),
+                .unwrap()
+                .len(),
             1
         );
         store

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -1441,6 +1441,51 @@ impl GraphStore {
         Ok(result.count())
     }
 
+    /// Return the UIDs of every Symbol currently attached to the given files.
+    ///
+    /// Liveness scoped to exactly the files a run touched, for targeted
+    /// embedding reconciliation. Deliberately NOT repo-scoped: the code
+    /// watcher runs this on every save, and a repo-wide symbol scan on a large
+    /// repo would put a six-figure row count in the path of every keystroke-
+    /// triggered re-index. One query per touched file mirrors what
+    /// `delete_symbols_in_file_on` already pays, so the added cost is a
+    /// constant factor on work the run does anyway.
+    ///
+    /// Sound because the file set is exactly the set the caller deleted from:
+    /// a UID can only reappear in a file the run wrote, and the rename path
+    /// touches both the source and destination paths.
+    pub fn symbol_uids_for_files(
+        &self,
+        repo_uid: &str,
+        file_paths: &[String],
+    ) -> Result<HashSet<String>, StoreError> {
+        let mut uids = HashSet::new();
+        if file_paths.is_empty() {
+            return Ok(uids);
+        }
+        let conn = self.conn()?;
+        // LadybugDB does not support parameterized compound WHERE clauses.
+        // Escaping deliberately mirrors `delete_symbols_in_file_on` (`\'`), NOT
+        // the SQL-style `''` doubling used elsewhere in this file: these two
+        // queries must select the SAME rows for the liveness difference to be
+        // sound, so they have to agree with each other rather than with the
+        // file. That the codebase carries two escaping conventions is a real
+        // inconsistency and its own cleanup.
+        let safe_repo_uid = repo_uid.replace('\'', "\\'");
+        for file_path in file_paths {
+            let safe_file_path = file_path.replace('\'', "\\'");
+            let result = conn
+                .query(&format!(
+                    "MATCH (s:Symbol) WHERE s.repo_uid = '{safe_repo_uid}' AND s.file_path = '{safe_file_path}' RETURN s.uid"
+                ))
+                .map_err(|e| StoreError::Query(format!("list symbol uids in file: {e}")))?;
+            for row in result {
+                uids.insert(extract_string(&row, 0)?);
+            }
+        }
+        Ok(uids)
+    }
+
     /// Return the authoritative set of graph-node UIDs supported by the
     /// sidecar embedding index. The embedding producers currently cover
     /// Symbols, Notes, and Headings; querying all three protects vault data

--- a/crates/nestweaver-store/src/search.rs
+++ b/crates/nestweaver-store/src/search.rs
@@ -1468,6 +1468,100 @@ impl EmbeddingIndex {
         entries
     }
 
+    /// Tombstone embeddings for a known-dead set of UIDs.
+    ///
+    /// The targeted counterpart to [`retain_uids`]: that function derives the
+    /// dead set by differencing against every live node, which costs a full
+    /// graph scan. Incremental indexing already KNOWS which UIDs it deleted, so
+    /// it pays only for what it removed. Both converge on the same tombstones;
+    /// this one is cheap enough to run on the watcher's per-save path.
+    ///
+    /// CALLERS MUST HAVE ALREADY EXCLUDED LIVE UIDS. An incremental re-index
+    /// deletes a file's symbols and re-inserts most of them under the SAME
+    /// UIDs, so passing the raw delete list would tombstone vectors for symbols
+    /// that still exist — silently deleting live embeddings, which is worse
+    /// than the orphans this exists to remove. See
+    /// `GraphStore::tombstone_deleted_symbol_embeddings`, which applies that
+    /// filter against the post-commit graph before calling here.
+    ///
+    /// Returns the number of vectors actually removed.
+    ///
+    /// [`retain_uids`]: EmbeddingIndex::retain_uids
+    pub(crate) fn tombstone_uids(&mut self, dead_uids: &[String]) -> usize {
+        let before = self.len();
+        for uid in dead_uids {
+            let in_overlay = self.embeddings.remove(uid).is_some();
+            // `base.contains` stays true for a UID ALREADY tombstoned — the row
+            // is still physically present, just hidden. Without the second
+            // clause a repeat tombstone (a file deleted, recreated, deleted
+            // again before any embed pass reaches it) re-journals a Delete that
+            // removes nothing, inflating the very journal length that triggers
+            // a full base rewrite.
+            let in_base = self
+                .base
+                .as_ref()
+                .is_some_and(|base| base.contains(uid) && !self.deleted_base_uids.contains(uid));
+            if in_base {
+                self.deleted_base_uids.insert(uid.clone());
+            }
+            // Only journal a delta for a UID the index actually held. A caller
+            // passing UIDs that were never embedded (a symbol deleted before an
+            // embed pass ever reached it) must not inflate the journal, which
+            // is what drives compaction.
+            if in_overlay || in_base {
+                self.pending_deltas
+                    .push(EmbeddingDelta::Delete { uid: uid.clone() });
+            }
+        }
+        before - self.len()
+    }
+
+    /// Pending journal deltas not yet flushed. Test-visible so the journaling
+    /// contract of `tombstone_uids` can be asserted directly rather than
+    /// inferred from file sizes.
+    #[cfg(test)]
+    pub(crate) fn pending_delta_count(&self) -> usize {
+        self.pending_deltas.len()
+    }
+
+    /// Number of base rows currently hidden by tombstones. Drives
+    /// ratio-triggered compaction and status reporting: unlike the journal
+    /// length, it survives compaction and reflects real reclaimable bytes.
+    pub fn tombstoned_len(&self) -> usize {
+        self.deleted_base_uids.len()
+    }
+
+    /// `(live, tombstoned, stored)` without an O(base) scan.
+    ///
+    /// [`len`] iterates every base row to exclude tombstoned and
+    /// overlay-shadowed UIDs, which is fine for the occasional call it was
+    /// written for but NOT for `brain status`, which is polled and would
+    /// otherwise hold this mutex — the one `vector_search_cancellable` needs —
+    /// across a 389k-row scan on a real brain.
+    ///
+    /// The arithmetic instead: the base contributes `rows.len()` physical rows,
+    /// of which `deleted_base_uids` are hidden. The overlay contributes only
+    /// its UIDs that are NOT already base rows, since a shadowing upsert
+    /// replaces a row rather than adding one — and that count is O(overlay),
+    /// which is bounded by what a single embed pass has written since the last
+    /// compaction, not by corpus size.
+    ///
+    /// [`len`]: EmbeddingIndex::len
+    pub(crate) fn occupancy(&self) -> (usize, usize, usize) {
+        let base_rows = self.base.as_ref().map_or(0, |base| base.rows.len());
+        let tombstoned = self.deleted_base_uids.len();
+        let overlay_only = match &self.base {
+            Some(base) => self
+                .embeddings
+                .keys()
+                .filter(|uid| !base.contains(uid))
+                .count(),
+            None => self.embeddings.len(),
+        };
+        let stored = base_rows + overlay_only;
+        (stored - tombstoned, tombstoned, stored)
+    }
+
     /// Retain only embeddings whose graph nodes still exist.
     ///
     /// Returns the number of removed vectors so callers can report and test
@@ -2473,6 +2567,46 @@ mod tests {
         assert!(
             error.to_string().contains("checksum mismatch"),
             "unexpected error: {error}"
+        );
+    }
+
+    /// nw-204. `tombstone_uids` must hide base rows, drop overlay rows, and
+    /// journal a delta ONLY for UIDs the index actually held — a symbol deleted
+    /// before any embed pass reached it must not inflate the journal, because
+    /// journal length is what drives compaction.
+    #[test]
+    fn tombstone_uids_hides_base_rows_without_journaling_unknown_uids() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_path = dir.path().join("base.bin");
+        let identity = test_identity();
+        let pipeline = test_pipeline("model-a", 2);
+        let mut original = EmbeddingIndex::new();
+        for (uid, vector) in [("a", vec![1.0, 0.0]), ("b", vec![0.0, 1.0])] {
+            assert!(original.add_with_pipeline(uid, vector, &pipeline, false));
+        }
+        original
+            .save_binary_v2(&base_path, &identity, 1, &pipeline)
+            .unwrap();
+
+        let mut index = EmbeddingIndex::load_binary_v2(&base_path).unwrap();
+        assert!(index.add_with_pipeline("c", vec![0.5, 0.5], &pipeline, false));
+        let deltas_before = index.pending_delta_count();
+
+        // "a" is in the mapped base, "c" is overlay-only, "ghost" was never
+        // embedded at all.
+        let removed =
+            index.tombstone_uids(&["a".to_string(), "c".to_string(), "ghost".to_string()]);
+
+        assert_eq!(removed, 2, "only the two held vectors count as removed");
+        assert_eq!(index.len(), 1);
+        assert_eq!(index.tombstoned_len(), 1, "only 'a' came from the base");
+        assert!(index.get("a").is_none());
+        assert!(index.get("c").is_none());
+        assert_eq!(index.get("b"), Some(vec![0.0, 1.0]));
+        assert_eq!(
+            index.pending_delta_count() - deltas_before,
+            2,
+            "the never-embedded UID must not produce a journal delta"
         );
     }
 

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -3800,53 +3800,67 @@ impl GraphStore {
     /// `repo_uid` AND `file_path`). Uses `DETACH DELETE` so all incident edges
     /// (CALLS, IMPORTS, EXTENDS_SYM, IMPLEMENTS_SYM, USES, ACCESSES, MEMBER_OF,
     /// FILE_HAS_SYMBOL, CROSS_REPO_LINK, REFERENCES_CODE_*) are automatically
-    /// removed. Returns the count of deleted symbols.
+    /// removed. Returns the UIDs of the deleted symbols.
     pub fn delete_symbols_in_file(
         &self,
         repo_uid: &str,
         file_path: &str,
-    ) -> Result<usize, StoreError> {
+    ) -> Result<Vec<String>, StoreError> {
         let conn = self.conn()?;
         Self::delete_symbols_in_file_on(&conn, repo_uid, file_path)
     }
 
-    /// Delete symbols in a file using an externally-provided connection (for transaction batching).
+    /// Delete symbols in a file using an externally-provided connection (for
+    /// transaction batching), returning the UIDs that were removed.
+    ///
+    /// nw-204: this used to return only a count, which is why the index
+    /// epilogue could not tombstone the embeddings of symbols it deleted —
+    /// there was nothing to tombstone them BY. The UIDs are read in the same
+    /// pass that previously counted them, so this costs no extra query; the
+    /// result is bounded by the number of symbols in one file.
+    ///
+    /// The returned list is the RAW delete set and routinely contains UIDs that
+    /// a re-index immediately re-inserts unchanged. It is not a dead set. See
+    /// `GraphStore::tombstone_deleted_symbol_embeddings`, which differences it
+    /// against the post-commit graph before anything is tombstoned.
     pub fn delete_symbols_in_file_on(
         conn: &lbug::Connection<'_>,
         repo_uid: &str,
         file_path: &str,
-    ) -> Result<usize, StoreError> {
+    ) -> Result<Vec<String>, StoreError> {
         // LadybugDB does not support parameterized compound WHERE clauses.
         // Sanitize user-derived values by escaping single quotes.
         let safe_repo_uid = repo_uid.replace('\'', "\\'");
         let safe_file_path = file_path.replace('\'', "\\'");
 
-        // Count first so we can report how many were deleted.
-        let count: usize = {
+        // Read the UIDs first, in the query that used to only count them.
+        let uids: Vec<String> = {
             let rows = conn
                 .query(&format!(
-                    "MATCH (s:Symbol) WHERE s.repo_uid = '{safe_repo_uid}' AND s.file_path = '{safe_file_path}' RETURN count(s)"
+                    "MATCH (s:Symbol) WHERE s.repo_uid = '{safe_repo_uid}' AND s.file_path = '{safe_file_path}' RETURN s.uid"
                 ))
-                .map_err(|e| StoreError::Query(format!("count symbols: {e}")))?;
+                .map_err(|e| StoreError::Query(format!("list symbols in file: {e}")))?;
             rows.filter_map(|row| {
                 row.first().and_then(|v| match v {
-                    lbug::Value::Int64(n) => Some(*n as usize),
+                    lbug::Value::String(uid) => Some(uid.clone()),
                     _ => None,
                 })
             })
-            .next()
-            .unwrap_or(0)
+            .collect()
         };
 
-        if count > 0 {
-            // Single bulk DETACH DELETE instead of per-UID queries.
-            conn.query(&format!(
-                "MATCH (s:Symbol) WHERE s.repo_uid = '{safe_repo_uid}' AND s.file_path = '{safe_file_path}' DETACH DELETE s"
-            ))
-            .map_err(|e| StoreError::Query(format!("delete symbols in file: {e}")))?;
-        }
+        // UNCONDITIONAL, deliberately. This used to run under `count > 0` from a
+        // `RETURN count(s)`; it now runs regardless of how many UIDs parsed out
+        // of the row set above. Gating the delete on the parsed list would make
+        // deletion depend on every row decoding as a String — a row that did
+        // not would silently leave symbols behind, turning a decode quirk into
+        // a data bug. The statement is a no-op when nothing matches.
+        conn.query(&format!(
+            "MATCH (s:Symbol) WHERE s.repo_uid = '{safe_repo_uid}' AND s.file_path = '{safe_file_path}' DETACH DELETE s"
+        ))
+        .map_err(|e| StoreError::Query(format!("delete symbols in file: {e}")))?;
 
-        Ok(count)
+        Ok(uids)
     }
 
     /// Delete all resolved (semantic) edges originating from symbols in a
@@ -3963,22 +3977,16 @@ impl GraphStore {
         )
     }
 
-    // `update_symbol_file_paths` / `_on` were REMOVED here, not merely orphaned.
-    // They rewrote a Symbol's `file_path` while KEEPING its UID — but
-    // `symbol_uid` hashes the file path, so every row they produced had a UID
-    // that disagreed with its own `file_path`, an inconsistency nothing
-    // downstream expected. Their only callers were the incremental index's two
-    // rename arms, where the rows were deleted two statements later and
+    // nw-206: `update_symbol_file_paths` / `_on` were REMOVED here, not merely
+    // orphaned. They rewrote a Symbol's `file_path` while KEEPING its UID —
+    // but `symbol_uid` hashes the file path, so every row they produced had a
+    // UID that disagreed with its own `file_path`, an inconsistency nothing
+    // downstream expected. Their only caller was the incremental index's
+    // rename arm, where the rows were deleted two statements later and
     // re-created from the parse, so they preserved nothing; and their per-row
     // CREATE poisoned the bulk `COPY Symbol` that followed in the same
-    // transaction, failing the whole incremental index on any parseable rename.
-    // A rename re-keys symbols: delete and re-insert them.
-    //
-    // They also carried a second, independent bug that this removal moots: the
-    // RETURN list omitted `s.end_line` while `row_to_symbol` reads by POSITION,
-    // shifting every column from index 6 on, so the parse hit `signature` where
-    // it expected an Int64 and the function errored for any symbol that had
-    // one. That error is what shielded the COPY failure above from view.
+    // transaction, failing the whole incremental index on any parseable
+    // rename. A rename re-keys symbols; delete and re-insert them.
 
     /// Update the `indexed_sha` field of a Repo node.
     pub fn update_repo_sha(&self, repo_uid: &str, new_sha: &str) -> Result<(), StoreError> {

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -44,7 +44,7 @@ Deep integration between NestWeaver's code knowledge graph and Claude Code.
 
 ## MCP Tools
 
-When configured as an MCP server, NestWeaver exposes 40 tools across these categories:
+When configured as an MCP server, NestWeaver exposes 41 tools across these categories:
 
 **Context & Search:**
 - **brain_context** — Task-focused subgraph via Personalized PageRank with type-aware resolution

--- a/integrations/cursor/README.md
+++ b/integrations/cursor/README.md
@@ -23,7 +23,19 @@ Restart Cursor to detect the MCP server.
 
 Cursor has a 40-tool cap across all MCP servers. NestWeaver uses `--lite` mode by default for Cursor, exposing 6 core tools: `brain_context`, `brain_search`, `brain_impact`, `brain_status`, `brain_guide`, `detect_changes`.
 
-To use all 40 tools, edit `.cursor/mcp.json` and remove `--lite` from the args.
+NestWeaver now advertises **41** tools, so the full set no longer fits under
+Cursor's cap on its own — and it counts against every other MCP server you have
+configured. Removing `--lite` from `.cursor/mcp.json` will exceed the cap unless
+NestWeaver is your only MCP server, and even then it is one over.
+
+Use `--tools` to pick an explicit subset instead, which is the supported way to
+go beyond lite mode without tripping the cap:
+
+```jsonc
+"args": ["mcp", "--tools", "brain_context,brain_search,brain_impact,flow_trace,read_symbols"]
+```
+
+Other editors have no such cap; this section is Cursor-specific.
 
 ## Environment Variables
 

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -223,6 +223,32 @@ message PruneStaleResponse {
   repeated ReconciliationFailure reconciliation_failures = 4;
 }
 
+// nw-204. Reclaim embedding vectors left behind by deleted graph nodes.
+message CompactEmbeddingsRequest {
+  // Report occupancy without writing anything. Note that a dry run can only
+  // report what is ALREADY tombstoned — orphans that were never tombstoned are
+  // found by the reconcile a real run performs, so a dry run's `tombstoned` is
+  // a floor, not a total.
+  bool dry_run = 1;
+}
+
+message CompactEmbeddingsResponse {
+  // Occupancy before the run.
+  uint64 stored_before = 1;
+  uint64 tombstoned_before = 2;
+  // Occupancy after. Equal to the `before` values on a dry run.
+  uint64 stored_after = 3;
+  uint64 live_after = 4;
+  // Vectors the reconcile found to be dead. 0 on a dry run.
+  uint64 reclaimed = 5;
+  // Sidecar file size in bytes, before and after. 0 when the artifact is
+  // absent or unreadable, which is not an error — an un-embedded brain has no
+  // sidecar and nothing to reclaim.
+  uint64 bytes_before = 6;
+  uint64 bytes_after = 7;
+  bool dry_run = 8;
+}
+
 message MergeInstanceRequest {
   string from_id = 1;
   string to_id = 2;
@@ -356,6 +382,21 @@ message EmbeddingStatus {
   int64 pass_started_at = 12;
   // Scope string of the running pass (all | symbols | notes | headings).
   string pass_scope = 13;
+
+  // ── Sidecar occupancy (added 7.1, nw-204) ────────────────────────
+  // Vectors a query can actually match, versus what the artifact physically
+  // stores. `index_stored - index_live` is dead weight that is both wasted
+  // disk AND, before it is tombstoned, scored: an untombstoned dead vector
+  // outranking a live one silently consumes a top-k slot.
+  //
+  // Reported so that a brain carrying a majority-dead index cannot keep
+  // describing itself as simply "ready", which is how this went unnoticed
+  // until over half of a real index was dead. Proto3 scalars, so an older
+  // daemon decodes as 0/0 rather than as an error; a client should treat
+  // index_stored == 0 as "not reported" rather than "empty index".
+  uint64 index_live = 14;
+  uint64 index_tombstoned = 15;
+  uint64 index_stored = 16;
 }
 message EffectiveConfig {
   // The daemon's effective configuration source. Absence of EffectiveConfig
@@ -709,6 +750,7 @@ service NestWeaverDaemon {
   rpc RemoveRepo(RemoveRepoRequest) returns (RemoveRepoResponse);
   rpc RemoveProject(RemoveProjectRequest) returns (RemoveProjectResponse);
   rpc PruneStale(PruneStaleRequest) returns (PruneStaleResponse);
+  rpc CompactEmbeddings(CompactEmbeddingsRequest) returns (CompactEmbeddingsResponse);
   rpc MergeInstance(MergeInstanceRequest) returns (MergeInstanceResponse);
   rpc PurgeInstance(PurgeInstanceRequest) returns (stream IndexProgress);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1440,6 +1440,22 @@ fn format_embedding_status(status: &nestweaver_proto::EmbeddingStatus) -> String
         format!("  Metal compiled:   {}", status.metal_compiled),
         format!("  Fallback used:    {}", status.fallback_used),
     ]);
+    // nw-204. Only shown when the daemon actually reported it (an older daemon
+    // sends proto3 zeros, and "0 stored" is indistinguishable from "not
+    // reported" — printing "0 vectors" for a healthy brain would be a lie).
+    if status.index_stored > 0 {
+        lines.push(format!(
+            "  Vectors:          {} live / {} stored",
+            status.index_live, status.index_stored
+        ));
+        if status.index_tombstoned > 0 {
+            let pct = status.index_tombstoned as f64 / status.index_stored as f64 * 100.0;
+            lines.push(format!(
+                "  Reclaimable:      {} tombstoned ({pct:.0}%) — run `nestweaver compact-embeddings`",
+                status.index_tombstoned
+            ));
+        }
+    }
     if !status.error.is_empty() {
         lines.push(format!("  Error:            {}", status.error));
     }
@@ -1463,6 +1479,9 @@ fn embedding_status_from_json(value: &serde_json::Value) -> nestweaver_proto::Em
         pass_total: value["pass_total"].as_u64().unwrap_or(0),
         pass_started_at: value["pass_started_at"].as_i64().unwrap_or(0),
         pass_scope: value["pass_scope"].as_str().unwrap_or("").to_string(),
+        index_live: value["index_live"].as_u64().unwrap_or(0),
+        index_tombstoned: value["index_tombstoned"].as_u64().unwrap_or(0),
+        index_stored: value["index_stored"].as_u64().unwrap_or(0),
     }
 }
 
@@ -1990,6 +2009,38 @@ enum Commands {
             help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
         )]
         db: Option<PathBuf>,
+    },
+    /// Reclaim embedding vectors left behind by deleted graph nodes.
+    ///
+    /// Reconciles the embedding sidecar against the live graph and rewrites it
+    /// without the dead rows. Does NOT load the embedding model and does NOT
+    /// re-embed anything, so it is cheap and safe to run on a large brain.
+    ///
+    /// Two reasons to run it. Disk is the obvious one. The other is result
+    /// quality: the vector scan skips rows that are tombstoned, so a dead
+    /// vector that was never tombstoned is still SCORED, and one outranking a
+    /// live result silently consumes a top-k slot in semantic search.
+    ///
+    /// Ongoing tombstoning is automatic (nw-204); this exists for brains that
+    /// already accumulated orphans, and as an explicit way to force the
+    /// reclaim rather than waiting for the ratio threshold.
+    ///
+    /// Runs through the daemon, which holds the same write gate for this that
+    /// it holds for indexing — so it cannot race an in-flight index or watcher
+    /// batch while rewriting the artifact.
+    #[command(
+        after_help = "Examples:\n  nestweaver compact-embeddings\n  nestweaver compact-embeddings --db ~/brain/.nestweaver/brain.lbug\n  nestweaver compact-embeddings --dry-run   # report occupancy, change nothing"
+    )]
+    CompactEmbeddings {
+        #[arg(
+            long,
+            help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
+        )]
+        db: Option<PathBuf>,
+        #[arg(long, help = "Report what would be reclaimed without writing anything")]
+        dry_run: bool,
+        #[arg(long, help = "Emit JSON")]
+        json: bool,
     },
     /// Remove repos and vaults whose paths no longer exist on disk.
     #[command(
@@ -8826,6 +8877,76 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             require_existing_db(&db_path)?;
             let code = run_repair_index_publication(&db_path, json, dry_run, force)?;
             Ok((code, None))
+        }
+
+        Commands::CompactEmbeddings { db, dry_run, json } => {
+            let db_path = db.unwrap_or_else(default_db_path);
+            require_existing_db(&db_path)?;
+            // Through the daemon, like every other write. Compaction rewrites
+            // the embedding base; doing that from a second process while the
+            // daemon indexes or a watcher batch flushes would race a store that
+            // is not crash-safe. The daemon holds the same write gate for this
+            // that it holds for indexing.
+            let rt = tokio::runtime::Runtime::new()?;
+            let mut client = rt
+                .block_on(nestweaver_client::DaemonClient::connect(&db_path, None))
+                .context("failed to connect to daemon")?;
+
+            let resp = match rt.block_on(client.compact_embeddings(dry_run)) {
+                Ok(resp) => resp,
+                Err(e) => {
+                    eprintln!("Error: compact-embeddings failed: {e}");
+                    return Ok((EXIT_ERROR, None));
+                }
+            };
+
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "dry_run": resp.dry_run,
+                        "live": resp.live_after,
+                        "stored_before": resp.stored_before,
+                        "stored_after": resp.stored_after,
+                        "tombstoned_before": resp.tombstoned_before,
+                        // stored_after - live_after: lets a scripted caller
+                        // verify the tombstones were actually cleared rather
+                        // than inferring it from the reclaim count.
+                        "tombstoned_after": resp.stored_after - resp.live_after,
+                        "reclaimed_vectors": resp.reclaimed,
+                        "bytes_before": resp.bytes_before,
+                        "bytes_after": resp.bytes_after,
+                    }))?
+                );
+            } else if resp.dry_run {
+                println!("Embedding index (dry run — nothing written):");
+                println!("  live vectors:      {}", resp.live_after);
+                println!("  tombstoned:        {}", resp.tombstoned_before);
+                println!("  stored on disk:    {}", resp.stored_before);
+                println!("  sidecar bytes:     {}", resp.bytes_before);
+                println!(
+                    "\nA dry run reports only what is ALREADY tombstoned. Orphans that were\n\
+                     never tombstoned are invisible here and are found by the reconcile\n\
+                     that a real run performs — run without --dry-run to see the true total."
+                );
+            } else if resp.reclaimed == 0 && resp.tombstoned_before == 0 {
+                println!(
+                    "Nothing to reclaim: all {} stored vectors are live.",
+                    resp.stored_after
+                );
+            } else {
+                println!("Reclaimed {} dead vector(s).", resp.reclaimed);
+                println!("  stored before:  {}", resp.stored_before);
+                println!("  stored after:   {}", resp.stored_after);
+                println!("  live:           {}", resp.live_after);
+                if resp.bytes_before > 0 && resp.bytes_after > 0 {
+                    println!(
+                        "  sidecar bytes:  {} -> {}",
+                        resp.bytes_before, resp.bytes_after
+                    );
+                }
+            }
+            Ok((EXIT_SUCCESS, None))
         }
 
         Commands::PruneStale { db } => {


### PR DESCRIPTION
> **Stacked on #280.** Base is `fix/nw-206-rename-fails-incremental-index`, not `main` — this branch hooks into the rename arm that #280 restructures. Review #280 first; this PR's diff shows only the embedding work.

## The bug

Deleted graph nodes left their embedding vectors in the sidecar forever. The visible symptom was disk — a 1.2 GB artifact on a 2.2 GB database — but that was the lesser half.

`vector_search_cancellable` skips rows in `deleted_base_uids`. **Nothing on the index path ever populated that set**, so dead vectors were *scored*, and one outranking a live result silently consumed a top-k slot in the semantic leg of every query.

Measured on a real brain: **389,407 stored against 188,126 live** — ~52% of the index dead, and roughly half the semantic budget spendable on nodes that no longer existed. Nothing surfaced it.

## Root cause

Not repo removal, which reconciles correctly. Every whole-graph delete path already called `reconcile_embedding_index_stages`. The **ordinary index-publication epilogue did not** — and that is where the overwhelming majority of deletions happen: a file deleted, a file re-parsed into fewer symbols, a scope or size-cap change. `delete_symbols_in_file_on` returned a count, not the UIDs, so nothing downstream could tombstone what it removed.

## Five layers

Correctness and reclamation have different cost profiles and must not share a trigger.

| # | Layer | Notes |
|---|---|---|
| 1 | **Tombstone on delete** | Four delete paths, incl. the watcher's per-save path whose `Replace` arm discarded the delete entirely |
| 2 | **Deferred backstop** | Own daemon loop, generation-gated, level-triggered; the only thing covering Note/Heading vectors |
| 3 | **Ratio compaction** | 20% dead, 1,000 floor; deliberately *not* on the flush path |
| 4 | **Escape hatch** | `compact-embeddings` CLI + `compact_embeddings` MCP tool, both via a daemon write RPC |
| 5 | **Visibility** | Occupancy in `brain status` and the MCP status payload |

**The liveness invariant is the sharp edge.** A re-index deletes a file's symbols and re-inserts most of them under the *same* UIDs, so tombstoning the raw delete list would drop **live** vectors — worse than the bug being fixed. The store applies the difference itself against the post-commit graph, so callers cannot misuse it. Liveness is scoped to the files the run touched, not the repo, so the watcher does not pay a repo-wide symbol scan on every save.

## A latent bug the new ordering test caught

`compact_embedding_index` guarded on `index.is_empty()`, which is `len() == 0` and counts only **live** vectors. An index whose rows were *all* tombstoned therefore reported itself empty, and compaction **returned early on the maximum-reclaim case** — a brain that removed all its repos could never reclaim its sidecar. Predates this work.

## Also folds in nw-205

`TEST_ENV_LOCK` exists and every *writer* takes it, but `daemon_identity_survives_a_publication_cutover` reads `socket_path()` twice without it, so a sibling test flipping `XDG_STATE_HOME` between the calls renders one instance id under two roots. An identical defect was already fixed in a sibling test with a comment describing the mechanism; this one was missed.

CI's macOS release gate also lacked `--no-fail-fast` while every other test job had it — which is what let that flake abort a run and **silently skip the store and engine suites entirely**.

## Validation

End-to-end against a daemon serving a copy of a real brain:

```
Reclaimed 201480 dead vector(s).
  stored before:  389695
  stored after:   188215
  sidecar bytes:  1221010948 -> 590203953        (5.4s, no model load)
```

Artifact verified structurally afterwards (envelope count matches the UID table; one repo went 201,535 rows → 241, its true live count). A semantic query then resolved 1 seed directly and **4 via semantic search** — proof the compacted vectors are readable *and being scored*, not merely present.

The acceptance test **asserts on search results, not vector counts**: the original criteria ("count drops, file shrinks") would have passed while leaving the recall bug intact. Mutation-checked — disabling the tombstone call reproduces the production symptom exactly, the dead vector scoring `1.0` and displacing the live result.

- `cargo test --locked --release --workspace --lib --no-fail-fast` → **3210 passed, 0 failed**
- `cargo test --locked --release --workspace --no-fail-fast -- --skip daemon_` → **3571 passed, 0 failed**
- `--test daemon_test` → 52/0 · `-p nestweaver-mcp --features daemon` → 183/0
- clippy `-D warnings`, `fmt --check`, `check --benches`, `config validate` → clean

## Heads-up: Cursor's 40-tool cap

We now advertise **41** MCP tools, and Cursor caps at 40 across all servers. The default Cursor config uses `--lite` (6 tools) so the common path is fine, but "remove `--lite` to get all tools" is no longer valid advice. `integrations/cursor/README.md` now says so and points at `--tools`. Flagging it as a product decision — staying at 40 would mean dropping the tool.

## Breaking change

`GraphStore::delete_symbols_in_file` / `delete_symbols_in_file_on` return `Vec<String>` instead of `usize`. Callers wanting the count use `.len()`.