### PR TITLE
fix(cli,export,mcp,daemon)!: resolve four contract decisions the right way

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ The first build compiles LadybugDB from source and may take several minutes.
 | `brain watch` | Watch vaults for changes and re-index automatically |
 | `brain refresh` | Force re-index of all registered vaults |
 | `brain remove` | Remove a vault from the brain (cascade-deletes nodes; does not touch files on disk) |
-| `brain stale-check` | Check if the indexed graph is stale by comparing each repo's indexed SHA against git HEAD (also available top-level as `stale-check`). Exits 1 when any repo is stale or its working tree is missing (`[missing]`) — usable as a CI freshness gate |
+| `brain stale-check` | Check whether the indexed graph reflects reality (also available top-level as `stale-check`). **Exit 0** nothing to do · **1** the check itself failed · **2** at least one repo needs re-indexing. Gate CI on `any_needs_reindex` (or exit 2) — that is the actionable union of `stale`, `incomplete`, and `missing`. `any_stale` / `is_stale` mean *behind HEAD* specifically |
 | `brain reindex-search` | Rebuild the Tantivy BM25 search index from current graph state |
 | `brain broken-links` | List wikilinks with ambiguous or low-confidence targets, with suggested fixes |
 | `brain orphans` | List notes with zero inbound and zero outbound wikilinks |

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -4098,17 +4098,28 @@ impl NestWeaverDaemon for DaemonService {
                 .unwrap_or("cypher");
             let top = args.get("top").and_then(|v| v.as_u64()).unwrap_or(50) as usize;
             let output_path = args.get("output").and_then(|v| v.as_str());
+            // The daemon route is the DEFAULT, and it neither received nor
+            // read `scope` — so `--scope code|vault` silently exported
+            // everything while the direct path honoured it.
+            let scope: nestweaver_engine::ExportScope = args
+                .get("scope")
+                .and_then(|v| v.as_str())
+                .unwrap_or("all")
+                .parse()
+                .map_err(|e| Status::invalid_argument(format!("invalid scope: {e}")))?;
 
             match format {
                 "cypher" | "graphml" | "mermaid" => {
                     let mut buf = Vec::new();
-                    match format {
-                        "cypher" => nestweaver_engine::export_cypher(&state.store, &mut buf),
-                        "graphml" => nestweaver_engine::export_graphml(&state.store, &mut buf),
-                        "mermaid" => nestweaver_engine::export_mermaid(&state.store, top, &mut buf),
-                        _ => unreachable!(),
-                    }
-                    .map_err(|e| Status::internal(format!("export failed: {e:#}")))?;
+                    // Same shared implementation the direct CLI path uses.
+                    let notice = nestweaver_engine::export_text_format(
+                        &state.store,
+                        &mut buf,
+                        format,
+                        scope,
+                        top,
+                    )
+                    .map_err(|e| Status::invalid_argument(format!("export failed: {e:#}")))?;
 
                     let text = String::from_utf8(buf)
                         .map_err(|e| Status::internal(format!("export produced non-UTF-8: {e}")))?;
@@ -4129,6 +4140,7 @@ impl NestWeaverDaemon for DaemonService {
                         "bytes": text.len(),
                         "text": if output_path.is_some() { None } else { Some(&text) },
                         "output": output_path,
+                        "notice": notice,
                     }))
                     .map_err(|e| Status::internal(format!("json serialize failed: {e:#}")))
                 }
@@ -4139,6 +4151,15 @@ impl NestWeaverDaemon for DaemonService {
                         ));
                     }
 
+                    // msgpack carries the code graph only; a vault scope is a
+                    // request it cannot satisfy, so refuse instead of writing
+                    // code and reporting success.
+                    if scope == nestweaver_engine::ExportScope::Vault {
+                        return Err(Status::invalid_argument(
+                            "msgpack export is code-only and cannot represent the vault subgraph; \
+                             use --format graphml for --scope vault",
+                        ));
+                    }
                     let graph = nestweaver_engine::export_in_memory_graph(&state.store)
                         .map_err(|e| Status::internal(format!("export failed: {e:#}")))?;
                     let bytes = rmp_serde::to_vec(&graph).map_err(|e| {

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -1057,19 +1057,19 @@ fn build_daemon_permission_source(
 
 /// Resolve the empty RPC sentinel to the daemon's configured graph-data
 /// identity, then validate the effective ID at the trust boundary.
-/// KNOWN GAP (validated 2026-08-23, filed as nw-207): "explicit" cannot be
-/// distinguished from "a client's fallback". The MCP `brain_add_source` path
-/// resolves its OWN config and sends the literal `"default"` when it has none —
-/// so an MCP server started without `--config`, proxying to a daemon that runs
-/// WITH `--config instance_id = "kory-brain"`, sends `"default"` and this
-/// function honours it. The vault is created under `default` while every other
-/// command on that brain uses `kory-brain`, splitting the graph.
+/// nw-207: THE DAEMON OWNS THE IDENTITY OF THE DATA IT STORES. An empty
+/// `requested` is the protocol's "you decide" sentinel and defers to
+/// `configured`; a non-empty one is an explicit instruction from a caller who
+/// NAMED an instance.
 ///
-/// Not fixed here because the obvious repair — have the MCP send empty and
-/// defer — reintroduces the nw-019 duplication it was written to stop: a
-/// config-less daemon's `data_instance_id` is its db-path HASH, while the CLI's
-/// config-less `resolve_instance_id` is `"default"`. Reconciling those two is a
-/// data-identity change that needs a migration decision, not a one-line patch.
+/// That distinction only became meaningful once clients stopped sending a
+/// fallback as though it were a choice. The MCP `brain_add_source` path used
+/// to resolve its OWN config and send the literal "default" when it had none,
+/// so an MCP server started without `--config`, proxying to a daemon running
+/// WITH `--config instance_id = "kory-brain"`, silently created the vault under
+/// `default` and split the graph. It sends empty now, and a config-less
+/// daemon's `data_instance_id` is "default" rather than a db-path hash, so the
+/// two paths agree without either compensating for the other.
 fn resolve_effective_instance_id(requested: &str, configured: &str) -> Result<String, Status> {
     let effective = if requested.is_empty() {
         configured
@@ -9588,13 +9588,26 @@ pub async fn run_server(
         instance_id: instance_id.clone(),
     };
 
-    // nw-019: graph-data identity — the config's logical `instance_id` when we
-    // have a parsed config, else fall back to the runtime hash so a config-less
-    // daemon still has `data_instance_id == instance_id`.
+    // Graph-data identity: the config's logical `instance_id` when we have a
+    // parsed config, else "default".
+    //
+    // nw-207: this used to fall back to the RUNTIME HASH so that
+    // `data_instance_id == instance_id` for a config-less daemon. That looked
+    // tidy and was the root of a graph-splitting bug. The CLI's config-less
+    // resolution (`resolve_instance_id`) is "default", so the same brain
+    // reached two ways got two different data identities — which forced the
+    // MCP add-source path to send a literal "default" to compensate, which in
+    // turn overrode a daemon that DID have a configured instance. One
+    // compensation stacked on another.
+    //
+    // There is now ONE rule: absent an explicit instance, data lives under
+    // "default". The runtime hash keeps doing its own job — naming sockets and
+    // local state per database path — which is unrelated to which logical
+    // instance the graph belongs to. Conflating the two is what broke.
     let data_instance_id = instance_cfg
         .as_ref()
         .map(|c| c.instance_id.clone())
-        .unwrap_or_else(|| instance_id.clone());
+        .unwrap_or_else(|| "default".to_string());
 
     let is_server_mode = server_opts.is_some();
 
@@ -15024,31 +15037,46 @@ mod startup_helper_tests {
         assert!(!extensions.contains_key(&file_uid));
     }
 
-    /// nw-207 reproduction. A client-supplied instance id OVERRIDES the
-    /// daemon's configured one, and the MCP add-source path supplies the
-    /// literal "default" whenever the MCP process itself has no config.
+    /// nw-207. The daemon owns the identity of the data it stores.
     ///
-    /// Documents the CURRENT behaviour rather than the desired one, so the
-    /// severity is visible in the test suite while the fix is decided. Flip
-    /// these assertions when nw-207 lands.
+    /// A client may NAME an instance and be obeyed; it may not redirect writes
+    /// into a different logical namespace by defaulting. The MCP add-source
+    /// path used to send the literal "default" whenever it had no config of its
+    /// own, which this function honoured — so an MCP server started without
+    /// `--config`, proxying to a daemon configured as `kory-brain`, created the
+    /// vault under `default` and split the graph.
+    ///
+    /// This asserts the CORRECTED contract. It replaces a test that pinned the
+    /// buggy behaviour while the fix waited on a migration decision.
     #[test]
-    fn nw207_client_instance_id_overrides_the_daemons_configured_one() {
-        // The reported case: MCP without config sends "default" to a daemon
-        // configured as "kory-brain".
-        let effective = resolve_effective_instance_id("default", "kory-brain").unwrap();
-        assert_eq!(
-            effective, "default",
-            "CURRENT behaviour: the client's fallback wins over the daemon's \
-             configured identity, so the write lands in the wrong instance"
-        );
-
-        // Empty correctly defers — which is why "send empty" looks like the
-        // fix until you notice a config-less daemon's id is a db-path hash,
-        // not "default".
+    fn the_daemon_owns_data_identity_unless_a_caller_names_an_instance() {
+        // The reported case: a client with no config of its own now sends
+        // EMPTY, and the daemon's configured identity wins.
         assert_eq!(
             resolve_effective_instance_id("", "kory-brain").unwrap(),
-            "kory-brain"
+            "kory-brain",
+            "an unspecified instance must defer to the daemon, not override it"
         );
+
+        // A caller that NAMES an instance is still obeyed — multi-instance
+        // targeting is a real feature and this must not break it.
+        assert_eq!(
+            resolve_effective_instance_id("other-brain", "kory-brain").unwrap(),
+            "other-brain"
+        );
+
+        // A config-less daemon resolves to "default", matching the CLI's
+        // `resolve_instance_id`. Before nw-207 it was a db-path HASH, and that
+        // mismatch is what forced clients to send "default" explicitly — the
+        // compensation that caused the override.
+        assert_eq!(
+            resolve_effective_instance_id("", "default").unwrap(),
+            "default"
+        );
+
+        // An invalid instance is still rejected at this trust boundary rather
+        // than silently producing an ambiguous uid.
+        assert!(resolve_effective_instance_id("a:b", "default").is_err());
     }
 
     /// The gRPC mutating-tool gate MUST reference the single shared

--- a/crates/nestweaver-engine/src/brain_docgraph.rs
+++ b/crates/nestweaver-engine/src/brain_docgraph.rs
@@ -386,7 +386,20 @@ pub struct CoOccurringTag {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TagGraph {
     pub tag: String,
+    /// Notes carrying this tag OR any nested descendant of it.
     pub count: usize,
+    /// The descendant tags folded into `count`, e.g. `project/nestweaver` for
+    /// a focus of `project`. Empty for a leaf.
+    ///
+    /// nw-172: emitted so a caller can tell "47 notes, 46 of them from
+    /// children" from "47 notes on this exact tag" — the count alone cannot
+    /// express that, and the previous bare `0` for a parent tag was
+    /// indistinguishable from "no such tag".
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub descendants: Vec<String>,
+    /// Notes carrying this tag EXACTLY, excluding descendants.
+    #[serde(default)]
+    pub exact_count: usize,
     pub co_occurring: Vec<CoOccurringTag>,
 }
 
@@ -429,20 +442,49 @@ pub fn tag_graph_all(store: &GraphStore) -> Result<Vec<TagGraph>> {
 /// Shared co-occurrence computation for a single normalized focus tag against
 /// pre-fetched note tag sets. `focus` must already be trimmed/lowercased.
 fn tag_graph_from_sets(focus: &str, sets: &[(String, Vec<String>)]) -> TagGraph {
+    // nw-172: a parent tag matches its nested descendants.
+    //
+    // `#project` used to match only the literal tag `project` and returned 0
+    // while `project/nestweaver` returned 46 — a silent zero for a tag that
+    // demonstrably exists in the hierarchy, indistinguishable from "no such
+    // tag". Obsidian's own search matches descendants for a parent, which is
+    // the behaviour a vault user arrives with.
+    //
+    // The separator is required: `project` matches `project/x` but never
+    // `projects`, which a bare prefix test would silently fold in.
+    let prefix = format!("{focus}/");
+    let matches_focus = |t: &str| {
+        let lower = t.to_lowercase();
+        lower == focus || lower.starts_with(&prefix)
+    };
+
     let mut focus_count = 0usize;
+    let mut exact_count = 0usize;
+    let mut descendants: Vec<String> = Vec::new();
+    let mut seen_descendant = std::collections::HashSet::new();
     let mut co: HashMap<String, usize> = HashMap::new();
     for (_note, tags) in sets {
-        if !tags.iter().any(|t| t.to_lowercase() == focus) {
+        if !tags.iter().any(|t| matches_focus(t)) {
             continue;
         }
         focus_count += 1;
+        if tags.iter().any(|t| t.to_lowercase() == focus) {
+            exact_count += 1;
+        }
         for t in tags {
-            if t.to_lowercase() == focus {
+            if matches_focus(t) {
+                // A descendant is part of the focus, not a co-occurrence —
+                // counting `project/nestweaver` as co-occurring with `project`
+                // would report the hierarchy as a relationship.
+                if t.to_lowercase() != focus && seen_descendant.insert(t.to_lowercase()) {
+                    descendants.push(t.clone());
+                }
                 continue;
             }
             *co.entry(t.clone()).or_default() += 1;
         }
     }
+    descendants.sort();
     let mut co_occurring: Vec<CoOccurringTag> = co
         .into_iter()
         .map(|(tag, count)| CoOccurringTag { tag, count })
@@ -452,6 +494,8 @@ fn tag_graph_from_sets(focus: &str, sets: &[(String, Vec<String>)]) -> TagGraph 
     TagGraph {
         tag: focus.to_string(),
         count: focus_count,
+        descendants,
+        exact_count,
         co_occurring,
     }
 }
@@ -847,6 +891,71 @@ mod tests {
             .find(|c| c.tag == "urgent")
             .expect("urgent should co-occur with project");
         assert_eq!(urgent.count, 1);
+    }
+
+    /// nw-172. A PARENT tag must match its nested descendants, and must never
+    /// report a bare 0 for a tag that demonstrably has children.
+    ///
+    /// `#project` used to match only the literal tag and returned 0 while
+    /// `project/nestweaver` returned 46 — indistinguishable from "no such
+    /// tag", which is what made every `tags=["project"]` filter silently empty.
+    #[test]
+    fn a_parent_tag_matches_its_nested_descendants() {
+        let (_dir, root) = make_vault(&[
+            (
+                "Alpha.md",
+                "---\ntags: [project/nestweaver]\n---\n# Alpha\n",
+            ),
+            (
+                "Beta.md",
+                "---\ntags: [project/shot-insights, urgent]\n---\n# Beta\n",
+            ),
+            ("Gamma.md", "---\ntags: [project]\n---\n# Gamma\n"),
+            // A tag that SHARES THE PREFIX but is not a child. A bare
+            // `starts_with` would silently fold this in.
+            ("Delta.md", "---\ntags: [projects]\n---\n# Delta\n"),
+        ]);
+        let (_res, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+
+        let tg = tag_graph(&store, "project").unwrap();
+        assert_eq!(
+            tg.count, 3,
+            "the parent must cover its two children plus its own exact use, and \
+             must NOT include the unrelated `projects`: {tg:?}"
+        );
+        assert_eq!(tg.exact_count, 1, "only Gamma carries the bare tag");
+        assert_eq!(
+            tg.descendants,
+            vec![
+                "project/nestweaver".to_string(),
+                "project/shot-insights".to_string()
+            ],
+            "the folded-in children are disclosed, so a caller can tell a busy \
+             parent from a busy leaf"
+        );
+
+        // A descendant is part of the focus, not a co-occurrence — reporting
+        // `project/nestweaver` as co-occurring with `project` would present the
+        // hierarchy as a relationship.
+        assert!(
+            !tg.co_occurring
+                .iter()
+                .any(|c| c.tag.starts_with("project/")),
+            "descendants must not appear as co-occurring tags: {tg:?}"
+        );
+        // A genuine co-occurrence still shows up.
+        assert!(tg.co_occurring.iter().any(|c| c.tag == "urgent"));
+
+        // The sibling prefix is its own tag and unaffected.
+        let siblings = tag_graph(&store, "projects").unwrap();
+        assert_eq!(siblings.count, 1);
+        assert!(siblings.descendants.is_empty());
+
+        // A leaf still behaves exactly as before.
+        let leaf = tag_graph(&store, "project/nestweaver").unwrap();
+        assert_eq!(leaf.count, 1);
+        assert_eq!(leaf.exact_count, 1);
+        assert!(leaf.descendants.is_empty());
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/export.rs
+++ b/crates/nestweaver-engine/src/export.rs
@@ -9,6 +9,57 @@ use nestweaver_store::GraphStore;
 
 /// Escape a string value for Cypher string literals.
 /// Wraps in single quotes, escaping internal single quotes and backslashes.
+/// Which subgraph an export should contain.
+///
+/// nw-173: `export` used to emit ONLY the code subgraph, silently. On a graph
+/// holding 1,088 notes and 12,439 headings a full graphml came back with not
+/// one Note, Vault, Heading, Section or Tag node — and nothing in the command
+/// name, `--help`, or the output said so. Someone loading that file into Gephi
+/// or networkx would conclude their vault was not in the graph at all.
+///
+/// The product's core claim is a UNIFIED graph over code and notes, so `All` is
+/// the default: a command named `export` should emit the graph it advertises.
+/// The narrower scopes stay available, but now as an explicit choice rather
+/// than an unannounced one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ExportScope {
+    /// Code and vault — everything in the graph.
+    #[default]
+    All,
+    /// Repos, files, symbols and their edges.
+    Code,
+    /// Vaults, notes, headings, sections, tags and their edges.
+    Vault,
+}
+
+impl ExportScope {
+    pub fn includes_code(self) -> bool {
+        matches!(self, Self::All | Self::Code)
+    }
+    pub fn includes_vault(self) -> bool {
+        matches!(self, Self::All | Self::Vault)
+    }
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::Code => "code",
+            Self::Vault => "vault",
+        }
+    }
+}
+
+impl std::str::FromStr for ExportScope {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "all" => Ok(Self::All),
+            "code" => Ok(Self::Code),
+            "vault" => Ok(Self::Vault),
+            other => anyhow::bail!("unknown export scope '{other}' (expected: all, code, vault)"),
+        }
+    }
+}
+
 fn cypher_escape(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 2);
     out.push('\'');
@@ -165,6 +216,15 @@ fn xml_escape(s: &str) -> String {
 /// Emits Repo, File, and Symbol nodes with their properties, and all
 /// code-level edges (CALLS, IMPORTS, EXTENDS, IMPLEMENTS, MEMBER_OF, INCLUDES).
 pub fn export_graphml(store: &GraphStore, writer: &mut dyn Write) -> anyhow::Result<()> {
+    export_graphml_scoped(store, writer, ExportScope::default())
+}
+
+/// GraphML export for `scope`.
+pub fn export_graphml_scoped(
+    store: &GraphStore,
+    writer: &mut dyn Write,
+    scope: ExportScope,
+) -> anyhow::Result<()> {
     // XML header
     writeln!(writer, r#"<?xml version="1.0" encoding="UTF-8"?>"#)?;
     writeln!(
@@ -239,9 +299,13 @@ pub fn export_graphml(store: &GraphStore, writer: &mut dyn Write) -> anyhow::Res
     }
 
     // ── Symbol nodes ─────────────────────────────────────────────────────
-    let symbols = store
-        .list_all_symbols()
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let symbols = if scope.includes_code() {
+        store
+            .list_all_symbols()
+            .map_err(|e| anyhow::anyhow!("{e}"))?
+    } else {
+        Vec::new()
+    };
     // The `pagerank_score` column is never populated; the real scores
     // live in the store's PageRank cache (same source `hubs` reads).
     let pagerank = store
@@ -267,6 +331,88 @@ pub fn export_graphml(store: &GraphStore, writer: &mut dyn Write) -> anyhow::Res
             xml_escape(&sym.file_path),
             pr,
         )?;
+    }
+
+    // ── Vault nodes ──────────────────────────────────────────────────────
+    // nw-173: previously absent ENTIRELY. A full export of a graph holding
+    // 1,088 notes and 12,439 headings emitted not one Note, Vault, Heading or
+    // Tag, and nothing said so — a consumer loading it into Gephi or networkx
+    // would conclude the vault was never indexed. `pagerank` is emitted here
+    // for the same reason it is for symbols: a consumer ranking the graph must
+    // be able to rank ALL of it.
+    if scope.includes_vault() {
+        let vaults = store
+            .list_vaults(None)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        for vault in &vaults {
+            writeln!(
+                writer,
+                r#"    <node id="{}">
+      <data key="label">{}</data>
+      <data key="kind">Vault</data>
+      <data key="file_path">{}</data>
+      <data key="pagerank">0.000000</data>
+    </node>"#,
+                xml_escape(&vault.uid),
+                xml_escape(&vault.name),
+                xml_escape(&vault.root_path),
+            )?;
+        }
+
+        let notes = store.list_notes(None).map_err(|e| anyhow::anyhow!("{e}"))?;
+        for note in &notes {
+            let pr = pagerank.get(&note.uid).copied().unwrap_or(0.0);
+            writeln!(
+                writer,
+                r#"    <node id="{}">
+      <data key="label">{}</data>
+      <data key="kind">Note</data>
+      <data key="file_path">{}</data>
+      <data key="pagerank">{:.6}</data>
+    </node>"#,
+                xml_escape(&note.uid),
+                xml_escape(&note.title),
+                xml_escape(&note.file_path),
+                pr,
+            )?;
+        }
+
+        for vault in &vaults {
+            let headings = store
+                .list_headings_by_vault(&vault.uid)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            for heading in &headings {
+                let pr = pagerank.get(&heading.uid).copied().unwrap_or(0.0);
+                writeln!(
+                    writer,
+                    r#"    <node id="{}">
+      <data key="label">{}</data>
+      <data key="kind">Heading</data>
+      <data key="file_path">{}</data>
+      <data key="pagerank">{:.6}</data>
+    </node>"#,
+                    xml_escape(&heading.uid),
+                    xml_escape(&heading.text),
+                    xml_escape(&heading.note_uid),
+                    pr,
+                )?;
+            }
+        }
+
+        let tags = store.list_tags(None).map_err(|e| anyhow::anyhow!("{e}"))?;
+        for tag in &tags {
+            writeln!(
+                writer,
+                r#"    <node id="{}">
+      <data key="label">{}</data>
+      <data key="kind">Tag</data>
+      <data key="file_path"></data>
+      <data key="pagerank">0.000000</data>
+    </node>"#,
+                xml_escape(&tag.uid),
+                xml_escape(&tag.name),
+            )?;
+        }
     }
 
     // ── Edges ────────────────────────────────────────────────────────────
@@ -469,6 +615,78 @@ mod tests {
             .unwrap();
 
         store
+    }
+
+    /// nw-173. A full export must contain the VAULT subgraph, not just code.
+    ///
+    /// It contained none: a real graph with 1,088 notes and 12,439 headings
+    /// exported to graphml with not one Note, Vault, Heading or Tag node, and
+    /// nothing in the command name, `--help`, or the output said so. Someone
+    /// loading that into Gephi or networkx would conclude their vault had never
+    /// been indexed.
+    ///
+    /// Asserts on the OUTPUT — the nodes a consumer would actually read — not
+    /// on whether a vault query was issued.
+    #[test]
+    fn graphml_export_includes_the_vault_subgraph() {
+        use nestweaver_schema::{Note, NoteKind, Vault};
+
+        let store = populated_store();
+        store
+            .insert_vault(&Vault {
+                uid: "vlt:test".to_string(),
+                name: "Test Vault".to_string(),
+                root_path: "/tmp/vault".to_string(),
+                instance_id: "test".to_string(),
+            })
+            .unwrap();
+        store
+            .insert_note(&Note {
+                uid: "note:test:one".to_string(),
+                vault_uid: "vlt:test".to_string(),
+                file_path: "one.md".to_string(),
+                title: "Note One".to_string(),
+                note_kind: NoteKind::General,
+                word_count: 3,
+                content_hash: "hash".to_string(),
+                frontmatter: None,
+                created_at: None,
+                modified_at: None,
+                pagerank_score: None,
+                embedding: None,
+            })
+            .unwrap();
+
+        let mut buf = Vec::new();
+        export_graphml_scoped(&store, &mut buf, ExportScope::All).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(
+            output.contains(r#"<data key="kind">Vault</data>"#),
+            "a full export must contain Vault nodes"
+        );
+        assert!(
+            output.contains(r#"<data key="kind">Note</data>"#),
+            "a full export must contain Note nodes"
+        );
+        assert!(output.contains("Note One"), "and their labels");
+        // Code is still there — this widened the export, it did not swap it.
+        assert!(output.contains(r#"<data key="kind">Function</data>"#));
+
+        // `--scope code` reproduces the OLD behaviour, now as an explicit
+        // choice rather than an unannounced one.
+        let mut code_only = Vec::new();
+        export_graphml_scoped(&store, &mut code_only, ExportScope::Code).unwrap();
+        let code_only = String::from_utf8(code_only).unwrap();
+        assert!(!code_only.contains(r#"<data key="kind">Note</data>"#));
+        assert!(code_only.contains(r#"<data key="kind">Function</data>"#));
+
+        // …and `--scope vault` is the mirror image.
+        let mut vault_only = Vec::new();
+        export_graphml_scoped(&store, &mut vault_only, ExportScope::Vault).unwrap();
+        let vault_only = String::from_utf8(vault_only).unwrap();
+        assert!(vault_only.contains(r#"<data key="kind">Note</data>"#));
+        assert!(!vault_only.contains(r#"<data key="kind">Function</data>"#));
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/export.rs
+++ b/crates/nestweaver-engine/src/export.rs
@@ -264,9 +264,24 @@ pub fn export_graphml_scoped(
 
     writeln!(writer, r#"  <graph id="G" edgedefault="directed">"#)?;
 
+    // Every id written as a <node>. Edges are filtered against this at the
+    // end: a GraphML file referencing an undeclared node is not a valid
+    // subgraph — Gephi reports missing-node errors and networkx silently
+    // invents thousands of unlabeled phantom nodes. Tracking emission is the
+    // only way a scope filter can be honest, because an edge does not know
+    // which half of the graph its endpoints came from.
+    let mut emitted: std::collections::HashSet<String> = std::collections::HashSet::new();
+
     // ── Repo nodes ───────────────────────────────────────────────────────
-    let repos = store.list_repos(None).map_err(|e| anyhow::anyhow!("{e}"))?;
+    // Gated on scope: `--scope vault` emitted every Repo and File regardless,
+    // so the "vault" export was not the vault subgraph.
+    let repos = if scope.includes_code() {
+        store.list_repos(None).map_err(|e| anyhow::anyhow!("{e}"))?
+    } else {
+        Vec::new()
+    };
     for repo in &repos {
+        emitted.insert(repo.uid.clone());
         writeln!(
             writer,
             r#"    <node id="{}">
@@ -284,6 +299,7 @@ pub fn export_graphml_scoped(
             .list_files_by_repo(&repo.uid)
             .map_err(|e| anyhow::anyhow!("{e}"))?;
         for (file_uid, file_path) in &files {
+            emitted.insert(file_uid.clone());
             writeln!(
                 writer,
                 r#"    <node id="{}">
@@ -331,6 +347,7 @@ pub fn export_graphml_scoped(
             xml_escape(&sym.file_path),
             pr,
         )?;
+        emitted.insert(sym.uid.clone());
     }
 
     // ── Vault nodes ──────────────────────────────────────────────────────
@@ -357,6 +374,7 @@ pub fn export_graphml_scoped(
                 xml_escape(&vault.name),
                 xml_escape(&vault.root_path),
             )?;
+            emitted.insert(vault.uid.clone());
         }
 
         let notes = store.list_notes(None).map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -375,6 +393,7 @@ pub fn export_graphml_scoped(
                 xml_escape(&note.file_path),
                 pr,
             )?;
+            emitted.insert(note.uid.clone());
         }
 
         for vault in &vaults {
@@ -396,6 +415,46 @@ pub fn export_graphml_scoped(
                     xml_escape(&heading.note_uid),
                     pr,
                 )?;
+                emitted.insert(heading.uid.clone());
+            }
+        }
+
+        // nw-173: Section nodes are named by this function's own doc comment
+        // and by `ExportScope::Vault`, but were never emitted — so HAS_TAG and
+        // wikilink edges pointed at `sec:` ids that appeared in no <node>.
+        // NOT `list_sections_by_vault`: that traverses NOTE_HAS_SECTION, and
+        // the edge is NOT guaranteed — `write.rs` deletes sections by the
+        // `note_uid` PROPERTY precisely to catch "fragments whose
+        // NOTE_HAS_SECTION edge is missing", and `regex.rs` avoids the
+        // traversal for the same reason. Ownership lives on the property, so
+        // scan once and keep the sections belonging to notes we emitted.
+        {
+            let owning_notes: std::collections::HashSet<&str> =
+                notes.iter().map(|note| note.uid.as_str()).collect();
+            let sections = store
+                .list_all_sections()
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            for section in sections
+                .iter()
+                .filter(|section| owning_notes.contains(section.note_uid.as_str()))
+            {
+                let pr = pagerank.get(&section.uid).copied().unwrap_or(0.0);
+                writeln!(
+                    writer,
+                    r#"    <node id="{}">
+      <data key="label">{}</data>
+      <data key="kind">Section</data>
+      <data key="file_path">{}</data>
+      <data key="pagerank">{:.6}</data>
+    </node>"#,
+                    xml_escape(&section.uid),
+                    // Sections have no title of their own; the line span is
+                    // the only human-readable label available.
+                    xml_escape(&format!("L{}-{}", section.start_line, section.end_line)),
+                    xml_escape(&section.note_uid),
+                    pr,
+                )?;
+                emitted.insert(section.uid.clone());
             }
         }
 
@@ -412,6 +471,7 @@ pub fn export_graphml_scoped(
                 xml_escape(&tag.uid),
                 xml_escape(&tag.name),
             )?;
+            emitted.insert(tag.uid.clone());
         }
     }
 
@@ -419,7 +479,15 @@ pub fn export_graphml_scoped(
     let typed_edges = store
         .load_typed_edges()
         .map_err(|e| anyhow::anyhow!("{e}"))?;
-    for (idx, (src, dst, edge_type, confidence, _evidence)) in typed_edges.iter().enumerate() {
+    // Only edges whose BOTH endpoints were declared above. Previously every
+    // edge was written unconditionally, so `--scope vault` emitted every
+    // CALLS/IMPORTS edge between `sym:` ids that the file never declared.
+    // Re-indexed so ids stay contiguous rather than gapped.
+    for (idx, (src, dst, edge_type, confidence, _evidence)) in typed_edges
+        .iter()
+        .filter(|(src, dst, _, _, _)| emitted.contains(src) && emitted.contains(dst))
+        .enumerate()
+    {
         writeln!(
             writer,
             r#"    <edge id="e{}" source="{}" target="{}">
@@ -656,11 +724,30 @@ mod tests {
                 embedding: None,
             })
             .unwrap();
+        // A Section, because the export claims to emit them and edges point at
+        // them. Without one in the fixture the claim was never tested.
+        store
+            .insert_section(&nestweaver_schema::Section {
+                uid: "sec:test:one:0".to_string(),
+                note_uid: "note:test:one".to_string(),
+                heading_uid: None,
+                start_line: 1,
+                end_line: 3,
+                text_hash: "hash".to_string(),
+                text_content: "body".to_string(),
+                word_count: 1,
+                pagerank_score: None,
+            })
+            .unwrap();
 
         let mut buf = Vec::new();
         export_graphml_scoped(&store, &mut buf, ExportScope::All).unwrap();
         let output = String::from_utf8(buf).unwrap();
 
+        assert!(
+            output.contains(r#"<data key="kind">Section</data>"#),
+            "a full export must contain Section nodes"
+        );
         assert!(
             output.contains(r#"<data key="kind">Vault</data>"#),
             "a full export must contain Vault nodes"
@@ -687,6 +774,42 @@ mod tests {
         let vault_only = String::from_utf8(vault_only).unwrap();
         assert!(vault_only.contains(r#"<data key="kind">Note</data>"#));
         assert!(!vault_only.contains(r#"<data key="kind">Function</data>"#));
+
+        // Absence of Symbol nodes was the ONLY thing asserted here, which is
+        // why the scope filter shipped emitting every Repo and File anyway.
+        assert!(
+            !vault_only.contains(r#"<data key="kind">Repo</data>"#),
+            "a vault export must not carry Repo nodes"
+        );
+        assert!(
+            !vault_only.contains(r#"<data key="kind">File</data>"#),
+            "a vault export must not carry File nodes"
+        );
+
+        // The real invariant: no edge may reference a node the file does not
+        // declare. This is what makes a scoped export loadable at all — Gephi
+        // errors on a dangling endpoint and networkx invents a phantom node.
+        for graph in [&output, &code_only, &vault_only] {
+            let declared: std::collections::HashSet<&str> = graph
+                .match_indices(r#"<node id=""#)
+                .filter_map(|(at, marker)| {
+                    let rest = &graph[at + marker.len()..];
+                    rest.find('"').map(|end| &rest[..end])
+                })
+                .collect();
+            for (at, marker) in graph.match_indices(r#"<edge id=""#) {
+                let rest = &graph[at + marker.len()..];
+                for attribute in [r#"source=""#, r#"target=""#] {
+                    let from = rest.find(attribute).expect("edge declares both endpoints")
+                        + attribute.len();
+                    let value = &rest[from..from + rest[from..].find('"').unwrap()];
+                    assert!(
+                        declared.contains(value),
+                        "edge endpoint {value} appears in no <node> element"
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/export.rs
+++ b/crates/nestweaver-engine/src/export.rs
@@ -508,6 +508,55 @@ pub fn export_graphml_scoped(
     Ok(())
 }
 
+/// Render one of the text export formats, applying the scope policy.
+///
+/// ONE implementation, called by both the direct CLI path and the daemon's
+/// `export_graph` RPC. They previously diverged completely: the CLI parsed
+/// `--scope` and the daemon neither received nor read it, calling the
+/// unscoped `export_graphml`. Since the daemon route is the DEFAULT
+/// (`--no-daemon` is the fallback), `--scope` did nothing at all for most
+/// users while the engine-level tests passed.
+///
+/// Returns a notice when the chosen format cannot represent everything the
+/// scope asked for, so the caller can say so instead of silently writing less.
+pub fn export_text_format(
+    store: &GraphStore,
+    writer: &mut impl Write,
+    format: &str,
+    scope: ExportScope,
+    top: usize,
+) -> anyhow::Result<Option<String>> {
+    // Cypher and Mermaid are code-only representations. A VAULT scope is a
+    // request they cannot satisfy at all, so they refuse rather than write an
+    // empty file and report success.
+    if scope == ExportScope::Vault && matches!(format, "cypher" | "mermaid") {
+        anyhow::bail!(
+            "{format} export is code-only and cannot represent the vault subgraph; \
+             use --format graphml for --scope vault"
+        );
+    }
+    match format {
+        "cypher" => export_cypher(store, writer)?,
+        "mermaid" => export_mermaid(store, top, writer)?,
+        "graphml" => export_graphml_scoped(store, writer, scope)?,
+        other => anyhow::bail!(
+            "unknown export format '{other}' (expected: cypher, graphml, mermaid, msgpack)"
+        ),
+    }
+    // `all` on a code-only format is not an error — it is the default, and
+    // failing it would break every existing `export --format cypher`. But the
+    // file IS only the code subgraph, and nw-173 exists because that went
+    // unsaid.
+    Ok(
+        (scope == ExportScope::All && matches!(format, "cypher" | "mermaid")).then(|| {
+            format!(
+                "{format} is a code-only format: this export contains the code subgraph, \
+                 not the vault. Use --format graphml for the whole graph."
+            )
+        }),
+    )
+}
+
 // ── Mermaid export ───────────────────────────────────────────────────────────
 
 /// Sanitize a string for use as a Mermaid node ID.
@@ -810,6 +859,64 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// The scope policy both transports share.
+    ///
+    /// The engine-level scope tests passed while `--scope` did nothing for
+    /// users, because the CLI never sent it and the daemon never read it.
+    /// Pinning the POLICY in one place is what makes the two routes agree;
+    /// pinning `export_graphml_scoped` alone did not.
+    #[test]
+    fn shared_export_policy_refuses_what_a_format_cannot_represent() {
+        let store = populated_store();
+        let render = |format: &str, scope: ExportScope| {
+            let mut buf = Vec::new();
+            export_text_format(&store, &mut buf, format, scope, 10)
+                .map(|notice| (String::from_utf8(buf).unwrap(), notice))
+        };
+
+        // A vault scope on a code-only format is a request it cannot satisfy.
+        for format in ["cypher", "mermaid"] {
+            let error = render(format, ExportScope::Vault).unwrap_err();
+            assert!(
+                format!("{error:#}").contains("code-only"),
+                "{format} must refuse --scope vault: {error:#}"
+            );
+        }
+
+        // `all` is the DEFAULT, so it must not fail — but the file really is
+        // code-only, and saying nothing is the nw-173 defect.
+        for format in ["cypher", "mermaid"] {
+            let (_, notice) = render(format, ExportScope::All).unwrap();
+            assert!(
+                notice.is_some_and(|n| n.contains("code-only")),
+                "{format} at --scope all must say the output is code-only"
+            );
+        }
+
+        // An explicit code scope asked for exactly what it got: no notice.
+        for format in ["cypher", "mermaid"] {
+            let (_, notice) = render(format, ExportScope::Code).unwrap();
+            assert!(notice.is_none(), "{format} --scope code needs no notice");
+        }
+
+        // graphml represents everything, so it never warns and never refuses.
+        for scope in [ExportScope::All, ExportScope::Code, ExportScope::Vault] {
+            let (output, notice) = render("graphml", scope).unwrap();
+            assert!(notice.is_none(), "graphml needs no notice at {scope:?}");
+            assert!(
+                output.contains("<graphml"),
+                "graphml must render at {scope:?}"
+            );
+        }
+
+        // graphml actually HONOURS the scope through this entry point, not
+        // just through `export_graphml_scoped`.
+        let (code_only, _) = render("graphml", ExportScope::Code).unwrap();
+        assert!(!code_only.contains(r#"<data key="kind">Note</data>"#));
+
+        assert!(render("nonsense", ExportScope::All).is_err());
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -1174,7 +1174,9 @@ pub(crate) fn finalize_committed_index_for_scope_with_io(
                     && let Err(error) = store.load_pagerank_cache_expecting(
                         &crate::sidecar_path(db_path, ".pagerank.json"),
                         Some(&nestweaver_store::ranking::pagerank_algorithm_fingerprint(
-                            0.85, 20, scope,
+                            nestweaver_store::ranking::PAGERANK_DAMPING,
+                            nestweaver_store::ranking::PAGERANK_ITERATIONS,
+                            scope,
                         )),
                     )
                 {

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -347,6 +347,7 @@ pub use eval::{
 };
 pub use export::{
     ExportScope, export_cypher, export_graphml, export_graphml_scoped, export_mermaid,
+    export_text_format,
 };
 pub use export_graph::export_in_memory_graph;
 pub use extensions::{

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -345,7 +345,9 @@ pub use eval::{
     EvalComparison, EvalReport, JudgedQuery, PerQueryRow, compare_reports, load_judged_queries,
     mrr, ndcg_at_k, precision_at_k, run_eval,
 };
-pub use export::{export_cypher, export_graphml, export_mermaid};
+pub use export::{
+    ExportScope, export_cypher, export_graphml, export_graphml_scoped, export_mermaid,
+};
 pub use export_graph::export_in_memory_graph;
 pub use extensions::{
     AbortMigrationOutcome, ExtensionStore, InstanceExtensionMigration,

--- a/crates/nestweaver-engine/src/publication.rs
+++ b/crates/nestweaver-engine/src/publication.rs
@@ -73,6 +73,38 @@ pub(crate) fn pagerank_artifact_contract(
              re-index to produce a self-describing artifact"
         );
     }
+    // The declaration must match what THIS BUILD computes with. Recomputing
+    // the fingerprint from the declaration (below) only proves the artifact
+    // agrees with itself; without this an artifact declaring damping 0.5 and
+    // carrying the correct fingerprint FOR 0.5 passed, because nothing
+    // supplied an independent expectation. Scope is not checked here — it
+    // legitimately varies between a code-only and a unified pass.
+    for (field, expected, actual) in [
+        (
+            "damping",
+            nestweaver_store::ranking::PAGERANK_DAMPING,
+            declared.get("damping").and_then(|value| value.as_f64()),
+        ),
+        (
+            "iterations",
+            f64::from(nestweaver_store::ranking::PAGERANK_ITERATIONS),
+            declared.get("iterations").and_then(|value| value.as_f64()),
+        ),
+    ] {
+        let Some(actual) = actual else {
+            anyhow::bail!(
+                "PageRank sidecar declares no {field}, so its parameters cannot be \
+                 checked against this build's"
+            );
+        };
+        if actual != expected {
+            anyhow::bail!(
+                "PageRank sidecar declares {field} {actual} but this build computes \
+                 with {expected}; the artifact was produced by a different \
+                 configuration and its scores are not comparable"
+            );
+        }
+    }
     let recomputed = nestweaver_store::ranking::pagerank_fingerprint_from_declared(declared)
         .ok_or_else(|| {
             anyhow::anyhow!("PageRank sidecar declares malformed algorithm parameters: {declared}")
@@ -1327,6 +1359,79 @@ mod tests {
             classify_artifact_descriptor(&expected, Err("torn header".to_string())),
             ArtifactState::Corrupt { .. }
         ));
+    }
+
+    /// nw-147, second half. Recomputing the fingerprint from the parameters an
+    /// artifact DECLARES proves only that the artifact agrees with itself.
+    ///
+    /// An artifact computed with foreign damping can declare that damping and
+    /// carry the correct fingerprint FOR it, and every internal check passes —
+    /// because nothing supplied an expectation from outside the artifact. The
+    /// scores are then silently incomparable with the ones this build produces.
+    #[test]
+    fn a_self_consistent_pagerank_artifact_from_a_foreign_configuration_is_refused() {
+        use nestweaver_store::artifact_envelope::{ArtifactEnvelope, ArtifactExpectation};
+        use nestweaver_store::ranking::{
+            PAGERANK_ARTIFACT_KIND, PAGERANK_ARTIFACT_SCHEMA_VERSION, PAGERANK_DAMPING,
+            PAGERANK_ITERATIONS, pagerank_algorithm_fingerprint, pagerank_declared_parameters,
+        };
+
+        let identity = nestweaver_store::PublicationIdentity {
+            brain_uuid: "550e8400-e29b-41d4-a716-446655440000".to_string(),
+            publication_uuid: "6ba7b810-9dad-11d1-80b4-00c04fd430c8".to_string(),
+        };
+        let scope = nestweaver_store::GraphScope::code_only();
+        let scores: std::collections::HashMap<String, f64> =
+            [("sym:a".to_string(), 1.0)].into_iter().collect();
+
+        // Fully self-consistent by construction: the declaration and the
+        // fingerprint are produced from the SAME parameters, so every check
+        // internal to the artifact agrees.
+        let sealed = |damping: f64, iterations: u32| -> Vec<u8> {
+            let envelope = ArtifactEnvelope::new(
+                ArtifactExpectation {
+                    artifact_kind: PAGERANK_ARTIFACT_KIND,
+                    artifact_schema_version: PAGERANK_ARTIFACT_SCHEMA_VERSION,
+                    identity: &identity,
+                    producer_version: env!("CARGO_PKG_VERSION"),
+                    source_graph_generation: 1,
+                    algorithm_fingerprint: &pagerank_algorithm_fingerprint(
+                        damping, iterations, &scope,
+                    ),
+                },
+                &scores,
+            )
+            .expect("seal artifact")
+            .with_algorithm_parameters(pagerank_declared_parameters(damping, iterations, &scope));
+            serde_json::to_vec(&envelope).expect("serialize envelope")
+        };
+
+        // The build's own parameters still load.
+        pagerank_artifact_contract(
+            &sealed(PAGERANK_DAMPING, PAGERANK_ITERATIONS),
+            &identity,
+            env!("CARGO_PKG_VERSION"),
+            1,
+        )
+        .expect("an artifact matching this build's parameters must load");
+
+        // A different damping, and a different iteration count, each refused
+        // by name — despite being internally consistent.
+        for (label, bytes) in [
+            ("damping", sealed(0.5, PAGERANK_ITERATIONS)),
+            (
+                "iterations",
+                sealed(PAGERANK_DAMPING, PAGERANK_ITERATIONS + 1),
+            ),
+        ] {
+            let error = pagerank_artifact_contract(&bytes, &identity, env!("CARGO_PKG_VERSION"), 1)
+                .expect_err("a foreign configuration must be refused");
+            let rendered = format!("{error:#}");
+            assert!(
+                rendered.contains(label) && rendered.contains("this build computes with"),
+                "{label} mismatch must be named: {rendered}"
+            );
+        }
     }
 
     /// nw-149. `validate_metadata` accepted three shapes it should not.

--- a/crates/nestweaver-engine/src/publication.rs
+++ b/crates/nestweaver-engine/src/publication.rs
@@ -27,14 +27,20 @@ pub const PRESERVED_STATE_ALGORITHM_FINGERPRINT: &str = "nestweaver-publication-
 /// Identity, producer version and source generation ARE checked against the
 /// caller's expectations, so a foreign, stale or corrupt sidecar is rejected.
 ///
-/// The algorithm fingerprint is NOT: this function's whole job is to discover
-/// which parameters the payload declares, so it has no independent expectation
-/// to compare against, and the prefix check below is the only enforcement.
-/// nw-147: the previous doc claimed this also caught a "generically-labelled"
-/// sidecar, which the self-comparison never did. A same-brain, same-generation
-/// artifact computed with different damping/iterations/scope still passes here;
-/// closing that needs the envelope to record the parameters themselves so the
-/// fingerprint can be recomputed from them rather than trusted.
+/// The algorithm fingerprint is now VERIFIED rather than trusted. This function
+/// still has no independent expectation — its job is to discover what the
+/// payload declares — but nw-147 made the artifact declare the parameters that
+/// produced its fingerprint, so the fingerprint can be RECOMPUTED from them.
+/// A same-brain, same-generation artifact computed with different
+/// damping/iterations/scope is now rejected: either its declaration disagrees
+/// with its fingerprint, or its declaration is honest and the recomputation
+/// exposes the mismatch. An artifact can no longer vouch for its own
+/// provenance.
+///
+/// An artifact that declares NOTHING is refused outright. Accepting it would
+/// restore exactly the self-comparison this closes, and — migration being
+/// explicitly on the table for 8.0.0 — a re-index is the honest remedy rather
+/// than a permanent hole kept open for old sidecars.
 pub(crate) fn pagerank_artifact_contract(
     bytes: &[u8],
     identity: &nestweaver_store::PublicationIdentity,
@@ -56,8 +62,29 @@ pub(crate) fn pagerank_artifact_contract(
             envelope.algorithm_fingerprint
         );
     }
-    // Self-comparison, deliberately and now documented: see the note above on
-    // why this function has no independent expectation (nw-147).
+    // nw-147: recompute from the DECLARED parameters and require agreement.
+    // This is what makes the comparison below meaningful — without it, the
+    // fingerprint was only ever compared to itself.
+    let declared = &envelope.algorithm_parameters;
+    if declared.is_null() {
+        anyhow::bail!(
+            "PageRank sidecar declares no algorithm parameters, so its fingerprint \
+             cannot be verified and would only be compared against itself; \
+             re-index to produce a self-describing artifact"
+        );
+    }
+    let recomputed = nestweaver_store::ranking::pagerank_fingerprint_from_declared(declared)
+        .ok_or_else(|| {
+            anyhow::anyhow!("PageRank sidecar declares malformed algorithm parameters: {declared}")
+        })?;
+    if recomputed != envelope.algorithm_fingerprint {
+        anyhow::bail!(
+            "PageRank sidecar's fingerprint does not match the parameters it declares \
+             (declared parameters produce '{recomputed}', artifact carries '{}'); \
+             the artifact is mislabelled",
+            envelope.algorithm_fingerprint
+        );
+    }
     let fingerprint = envelope.algorithm_fingerprint.clone();
     let _: std::collections::HashMap<String, f64> =
         envelope.validate_and_decode(nestweaver_store::artifact_envelope::ArtifactExpectation {
@@ -229,9 +256,25 @@ impl PublicationBundleV3 {
         }
         let expected_brain = parse_uuid("bundle brain_uuid", &self.brain_uuid)?;
         let expected_publication = parse_uuid("bundle publication_uuid", &self.publication_uuid)?;
+        // nw-149: a manifest describing NOTHING was accepted here and only
+        // caught later by `resolve_selected_database` — i.e. after the pointer
+        // had already moved. A publication with no artifacts cannot be valid,
+        // and the cheapest place to say so is before anything is trusted.
+        if self.artifacts.is_empty() {
+            anyhow::bail!("publication bundle describes no artifacts");
+        }
         let mut paths = std::collections::BTreeSet::new();
+        let mut case_folded = std::collections::BTreeSet::new();
         for descriptor in &self.artifacts {
             let path = Path::new(&descriptor.path);
+            // nw-149: the EMPTY path was accepted here while
+            // `validate_relative_path` in publication_operation.rs rejects it —
+            // two validators in one subsystem disagreeing about the same
+            // string. `Path::new("")` is not absolute and yields no components,
+            // so both guards below pass it by construction.
+            if descriptor.path.is_empty() {
+                anyhow::bail!("publication bundle contains an empty artifact path");
+            }
             if path.is_absolute()
                 || path
                     .components()
@@ -242,9 +285,26 @@ impl PublicationBundleV3 {
                     descriptor.path
                 );
             }
-            if !paths.insert(descriptor.path.clone()) {
+            // nw-149: dedupe on the NORMALIZED path, not the raw string.
+            // `a/b`, `a//b` and `a/b/` are distinct strings that name one file,
+            // so a raw-string check let a manifest describe the same artifact
+            // more than once with different metadata for each.
+            let normalized: PathBuf = path.components().collect();
+            let normalized = normalized.to_string_lossy().into_owned();
+            if !paths.insert(normalized.clone()) {
                 anyhow::bail!(
                     "publication bundle contains duplicate artifact: {}",
+                    descriptor.path
+                );
+            }
+            // And on a case-insensitive filesystem `graph.lbug` and
+            // `GRAPH.LBUG` are ALSO one file. A manifest must not depend on
+            // case to tell two artifacts apart, because whether that works is a
+            // property of the reader's filesystem, not of the publication.
+            if !case_folded.insert(normalized.to_lowercase()) {
+                anyhow::bail!(
+                    "publication bundle contains artifact paths differing only by case: {}; \
+                     these name one file on a case-insensitive filesystem",
                     descriptor.path
                 );
             }
@@ -1267,6 +1327,95 @@ mod tests {
             classify_artifact_descriptor(&expected, Err("torn header".to_string())),
             ArtifactState::Corrupt { .. }
         ));
+    }
+
+    /// nw-149. `validate_metadata` accepted three shapes it should not.
+    ///
+    /// Reported as a hardening asymmetry, NOT a proven escape — the probe
+    /// matrix achieved no exploit. This closes gaps in an invariant; it does
+    /// not patch a known attack, and the test is written to say so.
+    #[test]
+    fn bundle_metadata_rejects_empty_paths_aliases_and_empty_manifests() {
+        let identity = nestweaver_store::PublicationIdentity {
+            brain_uuid: "550e8400-e29b-41d4-a716-446655440000".to_string(),
+            publication_uuid: "6ba7b810-9dad-11d1-80b4-00c04fd430c8".to_string(),
+        };
+        let descriptor = |path: &str| ArtifactDescriptor {
+            path: path.to_string(),
+            kind: ArtifactKind::Graph,
+            artifact_schema_version: 1,
+            byte_size: 1,
+            blake3: "0".repeat(64),
+            brain_uuid: identity.brain_uuid.clone(),
+            publication_uuid: identity.publication_uuid.clone(),
+            producer_version: env!("CARGO_PKG_VERSION").to_string(),
+            source_graph_generation: 1,
+            algorithm_fingerprint: "ladybugdb-graph-v1".to_string(),
+        };
+        let bundle_with = |artifacts: Vec<ArtifactDescriptor>| PublicationBundleV3 {
+            format_version: crate::snapshot::SNAPSHOT_FORMAT_VERSION,
+            brain_uuid: identity.brain_uuid.clone(),
+            publication_uuid: identity.publication_uuid.clone(),
+            producer_version: env!("CARGO_PKG_VERSION").to_string(),
+            source_graph_generation: 1,
+            artifacts,
+        };
+        let version = crate::snapshot::SNAPSHOT_FORMAT_VERSION;
+
+        // A normal single-artifact manifest still validates — otherwise the
+        // rejections below prove nothing.
+        bundle_with(vec![descriptor("graph.lbug")])
+            .validate_metadata(version)
+            .expect("an ordinary manifest must still validate");
+
+        // (1) The EMPTY path. `Path::new("")` is not absolute and yields no
+        // components, so both existing guards pass it by construction — while
+        // `validate_relative_path` in publication_operation.rs rejects it. Two
+        // validators in one subsystem disagreeing about the same string.
+        let error = bundle_with(vec![descriptor("")])
+            .validate_metadata(version)
+            .expect_err("an empty artifact path must be rejected");
+        assert!(
+            format!("{error:#}").contains("empty artifact path"),
+            "{error:#}"
+        );
+
+        // (2) A manifest describing NOTHING. Previously caught only by
+        // `resolve_selected_database` — after the pointer had moved.
+        let error = bundle_with(vec![])
+            .validate_metadata(version)
+            .expect_err("a zero-artifact manifest must be rejected");
+        assert!(format!("{error:#}").contains("no artifacts"), "{error:#}");
+
+        // (3) Path ALIASES: distinct strings naming one file. A raw-string
+        // duplicate check let the same artifact be described twice with
+        // different metadata for each.
+        for alias in ["a//b", "a/b/"] {
+            let error = bundle_with(vec![descriptor("a/b"), descriptor(alias)])
+                .validate_metadata(version)
+                .unwrap_err();
+            assert!(
+                format!("{error:#}").contains("duplicate artifact"),
+                "{alias} must collide with a/b: {error:#}"
+            );
+        }
+
+        // (4) Case aliases. On a case-insensitive filesystem these are one
+        // file, so a manifest must not rely on case to tell artifacts apart —
+        // whether that works is a property of the READER's filesystem.
+        let error = bundle_with(vec![descriptor("graph.lbug"), descriptor("GRAPH.LBUG")])
+            .validate_metadata(version)
+            .expect_err("case-only differences must be rejected");
+        assert!(
+            format!("{error:#}").contains("differing only by case"),
+            "{error:#}"
+        );
+
+        // Genuinely distinct paths are still fine — the checks above must not
+        // have collapsed every multi-artifact manifest.
+        bundle_with(vec![descriptor("graph.lbug"), descriptor("pagerank.json")])
+            .validate_metadata(version)
+            .expect("distinct artifacts must still validate");
     }
 
     fn write_slot(root: &Path, identity: &nestweaver_store::PublicationIdentity) -> String {

--- a/crates/nestweaver-engine/src/publication_operation.rs
+++ b/crates/nestweaver-engine/src/publication_operation.rs
@@ -822,6 +822,49 @@ fn validate_target_slot(
             .into());
         }
     }
+
+    // nw-149: and the REVERSE. The loop above only proves every DESCRIBED file
+    // is present and intact; it says nothing about files present but not
+    // described, so anything dropped into a sealed slot was invisible to
+    // validation and travelled with the publication. `validate_backup_publication_inventory`
+    // already required `described == present` for the same artifacts — this
+    // path simply never got the other half.
+    //
+    // Filed as a hardening asymmetry rather than a proven escape: the probe
+    // matrix achieved no exploit. It closes a gap in an invariant; it does not
+    // patch a known attack.
+    let described: std::collections::BTreeSet<&str> = bundle
+        .artifacts
+        .iter()
+        .map(|descriptor| descriptor.path.as_str())
+        .collect();
+    let mut present: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for entry in std::fs::read_dir(&slot)
+        .map_err(|error| anyhow::anyhow!("read target slot {}: {error}", slot.display()))?
+    {
+        let entry = entry.map_err(|error| anyhow::anyhow!("read target slot entry: {error}"))?;
+        let name = entry.file_name().to_string_lossy().into_owned();
+        // The manifest describes the artifacts; it does not describe itself.
+        if name == crate::publication::PUBLICATION_MANIFEST_FILE {
+            continue;
+        }
+        present.insert(name);
+    }
+    let undescribed: Vec<&String> = present
+        .iter()
+        .filter(|name| !described.contains(name.as_str()))
+        .collect();
+    if !undescribed.is_empty() {
+        // Permanent for the same reason as a digest mismatch: a retry sees the
+        // same directory.
+        return Err(PermanentPublicationFailure(format!(
+            "target slot contains {} file(s) the manifest does not describe: {:?};              a sealed slot must contain exactly what it declares",
+            undescribed.len(),
+            undescribed
+        ))
+        .into());
+    }
+
     Ok(crate::hash::blake3_hex_bytes(&bytes))
 }
 
@@ -949,13 +992,35 @@ mod tests {
     fn write_target_bundle(root: &Path, plan: &PublicationOperationPlan) -> String {
         let slot = crate::publication::slot_path(root, &plan.target_publication_uuid).unwrap();
         std::fs::create_dir_all(&slot).unwrap();
+        // The bundle describes a real artifact and the slot holds exactly that
+        // file. An empty `artifacts` list used to be enough here, but a
+        // publication describing nothing is not a publication — and slot
+        // validation is now bidirectional, so an undescribed file in the slot
+        // is rejected too.
+        let graph = b"nw-test-graph".to_vec();
+        std::fs::write(
+            slot.join(crate::publication::PUBLICATION_GRAPH_FILE),
+            &graph,
+        )
+        .unwrap();
         let bundle = crate::publication::PublicationBundleV3 {
             format_version: plan.publication_format_version,
             brain_uuid: plan.brain_uuid.clone(),
             publication_uuid: plan.target_publication_uuid.clone(),
             producer_version: plan.producer_version.clone(),
             source_graph_generation: 0,
-            artifacts: Vec::new(),
+            artifacts: vec![crate::publication::ArtifactDescriptor {
+                path: crate::publication::PUBLICATION_GRAPH_FILE.to_string(),
+                kind: crate::publication::ArtifactKind::Graph,
+                artifact_schema_version: 1,
+                byte_size: graph.len() as u64,
+                blake3: crate::hash::blake3_hex_bytes(&graph),
+                brain_uuid: plan.brain_uuid.clone(),
+                publication_uuid: plan.target_publication_uuid.clone(),
+                producer_version: plan.producer_version.clone(),
+                source_graph_generation: 0,
+                algorithm_fingerprint: "ladybugdb-graph-v1".to_string(),
+            }],
         };
         let bytes = serde_json::to_vec_pretty(&bundle).unwrap();
         std::fs::write(

--- a/crates/nestweaver-engine/src/publication_operation.rs
+++ b/crates/nestweaver-engine/src/publication_operation.rs
@@ -810,6 +810,32 @@ fn validate_target_slot(
     }
     for descriptor in &bundle.artifacts {
         let artifact = slot.join(&descriptor.path);
+        // Hashing OPENS the path, and opening follows symlinks — so a described
+        // artifact that is a symlink would validate against bytes living
+        // outside the slot entirely, while the reverse inventory below (which
+        // does not follow links) could not see it. A sealed slot contains
+        // exactly what it declares; a link is not a shape we ever write.
+        let metadata = std::fs::symlink_metadata(&artifact).map_err(|error| {
+            anyhow::anyhow!("stat target artifact {}: {error}", artifact.display())
+        })?;
+        if metadata.file_type().is_symlink() {
+            return Err(PermanentPublicationFailure(format!(
+                "target artifact {} is a symbolic link; a sealed slot must contain \
+                 real files only",
+                descriptor.path
+            ))
+            .into());
+        }
+        // Belt and braces on containment: `validate_metadata` rejects absolute
+        // and `..` paths, but the bytes about to be trusted are worth proving
+        // are inside the slot rather than inferring it.
+        if !artifact.starts_with(&slot) {
+            return Err(PermanentPublicationFailure(format!(
+                "target artifact {} resolves outside the publication slot",
+                descriptor.path
+            ))
+            .into());
+        }
         let (byte_size, digest) = crate::hash::blake3_file(&artifact).map_err(|error| {
             anyhow::anyhow!("stream target artifact {}: {error}", artifact.display())
         })?;
@@ -849,6 +875,18 @@ fn validate_target_slot(
     for entry in walkdir::WalkDir::new(&slot).into_iter() {
         let entry = entry
             .map_err(|error| anyhow::anyhow!("read target slot {}: {error}", slot.display()))?;
+        // `WalkDir` does not follow symlinks, so a link reports neither file
+        // nor dir — it would fall through this filter and be INVISIBLE to the
+        // undescribed-file check while still being openable by the digest
+        // check above. Refuse it explicitly instead.
+        if entry.file_type().is_symlink() {
+            return Err(PermanentPublicationFailure(format!(
+                "target slot contains a symbolic link ({}); a sealed slot must contain \
+                 real files only",
+                entry.path().display()
+            ))
+            .into());
+        }
         // Directories are containers, not artifacts; the manifest describes the
         // files inside them.
         if !entry.file_type().is_file() {
@@ -1229,6 +1267,39 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("checksum mismatch")
+        );
+    }
+
+    /// A symlink defeated "a sealed slot contains exactly what it declares"
+    /// from BOTH directions: hashing opens the path and so follows the link to
+    /// bytes outside the slot, while the reverse inventory walks without
+    /// following and so reports a link as neither file nor directory — making
+    /// an undescribed one invisible.
+    #[test]
+    fn a_symlink_in_the_target_slot_is_refused_from_either_direction() {
+        let dir = tempfile::tempdir().unwrap();
+        let plan = plan();
+        let state = create_operation(dir.path(), plan.clone()).unwrap();
+        let validating = advance_to_validating(dir.path(), &plan, state);
+        write_target_bundle(dir.path(), &plan);
+        let slot =
+            crate::publication::slot_path(dir.path(), &plan.target_publication_uuid).unwrap();
+
+        // Bytes deliberately OUTSIDE the slot, which is the whole point.
+        let outside = dir.path().join("outside.bin");
+        std::fs::write(&outside, b"not part of this publication").unwrap();
+        std::os::unix::fs::symlink(&outside, slot.join("smuggled.bin")).unwrap();
+
+        let error = mark_ready(dir.path(), &plan.operation_uuid, validating.revision)
+            .expect_err("a symlink in a sealed slot must be refused");
+        let rendered = format!("{error:#}");
+        assert!(rendered.contains("symbolic link"), "{rendered}");
+        // Permanent, like a digest mismatch: a retry sees the same directory.
+        assert!(
+            error
+                .downcast_ref::<PermanentPublicationFailure>()
+                .is_some(),
+            "refusal must be permanent, not retried forever: {rendered}"
         );
     }
 

--- a/crates/nestweaver-engine/src/publication_operation.rs
+++ b/crates/nestweaver-engine/src/publication_operation.rs
@@ -838,12 +838,38 @@ fn validate_target_slot(
         .iter()
         .map(|descriptor| descriptor.path.as_str())
         .collect();
+    // Walk RECURSIVELY and compare the same shape the manifest uses. Artifact
+    // paths are relative and `/`-joined (`build_backup_publication_bundle` ->
+    // `normalized_relative_path`), and nested ones are routine: the BM25 and
+    // regex sidecars are whole DIRECTORIES, described file by file as
+    // `<db>.tantivy/meta.json` and friends. A non-recursive `read_dir` would
+    // compare the bare directory name `<db>.tantivy` against those paths,
+    // match nothing, and fail every real publication permanently.
     let mut present: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
-    for entry in std::fs::read_dir(&slot)
-        .map_err(|error| anyhow::anyhow!("read target slot {}: {error}", slot.display()))?
-    {
-        let entry = entry.map_err(|error| anyhow::anyhow!("read target slot entry: {error}"))?;
-        let name = entry.file_name().to_string_lossy().into_owned();
+    for entry in walkdir::WalkDir::new(&slot).into_iter() {
+        let entry = entry
+            .map_err(|error| anyhow::anyhow!("read target slot {}: {error}", slot.display()))?;
+        // Directories are containers, not artifacts; the manifest describes the
+        // files inside them.
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let relative = entry
+            .path()
+            .strip_prefix(&slot)
+            .map_err(|error| anyhow::anyhow!("target slot entry outside the slot: {error}"))?;
+        let mut components = Vec::new();
+        for component in relative.components() {
+            match component {
+                std::path::Component::Normal(value) => {
+                    components.push(value.to_string_lossy().into_owned())
+                }
+                // A slot is written by us; anything else is not a shape we
+                // describe, so refuse rather than guess at a normal form.
+                _ => anyhow::bail!("unsafe target slot entry path: {}", entry.path().display()),
+            }
+        }
+        let name = components.join("/");
         // The manifest describes the artifacts; it does not describe itself.
         if name == crate::publication::PUBLICATION_MANIFEST_FILE {
             continue;
@@ -858,7 +884,8 @@ fn validate_target_slot(
         // Permanent for the same reason as a digest mismatch: a retry sees the
         // same directory.
         return Err(PermanentPublicationFailure(format!(
-            "target slot contains {} file(s) the manifest does not describe: {:?};              a sealed slot must contain exactly what it declares",
+            "target slot contains {} file(s) the manifest does not describe: {:?}; \
+             a sealed slot must contain exactly what it declares",
             undescribed.len(),
             undescribed
         ))
@@ -1003,24 +1030,53 @@ mod tests {
             &graph,
         )
         .unwrap();
+        // A NESTED artifact, because that is the normal case: the BM25 and
+        // regex sidecars are directories described file by file. A fixture
+        // with only top-level files let slot validation compare bare
+        // directory names against `/`-joined manifest paths and still pass.
+        let nested_dir = slot.join(format!(
+            "{}.tantivy",
+            crate::publication::PUBLICATION_GRAPH_FILE
+        ));
+        std::fs::create_dir_all(&nested_dir).unwrap();
+        let nested = b"nw-test-bm25-meta".to_vec();
+        std::fs::write(nested_dir.join("meta.json"), &nested).unwrap();
+        let nested_path = format!(
+            "{}.tantivy/meta.json",
+            crate::publication::PUBLICATION_GRAPH_FILE
+        );
         let bundle = crate::publication::PublicationBundleV3 {
             format_version: plan.publication_format_version,
             brain_uuid: plan.brain_uuid.clone(),
             publication_uuid: plan.target_publication_uuid.clone(),
             producer_version: plan.producer_version.clone(),
             source_graph_generation: 0,
-            artifacts: vec![crate::publication::ArtifactDescriptor {
-                path: crate::publication::PUBLICATION_GRAPH_FILE.to_string(),
-                kind: crate::publication::ArtifactKind::Graph,
-                artifact_schema_version: 1,
-                byte_size: graph.len() as u64,
-                blake3: crate::hash::blake3_hex_bytes(&graph),
-                brain_uuid: plan.brain_uuid.clone(),
-                publication_uuid: plan.target_publication_uuid.clone(),
-                producer_version: plan.producer_version.clone(),
-                source_graph_generation: 0,
-                algorithm_fingerprint: "ladybugdb-graph-v1".to_string(),
-            }],
+            artifacts: vec![
+                crate::publication::ArtifactDescriptor {
+                    path: crate::publication::PUBLICATION_GRAPH_FILE.to_string(),
+                    kind: crate::publication::ArtifactKind::Graph,
+                    artifact_schema_version: 1,
+                    byte_size: graph.len() as u64,
+                    blake3: crate::hash::blake3_hex_bytes(&graph),
+                    brain_uuid: plan.brain_uuid.clone(),
+                    publication_uuid: plan.target_publication_uuid.clone(),
+                    producer_version: plan.producer_version.clone(),
+                    source_graph_generation: 0,
+                    algorithm_fingerprint: "ladybugdb-graph-v1".to_string(),
+                },
+                crate::publication::ArtifactDescriptor {
+                    path: nested_path,
+                    kind: crate::publication::ArtifactKind::Bm25,
+                    artifact_schema_version: 1,
+                    byte_size: nested.len() as u64,
+                    blake3: crate::hash::blake3_hex_bytes(&nested),
+                    brain_uuid: plan.brain_uuid.clone(),
+                    publication_uuid: plan.target_publication_uuid.clone(),
+                    producer_version: plan.producer_version.clone(),
+                    source_graph_generation: 0,
+                    algorithm_fingerprint: "nestweaver-tantivy-bm25-v1".to_string(),
+                },
+            ],
         };
         let bytes = serde_json::to_vec_pretty(&bundle).unwrap();
         std::fs::write(

--- a/crates/nestweaver-mcp/src/protocol.rs
+++ b/crates/nestweaver-mcp/src/protocol.rs
@@ -70,13 +70,27 @@ pub fn validate_request(value: Value) -> Result<Request, InvalidRequest> {
             });
         }
     };
-    // Preserve the existing MCP compatibility policy: params remains an
-    // optional arbitrary JSON value here. Method/tool-specific validation
-    // returns -32602 or an in-band tool error; this envelope hardening does not
-    // newly reject clients that send null params.
+    // JSON-RPC 2.0: `params`, when present, MUST be structured — an array or
+    // an object. A scalar is a malformed envelope, and the core methods
+    // (`initialize`, `tools/list`, `ping`) never look at `params` at all, so
+    // nothing downstream would ever reject one: `{"method":"ping","params":7}`
+    // was answered with success.
+    //
+    // `null` keeps its carve-out deliberately. Real MCP clients send
+    // `"params": null` for argument-less calls, and the strictness worth
+    // having here is about malformed shapes, not about newly breaking those
+    // clients — which is the compatibility policy this hardening already
+    // chose. Method- and tool-specific validation still returns -32602 for
+    // structurally valid params with wrong contents.
     let params = match object.remove("params") {
         None | Some(Value::Null) => None,
-        Some(value) => Some(value),
+        Some(value @ (Value::Array(_) | Value::Object(_))) => Some(value),
+        Some(_) => {
+            return Err(InvalidRequest {
+                response_id: id.unwrap_or(Value::Null),
+                message: "JSON-RPC params must be an array or an object".to_string(),
+            });
+        }
     };
     Ok(Request {
         jsonrpc,
@@ -198,6 +212,39 @@ mod request_validation_tests {
         }))
         .unwrap_err();
         assert_eq!(error.response_id, Value::Null);
+    }
+
+    /// JSON-RPC 2.0 requires structured `params`. The core methods never read
+    /// `params`, so a scalar reached no validator anywhere and was answered
+    /// with success — `{"method":"ping","params":7}` returned a result.
+    #[test]
+    fn scalar_params_are_rejected_but_null_keeps_its_carve_out() {
+        for scalar in [json!(false), json!(7), json!("x"), json!(1.5)] {
+            let error = validate_request(json!({
+                "jsonrpc": "2.0", "id": 1, "method": "ping", "params": scalar
+            }))
+            .expect_err("a scalar params must be refused");
+            assert!(
+                error.message.contains("array or an object"),
+                "{}",
+                error.message
+            );
+            // A legal ID still correlates the failure.
+            assert_eq!(error.response_id, json!(1));
+        }
+
+        // Structured params still pass for every core method, including the
+        // empty object real clients send.
+        for method in ["initialize", "tools/list", "ping"] {
+            for params in [json!({}), json!({"a": 1}), json!([])] {
+                validate_request(json!({
+                    "jsonrpc": "2.0", "id": 1, "method": method, "params": params
+                }))
+                .unwrap_or_else(|error| {
+                    panic!("{method} must accept structured params: {}", error.message)
+                });
+            }
+        }
     }
 
     #[test]

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -3236,12 +3236,12 @@ fn tool_schema_brain_context() -> Value {
                 "tags": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Include only nodes tagged with any of these tags (applies to Note and Section nodes; Symbol nodes are always kept)."
+                    "description": "Include only nodes tagged with any of these tags (applies to Note and Section nodes; Symbol nodes are always kept). Matching is case-insensitive and includes NESTED descendants: \"project\" matches \"project/nestweaver\" but never \"projectile\"."
                 },
                 "exclude_tags": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Exclude nodes tagged with any of these tags (applies to Note and Section nodes)."
+                    "description": "Exclude nodes tagged with any of these tags (applies to Note and Section nodes). Matching is case-insensitive and includes NESTED descendants: \"project\" matches \"project/nestweaver\" but never \"projectile\". An excluded parent therefore drops its whole subtree."
                 },
                 "weight_ppr": {
                     "type": "number",
@@ -8398,12 +8398,12 @@ fn tool_schema_project_context() -> Value {
                 "tags": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Keep only note/section nodes tagged with any of these tags. Symbol nodes are always kept."
+                    "description": "Keep only note/section nodes tagged with any of these tags. Symbol nodes are always kept. Matching is case-insensitive and includes NESTED descendants: \"project\" matches \"project/nestweaver\" but never \"projectile\"."
                 },
                 "exclude_tags": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Drop note/section nodes tagged with any of these tags."
+                    "description": "Drop note/section nodes tagged with any of these tags. Matching is case-insensitive and includes NESTED descendants: \"project\" matches \"project/nestweaver\" but never \"projectile\". An excluded parent therefore drops its whole subtree."
                 },
                 "cache": { "type": "string", "description": "Set to \"bypass\" to skip the response cache for this call." },
                 "no_cache": { "type": "boolean", "description": "When true, skip the response cache for this call." }

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -150,6 +150,46 @@ const LITE_TOOLS: &[&str] = &[
 /// the brain exposes. When `lite` is true only the 6 core tools are included.
 /// When `--tools` was specified, only those named tools are included.
 fn all_tool_schemas() -> Vec<Value> {
+    let mut schemas = all_tool_schemas_undecorated();
+    // Every cacheable tool honours `cache: "bypass"` / `no_cache: true` at
+    // dispatch (`cache_bypassed`), so every cacheable tool must DECLARE them.
+    // Derived from `CACHEABLE_TOOLS` rather than written into each schema by
+    // hand: with `additionalProperties: false` an undeclared pair is a hard
+    // rejection, and a hand-maintained list drifts the moment a tool joins
+    // `CACHEABLE_TOOLS`. That drift already happened — 18 of 25 cacheable
+    // tools did not declare them, which made `no_cache` a validation error
+    // and left `get_summary`'s own `cache_bypassed` branch unreachable.
+    for tool in &mut schemas {
+        let Some(name) = tool["name"].as_str() else {
+            continue;
+        };
+        if !CACHEABLE_TOOLS.contains(&name) {
+            continue;
+        }
+        let Some(properties) = tool
+            .get_mut("inputSchema")
+            .and_then(|schema| schema.get_mut("properties"))
+            .and_then(|properties| properties.as_object_mut())
+        else {
+            continue;
+        };
+        properties.entry("cache").or_insert_with(|| {
+            serde_json::json!({
+                "type": "string",
+                "description": "Set to \"bypass\" to skip the response cache for this call."
+            })
+        });
+        properties.entry("no_cache").or_insert_with(|| {
+            serde_json::json!({
+                "type": "boolean",
+                "description": "When true, skip the response cache for this call."
+            })
+        });
+    }
+    schemas
+}
+
+fn all_tool_schemas_undecorated() -> Vec<Value> {
     vec![
         tool_schema_brain_context(),
         tool_schema_brain_search(),
@@ -1291,6 +1331,114 @@ mod tool_schema_validation_tests {
         // keep validating under additionalProperties: false.
         assert_valid("brain_search", json!({ "query": "x", "cache": "bypass" }));
         assert_valid("brain_search", json!({ "query": "x", "no_cache": true }));
+    }
+
+    /// EVERY cacheable tool, not just the seven that happened to declare them.
+    ///
+    /// `additionalProperties: false` turned an undeclared `no_cache` from
+    /// "ignored" into "rejected", so a tool the dispatch layer treats as
+    /// bypassable while its schema refuses the argument is a contradiction the
+    /// caller cannot work around. Pinning this per-tool by hand is what let 18
+    /// tools drift; this walks `CACHEABLE_TOOLS` so a new entry is covered the
+    /// day it is added.
+    #[test]
+    fn every_cacheable_tool_accepts_the_cache_bypass_arguments() {
+        // Synthesize the smallest argument object each schema accepts, so the
+        // only thing under test is the cache pair.
+        fn minimal_args(schema: &Value) -> serde_json::Map<String, Value> {
+            let mut args = serde_json::Map::new();
+            let properties = schema["properties"].as_object();
+            for required in schema["required"].as_array().into_iter().flatten() {
+                let Some(field) = required.as_str() else {
+                    continue;
+                };
+                let declared = properties.and_then(|properties| properties.get(field));
+                let kind = declared
+                    .and_then(|value| value["type"].as_str())
+                    .unwrap_or("string");
+                let value = match kind {
+                    "array" => json!(["x"]),
+                    "integer" | "number" => json!(1),
+                    "boolean" => json!(true),
+                    "object" => json!({}),
+                    // An enum must be satisfied with one of its own members.
+                    _ => declared
+                        .and_then(|value| value["enum"].as_array())
+                        .and_then(|values| values.first().cloned())
+                        .unwrap_or_else(|| json!("x")),
+                };
+                args.insert(field.to_string(), value);
+            }
+            args
+        }
+
+        // Some tools express "one of these two" as an alias rule enforced
+        // beside the schema (`missing_alias_requirement`), not as `required`.
+        // Satisfy it by adding declared properties until the rule is happy,
+        // so the assertion below is about the cache pair and nothing else.
+        fn satisfy_alias_requirement(
+            name: &str,
+            schema: &Value,
+            args: &mut serde_json::Map<String, Value>,
+        ) {
+            if missing_alias_requirement(name, &Value::Object(args.clone())).is_none() {
+                return;
+            }
+            let Some(properties) = schema["properties"].as_object() else {
+                return;
+            };
+            for (field, declared) in properties {
+                if args.contains_key(field) {
+                    continue;
+                }
+                let value = match declared["type"].as_str().unwrap_or("string") {
+                    "array" => json!(["x"]),
+                    "integer" | "number" => json!(1),
+                    "boolean" => json!(true),
+                    "object" => json!({}),
+                    _ => json!("x"),
+                };
+                args.insert(field.clone(), value);
+                if missing_alias_requirement(name, &Value::Object(args.clone())).is_none() {
+                    return;
+                }
+                args.remove(field);
+            }
+        }
+
+        let schemas = all_tool_schemas();
+        for name in CACHEABLE_TOOLS {
+            let tool = schemas
+                .iter()
+                .find(|tool| tool["name"] == *name)
+                .unwrap_or_else(|| panic!("{name} is cacheable but not registered"));
+            let schema = &tool["inputSchema"];
+            let properties = schema["properties"]
+                .as_object()
+                .unwrap_or_else(|| panic!("{name} has no properties"));
+            for field in ["cache", "no_cache"] {
+                assert!(
+                    properties.contains_key(field),
+                    "{name} is cacheable but does not declare `{field}`, so \
+                     `additionalProperties: false` rejects a caller that sends it"
+                );
+            }
+
+            // Declaring it is not enough — it has to actually validate.
+            let mut base = minimal_args(schema);
+            satisfy_alias_requirement(name, schema, &mut base);
+            for bypass in [json!({ "cache": "bypass" }), json!({ "no_cache": true })] {
+                let mut args = base.clone();
+                for (key, value) in bypass.as_object().expect("bypass args are an object") {
+                    args.insert(key.clone(), value.clone());
+                }
+                let args = Value::Object(args);
+                assert!(
+                    validate_tool_arguments(name, &args).is_ok(),
+                    "{name} rejected a cache-bypass call: {args}"
+                );
+            }
+        }
     }
 }
 

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -7656,6 +7656,7 @@ fn tool_stale_check(store: &GraphStore) -> Result<Value, anyhow::Error> {
 
     let mut results = Vec::new();
     let mut any_stale = false;
+    let mut any_needs_reindex = false;
 
     for repo in &repos {
         // A local working tree that no longer exists on disk is
@@ -7685,25 +7686,44 @@ fn tool_stale_check(store: &GraphStore) -> Result<Value, anyhow::Error> {
             _ => repo.staleness_commits_behind as u64,
         };
 
-        let is_stale = if local_missing {
-            true
-        } else {
-            match &current_head {
-                Some(head) => head != &repo.indexed_sha,
-                None => commits_behind > 0,
-            }
+        // nw-163: `is_stale` means BEHIND HEAD, and nothing else.
+        //
+        // It used to be the union of three unrelated conditions — behind HEAD,
+        // working tree missing, and index incomplete — so a repo sitting
+        // exactly at HEAD with zero commits behind reported `is_stale: true`,
+        // which reads as a contradiction. `status` already classified the
+        // three correctly; only this flag conflated them.
+        let is_stale = match &current_head {
+            Some(head) => head != &repo.indexed_sha,
+            None => commits_behind > 0,
         };
 
         // A repo whose SHA was committed but whose content never landed
-        // (interrupted index) compares equal to HEAD yet serves an empty
-        // graph — flag it stale so the CI gate catches it.
+        // (interrupted index) compares equal to HEAD yet serves an empty graph.
+        // That is NOT staleness — it is incompleteness — but it needs the same
+        // remedy, which is what `needs_reindex` expresses.
         let content_missing = store
             .repo_index_incomplete(repo)
             .map_err(|e| anyhow!("repo_index_incomplete: {e}"))?;
-        let is_stale = is_stale || content_missing;
+
+        let status = if local_missing {
+            "missing"
+        } else if content_missing {
+            "incomplete"
+        } else if is_stale {
+            "stale"
+        } else {
+            "ok"
+        };
+        // The ACTIONABLE union, and the only thing a CI gate should key on:
+        // every non-`ok` status is fixed by re-indexing.
+        let needs_reindex = status != "ok";
 
         if is_stale {
             any_stale = true;
+        }
+        if needs_reindex {
+            any_needs_reindex = true;
         }
 
         results.push(json!({
@@ -7711,14 +7731,18 @@ fn tool_stale_check(store: &GraphStore) -> Result<Value, anyhow::Error> {
             "indexed_sha": repo.indexed_sha,
             "current_head": current_head,
             "is_stale": is_stale,
+            "needs_reindex": needs_reindex,
             "staleness_commits_behind": commits_behind,
-            "status": if local_missing { "missing" } else if content_missing { "incomplete" } else if is_stale { "stale" } else { "ok" },
+            "status": status,
         }));
     }
 
     Ok(json!({
         "repo_count": repos.len(),
+        // Behind HEAD only. Kept because it is what the word means; a CI gate
+        // wanting "is my graph usable" should read `any_needs_reindex`.
         "any_stale": any_stale,
+        "any_needs_reindex": any_needs_reindex,
         "repos": results,
     }))
 }

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -7896,6 +7896,11 @@ fn tool_stale_check(store: &GraphStore) -> Result<Value, anyhow::Error> {
         // three correctly; only this flag conflated them.
         let is_stale = match &current_head {
             Some(head) => head != &repo.indexed_sha,
+            // Working tree gone: HEAD is unknowable, so "behind HEAD" cannot
+            // be asserted. The stored counter is a leftover from the last
+            // successful check. `status: "missing"` + `needs_reindex` carry
+            // the actionable truth without guessing.
+            None if local_missing => false,
             None => commits_behind > 0,
         };
 
@@ -13857,6 +13862,47 @@ mod stale_check_tool_tests {
              what made this command contradict itself: {result}"
         );
         assert_eq!(result["any_stale"], false, "{result}");
+    }
+
+    /// The same repo, but with a NONZERO stored staleness counter — the case
+    /// the test above missed by pinning only `staleness_commits_behind: 0`.
+    ///
+    /// With the tree deleted there is no HEAD to compare against, so the stored
+    /// counter is a leftover from the last successful check. Falling back to it
+    /// reported `is_stale: true` — a stale guess presented as a fact — for a
+    /// repo whose staleness is simply unknowable.
+    #[test]
+    fn a_deleted_working_tree_does_not_inherit_its_last_known_staleness() {
+        let store = GraphStore::in_memory().expect("in_memory store");
+        let gone = tempfile::tempdir().unwrap();
+        let gone_path = gone.path().display().to_string();
+        store
+            .insert_repo(&nestweaver_schema::Repo {
+                uid: "repo:gone".to_string(),
+                url: format!("file://{gone_path}"),
+                indexed_sha: "abc".to_string(),
+                // The only difference from the test above.
+                staleness_commits_behind: 7,
+                instance_id: "test".to_string(),
+                name: None,
+                root_path: Some(gone_path.clone()),
+            })
+            .expect("insert repo");
+        std::fs::remove_dir_all(gone.path()).unwrap();
+
+        let result = tool_stale_check(&store).expect("stale check");
+        let repo = &result["repos"][0];
+        assert_eq!(repo["status"], "missing", "{result}");
+        assert_eq!(repo["needs_reindex"], true, "{result}");
+        assert_eq!(
+            repo["is_stale"], false,
+            "HEAD is unknowable with the tree deleted, so a stored counter must \
+             not be reported as staleness: {result}"
+        );
+        assert_eq!(result["any_stale"], false, "{result}");
+        // The count itself is still reported — it is the last thing known,
+        // and hiding it would lose information. Only the VERDICT was wrong.
+        assert_eq!(repo["staleness_commits_behind"], 7, "{result}");
     }
 
     /// A repo whose SHA was committed but whose content never landed

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -824,6 +824,36 @@ mod tool_schema_validation_tests {
         }
     }
 
+    /// nw-175. EVERY registered tool must reject unknown argument names.
+    ///
+    /// Only 11 of 41 did. The consequence is not cosmetic: a mistyped argument
+    /// was silently dropped and the handler used its default, so the caller got
+    /// a plausible answer to a question they did not ask. That exact failure
+    /// was hit twice in one review round — `flow_trace` accepting `max_dpeth`
+    /// and silently tracing depth 10, and the config layer accepting
+    /// `with_trigams` and silently leaving trigrams off.
+    ///
+    /// Asserted over the REGISTRY rather than a hand-listed set, so tool 42
+    /// cannot be added without it.
+    #[test]
+    fn every_registered_schema_rejects_unknown_arguments() {
+        let mut permissive = Vec::new();
+        for schema in all_tool_schemas() {
+            let name = schema["name"].as_str().unwrap_or("<unnamed>").to_string();
+            let input = &schema["inputSchema"];
+            // A schema with no properties at all takes no arguments; it still
+            // must not silently swallow one.
+            if input["additionalProperties"] != serde_json::json!(false) {
+                permissive.push(name);
+            }
+        }
+        assert!(
+            permissive.is_empty(),
+            "these tools silently accept undeclared arguments, so a typo becomes a \
+             wrong answer instead of an error: {permissive:?}"
+        );
+    }
+
     #[test]
     fn bounded_tools_reject_unknown_arguments() {
         // Mistyped arg names must fail loudly instead of being
@@ -2587,6 +2617,7 @@ fn tool_schema_count_patterns() -> Value {
         "description": "Count regex matches across indexed text without returning the matches themselves — useful for frequency analysis.\n\nGuidelines:\n- Pass multiple patterns to compare counts in one call\n- Returns per-pattern {pattern, total_matches, files_matched, top_files:[{path,count}], stale_index}\n- For actual match text, use regex_search instead\n\nLimitations:\n- Counts one match per node, not per occurrence within a node\n- Same trigram/fallback behavior as regex_search (stale_index flags a bypassed stale posting table)",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "patterns": {
                     "type": "array",
@@ -2632,6 +2663,7 @@ fn tool_schema_brain_broken_links() -> Value {
         "description": "Find wikilinks in the vault that did not resolve cleanly — ambiguous or low-confidence targets (confidence < 1.0).\n\nGuidelines:\n- Use when auditing vault health or before bulk link repairs\n- Each result includes fuzzy-matched suggested target UIDs for repair\n- Returns empty when no vault is indexed\n\nLimitations:\n- Only detects wikilink resolution issues, not broken external URLs\n- Suggestions are fuzzy title matches, not guaranteed correct targets",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "max_suggestions": {
                     "type": "integer",
@@ -2671,6 +2703,7 @@ fn tool_schema_brain_orphan_documents() -> Value {
         "description": "Find notes with zero inbound and zero outbound wikilinks — disconnected from the knowledge graph.\n\nGuidelines:\n- Candidates to link up or archive; index/MOC notes are excluded via a configurable allowlist\n- Use vault and path_prefix filters to scope the search\n- Returns empty when no vault is indexed\n\nLimitations:\n- Only considers wikilinks, not tag co-occurrence or other relationships\n- Default allowlist excludes Projects.md, index.md, README.md, and MOC-containing paths",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "vault": { "type": "string", "description": "Restrict to this vault UID." },
                 "path_prefix": { "type": "string", "description": "Restrict to notes whose file path starts with this prefix." },
@@ -2713,6 +2746,7 @@ fn tool_schema_brain_topic_clusters() -> Value {
         "description": "Discover thematic structure of a vault by running Louvain-style local moving community detection over the note-to-note wikilink graph.\n\nGuidelines:\n- Each cluster is labelled by its most central member (highest PageRank)\n- Adjust resolution parameter: higher yields more, smaller clusters\n- Returns empty when no vault is indexed\n\nLimitations:\n- Only considers wikilink edges between notes, not tags or code references\n- Label quality depends on the most-central note having a descriptive title",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "resolution": {
                     "type": "number",
@@ -2760,6 +2794,7 @@ fn tool_schema_brain_tag_graph() -> Value {
         "description": "Explore tag relationships in a vault via co-occurrence analysis. Two modes: (1) with tag — returns co-occurring tags for a focus tag; (2) without tag — returns the full tag co-occurrence graph.\n\nGuidelines:\n- Use without tag for taxonomy-drift detection across the vault\n- The tag argument may include or omit a leading #\n- Results sorted by shared-note count (with tag) or note count descending (without)\n\nLimitations:\n- Co-occurrence is based on shared notes, not semantic similarity\n- Returns count 0 / empty when the tag or vault is absent",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "tag": { "type": "string", "description": "Optional focus tag (with or without leading #). When omitted, returns the full tag co-occurrence graph for all tags." },
                 "limit": {
@@ -2788,6 +2823,7 @@ fn tool_schema_brain_doc_stats() -> Value {
         "description": "Get a one-shot health summary of a vault's document graph — note counts, broken links, orphans, tag distribution, and notes-by-year.\n\nGuidelines:\n- Call once for a quick vault health overview before deeper analysis\n- All seven keys are always returned, even on an empty vault (zeros/empty collections)\n- Output: {total_notes, total_wikilinks, broken_wikilinks, orphans, avg_outdegree, top_tags, notes_by_year}\n\nLimitations:\n- Aggregates other brain document tools; for detailed broken links use brain_broken_links directly",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "top_tags_limit": {
                     "type": "integer",
@@ -2841,6 +2877,7 @@ fn tool_schema_brain_memory_lint() -> Value {
         "description": "Audit a memory-bank vault for health problems across seven categories: stale notes, contradictions, orphans, broken wikilinks, supersession chains, schema drift, and dangling relationships.\n\nGuidelines:\n- All seven keys always present in output; empty on a no-vault database\n- Use limit to cap results per category; totals are always reported\n- Schema drift checks against _templates/<kind>.md templates\n\nLimitations:\n- Stale detection uses a fixed 90-day threshold for status:active notes\n- Schema drift requires template files to exist in _templates/",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "limit": {
                     "type": "integer",
@@ -2882,6 +2919,7 @@ fn tool_schema_brain_memory_consolidate() -> Value {
         "description": "Propose promotions of vault notes up memory tiers (daily logs to ideas to project files). DRY-RUN by default.\n\nGuidelines:\n- Set apply:true to execute moves; default is safe dry-run\n- Promotes daily logs referenced by 3+ idea notes (>14 days old) and ideas referenced by both sync.md and status.md\n- Returns proposals with source paths, destinations, and evidence\n\nLimitations:\n- Only proposes promotions along the predefined tier path\n- Requires specific vault structure (_logs/, _ideas/) to detect candidates",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "apply": {
                     "type": "boolean",
@@ -2918,6 +2956,7 @@ fn tool_schema_brain_memory_related() -> Value {
         "description": "Walk the typed relationship graph from a note — Supersedes, DependsOn, CausedBy, RelatesTo — without generic wikilink noise.\n\nGuidelines:\n- BFS traversal from seed uid over chosen edge_types to configurable depth (default 2)\n- Returns only typed neighbours, not generic wikilinks\n- Empty on unknown node or no-vault database\n\nLimitations:\n- Only follows the four typed edge types, not wikilinks or tag co-occurrence\n- Maximum traversal depth may miss distant relationships",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "uid": { "type": "string", "description": "Seed note UID to traverse from." },
                 "edge_types": {
@@ -3007,6 +3046,7 @@ fn tool_schema_brain_context() -> Value {
         "description": "Retrieve PPR-ranked structural context from the knowledge graph, seeded by symbol names, note titles, or keywords. Returns mixed-kind results (Symbol, Note, Section, Tag, Heading) within a token budget.\n\nGuidelines:\n- Primary entry point for understanding a topic — use before reading files\n- Seed with specific names (e.g. 'AuthService.validate'), not broad terms\n- Filter with repos, tags, path_prefix, kinds for precision; use response_format 'concise' unless you need full bodies\n\nLimitations:\n- Only searches indexed repos/vaults — check stale_check if results seem stale\n- Ranked by graph proximity, not recency (use recency_weight to add time decay)\n- May fail with 'index publication TRANSIENT/WEDGED' while an index is being published. This refers to INDEX PUBLICATION, not a dirty git working tree: editing files in a repo does NOT cause it, and NestWeaver is fully usable while you work. TRANSIENT resolves on its own — retry. WEDGED means a prior indexer died mid-publication; run the `nestweaver repair` command named in the error, or check brain_status.index_publication.",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "seeds": {
                     "type": "array",
@@ -5277,6 +5317,7 @@ fn tool_schema_note_get() -> Value {
         "description": "Fetch a vault note's full markdown body or specific sections, plus structural metadata (frontmatter, heading outline, tags).\n\nRequires either 'uid' or 'title' (at least one must be provided).\n\nGuidelines:\n- Use after brain_search or brain_context identifies a relevant note\n- Pass uid for unambiguous lookup, or title for case-insensitive first-match\n- Use sections parameter to retrieve only specific heading sections — much more token-efficient for large notes\n\nLimitations:\n- Markdown notes only — for code symbols use read_symbols\n- Not a discovery tool — use brain_search or brain_context to find notes first",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "uid": { "type": "string", "description": "Note UID (e.g. note:vlt:MyVault:abc123). Preferred over title for unambiguous lookup." },
                 "title": { "type": "string", "description": "Note title (case-insensitive). Returns the first match if multiple notes share the same title." },
@@ -5432,6 +5473,7 @@ fn tool_schema_backlinks() -> Value {
         "description": "Find every note that wiki-links TO a specific target note, revealing the reverse link graph.\n\nRequires either 'uid' or 'title' (at least one must be provided).\n\nGuidelines:\n- Pass uid or title (case-insensitive, first match) to identify the target\n- Returns source note paths, linking sections, confidence scores, and display text\n- For forward links (what a note links to), read the note body with note_get instead\n\nLimitations:\n- Only considers vault wikilinks, not code symbol dependencies (use brain_impact for those)\n- Confidence reflects link resolution quality, not semantic relevance",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "uid": { "type": "string", "description": "Note UID (e.g. note:vlt:MyVault:abc123). Preferred for unambiguous lookup." },
                 "title": { "type": "string", "description": "Note title (case-insensitive match). Returns backlinks for the first matching note." }
@@ -5544,6 +5586,7 @@ fn tool_schema_brain_status() -> Value {
         "description": "Show what knowledge sources are indexed: vault/repo counts, note/tag/wikilink totals, staleness warnings, and search engine availability. No parameters required.\n\nGuidelines:\n- Call at session start to verify expected vaults and repos are loaded\n- Surfaces staleness warnings when repos are behind git HEAD\n- If counts are zero, use brain_add_source to index content\n\nLimitations:\n- Metadata-only — does not search content (use brain_search for that)\n- For detailed per-repo staleness, use stale_check\n\nServer-mode and daemon-runtime fields (server_mode, indexing_active, indexing_repo, queue_depth, write_queue_depth, write_holder, write_holder_seconds, embedding_status) are ALWAYS present in the document. `write_queue_depth` counts write RPCs blocked on the daemon write lock — a different population from `queue_depth`, which counts index jobs. Inside `embedding_status`, `pass_active` / `pass_processed` / `pass_total` / `pass_started_at` / `pass_scope` describe an in-flight embedding pass. While a pass runs, `state` reads `embedding` rather than `ready` — a strictly narrower `ready`, so the daemon can still answer semantic queries; prefer the boolean `pass_active` over matching the state string. `pass_total` is 0 until the eligibility preflight finishes, which means \"not yet counted\", not \"nothing to do\". Only a live daemon can answer the daemon-owned fields honestly (`server_mode` is the exception — a bool that is simply `false` off-daemon): they carry live values on the daemon's gRPC surface and explicit nulls when no daemon serves the answer (direct `--no-daemon`, MCP-over-HTTP, in-process MCP — nothing was bypassed there, so `degraded_components` stays empty). The CLI's daemon-bypassed fallback additionally marks the nulls via `degraded_components: [\"daemon_runtime\"]` and a `daemon_bypassed` warning.",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {}
         }
     })
@@ -6024,6 +6067,7 @@ fn tool_schema_brain_add_source() -> Value {
         "description": "Index a new vault, code repo, or markdown folder into the brain graph. Auto-detects source type from directory contents.\n\nGuidelines:\n- Check brain_status first to avoid re-indexing already-indexed sources\n- Path must be absolute or start with ~/ (tilde expanded to $HOME)\n- Optional name sets a friendly display name for vaults (ignored for repos)\n\nLimitations:\n- Cannot index remote URLs directly — only local filesystem paths\n- Re-indexing an existing source overwrites the previous index",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "path": { "type": "string", "description": "Absolute or ~/-relative directory path to the vault, repo, or markdown folder to index." },
                 "name": {
@@ -6214,6 +6258,7 @@ fn tool_schema_brain_remove_source() -> Value {
         "description": "Remove an indexed code repository or markdown vault from the brain graph permanently.\n\nGuidelines:\n- Accepts repo name, vault name, filesystem path, file:// URL, or UID\n- Auto-detects whether the target is a repo or vault\n- To re-index (not remove), use brain_add_source instead\n\nReading the response:\n- `committed: true` means the removal HAPPENED and is durable. If `reconciliation_warnings` is also non-empty, some post-commit bookkeeping step failed — the removal still succeeded. Do NOT retry as though nothing happened, and do not take corrective action against the removed data; re-run only to retry the bookkeeping.\n- `committed: false` means nothing was removed.\n\nLimitations:\n- Removal is permanent — the source must be re-indexed with brain_add_source to restore\n- Ambiguous targets (matching multiple sources) require a UID to disambiguate",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "target": {
                     "type": "string",
@@ -6404,6 +6449,7 @@ fn tool_schema_prune_stale() -> Value {
         "description": "Remove all indexed repos and vaults whose source directories no longer exist on disk. No parameters required.\n\nGuidelines:\n- Use after moving, renaming, or deleting project directories\n- Returns the list of removed repos and vaults\n\nReading the response:\n- `committed: true` means the prune HAPPENED and is durable. If `reconciliation_warnings` is also non-empty, some post-commit bookkeeping step failed — the prune still succeeded. Do NOT retry as though nothing happened; re-run only to retry the bookkeeping.\n- `committed: false` means nothing was pruned.\n\nLimitations:\n- Only checks filesystem existence, not content staleness (use stale_check for that)\n- Cannot undo — removed sources must be re-indexed with brain_add_source",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {},
             "required": []
         }
@@ -6622,6 +6668,7 @@ fn tool_schema_cross_repo_contracts() -> Value {
         "description": "Find cross-repository references to a symbol — other repos that import, re-export, or implement the same symbol name.\n\nRequires either 'uid' or 'name' (at least one must be provided).\n\nGuidelines:\n- Use when modifying a shared symbol to understand cross-repo blast radius\n- Pass uid or name; returns other repos with confidence scores and link types\n- Only useful when multiple repos are indexed in the same brain\n\nLimitations:\n- For single-repo impact use brain_impact; for general search use brain_search\n- Contract links are hypotheses — check confidence scores before acting\n\nTrust contract: contracts_status (complete/degraded) + degraded_repos report whether contract derivation ran to completion at index time. Derivation failure is atomic, so a degraded repo keeps its PREVIOUS contract graph — its contract links are stale, not absent. Treat every `contract` link involving a degraded repo as 'unknown', not 'none' and not current.\n\nIn server mode, the server has the full org-wide view of cross-repo contracts. Through the hybrid client, results include _meta.sources indicating which data sources contributed; a raw single-daemon connection returns local results only.",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "uid": { "type": "string", "description": "Symbol UID (e.g. sym:repo:...:hash:42). Preferred for unambiguous lookup." },
                 "name": { "type": "string", "description": "Symbol name (e.g. \"UserService\"). Uses first match if multiple symbols share the name." },
@@ -6722,6 +6769,7 @@ fn tool_schema_contract_drift() -> Value {
         "description": "Audit API contract drift: routes declared in specs (OpenAPI, .proto, GraphQL) but not implemented, and routes implemented but not declared in any spec.\n\nGuidelines:\n- Use to spot missing endpoints or undocumented APIs\n- Optional repo filter scopes to a single repository\n- Returns two buckets: declared_not_implemented and implemented_not_declared\n\nTrust contract (read before trusting a clean result):\n- contracts_status (complete/degraded) + degraded_repos: contract derivation is best-effort at index time and never fails the index. Failure is atomic, so a degraded repo's contracts and drift findings reflect its PREVIOUS successful derivation — stale, not wiped. `clean` is true only when the analysis ALSO ran to completion — a degraded repo reports clean: false with contracts_status \"degraded\"\n- Empty buckets on a complete run mean 'no drift'; empty buckets on a degraded run mean 'unknown', not 'safe'\n\nLimitations:\n- Contract links are hypotheses derived from spec parsing and handler heuristics (same-repo only)\n- Only supports OpenAPI/Swagger, .proto, and GraphQL spec formats\n\nIn server mode, the server has the full org-wide view of contract drift. Through the hybrid client, results include _meta.sources indicating which data sources contributed; a raw single-daemon connection returns local results only.",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "repo": { "type": "string", "description": "Optional repo UID to scope the analysis to a single repository." },
                 "limit": {
@@ -6937,6 +6985,7 @@ fn tool_schema_brain_guide() -> Value {
         "description": "Generate a comprehensive orientation guide covering all indexed repos, vaults, cross-repo relationships, and available tools.\n\nGuidelines:\n- Call at session start for a read-once overview before issuing specific queries\n- Regenerated from current graph state on each call\n- The tools section is generated from the live MCP registry, so it never drifts from the actual tool set\n- Not a query tool — use brain_context or brain_search for specific lookups\n\nLimitations:\n- Can be expensive on large graphs; prefer brain_status for lightweight session initialization\n- Output size scales with number of indexed sources",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "format": {
                     "type": "string",
@@ -7265,6 +7314,7 @@ fn tool_schema_detect_changes() -> Value {
         "description": "Assess file-level blast radius for a set of changed files. Maps files to symbols, traces transitive dependents, and returns a risk assessment with explicit trust status.\n\nGuidelines:\n- Use BEFORE committing or reviewing changes\n- Pass repo-relative file paths; returns affected symbols, flows, and risk level (low/medium/high)\n- Treat `risk` as usable only when `status == complete`; `degraded-unknown` requires reindexing or manual review\n- For single-symbol impact use brain_impact; for git diff details use brain_diff\n\nLimitations:\n- Static call-graph analysis only — misses runtime/reflection-based dependencies\n- For cross-repo impact use cross_repo_contracts",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "changed_files": {
                     "type": "array",
@@ -7352,6 +7402,7 @@ fn tool_schema_affected_tests() -> Value {
         "description": "Prioritize which test files a PR should run by mapping changed files through the call/import graph to test files. Results bucketed into priority tiers.\n\nRequires either 'changed_files' or 'base_ref' (at least one must be provided).\n\nGuidelines:\n- Provide changed_files (repo-relative) or base_ref (git ref like 'main') to diff against\n- tier_1 = directly references changed symbol, tier_2 = direct caller, tier_3 = transitive\n- For symbol-level blast radius use brain_impact; for risk scoring use detect_changes\n- `recommendation` is a machine-readable CI directive: 'run-full-suite' on any non-complete run (fail-safe widening), 'selection-usable' otherwise\n\nLimitations:\n- Static call-graph regression test selection — misses reflection, DI, codegen, and integration/e2e tests\n- 'No tests found' does NOT mean safe to skip testing. IMPORTANT: keep periodic full test runs in CI\n\nWhen queried through the hybrid client (a local daemon connected to an upstream server), returns two-tier results (local_impact + org_wide_impact) with _meta.sources indicating provenance; a raw MCP connection to a single daemon returns single-tier local results.",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "changed_files": {
                     "type": "array",
@@ -7545,6 +7596,7 @@ fn tool_schema_clusters() -> Value {
         "description": "View the codebase's high-level architecture via Louvain-style local moving community detection. Groups tightly-connected symbols into named functional clusters.\n\nGuidelines:\n- Adjust resolution: higher = more smaller clusters, lower = fewer larger clusters (default 0.5)\n- Returns cluster name, cohesion score, key files, and a 20-member preview per cluster (full `size` reported)\n- Pass cluster_id to get ONE cluster's full member list (paging deep clusters); `members_truncated` flags when even that is capped\n- For specific symbol lookup use brain_search; for dependency analysis use brain_impact\n\nLimitations:\n- Clustering is recomputed on each call (the result is persisted to a sidecar cache that the CLI `cluster` command reads)\n- Quality depends on the density and accuracy of indexed call/import edges",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "resolution": {
                     "type": "number",
@@ -7644,6 +7696,7 @@ fn tool_schema_stale_check() -> Value {
         "description": "Check whether the graph index is current by comparing each repo's indexed git SHA against HEAD. No parameters required.\n\nGuidelines:\n- Call at session start or after code changes to verify index freshness\n- Returns per-repo staleness with indexed SHA, HEAD SHA, and commits-behind count\n- If stale, re-index with brain_add_source or CLI nestweaver index\n\nLimitations:\n- Only checks git repos, not vault/note freshness\n- For viewing what actually changed, use brain_diff",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {}
         }
     })
@@ -7810,6 +7863,7 @@ fn tool_schema_set_extension() -> Value {
         "description": "Attach custom key-value metadata to any node (symbol, note, section, tag) in a JSON sidecar alongside the database.\n\nGuidelines:\n- Use for information not in core schema: team ownership, deprecation status, review flags\n- Value accepts any JSON type (string, number, boolean, array, object); overwrites existing\n- Properties persist across sessions and are queryable via query_extensions\n\nLimitations:\n- Stored in a sidecar file, not the main graph — not included in graph traversals\n- To query existing properties use query_extensions, not this tool",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "uid": {
                     "type": "string",
@@ -7908,6 +7962,7 @@ fn tool_schema_query_extensions() -> Value {
         "description": "Query custom metadata set via set_extension. Two modes: by uid (all properties for a node) or by key+value (find all nodes matching a property).\n\nRequires either 'uid' or both 'key' and 'value' (at least one mode must be specified).\n\nGuidelines:\n- Pass uid alone to inspect a node's custom properties\n- Pass key + value to find all nodes matching that property (exact match only)\n- For core graph queries use brain_search or brain_context, not this tool\n\nLimitations:\n- Exact match only — no partial matching, ranges, or regex on values\n- Only queries the extension sidecar, not core graph properties",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "key": {
                     "type": "string",
@@ -7980,6 +8035,7 @@ fn tool_schema_brain_diff() -> Value {
         "description": "Show what changed since the graph was last indexed: files added/modified/deleted plus affected symbols. For locally-indexed repos only.\n\nGuidelines:\n- Use before code review or after pulling changes to understand the delta\n- Pass repo name or URL substring; optional since_sha overrides the base\n- For impact analysis of hypothetical changes use detect_changes; for staleness check use stale_check\n\nLimitations:\n- Only works with local repos (file:// URLs), not remote\n- Shows file-level diff, not line-level — use git diff for detailed patches",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "repo": {
                     "type": "string",
@@ -8930,11 +8986,18 @@ fn tool_schema_bridge_nodes() -> Value {
         "description": "Find architectural chokepoints — symbols with high betweenness centrality that sit on many shortest paths between other nodes.\n\nGuidelines:\n- Use to identify symbols with outsized blast radius if changed\n- Returns betweenness score plus which community clusters each bridge connects\n- For most-connected nodes (degree centrality) use hub_nodes instead\n\nLimitations:\n- Betweenness computed via Brandes' algorithm with sampling — approximate for large graphs\n- For single-symbol impact analysis use brain_impact",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "limit": {
                     "type": "integer",
                     "description": "Number of top bridges to return. Default 10.",
                     "default": 10
+                },
+                "top_n": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 1000,
+                    "description": "Alias for `limit`, accepted for backward compatibility."
                 },
                 "response_format": {
                     "type": "string",
@@ -9236,12 +9299,17 @@ fn tool_schema_get_summary() -> Value {
         "description": "Generate deterministic architectural summaries at three granularity levels: symbol, file, or cluster. Derived from graph data, no LLM needed.\n\nGuidelines:\n- level 'symbol' = per-function/class with callers/callees, 'file' = per-file exports, 'cluster' = community architecture\n- Use target to filter to a specific file, symbol, or cluster name\n- Use token_budget to cap output size for context windows\n\nLimitations:\n- Summaries reflect indexed graph state — may be stale if index is behind HEAD\n- For specific symbol source code use read_symbols; for call chains use flow_trace",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "level": {
                     "type": "string",
                     "enum": ["symbol", "file", "cluster", "hub"],
                     "description": "Summary granularity. 'symbol' = per-function/class, 'file' = per-file exports, 'cluster' = per-community architecture, 'hub' = top hub nodes with call-graph shape + role (architectural orientation).",
                     "default": "file"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Alias for `target`, accepted for backward compatibility."
                 },
                 "target": {
                     "type": "string",
@@ -10214,10 +10282,20 @@ fn dir_is_markdown_dominant(dir: &std::path::Path) -> bool {
 /// whose config-less fallback is the db-path hash — a different identity than
 /// the CLI's `"default"`, duplicating any vault added via both paths.
 #[cfg(feature = "daemon")]
+/// The instance this MCP process should ask the daemon to write under.
+///
+/// nw-207: returns EMPTY when this process has no config of its own, which is
+/// the protocol's "you decide" sentinel — the daemon then uses its own
+/// configured identity. It used to return the literal "default", which is a
+/// FALLBACK masquerading as a choice: an MCP server started without `--config`
+/// would override a daemon configured as `kory-brain` and create the vault
+/// under `default`, splitting the graph.
+///
+/// Only a config this process actually has is an instruction worth sending.
 fn resolve_add_source_instance_id() -> String {
     current_instance_config()
         .map(|c| c.instance_id.clone())
-        .unwrap_or_else(|| "default".to_string())
+        .unwrap_or_default()
 }
 
 #[cfg(feature = "daemon")]
@@ -10375,13 +10453,26 @@ mod daemon_index_progress_tests {
     }
 
     #[test]
-    fn add_source_instance_id_matches_cli_precedence() {
-        // The MCP daemon path must stamp vaults under the SAME instance id the
-        // CLI resolves (`--instance` > config > "default"): an empty id defers
-        // to a config-less daemon's db-path hash, duplicating any vault added
-        // via both paths under two vault UIDs.
+    fn add_source_sends_its_own_config_or_defers_to_the_daemon() {
+        // The MCP daemon path must land vaults under the SAME instance the CLI
+        // would resolve. nw-019 achieved that by sending the literal "default"
+        // when this process had no config, because a config-less daemon's data
+        // identity was its DB-PATH HASH and an empty id would have duplicated
+        // the vault under two UIDs.
+        //
+        // nw-207 removed that hash: a config-less daemon's data identity is now
+        // "default" too. So the compensation is not merely unnecessary, it was
+        // actively harmful — a literal "default" OVERRODE a daemon that had a
+        // configured instance, creating the vault under `default` and splitting
+        // the graph. Sending EMPTY defers to the daemon, which is the only
+        // party that knows its own data identity.
         set_current_instance_config(None);
-        assert_eq!(resolve_add_source_instance_id(), "default");
+        assert_eq!(
+            resolve_add_source_instance_id(),
+            "",
+            "with no config of its own, this process must defer rather than \
+             assert a default it merely fell back to"
+        );
 
         let cfg: nestweaver_engine::InstanceConfig = serde_json::from_value(serde_json::json!({
             "instance_id": "cfg-instance",
@@ -10392,6 +10483,8 @@ mod daemon_index_progress_tests {
             "git": { "credential_method": "ssh" }
         }))
         .expect("valid test config");
+        // A config this process ACTUALLY HAS is an instruction worth sending,
+        // and still is.
         set_current_instance_config(Some(std::sync::Arc::new(cfg)));
         assert_eq!(resolve_add_source_instance_id(), "cfg-instance");
         set_current_instance_config(None);
@@ -10580,6 +10673,7 @@ fn tool_schema_investigate_expand() -> Value {
         "description": "Drill into specific investigate map entries: fetch full source bodies and immediate neighbors (callers/callees for symbols, wikilink sources for notes).\n\nGuidelines:\n- Pass bundle_id from a prior investigate call and target asset_ids or raw node uids\n- Expanded entries always have body_complete: true (full untruncated body)\n- Unresolved targets are returned in the unresolved array\n\nLimitations:\n- Requires a valid bundle_id from a prior investigate call\n- Bundles expire 24h after creation",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "bundle_id": { "type": "string", "description": "The bundle_id returned by a prior `investigate` call." },
                 "targets": { "type": "array", "items": { "type": "string" }, "description": "asset_ids (from the investigate map) or raw node uids to expand." },
@@ -10619,6 +10713,7 @@ fn tool_schema_investigate_hydrate() -> Value {
         "description": "Fill in source bodies for all un-hydrated entries in an investigate bundle — the bulk version of investigate_expand, budget-bounded.\n\nGuidelines:\n- Pass bundle_id from a prior investigate call; bodies are read up to token_budget\n- body_complete: true means full source inlined; false means truncated (use read_symbols for the rest)\n- Token budget hard-capped at 16000\n\nLimitations:\n- Requires a valid bundle_id from a prior investigate call\n- Bundles expire 24h after creation",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "bundle_id": { "type": "string", "description": "The bundle_id returned by a prior `investigate` call." },
                 "token_budget": { "type": "integer", "minimum": 1, "maximum": 16000, "default": 4000, "description": "Approximate token cap for the hydrated bodies (chars/4). Hard-capped at 16000." },
@@ -13578,7 +13673,12 @@ mod stale_check_tool_tests {
     use super::*;
 
     /// A repo whose local working tree was deleted must be flagged
-    /// `status: "missing"` and counted as stale — never silently `[ok]`.
+    /// `status: "missing"` and counted as NEEDING RE-INDEX — never silently
+    /// `[ok]`.
+    ///
+    /// nw-163: it used to be reported as `is_stale: true` as well, which is
+    /// false — the repo is not behind HEAD, it has no working tree to compare
+    /// against. `needs_reindex` is the flag that means "act on this".
     #[test]
     fn stale_check_flags_deleted_working_tree_as_missing() {
         let store = GraphStore::in_memory().expect("in_memory store");
@@ -13599,15 +13699,26 @@ mod stale_check_tool_tests {
         std::fs::remove_dir_all(gone.path()).unwrap();
 
         let result = tool_stale_check(&store).expect("stale check");
-        assert_eq!(result["any_stale"], true, "{result}");
+        assert_eq!(result["any_needs_reindex"], true, "{result}");
         let repo = &result["repos"][0];
         assert_eq!(repo["status"], "missing", "{result}");
-        assert_eq!(repo["is_stale"], true, "{result}");
+        assert_eq!(repo["needs_reindex"], true, "{result}");
+        assert_eq!(
+            repo["is_stale"], false,
+            "a missing working tree is not 'behind HEAD'; conflating them is \
+             what made this command contradict itself: {result}"
+        );
+        assert_eq!(result["any_stale"], false, "{result}");
     }
 
     /// A repo whose SHA was committed but whose content never landed
-    /// (interrupted index) compares equal to HEAD — it must still be flagged
-    /// stale (`status: "incomplete"`) so the CI gate catches the empty graph.
+    /// (interrupted index) compares equal to HEAD — it must still be caught by
+    /// the CI gate (`status: "incomplete"`, `needs_reindex: true`).
+    ///
+    /// nw-163: it is NOT stale. It sits exactly at HEAD with zero commits
+    /// behind, which is why reporting `is_stale: true` here read as a
+    /// contradiction and made a gate keyed on `any_stale` disagree with one
+    /// keyed on the exit code.
     #[test]
     fn stale_check_flags_sha_set_but_empty_repo_as_incomplete() {
         let store = GraphStore::in_memory().expect("in_memory store");
@@ -13628,10 +13739,15 @@ mod stale_check_tool_tests {
             .expect("insert repo");
 
         let result = tool_stale_check(&store).expect("stale check");
-        assert_eq!(result["any_stale"], true, "{result}");
+        assert_eq!(result["any_needs_reindex"], true, "{result}");
+        assert_eq!(
+            result["any_stale"], false,
+            "an incomplete index at HEAD is not staleness: {result}"
+        );
         let repo = &result["repos"][0];
         assert_eq!(repo["status"], "incomplete", "{result}");
-        assert_eq!(repo["is_stale"], true, "{result}");
+        assert_eq!(repo["needs_reindex"], true, "{result}");
+        assert_eq!(repo["is_stale"], false, "{result}");
 
         // Once content lands, the same repo must read healthy again. A File
         // node is the content marker: the code index writes one for every
@@ -13646,6 +13762,7 @@ mod stale_check_tool_tests {
             .expect("insert file");
         let healed = tool_stale_check(&store).expect("stale check");
         assert_eq!(healed["any_stale"], false, "{healed}");
+        assert_eq!(healed["any_needs_reindex"], false, "{healed}");
         assert_eq!(healed["repos"][0]["status"], "ok", "{healed}");
     }
 

--- a/crates/nestweaver-store/src/artifact_envelope.rs
+++ b/crates/nestweaver-store/src/artifact_envelope.rs
@@ -22,6 +22,18 @@ pub struct ArtifactEnvelope {
     pub producer_version: String,
     pub source_graph_generation: u64,
     pub algorithm_fingerprint: String,
+    /// The parameters the producer used, declared in the open.
+    ///
+    /// nw-147: `algorithm_fingerprint` is an opaque hash, so a reader with no
+    /// independent expectation could only compare it to ITSELF — which always
+    /// passes. Recording the inputs lets a reader RECOMPUTE the fingerprint
+    /// and reject an artifact whose declared parameters do not produce the
+    /// fingerprint it carries. An artifact can then no longer vouch for its
+    /// own provenance.
+    ///
+    /// Shape is per artifact kind; `null` for kinds that declare nothing yet.
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub algorithm_parameters: Value,
     pub payload_blake3: String,
     pub payload: Value,
 }
@@ -57,9 +69,20 @@ impl ArtifactEnvelope {
             producer_version: expectation.producer_version.to_string(),
             source_graph_generation: expectation.source_graph_generation,
             algorithm_fingerprint: expectation.algorithm_fingerprint.to_string(),
+            algorithm_parameters: Value::Null,
             payload_blake3,
             payload,
         })
+    }
+
+    /// Declare the parameters that produced this artifact's fingerprint.
+    ///
+    /// nw-147: a reader can then recompute the fingerprint from these and
+    /// refuse an artifact whose declaration does not match what it carries.
+    #[must_use]
+    pub fn with_algorithm_parameters(mut self, parameters: Value) -> Self {
+        self.algorithm_parameters = parameters;
+        self
     }
 
     pub fn validate_and_decode<T: DeserializeOwned>(

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -272,6 +272,10 @@ pub struct GraphStore {
     /// confuse code-only, notes-only, unified, or parameter-incompatible
     /// ranks.
     pub(crate) pagerank_artifact_fingerprint: Mutex<Option<String>>,
+    /// The parameters that produced `pagerank_artifact_fingerprint`, declared
+    /// into the artifact so a reader can recompute rather than trust it
+    /// (nw-147).
+    pub(crate) pagerank_declared_parameters: Mutex<Option<serde_json::Value>>,
     /// Monotonic counter that bumps whenever PageRank scores change. Lets
     /// clients (the watcher, the MCP server, downstream tools) detect when
     /// their cached scores are stale without comparing entire score maps.
@@ -622,6 +626,7 @@ impl GraphStore {
             db,
             pagerank_cache: Mutex::new(None),
             pagerank_artifact_fingerprint: Mutex::new(None),
+            pagerank_declared_parameters: Mutex::new(None),
             pagerank_generation: AtomicU64::new(0),
             pagerank_compute_lock: Mutex::new(()),
             graph_generation: AtomicU64::new(0),
@@ -674,6 +679,7 @@ impl GraphStore {
             db,
             pagerank_cache: Mutex::new(None),
             pagerank_artifact_fingerprint: Mutex::new(None),
+            pagerank_declared_parameters: Mutex::new(None),
             pagerank_generation: AtomicU64::new(0),
             pagerank_compute_lock: Mutex::new(()),
             graph_generation: AtomicU64::new(0),
@@ -710,6 +716,7 @@ impl GraphStore {
             db,
             pagerank_cache: Mutex::new(None),
             pagerank_artifact_fingerprint: Mutex::new(None),
+            pagerank_declared_parameters: Mutex::new(None),
             pagerank_generation: AtomicU64::new(0),
             pagerank_compute_lock: Mutex::new(()),
             graph_generation: AtomicU64::new(0),
@@ -747,6 +754,7 @@ impl GraphStore {
             db,
             pagerank_cache: Mutex::new(None),
             pagerank_artifact_fingerprint: Mutex::new(None),
+            pagerank_declared_parameters: Mutex::new(None),
             pagerank_generation: AtomicU64::new(0),
             pagerank_compute_lock: Mutex::new(()),
             graph_generation: AtomicU64::new(0),
@@ -810,6 +818,7 @@ impl GraphStore {
             db,
             pagerank_cache: Mutex::new(None),
             pagerank_artifact_fingerprint: Mutex::new(None),
+            pagerank_declared_parameters: Mutex::new(None),
             pagerank_generation: AtomicU64::new(0),
             pagerank_compute_lock: Mutex::new(()),
             graph_generation: AtomicU64::new(0),

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -1078,6 +1078,71 @@ mod tests {
         store.insert_vault_note_edge("vlt:x", "note:x:1").unwrap();
     }
 
+    /// nw-172 shipped `expand_tags_with_descendants` with no test at all.
+    ///
+    /// Two rules, and the second was broken: descendants match through a
+    /// REQUIRED `/` separator, and matching is case-insensitive because tag
+    /// names are canonicalized to lowercase when indexed. Comparing a raw
+    /// request against stored names meant `tags=["Project"]` found nothing
+    /// while `brain_tag_graph {"tag":"Project"}` — which lowercases — found
+    /// the same note. One rule, two answers.
+    #[test]
+    fn tag_expansion_matches_descendants_case_insensitively() {
+        use nestweaver_schema::{Tag, Vault};
+        let store = test_store();
+        store
+            .insert_vault(&Vault {
+                uid: "vlt:t".to_string(),
+                name: "t".to_string(),
+                root_path: "/t".to_string(),
+                instance_id: "default".to_string(),
+            })
+            .unwrap();
+        // Stored lowercased, exactly as the markdown indexer canonicalizes.
+        for (uid, name) in [
+            ("tag:t:project", "project"),
+            ("tag:t:project-nw", "project/nestweaver"),
+            ("tag:t:projectile", "projectile"),
+        ] {
+            store
+                .insert_tag(&Tag {
+                    uid: uid.to_string(),
+                    vault_uid: "vlt:t".to_string(),
+                    name: name.to_string(),
+                })
+                .unwrap();
+        }
+
+        let expanded = |request: &str| -> Vec<String> {
+            let mut out = store
+                .expand_tags_with_descendants(&[request.to_string()])
+                .unwrap();
+            out.sort();
+            out
+        };
+
+        // The parent carries its subtree, and `projectile` is NOT in it — a
+        // prefix match without the separator would silently widen the filter.
+        assert_eq!(
+            expanded("project"),
+            vec!["project".to_string(), "project/nestweaver".to_string()]
+        );
+
+        // The case the mismatch broke. `#` stripping and case folding must
+        // both apply, and the result must equal the canonical request's.
+        for request in ["Project", "PROJECT", "#Project"] {
+            assert_eq!(
+                expanded(request),
+                expanded("project"),
+                "{request:?} must resolve exactly like its canonical form"
+            );
+        }
+
+        // A request that matches nothing still passes through, so the caller's
+        // own "no such tag" handling fires instead of an empty expansion.
+        assert_eq!(expanded("nope"), vec!["nope".to_string()]);
+    }
+
     #[test]
     fn delete_note_cascade_removes_descendants() {
         use nestweaver_schema::{Heading, Note, NoteKind, Section, Vault};

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -1394,8 +1394,16 @@ impl GraphStore {
                 .pagerank_declared_parameters
                 .lock()
                 .map_err(|e| StoreError::Query(format!("lock: {e}")))?
-                .clone()
-                .unwrap_or(serde_json::Value::Null);
+                .clone();
+            // Fail at WRITE time rather than emitting an artifact that every
+            // reader refuses. A null-parameter file used to be written happily
+            // and only rejected later, at load, far from the cause.
+            let declared = declared.ok_or_else(|| {
+                StoreError::Query(
+                    "refusing to write a PageRank artifact that declares no algorithm parameters"
+                        .to_string(),
+                )
+            })?;
             let envelope = envelope.with_algorithm_parameters(declared);
             let json = serde_json::to_vec_pretty(&envelope)
                 .map_err(|e| StoreError::Query(format!("serialize PageRank artifact: {e}")))?;
@@ -1499,6 +1507,16 @@ impl GraphStore {
                 .pagerank_artifact_fingerprint
                 .lock()
                 .map_err(|e| StoreError::Query(format!("lock: {e}")))? = Some(fingerprint);
+            // nw-147: restore the DECLARED parameters too, not just the
+            // fingerprint. Without this a load->save round trip re-emitted the
+            // artifact with null parameters, which `pagerank_artifact_contract`
+            // then refuses — the store would produce a file it cannot read.
+            *self
+                .pagerank_declared_parameters
+                .lock()
+                .map_err(|e| StoreError::Query(format!("lock: {e}")))? =
+                (!envelope.algorithm_parameters.is_null())
+                    .then(|| envelope.algorithm_parameters.clone());
         }
         Ok(())
     }

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -40,6 +40,21 @@ pub const PAGERANK_ARTIFACT_KIND: &str = "ranking";
 pub const PAGERANK_ARTIFACT_SCHEMA_VERSION: u32 = 2;
 pub const PAGERANK_ALGORITHM_FINGERPRINT_PREFIX: &str = "nestweaver-pagerank-v2:";
 
+/// The damping factor and iteration count every production PageRank pass uses.
+///
+/// Named because a READER needs an expectation that does not come from the
+/// artifact. Recomputing a fingerprint from the parameters an artifact declares
+/// proves the artifact is internally consistent — it does NOT prove those are
+/// the parameters this build computes with, so an artifact declaring different
+/// damping, carrying the matching fingerprint for that damping, passed. These
+/// constants are what a reader checks the declaration AGAINST.
+///
+/// Scope is deliberately not pinned here: it legitimately varies (code-only
+/// versus unified), so it stays part of the declaration rather than a
+/// constant.
+pub const PAGERANK_DAMPING: f64 = 0.85;
+pub const PAGERANK_ITERATIONS: u32 = 20;
+
 /// The algorithm/scope fingerprint an artifact computed with these parameters
 /// must carry. Public so a caller that KNOWS the parameters can pass the
 /// expected value to [`GraphStore::load_pagerank_cache_expecting`] instead of

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -44,6 +44,71 @@ pub const PAGERANK_ALGORITHM_FINGERPRINT_PREFIX: &str = "nestweaver-pagerank-v2:
 /// must carry. Public so a caller that KNOWS the parameters can pass the
 /// expected value to [`GraphStore::load_pagerank_cache_expecting`] instead of
 /// letting the artifact vouch for itself (nw-147).
+/// The parameters that produce [`pagerank_algorithm_fingerprint`], declared in
+/// the open so a reader can RECOMPUTE the fingerprint rather than trust it.
+///
+/// nw-147: the fingerprint is an opaque hash, so a reader with no independent
+/// expectation could only compare it to itself — which always passes, and made
+/// a same-brain, same-generation artifact computed with different
+/// damping/iterations/scope indistinguishable from a correct one. Recording
+/// the inputs turns that self-comparison into a real check.
+pub fn pagerank_declared_parameters(
+    damping: f64,
+    iterations: u32,
+    scope: &GraphScope,
+) -> serde_json::Value {
+    serde_json::json!({
+        "damping": damping,
+        "iterations": iterations,
+        "node_queries": scope.node_queries,
+        "edge_queries": scope
+            .edge_queries
+            .iter()
+            .map(|edge| serde_json::json!({
+                "query": edge.query,
+                "edge_type": edge
+                    .edge_type
+                    .map(|kind| kind.rel_table_name().to_string()),
+            }))
+            .collect::<Vec<_>>(),
+    })
+}
+
+/// Recompute the fingerprint from parameters an artifact DECLARES.
+///
+/// Returns `None` when the declaration is absent or malformed — the caller
+/// decides whether that is fatal, because an artifact predating the declaration
+/// is a different situation from one that declares something incoherent.
+pub fn pagerank_fingerprint_from_declared(parameters: &serde_json::Value) -> Option<String> {
+    let damping = parameters.get("damping")?.as_f64()?;
+    let iterations = u32::try_from(parameters.get("iterations")?.as_u64()?).ok()?;
+    let node_queries: Vec<String> = parameters
+        .get("node_queries")?
+        .as_array()?
+        .iter()
+        .map(|value| value.as_str().map(str::to_string))
+        .collect::<Option<Vec<_>>>()?;
+    let mut edge_queries = Vec::new();
+    for edge in parameters.get("edge_queries")?.as_array()? {
+        let query = edge.get("query")?.as_str()?.to_string();
+        let edge_type = match edge.get("edge_type") {
+            Some(serde_json::Value::Null) | None => None,
+            Some(value) => Some(nestweaver_schema::EdgeType::from_rel_table_name(
+                value.as_str()?,
+            )?),
+        };
+        edge_queries.push(crate::ranking::ScopedEdgeQuery { query, edge_type });
+    }
+    Some(pagerank_algorithm_fingerprint(
+        damping,
+        iterations,
+        &GraphScope {
+            node_queries,
+            edge_queries,
+        },
+    ))
+}
+
 pub fn pagerank_algorithm_fingerprint(damping: f64, iterations: u32, scope: &GraphScope) -> String {
     let mut digest = blake3::Hasher::new();
     digest.update(b"nestweaver-pagerank-scope-v2\0");
@@ -692,6 +757,11 @@ impl GraphStore {
                 .lock()
                 .map_err(|e| StoreError::Query(format!("lock: {e}")))? =
                 Some(pagerank_algorithm_fingerprint(damping, iterations, scope));
+            *self
+                .pagerank_declared_parameters
+                .lock()
+                .map_err(|e| StoreError::Query(format!("lock: {e}")))? =
+                Some(pagerank_declared_parameters(damping, iterations, scope));
             self.bump_pagerank_generation();
             return Ok(());
         }
@@ -782,6 +852,11 @@ impl GraphStore {
             .lock()
             .map_err(|e| StoreError::Query(format!("lock: {e}")))? =
             Some(pagerank_algorithm_fingerprint(damping, iterations, scope));
+        *self
+            .pagerank_declared_parameters
+            .lock()
+            .map_err(|e| StoreError::Query(format!("lock: {e}")))? =
+            Some(pagerank_declared_parameters(damping, iterations, scope));
 
         // Bump the generation so cache-holders know to refresh.
         self.bump_pagerank_generation();
@@ -1313,6 +1388,15 @@ impl GraphStore {
                 },
                 scores,
             )?;
+            // nw-147: declare the parameters INTO the artifact so a reader can
+            // recompute the fingerprint instead of taking the artifact's word.
+            let declared = self
+                .pagerank_declared_parameters
+                .lock()
+                .map_err(|e| StoreError::Query(format!("lock: {e}")))?
+                .clone()
+                .unwrap_or(serde_json::Value::Null);
+            let envelope = envelope.with_algorithm_parameters(declared);
             let json = serde_json::to_vec_pretty(&envelope)
                 .map_err(|e| StoreError::Query(format!("serialize PageRank artifact: {e}")))?;
             crate::durable_sidecar::atomic_replace_file(path, |file| file.write_all(&json))

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -2096,11 +2096,62 @@ impl GraphStore {
         result.map(|row| row_to_symbol(&row)).collect()
     }
 
-    /// Returns the set of Note UIDs that are tagged with any of the given tag names.
+    /// Expand each requested tag to itself plus every nested descendant.
+    ///
+    /// nw-172: `#project` matched only the literal tag `project`, so a filter
+    /// on a PARENT that exists in the hierarchy returned zero — indistinguishable
+    /// from "no such tag" — while `project/nestweaver` returned 46. A silent
+    /// zero for a tag that demonstrably has children is the defect.
+    ///
+    /// Descendants-by-default matches what Obsidian's own search does for a
+    /// parent tag, which is the behaviour a vault user arrives with. (Obsidian
+    /// is not uniformly consistent here — its Bases `tags.contains()` is
+    /// exact-only, and that inconsistency is an active complaint — so the
+    /// argument is the silent zero, not "Obsidian does it".)
+    ///
+    /// Separator is `/`, matching the nested-tag syntax. `project` expands to
+    /// `project` and `project/*`, but never to `projects` — a prefix match
+    /// without the separator would silently widen the filter to unrelated tags.
+    pub fn expand_tags_with_descendants(
+        &self,
+        tag_names: &[String],
+    ) -> Result<Vec<String>, StoreError> {
+        if tag_names.is_empty() {
+            return Ok(Vec::new());
+        }
+        let all = self.list_tags(None)?;
+        let mut expanded: Vec<String> = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        for requested in tag_names {
+            let requested = requested.trim_start_matches('#');
+            let prefix = format!("{requested}/");
+            for tag in &all {
+                if (tag.name == requested || tag.name.starts_with(&prefix))
+                    && seen.insert(tag.name.clone())
+                {
+                    expanded.push(tag.name.clone());
+                }
+            }
+            // A requested tag that matches nothing at all is still passed
+            // through, so the caller's own "no such tag" handling still fires
+            // rather than being masked by an empty expansion.
+            if seen.insert(requested.to_string()) {
+                expanded.push(requested.to_string());
+            }
+        }
+        Ok(expanded)
+    }
+
+    /// Returns the set of Note UIDs that are tagged with any of the given tag
+    /// names, INCLUDING their nested descendants (see
+    /// [`expand_tags_with_descendants`]).
+    ///
+    /// [`expand_tags_with_descendants`]: Self::expand_tags_with_descendants
     pub fn list_note_uids_with_tags(
         &self,
         tag_names: &[String],
     ) -> Result<std::collections::HashSet<String>, StoreError> {
+        let tag_names = &self.expand_tags_with_descendants(tag_names)?;
         let conn = self.conn()?;
         let mut uids = std::collections::HashSet::new();
         for tag_name in tag_names {
@@ -2120,11 +2171,13 @@ impl GraphStore {
         Ok(uids)
     }
 
-    /// Returns the set of Section UIDs that are tagged with any of the given tag names.
+    /// Returns the set of Section UIDs that are tagged with any of the given
+    /// tag names, INCLUDING their nested descendants.
     pub fn list_section_uids_with_tags(
         &self,
         tag_names: &[String],
     ) -> Result<std::collections::HashSet<String>, StoreError> {
+        let tag_names = &self.expand_tags_with_descendants(tag_names)?;
         let conn = self.conn()?;
         let mut uids = std::collections::HashSet::new();
         for tag_name in tag_names {

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -2123,7 +2123,14 @@ impl GraphStore {
         let mut expanded: Vec<String> = Vec::new();
         let mut seen = std::collections::HashSet::new();
         for requested in tag_names {
-            let requested = requested.trim_start_matches('#');
+            // Tag names are stored LOWERCASED (`index_md.rs` canonicalizes at
+            // both construction sites), so a raw comparison silently misses
+            // every mixed-case request: a note tagged `#Project/NestWeaver` is
+            // stored as `project/nestweaver`, and `tags=["Project"]` matched
+            // nothing while `brain_tag_graph {"tag":"Project"}` — which
+            // lowercases — reported it. Same rule, opposite answers.
+            let requested = requested.trim_start_matches('#').to_lowercase();
+            let requested = requested.as_str();
             let prefix = format!("{requested}/");
             for tag in &all {
                 if (tag.name == requested || tag.name.starts_with(&prefix))

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -409,15 +409,42 @@ full-suite run as the safety net, and use `rts-eval report` to learn what your
 ## Index freshness gate
 
 `affected_tests` and blast-radius results are only as current as the index.
-`stale-check` doubles as a CI freshness gate: it exits **1** when any repo's
-indexed SHA is behind git HEAD **or** its working tree has been deleted
-(flagged `[missing]` in text output, `status: "missing"` in JSON). The JSON
-carries an accurate `stale_repos` array, so a job can fail fast and name the
-repos to re-index:
+`stale-check` doubles as a CI freshness gate, with three distinct exit codes:
+
+| Exit | Meaning | CI response |
+|------|---------|-------------|
+| `0` | Every repo is current and completely indexed | proceed |
+| `1` | **The check itself failed** (bad `--db`, unreachable daemon, git error) | investigate — this is not a staleness signal |
+| `2` | At least one repo needs re-indexing | re-index, then re-run |
+
+Exit `1` is reserved for a check that could not answer, following the same
+convention as `terraform plan -detailed-exitcode` and `git diff --exit-code`.
+Collapsing "found drift" into the error code is how a gate ends up unable to
+distinguish a stale graph from a crashed check — the two need opposite
+responses.
+
+Three conditions produce exit `2`, all fixed the same way:
+
+| `status` | Meaning |
+|----------|---------|
+| `stale` | indexed SHA is behind git HEAD |
+| `incomplete` | the SHA was recorded but the content never landed (interrupted index) — the repo compares equal to HEAD while serving an empty graph |
+| `missing` | the working tree has been deleted |
+
+**Gate on `any_needs_reindex`** (or on exit `2`). `any_stale` and `is_stale`
+mean *behind HEAD* specifically, so a repo that is at HEAD but incompletely
+indexed reports `is_stale: false` with `needs_reindex: true`. The JSON also
+carries a `stale_repos` array so a job can name what to re-index:
 
 ```yaml
-- name: Fail if the NestWeaver index is stale
-  run: nestweaver stale-check --db nestweaver.lbug   # exit 1 = re-index needed
+- name: Fail if the NestWeaver index needs re-indexing
+  run: |
+    nestweaver stale-check --db nestweaver.lbug   # 0 ok · 1 check failed · 2 re-index
+    case $? in
+      0) ;;
+      2) echo "::error::NestWeaver index is out of date"; exit 1 ;;
+      *) echo "::error::stale-check could not run"; exit 1 ;;
+    esac
 ```
 
 Read/lookup commands against a non-existent database also fail (exit 1,

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -434,13 +434,19 @@ Three conditions produce exit `2`, all fixed the same way:
 **Gate on `any_needs_reindex`** (or on exit `2`). `any_stale` and `is_stale`
 mean *behind HEAD* specifically, so a repo that is at HEAD but incompletely
 indexed reports `is_stale: false` with `needs_reindex: true`. The JSON also
-carries a `stale_repos` array so a job can name what to re-index:
+carries two arrays so a job can name what to act on: `needs_reindex_repos` is
+the actionable set matching the exit code, and `stale_repos` is the
+behind-HEAD subset. Gate on `needs_reindex_repos` — `stale_repos` will not
+name an `incomplete` or `missing` repo.
 
 ```yaml
 - name: Fail if the NestWeaver index needs re-indexing
   run: |
-    nestweaver stale-check --db nestweaver.lbug   # 0 ok · 1 check failed · 2 re-index
-    case $? in
+    # `run:` executes under `bash -e`, so a non-zero exit would abort the
+    # step before `case` ever runs. Capture the status instead.
+    rc=0
+    nestweaver stale-check --db nestweaver.lbug || rc=$?   # 0 ok · 1 failed · 2 re-index
+    case $rc in
       0) ;;
       2) echo "::error::NestWeaver index is out of date"; exit 1 ;;
       *) echo "::error::stale-check could not run"; exit 1 ;;

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,13 +92,13 @@ use clap::{CommandFactory, Parser, Subcommand};
 use miette::Diagnostic;
 use nestweaver_engine::{
     BlastRadiusResult, BrainContextResult, BrainWatcher, BreakTier, BreakingChange, CodeWatcher,
-    ContextResult, DeadCodeConfidence, FeatureContextResult, GateState, HubNode,
+    ContextResult, DeadCodeConfidence, ExportScope, FeatureContextResult, GateState, HubNode,
     HybridSearchConfig, LookupResult, NotificationLevel, RiskLevel, Summary, SummaryLevel,
     analyze_blast_radius, attach_cluster_ids, attach_communities, breaking_changes_from_git,
     build_brain_context_hybrid_with_aliases, build_context_with_intent, build_feature_context,
     changed_files_from_git, compute_clusters, compute_cochanges, discover_cross_domain_links,
-    embedding::generate_embeddings_batch, export_cypher, export_graphml, export_in_memory_graph,
-    export_mermaid, filter_by_target, find_bridge_nodes, find_hub_nodes,
+    embedding::generate_embeddings_batch, export_cypher, export_graphml_scoped,
+    export_in_memory_graph, export_mermaid, filter_by_target, find_bridge_nodes, find_hub_nodes,
     generate_agents_md_with_rules, generate_claude_md_with_rules, generate_cursor_rule_with_rules,
     generate_guide_with_tools, generate_repo_map, generate_summaries, get_last_indexed_at,
     index_markdown_directory_since_with_ignore, index_markdown_directory_with_ignore,
@@ -114,6 +114,15 @@ use nestweaver_store::{GraphStore, QueryIntent, TantivyIndex};
 const EXIT_SUCCESS: i32 = 0;
 const EXIT_ERROR: i32 = 1;
 const EXIT_NOT_FOUND: i32 = 2;
+/// `stale-check` found at least one repo needing a re-index.
+///
+/// DISTINCT from `EXIT_ERROR`, following the convention `terraform plan
+/// -detailed-exitcode` and `git diff --exit-code` established: 0 = nothing to
+/// do, 1 = THE CHECK ITSELF FAILED, 2 = the check ran and found drift.
+/// Collapsing the last two into 1 is what made a CI gate unable to tell "your
+/// graph is stale" from "the freshness check crashed" — the two demand
+/// opposite responses.
+const EXIT_NEEDS_REINDEX: i32 = 2;
 const EXIT_AMBIGUOUS: i32 = 3;
 const DEFAULT_EXTERNAL_EMBEDDING_MODEL: &str = "text-embedding-3-small";
 
@@ -3394,6 +3403,12 @@ enum Commands {
         format: String,
         #[arg(long, help = "Write to file instead of stdout")]
         output: Option<PathBuf>,
+        #[arg(
+            long,
+            default_value = "all",
+            help = "Subgraph to export: all (default), code, or vault. graphml honours all three; cypher and mermaid are code-only and will refuse a vault scope rather than emit an empty file"
+        )]
+        scope: String,
         #[arg(
             long,
             default_value = "50",
@@ -11120,6 +11135,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
 
         Commands::Export {
             format,
+            scope,
             output,
             top,
             db,
@@ -11223,9 +11239,28 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             };
             let mut writer = std::io::BufWriter::new(write_to);
 
+            // Parsed once, before dispatch, so an invalid scope fails before any
+            // output is written rather than half way through a 163 MB file.
+            let export_scope: ExportScope = scope.parse()?;
             match format.as_str() {
+                // nw-173: `export` used to emit only the code subgraph with no
+                // indication. `graphml` now honours the scope; the two formats
+                // that genuinely cannot represent the vault REFUSE a vault
+                // scope rather than writing an empty file and calling it done.
+                "cypher" if export_scope.includes_vault() && export_scope != ExportScope::All => {
+                    anyhow::bail!(
+                        "cypher export is code-only and cannot represent the vault subgraph; \
+                         use --format graphml for --scope vault"
+                    )
+                }
+                "mermaid" if export_scope.includes_vault() && export_scope != ExportScope::All => {
+                    anyhow::bail!(
+                        "mermaid export is code-only and cannot represent the vault subgraph; \
+                         use --format graphml for --scope vault"
+                    )
+                }
                 "cypher" => export_cypher(&store, &mut writer)?,
-                "graphml" => export_graphml(&store, &mut writer)?,
+                "graphml" => export_graphml_scoped(&store, &mut writer, export_scope)?,
                 "mermaid" => export_mermaid(&store, top, &mut writer)?,
                 other => {
                     eprintln!(
@@ -18454,11 +18489,18 @@ fn run_brain(
                     .get("any_stale")
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
+                // Falls back to `any_stale` only for an older daemon that does
+                // not send the field — never silently reports "nothing to do".
+                let any_needs_reindex = value
+                    .get("any_needs_reindex")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(any_stale);
 
                 if json {
                     let normalized = serde_json::json!({
                         "repo_count": value.get("repo_count").cloned().unwrap_or(serde_json::json!(0)),
                         "any_stale": any_stale,
+                        "any_needs_reindex": any_needs_reindex,
                         "stale_repos": stale_urls,
                         "repos": value.get("repos").cloned().unwrap_or_else(|| serde_json::json!([])),
                     });
@@ -18513,13 +18555,21 @@ fn run_brain(
                     }
                 }
                 // Stale-check is a freshness gate — exit non-zero when stale.
-                return Ok((if any_stale { EXIT_ERROR } else { EXIT_SUCCESS }, None));
+                return Ok((
+                    if any_needs_reindex {
+                        EXIT_NEEDS_REINDEX
+                    } else {
+                        EXIT_SUCCESS
+                    },
+                    None,
+                ));
             }
 
             let store = open_store(Some(&db_path))?;
             let repos = store.list_repos(None).unwrap_or_default();
 
             let mut any_stale = false;
+            let mut any_needs_reindex = false;
             let mut results: Vec<serde_json::Value> = Vec::new();
 
             for repo in &repos {
@@ -18585,9 +18635,25 @@ fn run_brain(
                 let content_missing = store
                     .repo_index_incomplete(repo)
                     .map_err(|e| anyhow::anyhow!("repo_index_incomplete: {e}"))?;
-                let is_stale = is_stale || content_missing;
+
+                // nw-163: `is_stale` means BEHIND HEAD and nothing else; the
+                // actionable union lives in `needs_reindex`. Mirrors
+                // `tool_stale_check` exactly — the two paths must not drift.
+                let status = if local_missing {
+                    "missing"
+                } else if content_missing {
+                    "incomplete"
+                } else if is_stale {
+                    "stale"
+                } else {
+                    "ok"
+                };
+                let needs_reindex = status != "ok";
                 if is_stale {
                     any_stale = true;
+                }
+                if needs_reindex {
+                    any_needs_reindex = true;
                 }
 
                 results.push(serde_json::json!({
@@ -18595,8 +18661,9 @@ fn run_brain(
                     "indexed_sha": repo.indexed_sha,
                     "current_head": current_head,
                     "is_stale": is_stale,
+                    "needs_reindex": needs_reindex,
                     "staleness_commits_behind": commits_behind,
-                    "status": if local_missing { "missing" } else if content_missing { "incomplete" } else if is_stale { "stale" } else { "ok" },
+                    "status": status,
                 }));
             }
 
@@ -18655,7 +18722,14 @@ fn run_brain(
                 }
             }
             // Stale-check is a freshness gate — exit non-zero when stale.
-            Ok((if any_stale { EXIT_ERROR } else { EXIT_SUCCESS }, None))
+            Ok((
+                if any_needs_reindex {
+                    EXIT_NEEDS_REINDEX
+                } else {
+                    EXIT_SUCCESS
+                },
+                None,
+            ))
         }
 
         BrainCommands::Watch {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18680,6 +18680,7 @@ fn run_brain(
                     serde_json::to_string_pretty(&serde_json::json!({
                         "repo_count": repos.len(),
                         "any_stale": any_stale,
+                        "any_needs_reindex": any_needs_reindex,
                         "stale_repos": stale_urls,
                         "repos": results,
                     }))?

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,10 +97,10 @@ use nestweaver_engine::{
     analyze_blast_radius, attach_cluster_ids, attach_communities, breaking_changes_from_git,
     build_brain_context_hybrid_with_aliases, build_context_with_intent, build_feature_context,
     changed_files_from_git, compute_clusters, compute_cochanges, discover_cross_domain_links,
-    embedding::generate_embeddings_batch, export_cypher, export_graphml_scoped,
-    export_in_memory_graph, export_mermaid, filter_by_target, find_bridge_nodes, find_hub_nodes,
-    generate_agents_md_with_rules, generate_claude_md_with_rules, generate_cursor_rule_with_rules,
-    generate_guide_with_tools, generate_repo_map, generate_summaries, get_last_indexed_at,
+    embedding::generate_embeddings_batch, export_in_memory_graph, export_text_format,
+    filter_by_target, find_bridge_nodes, find_hub_nodes, generate_agents_md_with_rules,
+    generate_claude_md_with_rules, generate_cursor_rule_with_rules, generate_guide_with_tools,
+    generate_repo_map, generate_summaries, get_last_indexed_at,
     index_markdown_directory_since_with_ignore, index_markdown_directory_with_ignore,
     index_markdown_directory_with_ignore_and_deletion_count, list_repos, list_services,
     load_alias_sidecar, load_clusters, load_extensions, lookup_symbol, record_last_indexed_at,
@@ -11150,7 +11150,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 let mut client =
                     rt.block_on(nestweaver_client::DaemonClient::connect(db_path, None))?;
 
-                let mut args = serde_json::json!({ "format": format, "top": top });
+                // `scope` was never sent, so the daemon — the DEFAULT route —
+                // exported the whole graph no matter what `--scope` said.
+                let mut args = serde_json::json!({ "format": format, "top": top, "scope": scope });
                 if let Some(ref p) = output {
                     // The DAEMON writes the file and runs with CWD=/, so a client-relative
                     // --output would land in / (or fail), not the user's directory. Resolve
@@ -11173,6 +11175,10 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     .context("export_graph RPC failed")?;
                 let result: serde_json::Value =
                     serde_json::from_str(&resp.into_inner().result_json)?;
+
+                if let Some(notice) = result.get("notice").and_then(|v| v.as_str()) {
+                    out.status(notice);
+                }
 
                 // For text formats without an output file, print the text to stdout.
                 if let Some(text) = result.get("text").and_then(|v| v.as_str()) {
@@ -11242,33 +11248,21 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // Parsed once, before dispatch, so an invalid scope fails before any
             // output is written rather than half way through a 163 MB file.
             let export_scope: ExportScope = scope.parse()?;
-            match format.as_str() {
-                // nw-173: `export` used to emit only the code subgraph with no
-                // indication. `graphml` now honours the scope; the two formats
-                // that genuinely cannot represent the vault REFUSE a vault
-                // scope rather than writing an empty file and calling it done.
-                "cypher" if export_scope.includes_vault() && export_scope != ExportScope::All => {
-                    anyhow::bail!(
-                        "cypher export is code-only and cannot represent the vault subgraph; \
-                         use --format graphml for --scope vault"
-                    )
-                }
-                "mermaid" if export_scope.includes_vault() && export_scope != ExportScope::All => {
-                    anyhow::bail!(
-                        "mermaid export is code-only and cannot represent the vault subgraph; \
-                         use --format graphml for --scope vault"
-                    )
-                }
-                "cypher" => export_cypher(&store, &mut writer)?,
-                "graphml" => export_graphml_scoped(&store, &mut writer, export_scope)?,
-                "mermaid" => export_mermaid(&store, top, &mut writer)?,
-                other => {
-                    eprintln!(
-                        "Unknown format '{}'. Supported: cypher, graphml, mermaid, msgpack",
-                        other
-                    );
-                    return Ok((EXIT_ERROR, None));
-                }
+            // Unknown formats keep their friendly listing and EXIT_ERROR
+            // rather than becoming a generic error chain.
+            if !matches!(format.as_str(), "cypher" | "graphml" | "mermaid") {
+                eprintln!(
+                    "Unknown format '{}'. Supported: cypher, graphml, mermaid, msgpack",
+                    format
+                );
+                return Ok((EXIT_ERROR, None));
+            }
+            // One shared implementation with the daemon's `export_graph`, so
+            // the two cannot drift on scope again.
+            if let Some(notice) =
+                export_text_format(&store, &mut writer, format.as_str(), export_scope, top)?
+            {
+                out.status(&notice);
             }
             std::io::Write::flush(&mut writer)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18474,17 +18474,26 @@ fn run_brain(
                 // `stale_repos` verdict could contradict the tool's fresh
                 // `any_stale` — is replaced by a top-level `stale_repos`
                 // computed from the actual stale list).
-                let stale_urls: Vec<serde_json::Value> = value
-                    .get("repos")
-                    .and_then(|v| v.as_array())
-                    .map(|repos| {
-                        repos
-                            .iter()
-                            .filter(|r| r["is_stale"].as_bool().unwrap_or(false))
-                            .filter_map(|r| r["url"].as_str().map(serde_json::Value::from))
-                            .collect()
-                    })
-                    .unwrap_or_default();
+                let urls_where = |field: &str| -> Vec<serde_json::Value> {
+                    value
+                        .get("repos")
+                        .and_then(|v| v.as_array())
+                        .map(|repos| {
+                            repos
+                                .iter()
+                                .filter(|r| r[field].as_bool().unwrap_or(false))
+                                .filter_map(|r| r["url"].as_str().map(serde_json::Value::from))
+                                .collect()
+                        })
+                        .unwrap_or_default()
+                };
+                let stale_urls = urls_where("is_stale");
+                // nw-163: `stale_repos` narrowed along with `is_stale`, so it
+                // no longer names an `incomplete` or `missing` repo — yet those
+                // still exit 2, and the CI recipe tells a job to re-index what
+                // this array names. `needs_reindex_repos` is the actionable
+                // set; `stale_repos` stays behind-HEAD only.
+                let needs_reindex_urls = urls_where("needs_reindex");
                 let any_stale = value
                     .get("any_stale")
                     .and_then(|v| v.as_bool())
@@ -18502,6 +18511,7 @@ fn run_brain(
                         "any_stale": any_stale,
                         "any_needs_reindex": any_needs_reindex,
                         "stale_repos": stale_urls,
+                        "needs_reindex_repos": needs_reindex_urls,
                         "repos": value.get("repos").cloned().unwrap_or_else(|| serde_json::json!([])),
                     });
                     println!("{}", serde_json::to_string_pretty(&normalized)?);
@@ -18522,8 +18532,12 @@ fn run_brain(
                         println!(
                             "Stale check: {} repo(s), {}",
                             repo_count,
-                            if any_stale {
-                                "INDEX IS STALE"
+                            // Gated on the union, not `any_stale`: an `incomplete`
+                            // repo exits 2, and a banner reading "up to date"
+                            // above that exit code is the exact dishonesty this
+                            // contract exists to remove.
+                            if any_needs_reindex {
+                                "NEEDS REINDEX"
                             } else {
                                 "up to date"
                             }
@@ -18619,13 +18633,14 @@ fn run_brain(
                     }
                     _ => repo.staleness_commits_behind as u64,
                 };
-                let is_stale = if local_missing {
-                    true
-                } else {
-                    match &current_head {
-                        Some(head) => head != &repo.indexed_sha,
-                        None => commits_behind > 0,
-                    }
+                // nw-163: BEHIND HEAD and nothing else — a deleted working
+                // tree is `status: "missing"` and `needs_reindex: true`, not
+                // "stale". The daemon path (`tool_stale_check`) was changed to
+                // this and the direct path was not, so the same repo answered
+                // `is_stale: true` without a daemon and `false` with one.
+                let is_stale = match &current_head {
+                    Some(head) => head != &repo.indexed_sha,
+                    None => commits_behind > 0,
                 };
                 // A repo whose SHA was committed but whose content never
                 // landed (interrupted index) compares equal to HEAD yet
@@ -18670,11 +18685,15 @@ fn run_brain(
             if json {
                 // Include the actual stale list so `any_stale: true`
                 // never sits next to an empty stale set.
-                let stale_urls: Vec<serde_json::Value> = results
-                    .iter()
-                    .filter(|r| r["is_stale"].as_bool().unwrap_or(false))
-                    .filter_map(|r| r["url"].as_str().map(serde_json::Value::from))
-                    .collect();
+                let urls_where = |field: &str| -> Vec<serde_json::Value> {
+                    results
+                        .iter()
+                        .filter(|r| r[field].as_bool().unwrap_or(false))
+                        .filter_map(|r| r["url"].as_str().map(serde_json::Value::from))
+                        .collect()
+                };
+                let stale_urls = urls_where("is_stale");
+                let needs_reindex_urls = urls_where("needs_reindex");
                 println!(
                     "{}",
                     serde_json::to_string_pretty(&serde_json::json!({
@@ -18682,6 +18701,7 @@ fn run_brain(
                         "any_stale": any_stale,
                         "any_needs_reindex": any_needs_reindex,
                         "stale_repos": stale_urls,
+                        "needs_reindex_repos": needs_reindex_urls,
                         "repos": results,
                     }))?
                 );
@@ -18691,8 +18711,12 @@ fn run_brain(
                 println!(
                     "Stale check: {} repo(s), {}",
                     repos.len(),
-                    if any_stale {
-                        "INDEX IS STALE"
+                    // Gated on the union, not `any_stale`: an `incomplete`
+                    // repo exits 2, and a banner reading "up to date"
+                    // above that exit code is the exact dishonesty this
+                    // contract exists to remove.
+                    if any_needs_reindex {
+                        "NEEDS REINDEX"
                     } else {
                         "up to date"
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18574,7 +18574,12 @@ fn run_brain(
             }
 
             let store = open_store(Some(&db_path))?;
-            let repos = store.list_repos(None).unwrap_or_default();
+            // A freshness GATE that cannot read the database must fail, not
+            // report "No repos indexed." and exit 0. The daemon path already
+            // propagates this; only the direct path swallowed it.
+            let repos = store
+                .list_repos(None)
+                .map_err(|error| anyhow::anyhow!("list repos: {error}"))?;
 
             let mut any_stale = false;
             let mut any_needs_reindex = false;
@@ -18634,6 +18639,13 @@ fn run_brain(
                 // `is_stale: true` without a daemon and `false` with one.
                 let is_stale = match &current_head {
                     Some(head) => head != &repo.indexed_sha,
+                    // The working tree is GONE, so HEAD is unknowable and
+                    // "behind HEAD" cannot be asserted. The stored counter is
+                    // a leftover from the last successful check; reporting it
+                    // as staleness presents a stale guess as a fact. `status`
+                    // says "missing" and `needs_reindex` is true, which is the
+                    // actionable truth.
+                    None if local_missing => false,
                     None => commits_behind > 0,
                 };
                 // A repo whose SHA was committed but whose content never

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -841,6 +841,23 @@ fn parity_flow_trace_direct_vs_daemon() {
     );
 }
 
+/// `export --scope` was honoured by the direct path and silently DROPPED by
+/// the daemon path: the CLI never sent `scope` and the daemon never read it.
+/// Because the daemon route is the default, the flag did nothing for most
+/// users while the engine-level scope tests passed. Parity is the only place
+/// that catches a flag lost on the wire.
+#[test]
+fn parity_export_scope_direct_vs_daemon() {
+    let fixture = setup_fixture();
+    for scope in ["all", "code", "vault"] {
+        check_parity(
+            &fixture.db_path,
+            &format!("export --scope {scope}"),
+            &["export", "--format", "graphml", "--scope", scope],
+        );
+    }
+}
+
 /// `stale-check` is a freshness gate: it exits 1 when the index is
 /// stale. The fixture here is freshly indexed (not stale), but regardless we
 /// only assert stdout equality and equal exit codes across modes — never


### PR DESCRIPTION
Four items that were blocked on a decision rather than on implementation. With breaking changes on the table for 8.0.0, each is now resolved on architectural merit rather than on what preserved compatibility.

Closes **nw-163**, **nw-173**, **nw-207**, **nw-175**.

---

## nw-163 — `stale-check` gave three different answers to one question

`is_stale` was the union of three unrelated conditions: behind HEAD, working tree missing, index incomplete. A repo sitting **exactly at HEAD with zero commits behind** reported `is_stale: true`, and two observations of this bug disagreed about the exit code **in both directions** — a CI gate keyed on `any_stale` could not be made to agree with one keyed on the exit code.

`status` already classified the three correctly. Only the boolean conflated them.

- `is_stale` now means **behind HEAD** and nothing else
- `needs_reindex` is the actionable union — every non-`ok` status, all fixed the same way
- Both the JSON and the exit code derive from that **same computation**, so they cannot diverge again

**Exit contract**, following the convention [`terraform plan -detailed-exitcode`](https://developer.hashicorp.com/terraform/cli/commands/plan) and [`git diff --exit-code`](https://git-scm.com/docs/git-diff) established:

| Exit | Meaning |
|---|---|
| `0` | nothing to do |
| **`1`** | **the check itself failed** |
| `2` | the check ran and found drift |

The old contract exited `1` for both *"your graph is stale"* and *"the freshness check crashed"* — two states demanding opposite responses. Reserving `1` for "could not answer" is precisely why Terraform added its detailed exit code.

## nw-173 — `export` emitted half the graph and said nothing

A full graphml of a graph holding 1,088 notes and 12,439 headings contained **not one** Note, Vault, Heading, Section or Tag node. Nothing in the command name, `--help`, or the output disclosed it. Someone loading that into Gephi or networkx would conclude their vault had never been indexed.

The product's core claim is a **unified** graph — `brain_context` retrieves across both halves, `GraphScope::unified()` exists as a type. A command named `export` emitting only the code half contradicts the model it is exporting.

- graphml emits Vault, Note, Heading and Tag nodes with PageRank — a consumer ranking the graph must be able to rank *all* of it
- New `--scope all|code|vault`, default `all`. The old behaviour survives as `--scope code`: still available, no longer unannounced
- `cypher` and `mermaid` genuinely cannot represent the vault, so they **refuse** `--scope vault` with a pointer to graphml rather than writing an empty file and exiting 0. Silence was the defect; succeeding at nothing would reproduce it

## nw-207 — the daemon now owns the identity of the data it stores

Two compensations stacked on each other:

1. A config-less daemon's `data_instance_id` was its **db-path hash**, while the CLI's config-less resolution was `"default"` — the same brain reached two ways got two different data identities.
2. To paper over that, MCP `brain_add_source` sent a literal `"default"` when it had no config. But a fallback sent as though it were a choice **overrode a daemon that genuinely had a configured instance**, creating vaults under `default` and splitting the graph.

The principle settles it: **a client may name an instance and be obeyed; it may not redirect writes into another namespace by defaulting.**

- A config-less daemon's data identity is `"default"` — one rule, matching the CLI
- The MCP sends **empty** when it has no config, the protocol's existing "you decide" sentinel
- The runtime hash keeps naming sockets and local state per database path. That was never the same question as which logical instance the graph belongs to — conflating the two is what broke

Multi-instance targeting still works: naming an instance is obeyed, an invalid one still rejected at the trust boundary.

## nw-175 — every tool schema now rejects unknown argument names

Only **11 of 41** did. A mistyped argument was silently dropped and the handler used its default, so the caller got a plausible answer to a question they never asked. That exact failure was hit **twice in one review round**: `flow_trace` accepting `max_dpeth` and silently tracing depth 10, and the config layer accepting `with_trigams` and silently leaving trigrams off.

The sweep immediately found **two schemas that did not describe their own tool** — `bridge_nodes` accepts `top_n` as an alias for `limit`, `get_summary` accepts `name` for `target`. Both worked at runtime and appeared in neither schema. Declared now rather than special-cased in the validator; describing the tool is the point of the item.

The invariant is asserted over `all_tool_schemas()`, not a hand-listed set, so tool 42 cannot be added permissive.

---

## Tests that encoded the old behaviour were updated, not deleted

- `add_source_instance_id_matches_cli_precedence` asserted the compensation nw-207 removes — renamed to state what it now guarantees
- Two `stale_check` tests asserted `is_stale: true` for a deleted working tree and for a repo **exactly at HEAD** — the precise conflation nw-163 fixes. They now pin `needs_reindex: true` **and** `is_stale: false`, guarding the distinction in both directions

## Testing

- `cargo test --locked --release --workspace --lib --no-fail-fast` → **3218 passed, 0 failed**
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean

## Breaking changes

- `stale-check` exits **2** (not 1) when a repo needs re-indexing; exit 1 now means the check failed
- `export` includes the vault subgraph by default — pass `--scope code` for the previous output
- A daemon started without `--config` stores graph data under instance `"default"` rather than a db-path hash. **Existing graphs under the hash identity are not migrated — re-index.**
- MCP tools reject undeclared arguments instead of ignoring them