### PR TITLE
fix(store): bound the engine thread pool on READ opens too (nw-240, UNVERIFIED)

### DIFF
--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -570,6 +570,29 @@ fn env_u64(key: &str) -> Option<u64> {
 fn bounded_system_config() -> lbug::SystemConfig {
     lbug::SystemConfig::default()
         .max_db_size(env_u64("NESTWEAVER_LBUG_MAX_DB_SIZE").unwrap_or(DEFAULT_MAX_DB_SIZE_BYTES))
+        // nw-240 / nw-238: the engine thread bound now applies to READ opens
+        // too, not only write-capable ones.
+        //
+        // Two independent crash captures — 2026-08-26 07:49 and 15:29, on
+        // different SHAs and different builds — carry the identical faulting
+        // stack: a NULL deref (KERN_INVALID_ADDRESS at 0x0) in
+        // `VectorVersionInfo::getSelVectorForScan` -> `VersionInfo::getSelVectorToScan`
+        // -> `ChunkedNodeGroup::scan` -> `NodeTableScanState::scanNext`, reached
+        // from `ScanNodeTable::getNextTuplesInternal` on an lbug worker thread.
+        //
+        // That is MVCC version-chain traversal during a PARALLEL NODE-TABLE
+        // SCAN — squarely a read path. `hardened_system_config` bounded threads
+        // only on the three read-write opens, so `open_read_only` and
+        // `in_memory` (46 and 374 call sites) ran the very pool that faulted at
+        // full parallelism, and NESTWEAVER_LBUG_MAX_THREADS could not reach it.
+        //
+        // NOTE THE STATUS OF THIS CHANGE: it is a MEASURED EXPERIMENT, not a
+        // proven fix. The crash is intermittent at roughly 11% per run (2 in 18
+        // pooled), so a handful of clean runs proves nothing — 40 consecutive
+        // clean runs are needed to put a false pass under 1%. If it only
+        // REDUCES the rate rather than eliminating it, that is a different
+        // finding and the bar has to be recomputed from the new rate.
+        .max_num_threads(env_u64("NESTWEAVER_LBUG_MAX_THREADS").unwrap_or(1))
 }
 
 fn hardened_system_config() -> lbug::SystemConfig {
@@ -577,8 +600,9 @@ fn hardened_system_config() -> lbug::SystemConfig {
     // removes the eviction-vs-read race the crash needs. `1` is the only value
     // that fully eliminates it; keep it the default on the write path and let
     // ops raise it if they measure a query-latency cost on their workload.
-    let max_threads = env_u64("NESTWEAVER_LBUG_MAX_THREADS").unwrap_or(1);
-    let mut cfg = bounded_system_config().max_num_threads(max_threads);
+    // The thread bound now lives in `bounded_system_config`, so write and read
+    // opens share ONE rule rather than two that drifted apart.
+    let mut cfg = bounded_system_config();
     if let Some(bytes) = env_u64("NESTWEAVER_LBUG_BUFFER_POOL_BYTES") {
         cfg = cfg.buffer_pool_size(bytes);
     }


### PR DESCRIPTION
**Draft until the 40-run gate reports.** The latency question that originally held this back has been answered — see below.

## The evidence that points here

Two independent crash captures — 2026-08-26 **07:49** and **15:29**, different SHAs, different builds — carry the **identical** faulting stack:

```
EXC_BAD_ACCESS / SIGSEGV, KERN_INVALID_ADDRESS at 0x0
lbug::storage::VectorVersionInfo::getSelVectorForScan
lbug::storage::VersionInfo::getSelVectorToScan
lbug::storage::ChunkedNodeGroup::scan
lbug::storage::NodeGroup::scan
lbug::storage::NodeTableScanState::scanNext
lbug::processor::ScanNodeTable::getNextTuplesInternal
```

MVCC version-chain traversal during a **parallel node-table scan** — squarely a read path.

`hardened_system_config` bounded threads only on the three read-write opens, so `open_read_only` and `in_memory` — **46 and 374 call sites** — ran the very pool that faulted at full parallelism, and `NESTWEAVER_LBUG_MAX_THREADS` could not reach it.

Write and read opens now share **one** rule rather than two that drifted apart.

## Latency cost: none measurable

This was the open question and the original reason for the draft. Measured on a real graph — the NestWeaver workspace indexed into a throwaway DB, **482 files / 18,747 symbols / 47,073 edges** — on the operations that actually hit `ScanNodeTable`, 3 iterations each:

| operation | threads=1 | threads=8 | delta |
|---|---|---|---|
| `export --format graphml` (full graph scan) | 0.184s | 0.198s | **−7.2%** |
| `hubs` | 0.098s | 0.098s | +0.2% |
| `bridges --top 1000` (betweenness over whole graph) | 0.321s | 0.322s | −0.2% |
| `impact` | 0.048s | 0.048s | −0.4% |

The two heaviest available read paths do not move. `export` measuring *faster* single-threaded is almost certainly thread-setup overhead exceeding any parallel gain at this size.

So the global bound is a **defensible permanent shape**, not merely a crash workaround.

**Caveat on the record:** 18.7k symbols is one repo. A much larger multi-repo brain could differ, and that was not tested (it would mean copying the live DB). Nothing here suggests a cost; nothing here proves its absence at 10× scale.

## What would make this a fix

The crash is intermittent at roughly **11% per run** (2 in 18 pooled). A green suite says nothing, and neither would a handful of clean runs.

| consecutive clean runs | false-pass probability at 11% |
|---|---|
| 20 | 9.5% |
| 30 | 2.9% |
| **40** | **0.90%** |
| 50 | 0.28% |

**40 consecutive clean release runs** is the gate, currently running against HEAD.

Counterintuitive but important: a *rarer* intermittent bug needs **more** clean runs to declare dead, not fewer. **Any crash at all means not resolved** — the bar gets recomputed from the combined rate rather than the result being treated as a near-miss.

## Deliberately no unit test

There is no assertion that would mean anything here. The verification *is* the run-count gate. Manufacturing a unit test would be the hollow guard this review has spent the day cataloguing — I authored one such guard inside nw-241's own fix earlier today (a `const` assert placed inside `#[cfg(test)]`, so it never reached a release build) and would rather not repeat the pattern to look thorough.

## Local verification (necessary, not sufficient)

- `cargo test --workspace --all-targets` — exit 0, 39 targets, 0 failures
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean