### PR TITLE
fix(federation,mcp): stop the structured merger dropping required fields

### DIFF
--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -1818,7 +1818,21 @@ impl DaemonService {
                 let effective_limit = state
                     .safeguards
                     .effective_result_limit(&tool_name, client_limit);
-                if args.get("limit").is_some() {
+                // Written back UNCONDITIONALLY. Guarding on `args.get("limit")`
+                // meant `effective_result_limit`'s `None => default` arm was
+                // computed and thrown away: a caller that simply omitted the
+                // field escaped the configured cap entirely, so the safeguard
+                // was advertised and inert. Only tools with a configured
+                // default are touched — `effective_result_limit` falls back to
+                // 100 otherwise, so restrict this to tools that opted in, or a
+                // tool that legitimately returns everything would start
+                // truncating at a number nobody chose for it.
+                if args.get("limit").is_some()
+                    || state
+                        .safeguards
+                        .default_result_limits
+                        .contains_key(&tool_name)
+                {
                     args["limit"] = serde_json::json!(effective_limit);
                 }
                 Some(dr)

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -412,13 +412,14 @@ pub use publication::*;
 pub use publication_source::*;
 pub use pull::*;
 pub use query::{
-    BrainContextResult, BrainNode, ContextNode, ContextResult, CrossRepoLink, EmbedModelProvider,
-    EmbedQueryFn, FeatureContextResult, FeatureInfo, HybridSearchConfig, LinkInfo, LookupResult,
-    SymbolCandidate, SymbolDetail, apply_ranking_priors, build_brain_context,
-    build_brain_context_hybrid, build_brain_context_hybrid_with_aliases, build_context,
-    build_context_with_intent, build_feature_context, dedup_heading_section_pairs,
-    expand_query_with_aliases, explain_ranking_prior, generate_repo_map, list_repos, list_services,
-    lookup_symbol, populate_inline_bodies, promote_member_notes_into_connected,
+    BrainContextResult, BrainNode, CODE_CONTEXT_DEFAULT_LIMIT, ContextNode, ContextResult,
+    CrossRepoLink, EmbedModelProvider, EmbedQueryFn, FeatureContextResult, FeatureInfo,
+    HybridSearchConfig, LinkInfo, LookupResult, SymbolCandidate, SymbolDetail,
+    apply_ranking_priors, build_brain_context, build_brain_context_hybrid,
+    build_brain_context_hybrid_with_aliases, build_context, build_context_with_intent,
+    build_feature_context, dedup_heading_section_pairs, expand_query_with_aliases,
+    explain_ranking_prior, generate_repo_map, list_repos, list_services, lookup_symbol,
+    populate_inline_bodies, promote_member_notes_into_connected,
     promote_member_symbols_into_connected, search_symbols,
 };
 pub use recency::parse_iso8601_to_epoch;

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -490,6 +490,16 @@ pub fn build_context(
 /// When `intent` is `Some`, the intent's parameters override the defaults.
 /// When `intent` is `None` but auto-detection is desired, use
 /// [`QueryIntent`] with [`detect_intent`] on the resolved seeds.
+/// Connected symbols `code_context` returns when the caller omits a limit.
+///
+/// ONE constant, deliberately. `nestweaver context` and the `code_context` MCP
+/// tool are two routes to the same answer, and the moment a cap lives on only
+/// one of them the two stop agreeing — which is the whole defect class the
+/// `code_context` RPC was added to close. An omitted limit used to mean
+/// `usize::MAX` here, which made the advertised 500-result safeguard
+/// unreachable by simply not sending the field.
+pub const CODE_CONTEXT_DEFAULT_LIMIT: usize = 500;
+
 pub fn build_context_with_intent(
     store: &GraphStore,
     inputs: &[String],

--- a/crates/nestweaver-federation/src/results.rs
+++ b/crates/nestweaver-federation/src/results.rs
@@ -763,7 +763,6 @@ mod tests {
         assert_eq!(concat_fanout(&l2, &s2)["truncated"], json!(false));
     }
 
-    #[test]
     /// `nestweaver context` was BROKEN for anyone with an upstream configured.
     /// `merge_structured_results` rebuilds its envelope key by key, and
     /// `cross_repo_links` was not among the keys re-added — but it is a
@@ -895,6 +894,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn merge_structured_sums_token_accounting() {
         // tokens_used / seeds_expanded / token_budget must reflect BOTH tiers,
         // since `connected` is the merge of both.

--- a/crates/nestweaver-federation/src/results.rs
+++ b/crates/nestweaver-federation/src/results.rs
@@ -451,6 +451,57 @@ pub fn concat_fanout(local: &Value, server: &Value) -> Value {
 /// Merge two JSON responses, preserving structured schemas (e.g. brain_context's
 /// `{ seeds, connected, unresolved_seeds, expansion_terms }`) when detected.
 /// Falls back to flat `{ results: [...] }` envelope for non-structured responses.
+/// Union of both tiers' `cross_repo_links`, deduplicated on (package, link_type).
+///
+/// Where both tiers report the same link, the higher `confidence` wins: they are
+/// two independent estimates of one fact, not two facts.
+fn merge_cross_repo_links(local: &Value, server: &Value) -> Vec<Value> {
+    let mut order: Vec<(String, String)> = Vec::new();
+    let mut best: HashMap<(String, String), Value> = HashMap::new();
+
+    for tier in [local, server] {
+        let Some(links) = tier.get("cross_repo_links").and_then(|v| v.as_array()) else {
+            continue;
+        };
+        for link in links {
+            let key = (
+                link.get("package")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                link.get("link_type")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+            );
+            let confidence = link
+                .get("confidence")
+                .and_then(serde_json::Value::as_f64)
+                .unwrap_or(0.0);
+            match best.get(&key) {
+                Some(existing) => {
+                    let existing_confidence = existing
+                        .get("confidence")
+                        .and_then(serde_json::Value::as_f64)
+                        .unwrap_or(0.0);
+                    if confidence > existing_confidence {
+                        best.insert(key, link.clone());
+                    }
+                }
+                None => {
+                    order.push(key.clone());
+                    best.insert(key, link.clone());
+                }
+            }
+        }
+    }
+
+    order
+        .into_iter()
+        .filter_map(|key| best.remove(&key))
+        .collect()
+}
+
 pub fn merge_structured_results(local: &Value, server: &Value) -> Value {
     let local_connected = local.get("connected").and_then(|v| v.as_array());
     let server_connected = server.get("connected").and_then(|v| v.as_array());
@@ -533,6 +584,40 @@ pub fn merge_structured_results(local: &Value, server: &Value) -> Value {
             if let Some(val) = local.get(key) {
                 result[key] = val.clone();
             }
+        }
+
+        // `cross_repo_links` is a UNION, not a local-only copy: an upstream tier
+        // sees links a local graph cannot. Dropping it entirely — which this
+        // rebuilt envelope did — is worse than either, because
+        // `ContextResult::cross_repo_links` is a REQUIRED field, so the CLI's
+        // `serde_json::from_value` failed outright the moment both tiers
+        // answered. `nestweaver context` was broken for anyone with an upstream
+        // configured, and only for them.
+        //
+        // Deduplicated on (package, link_type) keeping the HIGHER confidence:
+        // the same dependency seen by both tiers is one link, and the stronger
+        // of two independent estimates is the better one to report.
+        let merged_links = merge_cross_repo_links(local, server);
+        if !merged_links.is_empty() {
+            result["cross_repo_links"] = Value::Array(merged_links);
+        } else if local.get("cross_repo_links").is_some()
+            || server.get("cross_repo_links").is_some()
+        {
+            // Present-but-empty is not the same as absent to a required field.
+            result["cross_repo_links"] = Value::Array(Vec::new());
+        }
+
+        // RECOMPUTED from the merged payload, never summed. `rrf_merge`
+        // deduplicates, so `local + server` overcounts by exactly the overlap —
+        // and these two describe the arrays the caller is holding, unlike the
+        // additive accounting above which describes work done by each tier.
+        if local.get("seeds_resolved").is_some() || server.get("seeds_resolved").is_some() {
+            let seeds_len = result["seeds"].as_array().map_or(0, Vec::len);
+            result["seeds_resolved"] = Value::from(seeds_len);
+        }
+        if local.get("connected_count").is_some() || server.get("connected_count").is_some() {
+            let connected_len = result["connected"].as_array().map_or(0, Vec::len);
+            result["connected_count"] = Value::from(connected_len);
         }
         // This envelope is rebuilt key by key above, so anything not re-added
         // here is silently dropped. `semantic_applied` / `degraded_components`
@@ -679,6 +764,137 @@ mod tests {
     }
 
     #[test]
+    /// `nestweaver context` was BROKEN for anyone with an upstream configured.
+    /// `merge_structured_results` rebuilds its envelope key by key, and
+    /// `cross_repo_links` was not among the keys re-added — but it is a
+    /// REQUIRED field of `ContextResult`, so the CLI's `serde_json::from_value`
+    /// failed outright the moment both tiers answered. Single-tier users never
+    /// saw it, because the merge path is only taken when both succeed.
+    #[test]
+    fn cross_repo_links_survive_a_two_tier_merge() {
+        let local = serde_json::json!({
+            "seeds": [], "connected": [],
+            "cross_repo_links": [{ "package": "serde", "link_type": "dependency", "confidence": 0.5 }],
+        });
+        let server = serde_json::json!({
+            "seeds": [], "connected": [],
+            "cross_repo_links": [{ "package": "tokio", "link_type": "dependency", "confidence": 0.9 }],
+        });
+
+        let merged = merge_structured_results(&local, &server);
+        let links = merged["cross_repo_links"]
+            .as_array()
+            .expect("must be present");
+
+        assert_eq!(links.len(), 2, "the union of both tiers, got {links:?}");
+        let packages: Vec<&str> = links
+            .iter()
+            .filter_map(|l| l.get("package").and_then(|v| v.as_str()))
+            .collect();
+        assert!(packages.contains(&"serde") && packages.contains(&"tokio"));
+    }
+
+    /// The same dependency seen by both tiers is ONE link, and the stronger of
+    /// two independent estimates is the better one to report. Without this, a
+    /// federated caller sees every shared dependency twice.
+    #[test]
+    fn a_link_both_tiers_report_is_deduplicated_at_the_higher_confidence() {
+        let local = serde_json::json!({
+            "seeds": [], "connected": [],
+            "cross_repo_links": [{ "package": "serde", "link_type": "dependency", "confidence": 0.4 }],
+        });
+        let server = serde_json::json!({
+            "seeds": [], "connected": [],
+            "cross_repo_links": [{ "package": "serde", "link_type": "dependency", "confidence": 0.8 }],
+        });
+
+        let merged = merge_structured_results(&local, &server);
+        let links = merged["cross_repo_links"].as_array().unwrap();
+
+        assert_eq!(links.len(), 1, "one dependency, one link");
+        assert_eq!(links[0]["confidence"], serde_json::json!(0.8));
+    }
+
+    /// Present-but-empty is not the same as absent to a required field.
+    #[test]
+    fn an_empty_cross_repo_links_stays_present_rather_than_vanishing() {
+        let local = serde_json::json!({ "seeds": [], "connected": [], "cross_repo_links": [] });
+        let server = serde_json::json!({ "seeds": [], "connected": [], "cross_repo_links": [] });
+
+        let merged = merge_structured_results(&local, &server);
+
+        assert_eq!(merged["cross_repo_links"], serde_json::json!([]));
+    }
+
+    /// `rrf_merge` DEDUPLICATES, so summing the tiers overcounts by exactly the
+    /// overlap. These two describe the arrays the caller is holding, unlike the
+    /// additive token accounting, which describes work each tier did.
+    #[test]
+    fn counts_describe_the_merged_payload_not_the_sum_of_tiers() {
+        let node = |uid: &str| serde_json::json!({ "uid": uid, "name": uid, "relevance": 1.0 });
+        let local = serde_json::json!({
+            "seeds": [node("sym:a")],
+            "connected": [node("sym:shared"), node("sym:local_only")],
+            "connected_count": 2, "seeds_resolved": 1,
+        });
+        let server = serde_json::json!({
+            "seeds": [],
+            "connected": [node("sym:shared")],
+            "connected_count": 1, "seeds_resolved": 0,
+        });
+
+        let merged = merge_structured_results(&local, &server);
+
+        let actual = merged["connected"].as_array().unwrap().len();
+        assert_eq!(
+            merged["connected_count"].as_u64().unwrap() as usize,
+            actual,
+            "connected_count must equal the array it describes, not 2 + 1"
+        );
+        assert_eq!(
+            merged["seeds_resolved"].as_u64().unwrap() as usize,
+            merged["seeds"].as_array().unwrap().len()
+        );
+    }
+
+    /// The CLASS guard, not the instance. This envelope is rebuilt key by key,
+    /// so any field a tool adds later is dropped SILENTLY — which is exactly how
+    /// `cross_repo_links` broke `nestweaver context` without a single test
+    /// noticing. A new key must either survive the merge or be added to the
+    /// intentionally-dropped list here, deliberately and with a reason.
+    #[test]
+    fn no_local_field_is_dropped_without_being_declared_intentional() {
+        // Per-tier bookkeeping that is meaningless after a merge.
+        const INTENTIONALLY_DROPPED: &[&str] = &["_meta"];
+
+        let local = serde_json::json!({
+            "seeds": [], "connected": [], "cross_repo_links": [],
+            "unresolved_seeds": ["ghost"], "expansion_terms": ["term"],
+            "seeds_expanded": 1, "tokens_used": 10, "token_budget": 100,
+            "project": "p", "project_uid": "proj:p", "external_refs": [],
+            "seeds_resolved": 0, "connected_count": 0,
+            "semantic_applied": true, "degraded_components": [],
+            "_meta": { "sources": ["local"] },
+        });
+        let server = serde_json::json!({ "seeds": [], "connected": [] });
+
+        let merged = merge_structured_results(&local, &server);
+
+        let dropped: Vec<&String> = local
+            .as_object()
+            .unwrap()
+            .keys()
+            .filter(|key| !INTENTIONALLY_DROPPED.contains(&key.as_str()))
+            .filter(|key| merged.get(key.as_str()).is_none())
+            .collect();
+
+        assert!(
+            dropped.is_empty(),
+            "these fields vanished in the merge: {dropped:?} — carry them through \
+             merge_structured_results, or add them to INTENTIONALLY_DROPPED with a reason"
+        );
+    }
+
     fn merge_structured_sums_token_accounting() {
         // tokens_used / seeds_expanded / token_budget must reflect BOTH tiers,
         // since `connected` is the merge of both.

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -3208,7 +3208,7 @@ fn tool_schema_code_context() -> Value {
                 "limit": {
                     "type": "integer",
                     "minimum": 1,
-                    "description": "Maximum connected symbols to return. Omit for no cap, which is what the CLI does when --limit is absent."
+                    "description": "Maximum connected symbols to return. Defaults to 500 when omitted; the response reports `total` and `truncated` so an omitted limit is never silently lossy."
                 },
                 "intent": {
                     "type": "string",
@@ -3337,6 +3337,20 @@ fn tool_schema_brain_context() -> Value {
     })
 }
 
+/// Truncate to `limit`, reporting whether anything was dropped.
+///
+/// The caller asks the engine for `limit + 1` so the extra row proves more rows
+/// exist without paying for a second query; this drops it and says so. Silent
+/// truncation is the failure mode being avoided: a caller that cannot tell a
+/// complete answer from a capped one will treat the cap as the whole graph.
+fn truncate_reporting<T>(items: &mut Vec<T>, limit: usize) -> bool {
+    let truncated = items.len() > limit;
+    if truncated {
+        items.truncate(limit);
+    }
+    truncated
+}
+
 /// `code_context` — the CODE-only structural subgraph around seed symbols.
 ///
 /// Distinct from `brain_context`, and the distinction is the whole point.
@@ -3365,13 +3379,20 @@ fn tool_code_context(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
     if seeds.is_empty() {
         anyhow::bail!("code_context requires at least one seed");
     }
-    // `Option<usize>`, matching the engine: absent means "no cap", which is
-    // what the CLI passes when `--limit` is omitted. Defaulting to a number
-    // here would silently truncate a route the direct path does not.
+    // An omitted `limit` used to mean NO CAP, matching the engine's
+    // `limit.unwrap_or(usize::MAX)`. That made the advertised 500-result
+    // safeguard unreachable by simply not sending the field, so a seed in a
+    // dense region serialized every connected symbol in the graph.
+    //
+    // It now defaults, and the CLI's direct path defaults to the SAME constant
+    // — a cap on one route only is how the two drifted apart to begin with.
+    // Truncation is disclosed rather than silent: `total` is the number of
+    // connected symbols found, `connected_count` the number returned.
     let limit = args
         .get("limit")
         .and_then(|v| v.as_u64())
-        .map(|n| n as usize);
+        .map(|n| n as usize)
+        .unwrap_or(nestweaver_engine::CODE_CONTEXT_DEFAULT_LIMIT);
     let intent = args
         .get("intent")
         .and_then(|v| v.as_str())
@@ -3383,7 +3404,11 @@ fn tool_code_context(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
         })
         .transpose()?;
 
-    let result = nestweaver_engine::build_context_with_intent(store, &seeds, intent, limit)?;
+    // One over the cap, so `truncated` can be reported without a second pass:
+    // the extra row proves more exist, and is dropped before rendering.
+    let mut result =
+        nestweaver_engine::build_context_with_intent(store, &seeds, intent, Some(limit + 1))?;
+    let truncated = truncate_reporting(&mut result.connected, limit);
 
     let render = |node: &nestweaver_engine::ContextNode| {
         json!({
@@ -3402,6 +3427,8 @@ fn tool_code_context(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
         "cross_repo_links": serde_json::to_value(&result.cross_repo_links)?,
         "seeds_resolved": result.seeds.len(),
         "connected_count": result.connected.len(),
+        "limit": limit,
+        "truncated": truncated,
     }))
 }
 
@@ -11838,6 +11865,67 @@ mod cache_dispatch_tests {
             RESPONSE_SHAPE_VERSION,
         );
         assert!(cache.is_empty(), "dirty responses must not be retained");
+    }
+
+    // ── code_context bounds: an omitted limit must not mean "everything" ──
+
+    /// The 500-result safeguard was advertised for `code_context` and reachable
+    /// by nobody: an omitted `limit` meant `usize::MAX` in the engine, so a
+    /// caller escaped the cap by simply not sending the field.
+    ///
+    /// Tested on the truncation helper rather than through a contrived graph:
+    /// what matters is that a capped result says it was capped, and that is a
+    /// property of this function, not of any particular fixture's shape.
+    #[test]
+    fn truncation_is_reported_not_silent() {
+        let mut over = vec![1, 2, 3, 4];
+        assert!(
+            truncate_reporting(&mut over, 3),
+            "four rows capped at three IS a truncation"
+        );
+        assert_eq!(over, vec![1, 2, 3], "and the extra row is dropped");
+
+        // The boundary: exactly at the limit is NOT truncated. Off-by-one here
+        // would report every full-but-fitting result as lossy.
+        let mut exact = vec![1, 2, 3];
+        assert!(!truncate_reporting(&mut exact, 3));
+        assert_eq!(exact, vec![1, 2, 3]);
+
+        let mut under = vec![1];
+        assert!(!truncate_reporting(&mut under, 3));
+        assert_eq!(under, vec![1]);
+
+        let mut empty: Vec<u8> = Vec::new();
+        assert!(!truncate_reporting(&mut empty, 0));
+    }
+
+    /// The other half: when everything fits, `truncated` must be false. Without
+    /// this, a field hardcoded to `true` would pass the test above.
+    #[test]
+    fn a_result_that_fits_is_not_reported_as_truncated() {
+        let (_dir, db_path) = index_on_disk();
+        set_current_db_path(db_path.clone());
+        let store = GraphStore::open(&db_path).unwrap();
+
+        let full = dispatch(
+            &store,
+            None,
+            "code_context",
+            json!({ "seeds": ["greet"] }),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(full["truncated"], json!(false));
+        assert_eq!(
+            full["limit"],
+            json!(nestweaver_engine::CODE_CONTEXT_DEFAULT_LIMIT),
+            "an omitted limit must report the default it actually applied"
+        );
+        assert_eq!(
+            full["connected"].as_array().unwrap().len(),
+            full["connected_count"].as_u64().unwrap() as usize
+        );
     }
 
     // ── nw-214: ranking staleness must reach the AGENT, not just the human ──

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -14601,3 +14601,81 @@ mod destructive_tool_contract_tests {
         }
     }
 }
+
+/// The END-TO-END half of the `cross_repo_links` regression.
+///
+/// `crates/nestweaver-federation` has the merge tests, but it cannot import
+/// `nestweaver-engine`, so it can only assert that a KEY survives. What
+/// actually broke `nestweaver context` was the next step: the CLI deserializing
+/// the merged envelope into `ContextResult`, where a missing `cross_repo_links`
+/// is not a missing key but a hard `Error("missing field")`.
+///
+/// This crate sees both, so it can assert the thing the user experiences. A
+/// federated `context` call has no other test that gets this far — the parity
+/// suite configures no upstream, which is precisely why a High-severity break
+/// shipped with 24 parity tests green.
+#[cfg(all(test, feature = "daemon"))]
+mod federated_context_roundtrip_tests {
+    use serde_json::json;
+
+    /// A `code_context` reply that has been through a two-tier merge must still
+    /// parse as the type the CLI parses it as.
+    #[test]
+    fn a_merged_code_context_reply_still_deserializes_for_the_cli() {
+        let node = |uid: &str| {
+            json!({
+                "uid": uid, "name": uid, "kind": "Function",
+                "file_path": "a.rs", "start_line": 1,
+                "signature": "fn", "relevance": 0.5,
+            })
+        };
+        let local = json!({
+            "seeds": [node("sym:seed")],
+            "connected": [node("sym:local")],
+            "cross_repo_links": [{ "package": "serde", "link_type": "dependency", "confidence": 0.5 }],
+            "seeds_resolved": 1,
+            "connected_count": 1,
+        });
+        let server = json!({
+            "seeds": [],
+            "connected": [node("sym:upstream")],
+            "cross_repo_links": [{ "package": "tokio", "link_type": "dependency", "confidence": 0.9 }],
+            "seeds_resolved": 0,
+            "connected_count": 1,
+        });
+
+        let merged = nestweaver_federation::results::merge_structured_results(&local, &server);
+
+        // Exactly what `Commands::Context` does with the daemon's reply.
+        let parsed: nestweaver_engine::ContextResult = serde_json::from_value(merged.clone())
+            .unwrap_or_else(|error| {
+                panic!("the CLI could not parse a merged reply: {error}\nmerged = {merged}")
+            });
+
+        assert_eq!(
+            parsed.cross_repo_links.len(),
+            2,
+            "both tiers' links must survive into the parsed result"
+        );
+        assert_eq!(
+            parsed.connected.len(),
+            2,
+            "both tiers' connected symbols must survive"
+        );
+    }
+
+    /// The single-tier path, which is what every existing test exercised — kept
+    /// so a fix that only works when both tiers answer cannot pass unnoticed.
+    #[test]
+    fn an_unmerged_reply_deserializes_too() {
+        let local = json!({
+            "seeds": [], "connected": [], "cross_repo_links": [],
+            "seeds_resolved": 0, "connected_count": 0,
+        });
+
+        let parsed: nestweaver_engine::ContextResult =
+            serde_json::from_value(local).expect("the un-merged shape must parse");
+
+        assert!(parsed.cross_repo_links.is_empty());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9846,7 +9846,10 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 Some(result) => Ok(result),
                 None => {
                     let store = open_store(Some(&db_path))?;
-                    build_context_with_intent(&store, &seeds, parsed_intent, limit)
+                    // The SAME default the `code_context` tool applies. A cap on
+                    // one route only is how these two drifted apart before.
+                    let effective = limit.unwrap_or(nestweaver_engine::CODE_CONTEXT_DEFAULT_LIMIT);
+                    build_context_with_intent(&store, &seeds, parsed_intent, Some(effective))
                 }
             };
             match built {


### PR DESCRIPTION
Two follow-ups to #297, both found in review and both confirmed by test before fixing.

---

## 1. High — `nestweaver context` was broken for anyone with an upstream

`merge_structured_results` rebuilds its envelope key by key. `cross_repo_links` was not among the keys re-added — and the function's own comment already warned:

> This envelope is rebuilt key by key above, so anything not re-added here is silently dropped.

`cross_repo_links` is a **required** field of `ContextResult`, so the CLI's `serde_json::from_value` failed outright the moment both tiers answered. Reproduced before fixing:

```
MERGED KEYS = Some(["_meta", "connected", "seeds"])
```

`cross_repo_links`, `seeds_resolved` and `connected_count` all gone. Single-tier users never saw it, because the merge path is only taken when local **and** upstream both succeed — which is why #297's tests passed.

**Fix:** `cross_repo_links` is a union, deduplicated on `(package, link_type)` keeping the higher confidence — the same dependency seen by both tiers is one link, and the stronger of two independent estimates is the better one to report. `seeds_resolved` and `connected_count` are **recomputed** from the merged payload, never summed: `rrf_merge` deduplicates, so `local + server` overcounts by exactly the overlap.

### The test that matters

Beyond the field-specific regressions, `no_local_field_is_dropped_without_being_declared_intentional` asserts that no key present in the local input vanishes from the merged output unless it is listed in `INTENTIONALLY_DROPPED` with a reason. That converts this whole class from silent to loud — which is what let `cross_repo_links` break a user-facing command without a single test noticing.

---

## 2. Medium — the advertised 500-result cap was reachable by nobody

`code_context`'s schema said an omitted `limit` meant no cap, and the engine's `limit.unwrap_or(usize::MAX)` honoured that literally. A seed in a dense region serialized every connected symbol in the graph. The safeguard was configured and inert.

**Fix:** an omitted limit defaults to `CODE_CONTEXT_DEFAULT_LIMIT` — **one** constant, applied by both the MCP tool and the CLI's direct path. A cap on one route only is the exact drift #297 existed to close. Truncation is disclosed rather than silent: the response carries `limit` and `truncated`, and the engine is asked for `limit + 1` so the extra row proves more exist without paying for a second query.

**Separately:** the daemon computed `effective_result_limit` and then threw it away unless the caller had already sent `limit`:

```rust
if args.get("limit").is_some() {
    args["limit"] = serde_json::json!(effective_limit);
}
```

So omitting the field escaped the configured cap for **every** tool, not just this one. Now written back for any tool with a configured default — and only those, so a tool that legitimately returns everything does not start truncating at a number nobody chose for it.

---

## Note on testing the truncation

Tested on the helper directly rather than through a contrived graph. That a capped result says it was capped is a property of the function, not of any fixture's shape — and my first two attempts at a graph-shaped fixture failed for reasons (0 connected symbols, then unresolvable seeds) that had nothing to do with the behaviour under test. The boundary case is included: exactly at the limit is **not** truncated, where an off-by-one would report every full-but-fitting result as lossy.