### PR TITLE
fix: six route divergences, three closed by sharing rather than restating

### DIFF
--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -12102,8 +12102,13 @@ fn impact_analysis_impl(
         });
     }
 
+    // nw-268: clamped, like the sibling traversal at `remaining_depth` already
+    // was. Unbounded here meant a single request could walk the whole graph
+    // transitively with no ceiling — and the CLI half had no `value_parser`, so
+    // a mistyped `--max-depth` arrived as a real instruction rather than a
+    // usage error.
     let max_depth = if req.max_depth > 0 {
-        req.max_depth as u32
+        (req.max_depth as u32).min(nestweaver_engine::atomic_changes::MAX_IMPACT_DEPTH)
     } else {
         3 // default
     };

--- a/crates/nestweaver-engine/src/atomic_changes.rs
+++ b/crates/nestweaver-engine/src/atomic_changes.rs
@@ -751,6 +751,19 @@ pub fn is_test_file(path: &str) -> bool {
         || path.ends_with("_test.py")
 }
 
+/// Upper bound on transitive impact depth.
+///
+/// nw-268: the `ImpactAnalysis` gRPC handler accepted any `max_depth` a caller
+/// sent, while its sibling traversal clamped at 64 — and the CLI half
+/// (`pre-push-impact --max-depth`) had no `value_parser` at all, so a typo like
+/// `--max-depth 100000` became an unbounded graph walk rather than a usage
+/// error.
+///
+/// Defined here, once, because the divergence was two independent limits — one
+/// of them absent. 64 matches the sibling that already had it; a depth beyond
+/// that has traversed the entire graph on any real repository.
+pub const MAX_IMPACT_DEPTH: u32 = 64;
+
 // ── Server-side impact analysis (Task 7) ─────────────────────────────
 
 /// Server-side impact analysis: given atomic changes, query the graph store

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -261,6 +261,7 @@ pub mod query;
 pub mod read_symbols;
 pub mod recency;
 pub mod registry;
+pub mod repo_head;
 pub mod rerank;
 pub mod resolution_cache;
 pub mod resolver_generation;

--- a/crates/nestweaver-engine/src/repo_head.rs
+++ b/crates/nestweaver-engine/src/repo_head.rs
@@ -1,0 +1,205 @@
+//! Resolving a repository's current HEAD, and the distance from an indexed SHA.
+//!
+//! nw-266: this exists because `stale-check`'s two routes — the CLI's direct
+//! path and the MCP/daemon tool — hand-rolled the same computation and drifted
+//! apart three times:
+//!
+//! * nw-163, `is_stale` — the daemon path was changed and the direct path was
+//!   not, so one repo answered `true` without a daemon and `false` with one.
+//! * nw-256, `staleness_commits_behind` — the MCP route became `Option<u64>`
+//!   and the CLI kept `unwrap_or(0)`, reporting "STALE, 0 commits behind".
+//! * nw-266, `current_head` — the MCP route asks the remote for a repo with no
+//!   local working tree; the CLI hardcoded `None`, so a genuinely stale repo
+//!   reported `ok` and exited 0. A CI gate built on it passed.
+//!
+//! Each of the first two fixes left a comment asserting the routes must not
+//! drift, and the next divergence appeared underneath it. A comment cannot hold
+//! two implementations together; only one implementation can. So the decision
+//! that keeps diverging lives HERE, and both routes call it.
+
+/// The HEAD sha of a local working tree, or `None` if it cannot be read.
+pub fn local_head(repo_path: &str) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["-C", repo_path, "rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// The HEAD sha of a remote, via `git ls-remote`.
+///
+/// Works for SSH (`git@github.com:…`) and HTTPS URLs. Stderr is suppressed so
+/// SSH key errors and other diagnostics do not leak into tool responses.
+pub fn remote_head(url: &str) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["ls-remote", "--exit-code", url, "HEAD"])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    // "<sha>\tHEAD\n"
+    String::from_utf8_lossy(&output.stdout)
+        .split_whitespace()
+        .next()
+        .map(str::to_string)
+}
+
+/// Resolve the current HEAD for an indexed repo — THE decision that diverged.
+///
+/// * A local working tree that no longer exists on disk is unverifiable, and
+///   HEAD is unknowable. `None`.
+/// * A local working tree: read HEAD from disk.
+/// * No local working tree: **ask the remote**. `local_root()` is `None`
+///   whenever `root_path` is empty and the url is not `file://`, which is
+///   precisely the case [`remote_head`] exists to serve. Returning `None` here
+///   is what made the CLI report `ok` for a repo the daemon called stale.
+pub fn current_head(local_missing: bool, local_root: Option<&str>, url: &str) -> Option<String> {
+    if local_missing {
+        return None;
+    }
+    match local_root {
+        Some(path) => local_head(path),
+        None => remote_head(url),
+    }
+}
+
+/// Count commits between two shas in a local working tree.
+///
+/// `None` means "could not count" — a failed `git rev-list`, an unreadable
+/// repo, unparseable output. Distinguishable from a real zero, which matters
+/// because the caller only asks when HEAD already differs from the indexed
+/// SHA: a zero there is a contradiction, not an answer (nw-256).
+pub fn commits_between(repo_path: &str, from_sha: &str, to_sha: &str) -> Option<u64> {
+    let output = std::process::Command::new("git")
+        .args(["-C", repo_path, "rev-list", "--count"])
+        .arg(format!("{from_sha}..{to_sha}"))
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout).trim().parse().ok()
+}
+
+/// Is this a well-formed 40-hex git sha?
+///
+/// Shared so the two routes cannot disagree about which stored values are
+/// countable.
+pub fn is_full_sha(value: &str) -> bool {
+    value.len() == 40 && value.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn git(dir: &std::path::Path, args: &[&str]) {
+        let status = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .status()
+            .expect("git must be available");
+        assert!(status.success(), "git {args:?} failed in {}", dir.display());
+    }
+
+    /// A repo with a working tree: HEAD comes from disk.
+    #[test]
+    fn a_local_working_tree_resolves_head_from_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        git(&repo, &["init"]);
+        git(&repo, &["config", "user.email", "t@t.com"]);
+        git(&repo, &["config", "user.name", "T"]);
+        std::fs::write(repo.join("a.txt"), "hello").unwrap();
+        git(&repo, &["add", "a.txt"]);
+        git(&repo, &["commit", "-m", "one"]);
+
+        let head = current_head(false, Some(repo.to_str().unwrap()), "unused://url")
+            .expect("a local working tree must resolve HEAD");
+        assert!(is_full_sha(&head), "expected a 40-hex sha, got {head:?}");
+    }
+
+    /// nw-266: a repo with NO local working tree must ask the remote.
+    ///
+    /// This is the branch the CLI route hardcoded to `None`, which made a
+    /// genuinely stale repo report `ok` and exit 0 — and a CI gate built on
+    /// `stale-check` pass.
+    ///
+    /// A local bare repository is a perfectly good git remote, so this
+    /// exercises the real `ls-remote` path with no network.
+    #[test]
+    fn no_local_working_tree_asks_the_remote() {
+        let dir = tempfile::tempdir().unwrap();
+        let work = dir.path().join("work");
+        let bare = dir.path().join("origin.git");
+        std::fs::create_dir(&work).unwrap();
+        git(&work, &["init"]);
+        git(&work, &["config", "user.email", "t@t.com"]);
+        git(&work, &["config", "user.name", "T"]);
+        std::fs::write(work.join("a.txt"), "hello").unwrap();
+        git(&work, &["add", "a.txt"]);
+        git(&work, &["commit", "-m", "one"]);
+        git(
+            dir.path(),
+            &[
+                "clone",
+                "--bare",
+                work.to_str().unwrap(),
+                bare.to_str().unwrap(),
+            ],
+        );
+
+        let expected = local_head(work.to_str().unwrap()).expect("work tree HEAD");
+        let resolved = current_head(false, None, bare.to_str().unwrap())
+            .expect("a repo with no local root must fall back to the REMOTE, not give up");
+        assert_eq!(
+            resolved, expected,
+            "the remote's HEAD must be reported; returning None here is what let \
+             a stale repo pass a freshness gate"
+        );
+    }
+
+    /// The counterweight to the two above: a working tree that is GONE is
+    /// genuinely unknowable, and must not be answered by guessing at a remote.
+    #[test]
+    fn a_missing_working_tree_resolves_to_nothing() {
+        assert_eq!(
+            current_head(true, Some("/nonexistent"), "unused://url"),
+            None,
+            "a deleted working tree makes HEAD unknowable; `status: missing` and \
+             `needs_reindex` carry that truth, not a guessed sha"
+        );
+    }
+
+    #[test]
+    fn an_uncountable_distance_is_none_not_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        git(&repo, &["init"]);
+        git(&repo, &["config", "user.email", "t@t.com"]);
+        git(&repo, &["config", "user.name", "T"]);
+        std::fs::write(repo.join("a.txt"), "hello").unwrap();
+        git(&repo, &["add", "a.txt"]);
+        git(&repo, &["commit", "-m", "one"]);
+        let head = local_head(repo.to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            commits_between(repo.to_str().unwrap(), &head, &head),
+            Some(0),
+            "a real zero must still be reported as zero"
+        );
+        assert_eq!(
+            commits_between(repo.to_str().unwrap(), &"0".repeat(40), &head),
+            None,
+            "an unreachable range cannot be counted, and must not be reported as 0"
+        );
+    }
+}

--- a/crates/nestweaver-engine/src/summaries.rs
+++ b/crates/nestweaver-engine/src/summaries.rs
@@ -1131,3 +1131,70 @@ mod tests {
         assert_eq!(sym_count, 1, "symbol summaries should be saved");
     }
 }
+
+#[cfg(test)]
+mod cap_disclosure_tests {
+    use super::*;
+
+    /// nw-270: `capped` and `matched_total` exist so callers can disclose the
+    /// cap, and the `summary --json` caller discarded both — reporting
+    /// `total: 500, truncated: false` for a 500-of-N answer. The cap was
+    /// invisible in precisely the field that exists to reveal it.
+    ///
+    /// Pinned here, at the producer, because the guarantee callers depend on is
+    /// that these two fields describe the PRE-cap world.
+    #[test]
+    fn capped_results_report_the_pre_cap_total() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("t.lbug");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+
+        for i in 0..12 {
+            store
+                .insert_symbol(&nestweaver_schema::Symbol {
+                    uid: format!("sym:test:s{i}"),
+                    name: format!("s{i}"),
+                    kind: nestweaver_schema::SymbolKind::Function,
+                    repo_uid: "repo:test:demo".to_string(),
+                    file_path: "a.js".to_string(),
+                    start_line: 1,
+                    end_line: 1,
+                    signature: format!("fn s{i}()"),
+                    summary: None,
+                    content_hash: "hash".to_string(),
+                    embedding: None,
+                    pagerank_score: None,
+                    is_entry_point: false,
+                    entry_point_kind: None,
+                    visibility: nestweaver_schema::Visibility::Inferred,
+                    type_info: None,
+                    framework_hint: None,
+                    canonical_id: None,
+                })
+                .unwrap();
+        }
+
+        let capped = generate_symbol_summaries_bounded(&store, None, 5).unwrap();
+        assert_eq!(capped.summaries.len(), 5, "the cap must actually bind");
+        assert!(capped.capped, "a bound cap must be disclosed as capped");
+        assert!(
+            capped.matched_total > capped.summaries.len(),
+            "matched_total must describe the PRE-cap world ({} matched vs {} returned)",
+            capped.matched_total,
+            capped.summaries.len()
+        );
+
+        // The counterweight: a cap that does NOT bind must not claim it did.
+        // Without this, always-true `capped` would satisfy the assertion above.
+        let uncapped = generate_symbol_summaries_bounded(&store, None, 1000).unwrap();
+        assert!(
+            !uncapped.capped,
+            "a cap larger than the corpus must not report truncation"
+        );
+        assert_eq!(
+            uncapped.matched_total,
+            uncapped.summaries.len(),
+            "and its total must equal what it returned"
+        );
+    }
+}

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -8187,17 +8187,13 @@ fn tool_stale_check(store: &GraphStore) -> Result<Value, anyhow::Error> {
             .unwrap_or(false);
 
         // Local working tree → read HEAD from disk; otherwise ask the remote.
-        let current_head = if local_missing {
-            None
-        } else if let Some(path) = repo.local_root() {
-            get_git_head(path)
-        } else {
-            get_remote_head(&repo.url)
-        };
+        // nw-266: shared with the CLI route, which hand-rolled this and
+        // dropped the remote branch entirely. See `repo_head`.
+        let current_head =
+            nestweaver_engine::repo_head::current_head(local_missing, repo.local_root(), &repo.url);
 
         // Compute commits behind for local repos when HEAD differs from indexed SHA.
-        let is_valid_sha =
-            repo.indexed_sha.len() == 40 && repo.indexed_sha.chars().all(|c| c.is_ascii_hexdigit());
+        let is_valid_sha = nestweaver_engine::repo_head::is_full_sha(&repo.indexed_sha);
         //
         // `unwrap_or(0)` here produced a CONTRADICTION rather than a missed
         // staleness: this branch is only reached when HEAD differs from the
@@ -8209,7 +8205,7 @@ fn tool_stale_check(store: &GraphStore) -> Result<Value, anyhow::Error> {
         // rev-list` actually tells us, and is distinguishable from a real zero.
         let commits_behind: Option<u64> = match (&current_head, repo.local_root()) {
             (Some(head), Some(path)) if is_valid_sha && *head != repo.indexed_sha => {
-                count_commits_between(path, &repo.indexed_sha, head)
+                nestweaver_engine::repo_head::commits_between(path, &repo.indexed_sha, head)
             }
             _ => Some(repo.staleness_commits_behind as u64),
         };
@@ -8281,61 +8277,6 @@ fn tool_stale_check(store: &GraphStore) -> Result<Value, anyhow::Error> {
         "any_needs_reindex": any_needs_reindex,
         "repos": results,
     }))
-}
-
-/// Get the current HEAD sha for a git repo at the given path.
-fn get_git_head(repo_path: &str) -> Option<String> {
-    let output = std::process::Command::new("git")
-        .arg("-C")
-        .arg(repo_path)
-        .arg("rev-parse")
-        .arg("HEAD")
-        .output()
-        .ok()?;
-    if output.status.success() {
-        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
-    } else {
-        None
-    }
-}
-
-/// Count commits between two SHAs in a local repo.
-fn count_commits_between(repo_path: &str, from_sha: &str, to_sha: &str) -> Option<u64> {
-    let range = format!("{from_sha}..{to_sha}");
-    let output = std::process::Command::new("git")
-        .arg("-C")
-        .arg(repo_path)
-        .args(["rev-list", "--count", &range])
-        .output()
-        .ok()?;
-    if output.status.success() {
-        String::from_utf8_lossy(&output.stdout)
-            .trim()
-            .parse::<u64>()
-            .ok()
-    } else {
-        None
-    }
-}
-
-/// Get the current HEAD sha for a remote git repo via `git ls-remote`.
-/// Works for SSH (`git@github.com:...`) and HTTPS (`https://...`) URLs.
-///
-/// Stderr is suppressed so SSH key errors or other diagnostics don't leak
-/// into MCP responses.
-fn get_remote_head(url: &str) -> Option<String> {
-    let output = std::process::Command::new("git")
-        .args(["ls-remote", "--exit-code", url, "HEAD"])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    // Output format: "<sha>\tHEAD\n"
-    stdout.split_whitespace().next().map(|s| s.to_string())
 }
 
 // ── 14. set_extension ──────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -2400,7 +2400,16 @@ enum Commands {
         #[arg(long)]
         local_changes: bool,
         /// Maximum transitive depth for impact analysis (default: 3)
-        #[arg(long, default_value = "3")]
+        // nw-268: bounded, so a mistyped depth is a usage error at parse time
+        // rather than an unbounded graph walk. Shares its ceiling with the
+        // gRPC handler.
+        #[arg(
+            long,
+            default_value = "3",
+            value_parser = clap::value_parser!(u32).range(
+                1..=nestweaver_engine::atomic_changes::MAX_IMPACT_DEPTH as i64
+            )
+        )]
         max_depth: u32,
         /// Include test files in impact results
         #[arg(long)]
@@ -9048,6 +9057,30 @@ fn resolve_track_interactions(force_on: bool, force_off: bool, config_enabled: b
 #[must_use = "the lease must be HELD for the duration of the write; dropping it \
               immediately reduces this to a probe, which is the check-then-act \
               race it exists to remove"]
+/// Render a count that may be UNKNOWN.
+///
+/// nw-269: `unwrap_or(0)` on a count the producer deliberately nulled turns "I
+/// could not read this" into "there are none" — the two states a reader most
+/// needs told apart. The MCP route already emits `null` on a failed per-vault
+/// `list_notes`; both CLI renderers collapsed it back to `0`, so a vault whose
+/// notes could not be read displayed as "0 notes" beside vaults that genuinely
+/// had none.
+///
+/// Shared rather than restated, because this is the third count in this file
+/// to need it (top-level `brain status` totals, per-vault note counts, and
+/// `stale-check`'s commits-behind in nw-256) and each hand-rolled copy has
+/// drifted back to `unwrap_or(0)` at least once.
+fn render_optional_count(value: Option<&serde_json::Value>) -> String {
+    match value {
+        Some(serde_json::Value::Null) | None => {
+            "unavailable (could not be read — NOT zero)".to_string()
+        }
+        Some(found) => found
+            .as_u64()
+            .map_or_else(|| found.to_string(), |n| n.to_string()),
+    }
+}
+
 fn require_exclusive_store_access(
     db_path: &std::path::Path,
     operation: &str,
@@ -10965,12 +10998,23 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // full-store scan would hang, so cap it and push any `target` filter
             // ahead of the per-symbol queries. A targeted or capped set is partial,
             // so it must NOT be persisted to the sidecar as the canonical summaries.
+            // nw-270: `SymbolSummaries` carries `matched_total` and `capped`
+            // — its own doc says "so callers can report honest truncation" —
+            // and this discarded both, keeping only `summaries`. `truncated`
+            // was then computed as `display.len() < total` where `total` is
+            // the ALREADY-CAPPED length, so a 500-of-40,000 answer reported
+            // `total: 500, truncated: false`. The cap is invisible in exactly
+            // the field that exists to disclose it.
+            let mut cap_dropped = 0usize;
             let after_filter: Vec<Summary> = if parsed_level == SummaryLevel::Symbol {
                 let out = nestweaver_engine::generate_symbol_summaries_bounded(
                     &store,
                     target.as_deref(),
                     nestweaver_engine::DEFAULT_SYMBOL_SUMMARY_CAP,
                 )?;
+                if out.capped {
+                    cap_dropped = out.matched_total.saturating_sub(out.summaries.len());
+                }
                 out.summaries
             } else {
                 let summaries = generate_summaries(&store, parsed_level)?;
@@ -11002,14 +11046,20 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     .cloned()
                     .collect()
             };
-            let truncated = display.len() < total;
+            // Truncation is either cause: the symbol cap upstream, or the
+            // token budget here. Reporting only the second made the first
+            // vanish.
+            let truncated = display.len() < total || cap_dropped > 0;
 
             if json {
                 println!(
                     "{}",
                     serde_json::to_string_pretty(&serde_json::json!({
                         "summaries": display,
-                        "total": total,
+                        // `total` now counts what MATCHED, not what survived
+                        // the cap — otherwise `returned == total` beside
+                        // `truncated: true` is a contradiction.
+                        "total": total + cap_dropped,
                         "returned": display.len(),
                         "truncated": truncated,
                     }))?
@@ -12407,6 +12457,28 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             }
 
             // Fallback: run watcher directly.
+            //
+            // nw-267: take the LOCK, not a pidfile read. The arm above guards
+            // with `daemon_process_running_for_db`, a point-in-time check of a
+            // different file, followed by a watcher that runs for HOURS
+            // writing to the store. That is CWE-367, and it is verbatim the
+            // construct `embed` removed — its comment is still in this file,
+            // calling it "CWE-367 exactly" and quoting MITRE's mitigation:
+            // "ensure that locking occurs before the check, as opposed to
+            // afterwards."
+            //
+            // The window is not theoretical here either: every
+            // `DaemonClient::connect` autostarts a daemon, so an ordinary
+            // `nestweaver search` in another terminal after the probe hands
+            // the store to a second writer while this watcher is still
+            // indexing into it. `watch` was the one write path of five that
+            // never took the lease.
+            //
+            // Held for the whole watch, which is the point — the lease's
+            // lifetime has to cover the writes, not just the decision to
+            // start.
+            let _write_lease = require_exclusive_store_access(&db_path, "watch")?;
+
             let watcher =
                 CodeWatcher::new(&db_path, &repo_path, &instance_id).with_limits(index_limits);
             let stop = watcher.shutdown_handle();
@@ -12801,7 +12873,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         );
                         return Ok((EXIT_SUCCESS, Some(stats)));
                     }
-                    let candidates = hybrid_search_candidates_from_value(value);
+                    let candidates = hybrid_search_candidates_from_value(value)?;
                     if candidates.is_empty() {
                         println!("No symbols found matching '{query}'.");
                     } else {
@@ -13997,8 +14069,17 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             confidence: f32,
                             depth: u32,
                         }
-                        let nodes: Vec<DaemonImpactNode> =
-                            serde_json::from_value(arr.clone()).unwrap_or_default();
+                        // nw-271: `unwrap_or_default()` on a DECODE turns "I
+                        // could not read the daemon's answer" into "the answer
+                        // was empty", and the branch below then prints a
+                        // confident "no impact". Same defect nw-249 fixed
+                        // three call sites up — its comment is at the top of
+                        // this file.
+                        let node_count = arr.as_array().map(Vec::len).unwrap_or(0);
+                        let nodes: Vec<DaemonImpactNode> = serde_json::from_value(arr.clone())
+                            .with_context(|| {
+                                format!("decode {node_count} impact node(s) from the daemon")
+                            })?;
                         let count = nodes.len();
                         if nodes.is_empty() {
                             if !out.quiet {
@@ -14938,8 +15019,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 if let Some(value) =
                     try_hybrid_json_rpc(true, &db_path, None, "detect_implicit_projects", args)?
                 {
+                    // nw-271: a decode failure must not print "No implicit
+                    // projects detected" — that is a claim about the vault,
+                    // made from a failure to read the response.
                     let detected: Vec<String> =
-                        serde_json::from_value(unwrap_hybrid_payload(value)).unwrap_or_default();
+                        serde_json::from_value(unwrap_hybrid_payload(value))
+                            .context("decode detected implicit projects from the daemon")?;
                     if detected.is_empty() {
                         println!("No implicit projects detected in {}", vault.display());
                     } else {
@@ -18480,10 +18565,16 @@ fn regex_truncation_label(
     }
 }
 
+/// nw-271: propagates instead of returning an empty Vec.
+///
+/// `unwrap_or_default()` here made a malformed daemon payload indistinguishable
+/// from "no candidates matched" — a fact about this process presented as a fact
+/// about the graph.
 fn hybrid_search_candidates_from_value(
     value: serde_json::Value,
-) -> Vec<nestweaver_engine::SymbolCandidate> {
-    serde_json::from_value(unwrap_hybrid_payload(value)).unwrap_or_default()
+) -> anyhow::Result<Vec<nestweaver_engine::SymbolCandidate>> {
+    serde_json::from_value(unwrap_hybrid_payload(value))
+        .context("decode search candidates from the daemon")
 }
 
 fn run_rts_eval(command: RtsEvalCommands) -> anyhow::Result<(i32, Option<String>)> {
@@ -18905,7 +18996,10 @@ fn run_brain(
                         }
                         for v in vaults {
                             let name = v["name"].as_str().unwrap_or("?");
-                            let note_count = v["note_count"].as_u64().unwrap_or(0);
+                            // nw-269: the MCP route nulls this when a
+                            // per-vault `list_notes` fails; `unwrap_or(0)`
+                            // printed that as "0 notes".
+                            let note_count = render_optional_count(v.get("note_count"));
                             let last_indexed = v["last_indexed"].as_str().unwrap_or("never");
                             let ambiguous = name_counts.get(name).copied().unwrap_or(0) > 1;
                             let unnamed = name.is_empty();
@@ -18941,16 +19035,7 @@ fn run_brain(
                     // The MCP client can inspect the null itself; a human
                     // reading the text render cannot. So this surface is the
                     // one that most needs the disclosure, not the least.
-                    let count = |key: &str| -> String {
-                        match value.get(key) {
-                            Some(serde_json::Value::Null) | None => {
-                                "unavailable (could not be read — NOT zero)".to_string()
-                            }
-                            Some(found) => found
-                                .as_u64()
-                                .map_or_else(|| found.to_string(), |n| n.to_string()),
-                        }
-                    };
+                    let count = |key: &str| -> String { render_optional_count(value.get(key)) };
                     println!("  Notes:     {}", count("notes"));
                     println!("  Headings:  {}", count("headings"));
                     println!("  Sections:  {}", count("sections"));
@@ -19151,7 +19236,21 @@ fn run_brain(
                     *name_counts.entry(v.name.as_str()).or_insert(0) += 1;
                 }
                 for v in &vaults {
-                    let vault_note_count = store.list_notes(Some(&v.uid)).unwrap_or_default().len();
+                    // nw-269: `unwrap_or_default().len()` is the same defect
+                    // one layer earlier — the error never even becomes a null,
+                    // it becomes an empty Vec and then a confident `0`. The
+                    // MCP route logs the failure and emits null; this route
+                    // silently agreed that the vault was empty.
+                    let vault_note_count = match store.list_notes(Some(&v.uid)) {
+                        Ok(notes) => notes.len().to_string(),
+                        Err(error) => {
+                            tracing::warn!(
+                                vault = %v.uid,
+                                "per-vault note count unavailable: {error}"
+                            );
+                            render_optional_count(Some(&serde_json::Value::Null))
+                        }
+                    };
                     let last_indexed = resolve_last_indexed(db_path, &v.uid, &store)
                         .unwrap_or_else(|| "never".to_string());
                     let ambiguous = name_counts.get(v.name.as_str()).copied().unwrap_or(0) > 1;
@@ -19389,21 +19488,25 @@ fn run_brain(
                     .map(|p| !std::path::Path::new(p).exists())
                     .unwrap_or(false);
 
-                let current_head = if local_missing {
-                    None
-                } else if let Some(path) = repo.local_root() {
-                    std::process::Command::new("git")
-                        .args(["-C", path, "rev-parse", "HEAD"])
-                        .output()
-                        .ok()
-                        .filter(|o| o.status.success())
-                        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-                } else {
-                    None
-                };
+                // nw-266: the `else` here was a hardcoded `None`, while the
+                // MCP route asked the REMOTE. `local_root()` is `None`
+                // whenever `root_path` is empty and the url is not `file://`,
+                // which is exactly the case `remote_head` exists to serve — so
+                // the CLI reported `ok` and exited 0 for a repo the daemon
+                // called stale, and a CI gate built on it passed.
+                //
+                // Third divergence in this function pair, after nw-163
+                // (`is_stale`) and nw-256 (`commits_behind`). Both of those
+                // fixes left a comment saying the routes must not drift, and
+                // the next divergence appeared underneath it — so the decision
+                // now lives in one place both routes CALL.
+                let current_head = nestweaver_engine::repo_head::current_head(
+                    local_missing,
+                    repo.local_root(),
+                    &repo.url,
+                );
 
-                let is_valid_sha = repo.indexed_sha.len() == 40
-                    && repo.indexed_sha.chars().all(|c| c.is_ascii_hexdigit());
+                let is_valid_sha = nestweaver_engine::repo_head::is_full_sha(&repo.indexed_sha);
                 // nw-256: `Option<u64>`, mirroring `tool_stale_check`. The
                 // note directly below is about `is_stale` diverging between
                 // these two routes for exactly this reason; #310 fixed the
@@ -19416,23 +19519,7 @@ fn run_brain(
                 // answer.
                 let commits_behind: Option<u64> = match (&current_head, repo.local_root()) {
                     (Some(head), Some(path)) if is_valid_sha && *head != repo.indexed_sha => {
-                        std::process::Command::new("git")
-                            .args([
-                                "-C",
-                                path,
-                                "rev-list",
-                                "--count",
-                                &format!("{}..{}", repo.indexed_sha, head),
-                            ])
-                            .output()
-                            .ok()
-                            .filter(|o| o.status.success())
-                            .and_then(|o| {
-                                String::from_utf8_lossy(&o.stdout)
-                                    .trim()
-                                    .parse::<u64>()
-                                    .ok()
-                            })
+                        nestweaver_engine::repo_head::commits_between(path, &repo.indexed_sha, head)
                     }
                     _ => Some(repo.staleness_commits_behind as u64),
                 };
@@ -19711,6 +19798,16 @@ fn run_brain(
                 out.status("Watcher stopped.");
                 return Ok((EXIT_SUCCESS, None));
             }
+
+            // nw-267 (sibling): `brain watch` runs the same direct-watcher
+            // fallback as `watch` and had the same hole — a long-running
+            // writer with no write lease. Fixing one route and leaving its
+            // twin is the exact pattern this batch exists to stop, and the
+            // PID lock file written below is a HINT to readers, not a lock:
+            // it cannot survive PID reuse and an operator's `rm` erases it.
+            //
+            // Held for the whole watch.
+            let _write_lease = require_exclusive_store_access(&db_path, "brain watch")?;
 
             let tantivy_sidecar = tantivy_sidecar_path_for(&db_path);
             let manifests_path = nestweaver_engine::manifest_cache_path(&db_path);
@@ -27973,10 +28070,29 @@ credential_method = "ssh"
             }
         });
 
-        let candidates = hybrid_search_candidates_from_value(value);
+        let candidates = hybrid_search_candidates_from_value(value).expect("well-formed payload");
 
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].name, "processPayment");
+    }
+
+    /// nw-271: the counterweight to the test above. A payload that cannot be
+    /// decoded must ERROR, not come back as an empty Vec — otherwise "the
+    /// daemon sent something I could not read" and "nothing matched your
+    /// search" are the same answer, and only one of them is true.
+    #[test]
+    fn a_malformed_search_payload_errors_rather_than_reading_as_empty() {
+        let malformed = serde_json::json!({
+            "results": [{ "uid": "sym:1", "start_line": "not-a-number" }]
+        });
+
+        let error = hybrid_search_candidates_from_value(malformed)
+            .expect_err("a malformed payload must not decode to an empty result set");
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("decode search candidates"),
+            "and the failure must say what could not be read: {rendered}"
+        );
     }
 
     #[test]
@@ -31388,6 +31504,38 @@ mod vault_command_config_parity_tests {
         assert_eq!(
             config.as_deref(),
             Some(std::path::Path::new("/etc/nestweaver/instance.toml"))
+        );
+    }
+}
+
+#[cfg(test)]
+mod optional_count_rendering_tests {
+    use super::render_optional_count;
+
+    /// nw-269: the whole point is that "unreadable" and "zero" must not print
+    /// the same. Both directions asserted, because either alone is satisfiable
+    /// by a renderer that always says one thing.
+    #[test]
+    fn unknown_and_zero_do_not_render_alike() {
+        let unknown = render_optional_count(Some(&serde_json::Value::Null));
+        let absent = render_optional_count(None);
+        let zero = render_optional_count(Some(&serde_json::json!(0)));
+        let real = render_optional_count(Some(&serde_json::json!(42)));
+
+        assert_eq!(zero, "0", "a real zero must render as a plain 0");
+        assert_eq!(real, "42", "a real count must render as itself");
+        assert_ne!(
+            unknown, zero,
+            "an unreadable count must not render like a real zero — that is the \
+             entire defect"
+        );
+        assert_eq!(
+            unknown, absent,
+            "an explicit null and a missing key are the same state: not read"
+        );
+        assert!(
+            unknown.contains("unavailable") && unknown.contains("NOT zero"),
+            "and it must say so in words a reader cannot mistake: {unknown}"
         );
     }
 }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -4702,3 +4702,198 @@ fn indexing_records_the_data_instance_id() {
          matters"
     );
 }
+
+/// nw-268: `pre-push-impact --max-depth` is bounded at parse time.
+///
+/// It had no `value_parser`, so a mistyped `--max-depth 100000` arrived as a
+/// real instruction and became an unbounded transitive graph walk. The gRPC
+/// half accepted whatever it was sent, while its own sibling traversal
+/// (`remaining_depth`) had clamped at 64 all along — two limits, one absent.
+///
+/// Asserts WHICH error, not merely that the command failed. My first version
+/// checked only a non-zero exit and passed with the bound removed, because
+/// `pre-push-impact` without `--local-changes` or `--diff` already exits
+/// non-zero for an unrelated reason. A refusal is only evidence when it is the
+/// refusal you asked for.
+#[test]
+fn pre_push_impact_depth_is_bounded_at_parse_time() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.lbug");
+    drop(nestweaver_store::GraphStore::open_or_create(&db_path).unwrap());
+
+    let depth_error = |depth: &str| -> String {
+        let out = nestweaver_cmd()
+            .args([
+                "pre-push-impact",
+                "--db",
+                &db_path.display().to_string(),
+                "--max-depth",
+                depth,
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            !out.status.success(),
+            "`--max-depth {depth}` unexpectedly succeeded"
+        );
+        String::from_utf8_lossy(&out.stderr).to_lowercase()
+    };
+
+    // Past the ceiling: a PARSE error naming the range.
+    let past = depth_error("100000");
+    assert!(
+        past.contains("invalid value") || past.contains("not in"),
+        "an out-of-range --max-depth must be refused by the parser, naming the \
+         range — not accepted and turned into an unbounded walk:\n{past}"
+    );
+
+    // The counterweight: an in-range depth must get PAST parsing. It still
+    // fails, on the missing `--local-changes`/`--diff` — which is exactly the
+    // error that made the naive version of this test vacuous, so asserting it
+    // here is what proves the two cases are distinguishable at all.
+    let ok = depth_error("8");
+    assert!(
+        ok.contains("--local-changes") || ok.contains("--diff"),
+        "a depth within the bound must parse and fail later, on the missing \
+         change source:\n{ok}"
+    );
+
+    // The boundary, as LITERALS. Deriving these from the constant would make
+    // the test agree with whatever the constant says.
+    let at_limit = depth_error("64");
+    assert!(
+        at_limit.contains("--local-changes") || at_limit.contains("--diff"),
+        "64 is the documented ceiling and must parse:\n{at_limit}"
+    );
+    let past_limit = depth_error("65");
+    assert!(
+        past_limit.contains("invalid value") || past_limit.contains("not in"),
+        "65 is past the documented ceiling and must be refused by the parser:\n{past_limit}"
+    );
+}
+
+/// nw-269: an unreadable count must render as unavailable, never as `0`.
+///
+/// Unit-level because the failure it guards — a per-vault `list_notes` erroring
+/// — cannot be provoked from the CLI without corrupting a store mid-run. What
+/// CAN be pinned exactly is the rendering decision, which is where all three
+/// instances of this bug have lived: `unwrap_or(0)` on a value the producer
+/// deliberately nulled.
+///
+/// Three counts in `main.rs` have needed this (top-level `brain status`
+/// totals, per-vault note counts, and `stale-check`'s commits-behind in
+/// nw-256), and each hand-rolled copy drifted back to `unwrap_or(0)` at least
+/// once — so the renderer is shared and this pins the shared one.
+#[test]
+fn an_unreadable_count_is_never_rendered_as_zero() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.lbug");
+    drop(nestweaver_store::GraphStore::open_or_create(&db_path).unwrap());
+
+    // A vault with genuinely nothing in it must still say "0 notes" — the
+    // counterweight. Without it, a renderer that called EVERYTHING unavailable
+    // would pass the assertion that matters.
+    let output = nestweaver_cmd()
+        .args(["brain", "status", "--db", &db_path.display().to_string()])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "brain status on an empty database must succeed:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("unavailable (could not be read"),
+        "a database that reads fine must report real counts, not unavailable:\n{stdout}"
+    );
+}
+
+/// nw-270: `summary --json` must disclose the symbol cap.
+///
+/// `SymbolSummaries` carries `matched_total` and `capped` — its own doc says
+/// "so callers can report honest truncation" — and this caller kept only
+/// `summaries`. `truncated` was then computed against the ALREADY-CAPPED
+/// length, so a 500-of-N answer reported `total: 500, truncated: false`. The
+/// cap was invisible in exactly the field that exists to disclose it.
+///
+/// Needs a corpus larger than `DEFAULT_SYMBOL_SUMMARY_CAP` (500) for the cap
+/// to bind at all — a smaller fixture cannot distinguish the states and the
+/// test would pass either way.
+#[test]
+fn summary_json_discloses_the_symbol_cap() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.lbug");
+    let repo = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+
+    let mut src = String::new();
+    for i in 0..640 {
+        src.push_str(&format!("export function fn{i}() {{ return {i}; }}\n"));
+    }
+    std::fs::write(repo.join("many.js"), src).unwrap();
+    let git = |args: &[&str]| {
+        let status = StdCommand::new("git")
+            .args(args)
+            .current_dir(&repo)
+            .status()
+            .expect("git failed to spawn");
+        assert!(status.success(), "git {args:?} failed");
+    };
+    git(&["init"]);
+    git(&["config", "user.email", "test@test.com"]);
+    git(&["config", "user.name", "Test"]);
+    git(&["add", "many.js"]);
+    git(&["commit", "-m", "init"]);
+
+    nestweaver_cmd()
+        .args([
+            "index",
+            "--repo",
+            &repo.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .assert()
+        .success();
+
+    let output = nestweaver_cmd()
+        .args([
+            "summary",
+            "--db",
+            &db_path.display().to_string(),
+            "--level",
+            "symbol",
+            "--token-budget",
+            "0",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("summary --json: {e}\n{}", &stdout[..stdout.len().min(400)]));
+
+    let returned = parsed["returned"].as_u64().expect("returned");
+    let total = parsed["total"].as_u64().expect("total");
+    let truncated = parsed["truncated"].as_bool().expect("truncated");
+
+    // The counterweight: the cap must actually have bound. If the indexer
+    // produced fewer than 500 symbols this proves nothing, and would pass
+    // against the unfixed code.
+    assert_eq!(
+        returned, 500,
+        "the fixture must exceed the 500-symbol cap for this to test anything; \
+         got {returned} returned of {total}"
+    );
+    assert!(
+        truncated,
+        "a capped answer must report truncated: true — reporting false is the \
+         defect:\n returned={returned} total={total}"
+    );
+    assert!(
+        total > returned,
+        "`total` must count what MATCHED, not what survived the cap; \
+         returned == total beside truncated:true is a contradiction \
+         (returned={returned}, total={total})"
+    );
+}

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -1398,3 +1398,59 @@ fn the_same_cli_writer_succeeds_once_the_daemon_is_gone() {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+/// nw-267: `watch` and `brain watch` must take the WRITE LEASE before running
+/// a direct watcher.
+///
+/// Both fell back to a direct watcher after a point-in-time
+/// `daemon_process_running_for_db` probe — a check of a different file,
+/// followed by a writer that runs for HOURS. That is CWE-367, and it is
+/// verbatim the construct `embed` removed; `embed`'s comment is still in the
+/// tree calling it "CWE-367 exactly" and quoting MITRE's mitigation: *"ensure
+/// that locking occurs before the check, as opposed to afterwards."*
+///
+/// Of five production write paths, these two were the ones that never took the
+/// lease. The `.lock` PID file they write is a hint for readers, not a lock —
+/// it cannot survive PID reuse and an operator's `rm` erases it.
+///
+/// Probed the same way as `a_cli_writer_is_refused_while_the_daemon_holds_the_lease`:
+/// with the daemon holding the lease, a direct watcher must refuse rather than
+/// start indexing into a store it does not own.
+#[test]
+fn a_direct_watcher_is_refused_while_the_daemon_holds_the_lease() {
+    let fixture = setup_fixture();
+    let repo_dir = fixture.db_path.parent().unwrap().join("watched-repo");
+    write_repo_files(
+        &repo_dir,
+        &[("src/a.js", "export function one() { return 1; }\n")],
+    );
+    let vault_dir = fixture.db_path.parent().unwrap().join("watched-vault");
+    std::fs::create_dir_all(&vault_dir).unwrap();
+    std::fs::write(vault_dir.join("note.md"), "# Note\n").unwrap();
+
+    let _guard = DaemonGuard::new(&fixture.db_path);
+    start_daemon(&fixture.db_path);
+
+    let repo_arg = repo_dir.display().to_string();
+    let vault_arg = vault_dir.display().to_string();
+    for (label, args) in [
+        ("watch", vec!["watch", repo_arg.as_str()]),
+        ("brain watch", vec!["brain", "watch", vault_arg.as_str()]),
+    ] {
+        let output = run_direct(&fixture.db_path, &args);
+
+        assert!(
+            !output.status.success(),
+            "`{label}` must refuse to run a direct watcher while the daemon \
+             holds the lease; a watcher that starts here writes into a store it \
+             does not own, for hours.\nstdout:\n{}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        let stderr = flatten_miette(&output.stderr);
+        assert!(
+            stderr.contains("write lease") || stderr.contains("holds the write lock"),
+            "`{label}`'s refusal must name who owns the database, not surface a \
+             generic I/O error:\n{stderr}"
+        );
+    }
+}


### PR DESCRIPTION
nw-266..nw-271, one branch one CI cycle. Every fix has a test verified by reverting the fix and watching it go red.

Three of the six are closed by **sharing an implementation** rather than restating one, because the recurring shape across this review has been *one route fixed and its twin left* — five times, in two function pairs.

## nw-266 — `stale-check`'s third divergence (blocker)

The CLI route never asked the remote. `grep -c ls-remote src/main.rs` was **0**; `tools.rs` had it twice. `local_root()` is `None` whenever `root_path` is empty and the url is not `file://` — precisely the case `get_remote_head` exists to serve — and the CLI hardcoded `None` there. A genuinely stale repo reported `ok` and exited 0, so **a CI gate built on `stale-check` passed**.

Third divergence in this one pair, after nw-163 (`is_stale`) and nw-256 (`commits_behind`). Each previous fix left a comment asserting the routes must not drift, and the next divergence appeared underneath it.

New `nestweaver-engine/src/repo_head.rs` owns `local_head`, `remote_head`, `current_head`, `commits_between`, `is_full_sha`. Both routes **call** it, and the three private copies in `tools.rs` are deleted — a leftover copy is where a fourth divergence starts.

Tested offline: a local bare repo is a perfectly good git remote, so `ls-remote` is exercised for real with no network.

## nw-267 — `watch` wrote for hours with no lease (blocker), **and its twin**

`watch` guarded its direct fallback with a point-in-time `daemon_process_running_for_db` probe — a check of a different file, followed by a writer that runs for hours. CWE-367, and verbatim the construct `embed` removed; `embed`'s comment is still in the tree calling it *"CWE-367 exactly"* and quoting MITRE's mitigation.

**`brain watch` had the same hole and was not in the report.** Fixed both.

The `.lock` PID file both write is a hint to readers, not a lock — it cannot survive PID reuse and an operator's `rm` erases it.

## nw-268 — unbounded impact depth

The `ImpactAnalysis` handler accepted any `max_depth` while its sibling traversal clamped at 64, and `pre-push-impact --max-depth` had no `value_parser` at all — so `--max-depth 100000` was an instruction rather than a usage error. One `MAX_IMPACT_DEPTH` now feeds both the clamp and the clap range.

## nw-269 — an unreadable count rendered as zero

The MCP route nulls per-vault `note_count` when `list_notes` fails; both CLI renderers collapsed it back to `0`, so a vault that could not be read displayed as "0 notes" beside vaults that genuinely had none. The direct route was worse — `unwrap_or_default().len()` meant the error never even became a null.

Three counts in `main.rs` have needed this rendering, and each hand-rolled copy drifted back to `unwrap_or(0)` at least once, so `render_optional_count` is shared.

## nw-270 — a cap reported as `truncated: false`

`SymbolSummaries` carries `matched_total` and `capped` — its own doc says *"so callers can report honest truncation"* — and `summary --json` discarded both, computing `truncated` against the already-capped length. A 500-of-40,000 answer reported `total: 500, truncated: false`. The cap was invisible in exactly the field that exists to disclose it.

## nw-271 — decode failures folding into confident empties

Three production sites turned "I could not read the daemon's answer" into "the answer was empty", then printed "no impact" / "No implicit projects detected" / an empty result set. The nw-249 fix comment for this same shape sits at the top of the file.

## Two of these tests were hollow first

Recorded because the mutation step caught them, not care:

- **nw-268's** first version asserted only a non-zero exit, and passed with the bound removed — `pre-push-impact` already exits non-zero when `--local-changes` is missing. Now asserts *which* error.
- **nw-267's** first version invoked `watch --repo <path>`; `watch` takes a positional. It failed on the reason rather than passing on the wrong exit, because the assertion named why it refused.

**A refusal is only evidence when it is the refusal you asked for.** A bare `assert!(!success())` goes green on a usage error and pins nothing.

## Verification

```
cargo fmt --all --check                                → 0
cargo clippy --workspace --all-targets -- -D warnings  → 0
cargo test --workspace --all-targets                   → 0   (3861 passed, 0 failed)
```

Not included, deliberately: **nw-263** (needs a design decision on where the lock lives) and **nw-272** (the mutation job's own regression).
