### PR TITLE
chore(deps): move off yanked chacha20 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,9 +1181,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
## Reported

> `cargo install --locked` warned that the release lockfile contains yanked chacha20 0.10.1. The v8.0.0 build still completed successfully, but that is release dependency hygiene worth noting upstream.

**Valid.** Confirmed against crates.io: `0.10.0` and `0.10.1` are both yanked; `0.10.2` is the only unyanked `0.10.x`.

## One nuance on the framing

`chacha20 0.10.2` was published **2026-08-27 17:51 UTC — after v8.0.0 was tagged**. The pin was not yanked when the release was cut, so this isn't a hygiene miss at release time; it's a dependency that got yanked the same day. No pre-release check could have caught it.

That does suggest a follow-up worth considering separately: nothing currently re-checks a *shipped* lockfile against later yanks. A periodic `cargo audit`/`cargo update --dry-run` in CI would surface this class without depending on a user reporting it.

## Change

Lockfile bump only — `chacha20` is transitive via `rand 0.10.2`. No manifest change, no API surface touched.

## Verification

`cargo build --locked` succeeds with no yanked-crate warning.