### PR TITLE
chore(ci): add advisory mutation testing on the PR diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,6 +555,85 @@ jobs:
           name: coverage-report
           path: lcov.info
 
+  mutants:
+    name: Mutation testing (advisory)
+    needs: changes
+    # ADVISORY ONLY — nothing gates on this, and there is deliberately no
+    # mutation-score threshold.
+    #
+    # A score target invites tests written to kill mutants rather than to check
+    # behaviour (Goodhart). Google's deployment reports surface individual
+    # SURVIVING mutants on the diff under review and never show developers a
+    # score; that is the model here.
+    #
+    # Why it exists: the post-7.0.0 review found ~20 tests that pass with the
+    # fix they guard reverted — several guarding named tickets, so they read as
+    # coverage while guarding nothing. Coverage cannot see that class; mutant
+    # detection correlates with real fault detection INDEPENDENTLY of coverage
+    # (Just et al., FSE 2014).
+    #
+    # `--in-diff` keeps it to the PR's own changes, which is what makes the
+    # runtime tolerable — a full baseline is a separate, occasional run.
+    if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
+          sudo apt-get clean
+      - uses: actions/checkout@v7
+        with:
+          # `--in-diff` needs the base commit to diff against.
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          key: mutants
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
+      - name: Install cargo-mutants
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
+      - name: Compute the PR diff
+        run: git diff "origin/${{ github.base_ref }}"...HEAD > /tmp/pr.diff
+      - name: Mutate only what this PR changed
+        # A timeout because an unkilled mutant can hang a test that would
+        # otherwise exit; without it one pathological mutant stalls the job.
+        # NESTWEAVER_NO_DAEMON keeps each run hermetic — cargo-mutants requires
+        # non-flaky tests, and a shared daemon would make results
+        # irreproducible.
+        run: |
+          cargo mutants --in-diff /tmp/pr.diff --timeout 300 --no-shuffle -- --no-fail-fast || true
+        env:
+          NESTWEAVER_NO_DAEMON: "1"
+          NESTWEAVER_ALLOW_NO_DAEMON: "1"
+      - name: Surviving mutants (read these — each one is a test that cannot fail)
+        if: always()
+        run: |
+          if [ -s mutants.out/missed.txt ]; then
+            echo "### Surviving mutants" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Each line is a change to this PR's code that NO test noticed." >> "$GITHUB_STEP_SUMMARY"
+            echo "That is not automatically a defect — but it is a test that would" >> "$GITHUB_STEP_SUMMARY"
+            echo "not have caught the bug it appears to guard." >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            cat mutants.out/missed.txt >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No surviving mutants in this diff." >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Upload mutants report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mutants-report
+          path: mutants.out/
+          if-no-files-found: ignore
+
   audit:
     name: Security Audit
     needs: changes


### PR DESCRIPTION
First of the guard rails. **Advisory only — nothing gates on this.**

## Why

The post-7.0.0 review found **~20 tests that pass with the fix they guard reverted**. Several guard named tickets, so they read as coverage while guarding nothing:

- one hand-built a struct, serialized it, and asserted the field it had just set
- one asserted two IDs differ when they come from *different hash algorithms* (SipHash vs SHA-256) and so can never collide — it passed with the regression it guarded fully reintroduced
- one had setup that made the branch under test unreachable
- the parity harness compared two modes byte-for-byte but never asserted either **succeeded**, so both failing identically was green

Coverage cannot see this class — it measures which lines a test *reaches*, not whether the test checks anything about their behaviour. Mutant detection correlates with real fault detection **independently of coverage** ([Just et al., FSE 2014](https://darioush.github.io/papers/fse-2014.pdf) — 357 real faults across five projects).

## Deliberately not a gate, and deliberately no score

`continue-on-error: true`, and **no mutation-score threshold**. A score target invites tests written to kill mutants rather than to check behaviour. [Google's deployment](https://research.google.com/pubs/archive/46584.pdf) surfaces individual *surviving mutants* on the diff under review and never shows developers a score; that's the model here.

The job writes surviving mutants to the step summary with a note that a survivor is **not automatically a defect** — it's a test that would not have caught the bug it appears to guard.

## Scoping

`--in-diff` keeps it to the PR's own changes, which is what makes the runtime tolerable. A **full baseline run is a separate, occasional job** and will almost certainly find hollow tests beyond the twenty already known (nw-216).

`NESTWEAVER_NO_DAEMON` keeps runs hermetic — cargo-mutants requires non-flaky tests, and a shared daemon would make results irreproducible. The `--timeout` exists because an unkilled mutant can hang a test that would otherwise exit.

## Note

This is the first PR to run the job, so its own diff is the first thing mutated. Expect that to be informative in itself.