### PR TITLE
fix(embeddings,daemon,mcp): close the review findings against 7.0.0's own fixes

### DIFF
--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -1405,6 +1405,11 @@ impl DaemonClient {
                 force,
             })
             .await
+            // The message carries an operator remedy — a pastable TOML
+            // stanza — and `tonic::Status`'s Display escapes it through
+            // `{:?}`, turning newlines into literal `\n`. Take the message
+            // verbatim so the remedy survives the transport.
+            .map_err(|status| anyhow::anyhow!("{}", status.message()))
             .context("watch_code RPC failed")?;
         Ok(resp.into_inner())
     }
@@ -1469,6 +1474,47 @@ impl DaemonClient {
             .await
             .context("purge_instance RPC failed")?;
         Ok(resp.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod status_rendering_tests {
+    /// nw-203 formatted a pastable TOML stanza at column 0 so an operator
+    /// could copy it straight into `instance.toml`. The CLI is that message's
+    /// only consumer, and `tonic::Status`'s Display writes
+    /// `", message: {:?}"` — `{:?}` on a `&str` ESCAPES newlines and quotes.
+    /// So the whole formatting effort was undone in transit and the operator
+    /// saw one long line of literal `\n` and `\"`.
+    ///
+    /// The existing test asserted on `status.message()`, the unescaped
+    /// server-side string, so it could not see the transport rendering at all.
+    #[test]
+    fn a_multi_line_remedy_survives_the_transport_but_not_status_display() {
+        let remedy = "vault path /home/me/brain is not in the allow-list.\n\nAdd this to                       your instance.toml:\n\n[[repos]]\ntype = \"vault\"\nurl =                       \"file:///home/me/brain\"";
+        let status = tonic::Status::invalid_argument(remedy);
+
+        // What the operator USED to get: escaped, single line, unpastable.
+        let via_display = format!("{status}");
+        assert!(
+            via_display.contains("\\n"),
+            "precondition: Status::Display escapes newlines: {via_display}"
+        );
+        assert!(
+            !via_display.contains("\n[[repos]]"),
+            "precondition: the stanza does not survive Display"
+        );
+
+        // What the fix takes instead: the message verbatim.
+        let error = anyhow::anyhow!("{}", status.message());
+        let rendered = format!("{error}");
+        assert!(
+            rendered.contains("\n[[repos]]\ntype = \"vault\""),
+            "the TOML stanza must arrive pastable, on its own lines: {rendered}"
+        );
+        assert!(
+            !rendered.contains("\\n"),
+            "no literal escape sequences may reach the operator: {rendered}"
+        );
     }
 }
 

--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -720,14 +720,14 @@ fn verify_requested_config_evidence(
     // larger action than that asks for — the same reasoning behind
     // `RefuseForeignIncumbent` never stopping a foreign daemon implicitly.
     // The remedy names `restart`, which is the command that owns that action.
-    anyhow::ensure!(
-        health.version == env!("CARGO_PKG_VERSION"),
-        "the running daemon is version {} but this client is {}; the upgrade has NOT been \
-         applied and its new behaviour is not active. {}",
-        health.version,
-        env!("CARGO_PKG_VERSION"),
-        restart_with_requested_config_remedy(db_path, requested)
-    );
+    if let Some(skew) =
+        nestweaver_schema::describe_version_skew(&health.version, env!("CARGO_PKG_VERSION"))
+    {
+        anyhow::bail!(
+            "{skew} {}",
+            restart_with_requested_config_remedy(db_path, requested)
+        );
+    }
     anyhow::ensure!(health.pid != 0, "running daemon HealthCheck returned PID 0");
     anyhow::ensure!(
         binding.pid == health.pid,

--- a/crates/nestweaver-daemon/src/lifecycle.rs
+++ b/crates/nestweaver-daemon/src/lifecycle.rs
@@ -2777,10 +2777,16 @@ mod tests {
              after the file is created; got {before} then {after}"
         );
 
-        // A relative path with a `..` component forks the same way one shape
-        // further out, which the bare case alone does not cover.
-        std::fs::create_dir("sub").unwrap();
-        let dotted = Path::new("sub/../nested.lbug");
+        // A relative path with a `..` component, where the parent chain does
+        // NOT resolve — `missing/` is never created. This is what reaches
+        // `lexically_normalize`.
+        //
+        // Creating `sub/` first (as this test used to) means
+        // `canonicalize("sub/..")` SUCCEEDS, so the pre-existing parent branch
+        // handles the path and the new relative branch is never entered. That
+        // version passed with `lexically_normalize` replaced by a plain
+        // `cwd.join`, i.e. with the bug it was written to catch still present.
+        let dotted = Path::new("missing/../nested.lbug");
         let before_dotted = instance_id_from_db_path(dotted);
         std::fs::write("nested.lbug", b"x").unwrap();
         let after_dotted = instance_id_from_db_path(dotted);
@@ -2788,6 +2794,14 @@ mod tests {
             before_dotted, after_dotted,
             "a relative db path containing `..` must also resolve to one id; \
              got {before_dotted} then {after_dotted}"
+        );
+        // …and to the SAME id as the path it normalizes to, so the `..` form
+        // and the plain form are one instance rather than two.
+        assert_eq!(
+            before_dotted,
+            instance_id_from_db_path(Path::new("nested.lbug")),
+            "`missing/../nested.lbug` and `nested.lbug` name the same database, \
+             so they must not fork the daemon into two instances"
         );
     }
 
@@ -2812,17 +2826,31 @@ mod tests {
 
         let bare = Path::new("nestweaver.lbug");
         // No file on disk: canonicalize fails, which is the only state where
-        // the legacy and current algorithms may differ.
-        let legacy = legacy_instance_id_from_db_path(bare);
-        let current = instance_id_from_db_path(bare);
+        // the legacy and current canonicalizations differ.
+        //
+        // The assertion that MATTERS is that the legacy hash still folds the
+        // UN-JOINED relative path. Comparing it against
+        // `instance_id_from_db_path` proves nothing — legacy is DefaultHasher
+        // (SipHash) masked to 32 bits and current is the first four bytes of
+        // SHA-256, so the two can never agree no matter which canonicalization
+        // legacy uses. That test passed with `legacy_canonical_db_path`
+        // swapped for `canonical_db_path`, i.e. with the regression it was
+        // written to prevent fully reintroduced.
+        //
+        // Joining against the cwd is exactly what `canonical_db_path` does to
+        // a relative path, so the legacy id must NOT match the id of the
+        // joined form.
+        let joined = std::env::current_dir().unwrap().join(bare);
         assert_ne!(
-            legacy, current,
-            "the legacy hash is a DIFFERENT algorithm (DefaultHasher over the \
-             un-joined relative path); if these ever agree, the legacy function \
-             has stopped reproducing history"
+            legacy_instance_id_from_db_path(bare),
+            legacy_instance_id_from_db_path(&joined),
+            "the legacy hash must fold the UN-JOINED relative path; if these \
+             agree it has started resolving against the cwd, and
+             `stop_legacy_hash_daemon` will look for an orphan under an id it \
+             never registered under"
         );
         assert_eq!(
-            legacy,
+            legacy_instance_id_from_db_path(bare),
             legacy_instance_id_from_db_path(bare),
             "the legacy hash must be stable"
         );

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -5356,22 +5356,18 @@ impl NestWeaverDaemon for DaemonService {
             // tombstoned rows, so running it alone on a brain whose orphans
             // were never tombstoned reclaims exactly nothing — which is the
             // state every pre-fix brain is in.
-            let reclaimed = state.store.reconcile_embedding_index()?;
+            state.store.reconcile_embedding_index()?;
             if state.store.embedding_index_occupancy().tombstoned > 0 {
                 state.store.compact_embedding_index()?;
             }
 
             let after = state.store.embedding_index_occupancy();
-            Ok(CompactEmbeddingsResponse {
-                stored_before: before.stored as u64,
-                tombstoned_before: before.tombstoned as u64,
-                stored_after: after.stored as u64,
-                live_after: after.live as u64,
-                reclaimed: reclaimed as u64,
+            Ok(compact_embeddings_response(
+                before,
+                after,
                 bytes_before,
-                bytes_after: bytes_of(&sidecar),
-                dry_run: false,
-            })
+                bytes_of(&sidecar),
+            ))
         })
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?
@@ -8157,6 +8153,92 @@ mod depth_clamp_tests {
         let mut b = serde_json::json!({ "depth": "not-a-number" });
         clamp_traversal_depth(&mut b);
         assert_eq!(b["depth"], serde_json::json!("not-a-number"));
+    }
+}
+
+/// Build the `compact_embeddings` reply from the occupancy measured either
+/// side of the run.
+///
+/// `reclaimed` is what actually LEFT the index — `stored_before -
+/// stored_after`. It used to be `reconcile_embedding_index`'s return value,
+/// i.e. only the orphans that pass newly DISCOVERED. Rows tombstoned earlier
+/// by the incremental epilogue are reclaimed by the compaction that follows
+/// and were counted nowhere, so on a post-fix brain the command printed
+/// "Reclaimed 0 dead vector(s)" directly above a stored-before/stored-after
+/// pair differing by thousands, and a several-hundred-megabyte byte drop.
+///
+/// Pure, so the arithmetic is testable without standing up a daemon — which is
+/// why the bug shipped: this RPC had no test of any kind.
+fn compact_embeddings_response(
+    before: nestweaver_store::EmbeddingIndexOccupancy,
+    after: nestweaver_store::EmbeddingIndexOccupancy,
+    bytes_before: u64,
+    bytes_after: u64,
+) -> CompactEmbeddingsResponse {
+    CompactEmbeddingsResponse {
+        stored_before: before.stored as u64,
+        tombstoned_before: before.tombstoned as u64,
+        stored_after: after.stored as u64,
+        live_after: after.live as u64,
+        // Saturating: compaction never grows the index, but a count that went
+        // backwards must not wrap into billions.
+        reclaimed: before.stored.saturating_sub(after.stored) as u64,
+        bytes_before,
+        bytes_after,
+        dry_run: false,
+    }
+}
+
+#[cfg(test)]
+mod compact_embeddings_response_tests {
+    use super::compact_embeddings_response;
+    use nestweaver_store::EmbeddingIndexOccupancy;
+
+    fn occupancy(live: usize, tombstoned: usize) -> EmbeddingIndexOccupancy {
+        EmbeddingIndexOccupancy {
+            live,
+            tombstoned,
+            stored: live + tombstoned,
+        }
+    }
+
+    /// The case that shipped wrong: a brain whose orphans were ALREADY
+    /// tombstoned by the incremental epilogue. `reconcile` discovers nothing
+    /// new, so reporting its return value said "Reclaimed 0" while compaction
+    /// dropped 5,000 rows in the same breath.
+    #[test]
+    fn reclaimed_counts_what_left_the_index_not_what_reconcile_discovered() {
+        let response = compact_embeddings_response(
+            occupancy(1_000, 5_000),
+            occupancy(1_000, 0),
+            600_000_000,
+            120_000_000,
+        );
+        assert_eq!(
+            response.reclaimed, 5_000,
+            "reclaimed must equal stored_before - stored_after"
+        );
+        assert_eq!(response.stored_before, 6_000);
+        assert_eq!(response.stored_after, 1_000);
+        assert_eq!(response.tombstoned_before, 5_000);
+        assert_eq!(response.live_after, 1_000);
+        // A reclaim count of zero beside a byte drop is the contradiction the
+        // report named; they must move together.
+        assert!(response.bytes_before > response.bytes_after);
+
+        // Nothing to do: no tombstones, nothing leaves, and the count is
+        // honestly zero rather than incidentally zero.
+        let idle = compact_embeddings_response(occupancy(1_000, 0), occupancy(1_000, 0), 42, 42);
+        assert_eq!(idle.reclaimed, 0);
+        assert_eq!(idle.stored_before, idle.stored_after);
+
+        // An index that somehow grew must not wrap a subtraction into
+        // billions.
+        let grown = compact_embeddings_response(occupancy(1, 0), occupancy(9, 0), 1, 1);
+        assert_eq!(
+            grown.reclaimed, 0,
+            "a negative delta must saturate, not wrap"
+        );
     }
 }
 

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -3411,7 +3411,7 @@ where
             // Atomic delete+insert: old data is only removed within the same
             // transaction that inserts the replacement, so concurrent readers
             // never see an empty repo.
-            let (deleted_files, deleted_symbols) = store
+            let (deleted_files, deleted_symbols, removed_symbol_uids) = store
                 .bulk_reindex_write(
                     &r_uid,
                     &all_files,
@@ -3424,6 +3424,17 @@ where
                 .context("bulk_reindex_write")?;
             files_deleted += deleted_files;
             symbols_deleted += deleted_symbols;
+            // nw-204: this arm removed every symbol in the repo and reported
+            // only a COUNT, so the epilogue below received an empty UID list,
+            // hit its `is_empty()` guard, and tombstoned nothing. The vectors
+            // of symbols that did not come back stayed live and kept being
+            // scored — the exact leak nw-204 closed for the incremental path,
+            // still open on the path its own operation label names ("full
+            // index over existing store"). `force_reindex` fires whenever
+            // `files_unchanged == 0`, which includes a missing or corrupt
+            // resolution-deps sidecar, so this is not a rare path.
+            reindex_deleted_uids.extend(removed_symbol_uids);
+            reindex_deleted_files.extend(all_files.iter().map(|file| file.path.clone()));
         } else {
             store
                 .bulk_index_write(
@@ -10088,6 +10099,99 @@ function hello(name) { return "Hello " + name; }
         assert!(
             store.has_embedding(&anchor_uid),
             "a rename elsewhere must not disturb an untouched file's embedding"
+        );
+    }
+
+    /// nw-204, the path the original fix missed. `index_directory`'s
+    /// `force_reindex` arm removes every symbol in the repo via
+    /// `bulk_reindex_write`, which reported only a COUNT — so the epilogue got
+    /// an empty UID list, hit its `is_empty()` guard, and tombstoned nothing.
+    ///
+    /// This is not a rare path: `force_reindex` fires whenever
+    /// `files_unchanged == 0`, which includes a missing or corrupt
+    /// resolution-deps sidecar. Only a running daemon's periodic reconciler
+    /// repaired it; a CLI-only `nestweaver index` never did.
+    #[test]
+    fn a_full_reindex_tombstones_symbols_that_do_not_come_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(
+            repo.join("doomed.js"),
+            "function doomed() { return 'doomed'; }",
+        )
+        .unwrap();
+        fs::write(
+            repo.join("anchor.js"),
+            "function anchor() { return 'anchor'; }",
+        )
+        .unwrap();
+
+        let repo_url = "https://example.com/nw-204-force-reindex";
+        index_directory(&repo, &db_path, "test", repo_url, "sha-one").unwrap();
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        let uid_in = |file: &str| {
+            store
+                .symbols_in_file(file)
+                .unwrap()
+                .into_iter()
+                .next()
+                .unwrap()
+                .uid
+        };
+        let doomed_uid = uid_in("doomed.js");
+        let anchor_uid = uid_in("anchor.js");
+        store.set_embedding_metadata("test-model", 2).unwrap();
+        // The doomed vector is the probe's nearest neighbour, so a regression
+        // displaces the survivor rather than merely lingering unnoticed.
+        assert!(store.add_embedding(&doomed_uid, vec![1.0, 0.0]));
+        assert!(store.add_embedding(&anchor_uid, vec![0.8, 0.6]));
+        store.flush_embedding_index().unwrap();
+        assert_eq!(
+            store.try_vector_search(&[1.0, 0.0], 1).unwrap()[0].0,
+            doomed_uid,
+            "precondition: the doomed vector must outrank the survivor"
+        );
+        drop(store);
+
+        // Delete the file AND the change-detection sidecar. Without the
+        // sidecar every remaining file classifies as changed, so
+        // `files_unchanged == 0` and `force_reindex` fires — the same state a
+        // missing or corrupt sidecar produces in the field, and the arm this
+        // test exists for. Deleting the file alone leaves `anchor.js`
+        // unchanged, which takes the INCREMENTAL arm instead and proves
+        // nothing about this one.
+        fs::remove_file(repo.join("doomed.js")).unwrap();
+        let filemeta = db_path.with_extension("lbug.filemeta.json");
+        assert!(
+            filemeta.exists(),
+            "precondition: the first index must have written {}",
+            filemeta.display()
+        );
+        fs::remove_file(&filemeta).unwrap();
+        index_directory(&repo, &db_path, "test", repo_url, "sha-two").unwrap();
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        assert!(
+            store.symbols_in_file("doomed.js").unwrap().is_empty(),
+            "precondition: the full re-index must have removed the symbol"
+        );
+        let hits = store.try_vector_search(&[1.0, 0.0], 2).unwrap();
+        assert!(
+            !hits.iter().any(|(uid, _)| uid == &doomed_uid),
+            "a symbol a full re-index dropped must not still be scored; got {hits:?}"
+        );
+        assert_eq!(
+            hits.first().map(|(uid, _)| uid.as_str()),
+            Some(anchor_uid.as_str()),
+            "the live symbol must take the top-k slot the dead vector held"
+        );
+        assert!(
+            store.has_embedding(&anchor_uid),
+            "a symbol the re-index re-inserted must KEEP its vector; tombstoning \
+             the raw delete list would drop every live vector in the repo"
         );
     }
 

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -972,6 +972,16 @@ fn index_markdown_since_with_reader(
         }
     }
     let project_note_refs = string_edge_refs(&project_note_edges);
+    // nw-204, vault half: collect the Note and Heading UIDs the refresh is
+    // about to remove, BEFORE it removes them. Applied after the commit with a
+    // liveness filter, because an edited note is deleted and re-inserted under
+    // the same uid.
+    let embedding_candidates: Vec<String> = delete_note_uids
+        .iter()
+        .filter_map(|uid| store.note_embedding_candidate_uids(uid).ok())
+        .flatten()
+        .collect();
+
     store
         .incremental_vault_refresh_atomically(
             &Vault {
@@ -1007,6 +1017,25 @@ fn index_markdown_since_with_reader(
     // that stales the trigram posting table (mirrors `index.rs` and the full
     // vault index above).
     store.bump_and_persist_generation();
+
+    // Best-effort and AFTER the commit, like the symbol epilogue: a
+    // tombstoning failure must not fail a refresh that already succeeded.
+    // Without this a CLI `brain refresh` that dropped 200 notes left every
+    // note and heading vector live and scored, with only a WRITABLE daemon's
+    // periodic reconciler as backstop — so a CLI-only run, or one against a
+    // read-only daemon, leaked indefinitely.
+    if !embedding_candidates.is_empty() {
+        match store.tombstone_deleted_vault_embeddings(&embedding_candidates) {
+            Ok(0) => {}
+            Ok(removed) => {
+                tracing::debug!("vault refresh: tombstoned {removed} dead vault vector(s)")
+            }
+            Err(error) => tracing::warn!(
+                "vault refresh: could not tombstone dead vault vectors: {error}; \
+                 the periodic reconciler will reclaim them"
+            ),
+        }
+    }
 
     Ok(MarkdownSinceResult {
         vault_name: vault_name.to_string(),
@@ -4137,6 +4166,73 @@ sub b body
         .unwrap();
         assert_eq!(store.lookup_vault(&uid).unwrap().name, "empty");
         assert_eq!(store.graph_generation(), generation);
+    }
+
+    /// nw-204, vault half. The vault side had NO synchronous tombstoning: a
+    /// refresh that dropped notes left their vectors live and scored, and only
+    /// a WRITABLE daemon's periodic reconciler repaired it — so a CLI-only
+    /// `brain refresh`, or one against a read-only daemon, leaked forever.
+    #[test]
+    fn a_vault_refresh_tombstones_vectors_of_notes_it_drops() {
+        let (_dir, root) = make_vault(&[("kept.md", "# Kept\n"), ("doomed.md", "# Doomed\n")]);
+        let store = GraphStore::in_memory().unwrap();
+        let db_path = root.join("unused.lbug");
+        index_markdown_directory_with_store(&store, &root, &db_path, "owned", "v", &[]).unwrap();
+
+        let uid_of = |title: &str| {
+            store
+                .list_notes(None)
+                .unwrap()
+                .into_iter()
+                .find(|note| note.title == title)
+                .unwrap_or_else(|| panic!("{title} indexed"))
+                .uid
+        };
+        let doomed_uid = uid_of("Doomed");
+        let kept_uid = uid_of("Kept");
+
+        store.set_embedding_metadata("test-model", 2).unwrap();
+        // The doomed vector is the probe's nearest neighbour, so a regression
+        // displaces the survivor rather than merely lingering unnoticed.
+        assert!(store.add_embedding(&doomed_uid, vec![1.0, 0.0]));
+        assert!(store.add_embedding(&kept_uid, vec![0.8, 0.6]));
+        store.flush_embedding_index().unwrap();
+        assert_eq!(
+            store.try_vector_search(&[1.0, 0.0], 1).unwrap()[0].0,
+            doomed_uid,
+            "precondition: the doomed vector must outrank the survivor"
+        );
+
+        // Drop the note by ignoring it — the same delete path a removed file
+        // takes, without racing the filesystem clock.
+        let result = index_markdown_directory_since_with_store_and_ignore(
+            &store,
+            &root,
+            "owned",
+            "v",
+            std::time::SystemTime::now() + std::time::Duration::from_secs(60),
+            &["doomed.md".to_string()],
+        )
+        .unwrap();
+        assert_eq!(
+            result.notes_deleted, 1,
+            "precondition: the note was dropped"
+        );
+
+        let hits = store.try_vector_search(&[1.0, 0.0], 2).unwrap();
+        assert!(
+            !hits.iter().any(|(uid, _)| uid == &doomed_uid),
+            "a dropped note's vector must not still be scored; got {hits:?}"
+        );
+        assert_eq!(
+            hits.first().map(|(uid, _)| uid.as_str()),
+            Some(kept_uid.as_str()),
+            "the live note must take the top-k slot the dead vector held"
+        );
+        assert!(
+            store.has_embedding(&kept_uid),
+            "a surviving note must KEEP its vector"
+        );
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/investigate.rs
+++ b/crates/nestweaver-engine/src/investigate.rs
@@ -1414,39 +1414,74 @@ mod tests {
             );
         }
 
-        // The RESPONSE is where the defect showed, so assert on the serialized
-        // shape a caller actually reads. `scope` echoing "vault" is not itself
-        // wrong — what was wrong is that nothing alongside it said whether a
-        // restriction happened.
-        let unrestricted = InvestigateResult {
-            bundle_id: "b".to_string(),
-            query: "q".to_string(),
-            scope: "vault".to_string(),
-            scope_filtered: false,
-            domains: vec![],
-            entries: vec![],
-            more_available: 0,
-            semantic_applied: false,
-            degraded_components: vec![],
-        };
-        let json = serde_json::to_value(&unrestricted).unwrap();
-        assert_eq!(
-            json["scope"], "vault",
-            "the caller's scope string is still echoed verbatim"
-        );
-        assert_eq!(
-            json["scope_filtered"], false,
-            "…and `scope_filtered` is what tells them nothing was restricted"
-        );
+        // Assert on what `investigate` ACTUALLY SETS, not on a struct built by
+        // hand here. The previous version of this constructed an
+        // `InvestigateResult` with `scope_filtered: false` and then asserted
+        // the serialized JSON said `false` — which tests serde, not the
+        // wiring. `scope_filtered: scope_filter.is_some()` was unexercised, so
+        // pinning it to a constant left this test green.
+        let (dir, src, store) = make_store();
+        let db_path = dir.path().join("nestweaver.lbug");
 
-        let restricted = InvestigateResult {
-            scope: "repo:acme".to_string(),
-            scope_filtered: true,
-            ..unrestricted
+        // A real project, so the restrictive case actually BUILDS a filter
+        // rather than erroring on an unknown scope.
+        let hello_uid = store
+            .lookup_symbols_by_name("hello")
+            .unwrap()
+            .into_iter()
+            .find(|symbol| symbol.name == "hello")
+            .expect("hello symbol exists")
+            .uid;
+        let project = nestweaver_schema::Project {
+            uid: "proj:test:onlyhello".to_string(),
+            name: "onlyhello".to_string(),
+            summary: None,
+            instance_id: "test".to_string(),
         };
+        store.upsert_project(&project).unwrap();
+        store
+            .batch_insert_project_symbol_edges(&project.uid, std::slice::from_ref(&hello_uid), 1.0)
+            .unwrap();
+
+        let investigate_with = |scope: &str| {
+            investigate(
+                &store,
+                None,
+                Some(&db_path),
+                &src,
+                "greet",
+                scope,
+                Some(4000),
+                None,
+            )
+            .unwrap_or_else(|error| panic!("investigate({scope:?}) failed: {error:#}"))
+        };
+
+        // Every documented pass-through reports FALSE, including the literal
+        // "vault" a caller may still send explicitly.
+        for pass_through in ["", "vault", "all"] {
+            let result = investigate_with(pass_through);
+            assert!(
+                !result.scope_filtered,
+                "{pass_through:?} builds no filter, so scope_filtered must be false"
+            );
+            assert_eq!(
+                serde_json::to_value(&result).unwrap()["scope_filtered"],
+                false,
+                "{pass_through:?} must serialize the same verdict it computed"
+            );
+        }
+
+        // A real restriction reports TRUE — and the scope string alone could
+        // never have expressed that, which is why the flag exists.
+        let restricted = investigate_with("project:onlyhello");
+        assert!(
+            restricted.scope_filtered,
+            "a project scope builds a filter, so scope_filtered must be true"
+        );
         assert_eq!(
-            serde_json::to_value(&restricted).unwrap()["scope_filtered"],
-            true
+            restricted.scope, "project:onlyhello",
+            "the caller's scope string is still echoed verbatim"
         );
     }
 

--- a/crates/nestweaver-engine/src/watcher.rs
+++ b/crates/nestweaver-engine/src/watcher.rs
@@ -692,6 +692,16 @@ impl BrainWatcher {
         // path because rename/remove delivery varies by backend.
         let file_exists = path.exists();
 
+        // nw-204, vault half: collect what the cascade is about to remove so
+        // the epilogue can tombstone whatever does not come back. Collected
+        // BEFORE the delete because the UIDs are unreachable afterwards, and
+        // applied AFTER the write because an edited note is deleted and
+        // re-inserted under the SAME uid — tombstoning the raw list here would
+        // drop live vectors.
+        let embedding_candidates = store
+            .note_embedding_candidate_uids(&n_uid)
+            .unwrap_or_default();
+
         // Step 1: always cascade-delete the existing graph data for this
         // note. Safe even when the note doesn't yet exist (no-op).
         store
@@ -704,6 +714,7 @@ impl BrainWatcher {
         }
 
         if !file_exists {
+            tombstone_vault_embeddings_after_commit(store, &embedding_candidates, "note deleted");
             return Ok(UpdateOutcome::Deleted { path });
         }
 
@@ -787,6 +798,11 @@ impl BrainWatcher {
                 tracing::warn!("tantivy.update_note failed: {e}");
             }
         }
+
+        // An edit keeps the note's own vector (same uid, still live) but a
+        // heading that vanished is gone for good; the liveness filter tells
+        // them apart.
+        tombstone_vault_embeddings_after_commit(store, &embedding_candidates, "note updated");
 
         Ok(UpdateOutcome::Updated {
             path,
@@ -1225,6 +1241,33 @@ fn format_system_time(t: std::time::SystemTime) -> Option<String> {
 }
 
 // ── tests ──────────────────────────────────────────────────────────────────
+
+/// Tombstone vault embeddings whose nodes did not survive a refresh.
+///
+/// Best-effort and AFTER the commit, exactly like the symbol epilogue: a
+/// tombstoning failure must not fail the refresh that already succeeded, and
+/// the periodic reconciler remains the backstop.
+fn tombstone_vault_embeddings_after_commit(
+    store: &GraphStore,
+    candidates: &[String],
+    operation: &str,
+) {
+    if candidates.is_empty() {
+        return;
+    }
+    match store.tombstone_deleted_vault_embeddings(candidates) {
+        Ok(0) => {}
+        Ok(removed) => {
+            tracing::debug!("{operation}: tombstoned {removed} dead vault vector(s)");
+        }
+        Err(error) => {
+            tracing::warn!(
+                "{operation}: could not tombstone dead vault vectors: {error}; \
+                 the periodic reconciler will reclaim them"
+            );
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/nestweaver-mcp/src/lib.rs
+++ b/crates/nestweaver-mcp/src/lib.rs
@@ -150,13 +150,32 @@ pub fn run_stdio_server(
         (Some(config), Some(source))
     } else {
         let sibling = db_path.parent().map(|d| d.join("instance.toml"));
-        match sibling.as_deref().and_then(|s| {
-            nestweaver_engine::InstanceConfig::from_file(s)
-                .ok()
-                .map(|c| (c, s.display().to_string()))
-        }) {
-            Some((c, path)) => (Some(c), Some(path)),
-            None => (None, None),
+        // A MISSING sibling is normal and stays silent. A sibling that exists
+        // and fails to parse is an operator error and must not be.
+        //
+        // `.ok()` used to swallow both. That was survivable while unknown keys
+        // were merely dropped: one typo cost you that key. With
+        // `deny_unknown_fields` a single typo fails the WHOLE file, so every
+        // setting — ranking priors, response tuning, cache sizing, the
+        // configured result limit — silently reverted to defaults with nothing
+        // logged anywhere. The explicit `--config` path fails loudly; this one
+        // did not, so the strictness landed hardest exactly where it was
+        // invisible.
+        match sibling.as_deref() {
+            Some(path) if path.exists() => match nestweaver_engine::InstanceConfig::from_file(path)
+            {
+                Ok(config) => (Some(config), Some(path.display().to_string())),
+                Err(error) => {
+                    tracing::warn!(
+                        config = %path.display(),
+                        "instance config found beside the database but could NOT be parsed, so \
+                         NO configured setting is in effect (ranking, limits, response, cache \
+                         and projects all fall back to defaults): {error:#}"
+                    );
+                    (None, None)
+                }
+            },
+            _ => (None, None),
         }
     };
     if let Some(cfg) = instance_cfg {

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -6715,11 +6715,34 @@ async fn inline_connect_daemon(
         .await
         .map_err(|e| anyhow::anyhow!("failed to connect to daemon: {e}"))?;
 
-    Ok(
+    let mut client =
         nestweaver_proto::nest_weaver_daemon_client::NestWeaverDaemonClient::new(channel)
             .max_decoding_message_size(256 * 1024 * 1024)
-            .max_encoding_message_size(256 * 1024 * 1024),
-    )
+            .max_encoding_message_size(256 * 1024 * 1024);
+
+    // nw-201 landed a version check on `daemon start --config` only. This path
+    // — how every MCP tool reaches the daemon — had NONE: `inline_ensure_daemon`
+    // returns as soon as the socket accepts a connection, and this function
+    // never issued a HealthCheck at all. So after an upgrade an agent kept
+    // talking to the previous binary, indexing through the old engine, with
+    // nothing anywhere reporting a skew. The commit that added that check cites
+    // "`brain status` looked healthy" as the tell; this is the path that made it
+    // look healthy.
+    //
+    // Verified HERE rather than at the six call sites, so a new caller cannot
+    // reintroduce the gap by forgetting it.
+    let health = client
+        .health_check(nestweaver_proto::HealthCheckRequest {})
+        .await
+        .map_err(|e| anyhow::anyhow!("daemon health check failed: {e}"))?
+        .into_inner();
+    if let Some(skew) =
+        nestweaver_schema::describe_version_skew(&health.version, env!("CARGO_PKG_VERSION"))
+    {
+        anyhow::bail!("{skew} Restart the daemon to apply it.");
+    }
+
+    Ok(client)
 }
 
 /// Ensure the daemon is running (spawning it if needed) and return the

--- a/crates/nestweaver-schema/src/lib.rs
+++ b/crates/nestweaver-schema/src/lib.rs
@@ -26,4 +26,4 @@ pub use uid::{
     normalize_http_path, note_uid, project_uid, repo_uid, scope_hash, scoped_contract_uid,
     section_uid, service_uid, symbol_uid, tag_uid, truncated_hash, vault_uid,
 };
-pub use version::{core_schema_hash, effective_schema_hash};
+pub use version::{core_schema_hash, describe_version_skew, effective_schema_hash};

--- a/crates/nestweaver-schema/src/version.rs
+++ b/crates/nestweaver-schema/src/version.rs
@@ -168,3 +168,115 @@ mod tests {
         );
     }
 }
+
+/// Describe a version mismatch between a running daemon and a client, or
+/// `None` when they agree.
+///
+/// Direction matters and the original check ignored it. It was a bare equality
+/// test whose message was hardcoded to the older-daemon case, so running an
+/// older client against a NEWER installed daemon reported "the upgrade has NOT
+/// been applied" — false — and then named `restart` as the remedy, which would
+/// replace the live newer daemon with the older build. An operator was told to
+/// perform a downgrade in the language of an upgrade.
+///
+/// Both versions are passed in rather than read from `CARGO_PKG_VERSION`
+/// here: this lives in the schema crate so the CLI, the client and the MCP
+/// server can all share one rule (the MCP crate cannot depend on the client —
+/// `mcp -> client -> daemon -> mcp` is a cycle), and each caller must report
+/// ITS OWN version, not this crate's.
+///
+/// An unparseable version on either side is reported as a plain mismatch
+/// rather than guessed at: unknown ordering must not become a confident claim.
+pub fn describe_version_skew(daemon_version: &str, client_version: &str) -> Option<String> {
+    if daemon_version == client_version {
+        return None;
+    }
+    let parse = |version: &str| -> Option<(u64, u64, u64)> {
+        // Ignore any pre-release/build suffix; the numeric triple is what
+        // orders two NestWeaver builds.
+        let core = version.split(['-', '+']).next().unwrap_or(version);
+        let mut parts = core.split('.');
+        let mut next = || parts.next()?.parse::<u64>().ok();
+        let (major, minor, patch) = (next()?, next()?, next()?);
+        parts.next().is_none().then_some((major, minor, patch))
+    };
+    let ordering = match (parse(daemon_version), parse(client_version)) {
+        (Some(daemon), Some(client)) => Some(daemon.cmp(&client)),
+        _ => None,
+    };
+    Some(match ordering {
+        Some(std::cmp::Ordering::Less) => format!(
+            "the running daemon is version {daemon_version} but this client is \
+             {client_version}; the upgrade has NOT been applied and its new behaviour \
+             is not active."
+        ),
+        Some(std::cmp::Ordering::Greater) => format!(
+            "the running daemon is version {daemon_version}, NEWER than this client \
+             ({client_version}); restarting it would DOWNGRADE the running daemon. \
+             Use the {daemon_version} binary, or stop the daemon deliberately if you \
+             intend to downgrade."
+        ),
+        // Equal is impossible here (the strings differ), so this is the
+        // unparseable case.
+        _ => format!(
+            "the running daemon reports version {daemon_version} and this client is \
+             {client_version}; the two do not match and their order cannot be \
+             determined."
+        ),
+    })
+}
+
+#[cfg(test)]
+mod version_skew_tests {
+    use super::describe_version_skew;
+
+    /// The original check was a bare equality test whose message was hardcoded
+    /// to the older-daemon direction, so a NEWER incumbent was described as
+    /// "the upgrade has NOT been applied" — false — and the remedy it named
+    /// (`restart`) would have replaced the live newer daemon with the older
+    /// client's build. A downgrade, described as an upgrade.
+    #[test]
+    fn skew_is_reported_by_direction_and_never_guesses() {
+        assert!(describe_version_skew("7.0.0", "7.0.0").is_none());
+
+        let older = describe_version_skew("6.4.0", "7.0.0").expect("older daemon is skew");
+        assert!(older.contains("has NOT been applied"), "{older}");
+
+        let newer = describe_version_skew("7.1.0", "7.0.0").expect("newer daemon is skew");
+        assert!(newer.contains("DOWNGRADE"), "{newer}");
+        assert!(
+            !newer.contains("has NOT been applied"),
+            "a newer daemon is not a missing upgrade: {newer}"
+        );
+
+        // Ordering across each component, not just the patch.
+        assert!(
+            describe_version_skew("8.0.0", "7.9.9")
+                .unwrap()
+                .contains("DOWNGRADE")
+        );
+        assert!(
+            describe_version_skew("7.9.9", "8.0.0")
+                .unwrap()
+                .contains("has NOT been applied")
+        );
+
+        // Unparseable: report a mismatch, but do NOT claim a direction.
+        for daemon in ["", "7.0", "seven", "7.0.0.1", "7.0.x"] {
+            let unknown = describe_version_skew(daemon, "7.0.0")
+                .unwrap_or_else(|| panic!("{daemon:?} differs from 7.0.0"));
+            assert!(
+                unknown.contains("cannot be determined"),
+                "{daemon:?} must not be given a direction: {unknown}"
+            );
+        }
+
+        // A pre-release suffix orders by its numeric core rather than falling
+        // into the unparseable branch.
+        assert!(
+            describe_version_skew("7.1.0-rc.1", "7.0.0")
+                .unwrap()
+                .contains("DOWNGRADE")
+        );
+    }
+}

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -2029,6 +2029,50 @@ impl GraphStore {
     /// Returns the number of vectors removed.
     ///
     /// [`reconcile_embedding_index`]: Self::reconcile_embedding_index
+    /// Tombstone the embeddings of vault nodes that a delete removed for good.
+    ///
+    /// The vault half of the graph had NO synchronous tombstoning at all: a
+    /// `brain refresh` that dropped 200 notes left every note and heading
+    /// vector live and scored, and only a writable daemon's periodic
+    /// reconciler ever repaired it — so a CLI-only run, or a read-only daemon
+    /// (which does not spawn the reconciler), leaked indefinitely.
+    ///
+    /// Takes CANDIDATES collected before the delete and applies the same
+    /// liveness difference the symbol path uses: an EDITED note is deleted and
+    /// re-inserted under the same UID, so tombstoning the raw candidate list
+    /// would drop live vectors — a far worse bug than the orphans it fixes.
+    pub fn tombstone_deleted_vault_embeddings(
+        &self,
+        candidate_uids: &[String],
+    ) -> Result<usize, StoreError> {
+        if candidate_uids.is_empty() {
+            return Ok(0);
+        }
+        let live = self.live_vault_node_uids(candidate_uids)?;
+        let dead: Vec<String> = candidate_uids
+            .iter()
+            .filter(|uid| !live.contains(uid.as_str()))
+            .cloned()
+            .collect();
+        if dead.is_empty() {
+            return Ok(0);
+        }
+        let removed = {
+            let mut idx = self
+                .embedding_index
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            idx.tombstone_uids(&dead)
+        };
+        // Nothing was held for those UIDs, so a flush would rewrite the
+        // sidecar for no change — same reasoning as the symbol path.
+        if removed == 0 {
+            return Ok(0);
+        }
+        self.flush_embedding_index()?;
+        Ok(removed)
+    }
+
     pub fn tombstone_deleted_symbol_embeddings(
         &self,
         repo_uid: &str,

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -1454,6 +1454,77 @@ impl GraphStore {
     /// Sound because the file set is exactly the set the caller deleted from:
     /// a UID can only reappear in a file the run wrote, and the rename path
     /// touches both the source and destination paths.
+    /// The Note and Heading UIDs owned by `note_uid` that currently carry an
+    /// embedding candidate — collected BEFORE a cascade delete so the caller
+    /// can tombstone whatever does not come back.
+    ///
+    /// Mirrors `delete_note_cascade_on`'s own two passes: ownership by the
+    /// `note_uid` PROPERTY and by the `NOTE_HAS_SECTION`/`NOTE_HAS_HEADING`
+    /// EDGE. The cascade runs both because the edge is not guaranteed, so
+    /// collecting by only one of them would miss exactly the fragments the
+    /// cascade exists to catch.
+    pub fn note_embedding_candidate_uids(&self, note_uid: &str) -> Result<Vec<String>, StoreError> {
+        let conn = self.conn()?;
+        // Same `\'` escaping as `symbol_uids_for_files`: these queries and the
+        // cascade's must select the SAME rows for the liveness difference to
+        // be sound.
+        let safe = note_uid.replace('\'', "\\'");
+        let mut uids = vec![note_uid.to_string()];
+        for query in [
+            format!("MATCH (h:Heading) WHERE h.note_uid = '{safe}' RETURN h.uid"),
+            format!(
+                "MATCH (n:Note {{uid: '{safe}'}})-[:NOTE_HAS_HEADING]->(h:Heading) RETURN h.uid"
+            ),
+        ] {
+            let Ok(mut stmt) = conn.prepare(&query) else {
+                // A schema without that edge type is not an error here; the
+                // property pass still covers ownership.
+                continue;
+            };
+            let rows = conn
+                .execute(&mut stmt, vec![])
+                .map_err(|e| StoreError::Query(format!("note embedding candidates: {e}")))?;
+            for row in rows {
+                if let Some(Value::String(uid)) = row.first() {
+                    uids.push(uid.clone());
+                }
+            }
+        }
+        uids.sort();
+        uids.dedup();
+        Ok(uids)
+    }
+
+    /// Which of `candidates` still exist as a Note or Heading.
+    pub fn live_vault_node_uids(
+        &self,
+        candidates: &[String],
+    ) -> Result<HashSet<String>, StoreError> {
+        let mut live = HashSet::new();
+        if candidates.is_empty() {
+            return Ok(live);
+        }
+        let conn = self.conn()?;
+        for candidate in candidates {
+            let safe = candidate.replace('\'', "\\'");
+            for label in ["Note", "Heading"] {
+                let query =
+                    format!("MATCH (n:{label}) WHERE n.uid = '{safe}' RETURN n.uid LIMIT 1");
+                let Ok(mut stmt) = conn.prepare(&query) else {
+                    continue;
+                };
+                let rows = conn
+                    .execute(&mut stmt, vec![])
+                    .map_err(|e| StoreError::Query(format!("live vault nodes: {e}")))?;
+                if rows.into_iter().next().is_some() {
+                    live.insert(candidate.clone());
+                    break;
+                }
+            }
+        }
+        Ok(live)
+    }
+
     pub fn symbol_uids_for_files(
         &self,
         repo_uid: &str,

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -1495,7 +1495,7 @@ impl GraphStore {
         file_symbol_edges: &[(&str, &str)],
         services: &[Service],
         service_symbol_edges: &[(&str, &str)],
-    ) -> Result<(usize, usize), StoreError> {
+    ) -> Result<(usize, usize, Vec<String>), StoreError> {
         Self::validate_bulk_reindex_input(
             repo_uid,
             files,
@@ -1508,7 +1508,8 @@ impl GraphStore {
         let conn = self.begin_transaction()?;
 
         // Delete old data within the transaction.
-        let counts = Self::bulk_delete_repo_files_and_symbols_on(&conn, repo_uid)?;
+        let (file_count, symbol_count, deleted_symbol_uids) =
+            Self::bulk_delete_repo_files_and_symbols_on(&conn, repo_uid)?;
         Self::clear_repo_derived_nodes_on(&conn, repo_uid)?;
 
         // Insert replacement data in the same transaction.
@@ -1525,7 +1526,7 @@ impl GraphStore {
         Self::mark_regex_scope_dirty_on(&conn, repo_uid, false)?;
 
         self.commit_transaction(&conn)?;
-        Ok(counts)
+        Ok((file_count, symbol_count, deleted_symbol_uids))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -4221,7 +4222,9 @@ impl GraphStore {
             let conn = self.begin_transaction()?;
             let mutation = Self::bulk_delete_repo_files_and_symbols_on(&conn, repo_uid);
             let counts = match mutation {
-                Ok(counts) => counts,
+                // This path reports counts only; the deleted UIDs matter to
+                // the re-index epilogue, not to fault-injection bookkeeping.
+                Ok((file_count, symbol_count, _)) => (file_count, symbol_count),
                 Err(error) => {
                     let rollback = self.rollback_transaction(&conn);
                     return Err(match rollback {
@@ -4515,9 +4518,10 @@ impl GraphStore {
         repo_uid: &str,
     ) -> Result<(usize, usize), StoreError> {
         let conn = self.begin_transaction()?;
-        let counts = Self::bulk_delete_repo_files_and_symbols_on(&conn, repo_uid)?;
+        let (file_count, symbol_count, _deleted_symbol_uids) =
+            Self::bulk_delete_repo_files_and_symbols_on(&conn, repo_uid)?;
         self.commit_transaction(&conn)?;
-        Ok(counts)
+        Ok((file_count, symbol_count))
     }
 
     /// Like [`bulk_delete_repo_files_and_symbols`](Self::bulk_delete_repo_files_and_symbols)
@@ -4529,29 +4533,35 @@ impl GraphStore {
     // time. Incident-profile readings of a full node-group scan / O(n²) in
     // relationships deleted are refuted; see benches/remove_repo_benchmarks.rs
     // for the regression benchmark and the full refuted-claims record.
+    /// Returns `(file_count, symbol_count, deleted_symbol_uids)`.
     pub fn bulk_delete_repo_files_and_symbols_on(
         conn: &lbug::Connection<'_>,
         repo_uid: &str,
-    ) -> Result<(usize, usize), StoreError> {
+    ) -> Result<(usize, usize, Vec<String>), StoreError> {
         let rid = lbug::Value::String(repo_uid.to_string());
 
-        // Count before deleting so the caller can log what was removed.
-        let sym_count: usize = {
+        // Collect the UIDS, not just a count. nw-204: the caller needs to know
+        // WHICH symbols went away so the epilogue can tombstone the embeddings
+        // of the ones that do not come back. Returning only a count made the
+        // whole-repo re-index path silently skip tombstoning entirely, which is
+        // the exact leak nw-204 set out to close, on the path its own commit
+        // message listed as covered.
+        let deleted_symbol_uids: Vec<String> = {
             let mut stmt = conn
-                .prepare("MATCH (s:Symbol) WHERE s.repo_uid = $rid RETURN count(s)")
-                .map_err(|e| StoreError::Query(format!("prepare count symbols: {e}")))?;
+                .prepare("MATCH (s:Symbol) WHERE s.repo_uid = $rid RETURN s.uid")
+                .map_err(|e| StoreError::Query(format!("prepare list symbols: {e}")))?;
             let rows = conn
                 .execute(&mut stmt, vec![("rid", rid.clone())])
-                .map_err(|e| StoreError::Query(format!("count symbols: {e}")))?;
+                .map_err(|e| StoreError::Query(format!("list symbols: {e}")))?;
             rows.filter_map(|row| {
                 row.first().and_then(|v| match v {
-                    lbug::Value::Int64(n) => Some(*n as usize),
+                    lbug::Value::String(uid) => Some(uid.clone()),
                     _ => None,
                 })
             })
-            .next()
-            .unwrap_or(0)
+            .collect()
         };
+        let sym_count = deleted_symbol_uids.len();
         let file_count: usize = {
             let mut stmt = conn
                 .prepare("MATCH (f:File) WHERE f.repo_uid = $rid RETURN count(f)")
@@ -4581,7 +4591,7 @@ impl GraphStore {
         conn.execute(&mut stmt, vec![("rid", rid)])
             .map_err(|e| StoreError::Query(format!("bulk delete files: {e}")))?;
 
-        Ok((file_count, sym_count))
+        Ok((file_count, sym_count, deleted_symbol_uids))
     }
 
     /// Delete a Repo node (and its REPO_HAS_FILE edges) by UID.

--- a/src/main.rs
+++ b/src/main.rs
@@ -15072,6 +15072,24 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                     nestweaver_client::autostart::daemon_boot_timeout(),
                                 )) {
                                     Ok(health) => {
+                                        // nw-201 covered `start --config` ONLY, and
+                                        // this configless branch is the DEFAULT path —
+                                        // the one `nestweaver daemon start` and MCP
+                                        // autostart both take. It reported
+                                        // "Daemon already running." and exit 0 while a
+                                        // previous binary kept serving, which is
+                                        // verbatim the incident nw-201 exists to
+                                        // prevent, with one flag omitted.
+                                        if let Some(skew) = nestweaver_schema::describe_version_skew(
+                                            &health.version,
+                                            env!("CARGO_PKG_VERSION"),
+                                        ) {
+                                            anyhow::bail!(
+                                                "{skew} Run `nestweaver daemon --db {} restart` \
+                                                 to apply it.",
+                                                db_path_abs.display()
+                                            );
+                                        }
                                         // A retry after a slow configless launchd boot
                                         // is allowed to finish the pending reset, but
                                         // only when the live binding for the healthy
@@ -15511,6 +15529,19 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                             nestweaver_client::autostart::daemon_boot_timeout(),
                                         ),
                                     )?;
+                                    // Same gap as the macOS branch: the
+                                    // configless path is the DEFAULT path and
+                                    // had no version check at all.
+                                    if let Some(skew) = nestweaver_schema::describe_version_skew(
+                                        &health.version,
+                                        env!("CARGO_PKG_VERSION"),
+                                    ) {
+                                        anyhow::bail!(
+                                            "{skew} Run `nestweaver daemon --db {} restart` to \
+                                             apply it.",
+                                            db_path.display()
+                                        );
+                                    }
                                     let binding = nestweaver_daemon::lifecycle::
                                         read_effective_config_binding_for_verified_pid(
                                             &instance_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8401,6 +8401,19 @@ fn restore_parent_stderr_tracing() {
         .try_init();
 }
 
+/// Convert a daemon `tonic::Status` into an error that renders its message
+/// VERBATIM.
+///
+/// `tonic::Status`'s `Display` writes `", message: {:?}"` — `{:?}` on a `&str`
+/// escapes newlines and quotes. So a multi-line operator remedy arrives as one
+/// long line of literal `\n` and `\"`, and the daemon's carefully
+/// column-0-indented TOML stanza is unpastable by the time a human sees it.
+/// The CLI is that message's only consumer, so the formatting effort was
+/// entirely undone in transit.
+fn daemon_status_error(status: tonic::Status) -> anyhow::Error {
+    anyhow::anyhow!("{}", status.message())
+}
+
 fn main() {
     // Install miette as the global error/panic report handler for rich
     // diagnostics (colours, help text, error codes) on supported terminals.
@@ -13760,7 +13773,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let token_budget = token_budget.unwrap_or(if detailed { 3000 } else { 1000 });
             let db_path = resolve_db_with_config(db, config.as_deref())?;
 
-            if let Some(value) = try_hybrid_json_rpc_checked(
+            let daemon_result = try_hybrid_json_rpc_checked(
                 use_daemon,
                 &db_path,
                 config.as_deref(),
@@ -13774,7 +13787,23 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     "recency_weight": recency_weight,
                     "recency_half_life_days": recency_half_life_days,
                 }),
-            )? {
+            );
+            // A project that does not exist is NOT FOUND, not a generic
+            // failure. The direct path returns `EXIT_NOT_FOUND` with an
+            // actionable message; the daemon path propagated the tool error and
+            // exited 1, so the same command answered with a different exit code
+            // depending on whether a daemon happened to be running — and a
+            // script could not distinguish "no such project" from "the query
+            // failed".
+            let daemon_value = match daemon_result {
+                Ok(value) => value,
+                Err(error) if format!("{error:#}").contains("not found") => {
+                    eprintln!("Project '{name}' not found. Try: nestweaver list-projects");
+                    return Ok((EXIT_NOT_FOUND, None));
+                }
+                Err(error) => return Err(error),
+            };
+            if let Some(value) = daemon_value {
                 render_project_context_daemon_response(&value, json, token_budget);
                 return Ok((EXIT_SUCCESS, None));
             }
@@ -18953,6 +18982,7 @@ fn run_brain(
                         .watch_vault(req)
                         .await
                         .map(|r| r.into_inner())
+                        .map_err(daemon_status_error)
                 })?;
                 if !resp.ok {
                     eprintln!("Error: {}", resp.message);
@@ -21622,6 +21652,13 @@ fn project_context_json_value(
     if !external_refs.is_null() {
         resp["external_refs"] = external_refs.clone();
     }
+    // Measured on the FINISHED object, so every optional field above is
+    // counted. Same 4-bytes-per-token rule the daemon path uses.
+    let actual_tokens = serde_json::to_string(&resp)
+        .map(|serialized| serialized.len().div_ceil(4))
+        .unwrap_or(0);
+    resp["tokens_used"] = serde_json::json!(actual_tokens);
+    resp["budget_exceeded"] = serde_json::json!(actual_tokens > token_budget);
     resp
 }
 

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -858,6 +858,21 @@ fn parity_export_scope_direct_vs_daemon() {
     }
 }
 
+/// nw-188's honesty fields — `more_available`, `truncated`, `budget_exceeded`,
+/// `seed_tokens_charged` — were added to the daemon/MCP path only, so the same
+/// command answered with four extra keys and a different `tokens_used`
+/// depending on whether a daemon happened to be running. A tight budget is
+/// used deliberately: it is the case that produced the original report.
+#[test]
+fn parity_project_context_direct_vs_daemon() {
+    let fixture = setup_fixture();
+    check_parity(
+        &fixture.db_path,
+        "project-context",
+        &["project-context", "demo", "--token-budget", "200"],
+    );
+}
+
 /// `stale-check` is a freshness gate: it exits 1 when the index is
 /// stale. The fixture here is freshly indexed (not stale), but regardless we
 /// only assert stdout equality and equal exit codes across modes — never


### PR DESCRIPTION
Follow-up to #286. A six-agent review of every PR merged since v7.0.0 found that several of those fixes did not close their own bug on the path users actually take. This closes those, plus three tests that could not fail.

## Fixes that did not reach the default path

- **The daemon version check ran only on `daemon start --config`.** The configless form is the default — `nestweaver daemon start` and MCP autostart both take it — and it printed "Daemon already running." and exited 0 while a previous binary kept serving. The MCP attach path had no check at all: it returned as soon as the socket accepted a connection and never issued a HealthCheck, so after an upgrade an agent kept talking to the old daemon with nothing reporting a skew.
- **The check was direction-blind.** An older client against a NEWER daemon was told "the upgrade has NOT been applied" — false — and pointed at `restart`, which would have replaced the live newer daemon with the older build: a downgrade described as an upgrade.
- **nw-204 missed `index_directory`'s `force_reindex` arm**, which reported a count rather than the deleted UIDs, so the epilogue tombstoned nothing. It fires whenever `files_unchanged == 0`, including a missing or corrupt filemeta sidecar.
- **Vault embeddings had no synchronous tombstoning at all** — only a writable daemon's periodic reconciler.
- **nw-188's honesty fields and nw-203's pastable remedy** existed only on one transport each.

## Tests that could not fail

Three, each replaced by one that can. The legacy-hash test compared two different digests (SipHash vs SHA-256), which can never agree regardless of canonicalization — it passed with the regression it guarded fully reintroduced.

## Verification

Every fix is mutation-checked: the fix is reverted and the suite must fail. Two caught themselves this way — a re-index test that passed with the fix reverted (it never reached the arm under test), and a mutation that silently did not apply because `cargo fmt` had reflowed its anchor line.

Parity gained `export --scope`, `project-context`, and found a divergence on its first run: a missing project exited 2 direct and 1 through the daemon.

Gates: workspace `--lib` 0 failed · `parity_test` 19/19 · clippy `-D warnings` · fmt — all exit-code checked.