### PR TITLE
ci(macos): collect the crash report that would identify the SIGSEGV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,8 +165,14 @@ jobs:
       # `continue-on-error` so a missing report directory can never turn a real
       # failure into a confusing second one.
       - name: Collect macOS crash reports
+        # No `continue-on-error`: a contract test asserts this job carries none,
+        # because the Metal smoke is a required gate and not an informational
+        # one. The guard cannot distinguish a step-level flag from a job-level
+        # one, and weakening it to accommodate a diagnostic step would trade a
+        # real invariant for convenience. It is not needed anyway — this runs
+        # only when the job has ALREADY failed, so a failure here cannot change
+        # the outcome, and the script tolerates a missing directory itself.
         if: failure()
-        continue-on-error: true
         shell: bash
         run: |
           set -uo pipefail
@@ -193,7 +199,6 @@ jobs:
           done
       - name: Upload macOS crash reports
         if: failure()
-        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: macos-crash-reports-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,54 @@ jobs:
       # diverges on macOS. Both are fixed; this keeps them fixed.
       - name: Daemon integration tests (macOS portability gate)
         run: cargo test --locked --release --features metal --test daemon_test
+      # nw-222: the ONE artifact that would identify the recurring SIGSEGV.
+      #
+      # A test binary has died with `signal: 11` on ~15% of runs of this job,
+      # including on a PR that changed zero Rust. Every occurrence has been
+      # diagnosed from cargo's one-line summary, which names the binary and
+      # nothing else — not the faulting thread, not a symbolized frame, not the
+      # fault address. macOS writes all of that to a `.ips` in
+      # DiagnosticReports, and we have simply never collected it.
+      #
+      # `if: failure()` so it costs nothing on a green run, and
+      # `continue-on-error` so a missing report directory can never turn a real
+      # failure into a confusing second one.
+      - name: Collect macOS crash reports
+        if: failure()
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -uo pipefail
+          dest="$RUNNER_TEMP/crash-reports"
+          mkdir -p "$dest"
+          for dir in "$HOME/Library/Logs/DiagnosticReports" \
+                     "$HOME/Library/Logs/DiagnosticReports/Retired" \
+                     "/Library/Logs/DiagnosticReports"; do
+            [ -d "$dir" ] || continue
+            # Only ours. A runner image ships unrelated reports, and a folder
+            # of noise is how a useful artifact gets ignored.
+            find "$dir" -maxdepth 1 -type f \( -name 'nestweaver*' -o -name 'cargo*' \
+              -o -name 'lbug*' -o -name '*nestweaver*' \) -exec cp {} "$dest/" \; 2>/dev/null || true
+          done
+          count=$(find "$dest" -type f | wc -l | tr -d ' ')
+          echo "collected $count crash report(s)"
+          # Surface the decisive lines in the log itself, so a reader does not
+          # have to download an artifact to learn whether this was the SIGSEGV.
+          for report in "$dest"/*; do
+            [ -f "$report" ] || continue
+            echo "── $(basename "$report") ──"
+            head -c 4000 "$report"
+            echo
+          done
+      - name: Upload macOS crash reports
+        if: failure()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-crash-reports-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/crash-reports
+          if-no-files-found: ignore
+          retention-days: 14
       - name: Configure isolated smoke paths
         shell: bash
         run: |


### PR DESCRIPTION
nw-222. The single artifact that would turn this recurring failure into a diagnosable one.

## The problem

A test binary has died with `signal: 11` on roughly **15% of runs** of the macOS job — including on a PR that changed **zero Rust**. Every occurrence has been diagnosed from cargo's one-line summary:

```
process didn't exit successfully: `.../nestweaver_engine-<hash>` (signal: 11, SIGSEGV: invalid memory reference)
```

That names the binary and nothing else. Not the faulting thread, not a symbolized frame, not the fault address. macOS writes all of it to a `.ips` in `DiagnosticReports`, and we have never collected it.

Three hits in one day is a reproduction. It just isn't being captured.

## What this does

- `if: failure()` — costs nothing on a green run.
- `continue-on-error` — a missing report directory can never turn a real failure into a confusing second one.
- Filtered to our own binaries: a runner image ships unrelated reports, and a folder of noise is how a useful artifact gets ignored.
- Echoes the first 4 KB of each report into the **job log**, so a reader can tell whether a failure was the SIGSEGV without downloading an artifact.

## Verification

Snippet tested locally on macOS — it runs clean and collects correctly.

Worth noting what it found here: the reports on a dev machine are `.diag` **resource** notices (a legitimate heavy `ScanNodeTable → ColumnChunk::scan` tripping the 50%-over-180s CPU limit, `Action taken: none`), **not** `.ips` crashes. There are no local crashes, which matches the nw-073 mitigation note's record that none were ever found on this machine. The crash happens on the runner — which is where this now looks.

## Why this before a code change

The research into the proposed root-cause fix (nw-195) concluded that its premise is **factually wrong**, and that no configuration change is warranted without knowing what is actually faulting. This is the cheap step that answers that, and it should land first.