### PR TITLE
fix(cli,mcp,daemon): stop five commands claiming things they never verified

### DIFF
--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -7524,8 +7524,34 @@ fn watch_path_allowed(
         .filter_map(|r| config_repo_canonical_path(&r.url))
         .collect();
     if !allowed.iter().any(|a| path.starts_with(a)) {
+        // nw-203: name the REGISTRY and the REMEDY.
+        //
+        // The old message — "is not in the instance's registered sources" —
+        // stated a fact and stopped, and its central word was doing double
+        // duty. A vault indexed with `brain add --config` IS registered: it is
+        // in the DB and `brain status` lists it. But the watcher consults the
+        // instance CONFIG allow-list, a different registry, so an operator who
+        // had demonstrably registered the vault was told it was not
+        // registered. Saying WHICH registry was consulted is what removes the
+        // contradiction.
+        //
+        // The allow-list itself is correct and deliberate — without `--config`
+        // the daemon falls back to a system-root denylist, and this list is
+        // what stops someone watching a home directory. So this is a message
+        // fix, not a policy change, and the remedy has to be the exact stanza
+        // rather than "register it", which is what the operator believes they
+        // already did.
+        let type_hint = if vault_only {
+            "\n  type = \"vault\""
+        } else {
+            ""
+        };
         return Err(Status::invalid_argument(format!(
-            "{kind} path {} is not in the instance's registered sources",
+            "{kind} path {} is not in the instance config's [[repos]] allow-list. \
+             Indexing it with `brain add` is NOT enough: the watcher checks the \
+             config, not the database.\n\
+             Add this to your instance.toml and restart the daemon:\n\n               [[repos]]{type_hint}\n  url = \"file://{}\"",
+            path.display(),
             path.display()
         )));
     }
@@ -19094,6 +19120,63 @@ mod watch_path_allowed_tests {
         std::fs::create_dir(&sub).unwrap();
         let sub = std::fs::canonicalize(&sub).unwrap();
         assert!(watch_path_allowed(Some(&repos), &sub, "repo", false).is_ok());
+    }
+
+    /// nw-203. The rejection must name the REGISTRY it consulted and the exact
+    /// remedy.
+    ///
+    /// The old message was "is not in the instance's registered sources", which
+    /// stated a fact and stopped — and its central word was doing double duty.
+    /// A vault indexed with `brain add --config` IS registered: it is in the DB
+    /// and `brain status` lists it. The watcher checks the instance CONFIG,
+    /// a different registry, so an operator who had demonstrably registered the
+    /// vault was told it was not registered.
+    ///
+    /// Asserts what an operator can ACT on, not the phrasing: which registry,
+    /// that indexing is not sufficient, and a stanza they can paste.
+    #[test]
+    fn rejection_names_the_config_registry_and_a_pastable_remedy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let registered = tmp.path().join("registered");
+        let outsider = tmp.path().join("outsider");
+        std::fs::create_dir(&registered).unwrap();
+        std::fs::create_dir(&outsider).unwrap();
+        let outsider = std::fs::canonicalize(&outsider).unwrap();
+        let repos = vec![repo_cfg(
+            &format!("file://{}", registered.display()),
+            Some(RepoType::Vault),
+        )];
+
+        let error = watch_path_allowed(Some(&repos), &outsider, "vault", true)
+            .expect_err("an unregistered path must still be refused");
+        let message = error.message();
+
+        assert!(
+            message.contains("[[repos]]"),
+            "must name the config allow-list it actually consulted: {message}"
+        );
+        assert!(
+            !message.contains("registered sources"),
+            "the ambiguous wording is the defect, not the phrasing: {message}"
+        );
+        assert!(
+            message.contains("brain add") && message.contains("NOT enough"),
+            "must resolve the contradiction for someone who already indexed it: {message}"
+        );
+        assert!(
+            message.contains(&format!("url = \"file://{}\"", outsider.display())),
+            "the remedy must be pastable, naming the path the operator asked for: {message}"
+        );
+        assert!(
+            message.contains("type = \"vault\""),
+            "a vault watch needs the type line, which is the part nothing documented: {message}"
+        );
+
+        // A code watch gets the same stanza WITHOUT the vault type line, which
+        // would otherwise be wrong advice.
+        let code_error = watch_path_allowed(Some(&repos), &outsider, "repo", false)
+            .expect_err("an unregistered path must still be refused");
+        assert!(!code_error.message().contains("type = \"vault\""));
     }
 
     /// Paths outside the config's registered sources are still rejected, and

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -7541,16 +7541,16 @@ fn watch_path_allowed(
         // fix, not a policy change, and the remedy has to be the exact stanza
         // rather than "register it", which is what the operator believes they
         // already did.
-        let type_hint = if vault_only {
-            "\n  type = \"vault\""
-        } else {
-            ""
-        };
+        // Column 0, matching the docs example. The stanza is the one thing
+        // this message is selling, so it must paste cleanly rather than
+        // inherit whatever indentation the source line happens to have.
+        let type_hint = if vault_only { "\ntype = \"vault\"" } else { "" };
         return Err(Status::invalid_argument(format!(
             "{kind} path {} is not in the instance config's [[repos]] allow-list. \
              Indexing it with `brain add` is NOT enough: the watcher checks the \
              config, not the database.\n\
-             Add this to your instance.toml and restart the daemon:\n\n               [[repos]]{type_hint}\n  url = \"file://{}\"",
+             Add this to your instance.toml and restart the daemon:\n\n\
+             [[repos]]{type_hint}\nurl = \"file://{}\"",
             path.display(),
             path.display()
         )));

--- a/crates/nestweaver-engine/src/investigate.rs
+++ b/crates/nestweaver-engine/src/investigate.rs
@@ -138,7 +138,20 @@ pub struct Domain {
 pub struct InvestigateResult {
     pub bundle_id: String,
     pub query: String,
+    /// The scope STRING the caller supplied, echoed back verbatim.
+    ///
+    /// nw-189: this alone reads as a restriction that was applied, which for
+    /// `vault`/`all`/empty is false — they are documented pass-throughs, and
+    /// the CLI additionally defaulted an unsupplied scope to the literal
+    /// "vault", so a caller who asked for nothing was told their results were
+    /// vault-scoped while code symbols from every repo came back. Pair it with
+    /// `scope_filtered` before drawing any conclusion from it.
     pub scope: String,
+    /// Whether a real filter was constructed and applied for `scope`.
+    ///
+    /// False for the pass-through scopes. A caller that wants to know whether
+    /// results were actually restricted must read THIS, not `scope`.
+    pub scope_filtered: bool,
     pub domains: Vec<Domain>,
     pub entries: Vec<BundleEntry>,
     /// Number of additional connected nodes dropped due to the token budget.
@@ -593,6 +606,7 @@ pub fn investigate(
         bundle_id,
         query: query.to_string(),
         scope: scope.to_string(),
+        scope_filtered: scope_filter.is_some(),
         domains,
         entries,
         more_available,
@@ -1377,6 +1391,44 @@ mod tests {
         assert_eq!(a, b, "same inputs → same asset id");
         assert_ne!(a, c, "different uid → different asset id");
         assert!(a.starts_with('a') && a.len() == 13);
+    }
+
+    /// nw-189. `vault` and `all` are documented PASS-THROUGHS — they construct
+    /// no filter — so a response that echoes `scope: "vault"` and nothing else
+    /// reads as a restriction that never happened. The CLI and MCP made it
+    /// worse by defaulting an unsupplied scope to the literal "vault", so a
+    /// caller who asked for nothing was told their results were vault-scoped
+    /// while code symbols from every repo came back.
+    ///
+    /// Pins the property that matters: whether a filter was BUILT, which is
+    /// what `scope_filtered` reports. Asserting on `resolve_scope` directly
+    /// keeps this independent of a populated graph.
+    #[test]
+    fn pass_through_scopes_build_no_filter_and_real_scopes_do() {
+        let store = GraphStore::in_memory().unwrap();
+
+        // Every documented pass-through, including the empty string and the
+        // case variants the resolver accepts.
+        for pass_through in ["", "vault", "all", "VAULT", "All", "  vault  "] {
+            let (_, filter) = resolve_scope(&store, "anything", pass_through).unwrap();
+            assert!(
+                filter.is_none(),
+                "{pass_through:?} is documented as no restriction, so it must build no filter"
+            );
+        }
+
+        // A repo scope for a repo that does not exist is an ERROR, not a
+        // silent pass-through — 6.4.0's fix, pinned here so a future change
+        // cannot quietly turn an unknown scope back into "no restriction",
+        // which would be indistinguishable from the bug above.
+        assert!(
+            resolve_scope(&store, "anything", "repo:does-not-exist").is_err(),
+            "an unresolvable repo scope must error rather than silently match everything"
+        );
+        assert!(
+            resolve_scope(&store, "anything", "project:does-not-exist").is_err(),
+            "an unresolvable project scope must error rather than silently match everything"
+        );
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/investigate.rs
+++ b/crates/nestweaver-engine/src/investigate.rs
@@ -1393,6 +1393,63 @@ mod tests {
         assert!(a.starts_with('a') && a.len() == 13);
     }
 
+    /// nw-189. `scope_filtered` must report whether a filter actually RAN,
+    /// which is the thing `scope` alone cannot express.
+    ///
+    /// The previous test in this module exercises `resolve_scope` only, and so
+    /// passes identically on `main` — it guards pre-existing behaviour rather
+    /// than this change. This one pins the new field against the same binding
+    /// that gates the filter, so the flag cannot drift from reality.
+    #[test]
+    fn scope_filtered_reports_whether_a_filter_actually_ran() {
+        let store = GraphStore::in_memory().unwrap();
+
+        // Every documented pass-through must report FALSE — including the
+        // literal "vault" a caller may still pass explicitly.
+        for pass_through in ["", "vault", "all"] {
+            let (_, filter) = resolve_scope(&store, "anything", pass_through).unwrap();
+            assert!(
+                filter.is_none(),
+                "{pass_through:?} builds no filter, so scope_filtered must be false"
+            );
+        }
+
+        // The RESPONSE is where the defect showed, so assert on the serialized
+        // shape a caller actually reads. `scope` echoing "vault" is not itself
+        // wrong — what was wrong is that nothing alongside it said whether a
+        // restriction happened.
+        let unrestricted = InvestigateResult {
+            bundle_id: "b".to_string(),
+            query: "q".to_string(),
+            scope: "vault".to_string(),
+            scope_filtered: false,
+            domains: vec![],
+            entries: vec![],
+            more_available: 0,
+            semantic_applied: false,
+            degraded_components: vec![],
+        };
+        let json = serde_json::to_value(&unrestricted).unwrap();
+        assert_eq!(
+            json["scope"], "vault",
+            "the caller's scope string is still echoed verbatim"
+        );
+        assert_eq!(
+            json["scope_filtered"], false,
+            "…and `scope_filtered` is what tells them nothing was restricted"
+        );
+
+        let restricted = InvestigateResult {
+            scope: "repo:acme".to_string(),
+            scope_filtered: true,
+            ..unrestricted
+        };
+        assert_eq!(
+            serde_json::to_value(&restricted).unwrap()["scope_filtered"],
+            true
+        );
+    }
+
     /// nw-189. `vault` and `all` are documented PASS-THROUGHS — they construct
     /// no filter — so a response that echoes `scope: "vault"` and nothing else
     /// reads as a restriction that never happened. The CLI and MCP made it

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -7225,6 +7225,13 @@ fn tool_schema_detect_changes() -> Value {
                     "items": { "type": "string" },
                     "minItems": 1,
                     "description": "Backward-compatible alias for changed_files."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 1000,
+                    "description": "Max affected symbols AND max affected processes to inline (default 50). The totals are always reported as affected_symbol_count / affected_process_count, and truncated says whether anything was omitted.",
+                    "default": DEFAULT_RESULT_LIMIT
                 }
             }
         }
@@ -7245,11 +7252,25 @@ fn tool_detect_changes(store: &GraphStore, args: Value) -> Result<Value, anyhow:
         return Err(anyhow!("'files' must contain at least one path"));
     }
 
+    // nw-174: this tool inlined EVERY affected symbol and process. On a
+    // high-fanout file that was 156 KB (~39K tokens) with 416 processes in one
+    // call — a fifth of a context window — while every neighbouring tool
+    // (brain_broken_links, brain_orphan_documents, blast_radius) already
+    // capped and reported total vs returned. The counts below were already
+    // honest; what was missing was the bound.
+    let limit = args
+        .get("limit")
+        .and_then(|v| v.as_u64())
+        .map(|n| n as usize)
+        .unwrap_or(DEFAULT_RESULT_LIMIT)
+        .clamp(1, 1000);
+
     let impact = detect_changes_impact(store, &files, 10).context("detect_changes_impact")?;
 
     let affected_symbols: Vec<Value> = impact
         .affected_symbols
         .iter()
+        .take(limit)
         .map(|s| {
             json!({
                 "uid": s.uid,
@@ -7262,6 +7283,7 @@ fn tool_detect_changes(store: &GraphStore, args: Value) -> Result<Value, anyhow:
     let affected_processes: Vec<Value> = impact
         .affected_processes
         .iter()
+        .take(limit)
         .map(|p| {
             json!({
                 "name": p.name,
@@ -7278,6 +7300,15 @@ fn tool_detect_changes(store: &GraphStore, args: Value) -> Result<Value, anyhow:
         nestweaver_engine::RiskLevel::High => "high",
     };
 
+    let symbols_omitted = impact
+        .affected_symbols
+        .len()
+        .saturating_sub(affected_symbols.len());
+    let processes_omitted = impact
+        .affected_processes
+        .len()
+        .saturating_sub(affected_processes.len());
+
     Ok(json!({
         "files": files,
         "risk": risk_str,
@@ -7286,9 +7317,16 @@ fn tool_detect_changes(store: &GraphStore, args: Value) -> Result<Value, anyhow:
         "notifications": serde_json::to_value(&impact.notifications)?,
         "blast_radius": impact.blast_radius,
         "affected_symbols": affected_symbols,
+        // The TOTAL, not the returned length — so `affected_symbol_count`
+        // against the array length is how a caller sees what was dropped, and
+        // `truncated` says it outright rather than requiring the comparison.
         "affected_symbol_count": impact.affected_symbols.len(),
         "affected_processes": affected_processes,
         "affected_process_count": impact.affected_processes.len(),
+        "limit": limit,
+        "truncated": symbols_omitted > 0 || processes_omitted > 0,
+        "symbols_omitted": symbols_omitted,
+        "processes_omitted": processes_omitted,
     }))
 }
 
@@ -8541,6 +8579,14 @@ fn tool_project_context(
     let remaining_budget = token_budget.saturating_sub(seed_tokens);
     let (cut, connected_tokens) = budgeted_cut(&result.connected, remaining_budget, concise);
     let used_tokens = seed_tokens + connected_tokens;
+    // nw-188: a caller could not distinguish "this project is empty" from
+    // "your budget was too small", because `connected: []` was reported
+    // identically in both cases with no flag. Seeds are charged against the
+    // budget FIRST, so a budget smaller than the seed overhead leaves zero for
+    // connected and drops every one of them silently — reproduced as
+    // token_budget 200 / tokens_used 257 / connected [] / seeds_expanded 114.
+    let connected_dropped = result.connected.len().saturating_sub(cut);
+    let budget_exceeded = used_tokens > token_budget;
 
     // 7. Load external_refs from extension sidecar.
     let ext_store = load_extensions(&db_path);
@@ -8595,6 +8641,9 @@ fn tool_project_context(
             "connected": connected_json,
             "tokens_used": used_tokens,
             "token_budget": token_budget,
+            "more_available": connected_dropped,
+            "truncated": connected_dropped > 0,
+            "budget_exceeded": budget_exceeded,
             "semantic_applied": result.semantic_applied,
             "degraded_components": &result.degraded_components,
         });
@@ -8621,6 +8670,11 @@ fn tool_project_context(
         }
     }
 
+    // nw-188: `more_available` and `truncated` name what was dropped;
+    // `budget_exceeded` says plainly that `tokens_used` is over `token_budget`
+    // rather than leaving a caller to notice the arithmetic. Reporting the
+    // real `tokens_used` and flagging it is the honest pair — silently
+    // clamping the number would trade one lie for another.
     let mut resp = json!({
         "project": project.name,
         "project_uid": project.uid,
@@ -8628,6 +8682,9 @@ fn tool_project_context(
         "connected": connected_json,
         "tokens_used": used_tokens,
         "token_budget": token_budget,
+        "more_available": connected_dropped,
+        "truncated": connected_dropped > 0,
+        "budget_exceeded": budget_exceeded,
         "semantic_applied": result.semantic_applied,
         "degraded_components": &result.degraded_components,
     });
@@ -10446,7 +10503,7 @@ fn tool_schema_investigate() -> Value {
             "type": "object",
             "properties": {
                 "query": { "type": "string", "description": "The topic/feature/subsystem to orient on (e.g. \"device pairing\", \"how indexing works\")." },
-                "scope": { "type": "string", "description": "Optional scope: \"project:<slug>\", \"repo:<name>\", or \"vault\"/\"all\" (default = no restriction)." },
+                "scope": { "type": "string", "description": "Optional scope. \"project:<slug>\" and \"repo:<name>\" genuinely restrict results; \"vault\" and \"all\" are PASS-THROUGHS that restrict nothing (default: \"all\"). Read `scope_filtered` in the response to know whether a filter was actually applied — `scope` only echoes what you asked for." },
                 "token_budget": { "type": "integer", "minimum": 1, "maximum": 16000, "default": 4000, "description": "Approximate token cap for the map (chars/4). Hard-capped at 16000." },
                 "root": { "type": "string", "description": "Filesystem root for reading inline source bodies. Defaults to the server's working directory." }
             },
@@ -10466,10 +10523,13 @@ fn tool_investigate(
         .get("query")
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow!("'query' must be a string"))?;
-    let scope = args
-        .get("scope")
-        .and_then(|v| v.as_str())
-        .unwrap_or("vault");
+    // nw-189: "all", not "vault". The result echoes this string back, and
+    // defaulting to "vault" told an agent that supplied NO scope that its
+    // results were vault-scoped while code symbols from every repo came back.
+    // Both are documented pass-throughs; "all" is the honest name for the
+    // default. `scope_filtered` in the response reports whether a filter was
+    // actually applied.
+    let scope = args.get("scope").and_then(|v| v.as_str()).unwrap_or("all");
     let token_budget = args
         .get("token_budget")
         .and_then(|v| v.as_u64())

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -7230,7 +7230,7 @@ fn tool_schema_detect_changes() -> Value {
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 1000,
-                    "description": "Max affected symbols AND max affected processes to inline (default 50). The totals are always reported as affected_symbol_count / affected_process_count, and truncated says whether anything was omitted.",
+                    "description": "Max affected symbols AND max affected processes to inline (default 50). The totals are always reported as affected_symbol_count / affected_process_count, and truncated says whether anything was omitted. NOTE: the cut is positional, not by importance — symbols are ordered by (file_path, name) and processes by name, because neither carries an impact score. Raise limit rather than assuming the first N are the most impactful; for ranked results use blast_radius.",
                     "default": DEFAULT_RESULT_LIMIT
                 }
             }
@@ -7267,8 +7267,21 @@ fn tool_detect_changes(store: &GraphStore, args: Value) -> Result<Value, anyhow:
 
     let impact = detect_changes_impact(store, &files, 10).context("detect_changes_impact")?;
 
-    let affected_symbols: Vec<Value> = impact
-        .affected_symbols
+    // Sorted before truncating. `affected_symbols` is built in
+    // changed_files x symbols_in_file discovery order with no scoring, so a
+    // bare `take(limit)` keeps an ARBITRARY subset — on a large change the
+    // highest-fanout symbol could be dropped while trivial helpers from the
+    // first file are kept, and which ones you got would shift with the order
+    // the caller happened to list their files in.
+    //
+    // `AffectedSymbol` carries no impact score, so this CANNOT rank by
+    // importance the way blast_radius does. Sorting by (file_path, name) buys
+    // determinism and nothing more — which is why the schema says the cut is
+    // positional rather than implying the first N matter most.
+    let mut ranked_symbols: Vec<_> = impact.affected_symbols.iter().collect();
+    ranked_symbols.sort_by(|a, b| a.file_path.cmp(&b.file_path).then(a.name.cmp(&b.name)));
+
+    let affected_symbols: Vec<Value> = ranked_symbols
         .iter()
         .take(limit)
         .map(|s| {
@@ -8585,8 +8598,12 @@ fn tool_project_context(
     // budget FIRST, so a budget smaller than the seed overhead leaves zero for
     // connected and drops every one of them silently — reproduced as
     // token_budget 200 / tokens_used 257 / connected [] / seeds_expanded 114.
-    let connected_dropped = result.connected.len().saturating_sub(cut);
-    let budget_exceeded = used_tokens > token_budget;
+    // Provisional: `budgeted_cut` decided this, but the probe loop below can
+    // drop more. The authoritative count is recomputed after it.
+    let provisional_dropped = result.connected.len().saturating_sub(cut);
+    // Overwritten by the probe block with the ACTUAL serialized size.
+    #[allow(unused_assignments)]
+    let mut final_payload_tokens = used_tokens;
 
     // 7. Load external_refs from extension sidecar.
     let ext_store = load_extensions(&db_path);
@@ -8641,9 +8658,9 @@ fn tool_project_context(
             "connected": connected_json,
             "tokens_used": used_tokens,
             "token_budget": token_budget,
-            "more_available": connected_dropped,
-            "truncated": connected_dropped > 0,
-            "budget_exceeded": budget_exceeded,
+            "more_available": provisional_dropped,
+            "truncated": provisional_dropped > 0,
+            "budget_exceeded": used_tokens > token_budget,
             "semantic_applied": result.semantic_applied,
             "degraded_components": &result.degraded_components,
         });
@@ -8657,18 +8674,28 @@ fn tool_project_context(
             probe["external_refs"] = external_refs.clone();
         }
         let serialized = serde_json::to_string(&probe)?;
-        let actual_tokens = serialized.len().div_ceil(4);
+        let mut actual_tokens = serialized.len().div_ceil(4);
         if actual_tokens > token_budget {
             while connected_json.len() > 1 {
                 connected_json.pop();
                 probe["connected"] = json!(connected_json);
                 let check = serde_json::to_string(&probe)?;
-                if check.len().div_ceil(4) <= token_budget {
+                actual_tokens = check.len().div_ceil(4);
+                if actual_tokens <= token_budget {
                     break;
                 }
             }
         }
+        final_payload_tokens = actual_tokens;
     }
+
+    // RECOMPUTED after the probe loop, not before it. The loop above pops
+    // further entries off `connected_json` to fit the SERIALIZED payload under
+    // the budget, so a count taken from `budgeted_cut` alone understates what
+    // the caller actually lost — the response would have reported a smaller
+    // `more_available` than the number of items genuinely missing, which is the
+    // same class of dishonesty this item exists to remove.
+    let connected_dropped = result.connected.len().saturating_sub(connected_json.len());
 
     // nw-188: `more_available` and `truncated` name what was dropped;
     // `budget_exceeded` says plainly that `tokens_used` is over `token_budget`
@@ -8680,11 +8707,20 @@ fn tool_project_context(
         "project_uid": project.uid,
         "seeds_expanded": result.seeds.len(),
         "connected": connected_json,
-        "tokens_used": used_tokens,
         "token_budget": token_budget,
         "more_available": connected_dropped,
         "truncated": connected_dropped > 0,
-        "budget_exceeded": budget_exceeded,
+        // The ACTUAL serialized size, not the pre-serialization estimate.
+        //
+        // The estimate charges `seed_tokens` against the budget even when
+        // `include_seeds` is false and the seeds are therefore NOT in the
+        // payload — which is how the reported case produced `tokens_used: 257`
+        // for a response that serialized to a fraction of that. Reporting the
+        // estimate as "used" was itself the dishonesty; `seed_tokens_charged`
+        // below explains where the budget actually went.
+        "tokens_used": final_payload_tokens,
+        "seed_tokens_charged": seed_tokens,
+        "budget_exceeded": final_payload_tokens > token_budget,
         "semantic_applied": result.semantic_applied,
         "degraded_components": &result.degraded_components,
     });

--- a/docs/guide/instance-config.md
+++ b/docs/guide/instance-config.md
@@ -318,6 +318,28 @@ sparse = false        # optional: disable sparse checkout (default: true)
 pin_sha = "abc123"    # optional: pin to a specific commit
 ```
 
+> **A path must appear here to be WATCHABLE, not just to be indexed.**
+>
+> `[[repos]]` is the allow-list the file watchers check. Indexing a path with
+> `brain add` registers it in the *database*, which is a different registry —
+> `brain status` will list the vault while `brain watch` still refuses it:
+>
+> ```
+> vault path /Users/me/brain is not in the instance config's [[repos]] allow-list
+> ```
+>
+> For a local vault, that means a `file://` entry with `type = "vault"`:
+>
+> ```toml
+> [[repos]]
+> type = "vault"
+> url = "file:///Users/me/brain"
+> ```
+>
+> Restart the daemon after adding it. The allow-list is deliberate: without
+> `--config` the daemon falls back to a system-root denylist, and this list is
+> what prevents watching an entire home directory.
+
 ### Optional sections
 
 #### `[daemon]` — Daemon lifecycle policy

--- a/src/main.rs
+++ b/src/main.rs
@@ -1986,7 +1986,7 @@ enum Commands {
     /// Remove an indexed repository and all its data (symbols, files,
     /// services, contracts) from the graph.
     #[command(
-        after_help = "Accepts a repo name, filesystem path, file:// URL, or UID.\n\nExamples:\n  nestweaver remove-repo acme-server\n  nestweaver remove-repo /home/user/dev/workspaces/acme/acme-server\n  nestweaver remove-repo repo:051a9ff9:abc123"
+        after_help = "Accepts the repo UID, its remote URL, its name, a filesystem path, or a file:// URL.\n\n`nestweaver list-repos` prints the UID and the URL for every indexed repo;\neither one works here.\n\nExamples:\n  nestweaver remove-repo acme-server\n  nestweaver remove-repo git@github.com:acme/acme-server.git\n  nestweaver remove-repo https://github.com/acme/acme-server.git\n  nestweaver remove-repo /home/user/dev/workspaces/acme/acme-server\n  nestweaver remove-repo repo:051a9ff9:abc123"
     )]
     RemoveRepo {
         /// Repo name, remote URL, filesystem path, file:// URL, or UID —
@@ -3336,6 +3336,12 @@ enum Commands {
             help = "Changed file paths, repo-relative (repeat for several)"
         )]
         files: Vec<String>,
+        #[arg(
+            long,
+            value_parser = clap::value_parser!(u64).range(1..=1000),
+            help = "Max affected symbols and processes to list (1-1000; default: 50, or [limits].default_result_limit from config). Totals are always reported; the cut is positional, not by importance"
+        )]
+        limit: Option<u64>,
         #[arg(long, help = "Output as JSON")]
         json: bool,
         #[arg(
@@ -7773,10 +7779,6 @@ async fn restart_live_daemon_preserving_config(
     }
 }
 
-/// nw-087: commands that operate on an existing database must fail
-/// `db_not_found` when the file is absent — never autostart a daemon that
-/// CREATES an empty DB (a typo'd `--db` must not false-green). The message is
-/// phrased so `into_diagnostic` maps it to `CliDiagnostic::DatabaseNotFound`.
 /// Whether `repo` is identified by `target` for `remove-repo`.
 ///
 /// Extracted from the command body so the rules are testable without a daemon
@@ -7788,8 +7790,57 @@ async fn restart_live_daemon_preserving_config(
 /// verbatim, its name, an absolute path or `file://` URL, the git origin
 /// remote of a local checkout, the stored root path, and a trailing path
 /// segment of the URL.
-fn repo_matches_target(repo: &nestweaver_schema::Repo, target: &str) -> bool {
-    let target_trimmed = target.trim_end_matches('/');
+/// The filesystem-derived forms of a target, computed ONCE.
+///
+/// `canonicalize` and — worse — `read_origin_url`, which spawns
+/// `git config --get remote.origin.url`, must not run per candidate repo. The
+/// original inline closure hoisted them above the filter; the first extraction
+/// moved them inside it, turning one subprocess into one per indexed repo.
+struct ResolvedTarget {
+    trimmed: String,
+    canonical_url: String,
+    url_form: String,
+    origin_url: String,
+    canonical_path: String,
+}
+
+impl ResolvedTarget {
+    fn new(target: &str) -> Self {
+        let trimmed = target.trim_end_matches('/').to_string();
+        let canonical_url = std::fs::canonicalize(&trimmed)
+            .map(|p| format!("file://{}", p.display()))
+            .unwrap_or_default();
+        let url_form = if trimmed.starts_with("file://") {
+            trimmed.clone()
+        } else if std::path::Path::new(&trimmed).is_absolute() {
+            format!("file://{trimmed}")
+        } else {
+            String::new()
+        };
+        // A path target may refer to a repo identified by its git origin
+        // remote rather than a file:// URL (the origin URL is read from git
+        // config, never fetched).
+        let origin_url = std::fs::canonicalize(&trimmed)
+            .ok()
+            .filter(|p| p.join(".git").exists())
+            .and_then(|p| nestweaver_engine::read_origin_url(&p).ok())
+            .unwrap_or_default();
+        let canonical_path = canonical_url
+            .strip_prefix("file://")
+            .unwrap_or_default()
+            .to_string();
+        Self {
+            trimmed,
+            canonical_url,
+            url_form,
+            origin_url,
+            canonical_path,
+        }
+    }
+}
+
+fn repo_matches_resolved_target(repo: &nestweaver_schema::Repo, target: &ResolvedTarget) -> bool {
+    let target_trimmed = target.trimmed.as_str();
     let r_url = repo.url.trim_end_matches('/');
 
     // nw-202: the REMOTE URL, matched verbatim, as a primary key.
@@ -7806,38 +7857,19 @@ fn repo_matches_target(repo: &nestweaver_schema::Repo, target: &str) -> bool {
         return true;
     }
 
-    let canonical_target = std::fs::canonicalize(target_trimmed)
-        .map(|p| format!("file://{}", p.display()))
-        .unwrap_or_default();
-    let url_target = if target_trimmed.starts_with("file://") {
-        target_trimmed.to_string()
-    } else if std::path::Path::new(target_trimmed).is_absolute() {
-        format!("file://{target_trimmed}")
-    } else {
-        String::new()
-    };
-    // A path target may refer to a repo identified by its git origin remote
-    // rather than a file:// URL — try that identity and the stored root_path
-    // too (the origin URL is read from git config, never fetched).
-    let origin_target = std::fs::canonicalize(target_trimmed)
-        .ok()
-        .filter(|p| p.join(".git").exists())
-        .and_then(|p| nestweaver_engine::read_origin_url(&p).ok())
-        .unwrap_or_default();
-    let canonical_path = canonical_target
-        .strip_prefix("file://")
-        .unwrap_or_default()
-        .to_string();
-
-    (!url_target.is_empty() && r_url == url_target)
-        || (!canonical_target.is_empty() && r_url == canonical_target)
-        || (!origin_target.is_empty() && r_url == origin_target.trim_end_matches('/'))
-        || (!canonical_path.is_empty()
+    (!target.url_form.is_empty() && r_url == target.url_form)
+        || (!target.canonical_url.is_empty() && r_url == target.canonical_url)
+        || (!target.origin_url.is_empty() && r_url == target.origin_url.trim_end_matches('/'))
+        || (!target.canonical_path.is_empty()
             && repo.local_root().map(|p| p.trim_end_matches('/'))
-                == Some(canonical_path.trim_end_matches('/')))
+                == Some(target.canonical_path.trim_end_matches('/')))
         || r_url.ends_with(&format!("/{target_trimmed}"))
 }
 
+/// nw-087: commands that operate on an existing database must fail
+/// `db_not_found` when the file is absent — never autostart a daemon that
+/// CREATES an empty DB (a typo'd `--db` must not false-green). The message is
+/// phrased so `into_diagnostic` maps it to `CliDiagnostic::DatabaseNotFound`.
 fn require_existing_db(db_path: &std::path::Path) -> anyhow::Result<()> {
     if !db_path.exists() {
         anyhow::bail!("database not found at {}", db_path.display());
@@ -8804,9 +8836,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // Resolve target → repo UID. Accepts UID, remote URL, name, path,
             // or file:// URL. See `repo_matches_target`, which is where the
             // rules live so they can be tested without a daemon.
+            // Resolved ONCE, outside the filter: it canonicalizes and may
+            // spawn `git config --get remote.origin.url`.
+            let resolved_target = ResolvedTarget::new(&target);
             let matched: Vec<&nestweaver_schema::Repo> = repos
                 .iter()
-                .filter(|r| repo_matches_target(r, &target))
+                .filter(|r| repo_matches_resolved_target(r, &resolved_target))
                 .collect();
 
             if matched.is_empty() {
@@ -10945,13 +10980,24 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
 
         Commands::DetectChanges {
             files,
+            limit,
             json,
             db,
             config,
         } => {
             let db_path = resolve_db_with_config(db, config.as_deref())?;
             require_existing_db(&db_path)?;
-            let args = serde_json::json!({ "changed_files": files });
+            // nw-174 added a default cap to the underlying tool. Without a flag
+            // here the CLI would inherit the ceiling with no way to raise it,
+            // silently truncating output for scripts and CI that parse
+            // `affected_symbols`.
+            let cfg = load_instance_config_opt(config.as_deref());
+            let limit = resolve_limit(
+                limit.map(|n| n as usize),
+                cfg.as_ref(),
+                nestweaver_engine::config::DEFAULT_RESULT_LIMIT,
+            );
+            let args = serde_json::json!({ "changed_files": files, "limit": limit });
             let payload = match try_hybrid_json_rpc_checked(
                 use_daemon,
                 &db_path,
@@ -26249,8 +26295,6 @@ credential_method = "gh"
         assert!(!missing.exists());
     }
 
-    /// nw-087: a nonexistent --db must fail with the db_not_found
-    /// diagnostic (exit 1), not silently create/spawn anything.
     /// nw-202. `list-repos` leads every entry with `URL: git@github.com:Org/repo.git`,
     /// and passing that exact string to `remove-repo` used to match NOTHING —
     /// the resolver was path- and `file://`-centric. The error then said "Run
@@ -26260,6 +26304,13 @@ credential_method = "gh"
     /// Asserts the identities `list-repos` actually PRINTS are accepted, which
     /// is the user-visible contract, rather than asserting on the internals of
     /// the match.
+    /// Exercises the SAME pair the command uses — `ResolvedTarget::new` then
+    /// `repo_matches_resolved_target` — rather than a test-only shim, so the
+    /// once-per-target resolution is on the tested path too.
+    fn repo_matches(repo: &nestweaver_schema::Repo, target: &str) -> bool {
+        repo_matches_resolved_target(repo, &ResolvedTarget::new(target))
+    }
+
     #[test]
     fn remove_repo_accepts_the_identities_list_repos_prints() {
         let repo = nestweaver_schema::Repo {
@@ -26274,38 +26325,37 @@ credential_method = "gh"
 
         // The two lines `list-repos` prints for every repo.
         assert!(
-            repo_matches_target(&repo, "git@github.com:Ballistic-X/web-app.git"),
+            repo_matches(&repo, "git@github.com:Ballistic-X/web-app.git"),
             "the ssh remote URL is the identity the tool advertises"
         );
-        assert!(repo_matches_target(&repo, "repo:kory-brain:29b71f654c79"));
+        assert!(repo_matches(&repo, "repo:kory-brain:29b71f654c79"));
 
         // Reproduced originally on an https URL too, so both forms are pinned.
         let https = nestweaver_schema::Repo {
             url: "https://github.com/Ballistic-X/web-app.git".to_string(),
             ..repo.clone()
         };
-        assert!(repo_matches_target(
+        assert!(repo_matches(
             &https,
             "https://github.com/Ballistic-X/web-app.git"
         ));
 
         // A trailing slash must not defeat either form.
-        assert!(repo_matches_target(
+        assert!(repo_matches(
             &https,
             "https://github.com/Ballistic-X/web-app.git/"
         ));
-        assert!(repo_matches_target(&repo, "repo:kory-brain:29b71f654c79/"));
+        assert!(repo_matches(&repo, "repo:kory-brain:29b71f654c79/"));
 
         // Name still works, and an unrelated string still does not — otherwise
         // this test would pass against a matcher that returns true for anything.
-        assert!(repo_matches_target(&repo, "web-app"));
-        assert!(!repo_matches_target(
-            &repo,
-            "git@github.com:Other/thing.git"
-        ));
-        assert!(!repo_matches_target(&repo, "repo:kory-brain:deadbeef"));
+        assert!(repo_matches(&repo, "web-app"));
+        assert!(!repo_matches(&repo, "git@github.com:Other/thing.git"));
+        assert!(!repo_matches(&repo, "repo:kory-brain:deadbeef"));
     }
 
+    /// nw-087: a nonexistent --db must fail with the db_not_found
+    /// diagnostic (exit 1), not silently create/spawn anything.
     #[test]
     fn require_existing_db_fails_db_not_found_on_missing_db() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1989,7 +1989,8 @@ enum Commands {
         after_help = "Accepts a repo name, filesystem path, file:// URL, or UID.\n\nExamples:\n  nestweaver remove-repo acme-server\n  nestweaver remove-repo /home/user/dev/workspaces/acme/acme-server\n  nestweaver remove-repo repo:051a9ff9:abc123"
     )]
     RemoveRepo {
-        /// Repo name, filesystem path, file:// URL, or UID
+        /// Repo name, remote URL, filesystem path, file:// URL, or UID —
+        /// including the exact `URL:` and UID lines `list-repos` prints
         target: String,
         #[arg(
             long,
@@ -4130,6 +4131,14 @@ enum BrainCommands {
     /// Runs in the foreground; Ctrl-C stops it cleanly. On each .md save
     /// the changed file is re-parsed and its nodes are replaced via
     /// cascade-delete + re-insert.
+    ///
+    /// When the daemon runs with `--config`, the vault must have a `[[repos]]`
+    /// entry with `type = "vault"` in instance.toml. Having indexed it with
+    /// `brain add` is NOT sufficient — that registers it in the database,
+    /// while the watcher checks the config allow-list.
+    #[command(
+        after_help = "Examples:\n  nestweaver brain watch ~/brain\n  nestweaver brain watch ~/brain --name my-vault\n\nWith a --config daemon, instance.toml needs:\n\n  [[repos]]\n  type = \"vault\"\n  url = \"file:///Users/me/brain\"\n\nIndexing with `brain add` registers the vault in the DATABASE; the watcher\nchecks the instance CONFIG. Both are required."
+    )]
     Watch {
         /// Vault directory to watch.
         path: PathBuf,
@@ -7768,6 +7777,67 @@ async fn restart_live_daemon_preserving_config(
 /// `db_not_found` when the file is absent — never autostart a daemon that
 /// CREATES an empty DB (a typo'd `--db` must not false-green). The message is
 /// phrased so `into_diagnostic` maps it to `CliDiagnostic::DatabaseNotFound`.
+/// Whether `repo` is identified by `target` for `remove-repo`.
+///
+/// Extracted from the command body so the rules are testable without a daemon
+/// or a database — the previous inline closure could only be exercised
+/// end-to-end, which is why nw-202 (a remote URL matching nothing) went
+/// unnoticed despite `list-repos` advertising exactly that identity.
+///
+/// Accepts, in rough order of directness: the repo UID, its remote URL
+/// verbatim, its name, an absolute path or `file://` URL, the git origin
+/// remote of a local checkout, the stored root path, and a trailing path
+/// segment of the URL.
+fn repo_matches_target(repo: &nestweaver_schema::Repo, target: &str) -> bool {
+    let target_trimmed = target.trim_end_matches('/');
+    let r_url = repo.url.trim_end_matches('/');
+
+    // nw-202: the REMOTE URL, matched verbatim, as a primary key.
+    // `list-repos` leads every entry with `URL: git@github.com:Org/repo.git`,
+    // and passing that exact string back used to match nothing: the resolver
+    // was path- and `file://`-centric, so `url_target` below stays empty for an
+    // ssh or https remote. The tool advertised an identity it would not accept,
+    // and the error then told the operator to re-run the command that printed
+    // it.
+    if r_url == target_trimmed
+        || repo.uid == target_trimmed
+        || repo.name.as_deref() == Some(target_trimmed)
+    {
+        return true;
+    }
+
+    let canonical_target = std::fs::canonicalize(target_trimmed)
+        .map(|p| format!("file://{}", p.display()))
+        .unwrap_or_default();
+    let url_target = if target_trimmed.starts_with("file://") {
+        target_trimmed.to_string()
+    } else if std::path::Path::new(target_trimmed).is_absolute() {
+        format!("file://{target_trimmed}")
+    } else {
+        String::new()
+    };
+    // A path target may refer to a repo identified by its git origin remote
+    // rather than a file:// URL — try that identity and the stored root_path
+    // too (the origin URL is read from git config, never fetched).
+    let origin_target = std::fs::canonicalize(target_trimmed)
+        .ok()
+        .filter(|p| p.join(".git").exists())
+        .and_then(|p| nestweaver_engine::read_origin_url(&p).ok())
+        .unwrap_or_default();
+    let canonical_path = canonical_target
+        .strip_prefix("file://")
+        .unwrap_or_default()
+        .to_string();
+
+    (!url_target.is_empty() && r_url == url_target)
+        || (!canonical_target.is_empty() && r_url == canonical_target)
+        || (!origin_target.is_empty() && r_url == origin_target.trim_end_matches('/'))
+        || (!canonical_path.is_empty()
+            && repo.local_root().map(|p| p.trim_end_matches('/'))
+                == Some(canonical_path.trim_end_matches('/')))
+        || r_url.ends_with(&format!("/{target_trimmed}"))
+}
+
 fn require_existing_db(db_path: &std::path::Path) -> anyhow::Result<()> {
     if !db_path.exists() {
         anyhow::bail!("database not found at {}", db_path.display());
@@ -8731,55 +8801,25 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     .context("failed to parse repo list")?
             };
 
-            // Resolve target → repo UID.  Accept: UID, name, path, or URL.
-            let target_trimmed = target.trim_end_matches('/');
-            let canonical_target = std::fs::canonicalize(target_trimmed)
-                .map(|p| format!("file://{}", p.display()))
-                .unwrap_or_default();
-
-            let url_target = if target_trimmed.starts_with("file://") {
-                target_trimmed.trim_end_matches('/').to_string()
-            } else if std::path::Path::new(target_trimmed).is_absolute() {
-                format!("file://{target_trimmed}")
-            } else {
-                String::new()
-            };
-
-            // A path target may refer to a repo identified by its git origin
-            // remote rather than a file:// URL — try that identity and the
-            // stored root_path too (the origin URL is read from git config,
-            // never fetched).
-            let origin_target = std::fs::canonicalize(target_trimmed)
-                .ok()
-                .filter(|p| p.join(".git").exists())
-                .and_then(|p| nestweaver_engine::read_origin_url(&p).ok())
-                .unwrap_or_default();
-            let canonical_path = canonical_target
-                .strip_prefix("file://")
-                .unwrap_or_default()
-                .to_string();
-
+            // Resolve target → repo UID. Accepts UID, remote URL, name, path,
+            // or file:// URL. See `repo_matches_target`, which is where the
+            // rules live so they can be tested without a daemon.
             let matched: Vec<&nestweaver_schema::Repo> = repos
                 .iter()
-                .filter(|r| {
-                    let r_url = r.url.trim_end_matches('/');
-                    r.uid == target
-                        || r.name.as_deref() == Some(target_trimmed)
-                        || r_url == url_target
-                        || r_url == canonical_target
-                        || (!origin_target.is_empty()
-                            && r_url == origin_target.trim_end_matches('/'))
-                        || (!canonical_path.is_empty()
-                            && r.local_root().map(|p| p.trim_end_matches('/'))
-                                == Some(canonical_path.trim_end_matches('/')))
-                        || r_url.ends_with(&format!("/{target_trimmed}"))
-                })
+                .filter(|r| repo_matches_target(r, &target))
                 .collect();
 
             if matched.is_empty() {
+                // nw-202: name what IS accepted. The previous remedy was "Run
+                // `nestweaver list-repos`" — the command that printed the
+                // rejected string — which is a closed loop for a genuine typo
+                // as well as for the URL case fixed above.
                 eprintln!(
                     "Error: no repo matching '{target}' found.\n  \
-                     Run `nestweaver list-repos` to see indexed repos."
+                     Accepted: the repo UID, its remote URL, its name, a filesystem \
+                     path, or a file:// URL.\n  \
+                     `nestweaver list-repos` prints the UID and the URL for every \
+                     indexed repo; either one works here."
                 );
                 return Ok((EXIT_NOT_FOUND, None));
             }
@@ -13983,7 +14023,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let tantivy_path = tantivy_sidecar_path_for(&db_path);
             let tantivy = TantivyIndex::open_reader_only(&tantivy_path).ok();
             let root = root.unwrap_or_else(detect_repo_root);
-            let scope = scope.unwrap_or_else(|| "vault".to_string());
+            // nw-189: "all", not "vault". Both are pass-throughs, but the
+            // result echoes this string back, and defaulting to "vault" told a
+            // caller who supplied NO scope that their results were
+            // vault-scoped — while code symbols from every repo came back.
+            // "all" is the honest name for the no-restriction default and is
+            // already an advertised option.
+            let scope = scope.unwrap_or_else(|| "all".to_string());
             let result = nestweaver_engine::investigate(
                 &store,
                 tantivy.as_ref(),
@@ -26205,6 +26251,61 @@ credential_method = "gh"
 
     /// nw-087: a nonexistent --db must fail with the db_not_found
     /// diagnostic (exit 1), not silently create/spawn anything.
+    /// nw-202. `list-repos` leads every entry with `URL: git@github.com:Org/repo.git`,
+    /// and passing that exact string to `remove-repo` used to match NOTHING —
+    /// the resolver was path- and `file://`-centric. The error then said "Run
+    /// `nestweaver list-repos`", i.e. re-run the command that printed the
+    /// rejected string. A closed loop.
+    ///
+    /// Asserts the identities `list-repos` actually PRINTS are accepted, which
+    /// is the user-visible contract, rather than asserting on the internals of
+    /// the match.
+    #[test]
+    fn remove_repo_accepts_the_identities_list_repos_prints() {
+        let repo = nestweaver_schema::Repo {
+            uid: "repo:kory-brain:29b71f654c79".to_string(),
+            url: "git@github.com:Ballistic-X/web-app.git".to_string(),
+            indexed_sha: "abc".to_string(),
+            staleness_commits_behind: 0,
+            instance_id: "kory-brain".to_string(),
+            name: Some("web-app".to_string()),
+            root_path: None,
+        };
+
+        // The two lines `list-repos` prints for every repo.
+        assert!(
+            repo_matches_target(&repo, "git@github.com:Ballistic-X/web-app.git"),
+            "the ssh remote URL is the identity the tool advertises"
+        );
+        assert!(repo_matches_target(&repo, "repo:kory-brain:29b71f654c79"));
+
+        // Reproduced originally on an https URL too, so both forms are pinned.
+        let https = nestweaver_schema::Repo {
+            url: "https://github.com/Ballistic-X/web-app.git".to_string(),
+            ..repo.clone()
+        };
+        assert!(repo_matches_target(
+            &https,
+            "https://github.com/Ballistic-X/web-app.git"
+        ));
+
+        // A trailing slash must not defeat either form.
+        assert!(repo_matches_target(
+            &https,
+            "https://github.com/Ballistic-X/web-app.git/"
+        ));
+        assert!(repo_matches_target(&repo, "repo:kory-brain:29b71f654c79/"));
+
+        // Name still works, and an unrelated string still does not — otherwise
+        // this test would pass against a matcher that returns true for anything.
+        assert!(repo_matches_target(&repo, "web-app"));
+        assert!(!repo_matches_target(
+            &repo,
+            "git@github.com:Other/thing.git"
+        ));
+        assert!(!repo_matches_target(&repo, "repo:kory-brain:deadbeef"));
+    }
+
     #[test]
     fn require_existing_db_fails_db_not_found_on_missing_db() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Five backlog items with one root: **the tool states something it has not checked.** Each currently costs somebody an investigation. All message/schema level, independently testable.

Closes nw-202, nw-203, nw-189, nw-188, nw-174.

---

### nw-202 — `remove-repo` rejected the exact identifier `list-repos` prints

`list-repos` leads every entry with `URL: git@github.com:Org/repo.git`. Passing that back matched **nothing** — the resolver was path- and `file://`-centric, so a remote URL never became a match key. The error then said:

> Run `nestweaver list-repos` to see indexed repos.

…the command that printed the rejected string. A closed loop.

The remote URL is now a primary key, and the error names what **is** accepted. The matcher moved out of an inline closure into `repo_matches_target` so the rules can be tested without a daemon — being reachable only end-to-end is why this survived. Mutation-checked.

> Note: the item also asked for `list-repos` to print UIDs by default. That is **already true** on main; that part of the item was stale.

### nw-203 — the watcher refusal named no remedy, and "registered" meant two things

A vault indexed by `brain add --config` **is** registered: it's in the DB and `brain status` lists it. The watcher checks the instance **config** allow-list — a different registry — so an operator who had demonstrably registered the vault was told it was not.

```
vault path /Users/me/brain is not in the instance config's [[repos]] allow-list.
Indexing it with `brain add` is NOT enough: the watcher checks the config, not
the database.
Add this to your instance.toml and restart the daemon:

  [[repos]]
  type = "vault"
  url = "file:///Users/me/brain"
```

`type = "vault"` appears only for vault watches — emitting it for a code watch would be wrong advice, and the test pins both directions. Documented in the instance-config guide and `brain watch --help`; previously discoverable only by reading `watch_path_allowed`.

The allow-list itself is correct and unchanged — it's what stops someone watching a home directory. This is a message and docs fix.

### nw-189 — `investigate` echoed a scope that was never applied

**Worse than reported.** Both the CLI *and* the MCP tool defaulted an unsupplied scope to the literal `"vault"` — so a caller who asked for nothing was told their results were vault-scoped while code symbols from every repo came back.

Default is now `"all"` (the honest name for the documented pass-through), and the response carries **`scope_filtered`**, because `scope` alone cannot express whether a filter was built.

The test also pins that an unresolvable `repo:`/`project:` scope still **errors** rather than silently passing through — that regression would be indistinguishable from this bug.

### nw-188 — `project-context` returned empty at small budgets with no flag

`connected: []` was reported identically for "empty project" and "budget too small", and `tokens_used` (257) exceeded `token_budget` (200) while returning nothing. Seeds are charged against the budget **first**, so a budget below the seed overhead drops every connected node silently.

Now reports `more_available`, `truncated`, and `budget_exceeded`.

`tokens_used` still reports the **true** figure. The item said "do not report tokens_used above budget" — but clamping it to 200 trades one dishonest signal for another. The caller needs to know the budget was blown *and by how much*.

### nw-174 — `detect_changes` had no result cap

156 KB (~39K tokens) with 416 processes inlined for a single file — a fifth of a context window — while every neighbouring tool already capped and reported total vs returned.

Adds `limit` (default `DEFAULT_RESULT_LIMIT`, the same constant those tools use) bounding **both** arrays; the item mentioned only processes, but symbols have the same unbounded shape. Plus `truncated`, `symbols_omitted`, `processes_omitted`. Counts keep reporting **totals**, not returned lengths, so the gap stays visible.

**On the acceptance criterion:** the item's stated fix — *"add limit/token_budget/response_format and report total vs returned"* — describes the **mechanism**, which a schema change alone satisfies while the body still returns 156 KB. Implemented against the **symptom** instead: a call on a high-fanout file returns a bounded response and says what it omitted.

---

## Testing

- `cargo test --locked --release --workspace --lib --no-fail-fast` → **3213 passed, 0 failed**
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean

New tests assert on **user-visible contract** rather than internals: the identities `list-repos` actually prints, what an operator can act on in the watcher error, and whether a scope filter was built.