### PR TITLE
fix(ci): mutate the packages the diff touches, not the whole workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -722,7 +722,15 @@ jobs:
         with:
           tool: cargo-mutants
       - name: Compute the PR diff
-        run: git diff "origin/${{ github.base_ref }}"...HEAD > /tmp/pr.diff
+        # ONE range expression, two artifacts. nw-272: the package list and the
+        # mutant list must come from the SAME diff — computing the range twice
+        # lets them drift silently, so `--in-diff` could generate a mutant in a
+        # package `-p` never built (skipped, invisible) or `-p` could baseline
+        # packages with no mutants (the exact cost this scoping removes). Both
+        # failure modes look like a normal run.
+        run: |
+          git diff "origin/${{ github.base_ref }}"...HEAD > /tmp/pr.diff
+          git diff --name-only "origin/${{ github.base_ref }}"...HEAD > /tmp/pr.files
       - name: Mutate only what this PR changed
         id: mutate
         # `--workspace` is load-bearing. This repo's root Cargo.toml is BOTH a
@@ -771,10 +779,24 @@ jobs:
           #
           # `--in-diff` already restricts which mutants are GENERATED; `-p`
           # restricts what gets BUILT and baselined, which is the expensive half.
-          pkgs=$(git diff --name-only "origin/${GITHUB_BASE_REF}"...HEAD \
-            | awk -F/ '/^crates\/[^\/]+\// { print $2 } /^(src|build\.rs)/ { print "nestweaver" }' \
-            | sort -u)
-          if [ -z "${pkgs}" ]; then
+          # Derived from /tmp/pr.files, written by the same step and the same
+          # range expression that produced /tmp/pr.diff — see the comment there.
+          #
+          # `print $2` is the crate DIRECTORY name. That is only valid because
+          # every directory under crates/ is named for its package; a future
+          # crate where those differ would emit `-p <dir>` and fail loudly,
+          # which is the right way for that assumption to break.
+          #
+          # Patterns are anchored: `/^src\//` and `/^build\.rs$/`, not
+          # `/^(src|build\.rs)/`, which would also match `srcgen/` and print a
+          # package the diff never touched — a wasted baseline, which is the
+          # resource this whole change exists to conserve.
+          mapfile -t pkgs < <(awk -F/ '
+            /^crates\/[^\/]+\// { print $2 }
+            /^src\//            { print "nestweaver" }
+            /^build\.rs$/       { print "nestweaver" }
+          ' /tmp/pr.files | sort -u)
+          if [ "${#pkgs[@]}" -eq 0 ]; then
             echo "no Rust package in this diff; nothing to mutate"
             {
               echo "status=0"
@@ -783,13 +805,11 @@ jobs:
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          pkg_args=""
-          for p in ${pkgs}; do pkg_args="${pkg_args} -p ${p}"; done
-          echo "mutating packages:${pkg_args}"
-          # shellcheck disable=SC2086  # word splitting is the point: pkg_args
-          # is a flat "-p a -p b" list and must expand to separate argv entries.
+          pkg_args=()
+          for pkg in "${pkgs[@]}"; do pkg_args+=(-p "${pkg}"); done
+          echo "mutating packages: ${pkgs[*]}"
           timeout --signal=INT --kill-after=120s "${MUTANTS_BUDGET}" \
-            cargo mutants ${pkg_args} --in-diff /tmp/pr.diff \
+            cargo mutants "${pkg_args[@]}" --in-diff /tmp/pr.diff \
               --timeout 300 --no-shuffle -- --no-fail-fast
           status=$?
           set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -760,8 +760,36 @@ jobs:
         # constraint on this runner, not CPU.
         run: |
           set +e
+          # nw-272: mutate the packages this DIFF touches, not the whole
+          # workspace. `--workspace` (nw-243) made cargo-mutants build and run
+          # every crate's test suite as its BASELINE before evaluating a single
+          # mutant, and on a 15-crate workspace that alone exceeds the budget:
+          # on #322 and #323 it found 53 and 110 mutants and tested ZERO, each
+          # time burning the full 35m on the baseline and reporting a green
+          # advisory check. nw-243's intent was that library crates be
+          # REACHABLE — not that the workspace be rebuilt every run.
+          #
+          # `--in-diff` already restricts which mutants are GENERATED; `-p`
+          # restricts what gets BUILT and baselined, which is the expensive half.
+          pkgs=$(git diff --name-only "origin/${GITHUB_BASE_REF}"...HEAD \
+            | awk -F/ '/^crates\/[^\/]+\// { print $2 } /^(src|build\.rs)/ { print "nestweaver" }' \
+            | sort -u)
+          if [ -z "${pkgs}" ]; then
+            echo "no Rust package in this diff; nothing to mutate"
+            {
+              echo "status=0"
+              echo "truncated=false"
+              echo "no_packages=true"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          pkg_args=""
+          for p in ${pkgs}; do pkg_args="${pkg_args} -p ${p}"; done
+          echo "mutating packages:${pkg_args}"
+          # shellcheck disable=SC2086  # word splitting is the point: pkg_args
+          # is a flat "-p a -p b" list and must expand to separate argv entries.
           timeout --signal=INT --kill-after=120s "${MUTANTS_BUDGET}" \
-            cargo mutants --workspace --in-diff /tmp/pr.diff \
+            cargo mutants ${pkg_args} --in-diff /tmp/pr.diff \
               --timeout 300 --no-shuffle -- --no-fail-fast
           status=$?
           set -e
@@ -770,7 +798,10 @@ jobs:
           # --kill-after SIGKILL was needed.
           if [ "${status}" -eq 124 ] || [ "${status}" -eq 137 ]; then
             echo "truncated=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::Mutation testing hit its ${MUTANTS_BUDGET} budget and was cut short; the mutant list is partial."
+            # NOT "partial" — a run cut short during the baseline tests ZERO
+            # mutants, and "partial" reads identically whether it reached 80 or
+            # none. The job summary carries the real count.
+            echo "::warning::Mutation testing hit its ${MUTANTS_BUDGET} budget and was cut short. It may have tested NO mutants at all — read the job summary for how far it actually got before treating this as a clean result."
           else
             echo "truncated=false" >> "$GITHUB_OUTPUT"
           fi
@@ -791,9 +822,20 @@ jobs:
         # all-clear — it never gets to print "No surviving mutants".
         env:
           TRUNCATED: ${{ steps.mutate.outputs.truncated }}
+          NO_PACKAGES: ${{ steps.mutate.outputs.no_packages }}
           MUTANTS_STATUS: ${{ steps.mutate.outputs.status }}
         run: |
           summary() { echo "$1" >> "$GITHUB_STEP_SUMMARY"; }
+
+          # nw-272: no Rust package in the diff is legitimately nothing to do —
+          # distinct from "the report is missing", which the branch below treats
+          # as a non-result. Saying the wrong one of those is the whole defect
+          # this job keeps re-learning.
+          if [ "${NO_PACKAGES}" = "true" ]; then
+            summary "### Mutation testing"
+            summary "No Rust package in this diff, so no mutants were generated. Nothing to report."
+            exit 0
+          fi
 
           # How far did it actually get? Every mutant that produced a verdict
           # lands in exactly one of these files; mutants.json is the full list


### PR DESCRIPTION
Fixes **nw-272**, a regression from **nw-243** — which I reviewed and merged, so this is mine to fix.

## What happened

nw-243 added `--workspace` so the mutation job could reach the library crates. Before it, `cargo mutants --list` emitted **2065 mutants and every one was in `src/main.rs` or `src/setup.rs`** — none of the 15 library crates had ever been mutated. That was the right goal, and on #321 it went from 1 mutant to 15 and found a genuine survivor.

But `--workspace` also makes cargo-mutants build and run **every** crate's test suite as its baseline before evaluating a single mutant. On the two PRs that followed:

| PR | mutants generated | mutants tested |
|---|---|---|
| #322 | 53 | **0** |
| #323 | 110 | **0** |

Both burned the full 35m on the baseline, were interrupted, wrote four empty verdict files, and reported a **green** advisory check.

So the fix for "the job never mutates library crates" produced "the job never mutates anything" — which is worse, because the first state was at least visible as a suspiciously small mutant count.

## The fix

`--in-diff` already restricts which mutants are **generated**. `-p` restricts what is **built and baselined**, which is the expensive half. The package list is derived from the diff, keeping nw-243's intent — library crates reachable — without rebuilding crates the diff never touched.

Validated against a real diff (#322's merge → 5 packages) and an empty one (→ 0, takes the no-op branch).

**This is proportional, not a guarantee.** A diff touching five crates still baselines five. If it truncates again the next lever is `--baseline skip` — which should only be taken *alongside* this, since it removes the check that the tree is green, and a mutation run against a red tree produces confident nonsense rather than an error.

## Two smaller corrections in the same area

**The truncation warning claimed "the mutant list is partial."** It wasn't partial, it was **empty** — 0 of 110 — and "partial" reads identically whether the run reached 80 mutants or none. It now says it may have tested none, and points at the summary, which carries the real count. Caught by the hardening agent against my own change.

**A diff with no Rust package now says so.** Without that it fell into the "cargo-mutants produced no report" branch, which reports *"a missing result, not a passing one"* — true of a crash, wrong for a docs-only PR. An absent signal and a clean signal must not look the same, and neither must a legitimate no-op and a failure.

## What is NOT changed, deliberately

**No `tested == 0` failure branch.** The disclosure already exists and already fired: the summary has both a `TRUNCATED` callout and a "No mutants were tested at all" branch, and a `::warning::` annotation was emitted on both runs. **The job was honest — two agents read `Mutation testing = SUCCESS` and took it for "the mutation testing passed", when `continue-on-error: true` means only that the advisory job finished.** Adding a failure branch would fix the wrong layer, and an advisory job that fails the build on a budget overrun would be a worse job.

`actionlint` clean, including shellcheck. The one `SC2086` suppression is deliberate and commented: word splitting on `pkg_args` is the point, since it must expand to separate argv entries.