### PR TITLE
docs(daemon): warn that systemctl stop does not stop an ad-hoc daemon

### DIFF
--- a/docs/guide/daemon-shutdown.md
+++ b/docs/guide/daemon-shutdown.md
@@ -173,6 +173,43 @@ Restart=on-failure
 Even so, this is a **hard deadline** systemd enforces. It moves the exposure
 window; it does not remove it.
 
+### Stopping the wrong daemon — **the supervisor does not own the lock**
+
+`systemctl stop nestweaver` stops *the unit*. It does not stop "the daemon
+serving this database", and those are not always the same process.
+
+Every CLI command auto-starts a daemon on first use. So if the unit is stopped
+when an index runs, the index starts its **own ad-hoc daemon**, unsupervised and
+outside systemd's control. A later `systemctl stop` then reports success having
+stopped nothing, the ad-hoc daemon keeps the write lock, and the next write —
+typically `embed` — blocks against a daemon the operator does not know exists.
+
+Use the CLI, which resolves the owner rather than the supervisor:
+
+```sh
+nestweaver daemon --db /var/lib/nestweaver/brain.lbug stop
+```
+
+`daemon stop` checks the launchd job (macOS) *and* falls through to the
+pidfile/socket, so it only reports success once nothing is left serving the
+database. That fall-through exists precisely for this case.
+
+For a scripted refresh, start the supervised service **before** the first
+command that touches the database, so no ad-hoc daemon is ever created:
+
+```sh
+systemctl start nestweaver          # or: nestweaver daemon start --config <toml>
+nestweaver brain refresh ... --config <toml>
+```
+
+> **Linux status is currently ambiguous about this.** On macOS `daemon status`
+> distinguishes `Daemon is running (launchd agent)` from a bare PID. On Linux
+> both a systemd-supervised daemon and an ad-hoc one print
+> `Daemon is running (PID <n>)`, so status alone will not tell you which you
+> have. Until that is disclosed, treat `systemctl is-active` and
+> `nestweaver daemon status` as answering **different questions**: whether the
+> unit is up, versus whether something is serving the database.
+
 ### macOS, launchd — **was the tightest exposure of all; now partially fixed**
 
 `daemon start` on macOS installs a launch agent. The generated plist set **no


### PR DESCRIPTION
## Reported

> The first refresh exposed an ownership gap in the brain refresh workflow: because the configured systemd service was initially stopped, the first index auto-started an ad-hoc daemon. The script would later have stopped only the systemd unit, potentially leaving embedding blocked.

**Valid, and well diagnosed.** Worth separating what is broken from what is not.

## `daemon stop` is already correct

It checks the launchd job on macOS *and* falls through to the pidfile/socket path, SIGTERMing whatever owns the database regardless of how it was started. It only reports success once nothing is left serving. The code comment names this exact scenario — "a detached auto-spawned daemon may still be serving this DB outside launchd's control".

So the failure mode is not a bug in `daemon stop`. It is that the script called `systemctl stop`, which stops *the unit*, not *the owner of the write lock*. Nothing in the docs said those differ, and on Linux `systemctl stop` is the natural instinct.

## The real product gap this exposes

On macOS, `daemon status` distinguishes `Daemon is running (launchd agent)` from a bare PID. On **Linux both a systemd-supervised daemon and an ad-hoc auto-spawn print `Daemon is running (PID <n>)`** — an operator cannot tell which one they have. That is the ambiguity that let this go unnoticed until they caught it by hand.

This PR documents the trap and records that gap honestly. It does **not** attempt to fix the Linux disclosure: detecting supervision means reading `/proc/<pid>/cgroup` for the unit, which is Linux-only code I cannot exercise on macOS, and shipping untested platform code to close an observability gap seemed worse than naming it. Happy to do it as a follow-up if you want it, ideally with a container-based test.

## Change

Adds a "Stopping the wrong daemon" section to `docs/guide/daemon-shutdown.md` covering:

- why `systemctl stop` can stop nothing at all
- `nestweaver daemon stop` as the command that resolves the owner
- ordering for scripted refreshes — start the service *before* the first command that touches the DB, so no ad-hoc daemon is created
- an explicit note that `systemctl is-active` and `nestweaver daemon status` answer different questions