### PR TITLE
feat(engine,cli,daemon): per-repo exclude globs for tracked code

### DIFF
--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -4806,19 +4806,34 @@ impl NestWeaverDaemon for DaemonService {
                 ..Default::default()
             }));
 
-            match nestweaver_engine::index::index_directory_with_store_cancellable_and_limits(
-                &state.store,
-                &repo_path,
-                &state.db_path,
+            // Per-repo `exclude` globs come from the daemon's own instance
+            // config — the daemon is started with `--config`, so no new field
+            // is needed on the index RPC. A daemon running without a config
+            // resolves to no excludes, which is the prior behaviour.
+            let repo_excludes: Vec<String> = state
+                .instance_cfg
+                .as_ref()
+                .map(|cfg| cfg.exclude_globs_for(&repo_url, Some(&repo_path)).to_vec())
+                .unwrap_or_default();
+
+            let index_opts = nestweaver_engine::index::IndexOptions::new(
                 // nw-019: stamp the effective logical instance on indexed repos —
                 // an explicit request `--instance` overrides the daemon default.
                 &effective_instance,
                 &repo_url,
                 &indexed_sha,
-                force,
-                name.as_deref(),
-                &cancel_for_index,
-                index_limits,
+            )
+            .force(force)
+            .name(name.as_deref())
+            .limits(index_limits)
+            .excludes(&repo_excludes);
+
+            match nestweaver_engine::index::index_directory_with_store_opts(
+                &state.store,
+                &repo_path,
+                &state.db_path,
+                &index_opts,
+                Some(&cancel_for_index),
             ) {
                 Ok(result) => {
                     let skipped_count = result.skipped_files.len();
@@ -16248,6 +16263,7 @@ mod startup_helper_tests {
             use_git_activity: None,
             branch: None,
             poll: None,
+            exclude: Vec::new(),
         }
     }
 
@@ -19809,6 +19825,7 @@ mod watch_path_allowed_tests {
             use_git_activity: None,
             branch: None,
             poll: None,
+            exclude: Vec::new(),
         }
     }
 

--- a/crates/nestweaver-engine/src/config.rs
+++ b/crates/nestweaver-engine/src/config.rs
@@ -4,6 +4,7 @@ use nestweaver_store::{PathDeboostRule, SEED_PATH_FACTOR_MAX, SEED_PATH_FACTOR_M
 pub use nestweaver_store::{SeedResolutionConfig, default_kind_priority};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::path::Path;
 
 /// Bounds applied to a ranking-prior multiplier and to the final product
 /// after a prior is applied. A multiplier below the floor would erase a
@@ -775,6 +776,20 @@ pub struct RepoConfig {
     pub branch: Option<String>,
     #[serde(default)]
     pub poll: Option<String>,
+    /// Glob patterns, matched against repo-relative paths, for code this repo
+    /// tracks but the graph should not hold.
+    ///
+    /// This is deliberately NOT a general ignore mechanism. The indexer walks
+    /// with `ignore::WalkBuilder` and already honours `.gitignore`, the global
+    /// gitignore, and `.git/info/exclude`, so anything git ignores is excluded
+    /// without configuration. This covers only the remaining case: source that
+    /// is legitimately committed but is not ours to reason about — a vendored
+    /// WordPress plugin tree, a checked-in SDK, generated bundles.
+    ///
+    /// A pattern ending in `/**` also prunes the directory it names, so an
+    /// excluded tree is never descended.
+    #[serde(default)]
+    pub exclude: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -1016,7 +1031,39 @@ fn reject_obsolete_instance_shape(s: &str) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// Normalize a repo reference so a `file://` url, a bare path, and a git
+/// remote compare on equal terms. Trailing slashes are insignificant.
+fn normalize_repo_ref(value: &str) -> &str {
+    value
+        .strip_prefix("file://")
+        .unwrap_or(value)
+        .trim_end_matches('/')
+}
+
 impl InstanceConfig {
+    /// Exclude globs declared for a repo by a `[[repos]]` entry, or an empty
+    /// slice when it declares none — the common case, and why this returns a
+    /// slice rather than an Option.
+    ///
+    /// A `[[repos]] url` is matched against EITHER the repo's identity url or
+    /// its local checkout path, because the same repo is spelled three ways in
+    /// practice: `brain-setup.sh` indexes by path, the graph records the git
+    /// origin, and vault entries use a `file://` url. Requiring one spelling
+    /// would make a declared exclude silently do nothing.
+    pub fn exclude_globs_for(&self, repo_url: &str, repo_path: Option<&Path>) -> &[String] {
+        let path_str = repo_path.map(|p| p.to_string_lossy().to_string());
+        self.repos
+            .iter()
+            .find(|r| {
+                let declared = normalize_repo_ref(&r.url);
+                declared == normalize_repo_ref(repo_url)
+                    || path_str
+                        .as_deref()
+                        .is_some_and(|p| declared == normalize_repo_ref(p))
+            })
+            .map_or(&[][..], |r| r.exclude.as_slice())
+    }
+
     /// The DB path declared by this instance, if any.
     pub fn db_path(&self) -> Option<std::path::PathBuf> {
         self.db.as_ref().map(std::path::PathBuf::from)
@@ -1973,6 +2020,120 @@ use_git_activity = false
             .expect("vendored repo");
         assert_eq!(live.use_git_activity, None);
         assert_eq!(vendored.use_git_activity, Some(false));
+    }
+
+    #[test]
+    fn exclude_globs_for_resolves_by_repo_url() {
+        let toml = format!(
+            r#"
+{MINIMAL_TOML}
+
+[[repos]]
+url = "git@github.com:example/wordpress.git"
+exclude = ["web/wp-content/plugins/**"]
+"#
+        );
+        let cfg = InstanceConfig::from_toml_str(&toml).expect("should parse");
+
+        assert_eq!(
+            cfg.exclude_globs_for("git@github.com:example/wordpress.git", None),
+            ["web/wp-content/plugins/**".to_string()]
+        );
+        assert!(
+            cfg.exclude_globs_for("git@github.com:example/other.git", None)
+                .is_empty(),
+            "an undeclared repo must resolve to no excludes, not inherit another repo's"
+        );
+    }
+
+    #[test]
+    fn exclude_globs_for_matches_url_or_local_path() {
+        // brain-setup.sh indexes local checkouts by PATH while the graph
+        // records the git origin as the repo url, and the vault is declared
+        // with a `file://` url. All three spellings must find the same entry,
+        // or a declared exclude silently does nothing.
+        let toml = format!(
+            r#"
+{MINIMAL_TOML}
+
+[[repos]]
+url = "git@github.com:example/wordpress.git"
+exclude = ["web/wp-content/plugins/**"]
+
+[[repos]]
+url = "file:///Users/me/dev/site"
+exclude = ["uploads/**"]
+"#
+        );
+        let cfg = InstanceConfig::from_toml_str(&toml).expect("should parse");
+
+        // by git url
+        assert_eq!(
+            cfg.exclude_globs_for("git@github.com:example/wordpress.git", None),
+            ["web/wp-content/plugins/**".to_string()]
+        );
+        // by local path, when the url is the origin remote
+        assert_eq!(
+            cfg.exclude_globs_for(
+                "git@github.com:example/wordpress.git",
+                Some(Path::new("/anywhere/wordpress"))
+            ),
+            ["web/wp-content/plugins/**".to_string()]
+        );
+        // by local path against a file:// url
+        assert_eq!(
+            cfg.exclude_globs_for("whatever", Some(Path::new("/Users/me/dev/site"))),
+            ["uploads/**".to_string()]
+        );
+        // plain path url spelling also resolves
+        assert_eq!(
+            cfg.exclude_globs_for("/Users/me/dev/site", None),
+            ["uploads/**".to_string()]
+        );
+        assert!(
+            cfg.exclude_globs_for("git@github.com:example/other.git", None)
+                .is_empty(),
+            "an undeclared repo must not inherit another repo's excludes"
+        );
+    }
+
+    #[test]
+    fn per_repo_exclude_globs_parse_and_default_empty() {
+        let toml = format!(
+            r#"
+{MINIMAL_TOML}
+
+[[repos]]
+url = "https://github.com/example/plain"
+
+[[repos]]
+url = "https://github.com/example/wordpress"
+exclude = ["web/wp-content/plugins/**", "**/*.min.js"]
+"#
+        );
+        let cfg = InstanceConfig::from_toml_str(&toml).expect("should parse");
+        let plain = cfg
+            .repos
+            .iter()
+            .find(|r| r.url == "https://github.com/example/plain")
+            .expect("plain repo");
+        let wp = cfg
+            .repos
+            .iter()
+            .find(|r| r.url == "https://github.com/example/wordpress")
+            .expect("wordpress repo");
+
+        assert!(
+            plain.exclude.is_empty(),
+            "a repo declaring no excludes must default to none, not fail to parse"
+        );
+        assert_eq!(
+            wp.exclude,
+            vec![
+                "web/wp-content/plugins/**".to_string(),
+                "**/*.min.js".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/content_reader.rs
+++ b/crates/nestweaver-engine/src/content_reader.rs
@@ -10,6 +10,7 @@ use std::thread::JoinHandle;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use globset::{Glob, GlobSet, GlobSetBuilder};
 
 use crate::git_cmd::{apply_git_isolation, git_net_timeout, run_git_with_timeout};
 use crate::index_limits::{DEFAULT_MAX_SOURCE_FILE_BYTES, IndexLimits};
@@ -135,10 +136,28 @@ pub trait ContentReader: Send + Sync {
     }
 }
 
+/// Whether a repo-relative directory is excluded outright, so the walker can
+/// skip descending into it rather than filtering its contents afterwards.
+///
+/// Free rather than a method because the walker's `filter_entry` closure must
+/// be `'static` and therefore cannot borrow the reader.
+fn dir_is_excluded(dir_excludes: Option<&GlobSet>, rel: &Path) -> bool {
+    dir_excludes.is_some_and(|gs| gs.is_match(rel))
+}
+
 /// Local filesystem reader — wraps the existing `ignore::WalkBuilder` + `fs::read_to_string`.
 pub struct FilesystemReader {
     repo_path: PathBuf,
     limits: IndexLimits,
+    /// Configured `[[repos]] exclude` globs, matched against repo-relative
+    /// paths. `None` when the repo declares none — the common case.
+    excludes: Option<GlobSet>,
+    /// Directory-level companion to [`Self::excludes`], used to prune the walk
+    /// instead of filtering after descent. A pattern like `big/**` names only
+    /// the CONTENTS of `big`, so it never matches `big` itself; without this
+    /// the walker would still descend the whole excluded tree — 8.3 GB in the
+    /// case this feature was built for.
+    dir_excludes: Option<GlobSet>,
 }
 
 impl FilesystemReader {
@@ -146,6 +165,8 @@ impl FilesystemReader {
         Self {
             repo_path: repo_path.to_path_buf(),
             limits: IndexLimits::default(),
+            excludes: None,
+            dir_excludes: None,
         }
     }
 
@@ -153,7 +174,39 @@ impl FilesystemReader {
         Self {
             repo_path: repo_path.to_path_buf(),
             limits,
+            excludes: None,
+            dir_excludes: None,
         }
+    }
+
+    /// Attach `[[repos]] exclude` globs. These are matched against
+    /// repo-relative paths and are the ONLY way to skip code that git itself
+    /// tracks — `.gitignore`/`.git/info/exclude` already cover everything git
+    /// ignores, and the walker honours those.
+    ///
+    /// An invalid glob is an error rather than a silently-dropped pattern: a
+    /// typo that quietly indexed a vendored tree is the failure this exists to
+    /// prevent.
+    pub fn excluding(mut self, globs: &[String]) -> Result<Self> {
+        if globs.is_empty() {
+            return Ok(self);
+        }
+        let mut builder = GlobSetBuilder::new();
+        let mut dir_builder = GlobSetBuilder::new();
+        for g in globs {
+            builder.add(Glob::new(g).with_context(|| format!("invalid exclude glob {g:?}"))?);
+
+            // Derive the directory this pattern encloses so the walk can be
+            // pruned. `big/**` -> `big`; a pattern naming a directory outright
+            // (`docs/vendor`) already prunes via itself.
+            let dir_pattern = g.strip_suffix("/**").unwrap_or(g);
+            dir_builder.add(
+                Glob::new(dir_pattern).with_context(|| format!("invalid exclude glob {g:?}"))?,
+            );
+        }
+        self.excludes = Some(builder.build().context("build exclude globset")?);
+        self.dir_excludes = Some(dir_builder.build().context("build exclude globset")?);
+        Ok(self)
     }
 }
 
@@ -217,18 +270,27 @@ impl ContentReader for FilesystemReader {
         use ignore::WalkBuilder;
 
         let mut files = Vec::new();
+        let root = self.repo_path.clone();
+        let dir_excludes = self.dir_excludes.clone();
         let walker = WalkBuilder::new(&self.repo_path)
             .follow_links(false)
             .hidden(false)
             .git_ignore(true)
             .git_global(true)
             .git_exclude(true)
-            .filter_entry(|e| {
-                if e.file_type().is_some_and(|ft| ft.is_dir())
-                    && let Some(name) = e.file_name().to_str()
-                    && crate::index::SKIP_DIRS.contains(&name)
-                {
-                    return false;
+            .filter_entry(move |e| {
+                if e.file_type().is_some_and(|ft| ft.is_dir()) {
+                    if let Some(name) = e.file_name().to_str()
+                        && crate::index::SKIP_DIRS.contains(&name)
+                    {
+                        return false;
+                    }
+                    if let Ok(rel) = e.path().strip_prefix(&root)
+                        && !rel.as_os_str().is_empty()
+                        && dir_is_excluded(dir_excludes.as_ref(), rel)
+                    {
+                        return false;
+                    }
                 }
                 true
             })
@@ -245,6 +307,9 @@ impl ContentReader for FilesystemReader {
             if entry.file_type().is_some_and(|ft| ft.is_file())
                 && let Ok(rel) = entry.path().strip_prefix(&self.repo_path)
             {
+                if self.excludes.as_ref().is_some_and(|gs| gs.is_match(rel)) {
+                    continue;
+                }
                 files.push(rel.to_path_buf());
             }
         }
@@ -845,6 +910,138 @@ mod tests {
             .collect();
         assert!(names.contains(&"real.rs".to_string()));
         assert!(!names.iter().any(|n| n.contains("node_modules")));
+    }
+
+    #[test]
+    fn filesystem_reader_applies_configured_excludes() {
+        // Files are NOT gitignored (no git repo here), so only a configured
+        // exclude can keep them out — which is the whole point of the feature:
+        // skipping code that is legitimately tracked.
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("web/wp-content/plugins/acme")).unwrap();
+        std::fs::write(dir.path().join("web/wp-content/plugins/acme/a.php"), "").unwrap();
+        std::fs::create_dir_all(dir.path().join("web/wp-content/themes/mine")).unwrap();
+        std::fs::write(dir.path().join("web/wp-content/themes/mine/b.php"), "").unwrap();
+
+        let reader = FilesystemReader::new(dir.path())
+            .excluding(&["web/wp-content/plugins/**".to_string()])
+            .unwrap();
+        let files = reader.list_files().unwrap();
+        let names: Vec<String> = files
+            .iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+
+        assert!(
+            names.contains(&"web/wp-content/themes/mine/b.php".to_string()),
+            "non-excluded file must survive: {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n.contains("plugins")),
+            "excluded glob must be skipped: {names:?}"
+        );
+    }
+
+    #[test]
+    fn filesystem_reader_rejects_invalid_exclude_glob() {
+        let dir = TempDir::new().unwrap();
+        let result = FilesystemReader::new(dir.path()).excluding(&["web/[unclosed".to_string()]);
+        assert!(
+            result.is_err(),
+            "an invalid glob must be rejected, not silently dropped"
+        );
+        let msg = format!("{:#}", result.err().unwrap());
+        assert!(
+            msg.contains("web/[unclosed"),
+            "error must name the offending glob: {msg}"
+        );
+    }
+
+    #[test]
+    fn filesystem_reader_exclude_skips_nested_files() {
+        // Asserts only that nested files under an excluded glob are absent.
+        // It deliberately does NOT claim the walk was pruned — filtering after
+        // descent produces an identical list. Pruning is covered by
+        // `exclude_prunes_directory_before_descending`, which tests the
+        // predicate the walker actually branches on.
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("big/nested/deep")).unwrap();
+        std::fs::write(dir.path().join("big/nested/deep/x.rs"), "").unwrap();
+        std::fs::write(dir.path().join("keep.rs"), "").unwrap();
+
+        let reader = FilesystemReader::new(dir.path())
+            .excluding(&["big/**".to_string()])
+            .unwrap();
+        let files = reader.list_files().unwrap();
+        let names: Vec<String> = files
+            .iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+
+        assert!(names.contains(&"keep.rs".to_string()), "{names:?}");
+        assert!(!names.iter().any(|n| n.starts_with("big/")), "{names:?}");
+    }
+
+    #[test]
+    fn exclude_prunes_directory_before_descending() {
+        // The motivating repo holds 8.3 GB under one excluded directory, so
+        // filtering files after descent is not enough — the walker has to
+        // refuse to enter. `big/**` names only the CONTENTS of `big`, so a
+        // naive is_match("big") is false and the walk descends anyway. This
+        // pins the prefix behaviour that makes pruning work.
+        let dir = TempDir::new().unwrap();
+        let reader = FilesystemReader::new(dir.path())
+            .excluding(&["big/**".to_string(), "docs/vendor".to_string()])
+            .unwrap();
+
+        let dirs = reader.dir_excludes.as_ref();
+        assert!(
+            dir_is_excluded(dirs, Path::new("big")),
+            "`big/**` must prune the `big` directory itself"
+        );
+        assert!(
+            dir_is_excluded(dirs, Path::new("docs/vendor")),
+            "an exact directory pattern must prune that directory"
+        );
+        assert!(
+            !dir_is_excluded(dirs, Path::new("src")),
+            "unrelated directories must not be pruned"
+        );
+        assert!(
+            !dir_is_excluded(dirs, Path::new("bigger")),
+            "prefix match must respect path boundaries"
+        );
+    }
+
+    #[test]
+    fn filesystem_reader_excludes_file_shaped_globs() {
+        // A glob that matches FILES without enclosing a directory cannot be
+        // handled by pruning — the parent must still be walked to reach its
+        // siblings. This pins the file-level filter, which directory-shaped
+        // patterns like `big/**` would otherwise make look redundant.
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("assets")).unwrap();
+        std::fs::write(dir.path().join("assets/app.min.js"), "").unwrap();
+        std::fs::write(dir.path().join("assets/app.js"), "").unwrap();
+
+        let reader = FilesystemReader::new(dir.path())
+            .excluding(&["**/*.min.js".to_string()])
+            .unwrap();
+        let names: Vec<String> = reader
+            .list_files()
+            .unwrap()
+            .iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+
+        assert!(
+            names.contains(&"assets/app.js".to_string()),
+            "sibling in the same directory must survive: {names:?}"
+        );
+        assert!(
+            !names.contains(&"assets/app.min.js".to_string()),
+            "file-shaped glob must be excluded: {names:?}"
+        );
     }
 
     // ---------- GitBareReader tests ----------

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -2022,6 +2022,89 @@ pub fn index_directory_with_options(
     )
 }
 
+/// Everything an index run needs beyond the store and the two paths.
+///
+/// Introduced to stop the entry points growing a new name per knob — the four
+/// `_with_store` / `_cancellable` / `_and_limits` spellings above are that
+/// growth, and `index_directory_with_options_and_limits` was already named for
+/// "options" it never had. It also removes a real hazard: the previous
+/// signature passed `instance_id`, `repo_url` and `indexed_sha` as three
+/// adjacent `&str`, so any two could be swapped at a call site and still
+/// compile.
+///
+/// The older functions remain as thin wrappers that build this with no
+/// excludes, so existing callers are unaffected.
+#[derive(Debug, Clone)]
+pub struct IndexOptions {
+    pub instance_id: String,
+    pub repo_url: String,
+    pub indexed_sha: String,
+    pub force: bool,
+    pub name: Option<String>,
+    pub limits: crate::index_limits::IndexLimits,
+    /// `[[repos]] exclude` globs — code this repo tracks that the graph should
+    /// not hold. Empty for every caller that does not resolve an instance
+    /// config. See `InstanceConfig::exclude_globs_for`.
+    pub excludes: Vec<String>,
+}
+
+impl IndexOptions {
+    pub fn new(instance_id: &str, repo_url: &str, indexed_sha: &str) -> Self {
+        Self {
+            instance_id: instance_id.to_string(),
+            repo_url: repo_url.to_string(),
+            indexed_sha: indexed_sha.to_string(),
+            force: false,
+            name: None,
+            limits: crate::index_limits::IndexLimits::default(),
+            excludes: Vec::new(),
+        }
+    }
+
+    pub fn force(mut self, force: bool) -> Self {
+        self.force = force;
+        self
+    }
+
+    pub fn name(mut self, name: Option<&str>) -> Self {
+        self.name = name.map(str::to_string);
+        self
+    }
+
+    pub fn limits(mut self, limits: crate::index_limits::IndexLimits) -> Self {
+        self.limits = limits;
+        self
+    }
+
+    pub fn excludes(mut self, excludes: &[String]) -> Self {
+        self.excludes = excludes.to_vec();
+        self
+    }
+}
+
+/// Index a directory using [`IndexOptions`], opening the store for writing.
+/// The CLI's entry point; mirrors `index_directory_with_options_and_limits`.
+pub fn index_directory_with_opts(
+    repo_path: &Path,
+    db_path: &Path,
+    opts: &IndexOptions,
+) -> Result<IndexResult, anyhow::Error> {
+    let store = open_store_for_writing_with_recovery(db_path)?;
+    index_directory_with_store_inner(&store, repo_path, db_path, opts, None)
+}
+
+/// Index into an existing store using [`IndexOptions`]. This is the funnel the
+/// older `_and_limits` entry points delegate to.
+pub fn index_directory_with_store_opts(
+    store: &GraphStore,
+    repo_path: &Path,
+    db_path: &Path,
+    opts: &IndexOptions,
+    cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
+) -> Result<IndexResult, anyhow::Error> {
+    index_directory_with_store_inner(store, repo_path, db_path, opts, cancel)
+}
+
 /// Index a directory with an explicit validated source-input ceiling.
 #[allow(clippy::too_many_arguments)]
 pub fn index_directory_with_options_and_limits(
@@ -2094,12 +2177,10 @@ pub fn index_directory_with_store_and_limits(
         store,
         repo_path,
         db_path,
-        instance_id,
-        repo_url,
-        indexed_sha,
-        force,
-        name,
-        limits,
+        &IndexOptions::new(instance_id, repo_url, indexed_sha)
+            .force(force)
+            .name(name)
+            .limits(limits),
         None,
     )
 }
@@ -2153,12 +2234,10 @@ pub fn index_directory_with_store_cancellable_and_limits(
         store,
         repo_path,
         db_path,
-        instance_id,
-        repo_url,
-        indexed_sha,
-        force,
-        name,
-        limits,
+        &IndexOptions::new(instance_id, repo_url, indexed_sha)
+            .force(force)
+            .name(name)
+            .limits(limits),
         Some(cancel),
     )
 }
@@ -2209,14 +2288,17 @@ fn index_directory_with_store_inner(
     store: &GraphStore,
     repo_path: &Path,
     db_path: &Path,
-    instance_id: &str,
-    repo_url: &str,
-    indexed_sha: &str,
-    force: bool,
-    name: Option<&str>,
-    limits: crate::index_limits::IndexLimits,
+    opts: &IndexOptions,
     cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
 ) -> Result<IndexResult, anyhow::Error> {
+    // Bind the option fields to the names the body already uses, so this
+    // refactor changes the signature without touching the 700-line body.
+    let instance_id = opts.instance_id.as_str();
+    let repo_url = opts.repo_url.as_str();
+    let indexed_sha = opts.indexed_sha.as_str();
+    let force = opts.force;
+    let name = opts.name.as_deref();
+    let limits = opts.limits;
     let filemeta_path = crate::sidecar_path(db_path, ".filemeta.json");
     crate::migrate_sidecar(db_path, "filemeta.json", ".filemeta.json");
     let r_uid = repo_uid(instance_id, repo_url);
@@ -2235,7 +2317,8 @@ fn index_directory_with_store_inner(
     let resolution_deps_path = crate::sidecar_path(db_path, ".resolution_deps.bin");
     let mut resolution_deps = crate::resolution_cache::ResolutionDeps::load(&resolution_deps_path);
 
-    let reader = crate::content_reader::FilesystemReader::with_limits(repo_path, limits);
+    let reader = crate::content_reader::FilesystemReader::with_limits(repo_path, limits)
+        .excluding(&opts.excludes)?;
     // Local filesystem index: the working tree location is `repo_path`.
     // Persisted as `root_path` on the Repo node so consumers never derive
     // a disk path from the identity `url`.
@@ -5124,10 +5207,38 @@ pub fn incremental_index_with_name_and_limits(
         repo_url,
         name,
         limits,
+        &[],
         &FileSystemIndexEpilogueIo,
     )
 }
 
+/// Incremental index honouring per-repo `exclude` globs.
+///
+/// The full-index route resolves excludes through [`IndexOptions`]; this is its
+/// twin, so a `--no-daemon` incremental run does not quietly index a tree the
+/// configured excludes remove.
+pub fn incremental_index_with_excludes(
+    repo_path: &Path,
+    db_path: &Path,
+    instance_id: &str,
+    repo_url: &str,
+    name: Option<&str>,
+    limits: crate::index_limits::IndexLimits,
+    excludes: &[String],
+) -> Result<IncrementalResult, anyhow::Error> {
+    incremental_index_with_name_and_io(
+        repo_path,
+        db_path,
+        instance_id,
+        repo_url,
+        name,
+        limits,
+        excludes,
+        &FileSystemIndexEpilogueIo,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
 fn incremental_index_with_name_and_io(
     repo_path: &Path,
     db_path: &Path,
@@ -5135,6 +5246,7 @@ fn incremental_index_with_name_and_io(
     repo_url: &str,
     name: Option<&str>,
     limits: crate::index_limits::IndexLimits,
+    excludes: &[String],
     epilogue_io: &dyn IndexEpilogueIo,
 ) -> Result<IncrementalResult, anyhow::Error> {
     // nw-C1: reconcile BEFORE the `old_sha == new_sha` short-circuit below,
@@ -5165,6 +5277,7 @@ fn incremental_index_with_name_and_io(
                     name,
                     force: false,
                     limits,
+                    excludes,
                     epilogue_io,
                 },
             );
@@ -5186,6 +5299,7 @@ fn incremental_index_with_name_and_io(
                     name,
                     force: false,
                     limits,
+                    excludes,
                     epilogue_io,
                 },
             );
@@ -5222,6 +5336,7 @@ fn incremental_index_with_name_and_io(
                 // graph and installs its replacement in one transaction.
                 force: true,
                 limits,
+                excludes,
                 epilogue_io,
             },
         );
@@ -5247,6 +5362,7 @@ fn incremental_index_with_name_and_io(
                 // graph and installs its replacement in one transaction.
                 force: true,
                 limits,
+                excludes,
                 epilogue_io,
             },
         );
@@ -5269,7 +5385,8 @@ fn incremental_index_with_name_and_io(
         "processing incremental changes"
     );
 
-    let reader = crate::content_reader::FilesystemReader::with_limits(repo_path, limits);
+    let reader = crate::content_reader::FilesystemReader::with_limits(repo_path, limits)
+        .excluding(excludes)?;
     let mut result = IncrementalResult::default();
 
     // nw-008 Phase 0 — transitive reverse-dependents from the LIVE graph, BEFORE
@@ -6438,6 +6555,10 @@ struct FullIndexFallback<'a> {
     name: Option<&'a str>,
     force: bool,
     limits: crate::index_limits::IndexLimits,
+    /// `[[repos]] exclude` globs. The fallback builds its OWN reader, so it
+    /// must carry these too — a fresh index takes this path, and without them
+    /// the very first index of a repo silently ignored its excludes.
+    excludes: &'a [String],
     epilogue_io: &'a dyn IndexEpilogueIo,
 }
 
@@ -6454,6 +6575,7 @@ fn full_index_fallback(
         name,
         force,
         limits,
+        excludes,
         epilogue_io,
     } = request;
     // Load filemeta sidecar for tiered change detection even in fallback.
@@ -6477,7 +6599,8 @@ fn full_index_fallback(
     let resolution_deps_path = crate::sidecar_path(db_path, ".resolution_deps.bin");
     let mut resolution_deps = crate::resolution_cache::ResolutionDeps::load(&resolution_deps_path);
 
-    let reader = crate::content_reader::FilesystemReader::with_limits(repo_path, limits);
+    let reader = crate::content_reader::FilesystemReader::with_limits(repo_path, limits)
+        .excluding(excludes)?;
     let local_root = repo_path.display().to_string();
     // nw-022: capture a re-identified legacy file:// uid so its filemeta
     // slice is dropped below, mirroring index_directory_with_store_inner.
@@ -9653,6 +9776,61 @@ function hello(name) { return "Hello " + name; }
     }
 
     #[test]
+    fn index_applies_repo_exclude_globs() {
+        // End-to-end: an exclude declared in IndexOptions must reach the real
+        // index run, not just the reader. `vendor/**` cannot be relied on here
+        // (SKIP_DIRS already drops `vendor`), so use a directory the indexer
+        // would otherwise happily walk.
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("repo");
+        fs::create_dir_all(src.join("plugins/acme")).unwrap();
+        fs::write(
+            src.join("plugins/acme/thirdparty.js"),
+            "function vendored() {}",
+        )
+        .unwrap();
+        fs::write(src.join("main.js"), "function visible() {}").unwrap();
+
+        let store = GraphStore::in_memory().unwrap();
+        let db_path = dir.path().join("t.lbug");
+        let opts = IndexOptions::new("test", "https://example.com/repo", "abc123")
+            .excludes(&["plugins/**".to_string()]);
+        let result = index_directory_with_store_opts(&store, &src, &db_path, &opts, None).unwrap();
+
+        assert_eq!(
+            result.files_count, 1,
+            "only main.js should survive the exclude"
+        );
+    }
+
+    #[test]
+    fn index_without_excludes_still_walks_everything() {
+        // Counterweight for the test above: the same tree with NO excludes must
+        // index both files. Without this, an exclude bug that dropped every
+        // file would still satisfy `files_count == 1` if the fixture happened
+        // to contain one file.
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("repo");
+        fs::create_dir_all(src.join("plugins/acme")).unwrap();
+        fs::write(
+            src.join("plugins/acme/thirdparty.js"),
+            "function vendored() {}",
+        )
+        .unwrap();
+        fs::write(src.join("main.js"), "function visible() {}").unwrap();
+
+        let store = GraphStore::in_memory().unwrap();
+        let db_path = dir.path().join("t.lbug");
+        let opts = IndexOptions::new("test", "https://example.com/repo", "abc123");
+        let result = index_directory_with_store_opts(&store, &src, &db_path, &opts, None).unwrap();
+
+        assert_eq!(
+            result.files_count, 2,
+            "both files must index when nothing is excluded"
+        );
+    }
+
+    #[test]
     fn index_skips_node_modules() {
         let dir = tempfile::tempdir().unwrap();
         let src = dir.path().join("repo");
@@ -12478,6 +12656,7 @@ function hello(name) { return "Hello " + name; }
             repo_url,
             None,
             crate::index_limits::IndexLimits::default(),
+            &[],
             &InjectedIndexEpilogueIo {
                 fail_generation: true,
                 fail_compute: true,
@@ -12553,6 +12732,7 @@ function hello(name) { return "Hello " + name; }
             repo_url,
             None,
             crate::index_limits::IndexLimits::default(),
+            &[],
             &InjectedIndexEpilogueIo {
                 fail_generation: true,
                 fail_compute: true,

--- a/docs/guide/instance-config.md
+++ b/docs/guide/instance-config.md
@@ -340,6 +340,48 @@ pin_sha = "abc123"    # optional: pin to a specific commit
 > `--config` the daemon falls back to a system-root denylist, and this list is
 > what prevents watching an entire home directory.
 
+##### `exclude` — skip code the repo tracks
+
+`exclude` takes glob patterns, matched against repo-relative paths, for source
+the repo commits but the graph should not hold.
+
+```toml
+[[repos]]
+url = "git@github.com:myorg/wordpress-site.git"
+exclude = [
+  "web/wp-content/plugins/**",   # vendored third-party plugins
+  "web/wp-content/themes/**",    # upstream theme
+  "**/*.min.js",                 # generated bundles
+]
+```
+
+**Reach for this last.** The indexer walks with `ignore::WalkBuilder` and
+already honours `.gitignore`, the global gitignore, and `.git/info/exclude`, so
+anything git ignores is skipped with no configuration at all. If the goal is to
+drop build output, dependencies, or media, put it in one of those files and
+every other tool benefits too. `exclude` exists for the case they cannot
+express: code that is *deliberately committed* and still not yours to reason
+about — a vendored plugin tree, a checked-in SDK, generated bundles.
+
+Notes:
+
+- **Matching.** The `url` is compared against the repo's identity url **or** its
+  local checkout path, so `git@github.com:myorg/site.git`,
+  `file:///Users/me/dev/site`, and `/Users/me/dev/site` all resolve to the same
+  entry. Requiring one spelling would let a declared exclude silently do
+  nothing.
+- **Pruning.** A pattern ending in `/**` also prunes the directory it names, so
+  an excluded tree is never descended rather than walked and filtered. That is
+  the difference between skipping 8 GB and reading it.
+- **Invalid globs fail the load.** A malformed pattern is an error naming the
+  offending glob, not a silently dropped rule — a typo that quietly indexed a
+  vendored tree is the failure this is guarding against.
+- **Excludes apply to every index route** — full, incremental, and the
+  first-index fallback — so a `--no-daemon` run and a daemon run index the same
+  files.
+- **Changing `exclude` needs a re-index** of that repo. Previously-indexed files
+  are not retroactively removed by editing the config alone.
+
 ### Optional sections
 
 #### `[daemon]` — Daemon lifecycle policy

--- a/src/main.rs
+++ b/src/main.rs
@@ -15418,17 +15418,26 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let (files_count, symbols_count, edges_count);
             let skipped_files;
 
+            // Per-repo `exclude` globs from `--config`. The daemon route
+            // resolves these from its own loaded config; this is the direct
+            // (`--no-daemon`) twin, so both routes exclude the same paths.
+            let repo_excludes: Vec<String> = load_instance_config_opt(config.as_deref())
+                .map(|cfg| cfg.exclude_globs_for(&repo_url, Some(&repo_path)).to_vec())
+                .unwrap_or_default();
+
             if force {
                 // Full re-index requested explicitly.
-                let result = nestweaver_engine::index::index_directory_with_options_and_limits(
-                    &repo_path,
-                    &db_path,
+                let opts = nestweaver_engine::index::IndexOptions::new(
                     &instance_id,
                     &repo_url,
                     &indexed_sha,
-                    true,
-                    name.as_deref(),
-                    index_limits,
+                )
+                .force(true)
+                .name(name.as_deref())
+                .limits(index_limits)
+                .excludes(&repo_excludes);
+                let result = nestweaver_engine::index::index_directory_with_opts(
+                    &repo_path, &db_path, &opts,
                 )
                 .context("index_directory")?;
 
@@ -15446,13 +15455,14 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 skipped_files = result.skipped_files;
             } else {
                 // Incremental index (falls back to full when no prior index exists).
-                let inc = nestweaver_engine::index::incremental_index_with_name_and_limits(
+                let inc = nestweaver_engine::index::incremental_index_with_excludes(
                     &repo_path,
                     &db_path,
                     &instance_id,
                     &repo_url,
                     name.as_deref(),
                     index_limits,
+                    &repo_excludes,
                 )
                 .context("incremental_index")?;
 


### PR DESCRIPTION
## Why

NestWeaver already honours `.gitignore`, the global gitignore, and `.git/info/exclude` — the indexer walks with `ignore::WalkBuilder` and all three are enabled. Anything git ignores is skipped with no configuration.

What had no answer was code that is **deliberately committed** and still not ours to reason about. The motivating repo is a WordPress production mirror that tracks **28,948 vendored plugin files against 25 of its own**; the vendored trees are committed on purpose, because plugin code cannot be refetched from wordpress.org.

## What

`[[repos]] exclude` — glob patterns matched against repo-relative paths.

```toml
[[repos]]
url = "git@github.com:myorg/wordpress-site.git"
exclude = ["web/wp-content/plugins/**", "**/*.min.js"]
```

- **Pruning.** A pattern ending in `/**` also prunes the directory it names. `big/**` does not match `big` itself, so without the derived directory pattern the walker would read the whole tree and filter afterwards — the difference between skipping 8 GB and reading it.
- **Matching.** `url` matches the repo's identity url **or** its local checkout path. The same repo is spelled three ways in practice (indexed by path, recorded as a git origin, declared as a `file://` url); requiring one spelling would let a declared exclude silently do nothing.
- **Invalid globs fail the load**, naming the offending pattern, rather than being silently dropped.
- **Every index route** — full, incremental, and the first-index fallback. `full_index_fallback` builds its own reader and a fresh index takes that path, so omitting it there would have meant the very first index of a repo ignored its excludes.

## IndexOptions

The entry points now funnel through a new `IndexOptions`. The four `_with_store` / `_cancellable` / `_and_limits` spellings were a name-per-knob growth pattern that excludes would have made worse, and `index_directory_with_options_and_limits` was already named for "options" it never had. It also removes a live hazard: the previous signature passed `instance_id`, `repo_url` and `indexed_sha` as three adjacent `&str`, so any two could be swapped at a call site and still compile.

Existing functions remain as thin wrappers building `IndexOptions` with no excludes, so the ~200 in-tree callers are untouched. Only `RepoConfig` gains a public field.

## Verification

- `cargo test -p nestweaver-engine --all-features` — 1210 passed
- `cargo test -p nestweaver-daemon --all-features` — 321 passed
- `cargo test -p nestweaver-mcp --all-features` — 205 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Each new test is paired with a counterweight asserting the non-excluded files survive, so a bug that dropped *everything* could not pass. Every behaviour was **mutation-checked** — neutering the file filter, the directory-prefix derivation, the glob validation, or the path-matching branch each fails its test.

End-to-end against the real repo: baseline indexes 241 results (mostly the vendored theme); with `exclude = ["web/wp-content/themes/**"]` it indexes 9 results and **zero** theme paths.