### PR TITLE
fix(release): use verified GNU linker contract

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -196,9 +196,10 @@ jobs:
       # The toolchain PPA also supplies a newer dynamic C++ runtime, which a
       # stock 22.04 installation does not have. The checked-in linker wrapper
       # records `$ORIGIN/lib` as the runtime search path, and the packaging step
-      # ships the matching GCC 13 libstdc++ and libgcc beside the binary. Do not
-      # statically link them: the v9.0.3 artifacts passed `--version` but
-      # segfaulted on the first LadybugDB open across its Rust/C++ boundary.
+      # ships the matching GCC 13 libstdc++ and libgcc beside the binary. Keep
+      # those libraries dynamic so the archive's C++ ABI is explicit and
+      # inspectable. The functional smoke below guards the separate final-link
+      # contract that `--version` alone missed in both v9.0.3 and v9.0.4.
       - name: Install build dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -285,7 +286,11 @@ jobs:
           if [ "${{ runner.os }}" = "Linux" ]; then
             CXX_VER=$("$CXX" -dumpfullversion -dumpversion)
             LINKER_HASH=$(shasum -a 256 scripts/gcc13-bundled-cxx-linker | cut -c1-12)
-            TOOLCHAIN_KEY="gcc${CXX_VER}-bundledcxx${LINKER_HASH}"
+            # CFLAGS changes Ladybug's vendored zstd objects. Include that
+            # native-code contract in the immutable cache key so a release
+            # cannot restore the pre-v9.0.5 ASM build and spend ~38 minutes
+            # discovering/rebuilding the mismatch during the final binary.
+            TOOLCHAIN_KEY="gcc${CXX_VER}-bundledcxx${LINKER_HASH}-zstdnoasm-gnuld"
           else
             TOOLCHAIN_KEY=$(clang --version | shasum -a 256 | cut -c1-16)
           fi

--- a/scripts/gcc13-bundled-cxx-linker
+++ b/scripts/gcc13-bundled-cxx-linker
@@ -5,8 +5,9 @@ set -euo pipefail
 # artifacts target stock Ubuntu 22.04. Keep libstdc++ and libgcc dynamic and
 # load the copies shipped beside the binary in `lib/`.
 #
-# Do not replace these libraries with static archives. LadybugDB passes C++
-# strings across its Rust/C++ boundary; statically linking the GCC runtime made
-# that boundary segfault on the first database open in the v9.0.3 artifacts.
-# The release workflow runs a real index smoke test to guard this contract.
+# Keep these libraries dynamic so the archive's C++ ABI is explicit and can be
+# inspected before shipping. The v9.0.3 static-runtime and v9.0.4 dynamic-runtime
+# binaries were both linked by mold and both segfaulted on the first database
+# open; using GNU ld fixed that separate final-link failure. The release workflow
+# runs a real index smoke test to guard the complete contract.
 exec gcc-13 '-Wl,-rpath,$ORIGIN/lib' "$@"

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1135,9 +1135,11 @@ fn release_matrix(workflow: &str) -> Vec<(String, Option<String>, Option<String>
 /// both lbug's AVX-512 FP16 intrinsics and `std::format`; GCC 12 has the former
 /// but its libstdc++ still lacks the latter. GCC 13 supplies both, but its
 /// dynamic libstdc++ is newer than the one installed on stock 22.04, so the C++
-/// and GCC runtimes must be shipped beside the release binary. They must remain
-/// dynamic: the statically linked v9.0.3 artifact segfaulted on its first
-/// LadybugDB open even though its version-only release check passed.
+/// and GCC runtimes must be shipped beside the release binary. The v9.0.3
+/// static-runtime and v9.0.4 dynamic-runtime artifacts were both linked with
+/// mold and both segfaulted on their first LadybugDB open even though their
+/// version-only release checks passed. GNU ld plus the real database smoke is
+/// the verified final-link contract.
 ///
 /// v9.0.0 failed on the SIMD requirement and v9.0.1 failed on `std::format`
 /// AFTER each tag was public. These constraints belong together and must be
@@ -1203,6 +1205,7 @@ fn release_workflow_pins_a_portable_linux_cxx20_toolchain() {
             && workflow.contains("github.event_name == 'workflow_dispatch'")
             && workflow.contains("CFLAGS: \"-DZSTD_DISABLE_ASM\"")
             && !workflow.contains("fuse-ld=mold")
+            && workflow.contains("zstdnoasm-gnuld")
             && workflow.contains("thread apply all backtrace")
             && workflow
                 .matches("if: github.event_name != 'workflow_dispatch'")


### PR DESCRIPTION
## Summary
- keep GNU ld as the verified Linux release linker after both v9.0.4 GNU artifacts passed real DB/trigram smoke tests in manual run 33554996575
- compile release Ladybug with the same `ZSTD_DISABLE_ASM` contract as normal CI
- version the native cache key for the new native-code/linker contract
- correct the runtime comments now that both v9.0.3 static-runtime and v9.0.4 dynamic-runtime mold-linked artifacts are known to crash

## Verification
- pre-tag four-platform artifact run 33554996575: all green
- `actionlint .github/workflows/release-please.yml`
- `bash -n scripts/gcc13-bundled-cxx-linker`
- `cargo fmt --all -- --check`
- focused release workflow contract test