### PR TITLE
fix(federation,mcp,cli): re-honour code_context's limit across a merge

### DIFF
--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -454,6 +454,21 @@ pub struct ContextResult {
     pub seeds: Vec<ContextNode>,
     pub connected: Vec<ContextNode>,
     pub cross_repo_links: Vec<CrossRepoLink>,
+    /// The cap that was applied, and whether it dropped anything.
+    ///
+    /// Without these the daemon's completeness metadata was DISCARDED at the
+    /// deserialization boundary: `code_context` computes `limit`/`truncated`,
+    /// and this struct — what the CLI parses the reply into — had nowhere to
+    /// put them, so a capped answer arrived looking complete.
+    ///
+    /// `Option`, and `#[serde(default)]`, so a reply from an older daemon (or
+    /// any producer that does not set them) still deserializes. `None` means
+    /// "not reported", which is distinct from `Some(false)` meaning "reported,
+    /// and nothing was dropped".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncated: Option<bool>,
 }
 
 /// Detect whether an input string looks like a file path.
@@ -631,6 +646,12 @@ pub fn build_context_with_intent(
         seeds,
         connected,
         cross_repo_links,
+        // The engine applies whatever cap it was given but does not know what
+        // the CALLER meant by it, so it reports nothing here. Callers that
+        // impose a cap (the `code_context` tool, the CLI's direct path) set
+        // these after deciding whether the extra row they asked for arrived.
+        limit: None,
+        truncated: None,
     })
 }
 

--- a/crates/nestweaver-federation/src/results.rs
+++ b/crates/nestweaver-federation/src/results.rs
@@ -615,6 +615,47 @@ pub fn merge_structured_results(local: &Value, server: &Value) -> Value {
             let seeds_len = result["seeds"].as_array().map_or(0, Vec::len);
             result["seeds_resolved"] = Value::from(seeds_len);
         }
+        // `limit` and `truncated` must survive AND be re-honoured.
+        //
+        // Carrying them through is not enough: each tier caps at the SAME
+        // requested limit independently, so a merge of two capped tiers returns
+        // up to 2x the cap. A caller asking for 1 could receive 2; an omitted
+        // limit could return 1000 against a documented default of 500. Worse,
+        // `truncated` from a single tier says nothing about whether the MERGED
+        // list is short of the total.
+        //
+        // So the cap is reapplied to the merged array, and `truncated` is the
+        // OR of "either tier truncated" and "the merge itself overflowed".
+        let requested_limit = local
+            .get("limit")
+            .or_else(|| server.get("limit"))
+            .and_then(Value::as_u64);
+        let mut merged_overflowed = false;
+        if let Some(limit) = requested_limit {
+            let limit = limit as usize;
+            if let Some(connected) = result["connected"].as_array_mut()
+                && connected.len() > limit
+            {
+                connected.truncate(limit);
+                merged_overflowed = true;
+            }
+            result["limit"] = Value::from(limit);
+        }
+        if local.get("truncated").is_some()
+            || server.get("truncated").is_some()
+            || merged_overflowed
+        {
+            let tier_truncated = |tier: &Value| {
+                tier.get("truncated")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            };
+            result["truncated"] =
+                Value::from(merged_overflowed || tier_truncated(local) || tier_truncated(server));
+        }
+
+        // Recomputed AFTER the cap above, so it describes the array the caller
+        // is holding rather than the pre-truncation merge.
         if local.get("connected_count").is_some() || server.get("connected_count").is_some() {
             let connected_len = result["connected"].as_array().map_or(0, Vec::len);
             result["connected_count"] = Value::from(connected_len);
@@ -856,6 +897,73 @@ mod tests {
         );
     }
 
+    /// Each tier caps at the SAME requested limit independently, so a merge of
+    /// two capped tiers returns up to 2x the cap unless it is reapplied. A
+    /// caller asking for 1 could receive 2; an omitted limit could return 1000
+    /// against a documented default of 500.
+    #[test]
+    fn the_requested_limit_is_reapplied_after_merging_both_tiers() {
+        let node = |uid: &str| serde_json::json!({ "uid": uid, "name": uid, "relevance": 1.0 });
+        let local = serde_json::json!({
+            "seeds": [], "connected": [node("sym:a")],
+            "limit": 1, "truncated": true, "connected_count": 1,
+        });
+        let server = serde_json::json!({
+            "seeds": [], "connected": [node("sym:b")],
+            "limit": 1, "truncated": true, "connected_count": 1,
+        });
+
+        let merged = merge_structured_results(&local, &server);
+
+        assert_eq!(
+            merged["connected"].as_array().unwrap().len(),
+            1,
+            "a limit of 1 must return 1, not one row per tier"
+        );
+        assert_eq!(merged["limit"], serde_json::json!(1));
+        assert_eq!(merged["truncated"], serde_json::json!(true));
+        assert_eq!(
+            merged["connected_count"],
+            serde_json::json!(1),
+            "the count must describe the post-cap array"
+        );
+    }
+
+    /// The counterweight: a merge that fits under the cap must NOT be reported
+    /// as truncated, or every federated call would claim to be lossy.
+    #[test]
+    fn a_merge_that_fits_is_not_reported_as_truncated() {
+        let node = |uid: &str| serde_json::json!({ "uid": uid, "name": uid, "relevance": 1.0 });
+        let local = serde_json::json!({
+            "seeds": [], "connected": [node("sym:a")], "limit": 500, "truncated": false,
+        });
+        let server = serde_json::json!({
+            "seeds": [], "connected": [node("sym:b")], "limit": 500, "truncated": false,
+        });
+
+        let merged = merge_structured_results(&local, &server);
+
+        assert_eq!(merged["connected"].as_array().unwrap().len(), 2);
+        assert_eq!(merged["truncated"], serde_json::json!(false));
+    }
+
+    /// One tier truncating means the MERGED answer is short of the total, even
+    /// if the merge itself fit under the cap.
+    #[test]
+    fn a_tier_that_truncated_makes_the_merge_truncated() {
+        let node = |uid: &str| serde_json::json!({ "uid": uid, "name": uid, "relevance": 1.0 });
+        let local = serde_json::json!({
+            "seeds": [], "connected": [node("sym:a")], "limit": 500, "truncated": true,
+        });
+        let server = serde_json::json!({
+            "seeds": [], "connected": [node("sym:b")], "limit": 500, "truncated": false,
+        });
+
+        let merged = merge_structured_results(&local, &server);
+
+        assert_eq!(merged["truncated"], serde_json::json!(true));
+    }
+
     /// The CLASS guard, not the instance. This envelope is rebuilt key by key,
     /// so any field a tool adds later is dropped SILENTLY — which is exactly how
     /// `cross_repo_links` broke `nestweaver context` without a single test
@@ -872,6 +980,7 @@ mod tests {
             "seeds_expanded": 1, "tokens_used": 10, "token_budget": 100,
             "project": "p", "project_uid": "proj:p", "external_refs": [],
             "seeds_resolved": 0, "connected_count": 0,
+            "limit": 500, "truncated": false,
             "semantic_applied": true, "degraded_components": [],
             "_meta": { "sources": ["local"] },
         });

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -3208,7 +3208,14 @@ fn tool_schema_code_context() -> Value {
                 "limit": {
                     "type": "integer",
                     "minimum": 1,
-                    "description": "Maximum connected symbols to return. Defaults to 500 when omitted; the response reports `total` and `truncated` so an omitted limit is never silently lossy."
+                    // A bound, because the handler asks the engine for
+                    // `limit + 1` and an unbounded value overflows that: a
+                    // debug panic, or a wrap to zero in release. The schema is
+                    // not the only defence — the handler saturates too — but a
+                    // knob with a minimum and no maximum is an omission either
+                    // way.
+                    "maximum": 5000,
+                    "description": "Maximum connected symbols to return. Defaults to 500 when omitted; the response reports `connected_count` and `truncated` so an omitted limit is never silently lossy."
                 },
                 "intent": {
                     "type": "string",
@@ -3406,8 +3413,17 @@ fn tool_code_context(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
 
     // One over the cap, so `truncated` can be reported without a second pass:
     // the extra row proves more exist, and is dropped before rendering.
-    let mut result =
-        nestweaver_engine::build_context_with_intent(store, &seeds, intent, Some(limit + 1))?;
+    // `saturating_add`, not `+`. Schema validation bounds `limit` on the MCP
+    // path, but this function is also reached from routes that do not validate
+    // against the schema, and `usize::MAX + 1` is a debug panic and a silent
+    // wrap to ZERO in release — which would turn "give me everything" into
+    // "give me nothing".
+    let mut result = nestweaver_engine::build_context_with_intent(
+        store,
+        &seeds,
+        intent,
+        Some(limit.saturating_add(1)),
+    )?;
     let truncated = truncate_reporting(&mut result.connected, limit);
 
     let render = |node: &nestweaver_engine::ContextNode| {
@@ -11606,6 +11622,12 @@ mod cache_dispatch_tests {
 
     /// Index a small JS repo to an on-disk db and return its path + the repo
     /// source dir (kept alive by the returned tempdir).
+    /// Shared with the federated round-trip guard, which needs a real store to
+    /// get real tool output.
+    pub(super) fn index_on_disk_for_merge_guard() -> (tempfile::TempDir, std::path::PathBuf) {
+        index_on_disk()
+    }
+
     fn index_on_disk() -> (tempfile::TempDir, std::path::PathBuf) {
         let dir = tempfile::tempdir().unwrap();
         let src = dir.path().join("repo");
@@ -14671,6 +14693,56 @@ mod federated_context_roundtrip_tests {
             parsed.connected.len(),
             2,
             "both tiers' connected symbols must survive"
+        );
+    }
+
+    /// THE GUARD THAT SHOULD HAVE CAUGHT THIS, and did not.
+    ///
+    /// The federation crate has a "no field is silently dropped" test, but its
+    /// input is a HAND-WRITTEN fixture — so it only protects the keys someone
+    /// remembered to list. When `code_context` later grew `limit` and
+    /// `truncated`, the fixture did not, and the merger dropped both while that
+    /// guard stayed green. A guard against silent drift that is itself
+    /// maintained by hand has the same weakness as the thing it guards.
+    ///
+    /// This one takes its field set from the REAL tool output, so a field added
+    /// to `code_context` is covered the moment it exists, with nobody having to
+    /// remember anything.
+    #[test]
+    fn every_field_the_real_tool_emits_survives_the_merge() {
+        let (_dir, db_path) = super::cache_dispatch_tests::index_on_disk_for_merge_guard();
+        super::set_current_db_path(db_path.clone());
+        let store = super::GraphStore::open(&db_path).unwrap();
+
+        let real = super::dispatch(
+            &store,
+            None,
+            "code_context",
+            json!({ "seeds": ["greet"] }),
+            None,
+        )
+        .expect("the tool must answer");
+
+        // Merged against itself: the point is which KEYS survive, and a second
+        // tier of the same shape is the honest stand-in for an upstream.
+        let merged = nestweaver_federation::results::merge_structured_results(&real, &real);
+
+        // Per-tier bookkeeping that is meaningless after a merge.
+        const INTENTIONALLY_DROPPED: &[&str] = &["_meta"];
+
+        let dropped: Vec<&String> = real
+            .as_object()
+            .expect("tool output is an object")
+            .keys()
+            .filter(|key| !INTENTIONALLY_DROPPED.contains(&key.as_str()))
+            .filter(|key| merged.get(key.as_str()).is_none())
+            .collect();
+
+        assert!(
+            dropped.is_empty(),
+            "code_context emits these and the merge loses them: {dropped:?}
+             real = {real}
+merged = {merged}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9942,17 +9942,51 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     // The SAME default the `code_context` tool applies. A cap on
                     // one route only is how these two drifted apart before.
                     let effective = limit.unwrap_or(nestweaver_engine::CODE_CONTEXT_DEFAULT_LIMIT);
-                    build_context_with_intent(&store, &seeds, parsed_intent, Some(effective))
+                    // Ask for one MORE than the cap, exactly as the
+                    // `code_context` tool does, so the extra row proves more
+                    // exist. Without this the direct path applied the same 500
+                    // cap as the daemon route but could not TELL it had — a
+                    // capped answer rendered identically to a complete one,
+                    // which is the silent truncation the cap was supposed to
+                    // stop being.
+                    build_context_with_intent(
+                        &store,
+                        &seeds,
+                        parsed_intent,
+                        Some(effective.saturating_add(1)),
+                    )
+                    .map(|mut result| {
+                        let truncated = result.connected.len() > effective;
+                        if truncated {
+                            result.connected.truncate(effective);
+                        }
+                        result.limit = Some(effective);
+                        result.truncated = Some(truncated);
+                        result
+                    })
                 }
             };
             match built {
                 Ok(mut result) => {
                     if let Some(budget) = token_budget {
                         let cut = context_token_budgeted_truncate(&result.connected, budget);
+                        if cut < result.connected.len() {
+                            result.truncated = Some(true);
+                        }
                         result.connected.truncate(cut);
                     }
+                    // Say so. A capped result that renders identically to a
+                    // complete one is the whole defect this reports on: the
+                    // caller cannot tell "this is the answer" from "this is
+                    // the first N of the answer".
+                    let truncation = match (result.truncated, result.limit) {
+                        (Some(true), Some(limit)) => {
+                            format!(", TRUNCATED at limit {limit} — pass --limit for more")
+                        }
+                        _ => String::new(),
+                    };
                     let stats = format!(
-                        "{} seeds, {} connected nodes in {} ({})",
+                        "{} seeds, {} connected nodes in {} ({}){}",
                         result.seeds.len(),
                         result.connected.len(),
                         format_elapsed(t0.elapsed()),
@@ -9960,7 +9994,8 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             "via daemon"
                         } else {
                             "local fallback"
-                        }
+                        },
+                        truncation
                     );
                     if json {
                         println!("{}", serde_json::to_string_pretty(&result)?);


### PR DESCRIPTION
Three defects in my own #299/#300 work, reported in review and **all confirmed**.

---

## 1. The merger dropped `limit`/`truncated` — and never reapplied the cap

Carrying the fields through would not have been enough. Each tier caps at the **same** requested limit independently, so a merge of two capped tiers returns up to **2× the cap**:

- `limit: 1` could return **2 results**
- an omitted limit could return **1000** against a documented default of 500

…with nothing saying so. And a single tier's `truncated` says nothing about whether the **merged** list is short of the total.

The cap is now reapplied to the merged array, `truncated` is the OR of *"either tier truncated"* and *"the merge itself overflowed"*, and `connected_count` is recomputed **after** the cap so it describes the array the caller holds.

## 2. `limit + 1` overflowed

Schema had `minimum: 1` and **no maximum**, so `usize::MAX` panicked in debug and **wrapped to zero** in release — turning *"give me everything"* into *"give me nothing"*.

Schema gains `maximum: 5000`; the handler uses `saturating_add`, because this function is also reached from routes that do not validate against the schema. The description also claimed the response reports `total` — it reports `connected_count`.

## 3. The CLI discarded the metadata at the type boundary

`ContextResult` held only `seeds`/`connected`/`cross_repo_links`, so a daemon reply's `limit`/`truncated` had **nowhere to land** — a capped answer arrived looking complete. And the direct path applied the same 500 cap while being structurally unable to detect it.

It now carries optional `limit`/`truncated` (`serde(default)`, so an older daemon still deserializes, and `None` = "not reported", distinct from `Some(false)` = "reported, nothing dropped"). The direct path asks for `limit + 1` exactly as the tool does, and output says `TRUNCATED at limit N`.

---

## The real defect is the fourth one

My *"no field is silently dropped"* guard took its input from a **hand-written fixture**, so it only protected keys someone remembered to list. When `code_context` grew `limit` and `truncated`, the fixture did not — and the merger dropped both while the guard stayed **green**.

> A guard against silent drift that is itself maintained by hand has the same weakness as the thing it guards.

The new guard takes its field set from the **real tool's output**, so a field added to `code_context` is covered the moment it exists, with nobody having to remember anything.

**Mutation-checked** — reintroducing the drop fails it with:

```
code_context emits these and the merge loses them: ["limit", "truncated"]
```

(My first attempt at that check silently failed to apply the mutation after `cargo fmt` reflowed the target, so the "pass" was meaningless. Redone against the real text.)

## Verification

- `cargo test --workspace --all-targets` — green (39 targets, 0 failures)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean