### PR TITLE
fix(ci): stop the release-PR lookup racing the label that identifies it

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,12 +40,51 @@ jobs:
         id: release_pr
         env:
           GH_TOKEN: ${{ github.token }}
+          ACTION_PR: ${{ steps.release.outputs.pr }}
+          PRS_CREATED: ${{ steps.release.outputs.prs_created }}
         run: |
           set -euo pipefail
-          PR_JSON="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
-            --label 'autorelease: pending' --json number,headRefName --limit 1)"
-          echo "number=$(jq -r '.[0].number // empty' <<< "$PR_JSON")" >> "$GITHUB_OUTPUT"
-          echo "branch=$(jq -r '.[0].headRefName // empty' <<< "$PR_JSON")" >> "$GITHUB_OUTPUT"
+          NUM=""
+          BRANCH=""
+
+          # PREFER THE ACTION'S OWN OUTPUT. When release-please has just CREATED
+          # the PR, its `autorelease: pending` label is not attached yet: PR #338
+          # was created at 04:49:05 and the label lookup here ran within five
+          # seconds, matched nothing, and skipped the sync -- reproducing the
+          # exact defect the lookup was added to fix, on the very next release.
+          # The action's output is populated in-process and cannot race.
+          if [ -n "${ACTION_PR:-}" ] && [ "$ACTION_PR" != "null" ]; then
+            NUM="$(jq -r '.number // empty' <<< "$ACTION_PR")"
+            BRANCH="$(jq -r '.headBranchName // empty' <<< "$ACTION_PR")"
+          fi
+
+          # FALL BACK TO THE LABEL for a PR that already existed and was merely
+          # UPDATED -- the case that has no `pr` output at all, and the reason
+          # 9.0.0 shipped with a stale lockfile. Retry: a just-labelled PR can
+          # take a moment to appear in the list API.
+          if [ -z "$NUM" ]; then
+            for attempt in 1 2 3; do
+              PR_JSON="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+                --label 'autorelease: pending' --json number,headRefName --limit 1)"
+              NUM="$(jq -r '.[0].number // empty' <<< "$PR_JSON")"
+              BRANCH="$(jq -r '.[0].headRefName // empty' <<< "$PR_JSON")"
+              [ -n "$NUM" ] && break
+              echo "no open release PR yet (attempt $attempt/3); retrying in 5s"
+              sleep 5
+            done
+          fi
+
+          # If the action says it created a PR and we still cannot find it, that
+          # is an inconsistency, not an absence. Failing here is far cheaper than
+          # discovering it after the tag is public.
+          if [ "${PRS_CREATED:-false}" = "true" ] && [ -z "$NUM" ]; then
+            echo "::error::release-please reported creating a PR but none could be located; refusing to skip the lockfile sync" >&2
+            exit 1
+          fi
+
+          echo "located release PR: ${NUM:-<none>} (${BRANCH:-<none>})"
+          echo "number=$NUM" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
       - name: Check out release PR
         if: steps.release_pr.outputs.number != ''
         uses: actions/checkout@v7

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1201,8 +1201,24 @@ fn release_workflow_syncs_the_lockfile_however_the_release_pr_got_there() {
     );
     assert!(
         workflow.contains("autorelease: pending"),
-        "the release PR must be located by its own label, which is present \
-         however the PR got there, rather than by a create-only output"
+        "the release PR must be locatable by its own label, for the UPDATE case \
+         where release-please emits no `pr` output at all"
+    );
+    // Both lookups are required, and neither is sufficient alone. The label
+    // alone RACES: PR #338 was created at 04:49:05 and the label lookup ran
+    // within five seconds, matched nothing, and skipped the sync -- shipping a
+    // 9.0.1 PR with a 9.0.0 lockfile, the exact defect the lookup was added to
+    // fix. The action output alone misses the update case.
+    assert!(
+        workflow.contains("steps.release.outputs.pr"),
+        "the job must prefer release-please's own `pr` output, which is \
+         populated in-process and cannot race the label being attached"
+    );
+    assert!(
+        workflow.contains("refusing to skip the lockfile sync"),
+        "if the action reports creating a PR that cannot then be located, that \
+         is an inconsistency and must fail the job -- silently skipping the \
+         sync is how a release reaches `cargo build --locked` with a stale lock"
     );
     assert!(
         workflow.contains("cargo metadata --locked"),


### PR DESCRIPTION
**Blocking for 9.0.1.** PR #338 currently carries `Cargo.toml` at 9.0.1 with `Cargo.lock` still at 9.0.0 — the state `cargo build --locked` refuses, and the exact way 9.0.0 shipped with no Linux binaries and no npm package.

## What happened

#336 replaced a create-only gate with a lookup by the `autorelease: pending` label, so an *updated* release PR would finally get its lockfile synced. That fix shipped with a race which broke the *create* case instead:

- PR #338 created at `04:49:05`
- the lookup step ran and finished by `04:49:10`
- release-please had not attached the label yet → no match → sync skipped

```
success  Locate the open release PR
skipped  Check out release PR
skipped  Install Rust toolchain
skipped  Synchronize release lockfile
```

The step **succeeded** and the next three were **skipped**, so nothing was red. A gate that cannot find its subject reported no problem.

## Fix

Both lookups, because neither is sufficient alone:

| Path | Covers | Fails on |
|---|---|---|
| `steps.release.outputs.pr` | **create** — populated in-process, cannot race | empty on update |
| `autorelease: pending` label (with retry) | **update** — no `pr` output exists | races on create |

And it **fails closed**: if the action reports creating a PR and none can be located, the job errors rather than skipping. An inconsistency is not an absence, and the cost of guessing wrong is a public tag with no artifacts.

## Why the test changed too

This is the second fix to this step in one day, and both defects were the same shape — a lookup answering "nothing to do" for a condition it could not observe. The test previously pinned only the *absence* of the original create-only gate, which is exactly why a regression could land inside the fix for it. It now pins all three properties: the label path, the action-output path, and the fail-closed guard.