### PR TITLE
fix(ci): make v9 Linux release builds portable

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -179,45 +179,66 @@ jobs:
         with:
           cache-targets: false
           cache-on-failure: true
-      # gcc-12 is REQUIRED and is not the 22.04 default.
+      # GCC 13 is REQUIRED and is not available in the 22.04 base archive.
       #
       # The runners are pinned to 22.04 so the shipped glibc floor is 2.35 (see
-      # the matrix comment). 22.04's default toolchain is GCC 11.4, and lbug
-      # vendors simsimd, which uses AVX-512 FP16 intrinsics that GCC 11 does not
-      # have: `unknown type name '__m512h'` and `attribute 'avx512fp16' argument
-      # 'target' is unknown`. That combination failed every Linux build of
-      # v9.0.0 AFTER the tag was already public.
+      # the matrix comment). lbug 0.19.1 requires BOTH C++20 `std::format` and,
+      # on x86_64, AVX-512 FP16 intrinsics. Ubuntu 22.04's GCC 11 has neither;
+      # GCC 12 has the intrinsics but its libstdc++ still has no `<format>`.
+      # GCC 13 is the first version that satisfies both requirements.
       #
-      # glibc and GCC are independent -- glibc comes from the OS, and the
-      # compiler version does not change which glibc symbols get linked. So
-      # gcc-12 on 22.04 gives BOTH a compiler new enough for simsimd and the
-      # 2.35 floor. Verified in an ubuntu:22.04 container: gcc-12 compiles an
-      # `_mm512_add_ph` probe with -mavx512fp16 (exit 0) while `ldd --version`
-      # reports 2.35.
+      # The toolchain PPA also supplies a newer dynamic C++ runtime, which a
+      # stock 22.04 installation does not have. The checked-in linker wrapper
+      # replaces lbug's explicit `-lstdc++` and Rust's `-lgcc_s` with the GCC 13
+      # static archives. This keeps the archive runnable on an unmodified 22.04
+      # system instead of silently trading a GLIBC_ failure for a GLIBCXX_ one.
       - name: Install build dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y cmake gcc-12 g++-12 libssl-dev libzstd-dev pkg-config protobuf-compiler mold
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install -y cmake gcc-13 g++-13 libssl-dev libzstd-dev pkg-config protobuf-compiler mold
+          LINKER="$GITHUB_WORKSPACE/scripts/gcc13-static-cxx-linker"
+          test -x "$LINKER"
           {
-            echo "CC=gcc-12"
-            echo "CXX=g++-12"
+            echo "CC=gcc-13"
+            echo "CXX=g++-13"
+            echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=$LINKER"
+            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=$LINKER"
           } >> "$GITHUB_ENV"
-      - name: Verify the Linux toolchain can build the vendored SIMD code
+      - name: Verify the Linux C++20 and architecture toolchain
         if: runner.os == 'Linux'
         run: |
           set -euo pipefail
-          # Fail HERE, in seconds, rather than twenty minutes into the C++ build
-          # of a release whose tag is already cut. A future runner image that
-          # drops gcc-12 must be loud, not slow.
-          gcc-12 --version | head -1
+          gcc-13 --version | head -1
+          g++-13 --version | head -1
+
+          # This catches the v9.0.1 x86_64 failure (`<format>` missing) on both
+          # architectures before the full LadybugDB build begins.
           printf '%s\n' \
-            '#include <immintrin.h>' \
-            '__attribute__((target("avx512fp16")))' \
-            'static __m512h probe(__m512h a, __m512h b) { return _mm512_add_ph(a, b); }' \
-            'int main(void) { (void)probe; return 0; }' > /tmp/fp16probe.c
-          gcc-12 -c /tmp/fp16probe.c -o /tmp/fp16probe.o -mavx512fp16
+            '#include <format>' \
+            '#include <string>' \
+            'int main() { return std::format("{}", 42) == "42" ? 0 : 1; }' \
+            > "$RUNNER_TEMP/cxx20-format-probe.cpp"
+          g++-13 -std=c++20 "$RUNNER_TEMP/cxx20-format-probe.cpp" \
+            -o "$RUNNER_TEMP/cxx20-format-probe"
+          "$RUNNER_TEMP/cxx20-format-probe"
+
+          # AVX-512 is an x86 ISA. Running this probe on the native ARM64 job
+          # caused the other v9.0.1 failure before Cargo even started.
+          if [ "${{ matrix.target }}" = "x86_64-unknown-linux-gnu" ]; then
+            printf '%s\n' \
+              '#include <immintrin.h>' \
+              '__attribute__((target("avx512fp16")))' \
+              'static __m512h probe(__m512h a, __m512h b) { return _mm512_add_ph(a, b); }' \
+              'int main(void) { (void)probe; return 0; }' \
+              > "$RUNNER_TEMP/fp16-probe.c"
+            gcc-13 -c "$RUNNER_TEMP/fp16-probe.c" \
+              -o "$RUNNER_TEMP/fp16-probe.o" -mavx512fp16
+          fi
       - name: Install build dependencies (macOS)
         if: runner.os == 'macOS'
         run: brew install protobuf
@@ -255,11 +276,18 @@ jobs:
           LBUG_VER=$(awk '/^name = "lbug"$/{getline; print $3}' Cargo.lock | tr -d '"')
           OSSL_VER=$(awk '/^name = "openssl-sys"$/{getline; print $3}' Cargo.lock | tr -d '"')
           RUSTC_VER=$(rustc --version | awk '{print $2}')
-          echo "key=${LBUG_VER}-${OSSL_VER}-rustc${RUSTC_VER}" >> "$GITHUB_OUTPUT"
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            CXX_VER=$("$CXX" -dumpfullversion -dumpversion)
+            LINKER_HASH=$(shasum -a 256 scripts/gcc13-static-cxx-linker | cut -c1-12)
+            TOOLCHAIN_KEY="gcc${CXX_VER}-staticcxx${LINKER_HASH}"
+          else
+            TOOLCHAIN_KEY=$(clang --version | shasum -a 256 | cut -c1-16)
+          fi
+          echo "key=${LBUG_VER}-${OSSL_VER}-rustc${RUSTC_VER}-${TOOLCHAIN_KEY}" >> "$GITHUB_OUTPUT"
       - name: Cache native build outputs (lbug C++, OpenSSL)
         # Keyed on package versions (not Cargo.lock) so the cache survives
-        # release lockfile churn; per-target since the build matrix crosses
-        # os/arch.
+        # release lockfile churn; per-target and per-native-toolchain so an
+        # incomplete GCC 12 build cannot poison the GCC 13 repair job.
         uses: actions/cache@v6
         with:
           path: |
@@ -338,8 +366,12 @@ jobs:
             fi
           else
             readelf -d "$BIN" | tee linked-libraries.txt
-            if grep -Eq 'Shared library: \[lib(ssl|crypto)\.so' linked-libraries.txt; then
-              echo "release binary has a dynamic OpenSSL dependency" >&2
+            if grep -Eq 'Shared library: \[lib(stdc\+\+|gcc_s|ssl|crypto)\.so' linked-libraries.txt; then
+              echo "release binary has an undeclared dynamic toolchain or OpenSSL dependency" >&2
+              exit 1
+            fi
+            if readelf -V "$BIN" 2>/dev/null | grep -q 'GLIBCXX_'; then
+              echo "release binary still requires a dynamic GLIBCXX symbol" >&2
               exit 1
             fi
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,20 @@
 # Installing NestWeaver
 
-Install a pre-built CLI from [GitHub Releases](https://github.com/Kehl-io/nestweaver/releases/latest), or build from source. There is currently no published npm or crates.io package.
+Install the CLI from npm or a verified pre-built archive from
+[GitHub Releases](https://github.com/Kehl-io/nestweaver/releases/latest), or
+build from source. There is currently no published crates.io package.
+
+## npm
+
+```sh
+npm install --global nestweaver
+nestweaver --version
+```
+
+The npm package downloads the matching release archive for macOS or Linux on
+x86_64 or arm64 and verifies its published SHA-256 checksum before installing
+the executable. See the platform baselines below when installing on Linux or
+macOS.
 
 ## Pre-built CLI (recommended)
 

--- a/README.md
+++ b/README.md
@@ -289,9 +289,16 @@ The `.app` bundle gives you a menubar status icon, Metal GPU acceleration (~5x f
 
 ### All platforms (CLI)
 
-The primary pre-built installation path is a GitHub Release archive. Select the
-archive for your platform, verify its matching SHA-256 file, then install it as
-described in [INSTALL.md](INSTALL.md#pre-built-cli-recommended). Starting with
+Install the release-matched CLI wrapper from npm:
+
+```sh
+npm install --global nestweaver
+nestweaver --version
+```
+
+Alternatively, select the GitHub Release archive for your platform, verify its
+matching SHA-256 file, then install it as described in
+[INSTALL.md](INSTALL.md#pre-built-cli-recommended). Starting with
 the release that contains this change, both macOS CLI archives are built with
 Metal support. The default `accelerator = "auto"` therefore requires Metal in
 those builds and reports a Metal initialization or inference-probe failure

--- a/scripts/gcc13-static-cxx-linker
+++ b/scripts/gcc13-static-cxx-linker
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# LadybugDB 0.19.1 requests dynamic libstdc++/libgcc_s from its Cargo build
+# script. Release builds use GCC 13 because it is the first libstdc++ with
+# std::format, but Ubuntu 22.04 users do not have that runtime. Replace only
+# those two native-library arguments with the matching GCC 13 static archives;
+# every other linker argument remains byte-for-byte unchanged.
+static_cxx="$(g++-13 -print-file-name=libstdc++.a)"
+static_gcc="$(gcc-13 -print-libgcc-file-name)"
+static_gcc_eh="$(dirname "$static_gcc")/libgcc_eh.a"
+
+for archive in "$static_cxx" "$static_gcc" "$static_gcc_eh"; do
+    if [ ! -f "$archive" ]; then
+        echo "required GCC 13 static runtime archive is missing: $archive" >&2
+        exit 1
+    fi
+done
+
+rewritten=()
+for argument in "$@"; do
+    case "$argument" in
+        -lstdc++) rewritten+=("$static_cxx") ;;
+        -lgcc_s) rewritten+=("$static_gcc_eh" "$static_gcc") ;;
+        *) rewritten+=("$argument") ;;
+    esac
+done
+
+exec gcc-13 "${rewritten[@]}"


### PR DESCRIPTION
Fixes both v9.0.1 Linux release failures and preserves the Ubuntu 22.04 runtime floor.

- use GCC 13, the first libstdc++ with C++20 std::format
- run the AVX-512 FP16 probe only on x86_64
- statically link the GCC 13 C++ and unwind runtimes
- reject dynamic GLIBCXX/toolchain dependencies in release verification
- include compiler/link policy in the native cache key

Validated with actionlint, a Cargo native-link reproduction, and a GCC 13 binary built on Jammy and executed in an unmodified Ubuntu 22.04 container.