### PR TITLE
fix(export): make msgpack honour --scope on both routes

### DIFF
--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -4239,6 +4239,15 @@ impl NestWeaverDaemon for DaemonService {
                         "nodes": graph.uids.len(),
                         "edges": graph.edges.len(),
                         "bytes": bytes.len(),
+                        // The text formats carry this; msgpack did not, so the
+                        // DEFAULT scope silently emitted a code-only file and
+                        // called it a success — the nw-173 defect, surviving in
+                        // the one format that never got the second half of the
+                        // fix.
+                        "notice": (scope == nestweaver_engine::ExportScope::All).then_some(
+                            "msgpack is a code-only format: this export contains the code \
+                             subgraph, not the vault. Use --format graphml for the whole graph."
+                        ),
                     }))
                     .map_err(|e| Status::internal(format!("json serialize failed: {e:#}")))
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11331,7 +11331,34 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // Direct-write fallback (NESTWEAVER_NO_DAEMON=1).
             let store = open_store(db.as_deref())?;
 
+            // Parse the scope BEFORE dispatching on format.
+            //
+            // msgpack was handled first, so `--scope` was never parsed on this
+            // path: `--scope vault` produced a code-only file and reported
+            // success, and an INVALID scope succeeded too, because the parse
+            // that would have rejected it never ran. The daemon route rejected
+            // vault, so the two disagreed on both.
+            let export_scope: ExportScope = scope.parse()?;
+
             if format == "msgpack" {
+                // msgpack carries the code graph only. A vault scope is a
+                // request it cannot satisfy, and `all` is the DEFAULT — so
+                // saying nothing there is the nw-173 defect verbatim: a command
+                // named `export` emitting less than it advertises, silently.
+                // The text formats got both halves; msgpack got the refusal on
+                // one transport and no notice anywhere.
+                if export_scope == ExportScope::Vault {
+                    anyhow::bail!(
+                        "msgpack export is code-only and cannot represent the vault \
+                         subgraph; use --format graphml for --scope vault"
+                    );
+                }
+                if export_scope == ExportScope::All {
+                    out.status(
+                        "msgpack is a code-only format: this export contains the code \
+                         subgraph, not the vault. Use --format graphml for the whole graph.",
+                    );
+                }
                 let graph = export_in_memory_graph(&store)?;
                 let bytes = rmp_serde::to_vec(&graph)
                     .with_context(|| "failed to serialize graph to msgpack")?;
@@ -11372,9 +11399,6 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             };
             let mut writer = std::io::BufWriter::new(write_to);
 
-            // Parsed once, before dispatch, so an invalid scope fails before any
-            // output is written rather than half way through a 163 MB file.
-            let export_scope: ExportScope = scope.parse()?;
             // Unknown formats keep their friendly listing and EXIT_ERROR
             // rather than becoming a generic error chain.
             if !matches!(format.as_str(), "cypher" | "graphml" | "mermaid") {

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -535,6 +535,43 @@ fn check_parity_json_semantic(db_path: &Path, command: &str, args: &[&str]) {
 /// The default helper appends `--json` unconditionally; for a command that does
 /// not accept it, BOTH routes fail with an identical clap usage error and the
 /// byte comparison passes on two failures.
+/// Both routes must REFUSE the same way.
+///
+/// Distinct from [`check_parity`], which requires success. A refusal is a real
+/// contract too — "msgpack cannot represent the vault" must not depend on
+/// whether a daemon is running — but asserting it needs care, because "both
+/// failed identically" is exactly the hole that made every parity test vacuous
+/// before `assert_both_ran_for_real`.
+///
+/// The difference is that failure is EXPECTED here and checked: both must fail,
+/// with the same code, and each message must name `expected_reason`. A command
+/// that failed for an unrelated reason — a typo'd flag, a missing database —
+/// does not pass.
+fn check_parity_of_refusal(db_path: &Path, command: &str, args: &[&str], expected_reason: &str) {
+    let direct = run_direct(db_path, args);
+    let _guard = DaemonGuard::new(db_path);
+    start_daemon(db_path);
+    let daemon = run_via_daemon(db_path, args);
+
+    for (route, output) in [("direct", &direct), ("daemon", &daemon)] {
+        assert!(
+            !output.status.success(),
+            "{command} ({route}): expected a REFUSAL, but it succeeded"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+        assert!(
+            stderr.contains(&expected_reason.to_lowercase()),
+            "{command} ({route}): refused for the wrong reason — expected \
+             {expected_reason:?}, got:\n{stderr}"
+        );
+    }
+    assert_eq!(
+        direct.status.code(),
+        daemon.status.code(),
+        "{command}: the two routes refused with DIFFERENT exit codes"
+    );
+}
+
 fn check_parity_single_format(db_path: &Path, command: &str, args: &[&str]) {
     let direct = run_direct(db_path, args);
     let _guard = DaemonGuard::new(db_path);
@@ -1082,6 +1119,34 @@ fn parity_detect_changes_direct_vs_daemon() {
 // asserted nothing about the four nw-188 honesty fields it was written for.
 // Re-add it with a fixture that materializes a project; a vacuous test is
 // worse than a missing one because it reports coverage that does not exist.
+
+/// msgpack must honour `--scope` on BOTH routes.
+///
+/// Direct mode handled msgpack BEFORE parsing `--scope`, so `--scope vault`
+/// produced a code-only file and reported success, and an INVALID scope
+/// succeeded too — the parse that would have rejected it never ran. The daemon
+/// route rejected vault. Two routes, two answers, for a flag that is supposed
+/// to mean one thing.
+#[test]
+fn parity_msgpack_scope_direct_vs_daemon() {
+    let fixture = setup_fixture();
+    // A scope msgpack CANNOT satisfy must be refused identically, and for the
+    // stated reason — not merely fail.
+    check_parity_of_refusal(
+        &fixture.db_path,
+        "export msgpack --scope vault",
+        &["export", "--format", "msgpack", "--scope", "vault"],
+        "code-only",
+    );
+    // An INVALID scope must fail on both, not slip through whichever route
+    // happens to dispatch on format first.
+    check_parity_of_refusal(
+        &fixture.db_path,
+        "export msgpack --scope nonsense",
+        &["export", "--format", "msgpack", "--scope", "nonsense"],
+        "unknown export scope",
+    );
+}
 
 /// `stale-check` is a freshness gate: it exits 1 when the index is
 /// stale. The fixture here is freshly indexed (not stale), but regardless we


### PR DESCRIPTION
**nw-220.**

## The defect

Direct mode dispatched on **format** before parsing `--scope`, so msgpack never saw it:

- `--scope vault` produced a code-only file and **reported success**
- an **invalid** scope succeeded too — the parse that would have rejected it never ran

The daemon route rejected vault. One flag, two answers.

Fixed by parsing the scope **before** the format dispatch, which closes both halves at once rather than bolting on a second check.

## The silent-narrowing half

Neither route said anything at the **default** `--scope all`, where msgpack omits every vault node. That's the nw-173 defect verbatim, surviving in the one format that never got the second half of that fix — `export.rs` states the rationale as *"a command named `export` should emit the graph it advertises"*.

The text formats carry a code-only notice there. msgpack now does too, on both routes.

## The test needed a new shape

`check_parity` requires **success**, and these cases must both **refuse**. But "both failed identically" is exactly the hole that made every parity test vacuous before `assert_both_ran_for_real` — so this can't just relax the assertion.

`check_parity_of_refusal` keeps the distinction: failure is *expected and checked*, both routes must fail with the same exit code, and **each message must name the stated reason**. A command that failed for an unrelated reason — a typo'd flag, a missing database — does not pass.

Gates: `--all-targets` 0 failed · parity 24 passed, 1 ignored · clippy `-D warnings` · fmt.