### PR TITLE
fix(ci,store,daemon): close the v8.0.0 test-quality debt — mutation scope, unlocked recovery, dead lifecycle guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -682,6 +682,19 @@ jobs:
     if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     continue-on-error: true
+    # Backstop only. The mutation run bounds itself with `timeout` (see the
+    # "Mutate only what this PR changed" step) so that the reporting steps
+    # still run and can DISCLOSE a truncated run. This job-level limit exists
+    # for everything the wrapper can't cover — a wedged apt/cargo install, a
+    # hung cache restore. Cancelling the job here skips the disclosure, so it
+    # is set well above the mutation budget and should never be what fires.
+    #
+    # Nothing bounded total runtime before: `--timeout` is PER CARGO COMMAND,
+    # not per job. On PR #319 this job ran 2h04m without finishing (~5m was
+    # the norm) and was still holding a runner. With one shared runner pool
+    # that is head-of-line blocking for every other PR — see the `concurrency`
+    # note at the top of this file.
+    timeout-minutes: 55
     steps:
       - name: Free disk space
         run: |
@@ -711,31 +724,143 @@ jobs:
       - name: Compute the PR diff
         run: git diff "origin/${{ github.base_ref }}"...HEAD > /tmp/pr.diff
       - name: Mutate only what this PR changed
-        # A timeout because an unkilled mutant can hang a test that would
-        # otherwise exit; without it one pathological mutant stalls the job.
+        id: mutate
+        # `--workspace` is load-bearing. This repo's root Cargo.toml is BOTH a
+        # [workspace] and a [package], so cargo-mutants defaults to the root
+        # package alone — src/main.rs and src/setup.rs. Measured: `--list`
+        # emitted 2065 mutants, every one of them in those two files, and not
+        # one of the 15 library crates (where essentially all the logic lives)
+        # had ever been mutated. On one PR's diff that was 1 mutant instead of
+        # 3; across a release, 96 instead of 572. Every "No surviving mutants
+        # in this diff" this job printed was therefore uninformative — the same
+        # manifest shape the Coverage job already works around with --workspace.
+        #
+        # `--timeout 300` bounds ONE cargo command, not the job: an unkilled
+        # mutant can hang a test that would otherwise exit, and without it one
+        # pathological mutant stalls everything. It says nothing about total
+        # runtime, and cargo-mutants (27.x) has no total-time flag — `--help`
+        # offers only per-command `--timeout`/`--build-timeout` and `--shard`.
+        # So the budget is enforced here with `timeout`, chosen over sharding
+        # (a shard matrix multiplies runners and cold builds for an advisory
+        # job) and over a mutant cap (which would silently drop mutants with no
+        # wall-clock guarantee anyway).
+        #
+        # SIGINT rather than SIGKILL so cargo-mutants shuts down cleanly and
+        # mutants.out/ keeps the results it had already written; --kill-after
+        # covers a process that ignores the interrupt. The exit status is
+        # recorded instead of swallowed by `|| true`, because the next step has
+        # to be able to tell a clean run from a cut-short one.
+        #
         # NESTWEAVER_NO_DAEMON keeps each run hermetic — cargo-mutants requires
         # non-flaky tests, and a shared daemon would make results
         # irreproducible.
+        #
+        # Not using `-j`: each parallel job needs its own copy of the tree and
+        # target dir, and disk (see "Free disk space") is the binding
+        # constraint on this runner, not CPU.
         run: |
-          cargo mutants --in-diff /tmp/pr.diff --timeout 300 --no-shuffle -- --no-fail-fast || true
+          set +e
+          timeout --signal=INT --kill-after=120s "${MUTANTS_BUDGET}" \
+            cargo mutants --workspace --in-diff /tmp/pr.diff \
+              --timeout 300 --no-shuffle -- --no-fail-fast
+          status=$?
+          set -e
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
+          # GNU timeout reports 124 when it had to interrupt, 137 when the
+          # --kill-after SIGKILL was needed.
+          if [ "${status}" -eq 124 ] || [ "${status}" -eq 137 ]; then
+            echo "truncated=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Mutation testing hit its ${MUTANTS_BUDGET} budget and was cut short; the mutant list is partial."
+          else
+            echo "truncated=false" >> "$GITHUB_OUTPUT"
+          fi
+          # Advisory job: surviving mutants (2), timeouts (3) and unviable
+          # mutants (4) are findings to report, not build failures.
+          exit 0
         env:
+          # Deliberately shorter than the job's timeout-minutes so this wrapper,
+          # not the runner, is what stops a long run — the difference is the
+          # headroom the reporting steps need.
+          MUTANTS_BUDGET: 35m
           NESTWEAVER_NO_DAEMON: "1"
           NESTWEAVER_ALLOW_NO_DAEMON: "1"
       - name: Surviving mutants (read these — each one is a test that cannot fail)
         if: always()
+        # An absent signal and a clean signal MUST NOT look the same. A run that
+        # stopped early, or never ran at all, reports that in place of the
+        # all-clear — it never gets to print "No surviving mutants".
+        env:
+          TRUNCATED: ${{ steps.mutate.outputs.truncated }}
+          MUTANTS_STATUS: ${{ steps.mutate.outputs.status }}
         run: |
+          summary() { echo "$1" >> "$GITHUB_STEP_SUMMARY"; }
+
+          # How far did it actually get? Every mutant that produced a verdict
+          # lands in exactly one of these files; mutants.json is the full list
+          # generated up front.
+          tested=0
+          for f in caught missed timeout unviable; do
+            if [ -f "mutants.out/${f}.txt" ]; then
+              tested=$(( tested + $(wc -l < "mutants.out/${f}.txt") ))
+            fi
+          done
+          total=""
+          if [ -f mutants.out/mutants.json ]; then
+            total=$(jq 'length' mutants.out/mutants.json 2>/dev/null || echo "")
+          fi
+          progress="${tested} mutants"
+          if [ -n "${total}" ]; then
+            progress="${tested} of ${total} mutants"
+          fi
+
+          summary "## Mutation testing (advisory)"
+          summary ""
+
+          incomplete=false
+          if [ "${TRUNCATED}" = "true" ]; then
+            incomplete=true
+            summary "> [!WARNING]"
+            summary "> **TRUNCATED — this run hit its time budget and did not finish.**"
+            summary "> It got through **${progress}** before being stopped."
+            summary "> The list below is PARTIAL. A mutant missing from it was not"
+            summary "> killed — it was never reached. Do not read this as an all-clear."
+            summary ""
+          elif [ ! -d mutants.out ]; then
+            incomplete=true
+            summary "> [!WARNING]"
+            summary "> **cargo-mutants produced no report** (exit status \`${MUTANTS_STATUS:-unknown}\`)."
+            summary "> Nothing was mutated. This is a missing result, not a passing one."
+            summary ""
+          elif [ "${MUTANTS_STATUS}" = "1" ]; then
+            incomplete=true
+            summary "> [!WARNING]"
+            summary "> **cargo-mutants exited with an error** (status 1) — the run did not"
+            summary "> complete normally. Treat any list below as partial."
+            summary ""
+          fi
+
           if [ -s mutants.out/missed.txt ]; then
-            echo "### Surviving mutants" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "Each line is a change to this PR's code that NO test noticed." >> "$GITHUB_STEP_SUMMARY"
-            echo "That is not automatically a defect — but it is a test that would" >> "$GITHUB_STEP_SUMMARY"
-            echo "not have caught the bug it appears to guard." >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            summary "### Surviving mutants"
+            summary ""
+            summary "Each line is a change to this PR's code that NO test noticed."
+            summary "That is not automatically a defect — but it is a test that would"
+            summary "not have caught the bug it appears to guard."
+            summary ""
+            summary '```'
             cat mutants.out/missed.txt >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            summary '```'
+          elif [ "${incomplete}" = "true" ]; then
+            if [ "${tested}" -eq 0 ]; then
+              summary "**No mutants were tested at all.** There is no result here to read."
+            else
+              summary "No surviving mutants among the ones this run did reach (${progress})."
+              summary "The rest were not tested."
+            fi
+          elif [ "${tested}" -eq 0 ]; then
+            # Not a pass and not a failure: the diff touched nothing mutable.
+            summary "This PR's diff generated no mutants — nothing in it was mutable."
           else
-            echo "No surviving mutants in this diff." >> "$GITHUB_STEP_SUMMARY"
+            summary "No surviving mutants in this diff (${progress} tested)."
           fi
       - name: Upload mutants report
         if: always()

--- a/crates/nestweaver-daemon/src/lifecycle.rs
+++ b/crates/nestweaver-daemon/src/lifecycle.rs
@@ -4689,4 +4689,138 @@ mod tests {
             assert!(fb.exists());
         });
     }
+
+    /// nw-245: `EFFECTIVE_CONFIG_BINDING_MAX_BYTES` is `64 * 1024`. Turning
+    /// that `*` into a `+` yields 1088 — still large enough for every small
+    /// record the other tests write, so nothing noticed. Pin the ceiling from
+    /// both sides at literal sizes chosen so multiplication and addition
+    /// disagree: an 8 KiB record must be ACCEPTED (1088 would reject it), and
+    /// an oversize record must report the real 65536 limit back to the caller.
+    #[test]
+    fn effective_config_binding_ceiling_accepts_eight_kib_and_reports_sixty_four_kib() {
+        let temp = tempfile::tempdir().unwrap();
+        with_xdg_runtime(temp.path(), || {
+            let binding =
+                EffectiveConfigBinding::new(4242, EffectiveConfigBindingSource::CompiledDefaults);
+            write_effective_config_binding("padded", &binding).unwrap();
+            let path = effective_config_binding_path("padded");
+
+            // Trailing whitespace keeps the payload valid JSON, so the only
+            // thing 8 KiB changes is whether the size gate lets it through.
+            let mut bytes = serde_json::to_vec(&binding).unwrap();
+            assert!(
+                bytes.len() < 8192,
+                "the unpadded record must be smaller than the padding target"
+            );
+            bytes.resize(8192, b' ');
+            std::fs::write(&path, &bytes).unwrap();
+            assert_eq!(std::fs::metadata(&path).unwrap().len(), 8192);
+
+            let read_back = read_effective_config_binding("padded").unwrap_or_else(|error| {
+                panic!(
+                    "an 8192-byte binding is under the 64 KiB ceiling and must be read back, \
+                     got {error}"
+                )
+            });
+            assert_eq!(read_back, binding);
+
+            // The ceiling the reader hands back must be the real one. A `+`
+            // mutant would surface 1088 here.
+            std::fs::write(&path, vec![b' '; 70_000]).unwrap();
+            match read_effective_config_binding("padded") {
+                Err(EffectiveConfigBindingError::TooLarge { size, max, .. }) => {
+                    assert_eq!(size, 70_000);
+                    assert_eq!(max, 65_536, "the binding ceiling must be 64 * 1024");
+                }
+                other => panic!("expected TooLarge for a 70000-byte binding, got {other:?}"),
+            }
+        });
+    }
+
+    /// nw-245: same arithmetic mutant on `LAST_SUCCESSFUL_CONFIG_MAX_BYTES`.
+    /// `64 + 1024` = 1088 still round-trips the tiny records the existing
+    /// tests write, and the existing oversize test sizes its payload FROM the
+    /// constant, so it moves with the mutation. Use literal sizes instead.
+    #[test]
+    fn last_successful_config_ceiling_accepts_eight_kib_and_reports_sixty_four_kib() {
+        let temp = tempfile::tempdir().unwrap();
+        with_xdg_state(temp.path(), || {
+            let db = temp.path().join("brain.lbug");
+            let config = temp.path().join("instance.toml");
+            std::fs::write(&config, "instance_id = \"test\"\n").unwrap();
+            let record = write_last_successful_config(&db, &config).unwrap();
+            let path = last_successful_config_path(&db);
+
+            let mut bytes = serde_json::to_vec(&record).unwrap();
+            assert!(
+                bytes.len() < 8192,
+                "the unpadded record must be smaller than the padding target"
+            );
+            bytes.resize(8192, b' ');
+            std::fs::write(&path, &bytes).unwrap();
+            assert_eq!(std::fs::metadata(&path).unwrap().len(), 8192);
+
+            let read_back = read_last_successful_config(&db).unwrap_or_else(|error| {
+                panic!(
+                    "an 8192-byte record is under the 64 KiB ceiling and must be read back, \
+                     got {error}"
+                )
+            });
+            assert_eq!(read_back, record);
+
+            std::fs::write(&path, vec![b' '; 70_000]).unwrap();
+            match read_last_successful_config(&db) {
+                Err(LastSuccessfulConfigError::TooLarge { size, max, .. }) => {
+                    assert_eq!(size, 70_000);
+                    assert_eq!(max, 65_536, "the record ceiling must be 64 * 1024");
+                }
+                other => panic!("expected TooLarge for a 70000-byte record, got {other:?}"),
+            }
+        });
+    }
+
+    /// nw-245: `mark_verified_nestweaver_managed_start`,
+    /// `clear_verified_nestweaver_managed_start`, and
+    /// `is_verified_nestweaver_managed_start` are the whole gate behind the
+    /// `DaemonLifecycleOwner` a daemon publishes (`server.rs`). Nothing
+    /// observed the marker, so gutting `mark`/`clear` into `()` — or pinning
+    /// the reader to `false`, which downgrades EVERY daemon to
+    /// `ExternalOrUnknown` — changed real behaviour with the suite still
+    /// green. Observe the effect: set, read back, clear, read back.
+    ///
+    /// Holds `ENV_LOCK` because the marker is process-global and `server.rs`'s
+    /// in-process daemon e2e tests read it while they run under the same lock.
+    #[test]
+    fn verified_nestweaver_managed_start_marker_sets_clears_and_reads_back() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let previous = is_verified_nestweaver_managed_start();
+
+        clear_verified_nestweaver_managed_start();
+        assert!(
+            !is_verified_nestweaver_managed_start(),
+            "an unmarked process must not claim a NestWeaver-managed start"
+        );
+
+        mark_verified_nestweaver_managed_start();
+        assert!(
+            is_verified_nestweaver_managed_start(),
+            "marking the managed start must be observable; otherwise every daemon \
+             publishes DaemonLifecycleOwner::ExternalOrUnknown"
+        );
+
+        // A second mark must stay idempotent rather than toggling.
+        mark_verified_nestweaver_managed_start();
+        assert!(is_verified_nestweaver_managed_start());
+
+        clear_verified_nestweaver_managed_start();
+        assert!(
+            !is_verified_nestweaver_managed_start(),
+            "clearing the marker must be observable; otherwise a failed spawn \
+             leaves the daemon falsely claiming NestWeaver management"
+        );
+
+        if previous {
+            mark_verified_nestweaver_managed_start();
+        }
+    }
 }

--- a/crates/nestweaver-store/src/tantivy_index.rs
+++ b/crates/nestweaver-store/src/tantivy_index.rs
@@ -21,6 +21,8 @@ use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
 use tantivy::collector::{Collector, SegmentCollector, TopDocs};
+use tantivy::directory::error::LockError;
+use tantivy::directory::{Directory, DirectoryLock, Lock, MmapDirectory};
 use tantivy::query::{Query, QueryParser};
 use tantivy::schema::{Field, STORED, STRING, Schema, TEXT, Value};
 use tantivy::store::StoreReader;
@@ -447,9 +449,20 @@ impl TantivyIndex {
     /// returned instance will return `TantivyError::WriterUnavailable`.
     ///
     /// Returns `Err` if the index directory does not exist or is corrupt.
+    ///
+    /// This open is strictly **non-destructive**. It runs in every CLI, MCP
+    /// and web process and holds no lock, so it must never perform the
+    /// rename/delete recovery in [`recover_interrupted_reindex`]: an
+    /// in-flight [`Self::rebuild_current_schema_atomically`] leaves exactly
+    /// the same on-disk shape (target absent, recovery copy present) between
+    /// its two renames, and "recovering" it from here consumes the copy the
+    /// migration is about to roll back to, or removes the copy it is about to
+    /// retire itself. When an interrupted migration is visible this serves
+    /// whichever of the two directories is a readable index and leaves both
+    /// in place; a writer route repairs the state later, under a lock.
     pub fn open_reader_only(path: &Path) -> Result<Self, TantivyError> {
-        recover_interrupted_reindex(path)?;
-        let index = Index::open_in_dir(path)?;
+        let resolved = resolve_read_only_index_path(path);
+        let index = Index::open_in_dir(&resolved)?;
         let reader = index
             .reader_builder()
             .reload_policy(ReloadPolicy::OnCommitWithDelay)
@@ -461,7 +474,7 @@ impl TantivyIndex {
             reader,
             writer: None,
             fields: schema.fields,
-            path: path.to_path_buf(),
+            path: resolved,
             counted_search_supported: schema.current,
             migration_completed: AtomicBool::new(false),
         })
@@ -545,6 +558,27 @@ impl TantivyIndex {
             ));
         }
         drop(verification);
+
+        // Everything from here to the final `remove_dir_all(&backup)` mutates
+        // whole directories, and between the two renames below the target is
+        // absent while the recovery copy exists. Hold the recovery lock across
+        // that whole window so a concurrent opener's
+        // `recover_interrupted_reindex` cannot restore the backup over this
+        // migration or retire it out from under the cleanup at the end.
+        //
+        // Tantivy's own `INDEX_WRITER_LOCK` cannot cover this: it lives at
+        // `<index>/.tantivy-writer.lock`, so it travels with the directory the
+        // first rename moves aside and stops excluding anything.
+        let _recovery_guard = match try_acquire_reindex_lock(&self.path)? {
+            Some(guard) => guard,
+            None => {
+                return Err(TantivyError::Io(format!(
+                    "index recovery or migration is already in progress for {}; \
+                     retry shortly",
+                    self.path.display()
+                )));
+            }
+        };
 
         let backup = reindex_backup_path(&self.path);
         if backup.exists() {
@@ -1432,8 +1466,108 @@ fn reindex_backup_path(path: &Path) -> PathBuf {
     PathBuf::from(backup)
 }
 
+/// Name of the exclusive lock that serialises destructive index recovery
+/// against an in-flight schema migration.
+///
+/// It deliberately lives in the index directory's **parent**. The migration
+/// renames the index directory itself (`path` -> `path.reindexing`), so a lock
+/// file stored inside `path` would travel with that rename and a second
+/// process would end up locking a different inode — which is precisely why
+/// Tantivy's `INDEX_WRITER_LOCK` cannot be reused here.
+fn reindex_lock_file_name(path: &Path) -> std::ffi::OsString {
+    let mut name = std::ffi::OsString::from(".");
+    name.push(
+        path.file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new("tantivy")),
+    );
+    name.push(".reindex.lock");
+    name
+}
+
+/// Try to take the recovery lock for `path`.
+///
+/// `Ok(None)` means another process or thread already holds it, i.e. a
+/// migration or recovery is in flight and the caller must not touch either
+/// directory. The lock is deliberately **non-blocking**: it is taken on the
+/// index-open path, and a daemon that died holding a blocking lock would
+/// otherwise wedge every subsequent opener.
+fn try_acquire_reindex_lock(path: &Path) -> Result<Option<DirectoryLock>, TantivyError> {
+    let parent = match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => Path::new("."),
+    };
+    std::fs::create_dir_all(parent)?;
+    let directory = MmapDirectory::open(parent).map_err(|error| {
+        TantivyError::Io(format!(
+            "open index parent {} for recovery lock: {error}",
+            parent.display()
+        ))
+    })?;
+    let lock = Lock {
+        filepath: PathBuf::from(reindex_lock_file_name(path)),
+        is_blocking: false,
+    };
+    match directory.acquire_lock(&lock) {
+        Ok(guard) => Ok(Some(guard)),
+        Err(LockError::LockBusy) => Ok(None),
+        Err(error) => Err(TantivyError::Io(format!(
+            "acquire index recovery lock for {}: {error}",
+            path.display()
+        ))),
+    }
+}
+
+/// True when `path` holds an index this build can open and interpret.
+fn index_is_readable(path: &Path) -> bool {
+    Index::open_in_dir(path)
+        .map_err(TantivyError::from)
+        .and_then(|index| inspect_schema(&index.schema()).map(|_| ()))
+        .is_ok()
+}
+
+/// Decide which directory a read-only open should serve, **without touching
+/// the filesystem**. See [`TantivyIndex::open_reader_only`].
+fn resolve_read_only_index_path(path: &Path) -> PathBuf {
+    let backup = reindex_backup_path(path);
+    if !backup.exists() {
+        return path.to_path_buf();
+    }
+    // An interrupted — or still running — migration is visible. Prefer the
+    // real target when it already holds a usable index (the migration got as
+    // far as installing the replacement), otherwise read through to the
+    // recovery copy. Either way both directories are left exactly as found.
+    if index_is_readable(path) {
+        return path.to_path_buf();
+    }
+    if index_is_readable(&backup) {
+        return backup;
+    }
+    // Neither is usable. Return the real target so the caller surfaces an
+    // error about the index it actually asked for.
+    path.to_path_buf()
+}
+
 fn recover_interrupted_reindex(path: &Path) -> Result<(), TantivyError> {
     let backup = reindex_backup_path(path);
+    if !backup.exists() {
+        return Ok(());
+    }
+
+    // Everything below renames and deletes whole directories, and a concurrent
+    // `rebuild_current_schema_atomically` mutates the same two paths. Between
+    // its two renames the target is absent and the backup present — exactly
+    // the state that drives this function down the restore branch. Serialise
+    // against it, and refuse rather than wait: this runs before the writer is
+    // acquired, on every open.
+    let Some(_guard) = try_acquire_reindex_lock(path)? else {
+        return Err(TantivyError::Io(format!(
+            "index recovery or migration is already in progress for {}; retry shortly",
+            path.display()
+        )));
+    };
+
+    // Re-read the state under the lock: the previous holder may have finished
+    // between the probe above and the acquisition.
     if !backup.exists() {
         return Ok(());
     }
@@ -2227,11 +2361,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn interrupted_schema_migration_recovers_the_rename_aside_copy() {
-        let root = tempdir().unwrap();
-        let index_path = root.path().join("search-index");
-        let idx = TantivyIndex::open_or_create(&index_path).unwrap();
+    /// Seed `index_path` with one searchable note and close the handle.
+    fn seed_recoverable_index(index_path: &Path) {
+        let idx = TantivyIndex::open_or_create(index_path).unwrap();
         idx.update_note(
             "note:recover",
             "Payment Recovery",
@@ -2243,20 +2375,149 @@ mod tests {
         )
         .unwrap();
         drop(idx);
+    }
+
+    #[test]
+    fn interrupted_schema_migration_recovers_the_rename_aside_copy() {
+        let root = tempdir().unwrap();
+        let index_path = root.path().join("search-index");
+        seed_recoverable_index(&index_path);
 
         let recovery_path = reindex_backup_path(&index_path);
         std::fs::rename(&index_path, &recovery_path).unwrap();
-        let reopened = TantivyIndex::open_reader_only(&index_path).unwrap();
+        // Recovery is a writer-route responsibility (nw-254): only the path
+        // that can take the recovery lock is allowed to mutate these dirs.
+        let reopened = TantivyIndex::open_or_create(&index_path).unwrap();
         assert_eq!(reopened.search("payment", 10).unwrap().len(), 1);
         assert!(index_path.exists());
         assert!(!recovery_path.exists());
     }
 
+    /// nw-254: `open_reader_only` runs in every CLI/MCP process and takes no
+    /// lock. The state it sees here — target absent, recovery copy present —
+    /// is also what a *live* writer exposes between its two renames, so
+    /// "recovering" it would consume the directory that writer is about to
+    /// roll back to. A read-only open must serve the data and mutate nothing.
     #[test]
-    fn failed_schema_migration_leaves_the_old_index_usable() {
+    fn read_only_open_never_mutates_an_interrupted_migration() {
         let root = tempdir().unwrap();
         let index_path = root.path().join("search-index");
-        std::fs::create_dir(&index_path).unwrap();
+        seed_recoverable_index(&index_path);
+
+        let recovery_path = reindex_backup_path(&index_path);
+        std::fs::rename(&index_path, &recovery_path).unwrap();
+
+        let reader = TantivyIndex::open_reader_only(&index_path).unwrap();
+        assert_eq!(
+            reader.search("payment", 10).unwrap().len(),
+            1,
+            "read-only open should read through to the recovery copy"
+        );
+        assert!(
+            recovery_path.exists(),
+            "read-only open consumed the recovery copy a live migration owns"
+        );
+        assert!(
+            !index_path.exists(),
+            "read-only open restored the index directory a live migration owns"
+        );
+    }
+
+    /// The other interrupted shape: the replacement is already installed and
+    /// only the retirement of the old copy is outstanding. A reader must not
+    /// perform that retirement either — the migrating writer removes the very
+    /// same directory itself and would report a bogus failure on NotFound.
+    #[test]
+    fn read_only_open_leaves_a_pending_recovery_copy_in_place() {
+        let root = tempdir().unwrap();
+        let index_path = root.path().join("search-index");
+        seed_recoverable_index(&index_path);
+        let recovery_path = reindex_backup_path(&index_path);
+        seed_recoverable_index(&recovery_path);
+
+        let reader = TantivyIndex::open_reader_only(&index_path).unwrap();
+        assert_eq!(reader.search("payment", 10).unwrap().len(), 1);
+        assert!(
+            recovery_path.exists(),
+            "read-only open retired a recovery copy the migrating writer still owns"
+        );
+    }
+
+    /// The writer route may still recover, but only under the recovery lock.
+    /// While a migration holds that lock the opener must refuse outright: it
+    /// must neither restore the backup nor fabricate a fresh empty index at
+    /// the target the migration is about to rename its staging dir onto.
+    #[test]
+    fn open_or_create_refuses_recovery_while_the_reindex_lock_is_held() {
+        let root = tempdir().unwrap();
+        let index_path = root.path().join("search-index");
+        seed_recoverable_index(&index_path);
+
+        let recovery_path = reindex_backup_path(&index_path);
+        std::fs::rename(&index_path, &recovery_path).unwrap();
+
+        let held = try_acquire_reindex_lock(&index_path)
+            .unwrap()
+            .expect("recovery lock should be free");
+
+        let error = match TantivyIndex::open_or_create(&index_path) {
+            Ok(_) => panic!("open_or_create recovered while the lock was held"),
+            Err(error) => error,
+        };
+        assert!(
+            error.to_string().contains("already in progress"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            recovery_path.exists(),
+            "recovery copy consumed while a migration held the lock"
+        );
+        assert!(
+            !index_path.exists(),
+            "empty index fabricated at the target while a migration held the lock"
+        );
+
+        // Releasing the lock must restore normal recovery, so the refusal
+        // above is genuinely gated on the lock and not a permanent breakage.
+        drop(held);
+        let recovered = TantivyIndex::open_or_create(&index_path).unwrap();
+        assert_eq!(recovered.search("payment", 10).unwrap().len(), 1);
+        assert!(index_path.exists());
+        assert!(!recovery_path.exists());
+    }
+
+    /// Symmetric guard on the migration itself: it must not start its rename
+    /// sequence while someone else holds the recovery lock.
+    #[test]
+    fn schema_migration_refuses_while_the_reindex_lock_is_held() {
+        let root = tempdir().unwrap();
+        let index_path = root.path().join("search-index");
+        write_legacy_schema_index(&index_path);
+
+        let legacy = TantivyIndex::open_or_create(&index_path).unwrap();
+        let held = try_acquire_reindex_lock(&index_path)
+            .unwrap()
+            .expect("recovery lock should be free");
+
+        let error = legacy
+            .reindex_from_store(&GraphStore::in_memory().unwrap())
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("already in progress"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !reindex_backup_path(&index_path).exists(),
+            "migration moved the index aside despite a held recovery lock"
+        );
+        assert_eq!(legacy.search("payment", 10).unwrap().len(), 1);
+        drop(held);
+    }
+
+    /// Build an index at `index_path` whose schema predates the stored
+    /// `note_uid` field, i.e. one `reindex_from_store` must migrate.
+    fn write_legacy_schema_index(index_path: &Path) {
+        std::fs::create_dir_all(index_path).unwrap();
         let mut schema_builder = Schema::builder();
         let uid = schema_builder.add_text_field("uid", STRING | STORED);
         let kind = schema_builder.add_text_field("kind", STRING | STORED);
@@ -2264,7 +2525,7 @@ mod tests {
         let body = schema_builder.add_text_field("body", TEXT);
         let vault_uid = schema_builder.add_text_field("vault_uid", STRING | STORED);
         let note_uid = schema_builder.add_text_field("note_uid", STRING);
-        let index = Index::create_in_dir(&index_path, schema_builder.build()).unwrap();
+        let index = Index::create_in_dir(index_path, schema_builder.build()).unwrap();
         let mut writer = index.writer(15_000_000).unwrap();
         writer
             .add_document(doc!(
@@ -2279,6 +2540,13 @@ mod tests {
         writer.commit().unwrap();
         drop(writer);
         drop(index);
+    }
+
+    #[test]
+    fn failed_schema_migration_leaves_the_old_index_usable() {
+        let root = tempdir().unwrap();
+        let index_path = root.path().join("search-index");
+        write_legacy_schema_index(&index_path);
 
         let legacy = TantivyIndex::open_or_create(&index_path).unwrap();
         let recovery_path = reindex_backup_path(&index_path);


### PR DESCRIPTION
Three independent items, consolidated into one PR so we pay for one CI cycle rather than three. Disjoint files, no overlap with the contract-divergence branch.

---

## nw-243 — the mutation job has never mutated a library crate

`.github/workflows/ci.yml` only.

The root `Cargo.toml` is both a `[workspace]` and a `[package]`, so `cargo mutants` defaulted to the root package alone. Measured: `--list` emitted **2065 mutants, every one** in `src/main.rs` or `src/setup.rs`. On one PR's diff that was 1 mutant instead of 3; across a release, **96 instead of 572**. None of the 15 library crates had ever been mutated, so every "No surviving mutants in this diff" this job printed was uninformative.

`--workspace` alone would make things worse: on #319 this job ran **2h04m without finishing** (~5m was the norm) and was still holding a runner. `--timeout 300` is per-cargo-command, not per job, and cargo-mutants 27.x has no total-time flag — verified against `--help` rather than assumed.

So the run is now wrapped in `timeout --signal=INT --kill-after=120s 35m`, with `timeout-minutes: 55` as a backstop that should never fire (a job-level cancellation would skip the reporting step and lose the disclosure). SIGINT rather than SIGKILL so `mutants.out/` keeps what it already wrote.

**An absent signal and a clean signal must not look the same.** A truncated run can no longer reach the "No surviving mutants" branch; it leads with a `[!WARNING]` stating how far it got and that *"a mutant missing from it was not killed — it was never reached."* A missing/errored report says "a missing result, not a passing one". A diff generating zero mutants says so explicitly.

Rejected: a shard matrix (multiplies runners and cold builds for an advisory job) and a mutant cap (drops work with no wall-clock guarantee).

## nw-254 — unlocked opens could clobber an in-flight index migration

`crates/nestweaver-store/src/tantivy_index.rs` only.

`recover_interrupted_reindex` performed unlocked `remove_dir_all` and `rename`, and ran on **every** open — including `open_reader_only`, which takes no lock at all. Between the migration's two renames the target is absent and the backup present, which is exactly the state that sends a concurrent opener down the restore branch. So an ordinary `brain search` could consume the directory a live writer was about to roll back to.

**Why the obvious fix doesn't work:** Tantivy's `INDEX_WRITER_LOCK` lives at `<index>/.tantivy-writer.lock` — *inside the directory being renamed*. It travels with the very rename it would guard, so a second process locks a different inode and excludes nothing. The recovery lock therefore sits in the parent.

- **Read path is now non-destructive.** `open_reader_only` no longer recovers; a pure-decision helper picks whichever of `{path, path.reindexing}` is readable and serves it. An interrupted migration is served *from the recovery copy* rather than degrading to substring search.
- **Writer routes serialise** on a non-blocking flock, held across the rename window but not across the expensive staging build.

A *blocking* lock was rejected deliberately: taken on the index-open path, a daemon holding it through a migration — or dying holding it — would wedge every subsequent opener and every CLI read. That failure mode is worse than the race.

The pre-existing `interrupted_schema_migration_recovers_the_rename_aside_copy` was retargeted from `open_reader_only` to `open_or_create` — it was asserting the exact behaviour that is the bug. Its assertions are unchanged; recovery coverage moved to the route that owns it, and new tests cover the read path's non-mutation.

## nw-245 — five surviving mutants in `lifecycle.rs`

`crates/nestweaver-daemon/src/lifecycle.rs` only; the diff is entirely inside `#[cfg(test)]`.

All five recovered from a `mutants.out/missed.txt` committed by accident and later removed — the data survived only in git history. All five still lived at HEAD. Each is now killed, verified by applying the mutation by hand and confirming the suite fails:

| mutant | test | result when mutated |
|---|---|---|
| `EFFECTIVE_CONFIG_BINDING_MAX_BYTES` `*`→`+` | `..._accepts_eight_kib_and_reports_sixty_four_kib` | 289 passed, **1 failed** |
| `LAST_SUCCESSFUL_CONFIG_MAX_BYTES` `*`→`+` | `..._accepts_eight_kib_and_reports_sixty_four_kib` | 289 passed, **1 failed** |
| `mark_verified_nestweaver_managed_start` → `()` | `..._marker_sets_clears_and_reads_back` | 289 passed, **1 failed** |
| `clear_verified_nestweaver_managed_start` → `()` | same test, **different assertion** | 289 passed, **1 failed** |
| `is_verified_nestweaver_managed_start` → `false` | same test | 288 passed, **2 failed** |

**Why the existing oversize tests could never have caught the arithmetic mutants:** they build payloads as `vec![b' '; MAX_BYTES as usize + 1]` — sized *from* the constant, so they move with the mutation and stay green at 1088. A test asserting a constant against itself. The new tests use literal `8192`/`70_000` and assert the `max` value the public `TooLarge` error reports, so the constant is observable through the API instead of self-referentially.

---

## Verification

- nw-245: `cargo test -p nestweaver-daemon --lib` → exit 0, **290 passed** (baseline 287, +3). fmt and clippy clean.
- nw-254: `cargo test -p nestweaver-store --lib tantivy` → exit 0, 34 passed. fmt and clippy clean.
- nw-243: `actionlint` exit 0, `shellcheck` on both run blocks, summary script executed against fixtures for five states. No cargo run — the change is YAML.

**One caveat stated plainly:** nw-254's *unfiltered* `cargo test -p nestweaver-store --lib` did not complete — it died relinking on `No space left on device`, a disk failure rather than a test failure. The filtered run still compiles and links the whole lib test binary, and nothing outside `tantivy_index.rs` constructs a `TantivyIndex`. That is an argument, not a result, and **this PR's CI is what closes it.**