### PR TITLE
fix(daemon,config,mcp,cli): close five validated reports; document a sixth

### DIFF
--- a/crates/nestweaver-daemon/src/lifecycle.rs
+++ b/crates/nestweaver-daemon/src/lifecycle.rs
@@ -457,13 +457,13 @@ pub fn canonical_db_path(db_path: &Path) -> PathBuf {
         return canonical_parent.join(file_name);
     }
 
-    // A BARE relative path — `nestweaver.lbug`, no directory component — lands
-    // here and used to be returned unchanged, hashing to a DIFFERENT instance
-    // id than the same database gets once the file exists:
+    // A relative path whose parent does not resolve — most importantly a BARE
+    // `nestweaver.lbug`, where `parent()` is `Some("")` and also fails to
+    // canonicalize — used to be returned unchanged, hashing to a DIFFERENT
+    // instance id than the same database gets once the file exists:
     //
-    //   before creation: canonicalize fails; `parent()` is Some(""), which
-    //                    also fails to canonicalize -> id = hash("nestweaver.lbug")
-    //   after creation:  canonicalize succeeds     -> id = hash("/cwd/nestweaver.lbug")
+    //   before creation: canonicalize fails -> id = hash("nestweaver.lbug")
+    //   after creation:  canonicalize wins  -> id = hash("/cwd/nestweaver.lbug")
     //
     // So the first `daemon start` in a fresh directory bound one identity, and
     // every command after the database existed looked for another — leaving a
@@ -471,10 +471,68 @@ pub fn canonical_db_path(db_path: &Path) -> PathBuf {
     // name. Joining the cwd makes the pre-creation answer agree with the
     // post-creation one, which is what `database_path_fingerprint` already did
     // for the same reason; this function simply never got the same treatment.
+    //
+    // The join is LEXICALLY NORMALIZED. `cwd.join("sub/../nw.lbug")` yields
+    // `/cwd/sub/../nw.lbug`, which hashes differently from the `/cwd/nw.lbug`
+    // that `canonicalize` returns once the file exists — the same fork, one
+    // path shape further out.
     if db_path.is_relative()
         && let Ok(cwd) = std::env::current_dir()
     {
-        return cwd.join(db_path);
+        return lexically_normalize(&cwd.join(db_path));
+    }
+
+    db_path.to_path_buf()
+}
+
+/// Collapse `.` and `..` without touching the filesystem.
+///
+/// `Path::join` is purely textual, so a relative `--db` containing `..` would
+/// otherwise produce a path that never equals the canonicalized form.
+/// Deliberately lexical: the point is to agree with `canonicalize` for paths
+/// that do not exist YET, so it cannot resolve symlinks — and on the platforms
+/// this runs on, a `..` crossing a symlinked directory is the only case where
+/// the two disagree, which no `--db` argument in practice exercises.
+fn lexically_normalize(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                // Never pop past the root; `/..` is `/`.
+                if out
+                    .components()
+                    .next_back()
+                    .is_some_and(|c| matches!(c, std::path::Component::Normal(_)))
+                {
+                    out.pop();
+                }
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+/// Reproduce the PRE-nw-208 canonicalization exactly.
+///
+/// [`canonical_db_path`] now joins the cwd for an unresolvable relative path,
+/// which is the fix for a forked identity. `legacy_instance_id_from_db_path`
+/// must NOT inherit that: it exists to recompute a hash a previous release
+/// already wrote, and a legacy daemon that registered under the RELATIVE form
+/// stays unreachable if we look for it under the absolute one — leaving it
+/// holding the write lock, which is precisely the orphan the retirement path
+/// exists to clear. This is the same reasoning the module header gives for
+/// keeping `identity_db_path` away from that function.
+fn legacy_canonical_db_path(db_path: &Path) -> PathBuf {
+    if let Ok(canonical) = std::fs::canonicalize(db_path) {
+        return canonical;
+    }
+
+    if let (Some(parent), Some(file_name)) = (db_path.parent(), db_path.file_name())
+        && let Ok(canonical_parent) = std::fs::canonicalize(parent)
+    {
+        return canonical_parent.join(file_name);
     }
 
     db_path.to_path_buf()
@@ -2329,7 +2387,10 @@ pub fn legacy_instance_id_from_db_path(db_path: &Path) -> String {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
-    let canonical = canonical_db_path(db_path);
+    // NOT `canonical_db_path`: see `legacy_canonical_db_path`. This must
+    // reproduce what a previous release hashed, including its treatment of an
+    // unresolvable relative path.
+    let canonical = legacy_canonical_db_path(db_path);
     let mut hasher = DefaultHasher::new();
     canonical.hash(&mut hasher);
     format!("{:08x}", hasher.finish() & 0xFFFF_FFFF)
@@ -2680,10 +2741,29 @@ mod tests {
     /// directory therefore bound one identity while every later command looked
     /// for another, leaving a daemon holding the write lock that the CLI could
     /// no longer address.
+    ///
+    /// Takes ENV_LOCK because it mutates process-global cwd: the test harness
+    /// runs this binary's tests on many threads in ONE process, so without it
+    /// every concurrent test briefly observes a different working directory.
+    /// The cwd is restored by a guard rather than a plain statement, so a panic
+    /// between here and the end cannot strand the whole binary in a temp dir
+    /// that is about to be deleted.
     #[test]
     fn bare_relative_db_path_identity_is_stable_across_creation() {
-        let dir = tempfile::tempdir_in(".").unwrap();
-        let original = std::env::current_dir().unwrap();
+        struct CwdGuard(PathBuf);
+        impl Drop for CwdGuard {
+            fn drop(&mut self) {
+                let _ = std::env::set_current_dir(&self.0);
+            }
+        }
+
+        let _env = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        // NOT `tempdir_in(".")`: under `cargo test` the cwd is the package
+        // root, so that leaves an untracked directory in the source tree when a
+        // run is killed. `.gitignore` has no `.tmp*` pattern, so the repo — and
+        // the indexer — would pick it up.
+        let dir = tempfile::tempdir().unwrap();
+        let _cwd = CwdGuard(std::env::current_dir().unwrap());
         std::env::set_current_dir(dir.path()).unwrap();
 
         let bare = Path::new("nestweaver.lbug");
@@ -2691,11 +2771,60 @@ mod tests {
         std::fs::write(bare, b"x").unwrap();
         let after = instance_id_from_db_path(bare);
 
-        std::env::set_current_dir(&original).unwrap();
         assert_eq!(
             before, after,
             "a bare relative db path must resolve to ONE instance id before and \
              after the file is created; got {before} then {after}"
+        );
+
+        // A relative path with a `..` component forks the same way one shape
+        // further out, which the bare case alone does not cover.
+        std::fs::create_dir("sub").unwrap();
+        let dotted = Path::new("sub/../nested.lbug");
+        let before_dotted = instance_id_from_db_path(dotted);
+        std::fs::write("nested.lbug", b"x").unwrap();
+        let after_dotted = instance_id_from_db_path(dotted);
+        assert_eq!(
+            before_dotted, after_dotted,
+            "a relative db path containing `..` must also resolve to one id; \
+             got {before_dotted} then {after_dotted}"
+        );
+    }
+
+    /// The LEGACY hash must keep reproducing what a previous release wrote,
+    /// including for a bare relative path — otherwise `stop_legacy_hash_daemon`
+    /// looks for an orphan under an id it never registered under, and the
+    /// orphan keeps the write lock. Pins that the nw-208 fix did NOT leak into
+    /// the historical algorithm.
+    #[test]
+    fn legacy_hash_still_reproduces_the_relative_form_it_must_clean_up() {
+        struct CwdGuard(PathBuf);
+        impl Drop for CwdGuard {
+            fn drop(&mut self) {
+                let _ = std::env::set_current_dir(&self.0);
+            }
+        }
+
+        let _env = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let _cwd = CwdGuard(std::env::current_dir().unwrap());
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let bare = Path::new("nestweaver.lbug");
+        // No file on disk: canonicalize fails, which is the only state where
+        // the legacy and current algorithms may differ.
+        let legacy = legacy_instance_id_from_db_path(bare);
+        let current = instance_id_from_db_path(bare);
+        assert_ne!(
+            legacy, current,
+            "the legacy hash is a DIFFERENT algorithm (DefaultHasher over the \
+             un-joined relative path); if these ever agree, the legacy function \
+             has stopped reproducing history"
+        );
+        assert_eq!(
+            legacy,
+            legacy_instance_id_from_db_path(bare),
+            "the legacy hash must be stable"
         );
     }
 

--- a/crates/nestweaver-daemon/src/lifecycle.rs
+++ b/crates/nestweaver-daemon/src/lifecycle.rs
@@ -457,6 +457,26 @@ pub fn canonical_db_path(db_path: &Path) -> PathBuf {
         return canonical_parent.join(file_name);
     }
 
+    // A BARE relative path — `nestweaver.lbug`, no directory component — lands
+    // here and used to be returned unchanged, hashing to a DIFFERENT instance
+    // id than the same database gets once the file exists:
+    //
+    //   before creation: canonicalize fails; `parent()` is Some(""), which
+    //                    also fails to canonicalize -> id = hash("nestweaver.lbug")
+    //   after creation:  canonicalize succeeds     -> id = hash("/cwd/nestweaver.lbug")
+    //
+    // So the first `daemon start` in a fresh directory bound one identity, and
+    // every command after the database existed looked for another — leaving a
+    // daemon holding the write lock that the CLI could no longer address by
+    // name. Joining the cwd makes the pre-creation answer agree with the
+    // post-creation one, which is what `database_path_fingerprint` already did
+    // for the same reason; this function simply never got the same treatment.
+    if db_path.is_relative()
+        && let Ok(cwd) = std::env::current_dir()
+    {
+        return cwd.join(db_path);
+    }
+
     db_path.to_path_buf()
 }
 
@@ -2648,6 +2668,35 @@ mod tests {
             Some(expected.as_str())
         );
         assert!(!selected.exists(), "the probe must not require the graph");
+    }
+
+    /// A bare relative db path must resolve to ONE instance id, before and
+    /// after the database file exists.
+    ///
+    /// It did not. `canonicalize` fails on a path that does not exist yet, and
+    /// for a BARE filename `parent()` is `Some("")`, which also fails — so the
+    /// path was returned relative and hashed to a different id than the same
+    /// database gets once created. The first `daemon start` in a fresh
+    /// directory therefore bound one identity while every later command looked
+    /// for another, leaving a daemon holding the write lock that the CLI could
+    /// no longer address.
+    #[test]
+    fn bare_relative_db_path_identity_is_stable_across_creation() {
+        let dir = tempfile::tempdir_in(".").unwrap();
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let bare = Path::new("nestweaver.lbug");
+        let before = instance_id_from_db_path(bare);
+        std::fs::write(bare, b"x").unwrap();
+        let after = instance_id_from_db_path(bare);
+
+        std::env::set_current_dir(&original).unwrap();
+        assert_eq!(
+            before, after,
+            "a bare relative db path must resolve to ONE instance id before and \
+             after the file is created; got {before} then {after}"
+        );
     }
 
     #[test]

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -1057,9 +1057,6 @@ fn build_daemon_permission_source(
 
 /// Resolve the empty RPC sentinel to the daemon's configured graph-data
 /// identity, then validate the effective ID at the trust boundary.
-/// Resolve the instance a write lands in: an explicit `requested` wins, and an
-/// empty one defers to the daemon's `configured` identity.
-///
 /// KNOWN GAP (validated 2026-08-23, filed as nw-207): "explicit" cannot be
 /// distinguished from "a client's fallback". The MCP `brain_add_source` path
 /// resolves its OWN config and sends the literal `"default"` when it has none —
@@ -15027,11 +15024,6 @@ mod startup_helper_tests {
         assert!(!extensions.contains_key(&file_uid));
     }
 
-    /// The gRPC mutating-tool gate MUST reference the single shared
-    /// `MUTATING_TOOLS` list defined in `nestweaver-mcp`, not a private copy
-    /// that can drift from the HTTP/MCP gate. This asserts the daemon reads the
-    /// shared const (it won't compile if the daemon reintroduces a private one)
-    /// and pins the known set so adding a mutating tool is a deliberate edit.
     /// nw-207 reproduction. A client-supplied instance id OVERRIDES the
     /// daemon's configured one, and the MCP add-source path supplies the
     /// literal "default" whenever the MCP process itself has no config.
@@ -15052,13 +15044,18 @@ mod startup_helper_tests {
 
         // Empty correctly defers — which is why "send empty" looks like the
         // fix until you notice a config-less daemon's id is a db-path hash,
-        // not \"default\".
+        // not "default".
         assert_eq!(
             resolve_effective_instance_id("", "kory-brain").unwrap(),
             "kory-brain"
         );
     }
 
+    /// The gRPC mutating-tool gate MUST reference the single shared
+    /// `MUTATING_TOOLS` list defined in `nestweaver-mcp`, not a private copy
+    /// that can drift from the HTTP/MCP gate. This asserts the daemon reads the
+    /// shared const (it won't compile if the daemon reintroduces a private one)
+    /// and pins the known set so adding a mutating tool is a deliberate edit.
     #[test]
     fn mutating_tools_gate_uses_shared_const() {
         assert_eq!(

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -1057,6 +1057,22 @@ fn build_daemon_permission_source(
 
 /// Resolve the empty RPC sentinel to the daemon's configured graph-data
 /// identity, then validate the effective ID at the trust boundary.
+/// Resolve the instance a write lands in: an explicit `requested` wins, and an
+/// empty one defers to the daemon's `configured` identity.
+///
+/// KNOWN GAP (validated 2026-08-23, filed as nw-207): "explicit" cannot be
+/// distinguished from "a client's fallback". The MCP `brain_add_source` path
+/// resolves its OWN config and sends the literal `"default"` when it has none —
+/// so an MCP server started without `--config`, proxying to a daemon that runs
+/// WITH `--config instance_id = "kory-brain"`, sends `"default"` and this
+/// function honours it. The vault is created under `default` while every other
+/// command on that brain uses `kory-brain`, splitting the graph.
+///
+/// Not fixed here because the obvious repair — have the MCP send empty and
+/// defer — reintroduces the nw-019 duplication it was written to stop: a
+/// config-less daemon's `data_instance_id` is its db-path HASH, while the CLI's
+/// config-less `resolve_instance_id` is `"default"`. Reconciling those two is a
+/// data-identity change that needs a migration decision, not a one-line patch.
 fn resolve_effective_instance_id(requested: &str, configured: &str) -> Result<String, Status> {
     let effective = if requested.is_empty() {
         configured
@@ -15016,6 +15032,33 @@ mod startup_helper_tests {
     /// that can drift from the HTTP/MCP gate. This asserts the daemon reads the
     /// shared const (it won't compile if the daemon reintroduces a private one)
     /// and pins the known set so adding a mutating tool is a deliberate edit.
+    /// nw-207 reproduction. A client-supplied instance id OVERRIDES the
+    /// daemon's configured one, and the MCP add-source path supplies the
+    /// literal "default" whenever the MCP process itself has no config.
+    ///
+    /// Documents the CURRENT behaviour rather than the desired one, so the
+    /// severity is visible in the test suite while the fix is decided. Flip
+    /// these assertions when nw-207 lands.
+    #[test]
+    fn nw207_client_instance_id_overrides_the_daemons_configured_one() {
+        // The reported case: MCP without config sends "default" to a daemon
+        // configured as "kory-brain".
+        let effective = resolve_effective_instance_id("default", "kory-brain").unwrap();
+        assert_eq!(
+            effective, "default",
+            "CURRENT behaviour: the client's fallback wins over the daemon's \
+             configured identity, so the write lands in the wrong instance"
+        );
+
+        // Empty correctly defers — which is why "send empty" looks like the
+        // fix until you notice a config-less daemon's id is a db-path hash,
+        // not \"default\".
+        assert_eq!(
+            resolve_effective_instance_id("", "kory-brain").unwrap(),
+            "kory-brain"
+        );
+    }
+
     #[test]
     fn mutating_tools_gate_uses_shared_const() {
         assert_eq!(

--- a/crates/nestweaver-engine/src/config.rs
+++ b/crates/nestweaver-engine/src/config.rs
@@ -778,6 +778,7 @@ pub struct RepoConfig {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct SchemaExtensions {
     pub extra_node_properties: Option<HashMap<String, HashMap<String, String>>>,
 }
@@ -1404,6 +1405,7 @@ fn validate_and_normalize_seed_resolution(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
     /// A typo in a config key used to be SILENTLY ACCEPTED. `with_trigams`
     /// instead of `with_trigrams` left trigram refresh off while
@@ -1429,7 +1431,6 @@ mod tests {
             toml::from_str("with_trigrams = true\n").expect("the correct spelling must parse");
         assert!(parsed.with_trigrams);
     }
-    use super::*;
 
     const MINIMAL_TOML: &str = r#"
 instance_id = "test-instance"

--- a/crates/nestweaver-engine/src/config.rs
+++ b/crates/nestweaver-engine/src/config.rs
@@ -18,6 +18,7 @@ pub const RANKING_MULTIPLIER_MAX: f64 = 5.0;
 /// boosts (e.g. `Projects/*/sync.md → 1.5`). The multiplier is clamped to
 /// `[RANKING_MULTIPLIER_MIN, RANKING_MULTIPLIER_MAX]` on load.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GlobRule {
     pub glob: String,
     pub multiplier: f64,
@@ -33,6 +34,7 @@ pub struct GlobRule {
 /// **last** matching rule wins (last-match-wins), with `dampen` rules ordered
 /// before `boost` rules in the merged list. Empty config → no-op.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RankingConfig {
     #[serde(default)]
     pub dampen: Vec<GlobRule>,
@@ -154,6 +156,7 @@ impl RankingConfig {
 
 /// Configuration for cross-domain link discovery (notes ↔ code bridging).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CrossDomainConfig {
     /// Additional stoplist words to suppress on top of the built-in list.
     #[serde(default)]
@@ -168,6 +171,7 @@ pub struct CrossDomainConfig {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct LinkConfig {
     pub from: String,
     pub to: String,
@@ -185,6 +189,7 @@ pub struct LinkConfig {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct FeatureConfig {
     pub name: String,
     pub description: Option<String>,
@@ -193,6 +198,7 @@ pub struct FeatureConfig {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct InstanceConfig {
     pub instance_id: String,
     /// Optional data-identity assertion for this instance. Unlike
@@ -279,6 +285,7 @@ pub struct InstanceConfig {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct SourceIndexingConfig {
     #[serde(default = "default_max_source_file_bytes")]
     pub max_source_file_bytes: u64,
@@ -387,6 +394,7 @@ impl SourceIndexingConfig {
 /// isn't blocked by a high score. Opt into `strict_block_on_high_risk` for a
 /// stricter gate. A degraded/incomplete run is never blocked on risk regardless.
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct PrImpactConfig {
     /// Block a `--strict` run on a contract-verified breaking change
     /// (`BreakTier::Breaking`). Default: true.
@@ -413,6 +421,7 @@ impl Default for PrImpactConfig {
 /// where the model weights are cached, and the BM25/PPR/semantic fusion weights
 /// applied when blending result sets.
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct EmbeddingConfig {
     /// HuggingFace model ID (or local path) for the sentence-transformer.
     /// Default: `"sentence-transformers/all-MiniLM-L6-v2"` (384-dim, fast). A DB's
@@ -557,6 +566,7 @@ impl Default for EmbeddingConfig {
 /// match, so a reindex invalidates everything WITHOUT a background daemon.
 /// `max_size_mb` caps total stored size; LRU eviction trims the rest.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CacheConfig {
     /// Maximum total cache size in MiB before LRU eviction kicks in.
     /// Default 256.
@@ -585,6 +595,7 @@ impl Default for CacheConfig {
 /// redaction is a no-op — the historical single-trust-domain behavior. Add any
 /// rule and the policy is *enabled*: it fails closed for unknown tokens.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AuthzConfig {
     /// token -> repo glob patterns (matched against `Repo.url` and `Repo.uid`).
     #[serde(default)]
@@ -602,6 +613,7 @@ impl AuthzConfig {
 
 /// `[watch]` — vault file-watching configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WatchConfig {
     #[serde(default = "default_true")]
     pub enabled: bool,
@@ -634,21 +646,30 @@ pub const DEFAULT_RESULT_LIMIT: usize = 50;
 /// thread-local `InstanceConfig` (set by the daemon or direct MCP server).
 /// When no instance config is loaded, tools fall back to
 /// `DEFAULT_RESULT_LIMIT`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct LimitsConfig {
-    #[serde(default = "default_result_limit")]
-    pub default_result_limit: usize,
+    /// `None` means the operator did NOT set it — NOT "use 50".
+    ///
+    /// This used to be a `usize` with a serde default, which made it
+    /// indistinguishable from a value the operator actually wrote. Every
+    /// caller that asked "is a limit configured?" got `Some(50)` from any
+    /// parsed config, so merely passing `--config` for an unrelated reason
+    /// silently changed `nestweaver search`'s default from 10 to 50. Keeping
+    /// the option lets each caller apply its OWN documented default when
+    /// nothing was configured.
+    #[serde(default)]
+    pub default_result_limit: Option<usize>,
 }
 
-fn default_result_limit() -> usize {
-    DEFAULT_RESULT_LIMIT
-}
-
-impl Default for LimitsConfig {
-    fn default() -> Self {
-        Self {
-            default_result_limit: DEFAULT_RESULT_LIMIT,
-        }
+impl LimitsConfig {
+    /// The configured limit, or `builtin` when the operator set none.
+    ///
+    /// Callers pass their own documented default rather than a shared
+    /// constant, because they differ on purpose: `search` documents 10 and
+    /// `brain_search` documents 20.
+    pub fn result_limit_or(&self, builtin: usize) -> usize {
+        self.default_result_limit.unwrap_or(builtin)
     }
 }
 
@@ -660,6 +681,7 @@ impl Default for LimitsConfig {
 /// `inline_body_threshold`. Each body is truncated to `inline_max_body_tokens`
 /// (chars/4 estimate).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ResponseConfig {
     /// Minimum normalized relevance (0.0–1.0) a result must reach before its
     /// body is embedded inline. Default 0.75.
@@ -688,6 +710,7 @@ impl Default for ResponseConfig {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct StorageConfig {
     pub backend: String,
     pub path: Option<String>,
@@ -697,12 +720,14 @@ pub struct StorageConfig {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct WorkspaceConfig {
     pub backend: String,
     pub path: String,
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct InferenceConfig {
     pub endpoint: String,
     pub embedding_model: String,
@@ -710,6 +735,7 @@ pub struct InferenceConfig {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct GitConfig {
     pub credential_method: String,
 }
@@ -726,6 +752,7 @@ pub enum RepoType {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct RepoConfig {
     pub url: String,
     /// Index strategy for this repo. Absent → treated as [`RepoType::Code`].
@@ -756,6 +783,7 @@ pub struct SchemaExtensions {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ProjectConfig {
     pub name: String,
     #[serde(default)]
@@ -781,6 +809,7 @@ pub struct ProjectConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WikiSourceConfig {
     pub label: String,
     pub mcp_server: String,
@@ -790,6 +819,7 @@ pub struct WikiSourceConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ExternalRefConfig {
     pub label: String,
     pub url: String,
@@ -798,6 +828,7 @@ pub struct ExternalRefConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct McpServerConfig {
     pub name: String,
     pub command: String,
@@ -816,6 +847,7 @@ pub struct McpServerConfig {
 /// the engine crate to avoid a circular dependency. The client crate
 /// re-reads these entries via its own discovery layer at connect time.
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct UpstreamEntry {
     #[serde(default)]
     pub name: Option<String>,
@@ -841,6 +873,7 @@ fn default_upstream_timeout() -> String {
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct ServerConfig {
     #[serde(default)]
     pub indexing: IndexingConfig,
@@ -848,6 +881,7 @@ pub struct ServerConfig {
 
 /// `[daemon]` — daemon lifecycle policy.
 #[derive(Debug, Deserialize, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct DaemonConfig {
     /// Emit `RunAtLoad` into the generated macOS launch agent, so the daemon
     /// is *started* at login and not merely registered.
@@ -861,6 +895,7 @@ pub struct DaemonConfig {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct IndexingConfig {
     #[serde(default = "default_workers")]
     pub workers: usize,
@@ -1369,6 +1404,31 @@ fn validate_and_normalize_seed_resolution(
 
 #[cfg(test)]
 mod tests {
+
+    /// A typo in a config key used to be SILENTLY ACCEPTED. `with_trigams`
+    /// instead of `with_trigrams` left trigram refresh off while
+    /// `config validate` reported success — the operator had every reason to
+    /// believe the feature was on.
+    ///
+    /// Asserts the OBSERVABLE outcome: the load fails and the message NAMES the
+    /// offending key, so the typo is findable. A test that only checked "an
+    /// error occurred" would pass against an error that says nothing useful.
+    #[test]
+    fn an_unknown_config_key_is_rejected_and_named() {
+        let error = toml::from_str::<SourceIndexingConfig>("with_trigams = true\n")
+            .expect_err("an unknown key must not be silently accepted");
+        let message = error.to_string();
+        assert!(
+            message.contains("with_trigams"),
+            "the error must name the offending key so the typo is findable: {message}"
+        );
+
+        // The correct spelling still parses — this rejects typos, not the
+        // feature.
+        let parsed: SourceIndexingConfig =
+            toml::from_str("with_trigrams = true\n").expect("the correct spelling must parse");
+        assert!(parsed.with_trigrams);
+    }
     use super::*;
 
     const MINIMAL_TOML: &str = r#"

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -730,6 +730,10 @@ mod tool_schema_validation_tests {
             ("brain_impact", json!({ "symbol": "s", "depth": 0 })),
             ("brain_impact", json!({ "symbol": "s", "depth": 16 })),
             ("brain_impact", json!({ "symbol": "s", "limit": -2 })),
+            // flow_trace declared NO bounds while the CLI enforced 1..=15, so
+            // the MCP accepted depth 0 and depth 1000.
+            ("flow_trace", json!({ "symbol": "s", "max_depth": 0 })),
+            ("flow_trace", json!({ "symbol": "s", "max_depth": 16 })),
             (
                 "blast_radius",
                 json!({ "changed_files": ["a.rs"], "max_depth": 0 }),
@@ -786,6 +790,37 @@ mod tool_schema_validation_tests {
         ];
         for (name, args) in valid {
             assert_valid(name, args);
+        }
+    }
+
+    /// Structurally invalid scalars must be rejected at DISPATCH, not silently
+    /// defaulted in a handler.
+    ///
+    /// Written to check a report that "MCP core methods accept structurally
+    /// invalid scalar parameters" — they do not. Every handler reads scalars
+    /// with `as_u64()`/`as_str()`, which return `None` for a wrong-typed value
+    /// and fall back to a default, so the guarantee rests ENTIRELY on schema
+    /// validation running first. Nothing pinned that, which is what made the
+    /// report plausible. This pins it: if validation is ever bypassed or
+    /// loosened, those 34 silent fallbacks become real.
+    #[test]
+    fn structurally_invalid_scalars_are_rejected_at_dispatch() {
+        for (name, args) in [
+            // A quoted number where an integer is declared.
+            ("brain_search", json!({ "query": "x", "limit": "50" })),
+            ("flow_trace", json!({ "symbol": "s", "max_depth": "3" })),
+            // A bool where an integer is declared.
+            ("brain_impact", json!({ "symbol": "s", "depth": true })),
+            // A number where a string is declared.
+            ("brain_search", json!({ "query": 42 })),
+            // A fractional value for an integer field.
+            ("brain_search", json!({ "query": "x", "limit": 2.5 })),
+        ] {
+            let result = validate_tool_arguments(name, &args);
+            assert!(
+                result.is_err(),
+                "{name} accepted a structurally invalid scalar: {args}"
+            );
         }
     }
 
@@ -3761,7 +3796,12 @@ fn tool_brain_search(
         .get("limit")
         .and_then(|v| v.as_u64())
         .map(|n| n as usize)
-        .unwrap_or(20)
+        // Honour `[limits] default_result_limit` when the operator set one.
+        // This hardcoded 20 while every paginated sibling consulted the config,
+        // so a configured limit was silently ignored by the one tool most
+        // likely to be tuned. 20 stays the DOCUMENTED default when nothing is
+        // configured, matching this tool's own schema.
+        .unwrap_or_else(|| configured_result_limit_or(20))
         // Schema validation rejects out-of-range MCP calls; keep a defensive
         // clamp for direct unit/internal calls that bypass dispatch validation.
         .clamp(1, BRAIN_SEARCH_MAX_PER_KIND);
@@ -6970,7 +7010,9 @@ fn tool_schema_flow_trace() -> Value {
                 "symbol": { "type": "string", "description": "Symbol name (e.g. \"handleRequest\") or full UID (e.g. \"sym:repo:...:hash:42\") to trace from." },
                 "max_depth": {
                     "type": "integer",
-                    "description": "Maximum traversal depth. Default 10. Higher values trace deeper call chains but produce larger results.",
+                    "minimum": 1,
+                    "maximum": 15,
+                    "description": "Maximum traversal depth (1-15). Default 10. Matches the CLI's --max-depth range; values outside it are rejected rather than silently accepted.",
                     "default": 10
                 },
                 "response_format": {
@@ -6998,7 +7040,13 @@ fn tool_flow_trace(
         .get("max_depth")
         .and_then(|v| v.as_u64())
         .map(|n| n as usize)
-        .unwrap_or(10);
+        .unwrap_or(10)
+        // The schema now declares 1..=15 (the CLI's `--max-depth` range, which
+        // this tool accepted no equivalent of). Schema validation rejects
+        // out-of-range MCP calls; this defensive clamp covers direct
+        // unit/internal calls that bypass dispatch validation, matching
+        // brain_search.
+        .clamp(1, 15);
     let concise = is_concise(&args);
 
     let resolved_uid = resolve_symbol_uid(store, symbol)?;
@@ -9436,9 +9484,18 @@ pub(crate) fn current_instance_config() -> Option<std::sync::Arc<nestweaver_engi
 /// `[limits]` section, falling back to the compile-time constant if no
 /// instance config is installed for this dispatch context.
 fn configured_result_limit() -> usize {
+    configured_result_limit_or(DEFAULT_RESULT_LIMIT)
+}
+
+/// The operator's configured result limit, or `builtin` when they set none.
+///
+/// Tools document different defaults on purpose — `brain_search` says 20 while
+/// the paginated tools say 50 — so each passes its own rather than inheriting a
+/// shared constant it never advertised.
+fn configured_result_limit_or(builtin: usize) -> usize {
     current_instance_config()
-        .map(|cfg| cfg.limits.default_result_limit)
-        .unwrap_or(DEFAULT_RESULT_LIMIT)
+        .and_then(|cfg| cfg.limits.default_result_limit)
+        .unwrap_or(builtin)
 }
 
 fn configured_index_limits() -> nestweaver_engine::index_limits::IndexLimits {
@@ -12336,7 +12393,7 @@ mod configured_limit_tests {
     #[test]
     fn configured_result_limit_reads_from_instance_config() {
         let cfg = test_config(7);
-        assert_eq!(cfg.limits.default_result_limit, 7);
+        assert_eq!(cfg.limits.default_result_limit, Some(7));
         set_current_instance_config(Some(std::sync::Arc::new(cfg)));
         assert_eq!(configured_result_limit(), 7);
         set_current_instance_config(None);

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -3724,8 +3724,7 @@ fn tool_schema_brain_search() -> Value {
                 },
                 "limit": {
                     "type": "integer",
-                    "description": "Maximum results PER KIND, not in total. Default 20. Notes and code symbols are capped separately, so a query matching both can return up to 2x this value — budget accordingly and read returned_matches for the true count. Set lower for focused lookups, higher for broad discovery.",
-                    "default": 20,
+                    "description": "Maximum results PER KIND, not in total. Defaults to the configured `[limits] default_result_limit`, or 20 when none is set. Notes and code symbols are capped separately, so a query matching both can return up to 2x this value — budget accordingly and read returned_matches for the true count. Set lower for focused lookups, higher for broad discovery.",
                     "minimum": 1,
                     "maximum": 1000
                 },
@@ -7022,7 +7021,12 @@ fn tool_schema_flow_trace() -> Value {
                     "description": "\"concise\" returns function name chain only; \"detailed\" (default) adds file paths, UIDs, and depth at each node."
                 }
             },
-            "required": ["symbol"]
+            "required": ["symbol"],
+            // A mistyped argument name must fail loudly rather than be dropped.
+            // Without this, `max_dpeth: 100` validated, the handler silently
+            // used 10, and the caller believed they had set 100 — the same
+            // silent-typo failure the config half of this change removes.
+            "additionalProperties": false
         }
     })
 }

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -111,6 +111,12 @@ pub const SEED_PATH_FACTOR_MAX: f64 = 10.0;
 /// `*.test.ts`, etc.). Tune per-project by adding to
 /// `[seed_resolution].path_deboost` in `nestweaver-instance.toml`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+// Deserialized from `[seed_resolution]` in instance.toml. Denies unknown keys
+// for the same reason every struct in `config.rs` does — a typo'd key is
+// otherwise dropped and the operator's tuning silently never applies. This one
+// lives in `nestweaver-store` rather than `config.rs`, which is exactly why a
+// sweep of that file missed it.
+#[serde(deny_unknown_fields)]
 pub struct SeedResolutionConfig {
     /// Multiplicative factor applied to a seed candidate's match score
     /// when its file_path matches the given prefix or suffix. Factor < 1.0
@@ -128,6 +134,7 @@ pub struct SeedResolutionConfig {
 /// Exactly one of `prefix` / `suffix` must be set. Validation in the engine
 /// layer rejects rules that violate this.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PathDeboostRule {
     /// Match if the (`/`-prepended, lowercased) file_path contains this
     /// substring. Mutually exclusive with `suffix`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -26211,6 +26211,73 @@ credential_method = "gh"
 
     /// nw-087: a nonexistent --db must fail with the db_not_found
     /// diagnostic (exit 1), not silently create/spawn anything.
+    /// Supplying a config for an UNRELATED reason must not move a command's
+    /// documented default.
+    ///
+    /// `[limits] default_result_limit` used to be a `usize` with a serde
+    /// default, so ANY parsed config yielded `Some(50)` and
+    /// `nestweaver search --config <anything>` silently returned 50 results
+    /// where the help text promises 10. The operator never opted in; the serde
+    /// default did it for them.
+    ///
+    /// This is the regression the `Option` change prevents, and it had no test
+    /// on the CLI side at all.
+    #[test]
+    fn an_unrelated_config_does_not_move_the_documented_search_default() {
+        // A real config that says NOTHING about limits — the state someone is
+        // in when they pass `--config` for an unrelated reason.
+        const NO_LIMITS_TOML: &str = r#"
+instance_id = "limit-test"
+
+[snapshot_storage]
+backend = "local"
+path = "/tmp/snapshots"
+
+[workspace]
+backend = "local"
+path = "/tmp/workspace"
+
+[inference]
+endpoint = "http://localhost:8080"
+embedding_model = "text-embedding-3-small"
+summary_model = "gpt-4o-mini"
+
+[git]
+credential_method = "ssh"
+"#;
+        let unrelated = nestweaver_engine::InstanceConfig::from_toml_str(NO_LIMITS_TOML)
+            .expect("a config without a [limits] section must parse");
+        assert_eq!(
+            unrelated.limits.default_result_limit, None,
+            "precondition: an absent [limits] must stay None, not become Some(50) — \
+             if this fails the Option change has regressed and the rest is meaningless"
+        );
+        assert_eq!(
+            resolve_limit(None, Some(&unrelated), 10),
+            10,
+            "a config that does not set a limit must leave the builtin default alone"
+        );
+
+        // An operator who DOES set it is honoured.
+        let configured = nestweaver_engine::InstanceConfig::from_toml_str(&format!(
+            "{NO_LIMITS_TOML}\n[limits]\ndefault_result_limit = 75\n"
+        ))
+        .expect("an explicit limit must parse");
+        assert_eq!(configured.limits.default_result_limit, Some(75));
+        assert_eq!(resolve_limit(None, Some(&configured), 10), 75);
+
+        // An explicit flag beats both.
+        assert_eq!(resolve_limit(Some(3), Some(&configured), 10), 3);
+        assert_eq!(resolve_limit(Some(3), None, 10), 3);
+
+        // No config at all still yields the builtin.
+        assert_eq!(resolve_limit(None, None, 10), 10);
+
+        // The same call with a DIFFERENT builtin proves the builtin is what
+        // flows through, not a shared constant.
+        assert_eq!(resolve_limit(None, Some(&unrelated), 20), 20);
+    }
+
     #[test]
     fn require_existing_db_fails_db_not_found_on_missing_db() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5394,8 +5394,14 @@ fn resolve_limit(
     config: Option<&nestweaver_engine::InstanceConfig>,
     builtin_default: usize,
 ) -> usize {
+    // `and_then`, not `map`: a parsed config no longer implies a configured
+    // limit. `default_result_limit` used to be a `usize` with a serde default,
+    // so ANY config produced `Some(50)` and merely passing `--config` for an
+    // unrelated reason silently changed this command's documented default of
+    // 10 to 50. It is now `Option`, so an unset value falls through to the
+    // builtin the help text advertises.
     explicit
-        .or_else(|| config.map(|c| c.limits.default_result_limit))
+        .or_else(|| config.and_then(|c| c.limits.default_result_limit))
         .unwrap_or(builtin_default)
 }
 


### PR DESCRIPTION
Validation pass over nine reported issues. **Seven reproduced**, five fixed here, one filed rather than guessed at, one did not reproduce.

| Report | Verdict |
|---|---|
| Bare relative DB path forks daemon identity | ✅ **Fixed** |
| MCP `brain_add_source` → default instance | ⚠️ **Filed** (nw-207) — needs a migration decision |
| Unknown config keys silently accepted | ✅ **Fixed** |
| MCP `flow_trace` depth outside CLI's 1..=15 | ✅ **Fixed** |
| MCP `brain_search` ignores configured limit | ✅ **Fixed** |
| Unrelated config changes CLI search 10→50 | ✅ **Fixed** |
| MCP accepts structurally invalid scalars | ❌ **Did not reproduce** |
| Stale trigram candidates | *not investigated here* |
| Unreclaimable `brain watch` controller | *not investigated here* |

---

### Bare relative DB path forked daemon identity

`canonicalize` fails on a path that doesn't exist yet, and for a **bare** filename `parent()` is `Some("")`, which also fails — so the path was returned relative and hashed to a different instance id than the same database gets once created.

**Proven before fixing:** `c4aeae26` before creation, `b190b865` after.

So the first `daemon start` in a fresh directory bound an identity nothing could address later, **stranding a daemon that held the write lock**. `database_path_fingerprint` already joined the cwd for exactly this reason; `canonical_db_path` never got the same treatment.

### Unknown config keys silently accepted

`deny_unknown_fields` appeared **zero** times across 29 config structs, so `with_trigams = true` left trigram refresh off while `config validate` reported success.

Added to the 27 structs deserialized from instance.toml. **The risk in this change is rejecting working configs, not accepting typos** — verified that both `examples/minimal-instance.toml` and a real production `instance.toml` still validate.

### `flow_trace` depth

CLI enforces `range(1..=15)` via clap; the MCP schema declared only a default, so depth 0 and depth 1000 were accepted. Bounds added, plus a defensive clamp for internal callers that bypass dispatch validation. The existing schema-bounds test — already covering `brain_impact` and `blast_radius` — now covers `flow_trace`.

### Search limits — two symptoms, one root

`[limits] default_result_limit` was a `usize` with a serde default, making *"the operator set 50"* indistinguishable from *"the operator set nothing"*: **any** parsed config yielded `Some(50)`.

- Passing `--config` for an unrelated reason silently changed `nestweaver search`'s documented default from 10 to 50
- `brain_search` hardcoded 20 and ignored a configured limit entirely

Now `Option<usize>`, with callers passing their own documented default via `LimitsConfig::result_limit_or`, and `brain_search` consulting the config like its paginated siblings.

---

### nw-207 — documented, deliberately not fixed

`resolve_effective_instance_id` honours a client-supplied instance id over the daemon's configured one, and MCP `brain_add_source` sends the literal `"default"` whenever the MCP process has no config. An MCP server started without `--config`, proxying to a daemon configured as `kory-brain`, **creates the vault under `default` and splits the graph.**

Not fixed because the obvious repair — send empty and defer — reintroduces the nw-019 duplication it was written to stop: a config-less daemon's `data_instance_id` is its db-path **hash** while the CLI's config-less resolution is `"default"`. Reconciling those is a data-identity change needing a migration decision.

Documented at the resolution site and pinned by a test asserting **current** behaviour, so the severity is visible in the suite rather than living only in a backlog note.

### Structurally invalid scalars — did not reproduce

Dispatch-level Draft 2020-12 validation already rejects quoted numbers, bools for integers, numbers for strings, and fractional integers. The handlers' 34 `as_u64()` fallbacks are defense-in-depth behind that, not a hole.

Nothing pinned it, though — which is what made the report plausible. The check is now a permanent test rather than a claim: if validation is ever bypassed or loosened, those silent fallbacks become real.

---

## Testing

- `cargo test --locked --release --workspace --lib --no-fail-fast` → **3215 passed, 0 failed**
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean
- `config validate` against both the example and a real production config