### PR TITLE
fix: give the database its own instance identity, established at creation

### DIFF
--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -2179,6 +2179,22 @@ fn index_directory_with_store_inner(
     let filemeta_path = crate::sidecar_path(db_path, ".filemeta.json");
     crate::migrate_sidecar(db_path, "filemeta.json", ".filemeta.json");
     let r_uid = repo_uid(instance_id, repo_url);
+    // nw-246: record the instance this database's data belongs to, once.
+    //
+    // This is the funnel every repo index passes through, so it is where the
+    // database's identity gets established. `ensure_data_instance_id` never
+    // replaces an existing value — a database that already knows its instance
+    // keeps it, and the CLI resolver refuses a disagreeing request before
+    // reaching here.
+    //
+    // Best-effort: a store that cannot record it still indexes correctly, it
+    // just falls back to inferring the instance from its own UIDs next time.
+    if let Err(error) = store.ensure_data_instance_id(instance_id) {
+        tracing::debug!(
+            instance = %instance_id,
+            "could not record the data instance id: {error}"
+        );
+    }
     // Capture generation-N derived state before graph publication advances to
     // N+2. Loading it after the graph commit would correctly reject it as
     // stale and, historically, `unwrap_or_default` then discarded every other

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -420,6 +420,25 @@ impl PublicationIdentity {
     }
 }
 
+/// The instance the DATA in this database was written under.
+///
+/// nw-246. Instance id is interpolated into every `repo_uid`, `vault_uid` and
+/// `project_uid`, so it is a property OF THE DATA — but it was re-derived from
+/// ambient inputs on every invocation: a db-path hash in 7.0.0, the literal
+/// `"default"` in 8.0.0. Changing the derivation therefore silently
+/// RE-IDENTIFIED existing data, forking a graph in place: two repo rows for one
+/// path, two UIDs per symbol, `stale-check` permanently non-zero, and
+/// `prune-stale` unable to clean it because nothing was actually orphaned.
+///
+/// Storing it is the same shape `PublicationIdentity` already uses for
+/// `brain_uuid` — mint once at creation, keep it in the database, read it
+/// thereafter, refuse on disagreement. That is also the established pattern
+/// outside this codebase: PostgreSQL's `system_identifier`, Terraform's state
+/// `lineage`, Kafka's `cluster.id`, etcd's cluster id. etcd states the
+/// precedence rule most plainly — consult the WAL first, and fall back to
+/// ambient flags ONLY when there is no WAL.
+const DATA_INSTANCE_ID_META_KEY: &str = "instance.data_instance_id";
+
 const BRAIN_UUID_META_KEY: &str = "publication.brain_uuid";
 const PUBLICATION_UUID_META_KEY: &str = "publication.publication_uuid";
 
@@ -2497,6 +2516,111 @@ impl GraphStore {
         Ok(identity)
     }
 
+    /// The instance the data in this database was written under, if recorded.
+    ///
+    /// `None` means a database predating nw-246, or one with no data yet.
+    pub fn data_instance_id(&self) -> Result<Option<String>, StoreError> {
+        let conn = self.conn()?;
+        Self::publication_meta_value_on(&conn, DATA_INSTANCE_ID_META_KEY)
+    }
+
+    /// Instance ids actually present in the graph, from the UIDs themselves.
+    ///
+    /// The backfill path for a database that predates nw-246. Its correct
+    /// instance cannot be MINTED the way `brain_uuid` can — the right value is
+    /// already baked into thousands of existing UIDs — so it has to be read
+    /// back out of them.
+    ///
+    /// More than one value means the database is ALREADY forked. That is a
+    /// damage state, not a question with an answer, so callers must refuse
+    /// rather than pick.
+    pub fn observed_instance_ids(&self) -> Result<Vec<String>, StoreError> {
+        let conn = self.conn()?;
+        let mut found: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        // Repo, Vault and Project are the three node kinds whose UIDs carry an
+        // instance. Symbols inherit theirs from the owning repo.
+        for query in [
+            "MATCH (r:Repo) RETURN DISTINCT r.instance_id",
+            "MATCH (v:Vault) RETURN DISTINCT v.instance_id",
+        ] {
+            let Ok(rows) = conn.query(query) else {
+                continue;
+            };
+            for row in rows {
+                if let Ok(value) = crate::read::extract_string(&row, 0)
+                    && !value.trim().is_empty()
+                {
+                    found.insert(value);
+                }
+            }
+        }
+        Ok(found.into_iter().collect())
+    }
+
+    /// Record the instance this database's data belongs to, once.
+    ///
+    /// Mirrors `initialize_publication_identity`: the re-check happens INSIDE
+    /// the write transaction, so two concurrent openers cannot each publish a
+    /// different instance for the same database. An existing value is never
+    /// replaced — it is returned, and a caller proposing a different one is
+    /// told rather than silently overridden.
+    pub fn ensure_data_instance_id(&self, proposed: &str) -> Result<String, StoreError> {
+        let proposed = proposed.trim();
+        if proposed.is_empty() {
+            return Err(StoreError::Query(
+                "refusing to record an empty data instance id".to_string(),
+            ));
+        }
+        let conn = self.conn()?;
+        conn.query("BEGIN TRANSACTION")
+            .map_err(|error| StoreError::Query(format!("begin data instance id: {error}")))?;
+        let result = (|| match Self::publication_meta_value_on(&conn, DATA_INSTANCE_ID_META_KEY)? {
+            Some(existing) => Ok(existing),
+            None => {
+                Self::create_publication_meta_on(&conn, DATA_INSTANCE_ID_META_KEY, proposed)?;
+                Ok(proposed.to_string())
+            }
+        })();
+        match result {
+            Ok(value) => {
+                conn.query("COMMIT").map_err(|error| {
+                    StoreError::Query(format!("commit data instance id: {error}"))
+                })?;
+                Ok(value)
+            }
+            Err(error) => {
+                let _ = conn.query("ROLLBACK");
+                Err(error)
+            }
+        }
+    }
+
+    /// Refuse when an explicitly requested instance disagrees with the one this
+    /// database's data was written under.
+    ///
+    /// Shaped after `assert_brain_uuid`, and refusing for the same reason every
+    /// comparable system refuses — PostgreSQL on `system_identifier`, Terraform
+    /// on state lineage, Kafka, etcd, Elasticsearch. Naming BOTH values matters:
+    /// the operator cannot fix a mismatch they cannot see.
+    pub fn assert_data_instance_id(&self, expected: &str) -> Result<(), StoreError> {
+        let Some(recorded) = self.data_instance_id()? else {
+            return Ok(());
+        };
+        if recorded == expected.trim() {
+            return Ok(());
+        }
+        Err(StoreError::Query(format!(
+            "this database's data was written under instance '{recorded}', but '{}' was \
+             requested. Indexing under a different instance would FORK the graph — every \
+             repo, vault and project UID embeds the instance, so the same content would \
+             appear twice and neither copy would supersede the other.\n\
+             Use instance '{recorded}', or migrate the database deliberately with \
+             `nestweaver instance merge --from {recorded} --to {}`.",
+            expected.trim(),
+            expected.trim()
+        )))
+    }
+
     fn initialize_publication_identity(
         &self,
         identity: &PublicationIdentity,
@@ -4035,5 +4159,108 @@ mod address_space_bound_tests {
             .collect();
 
         assert_eq!(stores.len(), 64, "all opens must be held simultaneously");
+    }
+}
+
+/// nw-246: the database owns its instance identity.
+#[cfg(test)]
+mod data_instance_identity_tests {
+    use super::GraphStore;
+
+    fn store(dir: &std::path::Path) -> GraphStore {
+        GraphStore::open_or_create(&dir.join("t.lbug")).unwrap()
+    }
+
+    /// Established once, then immutable. A later caller proposing a DIFFERENT
+    /// instance gets the recorded one back rather than overwriting it — the
+    /// same discipline `initialize_publication_identity` uses for brain_uuid,
+    /// and the reason a change of default cannot silently re-identify data.
+    #[test]
+    fn the_first_instance_recorded_is_the_one_that_sticks() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(dir.path());
+
+        assert_eq!(
+            store.ensure_data_instance_id("2051a9da").unwrap(),
+            "2051a9da"
+        );
+        assert_eq!(
+            store.ensure_data_instance_id("default").unwrap(),
+            "2051a9da",
+            "a later proposal must not overwrite the identity the data was written under"
+        );
+        assert_eq!(
+            store.data_instance_id().unwrap().as_deref(),
+            Some("2051a9da")
+        );
+    }
+
+    /// It has to survive reopen, or it is a cache rather than an identity.
+    #[test]
+    fn the_recorded_instance_survives_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let store = store(dir.path());
+            store.ensure_data_instance_id("2051a9da").unwrap();
+        }
+        let reopened = GraphStore::open(&dir.path().join("t.lbug")).unwrap();
+        assert_eq!(
+            reopened.data_instance_id().unwrap().as_deref(),
+            Some("2051a9da")
+        );
+    }
+
+    /// A disagreeing request is REFUSED, naming both values — the answer every
+    /// comparable system gives (PostgreSQL system_identifier, Terraform state
+    /// lineage, Kafka cluster.id, etcd). An error the operator cannot act on is
+    /// barely better than the silent fork.
+    #[test]
+    fn a_disagreeing_instance_is_refused_and_names_both() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(dir.path());
+        store.ensure_data_instance_id("2051a9da").unwrap();
+
+        let error = store
+            .assert_data_instance_id("default")
+            .expect_err("a disagreeing instance must be refused");
+        let rendered = error.to_string();
+
+        assert!(
+            rendered.contains("2051a9da"),
+            "must name the recorded instance: {rendered}"
+        );
+        assert!(
+            rendered.contains("default"),
+            "must name the requested one: {rendered}"
+        );
+        assert!(
+            rendered.contains("FORK"),
+            "must say what would happen: {rendered}"
+        );
+    }
+
+    /// The counterweight: agreement must be silent. A guard that refused
+    /// everything would pass the test above while making the tool unusable.
+    #[test]
+    fn an_agreeing_instance_passes_silently() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(dir.path());
+        store.ensure_data_instance_id("2051a9da").unwrap();
+
+        store.assert_data_instance_id("2051a9da").unwrap();
+        // And a database with no recorded identity cannot object to anything.
+        let fresh = GraphStore::open_or_create(&dir.path().join("fresh.lbug")).unwrap();
+        fresh.assert_data_instance_id("anything").unwrap();
+    }
+
+    /// An empty instance is not an identity. Recording one would make every
+    /// later comparison pass vacuously.
+    #[test]
+    fn an_empty_instance_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(dir.path());
+
+        assert!(store.ensure_data_instance_id("   ").is_err());
+        assert!(store.data_instance_id().unwrap().is_none());
     }
 }

--- a/docs/guide/instance-id-migration.md
+++ b/docs/guide/instance-id-migration.md
@@ -143,6 +143,22 @@ to the logical name.
 - `brain add`, `brain watch`, and `brain refresh` all resolve the instance the
   same way (`--instance` flag, then the config's `instance_id`, then
   `"default"`), so a `--config`-driven workflow stays consistent on its own.
+- **A command that names NO instance adopts the one the database already
+  holds**, rather than falling back to `"default"` and writing a second copy
+  (nw-246). This is what makes an upgrade safe: a database indexed under
+  7.0.0's db-path hash keeps that identity when you re-index without a config,
+  instead of forking into two repo rows for one path — with two UIDs per
+  symbol, `stale-check` permanently reporting a repo you just indexed as stale,
+  and `prune-stale` unable to clean it because nothing is actually orphaned.
+  The database records its instance on first write and reports it in
+  `list-repos`.
+- Naming an instance explicitly is still honoured, and a database may hold
+  several. That is a supported configuration — a daemon restarted under a
+  different `--config` writes new rows under the new instance, and
+  `nestweaver instance merge` consolidates them when you want one. What is
+  refused is the *ambiguous* case: an index with no `--instance` and no
+  `--config` against a database that already holds more than one instance,
+  where there is no safe default to pick.
 - `brain refresh` additionally resolves from an **existing registration** for
   that vault root, and prefers it over the `"default"` fallback (nw-098). A
   refresh with no `--instance`/`--config` therefore refreshes the vault that is

--- a/src/main.rs
+++ b/src/main.rs
@@ -5500,33 +5500,39 @@ fn explicit_instance_id(flag: Option<&str>, config: Option<&Path>) -> Option<Str
 }
 
 /// Resolve the instance for a command that touches `db_path`, consulting the
-/// DATABASE before any ambient input.
+/// DATABASE when — and only when — the caller did not name one.
 ///
-/// nw-246. `resolve_instance_id` answers from the flag, then the config, then
-/// the literal `"default"` — all ambient, none of them aware of what the
-/// database already contains. That is what let 8.0.0's change of default
-/// silently RE-IDENTIFY existing data and fork a graph in place.
+/// nw-246. The defect was a SILENT fork: a config-less `nestweaver index`
+/// resolved the instance from ambient inputs (a db-path hash in 7.0.0, the
+/// literal `"default"` in 8.0.0), so changing that derivation re-identified
+/// existing data with no user intent and no warning. Two repo rows for one
+/// path, two UIDs per symbol with an identical `canonical_id`, `stale-check`
+/// permanently non-zero, and `prune-stale` unable to clean it.
 ///
-/// The precedence here is etcd's: consult the store first, and fall back to
-/// ambient inputs only when the store has nothing to say.
+/// The guard is therefore scoped to the INFERRED case. Naming an instance —
+/// with `--instance` or a `--config` — is a deliberate act, and a database
+/// holding several instances is a SUPPORTED configuration that config
+/// switching manages, not a damage state. The daemon implements exactly that
+/// (`resolve_effective_instance_id`, the per-RPC override) and
+/// `daemon_restart_preserves_and_overrides_live_effective_config_without_early_shutdown`
+/// pins it: same database, restarted under a second config, new repos landing
+/// under the new instance. An unconditional guard would have retired that
+/// capability while claiming only to stop accidental forks.
 ///
-/// 1. Database records an instance -> that wins. An explicit flag or config
-///    that DISAGREES is refused, not silently honoured: disagreement is a
-///    mistake, not an instruction to fork. (The nw-098 vault guard already
-///    reached this conclusion for one command; this applies it to all of them.)
-/// 2. No record, but the graph already contains exactly one instance -> adopt
-///    it. This is the upgrade path: a 7.0.0 database keeps working untouched.
-/// 3. No record and SEVERAL instances present -> already forked. Refuse and
-///    name them, rather than picking one and compounding the damage.
-/// 4. Nothing at all -> a genuinely new database; use the ambient answer.
+/// Precedence when nothing was stated is etcd's: consult the store first, and
+/// fall back to ambient inputs only when it has nothing to say.
 fn resolve_instance_id_for_db(
     flag: Option<String>,
     config: Option<&Path>,
     db_path: &Path,
 ) -> anyhow::Result<String> {
-    let explicit = explicit_instance_id(flag.as_deref(), config);
+    let stated = explicit_instance_id(flag.as_deref(), config).is_some();
     let ambient = resolve_instance_id(flag, config)?;
 
+    // Stated intent passes through untouched.
+    if stated {
+        return Ok(ambient);
+    }
     // A database that does not exist yet cannot have an opinion.
     if !db_path.exists() {
         return Ok(ambient);
@@ -5537,38 +5543,23 @@ fn resolve_instance_id_for_db(
         return Ok(ambient);
     };
 
+    // Recorded identity wins over the ambient default.
     if let Ok(Some(recorded)) = store.data_instance_id() {
-        if let Some(asked) = explicit.as_deref()
-            && asked != recorded
-        {
-            store
-                .assert_data_instance_id(asked)
-                .map_err(|error| anyhow::anyhow!("{error}"))?;
-        }
         return Ok(recorded);
     }
 
-    // Legacy database: infer from the UIDs already written.
+    // Legacy database with no record: infer from the UIDs already written.
     match store.observed_instance_ids() {
-        Ok(observed) if observed.len() == 1 => {
-            let existing = observed.into_iter().next().unwrap_or(ambient.clone());
-            if let Some(asked) = explicit.as_deref()
-                && asked != existing
-            {
-                anyhow::bail!(
-                    "this database's data was written under instance '{existing}', but \
-                     '{asked}' was requested. Indexing under a different instance would FORK \
-                     the graph — every repo, vault and project UID embeds the instance.\n\
-                     Use instance '{existing}', or migrate deliberately with \
-                     `nestweaver instance merge --from {existing} --to {asked}`."
-                );
-            }
-            Ok(existing)
-        }
+        Ok(observed) if observed.len() == 1 => Ok(observed.into_iter().next().unwrap_or(ambient)),
+        // Several instances present and nothing stated. This IS ambiguous —
+        // adopting one at random is how the fork would deepen — so refuse and
+        // name them. Stating an instance resolves it, which is why this arm is
+        // unreachable when the caller named one.
         Ok(observed) if observed.len() > 1 => anyhow::bail!(
-            "this database already contains data under {} different instances: {}.\n\
-             That is a split graph, and continuing would deepen it. Consolidate first with \
-             `nestweaver instance merge --from <one> --to <keep>`, then re-run.",
+            "this database holds data under {} instances ({}), and no instance was \
+             specified, so there is no safe default.\n\
+             Name one with `--instance <id>` or a `--config`, or consolidate them with \
+             `nestweaver instance merge --from <one> --to <keep>`.",
             observed.len(),
             observed.join(", ")
         ),

--- a/src/main.rs
+++ b/src/main.rs
@@ -5499,6 +5499,83 @@ fn explicit_instance_id(flag: Option<&str>, config: Option<&Path>) -> Option<Str
         .or_else(|| load_instance_config_opt(config).map(|c| c.instance_id))
 }
 
+/// Resolve the instance for a command that touches `db_path`, consulting the
+/// DATABASE before any ambient input.
+///
+/// nw-246. `resolve_instance_id` answers from the flag, then the config, then
+/// the literal `"default"` — all ambient, none of them aware of what the
+/// database already contains. That is what let 8.0.0's change of default
+/// silently RE-IDENTIFY existing data and fork a graph in place.
+///
+/// The precedence here is etcd's: consult the store first, and fall back to
+/// ambient inputs only when the store has nothing to say.
+///
+/// 1. Database records an instance -> that wins. An explicit flag or config
+///    that DISAGREES is refused, not silently honoured: disagreement is a
+///    mistake, not an instruction to fork. (The nw-098 vault guard already
+///    reached this conclusion for one command; this applies it to all of them.)
+/// 2. No record, but the graph already contains exactly one instance -> adopt
+///    it. This is the upgrade path: a 7.0.0 database keeps working untouched.
+/// 3. No record and SEVERAL instances present -> already forked. Refuse and
+///    name them, rather than picking one and compounding the damage.
+/// 4. Nothing at all -> a genuinely new database; use the ambient answer.
+fn resolve_instance_id_for_db(
+    flag: Option<String>,
+    config: Option<&Path>,
+    db_path: &Path,
+) -> anyhow::Result<String> {
+    let explicit = explicit_instance_id(flag.as_deref(), config);
+    let ambient = resolve_instance_id(flag, config)?;
+
+    // A database that does not exist yet cannot have an opinion.
+    if !db_path.exists() {
+        return Ok(ambient);
+    }
+    let Ok(store) = nestweaver_store::GraphStore::open_read_only(db_path) else {
+        // Unreadable here is not a verdict — the caller's own open will report
+        // the real error with better context than this helper could.
+        return Ok(ambient);
+    };
+
+    if let Ok(Some(recorded)) = store.data_instance_id() {
+        if let Some(asked) = explicit.as_deref()
+            && asked != recorded
+        {
+            store
+                .assert_data_instance_id(asked)
+                .map_err(|error| anyhow::anyhow!("{error}"))?;
+        }
+        return Ok(recorded);
+    }
+
+    // Legacy database: infer from the UIDs already written.
+    match store.observed_instance_ids() {
+        Ok(observed) if observed.len() == 1 => {
+            let existing = observed.into_iter().next().unwrap_or(ambient.clone());
+            if let Some(asked) = explicit.as_deref()
+                && asked != existing
+            {
+                anyhow::bail!(
+                    "this database's data was written under instance '{existing}', but \
+                     '{asked}' was requested. Indexing under a different instance would FORK \
+                     the graph — every repo, vault and project UID embeds the instance.\n\
+                     Use instance '{existing}', or migrate deliberately with \
+                     `nestweaver instance merge --from {existing} --to {asked}`."
+                );
+            }
+            Ok(existing)
+        }
+        Ok(observed) if observed.len() > 1 => anyhow::bail!(
+            "this database already contains data under {} different instances: {}.\n\
+             That is a split graph, and continuing would deepen it. Consolidate first with \
+             `nestweaver instance merge --from <one> --to <keep>`, then re-run.",
+            observed.len(),
+            observed.join(", ")
+        ),
+        _ => Ok(ambient),
+    }
+}
+
 fn resolve_instance_id(flag: Option<String>, config: Option<&Path>) -> anyhow::Result<String> {
     // nw-047: treat an empty `--instance ""` as unset (not a literal empty
     // instance) so it falls through to the config's `instance_id` / "default".
@@ -12175,7 +12252,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // (mirrors `brain watch`/`brain add`; without this, `watch --config X`
             // with no --instance stamps symbols under "default" even with the
             // daemon up — an instance mismatch of the nw-019 class).
-            let instance_id = resolve_instance_id(instance, config.as_deref())?;
+            let instance_id = resolve_instance_id_for_db(instance, config.as_deref(), &db_path)?;
 
             if let Some(hours) = refresh_wiki_hours {
                 eprintln!(
@@ -15076,7 +15153,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // treated `--instance ""` as a literal empty instance). Mirrors the
             // daemon path's nw-019 resolution so the no-daemon direct write
             // stamps nodes under the same logical instance the daemon would.
-            let instance_id = resolve_instance_id(instance, config.as_deref())?;
+            let instance_id = resolve_instance_id_for_db(instance, config.as_deref(), &db_path)?;
 
             // Identity: prefer the git origin remote when configured (used
             // only as an identity string — never fetched); fall back to a
@@ -18453,7 +18530,8 @@ fn run_brain(
             // the store open with a bare OS error.
             ensure_db_parent_dir(&db_path)?;
             // nw-019: --instance flag > config's instance_id > "default".
-            let instance_id_owned = resolve_instance_id(instance, config.as_deref())?;
+            let instance_id_owned =
+                resolve_instance_id_for_db(instance, config.as_deref(), &db_path)?;
             let instance_id = instance_id_owned.as_str();
             let vault_name = name.unwrap_or_else(|| {
                 path.file_name()
@@ -19402,7 +19480,7 @@ fn run_brain(
             });
             // Resolve and validate the same instance precedence as brain add,
             // brain refresh, top-level index, and top-level watch.
-            let instance_id = resolve_instance_id(instance, config.as_deref())?;
+            let instance_id = resolve_instance_id_for_db(instance, config.as_deref(), &db_path)?;
             let instance_cfg = load_instance_config_opt(config.as_deref());
 
             if let Some(hours) = refresh_wiki_hours {
@@ -19671,7 +19749,7 @@ fn run_brain(
             let explicit = explicit_instance_id(instance.as_deref(), config.as_deref());
             let instance_id = match existing.as_slice() {
                 // Nothing registered here yet — a genuine create.
-                [] => resolve_instance_id(instance, config.as_deref())?,
+                [] => resolve_instance_id_for_db(instance, config.as_deref(), &db_path)?,
                 [(registered, uid)] => match &explicit {
                     // An explicit instance that disagrees with the registration
                     // is a mistake, not an instruction to fork. Name both and
@@ -19895,7 +19973,8 @@ fn run_brain(
             // here is what made this command ignore a config its siblings honour.
             let db_path = resolve_db_with_config(db, config.as_deref())?;
             let instance_specified = instance.is_some() || config.is_some();
-            let instance_id_owned = resolve_instance_id(instance, config.as_deref())?;
+            let instance_id_owned =
+                resolve_instance_id_for_db(instance, config.as_deref(), &db_path)?;
             let instance_id = instance_id_owned.as_str();
 
             let canonical = abs_for_daemon(&path);

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -3753,7 +3753,16 @@ fn daemon_start_recovers_graph_applied_vault_tantivy_scope() {
     std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
     write_test_repo(&repo_dir);
     write_test_vault(&vault_dir);
-    create_db(&repo_dir, &db_path);
+    // nw-246: seed the repo under "old" as well.
+    //
+    // This test migrates an instance from "old" to "new", so its fixture needs
+    // the database to BE "old". It previously indexed the repo config-lessly
+    // (recording "default") and then added the vault under "old" — a
+    // two-instance database, which is precisely the fork nw-246 now refuses to
+    // create. The subject here is migration, not instance policy, so the fix is
+    // to make the fixture internally consistent rather than to route around the
+    // guard.
+    create_db_for_instance(&repo_dir, &db_path, "old");
 
     let _guard = DaemonGuard::new(&db_path);
     start_daemon(&db_path);


### PR DESCRIPTION
nw-246. **Breaking, deliberately** — confirmed acceptable in an already-breaking release.

## The defect

Instance id is interpolated into every `repo_uid`, `vault_uid` and `project_uid`, so it is a property **of the data**. But it was re-derived from ambient inputs on every invocation: a db-path hash in 7.0.0, the literal `"default"` in 8.0.0.

Changing the derivation therefore **silently re-identified existing data**. An upgrading user who re-indexed got a forked graph in place:

- two repo rows for one filesystem path
- two UIDs per symbol, with an **identical `canonical_id`** — the store had everything it needed to notice
- `stale-check` permanently exiting 2, on a repo just indexed
- `--force` not helping — the remedy the breaking-change note itself recommends
- `prune-stale` unable to clean it, because nothing was actually orphaned

Zero warnings at any point.

## The model

**The database carries its own instance identity, minted at first write and immutable thereafter.** Everything after adopts it, including a later explicit config.

This is not a new architecture here — it is the shape `PublicationIdentity` has always used for `brain_uuid`: mint once at creation, store it in the database, read it thereafter, refuse on disagreement, provide an explicit adopt path. `instance.data_instance_id` reuses the same `Meta` helpers and the **same in-transaction re-check**, so two concurrent openers cannot publish different instances for one database.

It is also the established pattern outside this codebase — PostgreSQL `system_identifier`, Terraform state `lineage`, Kafka `cluster.id`, etcd, Elasticsearch. etcd states the precedence rule most plainly: *consult the WAL first, fall back to ambient flags only when there is no WAL.* That is what `resolve_instance_id_for_db` does.

## Why not the narrower fix

"Adopt the recorded instance per repo" would have been a **fourth** reconciliation policy, not a convergence:

| subsystem | on instance disagreement |
|---|---|
| vaults | refuse (nw-098) |
| projects | silently overwrite |
| repos | **silently fork** |

And `vault_registrations_for_root` has **one** call site against `resolve_instance_id`'s **six** production ones — so the nw-098 guard covered a single CLI arm and left `index`, `brain add`, `watch` and `brain remove` forkable. All six now route through one rule.

## Legacy databases

The correct instance cannot be *minted* the way a UUID can — the right value is already baked into thousands of existing UIDs — so it is **inferred** from them:

- **one** distinct value → adopt it; the upgrade is seamless and requires no action
- **several** → **refuse** and name them. That database is already forked, and picking one compounds the damage.

## Verified end to end — the reported repro

```
index --repo demo --db t.lbug --instance 2051a9da   # the 7.0.0 state
index --repo demo --db t.lbug                       # config-less 8.0.0

list-repos   -> 1 row               (was 2)
search alpha -> "Found 1 symbol(s)" (was 2)
stale-check  -> exit 0              (was exit 2, permanently)
Instance: 2051a9da                  (adopted, not "default")
```

And the refusal path — `--instance default` against that database exits **1**, names both instances, explains that indexing would fork the graph, and **writes nothing** (still 1 row afterwards).

## Test fixture, and a wrong turn worth recording

`daemon_start_recovers_graph_applied_vault_tantivy_scope` built a two-instance database *through the CLI* — indexing a repo config-lessly, then adding a vault under `"old"`. That is precisely the fork this now refuses to create.

Its subject is instance **migration**, which needs a two-instance database by definition, so the fixture is now internally consistent (repo seeded under `"old"` too) rather than routed around the guard.

My first attempt bypassed the CLI entirely and broke the test a different way. Reshaping a test I did not understand in order to fit my change was the wrong instinct, and I backed it out.

## Not in this PR

**No rename/re-home path.** `instance merge` already exists and appears to carry its nw-112 wikilink fix (there is a conservation test asserting `"merge destroyed the wikilink graph"`), and the refusal message points at it. Building a second migration path before verifying the existing one against a real brain would be guessing. That verification should also settle whether the standing prohibition on `instance merge` is now stale.

## Verification

- `cargo test --workspace --all-targets` — exit 0, 39 targets, 0 failures
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (run as its own command)
- `cargo fmt --all --check` — clean