### PR TITLE
fix(ci): pin gcc-12 on the 22.04 Linux runners so the release actually builds

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -140,9 +140,45 @@ jobs:
         with:
           cache-targets: false
           cache-on-failure: true
+      # gcc-12 is REQUIRED and is not the 22.04 default.
+      #
+      # The runners are pinned to 22.04 so the shipped glibc floor is 2.35 (see
+      # the matrix comment). 22.04's default toolchain is GCC 11.4, and lbug
+      # vendors simsimd, which uses AVX-512 FP16 intrinsics that GCC 11 does not
+      # have: `unknown type name '__m512h'` and `attribute 'avx512fp16' argument
+      # 'target' is unknown`. That combination failed every Linux build of
+      # v9.0.0 AFTER the tag was already public.
+      #
+      # glibc and GCC are independent -- glibc comes from the OS, and the
+      # compiler version does not change which glibc symbols get linked. So
+      # gcc-12 on 22.04 gives BOTH a compiler new enough for simsimd and the
+      # 2.35 floor. Verified in an ubuntu:22.04 container: gcc-12 compiles an
+      # `_mm512_add_ph` probe with -mavx512fp16 (exit 0) while `ldd --version`
+      # reports 2.35.
       - name: Install build dependencies (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y cmake gcc-12 g++-12 libssl-dev libzstd-dev pkg-config protobuf-compiler mold
+          {
+            echo "CC=gcc-12"
+            echo "CXX=g++-12"
+          } >> "$GITHUB_ENV"
+      - name: Verify the Linux toolchain can build the vendored SIMD code
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          # Fail HERE, in seconds, rather than twenty minutes into the C++ build
+          # of a release whose tag is already cut. A future runner image that
+          # drops gcc-12 must be loud, not slow.
+          gcc-12 --version | head -1
+          printf '%s\n' \
+            '#include <immintrin.h>' \
+            '__attribute__((target("avx512fp16")))' \
+            'static __m512h probe(__m512h a, __m512h b) { return _mm512_add_ph(a, b); }' \
+            'int main(void) { (void)probe; return 0; }' > /tmp/fp16probe.c
+          gcc-12 -c /tmp/fp16probe.c -o /tmp/fp16probe.o -mavx512fp16
       - name: Install build dependencies (macOS)
         if: runner.os == 'macOS'
         run: brew install protobuf

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1130,6 +1130,37 @@ fn release_matrix(workflow: &str) -> Vec<(String, Option<String>, Option<String>
     entries
 }
 
+/// The 22.04 runner pin fixes the glibc floor and BREAKS the C++ build unless
+/// the toolchain is also pinned. 22.04's default is GCC 11.4; lbug vendors
+/// simsimd, which uses AVX-512 FP16 intrinsics GCC 11 does not have. Measured on
+/// the exact translation unit CI died on, `simsimd/lib.c`, in an ubuntu:22.04
+/// container: gcc-11 gives exit 1 with 127 errors naming `__m512h` and
+/// `avx512fp16`; gcc-12 gives exit 0 and a 389 KB object. glibc stays 2.35
+/// either way, because the compiler does not choose the C library.
+///
+/// This shipped a v9.0.0 whose Linux binaries failed to build AFTER the tag was
+/// public, so the two pins belong together and neither may be removed alone.
+#[test]
+fn release_workflow_pins_a_linux_toolchain_new_enough_for_the_vendored_simd() {
+    let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workflow =
+        std::fs::read_to_string(repo_root.join(".github/workflows/release-please.yml")).unwrap();
+
+    for needle in ["gcc-12", "g++-12", "CC=gcc-12", "CXX=g++-12"] {
+        assert!(
+            workflow.contains(needle),
+            "the Linux build must pin {needle}: ubuntu-22.04 defaults to GCC 11, \
+             which cannot compile lbug's vendored simsimd"
+        );
+    }
+    assert!(
+        workflow.contains("avx512fp16"),
+        "the job must PREFLIGHT the intrinsics it needs, so a runner image that \
+         drops gcc-12 fails in seconds rather than twenty minutes into the C++ \
+         build of a release whose tag is already cut"
+    );
+}
+
 /// The release PR is the ONE pull request in this repo that receives no CI:
 /// release-please opens it with `GITHUB_TOKEN`, and GitHub deliberately does not
 /// trigger workflows for bot-token-created PRs. Everything that would otherwise


### PR DESCRIPTION
**v9.0.0 shipped with no Linux binaries and no npm package.** The tag and GitHub release were created, both macOS builds succeeded, and both Linux builds failed in `cargo build` — after the release was already public. `publish-npm` depends on `build`, so the first-ever npm publish was skipped.

## My error

`c2e0835b` pinned the Linux runners to `ubuntu-22.04` to fix the shipped glibc floor. I verified the floor would be **enforced** and never verified the build still **succeeds** there. The artifact-level glibc gate added in that same commit never ran — the compile died first.

That is the defect class this whole release was spent removing from the product: confirming a property is asserted rather than confirming the thing works. It landed in the workflow that ships it.

## Cause

22.04's default toolchain is GCC 11.4. lbug vendors `simsimd`, which uses AVX-512 FP16 intrinsics GCC 11 lacks:

```
error: unknown type name '__m512h'; did you mean '__m512bh'?
cc1: error: attribute 'avx512fp16' argument 'target' is unknown
gmake: *** [third_party/simsimd/CMakeFiles/simsimd.dir/lib.c.o] Error 1
```

## Fix, and why it keeps the glibc floor

glibc comes from the OS; the compiler does not change which glibc symbols get linked. So `gcc-12` on 22.04 gives a compiler new enough for simsimd **and** the 2.35 floor.

Measured on the exact translation unit CI died on, in an `ubuntu:22.04` container against the real vendored source:

| | Result |
|---|---|
| gcc-11 (22.04 default) | exit 1, **127 errors**, naming `__m512h` and `avx512fp16` |
| **gcc-12** | **exit 0, 0 errors, 389,120-byte object** |
| `ldd --version` on that image | **2.35** |

A synthetic intrinsic probe passed for *both* compilers in an earlier check, which is why the real file was compiled instead — the probe could not tell me whether the rest of simsimd builds.

## Preflight

The job now compiles a two-line `_mm512_add_ph` probe before anything else, so a runner image that drops gcc-12 fails in seconds rather than twenty minutes into the C++ build of a release whose tag is already public. The test pins the runner and the toolchain together, since they are only correct as a pair.