### PR TITLE
fix(daemon): refuse a stale-version incumbent instead of reporting success

### DIFF
--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -701,6 +701,33 @@ fn verify_requested_config_evidence(
         health.instance_id,
         restart_with_requested_config_remedy(db_path, requested)
     );
+    // nw-201: VERSION, not just config identity.
+    //
+    // `daemon start --config` used to verify only that the incumbent's
+    // effective config matched, then print "Daemon already running with
+    // requested config." and exit 0 — while the running process was the
+    // PREVIOUS binary. `brain status` looked healthy, so the upgrade appeared
+    // applied and was not. For 7.0.0 specifically that meant an operator ran
+    // neither the trigram reconcile loop nor nanosecond change detection while
+    // being told everything was fine.
+    //
+    // The same assertion already guarded a REPLACEMENT daemon in
+    // `verify_replacement_evidence`; the incumbent simply had no equivalent.
+    // This is an inconsistency between two paths, not a new policy.
+    //
+    // FAILS rather than restarting, deliberately. `start` means "ensure a
+    // daemon is running", and stopping one that is actively serving is a
+    // larger action than that asks for — the same reasoning behind
+    // `RefuseForeignIncumbent` never stopping a foreign daemon implicitly.
+    // The remedy names `restart`, which is the command that owns that action.
+    anyhow::ensure!(
+        health.version == env!("CARGO_PKG_VERSION"),
+        "the running daemon is version {} but this client is {}; the upgrade has NOT been \
+         applied and its new behaviour is not active. {}",
+        health.version,
+        env!("CARGO_PKG_VERSION"),
+        restart_with_requested_config_remedy(db_path, requested)
+    );
     anyhow::ensure!(health.pid != 0, "running daemon HealthCheck returned PID 0");
     anyhow::ensure!(
         binding.pid == health.pid,
@@ -1581,6 +1608,73 @@ credential_method = "gh"
         assert!(relative.as_path().unwrap().is_absolute());
     }
 
+    /// nw-201. `daemon start --config` verified the incumbent's CONFIG but not
+    /// its VERSION, so after `cargo install` of a new build it printed "Daemon
+    /// already running with requested config." and exited 0 while the previous
+    /// binary was still serving. `brain status` looked healthy, so the upgrade
+    /// appeared applied and was not — on 7.0.0 that meant running neither the
+    /// trigram reconcile loop nor nanosecond change detection.
+    ///
+    /// Asserts the failure NAMES both versions and the remedy: an operator who
+    /// is told "restart" without being told why is being asked to guess.
+    #[test]
+    fn explicit_config_evidence_refuses_a_stale_version_incumbent() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        let requested_path = fs::canonicalize(valid_config(&dir, "requested.toml")).unwrap();
+        let requested = RestartConfig::Configured(requested_path.clone());
+
+        // The config MATCHES — this is the exact state that used to report
+        // success. Only the version differs.
+        let stale = nestweaver_proto::HealthCheckResponse {
+            version: "0.0.1-stale".to_string(),
+            instance_id: nestweaver_daemon::lifecycle::instance_id_from_db_path(&db),
+            pid: 91,
+            ..Default::default()
+        };
+
+        let error = verify_requested_config_evidence(
+            &db,
+            &stale,
+            &requested,
+            binding(
+                91,
+                nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::Configured {
+                    path: requested_path.to_str().unwrap().to_string(),
+                },
+            ),
+        )
+        .expect_err("a stale-version incumbent must not verify as acceptable");
+
+        let message = format!("{error:#}");
+        assert!(message.contains("0.0.1-stale"), "{message}");
+        assert!(message.contains(env!("CARGO_PKG_VERSION")), "{message}");
+        assert!(
+            message.contains("has NOT been applied"),
+            "the message must say the upgrade did not take effect: {message}"
+        );
+        assert!(message.contains("restart --config"), "{message}");
+
+        // Control: the SAME evidence with a current version verifies cleanly,
+        // so the test cannot pass merely because the fixture is malformed.
+        let current = nestweaver_proto::HealthCheckResponse {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            ..stale.clone()
+        };
+        verify_requested_config_evidence(
+            &db,
+            &current,
+            &requested,
+            binding(
+                91,
+                nestweaver_daemon::lifecycle::EffectiveConfigBindingSource::Configured {
+                    path: requested_path.to_str().unwrap().to_string(),
+                },
+            ),
+        )
+        .expect("a current-version incumbent with a matching config must verify");
+    }
+
     #[test]
     fn explicit_config_evidence_names_requested_and_effective_mismatch_states() {
         let dir = tempfile::tempdir().unwrap();
@@ -1589,6 +1683,11 @@ credential_method = "gh"
         let effective_path = fs::canonicalize(valid_config(&dir, "effective.toml")).unwrap();
         let requested = RestartConfig::Configured(requested_path.clone());
         let health = nestweaver_proto::HealthCheckResponse {
+            // nw-201: a CURRENT version, so this test still exercises the
+            // config-mismatch states it is named for. Without it the version
+            // assertion fires first and this test would silently stop covering
+            // config identity at all.
+            version: env!("CARGO_PKG_VERSION").to_string(),
             instance_id: nestweaver_daemon::lifecycle::instance_id_from_db_path(&db),
             pid: 91,
             ..Default::default()


### PR DESCRIPTION
## The bug

`nestweaver daemon --db <db> start --config <toml>` verified the running daemon's **config**, then printed

```
Daemon already running with requested config.
```

and exited **0** — while the running process was the *previous* binary.

Reproduced during the 7.0.0 install. `brain status` looked healthy (metal, embedding ready, correct config). The only tell was a missing `trigram reconcile loop enabled` line in the daemon log, because that daemon predated the feature. Only an explicit `daemon restart` applied the upgrade.

**The upgrade appeared applied and was not.** That is worst on exactly the releases where it matters most: 7.0.0's two headline changes are the trigram reconcile loop and nanosecond change detection, so an operator who upgraded and ran `daemon start` was running **neither** — mtimes stayed second-granularity and nothing drained the trigram outbox — while being told everything was fine.

## The fix

The assertion already existed **one function away**. `verify_replacement_evidence` requires `health.version == env!("CARGO_PKG_VERSION")` for a *replacement* daemon. The incumbent path in `verify_requested_config_evidence` had no equivalent and compared config identity only.

This is an inconsistency between two paths, not a new capability.

### Why it fails rather than restarting

The backlog item offered either. I chose to fail:

- `start` means "ensure a daemon is running". Stopping one that is **actively serving** is a larger action than that asks for.
- It matches the surrounding policy: `IncumbentDisplacement::RefuseForeignIncumbent` already refuses to stop a foreign daemon implicitly. `restart` is the command that owns that action.

The message names **both versions** and says the upgrade did not take effect — an operator told to restart without being told why is being asked to guess:

```
the running daemon is version 0.0.1-stale but this client is 7.0.0; the upgrade
has NOT been applied and its new behaviour is not active. Run `nestweaver daemon
--db <db> restart --config <toml>` to apply the requested configuration
```

Happy to switch to auto-restart if you'd prefer matching the client path — it's a one-line change in intent.

## A trap this surfaced

The existing config-mismatch test built its `HealthCheckResponse` with `..Default::default()`, leaving `version` empty. The new assertion would have fired **first**, and that test would have silently stopped covering config identity while still passing for the wrong reason. It now pins a current version with a comment saying why.

## Testing

`explicit_config_evidence_refuses_a_stale_version_incumbent` sets a **matching config** and differs only in version — the exact state that used to report success. It asserts the message names both versions and the remedy, and includes a control proving a current-version incumbent with the same evidence still verifies cleanly, so it cannot pass because the fixture is malformed.

**Mutation-checked:** replacing the version assertion with `true` fails the new test while the config-mismatch test keeps passing, so each covers its own case.

- `cargo test --locked --release --workspace --lib --no-fail-fast` → **3211 passed, 0 failed**
- `cargo fmt --all -- --check` → clean

One file, +99 lines.