### PR TITLE
docs(cli): make the --no-daemon guard say what it does

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -542,10 +542,18 @@ struct Cli {
     #[arg(long, global = true)]
     plain: bool,
 
-    /// CI/testing only — bypass the daemon and open the database directly.
-    /// DO NOT use in normal operation. The daemon owns the write lock and
-    /// coordinates concurrent access; bypassing it risks WAL corruption.
-    /// Requires NESTWEAVER_NO_DAEMON=1 environment variable as a safety gate.
+    /// Test harnesses only — do not use in normal operation, including from
+    /// scripts and agents. Requests that this command skip autostarting a
+    /// daemon and open the database directly.
+    ///
+    /// The gate is `NESTWEAVER_ALLOW_NO_DAEMON`, NOT `NESTWEAVER_NO_DAEMON` —
+    /// the latter is a second way to REQUEST the bypass, not to permit it.
+    /// Without the gate this flag is ignored and the command routes through
+    /// the daemon.
+    ///
+    /// This is not what keeps the store single-writer: the write lease is
+    /// taken at the moment of the write and fails closed, so a bypass against
+    /// a daemon-owned database is refused, not silently doubled.
     #[arg(long, global = true, hide = true)]
     no_daemon: bool,
 
@@ -8867,14 +8875,18 @@ fn no_daemon_allowed_from(allow_optin: bool, _github_actions: bool, _ci: Option<
 /// Whether the daemon-bypass escape hatch (`--no-daemon` / `NESTWEAVER_NO_DAEMON`)
 /// is permitted in the current environment.
 ///
-/// Bypassing the daemon writes to the store directly, which risks WAL corruption
-/// and is strictly a CI/test convenience — yet the env var kept getting set in
-/// interactive and agent contexts, silently engaging the unsafe path. So outside
-/// a CI context we now *refuse* it and route through the daemon instead. It is
-/// honored only when one of these is present:
-///   - `NESTWEAVER_ALLOW_NO_DAEMON` — explicit local-test opt-in, or
-///   - `GITHUB_ACTIONS` — set by GitHub Actions, or
-///   - `CI` set to a truthy value — set by virtually every CI system.
+/// Honored by exactly ONE thing: `NESTWEAVER_ALLOW_NO_DAEMON`. `GITHUB_ACTIONS`
+/// and `CI` confer nothing — they are still read and passed in, but only so
+/// [`no_daemon_allowed_from`]'s tests can pin that they never grant permission.
+/// See that function for why an ambient, inherited variable is the wrong
+/// channel for this decision.
+///
+/// What the answer actually controls is narrow: whether a command may skip
+/// autostarting a daemon. It is NOT what protects the store from two writers —
+/// [`require_exclusive_store_access`] takes the write lease at the moment of
+/// the write and fails closed if anyone holds it, so a bypass against a
+/// daemon-owned database is refused rather than silently doubled. A wrong
+/// answer here costs a confusing refusal, not corruption.
 fn no_daemon_allowed() -> bool {
     no_daemon_allowed_from(
         std::env::var_os("NESTWEAVER_ALLOW_NO_DAEMON").is_some(),
@@ -9140,9 +9152,10 @@ fn resolve_use_daemon(no_daemon_flag: bool, warn: bool) -> bool {
     }
     if warn {
         eprintln!(
-            "Warning: --no-daemon / NESTWEAVER_NO_DAEMON is a CI/test-only escape hatch that \
-             bypasses the daemon and risks WAL corruption. Ignoring it and routing through the \
-             daemon. Set NESTWEAVER_ALLOW_NO_DAEMON=1 to force the bypass."
+            "Warning: --no-daemon / NESTWEAVER_NO_DAEMON is a test-harness-only escape \
+             hatch and is not permitted here. Routing through the daemon, which is the \
+             single writer for this database. If you are trying to stop a daemon that is \
+             holding the write lease, use `nestweaver daemon --db <path> stop`."
         );
     }
     true


### PR DESCRIPTION
## Context

Asked to gate the `--no-daemon` escape hatch so it "can never be used outside CI". Investigating it, **the gate is already there and is stronger than what I was about to add** — and the docs around it are what made it look otherwise.

## What I found

`no_daemon_allowed_from` already ignores `CI` and `GITHUB_ACTIONS` entirely (they're `_`-prefixed params), and its tests assert they *must not* confer permission. The body argues the case well: `CI` is ambient, set by unrelated tools and Docker images, and shouldn't decide writer exclusivity — the Netlify `CI=true` incident and `RUSTC_BOOTSTRAP` are cited.

So "refuse unless a CI environment is detected" is a decision this codebase already made and reversed, deliberately. Adding it back would be a regression.

More importantly: **the bypass is not what protects the store.** `require_exclusive_store_access` acquires the write lease at the moment of the write and fails closed with a message naming the holder. A `--no-daemon` write against a daemon-owned database is *refused*, not silently doubled. The corruption this reads as preventing is prevented one layer down.

## The actual defect

Three statements described this mechanism and none matched the code:

| Where | Said | Actually |
|---|---|---|
| `--no-daemon` flag help | "Requires `NESTWEAVER_NO_DAEMON=1` as a safety gate" | Wrong variable — that one *requests* the bypass; the gate is `NESTWEAVER_ALLOW_NO_DAEMON` |
| `no_daemon_allowed` doc | Honored by the opt-in, `GITHUB_ACTIONS`, **or** `CI` | Only the opt-in. Its own tests assert the other two never grant it |
| Runtime warning | "risks WAL corruption… **Set `NESTWEAVER_ALLOW_NO_DAEMON=1` to force the bypass**" | Advertises the hatch while calling it unsafe |

That last one is self-defeating: the guard's own comment records that the problem was "the env var kept getting set in interactive and agent contexts", and the warning is the thing teaching people the variable's name.

## Change

Docs and one user-facing string. **No behaviour change** — the guard and its tests are untouched.

The warning now points at `nestweaver daemon --db <path> stop`, which is what someone blocked by a lease-holding daemon actually needs, instead of handing them the bypass.

## Verification

- `cargo test -p nestweaver` — 215 + 4 + 2 + 5 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all` — clean

## Still open, if you want it

A build-feature gate (`--features unsafe-daemon-bypass`, off by default) would make the hatch physically absent from release binaries. It's viable, but given the lease already fails closed, it buys defence-in-depth rather than fixing a hole — and it costs test-harness plumbing, since `tests/cli_test.rs` and `tests/parity_test.rs` spawn the real binary and set the opt-in. Say the word.