### PR TITLE
fix: nine delta findings, two of them regressions we introduced

### DIFF
--- a/crates/nestweaver-daemon/src/lifecycle.rs
+++ b/crates/nestweaver-daemon/src/lifecycle.rs
@@ -906,6 +906,17 @@ pub fn write_lease_path(db_path: &Path) -> PathBuf {
 /// question a check-then-write cannot ask. Every comparable embedded store —
 /// SQLite, RocksDB, LMDB, DuckDB, Kuzu — holds a lock for the lifetime of the
 /// handle for exactly this reason.
+// nw-274: `#[must_use]` on the TYPE, not only on the helper that returns it.
+//
+// The single `#[must_use]` guarding this lived on `require_exclusive_store_access`
+// in `main.rs`, and an unrelated function inserted above it silently detached
+// the attribute — the fifth docblock detachment this release. A per-function
+// attribute protects one function and can be separated from it by an edit
+// elsewhere; on the type it covers every present and future producer, and
+// nothing can come between them.
+#[must_use = "the lease must be HELD for the duration of the write; dropping it \
+              immediately reduces this to a probe, which is the check-then-act \
+              race it exists to remove"]
 #[derive(Debug)]
 pub struct DbWriteLease {
     _file: std::fs::File,

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -931,14 +931,23 @@ pub struct DaemonState {
     /// repo/symbol/note we write, so users see and type one name everywhere
     /// (nw-019). Config-less starts collapse it back onto `instance_id`.
     pub data_instance_id: String,
-    /// nw-246: instances observed in a database that stated none, when there is
-    /// more than one. Empty in the normal case.
+    /// nw-246/nw-275: whether the daemon's own configuration NAMED an
+    /// instance.
     ///
-    /// Carried rather than fatal at startup: refusing to boot would block
-    /// READS, and reads are instance-agnostic. The ambiguity only has to be
-    /// refused where it can actually fork the graph, which is a write that
-    /// states no instance of its own.
-    pub ambiguous_instance_ids: Vec<String>,
+    /// This is a fact about how the daemon was started, so it is genuinely
+    /// immutable for the process's lifetime — unlike the set of instances the
+    /// database holds, which is not. That set was originally snapshotted here
+    /// at boot and read frozen by ten consumers, so a database that became
+    /// multi-instance DURING the daemon's lifetime stayed unguarded for the
+    /// rest of it, while the CLI re-read on every invocation. The two routes
+    /// nw-246 aligned would have diverged again on staleness rather than
+    /// logic.
+    ///
+    /// The ambiguity itself is now queried live at the write choke point.
+    /// `observed_instance_ids` scans only Repo and Vault nodes with DISTINCT,
+    /// so it costs a small query on writes that state no instance — and
+    /// nothing at all on the ones that do.
+    pub instance_stated_by_config: bool,
     pub start_time: Instant,
     pub active_reads: Arc<AtomicU32>,
     pub active_writes: Arc<AtomicU32>,
@@ -1146,11 +1155,26 @@ fn build_daemon_permission_source(
 /// `default` and split the graph. It sends empty now, and a config-less
 /// daemon's `data_instance_id` is "default" rather than a db-path hash, so the
 /// two paths agree without either compensating for the other.
-fn resolve_effective_instance_id(
-    requested: &str,
-    configured: &str,
-    ambiguous: &[String],
-) -> Result<String, Status> {
+/// The PURE half: request beats configured default, and the winner is
+/// validated.
+///
+/// Split from the policy below so it stays testable by value. The ambiguity
+/// guard needs the store (nw-275 made it a live query, not a boot snapshot);
+/// this does not, and forcing a `DaemonState` through it would have made a
+/// handful of table-driven validation tests build a daemon.
+fn pick_effective_instance_id(requested: &str, configured: &str) -> Result<String, Status> {
+    let effective = if requested.is_empty() {
+        configured
+    } else {
+        requested
+    };
+    nestweaver_engine::validate_instance_id(effective)
+        .map_err(|error| Status::invalid_argument(format!("{error:#}")))?;
+    Ok(effective.to_string())
+}
+
+fn resolve_effective_instance_id(requested: &str, state: &DaemonState) -> Result<String, Status> {
+    let configured = state.data_instance_id.as_str();
     // nw-246: a request that states no instance, against a database holding
     // several and having stated none itself, has no safe default. Adopting one
     // is how the fork deepens.
@@ -1165,24 +1189,39 @@ fn resolve_effective_instance_id(
     // `merge`/`purge` state both ids explicitly and so pass through untouched —
     // which matters, because `instance merge` is the documented REMEDY for
     // this exact state and must not be refused by the guard warning about it.
-    if requested.is_empty() && !ambiguous.is_empty() {
+    // nw-275: queried LIVE, not read from a boot snapshot. A database can
+    // become multi-instance while this daemon is running — an explicitly
+    // instanced write is exactly how — and the guard has to see the database
+    // as it is at the moment of the write, not as it was at startup.
+    let ambiguous: Vec<String> = if requested.is_empty() && !state.instance_stated_by_config {
+        state.store.observed_instance_ids().unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    if requested.is_empty() && ambiguous.len() > 1 {
         return Err(Status::failed_precondition(format!(
+            // nw-277: `--config` is NOT offered here, deliberately. This
+            // refusal comes from a RUNNING daemon, and `IndexRepoRequest`
+            // carries no config field — the daemon's own configuration is
+            // fixed at start. A user who follows a `--config` suggestion
+            // re-runs the command, sends the same empty instance, and gets the
+            // same refusal, having done exactly what the error told them to.
+            //
+            // `--instance` IS carried per-request, so it works. Restarting the
+            // daemon under a config also works, and is named as the second
+            // option because it is the one a `--config` user actually wants.
             "this database holds data under {} instances ({}), and neither this \
              request nor the daemon's configuration named one, so there is no safe \
-             default.\nName one with `--instance <id>` or a `--config`, or \
-             consolidate them with `nestweaver instance merge --from <one> --to <keep>`.",
+             default.\nName one per-request with `--instance <id>`; or restart the \
+             daemon under a config that names one (`nestweaver daemon --db <path> \
+             stop`, then `start --config <path>`) — a `--config` on this command \
+             cannot reach a daemon that is already running; or consolidate them \
+             with `nestweaver instance merge --from <one> --to <keep>`.",
             ambiguous.len(),
             ambiguous.join(", ")
         )));
     }
-    let effective = if requested.is_empty() {
-        configured
-    } else {
-        requested
-    };
-    nestweaver_engine::validate_instance_id(effective)
-        .map_err(|error| Status::invalid_argument(format!("{error:#}")))?;
-    Ok(effective.to_string())
+    pick_effective_instance_id(requested, configured)
 }
 
 /// Build the terminal `Phase::Done` message for `IndexRepo`. When
@@ -2354,11 +2393,11 @@ mod instance_id_validation_tests {
     #[test]
     fn effective_instance_id_uses_request_then_configured_default() {
         assert_eq!(
-            resolve_effective_instance_id("request-id", "configured-id", &[]).unwrap(),
+            pick_effective_instance_id("request-id", "configured-id").unwrap(),
             "request-id"
         );
         assert_eq!(
-            resolve_effective_instance_id("", "configured-id", &[]).unwrap(),
+            pick_effective_instance_id("", "configured-id").unwrap(),
             "configured-id"
         );
     }
@@ -2373,7 +2412,7 @@ mod instance_id_validation_tests {
             ("", "configured:bad"),
             ("", "configured bad"),
         ] {
-            let error = resolve_effective_instance_id(requested, configured, &[]).unwrap_err();
+            let error = pick_effective_instance_id(requested, configured).unwrap_err();
             assert_eq!(error.code(), tonic::Code::InvalidArgument);
             assert!(
                 error.message().contains("instance_id"),
@@ -3984,11 +4023,7 @@ impl NestWeaverDaemon for DaemonService {
         let req = request.into_inner();
         let vault_path = PathBuf::from(&req.vault_path);
         let vault_name = req.vault_name.clone();
-        let instance_id = resolve_effective_instance_id(
-            &req.instance_id,
-            &self.state.data_instance_id,
-            &self.state.ambiguous_instance_ids,
-        )?;
+        let instance_id = resolve_effective_instance_id(&req.instance_id, &self.state)?;
         let extra_patterns = req.extra_ignore_patterns.clone();
         let force = req.force;
 
@@ -4125,11 +4160,7 @@ impl NestWeaverDaemon for DaemonService {
         let req = request.into_inner();
         let repo_path = PathBuf::from(&req.repo_path);
         let force = req.force;
-        let instance_id = resolve_effective_instance_id(
-            &req.instance_id,
-            &self.state.data_instance_id,
-            &self.state.ambiguous_instance_ids,
-        )?;
+        let instance_id = resolve_effective_instance_id(&req.instance_id, &self.state)?;
 
         if !repo_path.exists() || !repo_path.is_dir() {
             return Ok(Response::new(WatchCodeResponse {
@@ -4407,11 +4438,7 @@ impl NestWeaverDaemon for DaemonService {
         }
         let req = request.into_inner();
         let state = self.state.clone();
-        let watch_instance = resolve_effective_instance_id(
-            &req.watch_instance_id,
-            &state.data_instance_id,
-            &state.ambiguous_instance_ids,
-        )?;
+        let watch_instance = resolve_effective_instance_id(&req.watch_instance_id, &state)?;
 
         let app_state = nestweaver_web::state::AppState::new_with_arc_tantivy(
             state.store.clone(),
@@ -4658,11 +4685,7 @@ impl NestWeaverDaemon for DaemonService {
         } else {
             Some(req.name.clone())
         };
-        let effective_instance = resolve_effective_instance_id(
-            &req.instance_id,
-            &state.data_instance_id,
-            &state.ambiguous_instance_ids,
-        )?;
+        let effective_instance = resolve_effective_instance_id(&req.instance_id, &state)?;
         let index_limits = if req.max_source_file_bytes == 0 {
             state
                 .instance_cfg
@@ -5022,11 +5045,7 @@ impl NestWeaverDaemon for DaemonService {
         let vault_path = PathBuf::from(&req.vault_path);
         let vault_name = req.vault_name.clone();
         let extra_patterns = req.extra_ignore_patterns.clone();
-        let instance_id = resolve_effective_instance_id(
-            &req.instance_id,
-            &self.state.data_instance_id,
-            &self.state.ambiguous_instance_ids,
-        )?;
+        let instance_id = resolve_effective_instance_id(&req.instance_id, &self.state)?;
         let state = self.state.clone();
 
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<IndexProgress, Status>>(16);
@@ -5190,11 +5209,7 @@ impl NestWeaverDaemon for DaemonService {
         let vault_path = PathBuf::from(&req.vault_path);
         let vault_name = req.vault_name.clone();
         let extra_patterns = req.extra_ignore_patterns.clone();
-        let instance_id = resolve_effective_instance_id(
-            &req.instance_id,
-            &self.state.data_instance_id,
-            &self.state.ambiguous_instance_ids,
-        )?;
+        let instance_id = resolve_effective_instance_id(&req.instance_id, &self.state)?;
         let since = std::time::UNIX_EPOCH
             .checked_add(Duration::from_secs(req.since_unix_seconds))
             .ok_or_else(|| Status::invalid_argument("since_unix_seconds is out of range"))?;
@@ -5305,11 +5320,7 @@ impl NestWeaverDaemon for DaemonService {
         }
         let req = request.into_inner();
         let config_path = PathBuf::from(&req.config_path);
-        let instance_id = resolve_effective_instance_id(
-            &req.instance_id,
-            &self.state.data_instance_id,
-            &self.state.ambiguous_instance_ids,
-        )?;
+        let instance_id = resolve_effective_instance_id(&req.instance_id, &self.state)?;
         // Configuration I/O and parsing do not mutate the graph and must not
         // occupy the sole writer while a slow filesystem is being read.
         let instance_config =
@@ -5635,16 +5646,8 @@ impl NestWeaverDaemon for DaemonService {
             return Err(Status::permission_denied("admin token required"));
         }
         let req = request.into_inner();
-        let from_id = resolve_effective_instance_id(
-            &req.from_id,
-            &self.state.data_instance_id,
-            &self.state.ambiguous_instance_ids,
-        )?;
-        let to_id = resolve_effective_instance_id(
-            &req.to_id,
-            &self.state.data_instance_id,
-            &self.state.ambiguous_instance_ids,
-        )?;
+        let from_id = resolve_effective_instance_id(&req.from_id, &self.state)?;
+        let to_id = resolve_effective_instance_id(&req.to_id, &self.state)?;
         if from_id == to_id {
             return Err(Status::invalid_argument(
                 "source and target instance IDs must differ",
@@ -5712,11 +5715,7 @@ impl NestWeaverDaemon for DaemonService {
             return Err(Status::permission_denied("admin token required"));
         }
         let req = request.into_inner();
-        let instance_id = resolve_effective_instance_id(
-            &req.instance_id,
-            &self.state.data_instance_id,
-            &self.state.ambiguous_instance_ids,
-        )?;
+        let instance_id = resolve_effective_instance_id(&req.instance_id, &self.state)?;
         let state = self.state.clone();
 
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<IndexProgress, Status>>(16);
@@ -10303,7 +10302,7 @@ pub async fn run_server(
         read_only,
         instance_id: instance_id.clone(),
         data_instance_id: data_instance_id.clone(),
-        ambiguous_instance_ids: ambiguous_instance_ids.clone(),
+        instance_stated_by_config: instance_cfg.is_some(),
         start_time: Instant::now(),
         active_reads: Arc::new(AtomicU32::new(0)),
         active_writes: Arc::new(AtomicU32::new(0)),
@@ -11835,7 +11834,13 @@ fn flow_trace_continue_impl(
     // Hard-cap depth: a peer daemon could send a huge remaining_depth, and the recursive
     // walk_trace below would otherwise overflow the stack. This typed RPC bypasses the
     // JSON-dispatch depth clamp, so it needs its own bound.
-    let max_depth = (req.remaining_depth.max(0) as usize).min(64);
+    // nw-277: shares `MAX_IMPACT_DEPTH` with the handler and the CLI flag.
+    // nw-268 introduced that constant with a doc comment saying "64 matches the
+    // sibling that already had it" — and left the sibling as a literal, so the
+    // claim was true only by coincidence and the next edit to either would have
+    // ended it.
+    let max_depth = (req.remaining_depth.max(0) as usize)
+        .min(nestweaver_engine::atomic_changes::MAX_IMPACT_DEPTH as usize);
     let trace_id = req.trace_id.clone();
 
     // Build the visited set from the request.
@@ -15680,7 +15685,7 @@ mod startup_helper_tests {
         // The reported case: a client with no config of its own now sends
         // EMPTY, and the daemon's configured identity wins.
         assert_eq!(
-            resolve_effective_instance_id("", "kory-brain", &[]).unwrap(),
+            pick_effective_instance_id("", "kory-brain").unwrap(),
             "kory-brain",
             "an unspecified instance must defer to the daemon, not override it"
         );
@@ -15688,7 +15693,7 @@ mod startup_helper_tests {
         // A caller that NAMES an instance is still obeyed — multi-instance
         // targeting is a real feature and this must not break it.
         assert_eq!(
-            resolve_effective_instance_id("other-brain", "kory-brain", &[]).unwrap(),
+            pick_effective_instance_id("other-brain", "kory-brain").unwrap(),
             "other-brain"
         );
 
@@ -15697,13 +15702,13 @@ mod startup_helper_tests {
         // mismatch is what forced clients to send "default" explicitly — the
         // compensation that caused the override.
         assert_eq!(
-            resolve_effective_instance_id("", "default", &[]).unwrap(),
+            pick_effective_instance_id("", "default").unwrap(),
             "default"
         );
 
         // An invalid instance is still rejected at this trust boundary rather
         // than silently producing an ambiguous uid.
-        assert!(resolve_effective_instance_id("a:b", "default", &[]).is_err());
+        assert!(pick_effective_instance_id("a:b", "default").is_err());
     }
 
     /// The gRPC mutating-tool gate MUST reference the single shared
@@ -16783,7 +16788,7 @@ mod startup_helper_tests {
             db_path,
             instance_id: "default".to_string(),
             data_instance_id: "default".to_string(),
-            ambiguous_instance_ids: Vec::new(),
+            instance_stated_by_config: false,
             start_time: Instant::now(),
             active_reads: Arc::new(AtomicU32::new(0)),
             active_writes: Arc::new(AtomicU32::new(0)),
@@ -16868,7 +16873,7 @@ credential_method = "gh"
             db_path: std::path::PathBuf::from(":memory:"),
             instance_id: "default".to_string(),
             data_instance_id: "default".to_string(),
-            ambiguous_instance_ids: Vec::new(),
+            instance_stated_by_config: false,
             start_time: Instant::now(),
             active_reads: Arc::new(AtomicU32::new(0)),
             active_writes: Arc::new(AtomicU32::new(0)),

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -2679,8 +2679,6 @@ where
     // scan/parse/collection so worker threads can fan out expensive parsing and
     // only serialize LadybugDB writes.
     let r_uid = repo_uid(instance_id, repo_url);
-    // The funnel the CLI index actually reaches (nw-246).
-    record_data_instance(store, instance_id);
 
     // Re-identify detection MUST happen before the scan/parse phases: the
     // filemeta sidecar was recorded when this working tree's graph rows
@@ -3289,6 +3287,18 @@ where
     };
 
     let _write_guard = acquire_write_guard()?;
+
+    // nw-246/nw-277: minted INSIDE the write guard, not ~600 lines earlier.
+    //
+    // `ensure_data_instance_id` never replaces an existing value, so recording
+    // before the guard meant an index that failed during scan or parse — a bad
+    // path, an unreadable file, a cancellation — had already stamped the
+    // database's identity permanently, under an instance whose write never
+    // landed. The identity of the data has to be established where the data
+    // is, which is here.
+    //
+    // This is also the funnel the CLI index actually reaches (nw-246).
+    record_data_instance(store, instance_id);
 
     let contract_plan = match contract_plan_result {
         Ok(plan) => plan,

--- a/crates/nestweaver-engine/src/repo_head.rs
+++ b/crates/nestweaver-engine/src/repo_head.rs
@@ -34,8 +34,32 @@ pub fn local_head(repo_path: &str) -> Option<String> {
 /// Works for SSH (`git@github.com:…`) and HTTPS URLs. Stderr is suppressed so
 /// SSH key errors and other diagnostics do not leak into tool responses.
 pub fn remote_head(url: &str) -> Option<String> {
+    // nw-276: guardrails, because nw-266 made a code path that previously
+    // performed NO network call start performing one — on a command the
+    // codebase itself calls a CI freshness gate.
+    //
+    // * `GIT_TERMINAL_PROMPT=0` and `GIT_ASKPASS`/`SSH_ASKPASS` — a private
+    //   repo with no usable credentials otherwise PROMPTS. In CI there is
+    //   nobody to answer.
+    // * `stdin(null)` — inherited stdin is what lets a prompt block forever.
+    //   Suppressing the prompt and leaving stdin attached still hangs on
+    //   `ssh`'s own host-key confirmation.
+    // * `--exit-code` keeps "reachable but empty" distinct from "unreachable".
+    //
+    // A timeout is deliberately NOT implemented with a thread+kill dance here:
+    // `git` honours these env vars by failing fast, and the mechanisms above
+    // remove the cases that hang. `stale-check`'s callers apply their own
+    // budget.
     let output = std::process::Command::new("git")
         .args(["ls-remote", "--exit-code", url, "HEAD"])
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_ASKPASS", "")
+        .env("SSH_ASKPASS", "")
+        .env(
+            "GIT_SSH_COMMAND",
+            "ssh -oBatchMode=yes -oStrictHostKeyChecking=accept-new",
+        )
+        .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
         .output()
@@ -201,5 +225,77 @@ mod tests {
             None,
             "an unreachable range cannot be counted, and must not be reported as 0"
         );
+    }
+}
+
+#[cfg(test)]
+mod remote_guardrail_tests {
+    use super::*;
+
+    /// nw-276: an unreachable remote must FAIL, not hang waiting for input.
+    ///
+    /// nw-266 made this branch perform a network call where it previously made
+    /// none, on a command the codebase calls a CI freshness gate. Without
+    /// `GIT_TERMINAL_PROMPT=0`, a null stdin, and SSH batch mode, a private
+    /// repo with no usable credentials prompts — and in CI nobody answers.
+    ///
+    /// A nonexistent local path is the cheapest unreachable remote there is:
+    /// no network, no waiting, and `git` still takes the same credential and
+    /// prompt paths.
+    #[test]
+    fn an_unreachable_remote_returns_none_promptly() {
+        let started = std::time::Instant::now();
+        let resolved = remote_head("/nonexistent/definitely-not-a-repo.git");
+        let elapsed = started.elapsed();
+
+        assert_eq!(
+            resolved, None,
+            "an unreachable remote must resolve to None, not a fabricated sha"
+        );
+        // Generous, because this asserts "did not hang", not a latency budget.
+        // A prompt-blocked `git` never returns at all.
+        assert!(
+            elapsed < std::time::Duration::from_secs(30),
+            "resolving an unreachable remote took {elapsed:?} — it should fail \
+             fast, not block on a credential or host-key prompt"
+        );
+    }
+
+    /// The counterweight: the guardrails must not have broken the working case.
+    /// Without this, a `remote_head` that always returned `None` would satisfy
+    /// the assertion above perfectly.
+    #[test]
+    fn the_guardrails_do_not_break_a_reachable_remote() {
+        let dir = tempfile::tempdir().unwrap();
+        let work = dir.path().join("work");
+        let bare = dir.path().join("origin.git");
+        std::fs::create_dir(&work).unwrap();
+        let git = |d: &std::path::Path, args: &[&str]| {
+            let status = std::process::Command::new("git")
+                .args(args)
+                .current_dir(d)
+                .status()
+                .expect("git must be available");
+            assert!(status.success(), "git {args:?} failed");
+        };
+        git(&work, &["init"]);
+        git(&work, &["config", "user.email", "t@t.com"]);
+        git(&work, &["config", "user.name", "T"]);
+        std::fs::write(work.join("a.txt"), "hello").unwrap();
+        git(&work, &["add", "a.txt"]);
+        git(&work, &["commit", "-m", "one"]);
+        git(
+            dir.path(),
+            &[
+                "clone",
+                "--bare",
+                work.to_str().unwrap(),
+                bare.to_str().unwrap(),
+            ],
+        );
+
+        let head = remote_head(bare.to_str().unwrap())
+            .expect("a reachable remote must still resolve with the guardrails on");
+        assert!(is_full_sha(&head), "expected a 40-hex sha, got {head:?}");
     }
 }

--- a/crates/nestweaver-engine/tests/index_cancellation.rs
+++ b/crates/nestweaver-engine/tests/index_cancellation.rs
@@ -214,3 +214,63 @@ fn uncancelled_reader_index_still_reads_and_writes() {
     );
     assert!(!store.list_repos(None).unwrap().is_empty());
 }
+
+/// nw-277: a failed index must not permanently mint the data instance id.
+///
+/// `ensure_data_instance_id` never replaces an existing value, and
+/// `record_data_instance` used to run ~600 lines BEFORE the write guard. An
+/// index that died after that point — during scan, parse, or on the guard
+/// itself — had already stamped the database's identity under an instance
+/// whose data never landed, and the stamp is permanent.
+///
+/// The write guard is an injectable closure, which makes this exact: a guard
+/// that REFUSES is a failure that lands squarely between the old minting
+/// point and the write. A missing repo path is not — that fails before the
+/// funnel is entered, which is why the first version of this test passed with
+/// the fix reverted.
+#[test]
+fn an_index_that_fails_at_the_write_gate_does_not_mint_the_instance_id() {
+    let store = GraphStore::in_memory().unwrap();
+    let reader = FilesystemReader::new(&testdata_js());
+
+    let result = nestweaver_engine::index_with_reader_and_write_gate(
+        &reader,
+        &store,
+        "never-landed",
+        "file:///test/js",
+        "abc",
+        None,
+        None,
+        || Err::<(), anyhow::Error>(anyhow::anyhow!("write gate refused")),
+    );
+
+    assert!(result.is_err(), "the guard refused, so the index must fail");
+    assert_eq!(
+        store.data_instance_id().unwrap(),
+        None,
+        "an index that never reached the write must not have minted an \
+         identity — `ensure_data_instance_id` never replaces, so this one \
+         would be permanent and would describe nothing in the graph"
+    );
+
+    // The counterweight: the SAME call with a guard that succeeds must mint.
+    // Without it, simply deleting `record_data_instance` would pass above.
+    let store = GraphStore::in_memory().unwrap();
+    let reader = FilesystemReader::new(&testdata_js());
+    nestweaver_engine::index_with_reader_and_write_gate(
+        &reader,
+        &store,
+        "did-land",
+        "file:///test/js",
+        "abc",
+        None,
+        None,
+        || Ok::<(), anyhow::Error>(()),
+    )
+    .expect("an unobstructed index must succeed");
+    assert_eq!(
+        store.data_instance_id().unwrap().as_deref(),
+        Some("did-land"),
+        "a successful index must still mint the identity"
+    );
+}

--- a/docs/guide/publication-rebuild.md
+++ b/docs/guide/publication-rebuild.md
@@ -9,8 +9,14 @@ change `CURRENT` until every artifact validates.
 
 Stop the daemon and any external watchers, then run:
 
+> `daemon stop` takes `--db`, not `--config`: the daemon subtree has no
+> config-based database resolution, so `--config` is rejected outright and a
+> bare `daemon stop` fails with "No database path provided". Its siblings
+> `daemon start` and `publication rebuild` DO take `--config`, which is what
+> makes this easy to miss.
+
 ```sh
-nestweaver daemon stop --config /path/to/instance.toml
+nestweaver daemon --db /path/to/brain.lbug stop
 nestweaver publication rebuild --config /path/to/instance.toml
 nestweaver daemon start --config /path/to/instance.toml
 ```
@@ -83,7 +89,7 @@ The predecessor remains retained after activation. If post-cutover validation
 finds a problem, stop the daemon and switch back without rebuilding:
 
 ```sh
-nestweaver daemon stop --config /path/to/instance.toml
+nestweaver daemon --db /path/to/brain.lbug stop
 nestweaver publication rollback --config /path/to/instance.toml
 nestweaver daemon start --config /path/to/instance.toml
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -4236,6 +4236,18 @@ enum BrainCommands {
             help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
         )]
         db: Option<PathBuf>,
+        // nw-280: `--config` like `list-repos` and `list-projects`, the two
+        // commands this one is documented alongside. The upgrade runbook's
+        // step 4 ("verify one convention everywhere") tells a config-driven
+        // user to add `--config` to all three; on this one it was rejected,
+        // and dropping it silently reads `./nestweaver.lbug` — the wrong
+        // database, reporting a clean result. A verification step that cannot
+        // be run as written is worse than one that is absent.
+        #[arg(
+            long,
+            help = "Path to instance config (TOML) — uses its instance_id and db field"
+        )]
+        config: Option<PathBuf>,
     },
     /// Show overall brain status: vault count, note count, source kinds.
     Status {
@@ -9057,30 +9069,6 @@ fn resolve_track_interactions(force_on: bool, force_off: bool, config_enabled: b
 #[must_use = "the lease must be HELD for the duration of the write; dropping it \
               immediately reduces this to a probe, which is the check-then-act \
               race it exists to remove"]
-/// Render a count that may be UNKNOWN.
-///
-/// nw-269: `unwrap_or(0)` on a count the producer deliberately nulled turns "I
-/// could not read this" into "there are none" — the two states a reader most
-/// needs told apart. The MCP route already emits `null` on a failed per-vault
-/// `list_notes`; both CLI renderers collapsed it back to `0`, so a vault whose
-/// notes could not be read displayed as "0 notes" beside vaults that genuinely
-/// had none.
-///
-/// Shared rather than restated, because this is the third count in this file
-/// to need it (top-level `brain status` totals, per-vault note counts, and
-/// `stale-check`'s commits-behind in nw-256) and each hand-rolled copy has
-/// drifted back to `unwrap_or(0)` at least once.
-fn render_optional_count(value: Option<&serde_json::Value>) -> String {
-    match value {
-        Some(serde_json::Value::Null) | None => {
-            "unavailable (could not be read — NOT zero)".to_string()
-        }
-        Some(found) => found
-            .as_u64()
-            .map_or_else(|| found.to_string(), |n| n.to_string()),
-    }
-}
-
 fn require_exclusive_store_access(
     db_path: &std::path::Path,
     operation: &str,
@@ -9115,6 +9103,30 @@ fn require_exclusive_store_access(
              crash-safe.",
             db_path.display()
         ),
+    }
+}
+
+/// Render a count that may be UNKNOWN.
+///
+/// nw-269: `unwrap_or(0)` on a count the producer deliberately nulled turns "I
+/// could not read this" into "there are none" — the two states a reader most
+/// needs told apart. The MCP route already emits `null` on a failed per-vault
+/// `list_notes`; both CLI renderers collapsed it back to `0`, so a vault whose
+/// notes could not be read displayed as "0 notes" beside vaults that genuinely
+/// had none.
+///
+/// Shared rather than restated, because this is the third count in this file
+/// to need it (top-level `brain status` totals, per-vault note counts, and
+/// `stale-check`'s commits-behind in nw-256) and each hand-rolled copy has
+/// drifted back to `unwrap_or(0)` at least once.
+fn render_optional_count(value: Option<&serde_json::Value>) -> String {
+    match value {
+        Some(serde_json::Value::Null) | None => {
+            "unavailable (could not be read — NOT zero)".to_string()
+        }
+        Some(found) => found
+            .as_u64()
+            .map_or_else(|| found.to_string(), |n| n.to_string()),
     }
 }
 
@@ -9160,6 +9172,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 anyhow::bail!("--value requires --key");
             }
             let db_path = resolve_db_with_config(db, config.as_deref())?;
+            // nw-281: read-only command — fail `db_not_found` on a missing
+            // `--db` like its 36 siblings, rather than reading a sidecar beside
+            // a database that does not exist and reporting "0 annotated
+            // node(s)". A typo'd `--db` is not an empty store.
+            require_existing_db(&db_path)?;
             // nw-257: `load_extensions` folds a corrupt or unreadable sidecar
             // into an empty map, which in THIS command would print
             // "0 annotated node(s)" and exit 0 — an audit reporting nothing
@@ -11072,6 +11089,20 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 if !text.ends_with('\n') {
                     println!();
                 }
+                // nw-277: the cap disclosure reached `--json` and stopped
+                // there. A human reading the default output saw 500 summaries
+                // and nothing telling them the other 39,500 exist — the same
+                // silence nw-270 removed from the JSON, left in place on the
+                // route most people actually use.
+                if truncated {
+                    let shown = display.len();
+                    let matched = total + cap_dropped;
+                    eprintln!(
+                        "note: showing {shown} of {matched} — output was capped. \
+                         Narrow it with `--target <substring>`, or raise \
+                         `--token-budget` (0 for unlimited)."
+                    );
+                }
             }
 
             let total_tokens: usize = display.iter().map(|s| s.token_estimate).sum();
@@ -12372,11 +12403,37 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // daemon up — an instance mismatch of the nw-019 class).
             let instance_id = resolve_instance_id_for_db(instance, config.as_deref(), &db_path)?;
 
+            // nw-273: `--refresh-wiki-hours` honours nothing on EITHER route,
+            // and claimed it did.
+            //
+            // The periodic thread is spawned only on the direct-watcher
+            // fallback, and it reaches the daemon via `DaemonClient::connect`,
+            // which AUTOSTARTS one. nw-267 gave the direct watcher the write
+            // lease it should always have had, and the daemon correctly refuses
+            // to start against a held lease. The thread swallows that into
+            // `tracing::warn!`, so the refresh silently stopped. On the
+            // daemon-routed branch the thread is never spawned at all — that
+            // route never honoured the flag. Both printed "Wiki refresh
+            // scheduled every {h}h" regardless.
+            //
+            // NOT restored in-process, deliberately. `materialize_projects` is
+            // callable directly, but serialising it against the watcher's own
+            // writes needs the `WatchMutationLeaseFactory` that only the daemon
+            // constructs. A second in-process writer without it trades a silent
+            // no-op for possible corruption — a worse bug than this one. The
+            // thread below is left unreachable rather than deleted: it is the
+            // starting point for a real implementation, and git history is a
+            // poor place to look for one.
             if let Some(hours) = refresh_wiki_hours {
                 eprintln!(
-                    "Wiki refresh scheduled every {}h (via materialize-projects)",
-                    hours
+                    "Error: --refresh-wiki-hours is not implemented (requested {hours}h).\n\
+                     It scheduled nothing on the daemon route, and since the watcher took \
+                     its write lease it schedules nothing on the direct route either — \
+                     while reporting that it had.\n\
+                     Run the refresh on your own schedule instead:\n  \
+                     nestweaver materialize-projects --config <path>"
                 );
+                return Ok((EXIT_USAGE, None));
             }
 
             // Route through the daemon when enabled. Choose ONE path up front
@@ -14330,25 +14387,35 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let materialized: Vec<nestweaver_schema::Project> = if use_daemon {
                 let db_path = resolved_db.clone();
                 let args = serde_json::json!({});
-                try_hybrid_json_rpc_checked(
+                // nw-277: three separate ways this reported "no projects" for
+                // reasons that had nothing to do with the graph.
+                //
+                // `.ok()` on the decode turned a malformed payload into a
+                // fallback; the fallback skipped
+                // `ensure_direct_store_fallback_allowed`, so a pinned
+                // `--config` was silently ignored and the direct read targeted
+                // a different instance than the caller named (nw-217 exactly);
+                // and both the open failure and `list_projects` itself
+                // collapsed into an empty Vec, so "I could not look" printed
+                // as "there is nothing".
+                match try_hybrid_json_rpc_checked(
                     true,
                     &db_path,
                     config.as_deref(),
                     "list_projects",
                     args,
-                )?
-                .and_then(|v| serde_json::from_value(unwrap_hybrid_payload(v)).ok())
-                .unwrap_or_else(|| {
-                    // Daemon unreachable / RPC failed — fall back to a direct read, but
-                    // never panic on a bad --db path; warn and return empty on error.
-                    match open_store(Some(&resolved_db)) {
-                        Ok(store) => store.list_projects().unwrap_or_default(),
-                        Err(e) => {
-                            eprintln!("Warning: could not open store: {e}");
-                            Vec::new()
-                        }
+                )? {
+                    Some(value) => serde_json::from_value(unwrap_hybrid_payload(value))
+                        .context("decode projects from the daemon")?,
+                    None => {
+                        // The direct store cannot honour a pinned config, so
+                        // falling back would silently target a different
+                        // instance than the caller named.
+                        ensure_direct_store_fallback_allowed(&resolved_db, config.as_deref())?;
+                        let store = open_store(Some(&resolved_db))?;
+                        store.list_projects().map_err(|e| anyhow::anyhow!(e))?
                     }
-                })
+                }
             } else {
                 let store = open_store(Some(&resolved_db))?;
                 store.list_projects().map_err(|e| anyhow::anyhow!(e))?
@@ -18877,13 +18944,22 @@ fn run_brain(
             Ok((EXIT_SUCCESS, Some(stats)))
         }
 
-        BrainCommands::List { json, db } => {
-            let db_default = default_db_path();
-            let db_path = db.as_deref().unwrap_or(&db_default);
+        BrainCommands::List { json, db, config } => {
+            // nw-280: resolved through the same helper as its two documented
+            // siblings, so a pinned `--config` selects the database its
+            // `db` field names instead of silently falling back to
+            // `./nestweaver.lbug`.
+            let db_path = resolve_db_with_config(db, config.as_deref())?;
+            let db_path = db_path.as_path();
 
             if use_daemon
-                && let Some(value) =
-                    try_hybrid_json_rpc(true, db_path, None, "list_vaults", serde_json::json!({}))?
+                && let Some(value) = try_hybrid_json_rpc(
+                    true,
+                    db_path,
+                    config.as_deref(),
+                    "list_vaults",
+                    serde_json::json!({}),
+                )?
             {
                 println!("{}", serde_json::to_string_pretty(&value)?);
                 return Ok((EXIT_SUCCESS, None));
@@ -19697,11 +19773,18 @@ fn run_brain(
             let instance_id = resolve_instance_id_for_db(instance, config.as_deref(), &db_path)?;
             let instance_cfg = load_instance_config_opt(config.as_deref());
 
+            // nw-273: same refusal as `watch` — see the comment there for why
+            // this is refused rather than restored in-process.
             if let Some(hours) = refresh_wiki_hours {
-                out.status(&format!(
-                    "Wiki refresh scheduled every {}h (via materialize-projects)",
-                    hours
-                ));
+                eprintln!(
+                    "Error: --refresh-wiki-hours is not implemented (requested {hours}h).\n\
+                     It scheduled nothing on the daemon route, and since the watcher took \
+                     its write lease it schedules nothing on the direct route either — \
+                     while reporting that it had.\n\
+                     Run the refresh on your own schedule instead:\n  \
+                     nestweaver materialize-projects --config <path>"
+                );
+                return Ok((EXIT_USAGE, None));
             }
 
             // Respect watch config when --config is provided.
@@ -22140,6 +22223,20 @@ mod cli_help_contract_tests {
             "nestweaver brain broken-links",
             "nestweaver brain context",
             "nestweaver brain doc-stats",
+            // nw-280: added deliberately. The upgrade runbook's step 4
+            // ("verify one convention everywhere") tells a config-driven user
+            // to add `--config` to `list-repos`, `list-projects` AND
+            // `brain list`; the first two took it and this one rejected it, so
+            // the verification step could not be run as written. Dropping the
+            // flag is worse than failing: without it the command reads
+            // `./nestweaver.lbug`, which is the wrong database, and reports a
+            // clean result — a verification step that cannot fail.
+            //
+            // Resolved through `resolve_db_with_config`, the same helper its
+            // two documented siblings use, so it inherits their behaviour
+            // rather than an unrelated fallback — which is exactly what this
+            // inventory exists to force a decision about.
+            "nestweaver brain list",
             "nestweaver brain orphans",
             "nestweaver brain refresh",
             // nw-217 A4: added deliberately. `brain remove` is a vault command
@@ -27318,7 +27415,11 @@ mod store_access_guard_tests {
         );
 
         drop(held);
-        require_exclusive_store_access(&db, "index directly")
+        // Bound rather than discarded: nw-274 put `#[must_use]` on the LEASE
+        // TYPE, and this is the one place the value is genuinely not needed —
+        // the assertion is that re-acquisition SUCCEEDS, not that the second
+        // lease does anything.
+        let _reacquired = require_exclusive_store_access(&db, "index directly")
             .expect("released on drop, with no stale state to reap");
     }
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -652,6 +652,11 @@ credential_method = "gh"
         &["bridges", "--json"][..],
         &["clusters", "--json"][..],
         &["brain", "status", "--json"][..],
+        // nw-280: `brain list` joins the matrix the moment it gained
+        // `--config`, as the inventory guard in `main.rs` requires — a command
+        // that takes both flags must be shown to HONOUR the config, not merely
+        // to accept it.
+        &["brain", "list", "--json"][..],
     ] {
         nestweaver_cmd()
             .current_dir(&unrelated_cwd)
@@ -4772,20 +4777,24 @@ fn pre_push_impact_depth_is_bounded_at_parse_time() {
     );
 }
 
-/// nw-269: an unreadable count must render as unavailable, never as `0`.
+/// nw-269 / nw-277: this is the COUNTERWEIGHT half, and it is named for what
+/// it actually asserts.
 ///
-/// Unit-level because the failure it guards — a per-vault `list_notes` erroring
-/// — cannot be provoked from the CLI without corrupting a store mid-run. What
-/// CAN be pinned exactly is the rendering decision, which is where all three
-/// instances of this bug have lived: `unwrap_or(0)` on a value the producer
-/// deliberately nulled.
+/// It was called `an_unreadable_count_is_never_rendered_as_zero`, which is not
+/// what it does: a per-vault `list_notes` failure cannot be provoked from the
+/// CLI without corrupting a store mid-run, so this only ever exercised the
+/// readable case. A test whose NAME claims the guarantee while its body checks
+/// the opposite direction is worse than no test — it answers the question for
+/// anyone who greps for it.
 ///
-/// Three counts in `main.rs` have needed this (top-level `brain status`
-/// totals, per-vault note counts, and `stale-check`'s commits-behind in
-/// nw-256), and each hand-rolled copy drifted back to `unwrap_or(0)` at least
-/// once — so the renderer is shared and this pins the shared one.
+/// The guarantee itself is pinned by value in
+/// `optional_count_rendering_tests::unknown_and_zero_do_not_render_alike`,
+/// which asserts both directions against the shared renderer. This one earns
+/// its place as the other half of that pair: a renderer that called EVERYTHING
+/// unavailable would satisfy the unit test's "unknown != zero" assertion and
+/// fail here.
 #[test]
-fn an_unreadable_count_is_never_rendered_as_zero() {
+fn a_readable_database_reports_real_counts_not_unavailable() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("test.lbug");
     drop(nestweaver_store::GraphStore::open_or_create(&db_path).unwrap());
@@ -4896,4 +4905,259 @@ fn summary_json_discloses_the_symbol_cap() {
          returned == total beside truncated:true is a contradiction \
          (returned={returned}, total={total})"
     );
+
+    // nw-277: the TEXT route must disclose it too. The nw-270 fix reached
+    // `--json` and stopped there, leaving the default output — the one most
+    // people actually read — showing 500 summaries with nothing saying the
+    // rest exist.
+    let text = nestweaver_cmd()
+        .args([
+            "summary",
+            "--db",
+            &db_path.display().to_string(),
+            "--level",
+            "symbol",
+            "--token-budget",
+            "0",
+        ])
+        .output()
+        .unwrap();
+    let notice = String::from_utf8_lossy(&text.stderr);
+    assert!(
+        notice.contains("capped") || notice.contains("showing"),
+        "the text route must say the output was capped, not just the JSON \
+         one:\n{notice}"
+    );
+}
+
+/// nw-273: `--refresh-wiki-hours` must REFUSE, not claim to have scheduled
+/// something.
+///
+/// The periodic refresh thread is spawned only on the direct-watcher fallback
+/// and reaches the daemon via `DaemonClient::connect`, which autostarts one —
+/// and nw-267 gave the direct watcher the write lease, so that autostart now
+/// correctly fails. The thread swallowed it into `tracing::warn!`. On the
+/// daemon route the thread is never spawned at all. Both routes printed
+/// "Wiki refresh scheduled every {h}h" regardless.
+///
+/// Our own fix produced this: nw-267's blast radius was not traced to the
+/// feature sitting beside it.
+#[test]
+fn refresh_wiki_hours_refuses_rather_than_claiming_to_schedule() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.lbug");
+    let vault = dir.path().join("vault");
+    let repo = dir.path().join("repo");
+    std::fs::create_dir_all(&vault).unwrap();
+    std::fs::create_dir_all(&repo).unwrap();
+    std::fs::write(vault.join("n.md"), "# n\n").unwrap();
+    drop(nestweaver_store::GraphStore::open_or_create(&db_path).unwrap());
+
+    let config = dir.path().join("instance.toml");
+    std::fs::write(
+        &config,
+        format!(
+            r#"instance_id = "wiki-refusal"
+db = "{}"
+repos = []
+
+[snapshot_storage]
+backend = "local"
+path = "/tmp/nestweaver/wiki-refusal/snapshots"
+
+[workspace]
+backend = "local"
+path = "/tmp/nestweaver/wiki-refusal/workspace"
+
+[inference]
+endpoint = "http://localhost:11434"
+embedding_model = "nomic-embed-text"
+summary_model = "qwen2.5-coder:7b"
+
+[git]
+credential_method = "gh"
+"#,
+            toml_basic_string(&db_path),
+        ),
+    )
+    .unwrap();
+
+    let cfg = config.display().to_string();
+    let vault_s = vault.display().to_string();
+    let repo_s = repo.display().to_string();
+    for (label, args) in [
+        (
+            "watch",
+            vec![
+                "watch",
+                &repo_s,
+                "--config",
+                &cfg,
+                "--refresh-wiki-hours",
+                "6",
+            ],
+        ),
+        (
+            "brain watch",
+            vec![
+                "brain",
+                "watch",
+                &vault_s,
+                "--config",
+                &cfg,
+                "--refresh-wiki-hours",
+                "6",
+            ],
+        ),
+    ] {
+        // Timed out deliberately. Without the refusal these commands START A
+        // WATCHER and block forever, so a regression would HANG this test
+        // rather than fail it — CI would eventually kill the job and report a
+        // timeout instead of the assertion that explains why. A test whose
+        // failure mode is a hang tells you almost nothing.
+        let out = nestweaver_cmd()
+            .args(&args)
+            .timeout(std::time::Duration::from_secs(20))
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+
+        assert!(
+            !out.status.success(),
+            "`{label} --refresh-wiki-hours` must refuse; it honours nothing.\
+             \nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("not implemented"),
+            "`{label}` must say the flag is not implemented:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("materialize-projects"),
+            "`{label}`'s refusal must name the remedy the user can actually \
+             run:\n{stderr}"
+        );
+        // The specific lie this replaces. A refusal that still printed it
+        // would be no better than the no-op.
+        assert!(
+            !stdout.contains("Wiki refresh scheduled")
+                && !stderr.contains("Wiki refresh scheduled"),
+            "`{label}` must not still claim it scheduled a refresh:\n{stdout}\n{stderr}"
+        );
+    }
+}
+
+/// nw-281: `extensions list` must fail on a missing `--db`, like its siblings.
+///
+/// It resolved a db path and read the sidecar beside it without ever checking
+/// the database existed — so a typo'd `--db` reported "0 annotated node(s)"
+/// and exited 0. In an auditing command that is the same defect nw-257 fixed
+/// one layer up: a fact about this invocation presented as a fact about the
+/// store. 36 other read commands call `require_existing_db`; this one did not.
+#[test]
+fn extensions_list_refuses_a_database_that_does_not_exist() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("not-created.lbug");
+
+    let refused = nestweaver_cmd()
+        .args(["extensions", "list", "--db", &missing.display().to_string()])
+        .output()
+        .unwrap();
+    assert!(
+        !refused.status.success(),
+        "a missing --db must be an error, not an empty audit"
+    );
+    assert!(
+        !String::from_utf8_lossy(&refused.stdout).contains("annotated node"),
+        "and it must not print a count as though it had looked:\n{}",
+        String::from_utf8_lossy(&refused.stdout)
+    );
+
+    // The counterweight: a database that DOES exist with no sidecar is still
+    // a successful, empty audit — that is a real answer, not a failure.
+    let present = dir.path().join("real.lbug");
+    drop(nestweaver_store::GraphStore::open_or_create(&present).unwrap());
+    nestweaver_cmd()
+        .args(["extensions", "list", "--db", &present.display().to_string()])
+        .assert()
+        .success();
+}
+
+/// nw-280: the three commands the upgrade runbook names must all accept
+/// `--config`.
+///
+/// `instance-id-migration.md` step 4 — "verify one convention everywhere" —
+/// tells a config-driven user to add `--config` to `list-repos`,
+/// `list-projects` and `brain list`. The first two took it; `brain list` did
+/// not, so the verification step could not be run as written. Dropping the
+/// flag doesn't rescue it either: without `--config` the command silently
+/// reads `./nestweaver.lbug`, which is the wrong database, and reports a clean
+/// result — a verification step that cannot fail.
+#[test]
+fn every_command_the_upgrade_runbook_names_accepts_a_pinned_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("configured.lbug");
+    drop(nestweaver_store::GraphStore::open_or_create(&db_path).unwrap());
+
+    let config_path = dir.path().join("instance.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"instance_id = "runbook-parity"
+db = "{}"
+repos = []
+
+[snapshot_storage]
+backend = "local"
+path = "/tmp/nestweaver/runbook-parity/snapshots"
+
+[workspace]
+backend = "local"
+path = "/tmp/nestweaver/runbook-parity/workspace"
+
+[inference]
+endpoint = "http://localhost:11434"
+embedding_model = "nomic-embed-text"
+summary_model = "qwen2.5-coder:7b"
+
+[git]
+credential_method = "gh"
+"#,
+            toml_basic_string(&db_path),
+        ),
+    )
+    .unwrap();
+
+    // Run from somewhere else entirely, so a fallback to `./nestweaver.lbug`
+    // cannot succeed by accident — which is the failure mode being guarded.
+    let unrelated_cwd = dir.path().join("unrelated-cwd");
+    std::fs::create_dir(&unrelated_cwd).unwrap();
+
+    for args in [
+        &["list-repos", "--json"][..],
+        &["list-projects", "--json"][..],
+        &["brain", "list", "--json"][..],
+    ] {
+        let out = nestweaver_cmd()
+            .current_dir(&unrelated_cwd)
+            .env_remove("NESTWEAVER_DB")
+            .args(args)
+            .arg("--config")
+            .arg(&config_path)
+            .output()
+            .unwrap();
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            out.status.success(),
+            "`{args:?} --config` must work — the upgrade runbook tells users to \
+             run exactly this:\n{stderr}"
+        );
+        // Specifically NOT an unknown-argument rejection, which is how this
+        // failed before: a bare non-zero exit would also be produced by a
+        // missing database, and the two mean very different things.
+        assert!(
+            !stderr.contains("unexpected argument"),
+            "`{args:?}` must ACCEPT --config, not reject it as unknown:\n{stderr}"
+        );
+    }
 }

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -5507,3 +5507,119 @@ fn daemon_refuses_a_configless_write_when_the_database_is_ambiguous() {
         .assert()
         .success();
 }
+
+/// nw-275: the ambiguity guard must see the database as it is AT THE WRITE,
+/// not as it was at boot.
+///
+/// It was computed once in `run_server` and stored as a plain `Vec<String>`,
+/// read frozen by ten consumers. A database that became multi-instance DURING
+/// the daemon's lifetime stayed unguarded for the rest of it — while the CLI
+/// re-read on every invocation. The two routes nw-246 aligned would have
+/// diverged again, on staleness rather than logic.
+///
+/// The sequence is ordinary: start a daemon against a single-instance
+/// database (nothing ambiguous at boot), add a second instance through that
+/// same daemon with an explicit `--instance` (allowed by design), then make an
+/// unqualified write. Under the boot snapshot the third write sails through
+/// against a database that is now genuinely ambiguous.
+#[test]
+fn ambiguity_arising_after_boot_is_still_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let first = dir.path().join("first");
+    let second = dir.path().join("second");
+    let third = dir.path().join("third");
+    let db_path = dir.path().join("test.lbug");
+
+    write_test_repo(&first);
+    write_test_repo(&second);
+    write_test_repo(&third);
+
+    // Single instance at boot: nothing for the guard to complain about.
+    no_daemon_cmd()
+        .args([
+            "index",
+            "--repo",
+            &first.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+            "--instance",
+            "one",
+        ])
+        .assert()
+        .success();
+
+    let _guard = DaemonGuard::new(&db_path);
+    start_daemon(&db_path);
+
+    // The counterweight, and it has to come first: an unqualified write must
+    // SUCCEED while the database is still unambiguous. Without this the test
+    // would pass against a daemon that refuses everything.
+    daemon_cmd()
+        .args([
+            "index",
+            "--repo",
+            &second.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .assert()
+        .success();
+
+    // Now make it ambiguous THROUGH THE RUNNING DAEMON — a stated instance,
+    // which is a supported operation and precisely how this happens in life.
+    daemon_cmd()
+        .args([
+            "index",
+            "--repo",
+            &third.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+            "--instance",
+            "two",
+        ])
+        .assert()
+        .success();
+
+    // The same unqualified write that succeeded a moment ago must now be
+    // refused. Under the boot snapshot it was not.
+    let refused = daemon_cmd()
+        .args([
+            "index",
+            "--repo",
+            &second.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !refused.status.success(),
+        "the database became multi-instance while this daemon was running; an \
+         unqualified write must be refused with the state as it IS, not as it \
+         was at boot"
+    );
+    let stderr: String = String::from_utf8_lossy(&refused.stderr)
+        .replace('\u{2502}', " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        stderr.contains("one") && stderr.contains("two"),
+        "the refusal must name both instances it can now see:\n{stderr}"
+    );
+
+    // nw-277: the remedy must be one this route can actually carry.
+    // `IndexRepoRequest` has no config field and a running daemon's
+    // configuration is fixed at start, so telling the user to pass `--config`
+    // sends them to re-run the command, send the same empty instance, and get
+    // the same refusal — having done exactly what the error asked.
+    assert!(
+        stderr.contains("--instance"),
+        "the refusal must offer `--instance`, which the request DOES carry:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("or a `--config`"),
+        "the refusal must not offer a bare `--config` as the fix; this request \
+         cannot carry one:\n{stderr}"
+    );
+}


### PR DESCRIPTION
nw-273..nw-277, nw-280, nw-281(a). Every fix verified by reverting it and watching the test go red.

```
cargo fmt --all --check                                → 0
cargo clippy --workspace --all-targets -- -D warnings  → 0
cargo test --workspace --all-targets                   → 0   (3868 passed, 0 failed)
```

## nw-273 (high) — our own fix silently broke a feature, and the feature was already broken

nw-267 gave the direct watcher the write lease it should always have had. The periodic wiki-refresh thread exists **only** on that path and works by calling `DaemonClient::connect`, which **autostarts a daemon** — and the daemon correctly refuses to start against a held lease. The thread swallowed that into `tracing::warn!`.

But it was worse than a regression. The `Wiki refresh scheduled every {h}h` message printed **before the route was chosen**, and the daemon-routed branch never spawns the thread at all. So the flag honoured nothing on **either** route and said it had. **nw-267 didn't break this — it made the direct route join a lie the daemon route was already telling.**

Refused unconditionally, `EXIT_USAGE`, naming `materialize-projects` as the thing the user can actually run.

**Not restored in-process, deliberately.** Serialising `materialize_projects` against the watcher's own writes needs the `WatchMutationLeaseFactory` only the daemon constructs; a second in-process writer without it trades a silent no-op for possible corruption. The unreachable threads are left in place as the starting point for a real implementation.

Release note wording: **"never functioned; now says so"**, not "removed".

## nw-274 (medium) — the fifth docblock detachment this release

nw-269 inserted a function between `#[must_use]` and `require_exclusive_store_access`, and `DbWriteLease` had no attribute of its own — so the only thing making a dropped lease a lint went missing, on the one helper where dropping the return value *is* the bug.

Fixed on the **type**, not the function. A per-function attribute protects one function and can be separated from it by an edit elsewhere; on the type it covers every present and future producer. It immediately flagged a site the per-function version never did.

## nw-275 (medium) — a guard that was a boot snapshot

The daemon's ambiguity check was computed once in `run_server` and read frozen by ten consumers, so a database that became multi-instance *during* the daemon's lifetime stayed unguarded for the rest of it — while the CLI re-read on every invocation. The two routes nw-262 aligned would have diverged again, on **staleness** rather than logic.

Queried live at the write choke point now. `observed_instance_ids` scans only Repo and Vault nodes with `DISTINCT`, so it costs a small query on writes that state no instance and nothing on those that do.

## nw-276 (medium) — nw-266 traded one failure mode for another

`remote_head` ran `git ls-remote` with **stdin inherited** and no prompt suppression, on a command this codebase calls a CI freshness gate. Now runs with `GIT_TERMINAL_PROMPT=0`, empty askpass, `ssh -oBatchMode=yes`, and null stdin — suppressing the prompt while leaving stdin attached still hangs on ssh's host-key confirmation.

## nw-277 — six smaller ones

- **(a)** Identity was minted ~600 lines **before** the write guard, so an index that died during scan or parse permanently stamped a database under an instance whose write never landed.
- **(b)** `MAX_IMPACT_DEPTH` left the sibling clamp a literal `64` — nw-268's doc claimed *"64 matches the sibling that already had it"*, true only by coincidence.
- **(c)** `list_projects` had three defects stacked: a swallowed decode, a fallback skipping `ensure_direct_store_fallback_allowed` (nw-217 again), and two error-to-empty collapses.
- **(d)** The cap disclosure reached `--json` and stopped there.
- **(e)** A test of mine named `an_unreadable_count_is_never_rendered_as_zero` that only ever exercised the *readable* case. Renamed to what it asserts.
- **(f)** Filed at 0.6 confidence, **confirmed at 1.0**: a running daemon's refusal offered `--config`, but `IndexRepoRequest` carries no config field — so following the advice re-runs the command, sends the same empty instance, and produces the same refusal.

## nw-280 — two runbooks prescribing flags that do not exist

`daemon stop --config` is rejected outright, at the **first command of a publication recovery**. Corrected, with a note on why `daemon start --config` and `publication rebuild --config` make it easy to miss.

The upgrade guide told config-driven users to pass `--config` to `list-repos`, `list-projects` and `brain list`. **This fixes the code, not the doc:** `brain list` lacking the flag is the same one-route-has-it shape as the rest of this batch, and without it the command silently reads `./nestweaver.lbug` and reports a clean result — a verification step that cannot fail.

`config_aware_database_command_inventory_is_explicit` caught the new flag and forced an explicit entry, which is the guard working as designed; the behavioural config-DB matrix is extended too, so `brain list` is shown to **honour** the config rather than merely accept it.

## nw-281(a) — an audit command that skipped its own precondition

`extensions list` read a sidecar beside a database it never checked existed, so a typo'd `--db` reported "0 annotated node(s)" and exited 0. 36 sibling read commands call `require_existing_db`.

## Not done, deliberately

**nw-281(b)** — `set_extension` writes and nothing deletes. There is no delete path anywhere: no `ExtensionCommands::Set/Unset`, no engine `remove_property`. That is a capability **never built**, not a route divergence, and adding one means new API surface days before a cut. Goes to Kory as a design decision alongside nw-263.

## Two of these tests were hollow first

Recorded because the mutation step caught them, not care:

- **nw-277(a)**: a missing repo path fails *before* the funnel is entered, so the first version passed with the fix reverted. Redone against `index_with_reader_and_write_gate` with a guard closure that **refuses** — a failure landing exactly between the old minting point and the write. The hollow version was deleted rather than kept.
- **nw-273**: restoring the false claim made the test **hang**, because without the refusal these commands start a watcher and block forever. CI would have reported a timeout instead of the assertion explaining why. `.timeout(20s)` so a regression fails fast *with its message*. **A test whose failure mode is a hang tells you almost nothing.**
