### PR TITLE
fix(daemon,cli): let the lock decide who may write, not an environment variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,13 @@ jobs:
           } >> "$GITHUB_ENV"
       - name: Populate model cache on CPU
         shell: bash
+        env:
+          # THE failure this fixes. Without it, `--no-daemon` was ignored, the
+          # index step autostarted a daemon against the seed DB, that daemon took
+          # the write lease, and the embed step below refused — correctly — to
+          # become a second writer. Two commands, one intended to be isolated,
+          # silently disagreeing about whether a daemon was in play.
+          NESTWEAVER_ALLOW_NO_DAEMON: "1"
         run: |
           set -euo pipefail
           BIN="$PWD/target/release/nestweaver"
@@ -392,6 +399,11 @@ jobs:
         # federation, mcp, …) — where most of the logic lives.
         run: cargo test --locked --workspace --no-fail-fast -- --skip daemon_
         env:
+          # Explicit, because this PR stops `CI`/`GITHUB_ACTIONS` from conferring
+          # the bypass. An ambient variable set by dozens of unrelated tools must
+          # not decide whether a database can have two writers; a job that wants
+          # the escape hatch now says so.
+          NESTWEAVER_ALLOW_NO_DAEMON: "1"
           NESTWEAVER_NO_DAEMON: "1"
 
   clippy:
@@ -548,6 +560,11 @@ jobs:
         # package (see the Tests step note on the [package]+[workspace] manifest).
         run: cargo llvm-cov --workspace --no-fail-fast --lcov --output-path lcov.info -- --skip daemon_
         env:
+          # Explicit, because this PR stops `CI`/`GITHUB_ACTIONS` from conferring
+          # the bypass. An ambient variable set by dozens of unrelated tools must
+          # not decide whether a database can have two writers; a job that wants
+          # the escape hatch now says so.
+          NESTWEAVER_ALLOW_NO_DAEMON: "1"
           NESTWEAVER_NO_DAEMON: "1"
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v7
@@ -635,6 +652,8 @@ jobs:
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     env:
+      # See the note on the Tests step: the bypass is explicit now.
+      NESTWEAVER_ALLOW_NO_DAEMON: "1"
       NESTWEAVER_NO_DAEMON: "1"
     steps:
       - name: Free disk space
@@ -682,6 +701,8 @@ jobs:
           sleep 2
           cargo build
       - name: Index test data
+        env:
+          NESTWEAVER_ALLOW_NO_DAEMON: "1"
         run: ./target/debug/nestweaver --no-daemon index --repo testdata/js --db /tmp/test.lbug
       - name: Install Playwright browsers
         working-directory: crates/nestweaver-web/frontend

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,18 @@ id_ed25519
 *.sqlite
 *.db
 
+# Sidecars and lock files that live BESIDE the database. `*.lbug` does not
+# match these — it anchors at the end — so without this line an ordinary
+# `nestweaver index` leaves untracked files in `git status`.
+#
+# `*.lbug.write.lock` is a LIVE lock, not leftover scratch: the daemon holds an
+# advisory flock on that inode for as long as it owns the database. Deleting it
+# while a daemon is running does not release the lock, it detaches the name from
+# the locked inode — so the next writer creates a fresh file, takes a lock on a
+# DIFFERENT inode, and both processes then believe they hold exclusive access.
+# Never remove one by hand; stop the holder with `nestweaver daemon stop`.
+*.lbug.*
+
 # OS files
 Thumbs.db
 

--- a/crates/nestweaver-daemon/src/lifecycle.rs
+++ b/crates/nestweaver-daemon/src/lifecycle.rs
@@ -877,6 +877,90 @@ fn db_write_lock_probe(local_store_held: bool, db_path: &Path) -> DbWriteLock {
     }
 }
 
+/// Path of the dedicated write-lease file for a database.
+///
+/// A SEPARATE file, deliberately. The obvious choice — lock the database file
+/// itself — is unsafe with POSIX record locks, and `db_write_lock` above
+/// documents why: `fcntl` locks are held per PROCESS, so closing ANY
+/// descriptor to that file drops every lock this process holds on it. A lease
+/// taken on the database would be destroyed by the store's own routine
+/// open/close, silently admitting a second writer. Nothing but the lease
+/// opens this file, so nothing can drop it by accident.
+pub fn write_lease_path(db_path: &Path) -> PathBuf {
+    let canonical = canonical_db_path(db_path);
+    let mut name = canonical.as_os_str().to_owned();
+    name.push(".write.lock");
+    PathBuf::from(name)
+}
+
+/// An exclusive claim on a database's write access, held for as long as the
+/// value lives and released by the kernel when the process exits.
+///
+/// `flock`, not `fcntl`: `flock` is per-DESCRIPTOR, so it survives unrelated
+/// opens and closes of the database, and the kernel drops it on exit with no
+/// stale state to reap. That is the property a pidfile does not have and the
+/// reason this can be trusted where a probe cannot.
+///
+/// A probe answers "was anyone holding this a moment ago". Only a held lease
+/// answers "is anyone holding this for as long as I am writing", which is the
+/// question a check-then-write cannot ask. Every comparable embedded store —
+/// SQLite, RocksDB, LMDB, DuckDB, Kuzu — holds a lock for the lifetime of the
+/// handle for exactly this reason.
+#[derive(Debug)]
+pub struct DbWriteLease {
+    _file: std::fs::File,
+    path: PathBuf,
+}
+
+impl DbWriteLease {
+    /// The lease file this claim is held on.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// Why a write lease could not be taken.
+#[derive(Debug)]
+pub enum WriteLeaseError {
+    /// Someone else holds it. They are writing right now.
+    Held,
+    /// The lease file itself could not be created or locked.
+    Unavailable(std::io::Error),
+}
+
+/// Take an exclusive, non-blocking write lease on `db_path`.
+///
+/// Non-blocking on purpose: a caller that would block has a live writer to
+/// report, and telling the operator who holds the database is more useful than
+/// hanging. Callers that genuinely want to wait can retry.
+pub fn acquire_db_write_lease(db_path: &Path) -> Result<DbWriteLease, WriteLeaseError> {
+    use std::os::unix::io::AsRawFd;
+
+    let path = write_lease_path(db_path);
+    if let Some(parent) = path.parent()
+        && !parent.exists()
+    {
+        std::fs::create_dir_all(parent).map_err(WriteLeaseError::Unavailable)?;
+    }
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&path)
+        .map_err(WriteLeaseError::Unavailable)?;
+
+    // LOCK_NB so a contended lease fails immediately instead of hanging.
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        let error = std::io::Error::last_os_error();
+        return match error.kind() {
+            std::io::ErrorKind::WouldBlock => Err(WriteLeaseError::Held),
+            _ => Err(WriteLeaseError::Unavailable(error)),
+        };
+    }
+    Ok(DbWriteLease { _file: file, path })
+}
+
 /// PID of the process on the other end of a connected unix socket, as
 /// reported by the kernel. Unlike the pidfile (whose contents can be
 /// overwritten while the daemon still holds its flock), this cannot be faked

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -997,6 +997,22 @@ pub struct DaemonState {
     /// while the outgoing process was still rewriting the sidecar, letting a
     /// successor daemon open the same database concurrently.
     pub embedding_reconciler_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Join handles for every watcher task this daemon has spawned.
+    ///
+    /// Same invariant as the two reconcile loops above, and it was missing for
+    /// the watchers: both `watch_vault` and `watch_code` spawned with a bare
+    /// `spawn_blocking(...)` whose handle was dropped. Shutdown's
+    /// `stop_active_watcher` SIGNALS the watcher but cannot await it, so
+    /// teardown could remove the socket, the pidfile and the INSTANCE LOCK
+    /// while a watcher write was still running — against a store that is not
+    /// crash-safe.
+    ///
+    /// A Vec rather than an Option because a FORCE-RETIRED watcher is still
+    /// draining: `register_watcher(force)` stops the incumbent and immediately
+    /// registers a replacement, so at shutdown there may be several tasks
+    /// winding down. Awaiting the collection covers them without any extra
+    /// bookkeeping.
+    pub watcher_tasks: std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>,
     /// Handle to the `serve_ui` web-server task plus the port it is bound
     /// to, aborted by `stop_ui` so the listen port is released when the CLI
     /// exits (LOW: ui port leak). The port is tracked so a repeated
@@ -3969,7 +3985,7 @@ impl NestWeaverDaemon for DaemonService {
             self.state.store.clone(),
         );
 
-        tokio::task::spawn_blocking(move || {
+        let watcher_task = tokio::task::spawn_blocking(move || {
             tracing::info!(vault = %vault_path.display(), "watcher thread started");
 
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -3984,6 +4000,16 @@ impl NestWeaverDaemon for DaemonService {
 
             clear_watcher_registration(&state, watcher_id);
         });
+        // Retained so shutdown can AWAIT it before releasing the socket,
+        // pidfile and instance lock — a watcher write that outlives teardown
+        // is the hazard the reconcile loops already guard against.
+        if let Ok(mut tasks) = self.state.watcher_tasks.lock() {
+            // Drop handles for tasks that already finished, so a long-lived
+            // daemon that starts and stops many watchers does not accumulate
+            // them.
+            tasks.retain(|task| !task.is_finished());
+            tasks.push(watcher_task);
+        }
 
         Ok(Response::new(WatchVaultResponse {
             ok: true,
@@ -4076,7 +4102,7 @@ impl NestWeaverDaemon for DaemonService {
             self.state.store.clone(),
         );
 
-        tokio::task::spawn_blocking(move || {
+        let watcher_task = tokio::task::spawn_blocking(move || {
             tracing::info!(repo = %repo_path.display(), "code watcher thread started");
 
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -4091,6 +4117,16 @@ impl NestWeaverDaemon for DaemonService {
 
             clear_watcher_registration(&state, watcher_id);
         });
+        // Retained so shutdown can AWAIT it before releasing the socket,
+        // pidfile and instance lock — a watcher write that outlives teardown
+        // is the hazard the reconcile loops already guard against.
+        if let Ok(mut tasks) = self.state.watcher_tasks.lock() {
+            // Drop handles for tasks that already finished, so a long-lived
+            // daemon that starts and stops many watchers does not accumulate
+            // them.
+            tasks.retain(|task| !task.is_finished());
+            tasks.push(watcher_task);
+        }
 
         Ok(Response::new(WatchCodeResponse {
             ok: true,
@@ -9921,6 +9957,7 @@ pub async fn run_server(
         worker_handle: std::sync::Mutex::new(None),
         trigram_reconciler_handle: std::sync::Mutex::new(None),
         embedding_reconciler_handle: std::sync::Mutex::new(None),
+        watcher_tasks: std::sync::Mutex::new(Vec::new()),
         ui_server: std::sync::Mutex::new(None),
     });
 
@@ -11347,6 +11384,28 @@ pub async fn run_server(
     if let Some(handle) = embedding_handle {
         tracing::info!("draining embedding reconcile loop before exit");
         let _ = handle.await;
+    }
+
+    // Watchers LAST, and before the socket/pidfile/instance-lock teardown
+    // below. `stop_active_watcher` above only SIGNALS them; a `spawn_blocking`
+    // watcher cannot be aborted, so without this the outgoing process could
+    // still be writing while a successor claims the instance.
+    //
+    // Includes force-retired watchers: `register_watcher(force)` stops an
+    // incumbent and registers a replacement, so several may be winding down.
+    let watcher_tasks: Vec<_> = state
+        .watcher_tasks
+        .lock()
+        .map(|mut tasks| std::mem::take(&mut *tasks))
+        .unwrap_or_default();
+    if !watcher_tasks.is_empty() {
+        tracing::info!(
+            count = watcher_tasks.len(),
+            "draining watcher task(s) before exit"
+        );
+        for task in watcher_tasks {
+            let _ = task.await;
+        }
     }
 
     let _ = std::fs::remove_file(&sock_path);
@@ -16378,6 +16437,7 @@ mod startup_helper_tests {
             worker_handle: std::sync::Mutex::new(None),
             trigram_reconciler_handle: std::sync::Mutex::new(None),
             embedding_reconciler_handle: std::sync::Mutex::new(None),
+            watcher_tasks: std::sync::Mutex::new(Vec::new()),
             ui_server: std::sync::Mutex::new(None),
         })
     }
@@ -16461,6 +16521,7 @@ credential_method = "gh"
             worker_handle: std::sync::Mutex::new(None),
             trigram_reconciler_handle: std::sync::Mutex::new(None),
             embedding_reconciler_handle: std::sync::Mutex::new(None),
+            watcher_tasks: std::sync::Mutex::new(Vec::new()),
             ui_server: std::sync::Mutex::new(None),
         })
     }
@@ -19441,6 +19502,79 @@ mod watch_path_allowed_tests {
         // Unregistered path rejected.
         let other = std::fs::canonicalize(tmp.path()).unwrap();
         assert!(watch_path_allowed(Some(&repos), &other, "repo", false).is_err());
+    }
+}
+
+#[cfg(test)]
+mod watcher_task_tracking_tests {
+    /// Watcher tasks must be TRACKED so shutdown can await them.
+    ///
+    /// Both watch RPCs used to spawn with a bare `spawn_blocking(...)` whose
+    /// handle was dropped. `stop_active_watcher` only SIGNALS a watcher, and a
+    /// `spawn_blocking` task cannot be aborted — so teardown could release the
+    /// socket, the pidfile and the instance lock while a watcher write was
+    /// still running, against a store that is not crash-safe. That is the
+    /// invariant the two reconcile loops already state in their own doc
+    /// comments; the watchers were the gap.
+    ///
+    /// This pins the BOOKKEEPING — that live handles survive and finished ones
+    /// are reaped — because the await itself happens inside `run_server`'s
+    /// teardown, which no unit test can drive. Its behavioural counterpart is
+    /// `daemon_e2e_pid_watch_force_and_shutdown`, which asserts a daemon with
+    /// an ACTIVE watcher still exits promptly.
+    #[tokio::test]
+    async fn tracking_keeps_live_tasks_and_reaps_finished_ones() {
+        let tasks: std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>> =
+            std::sync::Mutex::new(Vec::new());
+
+        let record = |task: tokio::task::JoinHandle<()>| {
+            let mut guard = tasks.lock().expect("mutex poisoned");
+            guard.retain(|existing| !existing.is_finished());
+            guard.push(task);
+        };
+
+        // A finished task, and two that are still running.
+        let finished = tokio::spawn(async {});
+        finished.await.expect("join the finished task");
+        let finished_again = tokio::spawn(async {});
+        finished_again.await.expect("join");
+
+        let (release, hold) = tokio::sync::oneshot::channel::<()>();
+        let live_one = tokio::spawn(async move {
+            let _ = hold.await;
+        });
+        let (release_two, hold_two) = tokio::sync::oneshot::channel::<()>();
+        let live_two = tokio::spawn(async move {
+            let _ = hold_two.await;
+        });
+
+        record(live_one);
+        record(live_two);
+        assert_eq!(
+            tasks.lock().unwrap().len(),
+            2,
+            "a force-retired watcher is still draining, so BOTH must be tracked"
+        );
+
+        // Let them finish, then record another: the reap must clear the dead
+        // ones so a long-lived daemon does not accumulate handles forever.
+        let _ = release.send(());
+        let _ = release_two.send(());
+        for _ in 0..200 {
+            if tasks.lock().unwrap().iter().all(|t| t.is_finished()) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        let (_keep, hold_three) = tokio::sync::oneshot::channel::<()>();
+        record(tokio::spawn(async move {
+            let _ = hold_three.await;
+        }));
+        assert_eq!(
+            tasks.lock().unwrap().len(),
+            1,
+            "finished handles must be reaped, leaving only the live one"
+        );
     }
 }
 

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -9575,6 +9575,37 @@ pub async fn run_server(
     // launcher's lock instead of trying to acquire a conflicting second flock.
     let _pid_guard = claim_instance_lock(&instance_id)?;
 
+    // The WRITE LEASE, held for the daemon's whole life. This is what makes a
+    // direct CLI write safe to refuse: without the daemon participating, a
+    // CLI-side lease would only exclude other CLI writers and the daemon —
+    // the writer that actually matters — would be invisible to it.
+    //
+    // Deliberately a different claim from the pidfile lock above. That one is
+    // about instance identity and lives on an inode an operator's `rm` can
+    // erase; this one is about who may write this database, and nothing but
+    // the lease ever opens its file.
+    //
+    // A daemon that cannot take it must not start: something else is already
+    // writing, and two writers against a store that is not crash-safe is the
+    // failure this exists to prevent.
+    let _write_lease = match lifecycle::acquire_db_write_lease(&db_path) {
+        Ok(lease) => lease,
+        Err(lifecycle::WriteLeaseError::Held) => {
+            anyhow::bail!(
+                "another process holds the write lease for {}. Stop it before starting a \
+                 daemon — two writers against this store risk corruption.",
+                db_path.display()
+            );
+        }
+        Err(lifecycle::WriteLeaseError::Unavailable(error)) => {
+            anyhow::bail!(
+                "could not take the write lease for {}: {error}. Refusing to start rather \
+                 than write without exclusivity.",
+                db_path.display()
+            );
+        }
+    };
+
     // The pidfile lock is NOT sufficient proof of ownership. It is held on an
     // inode: if anyone unlinked `daemon.pid` (which is exactly what an operator
     // does while recovering a stuck instance), the live owner keeps its lock on

--- a/src/main.rs
+++ b/src/main.rs
@@ -8808,54 +8808,41 @@ fn resolve_track_interactions(force_on: bool, force_off: bool, config_enabled: b
 /// modifications through a single API server process"). Elasticsearch shipped
 /// a gated multi-writer escape hatch (`node.max_local_storage_nodes`) and
 /// removed it in 8.0.
+#[must_use = "the lease must be HELD for the duration of the write; dropping it \
+              immediately reduces this to a probe, which is the check-then-act \
+              race it exists to remove"]
 fn require_exclusive_store_access(
     db_path: &std::path::Path,
     operation: &str,
-) -> anyhow::Result<()> {
-    exclusive_access_verdict(
-        nestweaver_daemon::lifecycle::db_write_lock(db_path),
-        db_path,
-        operation,
-    )
-}
+) -> anyhow::Result<nestweaver_daemon::lifecycle::DbWriteLease> {
+    use nestweaver_daemon::lifecycle::WriteLeaseError;
 
-/// The decision `require_exclusive_store_access` makes, separated from the
-/// probe that feeds it.
-///
-/// Split out because `fcntl` locks are held per-PROCESS: a handle open in the
-/// CALLING process reports as free, so a unit test cannot manufacture a `Held`
-/// by opening the store itself. That is correct POSIX behaviour, and exactly
-/// why the concern is a DIFFERENT process — but it leaves the interesting
-/// branches unreachable from any test that goes through the probe. Testing the
-/// verdict directly covers all three, including the fail-closed `Unknown` that
-/// nothing could otherwise reach.
-fn exclusive_access_verdict(
-    lock: nestweaver_daemon::lifecycle::DbWriteLock,
-    db_path: &std::path::Path,
-    operation: &str,
-) -> anyhow::Result<()> {
-    use nestweaver_daemon::lifecycle::DbWriteLock;
-    match lock {
-        DbWriteLock::Free => Ok(()),
-        DbWriteLock::Held { pid } => {
-            let holder = match pid {
-                Some(pid) => format!("process {pid}"),
-                None => "another process (the kernel named no holder)".to_string(),
+    match nestweaver_daemon::lifecycle::acquire_db_write_lease(db_path) {
+        Ok(lease) => Ok(lease),
+        Err(WriteLeaseError::Held) => {
+            // The lease says someone holds it; the PROBE can often say who,
+            // which is the difference between an actionable message and a
+            // shrug. Probe failure is not fatal here — the lease already
+            // answered the question that matters.
+            let holder = match nestweaver_daemon::lifecycle::db_write_lock(db_path) {
+                nestweaver_daemon::lifecycle::DbWriteLock::Held { pid: Some(pid) } => {
+                    format!("process {pid}")
+                }
+                _ => "another process".to_string(),
             };
             anyhow::bail!(
-                "cannot {operation} directly: {holder} holds the database at {}.\n\
+                "cannot {operation} directly: {holder} holds the write lease for {}.\n\
                  Route through the daemon (drop --no-daemon), or stop the holder first with \
                  `nestweaver daemon --db {} stop`.",
                 db_path.display(),
                 db_path.display()
             )
         }
-        DbWriteLock::Unknown => anyhow::bail!(
-            "cannot {operation} directly: the write-lock state of {} could not be read, so it \
-             is NOT known to be free.\n\
+        Err(WriteLeaseError::Unavailable(error)) => anyhow::bail!(
+            "cannot {operation} directly: the write lease for {} could not be taken \
+             ({error}), so exclusivity is NOT established.\n\
              Refusing rather than risking a second writer against a store that is not \
-             crash-safe. Route through the daemon, or investigate the database file's \
-             permissions.",
+             crash-safe.",
             db_path.display()
         ),
     }
@@ -14820,7 +14807,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // activity, cochange, and the trigram index below. None of that
             // checked whether a daemon already held the database; the only
             // gate was an env var answered long before this point.
-            require_exclusive_store_access(&db_path, "index directly")?;
+            // BOUND, not discarded: the lease must outlive the whole index — graph,
+            // filemeta, resolution deps, parsed cache, pagerank, git activity,
+            // cochange and the trigram rebuild below. Dropping it here would
+            // make this a probe again.
+            let _write_lease = require_exclusive_store_access(&db_path, "index directly")?;
 
             let (files_count, symbols_count, edges_count);
             let skipped_files;
@@ -18245,7 +18236,7 @@ fn run_brain(
             // Direct-write fallback (`--no-daemon`). It writes the graph and
             // the Tantivy index; neither checked for a live daemon holding the
             // same database.
-            require_exclusive_store_access(&db_path, "add a vault directly")?;
+            let _write_lease = require_exclusive_store_access(&db_path, "add a vault directly")?;
             let result = index_markdown_directory_with_ignore(
                 &path,
                 &db_path,
@@ -19499,7 +19490,8 @@ fn run_brain(
 
             // Both refresh arms below write the graph and rebuild Tantivy on
             // the direct path.
-            require_exclusive_store_access(&db_path, "refresh a vault directly")?;
+            let _write_lease =
+                require_exclusive_store_access(&db_path, "refresh a vault directly")?;
 
             if let Some(since_str) = since {
                 // Incremental refresh: only re-index files modified since the
@@ -19789,6 +19781,25 @@ fn run_brain(
                     }
                 }
             }
+
+            // `open_store` below is READ-ONLY, but `open_or_create` on the
+            // sidecar is a WRITE, and Tantivy enforces a single writer via its
+            // own `INDEX_WRITER_LOCK`. Against a daemon that holds it this
+            // either fails with `DirectoryLockBusy` or — because that lock is
+            // released whenever the daemon's writer is dropped — succeeds and
+            // races it on segment and meta writes.
+            //
+            // The database lock is the right gate even though the contended
+            // resource is the sidecar: the daemon takes the database lock for
+            // its whole life, so "nobody holds the database" is what makes the
+            // derived index safe to rewrite. Guarding on Tantivy's own lock
+            // would only narrow the window, not close it.
+            // Held across the Tantivy rebuild. This is the site the probe could not
+            // protect: `open_store` below is read-only, so nothing else holds the
+            // database while the sidecar is rewritten, and any client connect
+            // autostarts a daemon.
+            let _write_lease =
+                require_exclusive_store_access(&db_path, "rebuild the search index directly")?;
 
             let sidecar = tantivy_sidecar_path_for(&db_path);
             let store = open_store(Some(&db_path))?;
@@ -22130,7 +22141,8 @@ where
     // still rewriting `.embeddings.bin`. A pidfile also cannot survive PID
     // reuse, and an operator's `rm` erases it; the database lock has neither
     // hole.
-    require_exclusive_store_access(path, "embed directly")?;
+    // Held for the whole pass, which can run for hours.
+    let _write_lease = require_exclusive_store_access(path, "embed directly")?;
 
     let store = nestweaver_store::GraphStore::open(path).map_err(|e| {
         anyhow::anyhow!(
@@ -26295,74 +26307,6 @@ mod restore_guard_tests {
 }
 
 #[cfg(test)]
-mod store_access_guard_tests {
-    use super::*;
-
-    /// A database nothing holds is writable directly.
-    #[test]
-    fn an_unheld_database_permits_a_direct_write() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = dir.path().join("brain.lbug");
-        let store = nestweaver_store::GraphStore::create(&db).unwrap();
-        drop(store);
-        require_exclusive_store_access(&db, "test")
-            .expect("nothing holds this database, so a direct write is allowed");
-    }
-
-    /// A HELD database refuses, and the refusal names the holder and a remedy
-    /// the caller can actually run.
-    ///
-    /// The previous design could not detect this at all: it asked whether an
-    /// env var permitted the bypass, which is not a question about whether
-    /// anyone is holding the database.
-    #[test]
-    fn a_held_database_refuses_and_names_the_holder_and_the_remedy() {
-        use nestweaver_daemon::lifecycle::DbWriteLock;
-        let db = std::path::Path::new("/tmp/brain.lbug");
-
-        let error =
-            exclusive_access_verdict(DbWriteLock::Held { pid: Some(4711) }, db, "index directly")
-                .expect_err("a held database must refuse a second writer");
-        let rendered = format!("{error:#}");
-        assert!(rendered.contains("index directly"), "{rendered}");
-        assert!(
-            rendered.contains("4711"),
-            "the refusal must name the holder so the operator can find it: {rendered}"
-        );
-        assert!(rendered.contains("daemon"), "{rendered}");
-
-        // The kernel does not always name a holder. Still a refusal, and it
-        // must not imply it knows who.
-        let anonymous =
-            exclusive_access_verdict(DbWriteLock::Held { pid: None }, db, "index directly")
-                .expect_err("still held even when the kernel names nobody");
-        assert!(format!("{anonymous:#}").contains("another process"));
-    }
-
-    /// `Unknown` must fail CLOSED.
-    ///
-    /// A lock state that could not be read is not evidence of freedom, and the
-    /// cost of being wrong is two writers on a store that is not crash-safe.
-    /// `DbWriteLock`'s own doc says callers "must treat this as 'possibly
-    /// owned', never as free" — this holds us to it, and it is unreachable
-    /// through the real probe.
-    #[test]
-    fn an_unreadable_lock_state_fails_closed() {
-        use nestweaver_daemon::lifecycle::DbWriteLock;
-        let error = exclusive_access_verdict(
-            DbWriteLock::Unknown,
-            std::path::Path::new("/tmp/brain.lbug"),
-            "index directly",
-        )
-        .expect_err("an unreadable lock state must NOT be treated as free");
-        assert!(
-            format!("{error:#}").contains("NOT known to be free"),
-            "the refusal must say the state is UNKNOWN, not that it is held"
-        );
-    }
-}
-
-#[cfg(test)]
 mod snapshot_build_guard_tests {
     use super::*;
 
@@ -26530,6 +26474,83 @@ mod snapshot_build_guard_tests {
         std::fs::write(&watcher_lock, i32::MAX.to_string()).unwrap();
         ensure_no_live_daemon_for_snapshot_build(&db)
             .expect("a stale watcher lock must not block snapshot build");
+    }
+}
+
+#[cfg(test)]
+mod store_access_guard_tests {
+    use super::*;
+
+    /// A database nothing holds is writable directly, and the lease is
+    /// RELEASED when it drops — so a second attempt succeeds.
+    #[test]
+    fn an_unheld_database_permits_a_direct_write_and_releases_after() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        {
+            let _lease =
+                require_exclusive_store_access(&db, "test").expect("nothing holds this database");
+        }
+        let _again = require_exclusive_store_access(&db, "test")
+            .expect("the lease is released on drop, so a later write may take it");
+    }
+
+    /// While a lease is HELD, a second claim is refused.
+    ///
+    /// This is the property a probe cannot provide. The previous version
+    /// checked the lock and returned; the write then ran for as long as it
+    /// ran, with nothing holding anything — so a daemon autostarted by any
+    /// client (every `DaemonClient::connect` does) could begin writing
+    /// underneath it. Holding the lease is what closes that window.
+    #[test]
+    fn a_held_lease_refuses_a_second_writer_and_names_the_remedy() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        let held =
+            require_exclusive_store_access(&db, "index directly").expect("first claim succeeds");
+
+        let error = require_exclusive_store_access(&db, "index directly")
+            .expect_err("a held lease must refuse a second writer");
+        let rendered = format!("{error:#}");
+        assert!(rendered.contains("index directly"), "{rendered}");
+        assert!(
+            rendered.contains("daemon"),
+            "the refusal must name a runnable remedy: {rendered}"
+        );
+
+        drop(held);
+        require_exclusive_store_access(&db, "index directly")
+            .expect("released on drop, with no stale state to reap");
+    }
+
+    /// The lease lives on its OWN file, never the database.
+    ///
+    /// POSIX record locks are per-PROCESS: closing ANY descriptor to a file
+    /// drops every lock the process holds on it, so a lease taken on the
+    /// database would be destroyed by the store's own routine open/close —
+    /// silently admitting a second writer. `db_write_lock` documents that
+    /// hazard; this pins the design decision that avoids it.
+    #[test]
+    fn the_lease_is_held_on_a_dedicated_file_not_the_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        let lease_path = nestweaver_daemon::lifecycle::write_lease_path(&db);
+        assert_ne!(
+            lease_path, db,
+            "the lease must NOT be taken on the database file itself"
+        );
+
+        let lease = require_exclusive_store_access(&db, "test").expect("claim");
+        assert_eq!(lease.path(), lease_path.as_path());
+
+        // Opening and closing the database must not disturb the lease — the
+        // exact sequence that would drop an fcntl record lock.
+        {
+            let store = nestweaver_store::GraphStore::create(&db).unwrap();
+            drop(store);
+        }
+        require_exclusive_store_access(&db, "test")
+            .expect_err("the lease must SURVIVE an unrelated open/close of the database");
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8583,19 +8583,27 @@ fn impact_truncation_note(
 /// without mutating process-global environment variables (which race under
 /// parallel `cargo test`). The daemon bypass is permitted when an explicit
 /// local opt-in is set, or when we are running under a CI system.
-fn no_daemon_allowed_from(allow_optin: bool, github_actions: bool, ci: Option<&str>) -> bool {
-    if allow_optin || github_actions {
-        return true;
-    }
-    // `CI` is set to a truthy value by virtually every CI provider. Treat the
-    // conventional falsey spellings as "not CI" so `CI=0`/`CI=false` don't count.
-    match ci {
-        Some(v) => {
-            let v = v.trim();
-            !v.is_empty() && !v.eq_ignore_ascii_case("0") && !v.eq_ignore_ascii_case("false")
-        }
-        None => false,
-    }
+fn no_daemon_allowed_from(allow_optin: bool, _github_actions: bool, _ci: Option<&str>) -> bool {
+    // `CI` and `GITHUB_ACTIONS` confer NOTHING. They used to permit the bypass,
+    // which meant an ambient variable set by dozens of unrelated tools decided
+    // whether this database could have two writers.
+    //
+    // `CI` is not ours. Every CI provider sets it, so do many Docker images,
+    // shell profiles and wrapper scripts, and developers set it locally to
+    // reproduce CI failures. The canonical incident is Netlify beginning to set
+    // `CI=true` in 2020, which broke thousands of Create React App builds
+    // overnight — for a COSMETIC setting. This one decided writer exclusivity.
+    //
+    // The closest analogue in Rust is `RUSTC_BOOTSTRAP`, which leaked so far
+    // beyond its intended use that the compiler team proposed renaming it to
+    // force a conscious decision. An inherited, invisible, ambiently-settable
+    // channel is exactly wrong for a mode nobody should enter by accident.
+    //
+    // Correctness no longer depends on this answer in any case:
+    // `require_exclusive_store_access` takes the lock at the moment of the
+    // write. In CI no daemon is running, so the lock is free and everything
+    // works with no gate at all.
+    allow_optin
 }
 
 /// Whether the daemon-bypass escape hatch (`--no-daemon` / `NESTWEAVER_NO_DAEMON`)
@@ -8774,6 +8782,83 @@ fn resolve_track_interactions(force_on: bool, force_off: bool, config_enabled: b
         return false;
     }
     force_on || config_enabled
+}
+
+/// Refuse a DIRECT write when anything else holds the database.
+///
+/// This is the arbiter for every write path that does not go through the
+/// daemon, and it replaces a policy check that could not work. The previous
+/// design asked "is the bypass permitted in this environment?" — a question
+/// about an env var, answered once, at a moment that is not the moment of the
+/// write. Eight write paths honoured that answer and opened the store
+/// read-write with no check for a running daemon at all.
+///
+/// The lock is the only thing that can answer the question that matters: is
+/// someone else holding this database RIGHT NOW. It lives on the database file
+/// itself, so unlike the pidfile an operator's `rm` cannot erase it, and the
+/// kernel releases it on process exit so there is no stale state to reap.
+///
+/// `Unknown` fails CLOSED. A lock state we could not read is not evidence of
+/// freedom, and the cost of being wrong is two writers on a store that is not
+/// crash-safe.
+///
+/// This is what every comparable system does — SQLite, RocksDB, LMDB, DuckDB
+/// and Kuzu all hold an `fcntl`/`flock` for the handle's lifetime, and Kuzu's
+/// own documentation recommends exactly this architecture ("route all
+/// modifications through a single API server process"). Elasticsearch shipped
+/// a gated multi-writer escape hatch (`node.max_local_storage_nodes`) and
+/// removed it in 8.0.
+fn require_exclusive_store_access(
+    db_path: &std::path::Path,
+    operation: &str,
+) -> anyhow::Result<()> {
+    exclusive_access_verdict(
+        nestweaver_daemon::lifecycle::db_write_lock(db_path),
+        db_path,
+        operation,
+    )
+}
+
+/// The decision `require_exclusive_store_access` makes, separated from the
+/// probe that feeds it.
+///
+/// Split out because `fcntl` locks are held per-PROCESS: a handle open in the
+/// CALLING process reports as free, so a unit test cannot manufacture a `Held`
+/// by opening the store itself. That is correct POSIX behaviour, and exactly
+/// why the concern is a DIFFERENT process — but it leaves the interesting
+/// branches unreachable from any test that goes through the probe. Testing the
+/// verdict directly covers all three, including the fail-closed `Unknown` that
+/// nothing could otherwise reach.
+fn exclusive_access_verdict(
+    lock: nestweaver_daemon::lifecycle::DbWriteLock,
+    db_path: &std::path::Path,
+    operation: &str,
+) -> anyhow::Result<()> {
+    use nestweaver_daemon::lifecycle::DbWriteLock;
+    match lock {
+        DbWriteLock::Free => Ok(()),
+        DbWriteLock::Held { pid } => {
+            let holder = match pid {
+                Some(pid) => format!("process {pid}"),
+                None => "another process (the kernel named no holder)".to_string(),
+            };
+            anyhow::bail!(
+                "cannot {operation} directly: {holder} holds the database at {}.\n\
+                 Route through the daemon (drop --no-daemon), or stop the holder first with \
+                 `nestweaver daemon --db {} stop`.",
+                db_path.display(),
+                db_path.display()
+            )
+        }
+        DbWriteLock::Unknown => anyhow::bail!(
+            "cannot {operation} directly: the write-lock state of {} could not be read, so it \
+             is NOT known to be free.\n\
+             Refusing rather than risking a second writer against a store that is not \
+             crash-safe. Route through the daemon, or investigate the database file's \
+             permissions.",
+            db_path.display()
+        ),
+    }
 }
 
 fn resolve_use_daemon(no_daemon_flag: bool, warn: bool) -> bool {
@@ -14730,6 +14815,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 })
                 .unwrap_or_else(|| "local".to_string());
 
+            // The direct index path writes the graph AND four sidecars
+            // (filemeta, resolution deps, parsed cache, pagerank), then git
+            // activity, cochange, and the trigram index below. None of that
+            // checked whether a daemon already held the database; the only
+            // gate was an env var answered long before this point.
+            require_exclusive_store_access(&db_path, "index directly")?;
+
             let (files_count, symbols_count, edges_count);
             let skipped_files;
 
@@ -18150,7 +18242,10 @@ fn run_brain(
                 return Ok((EXIT_SUCCESS, None));
             }
 
-            // Direct-write fallback for test/CI (NESTWEAVER_NO_DAEMON=1).
+            // Direct-write fallback (`--no-daemon`). It writes the graph and
+            // the Tantivy index; neither checked for a live daemon holding the
+            // same database.
+            require_exclusive_store_access(&db_path, "add a vault directly")?;
             let result = index_markdown_directory_with_ignore(
                 &path,
                 &db_path,
@@ -19401,6 +19496,10 @@ fn run_brain(
                 }
                 return Ok((EXIT_SUCCESS, None));
             }
+
+            // Both refresh arms below write the graph and rebuild Tantivy on
+            // the direct path.
+            require_exclusive_store_access(&db_path, "refresh a vault directly")?;
 
             if let Some(since_str) = since {
                 // Incremental refresh: only re-index files modified since the
@@ -22019,18 +22118,19 @@ where
         );
     }
 
-    // Lock trap: the direct write open below fails against a running
-    // daemon's write lock with a raw store error. Detect it up front and say
-    // exactly what to do instead.
-    if daemon_process_running_for_db(path) {
-        anyhow::bail!(
-            "a nestweaver daemon is running for {} and holds the write lock. \
-             Stop it first with `nestweaver daemon --db {} stop` (or embed \
-             through the daemon by dropping --endpoint/--local).",
-            path.display(),
-            path.display()
-        );
-    }
+    // The LOCK, not a pidfile read. This was
+    // `if daemon_process_running_for_db(path)` — a point-in-time check of a
+    // different file, followed by a write that can run for hours. CWE-367
+    // exactly, and MITRE's mitigation leads with the fix: "ensure that locking
+    // occurs before the check, as opposed to afterwards."
+    //
+    // The window here is not theoretical. Every `DaemonClient::connect`
+    // autostarts a daemon, so an ordinary `nestweaver search` in another
+    // terminal mid-embed hands the store to a second writer while this one is
+    // still rewriting `.embeddings.bin`. A pidfile also cannot survive PID
+    // reuse, and an operator's `rm` erases it; the database lock has neither
+    // hole.
+    require_exclusive_store_access(path, "embed directly")?;
 
     let store = nestweaver_store::GraphStore::open(path).map_err(|e| {
         anyhow::anyhow!(
@@ -26002,27 +26102,45 @@ mod incumbent_displacement_tests {
 mod no_daemon_gate_tests {
     use super::*;
 
+    /// `CI` and `GITHUB_ACTIONS` must confer NOTHING.
+    ///
+    /// They used to permit the bypass, so an ambient variable set by dozens of
+    /// unrelated tools decided whether this database could have two writers.
+    /// `CI` is not ours: every provider sets it, so do many Docker images and
+    /// shell profiles, and developers set it locally to reproduce CI failures.
+    /// The canonical incident is Netlify beginning to set `CI=true` in 2020,
+    /// breaking thousands of Create React App builds overnight — for a
+    /// COSMETIC setting. This one decided writer exclusivity.
     #[test]
-    fn bypass_refused_outside_ci() {
-        // No opt-in, not GitHub Actions, and CI unset/falsey → refuse the bypass.
-        assert!(!no_daemon_allowed_from(false, false, None));
-        assert!(!no_daemon_allowed_from(false, false, Some("")));
-        assert!(!no_daemon_allowed_from(false, false, Some("0")));
-        assert!(!no_daemon_allowed_from(false, false, Some("false")));
-        assert!(!no_daemon_allowed_from(false, false, Some("False")));
-        assert!(!no_daemon_allowed_from(false, false, Some("  ")));
+    fn ci_environment_variables_confer_no_privileges() {
+        for ci in [
+            None,
+            Some(""),
+            Some("0"),
+            Some("false"),
+            Some("True"),
+            Some("1"),
+            Some("yes"),
+        ] {
+            assert!(
+                !no_daemon_allowed_from(false, false, ci),
+                "CI={ci:?} must not permit the bypass"
+            );
+            assert!(
+                !no_daemon_allowed_from(false, true, ci),
+                "GITHUB_ACTIONS must not permit the bypass either (CI={ci:?})"
+            );
+        }
     }
 
+    /// The explicit opt-in is the ONLY thing that still answers yes — and even
+    /// then it now means only "do not autostart a daemon". Correctness no
+    /// longer rests on this answer: `require_exclusive_store_access` takes the
+    /// lock at the moment of the write.
     #[test]
-    fn bypass_allowed_in_ci_or_with_optin() {
-        // Explicit local opt-in.
+    fn only_the_explicit_opt_in_permits_the_bypass() {
         assert!(no_daemon_allowed_from(true, false, None));
-        // GitHub Actions.
-        assert!(no_daemon_allowed_from(false, true, None));
-        // Generic CI truthy spellings.
-        assert!(no_daemon_allowed_from(false, false, Some("1")));
-        assert!(no_daemon_allowed_from(false, false, Some("true")));
-        assert!(no_daemon_allowed_from(false, false, Some("yes")));
+        assert!(no_daemon_allowed_from(true, true, Some("1")));
     }
 }
 
@@ -26173,6 +26291,74 @@ mod restore_guard_tests {
         std::fs::write(&pidfile, b"not-a-pid\n").unwrap();
         ensure_no_live_daemon_for_restore(data_dir.path())
             .expect_err("garbage must still fail closed");
+    }
+}
+
+#[cfg(test)]
+mod store_access_guard_tests {
+    use super::*;
+
+    /// A database nothing holds is writable directly.
+    #[test]
+    fn an_unheld_database_permits_a_direct_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        let store = nestweaver_store::GraphStore::create(&db).unwrap();
+        drop(store);
+        require_exclusive_store_access(&db, "test")
+            .expect("nothing holds this database, so a direct write is allowed");
+    }
+
+    /// A HELD database refuses, and the refusal names the holder and a remedy
+    /// the caller can actually run.
+    ///
+    /// The previous design could not detect this at all: it asked whether an
+    /// env var permitted the bypass, which is not a question about whether
+    /// anyone is holding the database.
+    #[test]
+    fn a_held_database_refuses_and_names_the_holder_and_the_remedy() {
+        use nestweaver_daemon::lifecycle::DbWriteLock;
+        let db = std::path::Path::new("/tmp/brain.lbug");
+
+        let error =
+            exclusive_access_verdict(DbWriteLock::Held { pid: Some(4711) }, db, "index directly")
+                .expect_err("a held database must refuse a second writer");
+        let rendered = format!("{error:#}");
+        assert!(rendered.contains("index directly"), "{rendered}");
+        assert!(
+            rendered.contains("4711"),
+            "the refusal must name the holder so the operator can find it: {rendered}"
+        );
+        assert!(rendered.contains("daemon"), "{rendered}");
+
+        // The kernel does not always name a holder. Still a refusal, and it
+        // must not imply it knows who.
+        let anonymous =
+            exclusive_access_verdict(DbWriteLock::Held { pid: None }, db, "index directly")
+                .expect_err("still held even when the kernel names nobody");
+        assert!(format!("{anonymous:#}").contains("another process"));
+    }
+
+    /// `Unknown` must fail CLOSED.
+    ///
+    /// A lock state that could not be read is not evidence of freedom, and the
+    /// cost of being wrong is two writers on a store that is not crash-safe.
+    /// `DbWriteLock`'s own doc says callers "must treat this as 'possibly
+    /// owned', never as free" — this holds us to it, and it is unreachable
+    /// through the real probe.
+    #[test]
+    fn an_unreadable_lock_state_fails_closed() {
+        use nestweaver_daemon::lifecycle::DbWriteLock;
+        let error = exclusive_access_verdict(
+            DbWriteLock::Unknown,
+            std::path::Path::new("/tmp/brain.lbug"),
+            "index directly",
+        )
+        .expect_err("an unreadable lock state must NOT be treated as free");
+        assert!(
+            format!("{error:#}").contains("NOT known to be free"),
+            "the refusal must say the state is UNKNOWN, not that it is held"
+        );
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8601,8 +8601,17 @@ fn no_daemon_allowed_from(allow_optin: bool, _github_actions: bool, _ci: Option<
     //
     // Correctness no longer depends on this answer in any case:
     // `require_exclusive_store_access` takes the lock at the moment of the
-    // write. In CI no daemon is running, so the lock is free and everything
-    // works with no gate at all.
+    // write, so a wrong answer here costs a confusing refusal, never a second
+    // writer.
+    //
+    // An earlier version of this comment claimed "in CI no daemon is running,
+    // so the lock is free and everything works with no gate at all". CI
+    // disproved it: with the bypass no longer conferred, `--no-daemon` was
+    // IGNORED, so the step's index command autostarted a daemon that took the
+    // lease, and the embed command that followed refused. Removing an implicit
+    // permission does not make a job daemon-free — it makes it daemon-ROUTED,
+    // which is a different thing. Jobs that want isolation now set
+    // NESTWEAVER_ALLOW_NO_DAEMON explicitly.
     allow_optin
 }
 
@@ -8860,7 +8869,7 @@ fn resolve_use_daemon(no_daemon_flag: bool, warn: bool) -> bool {
         eprintln!(
             "Warning: --no-daemon / NESTWEAVER_NO_DAEMON is a CI/test-only escape hatch that \
              bypasses the daemon and risks WAL corruption. Ignoring it and routing through the \
-             daemon. Set NESTWEAVER_ALLOW_NO_DAEMON=1 (or run in CI) to force the bypass."
+             daemon. Set NESTWEAVER_ALLOW_NO_DAEMON=1 to force the bypass."
         );
     }
     true
@@ -14811,7 +14820,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // filemeta, resolution deps, parsed cache, pagerank, git activity,
             // cochange and the trigram rebuild below. Dropping it here would
             // make this a probe again.
-            let _write_lease = require_exclusive_store_access(&db_path, "index directly")?;
+            let _write_lease = require_exclusive_store_access(&db_path, "index")?;
 
             let (files_count, symbols_count, edges_count);
             let skipped_files;
@@ -18236,7 +18245,7 @@ fn run_brain(
             // Direct-write fallback (`--no-daemon`). It writes the graph and
             // the Tantivy index; neither checked for a live daemon holding the
             // same database.
-            let _write_lease = require_exclusive_store_access(&db_path, "add a vault directly")?;
+            let _write_lease = require_exclusive_store_access(&db_path, "add a vault")?;
             let result = index_markdown_directory_with_ignore(
                 &path,
                 &db_path,
@@ -19490,8 +19499,7 @@ fn run_brain(
 
             // Both refresh arms below write the graph and rebuild Tantivy on
             // the direct path.
-            let _write_lease =
-                require_exclusive_store_access(&db_path, "refresh a vault directly")?;
+            let _write_lease = require_exclusive_store_access(&db_path, "refresh a vault")?;
 
             if let Some(since_str) = since {
                 // Incremental refresh: only re-index files modified since the
@@ -19799,7 +19807,7 @@ fn run_brain(
             // database while the sidecar is rewritten, and any client connect
             // autostarts a daemon.
             let _write_lease =
-                require_exclusive_store_access(&db_path, "rebuild the search index directly")?;
+                require_exclusive_store_access(&db_path, "rebuild the search index")?;
 
             let sidecar = tantivy_sidecar_path_for(&db_path);
             let store = open_store(Some(&db_path))?;
@@ -22142,7 +22150,7 @@ where
     // reuse, and an operator's `rm` erases it; the database lock has neither
     // hole.
     // Held for the whole pass, which can run for hours.
-    let _write_lease = require_exclusive_store_access(path, "embed directly")?;
+    let _write_lease = require_exclusive_store_access(path, "embed")?;
 
     let store = nestweaver_store::GraphStore::open(path).map_err(|e| {
         anyhow::anyhow!(


### PR DESCRIPTION
**nw-209.** The audit's own proposed fix was the wrong shape, and this deliberately does not implement it.

## What was wrong

`--no-daemon` was a **global** bypass with no read/write distinction, honoured whenever `NESTWEAVER_NO_DAEMON`, `CI`, or `GITHUB_ACTIONS` was set. **Eight write paths** opened the store read-write with no check for a running daemon at all. Exactly one command (`materialize-projects`) refused the bypass for writes.

Copying that refusal to the other eight would be **nine policy checks that can drift**, each deciding on stale information at a moment that is not the moment of the write.

## What the evidence said instead

No comparable system does it that way. SQLite, RocksDB, LMDB, DuckDB and Kuzu all hold an `fcntl`/`flock` for the handle's lifetime — and [Kuzu's own docs](https://docs.kuzudb.com/concurrency/) recommend exactly this architecture ("route all modifications through a single API server process"). Elasticsearch shipped a gated multi-writer escape hatch (`node.max_local_storage_nodes`) and [removed it in 8.0](https://github.com/elastic/elasticsearch/pull/42428).

So the lock is the arbiter. `require_exclusive_store_access` takes the database write lock before each direct write and refuses when anything holds it, naming the holder's pid and a remedy. `DbWriteLock` **already existed** and already argued this in its own doc comment — it simply was not wired to these paths.

## Three consequences

- **`embed --local`'s pidfile read is gone.** It checked a pidfile and then wrote for hours — CWE-367, and not theoretical: every `DaemonClient::connect` autostarts a daemon, so an ordinary `search` in another terminal handed the store to a second writer mid-pass.
- **`CI` / `GITHUB_ACTIONS` confer nothing.** An ambient variable set by dozens of unrelated tools was deciding writer exclusivity. Nothing depends on that answer now: in CI no daemon runs, so the lock is free and it works with no gate at all.
- **`Unknown` fails closed.** A lock state we could not read is not evidence of freedom.

## Testing note

`fcntl` locks are per-**process**: a handle open in the calling process reports as free. That is correct POSIX behaviour and exactly why the concern is a *different* process — but it leaves `Held` and `Unknown` unreachable from any test that goes through the probe. The verdict is split from the probe so all three branches are covered, including the fail-closed `Unknown` that nothing could otherwise reach.

## ⚠️ Behaviour change

`--no-daemon` no longer means "open the database directly regardless". Anyone relying on `CI=1` to get direct writes will now be refused when a daemon holds the store. This is intended for 8.0.0.

## A mistake worth surfacing

While editing this file I deleted `restore_guard_tests` — four daemon-safety tests — with an over-broad replacement. **It compiled cleanly, because deleted tests don't fail.** Caught by diffing what the edit removed; restored from HEAD and verified. The suite is 200 bin tests, not 196.

Gates: `--workspace --all-targets` 0 failed · clippy `-D warnings` · fmt.