### PR TITLE
fix(daemon,cli,engine): nw-246 was unfixed on the default path

### DIFF
--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -5032,6 +5032,29 @@ impl NestWeaverDaemon for DaemonService {
 
                     // Rebuild Tantivy search index so BM25 search reflects
                     // the freshly indexed vault content.
+                    //
+                    // nw-249: when there is NO writer this whole block was
+                    // skipped and the DONE phase below still reported a full
+                    // set of counts — so an index that could not touch the
+                    // search index at all looked identical to one that
+                    // rebuilt it. Unlike a failed rebuild, this is not an
+                    // error: a read-only replica legitimately has no writer.
+                    // So it is disclosed rather than failed, and the phrasing
+                    // says which of the two happened.
+                    let search_index_rebuilt = state
+                        .tantivy
+                        .as_ref()
+                        .is_some_and(|tantivy| tantivy.has_writer());
+                    if !search_index_rebuilt {
+                        let _ = tx.blocking_send(Ok(IndexProgress {
+                            message: "note: the graph was updated but the BM25 search index \
+                                      was NOT rebuilt (this daemon holds no search-index \
+                                      writer), so `brain search` will not reflect this \
+                                      index until one does"
+                                .to_string(),
+                            ..Default::default()
+                        }));
+                    }
                     if let Some(ref tantivy) = state.tantivy
                         && tantivy.has_writer()
                     {

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -17898,6 +17898,60 @@ external_model = "unavailable-test-model"
         drop(gate);
     }
 
+    /// nw-244: PR #308 wired `brain_memory_consolidate` to the write gate ONLY
+    /// when `apply: true`. The existing guards test `request_is_applying` as a
+    /// pure function, so the *wiring* was unasserted: replacing the call site
+    /// with `let applying = false;` left the whole suite green while every
+    /// file-moving consolidation ran ungated and invisible to the shutdown
+    /// drain.
+    ///
+    /// Probed like `set_extension_holds_write_gate`, but in BOTH directions —
+    /// the gating is conditional, so one direction alone cannot pin it:
+    /// `apply: true` must block on a held gate, and `apply: false` (a pure
+    /// dry-run) must NOT, because making the common preview call queue behind
+    /// a minutes-long drain is the regression the conditional exists to avoid.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn only_an_applying_memory_consolidate_blocks_on_the_write_gate() {
+        let state = test_state_with_writer();
+        let service = DaemonService::new(state.clone());
+
+        let gate = state.write_gate.mutex().lock_owned().await;
+
+        let applying = {
+            let mut req = Request::new(JsonRequest {
+                args_json: serde_json::json!({ "apply": true }).to_string(),
+            });
+            req.extensions_mut().insert(crate::auth::IsAdmin(true));
+            tokio::time::timeout(
+                std::time::Duration::from_millis(750),
+                service.brain_memory_consolidate(req),
+            )
+            .await
+        };
+        assert!(
+            applying.is_err(),
+            "an APPLYING memory consolidate moves vault files and must block on              the write gate while it is held; it returned without waiting"
+        );
+
+        let preview = {
+            let mut req = Request::new(JsonRequest {
+                args_json: serde_json::json!({ "apply": false }).to_string(),
+            });
+            req.extensions_mut().insert(crate::auth::IsAdmin(true));
+            tokio::time::timeout(
+                std::time::Duration::from_millis(750),
+                service.brain_memory_consolidate(req),
+            )
+            .await
+        };
+        assert!(
+            preview.is_ok(),
+            "a DRY-RUN memory consolidate touches nothing and must NOT queue              behind the write gate; it blocked"
+        );
+
+        drop(gate);
+    }
+
     /// T6.2: the Shutdown RPC MUST set `state.drained` synchronously — before
     /// it spawns the drain wait loop — so the worker pool STOPS CLAIMING new
     /// jobs the instant shutdown begins. Otherwise, under continuous webhook

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -931,6 +931,14 @@ pub struct DaemonState {
     /// repo/symbol/note we write, so users see and type one name everywhere
     /// (nw-019). Config-less starts collapse it back onto `instance_id`.
     pub data_instance_id: String,
+    /// nw-246: instances observed in a database that stated none, when there is
+    /// more than one. Empty in the normal case.
+    ///
+    /// Carried rather than fatal at startup: refusing to boot would block
+    /// READS, and reads are instance-agnostic. The ambiguity only has to be
+    /// refused where it can actually fork the graph, which is a write that
+    /// states no instance of its own.
+    pub ambiguous_instance_ids: Vec<String>,
     pub start_time: Instant,
     pub active_reads: Arc<AtomicU32>,
     pub active_writes: Arc<AtomicU32>,
@@ -1138,7 +1146,35 @@ fn build_daemon_permission_source(
 /// `default` and split the graph. It sends empty now, and a config-less
 /// daemon's `data_instance_id` is "default" rather than a db-path hash, so the
 /// two paths agree without either compensating for the other.
-fn resolve_effective_instance_id(requested: &str, configured: &str) -> Result<String, Status> {
+fn resolve_effective_instance_id(
+    requested: &str,
+    configured: &str,
+    ambiguous: &[String],
+) -> Result<String, Status> {
+    // nw-246: a request that states no instance, against a database holding
+    // several and having stated none itself, has no safe default. Adopting one
+    // is how the fork deepens.
+    //
+    // Checked HERE rather than at each handler because every caller of this
+    // function is a write or a write registration — index, vault index and
+    // refresh, the two watch registrations, materialize, merge, purge. Reads
+    // are instance-agnostic and never come through here, so this cannot refuse
+    // a read. Putting it at one choke point is what stops the next write path
+    // from being added without it, which is the mistake this whole item is.
+    //
+    // `merge`/`purge` state both ids explicitly and so pass through untouched —
+    // which matters, because `instance merge` is the documented REMEDY for
+    // this exact state and must not be refused by the guard warning about it.
+    if requested.is_empty() && !ambiguous.is_empty() {
+        return Err(Status::failed_precondition(format!(
+            "this database holds data under {} instances ({}), and neither this \
+             request nor the daemon's configuration named one, so there is no safe \
+             default.\nName one with `--instance <id>` or a `--config`, or \
+             consolidate them with `nestweaver instance merge --from <one> --to <keep>`.",
+            ambiguous.len(),
+            ambiguous.join(", ")
+        )));
+    }
     let effective = if requested.is_empty() {
         configured
     } else {
@@ -2318,11 +2354,11 @@ mod instance_id_validation_tests {
     #[test]
     fn effective_instance_id_uses_request_then_configured_default() {
         assert_eq!(
-            resolve_effective_instance_id("request-id", "configured-id").unwrap(),
+            resolve_effective_instance_id("request-id", "configured-id", &[]).unwrap(),
             "request-id"
         );
         assert_eq!(
-            resolve_effective_instance_id("", "configured-id").unwrap(),
+            resolve_effective_instance_id("", "configured-id", &[]).unwrap(),
             "configured-id"
         );
     }
@@ -2337,7 +2373,7 @@ mod instance_id_validation_tests {
             ("", "configured:bad"),
             ("", "configured bad"),
         ] {
-            let error = resolve_effective_instance_id(requested, configured).unwrap_err();
+            let error = resolve_effective_instance_id(requested, configured, &[]).unwrap_err();
             assert_eq!(error.code(), tonic::Code::InvalidArgument);
             assert!(
                 error.message().contains("instance_id"),
@@ -3948,8 +3984,11 @@ impl NestWeaverDaemon for DaemonService {
         let req = request.into_inner();
         let vault_path = PathBuf::from(&req.vault_path);
         let vault_name = req.vault_name.clone();
-        let instance_id =
-            resolve_effective_instance_id(&req.instance_id, &self.state.data_instance_id)?;
+        let instance_id = resolve_effective_instance_id(
+            &req.instance_id,
+            &self.state.data_instance_id,
+            &self.state.ambiguous_instance_ids,
+        )?;
         let extra_patterns = req.extra_ignore_patterns.clone();
         let force = req.force;
 
@@ -4086,8 +4125,11 @@ impl NestWeaverDaemon for DaemonService {
         let req = request.into_inner();
         let repo_path = PathBuf::from(&req.repo_path);
         let force = req.force;
-        let instance_id =
-            resolve_effective_instance_id(&req.instance_id, &self.state.data_instance_id)?;
+        let instance_id = resolve_effective_instance_id(
+            &req.instance_id,
+            &self.state.data_instance_id,
+            &self.state.ambiguous_instance_ids,
+        )?;
 
         if !repo_path.exists() || !repo_path.is_dir() {
             return Ok(Response::new(WatchCodeResponse {
@@ -4365,8 +4407,11 @@ impl NestWeaverDaemon for DaemonService {
         }
         let req = request.into_inner();
         let state = self.state.clone();
-        let watch_instance =
-            resolve_effective_instance_id(&req.watch_instance_id, &state.data_instance_id)?;
+        let watch_instance = resolve_effective_instance_id(
+            &req.watch_instance_id,
+            &state.data_instance_id,
+            &state.ambiguous_instance_ids,
+        )?;
 
         let app_state = nestweaver_web::state::AppState::new_with_arc_tantivy(
             state.store.clone(),
@@ -4613,8 +4658,11 @@ impl NestWeaverDaemon for DaemonService {
         } else {
             Some(req.name.clone())
         };
-        let effective_instance =
-            resolve_effective_instance_id(&req.instance_id, &state.data_instance_id)?;
+        let effective_instance = resolve_effective_instance_id(
+            &req.instance_id,
+            &state.data_instance_id,
+            &state.ambiguous_instance_ids,
+        )?;
         let index_limits = if req.max_source_file_bytes == 0 {
             state
                 .instance_cfg
@@ -4974,8 +5022,11 @@ impl NestWeaverDaemon for DaemonService {
         let vault_path = PathBuf::from(&req.vault_path);
         let vault_name = req.vault_name.clone();
         let extra_patterns = req.extra_ignore_patterns.clone();
-        let instance_id =
-            resolve_effective_instance_id(&req.instance_id, &self.state.data_instance_id)?;
+        let instance_id = resolve_effective_instance_id(
+            &req.instance_id,
+            &self.state.data_instance_id,
+            &self.state.ambiguous_instance_ids,
+        )?;
         let state = self.state.clone();
 
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<IndexProgress, Status>>(16);
@@ -5139,8 +5190,11 @@ impl NestWeaverDaemon for DaemonService {
         let vault_path = PathBuf::from(&req.vault_path);
         let vault_name = req.vault_name.clone();
         let extra_patterns = req.extra_ignore_patterns.clone();
-        let instance_id =
-            resolve_effective_instance_id(&req.instance_id, &self.state.data_instance_id)?;
+        let instance_id = resolve_effective_instance_id(
+            &req.instance_id,
+            &self.state.data_instance_id,
+            &self.state.ambiguous_instance_ids,
+        )?;
         let since = std::time::UNIX_EPOCH
             .checked_add(Duration::from_secs(req.since_unix_seconds))
             .ok_or_else(|| Status::invalid_argument("since_unix_seconds is out of range"))?;
@@ -5251,8 +5305,11 @@ impl NestWeaverDaemon for DaemonService {
         }
         let req = request.into_inner();
         let config_path = PathBuf::from(&req.config_path);
-        let instance_id =
-            resolve_effective_instance_id(&req.instance_id, &self.state.data_instance_id)?;
+        let instance_id = resolve_effective_instance_id(
+            &req.instance_id,
+            &self.state.data_instance_id,
+            &self.state.ambiguous_instance_ids,
+        )?;
         // Configuration I/O and parsing do not mutate the graph and must not
         // occupy the sole writer while a slow filesystem is being read.
         let instance_config =
@@ -5578,8 +5635,16 @@ impl NestWeaverDaemon for DaemonService {
             return Err(Status::permission_denied("admin token required"));
         }
         let req = request.into_inner();
-        let from_id = resolve_effective_instance_id(&req.from_id, &self.state.data_instance_id)?;
-        let to_id = resolve_effective_instance_id(&req.to_id, &self.state.data_instance_id)?;
+        let from_id = resolve_effective_instance_id(
+            &req.from_id,
+            &self.state.data_instance_id,
+            &self.state.ambiguous_instance_ids,
+        )?;
+        let to_id = resolve_effective_instance_id(
+            &req.to_id,
+            &self.state.data_instance_id,
+            &self.state.ambiguous_instance_ids,
+        )?;
         if from_id == to_id {
             return Err(Status::invalid_argument(
                 "source and target instance IDs must differ",
@@ -5647,8 +5712,11 @@ impl NestWeaverDaemon for DaemonService {
             return Err(Status::permission_denied("admin token required"));
         }
         let req = request.into_inner();
-        let instance_id =
-            resolve_effective_instance_id(&req.instance_id, &self.state.data_instance_id)?;
+        let instance_id = resolve_effective_instance_id(
+            &req.instance_id,
+            &self.state.data_instance_id,
+            &self.state.ambiguous_instance_ids,
+        )?;
         let state = self.state.clone();
 
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<IndexProgress, Status>>(16);
@@ -10060,10 +10128,68 @@ pub async fn run_server(
     // "default". The runtime hash keeps doing its own job — naming sockets and
     // local state per database path — which is unrelated to which logical
     // instance the graph belongs to. Conflating the two is what broke.
-    let data_instance_id = instance_cfg
-        .as_ref()
-        .map(|c| c.instance_id.clone())
-        .unwrap_or_else(|| "default".to_string());
+    //
+    // nw-246 (daemon path): this used to stop at config-or-"default" and never
+    // consult the store, which meant the identity the database RECORDS was read
+    // by exactly two places in the codebase, both inside the CLI's
+    // `resolve_instance_id_for_db` — a guard only reachable under
+    // `--no-daemon`. With a daemon running, which is the default, a
+    // config-less `nestweaver index` against a database recorded as `2051a9da`
+    // still wrote `default` and forked the graph. The original defect,
+    // verbatim, on the documented default path.
+    //
+    // Precedence mirrors `resolve_instance_id_for_db` exactly, and for the same
+    // reason it is etcd's: a STATED instance is intent and passes through
+    // untouched (config-driven instance switching stays a supported operation,
+    // which `daemon_restart_preserves_and_overrides_live_effective_config…`
+    // pins); only an INFERRED one consults the store.
+    // nw-246 (second hole): `observed_instance_ids` is consulted BEFORE the
+    // recorded value, not after. Checking the record first makes the ambiguity
+    // arm unreachable for any database that has one — and since
+    // `ensure_data_instance_id` runs on every repo index and never replaces an
+    // existing value, that is every database created or indexed under 8.0.0.
+    // A record is evidence of the last mint, not evidence that the graph is
+    // single-instance.
+    let (data_instance_id, ambiguous_instance_ids) =
+        match instance_cfg.as_ref().map(|c| c.instance_id.clone()) {
+            // Stated intent passes through untouched.
+            Some(stated) => (stated, Vec::new()),
+            None => {
+                let observed = store.observed_instance_ids().unwrap_or_default();
+                if observed.len() > 1 {
+                    // Several instances and nothing stated. Deliberately NOT a
+                    // startup failure: refusing to boot would block READS too, and
+                    // reads are instance-agnostic. A legacy multi-instance database
+                    // is a plausible thing to own, and a daemon that will not start
+                    // is a worse failure than the fork we are preventing. Carried
+                    // forward instead, and refused at the write funnel — where the
+                    // fork actually happens.
+                    ("default".to_string(), observed)
+                } else {
+                    match store.data_instance_id() {
+                        // The database's own record wins over the ambient default.
+                        Ok(Some(recorded)) => (recorded, Vec::new()),
+                        // Legacy database with no record: infer from what is written.
+                        _ => (
+                            observed
+                                .into_iter()
+                                .next()
+                                .unwrap_or_else(|| "default".to_string()),
+                            Vec::new(),
+                        ),
+                    }
+                }
+            }
+        };
+    if !ambiguous_instance_ids.is_empty() {
+        tracing::warn!(
+            instances = %ambiguous_instance_ids.join(", "),
+            "this database holds data under {} instances and no instance was stated; \
+             reads are unaffected, but writes will be refused until one is named with \
+             a --config `instance_id` or a per-request instance",
+            ambiguous_instance_ids.len()
+        );
+    }
 
     let is_server_mode = server_opts.is_some();
 
@@ -10177,6 +10303,7 @@ pub async fn run_server(
         read_only,
         instance_id: instance_id.clone(),
         data_instance_id: data_instance_id.clone(),
+        ambiguous_instance_ids: ambiguous_instance_ids.clone(),
         start_time: Instant::now(),
         active_reads: Arc::new(AtomicU32::new(0)),
         active_writes: Arc::new(AtomicU32::new(0)),
@@ -15548,7 +15675,7 @@ mod startup_helper_tests {
         // The reported case: a client with no config of its own now sends
         // EMPTY, and the daemon's configured identity wins.
         assert_eq!(
-            resolve_effective_instance_id("", "kory-brain").unwrap(),
+            resolve_effective_instance_id("", "kory-brain", &[]).unwrap(),
             "kory-brain",
             "an unspecified instance must defer to the daemon, not override it"
         );
@@ -15556,7 +15683,7 @@ mod startup_helper_tests {
         // A caller that NAMES an instance is still obeyed — multi-instance
         // targeting is a real feature and this must not break it.
         assert_eq!(
-            resolve_effective_instance_id("other-brain", "kory-brain").unwrap(),
+            resolve_effective_instance_id("other-brain", "kory-brain", &[]).unwrap(),
             "other-brain"
         );
 
@@ -15565,13 +15692,13 @@ mod startup_helper_tests {
         // mismatch is what forced clients to send "default" explicitly — the
         // compensation that caused the override.
         assert_eq!(
-            resolve_effective_instance_id("", "default").unwrap(),
+            resolve_effective_instance_id("", "default", &[]).unwrap(),
             "default"
         );
 
         // An invalid instance is still rejected at this trust boundary rather
         // than silently producing an ambiguous uid.
-        assert!(resolve_effective_instance_id("a:b", "default").is_err());
+        assert!(resolve_effective_instance_id("a:b", "default", &[]).is_err());
     }
 
     /// The gRPC mutating-tool gate MUST reference the single shared
@@ -16651,6 +16778,7 @@ mod startup_helper_tests {
             db_path,
             instance_id: "default".to_string(),
             data_instance_id: "default".to_string(),
+            ambiguous_instance_ids: Vec::new(),
             start_time: Instant::now(),
             active_reads: Arc::new(AtomicU32::new(0)),
             active_writes: Arc::new(AtomicU32::new(0)),
@@ -16735,6 +16863,7 @@ credential_method = "gh"
             db_path: std::path::PathBuf::from(":memory:"),
             instance_id: "default".to_string(),
             data_instance_id: "default".to_string(),
+            ambiguous_instance_ids: Vec::new(),
             start_time: Instant::now(),
             active_reads: Arc::new(AtomicU32::new(0)),
             active_writes: Arc::new(AtomicU32::new(0)),

--- a/crates/nestweaver-engine/src/extensions.rs
+++ b/crates/nestweaver-engine/src/extensions.rs
@@ -297,6 +297,19 @@ pub fn save_extensions(db_path: &Path, store: &ExtensionStore) -> Result<(), any
     write_extension_store_durable(&path, store)
 }
 
+/// Load the extension sidecar for `db_path`, surfacing read and parse errors.
+///
+/// nw-257: the auditing commands must not use [`load_extensions`], which folds
+/// a corrupt or unreadable sidecar into an empty map. A command whose whole
+/// purpose is to report what is annotated cannot answer "0 annotated node(s)"
+/// and exit 0 when the truth is that it could not read the file.
+///
+/// A sidecar that simply does not exist is still not an error — nothing has
+/// been annotated yet — so that case returns an empty store.
+pub fn load_extensions_checked(db_path: &Path) -> Result<ExtensionStore, anyhow::Error> {
+    Ok(load_extensions_strict(&sidecar_path(db_path))?.unwrap_or_default())
+}
+
 fn load_extensions_strict(path: &Path) -> Result<Option<ExtensionStore>, anyhow::Error> {
     let content = match std::fs::read_to_string(path) {
         Ok(content) => content,
@@ -2210,7 +2223,13 @@ pub fn query_by_property<'a>(
 /// Widget", had no expressible form. Membership makes the mode usable without
 /// weakening exact matching: an array query still compares whole-array, so
 /// `["Widget","widget"]` matches only that exact array.
-fn property_matches(stored: &serde_json::Value, query: &serde_json::Value) -> bool {
+///
+/// nw-257: `pub` because `nestweaver extensions list` documents its filtering
+/// as mirroring `query_extensions` "exactly". It had a second, hand-rolled
+/// equality-only implementation instead, so the CLI silently answered a
+/// different question than the tool. Two implementations of one documented
+/// contract is the divergence; sharing this one removes it.
+pub fn property_matches(stored: &serde_json::Value, query: &serde_json::Value) -> bool {
     if stored == query {
         return true;
     }

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -2163,6 +2163,47 @@ pub fn index_directory_with_store_cancellable_and_limits(
     )
 }
 
+/// nw-246: record the instance this database's data belongs to, once.
+///
+/// `ensure_data_instance_id` never replaces an existing value — a database that
+/// already knows its instance keeps it, and returns it.
+///
+/// Called from EVERY index funnel. nw-246's original wiring put it in
+/// `index_directory_with_store_inner` only, which is not the funnel the CLI
+/// index actually uses — so the record was never written, `data_instance_id()`
+/// returned `None` for every database, and the mint-once mechanism the whole
+/// item is built on was inert. One helper, called from both, so the next funnel
+/// added cannot quietly miss it.
+///
+/// A stated instance that differs from the record is `--config`-driven instance
+/// switching, which is supported — so this reports the disagreement rather than
+/// refusing it. The disagreement that IS a defect (an INFERRED instance
+/// differing from the record) is resolved upstream, where the distinction
+/// between stated and inferred still exists; by here that information is gone.
+///
+/// Best-effort: a store that cannot record it still indexes correctly, it just
+/// falls back to inferring the instance from its own UIDs next time. Logged at
+/// WARN, not DEBUG — this is the one write that establishes identity.
+fn record_data_instance(store: &GraphStore, instance_id: &str) {
+    match store.ensure_data_instance_id(instance_id) {
+        Ok(recorded) if recorded != instance_id => {
+            tracing::info!(
+                recorded = %recorded,
+                writing_as = %instance_id,
+                "this database records a different instance; writing under the \
+                 stated one (instance switching). `nestweaver list-repos` shows both."
+            );
+        }
+        Ok(_) => {}
+        Err(error) => {
+            tracing::warn!(
+                instance = %instance_id,
+                "could not record the data instance id: {error}"
+            );
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn index_directory_with_store_inner(
     store: &GraphStore,
@@ -2179,22 +2220,7 @@ fn index_directory_with_store_inner(
     let filemeta_path = crate::sidecar_path(db_path, ".filemeta.json");
     crate::migrate_sidecar(db_path, "filemeta.json", ".filemeta.json");
     let r_uid = repo_uid(instance_id, repo_url);
-    // nw-246: record the instance this database's data belongs to, once.
-    //
-    // This is the funnel every repo index passes through, so it is where the
-    // database's identity gets established. `ensure_data_instance_id` never
-    // replaces an existing value — a database that already knows its instance
-    // keeps it, and the CLI resolver refuses a disagreeing request before
-    // reaching here.
-    //
-    // Best-effort: a store that cannot record it still indexes correctly, it
-    // just falls back to inferring the instance from its own UIDs next time.
-    if let Err(error) = store.ensure_data_instance_id(instance_id) {
-        tracing::debug!(
-            instance = %instance_id,
-            "could not record the data instance id: {error}"
-        );
-    }
+    record_data_instance(store, instance_id);
     // Capture generation-N derived state before graph publication advances to
     // N+2. Loading it after the graph commit would correctly reject it as
     // stale and, historically, `unwrap_or_default` then discarded every other
@@ -2653,6 +2679,8 @@ where
     // scan/parse/collection so worker threads can fan out expensive parsing and
     // only serialize LadybugDB writes.
     let r_uid = repo_uid(instance_id, repo_url);
+    // The funnel the CLI index actually reaches (nw-246).
+    record_data_instance(store, instance_id);
 
     // Re-identify detection MUST happen before the scan/parse phases: the
     // filemeta sidecar was recorded when this working tree's graph rows

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -9520,7 +9520,13 @@ fn tool_schema_bridge_nodes() -> Value {
             "properties": {
                 "limit": {
                     "type": "integer",
-                    "description": "Number of top bridges to return. Default 10.",
+                    // nw-251: bounded to match `top_n` below. `limit` carried
+                    // NEITHER bound while its alias carried both — and the
+                    // handler PREFERS `limit`, so the bounded field was the
+                    // one that never applied.
+                    "minimum": 1,
+                    "maximum": 1000,
+                    "description": "Number of top bridges to return (1-1000). Default 10.",
                     "default": 10
                 },
                 "top_n": {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9100,12 +9100,20 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 anyhow::bail!("--value requires --key");
             }
             let db_path = resolve_db_with_config(db, config.as_deref())?;
-            let store = nestweaver_engine::extensions::load_extensions(&db_path);
+            // nw-257: `load_extensions` folds a corrupt or unreadable sidecar
+            // into an empty map, which in THIS command would print
+            // "0 annotated node(s)" and exit 0 — an audit reporting nothing
+            // wrong because it could not look. The checked loader still treats
+            // an absent sidecar as an empty store.
+            let store = nestweaver_engine::extensions::load_extensions_checked(&db_path)?;
 
-            // Filtering mirrors `query_extensions` exactly, including EXACT
-            // match on value — a CLI that matched differently would show a
-            // human a different answer than the agent acted on, which is the
-            // opposite of an audit.
+            // Filtering mirrors `query_extensions` exactly — by CALLING the
+            // same predicate rather than restating it. nw-257: the restatement
+            // did equality only and drifted from `property_matches`'s
+            // scalar-in-array membership, so `--key aliases --value Widget`
+            // printed "No extension annotations found." for data the agent
+            // matched. A CLI that answers a different question than the tool is
+            // the opposite of an audit.
             let mut rows: Vec<(
                 &String,
                 &std::collections::HashMap<String, serde_json::Value>,
@@ -9118,10 +9126,25 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         return false;
                     }
                     match (key.as_deref(), value.as_deref()) {
-                        (Some(k), Some(v)) => {
-                            props.get(k).and_then(|found| found.as_str()) == Some(v)
-                                || props.get(k).map(ToString::to_string).as_deref() == Some(v)
-                        }
+                        (Some(k), Some(v)) => props.get(k).is_some_and(|found| {
+                            // `--value` is a string on the command line, so the
+                            // shared predicate is asked the string question.
+                            nestweaver_engine::extensions::property_matches(
+                                found,
+                                &serde_json::Value::String(v.to_string()),
+                            )
+                                // Retained from the pre-nw-257 CLI so this stays
+                                // a widening: `--value 42` still matches a
+                                // stored number and `--value '["a","b"]'` still
+                                // matches that whole array. Compared
+                                // STRUCTURALLY rather than by serialised text,
+                                // so the match does not depend on serde's
+                                // spacing. A `--value` that is not valid JSON
+                                // (the common `--value Widget`) simply falls
+                                // through to the string question above.
+                                || serde_json::from_str::<serde_json::Value>(v)
+                                    .is_ok_and(|query| found == &query)
+                        }),
                         (Some(k), None) => props.contains_key(k),
                         _ => true,
                     }
@@ -19284,19 +19307,25 @@ fn run_brain(
                                 .as_str()
                                 .map(|h| &h[..8.min(h.len())])
                                 .unwrap_or("unknown");
-                            let behind = r["staleness_commits_behind"].as_u64().unwrap_or(0);
+                            // nw-256: `null` means the distance could not be
+                            // counted, and `unwrap_or(0)` made that print
+                            // identically to a real zero — undoing the fix one
+                            // layer down. Rendered as three distinct states.
+                            let behind = r["staleness_commits_behind"].as_u64();
                             let marker = match r["status"].as_str() {
                                 Some("missing") => "missing",
                                 Some("incomplete") => "incomplete",
                                 _ if stale => "STALE",
                                 _ => "ok",
                             };
-                            if stale && behind > 0 {
-                                println!(
+                            match behind {
+                                Some(behind) if stale && behind > 0 => println!(
                                     "  [{marker}] {url}  indexed={indexed}  HEAD={head}  ({behind} commits behind)"
-                                );
-                            } else {
-                                println!("  [{marker}] {url}  indexed={indexed}  HEAD={head}");
+                                ),
+                                None if stale => println!(
+                                    "  [{marker}] {url}  indexed={indexed}  HEAD={head}  (commits behind: unavailable — could not be counted)"
+                                ),
+                                _ => println!("  [{marker}] {url}  indexed={indexed}  HEAD={head}"),
                             }
                         }
                     }
@@ -19348,7 +19377,17 @@ fn run_brain(
 
                 let is_valid_sha = repo.indexed_sha.len() == 40
                     && repo.indexed_sha.chars().all(|c| c.is_ascii_hexdigit());
-                let commits_behind = match (&current_head, repo.local_root()) {
+                // nw-256: `Option<u64>`, mirroring `tool_stale_check`. The
+                // note directly below is about `is_stale` diverging between
+                // these two routes for exactly this reason; #310 fixed the
+                // daemon side of the COUNT and left this one on
+                // `unwrap_or(0)`, so the same defect recurred in the same
+                // function pair. A failed `git rev-list` means "could not
+                // count", and this branch is only reached when HEAD already
+                // differs from the indexed SHA — so a zero here is a
+                // self-contradiction ("stale, 0 commits behind"), not an
+                // answer.
+                let commits_behind: Option<u64> = match (&current_head, repo.local_root()) {
                     (Some(head), Some(path)) if is_valid_sha && *head != repo.indexed_sha => {
                         std::process::Command::new("git")
                             .args([
@@ -19367,9 +19406,8 @@ fn run_brain(
                                     .parse::<u64>()
                                     .ok()
                             })
-                            .unwrap_or(0)
                     }
-                    _ => repo.staleness_commits_behind as u64,
+                    _ => Some(repo.staleness_commits_behind as u64),
                 };
                 // nw-163: BEHIND HEAD and nothing else — a deleted working
                 // tree is `status: "missing"` and `needs_reindex: true`, not
@@ -19385,7 +19423,10 @@ fn run_brain(
                     // says "missing" and `needs_reindex` is true, which is the
                     // actionable truth.
                     None if local_missing => false,
-                    None => commits_behind > 0,
+                    // An uncountable distance is not a claim of zero: if HEAD
+                    // is unknown AND the stored counter cannot be read,
+                    // staleness is simply not assertable here.
+                    None => commits_behind.is_some_and(|behind| behind > 0),
                 };
                 // A repo whose SHA was committed but whose content never
                 // landed (interrupted index) compares equal to HEAD yet
@@ -19475,19 +19516,25 @@ fn run_brain(
                         .as_str()
                         .map(|h| &h[..8.min(h.len())])
                         .unwrap_or("unknown");
-                    let behind = r["staleness_commits_behind"].as_u64().unwrap_or(0);
+                    // nw-256: `null` means the distance could not be counted,
+                    // and `unwrap_or(0)` made that print identically to a real
+                    // zero — undoing the fix one layer down. Rendered as three
+                    // distinct states.
+                    let behind = r["staleness_commits_behind"].as_u64();
                     let marker = match r["status"].as_str() {
                         Some("missing") => "missing",
                         Some("incomplete") => "incomplete",
                         _ if stale => "STALE",
                         _ => "ok",
                     };
-                    if stale && behind > 0 {
-                        println!(
+                    match behind {
+                        Some(behind) if stale && behind > 0 => println!(
                             "  [{marker}] {url}  indexed={indexed}  HEAD={head}  ({behind} commits behind)"
-                        );
-                    } else {
-                        println!("  [{marker}] {url}  indexed={indexed}  HEAD={head}");
+                        ),
+                        None if stale => println!(
+                            "  [{marker}] {url}  indexed={indexed}  HEAD={head}  (commits behind: unavailable — could not be counted)"
+                        ),
+                        _ => println!("  [{marker}] {url}  indexed={indexed}  HEAD={head}"),
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2937,7 +2937,17 @@ enum Commands {
     /// outsized blast radius. Useful for identifying fragile connectors.
     #[command(after_help = "Examples:\n  nestweaver bridges\n  nestweaver bridges --top 20 --json")]
     Bridges {
-        #[arg(long, default_value = "10", help = "Number of top bridges to show")]
+        // nw-251: bounded like `hubs --top`, which has carried
+        // `range(1..=1000)` all along. Unbounded, `--top 0` asked for nothing
+        // and a huge value asked the betweenness walk for the whole graph —
+        // and the MCP `bridge_nodes` schema bounds its own `top_n` to the same
+        // 1..=1000, so the two surfaces disagreed on what was even accepted.
+        #[arg(
+            long,
+            default_value = "10",
+            value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=1000),
+            help = "Number of top bridges to show (1-1000; matches the MCP bridge_nodes schema)"
+        )]
         top: usize,
         #[arg(long, help = "Output as JSON")]
         json: bool,
@@ -10643,10 +10653,16 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 // both output modes match direct output byte-for-byte
                 // (the daemon envelope carries _meta/count the direct
                 // path never prints).
-                let hubs: Vec<HubNode> = value
-                    .get("hubs")
-                    .and_then(|v| serde_json::from_value(v.clone()).ok())
-                    .unwrap_or_default();
+                // nw-249: `.ok().unwrap_or_default()` turned a DECODE FAILURE
+                // into an empty list, which the branch below then renders as
+                // "No hub nodes found (graph may be empty)" — a confident claim
+                // about the graph made on the strength of a parse error. Same
+                // shape as the `list-repos` / `list-services` defect.
+                let hubs: Vec<HubNode> = match value.get("hubs") {
+                    Some(raw) => serde_json::from_value(raw.clone())
+                        .context("decode hub nodes from the daemon")?,
+                    None => Vec::new(),
+                };
                 if json {
                     println!("{}", serde_json::to_string_pretty(&hubs)?);
                 } else if hubs.is_empty() {
@@ -10746,13 +10762,16 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 )? {
                     // Deserialize the tool's `bridges` array into the
                     // direct path's type so both modes render identically.
-                    let bridges: Vec<nestweaver_engine::BridgeNode> = serde_json::from_value(
-                        strip_hybrid_meta(value)
-                            .get("bridges")
-                            .cloned()
-                            .unwrap_or(serde_json::Value::Null),
-                    )
-                    .unwrap_or_default();
+                    // nw-249: same defect as `hubs` above — a decode failure
+                    // became an empty list and rendered as "graph may be
+                    // empty". A `null` (no `bridges` key at all) is still an
+                    // honest empty result and stays one.
+                    let bridges: Vec<nestweaver_engine::BridgeNode> =
+                        match strip_hybrid_meta(value).get("bridges").cloned() {
+                            Some(serde_json::Value::Null) | None => Vec::new(),
+                            Some(raw) => serde_json::from_value(raw)
+                                .context("decode bridge nodes from the daemon")?,
+                        };
                     if json {
                         println!("{}", serde_json::to_string_pretty(&bridges)?);
                     } else if bridges.is_empty() {
@@ -12067,8 +12086,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     .map(|p| p.to_string_lossy().into_owned())
                     .collect()
             } else {
+                // nw-252: a USAGE error, so EXIT_USAGE (64, EX_USAGE from
+                // sysexits.h) — the same code clap's own parse failures
+                // return. Exiting 1 made "you invoked this wrong" and "the
+                // operation failed" indistinguishable to a caller.
                 eprintln!("Error: provide either --files or --base-ref");
-                return Ok((EXIT_ERROR, None));
+                return Ok((EXIT_USAGE, None));
             };
 
             if changed_files.is_empty() {
@@ -12217,8 +12240,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             config,
         } => {
             if refresh_wiki_hours.is_some() && config.is_none() {
+                // nw-252: a USAGE error, so EXIT_USAGE (64, EX_USAGE from
+                // sysexits.h) — the same code clap's own parse failures
+                // return. Exiting 1 made "you invoked this wrong" and "the
+                // operation failed" indistinguishable to a caller.
                 eprintln!("Error: --refresh-wiki-hours requires --config");
-                return Ok((EXIT_ERROR, None));
+                return Ok((EXIT_USAGE, None));
             }
             let repo_path = match repo {
                 Some(p) => p,
@@ -19455,8 +19482,12 @@ fn run_brain(
             force,
         } => {
             if refresh_wiki_hours.is_some() && config.is_none() {
+                // nw-252: a USAGE error, so EXIT_USAGE (64, EX_USAGE from
+                // sysexits.h) — the same code clap's own parse failures
+                // return. Exiting 1 made "you invoked this wrong" and "the
+                // operation failed" indistinguishable to a caller.
                 eprintln!("Error: --refresh-wiki-hours requires --config");
-                return Ok((EXIT_ERROR, None));
+                return Ok((EXIT_USAGE, None));
             }
             let db_path = resolve_db_with_config(db, config.as_deref())?;
             if !path.exists() || !path.is_dir() {
@@ -31155,6 +31186,27 @@ mod vault_command_config_parity_tests {
     /// nw-229. `set_extension` and `query_extensions` were BOTH agent-only, so
     /// an agent could write annotations that influence a human's results — the
     /// CLI consumes the sidecar internally — with no command to read them back.
+    /// nw-251. `hubs --top` has been bounded 1..=1000 all along and
+    /// `bridges --top` was not, while the MCP `bridge_nodes` schema bounds its
+    /// `top_n` to the same range — so the two surfaces disagreed on what was
+    /// even accepted.
+    #[test]
+    fn bridges_top_is_bounded_like_its_siblings() {
+        for bad in ["0", "1001"] {
+            let args = argv(&["nestweaver", "bridges", "--top", bad]);
+            assert!(
+                parse(args).is_err(),
+                "--top {bad} must be rejected, as `hubs --top` already rejects it"
+            );
+        }
+        // The counterweight: the range itself must still be usable, or a bound
+        // that rejected everything would pass the assertions above.
+        for good in ["1", "10", "1000"] {
+            let args = argv(&["nestweaver", "bridges", "--top", good]);
+            assert!(parse(args).is_ok(), "--top {good} must be accepted");
+        }
+    }
+
     #[test]
     fn a_human_can_read_back_what_agents_annotate() {
         let cli = parse(argv(&["nestweaver", "extensions", "list"])).expect("must parse");

--- a/src/main.rs
+++ b/src/main.rs
@@ -5553,26 +5553,53 @@ fn resolve_instance_id_for_db(
         return Ok(ambient);
     };
 
+    // Ambiguity is checked BEFORE the recorded value, not after.
+    //
+    // nw-246 (second hole): returning the record first made this arm
+    // unreachable for any database that HAS a record — and since
+    // `ensure_data_instance_id` runs on every repo index and never replaces an
+    // existing value, that is every database created or indexed under 8.0.0.
+    // Only a pre-nw-246 database could ever reach the refusal the runbook
+    // promises.
+    //
+    // The sequence was reachable entirely through supported behaviour:
+    // `index --instance one`, then `index --instance two` (stated, so it
+    // passes — that is the capability this rescope preserved), leaves a
+    // database holding two instances whose record still says `one`. A
+    // config-less index then adopted `one` and silently re-keyed the second
+    // repo. The nw-246 fork, verbatim, produced by the guard itself.
+    //
+    // A record is evidence of the last mint, not evidence that the graph is
+    // single-instance. `observed_instance_ids`' own contract says as much:
+    // more than one value is a damage state, and callers must refuse rather
+    // than pick.
+    let observed = store.observed_instance_ids();
+
+    if let Ok(ref ids) = observed
+        && ids.len() > 1
+    {
+        // Several instances present and nothing stated. Adopting one at random
+        // is how the fork would deepen, so refuse and name them. Stating an
+        // instance resolves it, which is why this is unreachable when the
+        // caller named one.
+        anyhow::bail!(
+            "this database holds data under {} instances ({}), and no instance was \
+             specified, so there is no safe default.\n\
+             Name one with `--instance <id>` or a `--config`, or consolidate them with \
+             `nestweaver instance merge --from <one> --to <keep>`.",
+            ids.len(),
+            ids.join(", ")
+        );
+    }
+
     // Recorded identity wins over the ambient default.
     if let Ok(Some(recorded)) = store.data_instance_id() {
         return Ok(recorded);
     }
 
     // Legacy database with no record: infer from the UIDs already written.
-    match store.observed_instance_ids() {
-        Ok(observed) if observed.len() == 1 => Ok(observed.into_iter().next().unwrap_or(ambient)),
-        // Several instances present and nothing stated. This IS ambiguous —
-        // adopting one at random is how the fork would deepen — so refuse and
-        // name them. Stating an instance resolves it, which is why this arm is
-        // unreachable when the caller named one.
-        Ok(observed) if observed.len() > 1 => anyhow::bail!(
-            "this database holds data under {} instances ({}), and no instance was \
-             specified, so there is no safe default.\n\
-             Name one with `--instance <id>` or a `--config`, or consolidate them with \
-             `nestweaver instance merge --from <one> --to <keep>`.",
-            observed.len(),
-            observed.join(", ")
-        ),
+    match observed {
+        Ok(ids) if ids.len() == 1 => Ok(ids.into_iter().next().unwrap_or(ambient)),
         _ => Ok(ambient),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18877,21 +18877,52 @@ fn run_brain(
                             }
                         }
                     }
-                    let notes = value.get("notes").and_then(|v| v.as_u64()).unwrap_or(0);
-                    let headings = value.get("headings").and_then(|v| v.as_u64()).unwrap_or(0);
-                    let sections = value.get("sections").and_then(|v| v.as_u64()).unwrap_or(0);
-                    let tags = value.get("tags").and_then(|v| v.as_u64()).unwrap_or(0);
-                    let wikilinks = value.get("wikilinks").and_then(|v| v.as_u64()).unwrap_or(0);
-                    let repo_count = value
-                        .get("repo_count")
-                        .and_then(|v| v.as_u64())
-                        .unwrap_or(0);
-                    println!("  Notes:     {notes}");
-                    println!("  Headings:  {headings}");
-                    println!("  Sections:  {sections}");
-                    println!("  Tags:      {tags}");
-                    println!("  Wikilinks: {wikilinks}");
-                    println!("  Repos:     {repo_count}");
+                    // nw-249(a): `unwrap_or(0)` collapsed a DELIBERATE null.
+                    //
+                    // The emitter sets these to `null` when the count could
+                    // not be READ, and `brain_status`'s own description says:
+                    // "a count of `null` means it could NOT BE READ, which is
+                    // NOT zero and is not a reason to re-index. Check
+                    // `unavailable` (and `counts_complete`) before acting on
+                    // any count." This render did exactly what that sentence
+                    // forbids — printed `Notes: 0`, which reads as "empty, go
+                    // re-index", for a vault that is merely unreadable.
+                    //
+                    // The MCP client can inspect the null itself; a human
+                    // reading the text render cannot. So this surface is the
+                    // one that most needs the disclosure, not the least.
+                    let count = |key: &str| -> String {
+                        match value.get(key) {
+                            Some(serde_json::Value::Null) | None => {
+                                "unavailable (could not be read — NOT zero)".to_string()
+                            }
+                            Some(found) => found
+                                .as_u64()
+                                .map_or_else(|| found.to_string(), |n| n.to_string()),
+                        }
+                    };
+                    println!("  Notes:     {}", count("notes"));
+                    println!("  Headings:  {}", count("headings"));
+                    println!("  Sections:  {}", count("sections"));
+                    println!("  Tags:      {}", count("tags"));
+                    println!("  Wikilinks: {}", count("wikilinks"));
+                    println!("  Repos:     {}", count("repo_count"));
+                    // And name what failed, so the reader is not left to infer
+                    // it from which rows say "unavailable".
+                    if let Some(unavailable) = value.get("unavailable").and_then(|v| v.as_array())
+                        && !unavailable.is_empty()
+                    {
+                        let names: Vec<String> = unavailable
+                            .iter()
+                            .filter_map(|entry| entry.as_str().map(ToOwned::to_owned))
+                            .collect();
+                        println!(
+                            "  NOTE: {} count(s) could not be read ({}). These are NOT zero, \
+                             and re-indexing is not the remedy.",
+                            names.len(),
+                            names.join(", ")
+                        );
+                    }
                     // One-line publication state when dirty — the "(see
                     // warning)" pointer is only printed when a warning
                     // actually follows (wedged), not for a routine in-flight

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -250,6 +250,209 @@ url = "{}"
     assert_eq!(entries, vec![std::ffi::OsString::from("instance.toml")]);
 }
 
+/// nw-256: `stale_check`'s commit distance must be `null` when it cannot be
+/// counted — never `0`.
+///
+/// The MCP route was fixed to `Option<u64>` in #310; the CLI kept
+/// `.unwrap_or(0)`, so the two routes answered differently for the same repo.
+/// That is the SECOND time this function pair diverged for this reason — the
+/// comment recording the first (`is_stale`, nw-163) sits four lines below the
+/// defect.
+///
+/// A zero here is not a missed detection, it is a self-contradiction: the
+/// branch is only reached when HEAD already differs from the indexed SHA, so
+/// the row reads "STALE, 0 commits behind".
+///
+/// Provoked the way it actually happens — a repo whose history was replaced
+/// (re-clone, force-push, squash). HEAD reads fine, but `indexed_sha..HEAD`
+/// spans no common ancestor and `git rev-list` fails.
+#[test]
+fn stale_check_reports_an_uncountable_commit_distance_as_null_not_zero() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_dir = dir.path().join("repo");
+    let db_path = dir.path().join("test.lbug");
+    std::fs::create_dir(&repo_dir).unwrap();
+
+    let git = |args: &[&str]| {
+        let status = StdCommand::new("git")
+            .args(args)
+            .current_dir(&repo_dir)
+            .status()
+            .expect("git command failed to spawn");
+        assert!(status.success(), "git {args:?} failed with {status:?}");
+    };
+    git(&["init"]);
+    git(&["config", "user.email", "test@test.com"]);
+    git(&["config", "user.name", "Test"]);
+    std::fs::write(repo_dir.join("a.js"), "function hello() {}").unwrap();
+    git(&["add", "a.js"]);
+    git(&["commit", "-m", "initial"]);
+
+    nestweaver_cmd()
+        .args([
+            "index",
+            "--repo",
+            &repo_dir.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .assert()
+        .success();
+
+    // Replace the history wholesale. HEAD is still a perfectly readable sha —
+    // it simply has no path back to the indexed one.
+    std::fs::remove_dir_all(repo_dir.join(".git")).unwrap();
+    git(&["init"]);
+    git(&["config", "user.email", "test@test.com"]);
+    git(&["config", "user.name", "Test"]);
+    std::fs::write(repo_dir.join("a.js"), "function hello() { return 1; }").unwrap();
+    git(&["add", "a.js"]);
+    git(&["commit", "-m", "unrelated history"]);
+
+    let output = nestweaver_cmd()
+        .args([
+            "stale-check",
+            "--db",
+            &db_path.display().to_string(),
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stale-check --json: {e}\n{stdout}"));
+
+    let repos = parsed["repos"]
+        .as_array()
+        .unwrap_or_else(|| panic!("no `repos` array in:\n{stdout}"));
+    let repo = repos.first().expect("exactly one repo was indexed");
+
+    // The counterweight: the row really is stale. Without this, a `null` count
+    // could just mean the whole check declined to look.
+    assert_eq!(
+        repo["is_stale"].as_bool(),
+        Some(true),
+        "the fixture must actually be stale for the count to be meaningful:\n{stdout}"
+    );
+    assert!(
+        repo["staleness_commits_behind"].is_null(),
+        "an uncountable commit distance must be null, not a fabricated 0 — \
+         `stale, 0 commits behind` is a contradiction:\n{stdout}"
+    );
+
+    // And the human-facing renderer must not collapse it back to a real zero.
+    let text = nestweaver_cmd()
+        .args(["stale-check", "--db", &db_path.display().to_string()])
+        .output()
+        .unwrap();
+    let text = String::from_utf8_lossy(&text.stdout);
+    assert!(
+        text.contains("unavailable"),
+        "the text renderer must say the count is unavailable rather than print \
+         the row as if nothing were behind:\n{text}"
+    );
+}
+
+/// nw-257: `extensions list` documents its filtering as mirroring
+/// `query_extensions` "exactly", and did not.
+///
+/// `property_matches` treats a scalar query as a membership test against an
+/// array-valued property, because that is the shape real sidecars have
+/// (`aliases: ["Widget","widget"]`) — nw-109 added it for exactly that reason.
+/// The CLI restated the filter as equality only, so the audit command printed
+/// "No extension annotations found." for data the agent matched.
+///
+/// The existing guards stop at clap: replacing the whole match arm with
+/// `_ => true` passes both of them, and the one named
+/// `the_filters_match_the_mcp_tools_two_modes` guards precisely the property
+/// that was broken.
+#[test]
+fn extensions_list_matches_array_valued_properties_like_the_mcp_tool() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.lbug");
+    drop(nestweaver_store::GraphStore::open_or_create(&db_path).unwrap());
+
+    std::fs::write(
+        sidecar_path(&db_path, ".extensions.json"),
+        r#"{"sym:repo:widget": {"aliases": ["Widget", "widget"], "owner": "platform"}}"#,
+    )
+    .unwrap();
+
+    let matched = nestweaver_cmd()
+        .args([
+            "extensions",
+            "list",
+            "--db",
+            &db_path.display().to_string(),
+            "--key",
+            "aliases",
+            "--value",
+            "Widget",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&matched.stdout);
+    assert!(
+        stdout.contains("sym:repo:widget"),
+        "a scalar --value must match a member of an array-valued property, the \
+         way `query_extensions` does:\n{stdout}"
+    );
+
+    // The counterweight: membership must not have become an any-of that
+    // matches everything. A value that is in no array still finds nothing.
+    let absent = nestweaver_cmd()
+        .args([
+            "extensions",
+            "list",
+            "--db",
+            &db_path.display().to_string(),
+            "--key",
+            "aliases",
+            "--value",
+            "Gadget",
+        ])
+        .output()
+        .unwrap();
+    let absent = String::from_utf8_lossy(&absent.stdout);
+    assert!(
+        !absent.contains("sym:repo:widget"),
+        "membership must stay a filter — a value in no array must not match:\n{absent}"
+    );
+}
+
+/// nw-257: the audit command must not report "0 annotated node(s)" because it
+/// could not read the sidecar.
+///
+/// `load_extensions` folds both a parse failure and an I/O failure into an
+/// empty map. In a command whose entire purpose is reporting what is
+/// annotated, that turns "I cannot tell you" into "there is nothing", and
+/// exits 0 while doing it.
+#[test]
+fn extensions_list_fails_loudly_on_an_unreadable_sidecar() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.lbug");
+    drop(nestweaver_store::GraphStore::open_or_create(&db_path).unwrap());
+
+    // The counterweight, first: NO sidecar is not an error. Nothing has been
+    // annotated yet, and "0 annotated node(s)" is the honest answer.
+    nestweaver_cmd()
+        .args(["extensions", "list", "--db", &db_path.display().to_string()])
+        .assert()
+        .success();
+
+    std::fs::write(
+        sidecar_path(&db_path, ".extensions.json"),
+        "{ this is not json",
+    )
+    .unwrap();
+
+    nestweaver_cmd()
+        .args(["extensions", "list", "--db", &db_path.display().to_string()])
+        .assert()
+        .failure()
+        .stdout(contains("0 annotated node(s)").not());
+}
+
 /// nw-244: PR #307 taught `brain remove` to honour `--config` like its two
 /// sibling vault commands, but both of its guards stop at clap — one asserts
 /// the flag is *accepted*, the other that it lands in the parsed struct.

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -250,6 +250,106 @@ url = "{}"
     assert_eq!(entries, vec![std::ffi::OsString::from("instance.toml")]);
 }
 
+/// nw-244: PR #307 taught `brain remove` to honour `--config` like its two
+/// sibling vault commands, but both of its guards stop at clap — one asserts
+/// the flag is *accepted*, the other that it lands in the parsed struct.
+/// Reverting the resolution itself leaves the flag parsing perfectly and the
+/// whole suite green, which is precisely the nw-217 bug returning: the command
+/// silently targets instance "default" and `./nestweaver.lbug`.
+///
+/// The behaviour that actually closes that hole is a REFUSAL. The direct
+/// (no-daemon) store cannot honour a pinned instance config, so rather than
+/// quietly acting on some other instance, `brain remove --config` fails and
+/// names the config it could not honour. Silence is the defect; the error is
+/// the fix.
+///
+/// Both halves are asserted, because the refusal alone would also be satisfied
+/// by a command that is simply broken: with the same vault and the same store
+/// addressed by `--db` instead, the remove must succeed.
+#[test]
+fn brain_remove_refuses_a_pinned_config_it_cannot_honor_rather_than_silently_defaulting() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("configured.lbug");
+    let vault_dir = dir.path().join("vault");
+    std::fs::create_dir(&vault_dir).unwrap();
+    std::fs::write(vault_dir.join("note.md"), "# Note\n\nBody.\n").unwrap();
+
+    let config_path = dir.path().join("instance.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"instance_id = "vault-config-parity"
+db = "{}"
+repos = []
+
+[snapshot_storage]
+backend = "local"
+path = "/tmp/nestweaver/vault-config-parity/snapshots"
+
+[workspace]
+backend = "local"
+path = "/tmp/nestweaver/vault-config-parity/workspace"
+
+[inference]
+endpoint = "http://localhost:11434"
+embedding_model = "nomic-embed-text"
+summary_model = "qwen2.5-coder:7b"
+
+[git]
+credential_method = "gh"
+"#,
+            toml_basic_string(&db_path),
+        ),
+    )
+    .unwrap();
+
+    // Run from somewhere that is neither the configured DB's directory nor the
+    // repository, so a fallback to `./nestweaver.lbug` cannot make anything
+    // pass by accident.
+    let unrelated_cwd = dir.path().join("unrelated-cwd");
+    std::fs::create_dir(&unrelated_cwd).unwrap();
+
+    nestweaver_cmd()
+        .current_dir(&unrelated_cwd)
+        .env_remove("NESTWEAVER_DB")
+        .args(["brain", "add"])
+        .arg(&vault_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .assert()
+        .success();
+    assert!(
+        db_path.exists(),
+        "`brain add --config` must have created the database the config names, \
+         at {}; it went somewhere else",
+        db_path.display()
+    );
+
+    nestweaver_cmd()
+        .current_dir(&unrelated_cwd)
+        .env_remove("NESTWEAVER_DB")
+        .args(["brain", "remove"])
+        .arg(&vault_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .assert()
+        .failure()
+        .stderr(contains("cannot be honored by the direct store"));
+
+    // The counterweight: the very same removal, addressed without a config,
+    // succeeds. Without this the refusal above would be indistinguishable from
+    // a `brain remove` that cannot remove anything at all.
+    nestweaver_cmd()
+        .current_dir(&unrelated_cwd)
+        .env_remove("NESTWEAVER_DB")
+        .args(["brain", "remove"])
+        .arg(&vault_dir)
+        .args(["--db", &db_path.display().to_string()])
+        .args(["--instance", "vault-config-parity"])
+        .assert()
+        .success();
+}
+
 #[test]
 fn commands_honor_database_declared_by_config() {
     let dir = tempfile::tempdir().unwrap();

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -446,11 +446,31 @@ fn extensions_list_fails_loudly_on_an_unreadable_sidecar() {
     )
     .unwrap();
 
-    nestweaver_cmd()
+    let output = nestweaver_cmd()
         .args(["extensions", "list", "--db", &db_path.display().to_string()])
-        .assert()
-        .failure()
-        .stdout(contains("0 annotated node(s)").not());
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "a sidecar that cannot be parsed must fail the audit, not be reported \
+         as an empty one"
+    );
+    // Asserted POSITIVELY. `.stdout(contains("0 annotated node(s)").not())`
+    // was the obvious way to write this and is the wrong one: a negative
+    // substring check passes for every reason a string can be absent,
+    // including a rendering change or a line wrap, so it would keep passing
+    // after the fix was undone in some other way.
+    let stderr = flatten_miette(&output.stderr);
+    assert!(
+        stderr.to_lowercase().contains("extension sidecar"),
+        "the failure must name the sidecar as the thing it could not read:\n{stderr}"
+    );
+    assert!(
+        !String::from_utf8_lossy(&output.stdout).contains("annotated node"),
+        "an unreadable sidecar must not also print a count as though it had \
+         looked:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
 }
 
 /// nw-244: PR #307 taught `brain remove` to honour `--config` like its two
@@ -528,16 +548,35 @@ credential_method = "gh"
         db_path.display()
     );
 
-    nestweaver_cmd()
+    let refused = nestweaver_cmd()
         .current_dir(&unrelated_cwd)
         .env_remove("NESTWEAVER_DB")
         .args(["brain", "remove"])
         .arg(&vault_dir)
         .arg("--config")
         .arg(&config_path)
-        .assert()
-        .failure()
-        .stderr(contains("cannot be honored by the direct store"));
+        .output()
+        .unwrap();
+    assert!(
+        !refused.status.success(),
+        "`brain remove --config` must not silently succeed against some other \
+         instance; that is the nw-217 defect"
+    );
+    let stderr = flatten_miette(&refused.stderr);
+    assert!(
+        stderr.contains("cannot be honored by the direct store"),
+        "the refusal must say WHY, and name the config it could not honour — \
+         a bare non-zero exit leaves the caller guessing:\n{stderr}"
+    );
+    // Compared with ALL whitespace removed, on both sides: miette breaks the
+    // line wherever the width runs out, and on a long macOS
+    // `/var/folders/...` temp path that break lands INSIDE the path itself.
+    // Any check that tolerates wrapping only between words still fails there.
+    let squeeze = |s: &str| -> String { s.chars().filter(|c| !c.is_whitespace()).collect() };
+    assert!(
+        squeeze(&stderr).contains(&squeeze(&config_path.display().to_string())),
+        "the refusal must name the config path it could not honour:\n{stderr}"
+    );
 
     // The counterweight: the very same removal, addressed without a config,
     // succeeds. Without this the refusal above would be indistinguishable from
@@ -3426,6 +3465,22 @@ fn no_daemon_index_rejects_colon_in_instance_flag() {
         .assert()
         .failure()
         .stderr(contains("colon"));
+}
+
+/// Flatten miette's rendered diagnostic into a single line.
+///
+/// miette hard-wraps a message to the terminal width and prefixes continuation
+/// lines with `\u{2502}`, so a `contains("...")` on any phrase long enough to
+/// span the wrap is really an assertion about the WIDTH — and the width here
+/// depends on the length of the temp path, which differs between a macOS
+/// `/var/folders/...` and a Linux `/tmp/...`. CI caught exactly that: the
+/// message was correct and the assertion still failed.
+fn flatten_miette(stderr: &[u8]) -> String {
+    String::from_utf8_lossy(stderr)
+        .replace('\u{2502}', " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn toml_basic_string(path: &std::path::Path) -> String {

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -4541,3 +4541,164 @@ fn daemon_gc_help_presents_db_as_optional() {
         "daemon gc --help presents --db as optional; keep behaviour and help in step"
     );
 }
+
+/// nw-246 (second hole), direct route: the ambiguity refusal must be
+/// REACHABLE.
+///
+/// `resolve_instance_id_for_db` returned the recorded identity before ever
+/// consulting `observed_instance_ids`, which made the refusal below dead code
+/// for any database that has a record. `ensure_data_instance_id` runs on every
+/// repo index and never replaces an existing value, so that is every database
+/// created or indexed under 8.0.0 — only a pre-nw-246 database could reach a
+/// refusal the runbook promises for everyone.
+///
+/// The sequence is entirely supported behaviour, which is what makes it bad:
+/// two STATED indexes pass by design (instance switching is a feature), and
+/// leave a database holding two instances whose record still names the first.
+/// A config-less index then adopted that record and silently re-keyed the
+/// repo — the nw-246 fork, produced by the guard meant to prevent it.
+///
+/// Reverting the ordering leaves the whole suite green without this test. That
+/// is why it exists.
+#[test]
+fn a_recorded_identity_does_not_mask_an_ambiguous_database() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.lbug");
+
+    let mut repos = Vec::new();
+    for name in ["first", "second", "third"] {
+        let repo = dir.path().join(name);
+        std::fs::create_dir_all(&repo).unwrap();
+        let git = |args: &[&str]| {
+            let status = StdCommand::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .status()
+                .expect("git failed to spawn");
+            assert!(status.success(), "git {args:?} failed");
+        };
+        git(&["init"]);
+        git(&["config", "user.email", "test@test.com"]);
+        git(&["config", "user.name", "Test"]);
+        std::fs::write(repo.join("a.js"), format!("function {name}() {{}}")).unwrap();
+        git(&["add", "a.js"]);
+        git(&["commit", "-m", "init"]);
+        repos.push(repo);
+    }
+
+    // Two STATED indexes. Both must succeed — instance switching is a
+    // supported operation, and a guard that refused these would have retired
+    // the capability rather than closed the hole.
+    for (repo, instance) in [(&repos[0], "one"), (&repos[1], "two")] {
+        nestweaver_cmd()
+            .args([
+                "index",
+                "--repo",
+                &repo.display().to_string(),
+                "--db",
+                &db_path.display().to_string(),
+                "--instance",
+                instance,
+            ])
+            .assert()
+            .success();
+    }
+
+    // Now the database holds two instances and its record names "one". A
+    // config-less index has no safe default.
+    let refused = nestweaver_cmd()
+        .args([
+            "index",
+            "--repo",
+            &repos[2].display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !refused.status.success(),
+        "a config-less index against a database holding two instances must be \
+         refused; adopting the recorded one silently re-keys the repo"
+    );
+    let stderr = flatten_miette(&refused.stderr);
+    assert!(
+        stderr.contains("one") && stderr.contains("two"),
+        "the refusal must name the instances it found:\n{stderr}"
+    );
+
+    // Counterweight: stating an instance still resolves it. Without this, the
+    // refusal is indistinguishable from an index that has stopped working.
+    nestweaver_cmd()
+        .args([
+            "index",
+            "--repo",
+            &repos[2].display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+            "--instance",
+            "one",
+        ])
+        .assert()
+        .success();
+}
+
+/// nw-246 (third hole): `nestweaver index` must actually RECORD the instance.
+///
+/// `ensure_data_instance_id`'s only caller was
+/// `index_directory_with_store_inner`, which is not the funnel the CLI index
+/// reaches — the CLI goes through `index_into_store_with_write_gate`. So the
+/// call ran on no real path, `data_instance_id()` returned `None` for every
+/// database, and the mint-once mechanism the whole item rests on was inert.
+///
+/// Nothing failed visibly, which is why it survived: `resolve_instance_id_for_db`
+/// falls back to inferring the instance from existing UIDs, and inference gives
+/// the same answer as the record in every single-instance case. The two only
+/// disagree where it matters — and there, silence looked like agreement.
+///
+/// Asserted against the store directly because the record has no CLI surface;
+/// `brain status` reports OBSERVED instances, which is the fallback, not this.
+#[test]
+fn indexing_records_the_data_instance_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.lbug");
+    let repo = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    let git = |args: &[&str]| {
+        let status = StdCommand::new("git")
+            .args(args)
+            .current_dir(&repo)
+            .status()
+            .expect("git failed to spawn");
+        assert!(status.success(), "git {args:?} failed");
+    };
+    git(&["init"]);
+    git(&["config", "user.email", "test@test.com"]);
+    git(&["config", "user.name", "Test"]);
+    std::fs::write(repo.join("a.js"), "function hello() {}").unwrap();
+    git(&["add", "a.js"]);
+    git(&["commit", "-m", "init"]);
+
+    nestweaver_cmd()
+        .args([
+            "index",
+            "--repo",
+            &repo.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+            "--instance",
+            "recorded-one",
+        ])
+        .assert()
+        .success();
+
+    let store = nestweaver_store::GraphStore::open_read_only(&db_path).unwrap();
+    assert_eq!(
+        store.data_instance_id().unwrap().as_deref(),
+        Some("recorded-one"),
+        "an index must record the instance its data belongs to; without it the \
+         database can only ever INFER its identity from existing UIDs, and the \
+         inference agrees with the record in exactly the cases where neither \
+         matters"
+    );
+}

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -5246,3 +5246,264 @@ fn gc_spares_running_daemon_reaps_orphans_and_stop_leaves_nothing() {
         "clean stop must unlink the socket-fallback dir"
     );
 }
+
+/// nw-246 (daemon path): a config-less `nestweaver index` through a RUNNING
+/// DAEMON must adopt the instance the database records — not write `default`
+/// and fork the graph.
+///
+/// This is the test whose absence let the defect ship. The original nw-246
+/// repro ran with `NESTWEAVER_ALLOW_NO_DAEMON=1`, which exercises
+/// `resolve_instance_id_for_db` — the one route that already had the guard.
+/// The daemon branch in `src/main.rs` returns before ever reaching it, and the
+/// daemon's own fallback never consulted the store, so the documented default
+/// path was unguarded while the fix looked verified.
+///
+/// Deliberately uses `daemon_cmd()` (no `NESTWEAVER_NO_DAEMON`) with an
+/// explicitly started daemon, and asserts the daemon is actually serving before
+/// the assertion that matters — otherwise a silent fallback to the direct store
+/// would make this pass for exactly the wrong reason.
+#[test]
+fn daemon_configless_index_adopts_the_recorded_instance_not_default() {
+    let dir = tempfile::tempdir().unwrap();
+    let first_repo = dir.path().join("first");
+    let second_repo = dir.path().join("second");
+    let db_path = dir.path().join("test.lbug");
+
+    write_test_repo(&first_repo);
+    write_test_repo(&second_repo);
+
+    // Establish the database's recorded identity as something that is NOT
+    // "default", so a fallback to the ambient default is visible.
+    no_daemon_cmd()
+        .args([
+            "index",
+            "--repo",
+            &first_repo.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+            "--instance",
+            "recorded-one",
+        ])
+        .assert()
+        .success();
+
+    let _guard = DaemonGuard::new(&db_path);
+    start_daemon(&db_path);
+
+    // The daemon really is serving. Without this the test would still pass if
+    // the CLI quietly fell back to the direct store, which is the guarded
+    // route — i.e. it would pass for the reason that hid the bug.
+    let status = daemon_cmd()
+        .args(["daemon", "--db", &db_path.display().to_string(), "status"])
+        .output()
+        .unwrap();
+    let status_text = String::from_utf8_lossy(&status.stdout).to_string();
+    assert!(
+        status.status.success() && status_text.contains("unning"),
+        "the daemon must be serving for this test to exercise the daemon \
+         route:\n{status_text}"
+    );
+
+    // Config-less, instance-less index of a SECOND repo through the daemon.
+    daemon_cmd()
+        .args([
+            "index",
+            "--repo",
+            &second_repo.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .assert()
+        .success();
+
+    let output = daemon_cmd()
+        .args([
+            "list-repos",
+            "--db",
+            &db_path.display().to_string(),
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let repos: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("list-repos --json: {e}\n{stdout}"));
+    let arr = repos.as_array().expect("expected a JSON array of repos");
+
+    // Counterweight: BOTH repos must be present. If the second index silently
+    // no-opped, every row would trivially carry the recorded instance and the
+    // assertion below would prove nothing.
+    assert_eq!(
+        arr.len(),
+        2,
+        "both repos must be indexed for this to test anything:\n{stdout}"
+    );
+    for repo in arr {
+        assert_eq!(
+            repo["instance_id"].as_str(),
+            Some("recorded-one"),
+            "a config-less index through the daemon must adopt the instance the \
+             database RECORDS; writing `default` here is the nw-246 fork:\n{stdout}"
+        );
+    }
+}
+
+/// nw-246: the same guarantee for MCP `brain_add_source`, which is a separate
+/// entry point sending its own `instance_id: String::new()`.
+///
+/// "The daemon computation is shared" is an argument, not a test — and the
+/// argument is exactly what was believed about the CLI path.
+#[test]
+fn mcp_add_source_adopts_the_recorded_instance_not_default() {
+    let dir = tempfile::tempdir().unwrap();
+    let first_repo = dir.path().join("first");
+    let second_repo = dir.path().join("second");
+    let db_path = dir.path().join("test.lbug");
+
+    write_test_repo(&first_repo);
+    write_test_repo(&second_repo);
+
+    no_daemon_cmd()
+        .args([
+            "index",
+            "--repo",
+            &first_repo.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+            "--instance",
+            "recorded-one",
+        ])
+        .assert()
+        .success();
+
+    let _guard = DaemonGuard::new(&db_path);
+    start_daemon(&db_path);
+
+    let request = format!(
+        concat!(
+            r#"{{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{{"#,
+            r#""name":"brain_add_source","arguments":{{"path":"{}"}}}}}}"#,
+            "\n"
+        ),
+        second_repo.display()
+    );
+    let mcp = daemon_cmd()
+        .args(["mcp", "--db", &db_path.display().to_string()])
+        .write_stdin(request)
+        .output()
+        .unwrap();
+    let mcp_out = String::from_utf8_lossy(&mcp.stdout).to_string();
+
+    let output = daemon_cmd()
+        .args([
+            "list-repos",
+            "--db",
+            &db_path.display().to_string(),
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let repos: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("list-repos --json: {e}\n{stdout}"));
+    let arr = repos.as_array().expect("expected a JSON array of repos");
+
+    assert_eq!(
+        arr.len(),
+        2,
+        "brain_add_source must actually have added the second repo, or this \
+         asserts nothing.\nmcp said:\n{mcp_out}\nrepos:\n{stdout}"
+    );
+    for repo in arr {
+        assert_eq!(
+            repo["instance_id"].as_str(),
+            Some("recorded-one"),
+            "MCP add-source must adopt the recorded instance too:\n{stdout}"
+        );
+    }
+}
+
+/// nw-246 (second hole): the ambiguity refusal must be reachable, and must be
+/// reachable THROUGH THE DAEMON.
+///
+/// Two things were wrong. `resolve_instance_id_for_db` returned the recorded
+/// value before ever consulting `observed_instance_ids`, so the refusal was
+/// unreachable for any database that had a record — and since
+/// `ensure_data_instance_id` runs on every index and never replaces, that is
+/// every database written under 8.0.0. And the daemon had no refusal at all.
+///
+/// The sequence below is entirely supported behaviour: two STATED indexes,
+/// which pass by design, leave a database holding two instances. A third,
+/// config-less index then had no safe default — and silently picked one.
+#[test]
+fn daemon_refuses_a_configless_write_when_the_database_is_ambiguous() {
+    let dir = tempfile::tempdir().unwrap();
+    let first_repo = dir.path().join("first");
+    let second_repo = dir.path().join("second");
+    let third_repo = dir.path().join("third");
+    let db_path = dir.path().join("test.lbug");
+
+    write_test_repo(&first_repo);
+    write_test_repo(&second_repo);
+    write_test_repo(&third_repo);
+
+    for (repo, instance) in [(&first_repo, "one"), (&second_repo, "two")] {
+        no_daemon_cmd()
+            .args([
+                "index",
+                "--repo",
+                &repo.display().to_string(),
+                "--db",
+                &db_path.display().to_string(),
+                "--instance",
+                instance,
+            ])
+            .assert()
+            .success();
+    }
+
+    let _guard = DaemonGuard::new(&db_path);
+    start_daemon(&db_path);
+
+    let refused = daemon_cmd()
+        .args([
+            "index",
+            "--repo",
+            &third_repo.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !refused.status.success(),
+        "a config-less index against a database holding two instances has no \
+         safe default and must be refused, not resolved to one of them"
+    );
+    let stderr: String = String::from_utf8_lossy(&refused.stderr)
+        .replace('\u{2502}', " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        stderr.contains("one") && stderr.contains("two"),
+        "the refusal must NAME the instances it found, so the caller can pick \
+         one or merge them:\n{stderr}"
+    );
+
+    // Counterweight: STATING an instance resolves the ambiguity. Without this
+    // the refusal above would be indistinguishable from a daemon that has
+    // simply stopped accepting indexes.
+    daemon_cmd()
+        .args([
+            "index",
+            "--repo",
+            &third_repo.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+            "--instance",
+            "one",
+        ])
+        .assert()
+        .success();
+}

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -1163,10 +1163,158 @@ fn parity_msgpack_scope_direct_vs_daemon() {
     );
 }
 
-/// `stale-check` is a freshness gate: it exits 1 when the index is
-/// stale. The fixture here is freshly indexed (not stale), but regardless we
-/// only assert stdout equality and equal exit codes across modes — never
-/// success.
+/// nw-244: `export`'s default scope is a CONTRACT, and only its help text
+/// asserted it.
+///
+/// The default moved from `code` to `all` deliberately, and reverting it kept
+/// the suite green — because nothing ran `export` with no `--scope` and checked
+/// what came out. A help string is not the behaviour.
+///
+/// `graphml` is the format that honours all three scopes, so it is the one that
+/// can tell them apart: under `all` the export carries vault nodes, under
+/// `code` it does not.
+#[test]
+fn export_defaults_to_the_all_scope_not_code() {
+    // A fixture with BOTH code and vault content. `setup_fixture` alone is
+    // code-only, so `all` and `code` produce identical output there and the
+    // test would pass under either default — the assertion at the bottom
+    // catches exactly that, and it fired the first time I wrote this.
+    let dir = tempfile::tempdir().unwrap();
+    let repo_dir = dir.path().join("repo");
+    let vault_dir = dir.path().join("vault");
+    let db_path = dir.path().join("db").join("test.lbug");
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(&vault_dir).unwrap();
+    write_repo_files(
+        &repo_dir,
+        &[("src/a.js", "export function one() { return 1; }\n")],
+    );
+    std::fs::write(
+        vault_dir.join("note.md"),
+        "# A Note\n\nSome vault content.\n",
+    )
+    .unwrap();
+    create_db(&repo_dir, &db_path);
+    no_daemon_cmd()
+        .args(["brain", "add"])
+        .arg(&vault_dir)
+        .args(["--db", &db_path.display().to_string()])
+        .assert()
+        .success();
+    let fixture = Fixture { _dir: dir, db_path };
+
+    let defaulted = run_direct(&fixture.db_path, &["export", "--format", "graphml"]);
+    assert!(
+        defaulted.status.success(),
+        "export with no --scope must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&defaulted.stderr)
+    );
+    let explicit_all = run_direct(
+        &fixture.db_path,
+        &["export", "--format", "graphml", "--scope", "all"],
+    );
+    let explicit_code = run_direct(
+        &fixture.db_path,
+        &["export", "--format", "graphml", "--scope", "code"],
+    );
+
+    assert_eq!(
+        defaulted.stdout, explicit_all.stdout,
+        "no --scope must behave exactly as `--scope all`"
+    );
+    // The counterweight, and the half that makes the assertion above mean
+    // something: `all` and `code` must actually DIFFER on this fixture. If they
+    // produced identical output the test would pass under either default and
+    // prove nothing.
+    assert_ne!(
+        explicit_all.stdout, explicit_code.stdout,
+        "the fixture cannot distinguish `all` from `code`, so this test would \
+         pass under either default — it needs vault content to be meaningful"
+    );
+}
+
+/// nw-244: the exit CODE is the contract, and nothing asserted it.
+///
+/// `stale_check_help_states_the_real_exit_contract` asserts against `--help`
+/// TEXT, so it passes with the runtime logic inverted. `parity_stale_check_...`
+/// below asserts the two routes AGREE, so it passes if both regress together.
+/// And its own doc comment said "exits 1" — the code is 2. Reverting
+/// `EXIT_NEEDS_REINDEX` to `EXIT_ERROR` kept the whole suite green.
+///
+/// This exercises the stale path for real: index, then advance the repo one
+/// commit so HEAD differs from the indexed SHA.
+#[test]
+fn stale_check_exits_needs_reindex_not_generic_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_dir = dir.path().join("repo");
+    let db_path = dir.path().join("db").join("test.lbug");
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+    write_repo_files(
+        &repo_dir,
+        &[("src/a.js", "export function one() { return 1; }\n")],
+    );
+    create_db(&repo_dir, &db_path);
+
+    // Advance HEAD past the indexed SHA.
+    std::fs::write(
+        repo_dir.join("src/b.js"),
+        "export function two() { return 2; }\n",
+    )
+    .unwrap();
+    for args in [
+        vec!["add", "."],
+        vec![
+            "-c",
+            "user.email=test@test.com",
+            "-c",
+            "user.name=Test",
+            "commit",
+            "-m",
+            "second",
+        ],
+    ] {
+        StdCommand::new("git")
+            .args(&args)
+            .current_dir(&repo_dir)
+            .output()
+            .unwrap();
+    }
+
+    let output = run_direct(&db_path, &["stale-check"]);
+    let code = output.status.code();
+
+    // 2 is EXIT_NEEDS_REINDEX; 1 is EXIT_ERROR. The distinction is the whole
+    // point — a CI gate keying on "stale" must not fire on an unrelated
+    // failure, and vice versa. Asserting `!= 0` would pass with them merged.
+    assert_eq!(
+        code,
+        Some(2),
+        "a stale index must exit EXIT_NEEDS_REINDEX (2), not EXIT_ERROR (1) or success; \
+         stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// The counterweight: a FRESH index must exit 0. Without it, a change making
+/// stale-check always return 2 would pass the test above.
+#[test]
+fn stale_check_exits_zero_when_the_index_is_current() {
+    let fixture = setup_fixture();
+
+    let output = run_direct(&fixture.db_path, &["stale-check"]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "a freshly indexed repo is not stale; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// `stale-check` is a freshness gate. The fixture here is freshly indexed, so
+/// this asserts only that the two routes agree — the exit-code contract itself
+/// is pinned by the two tests above.
 #[test]
 fn parity_stale_check_direct_vs_daemon() {
     let fixture = setup_fixture();


### PR DESCRIPTION
Branches off #322 — **merge that first**. Three holes, the third of which made the other two unfalsifiable.

## 1. The daemon never consulted the store

`nestweaver index` **with a daemon — the default** — bypassed the guard entirely. `src/main.rs` builds the RPC with the raw `--instance` flag and returns from the daemon branch before `resolve_instance_id_for_db` is reached; that helper is only live under `--no-daemon`.

`data_instance_id()` and `observed_instance_ids()` had **exactly two production call sites in the whole tree**, both inside that one unreachable helper. Nothing in the daemon or MCP crates ever read the identity the database records.

So a config-less index against a database recorded as `2051a9da` wrote `default` and forked the graph — the original defect, verbatim, on the documented default path. MCP `brain_add_source` had it too.

Fixed at the daemon's startup resolution, which feeds all ten `resolve_effective_instance_id` sites, so every RPC caller including MCP is covered by one change.

## 2. The ambiguity refusal was unreachable

`resolve_instance_id_for_db` returned the recorded value **before** consulting `observed_instance_ids`, making the refusal dead code for any database with a record.

Reachable through supported behaviour: `index --instance one`, then `index --instance two` (stated, so it passes — that is the capability this rescope preserved), leaves a database holding two instances whose record says `one`. A config-less index then adopted `one` and silently re-keyed the repo.

Ambiguity is now checked first in **both** routes. The daemon carries it rather than failing startup — refusing to boot would block **reads**, and reads are instance-agnostic. It is refused at `resolve_effective_instance_id`, the choke point all nine write and watch-registration handlers pass through.

`merge`/`purge` state both ids and so pass through — `instance merge` is the documented **remedy** for this state and must not be refused by the guard warning about it.

## 3. The record was never written at all

`ensure_data_instance_id`'s only caller was `index_directory_with_store_inner`, which is **not** the funnel the CLI index reaches — that is `index_into_store_with_write_gate`. The call ran on no real path. `data_instance_id()` returned `None` for every database that has ever existed, and the mint-once mechanism this item is built on has been inert since it was written.

It survived because the resolver falls back to inferring the instance from existing UIDs, and **inference agrees with the record in every single-instance case**. The two disagree only where it matters, so silence looked like agreement.

Found because the fix would not verify: the hole-2 test passed, and passed again with the ordering bug deliberately restored. *A test that passes under its own mutation is evidence about the system, not a nuisance.*

Fixed by extracting `record_data_instance` and calling it from **both** funnels — one implementation, two call sites, so the next funnel added cannot quietly miss it.

## Not done, deliberately

`assert_data_instance_id` is **not** wired into the index funnel. By that point the stated/inferred distinction is gone, so an unconditional assert cannot tell a config-driven instance switch from a fork — it would refuse the capability that stopped this work the first time. Resolved upstream in both routes instead, where the distinction still exists; the funnel logs the disagreement at INFO.

The funnel's comment claiming *"the CLI resolver refuses a disagreeing request before reaching here"* is deleted. It never did. Stating a guard that does not exist is worse than stating none.

## Tests

Five, each verified by reverting the fix and watching it go red:

- config-less index **through a running daemon** adopts the recorded instance — asserting the daemon is actually *serving* first, because a silent fallback to the direct store would make it pass for the very reason that hid this
- MCP `brain_add_source` the same, tested separately rather than argued from shared code
- ambiguity refused on the daemon route, **and** on the direct route
- an index actually **records** the instance

The original nw-246 repro ran with `NESTWEAVER_ALLOW_NO_DAEMON=1`. It exercised the one route that already had the guard.

## Verification

```
cargo fmt --all --check                                → 0
cargo clippy --workspace --all-targets -- -D warnings  → 0
cargo test --workspace --all-targets                   → 0   (3850 passed, 0 failed)
```
