### PR TITLE
fix(mcp,daemon,cli): close two MCP/CLI parity gaps — code_context and stale-ranking disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Personalized PageRank with per-edge-type weights (CALLS, IMPORTS, USES, ACCESSES
 </td>
 <td width="50%" valign="top">
 
-**41-Tool MCP Server**<br>
+**42-Tool MCP Server**<br>
 Model Context Protocol tools for AI agents. Drop-in for any MCP client, lite mode for Cursor. Daemon architecture enables concurrent access from multiple AI tools without lock contention.
 
 </td>
@@ -345,7 +345,7 @@ The regex-v3/embedding-v2 upgrade requires this one-time full rebuild. See the
 
 | Command | Description |
 |---------|-------------|
-| `mcp` | Start the MCP server (41 tools, or 6 in lite mode; auto-starts daemon) |
+| `mcp` | Start the MCP server (42 tools, or 6 in lite mode; auto-starts daemon) |
 | `daemon` | Manage the background daemon (`start`, `stop`, `status`, `restart`; `run --server` for server mode) |
 | `connect` | Connect to an upstream NestWeaver server (federated read/impact) |
 | `server` | Server management utilities (`init-tls`, `backup`, `status`) |
@@ -645,7 +645,7 @@ CLI commands (`search`, `brain search`, `brain context`) also respect this setti
 
 ## MCP Server
 
-NestWeaver exposes 41 tools via the [Model Context Protocol](https://modelcontextprotocol.io), giving any MCP-compatible AI agent structured access to your codebase graph without reading source files directly.
+NestWeaver exposes 42 tools via the [Model Context Protocol](https://modelcontextprotocol.io), giving any MCP-compatible AI agent structured access to your codebase graph without reading source files directly.
 
 ```sh
 nestweaver mcp --db ./nestweaver.lbug
@@ -654,7 +654,7 @@ NESTWEAVER_NO_DAEMON=1 nestweaver mcp --no-daemon --db ./nestweaver.lbug   # rea
 ```
 
 Direct mode advertises 35 read-only tools and rejects mutations before
-dispatch. Daemon-backed stdio exposes all 41 tools. `--tools` names are exact,
+dispatch. Daemon-backed stdio exposes all 42 tools. `--tools` names are exact,
 case-sensitive registry names; unknown, duplicate, empty, or transport-
 unavailable names fail at startup instead of silently producing an empty tool
 surface.
@@ -667,7 +667,7 @@ nestweaver daemon stop --db ./nestweaver.lbug     # stop the daemon manually
 pgrep -af "nestweaver daemon"                     # find running daemons (Linux)
 ```
 
-41 tools including type-aware context retrieval, confidence-weighted impact analysis (`impact_score` shows how strongly changes propagate), investigation bundles, co-change detection, dead code analysis, community detection, and vault/notes integration. Use `--tools` to expose only the tools you need. The `--tools`/`--lite` allowlists are enforced on every transport (local stdio, daemon proxy, hybrid, and MCP-over-HTTP), and tool schemas validate their arguments — numeric bounds (e.g. `token_budget` 1–16000, `depth`/`max_depth` 1–15) are enforced and unknown argument names are rejected instead of silently ignored.
+42 tools including type-aware context retrieval, confidence-weighted impact analysis (`impact_score` shows how strongly changes propagate), investigation bundles, co-change detection, dead code analysis, community detection, and vault/notes integration. Use `--tools` to expose only the tools you need. The `--tools`/`--lite` allowlists are enforced on every transport (local stdio, daemon proxy, hybrid, and MCP-over-HTTP), and tool schemas validate their arguments — numeric bounds (e.g. `token_budget` 1–16000, `depth`/`max_depth` 1–15) are enforced and unknown argument names are rejected instead of silently ignored.
 
 ### Key capabilities
 

--- a/crates/nestweaver-daemon/src/safeguards.rs
+++ b/crates/nestweaver-daemon/src/safeguards.rs
@@ -58,6 +58,7 @@ impl QuerySafeguards {
         for tool in &[
             "brain_search",
             "brain_context",
+            "code_context",
             "regex_search",
             "read_symbols",
             "count_patterns",
@@ -107,7 +108,7 @@ impl QuerySafeguards {
         hard_caps.insert("dead_code".to_string(), Duration::from_secs(120));
 
         // Standard hard caps
-        for tool in &["brain_search", "brain_context"] {
+        for tool in &["brain_search", "brain_context", "code_context"] {
             hard_caps.insert(tool.to_string(), Duration::from_secs(60));
         }
         hard_caps.insert("regex_search".to_string(), Duration::from_secs(30));
@@ -136,7 +137,7 @@ impl QuerySafeguards {
         }
 
         // Context tools: 500 default, 5000 cap
-        for tool in &["brain_context", "project_context"] {
+        for tool in &["brain_context", "code_context", "project_context"] {
             default_result_limits.insert(tool.to_string(), 500);
             max_result_limits.insert(tool.to_string(), 5_000);
         }

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -5763,6 +5763,20 @@ impl NestWeaverDaemon for DaemonService {
         }))
     }
 
+    /// CODE-only context, distinct from `get_context`'s hybrid.
+    ///
+    /// `nestweaver context` had no RPC of its own, so its daemon route sent
+    /// `brain_context` — code AND notes with alias resolution — while its
+    /// direct path ran PPR over the symbol graph alone. One command, two
+    /// algorithms over two different node sets, chosen by whether a daemon
+    /// happened to be running.
+    async fn code_context(
+        &self,
+        r: Request<JsonRequest>,
+    ) -> Result<Response<JsonResponse>, Status> {
+        json_rpc!(self, r, "code_context")
+    }
+
     async fn get_context(
         &self,
         r: Request<BrainContextRequest>,

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -417,7 +417,11 @@ mod counted_symbol_search_tests {
 // ── Context command types ─────────────────────────────────────────────────────
 
 /// A single node returned by `build_context`.
-#[derive(Debug, Serialize)]
+// Deserialize so the daemon's `code_context` reply round-trips back into the
+// same type the direct path builds, and BOTH render through one function.
+// Without it the two routes would need separate renderers, which is how
+// `context` came to mean different things on different transports.
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ContextNode {
     pub uid: String,
     pub name: String,
@@ -429,7 +433,11 @@ pub struct ContextNode {
 }
 
 /// A cross-repo relationship surfaced during context building.
-#[derive(Debug, Serialize)]
+// Deserialize so the daemon's `code_context` reply round-trips back into the
+// same type the direct path builds, and BOTH render through one function.
+// Without it the two routes would need separate renderers, which is how
+// `context` came to mean different things on different transports.
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CrossRepoLink {
     pub package: String,
     pub link_type: String,
@@ -437,7 +445,11 @@ pub struct CrossRepoLink {
 }
 
 /// The full result returned by `build_context`.
-#[derive(Debug, Serialize)]
+// Deserialize so the daemon's `code_context` reply round-trips back into the
+// same type the direct path builds, and BOTH render through one function.
+// Without it the two routes would need separate renderers, which is how
+// `context` came to mean different things on different transports.
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ContextResult {
     pub seeds: Vec<ContextNode>,
     pub connected: Vec<ContextNode>,

--- a/crates/nestweaver-federation/src/dispatch.rs
+++ b/crates/nestweaver-federation/src/dispatch.rs
@@ -76,6 +76,7 @@ pub async fn dispatch_json_rpc_authed(
         "count_patterns" => client.count_patterns(request).await,
         "cross_repo_contracts" => client.cross_repo_contracts(request).await,
         "contract_drift" => client.contract_drift(request).await,
+        "code_context" => client.code_context(request).await,
         "dead_code" => client.dead_code(request).await,
         "brain_broken_links" => client.brain_broken_links(request).await,
         "brain_orphan_documents" => client.brain_orphan_documents(request).await,

--- a/crates/nestweaver-federation/src/routing.rs
+++ b/crates/nestweaver-federation/src/routing.rs
@@ -34,9 +34,8 @@ pub enum ToolRouting {
 pub fn tool_routing(tool_name: &str) -> ToolRouting {
     match tool_name {
         // Search tools — merge
-        "brain_search" | "brain_context" | "project_context" | "search_symbols" => {
-            ToolRouting::Merge
-        }
+        "brain_search" | "brain_context" | "code_context" | "project_context"
+        | "search_symbols" => ToolRouting::Merge,
 
         // Navigation tools — local-first
         "read_symbols" | "investigate" | "investigate_hydrate" => ToolRouting::LocalFirst,
@@ -101,6 +100,7 @@ mod tests {
     fn search_tools_are_merge() {
         assert_eq!(tool_routing("brain_search"), ToolRouting::Merge);
         assert_eq!(tool_routing("brain_context"), ToolRouting::Merge);
+        assert_eq!(tool_routing("code_context"), ToolRouting::Merge);
         assert_eq!(tool_routing("project_context"), ToolRouting::Merge);
         assert_eq!(tool_routing("search_symbols"), ToolRouting::Merge);
     }

--- a/crates/nestweaver-mcp/src/lib.rs
+++ b/crates/nestweaver-mcp/src/lib.rs
@@ -949,10 +949,11 @@ mod tests {
                     "brain_memory_lint",
                     "brain_memory_consolidate",
                     "brain_memory_related",
+                    "code_context",
                 ] {
                     assert!(names.contains(&expected), "missing tool: {expected}");
                 }
-                assert_eq!(tools.len(), 41, "expected 41 tools, got {}", tools.len());
+                assert_eq!(tools.len(), 42, "expected 42 tools, got {}", tools.len());
                 // Every tool has a description leading with usage guidance.
                 for tool in tools {
                     let desc = tool["description"].as_str().expect("description");

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -192,6 +192,7 @@ fn all_tool_schemas() -> Vec<Value> {
 fn all_tool_schemas_undecorated() -> Vec<Value> {
     vec![
         tool_schema_brain_context(),
+        tool_schema_code_context(),
         tool_schema_brain_search(),
         tool_schema_note_get(),
         tool_schema_backlinks(),
@@ -530,7 +531,7 @@ mod tool_schema_validation_tests {
     }
 
     #[test]
-    fn registry_contains_exactly_the_41_advertised_unique_names() {
+    fn registry_contains_exactly_the_42_advertised_unique_names() {
         let expected: BTreeSet<&str> = [
             "affected_tests",
             "backlinks",
@@ -538,6 +539,7 @@ mod tool_schema_validation_tests {
             "brain_add_source",
             "brain_broken_links",
             "brain_context",
+            "code_context",
             "brain_diff",
             "brain_doc_stats",
             "brain_guide",
@@ -580,8 +582,8 @@ mod tool_schema_validation_tests {
         let schemas = all_tool_schemas();
         assert_eq!(
             schemas.len(),
-            41,
-            "registry must contain exactly 41 schemas"
+            42,
+            "registry must contain exactly 42 schemas"
         );
         let names: BTreeSet<&str> = schemas
             .iter()
@@ -866,7 +868,7 @@ mod tool_schema_validation_tests {
 
     /// nw-175. EVERY registered tool must reject unknown argument names.
     ///
-    /// Only 11 of 41 did. The consequence is not cosmetic: a mistyped argument
+    /// Only 11 of 42 did. The consequence is not cosmetic: a mistyped argument
     /// was silently dropped and the handler used its default, so the caller got
     /// a plausible answer to a question they did not ask. That exact failure
     /// was hit twice in one review round — `flow_trace` accepting `max_dpeth`
@@ -1031,7 +1033,8 @@ mod tool_schema_validation_tests {
             .iter()
             .filter_map(|tool| tool["name"].as_str())
             .collect::<Vec<_>>();
-        assert_eq!(names.len(), 35);
+        // 42 registered minus the mutating tools direct read-only hides.
+        assert_eq!(names.len(), 36);
         for mutator in crate::http::MUTATING_TOOLS {
             assert!(!names.contains(mutator), "direct mode advertised {mutator}");
             let error = dispatch(&store, None, mutator, json!({}), None)
@@ -1451,6 +1454,7 @@ mod tool_schema_validation_tests {
 pub fn tool_doc_entries() -> Vec<(String, String, String, Vec<String>)> {
     let categories: &[(&str, &str)] = &[
         ("brain_context", "Core retrieval"),
+        ("code_context", "Core retrieval"),
         ("brain_search", "Core retrieval"),
         ("note_get", "Core retrieval"),
         ("backlinks", "Core retrieval"),
@@ -1735,6 +1739,7 @@ fn dispatch_uncached(
 ) -> Result<Value, anyhow::Error> {
     match name {
         "brain_context" => tool_brain_context(store, tantivy, args, embed_model, cancel),
+        "code_context" => tool_code_context(store, args),
         "brain_search" => tool_brain_search(store, tantivy, args, visible),
         "note_get" => tool_note_get(store, args),
         "backlinks" => tool_backlinks(store, args),
@@ -3188,6 +3193,34 @@ fn validate_brain_context_kinds(kinds: &[String]) -> Result<(), anyhow::Error> {
 
 // ── 1. brain_context ────────────────────────────────────────────────────────
 
+fn tool_schema_code_context() -> Value {
+    json!({
+        "name": "code_context",
+        "description": "Structural subgraph around seed SYMBOLS: personalized PageRank over the code graph alone. Returns the seeds plus the most relevant connected symbols, ranked.\n\nGuidelines:\n- Use when the question is about code structure — what surrounds this function, what is near this class\n- Seeds are symbol names or `sym:` UIDs\n\nLimitations:\n- CODE ONLY. It does not consider notes, tags, or wikilinks, and it does not resolve taxonomy aliases — use brain_context for the unified code+notes view\n- Relevance is PPR over the symbol graph, so scores are NOT comparable with brain_context's, which ranks over a different graph",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "seeds": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Symbol names or `sym:` UIDs to seed the traversal."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Maximum connected symbols to return. Omit for no cap, which is what the CLI does when --limit is absent."
+                },
+                "intent": {
+                    "type": "string",
+                    "description": "Tunes PPR damping and edge weights. Omit for the standard damping (0.85)."
+                }
+            },
+            "required": ["seeds"],
+            "additionalProperties": false
+        }
+    })
+}
+
 fn tool_schema_brain_context() -> Value {
     json!({
         "name": "brain_context",
@@ -3302,6 +3335,74 @@ fn tool_schema_brain_context() -> Value {
             "required": ["seeds"]
         }
     })
+}
+
+/// `code_context` — the CODE-only structural subgraph around seed symbols.
+///
+/// Distinct from `brain_context`, and the distinction is the whole point.
+/// `brain_context` runs a HYBRID over code and notes with taxonomy-alias seed
+/// resolution; this runs PPR over the symbol graph alone.
+///
+/// It exists because `nestweaver context` had no RPC of its own. Its daemon
+/// route sent `brain_context`, while its direct path called
+/// `build_context_with_intent` — so one command ran a different algorithm over
+/// a different node set depending on whether a daemon happened to be running,
+/// and the relevance numbers differed for the same query. The command's own
+/// help says "structural subgraph around seed symbols", so the direct path was
+/// the correct one and the daemon route was silently substituting a different
+/// capability.
+fn tool_code_context(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error> {
+    let seeds: Vec<String> = args
+        .get("seeds")
+        .and_then(|v| v.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    if seeds.is_empty() {
+        anyhow::bail!("code_context requires at least one seed");
+    }
+    // `Option<usize>`, matching the engine: absent means "no cap", which is
+    // what the CLI passes when `--limit` is omitted. Defaulting to a number
+    // here would silently truncate a route the direct path does not.
+    let limit = args
+        .get("limit")
+        .and_then(|v| v.as_u64())
+        .map(|n| n as usize);
+    let intent = args
+        .get("intent")
+        .and_then(|v| v.as_str())
+        .filter(|value| !value.is_empty())
+        .map(|value| {
+            value
+                .parse::<nestweaver_store::ranking::QueryIntent>()
+                .map_err(|error| anyhow::anyhow!("invalid intent: {error}"))
+        })
+        .transpose()?;
+
+    let result = nestweaver_engine::build_context_with_intent(store, &seeds, intent, limit)?;
+
+    let render = |node: &nestweaver_engine::ContextNode| {
+        json!({
+            "uid": node.uid,
+            "name": node.name,
+            "kind": node.kind,
+            "file_path": node.file_path,
+            "start_line": node.start_line,
+            "signature": node.signature,
+            "relevance": node.relevance,
+        })
+    };
+    Ok(json!({
+        "seeds": result.seeds.iter().map(render).collect::<Vec<_>>(),
+        "connected": result.connected.iter().map(render).collect::<Vec<_>>(),
+        "cross_repo_links": serde_json::to_value(&result.cross_repo_links)?,
+        "seeds_resolved": result.seeds.len(),
+        "connected_count": result.connected.len(),
+    }))
 }
 
 fn tool_brain_context(

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -9259,7 +9259,7 @@ fn tool_dead_code(
 fn tool_schema_hub_nodes() -> Value {
     json!({
         "name": "hub_nodes",
-        "description": "Identify the most connected symbols in the codebase ranked by total degree (incoming + outgoing edges). These are the architectural core.\n\nGuidelines:\n- Use for quick orientation on which abstractions are most central\n- Includes optional cluster membership when clustering sidecar exists\n- For chokepoints between communities use bridge_nodes instead\n\nLimitations:\n- Degree centrality only — does not account for path importance (use bridge_nodes for betweenness)\n- For specific symbol dependencies use brain_impact or flow_trace",
+        "description": "Identify the most connected symbols in the codebase ranked by total degree (incoming + outgoing edges). These are the architectural core.\n\nGuidelines:\n- Use for quick orientation on which abstractions are most central\n- Includes optional cluster membership when clustering sidecar exists\n- For chokepoints between communities use bridge_nodes instead\n\nLimitations:\n- Degree centrality only — does not account for path importance (use bridge_nodes for betweenness)\n- For specific symbol dependencies use brain_impact or flow_trace\n- If `rankings_stale` is true, some repos were indexed before the nw-103 import-fan-out fix and these scores are computed over unrepaired edges — read `note` and re-index before trusting them",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -9341,9 +9341,14 @@ fn tool_hub_nodes(store: &GraphStore, args: Value) -> Result<Value, anyhow::Erro
         "clustering_available": clustering_available,
     });
     if !clustering_available {
-        resp["note"] = json!(
-            "cluster_id is null because clustering has not been computed. Run 'nestweaver cluster' to populate."
+        attach_note(
+            &mut resp,
+            "cluster_id is null because clustering has not been computed. Run 'nestweaver cluster' to populate.".to_string(),
         );
+    }
+    if let Some(note) = ranking_staleness_note(store) {
+        resp["rankings_stale"] = json!(true);
+        attach_note(&mut resp, note);
     }
     Ok(resp)
 }
@@ -9353,7 +9358,7 @@ fn tool_hub_nodes(store: &GraphStore, args: Value) -> Result<Value, anyhow::Erro
 fn tool_schema_bridge_nodes() -> Value {
     json!({
         "name": "bridge_nodes",
-        "description": "Find architectural chokepoints — symbols with high betweenness centrality that sit on many shortest paths between other nodes.\n\nGuidelines:\n- Use to identify symbols with outsized blast radius if changed\n- Returns betweenness score plus which community clusters each bridge connects\n- For most-connected nodes (degree centrality) use hub_nodes instead\n\nLimitations:\n- Betweenness computed via Brandes' algorithm with sampling — approximate for large graphs\n- For single-symbol impact analysis use brain_impact",
+        "description": "Find architectural chokepoints — symbols with high betweenness centrality that sit on many shortest paths between other nodes.\n\nGuidelines:\n- Use to identify symbols with outsized blast radius if changed\n- Returns betweenness score plus which community clusters each bridge connects\n- For most-connected nodes (degree centrality) use hub_nodes instead\n\nLimitations:\n- Betweenness computed via Brandes' algorithm with sampling — approximate for large graphs\n- For single-symbol impact analysis use brain_impact\n- If `rankings_stale` is true, some repos were indexed before the nw-103 import-fan-out fix and these scores are computed over unrepaired edges — read `note` and re-index before trusting them",
         "inputSchema": {
             "type": "object",
             "additionalProperties": false,
@@ -9417,11 +9422,16 @@ fn tool_bridge_nodes(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
         })
         .collect();
 
-    Ok(json!({
+    let mut resp = json!({
         "top_n": top_n,
         "count": nodes_json.len(),
         "bridges": nodes_json,
-    }))
+    });
+    if let Some(note) = ranking_staleness_note(store) {
+        resp["rankings_stale"] = json!(true);
+        attach_note(&mut resp, note);
+    }
+    Ok(resp)
 }
 
 // ── 21. blast_radius ─────────────────────────────────────────────────────
@@ -11126,6 +11136,46 @@ fn tool_investigate_hydrate(store: &GraphStore, args: Value) -> Result<Value, an
     Ok(serde_json::to_value(result)?)
 }
 
+/// The nw-103 resolver-staleness disclosure, for tools whose numbers it invalidates.
+///
+/// The CLI has warned about this at four call sites since nw-103. The MCP
+/// surface warned nowhere — so an AGENT asking for hub or bridge rankings got
+/// confidently-wrong numbers with nothing to indicate it, while a human running
+/// the same query through the CLI was told. The rankings are computed over
+/// edges the import-fan-out fix could not repair on disk; upgrading does not
+/// correct them, only re-indexing does.
+///
+/// Kubernetes shipped this exact bug and fixed it the same way in 1.19: the
+/// warning moved out of kubectl and into the API layer, because the CLI is not
+/// the only caller.
+///
+/// This belongs in the RESULT, never in `_meta`. `_meta` is client/UI-facing
+/// and is typically hidden from the model, so a disclosure placed there would
+/// be invisible to precisely the reader that needs it. It is a
+/// natural-language sentence because the model reads text.
+fn ranking_staleness_note(store: &GraphStore) -> Option<String> {
+    let db_path = current_db_path(store).ok()?;
+    let repos = store.list_repos(None).ok()?;
+    let uids: Vec<String> = repos.into_iter().map(|repo| repo.uid).collect();
+    if uids.is_empty() {
+        return None;
+    }
+    nestweaver_engine::resolver_generation::staleness_note(&db_path, &uids)
+}
+
+/// Attach a disclosure to a tool result without dropping one already there.
+///
+/// `note` is this surface's existing human-readable channel and some tools
+/// already set it for a different reason (clustering absent). Overwriting it
+/// would trade one silent omission for another, so applicable notes accumulate.
+fn attach_note(resp: &mut Value, note: String) {
+    let merged = match resp.get("note").and_then(Value::as_str) {
+        Some(existing) if !existing.is_empty() => format!("{existing} {note}"),
+        _ => note,
+    };
+    resp["note"] = json!(merged);
+}
+
 fn current_db_path(_store: &GraphStore) -> Result<std::path::PathBuf, anyhow::Error> {
     CURRENT_DB_PATH.with(|c| {
         c.borrow()
@@ -11743,6 +11793,96 @@ mod cache_dispatch_tests {
             RESPONSE_SHAPE_VERSION,
         );
         assert!(cache.is_empty(), "dirty responses must not be retained");
+    }
+
+    // ── nw-214: ranking staleness must reach the AGENT, not just the human ──
+
+    /// hub_nodes and bridge_nodes rank over edges the nw-103 import-fan-out fix
+    /// could not repair on disk. The CLI has warned about that at four call
+    /// sites; the MCP surface warned nowhere, so an agent got
+    /// confidently-wrong numbers with nothing to indicate it.
+    ///
+    /// Asserted on the RESULT, which is what becomes structuredContent. A
+    /// disclosure in `_meta` would not count: `_meta` is client/UI-facing and
+    /// is typically hidden from the model.
+    #[test]
+    fn stale_rankings_are_disclosed_to_the_agent_in_the_result() {
+        for tool in ["hub_nodes", "bridge_nodes"] {
+            let (_dir, db_path) = index_on_disk();
+            set_current_db_path(db_path.clone());
+            let store = GraphStore::open(&db_path).unwrap();
+
+            // Age the fixture: `index_directory` records a CURRENT generation,
+            // so the sidecar has to go for the repo to look pre-fix — which is
+            // exactly the on-disk state of any graph indexed before nw-103.
+            let sidecar = nestweaver_engine::sidecar_path(
+                &db_path,
+                nestweaver_engine::resolver_generation::RESOLVER_GENERATION_SIDECAR,
+            );
+            fs::remove_file(&sidecar).unwrap();
+
+            let value = dispatch(&store, None, tool, json!({}), None).unwrap();
+
+            assert_eq!(
+                value.get("rankings_stale").and_then(Value::as_bool),
+                Some(true),
+                "{tool} must flag stale rankings"
+            );
+            let note = value
+                .get("note")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            assert!(
+                note.contains("nw-103") && note.contains("index"),
+                "{tool} note must say what is wrong AND how to fix it, got: {note}"
+            );
+        }
+    }
+
+    /// The other half, and the half that makes the test above mean something:
+    /// once the repos ARE current, the disclosure must go away. Without this,
+    /// a helper hardcoded to always warn would pass.
+    #[test]
+    fn current_rankings_carry_no_staleness_disclosure() {
+        for tool in ["hub_nodes", "bridge_nodes"] {
+            let (_dir, db_path) = index_on_disk();
+            set_current_db_path(db_path.clone());
+            let store = GraphStore::open(&db_path).unwrap();
+
+            for repo in store.list_repos(None).unwrap() {
+                nestweaver_engine::resolver_generation::record(&db_path, &repo.uid).unwrap();
+            }
+
+            let value = dispatch(&store, None, tool, json!({}), None).unwrap();
+
+            assert!(
+                value.get("rankings_stale").is_none(),
+                "{tool} must not flag staleness once every repo is current"
+            );
+            let note = value
+                .get("note")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            assert!(
+                !note.contains("nw-103"),
+                "{tool} must not carry the staleness note once current, got: {note}"
+            );
+        }
+    }
+
+    /// `note` is a shared channel — hub_nodes already used it to say clustering
+    /// is absent. Adding a second disclosure must not silently drop the first,
+    /// which would trade one silent omission for another.
+    #[test]
+    fn a_second_disclosure_does_not_overwrite_the_first() {
+        let mut resp = json!({ "note": "first." });
+        attach_note(&mut resp, "second.".to_string());
+        assert_eq!(resp["note"], json!("first. second."));
+
+        let mut empty = json!({});
+        attach_note(&mut empty, "only.".to_string());
+        assert_eq!(empty["note"], json!("only."));
     }
 
     // ── nw-C2: index-publication wait, classification, and status ───────

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -10507,6 +10507,7 @@ pub fn dispatch_via_daemon(
                     "count_patterns" => client.count_patterns(req).await,
                     "cross_repo_contracts" => client.cross_repo_contracts(req).await,
                     "contract_drift" => client.contract_drift(req).await,
+                    "code_context" => client.code_context(req).await,
                     "dead_code" => client.dead_code(req).await,
                     "brain_broken_links" => client.brain_broken_links(req).await,
                     "brain_orphan_documents" => client.brain_orphan_documents(req).await,

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -782,6 +782,11 @@ service NestWeaverDaemon {
   // Read RPCs — typed hot-path
   rpc Search(BrainSearchRequest) returns (BrainSearchResponse);
   rpc GetContext(BrainContextRequest) returns (BrainContextResponse);
+  // CODE-only context: PPR over the symbol graph, no notes and no alias
+  // resolution. Distinct from GetContext, which runs the hybrid. `nestweaver
+  // context` had no RPC of its own, so its daemon route sent the hybrid while
+  // its direct path ran code-only PPR — one command, two algorithms.
+  rpc CodeContext(JsonRequest) returns (JsonResponse);
   rpc GetProjectContext(ProjectContextRequest) returns (ProjectContextResponse);
   rpc GetNote(NoteGetRequest) returns (NoteGetResponse);
   rpc BrainStatus(BrainStatusRequest) returns (BrainStatusResponse);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9751,60 +9751,66 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
             }
 
-            // ── Seed-based context: always try daemon first ──────────
-            // The daemon runs the full hybrid pipeline (PPR + BM25 +
-            // semantic) so we get better results and avoid the ~300ms
-            // double-RPC latency of the old name-resolution-then-fallback
-            // pattern.
-            let effective_limit = limit.unwrap_or(30);
+            // ── Seed-based context: daemon first, same algorithm either way ──
+            //
+            // This used to send `brain_context` — the code+notes HYBRID with
+            // taxonomy-alias seed resolution — while the fallback below ran
+            // code-only PPR. One command, two algorithms over two different
+            // node sets, and which one you got depended on whether a daemon
+            // happened to be running. `code_context` is the RPC for what this
+            // command actually means; `nestweaver brain context` is where the
+            // hybrid lives, and it is still there.
+            //
+            // Both routes now produce a `ContextResult` and render through the
+            // same code below, so the transport cannot change the answer.
+            let mut routed_via_daemon = false;
+            let mut context_result: Option<nestweaver_engine::ContextResult> = None;
             if use_daemon {
-                let hybrid_args = serde_json::json!({
-                    "seeds": seeds.clone(),
-                    "token_budget": token_budget.unwrap_or(0),
-                    "intent": intent.clone().unwrap_or_default(),
-                    "include_seeds": true,
-                });
+                let mut code_args = serde_json::json!({ "seeds": seeds.clone() });
+                // Omit rather than default: absent `--limit` means "no cap" on
+                // the direct path, and the schema rejects a 0.
+                if let Some(limit) = limit {
+                    code_args["limit"] = serde_json::json!(limit);
+                }
+                if let Some(intent) = intent.as_deref().filter(|value| !value.is_empty()) {
+                    code_args["intent"] = serde_json::json!(intent);
+                }
                 if let Some(result_json) = try_hybrid_json_rpc_checked(
                     use_daemon,
                     &db_path,
                     config.as_deref(),
-                    "brain_context",
-                    hybrid_args,
+                    "code_context",
+                    code_args,
                 )? {
-                    let result: nestweaver_engine::BrainContextResult =
-                        serde_json::from_value(result_json)?;
-                    let cut = match token_budget {
-                        Some(budget) => token_budgeted_truncate(&result.connected, budget),
-                        None => effective_limit.min(result.connected.len()),
-                    };
-                    if json {
-                        print_brain_context_json(&result, cut)?;
-                    } else {
-                        print_brain_context_text(&result, cut, token_budget);
-                    }
-                    let stats = format!(
-                        "{} seeds, {} connected nodes in {} (via hybrid)",
-                        result.seeds.len(),
-                        cut,
-                        format_elapsed(t0.elapsed())
-                    );
-                    return Ok((EXIT_SUCCESS, Some(stats)));
+                    context_result = Some(serde_json::from_value(result_json)?);
+                    routed_via_daemon = true;
                 }
             }
 
             // ── Local fallback (daemon unavailable) ──────────────────
-            let store = open_store(Some(&db_path))?;
-            match build_context_with_intent(&store, &seeds, parsed_intent, limit) {
+            let built = match context_result {
+                Some(result) => Ok(result),
+                None => {
+                    let store = open_store(Some(&db_path))?;
+                    build_context_with_intent(&store, &seeds, parsed_intent, limit)
+                }
+            };
+            match built {
                 Ok(mut result) => {
                     if let Some(budget) = token_budget {
                         let cut = context_token_budgeted_truncate(&result.connected, budget);
                         result.connected.truncate(cut);
                     }
                     let stats = format!(
-                        "{} seeds, {} connected nodes in {} (local fallback)",
+                        "{} seeds, {} connected nodes in {} ({})",
                         result.seeds.len(),
                         result.connected.len(),
-                        format_elapsed(t0.elapsed())
+                        format_elapsed(t0.elapsed()),
+                        if routed_via_daemon {
+                            "via daemon"
+                        } else {
+                            "local fallback"
+                        }
                     );
                     if json {
                         println!("{}", serde_json::to_string_pretty(&result)?);

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -605,7 +605,8 @@ fn direct_mcp_fails_closed_on_config_and_exposes_only_read_tools() {
         .collect::<Vec<_>>();
     assert_eq!(frames.len(), 2);
     let tools = frames[0]["result"]["tools"].as_array().unwrap();
-    assert_eq!(tools.len(), 35);
+    // 42 registered minus the mutating tools direct read-only hides.
+    assert_eq!(tools.len(), 36);
     for mutator in nestweaver_mcp::http::MUTATING_TOOLS {
         assert!(
             tools.iter().all(|tool| tool["name"] != *mutator),

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -1018,23 +1018,22 @@ fn parity_list_repos_direct_vs_daemon() {
     check_parity_json_semantic(&fixture.db_path, "list-repos", &["list-repos"]);
 }
 
-/// KNOWN FAILING — kept runnable rather than deleted, because it found a real
-/// bug the moment the harness stopped passing on two identical failures.
-///
-/// `context mainA` diverges three ways between the direct and daemon routes:
+/// This one found a real bug the moment the harness stopped passing on two
+/// identical failures. `context mainA` diverged three ways between routes:
 ///
 ///   1. kind rendering — `Function` vs `[Symbol/Function]`
-///   2. header — `Connected (3 symbols, …)` vs `Connected (3 of 3, …)`; only
-///      the daemon route discloses the total
-///   3. RELEVANCE SCORES DIFFER — 0.2096/0.2039/0.0208 direct versus
+///   2. header — `Connected (3 symbols, …)` vs `Connected (3 of 3, …)`
+///   3. RELEVANCE SCORES DIFFERED — 0.2096/0.2039/0.0208 direct versus
 ///      0.3117/0.3046/0.0403 via daemon
 ///
-/// (3) is the serious one: the same query returns different ranking values
-/// depending on whether a daemon happens to be running. That is not
-/// presentation drift, and it is not something byte-comparison could ever have
-/// surfaced while the harness accepted two failures as parity.
+/// (3) was the serious one, and (1) and (2) were downstream of it: the daemon
+/// route was answering with `brain_context`, the code+notes hybrid, because
+/// `context` had no RPC of its own. The same query returned different rankings
+/// depending on whether a daemon happened to be running. `code_context` is the
+/// RPC for what this command means, and both routes now build a
+/// `ContextResult` and render through one function — so this is a byte
+/// comparison again, and it holds.
 #[test]
-#[ignore = "FOUND A REAL DIVERGENCE — see the comment above; unignore with the fix"]
 fn parity_brain_context_direct_vs_daemon() {
     let fixture = setup_fixture();
     check_parity(


### PR DESCRIPTION
Two parity fixes from the same bug hunt. Both are cases where one surface behaved correctly and the other silently did not.

> **Scope note:** this PR started as `code_context` alone (nw-213). The nw-214 disclosure fix landed on the same branch. They are independent commits and reviewable separately; I chose not to force-push history apart after CI had already started.

---

## 1. nw-213 — `nestweaver context` ran a different algorithm on each transport

`nestweaver context` had no RPC of its own. Its daemon route sent `brain_context` — the code+notes **hybrid**, with taxonomy-alias seed resolution — while its direct path ran `build_context_with_intent`, PPR over the symbol graph alone.

One command, two algorithms over two different node sets, and which one you got depended on whether a daemon happened to be running. The parity harness caught it in the numbers:

| seed | direct | via daemon |
|---|---|---|
| helperC | 0.2096 | 0.3117 |
| helperB | 0.2039 | 0.3046 |
| utilA | 0.0208 | 0.0403 |

The command's own help says *"structural subgraph around seed symbols"*, so the direct path was correct and the daemon route was substituting a different capability. `nestweaver brain context` is where the hybrid lives and is **untouched** — nothing that wanted notes lost them.

**The fix, end to end:** `code_context` MCP tool + schema, a `CodeContext` RPC on the generic `JsonRequest`/`JsonResponse` pair every sibling tool uses, the daemon handler, the federation dispatch and routing arms (`Merge`, same family as `brain_context`), the MCP federated-client arm, and safeguard timeout/cap/result-limit classes.

The structural point: `ContextResult` and its node types gained `Deserialize`, so the daemon reply round-trips into the **same type** the direct path builds and both routes render through **one function**. The transport can no longer change the answer — which is what let the two renderings drift apart in the first place.

`limit` and `intent` are omitted rather than defaulted when absent: absent `--limit` means "no cap" on the direct path, and a `0` would either be rejected by the schema's `minimum: 1` or silently truncate a route the direct path does not.

`parity_brain_context_direct_vs_daemon` is **un-ignored** and is a byte comparison again. All 24 parity tests pass.

---

## 2. nw-214 — agents got confidently-wrong rankings with no disclosure

`hub_nodes` and `bridge_nodes` rank over edges the nw-103 import-fan-out fix could not repair on disk. Upgrading does not correct them; only re-indexing does.

The CLI has warned about this at four call sites since nw-103. The MCP surface warned **nowhere** — zero hits for `staleness_note` or `resolver_generation` anywhere in `nestweaver-mcp` or `nestweaver-daemon`. A human was told. An agent was not.

Kubernetes shipped this exact bug and fixed it the same way in 1.19: the warning moved out of kubectl and into the API layer, because the CLI is not the only caller.

The disclosure goes in the **result** — `rankings_stale: true` plus a natural-language `note` — and deliberately **not** in `_meta`. `_meta` is client/UI-facing and is typically hidden from the model, so a disclosure placed there would be invisible to precisely the reader that needs it. Both tool descriptions name the field, since that is the text the model reads before deciding to trust a score.

`note` was already carrying a different disclosure on `hub_nodes` (clustering absent), so notes now **accumulate** rather than overwrite — otherwise this would have traded one silent omission for another.

### Tests

Three, and the negative one is the point:

- staleness disclosed when the generation sidecar is absent
- **no** disclosure once every repo is current
- accumulation preserves an existing note

Verified the positive test fails when the helper is neutered to return `None`. Without the negative test, a helper hardcoded to always warn would pass.

---

## Verification

- `cargo test --workspace --all-targets` — green (39 targets, 0 failures)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- 24/24 parity tests pass