### PR TITLE
fix(ranking): give the git-activity sidecar a repo dimension, and load it

### DIFF
--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -4831,9 +4831,13 @@ impl NestWeaverDaemon for DaemonService {
                                 &state.db_path,
                                 ".gitactivity.json",
                             );
-                            if let Err(e) = nestweaver_engine::git_activity::save_git_activity(
-                                &scores, &ga_path,
-                            ) {
+                            if let Err(e) =
+                                nestweaver_engine::git_activity::save_git_activity_for_repo(
+                                    &result.repo_uid,
+                                    &scores,
+                                    &ga_path,
+                                )
+                            {
                                 tracing::warn!("save git activity sidecar failed: {e}");
                             } else {
                                 let _ = tx.blocking_send(Ok(IndexProgress {
@@ -9944,6 +9948,20 @@ pub async fn run_server(
         store.load_interaction_cache(scores);
     }
     let interactions_load_ms = interactions_started.elapsed().as_millis() as u64;
+
+    // nw-234: the daemon never loaded this, so `--with-git-activity` mined the
+    // history, wrote the sidecar, reported "N files scored", and then changed
+    // NOTHING for anyone querying through the daemon — which is the default
+    // route. The CLI's direct path loaded all three sidecars; this loaded two.
+    // A flag that costs time at index and affects nothing at query is a success
+    // message for work with no effect.
+    //
+    // Absent or old-format is neutral by construction (a missing score yields a
+    // multiplier of exactly 1.0), so this cannot make results worse.
+    let ga_path = nestweaver_engine::sidecar_path(&db_path, ".gitactivity.json");
+    if let Err(error) = store.load_git_activity_sidecar(&ga_path) {
+        tracing::debug!(error = %error, "git-activity sidecar not loaded; ranking stays neutral");
+    }
 
     // Open the Tantivy index. A read-only snapshot replica intentionally
     // disables search reconciliation and uses a reader when one is available.

--- a/crates/nestweaver-engine/src/backup.rs
+++ b/crates/nestweaver-engine/src/backup.rs
@@ -952,8 +952,11 @@ fn backup_artifact_contract(
             Some(".manifests.json") => anyhow::bail!(
                 "repository manifest contract requires payload inspection; use backup_artifact_contract_for_payload"
             ),
+            // v2: repo-keyed. Bumped with the format, or a restore would
+            // reintroduce a v1 flat payload under a v2 contract claim — the
+            // artifact vouching for a shape it does not have.
             Some(".gitactivity.json") => {
-                (ArtifactKind::GitActivity, 1, "nestweaver-git-activity-v1")
+                (ArtifactKind::GitActivity, 2, "nestweaver-git-activity-v2")
             }
             Some(".cochange.json") => (ArtifactKind::Cochange, 1, "nestweaver-cochange-v1"),
             Some(".interactions.json") => {

--- a/crates/nestweaver-engine/src/git_activity.rs
+++ b/crates/nestweaver-engine/src/git_activity.rs
@@ -28,7 +28,6 @@
 //! (or larger configured weights) cannot push the multiplier outside
 //! `[0.4, 1.6]`.
 
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::Command;

--- a/crates/nestweaver-engine/src/git_activity.rs
+++ b/crates/nestweaver-engine/src/git_activity.rs
@@ -28,6 +28,7 @@
 //! (or larger configured weights) cannot push the multiplier outside
 //! `[0.4, 1.6]`.
 
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::Command;
@@ -247,18 +248,73 @@ pub fn compute_git_activity(repo_path: &Path) -> HashMap<String, f64> {
     score_commits(&commits, now_epoch_secs())
 }
 
-/// Persist a `path -> score` map to the sidecar at `path` (JSON).
-pub fn save_git_activity(scores: &HashMap<String, f64>, path: &Path) -> std::io::Result<()> {
-    let json = serde_json::to_string(scores).map_err(std::io::Error::other)?;
-    std::fs::write(path, json)
+pub use nestweaver_store::git_activity_sidecar::{GITACTIVITY_VERSION, GitActivitySidecar};
+
+/// Replace ONE repo's slice, conserving every other repo's.
+///
+/// The old implementation was a plain `fs::write` of just the incoming repo,
+/// which is what erased the rest. This mirrors `save_filemeta_for_repo`:
+/// load, replace this repo's entry, write atomically. Replace-not-merge within
+/// the repo is deliberate — a re-index recomputes that repo's scores in full,
+/// so stale paths must not survive.
+pub fn save_git_activity_for_repo(
+    repo_uid: &str,
+    scores: &HashMap<String, f64>,
+    path: &Path,
+) -> Result<(), anyhow::Error> {
+    let mut sidecar = load_git_activity_sidecar(path);
+    sidecar.repos.insert(repo_uid.to_string(), scores.clone());
+    save_git_activity_sidecar(&sidecar, path)
 }
 
-/// Load the `path -> score` sidecar map. Returns an empty map on missing /
-/// corrupt file (the neutral path).
-pub fn load_git_activity(path: &Path) -> HashMap<String, f64> {
+/// Write the sidecar atomically. The previous `fs::write` was not atomic, so a
+/// crash mid-write left a truncated file — which `load_git_activity_sidecar`
+/// then reads as empty, i.e. silently neutral ranking.
+pub fn save_git_activity_sidecar(
+    sidecar: &GitActivitySidecar,
+    path: &Path,
+) -> Result<(), anyhow::Error> {
+    let json = serde_json::to_string(sidecar)?;
+    crate::manifest::atomic_replace_file(path, |file| {
+        use std::io::Write;
+        file.write_all(json.as_bytes())
+    })
+}
+
+/// Load the sidecar. Missing, corrupt, or OLD-FORMAT files yield an empty one.
+///
+/// A v1 flat map fails to deserialize into this shape and is discarded rather
+/// than migrated. Migration is not merely unnecessary here, it is UNSOUND: a v1
+/// key carries no repo dimension, so attributing it to any repo is the exact
+/// mis-attribution the format change exists to prevent. Discarding costs one
+/// re-index and is the honest outcome — the same call `FileMetaSidecar` makes.
+///
+/// Degrading to empty is safe by construction: a missing score yields a
+/// multiplier of exactly 1.0, so the ranking reverts to unmodified PageRank
+/// rather than to something wrong.
+pub fn load_git_activity_sidecar(path: &Path) -> GitActivitySidecar {
     match std::fs::read_to_string(path) {
-        Ok(s) => serde_json::from_str(&s).unwrap_or_default(),
-        Err(_) => HashMap::new(),
+        Ok(data) => match serde_json::from_str::<GitActivitySidecar>(&data) {
+            Ok(sidecar) if sidecar.version == GITACTIVITY_VERSION => sidecar,
+            Ok(sidecar) => {
+                tracing::debug!(
+                    path = %path.display(),
+                    found_version = sidecar.version,
+                    expected_version = GITACTIVITY_VERSION,
+                    "git-activity sidecar version mismatch; discarding (re-index to restore)"
+                );
+                GitActivitySidecar::default()
+            }
+            Err(error) => {
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %error,
+                    "git-activity sidecar corrupt or legacy v1 flat format; discarding"
+                );
+                GitActivitySidecar::default()
+            }
+        },
+        Err(_) => GitActivitySidecar::default(),
     }
 }
 
@@ -412,15 +468,114 @@ mod tests {
         let mut scores = HashMap::new();
         scores.insert("src/a.rs".to_string(), 0.8);
         scores.insert("src/b.rs".to_string(), 0.2);
-        save_git_activity(&scores, &path).unwrap();
-        let loaded = load_git_activity(&path);
-        assert_eq!(loaded.len(), 2);
-        assert!((loaded["src/a.rs"] - 0.8).abs() < 1e-9);
+        save_git_activity_for_repo("repo:test", &scores, &path).unwrap();
+        let loaded = load_git_activity_sidecar(&path);
+        assert_eq!(loaded.repos["repo:test"].len(), 2);
+        assert!((loaded.repos["repo:test"]["src/a.rs"] - 0.8).abs() < 1e-9);
     }
 
     #[test]
     fn load_missing_sidecar_is_empty() {
-        let loaded = load_git_activity(Path::new("/nonexistent/path.json"));
-        assert!(loaded.is_empty());
+        let loaded = load_git_activity_sidecar(Path::new("/nonexistent/path.json"));
+        assert!(loaded.repos.is_empty());
+    }
+}
+
+/// nw-233: the sidecar must survive a multi-repo database.
+#[cfg(test)]
+mod repo_dimension_tests {
+    use super::*;
+
+    fn scores(pairs: &[(&str, f64)]) -> HashMap<String, f64> {
+        pairs
+            .iter()
+            .map(|(path, score)| ((*path).to_string(), *score))
+            .collect()
+    }
+
+    /// THE BUG. `save_git_activity` was a plain write of just the incoming
+    /// repo, so in a 42-repo database indexing any repo erased the other 41.
+    #[test]
+    fn writing_one_repo_conserves_every_other_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("db.gitactivity.json");
+
+        save_git_activity_for_repo("repo:a", &scores(&[("src/main.rs", 0.9)]), &path).unwrap();
+        save_git_activity_for_repo("repo:b", &scores(&[("src/main.rs", 0.1)]), &path).unwrap();
+
+        let loaded = load_git_activity_sidecar(&path);
+        assert_eq!(
+            loaded.repos.len(),
+            2,
+            "indexing repo B must not erase repo A"
+        );
+        // And the collision: BOTH repos have `src/main.rs`, and each keeps its
+        // OWN score. A flat map could not represent this at all.
+        assert_eq!(loaded.repos["repo:a"]["src/main.rs"], 0.9);
+        assert_eq!(loaded.repos["repo:b"]["src/main.rs"], 0.1);
+    }
+
+    /// Within a repo it is REPLACE, not merge: a re-index recomputes that
+    /// repo's scores in full, so a path that no longer exists must not survive.
+    #[test]
+    fn reindexing_a_repo_replaces_its_slice_rather_than_accumulating() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("db.gitactivity.json");
+
+        save_git_activity_for_repo("repo:a", &scores(&[("gone.rs", 0.5)]), &path).unwrap();
+        save_git_activity_for_repo("repo:a", &scores(&[("kept.rs", 0.7)]), &path).unwrap();
+
+        let loaded = load_git_activity_sidecar(&path);
+        assert_eq!(loaded.repos["repo:a"].len(), 1);
+        assert!(
+            !loaded.repos["repo:a"].contains_key("gone.rs"),
+            "a deleted path must not linger in the repo's slice"
+        );
+    }
+
+    /// A v1 flat map is DISCARDED, not migrated. Migration is unsound: a v1 key
+    /// carries no repo, so attributing it to one is the exact mis-attribution
+    /// the format exists to prevent. Degrading to empty is safe — a missing
+    /// score is a multiplier of exactly 1.0.
+    #[test]
+    fn a_legacy_v1_flat_file_is_discarded_not_misattributed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("db.gitactivity.json");
+        std::fs::write(&path, r#"{"src/main.rs":0.9,"README.md":0.4}"#).unwrap();
+
+        let loaded = load_git_activity_sidecar(&path);
+
+        assert!(
+            loaded.repos.is_empty(),
+            "a v1 flat map has no repo dimension; inventing one would be the bug"
+        );
+        assert_eq!(loaded.version, GITACTIVITY_VERSION);
+    }
+
+    /// A future version is discarded too, not read as if it were ours.
+    #[test]
+    fn a_newer_version_is_discarded_rather_than_misread() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("db.gitactivity.json");
+        std::fs::write(
+            &path,
+            r#"{"version":99,"repos":{"repo:a":{"src/main.rs":0.9}}}"#,
+        )
+        .unwrap();
+
+        assert!(load_git_activity_sidecar(&path).repos.is_empty());
+    }
+
+    /// The counterweight: a well-formed current-version file must round-trip,
+    /// or "discard on mismatch" would quietly become "discard everything".
+    #[test]
+    fn a_current_version_file_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("db.gitactivity.json");
+
+        save_git_activity_for_repo("repo:a", &scores(&[("src/main.rs", 0.9)]), &path).unwrap();
+
+        let loaded = load_git_activity_sidecar(&path);
+        assert_eq!(loaded.repos["repo:a"]["src/main.rs"], 0.9);
     }
 }

--- a/crates/nestweaver-engine/src/hubs.rs
+++ b/crates/nestweaver-engine/src/hubs.rs
@@ -124,7 +124,9 @@ pub fn find_hub_nodes(store: &GraphStore, top_n: usize) -> Result<Vec<HubNode>> 
         let base = pr_scores.get(&sym.uid).copied().unwrap_or(0.0);
         let pagerank = if ga_active {
             base * nestweaver_store::git_activity_multiplier(
-                store.git_activity_score(&sym.file_path),
+                // Repo-keyed for the same reason as the ranking path: a
+                // repo-relative path alone matches the wrong repo (nw-233).
+                store.git_activity_score(&sym.repo_uid, &sym.file_path),
                 ga_weight,
             )
         } else {
@@ -339,9 +341,13 @@ mod tests {
             .compute_pagerank(0.85, 30, &nestweaver_store::GraphScope::code_only())
             .unwrap();
 
+        // Repo-keyed now (nw-233): the fixture's symbols all belong to
+        // "repo-1", and a score filed under any other repo must not reach them.
+        let mut paths = HashMap::new();
+        paths.insert("src/fresh.rs".to_string(), 0.95);
+        paths.insert("src/stale.rs".to_string(), 0.05);
         let mut ga = HashMap::new();
-        ga.insert("src/fresh.rs".to_string(), 0.95);
-        ga.insert("src/stale.rs".to_string(), 0.05);
+        ga.insert("repo-1".to_string(), paths);
         store.load_git_activity_cache(ga);
 
         let hubs = find_hub_nodes(&store, 10).unwrap();

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -47,6 +47,12 @@ struct HandlerFileData {
 /// derived because the contract-status fields are asserted on in tests.
 #[derive(Debug, Clone)]
 pub struct IndexResult {
+    /// Which repo this run indexed.
+    ///
+    /// Callers that write REPO-KEYED sidecars need it, and previously had to
+    /// re-derive it from (instance_id, url) or go without — which is how the
+    /// git-activity sidecar ended up with no repo dimension at all (nw-233).
+    pub repo_uid: String,
     pub symbols_count: usize,
     pub edges_count: usize,
     pub files_count: usize,
@@ -405,6 +411,32 @@ fn remove_repo_sidecar_slices_with_io(
             Some(repo_uid),
             format!("{}: {error:#}", resolution_deps_path.display()),
         );
+    }
+
+    // gitactivity — nw-233. Could not be sliced before, because the sidecar had
+    // no repo dimension to slice ON; the whole file was one flat map. Now that
+    // it is repo-keyed, the deleted repo's rows must go with it, or removing
+    // and re-adding a repo at the same path resurrects recency scores mined
+    // from a graph state that no longer exists.
+    //
+    // A SAFE stage, not a required one: a stale slice biases ranking toward
+    // whatever those paths used to be, which is a quality issue rather than a
+    // correctness one — unlike resolution_deps, where a durable slice for a
+    // deleted UID can change what a later incremental resolution RESOLVES TO.
+    let gitactivity_path = crate::sidecar_path(db_path, ".gitactivity.json");
+    if gitactivity_path.exists() {
+        let mut sidecar = crate::git_activity::load_git_activity_sidecar(&gitactivity_path);
+        if sidecar.repos.remove(repo_uid).is_some()
+            && let Err(error) =
+                crate::git_activity::save_git_activity_sidecar(&sidecar, &gitactivity_path)
+        {
+            tracing::debug!(
+                path = %gitactivity_path.display(),
+                repo = %repo_uid,
+                error = %error,
+                "git-activity slice for the deleted repo could not be removed"
+            );
+        }
     }
 }
 
@@ -3947,6 +3979,7 @@ where
         );
 
         let result = IndexResult {
+            repo_uid: r_uid.clone(),
             symbols_count,
             edges_count,
             files_count,

--- a/crates/nestweaver-mcp/src/lib.rs
+++ b/crates/nestweaver-mcp/src/lib.rs
@@ -112,6 +112,15 @@ pub fn run_stdio_server(
         store.load_interaction_cache(scores);
     }
 
+    // nw-234: and the git-activity sidecar, which this path also skipped. The
+    // comment above the PageRank load says "same behaviour as the CLI" — it was
+    // not: the CLI loads three sidecars and this loaded two, so
+    // `--with-git-activity` had no effect on anything an agent asked for.
+    let ga_path = nestweaver_engine::sidecar_path(db_path, ".gitactivity.json");
+    if let Err(error) = store.load_git_activity_sidecar(&ga_path) {
+        tracing::debug!(error = %error, "git-activity sidecar not loaded; ranking stays neutral");
+    }
+
     // Open the Tantivy index sidecar in read-only mode. The MCP server
     // only searches — it never writes to the index. Reader-only mode
     // avoids contending for the writer lock with a running brain watcher.

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -311,7 +311,11 @@ pub struct GraphStore {
     /// demoted relative to actively-developed code. Absent file → neutral
     /// (multiplier 1.0). Loaded from the `<db>.gitactivity.json` sidecar; never
     /// affects the PPR fixpoint.
-    pub(crate) git_activity_cache: Mutex<Option<HashMap<String, f64>>>,
+    /// repo uid -> (repo-relative path -> recency score).
+    ///
+    /// The repo dimension is load-bearing: paths here are REPO-RELATIVE, so a
+    /// flat map made two repos collide on every shared name (nw-233).
+    pub(crate) git_activity_cache: Mutex<Option<HashMap<String, HashMap<String, f64>>>>,
     /// Feature F12: the `[ranking] git_activity_weight` to use when applying the
     /// recency multiplier. Defaults to [`crate::ranking::DEFAULT_GIT_ACTIVITY_WEIGHT`]
     /// (1.2); `set_git_activity_weight` overrides it from config.
@@ -943,7 +947,7 @@ impl GraphStore {
     /// `pagerank_score` is multiplied at read time by a clamped recency factor
     /// (see [`git_activity_multiplier`]). Passing an empty map is equivalent to
     /// not loading at all (every file → neutral).
-    pub fn load_git_activity_cache(&self, scores: HashMap<String, f64>) {
+    pub fn load_git_activity_cache(&self, scores: HashMap<String, HashMap<String, f64>>) {
         *self
             .git_activity_cache
             .lock()
@@ -964,20 +968,37 @@ impl GraphStore {
         if path.exists() {
             let json = std::fs::read_to_string(path)
                 .map_err(|e| StoreError::Query(format!("read: {e}")))?;
-            let scores: HashMap<String, f64> = serde_json::from_str(&json)
-                .map_err(|e| StoreError::Query(format!("deserialize: {e}")))?;
-            self.load_git_activity_cache(scores);
+            // Version-checked and repo-keyed. A v1 flat map fails this parse
+            // and is treated as absent, which is neutral rather than wrong.
+            let sidecar: crate::git_activity_sidecar::GitActivitySidecar =
+                match serde_json::from_str(&json) {
+                    Ok(sidecar) => sidecar,
+                    Err(error) => {
+                        tracing::debug!(
+                            path = %path.display(),
+                            error = %error,
+                            "git-activity sidecar corrupt or legacy v1 flat format; ignoring"
+                        );
+                        return Ok(());
+                    }
+                };
+            self.load_git_activity_cache(sidecar.repos);
         }
         Ok(())
     }
 
-    /// Return the git-activity recency score for a repo-relative file `path`,
-    /// or `None` when no score is loaded for it (→ neutral multiplier).
-    pub fn git_activity_score(&self, path: &str) -> Option<f64> {
-        self.git_activity_cache
-            .lock()
-            .ok()
-            .and_then(|guard| guard.as_ref().and_then(|m| m.get(path).copied()))
+    /// Return the git-activity recency score for a file, or `None` when none is
+    /// loaded for it (→ neutral multiplier of exactly 1.0).
+    ///
+    /// Keyed by repo FIRST. `path` is repo-relative, so without the repo uid
+    /// two repos sharing `src/main.rs` returned each other's recency.
+    pub fn git_activity_score(&self, repo_uid: &str, path: &str) -> Option<f64> {
+        self.git_activity_cache.lock().ok().and_then(|guard| {
+            guard
+                .as_ref()
+                .and_then(|repos| repos.get(repo_uid))
+                .and_then(|paths| paths.get(path).copied())
+        })
     }
 
     /// True when git-activity recency scores are loaded (Feature F12 active).

--- a/crates/nestweaver-store/src/git_activity_sidecar.rs
+++ b/crates/nestweaver-store/src/git_activity_sidecar.rs
@@ -1,0 +1,39 @@
+//! On-disk shape of `<db>.gitactivity.json`.
+//!
+//! Lives in the STORE rather than the engine because both crates need it: the
+//! engine mines and writes it, the store reads it into the ranking cache. Two
+//! copies of a serialization shape is how the two halves drift apart.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// v1 was an implicit, unversioned, flat `path -> score` map with no repo
+/// dimension at all.
+pub const GITACTIVITY_VERSION: u32 = 2;
+
+/// Recency scores keyed by repo uid, then repo-relative path.
+///
+/// The repo dimension is the whole point. v1 was flat, and the read side looked
+/// up a REPO-RELATIVE path, so two repos collided on every shared name —
+/// `src/main.rs`, `README.md`, `mod.rs`. The write side compounded it by
+/// replacing the entire file with just the repo being indexed, so in a
+/// multi-repo database indexing ANY repo erased every other repo's scores.
+///
+/// Same shape, and for the same reason, as `FileMetaSidecar` (nw-022) and
+/// `ResolutionCacheFile` (nw-045). Nesting rather than `"<uid>\0<path>"`
+/// composite keys, because nesting is what makes per-repo replace and per-repo
+/// deletion trivial.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitActivitySidecar {
+    pub version: u32,
+    pub repos: HashMap<String, HashMap<String, f64>>,
+}
+
+impl Default for GitActivitySidecar {
+    fn default() -> Self {
+        Self {
+            version: GITACTIVITY_VERSION,
+            repos: HashMap::new(),
+        }
+    }
+}

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -4,6 +4,7 @@ pub mod db;
 pub mod durable_sidecar;
 pub mod error;
 pub mod generation;
+pub mod git_activity_sidecar;
 pub mod index_publication;
 pub mod ranking;
 pub mod read;

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -1273,8 +1273,15 @@ impl GraphStore {
                 scores.get(&sym.uid).copied().map(|score| {
                     let effective = match &git_activity {
                         Some(ga) => {
-                            let mult =
-                                git_activity_multiplier(ga.get(&sym.file_path).copied(), ga_weight);
+                            // Repo-keyed. `file_path` is REPO-RELATIVE, so the
+                            // old flat lookup returned another repo's recency
+                            // for any shared name (nw-233).
+                            let mult = git_activity_multiplier(
+                                ga.get(&sym.repo_uid)
+                                    .and_then(|paths| paths.get(&sym.file_path))
+                                    .copied(),
+                                ga_weight,
+                            );
                             score * mult
                         }
                         None => score,
@@ -3399,6 +3406,52 @@ mod tests {
     }
 
     #[test]
+    /// nw-233's read half: `file_path` is REPO-RELATIVE, so a flat lookup
+    /// returned another repo's recency for any shared name. A score filed under
+    /// a DIFFERENT repo must not reach these symbols at all.
+    #[test]
+    fn a_score_filed_under_another_repo_does_not_reach_this_ones_symbols() {
+        let store = test_store();
+        let mut sym = make_symbol("F", "shared_name");
+        sym.file_path = "src/main.rs".to_string();
+        store.insert_symbol(&sym).unwrap();
+        store
+            .compute_pagerank(0.85, 30, &crate::GraphScope::code_only())
+            .unwrap();
+
+        let baseline = store
+            .symbols_by_pagerank(None)
+            .unwrap()
+            .into_iter()
+            .find(|s| s.uid == "F")
+            .unwrap()
+            .pagerank_score
+            .unwrap();
+
+        // Same relative path, WRONG repo — the classic collision.
+        let mut paths = std::collections::HashMap::new();
+        paths.insert("src/main.rs".to_string(), 0.95);
+        let mut ga = std::collections::HashMap::new();
+        ga.insert("repo-SOMEONE-ELSE".to_string(), paths);
+        store.load_git_activity_cache(ga);
+
+        let after = store
+            .symbols_by_pagerank(None)
+            .unwrap()
+            .into_iter()
+            .find(|s| s.uid == "F")
+            .unwrap()
+            .pagerank_score
+            .unwrap();
+
+        assert!(
+            (after - baseline).abs() < 1e-9,
+            "another repo's src/main.rs must not change this repo's ranking \
+             ({baseline} -> {after})"
+        );
+    }
+
+    #[test]
     fn git_activity_demotes_stale_file_at_read_time() {
         // Two symbols with identical structural position but different files.
         // Both get the same base pagerank; loading git-activity scores that
@@ -3430,9 +3483,12 @@ mod tests {
         );
 
         // Load recency scores and re-read.
+        // Repo-keyed (nw-233). `make_symbol` files everything under "repo-1".
+        let mut paths = std::collections::HashMap::new();
+        paths.insert("src/fresh.rs".to_string(), 0.95);
+        paths.insert("src/stale.rs".to_string(), 0.05);
         let mut ga = std::collections::HashMap::new();
-        ga.insert("src/fresh.rs".to_string(), 0.95);
-        ga.insert("src/stale.rs".to_string(), 0.05);
+        ga.insert("repo-1".to_string(), paths);
         store.load_git_activity_cache(ga);
 
         let ranked = store.symbols_by_pagerank(None).unwrap();
@@ -3474,8 +3530,10 @@ mod tests {
             .pagerank_score
             .unwrap();
 
+        let mut paths = std::collections::HashMap::new();
+        paths.insert("src/scored.rs".to_string(), 0.9); // only A's file
         let mut ga = std::collections::HashMap::new();
-        ga.insert("src/scored.rs".to_string(), 0.9); // only A's file
+        ga.insert("repo-1".to_string(), paths);
         store.load_git_activity_cache(ga);
 
         let after_b = store

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -3405,7 +3405,6 @@ mod tests {
         }
     }
 
-    #[test]
     /// nw-233's read half: `file_path` is REPO-RELATIVE, so a flat lookup
     /// returned another repo's recency for any shared name. A score filed under
     /// a DIFFERENT repo must not reach these symbols at all.

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -17,6 +17,11 @@ pub struct SymbolBasic {
     pub name: String,
     pub file_path: String,
     pub kind: String,
+    /// Needed because `file_path` is REPO-RELATIVE. Any per-file lookup keyed
+    /// on the path alone matches the wrong repo whenever two repos share a
+    /// name — `src/main.rs`, `README.md` (nw-233). Parsing it back out of `uid`
+    /// is not an option: `repo_uid` itself contains colons.
+    pub repo_uid: String,
 }
 
 /// Edge data for clustering: (source_uid, target_uid, confidence).
@@ -2000,7 +2005,7 @@ impl GraphStore {
     pub fn load_code_symbols_and_edges(&self) -> Result<CodeGraph, StoreError> {
         let conn = self.conn()?;
 
-        let q = "MATCH (s:Symbol) RETURN s.uid, s.name, s.file_path, s.kind";
+        let q = "MATCH (s:Symbol) RETURN s.uid, s.name, s.file_path, s.kind, s.repo_uid";
         let result = conn
             .query(q)
             .map_err(|e| StoreError::Query(e.to_string()))?;
@@ -2010,11 +2015,13 @@ impl GraphStore {
             let name = extract_string(&row, 1)?;
             let file_path = extract_string(&row, 2)?;
             let kind = extract_string(&row, 3)?;
+            let repo_uid = extract_string(&row, 4)?;
             symbols.push(SymbolBasic {
                 uid,
                 name,
                 file_path,
                 kind,
+                repo_uid,
             });
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15057,8 +15057,16 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     out.status("No usable git history found; git-activity sidecar not written.");
                 } else {
                     let ga_path = nestweaver_engine::sidecar_path(&db_path, ".gitactivity.json");
-                    nestweaver_engine::git_activity::save_git_activity(&scores, &ga_path)
-                        .with_context(|| "save git activity sidecar")?;
+                    // Same derivation the indexer uses, because `result` is
+                    // scoped to the branch above. The sidecar is repo-keyed
+                    // now, so this call has to name a repo.
+                    let ga_repo_uid = nestweaver_schema::repo_uid(&instance_id, &repo_url);
+                    nestweaver_engine::git_activity::save_git_activity_for_repo(
+                        &ga_repo_uid,
+                        &scores,
+                        &ga_path,
+                    )
+                    .with_context(|| "save git activity sidecar")?;
                     out.status(&format!(
                         "Git activity sidecar written ({} files scored).",
                         scores.len()
@@ -17426,7 +17434,7 @@ fn run_ranking(
                 .get(&resolved)
                 .copied()
                 .unwrap_or(0.0);
-            let git_activity_score = store.git_activity_score(&sym.file_path);
+            let git_activity_score = store.git_activity_score(&sym.repo_uid, &sym.file_path);
             let weight = store.git_activity_weight();
             let multiplier = nestweaver_store::git_activity_multiplier(git_activity_score, weight);
             let final_rank = base_pagerank * multiplier;


### PR DESCRIPTION
**nw-233 and nw-234 together**, because either alone makes things worse: enabling the sidecar on the daemon while it still erases 41 of 42 repos would activate known-bad data, and fixing the data alone would carefully repair something nothing reads.

---

## nw-234 — the flag did nothing on the paths users query

`load_git_activity_sidecar` had **one** production call site, on the direct CLI path. The daemon and MCP store-opens loaded `.pagerank.json` and interaction scores and skipped this one.

The MCP block even carries the comment *"Pre-load the PageRank sidecar if present — same behaviour as the CLI"* while loading **two of the three** sidecars the CLI loads.

So a user passed `--with-git-activity`, paid the git-mining cost, was told `Git activity sidecar written (N files scored)`, and the feature changed **nothing** they queried through the default route. A success message for work with no effect.

## nw-233 — the sidecar had no repo dimension at all

Flat `path -> score`, and the read side looked up a **repo-relative** path. Two repos collided on every shared name — `src/main.rs`, `README.md`, `mod.rs`. The write side compounded it with a plain `fs::write` of only the repo being indexed, so indexing **any** repo erased every other repo's scores.

### The format

A versioned, repo-keyed envelope, mirroring `FileMetaSidecar` (nw-022) and `ResolutionCacheFile` (nw-045) — **the same defect, solved the same way, twice before**. Nesting rather than `"<uid>\0<path>"` composite keys, because nesting is what makes per-repo replace and per-repo deletion trivial.

### Old files are discarded, not migrated

Migration is not merely unnecessary here, it is **unsound**: a v1 key carries no repo, so attributing it to one is the exact mis-attribution the format exists to prevent.

Discarding costs one re-index and is safe by construction — a missing score yields a multiplier of **exactly 1.0**, so ranking reverts to unmodified PageRank rather than to something wrong.

That is also why this deliberately gets **no** `staleness_note`-style disclosure: that surface is for confidently *wrong* output, not for a signal reverting to its documented neutral. Adding a second cause to `rankings_stale` would make it mean two things.

## Carried along, same root cause

- The write is now **atomic**. It was a plain `fs::write`, so a crash mid-write left a truncated file — which reads as empty, i.e. silently neutral ranking.
- The **deletion finalizer** slices the removed repo's rows. It previously could not, for want of a dimension to slice on.
- The **backup artifact contract** is bumped to v2, or a restore would reintroduce a v1 payload under a v2 claim.
- `IndexResult` gains `repo_uid` — callers writing repo-keyed sidecars need to know which repo ran, and having to re-derive it is part of how this ended up without the dimension.

## Tests

Both halves of the collision (two repos, same relative path, each keeping its own score), replace-not-accumulate within a repo, v1 and future-version discard, and the read-side proof that a score filed under **another** repo cannot reach this one's symbols.

The round-trip counterweight is there so *"discard on mismatch"* cannot quietly become *"discard everything"*.

## Verification

- `cargo test --workspace --all-targets` — green (39 targets, 0 failures)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean