### PR TITLE
fix(ci): sync the release lockfile however the release PR got there

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,24 +22,47 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-      - name: Check out release PR
-        if: steps.release.outputs.prs_created == 'true'
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
-      - name: Install Rust toolchain
-        if: steps.release.outputs.prs_created == 'true'
-        uses: dtolnay/rust-toolchain@stable
-      - name: Synchronize release lockfile
-        if: steps.release.outputs.prs_created == 'true'
+      # Find the open release PR by LABEL, not by `prs_created`.
+      #
+      # `prs_created` is true only when release-please CREATES the PR. When it
+      # UPDATES an existing one -- every subsequent push to main -- it is false,
+      # so the lockfile sync below never ran. That is not hypothetical: PR #331
+      # sat with Cargo.toml at 9.0.0 and Cargo.lock still at 8.0.0, a state
+      # `cargo build --locked` refuses outright (verified: exit 101, "cannot
+      # update the lock file ... because --locked was passed"). Merging it would
+      # have CUT THE TAG and then failed every one of the four binary builds,
+      # publishing a release with no artifacts -- and the release PR is the one
+      # PR in this repo that gets no CI, so nothing would have caught it.
+      #
+      # `autorelease: pending` is release-please's own label on an open release
+      # PR and is present however the PR got there.
+      - name: Locate the open release PR
+        id: release_pr
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_PR: ${{ steps.release.outputs.pr }}
+        run: |
+          set -euo pipefail
+          PR_JSON="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+            --label 'autorelease: pending' --json number,headRefName --limit 1)"
+          echo "number=$(jq -r '.[0].number // empty' <<< "$PR_JSON")" >> "$GITHUB_OUTPUT"
+          echo "branch=$(jq -r '.[0].headRefName // empty' <<< "$PR_JSON")" >> "$GITHUB_OUTPUT"
+      - name: Check out release PR
+        if: steps.release_pr.outputs.number != ''
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.release_pr.outputs.branch }}
+      - name: Install Rust toolchain
+        if: steps.release_pr.outputs.number != ''
+        uses: dtolnay/rust-toolchain@stable
+      - name: Synchronize release lockfile
+        if: steps.release_pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_PR_NUMBER: ${{ steps.release_pr.outputs.number }}
+          RELEASE_PR_BRANCH: ${{ steps.release_pr.outputs.branch }}
         run: |
           set -euo pipefail
 
-          RELEASE_PR_NUMBER="$(jq -er '.number' <<< "$RELEASE_PR")"
-          RELEASE_PR_BRANCH="$(jq -er '.headBranchName' <<< "$RELEASE_PR")"
           cargo update --workspace
 
           if ! git diff --quiet -- Cargo.lock; then
@@ -49,6 +72,12 @@ jobs:
             git commit -m "chore: synchronize Cargo.lock for release"
             git push origin "HEAD:$RELEASE_PR_BRANCH"
           fi
+
+          # Prove the state we are about to let someone merge actually builds.
+          # `cargo update --workspace` exiting 0 is not that proof: it says the
+          # lock was refreshed, not that --locked now accepts it, and --locked
+          # is what the build job uses.
+          cargo metadata --locked --format-version 1 > /dev/null
 
           if [ "$(gh pr view "$RELEASE_PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')" = "true" ]; then
             gh pr ready "$RELEASE_PR_NUMBER" --repo "$GITHUB_REPOSITORY"

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1130,6 +1130,57 @@ fn release_matrix(workflow: &str) -> Vec<(String, Option<String>, Option<String>
     entries
 }
 
+/// The release PR is the ONE pull request in this repo that receives no CI:
+/// release-please opens it with `GITHUB_TOKEN`, and GitHub deliberately does not
+/// trigger workflows for bot-token-created PRs. Everything that would otherwise
+/// be caught by a check has to be caught here instead.
+///
+/// This pins the specific hole that reached a cut: the lockfile-sync steps were
+/// gated on `prs_created`, which release-please sets ONLY when it CREATES the
+/// PR. On every later push it UPDATES the existing PR, `prs_created` is false,
+/// and the sync never ran -- so `Cargo.toml` advanced to 9.0.0 while
+/// `Cargo.lock` stayed at 8.0.0. `cargo build --locked` refuses that outright
+/// ("cannot update the lock file ... because --locked was passed", exit 101),
+/// so merging would have cut the tag and then failed all four binary builds,
+/// publishing a release with no artifacts.
+#[test]
+fn release_workflow_syncs_the_lockfile_however_the_release_pr_got_there() {
+    let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workflow =
+        std::fs::read_to_string(repo_root.join(".github/workflows/release-please.yml")).unwrap();
+
+    assert!(
+        workflow.contains("Synchronize release lockfile"),
+        "the release job must synchronize Cargo.lock; without it a version bump \
+         ships a lockfile the build refuses"
+    );
+    // Assert on the GATES, not on the file text: the comments above these steps
+    // name `prs_created` deliberately, to explain why it is the wrong condition.
+    // A test that forbids the word would forbid the explanation.
+    let gated_on_prs_created: Vec<&str> = workflow
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("if:") && line.contains("prs_created"))
+        .collect();
+    assert!(
+        gated_on_prs_created.is_empty(),
+        "no step may be gated on `prs_created`: it is true only when \
+         release-please CREATES the PR, so an UPDATED release PR silently skips \
+         the step -- the defect this test exists to prevent. Found: {gated_on_prs_created:?}"
+    );
+    assert!(
+        workflow.contains("autorelease: pending"),
+        "the release PR must be located by its own label, which is present \
+         however the PR got there, rather than by a create-only output"
+    );
+    assert!(
+        workflow.contains("cargo metadata --locked"),
+        "the job must PROVE --locked accepts the synchronized tree; \
+         `cargo update` exiting 0 says the lock was refreshed, not that the \
+         build job's --locked will accept it"
+    );
+}
+
 /// The Linux entries pin an OLD runner deliberately: glibc is backward
 /// compatible but not forward, so the build host's glibc is the compatibility
 /// floor shipped to users. These were `ubuntu-latest`/`ubuntu-24.04-arm`, and


### PR DESCRIPTION
**PR #331 was one merge away from cutting a v9.0.0 tag with no binaries.**

## Measured, not inferred

#331 carries `Cargo.toml` at 9.0.0 with `Cargo.lock` still recording `version = "8.0.0"`. Reproducing that state locally and running the build job's own flag:

```
error: cannot update the lock file ... because --locked was passed to prevent this
exit 101
```

The `build` job runs `cargo build --locked` for all four targets. Merging #331 would have created the tag and GitHub release, then failed every binary build. `publish-npm` needs `build`, so the first-ever npm publish would not have run either — leaving an npm wrapper whose `postinstall` downloads an asset that does not exist.

## Cause

The four lockfile-sync steps were gated on `steps.release.outputs.prs_created`, which release-please sets **only when it creates the PR**. #331 was created before this work began and has been *updated* on every push to `main` since. On an update that output is false, so all four steps were skipped. The sync existed; it had simply never run for this release.

The PR is now found by its `autorelease: pending` label — release-please's own, present however the PR got there.

## The job now proves its own result

`cargo update --workspace` exiting 0 says the lock was refreshed, not that `--locked` accepts the tree. Those are different claims, and only the second is what the build job needs. It now runs `cargo metadata --locked` afterwards, so a bad state fails in the release job rather than in four builds after the tag is already public.

## Why this needed a test

The release PR is the **one pull request in this repo that gets no CI** — release-please opens it with `GITHUB_TOKEN`, and GitHub deliberately does not trigger workflows for bot-token-created PRs. Anything not asserted elsewhere is unchecked on the exact commit that becomes the release.

This was found by diffing that PR against a green `main` by hand. That is not a control that scales, so the contract is now a test — which asserts on the step **gates** rather than the file text, and is verified to fail against the previous workflow, naming all three gated steps.