### PR TITLE
fix: second backlog remediation pass — 42 ready items, four lanes

### DIFF
--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -5276,6 +5276,12 @@ impl NestWeaverDaemon for DaemonService {
                             {
                                 tracing::warn!("save git activity sidecar failed: {e}");
                             } else {
+                                // nw-258(a). The daemon loads this sidecar ONCE
+                                // at boot and is also its only writer, so
+                                // without this the message below announced work
+                                // that changed nothing for the rest of the
+                                // daemon's life.
+                                refresh_git_activity(&state.store, &ga_path);
                                 let _ = tx.blocking_send(Ok(IndexProgress {
                                     message: format!(
                                         "Git activity sidecar written ({} files scored).",
@@ -10135,6 +10141,40 @@ fn reconcile_index_publication_before_ppr_warm(store: &GraphStore, read_only: bo
             );
         }
         Err(e) => tracing::warn!("failed to warm PPR cache: {e}"),
+    }
+}
+
+/// nw-258(a). Make a freshly written git-activity sidecar visible to the
+/// RUNNING daemon.
+///
+/// The daemon loads this sidecar once, in `serve()`, and is also its only
+/// writer — so `index --with-git-activity` printed "N files scored" and changed
+/// nothing until the next restart. A flag that costs time at index and affects
+/// nothing at query is a success message for work with no effect.
+///
+/// `clear_git_activity_cache` has existed on the store since nw-233 with ZERO
+/// callers: the invalidator was written and never wired. This is that wiring.
+///
+/// Deliberately NOT the `RwLock<SearchRuntime>` shape that `40dececa` used for
+/// the same class of boot-frozen state. That precedent applies in DIAGNOSIS and
+/// not in machinery: opening a Tantivy index is expensive, can fail, and can be
+/// repaired EXTERNALLY while the daemon runs, so it needed a retry policy. None
+/// of that holds here — the cache already has interior mutability, the file is
+/// small JSON, a bad file degrades to neutral by construction, and the writer is
+/// the daemon itself, so there is nothing to poll for. Mirror
+/// `invalidate_pagerank`'s placement, not `SearchRuntime`'s machinery.
+///
+/// Clear THEN load, in that order: a load that fails must leave the cache
+/// neutral rather than serving scores mined from a graph state that no longer
+/// exists.
+fn refresh_git_activity(store: &GraphStore, ga_path: &Path) {
+    store.clear_git_activity_cache();
+    if let Err(error) = store.load_git_activity_sidecar(ga_path) {
+        tracing::debug!(
+            error = %error,
+            path = %ga_path.display(),
+            "git-activity sidecar could not be re-read after a write; ranking stays neutral"
+        );
     }
 }
 
@@ -17400,6 +17440,71 @@ mod startup_helper_tests {
         assert_eq!(resp.error, "port_in_use");
         assert_eq!(resp.port, 0);
         drop(blocker);
+    }
+
+    /// nw-258(a). The daemon writes this sidecar and never reloaded it, so
+    /// `--with-git-activity` printed "N files scored" and changed nothing for
+    /// the rest of that daemon's life. `clear_git_activity_cache` existed on the
+    /// store with ZERO callers — the invalidator was written and never wired.
+    ///
+    /// This test can FAIL when the property is broken: delete the
+    /// `refresh_git_activity` call in the index handler (or the body of the
+    /// helper) and the score below stays `None`.
+    #[test]
+    fn writing_the_git_activity_sidecar_makes_it_visible_to_the_running_daemon() {
+        let state = test_state_with_writer();
+        assert!(
+            !state.store.has_git_activity(),
+            "precondition: nothing loaded"
+        );
+
+        let ga_path = nestweaver_engine::sidecar_path(&state.db_path, ".gitactivity.json");
+        nestweaver_engine::git_activity::save_git_activity_for_repo(
+            "repo:x",
+            &std::collections::HashMap::from([("src/main.rs".to_string(), 0.9)]),
+            &ga_path,
+        )
+        .unwrap();
+
+        // Boot-frozen: the write alone is invisible to the running process.
+        assert_eq!(
+            state.store.git_activity_score("repo:x", "src/main.rs"),
+            None
+        );
+
+        super::refresh_git_activity(&state.store, &ga_path);
+
+        assert_eq!(
+            state.store.git_activity_score("repo:x", "src/main.rs"),
+            Some(0.9),
+            "a flag that costs time at index and affects nothing at query is a \
+             success message for work with no effect"
+        );
+    }
+
+    /// The other half: a refresh whose sidecar has gone away must leave ranking
+    /// NEUTRAL, not serving scores mined from a graph state that no longer
+    /// exists. This is why the helper clears before it loads.
+    #[test]
+    fn refreshing_from_a_vanished_sidecar_restores_neutral_ranking() {
+        let state = test_state_with_writer();
+        let ga_path = nestweaver_engine::sidecar_path(&state.db_path, ".gitactivity.json");
+        nestweaver_engine::git_activity::save_git_activity_for_repo(
+            "repo:x",
+            &std::collections::HashMap::from([("src/main.rs".to_string(), 0.9)]),
+            &ga_path,
+        )
+        .unwrap();
+        super::refresh_git_activity(&state.store, &ga_path);
+        assert!(state.store.has_git_activity());
+
+        std::fs::remove_file(&ga_path).unwrap();
+        super::refresh_git_activity(&state.store, &ga_path);
+
+        assert!(
+            !state.store.has_git_activity(),
+            "a refresh must not leave the previous slice loaded"
+        );
     }
 
     /// Build a minimal `DaemonState` with a writer-mode Tantivy index for

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -5636,7 +5636,7 @@ impl NestWeaverDaemon for DaemonService {
                     let _ = tx.blocking_send(Ok(IndexProgress {
                         phase: Phase::Done as i32,
                         message: format!(
-                            "Incremental refresh of vault '{}': checked {} file(s), updated {} note(s), dropped {} prior note(s), {} heading(s), {} section(s), {} tag(s), {} wikilink(s).",
+                            "Incremental refresh of vault '{}': checked {} file(s), updated {} note(s), dropped {} prior note(s), {} heading(s), {} section(s), {} tag(s), {} wikilink edge(s) on changed notes.",
                             result.vault_name,
                             result.files_checked,
                             result.notes_updated,
@@ -5644,7 +5644,7 @@ impl NestWeaverDaemon for DaemonService {
                             result.headings_count,
                             result.sections_count,
                             result.tags_count,
-                            result.wikilinks_resolved,
+                            result.changed_note_link_edges,
                         ),
                         files_processed: result.files_checked as u64,
                         files_total: result.files_checked as u64,

--- a/crates/nestweaver-engine/src/affected_tests.rs
+++ b/crates/nestweaver-engine/src/affected_tests.rs
@@ -232,11 +232,33 @@ fn affected_tests_within(
     // (nw-085). The per-symbol walk below is the identical confidence-weighted
     // max-product reverse BFS (same edge set, depth cap, confidence + threshold
     // pruning), just over the in-memory adjacency.
-    let symbols = match store.list_all_symbols() {
-        Ok(symbols) => symbols
-            .into_iter()
-            .filter(|symbol| allowed_symbols.is_none_or(|allowed| allowed.contains(&symbol.uid)))
-            .collect(),
+    //
+    // The scan TOLERATES a corrupt row (nw-335) rather than losing the whole
+    // corpus to it, so `Ok` no longer means "complete". Take the integrity with
+    // the rows: a test selection is a SAFETY claim ("you may skip everything
+    // else"), and a partial graph cannot justify a partial selection. nw-324
+    // was exactly this — `affected-tests` reporting `selection-usable` over a
+    // graph it could not fully read, and a regression shipping green.
+    let symbols = match store.list_all_symbols_with_integrity() {
+        Ok((symbols, integrity)) => {
+            if let Some(disclosure) = integrity.disclosure() {
+                notifications.push(Notification {
+                    level: NotificationLevel::Error,
+                    message: format!(
+                        "the symbol graph could not be read completely, so this \
+                         selection is not safe to trust: {disclosure}"
+                    ),
+                    descriptor: "store.list-symbols-incomplete".to_string(),
+                });
+                status = status.max(AnalysisStatus::Degraded);
+            }
+            symbols
+                .into_iter()
+                .filter(|symbol| {
+                    allowed_symbols.is_none_or(|allowed| allowed.contains(&symbol.uid))
+                })
+                .collect()
+        }
         Err(e) => {
             notifications.push(Notification {
                 level: NotificationLevel::Error,
@@ -675,9 +697,22 @@ mod tests {
                 .len(),
             1
         );
+        // nw-335 made the global scan TOLERATE the corrupt row instead of
+        // aborting the corpus, so it no longer returns `Err` — it returns a
+        // shorter list. The safety guarantee below only survives if that
+        // shortfall is a VALUE the caller can read, not a log line: assert the
+        // scan is degraded and that the corrupt row really is missing.
+        let (symbols, integrity) = store
+            .list_all_symbols_with_integrity()
+            .expect("the scan tolerates the corrupt row rather than aborting");
         assert!(
-            store.list_all_symbols().is_err(),
-            "global enumeration must encounter the unrelated corruption canary"
+            integrity.is_degraded(),
+            "global enumeration must OBSERVE the unrelated corruption canary, \
+             not merely log it: {integrity:?}"
+        );
+        assert!(
+            !symbols.iter().any(|s| s.uid == "sym:corrupt"),
+            "the corrupt row is genuinely absent from the graph this analysis walks"
         );
 
         let result =
@@ -685,10 +720,15 @@ mod tests {
 
         assert_eq!(result.status, AnalysisStatus::Degraded);
         assert_eq!(result.recommendation, "run-full-suite");
-        assert!(result.notifications.iter().any(|notification| {
-            notification.level == NotificationLevel::Error
-                && notification.descriptor == "store.list-symbols-failed"
-        }));
+        assert!(
+            result.notifications.iter().any(|notification| {
+                notification.level == NotificationLevel::Error
+                    && notification.descriptor == "store.list-symbols-incomplete"
+            }),
+            "an incomplete symbol graph must be disclosed as an error-level \
+             notification, not inferred: {:?}",
+            result.notifications
+        );
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/brain_docgraph.rs
+++ b/crates/nestweaver-engine/src/brain_docgraph.rs
@@ -509,19 +509,42 @@ pub struct TagCount {
     pub count: usize,
 }
 
-/// Aggregate statistics over the document graph. All seven keys are always
-/// present (empty DB → zeros / empty collections).
+/// Aggregate statistics over the document graph. Every key is always present
+/// (empty DB → zeros / empty collections).
+///
+/// nw-345: the link counts do not agree with each other and are not meant to —
+/// each names the population it counts. See
+/// [`crate::index_md::MarkdownIndexResult`] for the full set and why a
+/// de-duplication introduced to make a LIST readable is not a definition of a
+/// METRIC.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DocStats {
     pub total_notes: usize,
-    pub total_wikilinks: usize,
-    /// Links that point at no note at all. This is the vault-health number.
-    pub broken_wikilinks: usize,
+    /// nw-345: one per WIKILINK_TO_NOTE / WIKILINK_TO_HEADING EDGE, so a single
+    /// ambiguous link contributes N. It was printed as `total wikilinks:` one
+    /// line above a numerator that counts neither edges nor occurrences — a
+    /// denominator that matched nothing on the same screen.
+    pub wikilink_edges: usize,
+    /// Links that point at no note at all, deduped to distinct (source note,
+    /// target text). This is the vault-health number, and it is a strictly
+    /// smaller population than the indexer's occurrence count — see
+    /// [`crate::index_md::MarkdownIndexResult`] for all five.
+    pub unresolved_link_targets: usize,
+    /// The same links deduped only to (source section, target text) — the
+    /// granularity the graph actually stores. Reported so the step between the
+    /// indexer's occurrence count and `unresolved_link_targets` is visible
+    /// rather than left as an unexplained gap (nw-345).
+    ///
+    /// OCCURRENCES are deliberately absent: the graph does not record them, and
+    /// inventing a proxy for them here would recreate exactly the defect this
+    /// field exists to close. `brain add` reports them.
+    pub unresolved_link_section_targets: usize,
     /// Links that DID resolve, but below full confidence — a same-folder or
     /// unique filename-stem match rather than a path or unique-title match.
-    /// Counted separately because folding them into `broken_wikilinks` reported
-    /// 75% of a healthy vault as broken when the real figure was 11% (nw-100).
-    pub low_confidence_wikilinks: usize,
+    /// Counted separately because folding them into the unresolved count
+    /// reported 75% of a healthy vault as broken when the real figure was 11%
+    /// (nw-100). Same (source note, target text) dedup.
+    pub low_confidence_link_targets: usize,
     pub orphans: usize,
     pub avg_outdegree: f64,
     pub top_tags: Vec<TagCount>,
@@ -532,8 +555,11 @@ pub struct DocStats {
 /// summary. `top_tags` is capped at `top_tags_limit`. Graceful on empty DB.
 pub fn doc_stats(store: &GraphStore, top_tags_limit: usize) -> Result<DocStats> {
     let total_notes = store.count_notes().map_err(|e| anyhow::anyhow!(e))?;
-    let total_wikilinks = store
+    let wikilink_edges = store
         .count_wikilink_edges()
+        .map_err(|e| anyhow::anyhow!(e))?;
+    let unresolved_link_section_targets = store
+        .count_unresolved_wikilink_nodes()
         .map_err(|e| anyhow::anyhow!(e))?;
     let suspect = broken_links(store, 0)?;
     let broken = suspect.iter().filter(|l| l.is_unresolved()).count();
@@ -576,9 +602,10 @@ pub fn doc_stats(store: &GraphStore, top_tags_limit: usize) -> Result<DocStats> 
 
     Ok(DocStats {
         total_notes,
-        total_wikilinks,
-        broken_wikilinks: broken,
-        low_confidence_wikilinks: low_confidence,
+        wikilink_edges,
+        unresolved_link_targets: broken,
+        unresolved_link_section_targets,
+        low_confidence_link_targets: low_confidence,
         orphans,
         avg_outdegree,
         top_tags,
@@ -767,11 +794,11 @@ mod tests {
         // The headline metric must count only the dangling one.
         let stats = doc_stats(&store, 5).unwrap();
         assert_eq!(
-            stats.broken_wikilinks, 1,
+            stats.unresolved_link_targets, 1,
             "only [[Nowhere At All]] is broken; counting the resolved one is the nw-100 defect"
         );
         assert!(
-            stats.low_confidence_wikilinks >= 1,
+            stats.low_confidence_link_targets >= 1,
             "the lower-tier resolution must still be reported, just not as broken"
         );
     }
@@ -922,8 +949,8 @@ mod tests {
         // doc-stats broken count must be > 0.
         let stats = doc_stats(&store, 5).unwrap();
         assert!(
-            stats.broken_wikilinks > 0,
-            "doc-stats broken_wikilinks must be > 0"
+            stats.unresolved_link_targets > 0,
+            "doc-stats unresolved_link_targets must be > 0"
         );
     }
 
@@ -1063,15 +1090,16 @@ mod tests {
     }
 
     #[test]
-    fn doc_stats_returns_all_seven_keys() {
+    fn doc_stats_returns_every_key_with_its_population_named() {
         let (_dir, store) = f9_vault();
         let stats = doc_stats(&store, 10).unwrap();
-        // Serialize and assert the seven keys exist (graceful, all present).
+        // Serialize and assert every key exists (graceful, all present).
         let v = serde_json::to_value(&stats).unwrap();
         for key in [
             "total_notes",
-            "total_wikilinks",
-            "broken_wikilinks",
+            "wikilink_edges",
+            "unresolved_link_targets",
+            "unresolved_link_section_targets",
             "orphans",
             "avg_outdegree",
             "top_tags",
@@ -1081,7 +1109,7 @@ mod tests {
         }
         assert_eq!(stats.total_notes, 6);
         assert!(stats.orphans >= 1, "Island is an orphan");
-        assert!(stats.total_wikilinks > 0);
+        assert!(stats.wikilink_edges > 0);
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/content_reader.rs
+++ b/crates/nestweaver-engine/src/content_reader.rs
@@ -298,6 +298,20 @@ impl ContentReader for FilesystemReader {
             .into());
         }
         let source = String::from_utf8_lossy(&raw).into_owned();
+        // nw-335: the binary sniff above is WINDOWED -- the leading 8 KiB, which
+        // is what ripgrep, git and grep all look at. A NUL PAST that window is
+        // never seen, so a mostly-text file carrying one is (correctly) accepted
+        // as text and (incorrectly) carries the byte into the graph, where the
+        // store's WHOLE-string corruption canary then refuses the row and one
+        // bad row empties a whole-corpus scan. The reported file had its NUL at
+        // offset 47,354. Widening the sniff would reclassify such files as
+        // binary and lose them entirely; dropping the byte keeps the file.
+        //
+        // This covers the CODE pipeline (symbol signatures and summaries are
+        // content columns too). The markdown pipeline is covered independently
+        // at `parse_markdown`, because the watcher reads notes with
+        // `fs::read_to_string` and never passes through here.
+        let source = nestweaver_parser::strip_nul_bytes(&source).into_owned();
         if source.len() as u64 > self.limits.max_source_file_bytes() {
             return Err(SourceTooLarge {
                 path: rel_path.display().to_string(),
@@ -1868,6 +1882,46 @@ mod non_utf8_tests {
         assert!(
             source.contains('\u{FFFD}'),
             "invalid bytes should become the replacement character"
+        );
+    }
+
+    /// nw-335, the "where else": the binary sniff above is WINDOWED -- the
+    /// leading 8 KiB, as ripgrep, git and grep all do. A NUL PAST that window is
+    /// therefore not seen, and the file is decoded as text with the byte intact.
+    /// The reported file carried its NUL at offset 47,354, six times past the
+    /// window, which is exactly why it reached the graph. The store's canary
+    /// (`read::string_is_corrupt`) then scans the WHOLE string, so the reader
+    /// and the store disagree about what "contains a NUL" means and the gap is
+    /// bytes 8,193..EOF. Every content column both the markdown and the code
+    /// pipelines write flows through this one function.
+    #[test]
+    fn a_nul_past_the_binary_sniff_window_is_stripped_not_smuggled_through() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("late.js");
+        let mut bytes = b"// leading text\nfunction ok() { return 1; }\n".to_vec();
+        bytes.resize(20_000, b' ');
+        bytes.extend_from_slice(b"\nfunction late");
+        bytes.push(0);
+        bytes.extend_from_slice(b"r() { return 2; }\n");
+        assert!(bytes.len() > 8192, "the NUL must sit past the sniff window");
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(&bytes)
+            .unwrap();
+
+        let reader = FilesystemReader::new(dir.path());
+        let source = reader
+            .read_file(Path::new("late.js"))
+            .expect("a mostly-text file with one late NUL is text, not binary");
+        assert!(
+            !source.contains('\0'),
+            "nw-335: a NUL must never leave the reader -- it poisons every \
+             whole-corpus scan that later reads the row back"
+        );
+        assert!(
+            source.contains("function ok()") && source.contains("function later()"),
+            "the surrounding source must survive: dropping the byte is not \
+             dropping the file"
         );
     }
 

--- a/crates/nestweaver-engine/src/cross_domain.rs
+++ b/crates/nestweaver-engine/src/cross_domain.rs
@@ -150,8 +150,16 @@ fn discover_cross_domain_links_full(
         return Ok(CrossDomainResult::default());
     }
 
-    let notes = store.list_notes(None).context("list_notes")?;
+    // A note the STORE could not decode is a note this pass did not scan, and
+    // `skipped_unreadable` is already the field that says so — it just never
+    // saw these, because nw-335's corrupt-row tolerance drops them inside the
+    // scan and reports it in a log line. Left unwired, `notes_scanned` counts
+    // them in neither column and the pass claims it covered the vault.
+    let (notes, integrity) = store
+        .list_notes_with_integrity(None)
+        .context("list_notes")?;
     let mut result = CrossDomainResult::default();
+    result.skipped_unreadable += integrity.skipped_corrupt;
 
     // Scan all notes in memory first (no DB writes), then flush in
     // transaction-batched chunks. Earlier versions committed once per
@@ -691,6 +699,113 @@ mod tests {
 
         let count = store.count_references_code_edges().unwrap();
         assert!(count >= 1, "edges should be persisted");
+    }
+
+    /// This pass reports `notes_scanned` and already carries
+    /// `skipped_unreadable` for a note it could not read. nw-335 made the note
+    /// scan itself drop a row it cannot decode and say so only in a log line,
+    /// which put such a note in NEITHER column — the pass then reported having
+    /// covered the vault when it had not. The two counters must still account
+    /// for every note the vault holds.
+    #[test]
+    fn a_note_the_store_cannot_decode_is_counted_as_skipped_not_as_absent() {
+        let dir = tempdir().unwrap();
+        let vault_root = dir.path().join("vault");
+        std::fs::create_dir_all(&vault_root).unwrap();
+        std::fs::write(
+            vault_root.join("design.md"),
+            "# Auth Design\n\nThe AuthService.authenticate flow handles login.\n",
+        )
+        .unwrap();
+
+        let store = GraphStore::in_memory().unwrap();
+        let v_uid = vault_uid("default", &vault_root.to_string_lossy());
+        store
+            .insert_vault(&Vault {
+                uid: v_uid.clone(),
+                name: "v".to_string(),
+                root_path: vault_root.to_string_lossy().into_owned(),
+                instance_id: "default".to_string(),
+            })
+            .unwrap();
+
+        let note = |uid: &str, title: &str, file: &str| Note {
+            uid: uid.to_string(),
+            vault_uid: v_uid.clone(),
+            file_path: file.to_string(),
+            title: title.to_string(),
+            note_kind: NoteKind::Design,
+            word_count: 10,
+            content_hash: "h".to_string(),
+            frontmatter: None,
+            frontmatter_raw: None,
+            created_at: None,
+            modified_at: None,
+            pagerank_score: None,
+            embedding: None,
+        };
+        store
+            .insert_note(&note(
+                &format!("note:{v_uid}:ok"),
+                "Auth Design",
+                "design.md",
+            ))
+            .unwrap();
+        // A NUL in a note the store WROTE is the LadybugDB #678 pattern the
+        // canary exists to catch; the scan drops this row.
+        store
+            .insert_note(&note(
+                &format!("note:{v_uid}:bad"),
+                "Poi\u{0}soned",
+                "poisoned.md",
+            ))
+            .unwrap();
+
+        let r_uid = repo_uid("default", "https://example.com/r");
+        store
+            .insert_repo(&nestweaver_schema::Repo {
+                uid: r_uid.clone(),
+                url: "https://example.com/r".to_string(),
+                indexed_sha: "abc".to_string(),
+                staleness_commits_behind: 0,
+                instance_id: "default".to_string(),
+                name: None,
+                root_path: None,
+            })
+            .unwrap();
+        store
+            .insert_symbol(&Symbol {
+                uid: symbol_uid(&r_uid, "src/auth.ts", "AuthService", 1),
+                name: "AuthService".to_string(),
+                kind: SymbolKind::Class,
+                repo_uid: r_uid,
+                file_path: "src/auth.ts".to_string(),
+                start_line: 1,
+                end_line: 1,
+                signature: "class AuthService".to_string(),
+                summary: None,
+                content_hash: "h".to_string(),
+                embedding: None,
+                pagerank_score: None,
+                is_entry_point: false,
+                entry_point_kind: None,
+                visibility: Visibility::Inferred,
+                type_info: None,
+                framework_hint: None,
+                canonical_id: None,
+            })
+            .unwrap();
+
+        let result = discover_cross_domain_links(&store).unwrap();
+        assert_eq!(
+            result.skipped_unreadable, 1,
+            "a note the STORE could not decode is a note this pass did not \
+             scan, and `skipped_unreadable` is the field that says so: {result:?}"
+        );
+        assert_eq!(
+            result.notes_scanned, 1,
+            "the undecodable note must NOT be counted as scanned: {result:?}"
+        );
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/dead_code.rs
+++ b/crates/nestweaver-engine/src/dead_code.rs
@@ -438,9 +438,19 @@ fn detect_dead_code_inner(
         .collect();
 
     // Find unreachable class UIDs so we can suppress their members.
+    //
+    // nw-330: `Extension` counts here too. A Rust `impl` block is a container of
+    // members exactly as a class is — it used to BE `SymbolKind::Class`, and the
+    // only reason it no longer is, is that it needed an identity distinct from
+    // the struct it implements. Leaving it out would have made this suppression
+    // silently narrower as a side effect of a modelling fix, reporting every
+    // method of a dead impl block alongside the block itself.
     let unreachable_class_uids: HashSet<&str> = all_symbols
         .iter()
-        .filter(|s| !strong_reachable.contains(&s.uid) && s.kind == SymbolKind::Class)
+        .filter(|s| {
+            !strong_reachable.contains(&s.uid)
+                && matches!(s.kind, SymbolKind::Class | SymbolKind::Extension)
+        })
         .map(|s| s.uid.as_str())
         .collect();
 

--- a/crates/nestweaver-engine/src/dead_code.rs
+++ b/crates/nestweaver-engine/src/dead_code.rs
@@ -83,6 +83,24 @@ pub struct DeadCodeResult {
     /// declarations, properties, module declarations). These are not counted
     /// in `total_symbols`.
     pub excluded_count: usize,
+    /// Symbols the store reached but could NOT decode, and therefore dropped
+    /// before this analysis ever saw them (nw-335 corrupt-row tolerance).
+    ///
+    /// While this is non-zero, `total_symbols`, `reachable_symbols`,
+    /// `unreachable_symbols` and `dead_percentage` are all computed over a
+    /// corpus that is missing rows — every one of them is a FLOOR, and
+    /// "N of M unreachable" is not a truthful completeness claim. The store
+    /// only logged the skip; a number nobody can read is not a disclosure, so
+    /// it is carried here and rendered by both the CLI and the MCP tool.
+    pub undecodable_symbols: usize,
+}
+
+impl DeadCodeResult {
+    /// Whether the analysis saw the whole symbol corpus. False means the
+    /// counts above are floors — see [`Self::undecodable_symbols`].
+    pub fn coverage_is_complete(&self) -> bool {
+        self.undecodable_symbols == 0
+    }
 }
 
 /// Returns `true` for symbols that should be excluded from dead code analysis
@@ -282,9 +300,17 @@ fn detect_dead_code_inner(
     cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
 ) -> anyhow::Result<DeadCodeResult> {
     // 1. Load all symbols and partition into analysable / excluded.
-    let raw_symbols = store
-        .list_all_symbols()
+    //
+    // Take the scan's INTEGRITY, not just its rows: this pass reports
+    // "N of M symbols unreachable", which is a completeness claim over the
+    // whole corpus. nw-335's corrupt-row tolerance makes a short scan return
+    // `Ok`, so a dropped row would make both N and M quietly wrong while the
+    // percentage still read as exact. The count of dropped rows travels with
+    // the result so the CLI and the MCP tool can say the numbers are a floor.
+    let (raw_symbols, integrity) = store
+        .list_all_symbols_with_integrity()
         .map_err(|e| anyhow::anyhow!("list_all_symbols: {e}"))?;
+    let undecodable_symbols = integrity.skipped_corrupt;
 
     let function_local: HashSet<String> = function_local_bindings(&raw_symbols)
         .into_iter()
@@ -306,6 +332,10 @@ fn detect_dead_code_inner(
             reachable_symbols: 0,
             dead_percentage: 0.0,
             excluded_count,
+            // "0 symbols, all reachable" over a corpus that lost rows is the
+            // most misleading output this pass can produce, so the empty case
+            // discloses too.
+            undecodable_symbols,
         });
     }
 
@@ -536,6 +566,7 @@ fn detect_dead_code_inner(
         reachable_symbols,
         dead_percentage,
         excluded_count,
+        undecodable_symbols,
     })
 }
 
@@ -674,6 +705,52 @@ mod tests {
         assert_eq!(result.reachable_symbols, 0);
         assert!(result.unreachable_symbols.is_empty());
         assert_eq!(result.excluded_count, 0);
+        assert_eq!(result.undecodable_symbols, 0);
+        assert!(result.coverage_is_complete());
+    }
+
+    /// This pass states "N of M symbols unreachable" — a completeness claim
+    /// over the whole corpus. nw-335 made the whole-corpus scan skip a row it
+    /// cannot decode instead of failing, which silently makes BOTH numbers
+    /// wrong; the store discloses the skip only in a log line, which no caller
+    /// can read. So the shortfall must arrive as a VALUE on the result, or the
+    /// percentage is published as exact over a corpus that lost rows.
+    #[test]
+    fn an_undecodable_symbol_makes_the_counts_declare_themselves_a_floor() {
+        let store = GraphStore::in_memory().unwrap();
+        store
+            .insert_symbol(&make_symbol("entry", "main", true))
+            .unwrap();
+        store
+            .insert_symbol(&make_symbol("dead", "never_called", false))
+            .unwrap();
+
+        let clean = detect_dead_code(&store).unwrap();
+        assert_eq!(clean.total_symbols, 2);
+        assert!(
+            clean.coverage_is_complete(),
+            "a readable corpus must still report an EXACT total, or the \
+             degraded signal means nothing"
+        );
+
+        // A NUL anywhere in the corpus — in a symbol unrelated to either of the
+        // two above.
+        let mut corrupt = make_symbol("corrupt", "unrelated", false);
+        corrupt.name = "unre\u{0}lated".to_string();
+        store.insert_symbol(&corrupt).unwrap();
+
+        let degraded = detect_dead_code(&store).unwrap();
+        assert_eq!(
+            degraded.undecodable_symbols, 1,
+            "the dropped row must be COUNTED on the result, not just logged"
+        );
+        assert!(
+            !degraded.coverage_is_complete(),
+            "'N of M unreachable' is not truthful over a corpus that lost rows"
+        );
+        // The proof that this matters: the corrupt row is genuinely absent, so
+        // `total_symbols` is a floor and says nothing about it on its own.
+        assert_eq!(degraded.total_symbols, 2);
     }
 
     /// A pre-tripped cancel flag must make the reachability BFS return the

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -3988,6 +3988,12 @@ where
         {
             use nestweaver_schema::{EdgeType, ResolvedEdge};
 
+            // nw-330: `Extension` is deliberately NOT a container kind here.
+            // `container_map` is keyed by (file, name) and overwrites, so while
+            // Rust `impl` blocks were `SymbolKind::Class` a type's methods
+            // bound to whichever impl block was parsed LAST rather than to the
+            // type. Now that impl blocks carry their own kind, the struct is
+            // the only candidate and the binding is deterministic.
             let container_kinds = [
                 nestweaver_schema::SymbolKind::Class,
                 nestweaver_schema::SymbolKind::Interface,
@@ -13922,8 +13928,9 @@ function hello(name) { return "Hello " + name; }
     #[test]
     fn index_emits_member_of_edges_for_rust_struct_methods() {
         // Task 4: MEMBER_OF edges must be emitted from methods to their parent
-        // struct (which the parser classifies as SymbolKind::Class via the impl
-        // block).
+        // struct. nw-330: the parent is the `struct` itself (SymbolKind::Class);
+        // the `impl` block is now SymbolKind::Extension and no longer competes
+        // for the same (file, name) container key.
         let dir = tempfile::tempdir().unwrap();
         let src = dir.path().join("repo");
         fs::create_dir_all(&src).unwrap();

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -2342,6 +2342,17 @@ impl<'a> WikilinkLookup<'a> {
     /// must never score below a later one, so downstream consumers can
     /// threshold on confidence without inverting the resolver's own ordering.
     ///
+    /// ONE stated exception, and it is not a violation of the intent: priority
+    /// 7 re-enters priorities 2-4 with the key's BASENAME (nw-343), so it can
+    /// return 0.95/0.92/0.90 from a position below priority 5. The two ladders
+    /// are DISJOINT by construction — priorities 2-4 key on the whole key and
+    /// their maps can never hold a `/`, so they are a guaranteed miss for a
+    /// path-qualified key, and priority 7 is guarded by `key.contains('/')`.
+    /// Confidence therefore still reflects evidence strength: a basename that
+    /// earns the same-folder tier earns it whether or not the author also wrote
+    /// a path prefix. Do not "restore" monotonicity by capping the re-entry —
+    /// that is the confidence inversion nw-343 exists to remove.
+    ///
     /// **FILENAME BEFORE TITLE; DIRECTORY PROXIMITY BEFORE GLOBALITY.**
     ///
     /// - Priority 1: path match — target contains `/` and matches a known
@@ -2352,7 +2363,9 @@ impl<'a> WikilinkLookup<'a> {
     /// - Priority 5: unique global title → 1.0 when NO file in the vault
     ///   carries that stem, otherwise 0.80.
     /// - Priority 6: alias match → unique 0.7, ambiguous split.
-    /// - Priority 7: path-qualified fallback to the last segment → 0.85.
+    /// - Priority 7: path-qualified fallback — re-enters priorities 2-4 with
+    ///   the last path segment (0.95 / 0.92 / 0.90), then unique global title
+    ///   on that segment → 0.85.
     /// - Priority 8: ambiguous title match → same-folder narrowing 0.5,
     ///   otherwise split across all candidates.
     ///
@@ -2450,33 +2463,10 @@ impl<'a> WikilinkLookup<'a> {
         // `confidence < 1.0`, and `a_lower_tier_resolution_is_not_broken`
         // depends on a same-folder match remaining visible there as a
         // resolved-but-lower-tier row.
-        if let Some(uids) = self
-            .by_folder_stem
-            .get(&(source_folder.to_string(), key.clone()))
-            && uids.len() == 1
-        {
-            return ResolveOutcome::Resolved(vec![ResolveCandidate {
-                note_uid: uids[0].to_string(),
-                confidence: 0.95,
-            }]);
-        }
-
-        // Priority 3: nearest-ancestor filename stem (nw-306).
-        if let Some(uid) = self.nearest_ancestor_stem(&key, source_folder) {
-            return ResolveOutcome::Resolved(vec![ResolveCandidate {
-                note_uid: uid,
-                confidence: 0.92,
-            }]);
-        }
-
-        // Priority 4: global filename-stem match (Obsidian shortest-path).
-        if let Some(uids) = self.by_stem.get(&key)
-            && uids.len() == 1
-        {
-            return ResolveOutcome::Resolved(vec![ResolveCandidate {
-                note_uid: uids[0].to_string(),
-                confidence: 0.9,
-            }]);
+        // Priorities 2-4 are one ladder over a BARE stem, extracted so the
+        // path-qualified fallback below can RE-ENTER it (nw-343).
+        if let Some(candidate) = self.resolve_bare_stem(&key, source_folder) {
+            return ResolveOutcome::Resolved(vec![candidate]);
         }
 
         // Priority 5: unique global title. Full confidence ONLY when no file in
@@ -2514,25 +2504,30 @@ impl<'a> WikilinkLookup<'a> {
         }
 
         // nw-165: path-qualified fallback to the filename stem, which is what
-        // Obsidian does. by_stem / by_title / by_folder_name are keyed on bare
+        // Obsidian does. by_stem / by_title / by_folder_stem are keyed on bare
         // names and can never contain a slash, so a path-qualified key that
         // missed by_path above could not match ANY later tier and was reported
         // as a genuinely broken link -- 40 such links in the reference vault
         // had an existing target.
+        //
+        // nw-343: that fix named the miss and then hard-coded a GLOBAL lookup as
+        // the remedy, and both of its branches require `uids.len() == 1`. So a
+        // path-qualified key whose basename is not globally unique matched
+        // neither branch and died -- while the BARE form of the same link, from
+        // the same folder, resolved at 0.92 via the nearest-ancestor tier, which
+        // tolerates global ambiguity by design. Writing MORE of the path made
+        // the link resolve LESS often. Not hypothetical: the reference vault has
+        // 21 files named `_Overview.md`, so every path-qualified `_Overview`
+        // link in it was dead. Re-enter the ladder instead.
         if key.contains('/')
             && let Some(base) = key.rsplit('/').find(|segment| !segment.is_empty())
             && base != key
         {
+            if let Some(candidate) = self.resolve_bare_stem(base, source_folder) {
+                return ResolveOutcome::Resolved(vec![candidate]);
+            }
             // Below the exact-path tiers: only the filename was corroborated,
             // not the path component.
-            if let Some(uids) = self.by_stem.get(base)
-                && uids.len() == 1
-            {
-                return ResolveOutcome::Resolved(vec![ResolveCandidate {
-                    note_uid: uids[0].to_string(),
-                    confidence: 0.85,
-                }]);
-            }
             if let Some(uids) = self.by_title.get(base)
                 && uids.len() == 1
             {
@@ -2575,6 +2570,50 @@ impl<'a> WikilinkLookup<'a> {
         }
 
         ResolveOutcome::Unresolved
+    }
+
+    /// Priorities 2-4 as one reusable ladder over a BARE filename stem:
+    /// same folder (0.95) -> nearest ancestor (0.92) -> unique global (0.90).
+    ///
+    /// Extracted by nw-343 so the path-qualified fallback can re-enter it with
+    /// the key's basename. All three tiers key on the WHOLE key and
+    /// `by_folder_stem`/`by_stem` are built from `Path::file_stem()`, so their
+    /// keys can never contain `/` -- every one of them is a guaranteed miss for
+    /// a path-qualified key, which is why the fallback exists at all.
+    ///
+    /// Note the ORDER of tolerances, which is the whole point: 0.95 and 0.92
+    /// tolerate global ambiguity (they narrow by directory first), 0.90 does
+    /// not. Jumping straight to 0.90's global-uniqueness test threw away the
+    /// two tiers that could still have answered.
+    fn resolve_bare_stem(&self, key: &str, source_folder: &str) -> Option<ResolveCandidate> {
+        // Priority 2: same-folder filename stem.
+        if let Some(uids) = self
+            .by_folder_stem
+            .get(&(source_folder.to_string(), key.to_string()))
+            && uids.len() == 1
+        {
+            return Some(ResolveCandidate {
+                note_uid: uids[0].to_string(),
+                confidence: 0.95,
+            });
+        }
+        // Priority 3: nearest-ancestor filename stem (nw-306).
+        if let Some(uid) = self.nearest_ancestor_stem(key, source_folder) {
+            return Some(ResolveCandidate {
+                note_uid: uid,
+                confidence: 0.92,
+            });
+        }
+        // Priority 4: global filename-stem match (Obsidian shortest-path).
+        if let Some(uids) = self.by_stem.get(key)
+            && uids.len() == 1
+        {
+            return Some(ResolveCandidate {
+                note_uid: uids[0].to_string(),
+                confidence: 0.9,
+            });
+        }
+        None
     }
 
     /// Of the notes whose filename stem is `key`, return the one living in the

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -3077,6 +3077,60 @@ mod tests {
         (dir, root)
     }
 
+    /// nw-339 does NOT reproduce, and the fallback it asks for would be actively
+    /// harmful — so this pins the opposite: a headingless note IS searchable,
+    /// and adding a whole-body fallback Section would double-index it.
+    ///
+    /// The stated mechanism ("a note with no `#` heading produces no Section")
+    /// is false at the parser: `extract_sections` emits a preamble covering the
+    /// WHOLE body when `headings` is empty, which
+    /// `note_with_only_preamble_has_one_section` already pins. The observation
+    /// behind the ticket is explained by the other half — a file that is almost
+    /// entirely FRONTMATTER — and `6d99b96d` fixed that by indexing
+    /// `frontmatter_raw` as a fourth candidate shape. That commit is not an
+    /// ancestor of v8.0.0, which is the build the measurement was taken on.
+    ///
+    /// RESIDUAL, and it is real: `frontmatter_raw` is an additive column with no
+    /// backfill, so it is NULL for every note indexed by 8.0.0 and both
+    /// collectors `continue` past a `None`. Upgrading without a full reindex
+    /// preserves the exact symptom and says nothing. Filed separately.
+    #[test]
+    fn a_headingless_note_is_searchable_and_indexed_exactly_once() {
+        let (_dir, root) = make_vault(&[(
+            "backlog.md",
+            "---\nstatus: open\nid: nw-339\n---\n\nloadbearing prose with no heading at all.\n",
+        )]);
+        let (result, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+
+        assert!(result.headings_count == 0, "precondition: no headings");
+        assert_eq!(
+            result.sections_count, 1,
+            "the whole body is ONE preamble section — a fallback section would \
+             make this 2 and double-count every headingless note in \
+             `count_patterns` and in `sections_count`"
+        );
+
+        let body = store
+            .regex_search("loadbearing", None, None, Some(10), Some(5_000))
+            .unwrap();
+        assert_eq!(
+            body.results.len(),
+            1,
+            "the body must be searchable EXACTLY ONCE: {:?}",
+            body.results
+        );
+
+        // And the frontmatter is reachable too — the half that actually
+        // explained the reported observation.
+        let fm = store
+            .regex_search("nw-339", None, None, Some(10), Some(5_000))
+            .unwrap();
+        assert!(
+            !fm.results.is_empty(),
+            "frontmatter must be an exact-match candidate shape (6d99b96d)"
+        );
+    }
+
     /// nw-345: a single run produced TWO numbers for "unresolved links" and
     /// disclosed neither definition — the indexer counted OCCURRENCES,
     /// `doc-stats` and `broken-links` count DISTINCT TARGETS. Both are

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -1930,8 +1930,15 @@ where
     // must not be the default one, and the watcher route has no human reading
     // the exit code.
     if all_notes.is_empty() && vault_existed {
-        let existing = store
-            .list_notes(Some(&v_uid))
+        // The guard turns on "are there notes indexed?", so it can only be
+        // trusted if the answer is COMPLETE. nw-335 made this scan skip a row
+        // it cannot decode and disclose it in a log line, so a vault whose rows
+        // are all undecodable reads as "nothing indexed" — the guard stands
+        // down and the reindex deletes the vault it could not read. A count
+        // that could not be taken in full is not a count of zero, and this is
+        // the one place where reading it as zero is destructive.
+        let (existing, integrity) = store
+            .list_notes_with_integrity(Some(&v_uid))
             .context("count indexed notes before the stale-drop")?;
         if !existing.is_empty() {
             anyhow::bail!(
@@ -1940,6 +1947,15 @@ where
                  one of them. Check that the vault directory is readable and mounted; if it \
                  really is empty, drop it with `nestweaver brain remove`.",
                 existing.len()
+            );
+        }
+        if let Some(disclosure) = integrity.disclosure() {
+            anyhow::bail!(
+                "refusing to reindex vault '{vault_name}' at {root_str}: the scan found no \
+                 note files, and the indexed note count could not be read in full, so \
+                 \"nothing is indexed\" is NOT established -- {disclosure} Committing this \
+                 could delete notes this process was unable to see. Repair the graph \
+                 (`nestweaver brain add --force`) before reindexing."
             );
         }
     }
@@ -3646,6 +3662,98 @@ mod tests {
             store.list_notes(None).unwrap().len(),
             2,
             "the previously indexed notes must survive the refusal"
+        );
+    }
+
+    /// nw-287's guard turns on "are there notes indexed?", and nw-335 made
+    /// that question answerable INCOMPLETELY: the scan now skips a row it
+    /// cannot decode and says so only in a log line. A vault whose rows are all
+    /// undecodable therefore reads as "nothing is indexed", the guard stands
+    /// down, and the refresh deletes the vault it was unable to read — the
+    /// exact data loss nw-287 exists to prevent, reached through the success
+    /// arm instead of the empty one. A count that could not be taken in full is
+    /// not a count of zero.
+    #[test]
+    fn refresh_refuses_when_the_indexed_note_count_could_not_be_read_in_full() {
+        let (_dir, root) = make_vault(&[("f1.md", "# F1\n\ncontent one\n")]);
+        let store = GraphStore::in_memory().unwrap();
+        let db_path = root.join("unused.lbug");
+        index_markdown_directory_with_store_and_deletion_count(
+            &store,
+            &root,
+            &db_path,
+            "default",
+            "v",
+            &[],
+        )
+        .unwrap();
+
+        // Replace the indexed row with one the reader cannot decode, so the
+        // vault holds exactly one note and the scan can see none of it.
+        let v_uid = store
+            .list_vaults(None)
+            .unwrap()
+            .into_iter()
+            .next()
+            .expect("the index created a vault")
+            .uid;
+        for note in store.list_notes(None).unwrap() {
+            store.delete_note_cascade(&note.uid).unwrap();
+        }
+        store
+            .insert_note(&nestweaver_schema::Note {
+                uid: format!("note:{v_uid}:poisoned"),
+                vault_uid: v_uid.clone(),
+                file_path: "f1.md".to_string(),
+                title: "Poi\u{0}soned".to_string(),
+                note_kind: nestweaver_schema::NoteKind::General,
+                word_count: 1,
+                content_hash: "h".to_string(),
+                frontmatter: None,
+                frontmatter_raw: None,
+                created_at: None,
+                modified_at: None,
+                pagerank_score: None,
+                embedding: None,
+            })
+            .unwrap();
+        assert!(
+            store.list_notes(None).unwrap().is_empty(),
+            "precondition: the scan reads this vault as empty ..."
+        );
+        assert_eq!(
+            store.count_notes().unwrap(),
+            1,
+            "... even though the vault holds exactly one note"
+        );
+
+        // The mount goes away.
+        std::fs::remove_file(root.join("f1.md")).unwrap();
+
+        let observed = index_markdown_directory_with_store_and_deletion_count(
+            &store,
+            &root,
+            &db_path,
+            "default",
+            "v",
+            &[],
+        );
+        let Err(error) = observed else {
+            panic!(
+                "an empty scan over a vault whose note count could not be read \
+                 must fail closed, not commit a whole-vault deletion"
+            );
+        };
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("could not be read in full"),
+            "the refusal must name WHY the count is not trustworthy, so an \
+             operator can repair it rather than retry: {message}"
+        );
+        assert_eq!(
+            store.count_notes().unwrap(),
+            1,
+            "the row the reader could not decode must survive the refusal"
         );
     }
 

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -859,7 +859,29 @@ fn index_markdown_since_with_reader(
         rebuild_link_source_uids.push(candidate.note_uid.clone());
         let context = context_by_uid[&candidate.note_uid.as_str()];
         for wikilink in &context.wikilinks {
+            // nw-344: the same silent drop as the full-index path above, and it
+            // has to close on both or `--since` and a full re-index disagree
+            // about the vault's own link count.
             let Some(source_section) = context.section_uids.get(wikilink.section_idx) else {
+                tracing::warn!(
+                    "wikilink '{}' in '{}' names section {} of {}; recording it as \
+                     unresolved rather than dropping it silently",
+                    wikilink.target,
+                    candidate.rel_path,
+                    wikilink.section_idx,
+                    context.section_uids.len(),
+                );
+                unresolved.push((
+                    format!(
+                        "unresolved:{}:{}",
+                        candidate.note_uid,
+                        crate::hash::blake3_hex_short(&wikilink.target)
+                    ),
+                    candidate.note_uid.clone(),
+                    candidate.rel_path.clone(),
+                    candidate.parsed.title.clone(),
+                    wikilink.target.clone(),
+                ));
                 continue;
             };
             let display = wikilink
@@ -1900,10 +1922,38 @@ where
     for ctx in &note_contexts {
         for wl in &ctx.wikilinks {
             // Pass the source section's UID (where the link appears).
-            if wl.section_idx >= ctx.section_uids.len() {
+            //
+            // nw-344: this was a bare `continue`. A link taken by it produced no
+            // WIKILINK_TO_NOTE edge, no UnresolvedWikilink node and no increment
+            // to either counter — invisible on BOTH surfaces at once, which is a
+            // health tool reporting nothing wrong because it never saw the link.
+            // Record it as unresolved instead. `UnresolvedWikilink` is keyed on
+            // the source NOTE, not the section, so a note-scoped uid is enough,
+            // and LINK COUNT IN == EDGES OUT PLUS BROKEN ROWS becomes structural
+            // rather than a property of whichever fixture happens to be on hand.
+            let Some(source_section_uid) = ctx.section_uids.get(wl.section_idx) else {
+                tracing::warn!(
+                    "wikilink '{}' in '{}' names section {} of {}; recording it as \
+                     unresolved rather than dropping it silently",
+                    wl.target,
+                    ctx.rel_path,
+                    wl.section_idx,
+                    ctx.section_uids.len(),
+                );
+                wikilinks_unresolved += 1;
+                unresolved_records.push((
+                    format!(
+                        "unresolved:{}:{}",
+                        ctx.note_uid,
+                        crate::hash::blake3_hex_short(&wl.target)
+                    ),
+                    ctx.note_uid.clone(),
+                    ctx.rel_path.clone(),
+                    ctx.title.clone(),
+                    wl.target.clone(),
+                ));
                 continue;
-            }
-            let source_section_uid = &ctx.section_uids[wl.section_idx];
+            };
             let display = wl.display.clone().unwrap_or_else(|| wl.target.clone());
 
             match lookup.resolve(&wl.target, &ctx.folder) {

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -2936,6 +2936,323 @@ mod tests {
         (dir, root)
     }
 
+    /// nw-344: the double condition that makes silent link loss DETECTABLE.
+    /// A link that is neither an edge nor a broken row is invisible on BOTH
+    /// surfaces at once -- a health tool reporting nothing wrong because it
+    /// never saw the link. A test asserting only (a) would still permit that.
+    ///
+    /// LINK COUNT IN == EDGES OUT PLUS BROKEN ROWS.
+    ///
+    /// On the ticket's stated cause, honestly: `ad946989`'s nearest-ancestor
+    /// tier cannot be what repaired this shape. `nearest_ancestor_stem` compares
+    /// folder components element-wise SPECIFICALLY to reject
+    /// `Workspaces/Cortina` as an ancestor of `Workspaces/Cortina Precision/...`
+    /// -- that pair is the verbatim counter-example in its own doc comment. The
+    /// invariant below is still the right one; the narrative was not.
+    #[test]
+    fn every_link_becomes_an_edge_or_a_broken_row() {
+        // The Cortina Precision shape: a workspace hub whose links are
+        // path-qualified relative to its own folder, plus a sibling workspace
+        // sharing the `_Overview` stem so no tier can resolve by global
+        // uniqueness.
+        let (_dir, root) = make_vault(&[
+            (
+                "Workspaces/Cortina Precision/_Overview.md",
+                "# Cortina Precision\n\n\
+                 - [[plans/rollout]]\n\
+                 - [[notes/2026-08/research/recon]]\n\
+                 - [[brand-proposal-sprint/README]]\n\
+                 - [[Sibling Hub]]\n\
+                 - [[plans/does-not-exist]]\n",
+            ),
+            (
+                "Workspaces/Cortina Precision/plans/rollout.md",
+                "# Rollout\n",
+            ),
+            (
+                "Workspaces/Cortina Precision/notes/2026-08/research/recon.md",
+                "# Recon\n",
+            ),
+            (
+                "Workspaces/Cortina Precision/brand-proposal-sprint/README.md",
+                "# Runbook\n",
+            ),
+            (
+                "Workspaces/Cortina Precision/Sibling Hub.md",
+                "# Sibling Hub\n",
+            ),
+            // Shares the `_Overview` stem so global-uniqueness tiers cannot
+            // fire, and is NOT a component-wise ancestor of the source folder.
+            ("Workspaces/Cortina/_Overview.md", "# Cortina\n"),
+        ]);
+        const LINKS_IN: usize = 5;
+
+        let (result, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+
+        // (a) Nothing vanishes between the parser and the counters. The seam
+        //     that could: the `section_idx` bounds check below in this file,
+        //     which incremented no counter and recorded nothing.
+        assert_eq!(
+            result.wikilinks_resolved + result.wikilinks_unresolved,
+            LINKS_IN,
+            "nw-344: a link that is neither resolved nor unresolved has been \
+             SILENTLY DROPPED"
+        );
+        assert_eq!(result.wikilinks_resolved, LINKS_IN - 1);
+        assert_eq!(result.wikilinks_unresolved, 1);
+
+        // (b) The condition a per-tier test cannot see: a link that did NOT
+        //     resolve must be REPORTABLE. Without this half, an absent guard
+        //     and a passing guard are indistinguishable.
+        let rows = store.broken_wikilinks().unwrap();
+        assert!(
+            rows.iter()
+                .any(|r| r.wikilink_text == "plans/does-not-exist"
+                    && r.current_target_uid.is_empty()),
+            "nw-344: the unresolved link must appear in broken_wikilinks, got {rows:?}"
+        );
+
+        // The resolved four are edges, and the hub is not left at 1.
+        let edges = store.note_wikilink_edges().unwrap();
+        assert_eq!(
+            edges.len(),
+            LINKS_IN - 1,
+            "nw-344: 1 edge against 5 links is the exact failure this pins"
+        );
+    }
+
+    /// nw-344, the counterpart that keeps the conservation law honest under
+    /// tier REORDERING (nw-343 changes exactly these tiers): the totals must
+    /// hold regardless of which tier each link lands on, so this fixture is
+    /// written so several tiers fire at once.
+    ///
+    /// `note_wikilink_edges` drops self-edges and returns one row per resolved
+    /// CANDIDATE, and `broken_wikilinks` dedupes by (source note, link text) --
+    /// so the fixture deliberately holds no self-links, no ambiguous targets
+    /// and no repeated link text.
+    #[test]
+    fn conservation_holds_across_every_resolver_tier() {
+        let (_dir, root) = make_vault(&[
+            (
+                "f/src.md",
+                "# Src\n\n\
+                 - [[sibling]]\n\
+                 - [[hub]]\n\
+                 - [[globally-unique]]\n\
+                 - [[An Only Title]]\n\
+                 - [[the-alias]]\n\
+                 - [[deep/globally-unique]]\n\
+                 - [[nowhere at all]]\n",
+            ),
+            ("hub.md", "# Root Hub\n"),
+            ("f/sibling.md", "# Not The Same Title\n"),
+            ("z/globally-unique.md", "# Unique Stem\n"),
+            ("z/titled.md", "# An Only Title\n"),
+            (
+                "z/aliased.md",
+                "---\naliases: [the-alias]\n---\n# Aliased\n",
+            ),
+        ]);
+        const LINKS_IN: usize = 7;
+
+        let (result, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+        assert_eq!(
+            result.wikilinks_resolved + result.wikilinks_unresolved,
+            LINKS_IN,
+            "nw-344: conservation must survive any reordering of the tier ladder"
+        );
+
+        let edges = store.note_wikilink_edges().unwrap();
+        let broken = store
+            .broken_wikilinks()
+            .unwrap()
+            .into_iter()
+            .filter(|r| r.current_target_uid.is_empty())
+            .count();
+        assert_eq!(
+            edges.len() + broken,
+            LINKS_IN,
+            "nw-344: EDGES OUT PLUS BROKEN ROWS must equal LINKS IN"
+        );
+    }
+
+    /// nw-343, the LOSS case: a path-qualified key whose basename is not
+    /// globally unique matches NEITHER fallback branch (both require
+    /// `uids.len() == 1`) and dies -- while the BARE form of the same link,
+    /// from the same folder, resolves at 0.92 via the nearest-ancestor tier,
+    /// which tolerates global ambiguity by design. Writing MORE of the path
+    /// makes the link resolve LESS often. Not hypothetical: the reference vault
+    /// holds 21 files named `_Overview.md`.
+    #[test]
+    fn a_path_qualified_key_re_enters_the_proximity_ladder() {
+        let (_dir, root) = make_vault(&[
+            ("Workspaces/Cortina/_Overview.md", "# Cortina — Overview\n"),
+            ("Workspaces/Other/_Overview.md", "# Other — Overview\n"),
+            (
+                "Workspaces/Cortina/plans/astro.md",
+                "# Astro\n\nUp: [[Cortina/_Overview]]\n",
+            ),
+        ]);
+        let (result, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+        assert_eq!(
+            result.wikilinks_unresolved, 0,
+            "nw-343: `[[Cortina/_Overview]]` from Workspaces/Cortina/plans must not \
+             be DEAD when the bare `[[_Overview]]` from the same folder resolves \
+             at 0.92"
+        );
+        assert_eq!(result.wikilinks_resolved, 1);
+
+        let notes = store.list_notes(None).unwrap();
+        let cortina = notes
+            .iter()
+            .find(|n| n.file_path.contains("Workspaces/Cortina/_Overview.md"))
+            .map(|n| n.uid.clone())
+            .unwrap();
+        let edges = store.note_wikilink_edges().unwrap();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(
+            edges[0].1, cortina,
+            "the nearest ancestor must win, not a global guess"
+        );
+    }
+
+    /// nw-343, the CONFIDENCE case: a path-qualified key whose basename has a
+    /// same-folder match must score the same-folder tier (0.95), not the global
+    /// path-qualified fallback (0.85). Proximity must never DECREASE confidence
+    /// -- the principle `ad946989` established one tier over.
+    #[test]
+    fn a_path_qualified_key_scores_the_tier_its_basename_earns() {
+        let (_dir, root) = make_vault(&[
+            ("f/x.md", "# X\n\nSee [[sub/target]].\n"),
+            ("f/target.md", "# Alpha\n"),
+            ("g/target.md", "# Beta\n"),
+        ]);
+        let (_res, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+        let rows = store.broken_wikilinks().unwrap();
+        let row = rows
+            .iter()
+            .find(|r| r.wikilink_text.eq_ignore_ascii_case("sub/target"))
+            .expect("the path-qualified link must be present as a sub-1.0 row");
+        assert!(
+            (row.confidence - 0.95).abs() < 1e-6,
+            "nw-343: same-folder basename evidence scores 0.95; the global \
+             path-qualified fallback's 0.85 understates it (got {})",
+            row.confidence
+        );
+    }
+
+    /// nw-343: the re-entry must WIDEN the ladder, not start inventing matches.
+    /// `a_path_qualified_link_to_nowhere_stays_unresolved` already pins the
+    /// ABSENT target; this pins the AMBIGUOUS one, which is the case a careless
+    /// re-entry breaks first. `target` exists twice, in two folders neither of
+    /// which is the source's folder nor an ancestor of it -- so P2 (same
+    /// folder), P3 (nearest ancestor) and P4 (global uniqueness) must all
+    /// decline. Guessing here is nw-290.
+    #[test]
+    fn the_ladder_re_entry_declines_rather_than_guesses() {
+        let (_dir, root) = make_vault(&[
+            ("f/x.md", "# X\n\nSee [[sub/target]].\n"),
+            ("g/target.md", "# Alpha\n"),
+            ("h/target.md", "# Beta\n"),
+        ]);
+        let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+        assert_eq!(result.wikilinks_resolved, 0);
+        assert_eq!(result.wikilinks_unresolved, 1);
+    }
+
+    /// nw-342 end-to-end: the `\|` escape Obsidian REQUIRES inside a markdown
+    /// table must resolve at the tier its bare stem earns. `resolve` normalises
+    /// `\` to `/` (Windows path forms), so the unstripped escape produced the
+    /// key `backlog/` -- routed straight into nw-343's path-qualified fallback
+    /// and scored 0.85. One character of parsing; the count grows with table
+    /// usage, not with vault size.
+    #[test]
+    fn an_escaped_pipe_link_in_a_table_resolves_at_the_same_folder_tier() {
+        let (_dir, root) = make_vault(&[
+            (
+                "f/x.md",
+                "# X\n\n| col |\n| --- |\n| [[Backlog\\|the backlog]] |\n",
+            ),
+            ("f/Backlog.md", "# Not The Same Title\n"),
+        ]);
+        let (result, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+        assert_eq!(result.wikilinks_unresolved, 0);
+        let rows = store.broken_wikilinks().unwrap();
+        let row = rows
+            .iter()
+            .find(|r| r.wikilink_text.eq_ignore_ascii_case("backlog"))
+            .unwrap_or_else(|| panic!("the target must be stored as `Backlog`, got {rows:?}"));
+        assert!(
+            (row.confidence - 0.95).abs() < 1e-6,
+            "nw-342: the same-folder tier, not the path-qualified fallback (got {})",
+            row.confidence
+        );
+    }
+
+    /// nw-335: one raw NUL in one note aborted the ENTIRE Tantivy + trigram
+    /// build via `list_all_sections`' `collect::<Result<Vec<_>, _>>`, leaving
+    /// `docs=0` brain-wide while `brain status` reported a healthy graph. The
+    /// canary at `read::string_is_corrupt` is a LadybugDB #678 detector whose
+    /// stated premise is "note bodies ... none contain NUL"; a pasted NUL
+    /// falsifies the premise, so the store blames engine corruption for a byte
+    /// it recorded faithfully. The observed file carried its NUL at offset
+    /// 47,354 -- past the 8 KiB window the reader's binary sniff looks at.
+    #[test]
+    fn a_nul_byte_in_one_note_does_not_kill_the_whole_index() {
+        // The NUL must sit PAST the reader's 8 KiB binary-sniff window, or the
+        // file is (correctly) refused as binary and never reaches the graph at
+        // all -- which is a different, already-handled outcome. The reported
+        // file carried its NUL at offset 47,354, and that is what makes it a
+        // note the reader accepts and the store then refuses to read back.
+        let mut dirty = String::from("# Dirty\n\n");
+        dirty.push_str(&"filler line of ordinary vault prose.\n".repeat(400));
+        dirty.push_str("before\u{0}after\n");
+        assert!(dirty.len() > 8192, "the NUL must be past the sniff window");
+        let (_dir, root) = make_vault(&[
+            (
+                "clean.md",
+                "# Clean\n\nthe unique token loadbearing lives here.\n",
+            ),
+            ("dirty.md", dirty.as_str()),
+        ]);
+        let (result, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+        assert_eq!(
+            result.notes_count, 2,
+            "both notes must reach the graph; skipped: {:?}",
+            result.skipped
+        );
+
+        // The abort seam itself: one bad row must not empty the vector.
+        let sections = store
+            .list_all_sections()
+            .expect("a NUL in one note body must not fail the whole section scan");
+        assert!(
+            sections
+                .iter()
+                .any(|s| s.text_content.contains("loadbearing")),
+            "the CLEAN note's body must survive a sibling note's NUL"
+        );
+
+        // And the exact-match surface must still be alive brain-wide.
+        let hits = store
+            .regex_search("loadbearing", None, None, Some(100), Some(5_000))
+            .unwrap();
+        assert!(
+            !hits.results.is_empty(),
+            "nw-335: search must not go globally dark because one note holds a NUL"
+        );
+
+        // The poisoned note is not silently emptied either: the byte is dropped,
+        // the text around it survives, and the note stays searchable.
+        let dirty_hits = store
+            .regex_search("beforeafter", None, None, Some(100), Some(5_000))
+            .unwrap();
+        assert!(
+            !dirty_hits.results.is_empty(),
+            "nw-335: sanitising the NUL must keep the rest of that note indexed"
+        );
+    }
+
     /// True when the current process bypasses filesystem permission bits.
     #[cfg(unix)]
     fn running_as_root() -> bool {

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -26,6 +26,30 @@ use nestweaver_store::GraphStore;
 // still use direct fs access.
 
 /// Outcome of a markdown index run.
+///
+/// nw-345: every link count below names the POPULATION it counts. One run
+/// legitimately produces several and they do not agree, and calling them all
+/// "wikilinks" made a single run report two different numbers for the same
+/// English phrase with neither definition disclosed anywhere. In descending
+/// size, for one vault:
+///
+/// - OCCURRENCES — one per wikilink instance in the parse.
+/// - SECTION TARGETS — distinct (source section, target text). This is what the
+///   graph stores: an `UnresolvedWikilink` uid is derived from the source
+///   section plus the target, so two identical links in one section are one
+///   node.
+/// - TARGETS — distinct (source note, target text). This is what `broken-links`
+///   and `doc-stats` report, because `GraphStore::broken_wikilinks` dedupes on
+///   (source_uid, wikilink_text) and `source_uid` there is the NOTE.
+/// - EDGES — one per resolved CANDIDATE, so a single ambiguous link contributes
+///   N of them.
+///
+/// The de-duplication in `broken_wikilinks` was introduced for a PRESENTATION
+/// reason — collapsing N near-identical rows for one ambiguous link — and
+/// silently became a counting semantic when `doc_stats` called `len()` on the
+/// result. A de-duplication that exists to make a list readable is not a
+/// definition of a metric. Do NOT "fix" these numbers by making them agree;
+/// they are measuring different things and all of them are wanted.
 pub struct MarkdownIndexResult {
     pub vault_uid: String,
     pub vault_name: String,
@@ -33,8 +57,14 @@ pub struct MarkdownIndexResult {
     pub headings_count: usize,
     pub sections_count: usize,
     pub tags_count: usize,
-    pub wikilinks_resolved: usize,
-    pub wikilinks_unresolved: usize,
+    /// One per resolved CANDIDATE — an ambiguous link contributes N.
+    pub resolved_link_edges: usize,
+    /// One per unresolved link INSTANCE in the parse.
+    pub unresolved_link_occurrences: usize,
+    /// Distinct (source section, target) — the granularity the graph stores.
+    pub unresolved_link_section_targets: usize,
+    /// Distinct (source note, target) — what `broken-links` / `doc-stats` show.
+    pub unresolved_link_targets: usize,
     pub skipped: Vec<SkippedFile>,
 }
 
@@ -50,15 +80,17 @@ pub struct MarkdownRefreshResult {
 pub fn format_markdown_refresh_summary(result: &MarkdownRefreshResult) -> String {
     let mut summary = format!(
         "Refreshed vault '{}': dropped {} stale note(s), reindexed {} note(s), \
-         {} heading(s), {} section(s), {} tag(s), {} wikilink(s) ({} unresolved).",
+         {} heading(s), {} section(s), {} tag(s), {} wikilink edge(s), \
+         {} unresolved link occurrence(s) across {} distinct target(s).",
         result.index.vault_name,
         result.notes_deleted,
         result.index.notes_count,
         result.index.headings_count,
         result.index.sections_count,
         result.index.tags_count,
-        result.index.wikilinks_resolved,
-        result.index.wikilinks_unresolved,
+        result.index.resolved_link_edges,
+        result.index.unresolved_link_occurrences,
+        result.index.unresolved_link_targets,
     );
     if !result.index.skipped.is_empty() {
         summary.push_str(&format!(
@@ -373,7 +405,10 @@ pub struct MarkdownSinceResult {
     pub headings_count: usize,
     pub sections_count: usize,
     pub tags_count: usize,
-    pub wikilinks_resolved: usize,
+    /// nw-345: one per resolved CANDIDATE, and only for notes this pass
+    /// actually CHANGED — a fifth population, and the narrowest of them. It is
+    /// not comparable with a full index's `resolved_link_edges`.
+    pub changed_note_link_edges: usize,
 }
 
 /// Incrementally refresh only the files in `vault_root` whose filesystem
@@ -627,7 +662,7 @@ fn index_markdown_since_with_reader(
             headings_count: 0,
             sections_count: 0,
             tags_count: 0,
-            wikilinks_resolved: 0,
+            changed_note_link_edges: 0,
         });
     }
 
@@ -1088,7 +1123,7 @@ fn index_markdown_since_with_reader(
         headings_count: total_headings,
         sections_count: total_sections,
         tags_count: total_tags,
-        wikilinks_resolved: changed_wikilinks,
+        changed_note_link_edges: changed_wikilinks,
     })
 }
 
@@ -2014,7 +2049,21 @@ where
         }
     }
 
-    let wikilinks_resolved = wikilink_to_note.len() + wikilink_to_heading.len();
+    let resolved_link_edges = wikilink_to_note.len() + wikilink_to_heading.len();
+    // nw-345: report every population the run produces, so no consumer has to
+    // infer one from another. `unresolved_records` holds one entry per
+    // OCCURRENCE; its uid is the (section, target) key the graph dedupes on,
+    // and (note, target) is what `broken_wikilinks` collapses to downstream.
+    let unresolved_link_section_targets = unresolved_records
+        .iter()
+        .map(|record| record.0.as_str())
+        .collect::<std::collections::HashSet<_>>()
+        .len();
+    let unresolved_link_targets = unresolved_records
+        .iter()
+        .map(|record| (record.1.as_str(), record.4.as_str()))
+        .collect::<std::collections::HashSet<_>>()
+        .len();
 
     // 3 & 4. Flush all nodes and edges for this vault in one transaction.
     let notes_deleted = {
@@ -2135,12 +2184,13 @@ where
     // ── Summary ───────────────────────────────────────────────────────────
     let elapsed = started.elapsed();
     eprintln!(
-        "Done: {} notes, {} headings, {} sections, {} tags, {} wikilinks ({:.1}s)",
+        "Done: {} notes, {} headings, {} sections, {} tags, \
+         {} wikilink edges ({:.1}s)",
         notes_count,
         headings_count,
         sections_count,
         tags_count,
-        wikilinks_resolved,
+        resolved_link_edges,
         elapsed.as_secs_f64(),
     );
 
@@ -2152,8 +2202,10 @@ where
             headings_count,
             sections_count,
             tags_count,
-            wikilinks_resolved,
-            wikilinks_unresolved,
+            resolved_link_edges,
+            unresolved_link_occurrences: wikilinks_unresolved,
+            unresolved_link_section_targets,
+            unresolved_link_targets,
             skipped,
         },
         notes_deleted,
@@ -3025,6 +3077,90 @@ mod tests {
         (dir, root)
     }
 
+    /// nw-345: a single run produced TWO numbers for "unresolved links" and
+    /// disclosed neither definition — the indexer counted OCCURRENCES,
+    /// `doc-stats` and `broken-links` count DISTINCT TARGETS. Both are
+    /// defensible; having both under one name is not. Same class as nw-297
+    /// (page-count vs population-count) and nw-321 (`total` post-filter,
+    /// `total_available` pre-filter).
+    ///
+    /// There are THREE populations, not two. The middle one — distinct
+    /// (section, target), which is what the `UnresolvedWikilink` uid is derived
+    /// from — was never reported anywhere, and it is why the gap between the
+    /// two published numbers is not a clean factor.
+    ///
+    /// This fixture forces all three apart on purpose: the same dangling target
+    /// is written twice in one section of one note, once more in a second
+    /// section of that note, and once from a second note.
+    /// Occurrences = 4. (section, target) = 3. (note, target) = 2.
+    #[test]
+    fn every_unresolved_link_population_is_named_and_reported() {
+        let (_dir, root) = make_vault(&[
+            (
+                "a.md",
+                "# A\n\nSee [[nowhere]] and [[nowhere]].\n\n## Later\n\nAnd [[nowhere]].\n",
+            ),
+            ("b.md", "# B\n\nAlso [[nowhere]].\n"),
+        ]);
+        let (result, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+
+        assert_eq!(
+            result.unresolved_link_occurrences, 4,
+            "the indexer counts every unresolved link INSTANCE"
+        );
+        assert_eq!(
+            result.unresolved_link_section_targets, 3,
+            "the graph stores one UnresolvedWikilink per (section, target), so \
+             the two links in one section collapse — this is the population that \
+             was never reported and that explains the gap"
+        );
+        assert_eq!(
+            result.unresolved_link_targets, 2,
+            "broken_wikilinks dedupes by (source note, link text)"
+        );
+
+        // The contract: a consumer must be able to read the published
+        // populations off EITHER surface and never have to infer one from
+        // another.
+        let stats = crate::brain_docgraph::doc_stats(&store, 5).unwrap();
+        assert_eq!(stats.unresolved_link_targets, 2);
+        assert_eq!(stats.unresolved_link_section_targets, 3);
+
+        // Precondition: the fixture must actually separate them, or every
+        // assertion above passes vacuously.
+        assert!(
+            result.unresolved_link_occurrences > result.unresolved_link_section_targets
+                && result.unresolved_link_section_targets > result.unresolved_link_targets,
+            "fixture must force OCCURRENCES > SECTION TARGETS > TARGETS"
+        );
+    }
+
+    /// nw-345: OCCURRENCES are deliberately NOT offered by `doc_stats`. The
+    /// graph stores one node per (section, target) and nothing records an
+    /// instance count, so any occurrence number produced from the store would
+    /// be a proxy presented as a measurement — which is the exact defect this
+    /// work exists to close. The indexer is the only honest source, and it
+    /// reports them.
+    #[test]
+    fn doc_stats_does_not_invent_an_occurrence_count() {
+        let (_dir, root) = make_vault(&[(
+            "a.md",
+            "# A\n\nSee [[nowhere]] and [[nowhere]] and [[nowhere]].\n",
+        )]);
+        let (result, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+        assert_eq!(result.unresolved_link_occurrences, 3);
+
+        let stats = crate::brain_docgraph::doc_stats(&store, 5).unwrap();
+        let json = serde_json::to_value(&stats).unwrap();
+        assert!(
+            json.get("unresolved_link_occurrences").is_none(),
+            "doc_stats must not publish a number the graph cannot support: {json}"
+        );
+        // What it CAN support, it publishes, and both collapse to 1 here.
+        assert_eq!(stats.unresolved_link_section_targets, 1);
+        assert_eq!(stats.unresolved_link_targets, 1);
+    }
+
     /// nw-344: the double condition that makes silent link loss DETECTABLE.
     /// A link that is neither an edge nor a broken row is invisible on BOTH
     /// surfaces at once -- a health tool reporting nothing wrong because it
@@ -3082,13 +3218,13 @@ mod tests {
         //     that could: the `section_idx` bounds check below in this file,
         //     which incremented no counter and recorded nothing.
         assert_eq!(
-            result.wikilinks_resolved + result.wikilinks_unresolved,
+            result.resolved_link_edges + result.unresolved_link_occurrences,
             LINKS_IN,
             "nw-344: a link that is neither resolved nor unresolved has been \
              SILENTLY DROPPED"
         );
-        assert_eq!(result.wikilinks_resolved, LINKS_IN - 1);
-        assert_eq!(result.wikilinks_unresolved, 1);
+        assert_eq!(result.resolved_link_edges, LINKS_IN - 1);
+        assert_eq!(result.unresolved_link_occurrences, 1);
 
         // (b) The condition a per-tier test cannot see: a link that did NOT
         //     resolve must be REPORTABLE. Without this half, an absent guard
@@ -3146,7 +3282,7 @@ mod tests {
 
         let (result, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
         assert_eq!(
-            result.wikilinks_resolved + result.wikilinks_unresolved,
+            result.resolved_link_edges + result.unresolved_link_occurrences,
             LINKS_IN,
             "nw-344: conservation must survive any reordering of the tier ladder"
         );
@@ -3184,12 +3320,12 @@ mod tests {
         ]);
         let (result, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
         assert_eq!(
-            result.wikilinks_unresolved, 0,
+            result.unresolved_link_occurrences, 0,
             "nw-343: `[[Cortina/_Overview]]` from Workspaces/Cortina/plans must not \
              be DEAD when the bare `[[_Overview]]` from the same folder resolves \
              at 0.92"
         );
-        assert_eq!(result.wikilinks_resolved, 1);
+        assert_eq!(result.resolved_link_edges, 1);
 
         let notes = store.list_notes(None).unwrap();
         let cortina = notes
@@ -3245,8 +3381,8 @@ mod tests {
             ("h/target.md", "# Beta\n"),
         ]);
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
-        assert_eq!(result.wikilinks_resolved, 0);
-        assert_eq!(result.wikilinks_unresolved, 1);
+        assert_eq!(result.resolved_link_edges, 0);
+        assert_eq!(result.unresolved_link_occurrences, 1);
     }
 
     /// nw-342 end-to-end: the `\|` escape Obsidian REQUIRES inside a markdown
@@ -3265,7 +3401,7 @@ mod tests {
             ("f/Backlog.md", "# Not The Same Title\n"),
         ]);
         let (result, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
-        assert_eq!(result.wikilinks_unresolved, 0);
+        assert_eq!(result.unresolved_link_occurrences, 0);
         let rows = store.broken_wikilinks().unwrap();
         let row = rows
             .iter()
@@ -3512,7 +3648,7 @@ mod tests {
             ("Workspaces/NW/Backlog.md", "some body, no heading\n"),
         ]);
         let (result, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
-        assert_eq!(result.wikilinks_resolved, 1);
+        assert_eq!(result.resolved_link_edges, 1);
 
         let notes = store.list_notes(None).unwrap();
         let uid_of = |frag: &str| {
@@ -3572,10 +3708,10 @@ mod tests {
         ]);
         let (result, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
         assert_eq!(
-            result.wikilinks_unresolved, 0,
+            result.unresolved_link_occurrences, 0,
             "nw-306: a hub `Up:` link one directory down must not read as broken"
         );
-        assert_eq!(result.wikilinks_resolved, 1);
+        assert_eq!(result.resolved_link_edges, 1);
 
         let notes = store.list_notes(None).unwrap();
         let uid_of = |frag: &str| {
@@ -3605,9 +3741,9 @@ mod tests {
             ("g/target.md", "# Beta\n"),
         ]);
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
-        assert_eq!(result.wikilinks_resolved, 0);
+        assert_eq!(result.resolved_link_edges, 0);
         assert_eq!(
-            result.wikilinks_unresolved, 1,
+            result.unresolved_link_occurrences, 1,
             "no candidate is an ancestor of logs/, so the resolver must still decline"
         );
     }
@@ -3626,8 +3762,8 @@ mod tests {
             ),
         ]);
         let (result, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
-        assert_eq!(result.wikilinks_resolved, 1);
-        assert_eq!(result.wikilinks_unresolved, 0);
+        assert_eq!(result.resolved_link_edges, 1);
+        assert_eq!(result.unresolved_link_occurrences, 0);
 
         let notes = store.list_notes(None).unwrap();
         let cortina = notes
@@ -3710,7 +3846,7 @@ mod tests {
         assert_eq!(result.headings_count, 2);
         assert_eq!(result.sections_count, 2);
         assert_eq!(result.tags_count, 0);
-        assert_eq!(result.wikilinks_resolved, 0);
+        assert_eq!(result.resolved_link_edges, 0);
         assert!(result.skipped.is_empty());
 
         let notes = store.list_notes(None).unwrap();
@@ -3861,10 +3997,10 @@ sub b body
         ]);
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
         assert_eq!(
-            result.wikilinks_resolved, 1,
+            result.resolved_link_edges, 1,
             "a source-folder-relative path must resolve"
         );
-        assert_eq!(result.wikilinks_unresolved, 0);
+        assert_eq!(result.unresolved_link_occurrences, 0);
     }
 
     /// A full vault-relative path must keep working — that was the only form
@@ -3882,8 +4018,8 @@ sub b body
             ),
         ]);
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
-        assert_eq!(result.wikilinks_resolved, 1);
-        assert_eq!(result.wikilinks_unresolved, 0);
+        assert_eq!(result.resolved_link_edges, 1);
+        assert_eq!(result.unresolved_link_occurrences, 0);
     }
 
     /// A path-qualified link that matches nothing must still be unresolved —
@@ -3895,8 +4031,8 @@ sub b body
             "# Overview\n\nSee [[plans/Does Not Exist]].\n",
         )]);
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
-        assert_eq!(result.wikilinks_resolved, 0);
-        assert_eq!(result.wikilinks_unresolved, 1);
+        assert_eq!(result.resolved_link_edges, 0);
+        assert_eq!(result.unresolved_link_occurrences, 1);
     }
 
     #[test]
@@ -3906,16 +4042,16 @@ sub b body
             ("b.md", "# B\n\nI am B.\n"),
         ]);
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
-        assert_eq!(result.wikilinks_resolved, 1);
-        assert_eq!(result.wikilinks_unresolved, 0);
+        assert_eq!(result.resolved_link_edges, 1);
+        assert_eq!(result.unresolved_link_occurrences, 0);
     }
 
     #[test]
     fn unresolved_wikilink_counted() {
         let (_dir, root) = make_vault(&[("a.md", "# A\n\n[[Nonexistent Target]]\n")]);
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
-        assert_eq!(result.wikilinks_resolved, 0);
-        assert_eq!(result.wikilinks_unresolved, 1);
+        assert_eq!(result.resolved_link_edges, 0);
+        assert_eq!(result.unresolved_link_occurrences, 1);
     }
 
     #[test]
@@ -3928,7 +4064,7 @@ sub b body
             ("caller.md", "# Caller\n\nWe use [[AuthSvc]].\n"),
         ]);
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
-        assert_eq!(result.wikilinks_resolved, 1);
+        assert_eq!(result.resolved_link_edges, 1);
     }
 
     #[test]
@@ -3938,7 +4074,7 @@ sub b body
             ("root.md", "# R\n\nLink [[subdir/target]].\n"),
         ]);
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
-        assert_eq!(result.wikilinks_resolved, 1);
+        assert_eq!(result.resolved_link_edges, 1);
     }
 
     #[test]
@@ -3952,8 +4088,8 @@ sub b body
             ("logs/daily.md", "# Daily\n\nShipped [[Boost Billing]].\n"),
         ]);
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
-        assert_eq!(result.wikilinks_resolved, 1);
-        assert_eq!(result.wikilinks_unresolved, 0);
+        assert_eq!(result.resolved_link_edges, 1);
+        assert_eq!(result.unresolved_link_occurrences, 0);
     }
 
     #[test]
@@ -3967,7 +4103,7 @@ sub b body
             ("g/target.md", "# Beta\n\nbody\n"),
         ]);
         let (result, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
-        assert_eq!(result.wikilinks_resolved, 1);
+        assert_eq!(result.resolved_link_edges, 1);
 
         let notes = store.list_notes(None).unwrap();
         let uid_of = |path_frag: &str| {
@@ -3998,8 +4134,8 @@ sub b body
             ("g/target.md", "# Beta\n\nbody\n"),
         ]);
         let (result, _) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
-        assert_eq!(result.wikilinks_resolved, 0);
-        assert_eq!(result.wikilinks_unresolved, 1);
+        assert_eq!(result.resolved_link_edges, 0);
+        assert_eq!(result.unresolved_link_occurrences, 1);
     }
 
     #[test]
@@ -4012,7 +4148,7 @@ sub b body
             ("caller.md", "# C\n\nSee [[T#Setup]].\n"),
         ]);
         let (result, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
-        assert_eq!(result.wikilinks_resolved, 1);
+        assert_eq!(result.resolved_link_edges, 1);
 
         // Verify the wikilink went to the Heading variant.
         let count = store.count_wikilink_edges().unwrap();
@@ -4535,7 +4671,8 @@ sub b body
         assert_eq!(
             format_markdown_refresh_summary(&direct_changed),
             "Refreshed vault 'vault': dropped 2 stale note(s), reindexed 2 note(s), \
-             2 heading(s), 2 section(s), 0 tag(s), 0 wikilink(s) (0 unresolved)."
+             2 heading(s), 2 section(s), 0 tag(s), 0 wikilink edge(s), \
+             0 unresolved link occurrence(s) across 0 distinct target(s)."
         );
     }
 

--- a/crates/nestweaver-engine/src/instance_remedy.rs
+++ b/crates/nestweaver-engine/src/instance_remedy.rs
@@ -16,12 +16,16 @@
 /// `nestweaver-mcp/src/tools.rs` already applies after ranking by data volume,
 /// which is the information these call sites do not have.
 ///
-/// The caveat at the end is deliberate and is NOT decoration. `instance merge`
-/// does not currently update the database's recorded instance identity, so a
-/// later index can re-create the split (nw-264). Emitting a confident,
-/// pasteable command for a known-incomplete operation would be a worse defect
-/// than the placeholder it replaces, so the command is concrete and the
-/// sentence around it is honest about what it does not finish.
+/// nw-264 CLOSED THE HEDGE THIS USED TO CARRY. The sentence read *"a merge does
+/// not yet update the database's recorded instance identity, so verify with
+/// `nestweaver brain status` before relying on it"* — deliberate, because
+/// emitting a confident pasteable command for a known-incomplete operation
+/// would have been a worse defect than the placeholder it replaced. The merge
+/// now moves the record to the surviving instance, so the command is a genuine
+/// one-step fix and the hedge is gone rather than softened.
+///
+/// The re-index that remains is NOT a hedge: it rebuilds each repo's derived
+/// edges under the surviving instance, which a UID remap does not do.
 pub fn instance_consolidation_remedy(ids: &[String], keeper: Option<&str>) -> String {
     let mut sorted: Vec<&str> = ids.iter().map(String::as_str).collect();
     sorted.sort_unstable();
@@ -43,9 +47,8 @@ pub fn instance_consolidation_remedy(ids: &[String], keeper: Option<&str>) -> St
     }
     format!(
         "consolidate them into `{keeper}`:\n      {}\n    \
-         then re-index each repo — a merge does not yet update the database's \
-         recorded instance identity, so verify with `nestweaver brain status` \
-         before relying on it.",
+         then re-index each repo, which rebuilds its derived edges under \
+         `{keeper}`.",
         commands.join("\n      ")
     )
 }
@@ -69,8 +72,15 @@ mod tests {
             remedy.contains("nestweaver instance merge --from two --to one"),
             "the keeper must be deterministic (lexicographically smallest): {remedy}"
         );
-        // …and honest about what the merge does not finish (nw-264).
+        // The merge is now a genuine one-step fix (nw-264), so the remedy must
+        // no longer hedge that it leaves the recorded identity stale. The
+        // re-index that remains rebuilds derived edges and is real work.
         assert!(remedy.contains("re-index"), "{remedy}");
+        assert!(
+            !remedy.contains("does not yet") && !remedy.contains("before relying on it"),
+            "the hedge existed only because nw-264 was open; leaving it in tells \
+             the operator to distrust a command that now works: {remedy}"
+        );
 
         // One command per non-keeper, so N instances collapse in one pass.
         let three = vec!["b".to_string(), "c".to_string(), "a".to_string()];

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -556,7 +556,7 @@ pub use query::{
     BrainContextResult, BrainNode, CODE_CONTEXT_DEFAULT_LIMIT, ContextNode, ContextResult,
     CrossRepoLink, EmbedModelProvider, EmbedQueryFn, FeatureContextResult, FeatureInfo,
     HybridSearchConfig, LinkInfo, LookupResult, SearchIndexProvider, SymbolCandidate, SymbolDetail,
-    apply_ranking_priors, build_brain_context, build_brain_context_hybrid,
+    TruncationCause, apply_ranking_priors, build_brain_context, build_brain_context_hybrid,
     build_brain_context_hybrid_with_aliases, build_context, build_context_with_intent,
     build_feature_context, dedup_heading_section_pairs, expand_query_with_aliases,
     explain_ranking_prior, generate_repo_map, list_repos, list_services, lookup_symbol,

--- a/crates/nestweaver-engine/src/publication.rs
+++ b/crates/nestweaver-engine/src/publication.rs
@@ -1470,6 +1470,52 @@ use anyhow::Context;
 mod tests {
     use super::*;
 
+    /// nw-263, the CROSS-CRATE half — and the one no single reviewer could see,
+    /// because the two halves live in different crates.
+    ///
+    /// `validate_slot_contents` refuses ANY file the manifest does not describe,
+    /// unconditionally (the digest check is gated on `ArtifactBytes::Verified`;
+    /// the reverse inventory is not), with a `PermanentPublicationFailure` — so
+    /// retries are refused too. The rollback route passes `ArtifactBytes::Live`
+    /// and hits it. A slot's described set is sealed by `WalkDir` at seal time,
+    /// so anything created afterwards is undescribed BY CONSTRUCTION.
+    ///
+    /// The Tantivy recovery lock used to be written to the index directory's
+    /// parent, which for a slot-resident sidecar
+    /// (`<root>/slots/<uuid>/<name>.lbug.tantivy`) is the slot root. Tantivy
+    /// never removes a lock file, so one interrupted schema migration wedged
+    /// rollback of that slot forever.
+    ///
+    /// Asserted as a PATH composition rather than by running a migration: the
+    /// invariant is where the lock RESOLVES, and that is decidable without
+    /// touching a filesystem. Do NOT "fix" this by exempting the lock's name
+    /// from the inventory — that punches a permanent hole in a sealed-slot
+    /// invariant to paper over a layout bug.
+    #[test]
+    fn the_tantivy_recovery_lock_never_resolves_inside_a_publication_slot() {
+        let publication_root = std::path::Path::new("/var/nestweaver/publications");
+        let slot = slot_path(publication_root, "11111111-2222-3333-4444-555555555555").unwrap();
+        // Exactly the layout `tantivy_sidecar_path_for` produces: an OsString
+        // push onto the database path, so the sidecar is a SIBLING of the
+        // database file and its parent is the slot root.
+        let sidecar = slot.join("brain.lbug.tantivy");
+
+        let lock = nestweaver_store::reindex_lock_path(&sidecar);
+
+        assert!(
+            !lock.starts_with(&slot),
+            "the recovery lock resolves inside a sealed publication slot, where \
+             `validate_slot_contents` refuses it permanently: {}",
+            lock.display()
+        );
+        assert!(
+            !lock.starts_with(publication_root),
+            "the lock must not be anywhere under the publication root either — \
+             a future sweep or manifest could describe that tree too: {}",
+            lock.display()
+        );
+    }
+
     fn descriptor_fixture() -> (ArtifactExpectation, ArtifactDescriptor) {
         let identity = nestweaver_store::PublicationIdentity::new_brain();
         let descriptor = ArtifactDescriptor {

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -458,6 +458,58 @@ pub struct CrossRepoLink {
     pub confidence: f32,
 }
 
+/// WHICH cap truncated a result.
+///
+/// nw-259(a), machine route. A `context` arm carries more than one cap —
+/// `--limit`, `--token-budget`, and the `CODE_CONTEXT_DEFAULT_LIMIT` that
+/// stands in for an omitted `--limit` — and had a single `truncated` boolean
+/// and a single `limit` field to explain all of them. A caller who read
+/// `{"limit": 5000, "truncated": true}` after a BUDGET cut raised `--limit`,
+/// got the same rows, and had no next move. The human `--stats` line learned
+/// to name the cause; the JSON payload, which is what every agent and script
+/// reads, did not.
+///
+/// This is deliberately NOT a sixth spelling of the `(bound, total,
+/// truncated)` triple that `Bounded` standardised. It answers a question none
+/// of those three fields can: `total` says how many matched, `truncated` says
+/// the caller is not holding all of them, and this says which knob to turn.
+/// It rides ALONGSIDE the triple and is meaningful only when `truncated`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TruncationCause {
+    /// A row-count cap: `--limit`, the `limit` tool argument, or the default
+    /// that stands in for an omitted one.
+    Limit,
+    /// An output-size cap: `--token-budget` / the `token_budget` argument.
+    TokenBudget,
+}
+
+impl TruncationCause {
+    /// The wire spelling, so a renderer never restates the serde attribute.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Limit => "limit",
+            Self::TokenBudget => "token_budget",
+        }
+    }
+
+    /// Decide which cap to blame when more than one could have cut.
+    ///
+    /// **The budget wins.** It is applied AFTER the row cap, to whatever the
+    /// row cap left, so raising `--limit` alone cannot get past a budget that
+    /// is already full — prescribing it would be the wrong remedy even though
+    /// the row cap really did also fire. Every route that can apply both caps
+    /// calls this rather than restating the precedence; a second copy is how
+    /// the human route and the JSON route came to disagree in the first place.
+    pub const fn resolve(cut_by_token_budget: bool, cut_by_limit: bool) -> Option<Self> {
+        match (cut_by_token_budget, cut_by_limit) {
+            (true, _) => Some(Self::TokenBudget),
+            (false, true) => Some(Self::Limit),
+            (false, false) => None,
+        }
+    }
+}
+
 /// The full result returned by `build_context`.
 // Deserialize so the daemon's `code_context` reply round-trips back into the
 // same type the direct path builds, and BOTH render through one function.
@@ -496,6 +548,24 @@ pub struct ContextResult {
     /// were standardised on, so the CLI parses the daemon's reply into it.
     #[serde(default, rename = "total", skip_serializing_if = "Option::is_none")]
     pub connected_total: Option<usize>,
+    /// WHICH cap cut, when one did.
+    ///
+    /// `truncated` says the caller is not holding everything; this says what
+    /// to do about it. Set by whichever layer applied the cap — the engine
+    /// imposes none of its own — and resolved through
+    /// `TruncationCause::resolve` when more than one could have fired, so the
+    /// `--stats` line and this field cannot disagree.
+    ///
+    /// `None` when nothing was cut, and also when the producer predates this
+    /// field; `truncated == Some(true)` with no cause is the older-producer
+    /// case, and is exactly the ambiguity this exists to remove going forward.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncated_by: Option<TruncationCause>,
+    /// The token budget that was applied, echoed so a caller reading
+    /// `truncated_by: "token_budget"` can see the number it has to raise —
+    /// the same service `limit` performs for `truncated_by: "limit"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_budget: Option<usize>,
 }
 
 /// Detect whether an input string looks like a file path.
@@ -685,6 +755,8 @@ pub fn build_context_with_intent(
         // these after deciding whether the extra row they asked for arrived.
         limit: None,
         truncated: None,
+        truncated_by: None,
+        token_budget: None,
         // `connected_total` is different from the two above: it is not a
         // policy the caller chose, it is a fact only this traversal can
         // observe, so the engine is the only layer that CAN report it.
@@ -979,6 +1051,22 @@ pub struct FeatureContextResult {
     /// identical defect one screen away from the one that was reported.
     #[serde(default, rename = "total", skip_serializing_if = "Option::is_none")]
     pub connected_total: Option<usize>,
+    /// The same disclosure `ContextResult` carries, for the same reason.
+    ///
+    /// Where else does nw-259(a)'s property need to hold? Here. `context
+    /// --feature` runs through the SAME CLI arm and applies the SAME two caps
+    /// — `--limit` here, `--token-budget` in the caller — and reported neither
+    /// a `truncated` flag nor a cause, so a budget-cut feature context
+    /// rendered byte-identically to a complete one on both routes. `total` was
+    /// the only clue, and it says nothing about which knob to turn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncated: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncated_by: Option<TruncationCause>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_budget: Option<usize>,
 }
 
 /// Build a task-focused context for a declared feature bundle.
@@ -1119,6 +1207,9 @@ pub fn build_feature_context(
         })
         .collect();
 
+    // Computed BEFORE the literal moves `connected`.
+    let limit_truncated = connected_total > connected.len();
+
     Ok(FeatureContextResult {
         feature: FeatureInfo {
             name: feature.name.clone(),
@@ -1130,6 +1221,14 @@ pub fn build_feature_context(
         connected,
         unmatched_entry_points,
         connected_total: Some(connected_total),
+        // Reported by the layer that imposed it. The row cap is this
+        // builder's, so it answers for it; `--token-budget` is applied by the
+        // caller after this returns, and the caller upgrades `truncated_by`
+        // through `TruncationCause::resolve` when it also cuts.
+        limit,
+        truncated: Some(limit_truncated),
+        truncated_by: TruncationCause::resolve(false, limit_truncated),
+        token_budget: None,
     })
 }
 

--- a/crates/nestweaver-engine/src/resolver_generation.rs
+++ b/crates/nestweaver-engine/src/resolver_generation.rs
@@ -37,7 +37,17 @@ use std::path::Path;
 ///     an imported file. nw-323/nw-324: TS/JS `.js`-to-`.ts` specifiers,
 ///     `"./src/*"` tsconfig targets, `export … from` re-exports and
 ///     `new X()` all produced no edge at all. Both change edge SHAPE.
-pub const RESOLVER_GENERATION: u32 = 2;
+/// 3 — nw-349/nw-330/nw-340: functions in cpp, dart, cobol, svelte, vue and
+///     astro recorded `end_line == start_line`, so `find_enclosing_symbol`
+///     could not place a call inside the function containing it and the
+///     degenerate-span fallback attributed it to the nearest preceding one-line
+///     symbol of any kind — including `Constant`/`Variable`/`Property` symbols
+///     that cannot be call sites. Both the spans and the fallback's kind
+///     restriction change which SOURCE an edge is written from, and Rust `impl`
+///     blocks changing from `Class` to `Extension` changes the UIDs those edges
+///     point at. None of it is observable on a repo already indexed: the edges
+///     are on disk with the old sources.
+pub const RESOLVER_GENERATION: u32 = 3;
 
 /// An unrecorded repo reads as generation 0, so the current generation must
 /// stay above it — otherwise the pre-fix data this module exists to flag would

--- a/crates/nestweaver-federation/src/results.rs
+++ b/crates/nestweaver-federation/src/results.rs
@@ -644,8 +644,52 @@ pub fn merge_structured_results(local: &Value, server: &Value) -> Value {
                     .and_then(Value::as_bool)
                     .unwrap_or(false)
             };
-            result["truncated"] =
-                Value::from(merged_overflowed || tier_truncated(local) || tier_truncated(server));
+            let merged_truncated =
+                merged_overflowed || tier_truncated(local) || tier_truncated(server);
+            result["truncated"] = Value::from(merged_truncated);
+
+            // nw-259(a). `truncated` alone sends a caller to the wrong knob, so
+            // the CAUSE has to survive the merge with it — this envelope is
+            // rebuilt key by key, and a key not re-added here is silently
+            // dropped. Federating is precisely the case where a caller cannot
+            // reason it out themselves.
+            //
+            // `token_budget` beats `limit` for the same reason it does on a
+            // single tier: it is applied last, so raising the row cap alone
+            // cannot get past it. `merged_overflowed` contributes `limit`,
+            // because reapplying the requested cap to the merged array is a
+            // ROW cut.
+            fn tier_cause(tier: &Value) -> Option<&str> {
+                tier.get("truncated_by").and_then(Value::as_str)
+            }
+            let cause = if [local, server]
+                .iter()
+                .any(|tier| tier_cause(tier) == Some("token_budget"))
+            {
+                Some("token_budget")
+            } else if merged_overflowed
+                || [local, server]
+                    .iter()
+                    .any(|tier| tier_cause(tier) == Some("limit"))
+            {
+                Some("limit")
+            } else {
+                None
+            };
+            match cause {
+                Some(cause) if merged_truncated => {
+                    result["truncated_by"] = Value::String(cause.to_string());
+                }
+                // Present-but-null, matching what the tools emit: a caller
+                // parsing a fixed shape should not have to tell "absent
+                // because complete" from "absent because dropped in a merge".
+                _ if local.get("truncated_by").is_some()
+                    || server.get("truncated_by").is_some() =>
+                {
+                    result["truncated_by"] = Value::Null;
+                }
+                _ => {}
+            }
         }
 
         // Recomputed AFTER the cap above, so it describes the array the caller
@@ -678,6 +722,20 @@ pub fn merge_structured_results(local: &Value, server: &Value) -> Value {
             if total > connected_len {
                 result["truncated"] = Value::from(true);
             }
+        }
+        // Reconciled LAST, because the `total` block above can flip
+        // `truncated` on after the cause was resolved — which would leave a
+        // caller holding `truncated: true` with `truncated_by: null`, the
+        // exact silence this field exists to remove. A shortfall of the merged
+        // array against the summed total is a ROW shortfall, so `limit` is the
+        // cause; a budget cause already set above is never downgraded.
+        if result["truncated"] == Value::Bool(true)
+            && result
+                .get("truncated_by")
+                .is_none_or(|cause| cause.is_null())
+            && (local.get("truncated_by").is_some() || server.get("truncated_by").is_some())
+        {
+            result["truncated_by"] = Value::String("limit".to_string());
         }
         // This envelope is rebuilt key by key above, so anything not re-added
         // here is silently dropped. `semantic_applied` / `degraded_components`

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -7824,7 +7824,12 @@ fn tool_flow_trace(
 
     // Classes don't have CALLS edges — only their methods do. When the root
     // symbol is a class, expand to its methods and return a flow tree per method.
-    if root.kind == SymbolKind::Class {
+    //
+    // nw-330: an `Extension` (a Rust `impl` block) is in exactly the same
+    // position — a container whose members hold the calls — and used to BE
+    // `SymbolKind::Class`. Without this, `flow` on an impl block would return
+    // an empty tree instead of one per method.
+    if matches!(root.kind, SymbolKind::Class | SymbolKind::Extension) {
         let direct_callees = store
             .callees_of(&root.uid)
             .map_err(|e| anyhow!("callees_of: {e}"))?;

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -16631,3 +16631,114 @@ mod cluster_flag_forwarding_precondition_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod broken_links_window_tests {
+    use super::*;
+    use nestweaver_engine::index_markdown_directory_in_memory;
+    use std::fs;
+
+    fn make_vault(files: &[(&str, &str)]) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("vault");
+        fs::create_dir_all(&root).unwrap();
+        for (rel, content) in files {
+            let path = root.join(rel);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(&path, content).unwrap();
+        }
+        (dir, root)
+    }
+
+    /// nw-341: the ascending-confidence sort puts the same-folder (0.95) and
+    /// nearest-ancestor (0.92) tiers at the TAIL -- deliberately, so the most
+    /// severe rows come first (nw-297). With a cap and no offset, the tiers a
+    /// reviewer must inspect are exactly the ones that fall off the end: a
+    /// health tool that cannot be used to verify its own fixes.
+    ///
+    /// Note what this does NOT claim. The cap is not silent -- `read_limit`
+    /// REJECTS an out-of-range limit with an explicit error and `total` is
+    /// always in the envelope. The residual defects are the missing window and
+    /// the missing `truncated` flag, because `tool_brain_broken_links`
+    /// hand-rolls its disclosure instead of using the `Bounded` seam.
+    #[test]
+    fn the_high_confidence_tail_is_reachable_by_offset() {
+        // Three 0.70 alias rows sort ahead of one 0.95 same-folder row.
+        let (_dir, root) = make_vault(&[
+            (
+                "f/a.md",
+                "# A\n\nSee [[Sibling]], [[al-one]], [[al-two]], [[al-three]].\n",
+            ),
+            ("f/Sibling.md", "# Different Title Entirely\n"),
+            ("g/one.md", "---\naliases: [al-one]\n---\n# One\n"),
+            ("g/two.md", "---\naliases: [al-two]\n---\n# Two\n"),
+            ("g/three.md", "---\naliases: [al-three]\n---\n# Three\n"),
+        ]);
+        let (_res, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+
+        let page = tool_brain_broken_links(&store, json!({ "limit": 3 })).unwrap();
+        assert_eq!(page["total"], 4, "envelope: {page}");
+        assert_eq!(
+            page["truncated"],
+            json!(true),
+            "nw-341: a truncated page must SAY it is truncated, through the same \
+             (returned, total, truncated) seam every other bounded list uses: {page}"
+        );
+        let head: Vec<&str> = page["broken_links"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|l| l["wikilink_text"].as_str().unwrap())
+            .collect();
+        assert!(
+            !head.contains(&"Sibling"),
+            "precondition: the 0.95 row must be the one the cap removes, got {head:?}"
+        );
+
+        let tail = tool_brain_broken_links(&store, json!({ "limit": 3, "offset": 3 })).unwrap();
+        let tail_texts: Vec<&str> = tail["broken_links"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|l| l["wikilink_text"].as_str().unwrap())
+            .collect();
+        assert!(
+            tail_texts.contains(&"Sibling"),
+            "nw-341: the 0.95 same-folder tier must be REACHABLE -- it is precisely \
+             what a reviewer of the wikilink tier ladder has to inspect, got {tail_texts:?}"
+        );
+        assert_eq!(
+            tail["total"], 4,
+            "total must stay the PRE-offset population: {tail}"
+        );
+        assert_eq!(
+            tail["offset"], 3,
+            "the window's origin must be echoed, or a caller paging through \
+             cannot tell which page it is holding: {tail}"
+        );
+    }
+
+    /// nw-341: an offset past the end is an empty page, not an error and not a
+    /// wrapped-around page. It must still report the true population.
+    #[test]
+    fn an_offset_past_the_population_is_an_honest_empty_page() {
+        let (_dir, root) = make_vault(&[
+            ("f/a.md", "# A\n\nSee [[Sibling]].\n"),
+            ("f/Sibling.md", "# Different Title Entirely\n"),
+        ]);
+        let (_res, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+
+        let page = tool_brain_broken_links(&store, json!({ "offset": 500 })).unwrap();
+        assert_eq!(page["returned"], json!(0));
+        assert_eq!(page["total"], json!(1), "population, not remainder: {page}");
+        assert_eq!(page["truncated"], json!(true));
+        assert_eq!(
+            page["unresolved"].as_u64().unwrap() + page["low_confidence"].as_u64().unwrap(),
+            1,
+            "nw-297: classification is over the POPULATION, so it survives any \
+             window: {page}"
+        );
+    }
+}

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -6271,9 +6271,22 @@ fn tool_brain_status(
 ///
 /// The returned bool is "this vault's count could not be read", which
 /// [`counts_disclosure`] folds into `unavailable`/`counts_complete`.
+///
+/// The read is handed in as `(rows, ScanIntegrity)` because a whole-corpus scan
+/// can now come back SHORT without coming back `Err` (nw-335 tolerates a row it
+/// cannot decode rather than losing the corpus). A short scan reported as a
+/// confident smaller number is the same CWE-390 defect nw-260 fixed, just
+/// arriving through `Ok` instead of `unwrap_or_default()` — so an incomplete
+/// read takes the identical null-and-disclose path as a failed one.
 fn vault_status_json<E: std::fmt::Display>(
     vault: &nestweaver_schema::Vault,
-    notes: Result<Vec<nestweaver_schema::Note>, E>,
+    notes: Result<
+        (
+            Vec<nestweaver_schema::Note>,
+            nestweaver_store::ScanIntegrity,
+        ),
+        E,
+    >,
     ext_ts: Option<String>,
 ) -> (Value, bool) {
     // `unwrap_or_default()` turned a failed read into a vault holding zero
@@ -6282,9 +6295,21 @@ fn vault_status_json<E: std::fmt::Display>(
     // the most misleading of the set (CWE-390) — and this tool's own
     // description tells the caller to re-index on a zero.
     let (notes, note_count, read_failed) = match notes {
-        Ok(notes) => {
+        Ok((notes, integrity)) if integrity.is_complete() => {
             let count = notes.len();
             (notes, json!(count), false)
+        }
+        Ok((_, integrity)) => {
+            // Read, but not all of it. A number derived from part of a vault
+            // is not that vault's note count, and this tool tells the caller
+            // to re-index on a low one — so it is `null` plus a disclosure,
+            // exactly as a failed read is.
+            tracing::warn!(
+                vault = %vault.uid,
+                "brain_status: per-vault note count incomplete: {}",
+                integrity.disclosure().unwrap_or_default()
+            );
+            (Vec::new(), Value::Null, true)
         }
         Err(error) => {
             tracing::warn!(
@@ -6439,7 +6464,8 @@ pub fn brain_status_json(
                     "no extension-store timestamp; falling back to max(modified_at)"
                 );
             }
-            let (row, failed) = vault_status_json(v, store.list_notes(Some(&v.uid)), ext_ts);
+            let (row, failed) =
+                vault_status_json(v, store.list_notes_with_integrity(Some(&v.uid)), ext_ts);
             if failed {
                 vault_count_failures += 1;
             }
@@ -9855,6 +9881,13 @@ fn tool_dead_code(
         "truncated": matching_count > filtered.len(),
         "excluded_count": result.excluded_count,
         "dead_percentage": result.dead_percentage,
+        // Coverage contract: the counts above are a completeness claim over the
+        // whole symbol corpus. The store's whole-corpus scan TOLERATES a row it
+        // cannot decode (nw-335) rather than losing the corpus, so `coverage`
+        // says whether it actually saw everything — without it, "N of M" over a
+        // silently-shortened corpus reads as exact.
+        "coverage": if result.coverage_is_complete() { "complete" } else { "degraded" },
+        "undecodable_symbols": result.undecodable_symbols,
         "min_confidence": min_conf_str,
         "unreachable_symbols": filtered,
     }))
@@ -13461,6 +13494,24 @@ mod cache_dispatch_tests {
         assert!(resolved.is_none());
     }
 
+    fn note_fixture(uid: &str) -> nestweaver_schema::Note {
+        nestweaver_schema::Note {
+            uid: uid.to_string(),
+            vault_uid: "vlt:test".to_string(),
+            file_path: format!("{uid}.md"),
+            title: uid.to_string(),
+            note_kind: nestweaver_schema::NoteKind::General,
+            word_count: 1,
+            content_hash: "h".to_string(),
+            frontmatter: None,
+            frontmatter_raw: None,
+            created_at: None,
+            modified_at: Some("2026-01-01T00:00:00Z".to_string()),
+            pagerank_score: None,
+            embedding: None,
+        }
+    }
+
     fn vault_fixture() -> nestweaver_schema::Vault {
         nestweaver_schema::Vault {
             uid: "vlt:test".to_string(),
@@ -13484,7 +13535,13 @@ mod cache_dispatch_tests {
         let vault = vault_fixture();
         let (row, failed) = vault_status_json(
             &vault,
-            Err::<Vec<nestweaver_schema::Note>, _>(nestweaver_store::StoreError::Query(
+            Err::<
+                (
+                    Vec<nestweaver_schema::Note>,
+                    nestweaver_store::ScanIntegrity,
+                ),
+                _,
+            >(nestweaver_store::StoreError::Query(
                 "execute: injected".to_string(),
             )),
             None,
@@ -13514,7 +13571,10 @@ mod cache_dispatch_tests {
         // source, so the disclosure cannot be satisfied by nulling everything.
         let (healthy, failed) = vault_status_json(
             &vault,
-            Ok::<_, nestweaver_store::StoreError>(Vec::new()),
+            Ok::<_, nestweaver_store::StoreError>((
+                Vec::new(),
+                nestweaver_store::ScanIntegrity::default(),
+            )),
             None,
         );
         assert!(!failed);
@@ -13523,6 +13583,45 @@ mod cache_dispatch_tests {
             healthy["last_indexed_source"],
             json!("none"),
             "an empty vault we DID read has genuinely no timestamp: {healthy}"
+        );
+    }
+
+    /// nw-335 made `list_notes` tolerate a row it cannot decode, so the read
+    /// nw-260 hardened can now return `Ok` with FEWER notes than the vault
+    /// holds. That routes a short count straight past the null-and-disclose
+    /// path and republishes it as a confident number — the same CWE-390 defect
+    /// nw-260 fixed, arriving through the success arm. A count over part of a
+    /// vault is not that vault's count.
+    #[test]
+    fn a_vault_whose_notes_were_only_partly_read_reports_null_and_says_so() {
+        let vault = vault_fixture();
+        let degraded = nestweaver_store::ScanIntegrity {
+            returned: 2,
+            skipped_corrupt: 1,
+            first_reason: Some("column 1: embedded NUL byte".to_string()),
+        };
+        let (row, failed) = vault_status_json(
+            &vault,
+            Ok::<_, nestweaver_store::StoreError>((
+                vec![note_fixture("note:a"), note_fixture("note:b")],
+                degraded,
+            )),
+            None,
+        );
+
+        assert!(
+            failed,
+            "an incomplete read must be counted exactly as a failed one, or              `counts_complete` claims completeness over a short scan"
+        );
+        assert_eq!(
+            row["note_count"],
+            Value::Null,
+            "2 of 3 notes is not this vault's note count, and the tool's own              description tells the caller to re-index on a low number: {row}"
+        );
+        assert_ne!(
+            row["last_indexed_source"],
+            json!("none"),
+            "we did not see the whole vault, so we cannot claim we looked and              found no timestamp: {row}"
         );
     }
 

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -3494,7 +3494,7 @@ fn tool_schema_code_context() -> Value {
                     // knob with a minimum and no maximum is an omission either
                     // way.
                     "maximum": 5000,
-                    "description": "Maximum connected symbols to return. Defaults to 500 when omitted; the response reports `connected_count` and `truncated` so an omitted limit is never silently lossy."
+                    "description": "Maximum connected symbols to return. Defaults to 500 when omitted; the response reports `connected_count`, `truncated` and `truncated_by` (which cap cut) so an omitted limit is never silently lossy."
                 },
                 "intent": intent_schema(
                     "Tunes PPR damping and edge weights. Omit for the standard damping (0.85)."
@@ -3721,6 +3721,18 @@ fn tool_code_context(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
     // that counts survivors is not a total of anything.
     let returned = result.connected.len();
     let total = result.connected_total.unwrap_or(returned).max(returned);
+    // nw-259(a), machine route. This tool has exactly ONE cap, so `truncated`
+    // was never ambiguous HERE — but the CLI's daemon route parses this very
+    // payload into `ContextResult` and then applies `--token-budget` on top of
+    // it. Stating the cause explicitly is what lets that layer OVERRIDE a
+    // known cause rather than re-derive one, and it is what an MCP client
+    // reading this tool directly needs in order to parse one shape across
+    // `code_context` and `nestweaver context --json`.
+    //
+    // `resolve` rather than a literal: the precedence rule lives in ONE place
+    // even where only one branch of it is reachable.
+    let truncated_flag = truncated || total > returned;
+    let truncated_by = nestweaver_engine::TruncationCause::resolve(false, truncated_flag);
     let payload = json!({
         "seeds": result.seeds.iter().map(render).collect::<Vec<_>>(),
         "connected": result.connected.iter().map(render).collect::<Vec<_>>(),
@@ -3733,7 +3745,12 @@ fn tool_code_context(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
         "returned": returned,
         "total": total,
         "limit": limit,
-        "truncated": truncated || total > returned,
+        "truncated": truncated_flag,
+        // Emitted even when null, unlike the CLI's `skip_serializing_if`,
+        // because this payload always emits `truncated` and a caller parsing a
+        // fixed shape should not have to distinguish "absent because complete"
+        // from "absent because this producer is old".
+        "truncated_by": truncated_by.map(nestweaver_engine::TruncationCause::as_str),
     });
     Ok(payload)
 }
@@ -10436,6 +10453,26 @@ fn tool_get_summary(store: &GraphStore, args: Value) -> Result<Value, anyhow::Er
         };
         let total_tokens: usize = display.iter().map(|s| s.token_estimate).sum();
         let truncated_by_budget = display.len() < matched_total;
+        // nw-259(a), same property, different command. TWO caps reach this
+        // payload — the generator's `DEFAULT_SYMBOL_SUMMARY_CAP` and
+        // `token_budget` — and `truncated` was one boolean for both, so a
+        // caller could not tell whether to raise the budget or narrow with
+        // `target`.
+        //
+        // Named as INDEPENDENT booleans, the shape `brain_impact` already uses
+        // for `truncated_by_depth` / `truncated_by_threshold`, and deliberately
+        // NOT the single `truncated_by` string that `code_context` and
+        // `nestweaver context` carry. The difference is not cosmetic: there,
+        // the budget is applied to what the row cap left, so raising the row
+        // cap alone provably cannot help and naming both would prescribe a
+        // useless remedy. Here BOTH remedies stay independently useful — a
+        // narrower `target` shrinks the matched set even when the budget cut,
+        // and a bigger budget shows more even when the generator capped — so
+        // collapsing them to one winner would throw away a remedy that works.
+        //
+        // `partial` is kept as an alias of `truncated_by_cap` rather than a
+        // second computation, so the two cannot drift.
+        let truncated_by_cap = capped;
         let note = if capped {
             Some(format!(
                 "symbol-level summary is capped at {} symbols of {matched_total}; pass `target` \
@@ -10467,8 +10504,10 @@ fn tool_get_summary(store: &GraphStore, args: Value) -> Result<Value, anyhow::Er
             "total_available": matched_total,
             "tokens_used": total_tokens,
             "token_budget": token_budget,
-            "truncated": truncated_by_budget || capped,
-            "partial": capped,
+            "truncated": truncated_by_budget || truncated_by_cap,
+            "truncated_by_budget": truncated_by_budget,
+            "truncated_by_cap": truncated_by_cap,
+            "partial": truncated_by_cap,
             "cached": false,
             "note": note,
             "summaries": display,
@@ -10571,6 +10610,19 @@ fn tool_get_summary(store: &GraphStore, args: Value) -> Result<Value, anyhow::Er
         // Either cause: the generator's cap upstream, or the budget here.
         // Reporting only the second made the first vanish (F-DC-11).
         "truncated": display.len() < after_filter_len || cap_dropped > 0,
+        // nw-259(a). `truncated` alone does not say WHICH, and the two
+        // remedies are different: raise `token_budget`, or narrow with
+        // `target`. Independent booleans, per the symbol-level rationale
+        // above — both remedies stay useful when both caps fire.
+        //
+        // `truncated_by_cap` is `cap_dropped > 0`, which is FALSE on a sidecar
+        // cache hit even when the cached set was itself capped, because the
+        // generator did not run and nothing recorded what it dropped. That is
+        // a pre-existing hole in `truncated` itself, not one this field adds;
+        // it is called out here so the next reader does not mistake the field
+        // for a guarantee.
+        "truncated_by_budget": display.len() < after_filter_len,
+        "truncated_by_cap": cap_dropped > 0,
         "cached": from_cache,
         "summaries": display,
         "summaries_text": text,

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -3059,28 +3059,41 @@ fn tool_brain_broken_links(store: &GraphStore, args: Value) -> Result<Value, any
         1,
         RESULT_LIMIT_MAX,
     )?;
+    // nw-341: the ONLY axis that unblocks verification. The rows sort
+    // unresolved-first then by ascending confidence, so the 0.92
+    // nearest-ancestor and 0.95 same-folder tiers are the tail -- exactly what
+    // a cap removes and exactly what a reviewer of the tier ladder has to see.
+    // Reversing the sort is not an option: it would regress nw-297's
+    // `genuinely_broken_links_sort_before_lower_tier_resolutions`.
+    let offset = read_limit(&args, "offset", 0, 0, RESULT_LIMIT_MAX)?;
     let all_links = broken_links(store, max_suggestions)?;
-    let total = all_links.len();
-    // nw-297: classify over the POPULATION, before the truncation. The page is
+    // nw-297: classify over the POPULATION, before the window. The page is
     // a sample, and a caller that reads the page's own composition as the
     // vault's composition gets the wrong answer at every limit — which is
     // exactly what the CLI's summary line did.
     let unresolved = all_links.iter().filter(|l| l.is_unresolved()).count();
-    let low_confidence = total - unresolved;
-    let links: Vec<_> = all_links.into_iter().take(limit).collect();
-    Ok(json!({
-        "broken_links": serde_json::to_value(&links)?,
-        "total": total,
-        "returned": links.len(),
+    let low_confidence = all_links.len() - unresolved;
+    let rows: Vec<Value> = all_links
+        .iter()
+        .map(serde_json::to_value)
+        .collect::<Result<_, serde_json::Error>>()?;
+    // nw-341: through `Bounded`, not hand-rolled. This was the last bounded
+    // list in the catalogue still building its own (total, returned) pair, so
+    // it was also the only one that never emitted `truncated` -- a caller could
+    // not tell a complete page from a cut one without comparing two numbers.
+    let mut out = json!({
         "unresolved": unresolved,
         "low_confidence": low_confidence,
-    }))
+        "offset": offset,
+    });
+    Bounded::window(rows, offset, limit).merge_into(&mut out, "broken_links");
+    Ok(out)
 }
 
 fn tool_schema_brain_broken_links() -> Value {
     json!({
         "name": "brain_broken_links",
-        "description": "Find wikilinks in the vault that did not resolve cleanly. TWO POPULATIONS are returned together: links that resolved at a lower tier (confidence < 1.0 — same-folder or filename-stem matches, which are NOT broken) and links that resolved to nothing (`resolved_target_uid` absent — the only genuinely broken ones).\n\nGuidelines:\n- `unresolved` and `low_confidence` count the WHOLE population, not the returned page; `total` and `returned` describe the page. Read the population counts, never the page composition\n- Results are ordered unresolved-first, then by ascending confidence, so the first page is the most severe\n- Each result includes fuzzy-matched suggested target UIDs for repair\n- Returns empty when no vault is indexed\n\nLimitations:\n- Only detects wikilink resolution issues, not broken external URLs\n- Suggestions are fuzzy title matches, not guaranteed correct targets",
+        "description": "Find wikilinks in the vault that did not resolve cleanly. TWO POPULATIONS are returned together: links that resolved at a lower tier (confidence < 1.0 — same-folder or filename-stem matches, which are NOT broken) and links that resolved to nothing (`resolved_target_uid` absent — the only genuinely broken ones).\n\nGuidelines:\n- `unresolved` and `low_confidence` count the WHOLE population, not the returned page; `returned` and `truncated` describe the page and `total` is the pre-offset population. Read the population counts, never the page composition\n- Results are ordered unresolved-first, then by ascending confidence, so the first page is the most severe — and the HIGHEST-confidence tiers are the tail, reachable only via `offset`\n- Each result includes fuzzy-matched suggested target UIDs for repair\n- Returns empty when no vault is indexed\n\nLimitations:\n- Only detects wikilink resolution issues, not broken external URLs\n- Suggestions are fuzzy title matches, not guaranteed correct targets",
         "inputSchema": {
             "type": "object",
             "additionalProperties": false,
@@ -3093,7 +3106,10 @@ fn tool_schema_brain_broken_links() -> Value {
                     "Max suggested target UIDs per broken link (1-50, default 5).", 5, 1, 50),
                 "limit": limit_schema(
                     "Max broken links to return (1-1000, default 50). The total count is always reported.",
-                    DEFAULT_RESULT_LIMIT, 1, RESULT_LIMIT_MAX)
+                    DEFAULT_RESULT_LIMIT, 1, RESULT_LIMIT_MAX),
+                "offset": bounded_integer_schema(
+                    "Skip this many rows before the page (default 0). Rows sort unresolved-first then by ASCENDING confidence, so the high-confidence tiers (0.90/0.92/0.95) are the TAIL — offset is how you reach them. `total` stays the PRE-offset population.",
+                    0, RESULT_LIMIT_MAX)
             }
         }
     })
@@ -10686,9 +10702,27 @@ impl<T> Bounded<T> {
     /// `limit == 0` means unlimited, matching the CLI's documented
     /// `--limit 0 = all` convention. A tool that does not offer that escape
     /// hatch declares `minimum: 1` and never passes 0 here.
-    fn take(mut items: Vec<T>, limit: usize) -> Self {
+    fn take(items: Vec<T>, limit: usize) -> Self {
+        Self::window(items, 0, limit)
+    }
+
+    /// Cut `items` to the window `[offset, offset + limit)`, capturing the
+    /// PRE-WINDOW total.
+    ///
+    /// nw-341: `take` can only ever return the HEAD of a list. When the
+    /// ordering deliberately puts the rows a reviewer must inspect at the TAIL
+    /// -- as `broken_wikilinks` does, sorting unresolved-first then by
+    /// ASCENDING confidence so the most severe rows come first (nw-297) -- the
+    /// head is precisely the wrong page and there is no second one. A health
+    /// tool that cannot be used to verify its own fixes.
+    ///
+    /// `total` stays PRE-offset for the same reason it stays pre-cap: it
+    /// answers "how many matched", not "how many are left". Reporting the
+    /// remainder would make a caller's page arithmetic drift with every step.
+    fn window(mut items: Vec<T>, offset: usize, limit: usize) -> Self {
         let total = items.len();
-        if limit != 0 && total > limit {
+        items.drain(..offset.min(total));
+        if limit != 0 && items.len() > limit {
             items.truncate(limit);
         }
         Self { items, total }

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -6109,6 +6109,28 @@ fn resolve_note_by_title(
     store: &GraphStore,
     title: &str,
 ) -> Result<Option<nestweaver_schema::Note>, anyhow::Error> {
+    resolve_note_by_title_with(store, title, |uid| store.lookup_note(uid))
+}
+
+/// [`resolve_note_by_title`] with the HYDRATION step as an argument.
+///
+/// nw-260. The test that claimed to pin this contract asserted that a title
+/// matching nothing returns `Ok(None)` — which takes the `None => Ok(None)`
+/// arm and is true of the `.ok()` version this fix replaced. The contract is
+/// about the OTHER arm: a title that MATCHED a row and then failed to hydrate
+/// it must be an error, because `None` renders as "no note found with title
+/// '<title>'" — a claim about the vault made on the strength of a failure to
+/// read it.
+///
+/// That arm was unreachable from a test: `nestweaver-store` has no raw query
+/// API, so hydration cannot be made to fail on a store that opened. Taking the
+/// hydrator as a parameter is the seam; the production caller passes
+/// `store.lookup_note`.
+fn resolve_note_by_title_with(
+    store: &GraphStore,
+    title: &str,
+    hydrate: impl Fn(&str) -> Result<nestweaver_schema::Note, nestweaver_store::StoreError>,
+) -> Result<Option<nestweaver_schema::Note>, anyhow::Error> {
     let mut matches = store
         .lookup_notes_by_title(title)
         .with_context(|| format!("failed to look up notes with title '{title}'"))?;
@@ -6148,8 +6170,7 @@ fn resolve_note_by_title(
         // — "no note found with that title" about a note we had just found.
         // The uid branch at the top of this function already propagates with
         // `with_context(...)?`; same function, opposite handling.
-        Some(hit) => store
-            .lookup_note(&hit.uid)
+        Some(hit) => hydrate(&hit.uid)
             .map(Some)
             .with_context(|| format!("hydrate note '{}' matched by title", hit.uid)),
         None => Ok(None),
@@ -6212,6 +6233,105 @@ fn tool_brain_status(
     tantivy: Option<&TantivyIndex>,
 ) -> Result<Value, anyhow::Error> {
     brain_status_json(store, tantivy)
+}
+
+/// Build one `vaults[]` row, and say whether its note count could be READ.
+///
+/// # Why this is a free function
+///
+/// nw-260. The two tests #310 added for this disclosure asserted
+/// `counts_complete == true` and `note_count.is_number()` against
+/// `index_on_disk()` — a HEALTHY store — so every revert of the fixes they
+/// named still passed. That is not an assertion gap, it is a SEAM gap:
+/// `nestweaver-store` exposes no raw query escape hatch, so a test cannot make
+/// `list_notes` fail without corrupting a database file, which fails the OPEN
+/// long before `brain_status` runs. A disclosure contract about a failed read
+/// was untestable at the level those tests sat at, and nobody noticed because
+/// the healthy-path assertions were true.
+///
+/// Lifting the row builder out of the loop makes the failure an ARGUMENT. The
+/// error type is generic so a caller (or a test) can hand it any failure
+/// without this module depending on `StoreError`'s shape.
+///
+/// The returned bool is "this vault's count could not be read", which
+/// [`counts_disclosure`] folds into `unavailable`/`counts_complete`.
+fn vault_status_json<E: std::fmt::Display>(
+    vault: &nestweaver_schema::Vault,
+    notes: Result<Vec<nestweaver_schema::Note>, E>,
+    ext_ts: Option<String>,
+) -> (Value, bool) {
+    // `unwrap_or_default()` turned a failed read into a vault holding zero
+    // notes. The per-vault number is the one a caller actually looks at when
+    // deciding whether a vault indexed correctly, so a confident zero here is
+    // the most misleading of the set (CWE-390) — and this tool's own
+    // description tells the caller to re-index on a zero.
+    let (notes, note_count, read_failed) = match notes {
+        Ok(notes) => {
+            let count = notes.len();
+            (notes, json!(count), false)
+        }
+        Err(error) => {
+            tracing::warn!(
+                vault = %vault.uid,
+                "brain_status: per-vault note count unavailable: {error}"
+            );
+            (Vec::new(), Value::Null, true)
+        }
+    };
+    let (last_indexed, last_indexed_source) = if let Some(ts) = ext_ts {
+        (Some(ts), "extension_store")
+    } else if read_failed {
+        // `"none"` is a VERIFIED-ABSENCE claim, and it used to be manufactured
+        // from the same failed read that nulled the count: `notes` was bound to
+        // an empty vec, the fallback over it found no timestamp, and the row
+        // reported `"none"` next to `note_count: null`. "none" means "we looked
+        // and found no timestamp"; here we did not look.
+        (None, "unavailable")
+    } else {
+        let fallback = notes
+            .iter()
+            .filter_map(|n| n.modified_at.as_deref())
+            .max()
+            .map(|s| s.to_string());
+        if fallback.is_some() {
+            (fallback, "file_mtime")
+        } else {
+            (None, "none")
+        }
+    };
+    let row = json!({
+        // `uid` + `instance_id` let callers disambiguate rows that share a
+        // name/root_path (collision state) and target precise operations like
+        // `brain remove --instance <id>`.
+        "uid": vault.uid,
+        "instance_id": vault.instance_id,
+        "name": vault.name,
+        "root_path": vault.root_path,
+        "note_count": note_count,
+        "last_indexed": last_indexed,
+        "last_indexed_source": last_indexed_source,
+    });
+    (row, read_failed)
+}
+
+/// Fold per-vault read failures into the payload's own disclosure, and derive
+/// `counts_complete` from the same fold.
+///
+/// nw-260. These were two independent expressions — a `push` and an
+/// `unavailable.is_empty() && vault_count_failures == 0` — either of which
+/// could be deleted without any test noticing, because the only fixture that
+/// reached them was healthy and produced `(vec![], 0)` for both. Computing them
+/// together means a caller cannot be told "nothing is unavailable" and
+/// "counts are incomplete", or the reverse.
+fn counts_disclosure(
+    mut unavailable: Vec<&'static str>,
+    vault_count_failures: usize,
+) -> (Vec<&'static str>, bool) {
+    if vault_count_failures > 0 {
+        unavailable.push("per-vault note counts");
+    }
+    let counts_complete = unavailable.is_empty();
+    (unavailable, counts_complete)
 }
 
 /// The ONE `brain_status` document builder, shared by every serving path:
@@ -6291,26 +6411,6 @@ pub fn brain_status_json(
     let vaults_json: Vec<Value> = vaults
         .iter()
         .map(|v| {
-            // Same defect as the totals above, and it survived the fix that
-            // wrote that comment: `unwrap_or_default()` turns a failed read
-            // into a vault holding zero notes. The per-vault number is the one
-            // a caller actually looks at when deciding whether a vault indexed
-            // correctly, so a confident zero here is the most misleading of
-            // the set.
-            let (notes, note_count) = match store.list_notes(Some(&v.uid)) {
-                Ok(notes) => {
-                    let count = notes.len();
-                    (notes, json!(count))
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        vault = %v.uid,
-                        "brain_status: per-vault note count unavailable: {error}"
-                    );
-                    vault_count_failures += 1;
-                    (Vec::new(), Value::Null)
-                }
-            };
             // Prefer the extension-store timestamp (actual indexer run);
             // fall back to max(note.modified_at) for older databases.
             let ext_ts = db_path
@@ -6323,32 +6423,11 @@ pub fn brain_status_json(
                     "no extension-store timestamp; falling back to max(modified_at)"
                 );
             }
-            let (last_indexed, last_indexed_source) = if let Some(ts) = ext_ts {
-                (Some(ts), "extension_store")
-            } else {
-                let fallback = notes
-                    .iter()
-                    .filter_map(|n| n.modified_at.as_deref())
-                    .max()
-                    .map(|s| s.to_string());
-                if fallback.is_some() {
-                    (fallback, "file_mtime")
-                } else {
-                    (None, "none")
-                }
-            };
-            json!({
-                // `uid` + `instance_id` let callers disambiguate rows that
-                // share a name/root_path (collision state) and target precise
-                // operations like `brain remove --instance <id>`.
-                "uid": v.uid,
-                "instance_id": v.instance_id,
-                "name": v.name,
-                "root_path": v.root_path,
-                "note_count": note_count,
-                "last_indexed": last_indexed,
-                "last_indexed_source": last_indexed_source,
-            })
+            let (row, failed) = vault_status_json(v, store.list_notes(Some(&v.uid)), ext_ts);
+            if failed {
+                vault_count_failures += 1;
+            }
+            row
         })
         .collect();
 
@@ -6469,9 +6548,7 @@ pub fn brain_status_json(
 
     // Fold the per-vault failures into the same disclosure the totals use, so
     // a caller has ONE place to look for "what could not be read".
-    if vault_count_failures > 0 {
-        unavailable.push("per-vault note counts");
-    }
+    let (unavailable, counts_complete) = counts_disclosure(unavailable, vault_count_failures);
 
     Ok(json!({
         // `db` and `instance_ids` were direct-path-only keys; the daemon
@@ -6493,8 +6570,10 @@ pub fn brain_status_json(
         // A caller must not act on a null the way it would act on a 0.
         "unavailable": unavailable,
         // `counts_complete` must account for the PER-VAULT counts too, or it
-        // claims completeness for a payload that carries nulls.
-        "counts_complete": unavailable.is_empty() && vault_count_failures == 0,
+        // claims completeness for a payload that carries nulls. Computed by
+        // `counts_disclosure` alongside `unavailable`, so the two cannot
+        // disagree about the same failure.
+        "counts_complete": counts_complete,
         "repos": repos_json,
         "repo_count": repos.len(),
         "server_mode": is_server_mode(),
@@ -13256,10 +13335,12 @@ mod cache_dispatch_tests {
     // answer — a count of zero, an empty list, a "not found" — so the caller
     // could not tell "we looked and there is nothing" from "we failed to look".
 
-    /// `brain_status` already disclosed unreadable TOTALS via `unavailable` +
-    /// nulls. The per-vault note count, twenty lines below that block, still
-    /// reported a failed read as a vault holding zero notes. This pins the
-    /// disclosure contract both counts now share.
+    /// nw-260. The COUNTERWEIGHT, not the contract: the disclosure path must
+    /// not fire when nothing is wrong. Kept under its own name because it is
+    /// not wrong, it is insufficient — every revert of the fixes it was
+    /// written to pin still passes it, since `index_on_disk()` is a healthy
+    /// store and the failure arms never run. The contract itself is asserted
+    /// by `a_vault_whose_notes_cannot_be_read_reports_null_and_says_so` below.
     #[test]
     fn brain_status_reports_complete_counts_on_a_healthy_store() {
         let (_dir, db_path) = index_on_disk();
@@ -13285,11 +13366,12 @@ mod cache_dispatch_tests {
         }
     }
 
-    /// `resolve_note_by_title` matched a row and then hydrated it with `.ok()`,
-    /// so a failed hydration became "no note found with that title" — a claim
-    /// about the vault made on the strength of a failure to read it. A genuine
-    /// miss must still be a clean `None`, or the fix would just trade one wrong
-    /// answer for a spurious error.
+    /// nw-260. The COUNTERWEIGHT to
+    /// `a_title_that_matched_but_could_not_hydrate_is_an_error_not_a_miss`: a
+    /// genuine miss must stay a clean `None`, or the fix would trade one wrong
+    /// answer for a spurious error. On its own it proves nothing about the
+    /// contract it was filed under — it takes the `None => Ok(None)` arm, which
+    /// the `.ok()` version it names satisfied too.
     #[test]
     fn a_title_that_matches_nothing_is_still_a_clean_miss() {
         let (_dir, db_path) = index_on_disk();
@@ -13300,6 +13382,151 @@ mod cache_dispatch_tests {
             .expect("a miss is not an error");
 
         assert!(resolved.is_none());
+    }
+
+    fn vault_fixture() -> nestweaver_schema::Vault {
+        nestweaver_schema::Vault {
+            uid: "vlt:test".to_string(),
+            name: "test".to_string(),
+            root_path: "/v".to_string(),
+            instance_id: "default".to_string(),
+        }
+    }
+
+    /// nw-260. The test this joins asserted `counts_complete == true` on a
+    /// HEALTHY store, so all four reverts of the fixes it named still passed:
+    /// restoring `unwrap_or_default()` on the per-vault count, deleting the
+    /// failure counter, deleting `&& vault_count_failures == 0` from
+    /// `counts_complete`, and deleting the `unavailable.push` fold. A
+    /// disclosure contract is about the FAILURE, and the failure is what the
+    /// fixture has to be able to produce — which is why the fix here was a
+    /// SEAM (`vault_status_json` takes the read as an argument) rather than
+    /// more assertions against a store that cannot fail.
+    #[test]
+    fn a_vault_whose_notes_cannot_be_read_reports_null_and_says_so() {
+        let vault = vault_fixture();
+        let (row, failed) = vault_status_json(
+            &vault,
+            Err::<Vec<nestweaver_schema::Note>, _>(nestweaver_store::StoreError::Query(
+                "execute: injected".to_string(),
+            )),
+            None,
+        );
+
+        assert!(
+            failed,
+            "a failed read must be counted, or `counts_complete` cannot \
+             account for it"
+        );
+        assert_eq!(
+            row["note_count"],
+            Value::Null,
+            "a count that could not be READ is not a count of zero (CWE-390), \
+             and this tool's own description tells the caller to re-index on a \
+             zero: {row}"
+        );
+        assert_ne!(
+            row["last_indexed_source"],
+            json!("none"),
+            "`none` is a verified-absence claim manufactured from the SAME \
+             failed read that nulled the count — we did not look, so we cannot \
+             say we looked and found nothing: {row}"
+        );
+
+        // Counterweight: a readable vault reports a real number and a real
+        // source, so the disclosure cannot be satisfied by nulling everything.
+        let (healthy, failed) = vault_status_json(
+            &vault,
+            Ok::<_, nestweaver_store::StoreError>(Vec::new()),
+            None,
+        );
+        assert!(!failed);
+        assert_eq!(healthy["note_count"], json!(0));
+        assert_eq!(
+            healthy["last_indexed_source"],
+            json!("none"),
+            "an empty vault we DID read has genuinely no timestamp: {healthy}"
+        );
+    }
+
+    /// nw-260, the fold. `unavailable` and `counts_complete` were two
+    /// independent expressions over the same failure, and the only fixture that
+    /// reached them handed both `(vec![], 0)` — so either could be deleted
+    /// silently. They are one function now, and this is the assertion that
+    /// notices if the fold goes away again.
+    #[test]
+    fn a_failed_per_vault_read_reaches_the_payloads_own_disclosure() {
+        let (unavailable, counts_complete) = counts_disclosure(Vec::new(), 2);
+        assert!(
+            unavailable.contains(&"per-vault note counts"),
+            "a caller has ONE place to look for what could not be read, and \
+             this failure did not reach it: {unavailable:?}"
+        );
+        assert!(
+            !counts_complete,
+            "a payload carrying nulls must not claim its counts are complete"
+        );
+
+        let (unavailable, counts_complete) = counts_disclosure(Vec::new(), 0);
+        assert!(unavailable.is_empty());
+        assert!(
+            counts_complete,
+            "nothing failed, so nothing may be listed as unavailable"
+        );
+    }
+
+    /// nw-260, second half. A title that MATCHED and then failed to hydrate
+    /// must be an error, not `None` — `None` renders as "no note found with
+    /// title '<title>'", a claim about the vault made on the strength of a
+    /// failure to read it. The old test asserted only that a genuine MISS is
+    /// `None`, which the `.ok()` version it names satisfied.
+    #[test]
+    fn a_title_that_matched_but_could_not_hydrate_is_an_error_not_a_miss() {
+        let store = GraphStore::in_memory().unwrap();
+        // A FILENAME-STEM match, because that is the tier that hydrates: an
+        // exact title hit returns from `lookup_notes_by_title` and never
+        // reaches the hydration arm at all. This is the nw-259-shaped reason
+        // the shipped test could not have covered it even with a note present.
+        store
+            .insert_note(&nestweaver_schema::Note {
+                uid: "note:home".to_string(),
+                vault_uid: "vlt:test".to_string(),
+                file_path: "Home.md".to_string(),
+                title: "Brain - Command Center".to_string(),
+                note_kind: nestweaver_schema::NoteKind::General,
+                word_count: 10,
+                content_hash: "hash-home".to_string(),
+                frontmatter: None,
+                frontmatter_raw: None,
+                created_at: None,
+                modified_at: None,
+                pagerank_score: None,
+                embedding: None,
+            })
+            .unwrap();
+
+        let error = resolve_note_by_title_with(&store, "Home", |uid| {
+            Err(nestweaver_store::StoreError::Query(format!(
+                "execute: injected for {uid}"
+            )))
+        })
+        .expect_err("a failed hydration of a MATCHED row is not a clean miss");
+        assert!(
+            format!("{error:#}").contains("hydrate"),
+            "the error must name what failed, or the caller learns only that \
+             something went wrong: {error:#}"
+        );
+
+        // Counterweight: with a working hydrator the same title resolves, so
+        // the assertion above cannot be satisfied by failing unconditionally.
+        let resolved = resolve_note_by_title_with(&store, "Home", |uid| store.lookup_note(uid))
+            .expect("a stem-matched title resolves");
+        assert_eq!(
+            resolved.map(|n| n.uid),
+            Some("note:home".to_string()),
+            "the fixture must reach the hydration arm, or this test proves \
+             nothing"
+        );
     }
 
     // ── nw-214: ranking staleness must reach the AGENT, not just the human ──

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -9923,10 +9923,7 @@ fn tool_hub_nodes(store: &GraphStore, args: Value) -> Result<Value, anyhow::Erro
             "cluster_id is null because clustering has not been computed. Run 'nestweaver cluster' to populate.".to_string(),
         );
     }
-    if let Some(note) = ranking_staleness_note(store) {
-        resp["rankings_stale"] = json!(true);
-        attach_note(&mut resp, note);
-    }
+    attach_ranking_staleness(&mut resp, store);
     Ok(resp)
 }
 
@@ -10010,10 +10007,7 @@ fn tool_bridge_nodes(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
         "count": nodes_json.len(),
         "bridges": nodes_json,
     });
-    if let Some(note) = ranking_staleness_note(store) {
-        resp["rankings_stale"] = json!(true);
-        attach_note(&mut resp, note);
-    }
+    attach_ranking_staleness(&mut resp, store);
     Ok(resp)
 }
 
@@ -12131,6 +12125,42 @@ fn ranking_staleness_note(store: &GraphStore) -> Option<String> {
     nestweaver_engine::resolver_generation::staleness_note(&db_path, &uids)
 }
 
+/// WHICH repos are stale, not merely that some are.
+///
+/// nw-217a found this by comparing `hubs --json` against `hub_nodes` over MCP:
+/// the CLI emits `rankings_stale` UNCONDITIONALLY (nw-308) plus the list of
+/// stale repos, and these tools emitted `rankings_stale` only when it was TRUE
+/// and never named a repo. Two consequences, both the shape nw-315 closed for
+/// `stale_check`:
+///
+///  * an absent key cannot be read as `false`. "Not stale" and "this tool does
+///    not say" are the same observation to an agent, and only one of them is a
+///    reason to trust the numbers.
+///  * "N of M repos were indexed by an older resolver" tells a caller to go
+///    find out which. The human gets the list; the agent got a count.
+fn ranking_stale_repos(store: &GraphStore) -> Vec<String> {
+    let Ok(db_path) = current_db_path(store) else {
+        return Vec::new();
+    };
+    let Ok(repos) = store.list_repos(None) else {
+        return Vec::new();
+    };
+    let uids: Vec<String> = repos.into_iter().map(|repo| repo.uid).collect();
+    nestweaver_engine::resolver_generation::load(&db_path)
+        .stale_repos(uids.iter().map(|uid| uid.as_str()))
+}
+
+/// Attach the ranking-staleness disclosure to a result, in the shape the CLI
+/// has emitted since nw-308: both keys, always.
+fn attach_ranking_staleness(resp: &mut Value, store: &GraphStore) {
+    let note = ranking_staleness_note(store);
+    resp["rankings_stale"] = json!(note.is_some());
+    resp["stale_repos"] = json!(ranking_stale_repos(store));
+    if let Some(note) = note {
+        attach_note(resp, note);
+    }
+}
+
 /// Attach a disclosure to a tool result without dropping one already there.
 ///
 /// `note` is this surface's existing human-readable channel and some tools
@@ -13562,6 +13592,15 @@ mod cache_dispatch_tests {
                 Some(true),
                 "{tool} must flag stale rankings"
             );
+            // nw-217a: WHICH, not merely that some are. The human has had this
+            // list since nw-308; the agent was given a count and told to go
+            // find out — the same defect nw-315 closed for `stale_check`.
+            assert!(
+                value["stale_repos"]
+                    .as_array()
+                    .is_some_and(|repos| !repos.is_empty()),
+                "{tool} must name the stale repos: {value}"
+            );
             let note = value
                 .get("note")
                 .and_then(Value::as_str)
@@ -13590,9 +13629,21 @@ mod cache_dispatch_tests {
 
             let value = dispatch(&store, None, tool, json!({}), None).unwrap();
 
-            assert!(
-                value.get("rankings_stale").is_none(),
-                "{tool} must not flag staleness once every repo is current"
+            // nw-217a: `false`, not absent. An absent key cannot be read as
+            // "not stale" — "not stale" and "this tool does not say" are the
+            // same observation to an agent, and only one of them is a reason
+            // to trust the numbers. The CLI has said `false` since nw-308.
+            assert_eq!(
+                value.get("rankings_stale").and_then(Value::as_bool),
+                Some(false),
+                "{tool} must state that rankings are current, not merely omit \
+                 the claim"
+            );
+            assert_eq!(
+                value.get("stale_repos"),
+                Some(&json!([])),
+                "{tool} must name WHICH repos are stale, and an empty list is \
+                 how it says none are"
             );
             let note = value
                 .get("note")

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -3251,7 +3251,7 @@ fn tool_brain_doc_stats(store: &GraphStore, args: Value) -> Result<Value, anyhow
 fn tool_schema_brain_doc_stats() -> Value {
     json!({
         "name": "brain_doc_stats",
-        "description": "Get a one-shot health summary of a vault's document graph — note counts, broken links, orphans, tag distribution, and notes-by-year.\n\nGuidelines:\n- Call once for a quick vault health overview before deeper analysis\n- All seven keys are always returned, even on an empty vault (zeros/empty collections)\n- Output: {total_notes, total_wikilinks, broken_wikilinks, orphans, avg_outdegree, top_tags, notes_by_year}\n\nLimitations:\n- Aggregates other brain document tools; for detailed broken links use brain_broken_links directly",
+        "description": "Get a one-shot health summary of a vault's document graph — note counts, broken links, orphans, tag distribution, and notes-by-year.\n\nGuidelines:\n- Call once for a quick vault health overview before deeper analysis\n- All keys are always returned, even on an empty vault (zeros/empty collections)\n- Output: {total_notes, wikilink_edges, unresolved_link_targets, unresolved_link_section_targets, low_confidence_link_targets, orphans, avg_outdegree, top_tags, notes_by_year}\n- Every link count NAMES ITS POPULATION and they legitimately disagree: `wikilink_edges` counts edges (one ambiguous link contributes N), `unresolved_link_targets` counts distinct (note, link text), `unresolved_link_section_targets` counts distinct (section, link text). Link OCCURRENCES are not stored in the graph — `brain_add` reports those\n\nLimitations:\n- Aggregates other brain document tools; for detailed broken links use brain_broken_links directly",
         "inputSchema": {
             "type": "object",
             "additionalProperties": false,
@@ -6900,8 +6900,16 @@ fn tool_brain_add_source(store: &GraphStore, args: Value) -> Result<Value, anyho
                 "headings": result.headings_count,
                 "sections": result.sections_count,
                 "tags": result.tags_count,
-                "wikilinks_resolved": result.wikilinks_resolved,
-                "wikilinks_unresolved": result.wikilinks_unresolved,
+                // nw-345: each key names the POPULATION it counts. `resolved`
+                // is EDGES (an ambiguous link contributes N); the three
+                // unresolved numbers are occurrences, distinct (section,
+                // target), and distinct (note, target) — the last is the one
+                // `brain_doc_stats` and `brain_broken_links` report, and it is
+                // why one run used to print two different "unresolved" counts.
+                "resolved_link_edges": result.resolved_link_edges,
+                "unresolved_link_occurrences": result.unresolved_link_occurrences,
+                "unresolved_link_section_targets": result.unresolved_link_section_targets,
+                "unresolved_link_targets": result.unresolved_link_targets,
                 "coverage_status": if result.skipped.is_empty() { "complete" } else { "degraded" },
                 "skipped_count": result.skipped.len(),
                 "skipped_files": result.skipped,

--- a/crates/nestweaver-parser/src/astro.rs
+++ b/crates/nestweaver-parser/src/astro.rs
@@ -91,7 +91,14 @@ pub fn parse_astro(path: &Path, source: &str) -> ParsedFile {
         name: component_name.clone(),
         kind: SymbolKind::Class,
         start_line: 1,
-        end_line: 1,
+        // The component IS the file, so its span is the file. It used to be
+        // 1-1, which made every module-scope reference in the file belong to no
+        // symbol at all — the resolver then either dropped it or handed it to
+        // whatever one-line symbol happened to precede it. A file-spanning
+        // component is not a widened guess: it is the true containment, and
+        // because `find_enclosing_symbol` returns the INNERMOST containing
+        // span, a call inside a function still attributes to that function.
+        end_line: source.lines().count().max(1) as u32,
         signature: format!("<astro:component name=\"{component_name}\">"),
         content_hash: sha256_hex(&component_name),
         is_entry_point: false,
@@ -104,8 +111,21 @@ pub fn parse_astro(path: &Path, source: &str) -> ParsedFile {
 
     // Extract frontmatter block (between --- markers)
     if let Some((frontmatter, frontmatter_start)) = extract_frontmatter(source) {
-        for (idx, line) in frontmatter.lines().enumerate() {
-            let line_no = frontmatter_start + idx as u32 + 1;
+        let block_lines: Vec<&str> = frontmatter.lines().collect();
+        let offset = frontmatter_start;
+
+        for (idx, line) in block_lines.iter().enumerate() {
+            let line_no = crate::block_span::file_line(offset, idx);
+            // nw-349 span family: a declaration's span must cover its BODY.
+            // This scanner used to record `end_line: line_no`, so every
+            // function it extracted was ZERO-HEIGHT — `read-symbols` returned
+            // the signature alone, and the resolver could not place any call in
+            // the body inside its own function. `brace_block_end` returns None
+            // for a declaration that opens no block (a genuine one-liner) and
+            // for one it cannot match, so an unhandled shape degrades to the
+            // old span rather than to a confident wrong one.
+            let end_line = crate::block_span::brace_block_end(&block_lines, idx)
+                .map_or(line_no, |e| crate::block_span::file_line(offset, e));
             let trimmed = line.trim();
 
             // Skip empty lines and comments
@@ -122,7 +142,7 @@ pub fn parse_astro(path: &Path, source: &str) -> ParsedFile {
                     name,
                     kind: SymbolKind::Function,
                     start_line: line_no,
-                    end_line: line_no,
+                    end_line,
                     signature: trimmed.to_string(),
                     content_hash: sha256_hex(trimmed),
                     is_entry_point: false,
@@ -143,7 +163,7 @@ pub fn parse_astro(path: &Path, source: &str) -> ParsedFile {
                     name,
                     kind: SymbolKind::Function,
                     start_line: line_no,
-                    end_line: line_no,
+                    end_line,
                     signature: trimmed.to_string(),
                     content_hash: sha256_hex(trimmed),
                     is_entry_point: false,

--- a/crates/nestweaver-parser/src/block_span.rs
+++ b/crates/nestweaver-parser/src/block_span.rs
@@ -1,0 +1,196 @@
+//! Brace-delimited block spans for the regex-based single-file-component
+//! parsers (`astro`, `svelte`, `vue`).
+//!
+//! These three parsers are line scanners: they match a declaration on one line
+//! and then record `end_line: start_line`, so every function they extract has a
+//! ZERO-HEIGHT span that excludes its own body. That is the same defect family
+//! as `queries/cpp.scm` anchoring on `(function_declarator ..)` — the signature
+//! without the body — and it is not cosmetic:
+//!
+//! - `read-symbols` returns one line where the caller asked for a function.
+//! - `nestweaver-resolver`'s `find_enclosing_symbol` cannot place a reference
+//!   inside a function whose span is one line, so every call in the body falls
+//!   through to a degenerate fallback and is attributed to whatever one-line
+//!   symbol happened to precede it.
+//!
+//! The three parsers had one copy of the defect each, so they get one shared
+//! fix rather than three: the property "a symbol's span covers its body" is not
+//! a per-language fact.
+//!
+//! # What this deliberately does not do
+//!
+//! It is a brace matcher, not a JavaScript parser. It skips braces inside line
+//! comments, block comments, and string/template literals (with backslash
+//! escapes), because those are the cases that actually occur and that would
+//! otherwise silently mis-span a real function. It does NOT understand regex
+//! literals, and it requires the opening brace to be on the declaration line —
+//! Allman-style `function f()\n{` is not recognised.
+//!
+//! Every unhandled case returns `None`, which leaves the span exactly as it was
+//! before this module existed. A miscount therefore degrades to the old
+//! behaviour rather than to a confidently wrong span, which is the only
+//! acceptable failure mode for something feeding `read-symbols`.
+
+/// Where the scanner is when it reaches a given character.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Ctx {
+    Code,
+    LineComment,
+    BlockComment,
+    Single,
+    Double,
+    Template,
+}
+
+/// Index (0-based, into `lines`) of the line carrying the brace that closes the
+/// block opened on `lines[start]`.
+///
+/// Returns `None` when `lines[start]` opens no block at all — a genuine
+/// one-liner such as `export let count = 0` — and also when the block is never
+/// closed within `lines`. Both cases mean "leave the span alone".
+pub(crate) fn brace_block_end(lines: &[&str], start: usize) -> Option<usize> {
+    let mut depth: i32 = 0;
+    let mut opened = false;
+    let mut ctx = Ctx::Code;
+
+    for (offset, line) in lines.iter().enumerate().skip(start) {
+        // A line comment ends at the newline; the other contexts carry over.
+        if ctx == Ctx::LineComment {
+            ctx = Ctx::Code;
+        }
+
+        let bytes: Vec<char> = line.chars().collect();
+        let mut i = 0;
+        while i < bytes.len() {
+            let c = bytes[i];
+            let next = bytes.get(i + 1).copied();
+            match ctx {
+                Ctx::LineComment => break,
+                Ctx::BlockComment => {
+                    if c == '*' && next == Some('/') {
+                        ctx = Ctx::Code;
+                        i += 1;
+                    }
+                }
+                Ctx::Single | Ctx::Double | Ctx::Template => {
+                    if c == '\\' {
+                        // Escapes bind to the next character, including a
+                        // closing quote. Skip both.
+                        i += 1;
+                    } else if (ctx == Ctx::Single && c == '\'')
+                        || (ctx == Ctx::Double && c == '"')
+                        || (ctx == Ctx::Template && c == '`')
+                    {
+                        ctx = Ctx::Code;
+                    }
+                }
+                Ctx::Code => match c {
+                    '/' if next == Some('/') => {
+                        ctx = Ctx::LineComment;
+                        break;
+                    }
+                    '/' if next == Some('*') => {
+                        ctx = Ctx::BlockComment;
+                        i += 1;
+                    }
+                    '\'' => ctx = Ctx::Single,
+                    '"' => ctx = Ctx::Double,
+                    '`' => ctx = Ctx::Template,
+                    '{' => {
+                        depth += 1;
+                        opened = true;
+                    }
+                    '}' => {
+                        depth -= 1;
+                        if opened && depth <= 0 {
+                            return Some(offset);
+                        }
+                    }
+                    _ => {}
+                },
+            }
+            i += 1;
+        }
+
+        // The declaration line must open the block. Refusing to scan forward
+        // for a brace on a later line is what keeps a non-block declaration
+        // (`export let count = 0`) from swallowing the next function.
+        if offset == start && !opened {
+            return None;
+        }
+    }
+
+    None
+}
+
+/// Convert a 0-based index within a block into the 1-based file line number the
+/// parsers record, given the block's `offset` (the 0-based file index of the
+/// line *before* the block's first line, which is what all three parsers hold).
+pub(crate) fn file_line(offset: u32, idx: usize) -> u32 {
+    offset + idx as u32 + 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn end_of(src: &str, start: usize) -> Option<usize> {
+        let lines: Vec<&str> = src.lines().collect();
+        brace_block_end(&lines, start)
+    }
+
+    #[test]
+    fn a_function_span_reaches_its_closing_brace() {
+        let src = "function handleClick() {\n  count += 1\n  greet('World')\n}\n";
+        assert_eq!(end_of(src, 0), Some(3));
+    }
+
+    #[test]
+    fn a_declaration_that_opens_no_block_is_left_alone() {
+        // `export let count = 0` in testdata/svelte/simple.svelte:9 is a
+        // GENUINE one-liner. Reporting a span for it would be as wrong as
+        // reporting a one-line span for a function.
+        assert_eq!(end_of("export let count = 0\nfunction f() {\n}\n", 0), None);
+    }
+
+    #[test]
+    fn a_brace_inside_a_template_literal_does_not_close_the_block() {
+        // testdata/svelte/simple.svelte:5-7 — the body is a template literal
+        // with a `${..}` interpolation. Counting its braces as code braces
+        // balances by luck here; a literal containing only `}` would not.
+        let src = "function greet(name) {\n  return `Hello, ${name}!}`\n}\n";
+        assert_eq!(end_of(src, 0), Some(2));
+    }
+
+    #[test]
+    fn a_brace_inside_a_string_or_comment_does_not_close_the_block() {
+        let src = "function f() {\n  const s = \"}\"\n  // }\n  /* } */\n  const c = '}'\n}\n";
+        assert_eq!(end_of(src, 0), Some(5));
+    }
+
+    #[test]
+    fn an_escaped_quote_does_not_end_the_string() {
+        let src = "function f() {\n  const s = \"a\\\"}\"\n}\n";
+        assert_eq!(end_of(src, 0), Some(2));
+    }
+
+    #[test]
+    fn nested_blocks_close_at_the_outermost_brace() {
+        // testdata/astro/simple.astro:5-10 nests object literals inside an
+        // array inside the function body.
+        let src = "export function getStaticPaths() {\n  return [\n    { params: { id: '1' } },\n  ]\n}\n";
+        assert_eq!(end_of(src, 0), Some(4));
+    }
+
+    #[test]
+    fn an_unclosed_block_reports_nothing_rather_than_guessing_eof() {
+        // Degrading to the pre-existing zero-height span is acceptable;
+        // fabricating a span that runs to the end of the file is not.
+        assert_eq!(end_of("function f() {\n  broken(\n", 0), None);
+    }
+
+    #[test]
+    fn a_single_line_block_closes_on_its_own_line() {
+        assert_eq!(end_of("function f() { return 1 }\n", 0), Some(0));
+    }
+}

--- a/crates/nestweaver-parser/src/cobol.rs
+++ b/crates/nestweaver-parser/src/cobol.rs
@@ -199,10 +199,55 @@ pub fn parse_cobol(path: &Path, source: &str) -> ParsedFile {
         }
     }
 
+    close_symbol_spans(&mut symbols, source);
+
     ParsedFile {
         path: path_str,
         symbols,
         references,
         type_bindings: Vec::new(),
+    }
+}
+
+/// Give every section and paragraph the span of its own body.
+///
+/// nw-349 span family. This scanner records a symbol when it sees the LABEL
+/// line and has no other line to point at, so it wrote `end_line: start_line`
+/// for all of them. Every COBOL paragraph was therefore ZERO-HEIGHT:
+/// `read-symbols` returned the bare label, and the resolver could not place a
+/// `PERFORM` inside the paragraph that issued it — it fell through to the
+/// degenerate fallback and was attributed to whichever one-line symbol happened
+/// to precede it.
+///
+/// COBOL has no closing delimiter for a paragraph: a paragraph runs until the
+/// next label or the end of the division. So the span is closed by the NEXT
+/// symbol's start rather than by a matching token, and trailing blank and
+/// comment lines are trimmed back so the span is the body rather than the gap
+/// after it.
+///
+/// `symbols` is pushed in ascending line order by construction (one pass over
+/// the source), which is what makes the pairwise walk correct.
+fn close_symbol_spans(symbols: &mut [RawSymbol], source: &str) {
+    let lines: Vec<&str> = source.lines().collect();
+
+    let is_body_line = |idx: usize| -> bool {
+        let line = lines[idx];
+        // Column 7 (0-indexed 6) carries the comment indicator.
+        let is_comment = line.len() > 6 && line.as_bytes()[6] == b'*';
+        !line.trim().is_empty() && !is_comment
+    };
+
+    for i in 0..symbols.len() {
+        let start = symbols[i].start_line;
+        let limit = match symbols.get(i + 1) {
+            Some(next) => next.start_line.saturating_sub(1),
+            None => lines.len() as u32,
+        };
+        // Walk back from the limit to the last line that is actually code.
+        let mut end = limit;
+        while end > start && !is_body_line((end - 1) as usize) {
+            end -= 1;
+        }
+        symbols[i].end_line = end.max(start);
     }
 }

--- a/crates/nestweaver-parser/src/lib.rs
+++ b/crates/nestweaver-parser/src/lib.rs
@@ -1,6 +1,7 @@
 // nestweaver-parser: language-aware source parsing via tree-sitter (code) and comrak (markdown)
 
 pub mod astro;
+pub(crate) mod block_span;
 pub mod canvas;
 pub mod cobol;
 pub mod dataview;

--- a/crates/nestweaver-parser/src/lib.rs
+++ b/crates/nestweaver-parser/src/lib.rs
@@ -27,6 +27,6 @@ pub use markdown::{
 pub use mermaid::{MermaidDiagram, MermaidEdge, MermaidNode, parse_mermaid};
 pub use parse::{
     AstBindingKind, AstTypeBinding, ParseError, ParseResult, ParsedFile, RawReference, RawSymbol,
-    ReferenceKind, SkipReasonCode, SkippedFile, parse_batch, parse_source,
+    ReferenceKind, SkipReasonCode, SkippedFile, parse_batch, parse_source, strip_nul_bytes,
 };
 pub use registry::{LanguageParser, ParserRegistry};

--- a/crates/nestweaver-parser/src/markdown.rs
+++ b/crates/nestweaver-parser/src/markdown.rs
@@ -160,6 +160,12 @@ pub fn parse_markdown(rel_path: &str, source: &str) -> Result<ParsedNote, Markdo
     // 1. Strip Obsidian `%%...%%` comments from source before any further
     //    processing so they are excluded from indexing and search.
     let stripped_source = strip_obsidian_comments(source);
+    // nw-335: drop raw NUL bytes before anything downstream can carry one into
+    // a graph column. `content_hash` above is deliberately taken from the
+    // ORIGINAL bytes, so removing the byte does not hide the edit that removes
+    // it from change detection. See `parse::strip_nul_bytes` for why this is
+    // the right seam rather than the store's canary.
+    let stripped_source = crate::parse::strip_nul_bytes(&stripped_source).into_owned();
     let source = stripped_source.as_str();
 
     // 2. Split frontmatter (if any) from body.
@@ -1407,6 +1413,93 @@ top 2 body
         let note = parse_markdown("x.md", "").unwrap();
         assert!(note.headings.is_empty());
         assert!(note.sections.is_empty());
+    }
+
+    /// nw-342: inside a markdown TABLE, Obsidian REQUIRES the pipe of an
+    /// aliased wikilink to be escaped -- `[[Backlog\|alias]]` is the only
+    /// correct form there. `split_once('|')` then hands the target half back
+    /// with the backslash still attached, so `Backlog\` becomes the stored
+    /// target: a name no file can carry, and the string a user reads back out
+    /// of `broken-links` and `note_get`.
+    ///
+    /// The resolver fix alone would mask this. `resolve` normalises `\` to `/`
+    /// for Windows path forms, so the key becomes `backlog/` and the
+    /// path-qualified fallback happens to recover it at 0.85 -- the symptom
+    /// goes away while the wrong target string stays in the graph.
+    #[test]
+    fn an_escaped_pipe_wikilink_yields_a_bare_stem_target() {
+        let note =
+            parse_markdown("x.md", "| col |\n| --- |\n| [[Backlog\\|the backlog]] |\n").unwrap();
+        assert_eq!(note.wikilinks.len(), 1, "got {:?}", note.wikilinks);
+        assert_eq!(
+            note.wikilinks[0].target, "Backlog",
+            "nw-342: the `\\|` escape must be stripped -- `Backlog\\` is a name no \
+             file can carry, and it is what `broken-links` prints back at the user"
+        );
+        assert_eq!(note.wikilinks[0].display.as_deref(), Some("the backlog"));
+    }
+
+    /// nw-342, "where else": the same escape is legal outside a table, and an
+    /// unaliased link is unaffected. A trailing backslash that is NOT an escape
+    /// of the alias pipe has nowhere else to come from in a wikilink target, so
+    /// stripping is unconditional on the target half only -- the DISPLAY half
+    /// keeps whatever the user wrote.
+    #[test]
+    fn stripping_the_pipe_escape_leaves_other_wikilink_forms_alone() {
+        let note = parse_markdown(
+            "x.md",
+            "[[Plain]] and [[Some/Path\\|shown]] and [[Bare|shown two]]\n",
+        )
+        .unwrap();
+        let targets: Vec<&str> = note.wikilinks.iter().map(|w| w.target.as_str()).collect();
+        assert_eq!(
+            targets,
+            vec!["Plain", "Some/Path", "Bare"],
+            "{:?}",
+            note.wikilinks
+        );
+    }
+
+    /// nw-335: a pasted NUL is not corruption, it is a byte a user typed into a
+    /// note. The store's whole-string canary (`read::string_is_corrupt`) treats
+    /// it as LadybugDB #678 partial-scan corruption and refuses the row, which
+    /// aborted the whole-corpus section scan behind BOTH global derived indexes.
+    /// Sanitising at the single markdown ingest choke point makes the canary's
+    /// stated premise -- "note bodies ... none contain NUL" -- true again,
+    /// rather than weakening a canary that is doing real work on uids and paths.
+    #[test]
+    fn a_nul_byte_is_stripped_from_every_field_the_parser_emits() {
+        let note = parse_markdown(
+            "x.md",
+            "---\ntitle: Ti\u{0}tle\n---\n# Head\u{0}ing\n\nbe\u{0}fore [[Tar\u{0}get]] after\n",
+        )
+        .unwrap();
+        assert!(!note.title.contains('\0'), "title: {:?}", note.title);
+        assert!(
+            note.headings.iter().all(|h| !h.text.contains('\0')),
+            "headings: {:?}",
+            note.headings
+        );
+        assert!(
+            note.sections.iter().all(|s| !s.text.contains('\0')),
+            "sections: {:?}",
+            note.sections
+        );
+        assert!(
+            note.wikilinks.iter().all(|w| !w.target.contains('\0')),
+            "wikilinks: {:?}",
+            note.wikilinks
+        );
+        assert!(
+            note.frontmatter_raw
+                .as_deref()
+                .is_none_or(|r| !r.contains('\0')),
+            "frontmatter_raw: {:?}",
+            note.frontmatter_raw
+        );
+        // Deleting the byte must not delete the text around it.
+        assert!(note.sections[0].text.contains("before"));
+        assert_eq!(note.title, "Title");
     }
 
     #[test]

--- a/crates/nestweaver-parser/src/markdown.rs
+++ b/crates/nestweaver-parser/src/markdown.rs
@@ -635,7 +635,9 @@ fn kind_from_path(rel_path: &str) -> NoteKind {
 /// `[[wikilink#heading]]`, and `![[transclude]]` forms.
 ///
 /// Uses a hand-rolled scanner rather than a regex to keep the parser
-/// dep-light and to handle escapes / nesting predictably. We do NOT match
+/// dep-light. The ONE escape it understands is `\|` in an aliased link, which
+/// Obsidian requires inside a markdown table (nw-342); it does not handle
+/// nesting, and it never claimed to correctly. We do NOT match
 /// inside fenced code blocks (```...```) or inline code (`...`) — those
 /// are not real wikilinks.
 /// Parse every `[[wikilink]]` / `![[transclusion]]` on one line into `out`.
@@ -676,7 +678,27 @@ fn push_wikilinks_from_line(
             continue;
         }
         let (target_part, display) = match inside.split_once('|') {
-            Some((t, d)) => (t.trim().to_string(), Some(d.trim().to_string())),
+            // nw-342: inside a markdown TABLE, Obsidian REQUIRES the alias pipe
+            // to be escaped -- `[[Backlog\|alias]]` is the only correct form
+            // there. `split_once('|')` hands the target half back with the
+            // backslash still attached, so `Backlog\` became the stored target:
+            // a name no file can carry, and the string a user reads back out of
+            // `broken-links` and `note_get`.
+            //
+            // Fixing only the resolver would MASK this. `WikilinkLookup::resolve`
+            // normalises `\` to `/` for Windows path forms, so the key became
+            // `backlog/` and the path-qualified fallback happened to recover it
+            // at 0.85 -- the symptom disappears while the wrong target string
+            // stays in the graph. A trailing backslash on a wikilink TARGET has
+            // no other meaning, so stripping it is unconditional; the DISPLAY
+            // half keeps whatever the user wrote.
+            Some((t, d)) => {
+                let t = t.trim();
+                (
+                    t.strip_suffix('\\').unwrap_or(t).trim_end().to_string(),
+                    Some(d.trim().to_string()),
+                )
+            }
             None => (inside.trim().to_string(), None),
         };
         if target_part.is_empty() {

--- a/crates/nestweaver-parser/src/parse.rs
+++ b/crates/nestweaver-parser/src/parse.rs
@@ -1099,7 +1099,19 @@ pub fn parse_source(path: &Path, source: &str) -> Result<ParsedFile, ParseError>
                     "type" | "type_alias" => SymbolKind::TypeAlias,
                     "variable" | "var" => SymbolKind::Variable,
                     "macro" => SymbolKind::Function,
-                    "impl" => SymbolKind::Class,
+                    // nw-330 / nw-349 (5). `@definition.impl` is a distinct
+                    // capture in queries/rust.scm, and mapping it onto the
+                    // same SymbolKind::Class as `struct_item` threw that
+                    // distinction away at the last step: testdata/rust/simple.rs
+                    // minted THREE `Class SensorManager` rows (lines 4, 18, 28)
+                    // for ONE type, indistinguishable by name and kind.
+                    //
+                    // `Extension` already exists in the schema, already
+                    // round-trips through the store, and is semantically the
+                    // same thing an `impl` block is — a set of members attached
+                    // to a type — so the fact the query already carries now has
+                    // somewhere to live.
+                    "impl" => SymbolKind::Extension,
                     "constructor" => SymbolKind::Method,
                     other => {
                         tracing::debug!(
@@ -5426,6 +5438,83 @@ use crate::config::{Settings, load as load_config};
                 "objc"
             ),
             "@interface SimpleGreeter : NSObject"
+        );
+    }
+
+    // ── nw-330 / nw-349 (5): impl blocks need an identity of their own ────
+
+    #[test]
+    fn a_rust_impl_block_is_not_the_same_symbol_as_the_struct_it_implements() {
+        // `@definition.impl` is a distinct capture in queries/rust.scm, and
+        // parse.rs mapped it onto the SAME SymbolKind::Class as `struct_item`.
+        // testdata/rust/simple.rs therefore minted THREE `Class SensorManager`
+        // rows (lines 4, 18, 28) for one type, indistinguishable by name and
+        // kind — so "which impl block is this method from" was unanswerable and
+        // the impl rows were structural dead-code candidates.
+        let source = "\
+pub struct Foo {
+    x: u32,
+}
+
+pub trait Greet {
+    fn hi(&self);
+}
+
+impl Greet for Foo {
+    fn hi(&self) {}
+}
+
+impl Foo {
+    fn new() -> Self { Foo { x: 0 } }
+}
+";
+        let parsed = parse_source(Path::new("i.rs"), source).unwrap();
+        let foos: Vec<_> = parsed.symbols.iter().filter(|s| s.name == "Foo").collect();
+        assert_eq!(
+            foos.len(),
+            3,
+            "struct + two impl blocks: {:?}",
+            foos.iter()
+                .map(|s| (s.start_line, s.kind))
+                .collect::<Vec<_>>()
+        );
+
+        let classes: Vec<_> = foos
+            .iter()
+            .filter(|s| s.kind == SymbolKind::Class)
+            .collect();
+        assert_eq!(
+            classes.len(),
+            1,
+            "exactly ONE of the three may be a Class — the struct. The impl \
+             blocks must carry their own kind or they are indistinguishable \
+             from it: {:?}",
+            foos.iter()
+                .map(|s| (s.start_line, s.kind))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(classes[0].start_line, 1, "the Class is the struct");
+        assert!(
+            foos.iter()
+                .filter(|s| s.start_line != 1)
+                .all(|s| s.kind == SymbolKind::Extension),
+            "both impl blocks are Extensions"
+        );
+
+        // The trait relationship must stay recoverable STRUCTURALLY, not only
+        // from the signature string. nw-330's "the trait is simply absent from
+        // the model" is overstated — this reference already existed, and the
+        // kind change must not lose it.
+        assert!(
+            parsed.references.iter().any(|r| r.name == "Greet"
+                && r.kind == ReferenceKind::Extends
+                && r.start_line == 9),
+            "the trait impl must still emit an Extends reference: {:?}",
+            parsed
+                .references
+                .iter()
+                .map(|r| (&r.name, r.kind, r.start_line))
+                .collect::<Vec<_>>()
         );
     }
 

--- a/crates/nestweaver-parser/src/parse.rs
+++ b/crates/nestweaver-parser/src/parse.rs
@@ -261,6 +261,76 @@ fn first_line(text: &str) -> String {
     text.lines().next().unwrap_or("").trim().to_string()
 }
 
+/// The signature of a symbol: the first line of its node, plus — when that
+/// first line is an annotation the grammar folded INTO the node — the
+/// declaration line it decorates.
+///
+/// Most grammars keep annotations outside the declaration node (Rust's
+/// `#[test]` is a preceding sibling — see `leading_rust_attributes`), but some
+/// fold them in. Dart's `method_declaration` carries `annotation` as a child,
+/// so anchoring the capture on the declaration rather than on the bodiless
+/// signature made `SimpleGreeter.greet`'s signature the bare string
+/// `"@override"` — the span became correct and the signature became useless in
+/// the same change. Java already had that defect: BOTH overriding methods in
+/// `testdata/java/simple.java` recorded `signature: "@Override"`, which is also
+/// why neither carried any `type_info`.
+///
+/// # Why the annotation is APPENDED TO rather than replaced
+///
+/// The annotation is load-bearing. `frameworks.rs` recognises Spring by
+/// `signature.contains("@RestController")` and Flask/FastAPI by `@app.route` /
+/// `@router.`, and contract derivation reads the route out of
+/// `@GetMapping("/users/{id}")`. Dropping it to recover the declaration
+/// silently disabled all of that — seven engine tests, which is how it was
+/// caught. `frameworks.rs`'s own fixture spells a Spring controller as
+/// `"@RestController public class UserController"`, so the appended form is the
+/// shape the rest of the codebase already expects.
+///
+/// # Why only the FIRST annotation
+///
+/// So this change cannot alter which annotations are visible to any consumer.
+/// Joining *every* leading annotation makes a class-level
+/// `@RequestMapping("/v1/items")` visible for the first time, and contract
+/// derivation then mints it as an `ANY /v1/items` ROUTE with the controller
+/// class as its implementer — a base path is not an endpoint. That is a real
+/// latent defect in contract derivation, but it is not this change's to make
+/// observable: keeping the first line exactly as it is today means the set of
+/// annotations any consumer can see is unchanged, and all that is added is the
+/// declaration being decorated.
+///
+/// # Objective-C
+///
+/// Excluded: there `@` is a declaration KEYWORD, not an annotation marker.
+/// `@interface`, `@protocol`, `@implementation` and `@property` ARE the
+/// declarations, and appending folds a protocol's first method onto its header.
+/// `@Override` and `@protocol` are indistinguishable as text, so the exception
+/// is named rather than inferred from shape.
+fn signature_line(text: &str, lang_str: &str) -> String {
+    let first = first_line(text);
+    if lang_str == "objc" || !is_folded_annotation(&first) {
+        return first;
+    }
+    match text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .find(|l| !is_folded_annotation(l))
+    {
+        Some(declaration) => format!("{first} {declaration}"),
+        None => first,
+    }
+}
+
+/// Whether a trimmed line is an annotation the grammar folded into the node,
+/// rather than the declaration itself.
+fn is_folded_annotation(line: &str) -> bool {
+    line.starts_with("#[")
+        || (line.starts_with('@')
+            && !line.contains('{')
+            && !line.contains(';')
+            && !line.contains("=>"))
+}
+
 /// Whether a captured declaration node sits inside an `export_statement`.
 ///
 /// Tree-sitter's JS/TS grammars wrap exported declarations (`export function`,
@@ -1071,7 +1141,7 @@ pub fn parse_source(path: &Path, source: &str) -> Result<ParsedFile, ParseError>
                 }
 
                 let content_hash = sha256_hex(node_text);
-                let signature = first_line(node_text);
+                let signature = signature_line(node_text, lang_str);
 
                 let kind_label = match kind {
                     SymbolKind::Function => "function",
@@ -5300,6 +5370,306 @@ use crate::config::{Settings, load as load_config};
             matches!(err, ParseError::UnsupportedLanguage(_)),
             "expected UnsupportedLanguage, got: {err:?}"
         );
+    }
+
+    // ── Signature: annotations that the grammar folds in are JOINED ───────
+
+    #[test]
+    fn an_annotation_folded_into_a_declaration_is_joined_not_dropped_or_kept_alone() {
+        // Anchoring Dart methods on `method_declaration` (so the span covers
+        // the body) pulls `@override` into the node, and Java's class/method
+        // nodes already carried `@Override`/`@RestController`. Neither the
+        // annotation nor the declaration may be lost:
+        //
+        //  - dropping the annotation silently disabled Spring/Flask framework
+        //    detection and contract-route derivation, which read
+        //    `signature.contains("@RestController")` / `@app.route`;
+        //  - keeping only the annotation is what produced `signature:
+        //    "@Override"` with no `type_info` on both Java overrides.
+        assert_eq!(
+            signature_line("@Override\npublic String greet(String n) {\n}", "java"),
+            "@Override public String greet(String n) {"
+        );
+        assert_eq!(
+            signature_line(
+                "@RestController\n@RequestMapping(\"/api\")\npublic class C {",
+                "java"
+            ),
+            "@RestController public class C {",
+            "ONLY the first line is kept, so the set of annotations any consumer \
+             can see is exactly what it was before this function existed — \
+             making the second one visible mints a class-level @RequestMapping \
+             base path as an `ANY` route"
+        );
+        assert_eq!(
+            signature_line("public class Plain {\n}", "java"),
+            "public class Plain {",
+            "a declaration with no annotation is untouched"
+        );
+    }
+
+    #[test]
+    fn objective_c_at_signs_are_declarations_and_are_never_joined() {
+        // `@` is a declaration KEYWORD in Objective-C, not an annotation
+        // marker. Joining folded a protocol's first method onto its header:
+        // `@protocol GreeterProtocol` became `- (NSString *)greet:...;`.
+        assert_eq!(
+            signature_line(
+                "@protocol GreeterProtocol\n- (NSString *)greet;\n@end",
+                "objc"
+            ),
+            "@protocol GreeterProtocol"
+        );
+        assert_eq!(
+            signature_line(
+                "@interface SimpleGreeter : NSObject\n@property (nonatomic) NSString *p;\n@end",
+                "objc"
+            ),
+            "@interface SimpleGreeter : NSObject"
+        );
+    }
+
+    // ── Span coverage: a symbol's span must cover its own body ────────────
+    //
+    // Six languages recorded `end_line == start_line` for functions that have a
+    // body: cpp, dart (via tree-sitter queries anchored on the signature rather
+    // than the definition) and cobol, svelte, vue, astro (via line-scanning
+    // regex parsers that had no second line to point at). Fixing one and
+    // leaving five is how the identical defect survived a previous round, so
+    // all six are pinned here together.
+
+    /// Return the (start, end) span of the named symbol, for span assertions.
+    fn span_of(filename: &str, source: &str, name: &str) -> (u32, u32) {
+        let parsed = parse_source(Path::new(filename), source).unwrap();
+        let sym = parsed
+            .symbols
+            .iter()
+            .find(|s| s.name == name)
+            .unwrap_or_else(|| {
+                panic!(
+                    "no symbol named `{name}` in {filename}; got {:?}",
+                    parsed
+                        .symbols
+                        .iter()
+                        .map(|s| (&s.name, s.kind, s.start_line, s.end_line))
+                        .collect::<Vec<_>>()
+                )
+            });
+        (sym.start_line, sym.end_line)
+    }
+
+    #[test]
+    fn cpp_function_span_covers_the_body_not_just_the_declarator() {
+        // queries/cpp.scm anchored @definition.function/@definition.method on
+        // `(function_declarator ..)`, which is the signature WITHOUT the body,
+        // so every C++ function recorded end_line == start_line.
+        // queries/c.scm anchors the same capture on `(function_definition ..)`
+        // and has always been correct.
+        let source = "\
+void setup() {
+    SensorManager mgr;
+    mgr.initialize();
+}
+";
+        assert_eq!(
+            span_of("span.cpp", source, "setup"),
+            (1, 4),
+            "a 4-line C++ function must span 1..=4"
+        );
+    }
+
+    #[test]
+    fn cpp_out_of_line_method_span_covers_the_body() {
+        let source = "\
+void SensorManager::initialize() {
+    calibrate();
+}
+";
+        assert_eq!(span_of("m.cpp", source, "initialize"), (1, 3));
+    }
+
+    #[test]
+    fn cpp_inline_method_span_covers_the_body() {
+        // The `field_identifier` rule has to keep matching methods DEFINED
+        // inline in a class body, which is the common shape in a header.
+        let source = "\
+class Sensor {
+public:
+    void calibrate() {
+        reset();
+    }
+};
+";
+        assert_eq!(span_of("i.cpp", source, "calibrate"), (3, 5));
+    }
+
+    #[test]
+    fn cpp_bodiless_declarations_are_still_extracted_and_stay_one_line() {
+        // The other half of the same change, and the one that would have made
+        // this a regression rather than a fix: a C++ HEADER is nothing but
+        // declarations. Anchoring only on `function_definition` — the naive
+        // reading of "mirror queries/c.scm" — would extract ZERO symbols from
+        // every .h in the corpus. Declarations keep their own rule, and are
+        // genuinely one line, so `end_line == start_line` is CORRECT for them.
+        let source = "\
+class SensorManager {
+public:
+    void initialize();
+    double readTemperature();
+};
+
+void freeProto(int x);
+";
+        assert_eq!(span_of("h.cpp", source, "initialize"), (3, 3));
+        assert_eq!(span_of("h.cpp", source, "readTemperature"), (4, 4));
+        assert_eq!(span_of("h.cpp", source, "freeProto"), (7, 7));
+
+        // And a definition must NOT also match a declaration rule and mint a
+        // second, zero-height symbol for the same function.
+        let defined = "void setup() {\n    work();\n}\n";
+        let parsed = parse_source(Path::new("d.cpp"), defined).unwrap();
+        let setups: Vec<_> = parsed
+            .symbols
+            .iter()
+            .filter(|s| s.name == "setup")
+            .collect();
+        assert_eq!(
+            setups.len(),
+            1,
+            "one definition, one symbol: {:?}",
+            setups
+                .iter()
+                .map(|s| (s.start_line, s.end_line))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn dart_method_span_covers_the_body() {
+        // queries/dart.scm anchored @definition.method on `(method_signature
+        // ..)`. The top-level `function_declaration` rule right above it was
+        // already anchored correctly, so `main` had a real span while every
+        // method in the same file did not.
+        let source = "\
+class Greeter {
+  String greet(String name) {
+    return 'Hello, $name!';
+  }
+}
+";
+        assert_eq!(span_of("s.dart", source, "greet"), (2, 4));
+    }
+
+    #[test]
+    fn dart_abstract_method_declaration_is_extracted_and_stays_one_line() {
+        // The other half, and the reason "just anchor on the declaration" was
+        // not enough: an abstract member is a `declaration` wrapping a bare
+        // `function_signature`, never a `method_signature`, so
+        // testdata/dart/simple.dart's `Greeter.greet` was extracted as NOTHING
+        // at all. It has no body, so one line is the correct span.
+        let source = "\
+abstract class Greeter {
+  String greet(String name);
+}
+";
+        assert_eq!(span_of("a.dart", source, "greet"), (2, 2));
+    }
+
+    #[test]
+    fn cobol_paragraph_span_covers_its_statements() {
+        // A COBOL paragraph has no closing delimiter — it runs to the next
+        // label. The scanner recorded the label line as both ends, so every
+        // paragraph was zero-height and no PERFORM could be placed inside the
+        // paragraph that issued it.
+        let source = "\
+       PROCEDURE DIVISION.
+       MAIN-LOGIC SECTION.
+           PERFORM INITIALIZE-DATA
+           STOP RUN.
+
+       INITIALIZE-DATA.
+           MOVE \"World\" TO WS-NAME.
+
+       DISPLAY-RESULT.
+           DISPLAY WS-GREETING.
+";
+        assert_eq!(
+            span_of("p.cbl", source, "MAIN-LOGIC"),
+            (2, 4),
+            "the section ends at its last statement, not at the blank line after it"
+        );
+        assert_eq!(span_of("p.cbl", source, "INITIALIZE-DATA"), (6, 7));
+        assert_eq!(
+            span_of("p.cbl", source, "DISPLAY-RESULT"),
+            (9, 10),
+            "the last symbol runs to the last code line in the file"
+        );
+    }
+
+    #[test]
+    fn svelte_function_span_covers_the_body_and_a_one_liner_does_not_grow() {
+        let source = "\
+<script>
+  export function greet(name) {
+    return `Hello, ${name}!`
+  }
+
+  export let count = 0
+
+  function handleClick() {
+    count += 1
+  }
+</script>
+";
+        assert_eq!(span_of("s.svelte", source, "greet"), (2, 4));
+        assert_eq!(span_of("s.svelte", source, "handleClick"), (8, 10));
+        assert_eq!(
+            span_of("s.svelte", source, "count"),
+            (6, 6),
+            "`export let count = 0` opens no block; inventing a span for it \
+             would be the same defect pointing the other way"
+        );
+    }
+
+    #[test]
+    fn vue_function_span_covers_the_body() {
+        let source = "\
+<script>
+export function formatName(name) {
+  return name.trim()
+}
+
+function handleClick() {
+  console.log(formatName())
+}
+</script>
+";
+        assert_eq!(span_of("v.vue", source, "formatName"), (2, 4));
+        assert_eq!(span_of("v.vue", source, "handleClick"), (6, 8));
+    }
+
+    #[test]
+    fn astro_function_span_covers_the_body() {
+        let source = "\
+---
+export function getStaticPaths() {
+  return [
+    { params: { id: '1' } },
+  ]
+}
+
+function formatTitle(title) {
+  return title.toUpperCase()
+}
+---
+<main />
+";
+        assert_eq!(
+            span_of("a.astro", source, "getStaticPaths"),
+            (2, 6),
+            "nested object/array braces must not close the function early"
+        );
+        assert_eq!(span_of("a.astro", source, "formatTitle"), (8, 10));
     }
 
     // ── Snapshot tests ────────────────────────────────────────────────────

--- a/crates/nestweaver-parser/src/parse.rs
+++ b/crates/nestweaver-parser/src/parse.rs
@@ -179,6 +179,33 @@ pub struct ParsedFile {
     pub type_bindings: Vec<AstTypeBinding>,
 }
 
+/// Remove raw NUL bytes from decoded source text.
+///
+/// nw-335: a NUL is not text, but it is also not necessarily corruption -- a
+/// user can paste one into a note. `nestweaver-store`'s corruption canary
+/// (`read::string_is_corrupt`) is a LadybugDB #678 partial-scan detector whose
+/// stated premise is that no column NestWeaver stores contains a NUL, and it is
+/// applied to CONTENT columns as well as navigational ones. One pasted byte
+/// therefore made the store refuse a row it had recorded faithfully, which
+/// emptied every whole-corpus scan and took Tantivy and the regex trigram
+/// corpus to `docs=0` brain-wide.
+///
+/// Stripping here makes that premise TRUE again, rather than weakening a canary
+/// that is doing real work on uids and paths. It is deliberately at the parser,
+/// the one seam every ingest path crosses: the filesystem reader's binary sniff
+/// is WINDOWED to the leading 8 KiB (the ripgrep/git/grep heuristic), and the
+/// watcher's incremental path uses `fs::read_to_string` and has no sniff at all.
+///
+/// Borrows when there is nothing to strip, so the overwhelmingly common path
+/// costs one scan and no allocation -- the same shape as nw-190's lossy decode.
+pub fn strip_nul_bytes(source: &str) -> std::borrow::Cow<'_, str> {
+    if source.contains('\0') {
+        std::borrow::Cow::Owned(source.replace('\0', ""))
+    } else {
+        std::borrow::Cow::Borrowed(source)
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SkipReasonCode {

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_astro_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_astro_symbols.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 6136
 expression: "parsed_symbols(\"simple.astro\", &source)"
 ---
 - name: simple
   kind: Class
   start_line: 1
-  end_line: 1
+  end_line: 34
   signature: "<astro:component name=\"simple\">"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
@@ -17,7 +18,7 @@ expression: "parsed_symbols(\"simple.astro\", &source)"
 - name: getStaticPaths
   kind: Function
   start_line: 5
-  end_line: 5
+  end_line: 10
   signature: "export function getStaticPaths() {"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
@@ -29,7 +30,7 @@ expression: "parsed_symbols(\"simple.astro\", &source)"
 - name: formatTitle
   kind: Function
   start_line: 12
-  end_line: 12
+  end_line: 14
   signature: "function formatTitle(title) {"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_cobol_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_cobol_symbols.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 5912
 expression: "parsed_symbols(\"simple.cbl\", &source)"
 ---
 - name: MAIN-LOGIC
   kind: Module
   start_line: 12
-  end_line: 12
+  end_line: 16
   signature: MAIN-LOGIC SECTION.
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: true
@@ -17,7 +18,7 @@ expression: "parsed_symbols(\"simple.cbl\", &source)"
 - name: INITIALIZE-DATA
   kind: Function
   start_line: 18
-  end_line: 18
+  end_line: 19
   signature: INITIALIZE-DATA.
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
@@ -29,7 +30,7 @@ expression: "parsed_symbols(\"simple.cbl\", &source)"
 - name: PROCESS-GREETING
   kind: Function
   start_line: 21
-  end_line: 21
+  end_line: 25
   signature: PROCESS-GREETING.
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
@@ -41,7 +42,7 @@ expression: "parsed_symbols(\"simple.cbl\", &source)"
 - name: DISPLAY-RESULT
   kind: Function
   start_line: 27
-  end_line: 27
+  end_line: 28
   signature: DISPLAY-RESULT.
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
@@ -53,7 +54,7 @@ expression: "parsed_symbols(\"simple.cbl\", &source)"
 - name: CALL-EXTERNAL
   kind: Module
   start_line: 30
-  end_line: 30
+  end_line: 31
   signature: CALL-EXTERNAL SECTION.
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
@@ -65,7 +66,7 @@ expression: "parsed_symbols(\"simple.cbl\", &source)"
 - name: COPY-SECTION
   kind: Module
   start_line: 33
-  end_line: 33
+  end_line: 34
   signature: COPY-SECTION SECTION.
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_cpp_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_cpp_symbols.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 5800
 expression: "parsed_symbols(\"simple.cpp\", &source)"
 ---
 - name: SensorManager
@@ -18,7 +19,7 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
   kind: Method
   start_line: 6
   end_line: 6
-  signature: initialize()
+  signature: void initialize();
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
   entry_point_kind: ~
@@ -30,7 +31,7 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
   kind: Method
   start_line: 7
   end_line: 7
-  signature: readTemperature()
+  signature: double readTemperature();
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
   entry_point_kind: ~
@@ -53,8 +54,8 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
 - name: initialize
   kind: Method
   start_line: 12
-  end_line: 12
-  signature: "SensorManager::initialize()"
+  end_line: 14
+  signature: "void SensorManager::initialize() {"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
   entry_point_kind: ~
@@ -65,8 +66,8 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
 - name: readTemperature
   kind: Method
   start_line: 16
-  end_line: 16
-  signature: "SensorManager::readTemperature()"
+  end_line: 18
+  signature: "double SensorManager::readTemperature() {"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
   entry_point_kind: ~
@@ -161,8 +162,8 @@ expression: "parsed_symbols(\"simple.cpp\", &source)"
 - name: setup
   kind: Function
   start_line: 31
-  end_line: 31
-  signature: setup()
+  end_line: 36
+  signature: "void setup() {"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
   entry_point_kind: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_dart_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_dart_symbols.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 5836
 expression: "parsed_symbols(\"simple.dart\", &source)"
 ---
 - name: Greeter
@@ -14,6 +15,18 @@ expression: "parsed_symbols(\"simple.dart\", &source)"
   type_info: ~
   parent_name: ~
   scope_chain: ~
+- name: greet
+  kind: Method
+  start_line: 5
+  end_line: 5
+  signature: String greet(String name)
+  content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
+  is_entry_point: false
+  entry_point_kind: ~
+  visibility: Public
+  type_info: ~
+  parent_name: Greeter
+  scope_chain: Greeter
 - name: Loggable
   kind: Trait
   start_line: 8
@@ -29,8 +42,8 @@ expression: "parsed_symbols(\"simple.dart\", &source)"
 - name: log
   kind: Method
   start_line: 9
-  end_line: 9
-  signature: void log(String message)
+  end_line: 11
+  signature: "void log(String message) {"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
   entry_point_kind: ~
@@ -52,9 +65,9 @@ expression: "parsed_symbols(\"simple.dart\", &source)"
   scope_chain: ~
 - name: greet
   kind: Method
-  start_line: 16
-  end_line: 16
-  signature: String greet(String name)
+  start_line: 15
+  end_line: 19
+  signature: "@override String greet(String name) {"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
   entry_point_kind: ~
@@ -65,8 +78,8 @@ expression: "parsed_symbols(\"simple.dart\", &source)"
 - name: _formatName
   kind: Method
   start_line: 21
-  end_line: 21
-  signature: String _formatName(String name)
+  end_line: 23
+  signature: "String _formatName(String name) {"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
   entry_point_kind: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_java_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_java_symbols.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 5850
 expression: "parsed_symbols(\"Simple.java\", &source)"
 ---
 - name: Greeter
@@ -84,24 +85,30 @@ expression: "parsed_symbols(\"Simple.java\", &source)"
   kind: Method
   start_line: 16
   end_line: 19
-  signature: "@Override"
+  signature: "@Override public String greet(String name) {"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
   entry_point_kind: ~
   visibility: Inferred
-  type_info: ~
+  type_info:
+    declared_type: ~
+    parameter_types: []
+    return_type: String
   parent_name: SimpleGreeter
   scope_chain: SimpleGreeter
 - name: farewell
   kind: Method
   start_line: 21
   end_line: 24
-  signature: "@Override"
+  signature: "@Override public String farewell(String name) {"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
   entry_point_kind: ~
   visibility: Inferred
-  type_info: ~
+  type_info:
+    declared_type: ~
+    parameter_types: []
+    return_type: String
   parent_name: SimpleGreeter
   scope_chain: SimpleGreeter
 - name: main

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_rust_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_rust_symbols.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 5758
 expression: "parsed_symbols(\"simple.rs\", &source)"
 ---
 - name: SensorManager
@@ -51,7 +52,7 @@ expression: "parsed_symbols(\"simple.rs\", &source)"
   parent_name: ~
   scope_chain: ~
 - name: SensorManager
-  kind: Class
+  kind: Extension
   start_line: 18
   end_line: 26
   signature: "impl Readable for SensorManager {"
@@ -90,7 +91,7 @@ expression: "parsed_symbols(\"simple.rs\", &source)"
   parent_name: SensorManager
   scope_chain: SensorManager
 - name: SensorManager
-  kind: Class
+  kind: Extension
   start_line: 28
   end_line: 38
   signature: "impl SensorManager {"

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_svelte_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_svelte_symbols.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 6122
 expression: "parsed_symbols(\"simple.svelte\", &source)"
 ---
 - name: simple
   kind: Class
   start_line: 1
-  end_line: 1
+  end_line: 31
   signature: "<svelte:component name=\"simple\">"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
@@ -17,7 +18,7 @@ expression: "parsed_symbols(\"simple.svelte\", &source)"
 - name: greet
   kind: Function
   start_line: 5
-  end_line: 5
+  end_line: 7
   signature: "export function greet(name) {"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
@@ -41,7 +42,7 @@ expression: "parsed_symbols(\"simple.svelte\", &source)"
 - name: handleClick
   kind: Function
   start_line: 11
-  end_line: 11
+  end_line: 14
   signature: "function handleClick() {"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_vue_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_vue_symbols.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
+assertion_line: 6108
 expression: "parsed_symbols(\"simple.vue\", &source)"
 ---
 - name: formatName
   kind: Function
   start_line: 12
-  end_line: 12
+  end_line: 14
   signature: "export function formatName(name) {"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
@@ -17,7 +18,7 @@ expression: "parsed_symbols(\"simple.vue\", &source)"
 - name: simple
   kind: Class
   start_line: 16
-  end_line: 16
+  end_line: 31
   signature: "export default defineComponent({"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false
@@ -29,7 +30,7 @@ expression: "parsed_symbols(\"simple.vue\", &source)"
 - name: handleClick
   kind: Function
   start_line: 25
-  end_line: 25
+  end_line: 27
   signature: "function handleClick() {"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
   is_entry_point: false

--- a/crates/nestweaver-parser/src/svelte.rs
+++ b/crates/nestweaver-parser/src/svelte.rs
@@ -97,7 +97,14 @@ pub fn parse_svelte(path: &Path, source: &str) -> ParsedFile {
         name: component_name.clone(),
         kind: SymbolKind::Class,
         start_line: 1,
-        end_line: 1,
+        // The component IS the file, so its span is the file. It used to be
+        // 1-1, which made every module-scope reference in the file belong to no
+        // symbol at all — the resolver then either dropped it or handed it to
+        // whatever one-line symbol happened to precede it. A file-spanning
+        // component is not a widened guess: it is the true containment, and
+        // because `find_enclosing_symbol` returns the INNERMOST containing
+        // span, a call inside a function still attributes to that function.
+        end_line: source.lines().count().max(1) as u32,
         signature: format!("<svelte:component name=\"{component_name}\">"),
         content_hash: sha256_hex(&component_name),
         is_entry_point: false,
@@ -114,8 +121,20 @@ pub fn parse_svelte(path: &Path, source: &str) -> ParsedFile {
     for (script_content, script_start_line) in &script_blocks {
         let offset = *script_start_line;
 
-        for (idx, line) in script_content.lines().enumerate() {
-            let line_no = offset + idx as u32 + 1;
+        let block_lines: Vec<&str> = script_content.lines().collect();
+
+        for (idx, line) in block_lines.iter().enumerate() {
+            let line_no = crate::block_span::file_line(offset, idx);
+            // nw-349 span family: a declaration's span must cover its BODY.
+            // This scanner used to record `end_line: line_no`, so every
+            // function it extracted was ZERO-HEIGHT — `read-symbols` returned
+            // the signature alone, and the resolver could not place any call in
+            // the body inside its own function. `brace_block_end` returns None
+            // for a declaration that opens no block (a genuine one-liner) and
+            // for one it cannot match, so an unhandled shape degrades to the
+            // old span rather than to a confident wrong one.
+            let end_line = crate::block_span::brace_block_end(&block_lines, idx)
+                .map_or(line_no, |e| crate::block_span::file_line(offset, e));
             let trimmed = line.trim();
 
             // Skip empty lines and comments
@@ -132,7 +151,7 @@ pub fn parse_svelte(path: &Path, source: &str) -> ParsedFile {
                     name,
                     kind: SymbolKind::Function,
                     start_line: line_no,
-                    end_line: line_no,
+                    end_line,
                     signature: trimmed.to_string(),
                     content_hash: sha256_hex(trimmed),
                     is_entry_point: false,
@@ -153,7 +172,7 @@ pub fn parse_svelte(path: &Path, source: &str) -> ParsedFile {
                     name,
                     kind: SymbolKind::Function,
                     start_line: line_no,
-                    end_line: line_no,
+                    end_line,
                     signature: trimmed.to_string(),
                     content_hash: sha256_hex(trimmed),
                     is_entry_point: false,

--- a/crates/nestweaver-parser/src/vue.rs
+++ b/crates/nestweaver-parser/src/vue.rs
@@ -106,8 +106,20 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
     for (script_content, script_start_line) in &script_blocks {
         let offset = *script_start_line;
 
-        for (idx, line) in script_content.lines().enumerate() {
-            let line_no = offset + idx as u32 + 1;
+        let block_lines: Vec<&str> = script_content.lines().collect();
+
+        for (idx, line) in block_lines.iter().enumerate() {
+            let line_no = crate::block_span::file_line(offset, idx);
+            // nw-349 span family: a declaration's span must cover its BODY.
+            // This scanner used to record `end_line: line_no`, so every
+            // function it extracted was ZERO-HEIGHT — `read-symbols` returned
+            // the signature alone, and the resolver could not place any call in
+            // the body inside its own function. `brace_block_end` returns None
+            // for a declaration that opens no block (a genuine one-liner) and
+            // for one it cannot match, so an unhandled shape degrades to the
+            // old span rather than to a confident wrong one.
+            let end_line = crate::block_span::brace_block_end(&block_lines, idx)
+                .map_or(line_no, |e| crate::block_span::file_line(offset, e));
             let trimmed = line.trim();
 
             // Skip empty lines and comments
@@ -123,7 +135,7 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
                     name: component_name.clone(),
                     kind: SymbolKind::Class,
                     start_line: line_no,
-                    end_line: line_no,
+                    end_line,
                     signature: trimmed.to_string(),
                     content_hash: sha256_hex(trimmed),
                     is_entry_point: false,
@@ -141,7 +153,7 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
                     name: component_name.clone(),
                     kind: SymbolKind::Class,
                     start_line: line_no,
-                    end_line: line_no,
+                    end_line,
                     signature: trimmed.to_string(),
                     content_hash: sha256_hex(trimmed),
                     is_entry_point: false,
@@ -160,7 +172,7 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
                     name,
                     kind: SymbolKind::Function,
                     start_line: line_no,
-                    end_line: line_no,
+                    end_line,
                     signature: trimmed.to_string(),
                     content_hash: sha256_hex(trimmed),
                     is_entry_point: false,
@@ -181,7 +193,7 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
                     name,
                     kind: SymbolKind::Function,
                     start_line: line_no,
-                    end_line: line_no,
+                    end_line,
                     signature: trimmed.to_string(),
                     content_hash: sha256_hex(trimmed),
                     is_entry_point: false,

--- a/crates/nestweaver-resolver/src/resolve.rs
+++ b/crates/nestweaver-resolver/src/resolve.rs
@@ -111,12 +111,21 @@ pub fn resolve_references_with_context(
             for reference in references {
                 if reference.kind == ReferenceKind::Extends
                     && let Some(sym) = find_enclosing_symbol(sorted_syms, reference.start_line)
+                    // nw-330: `Extension` belongs here. A Rust `impl Trait
+                    // for Type` block IS the symbol that encloses the `Extends`
+                    // reference to the trait, and it used to be
+                    // `SymbolKind::Class`. Giving impl blocks their own kind
+                    // without widening this filter would have silently deleted
+                    // every Rust trait relationship from the MRO map — a
+                    // modelling fix quietly losing the one structural fact the
+                    // model already had.
                     && matches!(
                         sym.kind,
                         SymbolKind::Class
                             | SymbolKind::Enum
                             | SymbolKind::Interface
                             | SymbolKind::Trait
+                            | SymbolKind::Extension
                     )
                 {
                     map.entry(sym.name.clone())

--- a/crates/nestweaver-resolver/src/resolve.rs
+++ b/crates/nestweaver-resolver/src/resolve.rs
@@ -110,7 +110,8 @@ pub fn resolve_references_with_context(
         for ((_, _, references), sorted_syms) in files.iter().zip(sorted_symbols_per_file.iter()) {
             for reference in references {
                 if reference.kind == ReferenceKind::Extends
-                    && let Some(sym) = find_enclosing_symbol(sorted_syms, reference.start_line)
+                    && let Some(sym) =
+                        find_enclosing_symbol(sorted_syms, reference.start_line).symbol()
                     // nw-330: `Extension` belongs here. A Rust `impl Trait
                     // for Type` block IS the symbol that encloses the `Extends`
                     // reference to the trait, and it used to be
@@ -289,8 +290,8 @@ pub fn resolve_references_with_context(
             // never-exported string constant acquired 830 out-edges and ranked
             // #5 in a 158k-symbol graph. Pass 3a already emits a file-level
             // proxy edge per import, so connectivity does not depend on this.
-            let source_sym =
-                import_line.and_then(|line| find_enclosing_symbol(source_sorted_syms, line));
+            let source_sym = import_line
+                .and_then(|line| find_enclosing_symbol(source_sorted_syms, line).symbol());
 
             let source_uid = match source_sym {
                 Some(sym) => symbol_uid(repo_uid, file_path, &sym.name, sym.start_line),
@@ -399,7 +400,21 @@ fn resolve_single_reference(
         ReferenceKind::Import | ReferenceKind::ImportAlias | ReferenceKind::Uses => return None,
     };
 
-    let source_sym = find_enclosing_symbol(sorted_syms, reference.start_line)?;
+    // nw-349 (1). The three cases are now distinguishable, and only two of them
+    // name a source:
+    //
+    //   Exact      — a real span contains this line. Trustworthy.
+    //   Degenerate — no span contains it; the nearest preceding CODE-BEARING
+    //                one-line symbol is the best guess. Still a guess, but it can
+    //                no longer be a `Constant`/`Variable`/`Property`, which is
+    //                what it frequently was.
+    //   ModuleScope — the line belongs to no symbol. There is no source symbol to
+    //                name, and this pass declines to invent one. See the note on
+    //                `Enclosing` for why the obvious candidates were rejected.
+    let source_sym = match find_enclosing_symbol(sorted_syms, reference.start_line) {
+        Enclosing::Exact(s) | Enclosing::Degenerate(s) => s,
+        Enclosing::ModuleScope => return None,
+    };
     let source_uid = symbol_uid(repo_uid, file_path, &source_sym.name, source_sym.start_line);
 
     // ── Type-aware resolution for member calls with known receiver type ──
@@ -835,6 +850,72 @@ fn receiver_denotes(candidate_file: &str, sym: &RawSymbol, receiver: Option<&str
     sym.parent_name.as_deref() == Some(denoted)
 }
 
+/// What is actually known about the source of a reference.
+///
+/// nw-349. `find_enclosing_symbol` used to return `Option<&RawSymbol>`, which
+/// collapsed THREE distinct facts into two values:
+///
+/// - a real span contains this line;
+/// - no span contains it, but a preceding one-line symbol is the best guess;
+/// - this line is module-level code and belongs to no symbol.
+///
+/// The caller could not act on the difference because the difference was not in
+/// the type. `resolve_single_reference`'s `?` silently discarded the third case
+/// — so a shell script's own `main "$@"` produced no edge at all and `dead-code`
+/// reported the script's entry point as unreachable — while trusting the second
+/// case as if it were the first.
+#[derive(Debug, Clone, Copy)]
+enum Enclosing<'a> {
+    /// A symbol's real span contains `ref_line`.
+    Exact(&'a RawSymbol),
+    /// No span contains `ref_line`, but a preceding code-bearing symbol has a
+    /// degenerate (zero-height) span, so it is the best available guess. A
+    /// GUESS, and the type says so.
+    Degenerate(&'a RawSymbol),
+    /// `ref_line` belongs to no symbol: module-level code. A fact, not a
+    /// failure to resolve.
+    ModuleScope,
+}
+
+impl<'a> Enclosing<'a> {
+    /// The symbol, for callers that only need "some enclosing symbol" and have
+    /// no use for the distinction.
+    fn symbol(self) -> Option<&'a RawSymbol> {
+        match self {
+            Enclosing::Exact(s) | Enclosing::Degenerate(s) => Some(s),
+            Enclosing::ModuleScope => None,
+        }
+    }
+}
+
+/// Whether a symbol of this kind can contain executable code, and therefore be
+/// the source of a call, type reference or field access.
+///
+/// The degenerate fallback walks backwards to the nearest one-line symbol, and
+/// with no kind restriction that was frequently a DATA symbol. Measured on the
+/// checked-in fixtures before this restriction existed:
+///
+/// - `testdata/cpp/simple.cpp:35` recorded `logValue(temp)` as **the local
+///   variable `temp`** calling `logValue`;
+/// - `testdata/python/simple.py:37` recorded `main()` as **`Property name`**;
+/// - `testdata/js/simple.js:28` recorded `greet()` as **`Constant dog`**.
+///
+/// Those are not missing edges — they are edges with fabricated sources, which
+/// is worse, because a caller cannot tell them from real ones. A `Constant`,
+/// `Variable`, `Property` or `Field` has no body and cannot call anything.
+fn can_contain_code(kind: SymbolKind) -> bool {
+    matches!(
+        kind,
+        SymbolKind::Function
+            | SymbolKind::Method
+            | SymbolKind::Class
+            | SymbolKind::Module
+            | SymbolKind::Interface
+            | SymbolKind::Trait
+            | SymbolKind::Extension
+    )
+}
+
 /// Find the enclosing symbol: the innermost symbol whose span contains the
 /// reference line (`start_line <= ref_line <= end_line`).
 ///
@@ -842,17 +923,17 @@ fn receiver_denotes(candidate_file: &str, sym: &RawSymbol, receiver: Option<&str
 /// Binary search finds the last symbol starting at or before `ref_line`; if that
 /// symbol's span does not contain the line (e.g. Python module-level statements
 /// like `if __name__ == '__main__':` after the last `def`), walk back to an
-/// earlier symbol whose span does — or return `None` when the reference is
-/// module-level code that belongs to no symbol.
+/// earlier symbol whose span does — or report `ModuleScope` when the reference
+/// is module-level code that belongs to no symbol.
 ///
-/// Degenerate-span fallback: the regex-based parsers (astro, svelte, vue,
-/// cobol) emit one-line spans (`end_line == start_line`) while emitting Call
-/// references on later lines, so no span can ever contain those refs. When no
-/// span contains the line, attribute the reference to the nearest preceding
-/// symbol with a degenerate span (`end_line <= start_line`). Symbols with
-/// real spans that ended before `ref_line` still yield `None` — module-level
-/// code belongs to no symbol.
-fn find_enclosing_symbol<'a>(symbols: &'a [&'a RawSymbol], ref_line: u32) -> Option<&'a RawSymbol> {
+/// Degenerate-span fallback: some parsers still emit one-line spans while
+/// emitting Call references on later lines, so no span can contain those refs.
+/// When no span contains the line, attribute the reference to the nearest
+/// preceding CODE-BEARING symbol with a degenerate span (`end_line <=
+/// start_line`) and report it as `Degenerate`. Symbols with real spans that
+/// ended before `ref_line` still yield `ModuleScope` — module-level code
+/// belongs to no symbol.
+fn find_enclosing_symbol<'a>(symbols: &'a [&'a RawSymbol], ref_line: u32) -> Enclosing<'a> {
     debug_assert!(
         symbols
             .windows(2)
@@ -860,11 +941,11 @@ fn find_enclosing_symbol<'a>(symbols: &'a [&'a RawSymbol], ref_line: u32) -> Opt
         "find_enclosing_symbol requires symbols sorted by start_line"
     );
     if symbols.is_empty() {
-        return None;
+        return Enclosing::ModuleScope;
     }
     let idx = symbols.partition_point(|s| s.start_line <= ref_line);
     if idx == 0 {
-        return None;
+        return Enclosing::ModuleScope;
     }
     if let Some(enclosing) = symbols[..idx]
         .iter()
@@ -872,13 +953,14 @@ fn find_enclosing_symbol<'a>(symbols: &'a [&'a RawSymbol], ref_line: u32) -> Opt
         .find(|s| ref_line <= s.end_line.max(s.start_line))
         .copied()
     {
-        return Some(enclosing);
+        return Enclosing::Exact(enclosing);
     }
     symbols[..idx]
         .iter()
         .rev()
-        .find(|s| s.end_line <= s.start_line)
+        .find(|s| s.end_line <= s.start_line && can_contain_code(s.kind))
         .copied()
+        .map_or(Enclosing::ModuleScope, Enclosing::Degenerate)
 }
 
 #[cfg(test)]
@@ -1922,6 +2004,102 @@ mod tests {
     }
 
     #[test]
+    fn a_module_scope_reference_is_distinguishable_from_a_degenerate_span_guess() {
+        // nw-349 (1). find_enclosing_symbol used to return Option<&RawSymbol>,
+        // so "module scope" and "I guessed from a one-line symbol" arrived at
+        // the call site as the SAME value. resolve_single_reference's `?`
+        // discarded the former and silently trusted the latter.
+        let mut one_liner = make_symbol("helper", 1);
+        one_liner.end_line = 1; // a GENUINE one-line function
+        let real = make_symbol("caller", 10); // spans 10..=15
+
+        let syms: Vec<&RawSymbol> = {
+            let mut v = vec![&one_liner, &real];
+            v.sort_by_key(|s| s.start_line);
+            v
+        };
+
+        // Inside a real span: exact.
+        assert!(
+            matches!(find_enclosing_symbol(&syms, 12), Enclosing::Exact(s) if s.name == "caller")
+        );
+        // After every span, with a degenerate code-bearing symbol available:
+        // a GUESS, and the type must say so rather than looking like Exact.
+        assert!(matches!(
+            find_enclosing_symbol(&syms, 50),
+            Enclosing::Degenerate(s) if s.name == "helper"
+        ));
+        // Before any symbol: module scope, which is a FACT, not a failure.
+        assert!(matches!(
+            find_enclosing_symbol(&syms, 0),
+            Enclosing::ModuleScope
+        ));
+    }
+
+    #[test]
+    fn a_degenerate_span_fallback_never_attributes_a_call_to_a_data_symbol() {
+        // nw-349 (1), measured on the checked-in fixtures BEFORE this guard:
+        // testdata/cpp/simple.cpp:35 `logValue(temp);` was recorded as the
+        // LOCAL VARIABLE `temp` calling `logValue`, and
+        // testdata/python/simple.py:37 `main()` as `Property name` calling
+        // `main`. A Constant/Variable/Property/Field has no body and cannot be
+        // a call site, so an edge sourced at one is not a weak edge — it is a
+        // fabricated one, indistinguishable from a real edge downstream.
+        let mut var = make_symbol("temp", 34);
+        var.end_line = 34;
+        var.kind = SymbolKind::Variable;
+        let mut func = make_symbol("setup", 31);
+        func.end_line = 31; // the old C++ zero-height span
+        let syms: Vec<&RawSymbol> = vec![&func, &var];
+
+        match find_enclosing_symbol(&syms, 35) {
+            Enclosing::Degenerate(s) => assert_eq!(
+                s.name, "setup",
+                "the fallback must skip data symbols; got {} ({:?})",
+                s.name, s.kind
+            ),
+            other => panic!("expected a degenerate attribution, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_reference_after_a_lone_data_symbol_is_module_scope_not_a_fabricated_edge() {
+        // The other half: with NO code-bearing degenerate symbol to fall back
+        // on, the answer is `ModuleScope` — "this belongs to no symbol" — and
+        // not "the constant did it". testdata/js/simple.js:28 is the measured
+        // case: a module-top-level `greet()` recorded as `Constant dog`.
+        let mut konst = make_symbol("dog", 20);
+        konst.end_line = 20;
+        konst.kind = SymbolKind::Constant;
+        let syms: Vec<&RawSymbol> = vec![&konst];
+
+        assert!(
+            matches!(find_enclosing_symbol(&syms, 28), Enclosing::ModuleScope),
+            "a Constant cannot call anything"
+        );
+    }
+
+    #[test]
+    fn a_call_after_a_constant_produces_no_edge_rather_than_a_wrong_one() {
+        // End to end through resolve_references: the fabricated edge must not
+        // reach the graph at all.
+        let mut konst = make_symbol("dog", 20);
+        konst.end_line = 20;
+        konst.kind = SymbolKind::Constant;
+        let greet = make_symbol("greet", 1); // spans 1..=6
+        let files = vec![(
+            "src/simple.js".to_string(),
+            vec![greet, konst],
+            vec![make_ref("greet", ReferenceKind::Call, 28)],
+        )];
+        let edges = resolve_references(&files, Language::JavaScript, "repo:test:abc");
+        assert!(
+            !edges.iter().any(|e| e.source_uid.contains("dog")),
+            "a Constant must never be recorded as the source of a call: {edges:?}"
+        );
+    }
+
+    #[test]
     fn find_enclosing_symbol_binary_search_correctness() {
         // Helper that runs both an end-line-aware linear scan and the binary
         // search, asserting they agree, then returns the start_line of the result.
@@ -1940,7 +2118,9 @@ mod tests {
                 v.sort_by_key(|s| s.start_line);
                 v
             };
-            let binary = find_enclosing_symbol(&sorted, ref_line).map(|s| s.start_line);
+            let binary = find_enclosing_symbol(&sorted, ref_line)
+                .symbol()
+                .map(|s| s.start_line);
             let linear = linear_scan(symbols, ref_line);
             assert_eq!(
                 binary, linear,
@@ -2038,7 +2218,9 @@ mod tests {
                 v.sort_by_key(|s| s.start_line);
                 v
             };
-            find_enclosing_symbol(&sorted, ref_line).map(|s| s.start_line)
+            find_enclosing_symbol(&sorted, ref_line)
+                .symbol()
+                .map(|s| s.start_line)
         }
 
         // A call ref on a later line is owned by the nearest preceding

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -709,7 +709,8 @@ fn open_lbug_with_recovery(
                      .wal.checkpoint/.shadow that made the DB unopenable); retrying open",
                     path.display()
                 );
-                return Ok(lbug::Database::new(path, make_config())?);
+                return lbug::Database::new(path, make_config())
+                    .map_err(|e| StoreError::from(e).with_db_path(path));
             }
             if read_write
                 && is_orphaned_wal_error(&msg)
@@ -723,9 +724,13 @@ fn open_lbug_with_recovery(
                     path.display(),
                     quarantined.display()
                 );
-                return Ok(lbug::Database::new(path, make_config())?);
+                return lbug::Database::new(path, make_config())
+                    .map_err(|e| StoreError::from(e).with_db_path(path));
             }
-            Err(e.into())
+            // nw-346. This is the frame that knows WHICH database failed; the
+            // engine's message names no path, so attaching it here is what
+            // retires the caller's need to guess one.
+            Err(StoreError::from(e).with_db_path(path))
         }
     }
 }

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -1362,6 +1362,19 @@ impl GraphStore {
                 .map_err(|e| StoreError::Query(format!("read: {e}")))?;
             // Version-checked and repo-keyed. A v1 flat map fails this parse
             // and is treated as absent, which is neutral rather than wrong.
+            //
+            // nw-258(b). The version check is now PERFORMED, not merely
+            // claimed. This comment asserted it for a loader that never read
+            // `sidecar.version`, while the engine-side loader
+            // (`git_activity::load_git_activity_sidecar`) — used by the writer
+            // and the delete path, and by NO query route — did check it. So the
+            // guard `a_newer_version_is_discarded_rather_than_misread` pinned a
+            // property that all three RANKING paths lacked: this loader, the
+            // daemon's (`server.rs`), the MCP wrapper's and the CLI's.
+            //
+            // A shape check is not a version check. A v1 flat map fails the
+            // parse, but a v3 that keeps the shape and changes the SEMANTICS
+            // would have loaded silently and mis-ranked.
             let sidecar: crate::git_activity_sidecar::GitActivitySidecar =
                 match serde_json::from_str(&json) {
                     Ok(sidecar) => sidecar,
@@ -1374,6 +1387,15 @@ impl GraphStore {
                         return Ok(());
                     }
                 };
+            if sidecar.version != crate::git_activity_sidecar::GITACTIVITY_VERSION {
+                tracing::debug!(
+                    path = %path.display(),
+                    found_version = sidecar.version,
+                    expected_version = crate::git_activity_sidecar::GITACTIVITY_VERSION,
+                    "git-activity sidecar version mismatch; discarding (re-index to restore)"
+                );
+                return Ok(());
+            }
             self.load_git_activity_cache(sidecar.repos);
         }
         Ok(())
@@ -5095,5 +5117,97 @@ mod schema_migration_tests {
         assert!(!is_column_already_present(
             "Connection exception: Cannot execute write operations in a read-only database!"
         ));
+    }
+}
+
+/// nw-258(b): the loader every query route uses must honour the sidecar
+/// version, not merely claim to.
+#[cfg(test)]
+mod git_activity_loader_tests {
+    use super::GraphStore;
+    use crate::git_activity_sidecar::GITACTIVITY_VERSION;
+
+    /// The comment on this loader said "Version-checked"; the guard
+    /// `a_newer_version_is_discarded_rather_than_misread` pinned that property
+    /// on the OTHER loader — the one no query route uses. A future v3 would
+    /// have been read as v2 by all three query paths and silently mis-ranked.
+    #[test]
+    fn the_ranking_loader_discards_a_sidecar_from_a_future_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("g.gitactivity.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": GITACTIVITY_VERSION + 1,
+                "repos": { "repo:x": { "src/main.rs": 0.9 } }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let store = GraphStore::in_memory().unwrap();
+        store.load_git_activity_sidecar(&path).unwrap();
+
+        assert!(
+            !store.has_git_activity(),
+            "a sidecar this build cannot interpret must be neutral, not read as \
+             if it were the current version — which is what the loader's own \
+             comment and the engine-side test both promise"
+        );
+        assert_eq!(store.git_activity_score("repo:x", "src/main.rs"), None);
+    }
+
+    /// The other direction, which keeps the first from over-correcting: the
+    /// CURRENT version must still load. A version check that discards
+    /// everything is indistinguishable from a loader that never worked.
+    #[test]
+    fn the_ranking_loader_still_loads_the_current_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("g.gitactivity.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": GITACTIVITY_VERSION,
+                "repos": { "repo:x": { "src/main.rs": 0.9 } }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let store = GraphStore::in_memory().unwrap();
+        store.load_git_activity_sidecar(&path).unwrap();
+
+        assert!(store.has_git_activity());
+        assert_eq!(store.git_activity_score("repo:x", "src/main.rs"), Some(0.9));
+    }
+
+    /// nw-258(a)'s store-side half: the invalidator existed with ZERO callers,
+    /// so nothing could ever have proved it works. Clearing must restore
+    /// neutral ranking, and a reload after it must be visible — that pair is
+    /// what the daemon's refresh depends on.
+    #[test]
+    fn clearing_the_cache_restores_neutral_ranking_and_a_reload_is_visible() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("g.gitactivity.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": GITACTIVITY_VERSION,
+                "repos": { "repo:x": { "src/main.rs": 0.9 } }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let store = GraphStore::in_memory().unwrap();
+        store.load_git_activity_sidecar(&path).unwrap();
+        assert!(store.has_git_activity());
+
+        store.clear_git_activity_cache();
+        assert!(!store.has_git_activity());
+        assert_eq!(store.git_activity_score("repo:x", "src/main.rs"), None);
+
+        store.load_git_activity_sidecar(&path).unwrap();
+        assert_eq!(store.git_activity_score("repo:x", "src/main.rs"), Some(0.9));
     }
 }

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -611,7 +611,44 @@ fn bounded_system_config() -> lbug::SystemConfig {
         // clean runs are needed to put a false pass under 1%. If it only
         // REDUCES the rate rather than eliminating it, that is a different
         // finding and the bar has to be recomputed from the new rate.
-        .max_num_threads(env_u64("NESTWEAVER_LBUG_MAX_THREADS").unwrap_or(1))
+        .max_num_threads(engine_max_threads())
+}
+
+/// The engine thread bound, read from the environment ONCE per process.
+///
+/// nw-265. Since nw-240 EVERY store open in the binary routes through
+/// `bounded_system_config`, so this key is read by `open_read_only` and
+/// `in_memory` too — 46 and 374 call sites. Re-reading a process-global on
+/// every open means any writer anywhere in the process can hand the parallel
+/// scan pool that nw-240 exists to REMOVE to every store opened after it. A
+/// unit test did exactly that: it set the key to `4` mid-run under cargo's
+/// multithreaded harness, and a sibling test opening 64 stores concurrently sat
+/// in that window.
+///
+/// Latching also removes the read side of a documented data race. Rust 2024
+/// marks `set_var` unsafe because concurrent `setenv`/`getenv` is UB, not
+/// merely untidy.
+///
+/// This is configuration: its value is fixed for the process lifetime in every
+/// real deployment. Reading it as if it were dynamic bought nothing and cost
+/// the mitigation. NOTE the default of `1` lives HERE, in code — NOT in
+/// `.cargo/config.toml`, whose `[env]` block sets only `LBUG_BUILD_FROM_SOURCE`
+/// and `NESTWEAVER_LBUG_MAX_DB_SIZE`.
+fn engine_max_threads() -> u64 {
+    static LATCHED: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+    *LATCHED.get_or_init(|| {
+        parse_max_threads(std::env::var("NESTWEAVER_LBUG_MAX_THREADS").ok().as_deref())
+    })
+}
+
+/// Parse the thread bound out of an override, defaulting to the value that
+/// closes the nw-073 eviction-vs-read race.
+///
+/// Split out so the parse paths are testable WITHOUT mutating a global that
+/// every store open in the binary reads. That is the whole property the test
+/// this replaces was reaching for.
+fn parse_max_threads(raw: Option<&str>) -> u64 {
+    raw.and_then(|v| v.trim().parse::<u64>().ok()).unwrap_or(1)
 }
 
 fn hardened_system_config() -> lbug::SystemConfig {
@@ -4572,35 +4609,53 @@ mod tests {
 
 #[cfg(test)]
 mod hardened_config_tests {
+    /// nw-265. The test this replaces set `NESTWEAVER_LBUG_MAX_THREADS=4`
+    /// mid-run and asserted only "no panic" — buying weak coverage at the cost
+    /// of disarming a crash mitigation process-wide, because since nw-240 every
+    /// store open in the binary reads that key. The bound must be latched at
+    /// first read so a later mutation cannot reach an open.
+    ///
+    /// This test can FAIL when the property is broken: revert
+    /// `bounded_system_config` to `env_u64("NESTWEAVER_LBUG_MAX_THREADS")` and
+    /// the two reads below differ.
     #[test]
-    fn env_overrides_are_honored_and_default_bounds_threads() {
-        // Serialize the env mutation; other tests don't touch these keys.
-        // Default (no env): threads bounded to 1 to remove the eviction race.
-        // SAFETY: single-threaded test section; we set then clear.
-        unsafe {
-            std::env::remove_var("NESTWEAVER_LBUG_MAX_THREADS");
-            std::env::remove_var("NESTWEAVER_LBUG_BUFFER_POOL_BYTES");
-            std::env::remove_var("NESTWEAVER_LBUG_AUTO_CHECKPOINT");
-        }
-        // We can't read private SystemConfig fields, but we can prove the
-        // helper runs without panic under each override shape (parse paths).
+    fn the_thread_bound_is_latched_and_a_later_mutation_cannot_reach_an_open() {
+        let first = super::engine_max_threads();
+        // SAFETY: the value is latched, so this cannot reach an open — which is
+        // precisely what the assertion below proves. The key is restored
+        // immediately either way.
+        unsafe { std::env::set_var("NESTWEAVER_LBUG_MAX_THREADS", "64") };
+        let after = super::engine_max_threads();
+        unsafe { std::env::remove_var("NESTWEAVER_LBUG_MAX_THREADS") };
+
+        assert_eq!(
+            first, after,
+            "the engine thread bound was re-read after the process started; any \
+             store opened after that mutation runs the parallel scan pool the \
+             nw-240 crash mitigation removes"
+        );
+    }
+
+    /// The property the old test was reaching for, without mutating a global:
+    /// the parse helper tolerates every override shape. No env, no race, no UB.
+    #[test]
+    fn a_malformed_thread_bound_falls_back_to_the_default_rather_than_panicking() {
+        assert_eq!(super::parse_max_threads(None), 1);
+        assert_eq!(super::parse_max_threads(Some("not-a-number")), 1);
+        assert_eq!(super::parse_max_threads(Some("")), 1);
+        assert_eq!(super::parse_max_threads(Some(" 4 ")), 4);
+        assert_eq!(super::parse_max_threads(Some("4")), 4);
+    }
+
+    /// The remaining two keys are read in `hardened_system_config` only, which
+    /// `open_read_only` and `in_memory` do not call — so their blast radius is
+    /// the write path, not every open. Proving the helper survives each
+    /// override shape needs no env mutation at all now that the one key that
+    /// DID leak is latched.
+    #[test]
+    fn the_hardened_config_builds_under_every_override_shape() {
         let _default = super::hardened_system_config();
-        unsafe {
-            std::env::set_var("NESTWEAVER_LBUG_MAX_THREADS", "4");
-            std::env::set_var("NESTWEAVER_LBUG_BUFFER_POOL_BYTES", "1073741824");
-            std::env::set_var("NESTWEAVER_LBUG_AUTO_CHECKPOINT", "false");
-        }
-        let _overridden = super::hardened_system_config();
-        // Malformed values must not panic (fall back to default/auto).
-        unsafe {
-            std::env::set_var("NESTWEAVER_LBUG_MAX_THREADS", "not-a-number");
-        }
-        let _tolerant = super::hardened_system_config();
-        unsafe {
-            std::env::remove_var("NESTWEAVER_LBUG_MAX_THREADS");
-            std::env::remove_var("NESTWEAVER_LBUG_BUFFER_POOL_BYTES");
-            std::env::remove_var("NESTWEAVER_LBUG_AUTO_CHECKPOINT");
-        }
+        let _bounded = super::bounded_system_config();
     }
 }
 

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -2722,6 +2722,25 @@ impl GraphStore {
         Ok(())
     }
 
+    fn update_publication_meta_on(
+        conn: &lbug::Connection<'_>,
+        key: &str,
+        value: &str,
+    ) -> Result<(), StoreError> {
+        let mut statement = conn
+            .prepare("MATCH (m:Meta {key: $key}) SET m.value = $value")
+            .map_err(|error| StoreError::Query(format!("prepare publication identity: {error}")))?;
+        conn.execute(
+            &mut statement,
+            vec![
+                ("key", lbug::Value::String(key.to_string())),
+                ("value", lbug::Value::String(value.to_string())),
+            ],
+        )
+        .map_err(|error| StoreError::Query(format!("update publication identity: {error}")))?;
+        Ok(())
+    }
+
     /// Read the database-bound identity. A legacy read-only database may have
     /// neither key and returns `None`; a partial or malformed identity is an
     /// error because silently inventing the missing half could attach foreign
@@ -2877,6 +2896,90 @@ impl GraphStore {
                     StoreError::Query(format!("commit data instance id: {error}"))
                 })?;
                 Ok(value)
+            }
+            Err(error) => {
+                let _ = conn.query("ROLLBACK");
+                Err(error)
+            }
+        }
+    }
+
+    /// Move the recorded identity from a merged-away instance to the surviving
+    /// one.
+    ///
+    /// nw-264. DELIBERATELY DISTINCT from [`Self::ensure_data_instance_id`],
+    /// which must keep refusing to replace. That one guards against
+    /// *accidental* re-identification — a default changing under a database and
+    /// silently renaming its data. A merge is a *deliberate* re-identification,
+    /// and before this there was no API that could express one: the whole
+    /// workspace had exactly ONE writer of this key and it never replaced, so
+    /// `instance merge` rewrote every Repo/Vault/Project UID and left the
+    /// record naming the instance it had just merged away. The next config-less
+    /// `index` then adopted that name and re-forked the graph the merge healed
+    /// — the remedy nw-246's guard prints undid itself.
+    ///
+    /// Three guards keep it narrow:
+    ///
+    /// 1. It is a NO-OP unless the record currently equals `from`. A merge
+    ///    between two instances neither of which is the recorded one leaves the
+    ///    record alone; the write-once discipline still applies to every name
+    ///    except the merged-away one.
+    /// 2. It REFUSES if `observed_instance_ids` still contains `from`. The
+    ///    record must never claim a completion the graph does not show.
+    /// 3. It refuses an empty `to`, for the same reason `ensure_data_instance_id`
+    ///    does.
+    ///
+    /// On ordering: the merge has no single enclosing transaction to run inside
+    /// — it is a sequence of classified mutations with a final plan probe — so
+    /// this is called only where that probe has already reported `Applied`.
+    /// Guard 2 is what makes that safe rather than merely conventional: a
+    /// half-merged graph still shows `from`, and this refuses.
+    ///
+    /// Returns `true` when the record was moved.
+    pub fn rerecord_data_instance_id(&self, from: &str, to: &str) -> Result<bool, StoreError> {
+        let from = from.trim();
+        let to = to.trim();
+        if to.is_empty() {
+            return Err(StoreError::Query(
+                "refusing to record an empty data instance id".to_string(),
+            ));
+        }
+        if from == to {
+            return Ok(false);
+        }
+        // Guard 1: only the merged-away name is eligible.
+        if self.data_instance_id()?.as_deref() != Some(from) {
+            return Ok(false);
+        }
+        // Guard 2: the graph must already show the merge is done.
+        if self
+            .observed_instance_ids()?
+            .iter()
+            .any(|observed| observed == from)
+        {
+            return Err(StoreError::Query(format!(
+                "refusing to re-record the data instance id as {to:?}: rows still \
+                 observed under {from:?}, so the merge is not complete"
+            )));
+        }
+        let conn = self.conn()?;
+        conn.query("BEGIN TRANSACTION")
+            .map_err(|error| StoreError::Query(format!("begin re-record instance id: {error}")))?;
+        // Re-check inside the transaction, exactly as `ensure_data_instance_id`
+        // does, so two concurrent mergers cannot both win.
+        let result = (|| match Self::publication_meta_value_on(&conn, DATA_INSTANCE_ID_META_KEY)? {
+            Some(existing) if existing == from => {
+                Self::update_publication_meta_on(&conn, DATA_INSTANCE_ID_META_KEY, to)?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        })();
+        match result {
+            Ok(moved) => {
+                conn.query("COMMIT").map_err(|error| {
+                    StoreError::Query(format!("commit re-record instance id: {error}"))
+                })?;
+                Ok(moved)
             }
             Err(error) => {
                 let _ = conn.query("ROLLBACK");

--- a/crates/nestweaver-store/src/error.rs
+++ b/crates/nestweaver-store/src/error.rs
@@ -92,7 +92,19 @@ impl std::fmt::Display for CorruptionKind {
 /// replay" is how the crash-restart loop starts.
 pub fn classify_engine_corruption(message: &str) -> Option<CorruptionKind> {
     let lower = message.to_lowercase();
-    if lower.contains("corrupted wal") {
+    // The engine has at least TWO phrasings for an unreadable log and they do
+    // not share a word order:
+    //
+    //   "Corrupted wal file. Read out invalid WAL record type."
+    //   "Storage exception: Checksum verification failed, the WAL file is corrupted."
+    //
+    // The first came from the nw-332 outage. The SECOND was found by executing
+    // the recovery runbook on a temp database — write garbage to `<db>.wal`
+    // with no `<db>.shadow` beside it and every open reports it, no crash
+    // required. A phrase list captured from one incident is a phrase list that
+    // has seen one incident; this is the whole reason the classification lives
+    // in one function with `Unclassified` underneath it.
+    if lower.contains("corrupted wal") || (lower.contains("wal") && lower.contains("corrupt")) {
         return Some(CorruptionKind::WalUnreadable);
     }
     if lower.contains("shadow pages") || (lower.contains("replay") && lower.contains("read-only")) {
@@ -342,6 +354,14 @@ mod corruption_classification_tests {
         for (phrase, expected) in [
             (
                 "Corrupted wal file. Read out invalid WAL record type.",
+                CorruptionKind::WalUnreadable,
+            ),
+            // Reproduced deterministically on a temp database (garbage `.wal`,
+            // no `.shadow`), captured verbatim from the engine. The first
+            // phrasing does not match it and neither did the classifier until
+            // the runbook was actually executed.
+            (
+                "Storage exception: Checksum verification failed, the WAL file is corrupted.",
                 CorruptionKind::WalUnreadable,
             ),
             (

--- a/crates/nestweaver-store/src/error.rs
+++ b/crates/nestweaver-store/src/error.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 use thiserror::Error;
 
 /// Why an in-flight query was cancelled.
@@ -23,12 +25,135 @@ impl std::fmt::Display for CancelReason {
     }
 }
 
+/// What KIND of corruption the storage engine reported.
+///
+/// nw-346. Before this existed, every corruption decision in the product was a
+/// substring match on the engine's English prose: seven classifiers across
+/// three crates, ~15 phrases, zero types. `From<lbug::Error>` collapsed every
+/// engine failure into [`StoreError::Database`], so the one frame that
+/// provably held an engine error threw that fact away and each consumer
+/// re-derived it — from different substrings of different messages, which is
+/// how one condition ended up with three mutually contradictory remedies
+/// (nw-332).
+///
+/// The set is deliberately CLOSED and deliberately small. Each variant exists
+/// because it wants a DIFFERENT remedy; a distinction that does not change the
+/// advice does not belong here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CorruptionKind {
+    /// The write-ahead log exists but its records cannot be read
+    /// ("Corrupted wal file. Read out invalid WAL record type."). The database
+    /// FILE is typically intact — this is the shape a five-artifact move-aside
+    /// recovered in the nw-332 outage — so it must never inherit the
+    /// "delete this database" remedy.
+    WalUnreadable,
+    /// The log is readable and simply has not been replayed, which a read-only
+    /// open can never do. Recoverable by opening read-write.
+    WalUnreplayed,
+    /// The engine's catalog points past the end of the file. Nothing that runs
+    /// later lengthens a truncated file.
+    FileTruncated,
+    /// The vendored C++ tripped one of its own invariants and unwound rather
+    /// than faulting, so `open_crash_guard` never sees it.
+    EngineAssertion,
+    /// Corruption we could not name.
+    ///
+    /// LOAD-BEARING. It is what an unrecognised engine phrase becomes once
+    /// context establishes corruption, so a wording change upstream degrades
+    /// to "corruption, kind unknown" rather than silently reclassifying a
+    /// corrupt database as a generic error with no remedy at all.
+    Unclassified,
+}
+
+impl std::fmt::Display for CorruptionKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            CorruptionKind::WalUnreadable => "unreadable write-ahead log",
+            CorruptionKind::WalUnreplayed => "unreplayed write-ahead log",
+            CorruptionKind::FileTruncated => "truncated database file",
+            CorruptionKind::EngineAssertion => "storage engine assertion",
+            CorruptionKind::Unclassified => "unclassified corruption",
+        };
+        f.write_str(name)
+    }
+}
+
+/// Classify an engine message into a [`CorruptionKind`], or `None` when it
+/// describes an ordinary failure.
+///
+/// This is THE classifier. Every phrase in it was moved here verbatim from a
+/// call site — `into_diagnostic`'s `engine_corruption` block and its WAL arm in
+/// `src/main.rs`, and `daemon_held_store_error` — so the change is a
+/// RELOCATION, not new logic. Adding a phrase anywhere else re-opens nw-346.
+///
+/// Order matters: `WalUnreadable` is tested before `WalUnreplayed` because the
+/// nw-332 message ("Corrupted wal file. Read out invalid WAL record type.") is
+/// about a log that cannot be READ, and answering it with "open read-write to
+/// replay" is how the crash-restart loop starts.
+pub fn classify_engine_corruption(message: &str) -> Option<CorruptionKind> {
+    let lower = message.to_lowercase();
+    if lower.contains("corrupted wal") {
+        return Some(CorruptionKind::WalUnreadable);
+    }
+    if lower.contains("shadow pages") || (lower.contains("replay") && lower.contains("read-only")) {
+        return Some(CorruptionKind::WalUnreplayed);
+    }
+    if lower.contains("outside the database file") {
+        return Some(CorruptionKind::FileTruncated);
+    }
+    if lower.contains("assertion failed in file") {
+        return Some(CorruptionKind::EngineAssertion);
+    }
+    // A bare C++ exception `what()` with no sentence in it. Matched both as the
+    // raw engine text and as the already-Displayed `StoreError` prose, because
+    // this arm is reached from both directions.
+    if lower.starts_with("basic_string") || lower.contains("database error: basic_string") {
+        return Some(CorruptionKind::EngineAssertion);
+    }
+    None
+}
+
+/// The payload of [`StoreError::Corruption`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EngineCorruption {
+    pub kind: CorruptionKind,
+    /// The engine's own words, VERBATIM.
+    pub detail: String,
+    /// The database this is about. Engine messages name no path, which is why
+    /// the CLI kept a `LAST_OPENED_DB` global to guess one; a typed error can
+    /// simply carry it. Filled in by the store's single open funnel, which is
+    /// the frame that knows.
+    pub path: Option<PathBuf>,
+}
+
 #[derive(Error, Debug)]
 pub enum StoreError {
     #[error("database error: {0}")]
     Database(String),
     #[error("query error: {0}")]
     Query(String),
+    /// nw-346. Corruption the STORAGE ENGINE reported, classified once at the
+    /// FFI boundary — the only frame that provably knows an error came from the
+    /// engine.
+    ///
+    /// The taxonomy already had two corruption variants before this one, and
+    /// both describe corruption NestWeaver detected ITSELF: [`Self::CorruptValue`]
+    /// (an embedded NUL in a returned string) and [`Self::EmbeddingArtifactCorrupt`]
+    /// (a checksum failure). There was no variant for corruption the engine
+    /// reported, which is the only kind that bears on opening a database at
+    /// all. That asymmetry is nw-346 in one sentence.
+    ///
+    /// `detail` carries the engine's own words VERBATIM. It is the only thing
+    /// that says why, and a paraphrase at this boundary is what let
+    /// `daemon_held_store_error` destroy the evidence it had just classified on.
+    ///
+    /// BOXED deliberately. Inline, this variant is the largest in the enum and
+    /// it grew `StoreError` past the point where `clippy::result_large_err`
+    /// fires on `DeleteProjectCascadeError` three crates away — an error type
+    /// paying, on every `Ok` return, for a payload only the rarest failure
+    /// carries.
+    #[error("database corruption ({}): {}", .0.kind, .0.detail)]
+    Corruption(Box<EngineCorruption>),
     /// A ranking query was refused while an index publication is in flight:
     /// the ranking caches may describe a graph that no longer exists, so the
     /// query fails closed rather than answering with a successful-looking
@@ -78,7 +203,8 @@ impl StoreError {
                     || lower.contains("unique")
                     || lower.contains("constraint")
             }
-            StoreError::NotFound
+            StoreError::Corruption(_)
+            | StoreError::NotFound
             | StoreError::RankingUnavailable
             | StoreError::PresentationLimitExceeded { .. }
             | StoreError::Cancelled(_)
@@ -99,10 +225,214 @@ impl StoreError {
             _ => None,
         }
     }
+
+    /// Build a `StoreError` from a raw storage-engine message, classifying
+    /// corruption ONCE.
+    ///
+    /// This is what `From<lbug::Error>` calls. It is public so the classifier
+    /// can be exercised on the engine's exact phrasings — captured
+    /// character-for-character from real incidents — without needing the crash
+    /// that produced them.
+    pub fn from_engine_message(message: impl Into<String>) -> Self {
+        let detail = message.into();
+        match classify_engine_corruption(&detail) {
+            Some(kind) => StoreError::Corruption(Box::new(EngineCorruption {
+                kind,
+                detail,
+                path: None,
+            })),
+            None => StoreError::Database(detail),
+        }
+    }
+
+    /// Record corruption whose engine phrasing we do not recognise.
+    ///
+    /// For callers that know from CONTEXT that a database is damaged even
+    /// though the message is unfamiliar. The point of the variant is that such
+    /// a case degrades to "corruption, kind unknown" instead of falling back to
+    /// [`Self::Database`], which carries no remedy at all.
+    pub fn corruption_unclassified(message: impl Into<String>) -> Self {
+        StoreError::Corruption(Box::new(EngineCorruption {
+            kind: CorruptionKind::Unclassified,
+            detail: message.into(),
+            path: None,
+        }))
+    }
+
+    /// True when the engine refused the open because another process holds the
+    /// write lock.
+    ///
+    /// nw-346. Lives here for the same reason `corruption_kind` does: `repair`
+    /// and the CLI read funnel both need to tell "someone holds it" from "it is
+    /// damaged", and they were each deciding that from a different substring of
+    /// a different message. One phrase, one place.
+    pub fn is_lock_contention(&self) -> bool {
+        match self {
+            StoreError::Database(msg) | StoreError::Query(msg) => {
+                let lower = msg.to_lowercase();
+                lower.contains("could not set lock") || lower.contains("another process holds")
+            }
+            _ => false,
+        }
+    }
+
+    /// The corruption kind, if this error is engine-reported corruption.
+    ///
+    /// Sits beside `is_duplicate` / `is_cancelled` so consumers match a variant
+    /// rather than re-deriving prose one frame after it was structured.
+    pub fn corruption_kind(&self) -> Option<CorruptionKind> {
+        match self {
+            StoreError::Corruption(corruption) => Some(corruption.kind),
+            _ => None,
+        }
+    }
+
+    /// The engine's verbatim words, for corruption errors.
+    pub fn corruption_detail(&self) -> Option<&str> {
+        match self {
+            StoreError::Corruption(corruption) => Some(corruption.detail.as_str()),
+            _ => None,
+        }
+    }
+
+    /// The database this corruption is about, when the open funnel recorded it.
+    pub fn corruption_path(&self) -> Option<&Path> {
+        match self {
+            StoreError::Corruption(corruption) => corruption.path.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Name the database a corruption error is about.
+    ///
+    /// Only fills an EMPTY slot: a path attached closer to the failure is
+    /// better evidence than one attached by an outer frame, and a retry loop
+    /// must not be able to relabel an error with a different database.
+    #[must_use]
+    pub fn with_db_path(self, db_path: &Path) -> Self {
+        match self {
+            StoreError::Corruption(mut corruption) if corruption.path.is_none() => {
+                corruption.path = Some(db_path.to_path_buf());
+                StoreError::Corruption(corruption)
+            }
+            other => other,
+        }
+    }
 }
 
 impl From<lbug::Error> for StoreError {
     fn from(e: lbug::Error) -> Self {
-        StoreError::Database(e.to_string())
+        // nw-346. Classify HERE — the single frame that provably holds an
+        // engine error. Everything downstream matches a variant.
+        StoreError::from_engine_message(e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod corruption_classification_tests {
+    use super::*;
+
+    /// nw-346. The engine's five known corruption phrasings must each classify
+    /// to a KIND, at the FFI boundary, exactly once. Verbatim strings, captured
+    /// from real incidents (nw-285's three reproductions and nw-332's outage) —
+    /// so a phrasing change fails HERE, in one file, rather than silently
+    /// unselecting a recovery path three crates away.
+    #[test]
+    fn every_known_engine_corruption_phrase_classifies_to_a_kind() {
+        for (phrase, expected) in [
+            (
+                "Corrupted wal file. Read out invalid WAL record type.",
+                CorruptionKind::WalUnreadable,
+            ),
+            (
+                "catalog page range starts at 3567 and spans 5 pages, outside the \
+                 database file with 1696 pages",
+                CorruptionKind::FileTruncated,
+            ),
+            (
+                "Assertion failed in file \"<crate>/column.cpp\" on line 289: \
+                 startOffsetInSegment + length <= state.metadata.numValues",
+                CorruptionKind::EngineAssertion,
+            ),
+            (
+                "database error: basic_string",
+                CorruptionKind::EngineAssertion,
+            ),
+            (
+                "Couldn't replay shadow pages under read-only mode.",
+                CorruptionKind::WalUnreplayed,
+            ),
+        ] {
+            let error = StoreError::from_engine_message(phrase);
+            assert_eq!(
+                error.corruption_kind(),
+                Some(expected),
+                "engine phrase must classify at the FFI boundary, not at a call \
+                 site: {phrase}"
+            );
+        }
+    }
+
+    /// The other direction, and the one that makes the first non-vacuous: an
+    /// ordinary failure must NOT be called corruption.
+    #[test]
+    fn an_ordinary_engine_failure_is_not_corruption() {
+        for benign in [
+            "Could not set lock on file /tmp/x.lbug.lock",
+            "Binder exception: Table Symbol does not exist.",
+            "Runtime exception: Query interrupted.",
+            "IO exception: Cannot open file /tmp/x.lbug.shadow: No such file or directory",
+        ] {
+            assert_eq!(
+                StoreError::from_engine_message(benign).corruption_kind(),
+                None,
+                "a lock, a binder error, a cancellation and an orphaned log are \
+                 not corruption: {benign}"
+            );
+        }
+    }
+
+    /// The drift guard, and the reason `Unclassified` exists. An engine phrase
+    /// nobody has seen must still be reachable as corruption when the CONTEXT
+    /// says so — it must never silently become `Database(String)` again.
+    #[test]
+    fn an_unrecognised_phrase_degrades_to_unclassified_not_to_generic() {
+        let error = StoreError::corruption_unclassified("some future engine wording");
+        assert!(matches!(
+            error.corruption_kind(),
+            Some(CorruptionKind::Unclassified)
+        ));
+        assert!(!matches!(error, StoreError::Database(_)));
+    }
+
+    /// The engine names no path, which is why the CLI kept a global to guess
+    /// one. A typed error carries it — and only from the frame that knows,
+    /// which is why a second attribution cannot overwrite the first.
+    #[test]
+    fn a_corruption_error_carries_the_database_it_is_about_and_keeps_the_first_one() {
+        let error = StoreError::from_engine_message("Corrupted wal file.")
+            .with_db_path(Path::new("/tmp/first.lbug"))
+            .with_db_path(Path::new("/tmp/second.lbug"));
+        assert_eq!(error.corruption_path(), Some(Path::new("/tmp/first.lbug")));
+
+        // A non-corruption error is left exactly as it was.
+        let benign = StoreError::from_engine_message("Could not set lock")
+            .with_db_path(Path::new("/tmp/x.lbug"));
+        assert!(matches!(benign, StoreError::Database(_)));
+    }
+
+    /// The engine's own words must survive classification verbatim. The nw-332
+    /// regression was a call site that classified correctly and then paraphrased
+    /// the evidence away, so the NEXT classifier downstream saw only the
+    /// paraphrase and reached a different — contradictory — conclusion.
+    #[test]
+    fn classification_never_replaces_the_engines_own_words() {
+        const ENGINE: &str = "Corrupted wal file. Read out invalid WAL record type.";
+        let error = StoreError::from_engine_message(ENGINE);
+        assert_eq!(error.corruption_detail(), Some(ENGINE));
+        assert!(
+            error.to_string().contains(ENGINE),
+            "the rendered error must still carry the engine's sentence: {error}"
+        );
     }
 }

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -35,8 +35,8 @@ pub use ranking::{
     SeedResolutionConfig, default_kind_priority, detect_intent, git_activity_multiplier,
 };
 pub use read::{
-    BacklinkRow, BrokenWikilinkRow, CodeEdge, CodeGraph, CrossRepoRef, NoteLite, SymbolBasic,
-    VAULT_CODE_BRIDGE_RELATIONS, VAULT_RELATIONS, VaultRelation,
+    BacklinkRow, BrokenWikilinkRow, CodeEdge, CodeGraph, CrossRepoRef, NoteLite, ScanIntegrity,
+    SymbolBasic, VAULT_CODE_BRIDGE_RELATIONS, VAULT_RELATIONS, VaultRelation,
 };
 pub use regex::{
     CANDIDATE_CAP, DEFAULT_MAX_MILLIS, FileCount, PatternCount, RegexMatch, RegexSearchResult,

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -21,7 +21,9 @@ pub use db::{
     EmbeddingIndexOccupancy, EmbeddingIndexReconciliation, EmbeddingSnapshotLease,
     EmbeddingSnapshotState, GraphStore, IndexPublicationLease, PublicationIdentity,
 };
-pub use error::{CancelReason, StoreError};
+pub use error::{
+    CancelReason, CorruptionKind, EngineCorruption, StoreError, classify_engine_corruption,
+};
 
 /// Re-export the LadybugDB connection type so callers can use transactional
 /// APIs (`begin_transaction` / `commit_transaction`) and `_on` method variants

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -51,6 +51,7 @@ pub use search::{
 pub use tantivy_index::{
     PRF_EXPANSION_TERMS, PRF_EXPANSION_WEIGHT, PRF_MAX_QUERY_TERMS, PRF_TOP_K,
     SEARCH_PRESENTATION_LIMIT_MAX, SearchHit, SearchLogicalIdentity, TantivyError, TantivyIndex,
+    reindex_lock_path,
 };
 pub use traverse::{
     DEFAULT_IMPACT_THRESHOLD, IMPACT_EDGE_TYPES, ImpactEdge, ImpactNode, ImpactResult,

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -1974,6 +1974,31 @@ impl GraphStore {
     /// Count of all wikilink edges (to either Note or Heading). Cheap status
     /// summary — does two separate queries since LadybugDB splits the
     /// logical WIKILINK into two physical REL tables.
+    /// Count of `UnresolvedWikilink` NODES — distinct (source section, target
+    /// text) pairs.
+    ///
+    /// nw-345: this is the population that sits between the two the product
+    /// reports, and it was never reported anywhere, which is why the gap
+    /// between the indexer's number and `doc-stats`' is not a clean factor.
+    /// The node uid is derived from the source section plus the target text, so
+    /// two identical links in ONE section collapse to one node on insert, while
+    /// `broken_wikilinks` dedupes again to (source NOTE, text). Three
+    /// populations, one word.
+    ///
+    /// OCCURRENCES — one per link instance in the parse — are deliberately not
+    /// obtainable here. The graph does not store them: it stores one node per
+    /// (section, target). Only the indexer can report occurrences, and it does.
+    pub fn count_unresolved_wikilink_nodes(&self) -> Result<usize, StoreError> {
+        let conn = self.conn()?;
+        match conn.query("MATCH (u:UnresolvedWikilink) RETURN u.uid") {
+            Ok(result) => Ok(result.count()),
+            Err(e) => {
+                tracing::trace!("count_unresolved_wikilink_nodes: query skipped: {e}");
+                Ok(0)
+            }
+        }
+    }
+
     pub fn count_wikilink_edges(&self) -> Result<usize, StoreError> {
         let conn = self.conn()?;
         let to_notes = conn

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -229,6 +229,59 @@ pub(crate) fn extract_string(row: &[Value], idx: usize) -> Result<String, StoreE
     }
 }
 
+/// Collect a whole-corpus scan, degrading on a corrupt row rather than losing
+/// the corpus to it.
+///
+/// nw-335: `extract_string`'s NUL canary is a LadybugDB #678 detector, and
+/// `rows.map(row_to_x).collect::<Result<Vec<_>, _>>()` short-circuits on the
+/// first `Err` -- so ONE unreadable row emptied the entire vector. Both global
+/// derived indexes are built by consuming exactly these vectors (Tantivy's
+/// `write_full_corpus_with_fields` reads notes + headings + sections; the regex
+/// trigram corpus reads notes + sections + symbols), so a single note holding a
+/// pasted NUL took search to `docs=0` brain-wide while `brain status` still
+/// reported a healthy graph. A row the reader will not return is ONE lost row.
+///
+/// Only `CorruptValue` degrades. A type mismatch or an out-of-bounds column is a
+/// real query defect and still aborts: this is a corruption-tolerance seam, not
+/// a blanket `ok()`.
+///
+/// The precedent is `traverse.rs`, which skips a garbled caller uid and keeps
+/// walking. What that site got right and `extract_string` got wrong is that the
+/// canary fires on a NAVIGATIONAL key, where a NUL genuinely cannot be
+/// legitimate; `text_content` and `title` are CONTENT, where it merely should
+/// not be -- and is now stripped at ingest so that it is not.
+pub(crate) fn collect_tolerating_corrupt<T>(
+    rows: impl Iterator<Item = Result<T, StoreError>>,
+    what: &str,
+) -> Result<Vec<T>, StoreError> {
+    let mut out = Vec::new();
+    let mut skipped = 0usize;
+    let mut first_reason: Option<String> = None;
+    for row in rows {
+        match row {
+            Ok(value) => out.push(value),
+            Err(StoreError::CorruptValue { column, reason }) => {
+                skipped += 1;
+                if first_reason.is_none() {
+                    first_reason = Some(format!("column {column}: {reason}"));
+                }
+            }
+            Err(other) => return Err(other),
+        }
+    }
+    if skipped > 0 {
+        // Disclose, do not swallow: the caller's coverage is DEGRADED and an
+        // operator reading "search found nothing" needs to know why.
+        tracing::warn!(
+            "{what}: coverage DEGRADED -- skipped {skipped} corrupt row(s), \
+             kept {}; first: {}. Re-index to repair (`nestweaver brain add --force`).",
+            out.len(),
+            first_reason.as_deref().unwrap_or("unknown")
+        );
+    }
+    Ok(out)
+}
+
 fn extract_opt_string(row: &[Value], idx: usize) -> Result<Option<String>, StoreError> {
     let val = row
         .get(idx)
@@ -1388,7 +1441,7 @@ impl GraphStore {
             conn.query(&q)
                 .map_err(|e| StoreError::Query(e.to_string()))?
         };
-        result.map(|row| row_to_note(&row)).collect()
+        collect_tolerating_corrupt(result.map(|row| row_to_note(&row)), "list_notes")
     }
 
     /// Count of all Note nodes (cheap for status output — no body load).
@@ -1483,7 +1536,7 @@ impl GraphStore {
         let result = conn
             .query(&q)
             .map_err(|e| StoreError::Query(e.to_string()))?;
-        result.map(|row| row_to_heading(&row)).collect()
+        collect_tolerating_corrupt(result.map(|row| row_to_heading(&row)), "list_all_headings")
     }
 
     /// List all Section nodes across all vaults/notes (includes `text_content`).
@@ -1494,7 +1547,7 @@ impl GraphStore {
         let result = conn
             .query(&q)
             .map_err(|e| StoreError::Query(e.to_string()))?;
-        result.map(|row| row_to_section(&row)).collect()
+        collect_tolerating_corrupt(result.map(|row| row_to_section(&row)), "list_all_sections")
     }
 
     /// List all Heading nodes belonging to notes in the given vault.
@@ -1882,7 +1935,7 @@ impl GraphStore {
         let result = conn
             .query(&q)
             .map_err(|e| StoreError::Query(e.to_string()))?;
-        result.map(|row| row_to_symbol(&row)).collect()
+        collect_tolerating_corrupt(result.map(|row| row_to_symbol(&row)), "list_all_symbols")
     }
 
     /// All symbols' (uid, name, kind_string). Lightweight — no signature
@@ -3603,5 +3656,165 @@ mod repo_has_content_tests {
                 .repo_index_incomplete(&make_repo("repo:r", "https://example.com/r", "abc"))
                 .unwrap()
         );
+    }
+}
+
+#[cfg(test)]
+mod corrupt_row_tolerance_tests {
+    use super::*;
+
+    fn section(uid: &str, text: &str) -> Section {
+        Section {
+            uid: uid.to_string(),
+            note_uid: "note:n".to_string(),
+            heading_uid: None,
+            start_line: 1,
+            end_line: 2,
+            text_hash: "h".to_string(),
+            text_content: text.to_string(),
+            word_count: 1,
+            pagerank_score: None,
+        }
+    }
+
+    fn note(uid: &str, title: &str) -> Note {
+        Note {
+            uid: uid.to_string(),
+            vault_uid: "vault:v".to_string(),
+            file_path: format!("{uid}.md"),
+            title: title.to_string(),
+            note_kind: NoteKind::General,
+            word_count: 1,
+            content_hash: "h".to_string(),
+            frontmatter: None,
+            frontmatter_raw: None,
+            created_at: None,
+            modified_at: None,
+            pagerank_score: None,
+            embedding: None,
+        }
+    }
+
+    fn heading(uid: &str, text: &str) -> Heading {
+        Heading {
+            uid: uid.to_string(),
+            note_uid: "note:clean".to_string(),
+            level: 1,
+            text: text.to_string(),
+            slug: "s".to_string(),
+            start_line: 1,
+            end_line: 1,
+            content_hash: "h".to_string(),
+            embedding: None,
+        }
+    }
+
+    fn symbol(uid: &str, signature: &str) -> Symbol {
+        Symbol {
+            uid: uid.to_string(),
+            name: "s".to_string(),
+            kind: SymbolKind::Function,
+            repo_uid: "repo:r".to_string(),
+            file_path: "a.rs".to_string(),
+            start_line: 1,
+            end_line: 2,
+            signature: signature.to_string(),
+            summary: None,
+            content_hash: "h".to_string(),
+            embedding: None,
+            pagerank_score: None,
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Public,
+            type_info: None,
+            framework_hint: None,
+            canonical_id: None,
+        }
+    }
+
+    /// nw-335: a graph that ALREADY holds a NUL must stay readable without a
+    /// re-parse. `list_all_sections` collected into `Result<Vec<_>, _>`, which
+    /// short-circuits, so one unreadable row emptied the whole vector -- and
+    /// both global derived-index builds (Tantivy BM25 at
+    /// `tantivy_index.rs:1243`, the regex trigram corpus at `regex.rs:799`)
+    /// consume exactly that vector. One poisoned note therefore took search
+    /// brain-wide to `docs=0` while `brain status` still reported health.
+    ///
+    /// This is `traverse.rs:1089`'s precedent applied to the scan side: skip
+    /// the row, say so, keep the corpus.
+    #[test]
+    fn one_corrupt_row_degrades_the_scan_instead_of_emptying_it() {
+        let store = GraphStore::in_memory().unwrap();
+        store
+            .insert_section(&section("sec:clean", "loadbearing text"))
+            .unwrap();
+        store
+            .insert_section(&section("sec:dirty", "before\u{0}after"))
+            .unwrap();
+
+        let sections = store
+            .list_all_sections()
+            .expect("nw-335: one corrupt row must not fail the whole section scan");
+        assert!(
+            sections.iter().any(|s| s.uid == "sec:clean"),
+            "the clean row must survive its neighbour's NUL: {sections:?}"
+        );
+        assert!(
+            !sections.iter().any(|s| s.uid == "sec:dirty"),
+            "the corrupt row is DROPPED, not silently repaired -- the canary is \
+             still a #678 detector on a graph the reader did not write"
+        );
+    }
+
+    /// nw-335, the "where else" half: the same short-circuit sits under EVERY
+    /// whole-corpus scan the global index builds walk, not just sections.
+    /// `write_full_corpus_with_fields` reads notes, headings and sections; the
+    /// trigram corpus additionally reads symbols. A fix scoped to
+    /// `list_all_sections` would leave three identical cliffs standing.
+    #[test]
+    fn every_whole_corpus_scan_tolerates_a_corrupt_row() {
+        let store = GraphStore::in_memory().unwrap();
+
+        store.insert_note(&note("note:clean", "Clean")).unwrap();
+        store
+            .insert_note(&note("note:dirty", "Ti\u{0}tle"))
+            .unwrap();
+        let notes = store.list_notes(None).expect("nw-335: notes scan degrades");
+        assert!(notes.iter().any(|n| n.uid == "note:clean"));
+        assert!(!notes.iter().any(|n| n.uid == "note:dirty"));
+
+        store.insert_heading(&heading("h:clean", "Clean")).unwrap();
+        store
+            .insert_heading(&heading("h:dirty", "He\u{0}ad"))
+            .unwrap();
+        let headings = store
+            .list_all_headings()
+            .expect("nw-335: headings scan degrades");
+        assert!(headings.iter().any(|h| h.uid == "h:clean"));
+        assert!(!headings.iter().any(|h| h.uid == "h:dirty"));
+
+        store
+            .insert_symbol(&symbol("sym:clean", "fn ok()"))
+            .unwrap();
+        store
+            .insert_symbol(&symbol("sym:dirty", "fn b\u{0}ad()"))
+            .unwrap();
+        let symbols = store
+            .list_all_symbols()
+            .expect("nw-335: symbols scan degrades");
+        assert!(symbols.iter().any(|s| s.uid == "sym:clean"));
+        assert!(!symbols.iter().any(|s| s.uid == "sym:dirty"));
+    }
+
+    /// nw-335: degrading is scoped to CORRUPTION. A genuine query defect -- a
+    /// column that is not a String at all -- must still abort loudly, or the
+    /// tolerance seam turns into a blanket `ok()` that hides real bugs.
+    #[test]
+    fn a_type_mismatch_still_aborts_the_scan() {
+        let row = vec![Value::Int64(7)];
+        assert!(matches!(
+            collect_tolerating_corrupt(std::iter::once(extract_string(&row, 0)), "test"),
+            Err(StoreError::Query(_))
+        ));
     }
 }

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -229,6 +229,63 @@ pub(crate) fn extract_string(row: &[Value], idx: usize) -> Result<String, StoreE
     }
 }
 
+/// What a whole-corpus scan actually covered.
+///
+/// nw-335 made the whole-corpus scans TOLERATE a corrupt row instead of losing
+/// the corpus to it, and disclosed the skip with a `tracing::warn!`. A log line
+/// is legible to a human tailing logs and invisible to the caller — so a caller
+/// that makes a COMPLETENESS claim ("N of M symbols unreachable") or a SAFETY
+/// claim ("these are the tests you need to run") could state it over a
+/// knowingly-incomplete corpus and still read as usable. That is nw-324
+/// verbatim: `affected-tests` selecting zero tests and reporting
+/// `selection-usable` while a green build shipped a regression.
+///
+/// So the skip is a RETURN VALUE, not just a log. Callers that claim
+/// completeness or safety take the `*_with_integrity` sibling of their scan and
+/// degrade on [`ScanIntegrity::is_degraded`]; callers that claim nothing keep
+/// the plain scan. Modelled on `blast_radius::Coverage`, which exists for the
+/// same reason on the traversal side: it lets a consumer tell "no impact" from
+/// "incomplete coverage".
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct ScanIntegrity {
+    /// Rows decoded and returned to the caller.
+    pub returned: usize,
+    /// Rows the scan reached but could not decode, and therefore DROPPED. Any
+    /// total computed over `returned` is a floor while this is non-zero.
+    pub skipped_corrupt: usize,
+    /// The first corruption encountered, for disclosure to an operator.
+    pub first_reason: Option<String>,
+}
+
+impl ScanIntegrity {
+    /// The scan saw the whole corpus: every row it reached, it returned.
+    pub fn is_complete(&self) -> bool {
+        self.skipped_corrupt == 0
+    }
+
+    /// Rows were dropped — any count over this scan is a floor, and any
+    /// safety decision taken on it is taken on a partial graph.
+    pub fn is_degraded(&self) -> bool {
+        self.skipped_corrupt > 0
+    }
+
+    /// A one-line disclosure for a caller that has to tell a user why its
+    /// numbers are a floor. `None` when the scan was complete, so that
+    /// `if let Some(..)` is the whole disclosure path.
+    pub fn disclosure(&self) -> Option<String> {
+        if self.is_complete() {
+            return None;
+        }
+        Some(format!(
+            "coverage DEGRADED: {} corrupt row(s) skipped, {} kept; first: {}. \
+             Counts are a floor. Re-index to repair (`nestweaver brain add --force`).",
+            self.skipped_corrupt,
+            self.returned,
+            self.first_reason.as_deref().unwrap_or("unknown")
+        ))
+    }
+}
+
 /// Collect a whole-corpus scan, degrading on a corrupt row rather than losing
 /// the corpus to it.
 ///
@@ -250,10 +307,13 @@ pub(crate) fn extract_string(row: &[Value], idx: usize) -> Result<String, StoreE
 /// canary fires on a NAVIGATIONAL key, where a NUL genuinely cannot be
 /// legitimate; `text_content` and `title` are CONTENT, where it merely should
 /// not be -- and is now stripped at ingest so that it is not.
+/// Returns the rows AND a [`ScanIntegrity`]. The integrity value is the point:
+/// the `tracing::warn!` below discloses the skip to an operator, and only the
+/// return value discloses it to the caller.
 pub(crate) fn collect_tolerating_corrupt<T>(
     rows: impl Iterator<Item = Result<T, StoreError>>,
     what: &str,
-) -> Result<Vec<T>, StoreError> {
+) -> Result<(Vec<T>, ScanIntegrity), StoreError> {
     let mut out = Vec::new();
     let mut skipped = 0usize;
     let mut first_reason: Option<String> = None;
@@ -269,17 +329,18 @@ pub(crate) fn collect_tolerating_corrupt<T>(
             Err(other) => return Err(other),
         }
     }
-    if skipped > 0 {
+    let integrity = ScanIntegrity {
+        returned: out.len(),
+        skipped_corrupt: skipped,
+        first_reason,
+    };
+    if let Some(disclosure) = integrity.disclosure() {
         // Disclose, do not swallow: the caller's coverage is DEGRADED and an
-        // operator reading "search found nothing" needs to know why.
-        tracing::warn!(
-            "{what}: coverage DEGRADED -- skipped {skipped} corrupt row(s), \
-             kept {}; first: {}. Re-index to repair (`nestweaver brain add --force`).",
-            out.len(),
-            first_reason.as_deref().unwrap_or("unknown")
-        );
+        // operator reading "search found nothing" needs to know why. The
+        // caller learns the same fact from `integrity`.
+        tracing::warn!("{what}: {disclosure}");
     }
-    Ok(out)
+    Ok((out, integrity))
 }
 
 fn extract_opt_string(row: &[Value], idx: usize) -> Result<Option<String>, StoreError> {
@@ -1427,7 +1488,20 @@ impl GraphStore {
     }
 
     /// List all Note nodes, optionally filtered by vault UID.
+    ///
+    /// Corrupt rows are skipped (nw-335). A caller that states a TOTAL over
+    /// notes, or claims to have covered every note, must use
+    /// [`Self::list_notes_with_integrity`] instead — this signature cannot tell
+    /// it that rows were dropped.
     pub fn list_notes(&self, vault_uid: Option<&str>) -> Result<Vec<Note>, StoreError> {
+        Ok(self.list_notes_with_integrity(vault_uid)?.0)
+    }
+
+    /// [`Self::list_notes`] plus what the scan actually covered.
+    pub fn list_notes_with_integrity(
+        &self,
+        vault_uid: Option<&str>,
+    ) -> Result<(Vec<Note>, ScanIntegrity), StoreError> {
         let conn = self.conn()?;
         let result = if let Some(vid) = vault_uid {
             let q = format!("MATCH (n:Note) WHERE n.vault_uid = $vid RETURN {NOTE_COLUMNS}");
@@ -1530,7 +1604,18 @@ impl GraphStore {
     /// List all Heading nodes across all vaults/notes.
     /// Used by the brain_search substring fallback to extend title-only search
     /// to heading text.
+    ///
+    /// Corrupt rows are skipped (nw-335); see
+    /// [`Self::list_all_headings_with_integrity`] for callers that claim
+    /// completeness.
     pub fn list_all_headings(&self) -> Result<Vec<Heading>, StoreError> {
+        Ok(self.list_all_headings_with_integrity()?.0)
+    }
+
+    /// [`Self::list_all_headings`] plus what the scan actually covered.
+    pub fn list_all_headings_with_integrity(
+        &self,
+    ) -> Result<(Vec<Heading>, ScanIntegrity), StoreError> {
         let conn = self.conn()?;
         let q = format!("MATCH (h:Heading) RETURN {HEADING_COLUMNS}");
         let result = conn
@@ -1541,7 +1626,18 @@ impl GraphStore {
 
     /// List all Section nodes across all vaults/notes (includes `text_content`).
     /// Used by the brain_search substring fallback to search section bodies.
+    ///
+    /// Corrupt rows are skipped (nw-335); see
+    /// [`Self::list_all_sections_with_integrity`] for callers that claim
+    /// completeness.
     pub fn list_all_sections(&self) -> Result<Vec<Section>, StoreError> {
+        Ok(self.list_all_sections_with_integrity()?.0)
+    }
+
+    /// [`Self::list_all_sections`] plus what the scan actually covered.
+    pub fn list_all_sections_with_integrity(
+        &self,
+    ) -> Result<(Vec<Section>, ScanIntegrity), StoreError> {
         let conn = self.conn()?;
         let q = format!("MATCH (s:Section) RETURN {SECTION_COLUMNS}");
         let result = conn
@@ -1929,7 +2025,20 @@ impl GraphStore {
 
     /// All symbols with full details including the embedding field.
     /// Used by vector KNN search to load embeddings for cosine similarity.
+    ///
+    /// Corrupt rows are skipped (nw-335). `dead_code` and `affected_tests` —
+    /// the two callers that respectively state "N of M symbols unreachable" and
+    /// decide which tests may be skipped — take
+    /// [`Self::list_all_symbols_with_integrity`], because neither claim is
+    /// truthful over a corpus that silently lost rows.
     pub fn list_all_symbols(&self) -> Result<Vec<nestweaver_schema::Symbol>, StoreError> {
+        Ok(self.list_all_symbols_with_integrity()?.0)
+    }
+
+    /// [`Self::list_all_symbols`] plus what the scan actually covered.
+    pub fn list_all_symbols_with_integrity(
+        &self,
+    ) -> Result<(Vec<nestweaver_schema::Symbol>, ScanIntegrity), StoreError> {
         let conn = self.conn()?;
         let q = format!("MATCH (s:Symbol) RETURN {}", SYMBOL_COLUMNS);
         let result = conn
@@ -3829,6 +3938,86 @@ mod corrupt_row_tolerance_tests {
             .expect("nw-335: symbols scan degrades");
         assert!(symbols.iter().any(|s| s.uid == "sym:clean"));
         assert!(!symbols.iter().any(|s| s.uid == "sym:dirty"));
+    }
+
+    /// nw-335 tolerance made the scans survive a corrupt row; it disclosed the
+    /// skip only via `tracing::warn!`, which no caller can read. A caller that
+    /// claims completeness ("N of M symbols") or safety ("these are the tests
+    /// to run") therefore stated it over a corpus it did not know was partial
+    /// — nw-324's exact failure mode. Every tolerant scan must hand the caller
+    /// a VALUE it can branch on.
+    #[test]
+    fn every_tolerant_scan_hands_the_caller_an_observable_integrity() {
+        let store = GraphStore::in_memory().unwrap();
+
+        store.insert_note(&note("note:clean", "Clean")).unwrap();
+        store
+            .insert_note(&note("note:dirty", "Ti\u{0}tle"))
+            .unwrap();
+        store.insert_heading(&heading("h:clean", "Clean")).unwrap();
+        store
+            .insert_heading(&heading("h:dirty", "He\u{0}ad"))
+            .unwrap();
+        store
+            .insert_section(&section("sec:clean", "loadbearing text"))
+            .unwrap();
+        store
+            .insert_section(&section("sec:dirty", "before\u{0}after"))
+            .unwrap();
+        store
+            .insert_symbol(&symbol("sym:clean", "fn ok()"))
+            .unwrap();
+        store
+            .insert_symbol(&symbol("sym:dirty", "fn b\u{0}ad()"))
+            .unwrap();
+
+        let scans: Vec<(&str, ScanIntegrity)> = vec![
+            (
+                "list_notes",
+                store.list_notes_with_integrity(None).unwrap().1,
+            ),
+            (
+                "list_all_headings",
+                store.list_all_headings_with_integrity().unwrap().1,
+            ),
+            (
+                "list_all_sections",
+                store.list_all_sections_with_integrity().unwrap().1,
+            ),
+            (
+                "list_all_symbols",
+                store.list_all_symbols_with_integrity().unwrap().1,
+            ),
+        ];
+
+        for (what, integrity) in scans {
+            assert_eq!(integrity.skipped_corrupt, 1, "{what} must COUNT the skip");
+            assert_eq!(integrity.returned, 1, "{what} must keep the clean row");
+            assert!(integrity.is_degraded(), "{what} must read as degraded");
+            assert!(!integrity.is_complete(), "{what} is not complete");
+            assert!(
+                integrity
+                    .disclosure()
+                    .is_some_and(|d| d.contains("DEGRADED")),
+                "{what} must offer the caller a disclosure string"
+            );
+        }
+    }
+
+    /// The other half of the same contract: a CLEAN scan must report itself
+    /// complete, or a caller that degrades on `is_degraded()` would degrade
+    /// always and the signal would be worthless.
+    #[test]
+    fn a_clean_scan_reports_itself_complete() {
+        let store = GraphStore::in_memory().unwrap();
+        store
+            .insert_symbol(&symbol("sym:clean", "fn ok()"))
+            .unwrap();
+        let (symbols, integrity) = store.list_all_symbols_with_integrity().unwrap();
+        assert_eq!(symbols.len(), 1);
+        assert!(integrity.is_complete());
+        assert_eq!(integrity.skipped_corrupt, 0);
+        assert_eq!(integrity.disclosure(), None);
     }
 
     /// nw-335: degrading is scoped to CORRUPTION. A genuine query defect -- a

--- a/crates/nestweaver-store/src/regex.rs
+++ b/crates/nestweaver-store/src/regex.rs
@@ -168,8 +168,34 @@ pub enum RegexTruncationReason {
     ResultLimit,
     Deadline,
     CandidateCap,
+    /// The candidate corpus itself was short: a whole-corpus scan reached rows
+    /// it could not decode and dropped them (nw-335 corrupt-row tolerance).
+    ///
+    /// This module's contract is that an incomplete answer SAYS it is
+    /// incomplete — `Deadline` and `CandidateCap` exist for exactly that, and
+    /// nw-076 was this surface reporting a partial scan as definitive. A
+    /// tolerated corrupt row bypassed both: the corpus silently shrank and the
+    /// result still claimed `truncated: false`. "No matches" over a corpus with
+    /// unread rows is not a verified absence.
+    UndecodableRows,
     #[default]
     Unknown,
+}
+
+/// Pick the reason a caller can act on when two stages each reported one.
+///
+/// [`RegexTruncationReason::UndecodableRows`] describes the CORPUS, not the
+/// scan, so any genuine stop (deadline, cap, limit) outranks it — but it must
+/// survive when nothing else stopped, or a short corpus reports as complete.
+fn stronger_truncation(
+    first: Option<RegexTruncationReason>,
+    second: Option<RegexTruncationReason>,
+) -> Option<RegexTruncationReason> {
+    match (first, second) {
+        (Some(RegexTruncationReason::UndecodableRows), Some(other)) => Some(other),
+        (Some(first), _) => Some(first),
+        (None, second) => second,
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -784,11 +810,17 @@ impl GraphStore {
         };
 
         let mut out = Vec::new();
+        // Whether any whole-corpus scan below came back SHORT. The scans
+        // tolerate a row they cannot decode rather than losing the corpus
+        // (nw-335), so `Ok` no longer means "all of it" — and this function's
+        // entire job is to report an incomplete candidate set as incomplete.
+        let mut degraded = false;
 
         // Sections — body text is the richest source. We need the parent note's
         // file_path for the location, so build a note_uid -> path map once.
         if want_kind("Section") {
-            let notes = self.list_notes(None)?;
+            let (notes, integrity) = self.list_notes_with_integrity(None)?;
+            degraded |= integrity.is_degraded();
             if interrupted()? {
                 return Ok((out, Some(RegexTruncationReason::Deadline)));
             }
@@ -796,7 +828,9 @@ impl GraphStore {
                 .into_iter()
                 .map(|n| (n.uid, (n.file_path, n.vault_uid)))
                 .collect();
-            for s in self.list_all_sections()? {
+            let (sections, integrity) = self.list_all_sections_with_integrity()?;
+            degraded |= integrity.is_degraded();
+            for s in sections {
                 if interrupted()? {
                     return Ok((out, Some(RegexTruncationReason::Deadline)));
                 }
@@ -832,7 +866,9 @@ impl GraphStore {
 
         // Notes — index the title (the section body carries the rest).
         if want_kind("Note") {
-            for n in self.list_notes(None)? {
+            let (all_notes, integrity) = self.list_notes_with_integrity(None)?;
+            degraded |= integrity.is_degraded();
+            for n in all_notes {
                 if interrupted()? {
                     return Ok((out, Some(RegexTruncationReason::Deadline)));
                 }
@@ -863,7 +899,9 @@ impl GraphStore {
 
         // Frontmatter — the raw YAML, with a real file line offset.
         if want_kind("Frontmatter") {
-            for n in self.list_notes(None)? {
+            let (all_notes, integrity) = self.list_notes_with_integrity(None)?;
+            degraded |= integrity.is_degraded();
+            for n in all_notes {
                 if interrupted()? {
                     return Ok((out, Some(RegexTruncationReason::Deadline)));
                 }
@@ -899,7 +937,9 @@ impl GraphStore {
 
         // Symbols — signature text.
         if want_kind("Symbol") {
-            for sym in self.list_all_symbols()? {
+            let (symbols, integrity) = self.list_all_symbols_with_integrity()?;
+            degraded |= integrity.is_degraded();
+            for sym in symbols {
                 if interrupted()? {
                     return Ok((out, Some(RegexTruncationReason::Deadline)));
                 }
@@ -930,7 +970,12 @@ impl GraphStore {
 
         Ok((
             out,
-            interrupted()?.then_some(RegexTruncationReason::Deadline),
+            interrupted()?
+                .then_some(RegexTruncationReason::Deadline)
+                // A budget stop outranks a short corpus (it is the more
+                // specific reason the caller can act on), but a corpus that
+                // lost rows must never fall through as `None`.
+                .or_else(|| degraded.then_some(RegexTruncationReason::UndecodableRows)),
         ))
     }
 
@@ -964,6 +1009,9 @@ impl GraphStore {
             .collect();
         ordered.sort();
         let mut candidates = Vec::new();
+        // See `collect_candidates`: a scan that came back short must not leave
+        // the result claiming it was complete.
+        let mut degraded = false;
         for scope_uid in ordered {
             if interrupted()? {
                 return Ok((candidates, Some(RegexTruncationReason::Deadline)));
@@ -993,7 +1041,8 @@ impl GraphStore {
                     });
                 }
             }
-            let notes = self.list_notes(Some(&scope_uid))?;
+            let (notes, integrity) = self.list_notes_with_integrity(Some(&scope_uid))?;
+            degraded |= integrity.is_degraded();
             if interrupted()? {
                 return Ok((candidates, Some(RegexTruncationReason::Deadline)));
             }
@@ -1077,7 +1126,8 @@ impl GraphStore {
                 // is missing", so an edge traversal would silently drop those
                 // sections. Ownership lives on the property; scan once and filter by
                 // this scope's notes in memory.
-                let sections = self.list_all_sections()?;
+                let (sections, integrity) = self.list_all_sections_with_integrity()?;
+                degraded |= integrity.is_degraded();
                 for section in sections {
                     if interrupted()? {
                         return Ok((candidates, Some(RegexTruncationReason::Deadline)));
@@ -1117,7 +1167,9 @@ impl GraphStore {
         }
         Ok((
             candidates,
-            interrupted()?.then_some(RegexTruncationReason::Deadline),
+            interrupted()?
+                .then_some(RegexTruncationReason::Deadline)
+                .or_else(|| degraded.then_some(RegexTruncationReason::UndecodableRows)),
         ))
     }
 
@@ -1509,7 +1561,7 @@ impl GraphStore {
                             max_candidates: CANDIDATE_CAP,
                         },
                     )?;
-                    hydration_stop = fallback_stop.or(hydrated_stop);
+                    hydration_stop = stronger_truncation(fallback_stop, hydrated_stop);
                     let remaining = CANDIDATE_CAP.saturating_sub(candidates.len());
                     if hydrated.len() > remaining {
                         hydrated.truncate(remaining);
@@ -1544,6 +1596,17 @@ impl GraphStore {
         // ONLY when the scan actually stops early, so `truncated:true` with an
         // empty `results` now genuinely means "incomplete scan" rather than
         // "the match was ordered past a 5000 cap and never scanned" (nw-076).
+        // A short CORPUS is not a stopped SCAN, and the two must not share a
+        // channel. `hydration_stop` feeds `truncated`, and `truncated` breaks
+        // the verification loop below on its first iteration — so folding
+        // "some rows were undecodable" in here would make ONE unreadable row
+        // return zero results while reporting `truncated: true`, which is the
+        // nw-076 dishonesty in its worst form. Carry it alongside instead:
+        // scan everything that COULD be read, then say the corpus was short.
+        let corpus_degraded = hydration_stop == Some(RegexTruncationReason::UndecodableRows);
+        if corpus_degraded {
+            hydration_stop = None;
+        }
         let elapsed_deadline = elapsed_millis(start) >= deadline_ms;
         let mut truncated = planning_deadline || hydration_stop.is_some() || elapsed_deadline;
         let mut truncation_reason = if planning_deadline || elapsed_deadline {
@@ -1630,6 +1693,15 @@ impl GraphStore {
             }
         }
         let verification_ms = elapsed_millis(verification_started);
+
+        // The scan ran to completion over a corpus that was missing rows. The
+        // results are real, but "no more matches exist" is not established —
+        // so the result declares itself partial and names why. A stop that
+        // already happened is the more actionable reason and keeps its place.
+        if corpus_degraded && !truncated {
+            truncated = true;
+            truncation_reason = Some(RegexTruncationReason::UndecodableRows);
+        }
 
         // nw-097: attach the note at the source so no caller has to remember.
         Ok(RegexSearchResult {
@@ -2516,6 +2588,86 @@ mod tests {
             "must never return truncated:true with empty results on a scannable corpus"
         );
         assert!(!res.truncated, "small corpus scans fully, so not truncated");
+    }
+
+    /// nw-335's corrupt-row tolerance made the whole-corpus scans this module
+    /// builds its candidate set from come back SHORT without coming back
+    /// `Err`. This module's contract is that a partial answer says it is
+    /// partial — `Deadline` and `CandidateCap` exist for that, and nw-076 was
+    /// this surface reporting a partial scan as definitive — so a corpus that
+    /// lost rows must not be reported as `truncated: false`.
+    ///
+    /// The second half matters as much as the first: the disclosure must not
+    /// come at the cost of the results. `truncated` breaks the verification
+    /// loop, so routing the corpus signal through it would return ZERO matches
+    /// on one unreadable row.
+    #[test]
+    fn a_corpus_that_lost_rows_is_reported_partial_and_still_returns_its_matches() {
+        let store = store_with_text();
+        // The clean corpus answers definitively.
+        let clean = store
+            .regex_search("authenticateUser", None, None, None, None)
+            .unwrap();
+        assert!(!clean.results.is_empty(), "baseline must match");
+        assert!(
+            !clean.truncated && clean.truncation_reason.is_none(),
+            "a corpus read in full is NOT partial, or the signal is worthless: {clean:?}"
+        );
+
+        // Poison one unrelated section with a NUL. The store now skips it.
+        store
+            .insert_section(&Section {
+                uid: "sec:v:1:corrupt".to_string(),
+                note_uid: "note:v:1".to_string(),
+                heading_uid: None,
+                start_line: 20,
+                end_line: 21,
+                text_hash: "tc".to_string(),
+                text_content: "unrelated\u{0}poison".to_string(),
+                word_count: 2,
+                pagerank_score: None,
+            })
+            .unwrap();
+
+        let degraded = store
+            .regex_search("authenticateUser", None, None, None, None)
+            .unwrap();
+        assert!(
+            !degraded.results.is_empty(),
+            "one unreadable row must not cost every match — that is the \
+             nw-076 failure, not a fix for it: {degraded:?}"
+        );
+        assert!(
+            degraded.truncated,
+            "a scan over a corpus with unread rows has not established that \
+             no further matches exist: {degraded:?}"
+        );
+        assert_eq!(
+            degraded.truncation_reason,
+            Some(RegexTruncationReason::UndecodableRows),
+            "the caller is told WHICH kind of incompleteness this is: {degraded:?}"
+        );
+    }
+
+    /// A genuine stop is the reason a caller can act on; a short corpus must
+    /// still survive when nothing else stopped the scan.
+    #[test]
+    fn a_real_stop_outranks_a_short_corpus_but_a_short_corpus_outranks_nothing() {
+        use RegexTruncationReason::{CandidateCap, Deadline, UndecodableRows};
+        assert_eq!(
+            stronger_truncation(Some(UndecodableRows), Some(Deadline)),
+            Some(Deadline)
+        );
+        assert_eq!(
+            stronger_truncation(Some(CandidateCap), Some(UndecodableRows)),
+            Some(CandidateCap)
+        );
+        assert_eq!(
+            stronger_truncation(Some(UndecodableRows), None),
+            Some(UndecodableRows),
+            "nothing else stopped the scan, so the short corpus IS the reason"
+        );
+        assert_eq!(stronger_truncation(None, None), None);
     }
 
     /// An alternation is an OR, so the trigram pre-filter must union the

--- a/crates/nestweaver-store/src/tantivy_index.rs
+++ b/crates/nestweaver-store/src/tantivy_index.rs
@@ -1466,22 +1466,83 @@ fn reindex_backup_path(path: &Path) -> PathBuf {
     PathBuf::from(backup)
 }
 
+/// Where recovery locks live: ONE per-user root, never inside an index and
+/// never inside a publication slot.
+///
+/// nw-263. The lock used to live in the index directory's PARENT. That
+/// reasoning was locally correct — the migration renames `path` ->
+/// `path.reindexing`, so a lock inside `path` travels with the rename and stops
+/// excluding anything, which is also why Tantivy's own `INDEX_WRITER_LOCK`
+/// cannot be reused here — but the parent is the wrong parent in one
+/// configuration, and it is a configuration this product ships:
+///
+///   * the Tantivy sidecar is a SIBLING of the database file
+///     (`<db>.lbug` -> `<db>.lbug.tantivy`), and
+///   * with a publication `CURRENT` pointer the database is
+///     `<root>/slots/<uuid>/<name>.lbug`, so
+///   * the sidecar's parent is `<root>/slots/<uuid>` — the SLOT ROOT, and
+///   * `validate_slot_contents` refuses ANY file the slot manifest does not
+///     describe, with a `PermanentPublicationFailure` (retries refused too).
+///
+/// Tantivy never removes a lock file (`ReleaseLockFile::drop` only logs), so one
+/// interrupted schema migration left an undescribed file in a sealed slot and
+/// wedged rollback of that slot forever.
+///
+/// The lock's real requirement is only "a stable path both processes compute
+/// identically, that the rename does not move". The parent directory satisfied
+/// that accidentally, not necessarily. A per-user state root satisfies it
+/// deliberately.
+///
+/// `$XDG_STATE_HOME` is honoured on EVERY platform, mirroring
+/// `nestweaver-daemon::lifecycle`, so a test harness that redirects the state
+/// root gets this too. NOT `std::env::temp_dir()`: `$TMPDIR` differs between a
+/// launchd-spawned daemon and an interactive shell, so two processes would
+/// compute different roots and the lock would exclude nothing — the exact
+/// failure nw-254 exists to prevent.
+fn reindex_lock_root() -> PathBuf {
+    if let Some(xdg) = std::env::var_os("XDG_STATE_HOME").filter(|value| !value.is_empty()) {
+        return PathBuf::from(xdg).join("nestweaver").join("index-locks");
+    }
+    if let Some(home) = std::env::var_os("HOME").filter(|value| !value.is_empty()) {
+        return PathBuf::from(home)
+            .join(".local")
+            .join("state")
+            .join("nestweaver")
+            .join("index-locks");
+    }
+    // No HOME at all (a minimal container). A shared temp root is worse than a
+    // state root but better than a slot.
+    std::env::temp_dir().join("nestweaver-index-locks")
+}
+
 /// Name of the exclusive lock that serialises destructive index recovery
 /// against an in-flight schema migration.
 ///
-/// It deliberately lives in the index directory's **parent**. The migration
-/// renames the index directory itself (`path` -> `path.reindexing`), so a lock
-/// file stored inside `path` would travel with that rename and a second
-/// process would end up locking a different inode — which is precisely why
-/// Tantivy's `INDEX_WRITER_LOCK` cannot be reused here.
+/// Keyed by a digest of the index's ABSOLUTE path, so two indexes with the same
+/// directory name cannot collide inside the one shared lock root. The readable
+/// suffix is for the operator who finds the file; the digest is what makes it
+/// unique.
 fn reindex_lock_file_name(path: &Path) -> std::ffi::OsString {
-    let mut name = std::ffi::OsString::from(".");
+    let absolute = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
+    let digest = blake3::hash(absolute.as_os_str().as_encoded_bytes()).to_hex();
+    let mut name = std::ffi::OsString::from(&digest.as_str()[..32]);
+    name.push("-");
     name.push(
         path.file_name()
             .unwrap_or_else(|| std::ffi::OsStr::new("tantivy")),
     );
     name.push(".reindex.lock");
     name
+}
+
+/// The full path of the recovery lock for `index_path`.
+///
+/// Public so the PUBLICATION layer can assert the cross-crate property that
+/// nw-263 is about: this path must never be inside a slot. That composition
+/// spans two crates and no single reviewer saw both halves, which is how the
+/// defect was introduced.
+pub fn reindex_lock_path(index_path: &Path) -> PathBuf {
+    reindex_lock_root().join(reindex_lock_file_name(index_path))
 }
 
 /// Try to take the recovery lock for `path`.
@@ -1492,15 +1553,23 @@ fn reindex_lock_file_name(path: &Path) -> std::ffi::OsString {
 /// index-open path, and a daemon that died holding a blocking lock would
 /// otherwise wedge every subsequent opener.
 fn try_acquire_reindex_lock(path: &Path) -> Result<Option<DirectoryLock>, TantivyError> {
-    let parent = match path.parent() {
-        Some(parent) if !parent.as_os_str().is_empty() => parent,
-        _ => Path::new("."),
-    };
-    std::fs::create_dir_all(parent)?;
-    let directory = MmapDirectory::open(parent).map_err(|error| {
+    try_acquire_reindex_lock_in(&reindex_lock_root(), path)
+}
+
+/// The `_in` seam the repo already uses for sweeps and fallback roots
+/// (`gc_orphaned_daemon_dirs_in`, `NESTWEAVER_SOCK_FALLBACK_DIR`), so a test can
+/// assert PLACEMENT on a scratch root instead of the operator's state
+/// directory.
+fn try_acquire_reindex_lock_in(
+    root: &Path,
+    path: &Path,
+) -> Result<Option<DirectoryLock>, TantivyError> {
+    std::fs::create_dir_all(root)?;
+    let directory = MmapDirectory::open(root).map_err(|error| {
         TantivyError::Io(format!(
-            "open index parent {} for recovery lock: {error}",
-            parent.display()
+            "open recovery lock root {} for {}: {error}",
+            root.display(),
+            path.display()
         ))
     })?;
     let lock = Lock {
@@ -2514,6 +2583,164 @@ mod tests {
         );
         assert_eq!(legacy.search("payment", 10).unwrap().len(), 1);
         drop(held);
+    }
+
+    /// nw-263 + nw-255, one assertion. The lock must NOT be a sibling of the
+    /// index directory — that is the SLOT ROOT when the sidecar is
+    /// slot-resident, and `validate_slot_contents` refuses any undescribed file
+    /// there with a `PermanentPublicationFailure`, so one interrupted migration
+    /// wedged rollback of that slot forever. And it must not be in the CWD
+    /// either, which is what the `with false` mutation on the old
+    /// `!parent.as_os_str().is_empty()` guard produced.
+    ///
+    /// nw-255 is the reason this test exists at all: the two pre-existing lock
+    /// tests hold their lock IN-PROCESS under one working directory, so under
+    /// `with false` both the holder and the acquirer resolved `parent` to `.`,
+    /// locked the same file, and still saw "already in progress". They proved
+    /// the lock EXCLUDES; they proved nothing about where it IS. A daemon and a
+    /// CLI have different working directories, so that mutation is a silent,
+    /// total loss of mutual exclusion in a lock guarding a directory rename.
+    ///
+    /// This test CAN fail when the property is broken: point
+    /// `try_acquire_reindex_lock_in` at `index_path.parent()` and the first
+    /// assertion fires; point it at `Path::new(".")` and the second does.
+    #[test]
+    fn the_recovery_lock_is_placed_outside_the_index_and_outside_the_cwd() {
+        let root = tempdir().unwrap();
+        let lock_root = tempdir().unwrap();
+        let index_path = root.path().join("graph.lbug.tantivy");
+        std::fs::create_dir_all(&index_path).unwrap();
+
+        let held = try_acquire_reindex_lock_in(lock_root.path(), &index_path)
+            .unwrap()
+            .expect("lock free");
+
+        let siblings: Vec<String> = std::fs::read_dir(root.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains("reindex.lock"))
+            .collect();
+        assert!(
+            siblings.is_empty(),
+            "the lock landed beside the index; for a slot-resident sidecar that \
+             directory is a SEALED publication slot: {siblings:?}"
+        );
+
+        let inside: Vec<String> = std::fs::read_dir(&index_path)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains("reindex.lock"))
+            .collect();
+        assert!(
+            inside.is_empty(),
+            "a lock inside the index travels with the migration's rename and \
+             stops excluding anything: {inside:?}"
+        );
+
+        assert!(
+            !std::path::Path::new(".")
+                .join(reindex_lock_file_name(&index_path))
+                .exists(),
+            "the lock landed in the CWD — a daemon and a CLI with different \
+             working directories would lock different files and exclude nothing"
+        );
+
+        assert!(
+            lock_root
+                .path()
+                .join(reindex_lock_file_name(&index_path))
+                .exists(),
+            "the lock must exist SOMEWHERE; a test that only asserts absences \
+             passes when the lock is never taken"
+        );
+        drop(held);
+    }
+
+    /// The property the relocation has to preserve: it must still EXCLUDE, and
+    /// it must still be per-index. Two different indexes with the SAME
+    /// directory name now share one lock root, so a name collision there would
+    /// serialise unrelated migrations — or, worse, a digest that ignored the
+    /// path would make them the same lock.
+    #[test]
+    fn the_recovery_lock_still_excludes_and_two_indexes_do_not_collide() {
+        let lock_root = tempdir().unwrap();
+        let one = tempdir().unwrap();
+        let two = tempdir().unwrap();
+        let index_one = one.path().join("graph.lbug.tantivy");
+        let index_two = two.path().join("graph.lbug.tantivy");
+        std::fs::create_dir_all(&index_one).unwrap();
+        std::fs::create_dir_all(&index_two).unwrap();
+
+        assert_ne!(
+            reindex_lock_file_name(&index_one),
+            reindex_lock_file_name(&index_two),
+            "same directory name, different index: the lock must be keyed by \
+             the ABSOLUTE path or one migration blocks an unrelated one"
+        );
+
+        let held = try_acquire_reindex_lock_in(lock_root.path(), &index_one)
+            .unwrap()
+            .expect("lock free");
+        assert!(
+            try_acquire_reindex_lock_in(lock_root.path(), &index_one)
+                .unwrap()
+                .is_none(),
+            "the relocated lock must still exclude a second holder"
+        );
+        assert!(
+            try_acquire_reindex_lock_in(lock_root.path(), &index_two)
+                .unwrap()
+                .is_some(),
+            "an unrelated index must not be blocked by this lock"
+        );
+        drop(held);
+    }
+
+    /// nw-255's other surviving mutant. The old guard existed to handle
+    /// `Path::new("idx").parent() == Some("")`, which `MmapDirectory::open`
+    /// cannot use — and its fallback was `.`, the CWD. There is no guard to
+    /// mutate any more, and the CWD is no longer reachable: a bare relative
+    /// name resolves against the process CWD to a stable ABSOLUTE key, and the
+    /// lock file still lands in the lock root.
+    #[test]
+    fn a_bare_relative_index_name_still_takes_a_usable_lock_outside_the_cwd() {
+        assert_eq!(
+            std::path::Path::new("idx").parent().unwrap().as_os_str(),
+            ""
+        );
+        let lock_root = tempdir().unwrap();
+        let held = try_acquire_reindex_lock_in(lock_root.path(), std::path::Path::new("idx"))
+            .unwrap()
+            .expect("a bare relative name must still take a usable lock");
+        assert!(
+            !std::path::Path::new(".")
+                .join(reindex_lock_file_name(std::path::Path::new("idx")))
+                .exists(),
+            "a bare relative name must not put the lock in the CWD"
+        );
+        drop(held);
+    }
+
+    /// The default root, asserted as a PATH so no test writes to the operator's
+    /// state directory. It must never be the index's parent, which is the slot
+    /// root for a slot-resident sidecar.
+    #[test]
+    fn the_default_lock_root_is_never_the_directory_holding_the_index() {
+        let slot = std::path::Path::new("/publications/slots/abc-123");
+        let index_path = slot.join("brain.lbug.tantivy");
+        let lock = super::reindex_lock_path(&index_path);
+        assert!(
+            !lock.starts_with(slot),
+            "the recovery lock resolves inside the publication slot: {}",
+            lock.display()
+        );
+        assert!(
+            !lock.starts_with(&index_path),
+            "the recovery lock resolves inside the index it guards: {}",
+            lock.display()
+        );
     }
 
     /// Build an index at `index_path` whose schema predates the stored

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -6997,12 +6997,17 @@ impl GraphStore {
             }
         };
         if initial_state == InstanceUidRemapPlanState::Applied {
+            // An idempotent re-run of an already-applied plan. The graph needs
+            // nothing; the RECORD may still name the merged-away instance, and
+            // this is the only route that would otherwise never converge it.
+            let mut mutation_warnings = Vec::new();
+            self.converge_merged_instance_identity(from, to, &mut mutation_warnings);
             return Ok(MutationOutcome {
                 disposition: MutationDisposition::CommittedComplete,
                 confirmed_changed: true,
                 value: MergeResult::default(),
                 primary_failure: None,
-                mutation_warnings: Vec::new(),
+                mutation_warnings,
             });
         }
         let mut confirmed_changed = initial_state == InstanceUidRemapPlanState::PartiallyApplied;
@@ -7415,13 +7420,17 @@ impl GraphStore {
             self.verify_merge_plan(from, to, &remaining_plan, faults.verify)
         };
         match final_state {
-            Ok(InstanceUidRemapPlanState::Applied) => Ok(MutationOutcome {
-                disposition: MutationDisposition::CommittedComplete,
-                confirmed_changed,
-                value,
-                primary_failure: None,
-                mutation_warnings,
-            }),
+            Ok(InstanceUidRemapPlanState::Applied) => {
+                let mut mutation_warnings = mutation_warnings;
+                self.converge_merged_instance_identity(from, to, &mut mutation_warnings);
+                Ok(MutationOutcome {
+                    disposition: MutationDisposition::CommittedComplete,
+                    confirmed_changed,
+                    value,
+                    primary_failure: None,
+                    mutation_warnings,
+                })
+            }
             Ok(state) => self.classify_merge_error(
                 from,
                 to,
@@ -7445,6 +7454,48 @@ impl GraphStore {
                 )),
                 mutation_warnings,
             }),
+        }
+    }
+
+    /// nw-264. Converge the recorded identity on the surviving instance, at
+    /// every point a merge reports its plan fully `Applied`.
+    ///
+    /// Called from THREE places rather than one because a merge can reach
+    /// `Applied` three ways — an idempotent re-run of an already-applied plan,
+    /// the normal final probe, and a stage error whose probe nonetheless finds
+    /// the plan applied. A record that converged on only one of those routes
+    /// would be a fork that reappears depending on how the merge finished,
+    /// which is worse than one that never converges at all.
+    ///
+    /// A failure here is a WARNING, not a merge failure: the graph is already
+    /// correctly reparented, and turning a successful merge into an error
+    /// because a single Meta row would not move loses more than it protects.
+    /// `rerecord_data_instance_id` refuses unless the graph already shows the
+    /// merge complete, so the warning is the honest report of a record that is
+    /// now stale.
+    fn converge_merged_instance_identity(
+        &self,
+        from: &str,
+        to: &str,
+        mutation_warnings: &mut Vec<MutationFailure>,
+    ) {
+        match self.rerecord_data_instance_id(from, to) {
+            Ok(true) => {
+                tracing::info!(
+                    from = %from,
+                    to = %to,
+                    "merge moved the recorded data instance id to the surviving instance"
+                );
+            }
+            Ok(false) => {}
+            Err(error) => mutation_warnings.push(MutationFailure::new(
+                "merge-identity",
+                format!(
+                    "the graph was merged into {to:?} but the recorded data instance id \
+                     could not be moved off {from:?} ({error}); a config-less `index` \
+                     may re-adopt {from:?} and re-fork this graph"
+                ),
+            )),
         }
     }
 
@@ -7489,6 +7540,7 @@ impl GraphStore {
             }
             InstanceUidRemapPlanState::Applied => {
                 mutation_warnings.push(MutationFailure::new(stage, primary));
+                self.converge_merged_instance_identity(from, to, &mut mutation_warnings);
                 Ok(MutationOutcome {
                     disposition: MutationDisposition::CommittedComplete,
                     confirmed_changed: true,
@@ -9426,6 +9478,113 @@ mod tests {
             .merge_instance_ids("merge-coll-source", "merge-coll-target")
             .unwrap();
         assert_eq!(merged.vaults, 1);
+    }
+
+    /// nw-264 fixture: one vault under `instance`, which is enough for the
+    /// merge to have a non-empty plan and for `observed_instance_ids` to see it.
+    fn seed_vault(store: &GraphStore, instance: &str, root_path: &str) {
+        store
+            .insert_vault(&Vault {
+                uid: format!("vlt:{instance}:{}", root_path.replace('/', "-")),
+                name: root_path.to_string(),
+                root_path: root_path.to_string(),
+                instance_id: instance.to_string(),
+            })
+            .unwrap();
+    }
+
+    /// nw-264. The guard nw-246 ships tells the operator to run `instance
+    /// merge`. If the merge leaves the recorded identity naming the instance it
+    /// just merged AWAY, the next config-less `index` adopts that name and
+    /// re-forks the graph the merge healed — so the remedy the product prints
+    /// undoes itself. nw-310's shipped remedy string carried a hedge saying
+    /// exactly this.
+    #[test]
+    fn a_merge_moves_the_recorded_identity_to_the_surviving_instance() {
+        let store = GraphStore::in_memory().expect("store");
+        assert_eq!(store.ensure_data_instance_id("old").unwrap(), "old");
+        seed_vault(&store, "old", "/repo-a");
+        seed_vault(&store, "new", "/repo-b");
+
+        store.merge_instance_ids("old", "new").unwrap();
+
+        assert_eq!(
+            store.observed_instance_ids().unwrap(),
+            vec!["new".to_string()],
+            "precondition: the merge itself reparented every row"
+        );
+        assert_eq!(
+            store.data_instance_id().unwrap(),
+            Some("new".to_string()),
+            "the record still names the instance the merge removed; a \
+             config-less `index` will adopt it and re-fork the graph"
+        );
+    }
+
+    /// The guard that keeps the fix narrow. A merge between two instances,
+    /// NEITHER of which is the recorded one, must leave the record untouched —
+    /// the write-once discipline of `ensure_data_instance_id` still applies to
+    /// everything except the merged-away name.
+    #[test]
+    fn a_merge_that_does_not_involve_the_recorded_instance_leaves_it_alone() {
+        let store = GraphStore::in_memory().expect("store");
+        store.ensure_data_instance_id("keeper").unwrap();
+        seed_vault(&store, "a", "/repo-a");
+        seed_vault(&store, "b", "/repo-b");
+
+        store.merge_instance_ids("a", "b").unwrap();
+
+        assert_eq!(
+            store.data_instance_id().unwrap(),
+            Some("keeper".to_string())
+        );
+    }
+
+    /// Re-running an already-applied merge must converge the record too. This
+    /// is the route that returns before any graph mutation, and it is the one a
+    /// retry after a partial failure actually takes.
+    #[test]
+    fn re_running_an_applied_merge_still_converges_the_record() {
+        let store = GraphStore::in_memory().expect("store");
+        store.ensure_data_instance_id("old").unwrap();
+        seed_vault(&store, "old", "/repo-a");
+        seed_vault(&store, "new", "/repo-b");
+
+        store.merge_instance_ids("old", "new").unwrap();
+        // A second, no-op merge must be idempotent in BOTH the graph and the
+        // record.
+        store.merge_instance_ids("old", "new").unwrap();
+
+        assert_eq!(store.data_instance_id().unwrap(), Some("new".to_string()));
+    }
+
+    /// The record must never claim a completion the graph does not show. Called
+    /// directly, because reaching a half-merged graph through the public merge
+    /// API is exactly what the merge's own classification prevents.
+    #[test]
+    fn the_record_refuses_to_move_while_rows_remain_under_the_source() {
+        let store = GraphStore::in_memory().expect("store");
+        store.ensure_data_instance_id("old").unwrap();
+        seed_vault(&store, "old", "/repo-a");
+
+        let error = store
+            .rerecord_data_instance_id("old", "new")
+            .expect_err("a graph still showing `old` must not be re-recorded as `new`");
+        assert!(
+            error.to_string().contains("merge is not complete"),
+            "the refusal must say why: {error}"
+        );
+        assert_eq!(store.data_instance_id().unwrap(), Some("old".to_string()));
+    }
+
+    /// An empty target is refused for the same reason `ensure_data_instance_id`
+    /// refuses one: an unnamed instance is not an identity.
+    #[test]
+    fn the_record_refuses_an_empty_surviving_instance() {
+        let store = GraphStore::in_memory().expect("store");
+        store.ensure_data_instance_id("old").unwrap();
+        assert!(store.rerecord_data_instance_id("old", "   ").is_err());
+        assert_eq!(store.data_instance_id().unwrap(), Some("old".to_string()));
     }
 
     #[test]

--- a/queries/cpp.scm
+++ b/queries/cpp.scm
@@ -2,17 +2,46 @@
 ; Based on the official tree-sitter-cpp tags.scm with additions for
 ; reference extraction (calls, includes).
 
+; Function and method DEFINITIONS are anchored on `function_definition`, not on
+; `function_declarator`. The declarator is the signature WITHOUT the body, so
+; anchoring the capture there recorded `end_line == start_line` for every C++
+; function in the corpus — `setup` in testdata/cpp/simple.cpp read as 31-31
+; when it spans 31-36. `queries/c.scm` has always anchored on
+; `function_definition` and was always correct; this is that one-node diff.
+;
+; A zero-height function span is not cosmetic: `read-symbols` returns the
+; signature alone, and `find_enclosing_symbol` cannot place a call inside the
+; function containing it, so every call in a body was attributed to the nearest
+; preceding one-line symbol instead.
+
 ; Free function definitions
-(function_declarator
-  declarator: (identifier) @name) @definition.function
+(function_definition
+  declarator: (function_declarator
+    declarator: (identifier) @name)) @definition.function
 
 ; Method definitions via qualified identifier (e.g. Foo::bar)
-(function_declarator
-  declarator: (qualified_identifier
-    name: (identifier) @name)) @definition.method
+(function_definition
+  declarator: (function_declarator
+    declarator: (qualified_identifier
+      name: (identifier) @name))) @definition.method
 
-(function_declarator
-  declarator: (field_identifier) @name) @definition.method
+; Inline method definitions inside a class body
+(function_definition
+  declarator: (function_declarator
+    declarator: (field_identifier) @name)) @definition.method
+
+; DECLARATIONS with no body — a class's declared interface, and the prototypes
+; that make up a header. These are genuinely one line, so they keep the
+; declarator anchor. They are matched on their enclosing declaration node
+; rather than on `function_declarator` alone so a definition can never match
+; both a definition rule and a declaration rule and mint two symbols.
+(field_declaration
+  declarator: (function_declarator
+    declarator: (field_identifier) @name)) @definition.method
+
+(declaration
+  declarator: (function_declarator
+    declarator: (identifier) @name)) @definition.function
 
 ; Class definitions
 (class_specifier

--- a/queries/dart.scm
+++ b/queries/dart.scm
@@ -15,8 +15,26 @@
   signature: (function_signature
     name: (identifier) @name)) @definition.function
 
-; Method declarations (inside class body)
-(method_signature
+; Method DEFINITIONS (inside a class body).
+;
+; Anchored on `method_declaration`, not on `method_signature`. The signature is
+; the method WITHOUT its body, so anchoring there recorded
+; `end_line == start_line` for every Dart method — `greet` in
+; testdata/dart/simple.dart read as 16-16 when it spans 16-19. The top-level
+; `function_declaration` rule above was already anchored on the declaration and
+; was always correct, which is what made the inconsistency invisible: `main` had
+; a real span and every method in the same file did not.
+(method_declaration
+  signature: (method_signature
+    (function_signature
+      name: (identifier) @name))) @definition.method
+
+; ABSTRACT method declarations — no body, so genuinely one line. In an abstract
+; class or an interface these are a `class_member > declaration` wrapping a bare
+; `function_signature`, which no `method_signature` rule could ever match, so
+; `Greeter.greet` in testdata/dart/simple.dart was extracted as NOTHING. The
+; same split as C++: definitions carry a body span, declarations do not.
+(declaration
   (function_signature
     name: (identifier) @name)) @definition.method
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24112,7 +24112,7 @@ mod cli_help_contract_tests {
         // this equality is what then forces it into the inventory too.
         assert_eq!(
             inventory.len(),
-            9,
+            10,
             "a `CliDiagnostic` variant was added or removed without \
              classifying it here"
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -844,6 +844,13 @@ const ENV_REGISTRY: &[EnvVar] = &[
         name: "NESTWEAVER_DB",
         role: EnvRole::Configures,
     },
+    // nw-261. Pins miette's wrap column so a test harness can make wrap
+    // position a controlled input instead of an ambient one. Unset is today's
+    // behaviour (terminal detection), so it is a tuning knob, not a gate.
+    EnvVar {
+        name: "NESTWEAVER_DIAGNOSTIC_WIDTH",
+        role: EnvRole::Configures,
+    },
     EnvVar {
         name: "NESTWEAVER_DRAIN_TIMEOUT_SECS",
         role: EnvRole::Configures,
@@ -9647,11 +9654,41 @@ fn daemon_status_error(status: tonic::Status) -> anyhow::Error {
     anyhow::anyhow!("{}", status.message())
 }
 
+/// The render width miette wraps diagnostics at, when it is pinned.
+///
+/// nw-261. miette hard-wraps its message body and prefixes continuations with
+/// `│`, so a phrase the code emits contiguously — "the daemon has not been shut
+/// down" — can reach a test as "shut\n  │ down". A `stderr.contains(...)`
+/// assertion then fails for a RENDERING reason while the message is exactly
+/// right, which reads as a product bug and is not one. It fired once on CI
+/// (`flatten_diagnostic_recovers_a_phrase_miette_wrapped`) and the audit found
+/// five more assertions with the same exposure.
+///
+/// Flattening the assertion is the local fix and it only protects the
+/// assertions someone remembered to flatten. Pinning the width removes wrap
+/// position as an AMBIENT input to the whole suite — including for assertions
+/// nobody has audited — and, just as importantly, makes the property testable:
+/// a test can now force a narrow render and prove that flattening recovers the
+/// phrase, which was previously impossible to reproduce on demand.
+///
+/// Unset means today's behaviour exactly (miette detects the terminal width),
+/// so this changes nothing for a user.
+fn diagnostic_width() -> Option<usize> {
+    std::env::var("NESTWEAVER_DIAGNOSTIC_WIDTH")
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|width| *width > 0)
+}
+
 fn main() {
     // Install miette as the global error/panic report handler for rich
     // diagnostics (colours, help text, error codes) on supported terminals.
     miette::set_hook(Box::new(|_| {
-        Box::new(miette::MietteHandlerOpts::new().build())
+        let mut opts = miette::MietteHandlerOpts::new();
+        if let Some(width) = diagnostic_width() {
+            opts = opts.width(width);
+        }
+        Box::new(opts.build())
     }))
     .ok();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -418,6 +418,50 @@ enum CliDiagnostic {
     )]
     DatabaseCorrupt { path: String, cause: String },
 
+    /// nw-332. The write-ahead log cannot be READ. Deliberately its own
+    /// diagnostic, sitting between `db_wal_unreplayed` (the log is fine, a
+    /// replay is owed) and `db_corrupt` (the database file itself is damaged),
+    /// because before this the one condition reached the operator through
+    /// THREE code paths that gave three different, mutually contradictory
+    /// answers — and two of them made recovery HARDER:
+    ///
+    ///   * the CLI read funnel said `nestweaver daemon --db <p> start`, which
+    ///     against this state IS the crash-restart loop;
+    ///   * `db_corrupt` said "delete this database and re-index", for a state
+    ///     where moving five sidecars aside restored 1125 notes, 43 repos and
+    ///     189519 vectors — and per nw-289 its other branch, `backup restore
+    ///     <archive>`, may name an archive that does not exist because `backup
+    ///     save` was failing 100%;
+    ///   * `repair` said "another process holds the write lock", naming a
+    ///     process that does not exist.
+    ///
+    /// It MUST NOT inherit `db_corrupt`'s "delete this database" clause. The
+    /// database file was intact in the incident this comes from; the log was
+    /// not.
+    ///
+    /// The last release made this path WORSE, and that is worth stating:
+    /// `1e4de638` added `lower.contains("corrupted wal")` to the `db_corrupt`
+    /// classifier — from the commit whose entire purpose was making corruption
+    /// remedies accurate — routing a recoverable WAL state to a destructive
+    /// remedy.
+    #[error("Database write-ahead log is unreadable: {path}")]
+    #[diagnostic(
+        code(nestweaver::db_wal_corrupt),
+        help(
+            "{cause}\nThe database FILE may well be intact; its write-ahead log \
+             is not, and no read-only or read-write open can replay a log whose \
+             records do not parse.\n\
+             Do NOT start or restart the daemon against this state — a writer \
+             that crashes on open is what produces the crash-restart loop.\n\
+             {runbook}"
+        )
+    )]
+    DatabaseWalCorrupt {
+        path: String,
+        cause: String,
+        runbook: String,
+    },
+
     /// nw-285. A zero-length `.lbug`, or one that was created but never
     /// indexed. `require_openable_db` passes a zero-byte file on purpose (it
     /// is what the store itself initialises), and a read-only open does not
@@ -554,12 +598,118 @@ fn extract_db_path(message: &str) -> String {
         .unwrap_or_else(|| default_db_path().display().to_string())
 }
 
+/// THE recovery runbook for an unreadable write-ahead log. ONE definition,
+/// rendered by ONE diagnostic, reached by every path that can detect the
+/// condition.
+///
+/// nw-332 / nw-333. Before this, three independent sites each answered this
+/// condition from a different substring of a different message and landed on
+/// three different remedies, two of which made recovery harder. The remedy
+/// below is the one that was VERIFIED to work in the 2026-07-30 incident: five
+/// artifacts moved aside, reopen, full re-index.
+///
+/// Every clause is load-bearing:
+///
+///   * MOVE, never delete. A `.wal` can hold committed work, so destroying it
+///     to fix an outage trades one data-loss story for another. This is the
+///     same discipline `quarantine_orphaned_wal` already applies in the store.
+///   * ALL FIVE. The incident report first listed four and the reopen failed
+///     IDENTICALLY until the fifth moved (lbug-009). A partial list is
+///     indistinguishable from no list.
+///   * The re-index is REQUIRED, not advisory, and no message in this codebase
+///     said so before. Measured on 2026-08-28: raw `[[wikilink]]` occurrences in
+///     the vault grew 2183 -> 2394 while graph Wikilinks FELL 1838 -> 1791 and
+///     stayed there. Occurrences up, edges down — a real edge deficit, and
+///     nothing in `brain status` discloses it.
+///
+/// This is deliberately a runbook and NOT an automated recovery. The signature
+/// is not yet characterised well enough to act on: `quarantine_orphaned_wal`
+/// fires only on an exactly-diagnosable shape (`.wal` present, `.shadow`
+/// absent) which this state does NOT match — `.shadow` was present — and a full
+/// re-index is not something `repair` can perform. Print it; do not run it.
+fn wal_corruption_runbook(db: &str) -> String {
+    format!(
+        "Recover it in this order:\n  \
+         1. Stop everything that opens this database (daemon, watcher, UI).\n  \
+         2. MOVE ASIDE — do not delete — all five of these that exist:\n       \
+         {db}.wal\n       {db}.wal.checkpoint\n       {db}.shadow\n       \
+         {db}.checkpoint.apply.lock\n       {db}.checkpoint.intent.lock\n  \
+         3. Reopen the database. If it opens, the un-checkpointed tail of the \
+         log is lost; the graph already committed is not.\n  \
+         4. Run a full re-index. REQUIRED, not optional: derived edges for \
+         unchanged files are not rebuilt by the watcher, and nothing in \
+         `brain status` discloses the deficit.\n\
+         Moving only some of the five fails identically to moving none."
+    )
+}
+
+/// nw-346. ONE place turns a [`nestweaver_store::CorruptionKind`] into the
+/// diagnostic the operator sees.
+///
+/// Both routes into `into_diagnostic` — the typed one and the prose fallback —
+/// come through here, so they cannot disagree about what a given kind means.
+/// That divergence, across three call sites, is nw-332.
+fn corruption_diagnostic(
+    kind: nestweaver_store::CorruptionKind,
+    path: String,
+    message: String,
+) -> miette::Report {
+    use nestweaver_store::CorruptionKind;
+    match kind {
+        // The log is readable and merely owed a replay, which a read-only open
+        // cannot perform. Not a damaged file.
+        CorruptionKind::WalUnreplayed => CliDiagnostic::DatabaseWalUnreplayed {
+            wal: format!("{path}.wal"),
+            path,
+            cause: message,
+        }
+        .into(),
+        // nw-332. Its OWN diagnostic. Sending this to `db_corrupt` is what
+        // told an operator to delete a database a five-file `mv` restored.
+        CorruptionKind::WalUnreadable => CliDiagnostic::DatabaseWalCorrupt {
+            runbook: wal_corruption_runbook(&path),
+            path,
+            cause: drop_engine_retry_advice(&message),
+        }
+        .into(),
+        CorruptionKind::FileTruncated
+        | CorruptionKind::EngineAssertion
+        | CorruptionKind::Unclassified => CliDiagnostic::DatabaseCorrupt {
+            path,
+            cause: drop_engine_retry_advice(&message),
+        }
+        .into(),
+    }
+}
+
 /// Inspect an `anyhow::Error` and, when it matches a known pattern, convert it
 /// into a `miette::Report` with rich diagnostic information (help text, error
 /// code). Falls back to a plain `miette::Report` for unrecognised errors.
 fn into_diagnostic(err: anyhow::Error) -> miette::Report {
+    // nw-346. Ask the TYPE before asking the prose. `StoreError::Corruption`
+    // is classified once, at the FFI boundary, so an error that reached here
+    // with its source chain intact already knows what it is. The text arms
+    // below remain for errors that arrive from OUTSIDE the store — relayed
+    // over gRPC as a string, or synthesised by a CLI layer — where no type
+    // survived to consult.
+    let typed = err
+        .chain()
+        .find_map(|source| source.downcast_ref::<nestweaver_store::StoreError>())
+        .and_then(|store_error| {
+            store_error
+                .corruption_kind()
+                .map(|kind| (kind, store_error.corruption_path().map(Path::to_path_buf)))
+        });
+
     let message = redact_build_paths(&format!("{err:#}"));
     let lower = message.to_lowercase();
+
+    if let Some((kind, typed_path)) = typed {
+        let path = typed_path
+            .map(|p| redact_build_paths(&p.display().to_string()))
+            .unwrap_or_else(|| extract_db_path(&message));
+        return corruption_diagnostic(kind, path, message);
+    }
 
     // nw-285. Corruption must be classified BEFORE the WAL and not-found arms,
     // because a corrupt file produces text those arms recognise while their
@@ -580,22 +730,20 @@ fn into_diagnostic(err: anyhow::Error) -> miette::Report {
     // 3. `basic_string`. A bare C++ exception `what()` with no sentence in it,
     //    produced by a different corruption offset.
     //
-    // Matched on the storage engine's phrasing rather than on a `StoreError`
-    // variant because there is no variant for it: `From<lbug::Error>` collapses
-    // every engine failure into `StoreError::Database(String)`. That is the
-    // deeper fix and it is a store-crate change, noted here so the next reader
-    // knows this arm is the workaround and not the design.
-    let engine_corruption = lower.contains("outside the database file")
-        || lower.contains("assertion failed in file")
-        || lower.contains("database error: basic_string")
-        || lower.contains("corrupted wal");
-    if engine_corruption {
+    // nw-346. These phrases NO LONGER LIVE HERE. They moved verbatim into
+    // `nestweaver_store::classify_engine_corruption`, the single classifier,
+    // so an engine wording change is a one-file edit instead of a silent
+    // reclassification in whichever of seven call sites happened to miss it.
+    // The comment this replaces called itself the workaround; the workaround is
+    // gone.
+    //
+    // `WalUnreplayed` deliberately falls THROUGH to the WAL arm below, which
+    // has always owned that condition and extracts its path differently.
+    if let Some(kind) = nestweaver_store::classify_engine_corruption(&message)
+        && kind != nestweaver_store::CorruptionKind::WalUnreplayed
+    {
         let path = extract_db_path(&message);
-        return CliDiagnostic::DatabaseCorrupt {
-            path,
-            cause: drop_engine_retry_advice(&message),
-        }
-        .into();
+        return corruption_diagnostic(kind, path, message);
     }
 
     // nw-285. A zero-length `.lbug` passes `require_openable_db` by design, and
@@ -7014,36 +7162,61 @@ fn maybe_run_auto_setup(db_path: &Path, repo_root: &Path, out: &OutputConfig, fo
 ///
 /// The two matched substrings are also NOT the same condition, and were being
 /// given one answer. `Could not set lock` is live contention — stopping the
-/// daemon resolves it. `Corrupted wal` is a non-replayable write-ahead log,
-/// which a READ-ONLY open can never replay however many times it is retried
-/// (the same nw-126 hazard the `db_wal_unreplayed` diagnostic documents), so
-/// the only way through is a read-write open, i.e. the daemon.
+/// daemon resolves it. `Corrupted wal` is something else again, and this
+/// function used to get it exactly backwards.
+///
+/// nw-332. The `Corrupted wal` arm used to say *"Let this command route through
+/// the daemon, which holds the database read-write: `nestweaver daemon --db <p>
+/// start`."* That reasoning is right for an UNREPLAYED log and wrong for an
+/// UNREADABLE one — and `Corrupted wal` selects the unreadable case
+/// specifically. Starting a writer against a log whose records do not parse is
+/// the crash-restart loop, verbatim.
+///
+/// It had a second, subtler cost. `anyhow::anyhow!` with a plain message
+/// attaches NO source, so the engine's own text was destroyed right here — at
+/// the one site that had correctly identified the condition. `into_diagnostic`
+/// then saw only this paraphrase, which contains "replay" and "read-only", and
+/// classified it as `db_wal_unreplayed`. The typed error is now attached as the
+/// anyhow SOURCE so every layer above classifies on facts instead of on this
+/// function's prose.
+///
+/// The runbook itself is deliberately NOT repeated here: it is rendered once,
+/// by `db_wal_corrupt`'s help, which this error now reaches. One condition, one
+/// remedy, one definition.
 ///
 /// Extracted from a closure so the message is testable at all; see
 /// `no_daemon_refusal_never_prescribes_the_flag_already_passed`.
-fn daemon_held_store_error(path: &Path, upstream: &str) -> anyhow::Error {
-    if upstream.contains("Corrupted wal") {
-        anyhow::anyhow!(
-            "The database at {} has write-ahead log state that a read-only open \
-             cannot replay.\n\
-             Replay needs read-write access, which is why opening it directly \
-             cannot succeed here however often it is retried.\n\
-             Let this command route through the daemon, which holds the \
-             database read-write: `nestweaver daemon --db {} start`.",
-            path.display(),
-            path.display()
-        )
-    } else if upstream.contains("Could not set lock") {
-        anyhow::anyhow!(
+fn daemon_held_store_error(path: &Path, upstream: nestweaver_store::StoreError) -> anyhow::Error {
+    // nw-346: the phrase test moved into the store's single classifier, and the
+    // typed error is preserved rather than paraphrased away.
+    //
+    // Name the database ON THE ERROR rather than leaving `into_diagnostic` to
+    // recover it from prose. `extract_db_path` splits this function's own
+    // sentence on "database at " and then on ":", so a message that does not
+    // happen to put a colon after the path yields the rest of the sentence as
+    // the filename — and that filename is then interpolated into a recovery
+    // runbook. `with_db_path` only fills an EMPTY slot, so the store's own
+    // attribution (attached at the open funnel, closer to the failure) still
+    // wins when it is present.
+    let upstream = upstream.with_db_path(path);
+    if upstream.corruption_kind() == Some(nestweaver_store::CorruptionKind::WalUnreadable) {
+        let path = path.display().to_string();
+        return anyhow::Error::new(upstream).context(format!(
+            "The write-ahead log of the database at {path} cannot be READ, so no \
+             open can replay it — read-only or read-write, however often it is \
+             retried. Do not start or restart the daemon against this state."
+        ));
+    }
+    if upstream.is_lock_contention() {
+        return anyhow::Error::new(upstream).context(format!(
             "The NestWeaver daemon holds the write lock on the database at {}.\n\
              Either let this command route through the daemon, or stop the \
              daemon first: `nestweaver daemon --db {} stop`.",
             path.display(),
             path.display()
-        )
-    } else {
-        anyhow::anyhow!("failed to open database at {}: {upstream}", path.display())
+        ));
     }
+    anyhow::Error::new(upstream).context(format!("failed to open database at {}", path.display()))
 }
 
 fn open_store(db: Option<&Path>) -> anyhow::Result<GraphStore> {
@@ -7074,8 +7247,7 @@ fn open_store(db: Option<&Path>) -> anyhow::Result<GraphStore> {
     // cannot tell the operator WHICH database is broken — and with several
     // scratch databases open that is the only fact that matters.
     record_opened_db_path(path);
-    let store = GraphStore::open_read_only(path)
-        .map_err(|e| daemon_held_store_error(path, &e.to_string()))?;
+    let store = GraphStore::open_read_only(path).map_err(|e| daemon_held_store_error(path, e))?;
 
     // nw-029: load the PageRank sidecar from the canonical path. Every writer
     // and `migrate_sidecar` produce `<db>.lbug.pagerank.json` via
@@ -9157,6 +9329,58 @@ fn repair_outcome_name(
 /// `rm <db>.index-dirty`, discoverable only by reading the source — and an `rm`
 /// is the *wrong* repair, because it makes sidecars that predate the committed
 /// graph authoritative again.
+/// nw-333. Say what actually went wrong when `repair` cannot open the database
+/// read-write.
+///
+/// The arm this replaces bound `Err(error)`, interpolated it into a
+/// parenthetical, and then ignored it — attributing EVERY open failure to lock
+/// contention. Its own comment said "almost always"; the code said always. A
+/// corrupt WAL, a truncated file, a missing parent directory and a genuine
+/// `flock` conflict all produced the same sentence, and that sentence prescribed
+/// a daemon restart. Against a damaged database, restarting the daemon is what
+/// produces the crash-restart loop: of the whole error-remedy class this
+/// release, it is the first where following the advice was worse than ignoring
+/// it. The message *stated* the cause in its own parenthetical and prescribed a
+/// remedy for a different cause in the next clause.
+///
+/// The chicken-and-egg nw-333 names is real but narrower than it looks.
+/// `repair`'s subject is the publication MARKER, a sidecar file; it needs
+/// read-write on the database only to reconcile graph state against sidecars. So
+/// the three answers below are genuinely separable, and the classification comes
+/// from nw-346's variant rather than from a fifth substring match.
+fn repair_open_failure(db_path: &Path, error: nestweaver_store::StoreError) -> anyhow::Error {
+    // Name the database on the error; see `daemon_held_store_error` for why
+    // leaving it to prose extraction put the WRONG database in the runbook.
+    let error = error.with_db_path(db_path);
+    if error.corruption_kind().is_some() {
+        // The database itself is damaged. `repair` cannot and must not touch
+        // it. The publication marker is the lesser problem, and saying so is
+        // the point — the operator came here for the marker.
+        return anyhow::Error::new(error).context(format!(
+            "cannot repair the index publication for {}: the database itself \
+             could not be opened. The publication marker is the lesser problem \
+             and `repair` will not touch a damaged database.",
+            db_path.display()
+        ));
+    }
+    if error.is_lock_contention() {
+        // Correct here, and ONLY here.
+        return anyhow::Error::new(error).context(format!(
+            "could not open {} read-write. Another process holds the write lock; \
+             if that is the daemon, restart it (`nestweaver daemon --db {} stop` \
+             then start) and it will reconcile the publication itself.",
+            db_path.display(),
+            db_path.display()
+        ));
+    }
+    // Anything else: report it verbatim with NO attribution. A wrong guess is
+    // worse than no guess, which is the whole finding.
+    anyhow::Error::new(error).context(format!(
+        "could not open {} read-write, so the index publication was not repaired.",
+        db_path.display()
+    ))
+}
+
 fn run_repair_index_publication(
     db_path: &std::path::Path,
     json: bool,
@@ -9167,7 +9391,7 @@ fn run_repair_index_publication(
 
     let status = pubstat::status(db_path);
     let mut outcome: Option<nestweaver_engine::index::IndexPublicationRecovery> = None;
-    let mut open_error: Option<String> = None;
+    let mut open_error: Option<anyhow::Error> = None;
 
     if status.dirty && !dry_run {
         match nestweaver_store::GraphStore::open(db_path) {
@@ -9178,18 +9402,7 @@ fn run_repair_index_publication(
                     nestweaver_engine::index::recover_abandoned_index_publication(&store, true)?
                 });
             }
-            Err(error) => {
-                // The write lock is held — almost always by a running daemon,
-                // which is itself a writer and reconciles at startup. Say so
-                // instead of emitting a raw store error.
-                open_error = Some(format!(
-                    "could not open {} read-write ({error}). Another process holds the write \
-                     lock; if that is the daemon, restart it (`nestweaver daemon --db {} stop` \
-                     then start) and it will reconcile the publication itself.",
-                    db_path.display(),
-                    db_path.display()
-                ));
-            }
+            Err(error) => open_error = Some(repair_open_failure(db_path, error)),
         }
     }
 
@@ -9221,7 +9434,7 @@ fn run_repair_index_publication(
             "recovered": recovered,
             "outcome": outcome.as_ref().map(repair_outcome_name),
             "message": outcome.as_ref().map(|o| o.describe()),
-            "error": open_error,
+            "error": open_error.as_ref().map(|error| format!("{error:#}")),
         });
         println!("{}", serde_json::to_string_pretty(&payload)?);
         return Ok(exit);
@@ -9258,8 +9471,14 @@ fn run_repair_index_publication(
         return Ok(exit);
     }
     if let Some(error) = open_error {
-        eprintln!("Error: {error}");
-        return Ok(EXIT_ERROR);
+        // nw-333 (fourth defect). This used to be a bare `eprintln!`, so the
+        // message never became a `CliDiagnostic` and never passed through
+        // `into_diagnostic` — which means
+        // `no_permanent_diagnostic_advises_waiting_it_out`, the exhaustive
+        // inventory built for exactly this class of remedy, was STRUCTURALLY
+        // BLIND to it. Returning the error puts it on the one funnel every
+        // other CLI failure uses, so it is classified, redacted and covered.
+        return Err(error);
     }
     if let Some(outcome) = outcome {
         println!("{}", outcome.describe());
@@ -24265,6 +24484,17 @@ mod cli_help_contract_tests {
                 },
                 Clears::Never,
             ),
+            // nw-332. An unreadable write-ahead log is deterministic: no
+            // amount of waiting makes its records parse, and starting a
+            // writer against it is the crash-restart loop.
+            (
+                CliDiagnostic::DatabaseWalCorrupt {
+                    path: sample("d"),
+                    cause: sample("c"),
+                    runbook: wal_corruption_runbook("d"),
+                },
+                Clears::Never,
+            ),
             (
                 CliDiagnostic::DatabaseNoSchema {
                     path: sample("d"),
@@ -24292,6 +24522,7 @@ mod cli_help_contract_tests {
                 CliDiagnostic::DatabaseUnavailable { .. } => "db_unavailable",
                 CliDiagnostic::DatabaseWalUnreplayed { .. } => "db_wal_unreplayed",
                 CliDiagnostic::DatabaseCorrupt { .. } => "db_corrupt",
+                CliDiagnostic::DatabaseWalCorrupt { .. } => "db_wal_corrupt",
                 CliDiagnostic::DatabaseNoSchema { .. } => "db_no_schema",
                 CliDiagnostic::General { .. } => "error",
             }
@@ -24420,6 +24651,202 @@ lbug-0.19.1/lbug-src/src/storage/table/column.cpp\" on line 289: \
         );
     }
 
+    /// nw-332. The production WAL corruption reached the operator through
+    /// THREE independent paths that DISAGREED, and two of the three made
+    /// recovery harder. Each is pinned here on the engine's message
+    /// character-for-character, so none of them needs the crash that produced
+    /// it (lbug-001, which nobody can reproduce).
+    ///
+    /// The engine fault is upstream and is NOT NestWeaver's to fix. This is the
+    /// NestWeaver half: detect, report honestly, and give ONE recovery runbook.
+    #[test]
+    fn a_corrupt_wal_gets_one_remedy_and_it_is_the_one_that_worked() {
+        const ENGINE: &str = "Corrupted wal file. Read out invalid WAL record type.";
+
+        // (a) The CLI read funnel must not send the operator into the
+        //     crash-restart loop — and it must not destroy the engine's words
+        //     on the way, which is what made the diagnostic below misclassify.
+        let funnel = daemon_held_store_error(
+            std::path::Path::new("/tmp/x.lbug"),
+            nestweaver_store::StoreError::from_engine_message(ENGINE),
+        );
+        let funnel_text = format!("{funnel:#}");
+        assert!(
+            !funnel_text.contains("daemon --db /tmp/x.lbug start"),
+            "starting the daemon against a corrupt WAL IS the crash-restart \
+             loop:\n{funnel_text}"
+        );
+        assert!(
+            funnel_text.contains(ENGINE),
+            "the engine's own sentence is the only evidence of what happened \
+             and must survive to the classifier:\n{funnel_text}"
+        );
+
+        // (b) The diagnostic mapper must not prescribe destroying a database
+        //     whose graph a five-file `mv` restores. Both routes into
+        //     `into_diagnostic` are checked: the typed one (the funnel error,
+        //     which carries a `StoreError` source) and the prose fallback (a
+        //     message relayed as a bare string, e.g. over gRPC).
+        let typed = into_diagnostic(funnel);
+        let prose = into_diagnostic(anyhow::anyhow!(
+            "failed to open database at /tmp/x.lbug: {ENGINE}"
+        ));
+
+        for (label, report) in [("typed", &typed), ("prose", &prose)] {
+            let code = report.code().map(|c| c.to_string()).unwrap_or_default();
+            assert_eq!(
+                code, "nestweaver::db_wal_corrupt",
+                "{label}: an unreadable WAL is neither an unreplayed one nor a \
+                 damaged FILE, and both of those diagnostics give it the wrong \
+                 remedy"
+            );
+            let help = report.help().map(|h| h.to_string()).unwrap_or_default();
+            assert!(
+                !help.contains("delete this database"),
+                "{label}: the verified recovery preserved 1125 notes, 43 repos \
+                 and 189519 vectors; `db_corrupt`'s remedy discards them — and \
+                 per nw-289 its other branch names a backup archive that may not \
+                 exist:\n{help}"
+            );
+            // (c) It must name the recovery that actually worked, in full,
+            //     including the re-index — the step the 2026-08-28 measurement
+            //     showed is REQUIRED and that no message stated.
+            for artifact in [
+                ".wal",
+                ".wal.checkpoint",
+                ".shadow",
+                ".checkpoint.apply.lock",
+                ".checkpoint.intent.lock",
+            ] {
+                assert!(
+                    help.contains(artifact),
+                    "{label}: the runbook is FIVE artifacts; a partial list \
+                     failed IDENTICALLY until the fifth file moved. Missing \
+                     {artifact}:\n{help}"
+                );
+            }
+            assert!(
+                help.to_lowercase().contains("re-index"),
+                "{label}: WAL-loss recovery leaves the graph consistent but \
+                 INCOMPLETE and nothing in `brain status` discloses it:\n{help}"
+            );
+            assert!(
+                help.contains("MOVE ASIDE") && !help.to_lowercase().contains("delete <"),
+                "{label}: a `.wal` can hold committed work, so the runbook moves \
+                 rather than deletes:\n{help}"
+            );
+            assert!(
+                !help.contains("nestweaver daemon --db /tmp/x.lbug start"),
+                "{label}: the remedy must not restart the writer that crashes on \
+                 open:\n{help}"
+            );
+            assert!(
+                help.contains("/tmp/x.lbug.wal.checkpoint"),
+                "{label}: the runbook names files to MOVE, so it must name the \
+                 right database. Recovering the path from prose put \
+                 `./nestweaver.lbug` — an entirely different database — into \
+                 these instructions:\n{help}"
+            );
+        }
+
+        // All three paths, one text. `repair`'s open failure is the third, and
+        // it used to be a bare `eprintln!` the diagnostic inventory could not
+        // see at all.
+        let repair = into_diagnostic(repair_open_failure(
+            std::path::Path::new("/tmp/x.lbug"),
+            nestweaver_store::StoreError::from_engine_message(ENGINE),
+        ));
+        assert_eq!(
+            repair.code().map(|c| c.to_string()).unwrap_or_default(),
+            "nestweaver::db_wal_corrupt",
+            "`repair` blamed a lock nobody held; it must now report the same \
+             condition, with the same remedy, as the other two paths"
+        );
+        // Three paths, ONE remedy, from one constant. Each path keeps its own
+        // leading `{cause}` — they describe genuinely different situations, a
+        // read that could not open versus a repair that will not act — but the
+        // REMEDY below it must be byte-identical, because the divergence of the
+        // remedy is the whole defect.
+        let runbook = wal_corruption_runbook("/tmp/x.lbug");
+        for (label, report) in [("read funnel", &typed), ("repair", &repair)] {
+            let help = report.help().map(|h| h.to_string()).unwrap_or_default();
+            assert!(
+                help.contains(&runbook),
+                "{label}: the remedy must be the shared constant verbatim, not a \
+                 restatement of it — three restatements is exactly how one \
+                 condition acquired three contradictory answers:\n{help}"
+            );
+        }
+    }
+
+    /// nw-333. The other half, and what keeps the first from over-correcting:
+    /// a repair blocked by a REAL lock must still say so, and an open failure
+    /// that is neither corruption nor contention must be reported with NO
+    /// attribution at all. A wrong guess is worse than no guess.
+    #[test]
+    fn repair_only_blames_a_lock_when_the_engine_says_a_lock() {
+        let db = std::path::Path::new("/tmp/x.lbug");
+
+        let lock = format!(
+            "{:#}",
+            repair_open_failure(
+                db,
+                nestweaver_store::StoreError::from_engine_message(
+                    "Could not set lock on file /tmp/x.lbug.lock"
+                )
+            )
+        );
+        assert!(
+            lock.contains("Another process holds the write lock"),
+            "a genuinely held lock must still be reported as one: {lock}"
+        );
+
+        for damaged in [
+            "Corrupted wal file. Read out invalid WAL record type.",
+            "catalog page range starts at 3567 and spans 5 pages, outside the \
+             database file with 1696 pages",
+        ] {
+            let rendered = format!(
+                "{:#}",
+                repair_open_failure(
+                    db,
+                    nestweaver_store::StoreError::from_engine_message(damaged)
+                )
+            );
+            assert!(
+                !rendered.contains("Another process holds the write lock"),
+                "no process holds this database; the open failed because the \
+                 FILE is damaged, and the old message said so in its own \
+                 parenthetical before ignoring it:\n{rendered}"
+            );
+            assert!(
+                !rendered.contains("then start"),
+                "restarting the daemon against a damaged database is what \
+                 produces the crash-restart loop — the one remedy in this class \
+                 that makes recovery HARDER rather than merely wasting \
+                 time:\n{rendered}"
+            );
+        }
+
+        let unknown = format!(
+            "{:#}",
+            repair_open_failure(
+                db,
+                nestweaver_store::StoreError::from_engine_message(
+                    "Runtime exception: something nobody has classified"
+                )
+            )
+        );
+        assert!(
+            !unknown.contains("Another process holds the write lock"),
+            "an unrecognised failure must carry NO attribution: {unknown}"
+        );
+        assert!(
+            unknown.contains("something nobody has classified"),
+            "…and must still report what the engine said: {unknown}"
+        );
+    }
+
     /// nw-318 (defect A). `open_store`'s daemon-held refusal is reached ONLY
     /// by a caller who already bypassed the daemon, so prescribing
     /// `--no-daemon` to that caller is a closed loop — and "report it as a bug"
@@ -24427,8 +24854,13 @@ lbug-0.19.1/lbug-src/src/storage/table/column.cpp\" on line 289: \
     #[test]
     fn no_daemon_refusal_never_prescribes_the_flag_already_passed() {
         for upstream in ["Could not set lock on file", "Corrupted wal detected"] {
-            let rendered =
-                daemon_held_store_error(std::path::Path::new("/tmp/x.lbug"), upstream).to_string();
+            let rendered = format!(
+                "{:#}",
+                daemon_held_store_error(
+                    std::path::Path::new("/tmp/x.lbug"),
+                    nestweaver_store::StoreError::from_engine_message(upstream)
+                )
+            );
 
             assert!(
                 !rendered.contains("--no-daemon"),
@@ -24441,25 +24873,48 @@ lbug-0.19.1/lbug-src/src/storage/table/column.cpp\" on line 289: \
                  product defect. Got: {rendered}"
             );
             assert!(
-                rendered.contains("nestweaver daemon"),
-                "the refusal must name an action the caller has NOT already \
-                 taken. Got: {rendered}"
-            );
-            assert!(
                 rendered.contains("/tmp/x.lbug"),
-                "and it must name the database. Got: {rendered}"
+                "it must name the database. Got: {rendered}"
             );
         }
 
-        // The two conditions are NOT the same and must not get one answer: a
-        // read-only open can never replay a WAL however many times the caller
-        // stops and restarts things, so `stop` is the wrong advice for it.
-        let wal = daemon_held_store_error(std::path::Path::new("/tmp/x.lbug"), "Corrupted wal")
-            .to_string();
-        assert!(wal.contains("start"), "{wal}");
-        let lock =
-            daemon_held_store_error(std::path::Path::new("/tmp/x.lbug"), "Could not set lock")
-                .to_string();
+        // The two conditions are NOT the same and must not get one answer.
+        //
+        // nw-332 REVERSED what this pair used to assert for the WAL case. It
+        // used to require `wal.contains("start")` — because the shipped message
+        // said "Let this command route through the daemon: `nestweaver daemon
+        // --db <p> start`". That reasoning is correct for an UNREPLAYED log and
+        // wrong for an UNREADABLE one, and `Corrupted wal` selects the
+        // unreadable case specifically. Starting a writer against a log whose
+        // records do not parse is the crash-restart loop, so the old assertion
+        // was pinning the defect.
+        let wal = format!(
+            "{:#}",
+            daemon_held_store_error(
+                std::path::Path::new("/tmp/x.lbug"),
+                nestweaver_store::StoreError::from_engine_message("Corrupted wal")
+            )
+        );
+        assert!(
+            !wal.contains("daemon --db /tmp/x.lbug start"),
+            "starting the daemon against an unreadable WAL IS the crash-restart \
+             loop: {wal}"
+        );
+        assert!(
+            wal.to_lowercase().contains("do not start"),
+            "and it must say so, not merely omit it: {wal}"
+        );
+
+        // Live contention still gets the answer that works, and it still names
+        // an action the caller has not already taken.
+        let lock = format!(
+            "{:#}",
+            daemon_held_store_error(
+                std::path::Path::new("/tmp/x.lbug"),
+                nestweaver_store::StoreError::from_engine_message("Could not set lock")
+            )
+        );
+        assert!(lock.contains("nestweaver daemon"), "{lock}");
         assert!(lock.contains("stop"), "{lock}");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1453,19 +1453,47 @@ fn print_link_classification(total_unresolved: usize, total_low_confidence: usiz
     );
 }
 
-/// Provenance for a result computed WITHOUT the daemon.
+/// Stamp local-scope provenance onto a `--json` payload, unless a layer that
+/// knows more already stamped it.
 ///
-/// The federation layer attaches `_meta` (scope, sources, stale_repos) on the
-/// daemon path only, so `--json` returned a different SHAPE depending on whether
-/// a daemon happened to be running. The direct path is genuinely local scope, so
-/// it can state the same thing truthfully rather than omitting the field
-/// (nw-117).
-fn local_result_meta() -> serde_json::Value {
-    serde_json::json!({
-        "scope": "local",
-        "sources": ["local"],
-        "stale_repos": [],
-    })
+/// # Why this exists at all
+///
+/// `_meta` answers three questions a caller cannot answer any other way: what
+/// scope the answer covers, which sources contributed, and which repos were
+/// stale. `nestweaver_schema::provenance` is the one spelling of that answer and
+/// `nestweaver_mcp::tools` carries it on both dispatch seams (nw-315,
+/// `provenance_seam::Unstamped`). This file used to be the FOURTH and FIFTH
+/// authors of the same three keys — `local_result_meta` and `attach_local_meta`
+/// open-coded `provenance::provenance` and `provenance::ensure` byte for byte —
+/// while three other `--json` emitters (`print_ranking_json` for `hubs`/`bridges`
+/// and `render_brain_search_response`) emitted no `_meta` at all. Five authors
+/// is why the three that were missing went unnoticed (nw-347).
+///
+/// `ensure`, not `set`: the daemon envelope and the federation client both know
+/// strictly more than this layer does, so their richer verdict must survive.
+fn json_payload_with_provenance(mut payload: serde_json::Value) -> serde_json::Value {
+    nestweaver_schema::provenance::ensure(
+        &mut payload,
+        nestweaver_schema::provenance::SCOPE_LOCAL,
+        &[nestweaver_schema::provenance::SOURCE_LOCAL],
+        &[],
+    );
+    payload
+}
+
+/// Print a `--json` OBJECT payload. The only emitter that should exist.
+///
+/// Routing every `--json` object print through one function is what makes
+/// "every route discloses its provenance" a property of the code rather than of
+/// whoever wrote the most recent renderer. The enforcement is behavioural, not
+/// syntactic: `tests/parity_test.rs` compares each command's `--json` key paths
+/// against its MCP twin's, so a new emitter that forgets `_meta` fails there.
+fn print_json_payload(payload: &serde_json::Value) -> anyhow::Result<()> {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json_payload_with_provenance(payload.clone()))?
+    );
+    Ok(())
 }
 
 /// The single JSON shape `impact` emits, for every outcome.
@@ -1645,20 +1673,28 @@ impl ResolverStaleness {
 
 /// Print a ranking payload as an OBJECT carrying its own staleness, rather than
 /// the bare array that had nowhere to put it (nw-308).
+///
+/// `daemon_meta` is the `_meta` of the daemon envelope this payload was decoded
+/// from, or `None` on the direct route. It is a parameter because the daemon
+/// route DECODES through `strip_hybrid_meta` — the stripper exists so a typed
+/// `serde_json::from_value` sees the same shape the direct store produces — and
+/// stripping for the decode used to mean the printer had nothing to put back.
+/// Strip for the decode, carry the provenance to the print (nw-347).
 fn print_ranking_json<T: serde::Serialize>(
     key: &str,
     rows: &T,
     staleness: &ResolverStaleness,
+    daemon_meta: Option<serde_json::Value>,
 ) -> anyhow::Result<()> {
-    println!(
-        "{}",
-        serde_json::to_string_pretty(&serde_json::json!({
-            key: rows,
-            "rankings_stale": staleness.rankings_stale,
-            "stale_repos": staleness.stale_repos,
-        }))?
-    );
-    Ok(())
+    let mut payload = serde_json::json!({
+        key: rows,
+        "rankings_stale": staleness.rankings_stale,
+        "stale_repos": staleness.stale_repos,
+    });
+    if let (Some(meta), Some(obj)) = (daemon_meta, payload.as_object_mut()) {
+        obj.insert(nestweaver_schema::provenance::META_KEY.to_string(), meta);
+    }
+    print_json_payload(&payload)
 }
 
 /// Ambiguous resolution — carries `candidates`, never `nodes`, so it cannot be
@@ -1819,24 +1855,6 @@ fn render_investigate_text(payload: &serde_json::Value) {
         "\nDrill in: nestweaver investigate-expand {} --targets <asset_id,...>",
         text(payload, "bundle_id")
     );
-}
-
-/// Attach the local-scope provenance the federation layer adds on the daemon
-/// path, so `--json` has ONE shape regardless of whether a daemon is running.
-///
-/// Same divergence as nw-117: `_meta` is added by federation, which only runs in
-/// daemon mode, so a direct result was a different shape rather than a different
-/// value. The direct path is genuinely local scope and can say so truthfully.
-fn attach_local_meta(payload: &mut serde_json::Value) {
-    if let Some(obj) = payload.as_object_mut() {
-        obj.entry("_meta").or_insert_with(|| {
-            serde_json::json!({
-                "scope": "local",
-                "sources": ["local"],
-                "stale_repos": [],
-            })
-        });
-    }
 }
 
 /// Render a `blast-radius` result as text from its JSON payload.
@@ -10965,19 +10983,17 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 Some(value) => value,
                 None => {
                     let store = open_store(Some(&db_path))?;
-                    let mut value = nestweaver_mcp::tools::dispatch(
+                    nestweaver_mcp::tools::dispatch(
                         &store,
                         None,
                         "cross_repo_contracts",
                         args,
                         None,
-                    )?;
-                    attach_local_meta(&mut value);
-                    value
+                    )?
                 }
             };
             if json {
-                println!("{}", serde_json::to_string_pretty(&payload)?);
+                print_json_payload(&payload)?;
             } else {
                 println!(
                     "Cross-repo contracts for {}: {} returned of {} ({})",
@@ -11030,14 +11046,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 Some(value) => value,
                 None => {
                     let store = open_store(Some(&db_path))?;
-                    let mut value =
-                        nestweaver_mcp::tools::dispatch(&store, None, "backlinks", args, None)?;
-                    attach_local_meta(&mut value);
-                    value
+                    nestweaver_mcp::tools::dispatch(&store, None, "backlinks", args, None)?
                 }
             };
             if json {
-                println!("{}", serde_json::to_string_pretty(&payload)?);
+                print_json_payload(&payload)?;
             } else {
                 println!(
                     "Backlinks to {} ({}):",
@@ -11937,11 +11950,21 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         .context("decode hub nodes from the daemon")?,
                     None => Vec::new(),
                 };
+                // nw-347: the daemon knows more about provenance than this
+                // layer can (upstreams, a background staleness verdict), so its
+                // stamp is carried to the printer rather than discarded and
+                // re-invented.
+                let daemon_meta = value.get(nestweaver_schema::provenance::META_KEY).cloned();
                 if json {
                     // nw-308: the daemon route is the DEFAULT route, so the
                     // payload disclosure has to be here as well as on the
                     // direct path below.
-                    print_ranking_json("hubs", &hubs, &ResolverStaleness::from_sidecar(&db_path))?;
+                    print_ranking_json(
+                        "hubs",
+                        &hubs,
+                        &ResolverStaleness::from_sidecar(&db_path),
+                        daemon_meta,
+                    )?;
                 } else if hubs.is_empty() {
                     println!("No hub nodes found (graph may be empty).");
                 } else {
@@ -11999,6 +12022,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     "hubs",
                     &hubs,
                     &ResolverStaleness::from_store(&store, &db_path),
+                    None,
                 )?;
             } else if hubs.is_empty() {
                 println!("No hub nodes found (graph may be empty).");
@@ -12048,6 +12072,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     // became an empty list and rendered as "graph may be
                     // empty". A `null` (no `bridges` key at all) is still an
                     // honest empty result and stays one.
+                    // nw-347: `strip_hybrid_meta` exists so the typed decode
+                    // below sees the shape the direct store produces. Stripping
+                    // for the decode used to mean the PRINTER had nothing to put
+                    // back, so the daemon's own stamp was discarded on a route
+                    // where it is strictly richer than anything this layer knows.
+                    let daemon_meta = value.get(nestweaver_schema::provenance::META_KEY).cloned();
                     let bridges: Vec<nestweaver_engine::BridgeNode> =
                         match strip_hybrid_meta(value).get("bridges").cloned() {
                             Some(serde_json::Value::Null) | None => Vec::new(),
@@ -12061,6 +12091,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             "bridges",
                             &bridges,
                             &ResolverStaleness::from_sidecar(&db_path),
+                            daemon_meta,
                         )?;
                     } else if bridges.is_empty() {
                         println!("No bridge nodes found (graph may be empty).");
@@ -12116,6 +12147,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     "bridges",
                     &bridges,
                     &ResolverStaleness::from_store(&store, &db_path),
+                    None,
                 )?;
             } else if bridges.is_empty() {
                 println!("No bridge nodes found (graph may be empty).");
@@ -12853,15 +12885,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     // the `cochange-unavailable` disclosure, so the direct path
                     // would answer with LESS honesty than the daemon (nw-062).
                     nestweaver_mcp::tools::set_current_db_path(db_path.clone());
-                    let mut value =
-                        nestweaver_mcp::tools::dispatch(&store, None, "blast_radius", args, None)?;
-                    attach_local_meta(&mut value);
-                    value
+                    nestweaver_mcp::tools::dispatch(&store, None, "blast_radius", args, None)?
                 }
             };
 
             if json {
-                println!("{}", serde_json::to_string_pretty(&payload)?);
+                print_json_payload(&payload)?;
             } else {
                 render_blast_radius_text(&payload);
             }
@@ -12898,19 +12927,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 Some(value) => value,
                 None => {
                     let store = open_store(Some(&db_path))?;
-                    let mut value = nestweaver_mcp::tools::dispatch(
-                        &store,
-                        None,
-                        "detect_changes",
-                        args,
-                        None,
-                    )?;
-                    attach_local_meta(&mut value);
-                    value
+                    nestweaver_mcp::tools::dispatch(&store, None, "detect_changes", args, None)?
                 }
             };
             if json {
-                println!("{}", serde_json::to_string_pretty(&payload)?);
+                print_json_payload(&payload)?;
             } else {
                 println!(
                     "Change impact: risk={}, status={}, gate={}",
@@ -12964,15 +12985,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 None => {
                     let store = open_store(Some(&db_path))?;
                     nestweaver_mcp::tools::set_current_db_path(db_path.clone());
-                    let mut value =
-                        nestweaver_mcp::tools::dispatch(&store, None, "flow_trace", args, None)?;
-                    attach_local_meta(&mut value);
-                    value
+                    nestweaver_mcp::tools::dispatch(&store, None, "flow_trace", args, None)?
                 }
             };
 
             if json {
-                println!("{}", serde_json::to_string_pretty(&payload)?);
+                print_json_payload(&payload)?;
             } else {
                 render_flow_trace_text(&payload);
             }
@@ -13055,7 +13073,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // Built unconditionally so the text path renders from the SAME
             // payload the JSON path prints, and from the same payload the
             // daemon returns (nw-108).
-            let mut payload = serde_json::to_value(DeadCodeJson {
+            let payload = serde_json::to_value(DeadCodeJson {
                 total_symbols: result.total_symbols,
                 reachable_symbols: result.reachable_symbols,
                 unreachable_count: result.unreachable_symbols.len(),
@@ -13067,14 +13085,8 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 min_confidence: min_conf.to_string(),
                 unreachable_symbols: shown,
             })?;
-            // Match the daemon's envelope so `--json` has one shape regardless
-            // of whether a daemon is running (nw-117).
-            if let Some(obj) = payload.as_object_mut() {
-                obj.insert("_meta".to_string(), local_result_meta());
-            }
-
             if json {
-                println!("{}", serde_json::to_string_pretty(&payload)?);
+                print_json_payload(&payload)?;
             } else {
                 render_dead_code_text(&payload);
             }
@@ -22218,7 +22230,7 @@ fn run_brain(
             let response = response?;
 
             if json {
-                println!("{}", serde_json::to_string_pretty(&response)?);
+                print_json_payload(&response)?;
             } else {
                 render_brain_search_json(&response)?;
             }
@@ -23692,7 +23704,7 @@ fn render_brain_search_response(
         if !resp.expansion_terms.is_empty() {
             payload["expansion_terms"] = serde_json::json!(resp.expansion_terms);
         }
-        println!("{}", serde_json::to_string_pretty(&payload)?);
+        print_json_payload(&payload)?;
         return Ok(());
     }
 
@@ -24377,6 +24389,51 @@ mod cli_help_contract_tests {
              instead (for the daemon bypass that is NESTWEAVER_ALLOW_NO_DAEMON, \
              which `no_daemon_allowed()` actually reads): {offenders:#?}"
         );
+    }
+
+    /// nw-347, the counterweight. A stamp that is always
+    /// `{scope:"local", stale_repos:[]}` is not provenance, it is a constant —
+    /// and a fix that made every `--json` payload carry one unconditionally
+    /// would satisfy "every route has `_meta`" while telling a federated caller
+    /// its answer was local. The daemon route knows strictly more (upstreams, a
+    /// background staleness verdict this process cannot compute without I/O),
+    /// so its richer verdict must survive: the emitter calls
+    /// `provenance::ensure` (`entry().or_insert_with`), never `set`.
+    #[test]
+    fn the_cli_stamp_does_not_clobber_a_richer_verdict() {
+        let daemon_answer = serde_json::json!({
+            "hubs": [],
+            "_meta": {
+                "scope": "federated",
+                "sources": ["local", "upstream-a"],
+                "stale_repos": ["repo-a"],
+            },
+        });
+        let printed = json_payload_with_provenance(daemon_answer);
+        assert_eq!(
+            printed["_meta"]["scope"],
+            serde_json::json!("federated"),
+            "the CLI emitter overwrote a verdict it does not have the \
+             information to make: {printed}"
+        );
+        assert_eq!(
+            printed["_meta"]["stale_repos"],
+            serde_json::json!(["repo-a"]),
+            "a caller that was told which repos are stale must not have that \
+             replaced by an empty list: {printed}"
+        );
+
+        // And the direct route, which genuinely IS local scope, says so rather
+        // than omitting the field — the nw-347 defect in the other direction.
+        let direct_answer = json_payload_with_provenance(serde_json::json!({ "hubs": [] }));
+        for leg in ["scope", "sources", "stale_repos"] {
+            assert!(
+                direct_answer["_meta"].get(leg).is_some(),
+                "partial provenance is how a caller learns the wrong thing \
+                 confidently: {direct_answer}"
+            );
+        }
+        assert_eq!(direct_answer["_meta"]["scope"], serde_json::json!("local"));
     }
 
     /// S1/T3b — THE CHECK THAT CATCHES nw-329.
@@ -26226,13 +26283,12 @@ fn run_contracts(
                 cfg.as_ref(),
                 nestweaver_engine::config::DEFAULT_RESULT_LIMIT,
             );
-            let mut value = nestweaver_engine::contracts::drift_envelope(report, limit);
-            // nw-117: `_meta` is added by the federation layer, which only runs
-            // on the daemon path. This result is genuinely local scope and can
-            // say so, keeping ONE shape in both modes.
-            attach_local_meta(&mut value);
+            let value = nestweaver_engine::contracts::drift_envelope(report, limit);
             if json {
-                println!("{}", serde_json::to_string_pretty(&value)?);
+                // nw-117/nw-347: `_meta` is added by the federation layer, which
+                // only runs on the daemon path. This result is genuinely local
+                // scope and the emitter says so, keeping ONE shape in both modes.
+                print_json_payload(&value)?;
             } else {
                 render_contract_drift_human(&value);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4162,9 +4162,18 @@ enum Commands {
         after_help = "Examples:\n  nestweaver export --format cypher\n  nestweaver export --format graphml --output graph.xml\n  nestweaver export --format mermaid --top 30\n  nestweaver export --format msgpack --output graph.msgpack"
     )]
     Export {
+        // nw-312: `value_parser`, not a bare `String` validated downstream. The
+        // legal values were enumerated in the help text and enforced in the
+        // handler, so an invalid one arrived as a generic error and exited 1
+        // where the documented contract says 64 — while `--top`, three
+        // arguments below, is a `usize` and already exits 64 because clap's own
+        // parse rejects it. `PossibleValuesParser` keeps the field a `String`,
+        // so the `format == "msgpack"` comparisons and the wire value the
+        // daemon receives are unchanged.
         #[arg(
             long,
             default_value = "cypher",
+            value_parser = clap::builder::PossibleValuesParser::new(["cypher", "graphml", "mermaid", "msgpack"]),
             help = "Output format: cypher, graphml, mermaid, msgpack"
         )]
         format: String,
@@ -4173,7 +4182,8 @@ enum Commands {
         #[arg(
             long,
             default_value = "all",
-            help = "Subgraph to export: all (default), code, or vault. graphml honours all three; cypher and mermaid are code-only and will refuse a vault scope rather than emit an empty file"
+            value_parser = clap::builder::PossibleValuesParser::new(["all", "code", "vault"]),
+            help = "Subgraph to export: all (default), code, or vault. graphml honours all three; cypher and mermaid are code-only and will refuse a vault scope rather than emit an empty file; msgpack is code-only and refuses --scope vault outright"
         )]
         scope: String,
         #[arg(
@@ -13217,15 +13227,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             };
             let mut writer = std::io::BufWriter::new(write_to);
 
-            // Unknown formats keep their friendly listing and EXIT_ERROR
-            // rather than becoming a generic error chain.
-            if !matches!(format.as_str(), "cypher" | "graphml" | "mermaid") {
-                eprintln!(
-                    "Unknown format '{}'. Supported: cypher, graphml, mermaid, msgpack",
-                    format
-                );
-                return Ok((EXIT_ERROR, None));
-            }
+            // nw-312: the runtime listing that used to stand here is gone,
+            // not merely bypassed. `--format` now carries a
+            // `PossibleValuesParser`, so an unknown value is refused by clap
+            // before this arm runs on EITHER route, and keeping the branch
+            // would leave a third copy of the legal-value list to drift.
             // One shared implementation with the daemon's `export_graph`, so
             // the two cannot drift on scope again.
             if let Some(notice) =

--- a/src/main.rs
+++ b/src/main.rs
@@ -11664,12 +11664,34 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     limit,
                 ) {
                     Ok(mut result) => {
+                        // The SAME two caps as seed-mode, resolved by the SAME
+                        // rule. `build_feature_context` answers for the row cap
+                        // it applied; `--token-budget` is applied here and can
+                        // upgrade the cause, because it cuts LAST.
+                        let cut_by_limit = result.truncated == Some(true);
+                        let mut cut_by_budget = false;
                         if let Some(budget) = token_budget {
                             let cut = context_token_budgeted_truncate(&result.connected, budget);
+                            if cut < result.connected.len() {
+                                result.truncated = Some(true);
+                                cut_by_budget = true;
+                            }
                             result.connected.truncate(cut);
                         }
+                        result.truncated_by = nestweaver_engine::TruncationCause::resolve(
+                            cut_by_budget,
+                            cut_by_limit,
+                        );
+                        result.token_budget = token_budget;
+                        let truncation = context_truncation_notice(
+                            result.truncated_by,
+                            result.limit,
+                            result.token_budget,
+                        )
+                        .map(|notice| format!(", {notice}"))
+                        .unwrap_or_default();
                         let stats = format!(
-                            "{} seeds, {} connected nodes in {}",
+                            "{} seeds, {} connected nodes in {}{truncation}",
                             result.seeds.len(),
                             result.connected.len(),
                             format_elapsed(t0.elapsed())
@@ -11791,32 +11813,39 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     // The limit cut is whatever the builder already recorded —
                     // on either route. The budget cut happens here.
                     let cut_by_limit = result.truncated == Some(true);
-                    let mut cut_by_budget: Option<usize> = None;
+                    let mut cut_by_budget = false;
                     if let Some(budget) = token_budget {
                         let cut = context_token_budgeted_truncate(&result.connected, budget);
                         if cut < result.connected.len() {
                             result.truncated = Some(true);
-                            cut_by_budget = Some(budget);
+                            cut_by_budget = true;
                         }
                         result.connected.truncate(cut);
                     }
-                    // Say so, and say WHICH. A capped result that renders
-                    // identically to a complete one is the defect this reports
-                    // on; a capped result that blames the wrong cap is the same
-                    // defect wearing a disclosure.
+                    // Say so, and say WHICH — in the PAYLOAD, not only in the
+                    // prose. A capped result that renders identically to a
+                    // complete one is the defect this reports on; a capped
+                    // result that blames the wrong cap is the same defect
+                    // wearing a disclosure; and a disclosure that exists only
+                    // in the `--stats` string is that same defect for every
+                    // consumer that reads `--json`, which is the audience with
+                    // no prose to fall back on.
                     //
-                    // The budget wins when both fired, because it cut LAST:
-                    // raising `--limit` alone cannot get past a budget that is
-                    // already full.
-                    let truncation = match (cut_by_budget, cut_by_limit, result.limit) {
-                        (Some(budget), _, _) => {
-                            format!(", TRUNCATED by --token-budget {budget} — raise it for more")
-                        }
-                        (None, true, Some(limit)) => {
-                            format!(", TRUNCATED at limit {limit} — pass --limit for more")
-                        }
-                        _ => String::new(),
-                    };
+                    // Resolved ONCE, here, through the engine's shared
+                    // precedence rule. The `--stats` line below reads the
+                    // field rather than re-deciding, so the two cannot
+                    // disagree — a second copy of this decision is exactly how
+                    // the human route and the machine route diverged.
+                    result.truncated_by =
+                        nestweaver_engine::TruncationCause::resolve(cut_by_budget, cut_by_limit);
+                    result.token_budget = token_budget;
+                    let truncation = context_truncation_notice(
+                        result.truncated_by,
+                        result.limit,
+                        result.token_budget,
+                    )
+                    .map(|notice| format!(", {notice}"))
+                    .unwrap_or_default();
                     let stats = format!(
                         "{} seeds, {} connected nodes in {} ({}){}",
                         result.seeds.len(),
@@ -12657,7 +12686,22 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // Truncation is either cause: the symbol cap upstream, or the
             // token budget here. Reporting only the second made the first
             // vanish.
-            let truncated = display.len() < total || cap_dropped > 0;
+            //
+            // nw-259(a). Naming the CAUSE is the other half, and it has to be
+            // in the payload, not only in the stderr note below — the note
+            // lists both remedies at once, which is unhelpful rather than
+            // wrong, and a `--json` consumer never sees it at all.
+            //
+            // Independent booleans, matching `impact_json_ok`'s
+            // `truncated_by_threshold` / `truncated_by_depth` and the twin
+            // `get_summary` tool — not the single `truncated_by` string
+            // `context` carries. `context`'s caps compose in a strict order
+            // (the budget cuts what the limit left, so raising the limit alone
+            // cannot help); these two do not, and both remedies remain
+            // independently useful when both fire.
+            let truncated_by_budget = display.len() < total;
+            let truncated_by_cap = cap_dropped > 0;
+            let truncated = truncated_by_budget || truncated_by_cap;
 
             if json {
                 println!(
@@ -12670,6 +12714,8 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         "total": total + cap_dropped,
                         "returned": display.len(),
                         "truncated": truncated,
+                        "truncated_by_budget": truncated_by_budget,
+                        "truncated_by_cap": truncated_by_cap,
                     }))?
                 );
             } else if display.is_empty() {
@@ -19043,6 +19089,18 @@ fn print_context_text(result: &ContextResult) {
         }
     }
 
+    // `--stats` is OFF by default, and the truncation clause lived only there:
+    // with stats off, a capped list printed exactly like a complete one and the
+    // reader's only clue was a count they had nothing to compare against. The
+    // notice belongs to the RESULT, not to the timing line that happened to
+    // carry it. Printed after the rows, where a reader who scrolled to the end
+    // of a short list is looking.
+    if let Some(notice) =
+        context_truncation_notice(result.truncated_by, result.limit, result.token_budget)
+    {
+        println!("  … {notice}");
+    }
+
     if !result.cross_repo_links.is_empty() {
         println!();
         println!("Cross-repo links:");
@@ -19097,6 +19155,14 @@ fn print_feature_context_text(result: &FeatureContextResult) {
                 node.name, node.kind, node.file_path, node.start_line, node.relevance
             );
         }
+    }
+
+    // Same reason as `print_context_text`: `--stats` is off by default and a
+    // capped feature context printed identically to a complete one.
+    if let Some(notice) =
+        context_truncation_notice(result.truncated_by, result.limit, result.token_budget)
+    {
+        println!("  … {notice}");
     }
 }
 
@@ -23351,6 +23417,35 @@ fn token_budgeted_truncate(
         taken += 1;
     }
     taken
+}
+
+/// The ONE place the `context` truncation remedy is worded.
+///
+/// nw-259(a). Two readers need this sentence — the `--stats` line and the
+/// human renderer — and a third (`--json`) needs the same DECISION in
+/// machine-readable form. The decision is made once, by
+/// `TruncationCause::resolve`, and lands in `ContextResult::truncated_by`;
+/// this function is the only thing that turns that value into prose. A second
+/// copy of either half is how the human route came to name the right cap while
+/// the JSON payload named the wrong one.
+///
+/// Returns `None` when nothing was cut — and also when the cause is known but
+/// the cap's VALUE is not, because a remedy that cannot name the number to
+/// raise is not a remedy.
+fn context_truncation_notice(
+    truncated_by: Option<nestweaver_engine::TruncationCause>,
+    limit: Option<usize>,
+    token_budget: Option<usize>,
+) -> Option<String> {
+    match (truncated_by?, limit, token_budget) {
+        (nestweaver_engine::TruncationCause::TokenBudget, _, Some(budget)) => Some(format!(
+            "TRUNCATED by --token-budget {budget} — raise it for more"
+        )),
+        (nestweaver_engine::TruncationCause::Limit, Some(limit), _) => Some(format!(
+            "TRUNCATED at limit {limit} — pass --limit for more"
+        )),
+        _ => None,
+    }
 }
 
 fn context_token_budgeted_truncate(

--- a/src/main.rs
+++ b/src/main.rs
@@ -20304,14 +20304,16 @@ fn run_brain(
             } else {
                 println!(
                     "Indexed vault '{}': {} note(s), {} heading(s), {} section(s), \
-                     {} tag(s), {} wikilink(s) ({} unresolved).",
+                     {} tag(s), {} wikilink edge(s), {} unresolved link \
+                     occurrence(s) across {} distinct target(s).",
                     result.vault_name,
                     result.notes_count,
                     result.headings_count,
                     result.sections_count,
                     result.tags_count,
-                    result.wikilinks_resolved,
-                    result.wikilinks_unresolved,
+                    result.resolved_link_edges,
+                    result.unresolved_link_occurrences,
+                    result.unresolved_link_targets,
                 );
             }
 
@@ -21657,7 +21659,8 @@ fn run_brain(
                 println!(
                     "Incremental refresh of vault '{}' (since {}): \
                      checked {} file(s), updated {} note(s), dropped {} prior note(s), \
-                     {} heading(s), {} section(s), {} tag(s), {} wikilink(s).",
+                     {} heading(s), {} section(s), {} tag(s), \
+                     {} wikilink edge(s) on changed notes.",
                     result.vault_name,
                     since_str,
                     result.files_checked,
@@ -21666,7 +21669,7 @@ fn run_brain(
                     result.headings_count,
                     result.sections_count,
                     result.tags_count,
-                    result.wikilinks_resolved,
+                    result.changed_note_link_edges,
                 );
             } else {
                 // Full refresh: the markdown indexer's writable store performs
@@ -23068,11 +23071,23 @@ fn run_brain(
                     let stats: nestweaver_engine::DocStats = serde_json::from_value(value)?;
                     println!("Document graph stats:");
                     println!("  total notes:      {}", stats.total_notes);
-                    println!("  total wikilinks:  {}", stats.total_wikilinks);
-                    println!("  broken wikilinks: {}", stats.broken_wikilinks);
+                    // nw-345: each line says which POPULATION it counts. They
+                    // do not agree, and they are not meant to.
+                    println!(
+                        "  wikilink edges:                        {}",
+                        stats.wikilink_edges
+                    );
+                    println!(
+                        "  unresolved links (note + text):        {}",
+                        stats.unresolved_link_targets
+                    );
+                    println!(
+                        "  unresolved links (section + text):     {}",
+                        stats.unresolved_link_section_targets
+                    );
                     println!(
                         "  low-confidence (resolved, not broken): {}",
-                        stats.low_confidence_wikilinks
+                        stats.low_confidence_link_targets
                     );
                     println!("  orphans:          {}", stats.orphans);
                     println!("  avg out-degree:   {:.2}", stats.avg_outdegree);
@@ -23102,11 +23117,22 @@ fn run_brain(
             } else {
                 println!("Document graph stats:");
                 println!("  total notes:      {}", stats.total_notes);
-                println!("  total wikilinks:  {}", stats.total_wikilinks);
-                println!("  broken wikilinks: {}", stats.broken_wikilinks);
+                // nw-345: each line says which POPULATION it counts.
+                println!(
+                    "  wikilink edges:                        {}",
+                    stats.wikilink_edges
+                );
+                println!(
+                    "  unresolved links (note + text):        {}",
+                    stats.unresolved_link_targets
+                );
+                println!(
+                    "  unresolved links (section + text):     {}",
+                    stats.unresolved_link_section_targets
+                );
                 println!(
                     "  low-confidence (resolved, not broken): {}",
-                    stats.low_confidence_wikilinks
+                    stats.low_confidence_link_targets
                 );
                 println!("  orphans:          {}", stats.orphans);
                 println!("  avg out-degree:   {:.2}", stats.avg_outdegree);

--- a/src/main.rs
+++ b/src/main.rs
@@ -23710,6 +23710,205 @@ fn render_brain_search_response(
 mod cli_help_contract_tests {
     use super::*;
 
+    // ── nw-334. The ONE exhaustive inventory of `CliDiagnostic` ─────────────
+    //
+    // Three separate tiers ask three different questions of the same nine
+    // variants, and before this they asked them of three different lists: T3c
+    // destructured all nine, T3b hand-listed ONE while calling itself explicit,
+    // and the "is this remedy followable at all" question was asked by a
+    // five-phrase denylist in `tests/error_remedy_test.rs` that no variant had
+    // to answer. A new diagnostic therefore joined one check by failing to
+    // compile and escaped the other two in silence — the nw-217 shape, inside
+    // the fix for nw-334.
+    //
+    // One inventory, three axes, and `classify_is_total` below makes adding a
+    // variant a compile error until it is classified on all three.
+
+    /// Can this condition clear without the operator doing anything?
+    #[derive(PartialEq, Debug, Clone, Copy)]
+    enum Clears {
+        /// Another process is doing something that will finish.
+        OnItsOwn,
+        /// Nothing that runs later changes this file or this fact.
+        Never,
+    }
+
+    /// May this diagnostic's remedy name a command that WRITES?
+    ///
+    /// nw-329: the audience for "I found nothing" is by definition someone
+    /// whose targeting is already wrong, and a query that returned no rows has
+    /// not established that the database is empty — so sending them to `index`
+    /// is how a lookup miss becomes a production write.
+    #[derive(PartialEq, Debug, Clone, Copy)]
+    enum WriteRemedy {
+        /// The condition proves nothing about what the database holds, so a
+        /// write could destroy data this error knows nothing about.
+        Barred,
+        /// The condition itself establishes that there is nothing to lose — no
+        /// database at all, or one with no schema — so a write is the correct
+        /// remedy and naming it is safe.
+        Allowed,
+    }
+
+    /// What FORM does the remedy take? nw-334/G1.
+    #[derive(PartialEq, Debug, Clone, Copy)]
+    enum Remedy {
+        /// The help names a command to RUN, which
+        /// `backtick_quoted_remedies_still_name_a_real_subcommand` then checks
+        /// against the live clap tree.
+        Invocation,
+        /// The help says what to DO and no command can express it. The string
+        /// is the reason, recorded rather than assumed.
+        Instruction(&'static str),
+        /// The remedy is not static at all — it travels in the wrapped message.
+        /// No variant-level tier can see it; this is nw-334/G3, the
+        /// acknowledged residue, named here so it is a known hole rather than
+        /// an unnoticed one.
+        InMessage(&'static str),
+    }
+
+    /// Destructures every variant, so a new one cannot be added without
+    /// touching this match. The inventory's completeness is then the arm count.
+    fn classify_is_total(diagnostic: &CliDiagnostic) -> &'static str {
+        match diagnostic {
+            CliDiagnostic::DatabaseNotFound { .. } => "db_not_found",
+            CliDiagnostic::RepoPathNotFound { .. } => "repo_not_found",
+            CliDiagnostic::RepoPathNotADirectory { .. } => "repo_not_a_directory",
+            CliDiagnostic::EmptyDatabase => "empty_db",
+            CliDiagnostic::DatabaseUnavailable { .. } => "db_unavailable",
+            CliDiagnostic::DatabaseWalUnreplayed { .. } => "db_wal_unreplayed",
+            CliDiagnostic::DatabaseCorrupt { .. } => "db_corrupt",
+            CliDiagnostic::DatabaseNoSchema { .. } => "db_no_schema",
+            CliDiagnostic::General { .. } => "error",
+        }
+    }
+
+    fn diagnostic_inventory() -> Vec<(CliDiagnostic, Clears, WriteRemedy, Remedy)> {
+        let sample = |name: &str| name.to_string();
+        vec![
+            // No database exists at this path, so `index` cannot write over
+            // anything — the one case where prescribing a write is honest.
+            (
+                CliDiagnostic::DatabaseNotFound { path: sample("d") },
+                Clears::Never,
+                WriteRemedy::Allowed,
+                Remedy::Invocation,
+            ),
+            (
+                CliDiagnostic::RepoPathNotFound { path: sample("r") },
+                Clears::Never,
+                WriteRemedy::Barred,
+                Remedy::Instruction(
+                    "which path the caller meant is information this error does \
+                     not have; only the caller can supply it",
+                ),
+            ),
+            (
+                CliDiagnostic::RepoPathNotADirectory { path: sample("r") },
+                Clears::Never,
+                WriteRemedy::Barred,
+                Remedy::Instruction(
+                    "the fix is to pass a different argument, which is a change \
+                     to the invocation the caller is already writing",
+                ),
+            ),
+            // nw-329: a query that returned no rows has NOT established that
+            // the database is empty.
+            (
+                CliDiagnostic::EmptyDatabase,
+                Clears::Never,
+                WriteRemedy::Barred,
+                Remedy::Invocation,
+            ),
+            // The one genuinely transient case: a live holder of the write lock
+            // releases it. Its help says to stop that process rather than to
+            // wait, which is stronger, but waiting is not a lie here.
+            (
+                CliDiagnostic::DatabaseUnavailable {
+                    path: sample("d"),
+                    cause: sample("c"),
+                },
+                Clears::OnItsOwn,
+                WriteRemedy::Barred,
+                Remedy::Invocation,
+            ),
+            (
+                CliDiagnostic::DatabaseWalUnreplayed {
+                    path: sample("d"),
+                    wal: sample("w"),
+                    cause: sample("c"),
+                },
+                Clears::Never,
+                WriteRemedy::Barred,
+                Remedy::Invocation,
+            ),
+            (
+                CliDiagnostic::DatabaseCorrupt {
+                    path: sample("d"),
+                    cause: sample("c"),
+                },
+                Clears::Never,
+                WriteRemedy::Barred,
+                Remedy::Invocation,
+            ),
+            // A file with no schema demonstrably holds no data, so `index`
+            // cannot destroy anything here. Documented on the variant itself.
+            (
+                CliDiagnostic::DatabaseNoSchema {
+                    path: sample("d"),
+                    detail: sample("0 bytes"),
+                },
+                Clears::Never,
+                WriteRemedy::Allowed,
+                Remedy::Invocation,
+            ),
+            // The catch-all. Its remedy is whatever the wrapped `anyhow` chain
+            // said, so no static tier can check it — nw-334/G3.
+            (
+                CliDiagnostic::General {
+                    message: sample("m"),
+                },
+                Clears::Never,
+                WriteRemedy::Barred,
+                Remedy::InMessage(
+                    "the remedy is carried by the wrapped error, which is \
+                     composed at the call site; the end-to-end table in \
+                     tests/error_remedy_test.rs is the only thing that can see \
+                     it, one row per bug",
+                ),
+            ),
+        ]
+    }
+
+    /// nw-334/G2. The inventory must name every variant EXACTLY once, on every
+    /// axis. Without this, `read_path_diagnostics_never_prescribe_a_write` and
+    /// `every_diagnostic_declares_whether_its_remedy_is_runnable` would both
+    /// pass vacuously on a variant nobody added — which is precisely how T3b
+    /// spent a release checking one diagnostic out of nine.
+    #[test]
+    fn every_diagnostic_is_classified_on_every_axis() {
+        let inventory = diagnostic_inventory();
+        let covered: std::collections::HashSet<&str> = inventory
+            .iter()
+            .map(|(diagnostic, _, _, _)| classify_is_total(diagnostic))
+            .collect();
+        assert_eq!(
+            covered.len(),
+            inventory.len(),
+            "the inventory must name every variant exactly once: {covered:?}"
+        );
+        // The arm count is what makes the above a COMPLETENESS claim rather
+        // than a uniqueness one: `classify_is_total` destructures every
+        // variant, so a new one cannot compile until it is added there, and
+        // this equality is what then forces it into the inventory too.
+        assert_eq!(
+            inventory.len(),
+            9,
+            "a `CliDiagnostic` variant was added or removed without \
+             classifying it here"
+        );
+    }
+
     /// Stack size for the CLI-tree tests.
     ///
     /// `Cli::command()` alone overflows a test thread's default 2 MiB stack:
@@ -24165,11 +24364,17 @@ mod cli_help_contract_tests {
             "publication rollback",
         ];
 
-        // Explicit inventory, not a scan: a new diagnostic must be classified
-        // by a human, and the classification is the point.
-        let read_diagnostics = [CliDiagnostic::EmptyDatabase];
-
-        for diagnostic in read_diagnostics {
+        // nw-334/G2. This used to read `let read_diagnostics =
+        // [CliDiagnostic::EmptyDatabase];` under a comment calling itself an
+        // "explicit inventory" — a hand-maintained list of ONE, twenty lines
+        // from a neighbour that destructures all nine, so a new variant joined
+        // that neighbour by failing to compile and escaped THIS check in
+        // silence. The class this item exists to close, occurring inside the
+        // fix for it. Both tiers now read the same exhaustive inventory.
+        for (diagnostic, _, write_remedy, remedy) in diagnostic_inventory() {
+            if write_remedy != WriteRemedy::Barred {
+                continue;
+            }
             let help = diagnostic
                 .help()
                 .map(|help| help.to_string())
@@ -24181,17 +24386,82 @@ mod cli_help_contract_tests {
             for command in WRITE_COMMANDS {
                 assert!(
                     !help.contains(&format!("nestweaver {command}")),
-                    "`{code}` is a read-path diagnostic but its help prescribes \
-                     `nestweaver {command}`. A query that returned no rows has not \
-                     established that the database is empty, so it cannot know that \
-                     writing is safe. Help: {help}"
+                    "`{code}` is barred from prescribing a write but its help \
+                     prescribes `nestweaver {command}`. A query that returned no \
+                     rows has not established that the database is empty, so it \
+                     cannot know that writing is safe. Help: {help}"
                 );
             }
             assert!(
-                !help.is_empty(),
+                !help.is_empty() || matches!(remedy, Remedy::InMessage(_)),
                 "`{code}` must still offer something followable — the rule is \
                  'no writes', not 'no help'"
             );
+        }
+    }
+
+    /// nw-334/G1. A remedy is either something to RUN or something to DO, and
+    /// the shipped harness could only see the first: `suggested_command`
+    /// (`tests/error_remedy_test.rs`) returns `None` for anything that does not
+    /// contain the literal `nestweaver `, and the second form was a FIVE-PHRASE
+    /// DENYLIST (`TRANSIENT_ADVICE`). A denylist cannot enumerate the ways a
+    /// remedy can be unfollowable — "ask your administrator", "wait for the
+    /// index to settle", "the file may be locked by another tool" all pass it.
+    ///
+    /// Inverting it: every diagnostic declares WHICH FORM its remedy takes, on
+    /// the exhaustive inventory, so an instruction-shaped remedy is a decision
+    /// on the record rather than a silent no-op in the check built to catch
+    /// exactly that.
+    #[test]
+    fn every_diagnostic_declares_whether_its_remedy_is_runnable() {
+        use miette::Diagnostic;
+
+        for (diagnostic, _, _, remedy) in diagnostic_inventory() {
+            let help = diagnostic
+                .help()
+                .map(|help| help.to_string())
+                .unwrap_or_default();
+            let code = diagnostic
+                .code()
+                .map(|code| code.to_string())
+                .unwrap_or_default();
+            match remedy {
+                Remedy::Invocation => assert!(
+                    help.contains("nestweaver "),
+                    "`{code}` is declared runnable but its help names no \
+                     command, so `backtick_quoted_remedies_still_name_a_real_\
+                     subcommand` has nothing to parse and the remedy is \
+                     unchecked: {help}"
+                ),
+                Remedy::Instruction(why) => {
+                    assert!(
+                        !why.is_empty(),
+                        "`{code}` offers an instruction rather than a command; \
+                         say why no command can express it, or the harness \
+                         cannot see the remedy at all (nw-285)"
+                    );
+                    assert!(
+                        !help.is_empty(),
+                        "`{code}` is declared to carry an instruction and \
+                         carries nothing"
+                    );
+                    assert!(
+                        !help.contains("nestweaver "),
+                        "`{code}` names a command but is tagged \
+                         `Instruction`, so T1 never checks that the command is \
+                         real. Tag it `Invocation`: {help}"
+                    );
+                }
+                Remedy::InMessage(why) => {
+                    assert!(!why.is_empty());
+                    assert!(
+                        help.is_empty(),
+                        "`{code}` is declared to carry its remedy in the \
+                         wrapped message, but it also has static help — one of \
+                         the two is unchecked: {help}"
+                    );
+                }
+            }
         }
     }
 
@@ -24216,97 +24486,9 @@ mod cli_help_contract_tests {
     fn no_permanent_diagnostic_advises_waiting_it_out() {
         use miette::Diagnostic;
 
-        /// Can this condition clear without the operator doing anything?
-        #[derive(PartialEq, Debug)]
-        enum Clears {
-            /// Another process is doing something that will finish.
-            OnItsOwn,
-            /// Nothing that runs later changes this file or this fact.
-            Never,
-        }
+        let inventory = diagnostic_inventory();
 
-        let sample = |name: &str| name.to_string();
-        let inventory: Vec<(CliDiagnostic, Clears)> = vec![
-            (
-                CliDiagnostic::DatabaseNotFound { path: sample("d") },
-                Clears::Never,
-            ),
-            (
-                CliDiagnostic::RepoPathNotFound { path: sample("r") },
-                Clears::Never,
-            ),
-            (
-                CliDiagnostic::RepoPathNotADirectory { path: sample("r") },
-                Clears::Never,
-            ),
-            (CliDiagnostic::EmptyDatabase, Clears::Never),
-            // The one genuinely transient case: a live holder of the write lock
-            // releases it. Its help says to stop that process rather than to
-            // wait, which is stronger, but waiting is not a lie here.
-            (
-                CliDiagnostic::DatabaseUnavailable {
-                    path: sample("d"),
-                    cause: sample("c"),
-                },
-                Clears::OnItsOwn,
-            ),
-            (
-                CliDiagnostic::DatabaseWalUnreplayed {
-                    path: sample("d"),
-                    wal: sample("w"),
-                    cause: sample("c"),
-                },
-                Clears::Never,
-            ),
-            (
-                CliDiagnostic::DatabaseCorrupt {
-                    path: sample("d"),
-                    cause: sample("c"),
-                },
-                Clears::Never,
-            ),
-            (
-                CliDiagnostic::DatabaseNoSchema {
-                    path: sample("d"),
-                    detail: sample("0 bytes"),
-                },
-                Clears::Never,
-            ),
-            (
-                CliDiagnostic::General {
-                    message: sample("m"),
-                },
-                Clears::Never,
-            ),
-        ];
-
-        // Compile-time completeness: destructuring every variant means a new
-        // one cannot be added without touching this match, and the arm count
-        // must equal the inventory length.
-        fn classify_is_total(diagnostic: &CliDiagnostic) -> &'static str {
-            match diagnostic {
-                CliDiagnostic::DatabaseNotFound { .. } => "db_not_found",
-                CliDiagnostic::RepoPathNotFound { .. } => "repo_not_found",
-                CliDiagnostic::RepoPathNotADirectory { .. } => "repo_not_a_directory",
-                CliDiagnostic::EmptyDatabase => "empty_db",
-                CliDiagnostic::DatabaseUnavailable { .. } => "db_unavailable",
-                CliDiagnostic::DatabaseWalUnreplayed { .. } => "db_wal_unreplayed",
-                CliDiagnostic::DatabaseCorrupt { .. } => "db_corrupt",
-                CliDiagnostic::DatabaseNoSchema { .. } => "db_no_schema",
-                CliDiagnostic::General { .. } => "error",
-            }
-        }
-        let covered: std::collections::HashSet<&str> = inventory
-            .iter()
-            .map(|(diagnostic, _)| classify_is_total(diagnostic))
-            .collect();
-        assert_eq!(
-            covered.len(),
-            inventory.len(),
-            "the inventory must name every variant exactly once"
-        );
-
-        for (diagnostic, clears) in &inventory {
+        for (diagnostic, clears, _, _) in &inventory {
             let help = diagnostic
                 .help()
                 .map(|help| help.to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -9557,11 +9557,40 @@ fn affected_tests_rpc_args(changed_files: &[String]) -> serde_json::Value {
     serde_json::json!({ "changed_files": changed_files })
 }
 
+/// The filesystem root a source-reading RPC must send to the daemon.
+///
+/// nw-340. Every daemon-side tool that reads source spans resolves repo-relative
+/// `file_path`s against a `root` argument, and every one of them falls back to
+/// `std::env::current_dir()` when the argument is absent. That fallback is the
+/// **daemon's** cwd — a long-lived process started wherever it was started,
+/// which is essentially never the caller's repo. So an omitted `root` does not
+/// mean "use a sensible default"; it means "read the wrong tree", and the
+/// symptom is a well-formed response with empty bodies.
+///
+/// The client's cwd is the only working directory that means anything to the
+/// caller, so an absent `--root` resolves here, on the client, rather than
+/// being left for the server to guess.
+fn client_source_root(root: Option<&std::path::Path>) -> String {
+    root.map(std::path::Path::to_path_buf)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_default())
+        .to_string_lossy()
+        .into_owned()
+}
+
 /// `read_symbols` reads `include_neighbors` (never `neighbors`, nw-088) and an
 /// optional integer `token_budget`. The budget key is OMITTED when unset — the
 /// tool's integer schema rejects an explicit null, which used to fail schema
 /// validation on every budget-less call and silently fall back to the direct
 /// path.
+///
+/// `root`, by contrast, is ALWAYS sent (nw-340). It used to be omitted when
+/// `--root` was not passed, and the daemon then filled it from its own
+/// `current_dir()`. The daemon is long-lived and started wherever it happened
+/// to be started, so every repo-relative `file_path` failed to resolve, every
+/// `read_span` returned `None`, and `read-symbols` printed a well-formed header
+/// with no body under it. Since `resolve_use_daemon` returns true by default,
+/// that was the normal path, not an edge case. The client's cwd is the only
+/// working directory that means anything to the caller, so it is the default.
 fn read_symbols_rpc_args(
     targets: &[String],
     neighbors: u8,
@@ -9575,9 +9604,7 @@ fn read_symbols_rpc_args(
     if let Some(tb) = token_budget {
         args["token_budget"] = serde_json::json!(tb);
     }
-    if let Some(r) = root {
-        args["root"] = serde_json::json!(r.to_string_lossy());
-    }
+    args["root"] = serde_json::json!(client_source_root(root));
     args
 }
 
@@ -16167,9 +16194,10 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 if let Some(ref s) = scope {
                     args["scope"] = serde_json::json!(s);
                 }
-                if let Some(ref r) = root {
-                    args["root"] = serde_json::json!(r);
-                }
+                // nw-340: always send a root. An omitted `root` is filled by
+                // the DAEMON's cwd, not the caller's, so inline bodies come
+                // back empty from a response that otherwise looks fine.
+                args["root"] = serde_json::json!(client_source_root(root.as_deref()));
                 if let Some(value) = try_hybrid_json_rpc(true, &db_path, None, "investigate", args)?
                 {
                     if json {
@@ -16252,9 +16280,10 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     "bundle_id": bundle_id,
                     "targets": targets,
                 });
-                if let Some(ref r) = root {
-                    args["root"] = serde_json::json!(r);
-                }
+                // nw-340: always send a root. An omitted `root` is filled by
+                // the DAEMON's cwd, not the caller's, so inline bodies come
+                // back empty from a response that otherwise looks fine.
+                args["root"] = serde_json::json!(client_source_root(root.as_deref()));
                 if let Some(value) =
                     try_hybrid_json_rpc(true, &db_path, None, "investigate_expand", args)?
                 {
@@ -16323,9 +16352,10 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     "bundle_id": bundle_id,
                     "token_budget": token_budget,
                 });
-                if let Some(ref r) = root {
-                    args["root"] = serde_json::json!(r);
-                }
+                // nw-340: always send a root. An omitted `root` is filled by
+                // the DAEMON's cwd, not the caller's, so inline bodies come
+                // back empty from a response that otherwise looks fine.
+                args["root"] = serde_json::json!(client_source_root(root.as_deref()));
                 if let Some(value) =
                     try_hybrid_json_rpc(true, &db_path, None, "investigate_hydrate", args)?
                 {
@@ -19552,6 +19582,34 @@ fn ensure_direct_store_fallback_allowed(
     }
 }
 
+/// The header-plus-body text for one symbol window.
+///
+/// Extracted from `render_read_symbols` so the `body_available` branch is
+/// testable without capturing stdout (nw-340).
+///
+/// The engine already distinguishes "this symbol is genuinely empty" from "I
+/// could not read the source" and says so in `body_available`. The MCP surface
+/// honours that field; this renderer used to drop it and print `w.body`
+/// unconditionally, so an unreadable span emitted a correct-looking header
+/// followed by one blank line. That is the nw-249/nw-212 honesty class:
+/// reporting success for work that did not happen.
+fn read_symbols_window_text(w: &nestweaver_engine::read_symbols::SymbolWindow) -> String {
+    let tag = if w.is_neighbor { " [neighbor]" } else { "" };
+    let header = format!(
+        "\u{2500}\u{2500} {} ({}) {}:{}-{}{}",
+        w.name, w.kind, w.path, w.start_line, w.end_line, tag
+    );
+    if w.body_available {
+        format!("{header}\n{}", w.body)
+    } else {
+        format!(
+            "{header}\n   source unavailable: {} could not be read for lines {}-{} \
+             — pass --root <repo> or run from the repo root",
+            w.path, w.start_line, w.end_line
+        )
+    }
+}
+
 /// Render a `read_symbols` result and compute its exit code.
 ///
 /// Shared by the daemon and direct paths so `--json` and the exit-code
@@ -19564,12 +19622,7 @@ fn render_read_symbols(
         println!("{}", serde_json::to_string_pretty(&res)?);
     } else {
         for w in &res.symbols {
-            let tag = if w.is_neighbor { " [neighbor]" } else { "" };
-            println!(
-                "\u{2500}\u{2500} {} ({}) {}:{}-{}{}",
-                w.name, w.kind, w.path, w.start_line, w.end_line, tag
-            );
-            println!("{}", w.body);
+            println!("{}", read_symbols_window_text(w));
             println!();
         }
         for nf in &res.not_found {
@@ -19606,6 +19659,14 @@ fn render_read_symbols(
         if !res.ambiguous.is_empty() {
             return Ok((EXIT_AMBIGUOUS, None));
         }
+        return Ok((EXIT_NOT_FOUND, None));
+    }
+    // nw-340: symbols resolved, but not ONE of them yielded readable source.
+    // `read-symbols` exists to return source; a run that returned none of it
+    // answered no part of the question asked, and exiting 0 made that
+    // indistinguishable from success. A partial answer still succeeds — the
+    // bodies that were read are real.
+    if !res.symbols.is_empty() && res.symbols.iter().all(|w| !w.body_available) {
         return Ok((EXIT_NOT_FOUND, None));
     }
     Ok((EXIT_SUCCESS, None))
@@ -22257,7 +22318,11 @@ fn run_brain(
                         "intent": intent.clone().unwrap_or_default(),
                         "include_seeds": true,
                         "include_bodies": inline_bodies,
-                        "root": root.clone().unwrap_or_default().to_string_lossy().to_string(),
+                        // nw-340: an absent `--root` used to be sent as `""`,
+                        // which the daemon joins onto a repo-relative path and
+                        // so resolves against its OWN cwd — the same wrong-tree
+                        // read as omitting the key. Resolve it client-side.
+                        "root": client_source_root(root.as_deref()),
                         "prf": prf,
                         "rerank": rerank,
                         "weight_semantic": if no_embed { 0.0 } else { weight_semantic.unwrap_or(0.0) },
@@ -29945,13 +30010,16 @@ credential_method = "gh"
     #[test]
     fn read_symbols_rpc_args_omit_null_token_budget() {
         let args = read_symbols_rpc_args(&["main".to_string()], 0, None, None);
-        assert_eq!(
-            args,
-            serde_json::json!({ "targets": ["main"], "include_neighbors": 0 })
-        );
         assert!(args.get("token_budget").is_none());
-        assert!(args.get("root").is_none());
         assert!(args.get("neighbors").is_none());
+        // `root` is NOT omitted — see
+        // `read_symbols_rpc_args_always_sends_a_root` (nw-340).
+        assert_eq!(
+            args["targets"],
+            serde_json::json!(["main"]),
+            "targets and include_neighbors are the only other keys"
+        );
+        assert_eq!(args["include_neighbors"], serde_json::json!(0));
 
         let args = read_symbols_rpc_args(
             &["main".to_string()],
@@ -29968,6 +30036,123 @@ credential_method = "gh"
                 "root": "/repo",
             })
         );
+    }
+
+    /// nw-340. With no `--root` the CLI omitted `root`, so the DAEMON resolved
+    /// repo-relative file paths against ITS OWN cwd
+    /// (`nestweaver-mcp/src/tools.rs`, `unwrap_or_else(|| current_dir())`).
+    /// The daemon is long-lived and was started somewhere else, so EVERY body
+    /// came back empty and `read-symbols` printed headers with nothing under
+    /// them. `resolve_use_daemon` returns true by default, which is why this
+    /// looked universal rather than cwd-dependent.
+    #[test]
+    fn read_symbols_rpc_args_always_sends_a_root() {
+        let args = read_symbols_rpc_args(&["greet".to_string()], 0, None, None);
+        let root = args
+            .get("root")
+            .and_then(|v| v.as_str())
+            .expect("root must always be sent: the daemon's cwd is not the caller's");
+        assert_eq!(
+            std::path::Path::new(root),
+            std::env::current_dir().unwrap().as_path(),
+            "root must default to the CLIENT's cwd"
+        );
+    }
+
+    /// nw-340, the honesty half. The engine already sets
+    /// `body_available: false` (`read_symbols.rs`, pinned by
+    /// `read_symbols_flags_unreadable_body`); `render_read_symbols` never
+    /// consulted it, so a failed read produced a well-formed header, one blank
+    /// line, and EXIT_SUCCESS.
+    #[test]
+    fn an_unreadable_body_is_reported_not_printed_as_a_blank_line() {
+        let w = nestweaver_engine::read_symbols::SymbolWindow {
+            uid: "sym:x".into(),
+            name: "greet".into(),
+            kind: "Function".into(),
+            path: "src/greet.rs".into(),
+            start_line: 10,
+            end_line: 14,
+            body: String::new(),
+            body_available: false,
+            is_neighbor: false,
+        };
+        let out = read_symbols_window_text(&w);
+        assert!(
+            out.contains("source unavailable"),
+            "an unreadable body must say so rather than emitting nothing: {out:?}"
+        );
+        assert!(
+            out.contains("--root"),
+            "the remedy must be named, not implied: {out:?}"
+        );
+    }
+
+    /// nw-340's own pinning assertion, quoted from the item: "for a symbol
+    /// whose span is N lines, the emitted body must be N non-empty lines and
+    /// its first line must match the file's line at `start_line`."
+    #[test]
+    fn a_readable_body_emits_one_line_per_span_line() {
+        let w = nestweaver_engine::read_symbols::SymbolWindow {
+            uid: "sym:x".into(),
+            name: "greet".into(),
+            kind: "Function".into(),
+            path: "src/greet.rs".into(),
+            start_line: 1,
+            end_line: 3,
+            body: "fn greet() {\n    hello();\n}".into(),
+            body_available: true,
+            is_neighbor: false,
+        };
+        let text = read_symbols_window_text(&w);
+        let body: Vec<&str> = text.lines().skip(1).collect();
+        assert_eq!(
+            body.len(),
+            (w.end_line - w.start_line + 1) as usize,
+            "a 3-line span must emit 3 lines, got {body:?}"
+        );
+        assert_eq!(body[0], "fn greet() {");
+        assert!(body.iter().all(|l| !l.trim().is_empty()));
+    }
+
+    /// nw-340. A read where NO requested symbol had a readable body is a
+    /// failure the exit code must carry: the caller asked for source and
+    /// received none. Exit 2 ("not found") is the existing code for "the
+    /// question was not answered".
+    #[test]
+    fn a_read_where_no_body_was_readable_does_not_exit_success() {
+        let unreadable = |name: &str| nestweaver_engine::read_symbols::SymbolWindow {
+            uid: format!("sym:{name}"),
+            name: name.into(),
+            kind: "Function".into(),
+            path: "src/greet.rs".into(),
+            start_line: 10,
+            end_line: 14,
+            body: String::new(),
+            body_available: false,
+            is_neighbor: false,
+        };
+        let res = nestweaver_engine::read_symbols::ReadSymbolsResult {
+            symbols: vec![unreadable("greet")],
+            ..Default::default()
+        };
+        let (code, _) = render_read_symbols(&res, false).unwrap();
+        assert_eq!(
+            code, EXIT_NOT_FOUND,
+            "every requested body was unreadable; exiting 0 reports success for \
+             work that did not happen"
+        );
+
+        // One readable body is enough to succeed — the partial answer is real.
+        let mut ok = unreadable("other");
+        ok.body = "fn other() {}".into();
+        ok.body_available = true;
+        let res = nestweaver_engine::read_symbols::ReadSymbolsResult {
+            symbols: vec![unreadable("greet"), ok],
+            ..Default::default()
+        };
+        let (code, _) = render_read_symbols(&res, false).unwrap();
+        assert_eq!(code, EXIT_SUCCESS);
     }
 
     /// nw-108 (4): EVERY read-only open must produce the `db_not_found`

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,9 +103,9 @@ use nestweaver_engine::{
     generate_repo_map, generate_summaries, get_last_indexed_at,
     index_markdown_directory_since_with_ignore, index_markdown_directory_with_ignore,
     index_markdown_directory_with_ignore_and_deletion_count, list_repos, list_services,
-    load_alias_sidecar, load_clusters, load_extensions, lookup_symbol, record_last_indexed_at,
-    render_text, save_clusters, save_cochange_sidecar, save_summaries, search_symbols,
-    suggest_links, truncate_to_budget,
+    load_alias_sidecar, load_clusters, lookup_symbol, record_last_indexed_at, render_text,
+    save_clusters, save_cochange_sidecar, save_summaries, search_symbols, suggest_links,
+    truncate_to_budget,
 };
 use nestweaver_schema::{DEFAULT_DRAIN_CEILING_SECS, Symbol, parse_drain_ceiling};
 use nestweaver_store::{GraphStore, QueryIntent, TantivyIndex};
@@ -15866,6 +15866,10 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             if let Some(include_components) = include_components {
                 project_args["include_components"] = serde_json::json!(include_components);
             }
+            // Both routes send the SAME arguments. The direct leg used to
+            // build its own set from the same clap fields, which is how
+            // `include_components` came to differ between them (nw-316 leg 2).
+            let direct_args = project_args.clone();
             let daemon_result = try_hybrid_json_rpc_checked(
                 use_daemon,
                 &db_path,
@@ -15893,6 +15897,23 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 return Ok((EXIT_SUCCESS, None));
             }
 
+            // nw-316. This route used to be a hand-written SECOND
+            // implementation of `tool_project_context`: ~295 lines of member
+            // collection, PPR seeding, promotion/dedup/boost/sort, recency and
+            // budgeting, ending in a renderer that omitted `truncated`,
+            // `more_available` and `seed_tokens_charged` — so a `--no-daemon`
+            // caller could not tell a complete answer from the first N of one.
+            // It also cut with `token_budgeted_truncate` and then measured the
+            // finished object AFTER THE FACT, where the tool runs a
+            // serialized-size probe loop and re-cuts; this route could report
+            // `budget_exceeded: true` and still emit an over-budget payload.
+            //
+            // It now calls the tool, exactly as `BrainCommands::Search`'s direct
+            // leg does and as `context` was changed to do in 8.0.0. That closes
+            // the three missing fields and the probe-loop gap in one change
+            // instead of three, and it is why the alias/UID-substring resolution
+            // deleted here is not lost: the tool carries the identical
+            // resolution, extension-sidecar alias match included.
             let store = open_store(Some(&db_path))?;
             let tantivy_path = tantivy_sidecar_path_for(&db_path);
             let tantivy = TantivyIndex::open_reader_only(&tantivy_path).ok();
@@ -15900,294 +15921,33 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 tracing::info!("Tantivy index unavailable — BM25 search disabled for this query");
             }
 
-            // Resolve the project: name -> alias -> UID substring.
-            let project = if name.starts_with("proj:") {
-                let all = store.list_projects().map_err(|e| anyhow::anyhow!(e))?;
-                all.into_iter()
-                    .find(|p| p.uid == name || p.uid.contains(&name))
-                    .ok_or_else(|| anyhow::anyhow!("project '{}' not found", name))?
-            } else {
-                match store
-                    .lookup_project_by_name(&name)
-                    .map_err(|e| anyhow::anyhow!(e))?
-                {
-                    Some(p) => p,
-                    None => {
-                        // Try alias match via extension sidecar, then UID substring.
-                        let all = store.list_projects().map_err(|e| anyhow::anyhow!(e))?;
-                        let ext_store = load_extensions(&db_path);
-                        let needle = name.to_lowercase();
-                        let alias_match = all.iter().find(|p| {
-                            if let Some(serde_json::Value::Array(aliases)) =
-                                ext_store.get(&p.uid).and_then(|m| m.get("aliases"))
-                            {
-                                aliases
-                                    .iter()
-                                    .any(|a| a.as_str().is_some_and(|s| s.to_lowercase() == needle))
-                            } else {
-                                false
-                            }
-                        });
-                        if let Some(p) = alias_match {
-                            p.clone()
-                        } else {
-                            match all.into_iter().find(|p| p.uid.contains(&name)) {
-                                Some(p) => p,
-                                None => {
-                                    eprintln!(
-                                        "Project '{}' not found. Try: nestweaver list-projects",
-                                        name
-                                    );
-                                    return Ok((EXIT_NOT_FOUND, None));
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-
-            // Collect member UIDs for the post-PPR boost. These are the
-            // notes and symbols declared as belonging to this project.
-            // Member note UIDs are tracked separately: they get seeded into
-            // PPR and surfaced into `connected` (Bug #12).
-            let mut member_uids: Vec<String> = Vec::new();
-            let mut member_note_uids: std::collections::HashSet<String> =
-                std::collections::HashSet::new();
-            let note_uids = store
-                .list_project_note_uids(&project.uid)
-                .map_err(|e| anyhow::anyhow!(e))?;
-            member_note_uids.extend(note_uids.iter().cloned());
-            member_uids.extend(note_uids);
-            let sym_uids = store
-                .list_project_symbol_uids(&project.uid)
-                .map_err(|e| anyhow::anyhow!(e))?;
-            member_uids.extend(sym_uids);
-
-            // nw-316: the same documented default the tool applies
-            // (`unwrap_or(true)` in `tool_project_context`). Both routes now
-            // land on the schema's `default: true` rather than one of them on
-            // clap's.
-            let comp_uids = if include_components.unwrap_or(true) {
-                store
-                    .list_project_component_uids(&project.uid)
-                    .map_err(|e| anyhow::anyhow!(e))?
-            } else {
-                vec![]
-            };
-            for comp_uid in &comp_uids {
-                let comp_notes = store.list_project_note_uids(comp_uid).unwrap_or_default();
-                member_note_uids.extend(comp_notes.iter().cloned());
-                member_uids.extend(comp_notes);
-                member_uids.extend(store.list_project_symbol_uids(comp_uid).unwrap_or_default());
-            }
-
-            // Deduplicate members.
-            let mut seen = std::collections::HashSet::new();
-            member_uids.retain(|u| seen.insert(u.clone()));
-
-            if member_uids.is_empty() {
-                if json {
-                    println!(
-                        "{}",
-                        serde_json::to_string_pretty(&serde_json::json!({
-                            "project": project.name,
-                            "seeds": [],
-                            "connected": [],
-                            "note": "No notes or symbols associated with this project.",
-                        }))?
-                    );
-                } else {
-                    println!(
-                        "Project '{}' has no associated notes or symbols.",
-                        project.name
-                    );
-                }
-                return Ok((EXIT_SUCCESS, None));
-            }
-
-            // Seed PPR from the project node, its components, and the
-            // project's member notes (Bug #12). Seeding the notes guarantees
-            // they survive the `min_score` filter in PPR — when a project
-            // declares repos, the project node's mass is split across tens of
-            // thousands of PROJECT_INCLUDES_SYMBOL edges, leaving each note
-            // below threshold so it never reaches `connected`.
-            //
-            // Member symbols suffer the identical fan-out, so seed the
-            // top-K of them by PageRank as well. Without this, a project
-            // that declares any repo returns notes-only context even after
-            // `materialize-projects` writes hundreds of thousands of
-            // PROJECT_INCLUDES_SYMBOL edges (Bug #18 / wave-5 regression).
-            const PROJECT_SYMBOL_SEED_LIMIT: usize = 100;
-            let mut member_symbol_uids: std::collections::HashSet<String> =
-                std::collections::HashSet::new();
-            let top_symbols = store
-                .list_project_symbol_uids_by_pagerank(&project.uid, PROJECT_SYMBOL_SEED_LIMIT)
-                .map_err(|e| anyhow::anyhow!(e))?;
-            member_symbol_uids.extend(top_symbols.iter().cloned());
-            for comp_uid in &comp_uids {
-                let comp_top = store
-                    .list_project_symbol_uids_by_pagerank(comp_uid, PROJECT_SYMBOL_SEED_LIMIT)
-                    .unwrap_or_default();
-                member_symbol_uids.extend(comp_top);
-            }
-
-            let mut ppr_seeds: Vec<String> = vec![project.uid.clone()];
-            ppr_seeds.extend(comp_uids);
-            ppr_seeds.extend(member_note_uids.iter().cloned());
-            ppr_seeds.extend(member_symbol_uids.iter().cloned());
-
-            let defaults = HybridSearchConfig::default();
-            let search_config = if no_embed {
-                HybridSearchConfig {
-                    weight_semantic: 0.0,
-                    ..defaults
-                }
-            } else {
-                defaults
-            };
-            let aliases = load_alias_sidecar(&db_path);
-            match build_brain_context_hybrid_with_aliases(
+            nestweaver_mcp::tools::set_current_db_path(db_path.clone());
+            nestweaver_mcp::tools::set_current_instance_config(
+                load_instance_config_opt(config.as_deref()).map(std::sync::Arc::new),
+            );
+            let response = nestweaver_mcp::tools::dispatch(
                 &store,
-                &ppr_seeds,
                 tantivy.as_ref(),
-                &search_config,
-                &aliases,
-                Some(&db_path),
-                Some(nestweaver_store::QueryIntent::ProjectContext),
+                "project_context",
+                direct_args,
                 None,
-                None,
-            ) {
-                Ok(mut result) => {
-                    // Surface the project's curated member notes into
-                    // `connected` (Bug #12). Seeded notes land in `seeds`,
-                    // which print_brain_context_json does not render.
-                    nestweaver_engine::promote_member_notes_into_connected(
-                        &mut result,
-                        &member_note_uids,
-                    );
-                    // Surface the seeded member symbols into `connected`
-                    // for the same reason (companion to the notes promotion).
-                    nestweaver_engine::promote_member_symbols_into_connected(
-                        &mut result,
-                        &member_symbol_uids,
-                    );
-                    // Drop Heading/Section duplicates: notes-heavy projects
-                    // would otherwise spend ~25% of a 2000-token budget on
-                    // pairs that share `(file, title)` and add no information.
-                    nestweaver_engine::dedup_heading_section_pairs(&mut result);
+            );
+            nestweaver_mcp::tools::set_current_instance_config(None);
 
-                    // Post-PPR scope boost: multiply relevance for nodes that
-                    // belong to the project so declared content ranks highest.
-                    let member_set: std::collections::HashSet<&str> =
-                        member_uids.iter().map(|s| s.as_str()).collect();
-                    for node in &mut result.connected {
-                        if member_set.contains(node.uid.as_str()) {
-                            node.relevance *= 5.0;
-                        }
-                    }
-                    result.connected.sort_by(|a, b| {
-                        b.relevance
-                            .partial_cmp(&a.relevance)
-                            .unwrap_or(std::cmp::Ordering::Equal)
-                    });
-                    // since filter: hard filter Note/Section nodes by modified_at.
-                    if let Some(ref since_ts) = since {
-                        let recent_notes = store
-                            .list_note_uids_modified_since(since_ts)
-                            .map_err(|e| anyhow::anyhow!(e))?;
-                        let recent_sections = store
-                            .list_section_uids_modified_since(since_ts)
-                            .map_err(|e| anyhow::anyhow!(e))?;
-                        let filter_since = |nodes: &mut Vec<nestweaver_engine::BrainNode>| {
-                            nodes.retain(|item| {
-                                if item.kind.to_lowercase().contains("symbol") {
-                                    return true;
-                                }
-                                recent_notes.contains(&item.uid)
-                                    || recent_sections.contains(&item.uid)
-                            });
-                        };
-                        filter_since(&mut result.seeds);
-                        filter_since(&mut result.connected);
-                    }
-
-                    // recency bias: soft boost based on note modified_at age.
-                    if recency_weight > 0.0 {
-                        apply_recency_bias_cli(
-                            &store,
-                            &mut result.connected,
-                            recency_weight,
-                            recency_half_life_days,
-                        );
-                        apply_recency_bias_cli(
-                            &store,
-                            &mut result.seeds,
-                            recency_weight,
-                            recency_half_life_days,
-                        );
-                    }
-
-                    // Compute seed token cost and allocate the remainder to
-                    // connected. Don't double-count items the promotion helpers
-                    // copied from `seeds` into `connected` — those tokens belong
-                    // to the connected budget, not the seed overhead.
-                    let connected_uids: std::collections::HashSet<&str> =
-                        result.connected.iter().map(|n| n.uid.as_str()).collect();
-                    // nw-316: the SAME flag the renderer below is handed
-                    // (`!detailed`). Charging the detailed rate for a concise
-                    // response is what made this route return fewer items than
-                    // the daemon for an identical budget.
-                    let concise = !detailed;
-                    let seed_tokens: usize = result
-                        .seeds
-                        .iter()
-                        .filter(|n| !connected_uids.contains(n.uid.as_str()))
-                        .map(|n| render_cost_tokens(n, concise))
-                        .sum();
-                    let remaining_budget = token_budget.saturating_sub(seed_tokens);
-                    let cut = token_budgeted_truncate(&result.connected, remaining_budget, concise);
-                    let connected_tokens: usize = result
-                        .connected
-                        .iter()
-                        .take(cut)
-                        .map(|n| render_cost_tokens(n, concise))
-                        .sum();
-                    let used_tokens = seed_tokens + connected_tokens;
-                    // Load external_refs from the extension sidecar so the
-                    // local (--no-daemon) path matches the daemon/MCP wrapper
-                    // shape — agents rely on this for Workfront / wiki PRD
-                    // surfacing.
-                    let ext_store = nestweaver_engine::load_extensions(&db_path);
-                    let external_refs =
-                        nestweaver_engine::get_all_properties(&ext_store, &project.uid)
-                            .get("external_refs")
-                            .cloned()
-                            .unwrap_or(serde_json::Value::Null);
-                    if json {
-                        print_project_context_json(
-                            &project,
-                            &result,
-                            cut,
-                            used_tokens,
-                            token_budget,
-                            &external_refs,
-                            !detailed,
-                        )?;
-                    } else {
-                        println!("Project: {}  ({})", project.name, project.uid);
-                        if let Some(ref summary) = project.summary {
-                            println!("  {summary}");
-                        }
-                        println!();
-                        print_brain_context_text(&result, cut, Some(token_budget));
-                    }
-                    Ok((EXIT_SUCCESS, None))
+            // The same NOT_FOUND classification the daemon leg above applies,
+            // for the same reason: a script must be able to tell "no such
+            // project" from "the query failed", and which one it is told must
+            // not depend on which transport answered.
+            let value = match response {
+                Ok(value) => value,
+                Err(error) if format!("{error:#}").contains("not found") => {
+                    eprintln!("Project '{name}' not found. Try: nestweaver list-projects");
+                    return Ok((EXIT_NOT_FOUND, None));
                 }
-                Err(e) => {
-                    eprintln!("Error: {e}");
-                    Ok((EXIT_ERROR, None))
-                }
-            }
+                Err(error) => return Err(error),
+            };
+            render_project_context_daemon_response(&value, json, token_budget);
+            Ok((EXIT_SUCCESS, None))
         }
 
         Commands::Investigate {
@@ -25114,94 +24874,6 @@ fn brain_context_json_value(result: &BrainContextResult, limit: usize) -> serde_
     resp
 }
 
-/// Render the `project-context` JSON for the local (--no-daemon) path with
-/// the same wrapper shape the daemon / MCP `project_context` tool emits:
-/// `project`, `project_uid`, `seeds_expanded`, `connected`, `tokens_used`,
-/// `token_budget`, and optional `unresolved_seeds` / `external_refs`. Agents
-/// depend on these fields, so the local and daemon paths must stay aligned.
-#[allow(clippy::too_many_arguments)]
-fn print_project_context_json(
-    project: &nestweaver_schema::Project,
-    result: &BrainContextResult,
-    limit: usize,
-    tokens_used: usize,
-    token_budget: usize,
-    external_refs: &serde_json::Value,
-    concise: bool,
-) -> anyhow::Result<()> {
-    let resp = project_context_json_value(
-        project,
-        result,
-        limit,
-        tokens_used,
-        token_budget,
-        external_refs,
-        concise,
-    );
-    println!("{}", serde_json::to_string_pretty(&resp)?);
-    Ok(())
-}
-
-#[allow(clippy::too_many_arguments)]
-fn project_context_json_value(
-    project: &nestweaver_schema::Project,
-    result: &BrainContextResult,
-    limit: usize,
-    tokens_used: usize,
-    token_budget: usize,
-    external_refs: &serde_json::Value,
-    concise: bool,
-) -> serde_json::Value {
-    // Match the daemon/MCP `project_context` node shape EXACTLY (tools.rs render_node): concise
-    // = {kind,title,location}; detailed adds uid + relevance. Without this the --no-daemon path
-    // emitted full nodes regardless of response_format, diverging from the daemon path.
-    let render = |n: &nestweaver_engine::BrainNode| -> serde_json::Value {
-        if concise {
-            serde_json::json!({ "kind": n.kind, "title": n.title, "location": n.location })
-        } else {
-            serde_json::json!({
-                "uid": n.uid,
-                "kind": n.kind,
-                "title": n.title,
-                "location": n.location,
-                "relevance": n.relevance,
-            })
-        }
-    };
-    let connected: Vec<serde_json::Value> =
-        result.connected.iter().take(limit).map(render).collect();
-    let mut resp = serde_json::json!({
-        "project": project.name,
-        "project_uid": project.uid,
-        "seeds_expanded": result.seeds.len(),
-        "connected": connected,
-        "tokens_used": tokens_used,
-        "token_budget": token_budget,
-        "semantic_applied": result.semantic_applied,
-        "degraded_components": result.degraded_components,
-    });
-    if !result.unresolved_seeds.is_empty() {
-        resp["unresolved_seeds"] = serde_json::json!(result.unresolved_seeds);
-    }
-    if result.semantic_seed_count > 0 {
-        resp["semantic_seed_count"] = serde_json::json!(result.semantic_seed_count);
-    }
-    if !result.expansion_terms.is_empty() {
-        resp["expansion_terms"] = serde_json::json!(result.expansion_terms);
-    }
-    if !external_refs.is_null() {
-        resp["external_refs"] = external_refs.clone();
-    }
-    // Measured on the FINISHED object, so every optional field above is
-    // counted. Same 4-bytes-per-token rule the daemon path uses.
-    let actual_tokens = serde_json::to_string(&resp)
-        .map(|serialized| serialized.len().div_ceil(4))
-        .unwrap_or(0);
-    resp["tokens_used"] = serde_json::json!(actual_tokens);
-    resp["budget_exceeded"] = serde_json::json!(actual_tokens > token_budget);
-    resp
-}
-
 #[cfg(test)]
 mod context_json_renderer_tests {
     use super::*;
@@ -25227,31 +24899,6 @@ mod context_json_renderer_tests {
             serde_json::json!(["semantic"])
         );
         assert_eq!(value["unresolved_seeds"], serde_json::json!(["missing"]));
-    }
-
-    #[test]
-    fn direct_project_context_never_drops_semantic_honesty() {
-        let project = nestweaver_schema::Project {
-            uid: "project:test".to_string(),
-            name: "test".to_string(),
-            summary: None,
-            instance_id: "default".to_string(),
-        };
-        let value = project_context_json_value(
-            &project,
-            &degraded_context(),
-            30,
-            0,
-            1_000,
-            &serde_json::Value::Null,
-            false,
-        );
-        assert_eq!(value["semantic_applied"], false);
-        assert_eq!(
-            value["degraded_components"],
-            serde_json::json!(["semantic"])
-        );
-        assert_eq!(value["project_uid"], "project:test");
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3365,12 +3365,30 @@ enum Commands {
             help = "Query intent override: find-definition, understand-architecture, analyze-impact, general-context"
         )]
         intent: Option<String>,
-        #[arg(long, help = "Maximum number of connected nodes to return")]
+        // nw-259(b). `--token-budget`, declared immediately below, carries
+        // `range(1..=16000)` to match its schema. This carried nothing, while
+        // `code_context`'s schema says `"minimum": 1, "maximum": 5000` — with
+        // a comment explaining that the tool asks for `limit + 1` and an
+        // unbounded value overflows it — and the daemon proxy validates
+        // against that schema. So `context --limit 6000` was ACCEPTED without
+        // a daemon and REJECTED with one: the bound was a property of the
+        // transport rather than of the contract. The bound here is the
+        // schema's; it is not a new one.
+        #[arg(
+            long,
+            value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=5000),
+            help = "Maximum connected nodes to return (1-5000, matching the code_context schema; default 500). Applied BEFORE --token-budget, not instead of it"
+        )]
         limit: Option<usize>,
+        // nw-259(c): the help used to say `--token-budget` "takes precedence
+        // over --limit". It does not. `--limit` caps the walk FIRST and
+        // `--token-budget` then cuts the already-capped list, so
+        // `--limit 5 --token-budget 16000` returns 5 — the opposite of what
+        // the caller was told. They compose; neither overrides.
         #[arg(
             long,
             value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=16000),
-            help = "Approximate token budget for output (1-16000; takes precedence over --limit; matches the MCP brain_context schema)"
+            help = "Approximate token budget for output (1-16000; matches the MCP brain_context schema). Applied AFTER --limit, to whatever --limit left"
         )]
         token_budget: Option<usize>,
         #[arg(long, help = "Output as JSON")]
@@ -11421,8 +11439,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let mut context_result: Option<nestweaver_engine::ContextResult> = None;
             if use_daemon {
                 let mut code_args = serde_json::json!({ "seeds": seeds.clone() });
-                // Omit rather than default: absent `--limit` means "no cap" on
-                // the direct path, and the schema rejects a 0.
+                // Omit rather than default, so the TOOL's documented default
+                // governs — which is the same `CODE_CONTEXT_DEFAULT_LIMIT` the
+                // direct path applies below. nw-259(c): this comment used to
+                // claim absent `--limit` meant "no cap" on the direct path,
+                // contradicted twelve lines later by
+                // `limit.unwrap_or(CODE_CONTEXT_DEFAULT_LIMIT)`.
                 if let Some(limit) = limit {
                     code_args["limit"] = serde_json::json!(limit);
                 }
@@ -11484,19 +11506,42 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             };
             match built {
                 Ok(mut result) => {
+                    // nw-259(a). This arm carries THREE caps — `--limit`,
+                    // `--token-budget` and `CODE_CONTEXT_DEFAULT_LIMIT` — and
+                    // had one `truncated` boolean and one `limit` field to
+                    // explain all of them. A token-budget cut set `truncated`
+                    // and left `limit` at whatever the earlier cap set (always
+                    // `Some` on the direct path), so the message named the
+                    // wrong cap and prescribed a flag that cannot change the
+                    // outcome: raising `--limit` after a BUDGET cut returns the
+                    // same rows. Same shape as `impact`'s three JSON outputs
+                    // before `impact_json_ok` gave it a discriminator.
+                    //
+                    // The limit cut is whatever the builder already recorded —
+                    // on either route. The budget cut happens here.
+                    let cut_by_limit = result.truncated == Some(true);
+                    let mut cut_by_budget: Option<usize> = None;
                     if let Some(budget) = token_budget {
                         let cut = context_token_budgeted_truncate(&result.connected, budget);
                         if cut < result.connected.len() {
                             result.truncated = Some(true);
+                            cut_by_budget = Some(budget);
                         }
                         result.connected.truncate(cut);
                     }
-                    // Say so. A capped result that renders identically to a
-                    // complete one is the whole defect this reports on: the
-                    // caller cannot tell "this is the answer" from "this is
-                    // the first N of the answer".
-                    let truncation = match (result.truncated, result.limit) {
-                        (Some(true), Some(limit)) => {
+                    // Say so, and say WHICH. A capped result that renders
+                    // identically to a complete one is the defect this reports
+                    // on; a capped result that blames the wrong cap is the same
+                    // defect wearing a disclosure.
+                    //
+                    // The budget wins when both fired, because it cut LAST:
+                    // raising `--limit` alone cannot get past a budget that is
+                    // already full.
+                    let truncation = match (cut_by_budget, cut_by_limit, result.limit) {
+                        (Some(budget), _, _) => {
+                            format!(", TRUNCATED by --token-budget {budget} — raise it for more")
+                        }
+                        (None, true, Some(limit)) => {
                             format!(", TRUNCATED at limit {limit} — pass --limit for more")
                         }
                         _ => String::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2134,6 +2134,22 @@ fn render_dead_code_text(payload: &serde_json::Value) {
         }
     };
 
+    // The counts below are a completeness claim over the whole corpus. Say so
+    // FIRST when the scan could not read all of it, so nobody acts on
+    // "N of M unreachable" believing M is the total. Printed on both branches
+    // — "No dead code detected" over a short corpus is the worse of the two.
+    let undecodable = num("undecodable_symbols");
+    let coverage_note = || {
+        if undecodable > 0 {
+            println!(
+                "Coverage DEGRADED: {undecodable} symbol(s) could not be read and are missing \
+                 from this analysis. Every count below is a FLOOR. Re-index to repair \
+                 (`nestweaver index --force`).\n"
+            );
+        }
+    };
+    coverage_note();
+
     if matching == 0 {
         println!("No dead code detected ({total} symbols, all reachable from entry points).");
         excluded_note();
@@ -13362,6 +13378,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 truncated: bool,
                 excluded_count: usize,
                 dead_percentage: f64,
+                /// "complete" | "degraded". Every count above is a claim over
+                /// the WHOLE symbol corpus, and the store's whole-corpus scan
+                /// tolerates a row it cannot decode (nw-335) instead of
+                /// failing — so a caller cannot tell an exact total from a
+                /// floor unless the scan says which it produced.
+                coverage: &'static str,
+                undecodable_symbols: usize,
                 min_confidence: String,
                 unreachable_symbols: Vec<&'a nestweaver_engine::UnreachableSymbol>,
             }
@@ -13382,6 +13405,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 truncated,
                 excluded_count: result.excluded_count,
                 dead_percentage: result.dead_percentage,
+                coverage: if result.coverage_is_complete() {
+                    "complete"
+                } else {
+                    "degraded"
+                },
+                undecodable_symbols: result.undecodable_symbols,
                 min_confidence: min_conf.to_string(),
                 unreachable_symbols: shown,
             })?;
@@ -20189,6 +20218,9 @@ fn regex_truncation_label(
         Some(RegexTruncationReason::ResultLimit) => "result limit reached",
         Some(RegexTruncationReason::Deadline) => "time budget reached",
         Some(RegexTruncationReason::CandidateCap) => "candidate safety cap reached",
+        Some(RegexTruncationReason::UndecodableRows) => {
+            "corpus rows could not be read and were skipped — re-index to repair"
+        }
         Some(RegexTruncationReason::Unknown) | None => "search budget reached",
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23973,6 +23973,7 @@ mod cli_help_contract_tests {
             CliDiagnostic::DatabaseWalUnreplayed { .. } => "db_wal_unreplayed",
             CliDiagnostic::DatabaseCorrupt { .. } => "db_corrupt",
             CliDiagnostic::DatabaseNoSchema { .. } => "db_no_schema",
+            CliDiagnostic::DatabaseWalCorrupt { .. } => "db_wal_corrupt",
             CliDiagnostic::General { .. } => "error",
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5334,6 +5334,15 @@ enum BrainCommands {
             help = "Max broken links to return (default: 50, or [limits].default_result_limit from config)"
         )]
         limit: Option<usize>,
+        /// nw-341: rows sort unresolved-first then by ASCENDING confidence, so
+        /// the 0.90/0.92/0.95 tiers are the TAIL. Without this the tiers a
+        /// reviewer must inspect are exactly the ones a limit removes.
+        #[arg(
+            long,
+            default_value_t = 0,
+            help = "Skip this many rows before the page. The high-confidence tiers sort LAST, so this is how you reach them"
+        )]
+        offset: usize,
         #[arg(long, help = "Output as JSON")]
         json: bool,
         #[arg(
@@ -22619,6 +22628,7 @@ fn run_brain(
         BrainCommands::BrokenLinks {
             max_suggestions,
             limit,
+            offset,
             json,
             db,
             config,
@@ -22632,7 +22642,11 @@ fn run_brain(
                 &db_path,
                 config.as_deref(),
                 "brain_broken_links",
-                serde_json::json!({ "max_suggestions": max_suggestions, "limit": limit }),
+                serde_json::json!({
+                    "max_suggestions": max_suggestions,
+                    "limit": limit,
+                    "offset": offset,
+                }),
             )? {
                 if json {
                     println!("{}", serde_json::to_string_pretty(&value)?);
@@ -22693,7 +22707,8 @@ fn run_brain(
             // is grouped by category, not ranked by severity (nw-297).
             let unresolved = all_links.iter().filter(|l| l.is_unresolved()).count();
             let low_confidence = total - unresolved;
-            let links: Vec<_> = all_links.into_iter().take(limit).collect();
+            // nw-341: `total` stays the PRE-offset population on both routes.
+            let links: Vec<_> = all_links.into_iter().skip(offset).take(limit).collect();
             if json {
                 println!(
                     "{}",
@@ -22701,6 +22716,8 @@ fn run_brain(
                         "broken_links": links,
                         "total": total,
                         "returned": links.len(),
+                        "truncated": links.len() < total,
+                        "offset": offset,
                         "unresolved": unresolved,
                         "low_confidence": low_confidence,
                     }))?
@@ -22708,7 +22725,14 @@ fn run_brain(
             } else if links.is_empty() {
                 println!("No broken or ambiguous wikilinks found.");
             } else {
-                println!("Broken / ambiguous wikilinks ({} of {total}):", links.len());
+                if offset > 0 {
+                    println!(
+                        "Broken / ambiguous wikilinks ({} of {total}, from offset {offset}):",
+                        links.len()
+                    );
+                } else {
+                    println!("Broken / ambiguous wikilinks ({} of {total}):", links.len());
+                }
                 print_link_classification(unresolved, low_confidence);
                 for l in &links {
                     println!(

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -776,7 +776,17 @@ credential_method = "gh"
         .arg(&config_path)
         .assert()
         .success()
-        .stdout(contains("has no associated notes or symbols"));
+        // nw-316: the phrase moved because the direct route stopped
+        // re-implementing the tool. It used to print "<name> has no associated
+        // notes or symbols" while the daemon route printed the TOOL's note,
+        // "No notes or symbols are associated with this project yet." — one
+        // condition, two sentences, chosen by transport. What this assertion
+        // is actually for is the CONFIG resolution (the project named in
+        // `--config`'s database was found at all), and that is unchanged.
+        .stdout(contains(
+            "No notes or symbols are associated with this project yet.",
+        ))
+        .stdout(contains("configured-project"));
 
     // Repository-scoped commands have a different final fallback
     // (`<repo>/nestweaver.lbug`), so cover their shared resolver explicitly.

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -6756,3 +6756,90 @@ fn a_diagnostic_phrase_survives_a_narrow_render() {
         String::from_utf8_lossy(&ambient.stderr)
     );
 }
+
+/// nw-259(a). A token-budget cut must not tell the caller it hit `--limit`.
+///
+/// The `context` arm carries three caps and had one `truncated` boolean and one
+/// `limit` field to explain all of them, so a BUDGET cut set `truncated` and
+/// left `limit` at whatever the earlier cap set — reporting "TRUNCATED at limit
+/// 500 — pass --limit for more" for a cut `--limit` did not make and cannot
+/// undo. An agent following that remedy raises `--limit`, gets the same rows,
+/// and has no next move. That is an nw-334 instance none of the four shipped
+/// tiers can see: it is not a `CliDiagnostic`, not an environment variable, and
+/// not a backtick-quoted subcommand.
+///
+/// The counterweight is the second half: a genuine LIMIT cut must still say
+/// `--limit`, or deleting the message entirely would pass.
+#[test]
+fn a_context_budget_cut_names_the_budget_and_a_limit_cut_names_the_limit() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_dir = dir.path().join("repo");
+    let db_path = dir.path().join("test.lbug");
+    std::fs::create_dir_all(&repo_dir).unwrap();
+    std::fs::write(
+        repo_dir.join("a.js"),
+        "export function mainA(x){return helperB(x)+helperC(x);}\n\
+         export function helperB(n){return helperC(n)+1;}\n\
+         export function helperC(n){return n*3;}\n\
+         export function extraB(n){return n-1;}\n\
+         export function otherC(n){return n+7;}\n",
+    )
+    .unwrap();
+    nestweaver_cmd()
+        .args([
+            "index",
+            "--repo",
+            &repo_dir.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .assert()
+        .success();
+
+    // `--stats` is what prints the truncation clause.
+    let budget = nestweaver_cmd()
+        .args([
+            "--stats",
+            "context",
+            "mainA",
+            "--token-budget",
+            "1",
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .output()
+        .unwrap();
+    let stderr = flatten_miette(&budget.stderr);
+    assert!(
+        stderr.contains("TRUNCATED"),
+        "the fixture must actually truncate, or this test proves nothing: {stderr}"
+    );
+    assert!(
+        !stderr.contains("pass --limit for more"),
+        "a token-budget cut prescribed `--limit`, which cannot change the \
+         outcome — the budget is what cut, and it cut LAST: {stderr}"
+    );
+    assert!(
+        stderr.contains("--token-budget"),
+        "the message must name the cap that actually cut: {stderr}"
+    );
+
+    let limited = nestweaver_cmd()
+        .args([
+            "--stats",
+            "context",
+            "mainA",
+            "--limit",
+            "1",
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .output()
+        .unwrap();
+    let stderr = flatten_miette(&limited.stderr);
+    assert!(
+        stderr.contains("pass --limit for more"),
+        "a real limit cut must still say so, or deleting the message would \
+         satisfy the assertions above: {stderr}"
+    );
+}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -5288,6 +5288,113 @@ fn ui_watch_refuses_a_wholly_inferred_write_and_can_be_corrected() {
         .stdout(contains("--repo"));
 }
 
+/// nw-312. The documented exit-code contract is 0 ok / 1 error / 2 not-found /
+/// 64 usage, and 8.0.0 specifically split usage errors out so a caller could
+/// tell "you asked wrongly" from "it went wrong". An invalid enum value is a
+/// usage error, and `--format`/`--scope` were bare `String`s with the legal
+/// values enumerated only in prose — so validation happened in the handler and
+/// arrived as a generic error, exit 1.
+///
+/// The internal inconsistency is both the evidence and the counterweight:
+/// `--top` on the SAME command is a `usize`, so clap's own parse rejects a bad
+/// value and the binary already answers 64. The classification exists; these
+/// two arguments took a different route to it.
+#[test]
+fn export_rejects_an_invalid_enum_as_a_usage_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_dir = dir.path().join("repo");
+    let db_path = dir.path().join("test.lbug");
+    std::fs::create_dir_all(&repo_dir).unwrap();
+    std::fs::write(
+        repo_dir.join("main.js"),
+        "export function greet(n) { return n; }",
+    )
+    .unwrap();
+    nestweaver_cmd()
+        .args([
+            "index",
+            "--repo",
+            &repo_dir.display().to_string(),
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .assert()
+        .success();
+
+    // `--top 0` is the control: a bad value on this same command, already 64.
+    for argv in [
+        vec!["export", "--format", "bogus"],
+        vec!["export", "--scope", "bogus"],
+        vec!["export", "--top", "not-a-number"],
+    ] {
+        let output = nestweaver_cmd()
+            .args(&argv)
+            .args(["--db", &db_path.display().to_string()])
+            .output()
+            .unwrap();
+        assert_eq!(
+            output.status.code(),
+            Some(64),
+            "{argv:?} exited {:?}; `--top not-a-number` on this same command \
+             exits 64, so the classification exists and this path bypassed it.\
+             \nstderr:\n{}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    // Counterweight: every documented value must still be ACCEPTED, or a
+    // `value_parser` built from the wrong list would satisfy the above.
+    for (format, scope) in [
+        ("cypher", "code"),
+        ("graphml", "all"),
+        ("graphml", "vault"),
+        ("mermaid", "code"),
+    ] {
+        nestweaver_cmd()
+            .args([
+                "export",
+                "--format",
+                format,
+                "--scope",
+                scope,
+                "--db",
+                &db_path.display().to_string(),
+            ])
+            .assert()
+            .success();
+    }
+
+    // And `msgpack` must still reach its handler, which refuses `--scope vault`
+    // as a SEMANTIC combination rather than an unknown value — a distinction a
+    // `PossibleValuesParser` must not flatten.
+    let output = nestweaver_cmd()
+        .args([
+            "export",
+            "--format",
+            "msgpack",
+            "--scope",
+            "vault",
+            "--db",
+            &db_path.display().to_string(),
+        ])
+        .output()
+        .unwrap();
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "msgpack cannot represent the vault subgraph and must say so"
+    );
+    assert_ne!(
+        output.status.code(),
+        Some(64),
+        "`--scope vault` is a LEGAL value that this format cannot satisfy; \
+         reporting it as a usage error would tell the caller to fix the \
+         spelling of a word that is spelled correctly.\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 /// A read-only `ui` writes nothing, so S2 does not apply to it. Pinned so a
 /// later widening of the guard cannot quietly break plain `nestweaver ui`.
 #[test]

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -6572,3 +6572,70 @@ fn service_summary_text_warns_about_ambiguity_and_lists_entry_points() {
          a different command:\n{stdout}"
     );
 }
+
+/// nw-261. Wrap position must not be an ambient input to the suite.
+///
+/// The failure this closes is real and has fired: a phrase the code emits
+/// contiguously arrives at a `stderr.contains(...)` assertion split across
+/// miette's box-drawing gutter, so the assertion fails for a RENDERING reason
+/// while the message is exactly right. The audit found nine more assertions
+/// with the same exposure in `tests/daemon_test.rs`, all inside one
+/// Linux-gated test nobody can reproduce locally.
+///
+/// Flattening each assertion is the local fix and it only protects the
+/// assertions someone remembered to flatten. `NESTWEAVER_DIAGNOSTIC_WIDTH`
+/// pins the wrap column instead, which does two things flattening cannot:
+/// it covers assertions nobody has audited, and it makes the property
+/// TESTABLE — a wrap that previously depended on the tempdir path and the
+/// terminal can now be forced.
+///
+/// The first assertion is the vacuity guard, and it is the same one
+/// `flatten_diagnostic_recovers_a_phrase_miette_wrapped` uses: if the fixture
+/// does not actually reproduce the wrap, the test below it proves nothing.
+#[test]
+fn a_diagnostic_phrase_survives_a_narrow_render() {
+    // Chosen because width 40 wraps between `--repo` and `<path>`, which is
+    // what makes the vacuity guard below meaningful.
+    const PHRASE: &str = "index --repo <path>";
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("nope.lbug");
+
+    let narrow = nestweaver_cmd()
+        .env("NESTWEAVER_DIAGNOSTIC_WIDTH", "40")
+        .args(["hubs", "--db"])
+        .arg(&missing)
+        .output()
+        .unwrap();
+    let raw = String::from_utf8_lossy(&narrow.stderr).to_string();
+
+    assert!(
+        raw.contains("nestweaver index"),
+        "the fixture must reach the diagnostic at all: {raw}"
+    );
+    assert!(
+        !raw.contains(PHRASE),
+        "the fixture must reproduce the WRAP at width 40, or this test proves \
+         nothing — `NESTWEAVER_DIAGNOSTIC_WIDTH` is not being honoured and the \
+         render used the ambient width: {raw}"
+    );
+    assert!(
+        flatten_miette(&narrow.stderr).contains(PHRASE),
+        "flattening must recover a phrase miette wrapped, which is the whole \
+         reason a width-dependent assertion is a false failure: {raw}"
+    );
+
+    // Counterweight: unset must be TODAY's behaviour exactly. A knob that
+    // changed the default would be a user-visible rendering change shipped to
+    // make a test convenient.
+    let ambient = nestweaver_cmd()
+        .env_remove("NESTWEAVER_DIAGNOSTIC_WIDTH")
+        .args(["hubs", "--db"])
+        .arg(&missing)
+        .output()
+        .unwrap();
+    assert!(
+        flatten_miette(&ambient.stderr).contains(PHRASE),
+        "{}",
+        String::from_utf8_lossy(&ambient.stderr)
+    );
+}

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -2344,7 +2344,7 @@ credential_method = "gh"
         ])
         .assert()
         .failure()
-        .stderr(contains("restart --config"));
+        .stderr(says("restart --config"));
     assert_eq!(read_pid(), pid_a);
     assert_eq!(unsafe { libc::kill(pid_a, 0) }, 0);
     assert_eq!(list_vaults(), vaults_before_mismatch);
@@ -2384,7 +2384,7 @@ credential_method = "gh"
         ])
         .assert()
         .failure()
-        .stderr(contains("restart --config"));
+        .stderr(says("restart --config"));
     assert_eq!(read_pid(), pid_a);
     assert_eq!(unsafe { libc::kill(pid_a, 0) }, 0);
     assert_eq!(list_vaults(), vaults_before_mismatch);
@@ -2401,7 +2401,7 @@ credential_method = "gh"
         ])
         .assert()
         .failure()
-        .stderr(contains("restart --config"));
+        .stderr(says("restart --config"));
     assert_eq!(read_pid(), pid_a);
     assert_eq!(unsafe { libc::kill(pid_a, 0) }, 0);
     assert_eq!(list_vaults(), vaults_before_mismatch);
@@ -2461,13 +2461,13 @@ credential_method = "gh"
         .arg(&config_a)
         .assert()
         .failure()
-        .stderr(contains("effective config is unknown"));
+        .stderr(says("effective config is unknown"));
     assert_eq!(read_pid(), pid_preserved);
     assert_eq!(unsafe { libc::kill(pid_preserved, 0) }, 0);
     daemon_action_cmd(&db_path, "restart")
         .assert()
         .failure()
-        .stderr(contains("daemon has not been shut down"));
+        .stderr(says("daemon has not been shut down"));
     assert_eq!(read_pid(), pid_preserved);
     assert_eq!(unsafe { libc::kill(pid_preserved, 0) }, 0);
     assert!(status().contains(&format!("Config: {}", canonical_a.display())));
@@ -2486,7 +2486,7 @@ credential_method = "gh"
     daemon_action_cmd(&db_path, "restart")
         .assert()
         .failure()
-        .stderr(contains("daemon has not been shut down"));
+        .stderr(says("daemon has not been shut down"));
     assert_eq!(read_pid(), pid_preserved);
     assert_eq!(unsafe { libc::kill(pid_preserved, 0) }, 0);
 
@@ -2499,7 +2499,7 @@ credential_method = "gh"
         .arg(&config_b)
         .assert()
         .failure()
-        .stderr(contains("ownership could not be verified"));
+        .stderr(says("ownership could not be verified"));
     assert_eq!(read_pid(), pid_preserved);
     assert_eq!(unsafe { libc::kill(pid_preserved, 0) }, 0);
 
@@ -2530,7 +2530,7 @@ credential_method = "gh"
         .arg(&missing)
         .assert()
         .failure()
-        .stderr(contains("daemon has not been shut down"));
+        .stderr(says("daemon has not been shut down"));
     assert_eq!(read_pid(), pid_overridden);
     assert_eq!(unsafe { libc::kill(pid_overridden, 0) }, 0);
 
@@ -2541,7 +2541,7 @@ credential_method = "gh"
         .arg(&malformed)
         .assert()
         .failure()
-        .stderr(contains("daemon has not been shut down"));
+        .stderr(says("daemon has not been shut down"));
     assert_eq!(read_pid(), pid_overridden);
     assert_eq!(unsafe { libc::kill(pid_overridden, 0) }, 0);
 
@@ -5738,16 +5738,31 @@ fn flatten_diagnostic(stderr: &str) -> String {
 // once, not at the boot ceiling.
 // ---------------------------------------------------------------------------
 
-/// `spawn_daemon` used to drop the spawned `Child` with all three streams sent
-/// to `/dev/null`, and the readiness loop's only early abort reads the PIDFILE.
-/// A daemon that dies BEFORE writing a pidfile therefore leaves the loop
-/// nothing to observe: "will never boot" and "still booting" are the same
-/// observation, and the caller waits out the whole ceiling.
+/// `contains`, but against the FLATTENED diagnostic — so an assertion tests
+/// what the message SAYS rather than how wide the terminal was.
 ///
-/// Staged with an unwritable state directory, so the daemon cannot create its
-/// runtime directory and exits in milliseconds without ever writing a pidfile.
-/// `XDG_STATE_HOME` is honoured on every platform precisely so a test can do
-/// this without touching the operator's real state tree.
+/// nw-261. `flatten_diagnostic` reached this file and not its assertions: six
+/// `.stderr(contains(...))` calls in
+/// `daemon_restart_preserves_and_overrides_live_effective_config_without_early_shutdown`
+/// still read the raw bytes, and every phrase they assert is rendered INSIDE a
+/// miette diagnostic (the message is built in `nestweaver-client` and reaches
+/// the user through `into_diagnostic`). Unlike the CI failure that fired, the
+/// interpolated paths in that message come AFTER the asserted phrases, so the
+/// wrap position is a function of the phrase text and the render width alone —
+/// deterministic, and therefore latent rather than flaky. A width change flips
+/// all six at once.
+///
+/// One predicate, so the next site is cheap. Deliberately NOT loosened to
+/// single words: `contains("Permission")` passes on a message that lost
+/// `denied`.
+#[cfg(target_os = "linux")]
+fn says(phrase: &'static str) -> impl predicates::Predicate<[u8]> {
+    predicates::function::function(move |bytes: &[u8]| {
+        flatten_diagnostic(&String::from_utf8_lossy(bytes)).contains(phrase)
+    })
+    .fn_name("flattened diagnostic contains")
+}
+
 /// The wrapped form this helper exists for, captured verbatim from the CI run
 /// that failed on 2026-08-29 while the same test passed locally. Asserting on
 /// the raw string here would fail, which is what makes this test non-vacuous:
@@ -5764,6 +5779,16 @@ fn flatten_diagnostic_recovers_a_phrase_miette_wrapped() {
     assert!(flatten_diagnostic(as_ci_rendered).contains("create log dir"));
 }
 
+/// `spawn_daemon` used to drop the spawned `Child` with all three streams sent
+/// to `/dev/null`, and the readiness loop's only early abort reads the PIDFILE.
+/// A daemon that dies BEFORE writing a pidfile therefore leaves the loop
+/// nothing to observe: "will never boot" and "still booting" are the same
+/// observation, and the caller waits out the whole ceiling.
+///
+/// Staged with an unwritable state directory, so the daemon cannot create its
+/// runtime directory and exits in milliseconds without ever writing a pidfile.
+/// `XDG_STATE_HOME` is honoured on every platform precisely so a test can do
+/// this without touching the operator's real state tree.
 #[test]
 fn a_daemon_that_cannot_boot_is_reported_without_waiting_out_the_ceiling() {
     use std::os::unix::fs::PermissionsExt;

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -5711,18 +5711,6 @@ fn clusters_text_honours_limit_on_the_daemon_route() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// nw-309 (client half) — a daemon that will never boot must be reported at
-// once, not at the boot ceiling.
-// ---------------------------------------------------------------------------
-
-/// `spawn_daemon` used to drop the spawned `Child` with all three streams sent
-/// to `/dev/null`, and the readiness loop's only early abort reads the PIDFILE.
-/// A daemon that dies BEFORE writing a pidfile therefore leaves the loop
-/// nothing to observe: "will never boot" and "still booting" are the same
-/// observation, and the caller waits out the whole ceiling.
-///
-/// Staged with an unwritable state directory, so the daemon cannot create its
 /// Flatten a miette-rendered diagnostic so a phrase assertion cannot be broken
 /// by line wrapping.
 ///
@@ -5745,6 +5733,18 @@ fn flatten_diagnostic(stderr: &str) -> String {
         .join(" ")
 }
 
+// ---------------------------------------------------------------------------
+// nw-309 (client half) — a daemon that will never boot must be reported at
+// once, not at the boot ceiling.
+// ---------------------------------------------------------------------------
+
+/// `spawn_daemon` used to drop the spawned `Child` with all three streams sent
+/// to `/dev/null`, and the readiness loop's only early abort reads the PIDFILE.
+/// A daemon that dies BEFORE writing a pidfile therefore leaves the loop
+/// nothing to observe: "will never boot" and "still booting" are the same
+/// observation, and the caller waits out the whole ceiling.
+///
+/// Staged with an unwritable state directory, so the daemon cannot create its
 /// runtime directory and exits in milliseconds without ever writing a pidfile.
 /// `XDG_STATE_HOME` is honoured on every platform precisely so a test can do
 /// this without touching the operator's real state tree.

--- a/tests/error_remedy_test.rs
+++ b/tests/error_remedy_test.rs
@@ -605,3 +605,195 @@ fn no_source_file_hand_writes_a_placeholder_consolidation_command() {
          at every one of these sites: {offenders:?}"
     );
 }
+
+/// The five artifacts the WAL-corruption runbook names, in the order it names
+/// them.
+const WAL_RUNBOOK_ARTIFACTS: &[&str] = &[
+    ".wal",
+    ".wal.checkpoint",
+    ".shadow",
+    ".checkpoint.apply.lock",
+    ".checkpoint.intent.lock",
+];
+
+/// Make `db` report an unreadable write-ahead log.
+///
+/// nw-332 said the corrupt-WAL state could not be reproduced without lbug-001,
+/// which nobody can trigger. That is true of the SIGSEGV that produced it in
+/// production; it is NOT true of the state it leaves behind. Garbage in
+/// `<db>.wal` with no `<db>.shadow` beside it reproduces the unreadable-log open
+/// failure deterministically, in milliseconds, with no crash — the engine
+/// reports `Storage exception: Checksum verification failed, the WAL file is
+/// corrupted.`
+///
+/// This shape must NOT be confused with the orphaned-WAL one the store already
+/// recovers: `quarantine_orphaned_wal` fires on `.wal` present + `.shadow`
+/// absent, but only when the engine's message names the missing shadow file,
+/// which it does not here.
+fn corrupt_the_wal(db: &std::path::Path) {
+    let wal = std::path::PathBuf::from(format!("{}.wal", db.display()));
+    let shadow = std::path::PathBuf::from(format!("{}.shadow", db.display()));
+    let _ = std::fs::remove_file(&shadow);
+    std::fs::write(&wal, vec![0xA5u8; 4096]).unwrap();
+}
+
+/// nw-332. ONE condition, ONE remedy — and the remedy is EXECUTED here, not
+/// merely printed.
+///
+/// This condition used to reach the operator through three code paths that gave
+/// three different answers, two of which made recovery harder: "start the
+/// daemon" (which against this state is the crash-restart loop), "delete this
+/// database and re-index" (which discards a graph five files restore), and
+/// "another process holds the write lock" (naming a process that does not
+/// exist). The recovery that worked was named by none of them.
+#[test]
+fn a_corrupt_wal_prints_a_runbook_that_actually_recovers_the_database() {
+    let (dir, db) = indexed_fixture();
+    let repo = dir.path().join("repo");
+    corrupt_the_wal(&db);
+
+    let output = direct()
+        .args(["search", "a", "--db"])
+        .arg(&db)
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    // miette hard-wraps and indents `help` text, so a path long enough to wrap
+    // is split across lines mid-token. Compare on the unwrapped form: temp
+    // paths contain no whitespace, so removing all of it is lossless here and
+    // asserting on the wrapped text would silently weaken every check below.
+    let unwrapped: String = stderr.chars().filter(|c| !c.is_whitespace()).collect();
+
+    assert!(
+        stderr.contains("nestweaver::db_wal_corrupt"),
+        "an unreadable log is neither an unreplayed one nor a damaged FILE, and \
+         both of those diagnostics give it the wrong remedy:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("delete this database"),
+        "the database file is intact here — the runbook below recovers it — so \
+         prescribing deletion destroys a recoverable graph:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("daemon --db") || !stderr.contains("start"),
+        "starting a writer against a log that cannot be read IS the \
+         crash-restart loop:\n{stderr}"
+    );
+    for artifact in WAL_RUNBOOK_ARTIFACTS {
+        assert!(
+            unwrapped.contains(&format!("{}{artifact}", db.display())),
+            "the runbook is five artifacts and it must NAME them, against the \
+             right database: {artifact} missing from:\n{stderr}"
+        );
+    }
+    assert_no_transient_advice(&stderr, "an unreadable write-ahead log");
+
+    // NOW RUN IT. A remedy nobody executed is the exact defect class this file
+    // exists to close, and last round's fix for it introduced a new instance.
+    let aside = dir.path().join("aside");
+    std::fs::create_dir_all(&aside).unwrap();
+    let mut moved = 0;
+    for artifact in WAL_RUNBOOK_ARTIFACTS {
+        let from = std::path::PathBuf::from(format!("{}{artifact}", db.display()));
+        if from.exists() {
+            std::fs::rename(&from, aside.join(artifact.trim_start_matches('.'))).unwrap();
+            moved += 1;
+        }
+    }
+    assert!(moved > 0, "step 2 must have something to move");
+
+    // Step 3: reopen.
+    let reopened = direct()
+        .args(["search", "a", "--db"])
+        .arg(&db)
+        .output()
+        .unwrap();
+    assert!(
+        reopened.status.success(),
+        "the runbook this product prints must actually recover the \
+         database:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&reopened.stdout),
+        String::from_utf8_lossy(&reopened.stderr)
+    );
+
+    // Step 4: the full re-index the runbook says is REQUIRED, not optional.
+    direct()
+        .args(["index", "--db"])
+        .arg(&db)
+        .arg("--repo")
+        .arg(&repo)
+        .assert()
+        .success();
+    let after = direct()
+        .args(["search", "a", "--db"])
+        .arg(&db)
+        .output()
+        .unwrap();
+    assert!(
+        String::from_utf8_lossy(&after.stdout).contains("a "),
+        "the graph must be readable after the runbook: {}",
+        String::from_utf8_lossy(&after.stdout)
+    );
+    drop(dir);
+}
+
+/// nw-333. `repair` attributed EVERY read-write open failure to lock
+/// contention. This fixture holds no lock at all — the write-ahead log is
+/// unreadable — so the message named a process that does not exist and
+/// prescribed a daemon restart, which against a damaged database is what
+/// produces the crash-restart loop. Its error was also a bare `eprintln!`, so
+/// the `CliDiagnostic` inventory could not see it.
+#[test]
+fn repair_does_not_blame_a_lock_nobody_holds() {
+    let (dir, db) = indexed_fixture();
+
+    // A dirty publication marker with a writer that is provably gone, so
+    // `repair` gets past its CLEAN early return and reaches the open.
+    let marker = std::path::PathBuf::from(format!("{}.index-dirty", db.display()));
+    std::fs::write(&marker, r#"{"writer_pid":999999,"reason":"index"}"#).unwrap();
+    corrupt_the_wal(&db);
+
+    let output = direct().args(["repair", "--db"]).arg(&db).output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    assert!(
+        !stderr.contains("Another process holds the write lock"),
+        "no process holds this database; the open failed because the LOG is \
+         unreadable, and the message said so in its own parenthetical before \
+         ignoring it:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("then start"),
+        "restarting the daemon against a damaged database is what produces the \
+         crash-restart loop — the one remedy in this class that makes recovery \
+         HARDER rather than merely wasting time:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("nestweaver::db_wal_corrupt"),
+        "the open failure must reach the operator as a classified diagnostic, \
+         not a bare eprintln the CliDiagnostic inventory cannot see:\n{stderr}"
+    );
+    assert_no_transient_advice(&stderr, "repair on a damaged database");
+    drop(dir);
+}
+
+/// The other half, and what keeps the first from over-correcting: a repair
+/// blocked by a REAL lock must still say so. Without this, "delete the
+/// sentence" passes.
+#[test]
+fn repair_still_names_a_lock_that_is_genuinely_held() {
+    let (dir, db) = indexed_fixture();
+    let marker = std::path::PathBuf::from(format!("{}.index-dirty", db.display()));
+    std::fs::write(&marker, r#"{"writer_pid":999999,"reason":"index"}"#).unwrap();
+
+    let _holder =
+        nestweaver_store::GraphStore::open(&db).expect("a healthy fixture must open read-write");
+
+    let output = direct().args(["repair", "--db"]).arg(&db).output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    assert!(
+        stderr.contains("write lock"),
+        "a genuinely held lock must still be reported as one: {stderr}"
+    );
+    drop(dir);
+}

--- a/tests/error_remedy_test.rs
+++ b/tests/error_remedy_test.rs
@@ -292,11 +292,16 @@ fn suggested_command(message: &str) -> Option<String> {
 /// in scope at the bail site.
 ///
 /// Assertion (1) of the T3 contract: no `<placeholder>` when the values were
-/// in scope. Assertion (2): it parses. Assertion (4) — "run it, then re-run
-/// the original, and it succeeds" — is deliberately NOT made here: `instance
-/// merge` does not yet update the recorded instance identity, so a test that
-/// asserted the round-trip would be pinning a behaviour the product does not
-/// have. The message says so too, which is why it stops short of "run this".
+/// in scope. Assertion (2): it parses. Assertion (4) — "run it, then re-run the
+/// original, and it succeeds" — IS now made here.
+///
+/// It was deliberately withheld before, because `instance merge` did not update
+/// the recorded instance identity (nw-264), so the round-trip would have been
+/// pinning a behaviour the product did not have; the remedy string carried a
+/// matching hedge and stopped short of "run this". nw-264 closed that, so the
+/// round trip is the proof — and it is the only thing that can honestly justify
+/// deleting the hedge. A remedy nobody executed is the exact defect class this
+/// file exists to close.
 #[test]
 fn multi_instance_refusal_emits_a_runnable_consolidation_command() {
     let dir = tempfile::tempdir().unwrap();
@@ -363,6 +368,52 @@ fn multi_instance_refusal_emits_a_runnable_consolidation_command() {
     let mut argv: Vec<String> = command.split_whitespace().map(str::to_string).collect();
     argv.remove(0); // the binary name
     direct().args(&argv).arg("--help").assert().success();
+
+    // Assertion (4), nw-264: RUN the remedy, then re-run the invocation that
+    // failed. The merge must both consolidate the graph AND move the recorded
+    // identity, or the config-less index refuses again for the same reason and
+    // the remedy is one the operator can follow to no effect.
+    let merged = direct()
+        .args(&argv)
+        .args(["--db"])
+        .arg(&db)
+        .output()
+        .unwrap();
+    assert!(
+        merged.status.success(),
+        "the remedy this product printed must actually run:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&merged.stdout),
+        String::from_utf8_lossy(&merged.stderr)
+    );
+
+    // `instance merge` autostarts a daemon even under `NESTWEAVER_NO_DAEMON=1`
+    // (it is a write path and dials the daemon), and that daemon holds the
+    // write LEASE on this temp database for its idle timeout — an hour. Leaving
+    // it up would make the direct re-index below fail for a reason that has
+    // nothing to do with nw-264, and would leak a daemon out of the test.
+    // Stopping it is best-effort: if the merge ran directly there is nothing to
+    // stop, and that is not a failure.
+    let _ = direct()
+        .args(["daemon", "--db"])
+        .arg(&db)
+        .arg("stop")
+        .output();
+
+    let after = direct()
+        .args(["index", "--db"])
+        .arg(&db)
+        .arg("--repo")
+        .arg(&repo_one)
+        .output()
+        .unwrap();
+    let after_stderr = String::from_utf8_lossy(&after.stderr).to_string();
+    assert!(
+        after.status.success(),
+        "after the remedy the original invocation must succeed; it still \
+         refuses, so the merge left the recorded identity naming the \
+         merged-away instance and the fork returns on the next index \
+         (nw-264):\n{after_stderr}"
+    );
 }
 
 /// nw-328. Two symbols with the same name inside ONE repo: `--repo` is already

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -2176,3 +2176,159 @@ fn mcp_stale_check_reports_which_repos_not_merely_that_some_do() {
         );
     }
 }
+
+/// nw-347. `_meta` is a promise `SERVER_INSTRUCTIONS` makes on every route, and
+/// three of the four CLI emitters break it. `print_ranking_json` (`hubs`,
+/// `bridges`) has no `_meta` parameter at all, and the `bridges` daemon leg
+/// actively runs `strip_hybrid_meta` over the envelope before rendering it —
+/// so the daemon's own stamp is discarded and the renderer has nothing to put
+/// back. Meanwhile `hub_nodes`/`bridge_nodes` over MCP carry one, because
+/// `tools::dispatch` stamps.
+///
+/// Asserted CLI-vs-MCP rather than CLI-vs-CLI because MCP is the route with no
+/// presentation layer above the tool: whatever the CLI does not print, the
+/// human never learns, and the two surfaces are documented to agree.
+#[test]
+fn every_json_cli_surface_carries_the_provenance_mcp_carries() {
+    let fixture = setup_fixture();
+    let db = &fixture.db_path;
+
+    for (argv, tool, args) in [
+        (
+            vec!["hubs", "--json", "--top", "3"],
+            "hub_nodes",
+            serde_json::json!({ "top_n": 3 }),
+        ),
+        (
+            vec!["bridges", "--json", "--top", "3"],
+            "bridge_nodes",
+            serde_json::json!({ "top_n": 3 }),
+        ),
+        (
+            vec!["brain", "search", "mainA", "--json"],
+            "brain_search",
+            serde_json::json!({ "query": "mainA" }),
+        ),
+    ] {
+        let label = argv.join(" ");
+        let cli = run_direct(db, &argv);
+        assert!(
+            cli.status.success(),
+            "{label} failed:\n{}",
+            String::from_utf8_lossy(&cli.stderr)
+        );
+        let cli_json = parse_stdout(&label, &cli);
+        let mcp_json = run_via_mcp(db, tool, args);
+
+        assert!(
+            cli_json["_meta"]["sources"].is_array(),
+            "`{label}` --json carries no `_meta`, while `{tool}` over MCP does. A \
+             renderer that rebuilds from a typed struct dropped the field the tool \
+             layer was given one author for (nw-315/nw-347): {cli_json}"
+        );
+        for leg in ["scope", "stale_repos"] {
+            assert!(
+                cli_json["_meta"].get(leg).is_some(),
+                "`{label}`: partial provenance is how a caller learns the wrong \
+                 thing confidently: {cli_json}"
+            );
+        }
+        assert_eq!(
+            cli_json["_meta"], mcp_json["_meta"],
+            "`{label}`: the CLI and MCP disagree about where the same answer came \
+             from"
+        );
+    }
+}
+
+/// nw-347, the sharpest leg: the split is INSIDE one command. `brain search
+/// --json` prints `tools::dispatch`'s stamped payload verbatim on the direct
+/// route (`src/main.rs`, the `BrainCommands::Search` direct leg) and rebuilds
+/// field-by-field from `nestweaver_proto::BrainSearchResponse` on the daemon
+/// route (`render_brain_search_response`), and that proto has no `_meta` field.
+/// So the SHAPE of the answer tracks whether a daemon happens to be running
+/// rather than what the caller asked for — nw-108's defect recurring on the
+/// provenance field, on the DEFAULT route.
+#[test]
+fn brain_search_json_has_one_shape_whether_or_not_a_daemon_is_running() {
+    let fixture = setup_fixture();
+    let db = &fixture.db_path;
+    let argv = ["brain", "search", "mainA", "--json"];
+
+    let direct = run_direct(db, &argv);
+    assert!(
+        direct.status.success(),
+        "brain search (direct) failed:\n{}",
+        String::from_utf8_lossy(&direct.stderr)
+    );
+    let direct_json = parse_stdout("brain search (direct)", &direct);
+
+    let _guard = DaemonGuard::new(db);
+    start_daemon(db);
+    let daemon = run_via_daemon(db, &argv);
+    assert!(
+        daemon.status.success(),
+        "brain search (daemon) failed:\n{}",
+        flatten_miette(&daemon.stderr)
+    );
+    let daemon_json = parse_stdout("brain search (daemon)", &daemon);
+
+    assert_eq!(
+        direct_json["_meta"].is_object(),
+        daemon_json["_meta"].is_object(),
+        "`brain search --json` emits `_meta` on one route and not the other, so a \
+         caller parsing the response has to know which transport answered.\n\
+         direct: {direct_json}\ndaemon: {daemon_json}"
+    );
+    assert!(
+        daemon_json["_meta"]["sources"].is_array(),
+        "the daemon route lost the provenance the proto boundary could not \
+         carry: {daemon_json}"
+    );
+}
+
+/// nw-259(b). `--token-budget` got `range(1..=16000)` to match its schema;
+/// `--limit`, declared six lines below it, got nothing — while `code_context`'s
+/// schema carries `maximum: 5000` (with a comment explaining that the tool asks
+/// for `limit + 1` and an unbounded value overflows it) and the daemon proxy
+/// validates against that schema. So the same invocation was accepted or
+/// rejected by whether a daemon happened to be running: the bound was a
+/// property of the transport, not of the contract.
+#[test]
+fn context_limit_is_bounded_identically_on_both_routes() {
+    let fixture = setup_fixture();
+    let db = &fixture.db_path;
+    let args = &["context", "mainA", "--limit", "6000"];
+
+    let direct = run_direct(db, args);
+
+    let _guard = DaemonGuard::new(db);
+    start_daemon(db);
+    let daemon = run_via_daemon(db, args);
+
+    assert_eq!(
+        direct.status.code(),
+        daemon.status.code(),
+        "`--limit 6000` is rejected on one route and accepted on the other.\n\
+         direct ({:?}):\n{}\ndaemon ({:?}):\n{}",
+        direct.status.code(),
+        flatten_miette(&direct.stderr),
+        daemon.status.code(),
+        flatten_miette(&daemon.stderr)
+    );
+    assert_eq!(
+        direct.status.code(),
+        Some(64),
+        "an out-of-range argument is a USAGE error; `--token-budget` already \
+         classifies it that way on this same command"
+    );
+
+    // Counterweight: a value INSIDE the bound must still be accepted on both,
+    // or a parser with the wrong range would satisfy the above.
+    let ok_args = &["context", "mainA", "--limit", "5000"];
+    assert!(
+        run_direct(db, ok_args).status.success(),
+        "5000 is the schema's maximum and must be accepted"
+    );
+    assert!(run_via_daemon(db, ok_args).status.success());
+}

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -1906,10 +1906,153 @@ fn intent_vocabulary_agrees_across_all_three_routes() {
     );
 }
 
+/// nw-217a. The containment guard, generalised from ONE tool to a table.
+///
+/// nw-217 is the most recurrent defect class in this workspace — "a guard
+/// present in one implementation and absent in its twin" — and it decomposes
+/// into six shapes that do NOT share one answer. This is the mechanical check
+/// for the third and highest-leverage of them: response-shape drift between
+/// routes. A key the CLI emits and MCP does not is a field an agent cannot see;
+/// the converse is a field a human cannot see.
+///
+/// `the_mcp_route_does_not_grow_new_disclosure_gaps` has held `stale_check` to
+/// this since nw-315 and held nothing else to it, which is how nw-316's three
+/// missing `project_context` disclosure fields and nw-347's missing `_meta` on
+/// `hubs`/`bridges` both survived a release that spent six commits on route
+/// parity. Both of those rows are in this table now, and both fail without the
+/// fixes in this branch.
+///
+/// The assertion is CONTAINMENT against an explicit `KNOWN_GAPS` list, not
+/// equality: closing a gap shrinks the set safely, opening a new one fails, and
+/// a deliberate asymmetry has to be written down with the reason.
+///
+/// NOT covered by this, and not claimed: shapes S1 (two dispatch seams — a
+/// TYPE, `provenance_seam::Unstamped`), S2 (registry drift — enumeration),
+/// S4 (argument-contract drift — the clap/schema cross-check, nw-217b),
+/// S5 (guard call-site parity) and S6 (semantic divergence, which needs a
+/// fixture that can tell two behaviours apart and is the parity harness, one
+/// test at a time).
+#[test]
+fn no_cli_command_discloses_more_than_its_mcp_twin() {
+    /// A gap is `(tool, key path)` with the finding that owns it. EMPTY is the
+    /// goal; an entry is a promise, not a permission.
+    const KNOWN_GAPS: &[(&str, &str)] = &[];
+
+    // Rows are (CLI argv, MCP tool, MCP arguments). Arguments must be the
+    // SAME question on both sides or the diff is about the question, not the
+    // route.
+    let rows: Vec<(Vec<&str>, &str, serde_json::Value)> = vec![
+        (
+            vec!["stale-check", "--json"],
+            "stale_check",
+            serde_json::json!({}),
+        ),
+        (
+            vec!["hubs", "--json", "--top", "3"],
+            "hub_nodes",
+            serde_json::json!({ "top_n": 3 }),
+        ),
+        (
+            vec!["bridges", "--json", "--top", "3"],
+            "bridge_nodes",
+            serde_json::json!({ "top_n": 3 }),
+        ),
+        (
+            vec!["brain", "search", "mainA", "--json"],
+            "brain_search",
+            serde_json::json!({ "query": "mainA" }),
+        ),
+        (
+            vec!["dead-code", "--json"],
+            "dead_code",
+            serde_json::json!({}),
+        ),
+        (
+            vec!["flow-trace", "mainA", "--json"],
+            "flow_trace",
+            serde_json::json!({ "symbol": "mainA" }),
+        ),
+        (
+            vec!["blast-radius", "--files", "src/a.js", "--json"],
+            "blast_radius",
+            serde_json::json!({ "changed_files": ["src/a.js"] }),
+        ),
+    ];
+
+    let fixture = setup_fixture();
+    let db = &fixture.db_path;
+    let mut failures: Vec<String> = Vec::new();
+
+    for (argv, tool, args) in rows {
+        let label = argv.join(" ");
+        let cli = run_direct(db, &argv);
+        assert!(
+            cli.status.success(),
+            "{label} (direct) failed:\n{}",
+            String::from_utf8_lossy(&cli.stderr)
+        );
+        let cli_json = parse_stdout(&label, &cli);
+        let mcp_json = run_via_mcp(db, tool, args);
+
+        let mcp_keys = json_key_paths(&mcp_json);
+        let missing: Vec<String> = json_key_paths(&cli_json)
+            .into_iter()
+            .filter(|key| !mcp_keys.contains(key))
+            .filter(|key| !KNOWN_GAPS.contains(&(tool, key.as_str())))
+            .collect();
+        if !missing.is_empty() {
+            failures.push(format!(
+                "`{label}` -> `{tool}`: {missing:?}\n  CLI: {cli_json}\n  MCP: {mcp_json}"
+            ));
+        }
+    }
+
+    // `project_context` needs a project, which is why this row could not exist
+    // before nw-218 — `setup_fixture` creates none, so both routes answered
+    // NOT_FOUND and any comparison passed on two identical failures.
+    let project = setup_project_fixture();
+    let argv = ["project-context", "demo", "--json", "--token-budget", "400"];
+    let cli = run_direct(&project.db_path, &argv);
+    assert!(
+        cli.status.success(),
+        "project-context (direct) failed:\n{}",
+        String::from_utf8_lossy(&cli.stderr)
+    );
+    let cli_json = parse_stdout("project-context", &cli);
+    let mcp_json = run_via_mcp(
+        &project.db_path,
+        "project_context",
+        serde_json::json!({ "project": "demo", "token_budget": 400 }),
+    );
+    let mcp_keys = json_key_paths(&mcp_json);
+    let missing: Vec<String> = json_key_paths(&cli_json)
+        .into_iter()
+        .filter(|key| !mcp_keys.contains(key))
+        .filter(|key| !KNOWN_GAPS.contains(&("project_context", key.as_str())))
+        .collect();
+    if !missing.is_empty() {
+        failures.push(format!(
+            "`project-context` -> `project_context`: {missing:?}\n  CLI: {cli_json}\n  MCP: {mcp_json}"
+        ));
+    }
+
+    assert!(
+        failures.is_empty(),
+        "these fields reach a CLI caller and not an MCP one, and they are not in \
+         the list of gaps this workspace knowingly left open:\n{}",
+        failures.join("\n")
+    );
+}
+
 /// The structural guard: for a tool with a CLI twin, any key the CLI emits and
 /// MCP does not is a field an agent cannot see. The known gaps are listed
 /// explicitly with the finding that owns them, and the assertion is
 /// CONTAINMENT — closing one shrinks the set safely, opening a new one fails.
+///
+/// Kept alongside `no_cli_command_discloses_more_than_its_mcp_twin` rather than
+/// folded into it: this one names `stale_check` in its failure message, which
+/// is the row nw-315 closed, and its docstring records why the `._meta*`
+/// entries that used to sit in `KNOWN_GAPS` were INERT.
 #[test]
 fn the_mcp_route_does_not_grow_new_disclosure_gaps() {
     /// EMPTY, and that is the point. nw-315 owned every entry that used to be

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -189,6 +189,11 @@ struct Fixture {
     // Keeps the tempdir alive for the duration of the test.
     _dir: TempDir,
     db_path: PathBuf,
+    /// The indexed repo's checkout root. `read-symbols` resolves each symbol's
+    /// repo-relative `file_path` against a root, so a test that omits it reads
+    /// against the test process's cwd, finds nothing, and compares two empty
+    /// bodies (nw-340).
+    repo_dir: PathBuf,
 }
 
 /// Create a scratch DB indexing a small JS repo with enough cross-directory
@@ -229,7 +234,11 @@ fn setup_fixture() -> Fixture {
     );
     create_db(&repo_dir, &db_path);
 
-    Fixture { _dir: dir, db_path }
+    Fixture {
+        _dir: dir,
+        db_path,
+        repo_dir,
+    }
 }
 
 fn setup_contract_fixture() -> Fixture {
@@ -245,7 +254,11 @@ fn setup_contract_fixture() -> Fixture {
         )],
     );
     create_db(&repo_dir, &db_path);
-    Fixture { _dir: dir, db_path }
+    Fixture {
+        _dir: dir,
+        db_path,
+        repo_dir,
+    }
 }
 
 // ─── Mode runners ────────────────────────────────────────────────────────────
@@ -1206,8 +1219,30 @@ fn parity_search_direct_vs_daemon() {
 
 #[test]
 fn parity_read_symbols_direct_vs_daemon() {
+    // nw-340: `--root` is not decoration here. Without it the DIRECT route
+    // resolves `src/a.js` against the test process's cwd and the DAEMON route
+    // against its own — neither is the fixture repo — so both printed a header
+    // with a blank line under it and this test compared two empty bodies and
+    // called it parity. It is also the reason the exit code had to become a
+    // discriminator: with `EXIT_SUCCESS` on an unreadable body there was
+    // nothing for the test to notice.
     let fixture = setup_fixture();
-    check_parity(&fixture.db_path, "read-symbols", &["read-symbols", "mainA"]);
+    let root = fixture.repo_dir.display().to_string();
+    let args = ["read-symbols", "mainA", "--root", root.as_str()];
+    check_parity(&fixture.db_path, "read-symbols", &args);
+
+    // And the body must actually be there, on both routes. Parity alone would
+    // still pass on two identical blanks.
+    let direct = run_direct(&fixture.db_path, &args);
+    let stdout = String::from_utf8_lossy(&direct.stdout);
+    assert!(
+        stdout.contains("export function mainA"),
+        "read-symbols must emit the symbol's SOURCE, not just its header: {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("source unavailable"),
+        "the fixture root was passed, so the body must be readable: {stdout:?}"
+    );
 }
 
 #[test]
@@ -1294,7 +1329,11 @@ fn export_defaults_to_the_all_scope_not_code() {
         .args(["--db", &db_path.display().to_string()])
         .assert()
         .success();
-    let fixture = Fixture { _dir: dir, db_path };
+    let fixture = Fixture {
+        _dir: dir,
+        db_path,
+        repo_dir,
+    };
 
     let defaulted = run_direct(&fixture.db_path, &["export", "--format", "graphml"]);
     assert!(

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -1248,11 +1248,17 @@ fn parity_msgpack_scope_direct_vs_daemon() {
     );
     // An INVALID scope must fail on both, not slip through whichever route
     // happens to dispatch on format first.
+    //
+    // nw-312 moved this refusal from the handler to the PARSER, so the reason
+    // changed from `unknown export scope` (an `anyhow` chain, exit 1) to clap's
+    // usage error, which enumerates the legal values and exits 64. The parity
+    // is now structural rather than asserted: clap runs before either route
+    // dispatches, so the two cannot disagree about what a bad `--scope` is.
     check_parity_of_refusal(
         &fixture.db_path,
         "export msgpack --scope nonsense",
         &["export", "--format", "msgpack", "--scope", "nonsense"],
-        "unknown export scope",
+        "possible values: all, code, vault",
     );
 }
 

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -232,6 +232,53 @@ fn setup_fixture() -> Fixture {
     Fixture { _dir: dir, db_path }
 }
 
+/// A fixture that carries a real Project.
+///
+/// nw-218. `project-context` cannot be compared on a database that has none:
+/// a NOT_FOUND on both routes is a byte-identical failure that asserts nothing,
+/// which is why `parity_project_context_direct_vs_daemon` was DELETED rather
+/// than kept. `setup_fixture` indexes four plain `.js` files and indexing never
+/// creates a Project node.
+///
+/// The blocker was smaller than the tombstone implies: projects do not need
+/// `materialize-projects` (which needs a live daemon). Three store writers are
+/// enough, and all three are already used by fixtures elsewhere in this
+/// workspace — `insert_project` in `tests/cli_test.rs` and
+/// `tests/daemon_test.rs`, and both batch edge writers in
+/// `crates/nestweaver-mcp/src/tools.rs`.
+fn setup_project_fixture() -> Fixture {
+    let fixture = setup_fixture();
+    {
+        let store = nestweaver_store::GraphStore::open_or_create(&fixture.db_path).unwrap();
+        store
+            .insert_project(&nestweaver_schema::Project {
+                uid: "proj:parity:demo".to_string(),
+                name: "demo".to_string(),
+                summary: Some("parity fixture".to_string()),
+                instance_id: "default".to_string(),
+            })
+            .unwrap();
+        // Every indexed symbol is a member, so the project has real mass and a
+        // small `--token-budget` genuinely truncates. A project whose members
+        // all fit is a fixture that cannot observe truncation at all.
+        let members: Vec<String> = store
+            .list_all_symbols()
+            .unwrap()
+            .into_iter()
+            .map(|symbol| symbol.uid)
+            .collect();
+        assert!(
+            members.len() >= 4,
+            "the fixture must have symbol mass, or a budget cannot cut: {}",
+            members.len()
+        );
+        store
+            .batch_insert_project_symbol_edges("proj:parity:demo", &members, 1.0)
+            .unwrap();
+    }
+    fixture
+}
+
 fn setup_contract_fixture() -> Fixture {
     let dir = tempfile::tempdir().unwrap();
     let repo_dir = dir.path().join("ContrÁct-Repo");
@@ -1220,13 +1267,71 @@ fn parity_detect_changes_direct_vs_daemon() {
     );
 }
 
-// `parity_project_context_direct_vs_daemon` is deliberately absent until the
-// fixture can carry a project. `setup_fixture` indexes four plain `.js` files
-// and creates no Project node, so `project-context demo` exited NOT_FOUND on
-// both routes — the byte comparison then passed on two identical failures and
-// asserted nothing about the four nw-188 honesty fields it was written for.
-// Re-add it with a fixture that materializes a project; a vacuous test is
-// worse than a missing one because it reports coverage that does not exist.
+/// nw-218. `parity_project_context_direct_vs_daemon` was DELETED in 8.0.0
+/// because `setup_fixture` creates no Project, so both routes exited NOT_FOUND
+/// and the byte comparison passed on two identical failures. `setup_project_fixture`
+/// removes that blocker.
+///
+/// Restored as a KEY-SET comparison, not the byte comparison it used to be.
+/// The two routes legitimately differ on `semantic_applied` and
+/// `degraded_components` — the direct path passes `HybridSearchConfig::default()`
+/// and `embed_model: None` — so a byte comparison would fail for a reason that
+/// is not the defect, and "the test is red for a known-benign reason" is how a
+/// suite stops being read.
+#[test]
+fn parity_project_context_direct_vs_daemon() {
+    let fixture = setup_project_fixture();
+    let db = &fixture.db_path;
+    let args = &["project-context", "demo", "--json", "--token-budget", "400"];
+
+    let direct = run_direct(db, args);
+    assert!(
+        direct.status.success(),
+        "project-context (direct) failed:\n{}",
+        String::from_utf8_lossy(&direct.stderr)
+    );
+
+    let _guard = DaemonGuard::new(db);
+    start_daemon(db);
+    let daemon = run_via_daemon(db, args);
+    assert!(
+        daemon.status.success(),
+        "project-context (daemon) failed:\n{}",
+        flatten_miette(&daemon.stderr)
+    );
+
+    assert_both_ran_for_real("project-context", "json", &direct, &daemon);
+    assert_same_key_sets("project-context", &direct, &daemon);
+
+    // The nw-188 honesty fields the deleted test was written for. These are
+    // the ones a caller acts on, so they must AGREE, not merely both exist.
+    let direct_json = parse_stdout("project-context (direct)", &direct);
+    let daemon_json = parse_stdout("project-context (daemon)", &daemon);
+    for field in ["truncated", "more_available", "seed_tokens_charged"] {
+        assert_eq!(
+            direct_json[field], daemon_json[field],
+            "`{field}` differs between routes for the same project and the same \
+             budget, so how much was dropped depends on which transport \
+             answered.\ndirect: {direct_json}\ndaemon: {daemon_json}"
+        );
+    }
+
+    // Counterweight: a budget the project fits must report NOT truncated, or
+    // the equality above is satisfiable by both routes hardcoding `true`.
+    let roomy = &[
+        "project-context",
+        "demo",
+        "--json",
+        "--token-budget",
+        "16000",
+    ];
+    let roomy_direct = parse_stdout("project-context (roomy)", &run_direct(db, roomy));
+    assert_eq!(
+        roomy_direct["truncated"],
+        serde_json::json!(false),
+        "a budget that fits must not report truncation: {roomy_direct}"
+    );
+}
 
 /// msgpack must honour `--scope` on BOTH routes.
 ///

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -2371,3 +2371,288 @@ fn context_limit_is_bounded_identically_on_both_routes() {
     );
     assert!(run_via_daemon(db, ok_args).status.success());
 }
+
+/// nw-259(a), machine route. **Which cap cut** must be readable by a consumer
+/// that cannot read prose.
+///
+/// The human route already names the cause — `TRUNCATED by --token-budget 200
+/// — raise it for more` versus `TRUNCATED at limit 5 — pass --limit for more`
+/// — but that disclosure lived only in the `--stats` string. `--json` emitted
+/// `{"total": 576, "limit": 5000, "truncated": true}` for a cut the BUDGET
+/// made, so an agent read "truncated at limit 5000", raised `--limit`, and got
+/// the same rows back. That is the wrong-remedy defect nw-259 exists to close,
+/// still live for every script and every agent — the audience with no prose to
+/// fall back on.
+///
+/// Asserted on all three routes, because the direct path, the daemon path and
+/// the MCP tool each decide this independently and a fix to one is how they
+/// diverged before.
+#[test]
+fn context_truncation_names_the_cause_on_every_route() {
+    let fixture = setup_fixture();
+    let db = &fixture.db_path;
+
+    // A LIMIT cut: the budget is roomy, so only `--limit` can have cut.
+    let by_limit = ["context", "mainA", "--json", "--limit", "1"];
+    // A BUDGET cut: the limit is the schema maximum and cannot bite, so only
+    // the budget can have cut. This is the case that reported `limit`.
+    let by_budget = [
+        "context",
+        "mainA",
+        "--json",
+        "--limit",
+        "5000",
+        "--token-budget",
+        "1",
+    ];
+    // BOTH fired. The budget cut LAST, so raising `--limit` alone cannot get
+    // past it — naming the limit here is the wrong remedy.
+    let by_both = [
+        "context",
+        "mainA",
+        "--json",
+        "--limit",
+        "1",
+        "--token-budget",
+        "1",
+    ];
+    // Neither fired: the field must not accuse a cap that did nothing.
+    let uncapped = ["context", "mainA", "--json", "--limit", "5000"];
+
+    let assert_cause =
+        |route: &str, payload: &serde_json::Value, expected: Option<&str>| match expected {
+            Some(cause) => {
+                assert_eq!(
+                    payload["truncated"],
+                    serde_json::json!(true),
+                    "{route}: the cap must actually bite or this proves nothing: {payload}"
+                );
+                assert_eq!(
+                    payload.get("truncated_by").and_then(|v| v.as_str()),
+                    Some(cause),
+                    "{route}: a consumer cannot tell WHICH cap cut, so it will raise the \
+                     wrong knob and get the same rows: {payload}"
+                );
+            }
+            None => {
+                assert_ne!(
+                    payload["truncated"],
+                    serde_json::json!(true),
+                    "{route}: nothing was capped: {payload}"
+                );
+                assert!(
+                    payload
+                        .get("truncated_by")
+                        .is_none_or(serde_json::Value::is_null),
+                    "{route}: a complete answer must not blame a cap: {payload}"
+                );
+            }
+        };
+
+    // ── Route 1: direct ──
+    for (args, expected) in [
+        (&by_limit[..], Some("limit")),
+        (&by_budget[..], Some("token_budget")),
+        (&by_both[..], Some("token_budget")),
+        (&uncapped[..], None),
+    ] {
+        let out = run_direct(db, args);
+        assert!(
+            out.status.success(),
+            "context (direct) {args:?} failed:\n{}",
+            flatten_miette(&out.stderr)
+        );
+        assert_cause(
+            &format!("direct {args:?}"),
+            &parse_stdout("context (direct)", &out),
+            expected,
+        );
+    }
+
+    // ── Route 3: MCP, before the daemon takes the DB lock ──
+    //
+    // `code_context` has ONE cap, so `truncated: true` is unambiguous there
+    // *today* — but the CLI's daemon route parses this very payload and then
+    // applies its own budget on top, so the cause has to be IN the payload for
+    // route 2 to be able to override it rather than recompute it.
+    let mcp_capped = run_via_mcp(
+        db,
+        "code_context",
+        serde_json::json!({ "seeds": ["mainA"], "limit": 1 }),
+    );
+    assert_cause("mcp code_context limit=1", &mcp_capped, Some("limit"));
+    let mcp_uncapped = run_via_mcp(
+        db,
+        "code_context",
+        serde_json::json!({ "seeds": ["mainA"], "limit": 5000 }),
+    );
+    assert_cause("mcp code_context limit=5000", &mcp_uncapped, None);
+
+    // ── Route 2: daemon ──
+    let _guard = DaemonGuard::new(db);
+    start_daemon(db);
+    for (args, expected) in [
+        (&by_limit[..], Some("limit")),
+        (&by_budget[..], Some("token_budget")),
+        (&by_both[..], Some("token_budget")),
+        (&uncapped[..], None),
+    ] {
+        let out = run_via_daemon(db, args);
+        assert!(
+            out.status.success(),
+            "context (daemon) {args:?} failed:\n{}",
+            flatten_miette(&out.stderr)
+        );
+        assert_cause(
+            &format!("daemon {args:?}"),
+            &parse_stdout("context (daemon)", &out),
+            expected,
+        );
+    }
+}
+
+/// nw-259(a), the human half. `--stats` is OFF by default.
+///
+/// The truncation clause was built into the `--stats` line, so the DEFAULT
+/// human output of a capped `context` was byte-identical to a complete one:
+/// the reader saw `Connected (1 symbols, ranked by relevance)` and had nothing
+/// to compare it against. Disclosure that only appears under an opt-in flag is
+/// the same silence the cap was supposed to stop being.
+///
+/// Asserted with `--stats` absent on purpose. The counterweight is the second
+/// half: an UNCAPPED run must stay quiet, or printing the notice
+/// unconditionally would satisfy the first assertion.
+#[test]
+fn a_capped_context_says_so_with_stats_off() {
+    let fixture = setup_fixture();
+    let db = &fixture.db_path;
+
+    let capped = run_direct(db, &["context", "mainA", "--limit", "1"]);
+    let stdout = String::from_utf8_lossy(&capped.stdout);
+    assert!(
+        stdout.contains("TRUNCATED at limit 1"),
+        "a capped result renders identically to a complete one with `--stats` \
+         off, which is the whole defect:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("pass --limit for more"),
+        "the notice must carry the remedy, not just the fact:\n{stdout}"
+    );
+
+    let budgeted = run_direct(
+        db,
+        &["context", "mainA", "--limit", "5000", "--token-budget", "1"],
+    );
+    let stdout = String::from_utf8_lossy(&budgeted.stdout);
+    assert!(
+        stdout.contains("--token-budget"),
+        "the human notice must name the cap that actually cut, exactly as the \
+         `--stats` line does — they read the SAME field:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("pass --limit for more"),
+        "a budget cut prescribed `--limit`, which cannot change the outcome:\n{stdout}"
+    );
+
+    let complete = run_direct(db, &["context", "mainA", "--limit", "5000"]);
+    let stdout = String::from_utf8_lossy(&complete.stdout);
+    assert!(
+        !stdout.contains("TRUNCATED"),
+        "nothing was capped, so nothing may be claimed:\n{stdout}"
+    );
+}
+
+/// Where else does the property hold? `summary` — TWO caps, one boolean.
+///
+/// A `summary` result can be cut by the level's generator cap (500 symbols, 50
+/// clusters, 30 hubs — none of them a knob the caller passed) or by
+/// `--token-budget`, and both routes reported a single `truncated` for both.
+/// The remedies are different — narrow with `--target`, or raise the budget —
+/// so `truncated: true` alone leaves a consumer guessing.
+///
+/// Named as INDEPENDENT booleans, not as `context`'s single `truncated_by`
+/// string, because these two caps do not compose in an order: both remedies
+/// stay useful when both fire. That is `brain_impact`'s existing shape
+/// (`truncated_by_depth` / `truncated_by_threshold`), not a new one.
+#[test]
+fn summary_names_which_cap_cut_on_both_routes() {
+    let fixture = setup_fixture();
+    let db = &fixture.db_path;
+
+    let cli = run_direct(
+        db,
+        &[
+            "summary",
+            "--level",
+            "file",
+            "--json",
+            "--token-budget",
+            "1",
+        ],
+    );
+    assert!(
+        cli.status.success(),
+        "summary (direct) failed:\n{}",
+        flatten_miette(&cli.stderr)
+    );
+    let payload = parse_stdout("summary (direct)", &cli);
+    assert_eq!(
+        payload["truncated"],
+        serde_json::json!(true),
+        "the budget must bite or this proves nothing: {payload}"
+    );
+    assert_eq!(
+        payload["truncated_by_budget"],
+        serde_json::json!(true),
+        "a budget cut must say so: {payload}"
+    );
+    assert_eq!(
+        payload["truncated_by_cap"],
+        serde_json::json!(false),
+        "the generator cap did not fire; blaming it sends the caller to \
+         `--target`, which cannot help here: {payload}"
+    );
+
+    let mcp = run_via_mcp(
+        db,
+        "get_summary",
+        serde_json::json!({ "level": "file", "token_budget": 1 }),
+    );
+    assert_eq!(
+        mcp["truncated"],
+        serde_json::json!(true),
+        "the budget must bite on the MCP route too: {mcp}"
+    );
+    assert_eq!(
+        mcp["truncated_by_budget"],
+        serde_json::json!(true),
+        "the agent-facing route is the one with no prose to fall back on: {mcp}"
+    );
+    assert_eq!(mcp["truncated_by_cap"], serde_json::json!(false));
+
+    // Counterweight: an unbounded run must set neither, or hardcoding `true`
+    // would satisfy everything above.
+    let roomy = run_direct(
+        db,
+        &[
+            "summary",
+            "--level",
+            "file",
+            "--json",
+            "--token-budget",
+            "0",
+        ],
+    );
+    let payload = parse_stdout("summary (unbounded)", &roomy);
+    assert_eq!(payload["truncated"], serde_json::json!(false), "{payload}");
+    assert_eq!(
+        payload["truncated_by_budget"],
+        serde_json::json!(false),
+        "{payload}"
+    );
+    assert_eq!(
+        payload["truncated_by_cap"],
+        serde_json::json!(false),
+        "{payload}"
+    );
+}


### PR DESCRIPTION
Second remediation pass over the NestWeaver backlog: the 42 items marked `ready`
after PR #332's grooming. **35 commits · 4,201 passed / 0 failed / 6 ignored**
(base 4,102 → **+99 tests**) · fmt clean · clippy `-D warnings` clean.

Four lanes in parallel worktrees, merged serially with a full suite between each,
then verified against a disposable copy of a real 1 GB graph.

---

## The Phase-1 gate removed a third of the scope before any code was written

Four read-only localisation agents produced 6,327 lines of analysis and
**disproved or retired seven items**:

- **nw-339** — mechanism false. `extract_sections` has always emitted a whole-body
  preamble for headingless notes, pinned by an existing test. The real cause of the
  observation was frontmatter indexing, already fixed in #332. Implementing the
  filed "fix" would have **double-indexed every headingless note**.
- **nw-331**, **nw-311** — already fixed in `b1ac8a40`; the tickets described code
  that no longer exists.
- **nw-330** — collapses into nw-349; one line.
- **nw-073 / nw-195 / nw-236** — upstream lbug defects, now tracked in their own
  workspace. NestWeaver cannot fix them.

Three more had their stated cause disproved but survived as items: **nw-344**
(the cited ancestry is the verbatim counter-example in the source comment),
**nw-342** (the key is `backlog/`, not `Backlog\`, because a `replace` runs first),
**nw-341** (the "silent cap" does not exist — `read_limit` rejects, and the direct
path is uncapped).

**nw-343 got worse on inspection**: both P7 fallback branches require a globally
unique basename, so **writing more of the path makes a link resolve less often**
than the bare form. Live in a vault with 21 `_Overview.md` files.

---

## A regression this project shipped in #332, found and fixed

`1e4de638` added `"corrupted wal"` to the `db_corrupt` classifier, whose remedy is
**"delete this database and re-index"** — routing a *recoverable* state to a
destructive one, from the commit whose purpose was making corruption remedies
accurate. One condition reached the operator through **three contradictory
remedies**, and the verified recovery was named by none.

Now one runbook on all three paths: **move aside, do not delete**, naming all five
artifacts, with a required re-index. **It was executed, not written** — 4 KB of
garbage in the WAL reproduces the state deterministically, and following the
printed steps verbatim recovered the database to the same top hit at the same
score. Executing it also found a **second corrupt-WAL phrasing** the classifier
missed, and a shipped-path defect where `extract_db_path` could name **an entirely
different database** inside instructions telling the operator which files to move.

---

## The integration seam

Two lanes were individually correct and their combination was not. The vault lane
made whole-corpus scans **tolerate** a corrupt row; a pre-existing test encodes
that a corrupt symbol forces `affected-tests` to `run-full-suite`, because a
partial graph cannot justify a partial selection. The tolerance disclosed via
`tracing::warn!` — **a log line, not a return value** — so the safety decision
could not see it.

That is **nw-324 from the previous release verbatim**: *affected-tests reporting
`selection-usable` while a regression escapes with a green build.* Fixed with
`ScanIntegrity`, a value callers branch on, wired through six completeness claims
and **named caller-by-caller for the rest**.

Auditing it found a **latent data-loss path in #332's own nw-287 guard**: a vault
whose note rows are all undecodable reads as "nothing indexed", so the
anti-mass-delete guard stands down and the refresh deletes the vault it could not
read. Now pinned by a test.

---

## Verified on a real 1 GB graph, not fixtures

| | Result |
| --- | --- |
| Corpus completeness | 1138 vs 1138, **0 ghosts, 0 missing** |
| Sections↔headings | gap 212 = 212 preamble notes, **symdiff 0** |
| Tag fidelity | **572/572** exact note-sets (was 569/571), 0 dataview leaks |
| Dead vectors | **1688/1688** live across 35 queries |
| Wikilink ladder | 10 links lost = **exactly** the 10 cross-workspace thefts, 0 legitimate losses |
| Span fix | Exact **214 → 250**, Degenerate **33 → 5**; `.h` files still yield 8,030 symbols |
| `_meta` parity | `brain search --json` byte-identical on both routes |
| Exit codes | invalid `--format`/`--scope` → **64**, msgpack/cypher/graphml/mermaid all still work |

The escaped-pipe residual left open by #332 is **fixed**: `[[Backlog\|Orbit — Backlog]]`
moved from NestWeaver's Backlog @0.85 to **Orbit's own @0.92**, reproduced on two
independent indexes.

---

## Not claimed, and two things to fix next

- **`dead-code` is 0% precise on real C++** — 0 of 11,730 symbols reachable while
  asserting `coverage: "complete"`, with 1,523 asserted dead at medium confidence.
  Rust control on the same binary: 85% reachable. **Pre-existing, not caused here**,
  and it is the same "confidently wrong" class as the previous release blocker.
- **821 of 822 real C++ `class` definitions are not extracted** (struct 91%, class
  0.1%). The class rule is untouched by this branch, so pre-existing — but it almost
  certainly causes the above, and **no fixture can see it**: the fixture's simple
  `class SensorManager` extracts fine.
- **`brain_context` has no truncation disclosure at all** — no `truncated`, `total`,
  `returned` or `more_available`. `budgeted_cut` computes the cut and discards it, so
  a capped answer is byte-indistinguishable from a complete one. Strictly worse than
  the defect nw-259 closed; deliberately not half-fixed here.
- **nw-349's module-scope promotion was built and then removed**, with the
  enumeration to justify it: the canonical reproduction is false (bash `main` is
  already an entry point), and of 20 remaining module-scope references, none would
  produce a non-fabricated edge. The discriminated enum ships so it can be
  revisited without re-deriving any of it.
- **nw-291, nw-305, nw-319, nw-322, nw-334** stay open by design. nw-305 has three
  options with consequences and no silent pick; nw-322 ships nothing and **the
  unverified 4–10× figure appears in no commit message**.

## Method note

Every commit answers **"where else does this property need to hold?"** — 26 such
sections across 35 commits. It repeatedly paid: the span defect was **six**
languages rather than one; the NUL canary sat under **four** whole-corpus scans;
not widening the extends map would have **silently deleted every Rust trait
relationship**; and `nw-330`'s one-line kind change required four call-site
decisions, one of which was deliberately left alone.

**Three vacuous checks were found by running them against a tree where the bug was
present**: `parity_read_symbols_direct_vs_daemon` was passing on **two empty
bodies**; `read_path_diagnostics_never_prescribe_a_write` guarded a hand-list of
**one**, twenty lines from a neighbour that destructures all nine; and four
separate reverts left `nw-260`'s tests green.

A tripwire we have relied on twice turns out to be a **tautology**: `note_get`
byte-identity re-reads the body from disk, so it can never detect index/disk
divergence — it compared identical against a snapshot whose source file had
demonstrably changed.
