### PR TITLE
ci: cancel superseded PR runs and stop the advisory job building cold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,23 @@ on:
   pull_request:
     branches: [main, staging]
 
+# Cancel a PR's earlier run when a new commit supersedes it.
+#
+# There was no concurrency group at all, so every push to a branch left its
+# previous run going: a full matrix — Build & Tests ~1h, Daemon Integration
+# ~55m, E2E ~50m, Cold Metal ~43m, mutants ~45m — computing an answer about
+# a commit nobody would look at again. With one shared runner pool that is not
+# just waste, it is HEAD-OF-LINE BLOCKING: those obsolete jobs sit in front of
+# every other PR's real work, which is why runs queued for over an hour while
+# several PRs were open.
+#
+# `cancel-in-progress` is deliberately scoped to pull_request. A push to main
+# must NEVER be cancelled — release-please and the publish flow run there, and
+# cancelling one mid-flight would leave a release half-cut.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -625,7 +642,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-          key: mutants
+          # Share the `build` cache the other Rust jobs populate, instead of a
+          # private key that starts cold on every PR. This job is ADVISORY, and
+          # it was spending most of its ~45m rebuilding a workspace three other
+          # jobs had already built. `save-if: false` so an advisory job never
+          # writes over the cache the gating jobs depend on.
+          shared-key: build
+          save-if: false
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
       - name: Install cargo-mutants


### PR DESCRIPTION
Two changes aimed at CI wall-clock, after watching several PRs queue behind each other for over an hour this session.

## 1. No `concurrency` group existed

Every push to a branch left its **previous run going**: a full matrix computing an answer about a commit nobody would look at again.

| job | duration |
|---|---|
| Build & Tests | ~1h |
| Daemon Integration | ~55m |
| E2E | ~50m |
| Cold Metal | ~43m |
| mutants (advisory) | ~45m |

With one shared runner pool this is not just waste — it is **head-of-line blocking**. Those obsolete jobs sit in front of every other PR's real work. It is why a macOS job could sit at `pending 0` for an hour before starting, and why merging anything took several hours of wall-clock today.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

`cancel-in-progress` is deliberately scoped to `pull_request`. **A push to `main` must never be cancelled** — release-please and the publish flow run there, and cancelling one mid-flight would leave a release half-cut.

## 2. The advisory `mutants` job started cold every time

It used a private cache key (`key: mutants`), so it spent most of its ~45m rebuilding a workspace three other jobs had already built under `shared-key: build`. It now shares that cache, with `save-if: false` so an **advisory** job can never write over the cache the **gating** jobs depend on.

## Known and unchanged

`.github/workflows/ci.yml` is in both the `rust` and `metal` path filters, so a CI-only PR like this one still runs the full matrix including the 90-minute Metal job. That is correct — a change to CI should be validated by CI. It just means this particular saving costs one full cycle to land.

I also looked at whether `README.md` / `CLAUDE.md` / `docs/**` should keep triggering the full Rust matrix. They should: there is a README-command-coverage test that reads them. Left alone rather than trimmed on a guess.