### PR TITLE
feat(cli): let a human read back what agents annotate, and say who can repair

### DIFF
--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -1705,7 +1705,7 @@ fn classify_index_publication_error(store: &GraphStore, error: anyhow::Error) ->
             "index publication WEDGED: ranked queries are failing closed because {} exists \
              and {writer} (marker age {age}). {preamble} The PageRank and generation sidecars \
              may predate the committed graph, so serving them would return wrong ranks. \
-             Recover with: {repair}{}",
+             A HUMAN must recover with (there is no MCP tool for this): {repair}{}",
             status.marker_path,
             if status.writer_reason.as_deref()
                 == Some(nestweaver_store::index_publication::MARKER_REASON_CANCELLED)
@@ -3224,7 +3224,7 @@ fn tool_schema_code_context() -> Value {
 fn tool_schema_brain_context() -> Value {
     json!({
         "name": "brain_context",
-        "description": "Retrieve PPR-ranked structural context from the knowledge graph, seeded by symbol names, note titles, or keywords. Returns mixed-kind results (Symbol, Note, Section, Tag, Heading) within a token budget.\n\nGuidelines:\n- Primary entry point for understanding a topic — use before reading files\n- Seed with specific names (e.g. 'AuthService.validate'), not broad terms\n- Filter with repos, tags, path_prefix, kinds for precision; use response_format 'concise' unless you need full bodies\n\nLimitations:\n- Only searches indexed repos/vaults — check stale_check if results seem stale\n- Ranked by graph proximity, not recency (use recency_weight to add time decay)\n- May fail with 'index publication TRANSIENT/WEDGED' while an index is being published. This refers to INDEX PUBLICATION, not a dirty git working tree: editing files in a repo does NOT cause it, and NestWeaver is fully usable while you work. TRANSIENT resolves on its own — retry. WEDGED means a prior indexer died mid-publication; run the `nestweaver repair` command named in the error, or check brain_status.index_publication.",
+        "description": "Retrieve PPR-ranked structural context from the knowledge graph, seeded by symbol names, note titles, or keywords. Returns mixed-kind results (Symbol, Note, Section, Tag, Heading) within a token budget.\n\nGuidelines:\n- Primary entry point for understanding a topic — use before reading files\n- Seed with specific names (e.g. 'AuthService.validate'), not broad terms\n- Filter with repos, tags, path_prefix, kinds for precision; use response_format 'concise' unless you need full bodies\n\nLimitations:\n- Only searches indexed repos/vaults — check stale_check if results seem stale\n- Ranked by graph proximity, not recency (use recency_weight to add time decay)\n- May fail with 'index publication TRANSIENT/WEDGED' while an index is being published. This refers to INDEX PUBLICATION, not a dirty git working tree: editing files in a repo does NOT cause it, and NestWeaver is fully usable while you work. TRANSIENT resolves on its own — retry. WEDGED means a prior indexer died mid-publication; ASK THE OPERATOR to run the `nestweaver repair` command named in the error — repair is a destructive publication recovery with no MCP tool, so it cannot be done from here — or check brain_status.index_publication.",
         "inputSchema": {
             "type": "object",
             "additionalProperties": false,
@@ -8584,7 +8584,7 @@ fn tool_brain_diff(
 fn tool_schema_project_context() -> Value {
     json!({
         "name": "project_context",
-        "description": "Retrieve context for a named project: notes, symbols, and sections ranked by PPR within the project's subgraph, bounded by token budget.\n\nGuidelines:\n- Use when you know the project name — for ad-hoc topics use brain_context with seeds instead\n- Returns a CONCISE orientation by default (~1000 tokens: kind/title/location per node); pass response_format:'detailed' for full metadata (uid + relevance, ~3000 tokens)\n- Narrow with repos, path_prefix, tags/exclude_tags, kinds, since, recency_weight — carry the same filter names over to brain_context when drilling in\n- For composite projects, include_components pulls in sub-project content\n\nLimitations:\n- Requires projects to be defined in the graph (via vault taxonomy or instance config)\n- If you don't know the project name, use brain_search to find it first\n- May fail with 'index publication TRANSIENT/WEDGED' while an index is being published. This refers to INDEX PUBLICATION, not a dirty git working tree: editing files in a repo does NOT cause it, and NestWeaver is fully usable while you work. TRANSIENT resolves on its own — retry. WEDGED means a prior indexer died mid-publication; run the `nestweaver repair` command named in the error, or check brain_status.index_publication.",
+        "description": "Retrieve context for a named project: notes, symbols, and sections ranked by PPR within the project's subgraph, bounded by token budget.\n\nGuidelines:\n- Use when you know the project name — for ad-hoc topics use brain_context with seeds instead\n- Returns a CONCISE orientation by default (~1000 tokens: kind/title/location per node); pass response_format:'detailed' for full metadata (uid + relevance, ~3000 tokens)\n- Narrow with repos, path_prefix, tags/exclude_tags, kinds, since, recency_weight — carry the same filter names over to brain_context when drilling in\n- For composite projects, include_components pulls in sub-project content\n\nLimitations:\n- Requires projects to be defined in the graph (via vault taxonomy or instance config)\n- If you don't know the project name, use brain_search to find it first\n- May fail with 'index publication TRANSIENT/WEDGED' while an index is being published. This refers to INDEX PUBLICATION, not a dirty git working tree: editing files in a repo does NOT cause it, and NestWeaver is fully usable while you work. TRANSIENT resolves on its own — retry. WEDGED means a prior indexer died mid-publication; ASK THE OPERATOR to run the `nestweaver repair` command named in the error — repair is a destructive publication recovery with no MCP tool, so it cannot be done from here — or check brain_status.index_publication.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -14776,6 +14776,35 @@ mod schema_default_honesty_tests {
             tool["inputSchema"]["properties"]["response_format"]["default"],
             json!("concise")
         );
+    }
+
+    /// nw-230. MCP error text told the agent to "run the `nestweaver repair`
+    /// command" — but `repair` has no MCP tool, so the agent was instructed to
+    /// do something it cannot do from the surface it is on. Repair is
+    /// destructive publication recovery, so requiring a human is the right
+    /// call; the message just has to SAY so.
+    #[test]
+    fn repair_guidance_names_who_can_actually_run_it() {
+        let has_repair_tool = all_tool_schemas()
+            .iter()
+            .any(|tool| tool["name"].as_str() == Some("repair"));
+        assert!(
+            !has_repair_tool,
+            "a repair TOOL now exists; this test and the guidance text must change together"
+        );
+
+        for tool in all_tool_schemas() {
+            let name = tool["name"].as_str().unwrap_or("?").to_string();
+            let description = tool["description"].as_str().unwrap_or_default().to_string();
+            if !description.contains("nestweaver repair") {
+                continue;
+            }
+            assert!(
+                description.contains("ASK THE OPERATOR"),
+                "{name} tells the agent to run `nestweaver repair` without saying a \
+                 human has to do it: {description}"
+            );
+        }
     }
 
     /// `get_summary` must advertise the bound it now applies. nw-182 bounded

--- a/src/main.rs
+++ b/src/main.rs
@@ -1986,6 +1986,21 @@ mod daemon_status_renderer_tests {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Read the custom annotations agents write via the `set_extension` MCP tool.
+    ///
+    /// nw-229: `set_extension` and `query_extensions` were BOTH agent-only, so
+    /// an agent could write key/value annotations that influence a human's
+    /// results — the CLI consumes the sidecar internally for alias matching and
+    /// `external_refs` — with no command to read them back. Write-only-for-
+    /// agents is a defensible design; write-AND-read-only-for-agents makes a
+    /// persistent store that affects output unauditable by its owner.
+    #[command(
+        after_help = "Examples:\n  nestweaver extensions list\n  nestweaver extensions list --uid sym:repo:abc\n  nestweaver extensions list --key owner --value platform-team\n  nestweaver extensions list --json"
+    )]
+    Extensions {
+        #[command(subcommand)]
+        command: ExtensionCommands,
+    },
     /// List all indexed repositories
     ListRepos {
         #[arg(long, help = "Filter by instance ID")]
@@ -4123,6 +4138,31 @@ enum RtsEvalCommands {
             help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
         )]
         db: Option<PathBuf>,
+    },
+}
+
+#[derive(Subcommand)]
+enum ExtensionCommands {
+    /// List annotations. With no filter, every annotated node.
+    List {
+        /// Show only this node's annotations.
+        #[arg(long)]
+        uid: Option<String>,
+        /// Show only nodes carrying this key (with `--value`, this exact value).
+        #[arg(long)]
+        key: Option<String>,
+        /// Requires `--key`. Exact match only, matching the MCP tool.
+        #[arg(long)]
+        value: Option<String>,
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+        #[arg(
+            long,
+            help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
+        )]
+        db: Option<PathBuf>,
+        #[arg(long, help = "Path to instance config (TOML)")]
+        config: Option<PathBuf>,
     },
 }
 
@@ -8950,6 +8990,77 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
         !matches!(cli.command, Commands::Daemon { .. }),
     );
     match cli.command {
+        Commands::Extensions {
+            command:
+                ExtensionCommands::List {
+                    uid,
+                    key,
+                    value,
+                    json,
+                    db,
+                    config,
+                },
+        } => {
+            if value.is_some() && key.is_none() {
+                anyhow::bail!("--value requires --key");
+            }
+            let db_path = resolve_db_with_config(db, config.as_deref())?;
+            let store = nestweaver_engine::extensions::load_extensions(&db_path);
+
+            // Filtering mirrors `query_extensions` exactly, including EXACT
+            // match on value — a CLI that matched differently would show a
+            // human a different answer than the agent acted on, which is the
+            // opposite of an audit.
+            let mut rows: Vec<(
+                &String,
+                &std::collections::HashMap<String, serde_json::Value>,
+            )> = store
+                .iter()
+                .filter(|(node_uid, props)| {
+                    if let Some(wanted) = uid.as_deref()
+                        && node_uid.as_str() != wanted
+                    {
+                        return false;
+                    }
+                    match (key.as_deref(), value.as_deref()) {
+                        (Some(k), Some(v)) => {
+                            props.get(k).and_then(|found| found.as_str()) == Some(v)
+                                || props.get(k).map(ToString::to_string).as_deref() == Some(v)
+                        }
+                        (Some(k), None) => props.contains_key(k),
+                        _ => true,
+                    }
+                })
+                .collect();
+            rows.sort_by(|a, b| a.0.cmp(b.0));
+
+            if json {
+                let payload: serde_json::Map<String, serde_json::Value> = rows
+                    .iter()
+                    .map(|(node_uid, props)| {
+                        (
+                            (*node_uid).clone(),
+                            serde_json::to_value(props).unwrap_or(serde_json::Value::Null),
+                        )
+                    })
+                    .collect();
+                println!("{}", serde_json::to_string_pretty(&payload)?);
+            } else if rows.is_empty() {
+                println!("No extension annotations found.");
+            } else {
+                for (node_uid, props) in &rows {
+                    println!("{node_uid}");
+                    let mut keys: Vec<&String> = props.keys().collect();
+                    keys.sort();
+                    for k in keys {
+                        println!("  {k}: {}", props[k]);
+                    }
+                }
+            }
+            let stats = format!("{} annotated node(s)", rows.len());
+            Ok((EXIT_SUCCESS, Some(stats)))
+        }
+
         Commands::ListRepos {
             instance,
             json,
@@ -21669,6 +21780,10 @@ mod cli_help_contract_tests {
             "nestweaver count-patterns",
             "nestweaver cross-repo-contracts",
             "nestweaver detect-changes",
+            // nw-229: added deliberately. It reads the extension sidecar
+            // beside the database, so it resolves the pair through the same
+            // `resolve_db_with_config` helper every other entry here uses.
+            "nestweaver extensions list",
             "nestweaver flow-trace",
             "nestweaver generate-guide",
             "nestweaver hubs",
@@ -30834,6 +30949,64 @@ mod vault_command_config_parity_tests {
 
     /// The value must actually reach the command, not merely parse. A flag
     /// accepted and dropped would pass the test above while changing nothing.
+    /// nw-229. `set_extension` and `query_extensions` were BOTH agent-only, so
+    /// an agent could write annotations that influence a human's results — the
+    /// CLI consumes the sidecar internally — with no command to read them back.
+    #[test]
+    fn a_human_can_read_back_what_agents_annotate() {
+        let cli = parse(argv(&["nestweaver", "extensions", "list"])).expect("must parse");
+
+        let Commands::Extensions { command } = cli.command else {
+            panic!("expected `extensions`");
+        };
+        let ExtensionCommands::List {
+            uid, key, value, ..
+        } = command;
+        assert!(
+            uid.is_none() && key.is_none() && value.is_none(),
+            "an unfiltered list must be the default — auditing starts with 'show me everything'"
+        );
+    }
+
+    /// Filters mirror `query_extensions`: by uid, or by key (+ optional value).
+    #[test]
+    fn the_filters_match_the_mcp_tools_two_modes() {
+        let by_uid = parse(argv(&[
+            "nestweaver",
+            "extensions",
+            "list",
+            "--uid",
+            "sym:repo:abc",
+        ]))
+        .expect("uid mode must parse");
+        let Commands::Extensions {
+            command: ExtensionCommands::List { uid, .. },
+        } = by_uid.command
+        else {
+            panic!("expected `extensions list`");
+        };
+        assert_eq!(uid.as_deref(), Some("sym:repo:abc"));
+
+        let by_kv = parse(argv(&[
+            "nestweaver",
+            "extensions",
+            "list",
+            "--key",
+            "owner",
+            "--value",
+            "platform",
+        ]))
+        .expect("key+value mode must parse");
+        let Commands::Extensions {
+            command: ExtensionCommands::List { key, value, .. },
+        } = by_kv.command
+        else {
+            panic!("expected `extensions list`");
+        };
+        assert_eq!(key.as_deref(), Some("owner"));
+        assert_eq!(value.as_deref(), Some("platform"));
+    }
+
     #[test]
     fn brain_remove_carries_the_config_through_to_the_command() {
         let cli = parse(argv(&[


### PR DESCRIPTION
## nw-229 — the extension sidecar was agent-only in *both* directions

`set_extension` and `query_extensions` were both MCP-only. An agent could write key/value annotations that **influence a human's results** — the CLI consumes the sidecar internally for alias matching and `external_refs` — and there was no command to read them back.

> Write-only-for-agents is a defensible design. Write-**and**-read-only-for-agents is not: it makes a persistent store that shapes output unauditable by its owner.

This was the sharpest asymmetry the nw-215 capability inventory found, and notably **not** one of the four originally-named claims — the original sweep listed `query_extensions` but missed that its write counterpart was agent-only too.

`nestweaver extensions list` mirrors `query_extensions`' two modes — by `--uid`, or by `--key` with an optional `--value` — including **exact** match on value. A CLI that matched differently would show a human a different answer than the agent acted on, which is the opposite of an audit. The unfiltered listing is the default, because auditing starts with *"show me everything"*.

I deliberately did **not** add a CLI writer. The write staying agent-side is fine; it was the missing read that made the store opaque.

## nw-230 — the error told the agent to do something it cannot do

MCP error text said to *"run the `nestweaver repair` command named in the error"*, but `repair` has no MCP tool. The agent was being instructed to act on a surface it isn't on.

Repair is destructive publication recovery, so **requiring a human is the right call** — the message just has to say so. Both the runtime error and the two tool descriptions carrying that guidance now name the operator.

The test pins this and **fails loudly if a repair tool is ever added**, so the text and the capability have to change together rather than drifting apart.

## Contract test

The `--db` + `--config` inventory test caught the new command and demanded a deliberate decision — which is its job. Entry added with its reason.

## Verification

- `cargo test --workspace --all-targets` — green (39 targets, 0 failures)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean