### PR TITLE
fix(daemon,cli): reclaim an orphaned watcher, and stop the reconciler racing teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ The first build compiles LadybugDB from source and may take several minutes.
 |---------|-------------|
 | `index` | Parse and index a repository (auto-detects repo root from `.git`). Use `--name` to set a custom repo name for multi-repo setups. Indexing does NOT refresh trigrams implicitly — the daemon's reconcile loop owns that (see `[indexing] trigram_reconcile_interval`). `--with-trigrams` forces an inline refresh for one run (CI, scripted reindex), `--no-trigrams` suppresses it (and conflicts with `--rebuild-trigrams`), `--rebuild-trigrams` forces a full rebuild. The direct `--local` path still refreshes inline, since no daemon exists there to drain for it. |
 | `watch` | Live re-indexing via filesystem watcher with debouncing. Runs daemon-side (no instance config required; unsafe roots are denylisted); `--force` replaces an existing watcher. Incremental reindex preserves CALLS/IMPORTS edges (reverse dependents are re-resolved) and reports per-file failures instead of dying |
+| `watch-stop` | Stop the daemon's active watcher. The watcher slot is global and the daemon keeps no liveness check on the CLI that registered it, so a watch killed without a clean shutdown (SIGKILL, or a closed terminal) leaves the slot occupied and every later watch refused; this releases it without restarting the daemon |
 | `context` | Get task-focused context via PPR (supports `--intent` for tuned retrieval) |
 | `search` | Full-text search across indexed symbols and notes |
 | `symbol` | Look up a symbol by name and display its metadata |
@@ -264,7 +265,7 @@ The first build compiles LadybugDB from source and may take several minutes.
 | `brain context` | Get unified context spanning both code symbols and notes (skips the semantic leg entirely when the DB has no embeddings; identical concurrent calls coalesce single-flight) |
 | `brain list` | List all registered vaults |
 | `brain status` | Show vault counts, per-vault staleness, and index health |
-| `brain watch` | Watch vaults for changes and re-index automatically |
+| `brain watch` | Watch vaults for changes and re-index automatically. `--force` adopts an existing watcher registration instead of being refused by it — the vault counterpart of `watch --force` |
 | `brain refresh` | Force re-index of all registered vaults |
 | `brain remove` | Remove a vault from the brain (cascade-deletes nodes; does not touch files on disk) |
 | `brain stale-check` | Check whether the indexed graph reflects reality (also available top-level as `stale-check`). **Exit 0** nothing to do · **1** the check itself failed · **2** at least one repo needs re-indexing. Gate CI on `any_needs_reindex` (or exit 2) — that is the actionable union of `stale`, `incomplete`, and `missing`. `any_stale` / `is_stale` mean *behind HEAD* specifically |

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -985,6 +985,18 @@ pub struct DaemonState {
     /// handles, so a discarded handle would let that teardown race a write in
     /// progress — against a store that is not crash-safe (nw-126).
     pub trigram_reconciler_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Join handle for the embedding reconcile loop.
+    ///
+    /// Retained for exactly the reason stated above, which this task violated
+    /// by being spawned detached: it performs the same kind of unabortable
+    /// blocking store write on a `spawn_blocking` thread. The write gate
+    /// covers the common case, but `ConnectionGuard::write` reads
+    /// `shutdown_started` with `Relaxed` and then increments `active_writes`
+    /// — a pass that slips between those two steps is invisible to the drain,
+    /// so teardown could remove the socket, the pidfile and the INSTANCE LOCK
+    /// while the outgoing process was still rewriting the sidecar, letting a
+    /// successor daemon open the same database concurrently.
+    pub embedding_reconciler_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
     /// Handle to the `serve_ui` web-server task plus the port it is bound
     /// to, aborted by `stop_ui` so the listen port is released when the CLI
     /// exits (LOW: ui port leak). The port is tracked so a repeated
@@ -1501,7 +1513,20 @@ async fn run_embedding_reconciler(state: Arc<DaemonState>, period: Duration) {
         let lease = state.write_gate.lock("embedding_reconcile").await;
         let reconcile_state = Arc::clone(&state);
         let outcome = tokio::task::spawn_blocking(move || {
-            let removed = reconcile_state.store.reconcile_embedding_index()?;
+            // Occupancy either side of the pass, for the same reason
+            // `compact_embeddings` reports `stored_before - stored_after`:
+            // `reconcile_embedding_index` returns only the orphans THIS pass
+            // discovered, while the compaction below drops every tombstoned
+            // row — including all those the synchronous delete epilogue
+            // tombstoned earlier, which this count never saw. On a brain that
+            // tombstones as it deletes, a pass could log `removed=0` beside
+            // "reclaimed vectors for deleted nodes" while a full base rewrite
+            // dropped tens of thousands.
+            //
+            // This is the twin of the `compact_embeddings` accounting bug; the
+            // two paths share the defect because they share the shape.
+            let before = reconcile_state.store.embedding_index_occupancy();
+            let discovered = reconcile_state.store.reconcile_embedding_index()?;
             // Compaction is deliberately here and NOT in `flush_embedding_index`:
             // the watcher flushes on every save, and compaction rewrites the
             // whole base.
@@ -1511,21 +1536,30 @@ async fn run_embedding_reconciler(state: Arc<DaemonState>, period: Duration) {
             } else {
                 false
             };
-            Ok::<_, nestweaver_store::StoreError>((removed, compacted))
+            let after = reconcile_state.store.embedding_index_occupancy();
+            // Saturating: a pass never grows the index, but a count that went
+            // backwards must not wrap.
+            let reclaimed = before.stored.saturating_sub(after.stored);
+            Ok::<_, nestweaver_store::StoreError>((discovered, reclaimed, compacted))
         })
         .await;
         drop(lease);
 
         match outcome {
-            Ok(Ok((removed, compacted))) => {
+            Ok(Ok((discovered, reclaimed, compacted))) => {
                 consecutive_failures = 0;
                 backoff_until = None;
                 // Only advance the watermark on success, so a failed pass is
                 // retried rather than skipped.
                 last_generation = Some(generation);
-                if removed > 0 || compacted {
+                if reclaimed > 0 || discovered > 0 || compacted {
                     tracing::info!(
-                        removed,
+                        // What actually LEFT the index…
+                        reclaimed,
+                        // …and how much of it this pass had to find itself.
+                        // Reporting both keeps the backstop's own contribution
+                        // visible without letting it stand in for the total.
+                        discovered,
                         compacted,
                         generation,
                         "embedding reconcile: reclaimed vectors for deleted nodes"
@@ -3847,6 +3881,7 @@ impl NestWeaverDaemon for DaemonService {
         let instance_id =
             resolve_effective_instance_id(&req.instance_id, &self.state.data_instance_id)?;
         let extra_patterns = req.extra_ignore_patterns.clone();
+        let force = req.force;
 
         if !vault_path.exists() || !vault_path.is_dir() {
             return Ok(Response::new(WatchVaultResponse {
@@ -3903,12 +3938,20 @@ impl NestWeaverDaemon for DaemonService {
         let admission_guard = ConnectionGuard::write(&self.state)?;
 
         // register_watcher holds the lock across check + store (TOCTOU-safe).
-        let watcher_id = match register_watcher(&self.state, shutdown_handle, false) {
+        // `force` now reaches here, as it always has for `watch_code`: the
+        // watcher slot is global and has no client-liveness check, so an
+        // orphaned registration otherwise blocks every later vault watch until
+        // the daemon restarts.
+        let watcher_id = match register_watcher(&self.state, shutdown_handle, force) {
             Ok(id) => id,
             Err(e) if e.code() == tonic::Code::AlreadyExists => {
                 return Ok(Response::new(WatchVaultResponse {
                     ok: false,
-                    message: "A watcher is already running. Stop it first with StopWatch."
+                    // Names COMMANDS, not an RPC. The previous wording said
+                    // "Stop it first with StopWatch" — an RPC no CLI
+                    // subcommand exposed, so the advice could not be followed.
+                    message: "A watcher is already running. Stop it with \
+                              `nestweaver watch-stop`, or retry with --force to adopt it."
                         .to_string(),
                 }));
             }
@@ -4016,8 +4059,8 @@ impl NestWeaverDaemon for DaemonService {
             Err(e) if e.code() == tonic::Code::AlreadyExists => {
                 return Ok(Response::new(WatchCodeResponse {
                     ok: false,
-                    message: "A watcher is already running. Stop it first with StopWatch \
-                              (or retry with --force)."
+                    message: "A watcher is already running. Stop it with \
+                              `nestweaver watch-stop`, or retry with --force to adopt it."
                         .to_string(),
                 }));
             }
@@ -9877,6 +9920,7 @@ pub async fn run_server(
         admin_state: std::sync::OnceLock::new(),
         worker_handle: std::sync::Mutex::new(None),
         trigram_reconciler_handle: std::sync::Mutex::new(None),
+        embedding_reconciler_handle: std::sync::Mutex::new(None),
         ui_server: std::sync::Mutex::new(None),
     });
 
@@ -10054,10 +10098,14 @@ pub async fn run_server(
             interval_secs = EMBEDDING_RECONCILE_INTERVAL.as_secs(),
             "embedding reconcile loop enabled"
         );
-        tokio::spawn(run_embedding_reconciler(
+        let embedding_handle = tokio::spawn(run_embedding_reconciler(
             Arc::clone(&state),
             EMBEDDING_RECONCILE_INTERVAL,
         ));
+        *state
+            .embedding_reconciler_handle
+            .lock()
+            .expect("embedding_reconciler_handle mutex poisoned") = Some(embedding_handle);
     }
 
     let uds = tokio::net::UnixListener::bind(&sock_path)
@@ -11287,6 +11335,17 @@ pub async fn run_server(
         .and_then(|mut guard| guard.take());
     if let Some(handle) = reconciler_handle {
         tracing::info!("draining trigram reconcile loop before exit");
+        let _ = handle.await;
+    }
+    // Awaited BEFORE the socket, pidfile and instance lock are released
+    // below, for the same reason as the trigram loop.
+    let embedding_handle = state
+        .embedding_reconciler_handle
+        .lock()
+        .ok()
+        .and_then(|mut guard| guard.take());
+    if let Some(handle) = embedding_handle {
+        tracing::info!("draining embedding reconcile loop before exit");
         let _ = handle.await;
     }
 
@@ -16318,6 +16377,7 @@ mod startup_helper_tests {
             admin_state: std::sync::OnceLock::new(),
             worker_handle: std::sync::Mutex::new(None),
             trigram_reconciler_handle: std::sync::Mutex::new(None),
+            embedding_reconciler_handle: std::sync::Mutex::new(None),
             ui_server: std::sync::Mutex::new(None),
         })
     }
@@ -16400,6 +16460,7 @@ credential_method = "gh"
             admin_state: std::sync::OnceLock::new(),
             worker_handle: std::sync::Mutex::new(None),
             trigram_reconciler_handle: std::sync::Mutex::new(None),
+            embedding_reconciler_handle: std::sync::Mutex::new(None),
             ui_server: std::sync::Mutex::new(None),
         })
     }
@@ -18003,6 +18064,7 @@ external_model = "unavailable-test-model"
                 vault_name: "test-vault".to_string(),
                 instance_id: String::new(),
                 extra_ignore_patterns: Vec::new(),
+                force: false,
             }))
             .await
             .expect("WatchVault RPC")
@@ -19529,6 +19591,73 @@ mod watcher_e2e_tests {
             r3.ok,
             "force watch must adopt the orphaned slot: {}",
             r3.message
+        );
+
+        // The VAULT half of the same contract. `WatchVaultRequest` had no
+        // `force` field at all while its sibling `WatchCodeRequest` did, so an
+        // orphaned watcher — the state simulated above — refused every later
+        // `brain watch` for the daemon's lifetime with no way to adopt it.
+        let vault = tmp.path().join("vault");
+        std::fs::create_dir(&vault).unwrap();
+        let mk_vault_req = |force: bool| nestweaver_proto::WatchVaultRequest {
+            vault_path: vault.to_string_lossy().to_string(),
+            vault_name: "test-vault".to_string(),
+            instance_id: String::new(),
+            extra_ignore_patterns: Vec::new(),
+            force,
+        };
+
+        let v1 = client
+            .watch_vault(mk_vault_req(false))
+            .await
+            .expect("watch_vault")
+            .into_inner();
+        assert!(
+            !v1.ok,
+            "a vault watch must still be refused while a watcher is registered"
+        );
+        assert!(
+            v1.message.contains("already running"),
+            "unexpected refusal message: {}",
+            v1.message
+        );
+        // The refusal must name something a user can actually RUN. It used to
+        // say "Stop it first with StopWatch" — an RPC no CLI subcommand
+        // exposed, so the advice could not be followed.
+        assert!(
+            v1.message.contains("watch-stop") || v1.message.contains("--force"),
+            "the refusal must name a runnable remedy: {}",
+            v1.message
+        );
+
+        let v2 = client
+            .watch_vault(mk_vault_req(true))
+            .await
+            .expect("watch_vault")
+            .into_inner();
+        assert!(
+            v2.ok,
+            "force must let a vault watch adopt the orphaned slot: {}",
+            v2.message
+        );
+
+        // And `StopWatch` empties the slot, which is what the new
+        // `nestweaver watch-stop` subcommand issues.
+        let stopped = client
+            .stop_watch(nestweaver_proto::StopWatchRequest {})
+            .await
+            .expect("stop_watch")
+            .into_inner();
+        assert!(stopped.ok, "stop_watch must report stopping the watcher");
+        let v3 = client
+            .watch_vault(mk_vault_req(false))
+            .await
+            .expect("watch_vault")
+            .into_inner();
+        assert!(
+            v3.ok,
+            "after a stop, a plain vault watch must succeed: {}",
+            v3.message
         );
 
         // Shutdown with the watcher ACTIVE must stop it and exit

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -90,6 +90,12 @@ message WatchVaultRequest {
   string vault_name = 2;
   string instance_id = 3;
   repeated string extra_ignore_patterns = 4;
+  // Adopt an existing watcher registration instead of being refused by it.
+  // `WatchCodeRequest` has carried this since watchers could be orphaned; the
+  // vault side did not, so a `brain watch` whose CLI was killed without
+  // sending StopWatch (SIGKILL, or a closed terminal — SIGHUP is not handled)
+  // blocked every later vault watch for the daemon's lifetime.
+  bool force = 5;
 }
 
 message WatchVaultResponse {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3521,6 +3521,28 @@ enum Commands {
         db: Option<PathBuf>,
     },
 
+    /// Stop the daemon's active file watcher, if any.
+    ///
+    /// The watcher slot is global and the daemon keeps no liveness check on the
+    /// CLI that registered it, so a `watch` or `brain watch` killed without a
+    /// clean shutdown (SIGKILL, or a closed terminal — SIGHUP is not handled)
+    /// leaves the slot occupied and every later watch refused. The refusal
+    /// message named `StopWatch`, an RPC no subcommand exposed; this is that
+    /// subcommand.
+    #[command(
+        name = "watch-stop",
+        after_help = "Examples:\n  nestweaver watch-stop\n  nestweaver watch-stop --db ./custom.lbug"
+    )]
+    WatchStop {
+        #[arg(
+            long,
+            help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
+        )]
+        db: Option<PathBuf>,
+        #[arg(long, help = "Path to instance config (TOML)")]
+        config: Option<PathBuf>,
+    },
+
     /// Watch a repository for source file changes and re-index incrementally
     ///
     /// Monitors the repo directory for creates, modifies, and deletes of
@@ -4181,6 +4203,12 @@ enum BrainCommands {
             help = "Path to instance config (TOML) — required for --refresh-wiki-hours"
         )]
         config: Option<PathBuf>,
+        #[arg(
+            long,
+            help = "Adopt an existing watcher instead of being refused by it (use after a \
+                    previous `brain watch` was killed without stopping cleanly)"
+        )]
+        force: bool,
     },
     /// Force a full re-index of a vault. Drops the vault's existing notes
     /// from the graph (via cascade-delete) then re-runs the indexer from
@@ -11725,6 +11753,32 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             Ok((EXIT_SUCCESS, Some(stats)))
         }
 
+        Commands::WatchStop { db, config } => {
+            let db_path = db.unwrap_or_else(default_db_path);
+            let rt = tokio::runtime::Runtime::new()?;
+            let mut client = rt.block_on(nestweaver_client::DaemonClient::connect(
+                &db_path,
+                config.as_deref(),
+            ))?;
+            let resp = rt
+                .block_on(async {
+                    client
+                        .inner_mut()
+                        .stop_watch(nestweaver_proto::StopWatchRequest {})
+                        .await
+                })
+                .map_err(daemon_status_error)?
+                .into_inner();
+            // Stopping a watcher that is not running is the SUCCESS case for
+            // this command: the caller wanted an empty slot and now has one.
+            if resp.ok {
+                out.status("Stopped the daemon's active watcher.");
+            } else {
+                out.status("No watcher was running.");
+            }
+            Ok((EXIT_SUCCESS, None))
+        }
+
         Commands::Watch {
             repo,
             db,
@@ -18923,6 +18977,7 @@ fn run_brain(
             ignore,
             refresh_wiki_hours,
             config,
+            force,
         } => {
             if refresh_wiki_hours.is_some() && config.is_none() {
                 eprintln!("Error: --refresh-wiki-hours requires --config");
@@ -18971,6 +19026,7 @@ fn run_brain(
                 // Absolute path: the daemon runs with CWD=/ (would watch the wrong dir).
                 let vault_abs = abs_for_daemon(&path);
                 let req = nestweaver_proto::WatchVaultRequest {
+                    force,
                     vault_path: vault_abs.to_string_lossy().to_string(),
                     vault_name: vault_name.clone(),
                     instance_id: instance_id.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -11754,7 +11754,14 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
         }
 
         Commands::WatchStop { db, config } => {
-            let db_path = db.unwrap_or_else(default_db_path);
+            // `resolve_db_with_config`, not a bare `--db` fallback: this
+            // command accepts `--config`, so it must resolve the database the
+            // way every other config-aware command does — honouring the
+            // config's `db`, following the publication CURRENT pointer, and
+            // asserting `expected_brain_uuid`. Taking `--config` and then
+            // ignoring it is exactly what the config-DB inventory contract
+            // exists to catch, and it caught this.
+            let db_path = resolve_db_with_config(db, config.as_deref())?;
             let rt = tokio::runtime::Runtime::new()?;
             let mut client = rt.block_on(nestweaver_client::DaemonClient::connect(
                 &db_path,
@@ -21385,6 +21392,7 @@ mod cli_help_contract_tests {
             "nestweaver suggest-links",
             "nestweaver ui",
             "nestweaver watch",
+            "nestweaver watch-stop",
         ]
         .map(str::to_string)
         .to_vec();


### PR DESCRIPTION
Closes the last of the outstanding reports. **Two of the five turned out not to be defects** and are closed unchanged — see below.

## Watcher: an orphan blocked every later vault watch

The watcher slot is global and the daemon keeps **no liveness check** on the CLI that registered it. Ctrl-C and SIGTERM stop cleanly; SIGKILL and a closed terminal do not (SIGHUP isn't registered), and after either, every later `brain watch` is refused for the daemon's lifetime.

- `WatchCodeRequest` has carried `force` since watchers could be orphaned. `WatchVaultRequest` had no such field, so the vault half could not adopt an orphan at all. It can now.
- Both refusals said *"Stop it first with StopWatch"* — an RPC **no CLI subcommand exposed**, so the advice could not be followed. `nestweaver watch-stop` is that subcommand, and the messages now name commands a user can run.

Reported as "unreclaimable, requires a daemon restart". That part was **wrong** — `watch --force` already worked as an awkward workaround. The real defects were the missing vault `force` and the unreachable remedy.

## Reconciler: a detached handle and a miscount

The embedding reconcile loop was spawned detached while its sibling trigram loop retains its handle and is awaited before teardown. The doc comment on that sibling states the rule **twenty lines from the violation**: a discarded handle lets teardown race a write in progress, against a store that is not crash-safe.

The write gate covers the common case, but `ConnectionGuard::write` reads `shutdown_started` `Relaxed` and *then* increments `active_writes` — a pass slipping between those steps is invisible to the drain, so the socket, pidfile and **instance lock** could be released while the outgoing process was still rewriting the sidecar, letting a successor daemon open the same database concurrently.

Its accounting had the same defect #287 fixed in `compact_embeddings` — 1,500 lines up, and missed at the time. A pass could log `removed=0` beside "reclaimed vectors for deleted nodes" while a full base rewrite dropped tens of thousands. Now reports `reclaimed` (what left the index) alongside `discovered` (what this pass found itself); collapsing them would hide the backstop's contribution, which is the point of the line.

## Closed as NOT defects

- **Stale trigram postings** — premise right (postings persist; `delete_note_cascade` doesn't mark its scope dirty), conclusion wrong. Shards store *uid, kind, text_hash, trigrams — no text*. Candidates are re-hydrated from the live graph by uid probe and re-verified with the compiled regex, so a deleted node yields no `Candidate`. A phantom posting costs one wasted uid in a `HashSet`.
- **Reconciler lifetime / racing / shutdown-flush** — the task owns an `Arc` (cannot dangle), takes the same process-wide write gate as every other writer, and there is no shutdown-time flush.

## Verification

Extended the existing watcher e2e rather than adding a parallel one — it already stands up a daemon and simulates the orphan. Mutation-checked: with `watch_vault` ignoring `force` again, it fails with the refusal quoted back.

Gates: workspace `--lib` 0 failed · `parity_test` 19/19 · clippy `-D warnings` · fmt.