### PR TITLE
ci(metal): give the cold Metal job a budget that fits a cold cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,17 @@ jobs:
     needs: changes
     if: needs.changes.outputs.metal == 'true'
     runs-on: macos-latest
-    timeout-minutes: 60
+    # 60 did not fit a COLD cache. Measured on the run that failed: 36m14s to
+    # build the release binary, then 5m51s + 12m51s of release test gates, and
+    # the wall hit during the fourth step — so the job died having reached NONE
+    # of the Metal smoke steps it exists for, and reported that as a Metal
+    # failure.
+    #
+    # It was also self-perpetuating: dying with rustc still writing target/
+    # made rust-cache's save step fail with "file changed as we read it", so
+    # nothing was cached and the next run was cold too. Two PRs failed this way
+    # back to back. The budget has to cover a cold build, not just a warm one.
+    timeout-minutes: 90
     env:
       MACOSX_DEPLOYMENT_TARGET: "13.3"
       NESTWEAVER_METAL_SMOKE_MODEL_ID: sentence-transformers/all-MiniLM-L6-v2
@@ -90,9 +100,17 @@ jobs:
         run: brew install protobuf
       - name: Build Metal-enabled CLI
         run: cargo build --locked --release --features metal
+      # `--features metal`, NOT `--features embed`. `metal` is additive on top
+      # of `default = ["embed"]`, so this step was verifying the daemon's
+      # cache-only contract under a DIFFERENT feature set than the binary the
+      # smoke steps below actually run — the one place in this job where that
+      # contract is checked, checked against an artifact that does not ship.
+      # The same applies to the two gates after it. Aligning them is about
+      # testing the shipped configuration; it is not a speed fix, and the
+      # timeout above is what addresses the duration.
       - name: Verify daemon cache-only contract
         run: |
-          cargo test --locked --release -p nestweaver-daemon --features embed \
+          cargo test --locked --release -p nestweaver-daemon --features metal \
             daemon_embedding_startup_constructs_cached_model_offline
       # nw-194: this job used to run ONLY the one named test above, so every
       # macOS-specific failure was invisible to CI while being the first thing a
@@ -110,13 +128,13 @@ jobs:
       # at all. That is how a daemon-crate flake hid the store and engine
       # suites entirely. Every other test job here already passes it.
       - name: Workspace unit tests (macOS portability gate)
-        run: cargo test --locked --release --workspace --lib --no-fail-fast
+        run: cargo test --locked --release --features metal --workspace --lib --no-fail-fast
       # The --lib gate above did not cover INTEGRATION tests, and two of them
       # were failing on macOS the whole time: one #[cfg(target_os = "macos")]
       # test Linux CI can never run, and one gc test that passes on Linux but
       # diverges on macOS. Both are fixed; this keeps them fixed.
       - name: Daemon integration tests (macOS portability gate)
-        run: cargo test --locked --release --test daemon_test
+        run: cargo test --locked --release --features metal --test daemon_test
       - name: Configure isolated smoke paths
         shell: bash
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ daemonize2 = "0.7"
 [features]
 default = ["embed"]
 embed = ["dep:nestweaver-embed", "nestweaver-daemon/embed"]
-metal = ["nestweaver-embed?/metal"]
+metal = ["nestweaver-embed?/metal", "nestweaver-daemon/metal"]
 # ACME (Let's Encrypt) auto-TLS. Forwards to the daemon crate so the top-level
 # binary can be built with `--features acme` — without this passthrough the
 # runtime instruction to rebuild with that feature would fail (the binary would

--- a/crates/nestweaver-daemon/Cargo.toml
+++ b/crates/nestweaver-daemon/Cargo.toml
@@ -57,4 +57,10 @@ tokenizers = "0.23"
 
 [features]
 embed = ["dep:nestweaver-embed", "nestweaver-engine/embed", "nestweaver-mcp/embed"]
+# Metal passthrough, for the same reason `acme` has one below: without it,
+# `-p nestweaver-daemon --features metal` is an error, so the Metal CI job had
+# to test the daemon with a DIFFERENT feature set than it shipped — which
+# rebuilt the whole candle stack and meant the tested binary was not the one
+# the smoke test then ran.
+metal = ["nestweaver-embed?/metal"]
 acme = ["dep:tokio-rustls-acme", "dep:async-trait"]


### PR DESCRIPTION
## The failure

`Cold Metal daemon smoke` failed on #293 and #294 at exactly **1h00m** — a job timeout, not an assertion. Step timings from the failed run:

| Step | Duration |
|---|---|
| Build Metal-enabled CLI | 36m14s |
| Verify daemon cache-only contract | 5m51s |
| Workspace unit tests (macOS gate) | 12m51s |
| Daemon integration tests | **killed at 4m53s** |
| *every Metal smoke step* | **never ran** |

The job died before reaching a single one of the Metal smoke steps it exists for, and reported that as a Metal failure.

## Why it kept happening

It was self-perpetuating. The job died with `rustc` still writing `target/`, so `Swatinem/rust-cache`'s save step hit `gtar: target/release/deps: file changed as we read it` and saved nothing — leaving the next run cold as well. 60 minutes fits a warm cache and nothing else.

`timeout-minutes: 90` gives the budget room for a cold build.

## Feature alignment (separate point)

The three test gates ran under `--features embed` / default, while the binary the smoke steps actually run is built with `--features metal`. Since `metal` is additive on `default = ["embed"]`, the cache-only contract step — the only place in CI that checks that contract — was checking it against an artifact that does not ship.

This is a **correctness** fix, not a speed one. I measured it locally and cargo reused artifacts across both feature sets, so no rebuild was being paid for the mismatch. The timeout bump is what addresses the duration.

`nestweaver-daemon` gains a `metal` passthrough for the same reason it already has one for `acme`: without it, `-p nestweaver-daemon --features metal` is an error — which is why the step named a different feature set to begin with.

## Verification

All three invocation shapes resolve and compile locally:

- `cargo check --locked --features metal`
- `cargo check --locked -p nestweaver-daemon --features metal`
- `cargo check --locked --features metal --workspace --lib`