### PR TITLE
fix(mcp,federation): stop restating which tools mutate

### DIFF
--- a/crates/nestweaver-federation/src/routing.rs
+++ b/crates/nestweaver-federation/src/routing.rs
@@ -80,11 +80,25 @@ pub fn tool_routing(tool_name: &str) -> ToolRouting {
             ToolRouting::LocalOnly
         }
 
-        // Admin/mutation tools — local-only
+        // Admin/mutation tools — local-only.
+        //
+        // EVERY entry of `nestweaver_mcp::http::MUTATING_TOOLS` must appear
+        // here: a mutation sent upstream would write to someone else's graph.
+        // `compact_embeddings` was missing, so it fell to the `LocalFirst`
+        // default below, reached `dispatch_json_rpc`, found no arm, and failed
+        // with "unsupported tool for JSON dispatch" — advertised in
+        // `tools/list` and broken for every caller with an upstream.
+        //
+        // This arm is deliberately a SUPERSET: `query_extensions` and the
+        // memory tools are local-only reads over a personal vault, not
+        // mutations. That is why it cannot simply BE the canonical list — but
+        // the containment is pinned by
+        // `every_mutating_tool_is_local_only` in nestweaver-mcp.
         "brain_add_source"
         | "brain_remove_source"
         | "prune_stale"
         | "set_extension"
+        | "compact_embeddings"
         | "query_extensions" => ToolRouting::LocalOnly,
 
         // Everything else — local-first (safe default)
@@ -101,6 +115,11 @@ mod tests {
         assert_eq!(tool_routing("brain_search"), ToolRouting::Merge);
         assert_eq!(tool_routing("brain_context"), ToolRouting::Merge);
         assert_eq!(tool_routing("code_context"), ToolRouting::Merge);
+        assert_eq!(
+            tool_routing("compact_embeddings"),
+            ToolRouting::LocalOnly,
+            "a mutation must never be routed upstream"
+        );
         assert_eq!(tool_routing("project_context"), ToolRouting::Merge);
         assert_eq!(tool_routing("search_symbols"), ToolRouting::Merge);
     }

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -14800,3 +14800,41 @@ mod schema_default_honesty_tests {
         );
     }
 }
+
+/// nw-232: the three places that encode "this tool mutates" must agree.
+///
+/// `MUTATING_TOOLS` calls itself the SINGLE canonical list, and most consumers
+/// read it. Two did not: the federation router restated a local-only set, and
+/// the hybrid stdio server restated a write-tool set as a literal. Both had
+/// drifted — `compact_embeddings` was missing from each, so it was advertised
+/// in `tools/list` and failed with "unsupported tool for JSON dispatch" for
+/// every caller with an upstream configured.
+///
+/// The stdio copy is now derived. The router's set cannot simply BE the
+/// canonical list — it is a deliberate superset that also covers local-only
+/// READS like `query_extensions` and the memory tools — so the invariant is
+/// containment, and it is pinned here rather than left to discipline.
+#[cfg(all(test, feature = "daemon"))]
+mod mutating_tool_routing_invariant_tests {
+    /// A mutation routed anywhere but locally would write to someone else's
+    /// graph. There is no tool for which that is acceptable, so this is a
+    /// containment check over the whole canonical list, not a spot check.
+    #[test]
+    fn every_mutating_tool_is_local_only() {
+        use nestweaver_federation::routing::{ToolRouting, tool_routing};
+
+        let stragglers: Vec<&str> = crate::http::MUTATING_TOOLS
+            .iter()
+            .copied()
+            .filter(|tool| tool_routing(tool) != ToolRouting::LocalOnly)
+            .collect();
+
+        assert!(
+            stragglers.is_empty(),
+            "these mutating tools are not routed LocalOnly: {stragglers:?} — they would \
+             be sent upstream, or fall to LocalFirst and fail in dispatch_json_rpc with \
+             'unsupported tool for JSON dispatch' while still being advertised. Add them \
+             to the Admin/mutation arm in nestweaver-federation's routing.rs"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -24267,10 +24267,25 @@ fn run_mcp_hybrid(
     let mut reader = stdin.lock();
 
     // Write tools that must bypass hybrid routing.
-    let write_tools: std::collections::HashSet<&str> =
-        ["brain_add_source", "brain_remove_source", "prune_stale"]
-            .into_iter()
-            .collect();
+    //
+    // Taken from `MUTATING_TOOLS`, not restated. This was a hardcoded literal
+    // holding three of the six, and the three it omitted —
+    // `compact_embeddings`, `set_extension`, `brain_memory_consolidate` — were
+    // therefore routed as ordinary reads into `hybrid.query`, reached
+    // `dispatch_json_rpc`, found no arm, and failed with "unsupported tool for
+    // JSON dispatch". They were still advertised in `tools/list`, so an agent
+    // with an upstream configured saw the tools, called them, and got an
+    // internal-sounding error every time.
+    //
+    // `MUTATING_TOOLS` calls itself "the SINGLE canonical list" and every other
+    // consumer — the daemon's `json_rpc!` gate, the read-only refusals in
+    // tools.rs — already reads it. This was the only place that restated it,
+    // and a second copy cannot be kept in sync by discipline: the tools were
+    // added to the canonical list and nobody knew to add them here.
+    let write_tools: std::collections::HashSet<&str> = nestweaver_mcp::http::MUTATING_TOOLS
+        .iter()
+        .copied()
+        .collect();
 
     loop {
         line.clear();


### PR DESCRIPTION
nw-232. `compact_embeddings` was **advertised in `tools/list` and failed every time** an upstream was configured, with `unsupported tool for JSON dispatch`. So were `set_extension` and `brain_memory_consolidate`.

## Three copies of one fact

`MUTATING_TOOLS` calls itself *"the SINGLE canonical list"*, and most consumers read it — the daemon's `json_rpc!` admin gate, the read-only refusals in `tools.rs`. **Two places restated it**, and both had drifted:

| | entries | missing |
|---|---|---|
| `MUTATING_TOOLS` (canonical) | 6 | — |
| hybrid stdio `write_tools` literal | 3 | `compact_embeddings`, `set_extension`, `brain_memory_consolidate` |
| federation router Admin/mutation arm | 5 | `compact_embeddings` |

Anything not in the stdio literal was routed as an ordinary read into `hybrid.query` → `dispatch_json_rpc` → no arm → fail. Anything not in the router's arm fell to the `LocalFirst` default and hit the same dead end.

## The fix

The stdio copy is **deleted** — it now derives from the canonical list.

The router's set **cannot** simply *be* the canonical list: it is a deliberate superset that also covers local-only **reads** like `query_extensions` and the memory tools, which are not mutations. So the invariant is **containment** — every mutating tool must route `LocalOnly`, because a mutation sent upstream would write to someone else's graph — and that is now pinned by a test rather than left to discipline.

```
these mutating tools are not routed LocalOnly: ["compact_embeddings"] — they would be
sent upstream, or fall to LocalFirst and fail in dispatch_json_rpc with 'unsupported
tool for JSON dispatch' while still being advertised. Add them to the Admin/mutation
arm in nestweaver-federation's routing.rs
```

**Mutation-checked** — that message is what the test actually prints when the drift is reintroduced.

This is the same shape as nw-215's schema defaults: a second copy of a fact cannot be kept in sync by care. The tools were added to the canonical list and nobody knew there were two other places to add them.

## Provenance

Found by the nw-217 verification pass, which established that the original A2 claim — *"a hybrid call compacts locally and then again upstream"* — was **mis-premised**. Nothing compacted twice; nothing compacted at all. Fixing the claim as written would have addressed a bug that did not exist while leaving this one in place.

## Verification

- `cargo test --workspace --all-targets` — green (39 targets, 0 failures)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean