### PR TITLE
fix(proto): support Ubuntu 22.04 protoc

### DIFF
--- a/crates/nestweaver-proto/build.rs
+++ b/crates/nestweaver-proto/build.rs
@@ -5,6 +5,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_prost_build::configure()
         .build_server(true)
         .build_client(true)
+        // Ubuntu 22.04 ships protoc 3.12, where proto3 optional fields still
+        // require this opt-in. Newer protoc versions continue to accept the
+        // flag, so keeping it here makes source and release builds portable
+        // across the project's declared Linux baseline.
+        .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(
             &["../../proto/nestweaver/daemon/v1/service.proto"],
             &["../../proto"],

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1183,6 +1183,22 @@ fn release_workflow_pins_a_portable_linux_cxx20_toolchain() {
     );
 }
 
+/// Ubuntu 22.04's protobuf-compiler is protoc 3.12. The schema uses proto3
+/// optional fields, which that version refuses unless explicitly enabled.
+/// Current protoc releases still accept the compatibility flag, so the build
+/// script must carry it rather than making only one CI runner special.
+#[test]
+fn proto_build_supports_the_declared_ubuntu_2204_baseline() {
+    let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let build_script =
+        std::fs::read_to_string(repo_root.join("crates/nestweaver-proto/build.rs")).unwrap();
+
+    assert!(
+        build_script.contains(".protoc_arg(\"--experimental_allow_proto3_optional\")"),
+        "the proto build must opt into proto3 optional fields for Ubuntu 22.04's protoc 3.12"
+    );
+}
+
 /// The release PR is the ONE pull request in this repo that receives no CI:
 /// release-please opens it with `GITHUB_TOKEN`, and GitHub deliberately does not
 /// trigger workflows for bot-token-created PRs. Everything that would otherwise


### PR DESCRIPTION
## Summary
- pass `--experimental_allow_proto3_optional` from the proto build script
- support Ubuntu 22.04 protoc 3.12 while remaining compatible with current protoc
- add a regression guard for the declared Linux release baseline

## Root cause
The v9.0.2 ARM64 Linux build passed the repaired GCC 13/architecture preflight, then protoc 3.12 refused the schema optional fields because the compatibility flag was absent.

## Validation
- `protoc --experimental_allow_proto3_optional --version` with local protoc 25.1
- `cargo check -p nestweaver-proto`
- `cargo fmt --all -- --check`
- `git diff --check`