### PR TITLE
fix: security, coverage-disclosure and merge-gate sweep across 12 items

### DIFF
--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -10488,9 +10488,16 @@ pub async fn run_server(
     // `.pagerank.json` is 13 MB of JSON), which is a candidate but not yet a
     // conclusion.
     let sidecar_started = std::time::Instant::now();
-    nestweaver_engine::migrate_sidecar(&db_path, "pagerank.json", ".pagerank.json");
-    let pr_path = nestweaver_engine::sidecar_path(&db_path, ".pagerank.json");
-    let _ = store.load_pagerank_cache(&pr_path);
+    // nw-391: the daemon is the DEFAULT route, so a sidecar it silently
+    // declines to load degrades ranking for every client of this process for
+    // as long as it runs — and this is the one load that happened before any
+    // request existed to carry a notification. `warn`, not `debug`: the
+    // git-activity sidecar below is neutral when absent (a missing score is a
+    // multiplier of exactly 1.0), while a REFUSED PageRank artifact means the
+    // ranks being served are not the ranks that were computed and published.
+    if let Some(disclosure) = nestweaver_mcp::warm_pagerank_from_sidecar(&store, &db_path) {
+        tracing::warn!("{disclosure}");
+    }
     let pagerank_load_ms = sidecar_started.elapsed().as_millis() as u64;
 
     let interactions_started = std::time::Instant::now();

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -2173,8 +2173,12 @@ impl DaemonService {
         &self,
         tool_name: &str,
         args_json: &str,
-        visible: nestweaver_engine::authz::VisibleRepos,
+        extensions: &tonic::Extensions,
     ) -> Result<Response<JsonResponse>, Status> {
+        // nw-415: the scope is RESOLVED here, from the request's own
+        // extensions, rather than accepted from the caller. See
+        // `dispatch_tool_json` for why the parameter changed shape.
+        let visible = self.state.visible_repos_for(extensions)?;
         let started = std::time::Instant::now();
         // Increment gRPC request counter for this tool/method.
         nestweaver_web::routes::metrics::GRPC_REQUESTS
@@ -2381,8 +2385,25 @@ impl DaemonService {
         &self,
         tool_name: &str,
         args: serde_json::Value,
-        visible: nestweaver_engine::authz::VisibleRepos,
+        extensions: &tonic::Extensions,
     ) -> Result<serde_json::Value, Status> {
+        // nw-415: TAKES THE REQUEST'S EXTENSIONS, NOT A CALLER-SUPPLIED SCOPE.
+        //
+        // Six typed RPCs used to hand this a literal `VisibleRepos::All` under
+        // the comment "Fixed non-blast_radius tool — pass `VisibleRepos::All`
+        // (no scoping)", throwing away the `Identity` the auth interceptor
+        // attaches to every request. That was not a misclassification nw-403's
+        // `repo_scope` table could correct: `dispatch_uncached` short-circuits
+        // on anything that is not `Only(_)`, so an `All` argument makes the
+        // entire table UNREACHABLE — those tools were never consulted, not
+        // wrongly consulted, and the coverage test (which derives from
+        // `tool_list()`) could never observe a caller that skipped dispatch.
+        //
+        // Fixing the six call sites would have left the seventh writable. The
+        // parameter is the request's extensions instead, so the ONLY way to
+        // reach `All` is for `visible_repos_for` to genuinely resolve it —
+        // "no scoping" is no longer something a call site can express.
+        let visible = self.state.visible_repos_for(extensions)?;
         let started = std::time::Instant::now();
         // Increment gRPC request counter for this tool/method.
         nestweaver_web::routes::metrics::GRPC_REQUESTS
@@ -2782,16 +2803,17 @@ macro_rules! json_rpc {
                 )));
             }
         }
-        // R9/R9b: resolve the caller's per-repo visibility from the request's
-        // Identity extension BEFORE consuming the request. This covers the
-        // generic `/mcp` tool path and every typed RPC routed through this
-        // macro (including `blast_radius`), so their output is redacted to the
-        // caller's visible repos. No `[authz]` config ⇒ `VisibleRepos::All` ⇒
-        // no-op redaction (backward compatible).
-        let visible = $self.state.visible_repos_for($request.extensions())?;
-        let req = $request.into_inner();
+        // R9/R9b: carry the request's extensions THROUGH to dispatch, which
+        // resolves the caller's per-repo visibility from the `Identity` the
+        // auth interceptor attached. This covers the generic `/mcp` tool path
+        // and every typed RPC routed through this macro (including
+        // `blast_radius`), so their output is redacted to the caller's visible
+        // repos. No `[authz]` config ⇒ `VisibleRepos::All` ⇒ no-op redaction
+        // (backward compatible). nw-415: `into_parts` rather than
+        // `into_inner`, because the extensions must outlive the message.
+        let (_, extensions, req) = $request.into_parts();
         $self
-            .dispatch_json_tool($tool, &req.args_json, visible)
+            .dispatch_json_tool($tool, &req.args_json, &extensions)
             .await
     }};
 }
@@ -2923,6 +2945,93 @@ fn reconcile_deleted_extension_uids(
             format!("targeted extension metadata reconciliation failed: {error:#}"),
         ),
     }
+}
+
+/// The notification descriptor attached when a blast-radius run's graph is
+/// resolver-generation-stale.
+///
+/// Same string as `BLAST_RADIUS_RESOLVER_STALE_DESCRIPTOR` in the MCP crate
+/// (`tools.rs`) and in the CLI (`src/main.rs`), so a consumer matching on the
+/// descriptor sees ONE code from all three surfaces.
+const BLAST_RADIUS_RESOLVER_STALE_DESCRIPTOR: &str = "resolver.generation-stale";
+
+/// Degrade a daemon-computed blast-radius result when this graph's edges
+/// predate the running resolver.
+///
+/// nw-412, the DAEMON twin of `degrade_blast_radius_if_resolver_stale` in
+/// `src/main.rs` and of the block in `tool_blast_radius`. It exists because
+/// `pr_impact_json` calls `nestweaver_engine::analyze_blast_radius` DIRECTLY
+/// rather than dispatching the `blast_radius` tool, so neither of the other
+/// two degrades could reach it — and the daemon route is the DEFAULT route,
+/// which made this the one path a user actually takes. On a stale graph
+/// `pr_impact_exit_code` still saw `GateState::Ok` over a shrunken affected
+/// set and `print_pr_impact_hook` printed nothing at all, because that banner
+/// is skipped for exactly `Ok` + `Low` + nothing-affected.
+///
+/// The degrade rather than a refusal is argued at
+/// `BLAST_RADIUS_RESOLVER_STALE_DESCRIPTOR` in the CLI: `pr-impact` is an
+/// assessment, not a selector, and a refusal payload is not a valid SARIF run.
+///
+/// `status` is only ever pushed DOWN (`.max` over the ordered ladder
+/// Complete < Partial < Degraded < Failed), matching nw-105's rule that a run
+/// already Degraded or Failed is never upgraded by a later finding, and
+/// `gate_state` is then forced to `DegradedUnknown`. That mirrors
+/// `derive_gate_state`'s "non-Complete => DegradedUnknown" without calling it
+/// (it is `pub(crate)` to the engine) and closes the direction that made this
+/// dangerous: a stale-resolver run can no longer report `ok` at all.
+///
+/// The repo set is filtered to the caller's VISIBLE repos first, mirroring
+/// `resolver_generation_refusal` in the MCP crate: `DeadCodeRefusal::message()`
+/// emits one `nestweaver index --repo <local path> --force` line per stale
+/// repo, so building it from every repo would hand a repo-scoped caller the
+/// on-disk paths of repos it cannot see.
+///
+/// `list_repos` PROPAGATES rather than becoming a degrade, for the same reason
+/// the CLI twin does: a store that cannot enumerate repos cannot have served
+/// the traversal either, so the caller should see the store's own failure and
+/// not a paragraph about resolver generations.
+fn degrade_blast_radius_if_resolver_stale(
+    store: &GraphStore,
+    db_path: &Path,
+    visible: &nestweaver_engine::authz::VisibleRepos,
+    result: &mut nestweaver_engine::blast_radius::BlastRadiusResult,
+) -> Result<(), Status> {
+    let repos: Vec<nestweaver_schema::Repo> = store
+        .list_repos(None)
+        .map_err(|error| {
+            // Log the chain server-side; the client gets no store internals.
+            tracing::error!("pr_impact: listing repos for resolver staleness: {error:#}");
+            Status::unavailable("repo listing unavailable")
+        })?
+        .into_iter()
+        .filter(|repo| visible.allows(&repo.uid))
+        .collect();
+    let Some(refusal) =
+        nestweaver_engine::resolver_generation::DeadCodeRefusal::for_repos(db_path, &repos)
+    else {
+        return Ok(());
+    };
+    result.status = result
+        .status
+        .max(nestweaver_engine::blast_radius::AnalysisStatus::Degraded);
+    result.gate_state = nestweaver_engine::blast_radius::GateState::DegradedUnknown;
+    result
+        .notifications
+        .push(nestweaver_engine::blast_radius::Notification {
+            level: nestweaver_engine::blast_radius::NotificationLevel::Error,
+            message: refusal.message(),
+            descriptor: BLAST_RADIUS_RESOLVER_STALE_DESCRIPTOR.to_string(),
+        });
+    // `render_blast_summary` appends `[status: …]` for any non-Complete run
+    // and is `pub(crate)`, so the marker is restated here rather than leaving
+    // the human summary claiming a clean run. Guarded so a summary that
+    // already carries one is not double-tagged.
+    if !result.summary.contains("[status: ") {
+        result
+            .summary
+            .push_str(&format!(" [status: {}]", result.status.label()));
+    }
+    Ok(())
 }
 
 fn push_reconciliation_failure(
@@ -6206,8 +6315,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<BrainSearchRequest>,
     ) -> Result<Response<BrainSearchResponse>, Status> {
-        let visible = self.state.visible_repos_for(r.extensions())?;
-        let req = r.into_inner();
+        let (_, extensions, req) = r.into_parts();
         let mut args = serde_json::json!({
             "query": req.query,
             "include_bodies": req.include_bodies,
@@ -6227,7 +6335,7 @@ impl NestWeaverDaemon for DaemonService {
         // `brain_search` includes repo-owned symbols, so the typed hot path
         // must enforce the same request-derived scope as generic JSON-RPC.
         let value = self
-            .dispatch_tool_json("brain_search", args, visible)
+            .dispatch_tool_json("brain_search", args, &extensions)
             .await?;
 
         // Parse JSON result into typed response.
@@ -6362,7 +6470,21 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<BrainContextRequest>,
     ) -> Result<Response<BrainContextResponse>, Status> {
-        let req = r.into_inner();
+        // nw-415: `into_parts`, not `into_inner` — the request's extensions
+        // carry the `Identity` the auth interceptor attached, and dispatch
+        // resolves the caller's repo scope from them. This handler used to
+        // hand `dispatch_tool_json` a literal `VisibleRepos::All`, which made
+        // nw-403's whole `repo_scope` table unreachable (see the argument on
+        // `dispatch_tool_json`); `code_context`, one method away on the same
+        // surface, was scoped the whole time.
+        //
+        // `brain_context` is one of the tools nw-403's own measurement named
+        // as leaking (hidden-repo symbols, file paths and note prose). It is
+        // `RepoScope::RedactedAfterDispatch`, so a scoped caller now gets only
+        // the rows it owns, and a `response_format: "concise"` request — which
+        // omits the very uids attribution needs — is refused rather than
+        // served unfiltered.
+        let (_, extensions, req) = r.into_parts();
         let mut args = serde_json::json!({
             "seeds": req.seeds,
             "include_seeds": req.include_seeds,
@@ -6419,13 +6541,8 @@ impl NestWeaverDaemon for DaemonService {
             args["recency_half_life_days"] = serde_json::json!(req.recency_half_life_days);
         }
 
-        // Fixed non-blast_radius tool — see brain_search above.
         let value = self
-            .dispatch_tool_json(
-                "brain_context",
-                args,
-                nestweaver_engine::authz::VisibleRepos::All,
-            )
+            .dispatch_tool_json("brain_context", args, &extensions)
             .await?;
         let result_json = serde_json::to_string(&value)
             .map_err(|e| Status::internal(format!("failed to serialize result: {e}")))?;
@@ -6455,7 +6572,12 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<ProjectContextRequest>,
     ) -> Result<Response<ProjectContextResponse>, Status> {
-        let req = r.into_inner();
+        // nw-415, argued at `dispatch_tool_json`. `project_context` is
+        // `RepoScope::RedactedAfterDispatch` AND its `response_format`
+        // DEFAULTS to concise, so a repo-scoped caller that sends no format at
+        // all is refused rather than handed uid-free rows that nothing
+        // downstream can attribute to a repo.
+        let (_, extensions, req) = r.into_parts();
         let mut args = serde_json::json!({
             "project": req.project,
             "include_seeds": req.include_seeds,
@@ -6500,13 +6622,8 @@ impl NestWeaverDaemon for DaemonService {
             args["exclude_tags"] = serde_json::json!(req.exclude_tags);
         }
 
-        // Fixed non-blast_radius tool — see brain_search above.
         let value = self
-            .dispatch_tool_json(
-                "project_context",
-                args,
-                nestweaver_engine::authz::VisibleRepos::All,
-            )
+            .dispatch_tool_json("project_context", args, &extensions)
             .await?;
         let result_json = serde_json::to_string(&value)
             .map_err(|e| Status::internal(format!("failed to serialize result: {e}")))?;
@@ -6518,7 +6635,15 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<NoteGetRequest>,
     ) -> Result<Response<NoteGetResponse>, Status> {
-        let req = r.into_inner();
+        // nw-415, argued at `dispatch_tool_json`. `note_get` is the one of
+        // the six that carries a WRITTEN `RepoScope::NotRepoScoped` exemption
+        // (Note/Section/Heading nodes belong to a vault and have no
+        // `repo_uid`), so routing the identity here is not expected to change
+        // its answer. It is routed anyway because the exemption has to be the
+        // TABLE's decision — logged, falsifiable, and revisitable if `note_get`
+        // ever grows a repo-derived field — not a `VisibleRepos::All` literal
+        // at a call site no policy can reach.
+        let (_, extensions, req) = r.into_parts();
         let mut args = serde_json::json!({});
         // nw-316: omit when the caller did not say, so the tool's documented
         // default governs instead of proto3's zero value.
@@ -6535,13 +6660,8 @@ impl NestWeaverDaemon for DaemonService {
             args["sections"] = serde_json::json!(req.sections);
         }
 
-        // Fixed non-blast_radius tool — see brain_search above.
         let value = self
-            .dispatch_tool_json(
-                "note_get",
-                args,
-                nestweaver_engine::authz::VisibleRepos::All,
-            )
+            .dispatch_tool_json("note_get", args, &extensions)
             .await?;
 
         Ok(Response::new(NoteGetResponse {
@@ -6617,16 +6737,18 @@ impl NestWeaverDaemon for DaemonService {
 
     async fn brain_status(
         &self,
-        _r: Request<BrainStatusRequest>,
+        r: Request<BrainStatusRequest>,
     ) -> Result<Response<BrainStatusResponse>, Status> {
+        // nw-415, argued at `dispatch_tool_json`. `brain_status` is the most
+        // direct enumeration in the catalogue — nw-403 gave it its own
+        // `RepoScope::EnforcedInArm` treatment because `repos[]` carries each
+        // repo's URL and indexed git SHA, i.e. repo IDENTITY rather than repo
+        // content. Handing it `All` meant the enforcing arm was never reached
+        // and `repo_count` counted tenants the caller cannot see.
+        let (_, extensions, _) = r.into_parts();
         let args = serde_json::json!({});
-        // Fixed non-blast_radius tool — see brain_search above.
         let value = self
-            .dispatch_tool_json(
-                "brain_status",
-                args,
-                nestweaver_engine::authz::VisibleRepos::All,
-            )
+            .dispatch_tool_json("brain_status", args, &extensions)
             .await?;
 
         let indexing_active = self.state.indexing_active.load(Ordering::Relaxed);
@@ -6686,7 +6808,10 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<HubNodesRequest>,
     ) -> Result<Response<HubNodesResponse>, Status> {
-        let req = r.into_inner();
+        // nw-415, argued at `dispatch_tool_json`. `hub_nodes` is the third
+        // tool nw-403's measurement named (8 hidden-repo tokens); it is
+        // `RepoScope::RedactedAfterDispatch`.
+        let (_, extensions, req) = r.into_parts();
         let mut args = serde_json::json!({});
         if req.top_n > 0 {
             args["top_n"] = serde_json::json!(req.top_n);
@@ -6695,13 +6820,8 @@ impl NestWeaverDaemon for DaemonService {
             args["response_format"] = serde_json::json!(req.response_format);
         }
 
-        // Fixed non-blast_radius tool — see brain_search above.
         let value = self
-            .dispatch_tool_json(
-                "hub_nodes",
-                args,
-                nestweaver_engine::authz::VisibleRepos::All,
-            )
+            .dispatch_tool_json("hub_nodes", args, &extensions)
             .await?;
         let result_json = serde_json::to_string(&value)
             .map_err(|e| Status::internal(format!("failed to serialize result: {e}")))?;
@@ -6713,14 +6833,13 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<JsonRequest>,
     ) -> Result<Response<JsonResponse>, Status> {
-        let req = r.into_inner();
-        // Fixed non-blast_radius tool — pass `VisibleRepos::All` (no scoping).
+        // nw-415, argued at `dispatch_tool_json`. Same tool, same
+        // enumeration, SECOND DOOR: the JSON twin bypassed the gate
+        // independently of the typed `brain_status` RPC, so fixing only that
+        // one would have left the repo-identity leak fully reachable here.
+        let (_, extensions, req) = r.into_parts();
         let resp = self
-            .dispatch_json_tool(
-                "brain_status",
-                &req.args_json,
-                nestweaver_engine::authz::VisibleRepos::All,
-            )
+            .dispatch_json_tool("brain_status", &req.args_json, &extensions)
             .await?;
         // Inject server-side indexing status into the JSON response so
         // AI agents see it via the MCP tool path as well.
@@ -7689,6 +7808,17 @@ impl NestWeaverDaemon for DaemonService {
                         &repos,
                     );
                 }
+                // nw-412: a generation-stale graph is a run that did not
+                // complete. Applied HERE — after analysis and after the R9b
+                // redaction, before serialization — so the degrade is computed
+                // over the same repo set the caller is allowed to see, exactly
+                // where `tool_blast_radius` applies its own.
+                degrade_blast_radius_if_resolver_stale(
+                    &state.store,
+                    &state.db_path,
+                    &visible,
+                    &mut result,
+                )?;
                 serde_json::to_string(&result)
                     .map_err(|e| Status::internal(format!("serialization failed: {e:#}")))
             })
@@ -18703,6 +18833,558 @@ external_model = "unavailable-test-model"
         assert!(
             response.results.iter().all(|row| row.uid != "sym:hidden"),
             "typed Search must not leak hidden symbol rows"
+        );
+    }
+
+    // ── nw-415 ──────────────────────────────────────────────────────
+    //
+    // Six typed gRPC RPCs hand-built their args and called
+    // `dispatch_tool_json(tool, args, VisibleRepos::All)`, discarding the
+    // `Identity` the auth interceptor attaches to every request. That is not a
+    // misclassification nw-403's `repo_scope` table could correct:
+    // `dispatch_uncached` short-circuits on anything that is not `Only(_)`, so
+    // an `All` argument makes the entire table UNREACHABLE — the tools were
+    // never consulted, not wrongly consulted.
+    //
+    // THE TESTS BELOW GO THROUGH THE SERVICE, NOT THROUGH `dispatch`, and that
+    // is the point. `the_visibility_table_covers_every_tool` in the MCP crate
+    // derives its table from `tool_list()`, so it proves every DISPATCHED tool
+    // is classified and can never observe a caller that bypasses dispatch
+    // entirely. A per-tool table test is not a chokepoint test.
+
+    const NW415_HIDDEN_URL: &str = "https://github.com/acme/nw415-hidden.git";
+    const NW415_VISIBLE_URL: &str = "https://github.com/acme/nw415-visible.git";
+    const NW415_HIDDEN_SYMBOL: &str = "sym:nw415-hidden";
+    const NW415_VISIBLE_SYMBOL: &str = "sym:nw415-visible";
+    const NW415_TOKEN: &str = "nw415-repo-scoped-token";
+
+    /// Two repos, one symbol each, and a vault note — the smallest graph in
+    /// which "answered from the hidden repo" is observable on every one of the
+    /// six RPCs.
+    fn nw415_store() -> Arc<GraphStore> {
+        use nestweaver_schema::{Symbol, SymbolKind, Visibility};
+
+        let store = Arc::new(GraphStore::in_memory().unwrap());
+        for repo in [
+            test_repo("repo:nw415-visible", NW415_VISIBLE_URL, None),
+            test_repo("repo:nw415-hidden", NW415_HIDDEN_URL, None),
+        ] {
+            store.insert_repo(&repo).unwrap();
+        }
+        for (uid, repo_uid, name) in [
+            (
+                NW415_VISIBLE_SYMBOL,
+                "repo:nw415-visible",
+                "nw415needle_visible",
+            ),
+            (
+                NW415_HIDDEN_SYMBOL,
+                "repo:nw415-hidden",
+                "nw415needle_hidden",
+            ),
+        ] {
+            store
+                .insert_symbol(&Symbol {
+                    uid: uid.to_string(),
+                    name: name.to_string(),
+                    kind: SymbolKind::Function,
+                    repo_uid: repo_uid.to_string(),
+                    file_path: format!("src/{name}.rs"),
+                    start_line: 1,
+                    end_line: 2,
+                    signature: format!("fn {name}()"),
+                    summary: None,
+                    content_hash: format!("hash:{uid}"),
+                    embedding: None,
+                    pagerank_score: Some(0.5),
+                    is_entry_point: false,
+                    entry_point_kind: None,
+                    visibility: Visibility::Public,
+                    type_info: None,
+                    framework_hint: None,
+                    canonical_id: Some(format!("canonical:{uid}")),
+                })
+                .unwrap();
+        }
+        store
+            .insert_vault(&nestweaver_schema::Vault {
+                uid: "vlt:nw415".to_string(),
+                name: "nw415".to_string(),
+                root_path: "/tmp/nw415".to_string(),
+                instance_id: "test".to_string(),
+            })
+            .unwrap();
+        store
+            .insert_note(&nestweaver_schema::Note {
+                uid: "note:nw415".to_string(),
+                vault_uid: "vlt:nw415".to_string(),
+                file_path: "nw415.md".to_string(),
+                title: "nw415 vault note".to_string(),
+                note_kind: nestweaver_schema::NoteKind::General,
+                word_count: 3,
+                content_hash: "hash:note:nw415".to_string(),
+                frontmatter: None,
+                frontmatter_raw: None,
+                created_at: None,
+                modified_at: None,
+                pagerank_score: None,
+                embedding: None,
+            })
+            .unwrap();
+        store
+            .insert_vault_note_edge("vlt:nw415", "note:nw415")
+            .unwrap();
+        store
+    }
+
+    /// A service whose `[authz]` policy is ENABLED and grants `NW415_TOKEN`
+    /// exactly one of the two repos.
+    fn nw415_service() -> DaemonService {
+        use nestweaver_engine::authz::StaticConfigPermissionSource;
+
+        let source = Arc::new(StaticConfigPermissionSource::new(
+            [(
+                NW415_TOKEN.to_string(),
+                vec!["repo:nw415-visible".to_string()],
+            )]
+            .into_iter()
+            .collect(),
+        ));
+        DaemonService::new(test_state_with_authz(nw415_store(), source))
+    }
+
+    fn nw415_request<T>(message: T, identity: nestweaver_engine::authz::Identity) -> Request<T> {
+        let mut request = Request::new(message);
+        request.extensions_mut().insert(identity);
+        request
+    }
+
+    fn nw415_context_request() -> BrainContextRequest {
+        BrainContextRequest {
+            seeds: vec!["nw415needle".to_string()],
+            include_seeds: true,
+            token_budget: 4000,
+            response_format: "detailed".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn nw415_hub_request() -> HubNodesRequest {
+        HubNodesRequest {
+            top_n: 10,
+            response_format: "detailed".to_string(),
+        }
+    }
+
+    fn nw415_note_request() -> NoteGetRequest {
+        NoteGetRequest {
+            uid: Some("note:nw415".to_string()),
+            title: None,
+            sections: Vec::new(),
+            include_body: Some(false),
+        }
+    }
+
+    /// nw-415 — every one of the six RPCs now resolves the request `Identity`
+    /// the way `json_rpc!` already did, so nw-403's table actually decides.
+    ///
+    /// Each assertion is against the disposition the tool DECLARES, not
+    /// against a uniform "returns less":
+    ///   * `brain_status` (typed and JSON) — `EnforcedInArm`. It enumerates
+    ///     each repo's URL and indexed git SHA, which is repo IDENTITY and the
+    ///     most direct enumeration in the catalogue.
+    ///   * `brain_context` / `hub_nodes` — `RedactedAfterDispatch`. No token
+    ///     naming the hidden repo may survive anywhere in the payload.
+    ///   * `project_context` — `RedactedAfterDispatch` whose `response_format`
+    ///     DEFAULTS to concise, so an unattributable rendering is REFUSED.
+    ///   * `note_get` — `NotRepoScoped`, and it must still answer.
+    #[tokio::test]
+    async fn every_typed_grpc_rpc_that_bypassed_dispatch_now_scopes_to_the_request_identity() {
+        use nestweaver_engine::authz::Identity;
+
+        let service = nw415_service();
+        let scoped = || Identity::Token(NW415_TOKEN.to_string());
+        // Every RPC is exercised and every violation COLLECTED, rather than
+        // asserted one at a time. All six sites were the same defect committed
+        // six times; a test that stops at the first would have to be re-run
+        // six times to prove the other five, which is exactly the shape that
+        // lets one of them be missed.
+        let mut leaks: Vec<String> = Vec::new();
+
+        // `brain_status`, typed: `EnforcedInArm`, because `repos[]` carries
+        // each repo's URL and indexed git SHA — repo IDENTITY, the most direct
+        // enumeration in the catalogue.
+        let status = service
+            .brain_status(nw415_request(BrainStatusRequest {}, scoped()))
+            .await
+            .expect("a repo-scoped brain_status is scoped, not refused")
+            .into_inner();
+        if status.repo_count != 1 {
+            leaks.push(format!(
+                "typed brain_status counted {} repos; the caller may see 1",
+                status.repo_count
+            ));
+        }
+
+        // `brain_status`, JSON: the second door onto the same enumeration.
+        let status_json = service
+            .brain_status_json(nw415_request(
+                JsonRequest {
+                    args_json: "{}".to_string(),
+                },
+                scoped(),
+            ))
+            .await
+            .expect("a repo-scoped brain_status_json is scoped, not refused")
+            .into_inner();
+        if status_json.result_json.contains(NW415_HIDDEN_URL) {
+            leaks.push(format!(
+                "brain_status_json leaked the hidden repo's URL: {}",
+                status_json.result_json
+            ));
+        }
+        if !status_json.result_json.contains(NW415_VISIBLE_URL) {
+            leaks.push(format!(
+                "brain_status_json dropped the repo the caller DOES own: {}",
+                status_json.result_json
+            ));
+        }
+        let status_value: serde_json::Value =
+            serde_json::from_str(&status_json.result_json).unwrap();
+        if status_value["visibility"]["scoped"] != serde_json::json!(true) {
+            leaks.push(format!(
+                "brain_status_json did not disclose that it was scoped: {status_value}"
+            ));
+        }
+
+        // `brain_context`: `RedactedAfterDispatch`.
+        let context = service
+            .get_context(nw415_request(nw415_context_request(), scoped()))
+            .await
+            .expect("a repo-scoped brain_context is redacted, not refused")
+            .into_inner();
+        if context.result_json.contains(NW415_HIDDEN_SYMBOL)
+            || context.result_json.contains("nw415needle_hidden")
+        {
+            leaks.push(format!(
+                "brain_context leaked a hidden-repo symbol: {}",
+                context.result_json
+            ));
+        }
+
+        // `hub_nodes`: `RedactedAfterDispatch`.
+        //
+        // The assertion is over the hidden SYMBOL, not the hidden repo uid, on
+        // purpose: `hub_nodes` also returns `stale_repos`, a bare string array
+        // of repo uids that the redactor cannot see (it early-returns `true`
+        // for any array element that is not an object). That is [[nw-416]],
+        // whose fix lives in the MCP crate's redactor; asserting it here would
+        // pin a defect this change cannot reach.
+        let hubs = service
+            .hub_nodes(nw415_request(nw415_hub_request(), scoped()))
+            .await
+            .expect("a repo-scoped hub_nodes is redacted, not refused")
+            .into_inner();
+        if hubs.result_json.contains(NW415_HIDDEN_SYMBOL)
+            || hubs.result_json.contains("nw415needle_hidden")
+        {
+            leaks.push(format!(
+                "hub_nodes leaked a hidden-repo symbol: {}",
+                hubs.result_json
+            ));
+        }
+
+        // `project_context`: `RedactedAfterDispatch` whose `response_format`
+        // DEFAULTS to concise, so the rows carry no uid to attribute and the
+        // call is REFUSED rather than served unfiltered.
+        match service
+            .get_project_context(nw415_request(
+                ProjectContextRequest {
+                    project: "anything".to_string(),
+                    ..Default::default()
+                },
+                scoped(),
+            ))
+            .await
+        {
+            Ok(response) => leaks.push(format!(
+                "project_context served an unattributable concise rendering: {}",
+                response.into_inner().result_json
+            )),
+            Err(error) if !error.message().contains("response_format") => leaks.push(format!(
+                "project_context failed for the wrong reason (the refusal must name its remedy): {}",
+                error.message()
+            )),
+            Err(_) => {}
+        }
+
+        // `note_get`: the WRITTEN `NotRepoScoped` exemption must still answer.
+        // This leg is what keeps the fix from degenerating into "scope
+        // everything" — the table's opt-out has to survive it.
+        let note = service
+            .get_note(nw415_request(nw415_note_request(), scoped()))
+            .await
+            .expect("note_get carries a written not-repo-scoped exemption")
+            .into_inner();
+        if note.uid != "note:nw415" || note.title != "nw415 vault note" {
+            leaks.push(format!(
+                "note_get's not-repo-scoped exemption was over-applied: {note:?}"
+            ));
+        }
+
+        assert!(
+            leaks.is_empty(),
+            "gRPC RPCs that did not honour the caller's repo scope:\n  - {}",
+            leaks.join("\n  - ")
+        );
+    }
+
+    /// COUNTERWEIGHT to the test above, and the leg that keeps it from being
+    /// vacuous: an UNSCOPED identity must still see everything.
+    ///
+    /// Without this, "returns nothing" would pass the scoped assertions for
+    /// the wrong reason — a fixture whose hidden rows were never reachable at
+    /// all proves nothing about the gate. Every hidden-repo token asserted
+    /// ABSENT above is asserted PRESENT here, through the same six RPCs on the
+    /// same graph, under `Identity::Admin` (which an enabled policy resolves
+    /// to `VisibleRepos::All`).
+    #[tokio::test]
+    async fn an_unscoped_identity_still_sees_every_repo_through_those_same_grpc_rpcs() {
+        use nestweaver_engine::authz::Identity;
+
+        let service = nw415_service();
+
+        let status = service
+            .brain_status(nw415_request(BrainStatusRequest {}, Identity::Admin))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(
+            status.repo_count, 2,
+            "an unscoped caller must still see both repos"
+        );
+
+        let status_json = service
+            .brain_status_json(nw415_request(
+                JsonRequest {
+                    args_json: "{}".to_string(),
+                },
+                Identity::Admin,
+            ))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(
+            status_json.result_json.contains(NW415_HIDDEN_URL)
+                && status_json.result_json.contains(NW415_VISIBLE_URL),
+            "an unscoped brain_status_json must enumerate both repos: {}",
+            status_json.result_json
+        );
+        assert!(
+            !status_json.result_json.contains("\"scoped\":true"),
+            "an unscoped response must not claim it was scoped: {}",
+            status_json.result_json
+        );
+
+        let context = service
+            .get_context(nw415_request(nw415_context_request(), Identity::Admin))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(
+            context.result_json.contains(NW415_HIDDEN_SYMBOL),
+            "PRECONDITION: the hidden symbol must be reachable unscoped, or \
+             the scoped assertion proves nothing: {}",
+            context.result_json
+        );
+
+        let hubs = service
+            .hub_nodes(nw415_request(nw415_hub_request(), Identity::Admin))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(
+            hubs.result_json.contains(NW415_HIDDEN_SYMBOL),
+            "PRECONDITION: hub_nodes must reach the hidden symbol unscoped: {}",
+            hubs.result_json
+        );
+
+        // `project_context` is refused for a SCOPED caller only because the
+        // rendering cannot be attributed — an unscoped caller must never meet
+        // that refusal.
+        let unscoped_project = service
+            .get_project_context(nw415_request(
+                ProjectContextRequest {
+                    project: "anything".to_string(),
+                    ..Default::default()
+                },
+                Identity::Admin,
+            ))
+            .await;
+        if let Err(error) = unscoped_project {
+            assert!(
+                !error.message().contains("response_format"),
+                "an unscoped caller must not be refused for being unattributable: {}",
+                error.message()
+            );
+        }
+
+        let note = service
+            .get_note(nw415_request(nw415_note_request(), Identity::Admin))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(note.uid, "note:nw415");
+    }
+
+    // ── nw-412 ──────────────────────────────────────────────────────
+    //
+    // `pr_impact_json` calls `nestweaver_engine::analyze_blast_radius`
+    // DIRECTLY rather than dispatching the `blast_radius` tool, so neither the
+    // CLI's `degrade_blast_radius_if_resolver_stale` nor `tool_blast_radius`'s
+    // own block could reach it. The daemon is the DEFAULT route, so this was
+    // the path a user actually takes.
+
+    const NW412_REPO: &str = "repo:nw412:aaaaaaaaaaaa";
+
+    /// A daemon over a real on-disk db (so the resolver-generation sidecar has
+    /// somewhere to live) holding one repo and one symbol in the file the
+    /// pr-impact call names.
+    ///
+    /// The symbol matters: a changed file with NO indexed symbol is already
+    /// `partial`/`degraded-unknown` on its own (`changed-file-no-symbols`), so
+    /// a fixture without it could not tell this degrade from the baseline —
+    /// the counterweight would be unfalsifiable.
+    fn nw412_state() -> Arc<DaemonState> {
+        use nestweaver_schema::{Symbol, SymbolKind, Visibility};
+
+        let state = test_state_with_writer();
+        state
+            .store
+            .insert_repo(&test_repo(
+                NW412_REPO,
+                "https://github.com/example/nw412",
+                Some("/tmp/nw412"),
+            ))
+            .unwrap();
+        state
+            .store
+            .insert_symbol(&Symbol {
+                uid: "sym:nw412".to_string(),
+                name: "nw412_changed".to_string(),
+                kind: SymbolKind::Function,
+                repo_uid: NW412_REPO.to_string(),
+                file_path: "src/lib.rs".to_string(),
+                start_line: 1,
+                end_line: 2,
+                signature: "fn nw412_changed()".to_string(),
+                summary: None,
+                content_hash: "hash:sym:nw412".to_string(),
+                embedding: None,
+                pagerank_score: None,
+                is_entry_point: false,
+                entry_point_kind: None,
+                visibility: Visibility::Public,
+                type_info: None,
+                framework_hint: None,
+                canonical_id: Some("canonical:sym:nw412".to_string()),
+            })
+            .unwrap();
+        state
+    }
+
+    async fn nw412_pr_impact(state: Arc<DaemonState>) -> serde_json::Value {
+        let response = DaemonService::new(state)
+            .pr_impact_json(Request::new(JsonRequest {
+                args_json: serde_json::json!({ "files": ["src/lib.rs"] }).to_string(),
+            }))
+            .await
+            .expect("pr_impact must answer, degraded or not")
+            .into_inner();
+        serde_json::from_str(&response.result_json).expect("pr_impact returns a JSON result")
+    }
+
+    /// nw-412 — the direction that made this dangerous is that a stale graph
+    /// UNDERSTATES impact, and the run that understates it most is the one
+    /// that looks cleanest. Driven through the RPC, because that is the route
+    /// the CLI's and MCP's twin degrades could not reach.
+    ///
+    /// `print_pr_impact_hook` is silent on exactly `Ok` + `Low` +
+    /// nothing-affected, and `pr_impact_exit_code` reads `gate_state`, so
+    /// before this the pre-push hook printed NOTHING on a stale graph. After
+    /// the degrade the run cannot report `ok` at all.
+    #[tokio::test]
+    async fn pr_impact_through_the_daemon_cannot_report_a_clean_gate_on_a_resolver_stale_graph() {
+        // No sidecar is written: an unrecorded repo reads as generation 0,
+        // which is the "indexed before this record existed" case by definition.
+        let value = nw412_pr_impact(nw412_state()).await;
+
+        assert_eq!(
+            value["gate_state"],
+            serde_json::json!("degraded-unknown"),
+            "a stale-resolver run must not report a gate verdict: {value}"
+        );
+        assert_eq!(
+            value["status"],
+            serde_json::json!("degraded"),
+            "status must be pushed down to at least degraded: {value}"
+        );
+        let notifications = value["notifications"].as_array().expect("notifications");
+        let stale = notifications
+            .iter()
+            .find(|n| n["descriptor"] == serde_json::json!("resolver.generation-stale"))
+            .unwrap_or_else(|| panic!("no resolver.generation-stale notification: {value}"));
+        assert_eq!(
+            stale["level"],
+            serde_json::json!("error"),
+            "the descriptor must arrive at error level, matching the CLI and MCP twins"
+        );
+        assert!(
+            stale["message"]
+                .as_str()
+                .is_some_and(|m| m.contains("--force")),
+            "the notification must carry the runnable remedy: {stale}"
+        );
+        assert!(
+            value["summary"]
+                .as_str()
+                .is_some_and(|s| s.contains("[status: degraded]")),
+            "the human summary must not still read as a clean run: {value}"
+        );
+    }
+
+    /// COUNTERWEIGHT: a generation-CURRENT graph must NOT be degraded.
+    ///
+    /// Required by nw-412 explicitly, and it is what stops the fix from being
+    /// "always report degraded" — which would be honest about nothing and
+    /// would make the gate useless rather than safe.
+    #[tokio::test]
+    async fn a_generation_current_graph_still_reports_a_clean_pr_impact_gate_through_the_daemon() {
+        let state = nw412_state();
+        nestweaver_engine::resolver_generation::record(&state.db_path, NW412_REPO)
+            .expect("recording the current generation must succeed");
+
+        let value = nw412_pr_impact(state).await;
+
+        assert_eq!(
+            value["gate_state"],
+            serde_json::json!("ok"),
+            "a current graph must still be able to report a clean gate: {value}"
+        );
+        assert_eq!(value["status"], serde_json::json!("complete"), "{value}");
+        assert!(
+            value["notifications"]
+                .as_array()
+                .expect("notifications")
+                .iter()
+                .all(|n| n["descriptor"] != serde_json::json!("resolver.generation-stale")),
+            "a current graph must not be told its resolver is stale: {value}"
+        );
+        assert!(
+            value["summary"]
+                .as_str()
+                .is_some_and(|s| !s.contains("[status: ")),
+            "a complete run must not be tagged with a status marker: {value}"
         );
     }
 

--- a/crates/nestweaver-engine/src/content_reader.rs
+++ b/crates/nestweaver-engine/src/content_reader.rs
@@ -134,6 +134,70 @@ pub trait ContentReader: Send + Sync {
     fn max_source_file_bytes(&self) -> u64 {
         DEFAULT_MAX_SOURCE_FILE_BYTES
     }
+
+    /// Directories the last [`Self::list_files`] pruned, for disclosure.
+    ///
+    /// nw-387 PUT THIS ON THE TRAIT. It existed only as an inherent method on
+    /// [`FilesystemReader`], and `index_into_store_with_write_gate` holds a
+    /// `&dyn ContentReader` — so the indexer *could not* reach it even in
+    /// principle, and the accessor's one and only caller in the whole workspace
+    /// was the `#[cfg(test)]` test that asserted it. nw-325 shipped the
+    /// recorder and the `unskip` re-admission but never the disclosure, so a
+    /// pruned `vendor/` produced `skipped_files: []`,
+    /// `coverage_status: "complete"` and `--fail-on-skip` exit 0 — a wrong
+    /// answer that was byte-identical to a complete one. Widening this to the
+    /// trait is what makes the drain at the indexer possible at all.
+    ///
+    /// Default is empty, i.e. "this reader prunes nothing it has not already
+    /// reported". That is honest for the mock readers in the test suites, and
+    /// KNOWINGLY INCOMPLETE for [`GitBareReader`], which drops `SKIP_DIRS`
+    /// paths per-entry via `crate::index::path_in_skip_dir` and records
+    /// nothing. Its prune is therefore still silent; the filesystem path —
+    /// which is what every local `index`/`--fail-on-skip` run uses, and what
+    /// nw-387 measured — is covered. Closing the bare-clone half needs a
+    /// recorder in `list_files` there and is deliberately not smuggled in here.
+    fn skipped_dirs(&self) -> Vec<SkippedDir> {
+        Vec::new()
+    }
+}
+
+/// Rewrite lone `\r` line endings to `\n`, leaving `\r\n` byte-for-byte alone.
+///
+/// nw-386. See the call site in [`FilesystemReader::read_file`] for the failure
+/// this exists to stop. Free and pure so it is testable without a filesystem.
+///
+/// Written as a scan-and-splice rather than a byte-level `replace` so no
+/// re-validation of UTF-8 is needed: `\r` is ASCII and cannot appear inside a
+/// multi-byte sequence, but building the result out of `&str` slices makes that
+/// a property of the code rather than a comment. Returns `Cow::Borrowed` — no
+/// allocation — for the overwhelmingly common LF and CRLF inputs.
+fn normalize_lone_cr(source: &str) -> std::borrow::Cow<'_, str> {
+    // Fast path: LF-only files have no `\r` at all, CRLF files have every `\r`
+    // followed by `\n`. Either way there is nothing to rewrite.
+    let has_lone_cr = source
+        .as_bytes()
+        .iter()
+        .enumerate()
+        .any(|(i, &b)| b == b'\r' && source.as_bytes().get(i + 1) != Some(&b'\n'));
+    if !has_lone_cr {
+        return std::borrow::Cow::Borrowed(source);
+    }
+    let mut out = String::with_capacity(source.len());
+    let mut rest = source;
+    while let Some(idx) = rest.find('\r') {
+        out.push_str(&rest[..idx]);
+        if rest[idx + 1..].starts_with('\n') {
+            // CRLF: preserved verbatim. It is already correct, and rewriting it
+            // would change byte offsets the store holds.
+            out.push_str("\r\n");
+            rest = &rest[idx + 2..];
+        } else {
+            out.push('\n');
+            rest = &rest[idx + 1..];
+        }
+    }
+    out.push_str(rest);
+    std::borrow::Cow::Owned(out)
 }
 
 /// Whether a repo-relative directory is excluded outright, so the walker can
@@ -212,14 +276,6 @@ impl FilesystemReader {
     pub fn unskipping(mut self, names: &[String]) -> Self {
         self.unskip = names.iter().map(|n| n.trim().to_string()).collect();
         self
-    }
-
-    /// Directories the last [`Self::list_files`] pruned.
-    pub fn skipped_dirs(&self) -> Vec<SkippedDir> {
-        self.skipped_dirs
-            .lock()
-            .map(|v| v.clone())
-            .unwrap_or_default()
     }
 
     /// Attach `[[repos]] exclude` globs. These are matched against
@@ -312,6 +368,35 @@ impl ContentReader for FilesystemReader {
         // at `parse_markdown`, because the watcher reads notes with
         // `fs::read_to_string` and never passes through here.
         let source = nestweaver_parser::strip_nul_bytes(&source).into_owned();
+        // nw-386: normalise LONE CR (a `\r` not followed by `\n`) to `\n`.
+        //
+        // Classic-Mac / lone-CR files contributed ZERO symbols and said nothing
+        // about it. With no `\n` anywhere in the file, a leading `//` or `#`
+        // line comment never terminates and tree-sitter swallows the entire
+        // source: a measured 4-file fixture (`hdr.rs`, `hdr.py`, `hdr.go` plus
+        // one LF control) reported `files_processed: 4, symbols_found: 1,
+        // skipped_count: 0, coverage_status: "complete"`. Three files
+        // contributed nothing and the index called that complete.
+        //
+        // The second symptom needs no comment: every symbol's span collapses to
+        // line 1, so `read_symbols`' `read_span` — which splits on `text.lines()`
+        // — hands back the WHOLE FILE for each symbol with `truncated: false`.
+        //
+        // It is language-dependent, which is why no fixture caught it:
+        // JavaScript survives because tree-sitter honours CR as a line
+        // terminator per ECMAScript; Rust, Python, Ruby and Go do not.
+        //
+        // CRLF IS ALREADY CORRECT and must stay untouched — exact line numbers,
+        // byte-identical `read-symbols` bodies. So this rewrites only the LONE
+        // CR and steps over `\r\n` verbatim. Mixed CRLF-then-CR was already fine
+        // for the same reason (the first `\n` terminates the header).
+        //
+        // BYTE LENGTH IS PRESERVED: one ASCII `\r` becomes one ASCII `\n`, so
+        // every byte offset the store already holds stays valid and the
+        // oversize check below is unaffected. Borrows when there is no lone CR,
+        // so the overwhelmingly common path costs one scan and no allocation —
+        // the same shape as `strip_nul_bytes` next door.
+        let source = normalize_lone_cr(&source).into_owned();
         if source.len() as u64 > self.limits.max_source_file_bytes() {
             return Err(SourceTooLarge {
                 path: rel_path.display().to_string(),
@@ -447,6 +532,20 @@ impl ContentReader for FilesystemReader {
 
     fn max_source_file_bytes(&self) -> u64 {
         self.limits.max_source_file_bytes()
+    }
+
+    /// The prunes recorded by the most recent [`Self::list_files`].
+    ///
+    /// nw-387: lives on the trait impl, not as an inherent method, so the
+    /// indexer's `&dyn ContentReader` can actually call it. An inherent method
+    /// here would compile, satisfy the existing test, and remain unreachable
+    /// from the only place that needed it — which is precisely how nw-325
+    /// shipped half-done.
+    fn skipped_dirs(&self) -> Vec<SkippedDir> {
+        self.skipped_dirs
+            .lock()
+            .map(|v| v.clone())
+            .unwrap_or_default()
     }
 }
 
@@ -934,6 +1033,79 @@ mod tests {
     }
 
     #[test]
+    fn a_lone_cr_source_reads_as_lf_while_crlf_and_lf_stay_byte_identical() {
+        // nw-386. A lone-CR file (`\r` never followed by `\n`) contributed ZERO
+        // symbols: with no `\n` anywhere the leading `//` comment never
+        // terminates and tree-sitter swallows the entire source, while the
+        // index reported `coverage_status: "complete", skipped_count: 0`.
+        // `read_file` is the seam every code-indexing read crosses, so it is
+        // where the normalisation lives.
+        //
+        // COUNTERWEIGHT, and the reason this is NOT a blanket
+        // `replace('\r', "\n")`: CRLF is already correct today — exact line
+        // numbers, byte-identical `read-symbols` bodies — so it must come back
+        // unchanged, byte for byte, as must LF.
+        let dir = TempDir::new().unwrap();
+        let lf = "// header\nfn one() {}\nfn two() {}\n";
+        let cr = lf.replace('\n', "\r");
+        let crlf = lf.replace('\n', "\r\n");
+        std::fs::write(dir.path().join("cr.rs"), &cr).unwrap();
+        std::fs::write(dir.path().join("lf.rs"), lf).unwrap();
+        std::fs::write(dir.path().join("crlf.rs"), &crlf).unwrap();
+        let reader = FilesystemReader::new(dir.path());
+
+        assert_eq!(
+            reader.read_file(Path::new("cr.rs")).unwrap(),
+            lf,
+            "a lone-CR source must read as its LF twin"
+        );
+        assert_eq!(
+            reader.read_file(Path::new("lf.rs")).unwrap(),
+            lf,
+            "LF must be untouched"
+        );
+        assert_eq!(
+            reader.read_file(Path::new("crlf.rs")).unwrap(),
+            crlf,
+            "CRLF is already correct and must survive byte for byte"
+        );
+        // Byte length is preserved in every case, which is what keeps the byte
+        // offsets already recorded in the store valid.
+        assert_eq!(
+            reader.read_file(Path::new("cr.rs")).unwrap().len(),
+            cr.len()
+        );
+    }
+
+    #[test]
+    fn normalising_a_lone_cr_does_not_disturb_an_adjacent_crlf_and_borrows_when_idle() {
+        // nw-386, the boundary cases the file-level test above cannot reach.
+        // Mixed CRLF-then-CR was ALREADY fine before the fix (the first `\n`
+        // terminates the header), so the rewrite must step over the `\r\n`
+        // rather than consuming its `\n` and turning the pair into `\n\n`.
+        assert_eq!(normalize_lone_cr("a\r\n\rb").into_owned(), "a\r\n\nb");
+        // A lone CR at EOF has no following byte to inspect.
+        assert_eq!(normalize_lone_cr("a\r").into_owned(), "a\n");
+        // `\r` is ASCII and cannot occur inside a multi-byte sequence, but pin
+        // that the splice is done on char boundaries and not byte-mangled.
+        assert_eq!(normalize_lone_cr("é\rß").into_owned(), "é\nß");
+        // The common paths allocate nothing, matching `strip_nul_bytes` next
+        // door — this runs on every file of every index.
+        assert!(matches!(
+            normalize_lone_cr("a\nb"),
+            std::borrow::Cow::Borrowed(_)
+        ));
+        assert!(matches!(
+            normalize_lone_cr("a\r\nb"),
+            std::borrow::Cow::Borrowed(_)
+        ));
+        assert!(matches!(
+            normalize_lone_cr("a\rb"),
+            std::borrow::Cow::Owned(_)
+        ));
+    }
+
+    #[test]
     fn filesystem_reader_read_missing_file_errors() {
         let dir = TempDir::new().unwrap();
         let reader = FilesystemReader::new(dir.path());
@@ -1078,6 +1250,17 @@ mod tests {
         // SkippedFile channel already carries the minified-bundle policy and
         // carried nothing here, because the prune happens inside
         // WalkBuilder::filter_entry before the file is ever enumerated.
+        //
+        // THIS TEST IS NOT THE GUARD FOR THAT PROPERTY — read nw-387 before
+        // trusting it. It asserts the RECORDER, and the recorder always worked;
+        // what was missing for a whole release was the wiring from here into
+        // `IndexResult::skipped_files`, so a pruned `vendor/` still reported
+        // `coverage_status: \"complete\"` and `--fail-on-skip` exit 0. A test at
+        // this level cannot fail for that reason and so cannot detect it. It is
+        // kept as a unit-level check on the recorder itself; the property that
+        // actually matters is pinned end-to-end by
+        // `a_pruned_directory_is_disclosed_on_the_index_result_not_only_on_the_recorder`
+        // in `index.rs`. Do not delete that one in favour of this one.
         let dir = TempDir::new().unwrap();
         std::fs::create_dir_all(dir.path().join("packages/app/dist")).unwrap();
         std::fs::write(dir.path().join("packages/app/dist/bundle.js"), "").unwrap();

--- a/crates/nestweaver-engine/src/content_reader.rs
+++ b/crates/nestweaver-engine/src/content_reader.rs
@@ -236,12 +236,28 @@ pub struct FilesystemReader {
     skipped_dirs: std::sync::Arc<std::sync::Mutex<Vec<SkippedDir>>>,
 }
 
+/// The `reason` a [`SkippedDir`] carries when a configured `[[repos]] exclude`
+/// glob pruned the directory, rather than a `SKIP_DIRS` default.
+///
+/// nw-387 follow-up. The two reasons need DIFFERENT remedies and the first cut
+/// of the disclosure offered only one: `[[repos]] unskip` re-admits a
+/// `SKIP_DIRS` entry and governs NOTHING ELSE, so a repo that excluded a tree on
+/// purpose was told to "re-admit it with `[[repos]] unskip`" — an instruction
+/// that does nothing — while its coverage read `degraded` and `--fail-on-skip`
+/// exited 1. Named rather than left as a bare literal so the recorder here and
+/// the message builder in `index::disclose_pruned_dir` cannot drift apart
+/// silently; a rename breaks the build instead of the remedy.
+pub const CONFIGURED_EXCLUDE_REASON: &str = "configured exclude";
+
 /// A directory the walk pruned, and why.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SkippedDir {
     /// Repo-relative path of the pruned directory.
     pub path: String,
-    /// The `SKIP_DIRS` entry that matched, or the configured exclude pattern.
+    /// The `SKIP_DIRS` entry that matched, or [`CONFIGURED_EXCLUDE_REASON`]
+    /// when a `[[repos]] exclude` glob did. That second value is a MARKER, not
+    /// the glob itself: `filter_entry` matches against a compiled `GlobSet`,
+    /// which reports THAT something matched and not WHICH pattern.
     pub reason: String,
 }
 
@@ -479,7 +495,7 @@ impl ContentReader for FilesystemReader {
                         && !rel.as_os_str().is_empty()
                         && dir_is_excluded(dir_excludes.as_ref(), rel)
                     {
-                        note("configured exclude");
+                        note(CONFIGURED_EXCLUDE_REASON);
                         return false;
                     }
                 }
@@ -885,9 +901,48 @@ impl GitBareReader {
                 String::from_utf8_lossy(&output.stderr).trim()
             );
         }
-        String::from_utf8(output.stdout)
-            .with_context(|| format!("non-utf8 content in {}", rel_path.display()))
+        // nw-386: the fallback decodes through the same seam as the batch path.
+        // It fires on spawn failure and on mid-stream process death, so leaving
+        // it un-normalised would make correctness depend on whether a `git`
+        // subprocess happened to survive.
+        decode_git_blob(rel_path, output.stdout)
     }
+}
+
+/// Decode blob bytes handed back by git into the source string the parser sees.
+///
+/// nw-386, SECOND CALL SITE. `normalize_lone_cr` shipped wired only into
+/// [`FilesystemReader::read_file`], and the comment on its test called that
+/// "the seam every code-indexing read crosses". THAT WAS FALSE while
+/// [`GitBareReader`] existed: it is the body reader for `read_symbols` in
+/// SERVER mode and the enumeration/read pair for bare-clone indexing, and both
+/// of its decode points returned raw UTF-8. So both nw-386 symptoms survived
+/// verbatim on that reader — a lone-CR file contributed ZERO symbols (with no
+/// `\n` anywhere the leading `//`/`#` comment never terminates and tree-sitter
+/// swallows the whole source), and every surviving span collapsed to line 1 so
+/// `read_symbols` returned the WHOLE FILE for each symbol with
+/// `truncated: false`.
+///
+/// Funnelling BOTH git decode points (`cat-file --batch` and the `git show`
+/// fallback) through one function is the point: the fallback fires on spawn
+/// failure and on mid-stream process death, so a normalisation applied to only
+/// the batch arm would be correct until the day a `git` subprocess died and
+/// then silently wrong.
+///
+/// CRLF is stepped over verbatim and byte length is preserved — see
+/// [`normalize_lone_cr`]. Returns the original `String` untouched, with no
+/// second allocation, whenever there is no lone CR to rewrite.
+fn decode_git_blob(rel_path: &Path, bytes: Vec<u8>) -> Result<String> {
+    let text = String::from_utf8(bytes)
+        .with_context(|| format!("non-utf8 content in {}", rel_path.display()))?;
+    // Destructured rather than `.into_owned()`: on the overwhelmingly common
+    // `Cow::Borrowed` path `into_owned` would clone the entire file body for
+    // nothing, and this runs on every blob of every server-side read.
+    let rewritten = match normalize_lone_cr(&text) {
+        std::borrow::Cow::Borrowed(_) => None,
+        std::borrow::Cow::Owned(normalized) => Some(normalized),
+    };
+    Ok(rewritten.unwrap_or(text))
 }
 
 impl ContentReader for GitBareReader {
@@ -910,8 +965,9 @@ impl ContentReader for GitBareReader {
 
         let batch = guard.as_mut().expect("batch initialized above");
         match batch.request(&self.sha, rel_path) {
-            Ok(BatchObject::Found(content)) => String::from_utf8(content)
-                .with_context(|| format!("non-utf8 content in {}", rel_path.display())),
+            // nw-386: normalise lone CR here, not at the caller — see
+            // `decode_git_blob`.
+            Ok(BatchObject::Found(content)) => decode_git_blob(rel_path, content),
             Ok(BatchObject::Missing) => anyhow::bail!(
                 "path {} not found at {} in {}",
                 rel_path.display(),
@@ -1038,8 +1094,16 @@ mod tests {
         // symbols: with no `\n` anywhere the leading `//` comment never
         // terminates and tree-sitter swallows the entire source, while the
         // index reported `coverage_status: "complete", skipped_count: 0`.
-        // `read_file` is the seam every code-indexing read crosses, so it is
-        // where the normalisation lives.
+        // `read_file` is where the normalisation lives, because it is the one
+        // place a reader turns bytes into the string the parser sees.
+        //
+        // THIS COMMENT USED TO CLAIM `read_file` WAS "THE SEAM EVERY
+        // CODE-INDEXING READ CROSSES", SINGULAR. It is not, and the claim let a
+        // whole reader ship unpatched: `GitBareReader` has its own decode points
+        // and both symptoms survived there verbatim. There are TWO seams, one
+        // per reader — this test covers `FilesystemReader`, and
+        // `a_lone_cr_blob_read_from_a_bare_clone_matches_its_lf_twin` covers the
+        // other.
         //
         // COUNTERWEIGHT, and the reason this is NOT a blanket
         // `replace('\r', "\n")`: CRLF is already correct today — exact line
@@ -1471,6 +1535,15 @@ mod tests {
             .current_dir(&src)
             .output()
             .unwrap();
+        // nw-386: pin end-of-line conversion OFF so the CRLF counterweight in
+        // `a_lone_cr_blob_read_from_a_bare_clone_matches_its_lf_twin` measures
+        // this crate's normalisation and not a globally-configured
+        // `core.autocrlf` on the machine running the suite.
+        Command::new("git")
+            .args(["config", "core.autocrlf", "false"])
+            .current_dir(&src)
+            .output()
+            .unwrap();
 
         // Write files.
         for (path, content) in files {
@@ -1533,6 +1606,68 @@ mod tests {
         assert_eq!(
             reader.read_file(Path::new("lib/util.js")).unwrap(),
             "export const x = 1;"
+        );
+    }
+
+    #[test]
+    fn a_lone_cr_blob_read_from_a_bare_clone_matches_its_lf_twin() {
+        // nw-386 RESIDUAL. `normalize_lone_cr` shipped wired only into
+        // `FilesystemReader::read_file`, so both symptoms survived verbatim on
+        // `GitBareReader` — which is the body reader for `read_symbols` in
+        // SERVER mode and for bare-clone indexing. A lone-CR source contributed
+        // ZERO symbols (the leading `//` comment never terminates without a
+        // `\n`, so tree-sitter swallows the file) and every span collapsed to
+        // line 1, making `read_symbols` return the whole file per symbol.
+        //
+        // COUNTERWEIGHT, and the reason this is not `replace('\r', "\n")`: CRLF
+        // was ALREADY CORRECT on this reader too, so it must come back byte for
+        // byte. LF is asserted alongside it as the untouched control.
+        let lf = "// header\nfn one() {}\nfn two() {}\n";
+        let cr = lf.replace('\n', "\r");
+        let crlf = lf.replace('\n', "\r\n");
+        let (_tmp, bare, sha) = setup_bare_repo(&[
+            ("cr.rs", cr.as_str()),
+            ("lf.rs", lf),
+            ("crlf.rs", crlf.as_str()),
+        ]);
+        let reader = GitBareReader::new(&bare, &sha);
+
+        assert_eq!(
+            reader.read_file(Path::new("cr.rs")).unwrap(),
+            lf,
+            "a lone-CR blob must read as its LF twin through GitBareReader too"
+        );
+        assert_eq!(
+            reader.read_file(Path::new("lf.rs")).unwrap(),
+            lf,
+            "LF must be untouched"
+        );
+        assert_eq!(
+            reader.read_file(Path::new("crlf.rs")).unwrap(),
+            crlf,
+            "CRLF is already correct and must survive byte for byte"
+        );
+        // Byte length is preserved, which is what keeps the byte offsets the
+        // store already holds valid.
+        assert_eq!(
+            reader.read_file(Path::new("cr.rs")).unwrap().len(),
+            cr.len()
+        );
+
+        // The `git show` fallback is a SEPARATE decode point, reached whenever
+        // the pooled `cat-file --batch` process fails to spawn or dies
+        // mid-stream. Exercised directly because that failure cannot be induced
+        // from the public surface, and a fix applied to only one of the two
+        // arms would be correct until the day a subprocess died.
+        assert_eq!(
+            reader.read_file_via_show(Path::new("cr.rs")).unwrap(),
+            lf,
+            "the git-show fallback must normalise identically to the batch path"
+        );
+        assert_eq!(
+            reader.read_file_via_show(Path::new("crlf.rs")).unwrap(),
+            crlf,
+            "the git-show fallback must leave CRLF alone"
         );
     }
 

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -1945,11 +1945,19 @@ fn tiered_change_check(
 ///
 /// This is a DEFAULT, not a definition of coverage. Three properties hold:
 ///
-///  1. Every prune is DISCLOSED (`FilesystemReader::skipped_dirs`, surfaced as
-///     `IndexResult::skipped_files`). nw-325: the prune runs inside
-///     `WalkBuilder::filter_entry`, which cuts the subtree before enumeration,
-///     so nothing below it could ever reach the `SkippedFile` channel and a
-///     wrong answer was indistinguishable from a complete one.
+///  1. Every prune is DISCLOSED (`ContentReader::skipped_dirs`, drained into
+///     `IndexResult::skipped_files` in `index_into_store_with_write_gate`'s
+///     scan phase). nw-325: the prune runs inside `WalkBuilder::filter_entry`,
+///     which cuts the subtree before enumeration, so nothing below it could
+///     ever reach the `SkippedFile` channel and a wrong answer was
+///     indistinguishable from a complete one.
+///
+///     THIS SENTENCE WAS FALSE FOR A RELEASE. nw-325 shipped the recorder and
+///     never the drain, so the accessor's only caller was its own test and a
+///     pruned `vendor/` still reported `coverage_status: "complete"`. nw-387
+///     wired it up. The exception is `.git`, which is deliberately not
+///     disclosed — see `UNDISCLOSED_PRUNES` for why a universally-present
+///     finding would destroy the signal.
 ///  2. A repo can opt any entry back in (`FilesystemReader::unskipping`).
 ///  3. `ios` and `android` are NOT here. In an Expo / React Native / Capacitor
 ///     layout they are first-party source by default — a nested
@@ -1997,6 +2005,29 @@ pub(crate) const SKIP_DIRS: &[&str] = &[
     ".output",
     "storybook-static",
 ];
+
+/// `SKIP_DIRS` entries whose prune is NOT reported as a coverage loss.
+///
+/// nw-387 wired `FilesystemReader::skipped_dirs` into
+/// `IndexResult::skipped_files`, which is what `coverage_status` and
+/// `--fail-on-skip` read. That drain needs exactly one exception, because
+/// EVERY repository contains a `.git` and recording it would leave
+/// `coverage_status` permanently `"degraded"` and `--fail-on-skip` permanently
+/// exiting 1. A gate that always fires carries the same amount of information
+/// as one that never fires — and it would bury the pruned-`vendor/` case this
+/// disclosure exists to surface underneath a finding present in 100% of runs.
+///
+/// `.git` earns the carve-out by NOT being a heuristic: it is git's own object
+/// store, git itself never tracks it, and it holds no first-party source by
+/// construction. Every other `SKIP_DIRS` entry is a GUESS about content —
+/// `public/`, `build/`, `vendor/` and `out/` all hold hand-written source in
+/// real repositories, which is the entire reason `FilesystemReader::unskipping`
+/// exists — and a guess is precisely the thing that has to be disclosed.
+///
+/// DO NOT grow this list to quiet a noisy repo. The supported answers are
+/// `[[repos]] unskip` (re-admit the directory) or accepting the degraded
+/// status as the true statement it is.
+const UNDISCLOSED_PRUNES: &[&str] = &[".git"];
 
 /// Index a directory into a persistent GraphStore at `db_path`.
 ///
@@ -2849,6 +2880,55 @@ where
     let discovered_files = reader
         .list_files()
         .context("ContentReader::list_files failed")?;
+
+    // nw-387: DRAIN THE PRUNE RECORDER INTO THE SKIP CHANNEL.
+    //
+    // nw-325 built `FilesystemReader::skipped_dirs` and stopped there. Its only
+    // caller in the workspace was the test that asserted it, so the recorder
+    // was write-only in production: a repo of `canary.py` plus a committed
+    // `vendor/v.py` indexed 1 file and reported `skipped_files: []`,
+    // `coverage_status: "complete"` and `--fail-on-skip` exit 0. `vendor/v.py`
+    // vanished with no trace, and the doc on `SKIP_DIRS` above asserted the
+    // opposite as an invariant. This loop is that invariant's implementation.
+    //
+    // The prune runs inside `WalkBuilder::filter_entry`, which cuts the SUBTREE
+    // before enumeration — the files below it are never listed, so they can
+    // never arrive as a per-file `ParseOutcome::Skipped`. The pruned DIRECTORY
+    // is the only artefact that survives, which is why it is what gets
+    // reported.
+    //
+    // MUST STAY IMMEDIATELY AFTER `list_files`. The recorder is cleared at the
+    // top of every `list_files` call, and this same `reader` is walked again
+    // later in the run — `crate::manifest::parse_manifest` -> `find_csproj`
+    // calls `list_files` — which would refill it against a different question.
+    // Reading it here, while it still describes the walk that produced
+    // `discovered_files`, is what makes the two consistent.
+    //
+    // `Ignored` is the reason code because this is a POLICY skip, the same
+    // class as the minified-bundle skip below, not a read or parse defect.
+    //
+    // KNOWN ASYMMETRY, stated rather than hidden: the recorder also captures
+    // `[[repos]] exclude` patterns that prune a whole DIRECTORY, so those are
+    // disclosed here too, while the same feature's per-FILE matches are still
+    // dropped silently in `FilesystemReader::list_files`. Disclosing the half
+    // that is recorded is strictly better than disclosing neither, and this
+    // channel is deliberately not scoped to `SKIP_DIRS` alone — nw-394 (the
+    // git-tracked/gitignored divergence) is sequenced behind this item and
+    // needs to add its own rows to exactly this list.
+    for pruned in reader.skipped_dirs() {
+        if UNDISCLOSED_PRUNES.contains(&pruned.reason.as_str()) {
+            continue;
+        }
+        scan_skipped_files.push(SkippedFile::new(
+            pruned.path,
+            SkipReasonCode::Ignored,
+            format!(
+                "directory pruned before enumeration by skip-dir policy ({}); \
+                 re-admit it with `[[repos]] unskip`",
+                pruned.reason
+            ),
+        ));
+    }
 
     for rel_path in &discovered_files {
         let path = repo_path.join(rel_path);
@@ -6853,6 +6933,234 @@ mod tests {
         assert_eq!(
             result.skipped_files[0].observed_bytes,
             Some(200 * 1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn a_pruned_directory_is_disclosed_on_the_index_result_not_only_on_the_recorder() {
+        // nw-387. nw-325 built `FilesystemReader::skipped_dirs` and shipped the
+        // `unskip` re-admission half, but never drained the recorder into the
+        // result — its ONLY caller in the workspace was the `#[cfg(test)]` test
+        // that asserted it. So this exact fixture (`canary.py` plus a committed
+        // `vendor/v.py`) reported `files_processed: 1, skipped_files: [],
+        // coverage_status: "complete"` and `--fail-on-skip` exit 0. `vendor/v.py`
+        // was gone with no trace.
+        //
+        // THE ASSERTION IS ON `IndexResult`, DELIBERATELY. A test that calls
+        // `reader.skipped_dirs()` cannot fail for the reason this item was
+        // filed — the recorder always worked; the WIRING was missing. That
+        // vacuous shape is what let the gap ship, so it is not repeated here.
+        // `coverage_status` and `--fail-on-skip` are both derived from
+        // `skipped_files` being non-empty (src/main.rs, the daemon and the MCP
+        // layer all agree), so a non-empty `skipped_files` is exactly the
+        // condition that degrades coverage and fails the gate.
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(repo.join("vendor")).unwrap();
+        fs::write(repo.join("canary.py"), "def canary():\n    return 1\n").unwrap();
+        fs::write(repo.join("vendor/v.py"), "def vendored():\n    return 2\n").unwrap();
+        let db = dir.path().join("graph.lbug");
+        let result = index_directory_with_options_and_limits(
+            &repo,
+            &db,
+            "test",
+            "https://example.test/pruned-vendor",
+            "fixture",
+            true,
+            None,
+            crate::index_limits::IndexLimits::default(),
+        )
+        .unwrap();
+
+        // The prune itself is unchanged — this item is about disclosure, not
+        // about indexing `vendor/`.
+        assert_eq!(result.files_count, 1, "vendor/ is still pruned");
+        let disclosed: Vec<&nestweaver_parser::SkippedFile> = result
+            .skipped_files
+            .iter()
+            .filter(|skipped| skipped.path == "vendor")
+            .collect();
+        assert_eq!(
+            disclosed.len(),
+            1,
+            "the pruned directory must reach IndexResult::skipped_files: {:?}",
+            result.skipped_files
+        );
+        assert_eq!(
+            disclosed[0].reason_code,
+            nestweaver_parser::SkipReasonCode::Ignored,
+            "a policy prune is Ignored, not a read or parse defect"
+        );
+        assert!(
+            disclosed[0].reason.contains("vendor"),
+            "the reason must name the matched SKIP_DIRS entry: {:?}",
+            disclosed[0].reason
+        );
+    }
+
+    #[test]
+    fn a_repo_with_nothing_pruned_but_its_own_git_dir_still_reports_complete_coverage() {
+        // COUNTERWEIGHT to the test above, and the reason `UNDISCLOSED_PRUNES`
+        // exists. `.git` is in SKIP_DIRS and every repository has one, so a
+        // naive drain would report a skip on 100% of indexes: `coverage_status`
+        // would be permanently `"degraded"`, `--fail-on-skip` would permanently
+        // exit 1, and the pruned-`vendor/` finding nw-387 exists to surface
+        // would be buried under a finding that is always present.
+        //
+        // Two repos, one property: an index that omitted nothing a user would
+        // call source must still report an EMPTY `skipped_files`.
+        let dir = tempfile::tempdir().unwrap();
+
+        let clean = dir.path().join("clean");
+        fs::create_dir_all(&clean).unwrap();
+        fs::write(clean.join("canary.py"), "def canary():\n    return 1\n").unwrap();
+        let clean_result = index_directory_with_options_and_limits(
+            &clean,
+            &dir.path().join("clean.lbug"),
+            "test",
+            "https://example.test/clean-coverage",
+            "fixture",
+            true,
+            None,
+            crate::index_limits::IndexLimits::default(),
+        )
+        .unwrap();
+        assert!(
+            clean_result.skipped_files.is_empty(),
+            "a repo with no pruned directory must not report degraded coverage: {:?}",
+            clean_result.skipped_files
+        );
+
+        let with_git = dir.path().join("with_git");
+        fs::create_dir_all(with_git.join(".git/objects")).unwrap();
+        fs::write(with_git.join(".git/HEAD"), "ref: refs/heads/main\n").unwrap();
+        fs::write(with_git.join(".git/objects/pack.idx"), "not source\n").unwrap();
+        fs::write(with_git.join("canary.py"), "def canary():\n    return 1\n").unwrap();
+        let git_result = index_directory_with_options_and_limits(
+            &with_git,
+            &dir.path().join("with_git.lbug"),
+            "test",
+            "https://example.test/git-dir-coverage",
+            "fixture",
+            true,
+            None,
+            crate::index_limits::IndexLimits::default(),
+        )
+        .unwrap();
+        assert!(
+            git_result.skipped_files.is_empty(),
+            "pruning `.git` is not a coverage loss and must not degrade the gate: {:?}",
+            git_result.skipped_files
+        );
+        assert_eq!(
+            git_result.files_count, 1,
+            "precondition: the canary was indexed in both repos"
+        );
+    }
+
+    #[test]
+    fn a_lone_cr_source_yields_the_same_symbols_and_line_numbers_as_its_lf_twin() {
+        // nw-386. A lone-CR file (`\r` with no `\n` anywhere) contributed ZERO
+        // symbols: the leading line comment never terminates, so tree-sitter
+        // swallows the whole source. The measured 4-file fixture reported
+        // `files_processed: 4, symbols_found: 1, skipped_count: 0,
+        // coverage_status: "complete"` — three files contributed nothing and
+        // NOTHING SAID SO. The second symptom is the span: every symbol
+        // collapsed to line 1, so `read-symbols` returned the whole file per
+        // symbol with `truncated: false`. Line numbers are therefore asserted,
+        // not just the symbol names.
+        //
+        // It is language-dependent, which is why no fixture caught it: JS
+        // survives (tree-sitter honours CR per ECMAScript), Rust/Python/Go do
+        // not — so all three named languages are exercised here.
+        //
+        // COUNTERWEIGHT: CRLF was ALREADY CORRECT before the fix (exact line
+        // numbers, byte-identical bodies). It is asserted identical to the LF
+        // control too, so a normalisation that over-applied — collapsing
+        // `\r\n` and shifting every byte offset the store holds — would fail
+        // here rather than ship.
+        const FIXTURES: [(&str, &str); 3] = [
+            (
+                "hdr.rs",
+                "// module header\npub fn alpha() -> u32 {\n    1\n}\n\npub fn beta() -> u32 {\n    2\n}\n",
+            ),
+            (
+                "hdr.py",
+                "# module header\ndef alpha():\n    return 1\n\n\ndef beta():\n    return 2\n",
+            ),
+            (
+                "hdr.go",
+                "// module header\npackage hdr\n\nfunc Alpha() int {\n\treturn 1\n}\n\nfunc Beta() int {\n\treturn 2\n}\n",
+            ),
+        ];
+
+        let dir = tempfile::tempdir().unwrap();
+        let scan = |label: &str, eol: &str| -> Vec<(String, String, u32, u32)> {
+            let repo = dir.path().join(label);
+            fs::create_dir_all(&repo).unwrap();
+            for (name, body) in FIXTURES {
+                fs::write(repo.join(name), body.replace('\n', eol)).unwrap();
+            }
+            let result = index_directory_with_options_and_limits(
+                &repo,
+                &dir.path().join(format!("{label}.lbug")),
+                "test",
+                &format!("https://example.test/eol-{label}"),
+                "fixture",
+                true,
+                None,
+                crate::index_limits::IndexLimits::default(),
+            )
+            .unwrap();
+            assert!(
+                result.skipped_files.is_empty(),
+                "{label}: {:?}",
+                result.skipped_files
+            );
+            let store =
+                GraphStore::open_or_create(&dir.path().join(format!("{label}.lbug"))).unwrap();
+            let mut rows: Vec<(String, String, u32, u32)> = store
+                .list_all_symbols()
+                .unwrap()
+                .into_iter()
+                .map(|symbol| {
+                    (
+                        symbol.file_path,
+                        symbol.name,
+                        symbol.start_line,
+                        symbol.end_line,
+                    )
+                })
+                .collect();
+            rows.sort();
+            rows
+        };
+
+        let lf = scan("lf", "\n");
+        // Guard against a vacuous pass: if the LF control found nothing, an
+        // empty-equals-empty comparison would "prove" the bug fixed.
+        let lf_files: std::collections::HashSet<&String> =
+            lf.iter().map(|(path, ..)| path).collect();
+        assert_eq!(
+            lf_files.len(),
+            3,
+            "precondition: all three languages must contribute symbols: {lf:?}"
+        );
+        assert!(
+            lf.iter().any(|(_, _, start, _)| *start > 1),
+            "precondition: the control must have symbols below line 1, or the \
+             collapsed-span symptom is untestable: {lf:?}"
+        );
+
+        assert_eq!(
+            scan("cr", "\r"),
+            lf,
+            "nw-386: a lone-CR source must yield its LF twin's symbols AND line numbers"
+        );
+        assert_eq!(
+            scan("crlf", "\r\n"),
+            lf,
+            "counterweight: CRLF was already correct and must not regress"
         );
     }
 

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -1945,19 +1945,25 @@ fn tiered_change_check(
 ///
 /// This is a DEFAULT, not a definition of coverage. Three properties hold:
 ///
-///  1. Every prune is DISCLOSED (`ContentReader::skipped_dirs`, drained into
-///     `IndexResult::skipped_files` in `index_into_store_with_write_gate`'s
-///     scan phase). nw-325: the prune runs inside `WalkBuilder::filter_entry`,
-///     which cuts the subtree before enumeration, so nothing below it could
-///     ever reach the `SkippedFile` channel and a wrong answer was
-///     indistinguishable from a complete one.
+///  1. Every prune is DISCLOSED (`ContentReader::skipped_dirs`, drained through
+///     `disclose_pruned_dir` at every site that assembles a skip list: the scan
+///     phase of `index_into_store_with_write_gate`, and both incremental paths
+///     — including their `old_sha == new_sha` steady state on the CLI).
+///     nw-325: the prune runs inside `WalkBuilder::filter_entry`, which cuts the
+///     subtree before enumeration, so nothing below it could ever reach the
+///     `SkippedFile` channel and a wrong answer was indistinguishable from a
+///     complete one.
 ///
-///     THIS SENTENCE WAS FALSE FOR A RELEASE. nw-325 shipped the recorder and
-///     never the drain, so the accessor's only caller was its own test and a
-///     pruned `vendor/` still reported `coverage_status: "complete"`. nw-387
-///     wired it up. The exception is `.git`, which is deliberately not
-///     disclosed — see `UNDISCLOSED_PRUNES` for why a universally-present
-///     finding would destroy the signal.
+///     THIS SENTENCE WAS FALSE FOR A RELEASE, THEN HALF-TRUE FOR A PR. nw-325
+///     shipped the recorder and never the drain, so the accessor's only caller
+///     was its own test and a pruned `vendor/` still reported
+///     `coverage_status: "complete"`. nw-387's first cut drained only the
+///     `--force` scan, so the plain `nestweaver index` that follows it reported
+///     `complete` again on the same tree — the word EVERY above is load-bearing
+///     and means every command, not every code path of one command. The
+///     exception is `.git`, which is deliberately not disclosed — see
+///     `UNDISCLOSED_PRUNES` for why a universally-present finding would destroy
+///     the signal.
 ///  2. A repo can opt any entry back in (`FilesystemReader::unskipping`).
 ///  3. `ios` and `android` are NOT here. In an Expo / React Native / Capacitor
 ///     layout they are first-party source by default — a nested
@@ -2028,6 +2034,50 @@ pub(crate) const SKIP_DIRS: &[&str] = &[
 /// `[[repos]] unskip` (re-admit the directory) or accepting the degraded
 /// status as the true statement it is.
 const UNDISCLOSED_PRUNES: &[&str] = &[".git"];
+
+/// Turn one recorded prune into the `SkippedFile` row the coverage gate reads,
+/// or `None` when that prune is deliberately not disclosed.
+///
+/// ONE BUILDER, because there is more than one drain site and the first cut of
+/// nw-387 only had one. The `--force`/full scan in
+/// `index_into_store_with_write_gate` was wired; the incremental paths were not,
+/// so on the item's own fixture run 1 (`--force`) reported `degraded` and exited
+/// 1 while run 2 (a plain `nestweaver index`, the normal CI shape) reported
+/// `skipped_files: []`, `complete` and exit 0 on the SAME unchanged repo. A
+/// disclosure that survives only one of the two commands a user actually runs is
+/// not a disclosure — so every site now funnels through here.
+///
+/// THE REMEDY HAS TO MATCH THE REASON. This message used to offer
+/// `[[repos]] unskip` unconditionally, but `SkippedDir::reason` is also
+/// [`crate::content_reader::CONFIGURED_EXCLUDE_REASON`] when a `[[repos]]
+/// exclude` glob pruned the directory — and `unskip` re-admits `SKIP_DIRS`
+/// entries only, it does not govern `exclude` at all. A repo using `exclude`
+/// exactly as designed was therefore told its coverage was degraded, failed
+/// `--fail-on-skip`, and was handed an instruction that does nothing. The
+/// exclude case gets the remedy that actually works (drop or narrow the
+/// pattern), and its row exists at all only because a pruned tree is invisible
+/// either way — see the KNOWN ASYMMETRY note at the scan-phase drain.
+fn disclose_pruned_dir(pruned: crate::content_reader::SkippedDir) -> Option<SkippedFile> {
+    if UNDISCLOSED_PRUNES.contains(&pruned.reason.as_str()) {
+        return None;
+    }
+    let reason = if pruned.reason == crate::content_reader::CONFIGURED_EXCLUDE_REASON {
+        "directory pruned before enumeration by a configured `[[repos]] exclude` \
+         glob; drop or narrow that pattern to index it"
+            .to_string()
+    } else {
+        format!(
+            "directory pruned before enumeration by skip-dir policy ({}); \
+             re-admit it with `[[repos]] unskip`",
+            pruned.reason
+        )
+    };
+    Some(SkippedFile::new(
+        pruned.path,
+        SkipReasonCode::Ignored,
+        reason,
+    ))
+}
 
 /// Index a directory into a persistent GraphStore at `db_path`.
 ///
@@ -2915,19 +2965,13 @@ where
     // channel is deliberately not scoped to `SKIP_DIRS` alone — nw-394 (the
     // git-tracked/gitignored divergence) is sequenced behind this item and
     // needs to add its own rows to exactly this list.
+    // The row itself — reason code, message and the `.git` carve-out — is built
+    // by `disclose_pruned_dir`, shared with the incremental drains so the two
+    // commands cannot disagree about the same repo.
     for pruned in reader.skipped_dirs() {
-        if UNDISCLOSED_PRUNES.contains(&pruned.reason.as_str()) {
-            continue;
+        if let Some(skipped) = disclose_pruned_dir(pruned) {
+            scan_skipped_files.push(skipped);
         }
-        scan_skipped_files.push(SkippedFile::new(
-            pruned.path,
-            SkipReasonCode::Ignored,
-            format!(
-                "directory pruned before enumeration by skip-dir policy ({}); \
-                 re-admit it with `[[repos]] unskip`",
-                pruned.reason
-            ),
-        ));
     }
 
     for rel_path in &discovered_files {
@@ -5297,6 +5341,34 @@ fn record_incremental_file_outcome(
     }
 }
 
+/// Drain a reader's prune recorder into an [`IncrementalResult`].
+///
+/// nw-387 RESIDUAL. `IncrementalResult::skipped_files` is the THIRD assembly
+/// site for the skip channel (`src/main.rs` reads it straight out of the
+/// incremental branch), and it was never drained — so `--force` reported a
+/// pruned `vendor/` and the plain `nestweaver index` that follows it reported
+/// `complete`, exit 0, on a byte-identical repo. Coverage that depends on which
+/// flag you passed is not coverage.
+///
+/// CALL THIS ONLY WHERE `list_files` HAS JUST RUN. The recorder is cleared at
+/// the top of every `FilesystemReader::list_files`, so what it holds always
+/// describes the most recent walk; reading it next to that walk is what keeps
+/// the disclosure and the enumeration talking about the same question.
+///
+/// Routed through `record_incremental_file_outcome` rather than pushed
+/// directly so `files_skipped` stays in step with `skipped_files` and a repeat
+/// row cannot double-count.
+fn drain_pruned_dirs_into_incremental(
+    reader: &dyn crate::content_reader::ContentReader,
+    result: &mut IncrementalResult,
+) {
+    for pruned in reader.skipped_dirs() {
+        if let Some(skipped) = disclose_pruned_dir(pruned) {
+            record_incremental_file_outcome(result, IncrementalFileOutcome::PolicySkipped(skipped));
+        }
+    }
+}
+
 /// Incrementally re-index a repository using git diff.
 ///
 /// Opens the store at `db_path`, looks up the previously indexed SHA, and
@@ -5514,7 +5586,43 @@ fn incremental_index_with_name_and_io(
     // 4. Nothing changed.
     if old_sha == new_sha {
         tracing::debug!(sha = old_sha, "repo is already up to date; skipping");
-        return Ok(IncrementalResult::default());
+        // nw-387 RESIDUAL: THE DISCLOSURE HAS TO BE DURABLE, AND THIS IS THE
+        // BRANCH THAT BROKE IT. On the item's own fixture (`canary.py` plus a
+        // committed `vendor/v.py`) run 1 reported `degraded` and exited 1; run
+        // 2 — a plain `nestweaver index` over the same unchanged tree, which is
+        // the normal CI shape — took exactly this early return, handed back
+        // `IncrementalResult::default()`, and reported `skipped_files: []`,
+        // `coverage_status: "complete"`, exit 0. The pruned tree is still
+        // missing on run 2; only the report changed. A gate a second run
+        // silently clears is worse than no gate, because it teaches people to
+        // re-run until it passes.
+        //
+        // A prune is a property of the tree and the config, not of the diff, so
+        // it must be RE-DERIVED here rather than remembered — and re-deriving it
+        // needs the walk, which is why `list_files` is called for its side
+        // effect on the recorder and its result discarded. That is a real cost
+        // on an up-to-date repo (one `ignore` walk, no parsing, no reads), paid
+        // deliberately: `nestweaver index` is user-invoked, and the alternative
+        // is a coverage claim that is only true the first time.
+        let reader = crate::content_reader::FilesystemReader::with_limits(repo_path, limits)
+            .excluding(excludes)?;
+        let mut result = IncrementalResult::default();
+        // Fully qualified because this module deliberately does not import the
+        // `ContentReader` trait; every other call here goes through `&dyn`.
+        if let Err(error) = crate::content_reader::ContentReader::list_files(&reader) {
+            // Enumeration failure is not "nothing was pruned" (nw-287). Say so
+            // and return the clean result rather than inventing rows: the index
+            // itself is untouched on this branch, so a hard error here would
+            // fail a run that did no work.
+            tracing::warn!(
+                %error,
+                "could not re-walk an up-to-date repo; pruned directories are not \
+                 disclosed on this run"
+            );
+        } else {
+            drain_pruned_dirs_into_incremental(&reader, &mut result);
+        }
+        return Ok(result);
     }
 
     // 5. Detect file-level changes.
@@ -5551,6 +5659,17 @@ fn incremental_index_with_name_and_io(
         .skipped_files
         .extend(contract_plan.skipped_files.iter().cloned());
     result.files_skipped += contract_plan.skipped_files.len();
+    // nw-387 RESIDUAL: the changed-file half of the same durability problem.
+    // Free here — `prepare_incremental_contract_derivation` has just walked the
+    // tree via `list_files`, so the recorder is populated and current.
+    //
+    // This is also what covers the per-file `path_in_skip_dir(rel_path)`
+    // `continue`s in the change loop below, which are silent by construction: a
+    // file added under `vendor/` is dropped there with no row, and the pruned
+    // DIRECTORY reported here is the same artefact the full scan reports for
+    // the same repo. Disclosing at directory granularity keeps the two commands
+    // saying the same thing.
+    drain_pruned_dirs_into_incremental(&reader, &mut result);
     let prepared_files =
         prepare_incremental_files(&reader, &changes).context("prepare incremental source files")?;
 
@@ -5861,6 +5980,19 @@ where
         .skipped_files
         .extend(contract_plan.skipped_files.iter().cloned());
     result.files_skipped += contract_plan.skipped_files.len();
+    // nw-387: same drain as the CLI incremental path, so the daemon's view of a
+    // repo's coverage matches the CLI's instead of being quietly rosier.
+    // `prepare_incremental_contract_derivation` above has just walked, so the
+    // recorder is current. A no-op for `GitBareReader`, whose `skipped_dirs`
+    // default is empty and whose prune is still silent — stated on the trait,
+    // not smuggled in here.
+    //
+    // Deliberately NOT added to this function's `old_sha == new_sha` early
+    // return, unlike the CLI's: that branch is the daemon's poll-loop steady
+    // state, and re-walking the tree on every poll to re-derive an unchanged
+    // prune set is a cost with no reader. The durable-disclosure guarantee is
+    // carried by `nestweaver index`, which is what `--fail-on-skip` gates.
+    drain_pruned_dirs_into_incremental(reader, &mut result);
 
     for change in &changes {
         match change {
@@ -7055,6 +7187,226 @@ mod tests {
         assert_eq!(
             git_result.files_count, 1,
             "precondition: the canary was indexed in both repos"
+        );
+    }
+
+    /// `git init` + identity + an initial commit, returning a closure that runs
+    /// further git commands in `repo`. Shared by the nw-387 durability tests
+    /// below, which need a real SHA so `incremental_index` takes the
+    /// incremental route instead of the full-index fallback.
+    fn commit_all_in(repo: &Path, message: &str) -> impl Fn(&[&str]) -> String + use<> {
+        let repo = repo.to_path_buf();
+        let git = move |args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            String::from_utf8(output.stdout).unwrap().trim().to_string()
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "NestWeaver Test"]);
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", message]);
+        git
+    }
+
+    #[test]
+    fn a_pruned_directory_stays_disclosed_across_a_plain_incremental_reindex() {
+        // nw-387 RESIDUAL. The drain shipped on the `--force` path only, so the
+        // disclosure was NOT DURABLE: measured on this exact fixture, run 1
+        // reported `coverage_status: "degraded"` and `--fail-on-skip` exit 1,
+        // and run 2 — a plain `nestweaver index` over the identical unchanged
+        // tree, which is the normal CI shape — reported `skipped_files: []`,
+        // `complete`, exit 0. `vendor/v.py` is just as absent on run 2; only the
+        // report changed. A gate that a second run silently clears is worse than
+        // no gate, because it teaches people to re-run until it passes.
+        //
+        // THREE RUNS, because the incremental route has two distinct branches
+        // and they failed independently: the `old_sha == new_sha` steady state
+        // (run 2) and the changed-file branch (run 3). Asserting only one would
+        // leave the other exactly as silent as before.
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(repo.join("vendor")).unwrap();
+        fs::write(repo.join("canary.py"), "def canary():\n    return 1\n").unwrap();
+        fs::write(repo.join("vendor/v.py"), "def vendored():\n    return 2\n").unwrap();
+        let git = commit_all_in(&repo, "initial");
+        let head = git(&["rev-parse", "HEAD"]);
+
+        let db = dir.path().join("graph.lbug");
+        let repo_url = "https://example.test/durable-pruned-vendor";
+        let first = index_directory_with_options_and_limits(
+            &repo,
+            &db,
+            "test",
+            repo_url,
+            &head,
+            true,
+            None,
+            crate::index_limits::IndexLimits::default(),
+        )
+        .unwrap();
+        assert!(
+            first.skipped_files.iter().any(|s| s.path == "vendor"),
+            "precondition: the --force run discloses the prune: {:?}",
+            first.skipped_files
+        );
+
+        let second = incremental_index(&repo, &db, "test", repo_url).unwrap();
+        assert!(
+            second.skipped_files.iter().any(|s| s.path == "vendor"),
+            "an up-to-date incremental run must re-derive the prune, not forget \
+             it: {:?}",
+            second.skipped_files
+        );
+        assert_eq!(
+            second.files_skipped,
+            second.skipped_files.len(),
+            "the count the CLI prints must match the rows it lists"
+        );
+
+        fs::write(repo.join("later.py"), "def later():\n    return 3\n").unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "later"]);
+        let third = incremental_index(&repo, &db, "test", repo_url).unwrap();
+        assert_eq!(
+            third.files_added, 1,
+            "precondition: the new file was indexed"
+        );
+        assert!(
+            third.skipped_files.iter().any(|s| s.path == "vendor"),
+            "a changed-file incremental run must disclose the prune too: {:?}",
+            third.skipped_files
+        );
+    }
+
+    #[test]
+    fn a_clean_incremental_reindex_reports_no_skips_at_all() {
+        // COUNTERWEIGHT to the test above. The durable disclosure is only worth
+        // anything if silence still means something: a repo with nothing pruned
+        // but its own `.git` must come back with an EMPTY `skipped_files` on
+        // both incremental branches, so `coverage_status` stays `complete` and
+        // `--fail-on-skip` keeps exiting 0. Without this, "drain the recorder"
+        // could be satisfied by a run that reports a skip every time — which
+        // carries exactly as little information as reporting none.
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(repo.join("canary.py"), "def canary():\n    return 1\n").unwrap();
+        let git = commit_all_in(&repo, "initial");
+        let head = git(&["rev-parse", "HEAD"]);
+
+        let db = dir.path().join("graph.lbug");
+        let repo_url = "https://example.test/clean-incremental";
+        index_directory_with_options_and_limits(
+            &repo,
+            &db,
+            "test",
+            repo_url,
+            &head,
+            true,
+            None,
+            crate::index_limits::IndexLimits::default(),
+        )
+        .unwrap();
+
+        let up_to_date = incremental_index(&repo, &db, "test", repo_url).unwrap();
+        assert!(
+            up_to_date.skipped_files.is_empty(),
+            "an up-to-date clean repo must still report complete coverage: {:?}",
+            up_to_date.skipped_files
+        );
+        assert_eq!(up_to_date.files_skipped, 0);
+
+        fs::write(repo.join("later.py"), "def later():\n    return 2\n").unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "later"]);
+        let changed = incremental_index(&repo, &db, "test", repo_url).unwrap();
+        assert_eq!(changed.files_added, 1, "precondition: the new file landed");
+        assert!(
+            changed.skipped_files.is_empty(),
+            "a clean changed-file incremental run must report complete coverage: {:?}",
+            changed.skipped_files
+        );
+        assert_eq!(changed.files_skipped, 0);
+    }
+
+    #[test]
+    fn a_directory_pruned_by_a_configured_exclude_is_not_offered_the_unskip_remedy() {
+        // nw-387 RESIDUAL. The disclosure message told every pruned directory to
+        // "re-admit it with `[[repos]] unskip`", but `SkippedDir::reason` is also
+        // `configured exclude` when a `[[repos]] exclude` glob did the pruning —
+        // and `unskip` re-admits `SKIP_DIRS` entries only, it does not govern
+        // `exclude`. So a repo using `exclude` exactly as designed had its
+        // coverage degraded, failed `--fail-on-skip`, and was handed an
+        // instruction that does nothing.
+        //
+        // ONE RUN, BOTH DIRECTIONS: `plugins/` is excluded by config and
+        // `vendor/` by the `SKIP_DIRS` default, so a fix that simply deleted the
+        // `unskip` sentence — or that mislabelled every prune as an exclude —
+        // fails here rather than shipping.
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("repo");
+        fs::create_dir_all(src.join("plugins/acme")).unwrap();
+        fs::create_dir_all(src.join("vendor")).unwrap();
+        fs::write(
+            src.join("plugins/acme/thirdparty.js"),
+            "function vendored() {}",
+        )
+        .unwrap();
+        fs::write(src.join("vendor/v.js"), "function alsoVendored() {}").unwrap();
+        fs::write(src.join("main.js"), "function visible() {}").unwrap();
+
+        let store = GraphStore::in_memory().unwrap();
+        let db_path = dir.path().join("t.lbug");
+        let opts = IndexOptions::new("test", "https://example.com/exclude-remedy", "abc123")
+            .excludes(&["plugins/**".to_string()]);
+        let result = index_directory_with_store_opts(&store, &src, &db_path, &opts, None).unwrap();
+
+        let excluded = result
+            .skipped_files
+            .iter()
+            .find(|skipped| skipped.path == "plugins")
+            .unwrap_or_else(|| {
+                panic!(
+                    "the excluded directory must still be disclosed: {:?}",
+                    result.skipped_files
+                )
+            });
+        assert!(
+            excluded.reason.contains("exclude"),
+            "the remedy must name the mechanism that actually pruned it: {:?}",
+            excluded.reason
+        );
+        assert!(
+            !excluded.reason.contains("unskip"),
+            "`unskip` does not govern `exclude`; offering it is a remedy that \
+             does nothing: {:?}",
+            excluded.reason
+        );
+
+        let default_prune = result
+            .skipped_files
+            .iter()
+            .find(|skipped| skipped.path == "vendor")
+            .unwrap_or_else(|| {
+                panic!(
+                    "the SKIP_DIRS prune must still be disclosed: {:?}",
+                    result.skipped_files
+                )
+            });
+        assert!(
+            default_prune.reason.contains("unskip"),
+            "a SKIP_DIRS prune IS re-admissible with `unskip` and must keep \
+             saying so: {:?}",
+            default_prune.reason
         );
     }
 

--- a/crates/nestweaver-engine/src/investigate.rs
+++ b/crates/nestweaver-engine/src/investigate.rs
@@ -504,6 +504,61 @@ pub fn load_bundle(db_path: &Path, bundle_id: &str) -> Option<Bundle> {
     load_bundle_store(db_path).bundles.remove(bundle_id)
 }
 
+/// Fail a ranked query closed while an index publication is in flight.
+///
+/// nw-384. The contract is stated verbatim in four operator-facing places —
+/// `repair --help` (`src/main.rs`), the `investigate` MCP tool description
+/// (`nestweaver-mcp/src/tools.rs`) and the daemon's (`server.rs`) — all of the
+/// form "every ranked query (brain_context, project_context, investigate)
+/// fails closed ... because the PageRank and generation sidecars may predate
+/// the committed graph". `investigate` was named in all four and honoured none
+/// of them, because it never reaches the guard that enforces it for `context`:
+///
+/// * `context` errors through `personalized_pagerank_with_intent`, which
+///   returns `Err(RankingUnavailable)` on a dirty marker.
+/// * `investigate`'s seed path lands on the SILENT-EMPTY guards instead —
+///   `symbols_by_pagerank` -> `Ok(vec![])`, `pagerank_scores` -> an empty map —
+///   and then, when hybrid retrieval bails, on a BM25 fallback with no
+///   publication check at all.
+///
+/// That split gives the SAME bug two opposite faces, and both were observed on
+/// the same build: on a small graph, `returned: 0, dropped_reasons: {}` at exit
+/// 0 — a "this code does not exist" answer; on the 193k-node live graph, a
+/// fully populated `returned: 30, total: 30, truncated: false` at exit 0,
+/// ranked against sidecars the guard itself declares untrustworthy. **The
+/// populated face is the worse one**, because an empty map invites suspicion
+/// and a complete-looking one does not.
+///
+/// Deliberately the STORE's own condition (`is_index_publication_dirty`) and
+/// the STORE's own error, not a second formulation: `classify_index_publication_error`
+/// at the MCP boundary keys on the substring "index publication", so reusing
+/// `RankingUnavailable` is what makes `investigate` produce the identical
+/// TRANSIENT/WEDGED message `context` produces rather than a near-miss of it.
+/// An in-memory store has no marker and is never dirty, so this is inert there.
+fn ensure_ranking_publication_clean(store: &GraphStore) -> Result<(), anyhow::Error> {
+    if store.is_index_publication_dirty() {
+        return Err(anyhow::anyhow!(
+            nestweaver_store::StoreError::RankingUnavailable
+        ));
+    }
+    Ok(())
+}
+
+/// Whether a retrieval failure is the fail-closed publication guard rather
+/// than an ordinary "no seeds resolved" miss.
+///
+/// nw-384. `investigate` used to match `Err(_)` and fall through to BM25, so a
+/// guard firing DEEPER in retrieval was converted into a successful-looking
+/// answer — the exact inversion the guard exists to prevent. Matched on the
+/// rendered chain (`{:#}`) rather than by downcast because the error crosses
+/// `build_brain_context_hybrid_with_aliases`'s `anyhow` boundary, where it may
+/// already have been wrapped in context; the substring is the same one
+/// `classify_index_publication_error` keys on, so the two cannot drift apart
+/// on one route and not the other.
+fn is_index_publication_failure(error: &anyhow::Error) -> bool {
+    format!("{error:#}").contains("index publication")
+}
+
 // ── Public API ──────────────────────────────────────────────────────────────
 
 /// Run an investigation: hybrid retrieval → domain grouping → inline bodies →
@@ -538,6 +593,14 @@ pub fn investigate(
     let budget = token_budget
         .unwrap_or(DEFAULT_TOKEN_BUDGET)
         .min(MAX_TOKEN_BUDGET);
+
+    // 0. nw-384. Fail closed BEFORE any retrieval, exactly as `context` does.
+    //    This has to be an up-front refusal and not an after-the-fact check on
+    //    the results, because the two faces of this bug are contradictory:
+    //    "empty" and "fully populated" are both wrong here, and no assertion
+    //    about the RESULT can reject both. The only thing they share is the
+    //    condition, so the condition is what is tested.
+    ensure_ranking_publication_clean(store)?;
 
     // 1. Resolve scope into the seed inputs and an optional post-filter.
     let (seed_inputs, scope_filter) = resolve_scope(store, query, scope)?;
@@ -578,8 +641,33 @@ pub fn investigate(
             );
             nodes
         }
-        Err(_) => bm25_fallback(store, tantivy, query, DEFAULT_RETRIEVAL_BREADTH),
+        Err(e) => {
+            // nw-384. A publication that BEGAN after the step-0 check is the
+            // window this arm used to launder: hybrid retrieval fails closed,
+            // `Err(_)` swallows it, and the BM25 fallback added by `36c8ecab`
+            // — which has no publication check of its own — answers instead.
+            // That fallback is why the large-graph face returned a complete
+            // 30-entry map at exit 0 rather than an empty one.
+            if is_index_publication_failure(&e) {
+                return Err(e);
+            }
+            // Re-check before falling back for the OTHER half of the same
+            // race: the seed path's guards are silent-empty
+            // (`symbols_by_pagerank` -> `Ok(vec![])`), so a publication
+            // starting mid-retrieval can surface as a benign-looking "no seeds
+            // resolved" that carries no publication string to recognise.
+            ensure_ranking_publication_clean(store)?;
+            bm25_fallback(store, tantivy, query, DEFAULT_RETRIEVAL_BREADTH)
+        }
     };
+    // nw-384, third and last site. The `Ok` branch needs its own re-check for
+    // the reason the `Err` branch cannot cover it: the seed path's publication
+    // guards return `Ok(vec![])` / an empty score map rather than an error, so
+    // a publication that began mid-retrieval produces a SUCCESS carrying
+    // silently degraded ranks. Mirrors `compute_pagerank_warm_inner`'s own
+    // mid-compute dirty re-check — the whole point of a fail-closed guard is
+    // that it is cheaper to refuse a good answer than to serve a bad one.
+    ensure_ranking_publication_clean(store)?;
     if let Some(ref filter) = scope_filter {
         connected.retain(|n| node_in_scope(store, n, filter));
     }
@@ -1496,6 +1584,169 @@ mod tests {
             load_bundle(&db_path, &result.bundle_id).is_some(),
             "bundle should be persisted to the sidecar"
         );
+    }
+
+    // ── nw-384: the index-publication fail-closed guard ──────────────────
+    //
+    // A file-backed store is mandatory for these: the marker is a FILE beside
+    // the db, and `index_directory_in_memory` (which every other test here
+    // uses) yields a store with no `db_path` and therefore no marker to be
+    // dirty. That is exactly why this guard could sit unenforced under a full
+    // test suite.
+
+    fn on_disk_store() -> (tempfile::TempDir, std::path::PathBuf, GraphStore) {
+        use nestweaver_schema::{Symbol, SymbolKind, Visibility};
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("nestweaver.lbug");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        for (i, name) in ["greet", "greetUser", "formatGreeting"].iter().enumerate() {
+            store
+                .insert_symbol(&Symbol {
+                    uid: format!("sym:g{i}"),
+                    name: (*name).to_string(),
+                    kind: SymbolKind::Function,
+                    repo_uid: "repo:test".to_string(),
+                    file_path: format!("src/g{i}.js"),
+                    start_line: 1,
+                    end_line: 2,
+                    signature: format!("function {name}()"),
+                    summary: None,
+                    content_hash: format!("g{i}"),
+                    embedding: None,
+                    pagerank_score: None,
+                    is_entry_point: false,
+                    entry_point_kind: None,
+                    visibility: Visibility::Inferred,
+                    type_info: None,
+                    framework_hint: None,
+                    canonical_id: None,
+                })
+                .unwrap();
+        }
+        (dir, db_path, store)
+    }
+
+    /// Plant the same durable marker a real in-flight publication writes.
+    fn begin_publication(db_path: &std::path::Path) {
+        let marker = nestweaver_store::index_publication::marker_path(db_path);
+        fs::write(
+            &marker,
+            nestweaver_store::index_publication::format_marker_payload(std::process::id(), 1, None),
+        )
+        .unwrap();
+    }
+
+    fn run(
+        store: &GraphStore,
+        db_path: &std::path::Path,
+        root: &std::path::Path,
+        query: &str,
+    ) -> Result<InvestigateResult, anyhow::Error> {
+        investigate(
+            store,
+            None,
+            Some(db_path),
+            root,
+            query,
+            "vault",
+            Some(4000),
+            None,
+        )
+    }
+
+    /// FACE ONE — seeds resolve, so retrieval succeeds and `investigate` used
+    /// to hand back `returned: 30, total: 30, truncated: false,
+    /// dropped_reasons: {}` at exit 0 while `context` on the same DB at the
+    /// same moment refused. This is the WORSE face: an empty map invites
+    /// suspicion and a complete-looking one does not.
+    #[test]
+    fn a_dirty_publication_refuses_an_investigation_whose_seeds_resolve() {
+        let (dir, db_path, store) = on_disk_store();
+
+        // The fixture must actually produce a populated answer, or this test
+        // would pass for the wrong reason — refusing something that was empty
+        // anyway proves nothing about the populated face.
+        let clean = run(&store, &db_path, dir.path(), "greet").unwrap();
+        assert!(
+            !clean.entries.is_empty(),
+            "fixture must yield a populated map so the guard is proven against \
+             the face that looks complete"
+        );
+
+        begin_publication(&db_path);
+
+        let error = run(&store, &db_path, dir.path(), "greet")
+            .expect_err("a ranked query must fail closed during a dirty publication");
+        assert!(
+            format!("{error:#}").contains("index publication"),
+            "the error must carry the substring `classify_index_publication_error` keys on, \
+             so `investigate` produces the SAME TRANSIENT/WEDGED message `context` does; got: {error:#}"
+        );
+    }
+
+    /// FACE TWO — no seed resolves, so retrieval bails and the BM25 fallback
+    /// (`36c8ecab`, which carries no publication check) answers. On the sweep's
+    /// smaller graph that produced `0 domains, 0 entries` at exit 0: a "this
+    /// code does not exist" answer. Same guard, opposite symptom; closing only
+    /// one of them closes neither.
+    #[test]
+    fn a_dirty_publication_refuses_an_investigation_that_falls_back_to_bm25() {
+        let (dir, db_path, store) = on_disk_store();
+
+        let clean = run(&store, &db_path, dir.path(), "no_such_identifier_anywhere").unwrap();
+        assert!(
+            clean.entries.is_empty(),
+            "fixture must exercise the empty/fallback face"
+        );
+
+        begin_publication(&db_path);
+
+        let error = run(&store, &db_path, dir.path(), "no_such_identifier_anywhere")
+            .expect_err("the BM25 fallback must fail closed too, not report an empty graph");
+        assert!(
+            format!("{error:#}").contains("index publication"),
+            "got: {error:#}"
+        );
+    }
+
+    /// COUNTERWEIGHT. A clean publication must not trigger the guard on either
+    /// face — a fail-closed check that fires when nothing is in flight would
+    /// convert this honesty fix into an outage.
+    #[test]
+    fn a_clean_publication_does_not_trigger_the_fail_closed_guard() {
+        let (dir, db_path, store) = on_disk_store();
+        assert!(
+            !store.is_index_publication_dirty(),
+            "a freshly created store has no publication in flight"
+        );
+
+        let populated = run(&store, &db_path, dir.path(), "greet")
+            .expect("a clean publication must serve the populated face");
+        assert!(!populated.entries.is_empty());
+
+        let empty = run(&store, &db_path, dir.path(), "no_such_identifier_anywhere")
+            .expect("a clean publication must serve the empty face as a normal answer");
+        assert!(empty.entries.is_empty());
+
+        // And it must still be clean afterwards: the guard reads the marker,
+        // it never plants one.
+        assert!(!store.is_index_publication_dirty());
+    }
+
+    /// A retired marker restores service. The guard is a WINDOW, not a latch —
+    /// if it were a latch, the remedy an operator is told to wait for would
+    /// never take effect.
+    #[test]
+    fn retiring_the_marker_restores_investigation_service() {
+        let (dir, db_path, store) = on_disk_store();
+        begin_publication(&db_path);
+        assert!(run(&store, &db_path, dir.path(), "greet").is_err());
+
+        fs::remove_file(nestweaver_store::index_publication::marker_path(&db_path)).unwrap();
+
+        let result = run(&store, &db_path, dir.path(), "greet")
+            .expect("service resumes once the publication retires");
+        assert!(!result.entries.is_empty());
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -510,6 +510,111 @@ impl TruncationCause {
     }
 }
 
+/// How many symbols ONE bare-name seed input may contribute to the PPR
+/// personalization vector.
+///
+/// nw-393. This cap has existed since the first `context` implementation, as
+/// a bare `5` inlined at two call sites, and it is the only cap in the
+/// pipeline the caller cannot raise: `--limit` bounds the CONNECTED list,
+/// `--token-budget` bounds the rendered output, and neither can recover a
+/// seed that was never resolved. `context validate` on the live graph seeded
+/// PPR from 5 of 200+ symbols named `validate`, and then derived `total`,
+/// `truncated` and `truncated_by: "limit"` from that subgraph — so the one
+/// number that was silently wrong was also the input to every number that
+/// looked right.
+///
+/// ONE constant, for the same reason [`CODE_CONTEXT_DEFAULT_LIMIT`] is one:
+/// `nestweaver context` / `code_context` and `brain context` / `brain_context`
+/// are separate routes to the same seed resolution, and a cap that lives on
+/// only one of them is how the two come to disagree.
+pub const SEED_NAME_MATCH_LIMIT: usize = 5;
+
+/// What the bare-name seed searches matched, versus what they contributed.
+///
+/// nw-393. `seeds_resolved: 5` is INDISTINGUISHABLE from a name that
+/// genuinely has five definitions, which is why a count of survivors is not a
+/// disclosure. This carries the `(returned, total, truncated)` triple
+/// `Bounded` standardised — the same shape nw-353 landed for the CONNECTED
+/// list — one layer earlier, over the SEED set.
+///
+/// [`SearchTotal`] verbatim rather than a bare `usize`: the store's counted
+/// search is precise only up to `SYMBOL_SEARCH_COUNT_CAP`, and collapsing its
+/// `exact` / `lower_bound` relation into a plain number would reintroduce, in
+/// the disclosure itself, exactly the over-confidence this reports on.
+#[derive(Debug, Clone, Copy, Default)]
+struct SeedNameMatchTally {
+    /// Symbols the name searches actually contributed as PPR seeds.
+    resolved: usize,
+    /// Symbols the name searches MATCHED, summed across every bare-name
+    /// input, before [`SEED_NAME_MATCH_LIMIT`] cut.
+    matched: usize,
+    /// `true` once any constituent count saturated `SYMBOL_SEARCH_COUNT_CAP`,
+    /// so `matched` is a floor rather than a census.
+    lower_bound: bool,
+    /// Whether ANY bare-name input matched more than it was allowed to
+    /// contribute. Deliberately not derived from `matched > resolved`: a
+    /// two-input query where one name is capped and the other resolves
+    /// nothing must still report the cap.
+    truncated: bool,
+    /// Whether any bare-name input was resolved at all. `false` means the
+    /// whole tally is inapplicable (UID / file-path / note-title seeds only),
+    /// which is distinct from "resolved, and nothing was cut".
+    applicable: bool,
+}
+
+impl SeedNameMatchTally {
+    /// Fold one bare-name search's page into the tally.
+    ///
+    /// `returned` is the page's own symbol count and not `SEED_NAME_MATCH_LIMIT`,
+    /// because a name with three definitions returns three under a cap of five
+    /// and must not be reported as truncated — that counterweight is the whole
+    /// reason this compares two observed numbers instead of comparing against
+    /// the constant.
+    fn record(&mut self, page: &nestweaver_store::traverse::SymbolSearchPage) {
+        use nestweaver_store::tantivy_index::SearchTotalRelation;
+        self.applicable = true;
+        self.resolved += page.symbols.len();
+        self.matched += page.total.value;
+        if page.total.relation == SearchTotalRelation::LowerBound {
+            self.lower_bound = true;
+        }
+        if page.total.value > page.symbols.len() {
+            self.truncated = true;
+        }
+    }
+
+    /// The honest match total, or `None` when no bare-name input was resolved
+    /// and there is therefore nothing to disclose.
+    fn total(&self) -> Option<usize> {
+        if !self.applicable {
+            return None;
+        }
+        Some(self.matched)
+    }
+
+    /// The relation spelling that rides beside [`Self::total`], using
+    /// `brain_search`'s `"eq"` / `"gte"` vocabulary so one convention covers
+    /// every "count that may be a lower bound" on the wire.
+    fn total_relation(&self) -> Option<String> {
+        if !self.applicable {
+            return None;
+        }
+        Some(if self.lower_bound { "gte" } else { "eq" }.to_string())
+    }
+
+    /// Whether the seed set the caller is holding is a proper subset of what
+    /// its own query named. `None` when no bare-name input was resolved.
+    fn truncated(&self) -> Option<bool> {
+        self.applicable.then_some(self.truncated)
+    }
+
+    /// Symbols the bare-name inputs contributed. `None` when inapplicable, so
+    /// a renderer never prints `0 of 0` for a UID-seeded query.
+    fn resolved(&self) -> Option<usize> {
+        self.applicable.then_some(self.resolved)
+    }
+}
+
 /// The full result returned by `build_context`.
 // Deserialize so the daemon's `code_context` reply round-trips back into the
 // same type the direct path builds, and BOTH render through one function.
@@ -566,6 +671,72 @@ pub struct ContextResult {
     /// the same service `limit` performs for `truncated_by: "limit"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_budget: Option<usize>,
+    /// How many symbols the bare-name seed inputs MATCHED, before
+    /// [`SEED_NAME_MATCH_LIMIT`] cut them down to the PPR seed set.
+    ///
+    /// nw-393. The seed cap is one layer UPSTREAM of everything nw-320 /
+    /// nw-353 disclose: `connected`, `connected_total` and `truncated_by` are
+    /// all computed from the subgraph this cap chose, so a caller reading a
+    /// complete-looking `total: 737` was reading an honest count of an
+    /// arbitrary 5-of-200+ seeding. The store already computes this number and
+    /// the engine used to throw it away by calling the `total`-discarding
+    /// `search_symbols_by_name` wrapper.
+    ///
+    /// `None` when no bare-name input was resolved (UID, file-path or
+    /// note-title seeds only) and there is nothing to disclose — distinct from
+    /// a `Some` total that equals the resolved count, which means "counted,
+    /// and nothing was cut".
+    ///
+    /// The relation is carried alongside in `seed_matches_total_relation`
+    /// (`"eq"` / `"gte"`) rather than nested, so the count never claims a
+    /// census the counted search does not perform past
+    /// `SYMBOL_SEARCH_COUNT_CAP`.
+    ///
+    /// FLAT, NOT A NESTED `SearchTotal`, and this is load-bearing rather than
+    /// cosmetic. This struct is not only a return value: the CLI's DAEMON route
+    /// deserializes the `code_context` MCP payload straight back into it. A
+    /// nested struct made the two routes disagree in SHAPE — the direct route
+    /// serialized `{"value":2,"relation":"exact"}` while the MCP payload built
+    /// the flat `brain_search` spelling — so the daemon route died with
+    /// `invalid type: integer 2, expected struct SearchTotal` and five
+    /// `parity_test` cases failed. Flat is also the spelling `brain_search`
+    /// already ships (`total_matches` + `total_matches_relation`), so there is
+    /// one convention for "a count that may be a lower bound", not two.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed_matches_total: Option<usize>,
+    /// `"eq"` when the count is exact, `"gte"` when the counted search stopped
+    /// at `SYMBOL_SEARCH_COUNT_CAP`. Same spelling as `brain_search`'s
+    /// `total_matches_relation`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed_matches_total_relation: Option<String>,
+    /// Whether the PPR seed set is a proper subset of what the query named.
+    ///
+    /// nw-393. Deliberately a SEPARATE boolean rather than a third
+    /// [`TruncationCause`] variant, and for the reason the impact arm already
+    /// records for `truncated_by_depth` / `truncated_by_limit`: these caps do
+    /// not compose into a precedence. `truncated_by: "limit"` is a correct and
+    /// actionable statement about `connected` even while the seed set was also
+    /// cut, and folding the two would make the caller raise `--limit` — which
+    /// is precisely the misdirection reported, since NO caller-settable knob
+    /// can recover a seed that was never resolved.
+    ///
+    /// `None` when no bare-name input was resolved. `Some(false)` is the
+    /// counterweight case that must stay reachable: a name with exactly
+    /// [`SEED_NAME_MATCH_LIMIT`] definitions resolved all of them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seeds_truncated: Option<bool>,
+    /// The per-input name-match cap that `seeds_truncated` reports on, echoed
+    /// for the same reason `token_budget` is echoed: a disclosure that names a
+    /// cut without naming the bound leaves the caller unable to judge how much
+    /// was lost.
+    ///
+    /// Present whenever the cap was IN FORCE, not only when it bit — same rule
+    /// `token_budget` follows. `{limit: 5, truncated: false}` is a stronger
+    /// statement than an absent field: it says a bound existed and did not
+    /// reach. Not settable today, and that it is a constant is itself what the
+    /// caller needs to know, because it is why no retry can widen it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed_resolution_limit: Option<usize>,
 }
 
 /// Detect whether an input string looks like a file path.
@@ -582,7 +753,10 @@ fn is_file_path(input: &str) -> bool {
 /// Each entry in `inputs` is resolved to one or more symbol UIDs:
 /// - Starts with `"sym:"` or `"repo:"` → UID lookup
 /// - Looks like a file path → `symbols_in_file`
-/// - Otherwise → `search_symbols_by_name(input, 5)`
+/// - Otherwise → a name search bounded by [`SEED_NAME_MATCH_LIMIT`], whose
+///   pre-cap match count is reported as `seed_matches_total` /
+///   `seeds_truncated` (nw-393) because no caller-settable knob can recover a
+///   seed this cap dropped
 ///
 /// Personalized PageRank (d = 0.85, 20 iterations) is then run from all
 /// resolved seeds and the results are split into `seeds` and `connected`.
@@ -620,6 +794,12 @@ pub fn build_context_with_intent(
 ) -> Result<ContextResult, anyhow::Error> {
     let mut seed_uids: Vec<String> = Vec::new();
     let mut file_paths_tried: Vec<String> = Vec::new();
+    // nw-393. Accumulated across every bare-name input so the cap that chose
+    // the PPR personalization vector is reportable at all. Without it the only
+    // seed number any surface could quote was `seeds.len()` — a count of
+    // survivors, which agrees with the returned list by construction and so
+    // reads identically whether the name had five definitions or five hundred.
+    let mut seed_name_tally = SeedNameMatchTally::default();
 
     for input in inputs {
         if input.starts_with("sym:") || input.starts_with("repo:") {
@@ -644,15 +824,22 @@ pub fn build_context_with_intent(
                 seed_uids.push(sym.uid);
             }
         } else {
-            // Name search — take up to 5 matches.
-            let matches = store
-                .search_symbols_by_name(
+            // Name search — take up to `SEED_NAME_MATCH_LIMIT` matches.
+            //
+            // nw-393: the `_page` variant, not the `total`-discarding
+            // `search_symbols_by_name` wrapper. Both run the identical scan;
+            // the wrapper's only difference is that it drops the count on the
+            // floor, and that dropped count is the entire disclosure gap —
+            // the honest number was already computed on every single call.
+            let page = store
+                .search_symbols_by_name_page(
                     input,
-                    5,
+                    SEED_NAME_MATCH_LIMIT,
                     &nestweaver_store::SeedResolutionConfig::default(),
                 )
                 .map_err(|e| anyhow::anyhow!(e))?;
-            for sym in matches {
+            seed_name_tally.record(&page);
+            for sym in page.symbols {
                 seed_uids.push(sym.uid);
             }
         }
@@ -761,6 +948,16 @@ pub fn build_context_with_intent(
         // policy the caller chose, it is a fact only this traversal can
         // observe, so the engine is the only layer that CAN report it.
         connected_total: Some(connected_total),
+        // nw-393. Same argument as `connected_total`, one layer earlier: the
+        // seed cap is the engine's own, no caller states it and no caller can
+        // raise it, so the engine is the only layer that can report it — and
+        // it is reported unconditionally rather than left for a caller to
+        // "decide whether the extra row arrived", because there is no extra
+        // row to ask for.
+        seed_matches_total: seed_name_tally.total(),
+        seed_matches_total_relation: seed_name_tally.total_relation(),
+        seeds_truncated: seed_name_tally.truncated(),
+        seed_resolution_limit: seed_name_tally.resolved().map(|_| SEED_NAME_MATCH_LIMIT),
     })
 }
 
@@ -812,6 +1009,7 @@ mod promote_tests {
             semantic_applied: false,
             semantic_seed_count: 0,
             degraded_components: vec![],
+            ..Default::default()
         };
         let members: HashSet<String> = ["note:prd".to_string(), "note:status".to_string()]
             .into_iter()
@@ -842,6 +1040,7 @@ mod promote_tests {
             semantic_applied: false,
             semantic_seed_count: 0,
             degraded_components: vec![],
+            ..Default::default()
         };
         let members: HashSet<String> = ["note:prd".to_string()].into_iter().collect();
 
@@ -881,6 +1080,7 @@ mod promote_tests {
             semantic_applied: false,
             semantic_seed_count: 0,
             degraded_components: vec![],
+            ..Default::default()
         };
         let members: HashSet<String> = ["sym:foo".to_string(), "sym:bar".to_string()]
             .into_iter()
@@ -913,6 +1113,7 @@ mod promote_tests {
             semantic_applied: false,
             semantic_seed_count: 0,
             degraded_components: vec![],
+            ..Default::default()
         };
         let members: HashSet<String> = ["sym:foo".to_string()].into_iter().collect();
 
@@ -1298,7 +1499,10 @@ fn is_zero_usize(n: &usize) -> bool {
     *n == 0
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+// `Default` so the three disclosure fields nw-393 added (and any future one)
+// can be appended without rewriting every struct literal that only cares about
+// two of them — that churn is what keeps honesty fields out of shared types.
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct BrainContextResult {
     /// Resolved seed nodes. The MCP `brain_context` tool omits this field
     /// when `include_seeds=false` is requested, so deserializing daemon
@@ -1337,6 +1541,36 @@ pub struct BrainContextResult {
     /// PPR, and BM25 legs remain usable when semantic retrieval degrades.
     #[serde(default)]
     pub degraded_components: Vec<String>,
+    /// nw-393, brain half. How many symbols the bare-name seed inputs MATCHED
+    /// before [`SEED_NAME_MATCH_LIMIT`] cut them down to the PPR seed set.
+    ///
+    /// The twin of [`ContextResult::seed_matches_total`], and it exists
+    /// separately because `brain context` / `brain_context` resolve seeds
+    /// through their OWN loop (UID prefixes, note titles, tags, projects,
+    /// aliases, then symbol names) rather than through `build_context`. The
+    /// same cap sat inlined in both loops; a disclosure on only one of them is
+    /// how the two routes would start disagreeing about the same query.
+    ///
+    /// `None` when no bare-name input reached symbol search — UID, tag, note
+    /// title, project and semantic-only seeds are not capped by this bound and
+    /// must not be described as if they were.
+    ///
+    /// [`SearchTotal`]: nestweaver_store::tantivy_index::SearchTotal
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed_matches_total: Option<usize>,
+    /// `"eq"` / `"gte"`; see [`ContextResult::seed_matches_total_relation`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed_matches_total_relation: Option<String>,
+    /// Whether the seed set is a proper subset of what the query named.
+    /// `Some(false)` — a name with exactly [`SEED_NAME_MATCH_LIMIT`]
+    /// definitions — is the counterweight case and must stay reachable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seeds_truncated: Option<bool>,
+    /// The cap `seeds_truncated` reports on, echoed so the caller can see the
+    /// bound and not merely that a bound existed. Present whenever the cap was
+    /// in force, matching `ContextResult::seed_resolution_limit`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed_resolution_limit: Option<usize>,
 }
 
 /// Surface a project's curated member notes into the rendered `connected`
@@ -1605,6 +1839,10 @@ pub fn build_brain_context_hybrid_with_aliases(
 
     let mut seed_uids: Vec<String> = Vec::new();
     let mut unresolved: Vec<String> = Vec::new();
+    // nw-393. Only bare-name symbol resolution is capped here; UID, tag, note
+    // title and project seeds are exhaustive, so an inapplicable tally reports
+    // nothing rather than a misleading `0 of 0`.
+    let mut seed_name_tally = SeedNameMatchTally::default();
 
     for raw in inputs {
         let trimmed = raw.trim();
@@ -1647,11 +1885,17 @@ pub fn build_brain_context_hybrid_with_aliases(
         // [`HybridSearchConfig::seed_resolution`] (sourced from
         // `[seed_resolution]` in instance config) so user overrides actually
         // take effect at seed resolution.
-        let symbol_matches = store
-            .search_symbols_by_name(trimmed, 5, &config.seed_resolution)
+        //
+        // nw-393: `_page`, not the `total`-discarding wrapper. `brain context`
+        // reported `semantic_seed_count: 5` for a name with 200+ definitions
+        // and nothing distinguished that from a name with five — the count was
+        // computed by this very call and dropped one frame later.
+        let symbol_page = store
+            .search_symbols_by_name_page(trimmed, SEED_NAME_MATCH_LIMIT, &config.seed_resolution)
             .map_err(|e| anyhow::anyhow!(e))?;
-        if !symbol_matches.is_empty() {
-            for s in symbol_matches {
+        if !symbol_page.symbols.is_empty() {
+            seed_name_tally.record(&symbol_page);
+            for s in symbol_page.symbols {
                 seed_uids.push(s.uid);
             }
             continue;
@@ -1912,6 +2156,13 @@ pub fn build_brain_context_hybrid_with_aliases(
         } else {
             Vec::new()
         },
+        // nw-393. Reported unconditionally: the seed cap is the engine's own,
+        // it is not a policy any caller stated, and the `None` case already
+        // encodes "no bare-name input was capped by it".
+        seed_matches_total: seed_name_tally.total(),
+        seed_matches_total_relation: seed_name_tally.total_relation(),
+        seeds_truncated: seed_name_tally.truncated(),
+        seed_resolution_limit: seed_name_tally.resolved().map(|_| SEED_NAME_MATCH_LIMIT),
     })
 }
 
@@ -2726,6 +2977,179 @@ pub fn expand_query_with_aliases(
     format!("{} {}", query, expansions.join(" "))
 }
 
+// nw-393. The seed cap is the ONE cap in the context pipeline that no caller
+// can raise, so a disclosure of it is the only thing that distinguishes "this
+// name has five definitions" from "this name has two hundred and you were
+// handed five of them". Both routes are tested because the cap sat inlined in
+// two separate seed loops (`build_context` and the brain hybrid path) and a
+// fix to one of them is how the two routes start disagreeing.
+#[cfg(test)]
+mod seed_resolution_disclosure_tests {
+    use nestweaver_schema::{Symbol, SymbolKind, Visibility};
+    use nestweaver_store::GraphStore;
+
+    use super::{
+        HybridSearchConfig, SEED_NAME_MATCH_LIMIT, build_brain_context_hybrid_with_aliases,
+        build_context,
+    };
+
+    fn symbol(uid: &str, name: &str) -> Symbol {
+        Symbol {
+            uid: format!("sym:{uid}"),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            repo_uid: "repo:test".to_string(),
+            file_path: format!("src/{uid}.rs"),
+            start_line: 1,
+            end_line: 2,
+            signature: format!("fn {name}()"),
+            summary: None,
+            content_hash: uid.to_string(),
+            embedding: None,
+            pagerank_score: None,
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Inferred,
+            type_info: None,
+            framework_hint: None,
+            canonical_id: None,
+        }
+    }
+
+    /// `count` distinct symbols whose names all contain `validate`, and one
+    /// control that does not — so a total that accidentally counted the whole
+    /// symbol table would be caught rather than passing by coincidence.
+    fn store_with_validate_definitions(count: usize) -> GraphStore {
+        let store = GraphStore::in_memory().unwrap();
+        for i in 0..count {
+            store
+                .insert_symbol(&symbol(&format!("v{i}"), &format!("validate{i}")))
+                .unwrap();
+        }
+        store.insert_symbol(&symbol("other", "unrelated")).unwrap();
+        store
+    }
+
+    fn brain_context_for(
+        store: &GraphStore,
+        seed: &str,
+    ) -> Result<super::BrainContextResult, anyhow::Error> {
+        build_brain_context_hybrid_with_aliases(
+            store,
+            &[seed.to_string()],
+            None,
+            &HybridSearchConfig::default(),
+            &std::collections::HashMap::new(),
+            None,
+            None,
+            None,
+            None,
+        )
+    }
+
+    #[test]
+    fn a_seed_name_with_more_definitions_than_the_cap_cannot_report_a_complete_seed_set() {
+        let store = store_with_validate_definitions(50);
+
+        let result = build_context(&store, &["validate".to_string()]).unwrap();
+
+        let total = result
+            .seed_matches_total
+            .expect("a bare-name seed must report what it matched");
+        assert_eq!(
+            total, 50,
+            "the honest match count is computed by the same scan that returns the seeds"
+        );
+        assert_eq!(
+            result.seed_matches_total_relation.as_deref(),
+            Some("eq"),
+            "50 is far below SYMBOL_SEARCH_COUNT_CAP, so the count is a census not a floor"
+        );
+        assert_eq!(
+            result.seeds_truncated,
+            Some(true),
+            "45 of 50 definitions never entered the PPR personalization vector"
+        );
+        assert_eq!(
+            result.seed_resolution_limit,
+            Some(SEED_NAME_MATCH_LIMIT),
+            "naming the cut without naming the bound leaves the caller unable to judge the loss"
+        );
+    }
+
+    /// Counterweight. The disclosure must not fire on a name that genuinely has
+    /// exactly as many definitions as the cap allows — that case is
+    /// indistinguishable from the bug by seed COUNT alone, which is precisely
+    /// why the count was never a disclosure.
+    #[test]
+    fn a_seed_name_with_exactly_the_cap_many_definitions_is_not_reported_as_truncated() {
+        let store = store_with_validate_definitions(SEED_NAME_MATCH_LIMIT);
+
+        let result = build_context(&store, &["validate".to_string()]).unwrap();
+
+        assert_eq!(
+            result.seed_matches_total,
+            Some(SEED_NAME_MATCH_LIMIT),
+            "every definition matched"
+        );
+        assert_eq!(
+            result.seeds_truncated,
+            Some(false),
+            "a complete seed set must not be reported as cut"
+        );
+        assert_eq!(
+            result.seed_resolution_limit,
+            Some(SEED_NAME_MATCH_LIMIT),
+            "the bound is echoed whenever it was in force — `limit: 5, truncated: false` \
+             says more than an absent field, exactly as `token_budget` does"
+        );
+    }
+
+    /// A UID-seeded query is not bounded by this cap at all. Reporting
+    /// `0 of 0` there would be a second false disclosure, not a fix.
+    #[test]
+    fn a_seed_form_the_cap_does_not_bound_reports_no_seed_truncation_at_all() {
+        let store = store_with_validate_definitions(50);
+
+        let result = build_context(&store, &["sym:v0".to_string()]).unwrap();
+
+        assert_eq!(
+            result.seed_matches_total, None,
+            "UID lookup is exhaustive; it has no match total to disclose"
+        );
+        assert_eq!(result.seeds_truncated, None);
+        assert_eq!(result.seed_resolution_limit, None);
+    }
+
+    #[test]
+    fn brain_context_discloses_the_same_seed_cut_the_code_route_does() {
+        let store = store_with_validate_definitions(50);
+
+        let result = brain_context_for(&store, "validate").unwrap();
+
+        assert_eq!(
+            result.seed_matches_total,
+            Some(50),
+            "`brain context` resolves seeds through its own loop and must not \
+             under-report where `nestweaver context` reports"
+        );
+        assert_eq!(result.seeds_truncated, Some(true));
+        assert_eq!(result.seed_resolution_limit, Some(SEED_NAME_MATCH_LIMIT));
+    }
+
+    /// Counterweight for the brain route.
+    #[test]
+    fn brain_context_does_not_report_a_seed_cut_that_did_not_happen() {
+        let store = store_with_validate_definitions(SEED_NAME_MATCH_LIMIT);
+
+        let result = brain_context_for(&store, "validate").unwrap();
+
+        assert_eq!(result.seed_matches_total, Some(SEED_NAME_MATCH_LIMIT));
+        assert_eq!(result.seeds_truncated, Some(false));
+        assert_eq!(result.seed_resolution_limit, Some(SEED_NAME_MATCH_LIMIT));
+    }
+}
+
 #[cfg(test)]
 mod render_brain_node_tests {
     use nestweaver_schema::{Note, NoteKind, Section};
@@ -3414,6 +3838,7 @@ mod dedup_heading_section_tests {
             semantic_applied: false,
             semantic_seed_count: 0,
             degraded_components: vec![],
+            ..Default::default()
         }
     }
 

--- a/crates/nestweaver-federation/src/results.rs
+++ b/crates/nestweaver-federation/src/results.rs
@@ -609,6 +609,63 @@ pub fn merge_structured_results(local: &Value, server: &Value) -> Value {
             let seeds_len = result["seeds"].as_array().map_or(0, Vec::len);
             result["seeds_resolved"] = Value::from(seeds_len);
         }
+        // nw-393. The SEED cap, merged across tiers.
+        //
+        // `seed_resolution_limit` is a compile-time BOUND, not a count — both
+        // tiers run the same `SEED_NAME_MATCH_LIMIT` — so it is CARRIED, never
+        // summed. Summing a bound would state a limit neither tier applied.
+        //
+        // `seeds_truncated` is the OR: a seed cut on EITHER tier means the
+        // merged seed set is short, and a `false` from the other tier cannot
+        // undo that.
+        //
+        // `seed_matches_total` is SUMMED — but the sum cannot be exact, and
+        // saying so is the whole point of carrying a relation. The
+        // matched-but-CUT symbols never reach the payload, so unlike
+        // `seeds_resolved` above (which is recomputed from the merged array
+        // precisely because `rrf_merge` deduplicates) there is nothing here to
+        // deduplicate against: a repo indexed on BOTH tiers is counted twice
+        // and we cannot detect it. So whenever both tiers contributed a total,
+        // the merged relation is forced to `gte` — the sum is an honest LOWER
+        // BOUND, which is exactly what `SearchTotal`'s `gte` already means.
+        // Reporting a two-tier sum as `eq` would be the one answer that is
+        // affirmatively wrong.
+        let local_total = local.get("seed_matches_total").and_then(Value::as_u64);
+        let server_total = server.get("seed_matches_total").and_then(Value::as_u64);
+        if local_total.is_some() || server_total.is_some() {
+            let summed = local_total
+                .unwrap_or(0)
+                .saturating_add(server_total.unwrap_or(0));
+            result["seed_matches_total"] = Value::from(summed);
+            let either_is_gte = [
+                local.get("seed_matches_total_relation"),
+                server.get("seed_matches_total_relation"),
+            ]
+            .iter()
+            .flatten()
+            .any(|v| v.as_str() == Some("gte"));
+            let both_contributed = local_total.is_some() && server_total.is_some();
+            result["seed_matches_total_relation"] =
+                Value::from(if either_is_gte || both_contributed {
+                    "gte"
+                } else {
+                    "eq"
+                });
+        }
+        let local_cut = local.get("seeds_truncated").and_then(Value::as_bool);
+        let server_cut = server.get("seeds_truncated").and_then(Value::as_bool);
+        if local_cut.is_some() || server_cut.is_some() {
+            result["seeds_truncated"] =
+                Value::from(local_cut.unwrap_or(false) || server_cut.unwrap_or(false));
+        }
+        if let Some(bound) = local
+            .get("seed_resolution_limit")
+            .or_else(|| server.get("seed_resolution_limit"))
+            .and_then(Value::as_u64)
+        {
+            result["seed_resolution_limit"] = Value::from(bound);
+        }
+
         // `limit` and `truncated` must survive AND be re-honoured.
         //
         // Carrying them through is not enough: each tier caps at the SAME

--- a/crates/nestweaver-mcp/src/lib.rs
+++ b/crates/nestweaver-mcp/src/lib.rs
@@ -70,6 +70,67 @@ fn open_direct_read_only_store(db_path: &Path) -> Result<GraphStore, anyhow::Err
         .with_context(|| format!("open read-only GraphStore at {}", db_path.display()))
 }
 
+/// Warm the in-memory PageRank cache from the `<db>.lbug.pagerank.json`
+/// sidecar, RETURNING the loader's refusal instead of discarding it.
+///
+/// nw-391. Every front end did this — the CLI's `open_store`, the daemon's
+/// boot, and the stdio server below — with the identical three lines, the last
+/// of which was literally `let _ = store.load_pagerank_cache(&pr_path);`. The
+/// loader is strict and correct: it validates the artifact envelope's brain
+/// UUID, publication UUID, source graph generation, producer version,
+/// algorithm fingerprint and payload BLAKE3, and on any mismatch it invalidates
+/// the ranking caches and returns a message that names the file, names the
+/// field that did not match, and prescribes a re-index. All three callers threw
+/// that away — so a sidecar one generation behind, which is exactly what a
+/// restored backup, a copied database or the 9.0.0 resolver-generation bump
+/// leaves, was refused in total silence at exit 0 while every ranked surface
+/// (`hubs`, `bridges`, `repo-map`, `context`, `investigate`) answered from
+/// whatever the store did next.
+///
+/// WHAT IS FIXED HERE IS THE SILENCE, and the scope is worth stating precisely
+/// because nw-391 reports a worse symptom than reproduced on this branch. The
+/// item measured an 11-symbol graph collapsing to a uniform 0.0909 = 1/11 after
+/// any one of three envelope fields was tampered with. Re-measuring 9.0.5 on a
+/// scratch graph through `hubs` and `repo-map`, both routes returned ranks
+/// byte-identical to the untampered baseline: the loader invalidates the cache
+/// BEFORE it validates, so the next `pagerank_scores()` finds an empty cache
+/// and recomputes from the graph. That is also why the item's own perverse
+/// finding holds — an unparseable sidecar, a truncated one, a directory and a
+/// `chmod 000` file all fail earlier in the same function and all rank
+/// correctly. The recompute is therefore not something this change adds; it is
+/// something the tests below now PIN, alongside the disclosure that was
+/// missing.
+///
+/// Returns `None` when the sidecar loaded, when it is absent (the loader treats
+/// that as a no-op), or during a dirty index publication (also a no-op, and
+/// deliberately not an error — see `load_pagerank_cache`). `Some(message)` is
+/// an operator-facing sentence; the caller chooses the channel, because a CLI
+/// writes to stderr and a daemon writes to `tracing`.
+///
+/// It lives in this crate because it is the only one both the `nestweaver`
+/// binary and `nestweaver-daemon` depend on, and a single function is the only
+/// way three front ends can be made to AGREE rather than to each remember.
+pub fn warm_pagerank_from_sidecar(store: &GraphStore, db_path: &Path) -> Option<String> {
+    // nw-029: the canonical sidecar name. `with_extension` yielded
+    // `<db>.pagerank.json` and the writers all produce `<db>.lbug.pagerank.json`,
+    // so a front end that reinvents this path warm-loads nothing at all.
+    nestweaver_engine::migrate_sidecar(db_path, "pagerank.json", ".pagerank.json");
+    let pr_path = nestweaver_engine::sidecar_path(db_path, ".pagerank.json");
+    match store.load_pagerank_cache(&pr_path) {
+        Ok(()) => None,
+        // The loader's own sentence is carried verbatim rather than
+        // paraphrased. It already names the field that did not match and ends
+        // in a runnable `nestweaver index --repo <path> --force`, and a
+        // paraphrase here is how three front ends start describing the same
+        // file three different ways again.
+        Err(error) => Some(format!(
+            "ranking sidecar {} was not loaded, so ranks are recomputed from \
+             the graph and the sidecar stays stale: {error}",
+            pr_path.display()
+        )),
+    }
+}
+
 /// Run the brain server on stdio until the client closes stdin or sends
 /// no more lines. Returns Ok on clean shutdown; errors only on truly
 /// unrecoverable conditions (the database failing to open, etc.). Per-call
@@ -102,9 +163,16 @@ pub fn run_stdio_server(
 
     let store = open_direct_read_only_store(db_path)?;
     // Pre-load the PageRank sidecar if present — same behaviour as the CLI.
-    nestweaver_engine::migrate_sidecar(db_path, "pagerank.json", ".pagerank.json");
-    let pr_path = nestweaver_engine::sidecar_path(db_path, ".pagerank.json");
-    let _ = store.load_pagerank_cache(&pr_path);
+    //
+    // nw-391: and disclose a refusal. stderr is the only channel available
+    // here that is not the MCP wire — stdout carries JSON-RPC frames and
+    // NOTHING else may go there (see the module header), and this runs before
+    // any request exists to attach a notification to. `tracing` is configured
+    // by the caller to write to stderr, which is where an MCP client shows
+    // server diagnostics.
+    if let Some(disclosure) = warm_pagerank_from_sidecar(&store, db_path) {
+        tracing::warn!("{disclosure}");
+    }
 
     // Load interaction memory scores so PPR can apply a small bias toward
     // frequently-accessed nodes.
@@ -1641,5 +1709,178 @@ mod line_separator_framing_tests {
         assert_eq!(line, frame, "an escaped sequence is left exactly as it was");
         let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
         assert_eq!(parsed["result"]["text"].as_str().unwrap(), "a\u{2028}b");
+    }
+}
+
+/// nw-391. The PageRank sidecar disclosure, and the counterweight that a VALID
+/// sidecar still loads silently.
+#[cfg(test)]
+mod pagerank_sidecar_disclosure_tests {
+    use nestweaver_schema::{EdgeType, ResolvedEdge, Symbol, SymbolKind, Visibility};
+    use nestweaver_store::{GraphScope, GraphStore};
+
+    use super::warm_pagerank_from_sidecar;
+
+    fn symbol(uid: &str, name: &str) -> Symbol {
+        Symbol {
+            uid: uid.to_string(),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            repo_uid: "repo-1".to_string(),
+            file_path: "src/lib.rs".to_string(),
+            start_line: 1,
+            end_line: 1,
+            signature: format!("fn {name}()"),
+            summary: None,
+            content_hash: "hash".to_string(),
+            embedding: None,
+            pagerank_score: None,
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Inferred,
+            type_info: None,
+            framework_hint: None,
+            canonical_id: None,
+        }
+    }
+
+    fn calls(source: &str, target: &str) -> ResolvedEdge {
+        ResolvedEdge {
+            source_uid: source.to_string(),
+            target_uid: target.to_string(),
+            edge_type: EdgeType::Calls,
+            confidence: 1.0,
+            link_type: None,
+            evidence: Vec::new(),
+        }
+    }
+
+    /// A graph whose ranks are demonstrably NOT uniform, so "flat" is a
+    /// detectable outcome rather than an assumption. `sink` is called by both
+    /// of the others; `source` is called by nobody.
+    fn seeded_store(db: &std::path::Path) -> GraphStore {
+        let store = GraphStore::create(db).unwrap();
+        for (uid, name) in [("A", "source"), ("B", "middle"), ("C", "sink")] {
+            store.insert_symbol(&symbol(uid, name)).unwrap();
+        }
+        store.insert_edge(&calls("A", "B")).unwrap();
+        store.insert_edge(&calls("B", "C")).unwrap();
+        store.insert_edge(&calls("A", "C")).unwrap();
+        store
+    }
+
+    fn spread(scores: &std::collections::HashMap<String, f64>) -> f64 {
+        let max = scores.values().cloned().fold(f64::MIN, f64::max);
+        let min = scores.values().cloned().fold(f64::MAX, f64::min);
+        max - min
+    }
+
+    /// nw-391. The whole item in one test: a sidecar the loader REFUSES must
+    /// not pass unremarked, and the ranks that come out must not be the flat
+    /// 1/N the refusal used to leave behind.
+    ///
+    /// The tamper is `source_graph_generation`, which is the field a restored
+    /// backup, a copied database and the 9.0.0 resolver-generation bump all
+    /// change in the real world — the reason this is not an academic
+    /// corruption case.
+    #[test]
+    fn a_generation_mismatched_sidecar_is_disclosed_and_does_not_yield_flat_ranks() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("graph.lbug");
+        let sidecar = dir.path().join("graph.lbug.pagerank.json");
+
+        let store = seeded_store(&db);
+        store
+            .compute_pagerank(0.85, 20, &GraphScope::code_only())
+            .unwrap();
+        store.save_pagerank_cache(&sidecar).unwrap();
+        drop(store);
+
+        // COUNTERWEIGHT, and it runs FIRST so a disclosure that fires for every
+        // sidecar cannot pass this test: the artifact just written is valid,
+        // must load, and must say nothing at all.
+        let store = GraphStore::open(&db).unwrap();
+        assert_eq!(
+            warm_pagerank_from_sidecar(&store, &db),
+            None,
+            "a valid sidecar must load silently — a warning on every open is \
+             noise that trains the operator to ignore the real one"
+        );
+        let loaded = store.pagerank_scores().unwrap();
+        assert!(
+            spread(&loaded) > 1e-6,
+            "the fixture must produce non-uniform ranks or the flat check below \
+             asserts nothing: {loaded:?}"
+        );
+        drop(store);
+
+        // Now the reported state: a well-formed envelope that does not match.
+        let mut envelope: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&sidecar).unwrap()).unwrap();
+        let generation = envelope["source_graph_generation"].as_u64().unwrap();
+        envelope["source_graph_generation"] = serde_json::json!(generation + 7);
+        std::fs::write(&sidecar, serde_json::to_vec_pretty(&envelope).unwrap()).unwrap();
+
+        let store = GraphStore::open(&db).unwrap();
+        let disclosure = warm_pagerank_from_sidecar(&store, &db)
+            .expect("a refused sidecar must reach the caller, not `let _ =`");
+        assert!(
+            disclosure.contains("nestweaver index"),
+            "the loader's own RUNNABLE remedy must survive the trip: {disclosure}"
+        );
+        assert!(
+            disclosure.contains("generation"),
+            "the disclosure must name what did not match: {disclosure}"
+        );
+        assert!(
+            disclosure.contains("graph.lbug.pagerank.json"),
+            "the disclosure must name the file it refused: {disclosure}"
+        );
+
+        // And the ranks themselves: 1/N for every symbol is the silent-wrong
+        // -answer this item is about, and it is what the caller gets if the
+        // refusal leaves an empty cache nobody refills.
+        let after = store.pagerank_scores().unwrap();
+        assert!(
+            spread(&after) > 1e-6,
+            "a refused sidecar collapsed ranking to uniform 1/N: {after:?}"
+        );
+    }
+
+    /// The other two envelope fields nw-391 measured, checked because they fail
+    /// at DIFFERENT validation stages — identity before the payload digest — and
+    /// a fix that only reached one stage would look complete against a single
+    /// tamper.
+    #[test]
+    fn a_foreign_brain_or_a_tampered_payload_is_disclosed_the_same_way() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("graph.lbug");
+        let sidecar = dir.path().join("graph.lbug.pagerank.json");
+
+        let store = seeded_store(&db);
+        store
+            .compute_pagerank(0.85, 20, &GraphScope::code_only())
+            .unwrap();
+        store.save_pagerank_cache(&sidecar).unwrap();
+        let valid = std::fs::read(&sidecar).unwrap();
+        drop(store);
+
+        for field in ["brain_uuid", "payload_blake3"] {
+            let mut envelope: serde_json::Value = serde_json::from_slice(&valid).unwrap();
+            // A well-FORMED value of the right shape, not garbage: an
+            // unparseable file already behaved correctly before this fix.
+            envelope[field] = serde_json::json!("00000000-0000-4000-8000-000000000000");
+            std::fs::write(&sidecar, serde_json::to_vec_pretty(&envelope).unwrap()).unwrap();
+
+            let store = GraphStore::open(&db).unwrap();
+            assert!(
+                warm_pagerank_from_sidecar(&store, &db).is_some(),
+                "a mismatched `{field}` must be disclosed"
+            );
+            assert!(
+                spread(&store.pagerank_scores().unwrap()) > 1e-6,
+                "a mismatched `{field}` collapsed ranking to uniform 1/N"
+            );
+        }
     }
 }

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -82,24 +82,242 @@ fn resolve_symbol_uid(store: &GraphStore, name_or_uid: &str) -> Result<String, a
     }
 }
 
-/// Build a map from repo UID → display name for repo filter matching.
-fn build_repo_name_map(store: &GraphStore) -> std::collections::HashMap<String, String> {
-    store
+// ── nw-405/406/407: scope filters for brain_context / project_context ───────
+
+/// Which container owns a graph node, decided from the node's UID alone.
+///
+/// nw-405. `brain_context`'s and `project_context`'s `repos:` / `vaults:`
+/// filters used to answer this question with
+/// `n.uid.to_lowercase().contains(r) || n.location.to_lowercase().contains(r)`,
+/// commented "Fallback: UID or location substring". That is a text search, not
+/// an ownership test, and it was wrong in FOUR separately measured directions
+/// on the live 44-repo + 1-vault graph:
+///
+///  * OVER-INCLUDE, vault: `repos:["nestweaver"]` returned 14 of 20 rows as
+///    `note:`/`sec:`/`head:` nodes under `Workspaces/NestWeaver/` — vault
+///    content, which belongs to no repo at all. On a consulting vault that is
+///    `repos:["clientA"]` returning clientB's notes because the PATH happens
+///    to contain the string.
+///  * OVER-INCLUDE, collision: `repos:["website"]` returned symbols from TWO
+///    different repos, because display names collide under `.contains()`.
+///  * UNDER-INCLUDE: `--repos website` returned ZERO symbols from the repo it
+///    named — a symbol's `location` is REPO-RELATIVE and therefore never
+///    contains its own repo name.
+///  * The documented UID form `repos:["repo:kory-brain:21ada82cccf0"]`
+///    answered `connected: 0`.
+///
+/// The UID is the authority because it is the only field on a `BrainNode` that
+/// NAMES an owner: `sym:`/`file:`/`svc:` embed the whole `repo:{inst}:{hash}`,
+/// and `note:`/`sec:`/`head:`/`tag:` embed the whole `vlt:{inst}:{hash}`.
+/// `location` names neither.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum NodeOwner {
+    /// Owned by this repo UID.
+    Repo(String),
+    /// Owned by this vault UID. Vault content carries no `repo_uid` at all —
+    /// the same fact `RepoScope::NotRepoScoped` is written on.
+    Vault(String),
+    /// Nothing in the UID names an owner.
+    Unattributable,
+}
+
+/// The owner of `uid`.
+///
+/// The match is over [`nestweaver_schema::uid::UidKind`] rather than an `if`
+/// chain of `starts_with`, for nw-301's reason: an `if` chain cannot be
+/// exhaustive, so a twelfth UID domain would fall silently into whatever the
+/// trailing arm does instead of failing this build.
+fn node_owner(uid: &str) -> NodeOwner {
+    use nestweaver_schema::uid::UidKind;
+
+    /// `{prefix}{owner_uid}:{…}` — an owner UID is always exactly three
+    /// colon-separated components (`repo:{inst}:{hash}`, `vlt:{inst}:{hash}`),
+    /// so take three and discard the node-specific tail.
+    fn owner_head(rest: &str) -> Option<String> {
+        let parts: Vec<&str> = rest.splitn(4, ':').collect();
+        (parts.len() >= 3).then(|| format!("{}:{}:{}", parts[0], parts[1], parts[2]))
+    }
+
+    let Some(kind) = UidKind::of(uid) else {
+        return NodeOwner::Unattributable;
+    };
+    let rest = &uid[kind.prefix().len()..];
+    match kind {
+        // The container node itself.
+        UidKind::Repo => NodeOwner::Repo(uid.to_string()),
+        UidKind::Vault => NodeOwner::Vault(uid.to_string()),
+        // `{prefix}{repo_uid}:{…}`
+        UidKind::File | UidKind::Service | UidKind::Symbol => {
+            owner_head(rest).map_or(NodeOwner::Unattributable, NodeOwner::Repo)
+        }
+        // `{prefix}{vault_uid}:{…}`
+        UidKind::Note | UidKind::Tag => {
+            owner_head(rest).map_or(NodeOwner::Unattributable, NodeOwner::Vault)
+        }
+        // `sec:{note_uid}:{…}` / `head:{note_uid}:{…}`, and a note UID is
+        // itself `note:{vault_uid}:{…}`, so the inner `note:` comes off too.
+        UidKind::Section | UidKind::Heading => rest
+            .strip_prefix(UidKind::Note.prefix())
+            .and_then(owner_head)
+            .map_or(NodeOwner::Unattributable, NodeOwner::Vault),
+        // `proj:{instance}:{hash}` names an INSTANCE, not a repo, and a
+        // contract UID carries no repo component at all (see
+        // `tool_cross_repo_contracts`'s `FailClosed` reason). Neither can be
+        // attributed, so neither survives a scope filter.
+        UidKind::Project | UidKind::Contract => NodeOwner::Unattributable,
+    }
+}
+
+/// Resolve caller-supplied `repos:` entries to concrete repo UIDs.
+///
+/// nw-405's acceptance criterion is "each entry resolves to a concrete
+/// `repo_uid` (exact name / uid / url, erroring on unresolvable)". The
+/// resolution is [`nestweaver_engine::resolve_repo_selector`] — the SAME
+/// resolver `--repo` already uses everywhere else — so these two tools cannot
+/// grow a second, drifting notion of what a repo name means, and an ambiguous
+/// selector (`website` under two orgs) FAILS naming both candidates instead of
+/// quietly merging two tenants' code into one answer.
+///
+/// `visible` filters the candidate set first. Without it the resolver's own
+/// "not found" / "ambiguous, candidates are …" messages would enumerate repos
+/// a repo-scoped caller cannot see — an error string is not walked by
+/// `redact_response_for_visibility`, so this would have re-opened nw-403 on
+/// the error path. Filtered, a hidden repo is indistinguishable from one that
+/// does not exist.
+fn resolve_repo_filter(
+    store: &GraphStore,
+    selectors: &[String],
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
+) -> Result<HashSet<String>, anyhow::Error> {
+    let repos: Vec<nestweaver_schema::Repo> = store
         .list_repos(None)
-        .unwrap_or_default()
+        .context("listing repositories to resolve the `repos` filter")?
+        .into_iter()
+        .filter(|repo| repo_is_visible(&repo.uid, visible))
+        .collect();
+    selectors
         .iter()
-        .map(|r| (r.uid.clone(), nestweaver_engine::repo_display_name(r)))
+        .map(|selector| {
+            nestweaver_engine::resolve_repo_selector(&repos, selector)
+                .map(|repo| repo.uid.clone())
+                // Flattened with `{error:#}` rather than `.context(…)`: an MCP
+                // client renders `Error::to_string()`, which shows only the
+                // OUTERMOST context — so a `.context()` here would hide the
+                // resolver's own "ambiguous; use an exact UID: …" candidate
+                // list, which is the only actionable part of the message.
+                .map_err(|error| anyhow!("`repos` filter entry {selector:?}: {error:#}"))
+        })
         .collect()
 }
 
-/// Build a map from vault UID → display name for vault filter matching.
-fn build_vault_name_map(store: &GraphStore) -> std::collections::HashMap<String, String> {
-    store
+/// Resolve caller-supplied `vaults:` entries to concrete vault UIDs.
+///
+/// The mirror of [`resolve_repo_filter`], written here rather than shared with
+/// it because there is no engine-side vault selector to reuse: `--repo` is a
+/// first-class CLI selector and `--vault` is not. The precedence deliberately
+/// matches `resolve_repo_selector`'s (exact UID, then case-insensitive exact
+/// name, then exact root path), and it is exact-only — no substring leg —
+/// because the substring leg is precisely what nw-405 is removing.
+fn resolve_vault_filter(
+    store: &GraphStore,
+    selectors: &[String],
+) -> Result<HashSet<String>, anyhow::Error> {
+    let vaults = store
         .list_vaults(None)
-        .unwrap_or_default()
+        .context("listing vaults to resolve the `vaults` filter")?;
+    selectors
         .iter()
-        .map(|v| (v.uid.clone(), v.name.clone()))
+        .map(|selector| {
+            let needle = selector.to_lowercase();
+            let matches: Vec<&nestweaver_schema::Vault> = vaults
+                .iter()
+                .filter(|vault| {
+                    vault.uid == *selector
+                        || vault.name.to_lowercase() == needle
+                        || vault.root_path == *selector
+                })
+                .collect();
+            match matches.as_slice() {
+                [vault] => Ok(vault.uid.clone()),
+                // An unresolvable entry ERRORS. The old predicate matched
+                // nothing and returned a confident empty result, which reads
+                // as "this vault has no relevant content" rather than "you
+                // named a vault that is not here".
+                [] => {
+                    let known: Vec<&str> = vaults.iter().map(|vault| vault.name.as_str()).collect();
+                    Err(anyhow!(
+                        "`vaults` filter entry {selector:?} matches no indexed vault; \
+                         known vaults: {}",
+                        if known.is_empty() {
+                            "(none indexed)".to_string()
+                        } else {
+                            known.join(", ")
+                        }
+                    ))
+                }
+                ambiguous => Err(anyhow!(
+                    "`vaults` filter entry {selector:?} is ambiguous; use an exact UID: {}",
+                    ambiguous
+                        .iter()
+                        .map(|vault| format!("{} ({})", vault.name, vault.uid))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )),
+            }
+        })
         .collect()
+}
+
+/// Keep only nodes owned by one of `repo_uids`.
+///
+/// **VAULT NODES ARE DROPPED.** This is nw-405's required recorded decision,
+/// and the schema text for `repos` says so in the same words. A Note, Section,
+/// Heading or Tag belongs to a VAULT and carries no `repo_uid`, so it is not
+/// "in repo X" under any reading — keeping it is exactly the measured
+/// over-include where `repos:["clientA"]` returns clientB's notes because
+/// their path contains the string. Vault content is scoped with `vaults:`,
+/// which is the parameter that can actually answer the question.
+///
+/// A node whose UID names no owner is dropped for the reason nw-403's
+/// redactor drops one: "I cannot tell what owns this" is not a reason to
+/// return it under a scope argument.
+fn retain_nodes_in_repos(
+    nodes: &mut Vec<nestweaver_engine::BrainNode>,
+    repo_uids: &HashSet<String>,
+) {
+    nodes.retain(
+        |node| matches!(node_owner(&node.uid), NodeOwner::Repo(uid) if repo_uids.contains(&uid)),
+    );
+}
+
+/// Keep only nodes owned by one of `vault_uids`.
+///
+/// The mirror of [`retain_nodes_in_repos`]: Symbol/File/Service nodes belong
+/// to a repo, so they cannot satisfy a vault scope and are dropped.
+fn retain_nodes_in_vaults(
+    nodes: &mut Vec<nestweaver_engine::BrainNode>,
+    vault_uids: &HashSet<String>,
+) {
+    nodes.retain(
+        |node| matches!(node_owner(&node.uid), NodeOwner::Vault(uid) if vault_uids.contains(&uid)),
+    );
+}
+
+/// Apply `path_prefix`, exempting nodes that have no path at all.
+///
+/// nw-406. The predicate was the bare
+/// `nodes.retain(|n| n.location.starts_with(prefix))`, and a Tag node carries
+/// `location: ""`: `"".starts_with("Workspaces/")` is false, so
+/// `--kinds Tag --path-prefix Workspaces/` measured 25 Tag nodes -> 0 on a
+/// vault whose 606 tags ALL live under `Workspaces/`. A confident zero with no
+/// disclosure.
+///
+/// A tag is not "outside" the prefix — it has no path concept for the prefix
+/// to test, which is the same unhandled-kind omission as the `tags`-vs-Symbol
+/// carve-out. An empty location is therefore EXEMPT rather than excluded: a
+/// filter that cannot decide a kind must not silently delete all of it.
+fn retain_nodes_under_path_prefix(nodes: &mut Vec<nestweaver_engine::BrainNode>, prefix: &str) {
+    nodes.retain(|node| node.location.is_empty() || node.location.starts_with(prefix));
 }
 
 /// Resolve authoritative symbol ownership only when repository scoping is
@@ -133,6 +351,330 @@ fn repo_is_visible(
         }
         _ => true,
     }
+}
+
+// ── nw-403: per-repo visibility, per tool ───────────────────────────────────
+
+/// What repo-scoped visibility MEANS for one MCP tool.
+///
+/// nw-403. The rule used to be written on `dispatch_cancellable` as "tools
+/// whose data is not repo-scoped ignore it", and that second clause was the
+/// bug: only 5 of the 42 dispatch arms were ever HANDED `visible`, so
+/// `brain_context`, `code_context`, `regex_search`, `count_patterns`,
+/// `get_summary`, `flow_trace`, `dead_code`, `hub_nodes`, `clusters`,
+/// `detect_changes`, `read_symbols` and `brain_status` returned hidden-repo
+/// symbols, file paths, prose and repo identity (URL + indexed git SHA) to a
+/// repo-restricted bearer token. Every one of those returns symbol-, file- or
+/// path-derived data, which is exactly repo-scoped.
+///
+/// The failure survived because `brain_search` — the one tool an operator
+/// spot-checks to validate an `[authz]` policy — is in the enforcing five, so
+/// the boundary LOOKED like it worked.
+///
+/// The default is INVERTED here. [`repo_scope`] is a match whose fallback arm
+/// is [`RepoScope::FailClosed`], so a tool added tomorrow refuses a
+/// repo-scoped call until somebody writes down which of these four
+/// dispositions applies to it. The previous default was "leak".
+///
+/// The PREDICATE is unchanged and is not re-implemented: everything here
+/// decides visibility through [`repo_is_visible`] (which is what guards
+/// `VisibleRepos::allows`'s empty-`repo_uid` early return) over the ownership
+/// map [`restricted_symbol_owners`] already builds.
+#[derive(Debug, Clone, Copy)]
+enum RepoScope {
+    /// The dispatch arm receives `visible` and filters — or fails closed —
+    /// itself. Used where the filter needs the TYPED rows: the response is
+    /// keyed by repo rather than by node uid (`brain_status`, `stale_check`),
+    /// or dropping a node has to leave a marker behind rather than vanish
+    /// (`flow_trace`, whose empty `children` is nw-390's defect).
+    EnforcedInArm,
+    /// Filtered after dispatch by [`redact_response_for_visibility`], which
+    /// walks the response and removes every row whose owning repo is not
+    /// visible.
+    ///
+    /// Sound only because every row of these tools names the entity it
+    /// describes (`uid` / `repo_uid` / `target_uid` / ...). A
+    /// `response_format: "concise"` response drops exactly that field, which
+    /// is why a concise call from a repo-scoped caller is REFUSED rather than
+    /// served unfiltered — an unidentifiable row cannot be attributed to a
+    /// repo, and "cannot attribute" must mean "do not return".
+    RedactedAfterDispatch,
+    /// Opt-out. The response is provably free of repo-, symbol-, file- and
+    /// path-derived data — the vault surfaces, whose Note/Section/Heading/Tag
+    /// nodes belong to a vault and carry no `repo_uid` at all.
+    ///
+    /// The `&'static str` is mandatory so an opt-out is a WRITTEN claim
+    /// somebody can falsify, not an omission nobody notices. That is the
+    /// difference between this arm and the 37 silent drops it replaces.
+    NotRepoScoped(&'static str),
+    /// Refuse. Either the response cannot be filtered without lying about its
+    /// own aggregates (graph-wide counts, generated prose, cross-repo link
+    /// tables computed over every repo), or it mutates brain-wide state that a
+    /// repo-restricted identity does not own.
+    ///
+    /// Returning a scoped-looking answer built from unscoped data would be
+    /// worse than refusing: it is the shape that let nw-403 survive.
+    FailClosed(&'static str),
+}
+
+/// UID prefixes that name a VAULT-owned node. A vault node has no `repo_uid`,
+/// so repo visibility neither permits nor forbids it and it survives
+/// redaction. Everything else — `sym:`, `proc:`, cluster ids, anything a
+/// future indexer invents — is treated as unattributable and DROPPED, because
+/// "I cannot tell which repo owns this" is not a reason to return it.
+const VAULT_OWNED_UID_PREFIXES: &[&str] = &["note:", "sec:", "head:", "tag:", "vlt:"];
+
+/// The keys under which a response row names the entity it describes. A row
+/// carrying any of them is attributed through that uid; `repo_uid` (checked
+/// first, since it is the direct answer) short-circuits the lookup.
+const IDENTIFYING_UID_KEYS: &[&str] = &[
+    "uid",
+    "target_uid",
+    "source_uid",
+    "symbol_uid",
+    "node_uid",
+    "root_uid",
+];
+
+/// The reason attached to a tool nobody has classified. Named so the coverage
+/// test can assert that no REAL tool carries it — a fail-closed default only
+/// helps if somebody notices when it fires.
+const UNDECLARED_TOOL_SCOPE: &str = "this tool has no recorded repo-visibility disposition; \
+     nw-403 inverted the default, so a tool must declare one in `repo_scope` before it may \
+     answer a repository-scoped caller";
+
+/// The scoping disposition of every tool in the dispatch table.
+///
+/// This is deliberately ONE match rather than per-arm judgement scattered
+/// through `dispatch_uncached`: the count that made nw-403 critical ("5 of 42")
+/// is only checkable if the dispositions live in one place, and
+/// `every_dispatch_arm_declares_a_repo_scope_disposition` checks it.
+fn repo_scope(tool: &str) -> RepoScope {
+    match tool {
+        // ── Enforced inside the arm ──────────────────────────────────────
+        // The original five. Each takes `visible` and filters over
+        // `repo_is_visible` / `restricted_symbol_owners`.
+        "brain_search" | "brain_impact" | "brain_diff" | "blast_radius" | "affected_tests" => {
+            RepoScope::EnforcedInArm
+        }
+        // nw-403: `brain_status` enumerated every repo's URL and indexed git
+        // SHA — repo IDENTITY, the most direct enumeration of a hidden tenant
+        // in the catalogue. Its rows are keyed by url/name, not by node uid,
+        // so the generic redactor cannot see them.
+        "brain_status" => RepoScope::EnforcedInArm,
+        // Keyed by repo, same reason as `brain_status`.
+        "stale_check" => RepoScope::EnforcedInArm,
+        // Filtering has to happen DURING the walk. Redacting a call tree
+        // afterwards would delete a subtree and leave `children: []`, which is
+        // precisely the "looks like a leaf" defect nw-390 exists to remove.
+        "flow_trace" => RepoScope::EnforcedInArm,
+
+        // ── Redacted after dispatch ──────────────────────────────────────
+        // Every row of these carries a uid, so one walk attributes them all.
+        "brain_context" | "code_context" | "project_context" | "regex_search" | "dead_code"
+        | "hub_nodes" | "bridge_nodes" | "detect_changes" | "read_symbols" => {
+            RepoScope::RedactedAfterDispatch
+        }
+
+        // ── Opt-outs: genuinely not repo-scoped ──────────────────────────
+        "note_get" | "backlinks" => RepoScope::NotRepoScoped(
+            "vault notes and wikilink edges; Note/Section/Heading nodes belong to a vault \
+             and carry no repo_uid",
+        ),
+        "brain_broken_links"
+        | "brain_orphan_documents"
+        | "brain_topic_clusters"
+        | "brain_tag_graph"
+        | "brain_doc_stats" => RepoScope::NotRepoScoped(
+            "document-graph analytics computed over vault notes, sections and tags only",
+        ),
+        "brain_memory_lint" | "brain_memory_consolidate" | "brain_memory_related" => {
+            RepoScope::NotRepoScoped(
+                "memory notes live in a vault and carry no repo_uid; the lint/consolidate/related \
+                 graphs never traverse a Symbol edge",
+            )
+        }
+
+        // ── Fail closed ──────────────────────────────────────────────────
+        "get_summary" => RepoScope::FailClosed(
+            "summaries are generated PROSE that enumerates a file's exported symbols \
+             (\"src/beta.py: exports 2 symbols: betaSecretHelper (Function)\"), the sidecar \
+             they are cached in is graph-wide, and there is no per-repo generation path — \
+             so a scoped answer cannot be built from it",
+        ),
+        "count_patterns" => RepoScope::FailClosed(
+            "the response is corpus-wide aggregates (total_matches, files_matched, top_files) \
+             with no node uid to attribute; a count filtered to nothing and a count of zero \
+             are indistinguishable, and top_files leaks hidden repo paths outright",
+        ),
+        "clusters" => RepoScope::FailClosed(
+            "communities are computed over the WHOLE graph — modularity, cohesion, size and \
+             key_files describe cross-repo partitions, so redacting members would leave every \
+             surviving number describing a population the caller cannot see",
+        ),
+        "brain_guide" => RepoScope::FailClosed(
+            "the guide is generated prose over the whole graph, including cross-repo edges \
+             and repo names, with no structure to filter",
+        ),
+        "cross_repo_contracts" => RepoScope::FailClosed(
+            "the tool's entire output is links that CROSS repo boundaries, plus a \
+             degraded_repos list of repo identities; a repo-scoped caller asking it is asking \
+             for exactly the data the policy withholds",
+        ),
+        "contract_drift" => RepoScope::FailClosed(
+            "contract UIDs carry no repo component (see tool_cross_repo_contracts), so drift \
+             rows cannot be attributed to a repo even when a `repo` argument narrows the \
+             analysis",
+        ),
+        "investigate" | "investigate_expand" | "investigate_hydrate" => RepoScope::FailClosed(
+            "the investigation bundle interleaves symbols, notes, hypotheses and rendered \
+             evidence text, so a row-level filter cannot bound what the prose already quoted",
+        ),
+        "brain_add_source" | "brain_remove_source" | "prune_stale" | "compact_embeddings" => {
+            RepoScope::FailClosed(
+                "a mutation of brain-wide state (source registration, stale-repo pruning, \
+                 embedding sidecar rewrite) that a repo-restricted identity does not own; \
+                 prune_stale additionally returns the pruned repos by identity",
+            )
+        }
+        "set_extension" | "query_extensions" => RepoScope::FailClosed(
+            "the extension store is keyed by scope uid (a repo or vault uid), so both reading \
+             and writing it enumerate or address repos outside the caller's scope",
+        ),
+
+        // ── The inverted default ─────────────────────────────────────────
+        // A tool with no recorded disposition does not answer a repo-scoped
+        // caller. nw-403's whole shape was 37 tools defaulting the other way.
+        _ => RepoScope::FailClosed(UNDECLARED_TOOL_SCOPE),
+    }
+}
+
+/// True when this call asked for the identifier-free rendering.
+///
+/// `project_context` is the exception the generic [`is_concise`] cannot
+/// express: its `response_format` DEFAULTS to concise (anything but
+/// "detailed" is concise), so a scoped caller who sends no `response_format`
+/// at all would otherwise receive uid-free rows that nothing can attribute.
+/// The default is restated rather than shared because the two live far apart
+/// and the safe reading of an absent field differs between them.
+fn response_omits_identifiers(tool: &str, args: &Value) -> bool {
+    match tool {
+        "project_context" => args
+            .get("response_format")
+            .and_then(|v| v.as_str())
+            .map(|s| !s.eq_ignore_ascii_case("detailed"))
+            .unwrap_or(true),
+        _ => is_concise(args),
+    }
+}
+
+/// Walks a tool response and removes every row whose owning repo is not
+/// visible to the caller.
+///
+/// It attributes a row through the ownership map `restricted_symbol_owners`
+/// already builds, so there is exactly ONE symbol→repo authority in this file,
+/// and it decides through [`repo_is_visible`], so there is exactly one
+/// predicate. A row it cannot attribute is dropped, not kept.
+struct VisibilityRedactor<'a> {
+    owners: &'a HashMap<String, String>,
+    visible: Option<&'a nestweaver_engine::authz::VisibleRepos>,
+    removed: usize,
+}
+
+impl VisibilityRedactor<'_> {
+    /// A uid is allowed when its owning repo is visible. An unknown `sym:`
+    /// uid (a row the ownership scan did not see, e.g. a tombstoned symbol)
+    /// is NOT allowed: unattributable is not the same as unowned.
+    fn uid_allowed(&self, uid: &str) -> bool {
+        match self.owners.get(uid) {
+            Some(repo_uid) => repo_is_visible(repo_uid, self.visible),
+            None => VAULT_OWNED_UID_PREFIXES
+                .iter()
+                .any(|prefix| uid.starts_with(prefix)),
+        }
+    }
+
+    /// A row with no identifying key at all is kept — it carries no entity to
+    /// leak (a `{"path": ..., "count": ...}` echo of the caller's own input,
+    /// a timings block). The tools routed here all emit an identifier on
+    /// every ENTITY row; the concise renderings that do not are refused
+    /// upstream in `dispatch_uncached` rather than silently trusted here.
+    fn row_allowed(&self, row: &Value) -> bool {
+        let Some(object) = row.as_object() else {
+            return true;
+        };
+        if let Some(repo_uid) = object.get("repo_uid").and_then(Value::as_str)
+            && !repo_uid.is_empty()
+        {
+            return repo_is_visible(repo_uid, self.visible);
+        }
+        IDENTIFYING_UID_KEYS.iter().all(|key| {
+            object
+                .get(*key)
+                .and_then(Value::as_str)
+                .is_none_or(|uid| self.uid_allowed(uid))
+        })
+    }
+
+    fn redact(&mut self, value: &mut Value) {
+        match value {
+            Value::Array(items) => {
+                let before = items.len();
+                items.retain(|item| self.row_allowed(item));
+                self.removed += before - items.len();
+                for item in items.iter_mut() {
+                    self.redact(item);
+                }
+            }
+            Value::Object(map) => {
+                for (_key, child) in map.iter_mut() {
+                    self.redact(child);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Apply [`VisibilityRedactor`] to one tool response and DISCLOSE the cut.
+///
+/// The disclosure is not decoration. Aggregate scalars in these payloads
+/// (`total`, `total_symbols`, `dead_percentage`, `posting_hits`) are computed
+/// over the whole graph before any row is dropped, so a scoped caller reading
+/// `returned` against `total` would otherwise conclude the tool truncated for
+/// budget reasons. `visibility.redacted_entries` names the real cause.
+fn redact_response_for_visibility(
+    store: &GraphStore,
+    value: &mut Value,
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
+) -> Result<(), anyhow::Error> {
+    // `None` for an unrestricted caller, so this is a no-op (and costs no
+    // ownership scan) on the single-trust-domain default. A store error
+    // PROPAGATES: a scoped response built without the ownership map would be
+    // unfiltered, which is the bug.
+    let Some(owners) = restricted_symbol_owners(store, visible)? else {
+        return Ok(());
+    };
+    let mut redactor = VisibilityRedactor {
+        owners: &owners,
+        visible,
+        removed: 0,
+    };
+    redactor.redact(value);
+    let removed = redactor.removed;
+    if let Some(object) = value.as_object_mut() {
+        object.insert(
+            "visibility".to_string(),
+            json!({
+                "scoped": true,
+                "redacted_entries": removed,
+                 "note": "Rows owned by repositories outside this caller's [authz] visibility \
+                 were removed. Aggregate counts in this response are computed over the \
+                 whole graph BEFORE that removal, so they may exceed the rows returned.",
+            }),
+        );
+    }
+    Ok(())
 }
 
 // ── Tool catalogue ──────────────────────────────────────────────────────────
@@ -1291,14 +1833,14 @@ mod tool_schema_validation_tests {
             })
             .unwrap();
 
-        let all = tool_dead_code(&store, json!({}), None).expect("dead_code low");
+        let all = tool_dead_code(&store, json!({}), None, None).expect("dead_code low");
         assert_eq!(all["unreachable_count"], 1);
         assert_eq!(all["matching_count"], 1);
         assert_eq!(all["returned"], 1);
 
         // Inferred visibility maps to Medium confidence, so a High filter
         // drops it from the results but NOT from the unfiltered total.
-        let high = tool_dead_code(&store, json!({ "min_confidence": "high" }), None)
+        let high = tool_dead_code(&store, json!({ "min_confidence": "high" }), None, None)
             .expect("dead_code high");
         assert_eq!(
             high["unreachable_count"], 1,
@@ -1813,9 +2355,23 @@ pub fn dispatch(
 /// `visible` carries the caller's per-repo visibility, resolved by the
 /// HTTP boundary from the bearer identity. `None` (and `Some(VisibleRepos::All)`)
 /// means no scoping — the backward-compatible single-trust-domain default, in
-/// which repo-scoped authorization is a no-op. `brain_search`, `brain_impact`,
-/// `blast_radius`, and `affected_tests` enforce it; tools whose data is not
-/// repo-scoped ignore it.
+/// which repo-scoped authorization is a no-op.
+///
+/// THE RULE, restated by nw-403 because the sentence that used to be here was
+/// false. It read "`brain_search`, `brain_impact`, `blast_radius`, and
+/// `affected_tests` enforce it; tools whose data is not repo-scoped ignore
+/// it", and that second clause was the bug: it granted a silent exemption to
+/// 37 of the 42 dispatch arms, including `brain_context`, `code_context`,
+/// `regex_search`, `get_summary`, `flow_trace`, `dead_code`, `hub_nodes`,
+/// `clusters`, `detect_changes`, `read_symbols` and `brain_status` — all of
+/// which return symbol-, file- or path-derived data, which IS repo-scoped.
+///
+/// The real rule is: **every tool is repo-scoped until it is written down
+/// that it is not.** `repo_scope` records one of four dispositions for every
+/// tool in the catalogue and `dispatch_uncached` enforces it before the arm
+/// runs; a tool with no recorded disposition fails closed. Nothing "ignores"
+/// visibility any more — a tool either filters, declares itself vault-only,
+/// or refuses.
 pub fn dispatch_cancellable(
     store: &GraphStore,
     tantivy: Option<&TantivyIndex>,
@@ -1986,7 +2542,21 @@ fn classify_index_publication_error(store: &GraphStore, error: anyhow::Error) ->
     }
 }
 
-/// The actual tool dispatch table, after cache handling.
+/// The repo-visibility gate, then the tool dispatch table.
+///
+/// nw-403. The gate sits HERE, above the match, because "did this arm receive
+/// `visible`?" is exactly the question nobody could answer while the answer
+/// was spread across 42 call expressions — and the answer was "5 of them".
+/// `repo_scope` now answers it for every tool in one place, and an unlisted
+/// tool refuses rather than leaks.
+///
+/// The gate is inert unless an `[authz]` policy actually restricts this
+/// caller: `VisibleRepos::All` and `None` take the identical path they always
+/// took, so a single-trust-domain deployment sees no behaviour change.
+///
+/// Placing it below the response cache is safe because the cache key is
+/// already visibility-salted (`visibility_cache_salt`), so a redacted response
+/// can never be served to a different scope.
 fn dispatch_uncached(
     store: &GraphStore,
     tantivy: Option<&TantivyIndex>,
@@ -1996,13 +2566,74 @@ fn dispatch_uncached(
     cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
     visible: Option<&nestweaver_engine::authz::VisibleRepos>,
 ) -> Result<Value, anyhow::Error> {
+    if !matches!(
+        visible,
+        Some(nestweaver_engine::authz::VisibleRepos::Only(_))
+    ) {
+        return dispatch_tool_arm(store, tantivy, name, args, embed_model, cancel, visible);
+    }
+    match repo_scope(name) {
+        // The arm takes `visible` itself; nothing to do here.
+        RepoScope::EnforcedInArm => {
+            dispatch_tool_arm(store, tantivy, name, args, embed_model, cancel, visible)
+        }
+        // A written, falsifiable claim that this response contains no
+        // repo-owned data. Dispatched unchanged — and the justification is
+        // LOGGED, so an operator auditing an `[authz]` policy can see which
+        // tools claimed an exemption and why, rather than having to infer the
+        // exemptions from source the way nw-403 had to be.
+        RepoScope::NotRepoScoped(reason) => {
+            tracing::debug!(
+                tool = name,
+                reason,
+                "tool answered a repository-scoped caller under a not-repo-scoped exemption"
+            );
+            dispatch_tool_arm(store, tantivy, name, args, embed_model, cancel, visible)
+        }
+        RepoScope::RedactedAfterDispatch => {
+            // A concise rendering omits the very uid the redactor attributes
+            // rows by, so it cannot be filtered — and an unfilterable
+            // response is refused, not served. The remedy is in the message
+            // because `project_context` defaults to concise and its callers
+            // never sent the field at all.
+            if response_omits_identifiers(name, &args) {
+                return Err(anyhow!(
+                    "{name}: response_format \"concise\" omits the per-row UIDs that repository \
+                     visibility filtering attributes rows by, so it cannot be scoped to this \
+                     caller's repositories. Re-request with response_format \"detailed\"."
+                ));
+            }
+            let mut value =
+                dispatch_tool_arm(store, tantivy, name, args, embed_model, cancel, visible)?;
+            redact_response_for_visibility(store, &mut value, visible)?;
+            Ok(value)
+        }
+        RepoScope::FailClosed(reason) => Err(anyhow!(
+            "{name} is not available to a repository-scoped caller: {reason}. Refusing rather \
+             than returning data from outside the caller's visible repositories (nw-403)."
+        )),
+    }
+}
+
+/// The actual tool dispatch table, after cache handling and the nw-403
+/// visibility gate.
+#[allow(clippy::too_many_arguments)]
+fn dispatch_tool_arm(
+    store: &GraphStore,
+    tantivy: Option<&TantivyIndex>,
+    name: &str,
+    args: Value,
+    embed_model: Option<&dyn EmbedQueryFn>,
+    cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
+) -> Result<Value, anyhow::Error> {
     match name {
-        "brain_context" => tool_brain_context(store, tantivy, args, embed_model, cancel),
+        "brain_context" => tool_brain_context(store, tantivy, args, embed_model, cancel, visible),
         "code_context" => tool_code_context(store, args),
         "brain_search" => tool_brain_search(store, tantivy, args, visible),
         "note_get" => tool_note_get(store, args),
         "backlinks" => tool_backlinks(store, args),
-        "brain_status" => tool_brain_status(store, tantivy),
+        "brain_status" => tool_brain_status(store, tantivy, visible),
         "brain_add_source" => tool_brain_add_source(store, args),
         "brain_remove_source" => tool_brain_remove_source(store, args),
         "prune_stale" => tool_prune_stale(store),
@@ -2010,15 +2641,17 @@ fn dispatch_uncached(
         "cross_repo_contracts" => tool_cross_repo_contracts(store, args),
         "brain_impact" => tool_brain_impact(store, args, cancel, visible),
         "brain_guide" => tool_brain_guide(store, args),
-        "flow_trace" => tool_flow_trace(store, args, cancel),
+        "flow_trace" => tool_flow_trace(store, args, cancel, visible),
         "detect_changes" => tool_detect_changes(store, args),
         "clusters" => tool_clusters(store, args),
-        "stale_check" => tool_stale_check(store),
+        "stale_check" => tool_stale_check(store, visible),
         "set_extension" => tool_set_extension(args),
         "query_extensions" => tool_query_extensions(args),
         "brain_diff" => tool_brain_diff(store, args, visible),
-        "project_context" => tool_project_context(store, tantivy, args, embed_model, cancel),
-        "dead_code" => tool_dead_code(store, args, cancel),
+        "project_context" => {
+            tool_project_context(store, tantivy, args, embed_model, cancel, visible)
+        }
+        "dead_code" => tool_dead_code(store, args, cancel, visible),
         "hub_nodes" => tool_hub_nodes(store, args),
         "bridge_nodes" => tool_bridge_nodes(store, args),
         "blast_radius" => tool_blast_radius(store, args, cancel, visible),
@@ -2610,26 +3243,65 @@ fn cache_stats(db_path: &Path) -> (u64, usize, Option<f64>) {
 
 /// F5: read a symbol's source span (not the whole file). Resolves UIDs/names/
 /// FQNs, optionally includes adjacent symbols, and respects a token budget.
+/// The largest list of client-supplied identifiers a tool will accept, and the
+/// longest single identifier in it. Both are also declared as `maxItems` /
+/// `maxLength` on `read_symbols.targets` and `affected_tests.changed_files`,
+/// so the MCP path is rejected by schema validation before a handler runs;
+/// this pair is the backstop for the routes that do not validate against the
+/// schema (the daemon's `dispatch_tool_json`, direct/internal calls, unit
+/// tests) — the same belt-and-braces arrangement `flow_trace.max_depth` uses.
+pub(crate) const MAX_IDENTIFIER_COUNT: usize = 1000;
+pub(crate) const MAX_IDENTIFIER_LEN: usize = 512;
+
 /// Bound a list of client-supplied identifiers (symbol UIDs/names/FQNs, repo-
 /// relative paths) so an oversized entry or an over-long list can't be echoed
-/// back verbatim (a response-amplification lever) or waste work. A real
-/// identifier is at most a few hundred bytes, so truncating a huge one keeps it
-/// non-matching (→ not_found) while capping the response. Truncation is
-/// char-boundary safe.
-fn bound_identifiers(mut v: Vec<String>) -> Vec<String> {
-    const MAX_LEN: usize = 512;
-    const MAX_COUNT: usize = 1000;
-    v.truncate(MAX_COUNT);
-    for s in &mut v {
-        if s.len() > MAX_LEN {
-            let mut end = MAX_LEN;
-            while end > 0 && !s.is_char_boundary(end) {
-                end -= 1;
-            }
-            s.truncate(end);
-        }
+/// back verbatim (a response-amplification lever) or waste work.
+///
+/// nw-392: this REJECTS. It used to `v.truncate(MAX_COUNT)` and truncate each
+/// over-long string in place, silently narrowing the caller's own REQUEST, and
+/// both callers then reported the narrowed run as whole:
+///
+/// * `read_symbols` with 1000 junk targets plus one real symbol as the 1001st
+///   returned that symbol in NEITHER `symbols` nor `not_found` nor `dropped`,
+///   with `truncated: false` — and `dropped` is an existing, empty array that
+///   was the obvious home for the disclosure.
+/// * `affected_tests.changed_files` is the selector that decides which tests a
+///   PR must run. Measured on the live graph, a changed file at index 1001 was
+///   dropped before analysis and the run still reported `status: complete` /
+///   `recommendation: selection-usable` with `notifications: []`, hiding 113
+///   test files the tool itself said the change required. The tool's contract
+///   is fail-safe WIDENING ("run-full-suite on any non-complete run"); silently
+///   narrowing its input inverts it. A safety selector must refuse a request it
+///   cannot honour rather than answer a smaller one.
+///
+/// The per-string cap rejects for a sharper reason: truncating a long FQN did
+/// not drop it, it MUTATED it into a different identifier that then reported
+/// back as `not_found`. A corrupted identifier is harder to notice than a
+/// missing one, and "not found" is an answer about a symbol the caller never
+/// asked about.
+fn bound_identifiers(v: Vec<String>, field: &str) -> Result<Vec<String>, anyhow::Error> {
+    if v.len() > MAX_IDENTIFIER_COUNT {
+        anyhow::bail!(
+            "'{field}' has {} entries; the maximum is {MAX_IDENTIFIER_COUNT}. The request is \
+             REJECTED rather than silently shortened: a truncated request answered as though it \
+             were whole is indistinguishable from a complete one. Split it into batches of \
+             {MAX_IDENTIFIER_COUNT} or fewer.",
+            v.len()
+        );
     }
-    v
+    if let Some((index, over_long)) = v
+        .iter()
+        .enumerate()
+        .find(|(_, entry)| entry.len() > MAX_IDENTIFIER_LEN)
+    {
+        anyhow::bail!(
+            "'{field}[{index}]' is {} bytes; the maximum is {MAX_IDENTIFIER_LEN}. The request is \
+             REJECTED rather than shortened: truncating an identifier does not drop it, it \
+             changes it into a DIFFERENT identifier that then reports back as not-found.",
+            over_long.len()
+        );
+    }
+    Ok(v)
 }
 
 fn tool_read_symbols(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error> {
@@ -2643,7 +3315,12 @@ fn tool_read_symbols(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
                     .collect()
             })
             .unwrap_or_default(),
-    );
+        if args.get("targets").is_some() {
+            "targets"
+        } else {
+            "uids_or_fqns"
+        },
+    )?;
     if targets.is_empty() {
         return Err(anyhow!(
             "'targets' must be a non-empty array of symbol UIDs, names, or FQNs"
@@ -2926,17 +3603,25 @@ fn tool_schema_read_symbols() -> Value {
         "inputSchema": {
             "type": "object",
             "properties": {
+                // nw-392: `maxItems`/`maxLength` are the REJECTION path. The
+                // handler used to accept any length and quietly cut the list
+                // at 1000 and each entry at 512 bytes, then report
+                // `truncated: false` with an empty `dropped`. Declaring the
+                // bounds here makes an oversized call a validation error at
+                // the boundary instead of a narrowed answer that looks whole.
                 "targets": {
                     "type": "array",
-                    "items": { "type": "string" },
+                    "items": { "type": "string", "maxLength": MAX_IDENTIFIER_LEN },
                     "minItems": 1,
-                    "description": "Symbol UIDs (sym:...), names, or FQNs to read. One of 'targets' or 'uids_or_fqns' is required."
+                    "maxItems": MAX_IDENTIFIER_COUNT,
+                    "description": "Symbol UIDs (sym:...), names, or FQNs to read. One of 'targets' or 'uids_or_fqns' is required. At most 1000 entries of at most 512 bytes each; an oversized request is REJECTED, never silently shortened."
                 },
                 "uids_or_fqns": {
                     "type": "array",
-                    "items": { "type": "string" },
+                    "items": { "type": "string", "maxLength": MAX_IDENTIFIER_LEN },
                     "minItems": 1,
-                    "description": "Backward-compatible alias for targets."
+                    "maxItems": MAX_IDENTIFIER_COUNT,
+                    "description": "Backward-compatible alias for targets. Same 1000-entry / 512-byte bounds."
                 },
                 "include_neighbors": {
                     "type": "integer",
@@ -3593,12 +4278,12 @@ fn tool_schema_brain_context() -> Value {
                 "repos": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Filter to specific repo UIDs or names (post-PPR). Only nodes whose location matches one of these strings are kept."
+                    "description": "Filter to specific repositories (post-PPR). Each entry must RESOLVE to one repo — exact repo UID (\"repo:{instance}:{hash}\"), exact display name (case-insensitive), or exact clone URL / local root; an entry that names no repo, or that names two, is an ERROR rather than a filter that quietly matches nothing. Only nodes OWNED by a resolved repo are kept. Vault content (Note/Section/Heading/Tag) belongs to a vault and not to any repository, so it is DROPPED when this is set — use `vaults` to scope vault content."
                 },
                 "vaults": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Filter to specific vault UIDs or names (post-PPR). Only note/heading/section nodes whose UID or location matches are kept."
+                    "description": "Filter to specific vaults (post-PPR). Each entry must RESOLVE to one vault — exact vault UID (\"vlt:{instance}:{hash}\"), exact name (case-insensitive), or exact root path; an unresolvable or ambiguous entry is an ERROR. Only nodes OWNED by a resolved vault (Note/Section/Heading/Tag) are kept; Symbol nodes belong to a repository and are DROPPED when this is set."
                 },
                 "kinds": {
                     "type": "array",
@@ -3607,12 +4292,12 @@ fn tool_schema_brain_context() -> Value {
                 },
                 "path_prefix": {
                     "type": "string",
-                    "description": "Include only nodes whose location (file path) starts with this prefix."
+                    "description": "Include only nodes whose location (file path) starts with this prefix. Nodes that have NO path at all (Tag nodes carry an empty location) are exempt rather than excluded — a filter that cannot decide a kind does not delete all of it."
                 },
                 "tags": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Include only nodes tagged with any of these tags (applies to Note and Section nodes; Symbol nodes are always kept). Matching is case-insensitive and includes NESTED descendants: \"project\" matches \"project/nestweaver\" but never \"projectile\"."
+                    "description": "Include only nodes tagged with any of these tags. Applies to Note and Section nodes; Symbol nodes carry no tags and are DROPPED when this is set, so a tag-scoped result can never be larger than the unscoped one. Matching is case-insensitive and includes NESTED descendants: \"project\" matches \"project/nestweaver\" but never \"projectile\"."
                 },
                 "exclude_tags": {
                     "type": "array",
@@ -3796,6 +4481,28 @@ fn tool_code_context(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
         "connected": result.connected.iter().map(render).collect::<Vec<_>>(),
         "cross_repo_links": serde_json::to_value(&result.cross_repo_links)?,
         "seeds_resolved": result.seeds.len(),
+        // nw-393. The SEED cap, one layer upstream of the connected-list
+        // disclosure: `seeds_resolved`/`seeds_expanded` alone cannot distinguish
+        // a name with five definitions from a name with two hundred, and
+        // `truncated_by: "limit"` misdirects because no caller-settable knob can
+        // recover a seed that was never resolved.
+        //
+        // FOUR INDEPENDENT FIELDS rather than a `truncated_by: "seed_resolution"`
+        // variant, because the two caps do not compose: `truncated_by: "limit"`
+        // stays a correct statement about `connected` even when the seed set was
+        // ALSO cut, so collapsing them into the scalar makes one of two true
+        // things unsayable. The relation label is `search_total_relation_label`'s
+        // "eq"/"gte" — `brain_search`'s spelling, not a second convention.
+        //
+        // Hand-built here because the engine computes these on
+        // `ContextResult`/`BrainContextResult` and this payload is assembled
+        // field by field; without these four lines the numbers exist and reach
+        // nobody, and the CLI's DAEMON route (which parses this very payload back
+        // into `ContextResult`) discloses only on its local fallback.
+        "seed_matches_total": result.seed_matches_total,
+        "seed_matches_total_relation": result.seed_matches_total_relation.clone(),
+        "seeds_truncated": result.seeds_truncated,
+        "seed_resolution_limit": result.seed_resolution_limit,
         // Retained as the returned count, which is what it has always meant
         // and what `merge_json_results` recomputes after a federated cap.
         // `total` is the field that was missing.
@@ -3819,6 +4526,10 @@ fn tool_brain_context(
     args: Value,
     embed_model: Option<&dyn EmbedQueryFn>,
     cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    // nw-405: the arm still returns rows through `RepoScope::RedactedAfterDispatch`;
+    // `visible` is taken here only so `resolve_repo_filter`'s ERROR text — which
+    // no redactor walks — cannot enumerate repos this caller may not see.
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
 ) -> Result<Value, anyhow::Error> {
     let seeds: Vec<String> = args
         .get("seeds")
@@ -3949,16 +4660,17 @@ fn tool_brain_context(
     // ResponseConfig::default()), so there is no `[ranking]` to load. Priors are
     // applied on the CLI `brain context` / `brain search` paths instead.
 
-    // Build name maps once if filters are present.
-    let repo_names = if filter_repos.is_some() {
-        build_repo_name_map(store)
-    } else {
-        std::collections::HashMap::new()
+    // nw-405: resolve the scope arguments to CONCRETE container UIDs before
+    // filtering anything. Resolution happens here, outside the per-list
+    // closure, so an unresolvable entry is one ERROR for the call rather than
+    // a predicate that silently matches nothing on both lists.
+    let repo_scope = match filter_repos {
+        Some(ref selectors) => Some(resolve_repo_filter(store, selectors, visible)?),
+        None => None,
     };
-    let vault_names = if filter_vaults.is_some() {
-        build_vault_name_map(store)
-    } else {
-        std::collections::HashMap::new()
+    let vault_scope = match filter_vaults {
+        Some(ref selectors) => Some(resolve_vault_filter(store, selectors)?),
+        None => None,
     };
 
     // RFC #2: apply post-PPR filters to seeds and connected lists.
@@ -3969,77 +4681,35 @@ fn tool_brain_context(
                 kinds.iter().any(|k| kind_lower.starts_with(k.as_str()))
             });
         }
-        if let Some(ref repos) = filter_repos {
-            nodes.retain(|n| {
-                let filter_lower: Vec<String> = repos.iter().map(|r| r.to_lowercase()).collect();
-                // Extract repo_uid from symbol UIDs (sym:repo:{inst}:{hash}:...)
-                let node_repo_uid = if n.uid.starts_with("sym:") {
-                    let parts: Vec<&str> = n.uid[4..].splitn(4, ':').collect();
-                    if parts.len() >= 3 {
-                        Some(format!("{}:{}:{}", parts[0], parts[1], parts[2]))
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
-                filter_lower.iter().any(|r| {
-                    // Match by repo display name
-                    if let Some(ref repo_uid) = node_repo_uid
-                        && let Some(name) = repo_names.get(repo_uid)
-                        && name.to_lowercase().contains(r)
-                    {
-                        return true;
-                    }
-                    // Fallback: UID or location substring
-                    n.uid.to_lowercase().contains(r) || n.location.to_lowercase().contains(r)
-                })
-            });
+        if let Some(ref repo_uids) = repo_scope {
+            retain_nodes_in_repos(nodes, repo_uids);
         }
-        if let Some(ref vaults) = filter_vaults {
-            nodes.retain(|n| {
-                let filter_lower: Vec<String> = vaults.iter().map(|v| v.to_lowercase()).collect();
-                // Extract vault_uid from note UIDs (note:vlt:{inst}:{hash}:...)
-                // or section/heading UIDs (sec:note:vlt:... / head:note:vlt:...)
-                let node_vault_uid = {
-                    let search = if n.uid.starts_with("note:") {
-                        Some(&n.uid[5..])
-                    } else if n.uid.starts_with("sec:note:") {
-                        Some(&n.uid[9..])
-                    } else if n.uid.starts_with("head:note:") {
-                        Some(&n.uid[10..])
-                    } else {
-                        None
-                    };
-                    search.and_then(|s| {
-                        let parts: Vec<&str> = s.splitn(4, ':').collect();
-                        if parts.len() >= 3 {
-                            Some(format!("{}:{}:{}", parts[0], parts[1], parts[2]))
-                        } else {
-                            None
-                        }
-                    })
-                };
-                filter_lower.iter().any(|v| {
-                    if let Some(ref vault_uid) = node_vault_uid
-                        && let Some(name) = vault_names.get(vault_uid)
-                        && name.to_lowercase().contains(v)
-                    {
-                        return true;
-                    }
-                    n.uid.to_lowercase().contains(v) || n.location.to_lowercase().contains(v)
-                })
-            });
+        if let Some(ref vault_uids) = vault_scope {
+            retain_nodes_in_vaults(nodes, vault_uids);
         }
         if let Some(ref prefix) = path_prefix {
-            nodes.retain(|n| n.location.starts_with(prefix.as_str()));
+            retain_nodes_under_path_prefix(nodes, prefix.as_str());
         }
     };
     apply_filters(&mut result.seeds);
     apply_filters(&mut result.connected);
 
     // tags filter: keep only note/section nodes tagged with any of these tags.
-    // Symbol nodes are always kept (no tag concept for code).
+    //
+    // nw-407: Symbol nodes used to be kept UNCONDITIONALLY here, commented
+    // "Symbol nodes are always kept (no tag concept for code)". That made
+    // `tags` an EXPANSION rather than a filter. Measured on the live graph at
+    // the same seed and budget: `brain_context{seeds:["authentication"],
+    // tags:["security"]}` returned n=71 of which 70 were Symbols and ONE was a
+    // tagged Note, while the same call with no `tags` returned n=30 with 22 of
+    // 30 vault content. Adding the filter GREW the result 30 -> 71 and drove
+    // the tagged share from 22/30 to 1/71.
+    //
+    // The budget leg is why this is not cosmetic: the pass-through happens
+    // before the token budget is spent, so untagged symbols eat the budget the
+    // tagged notes were asked for. "No tag concept for code" means a symbol
+    // cannot SATISFY a tag scope, not that it is exempt from one — the comment
+    // documented the mechanism and never the consequence.
     if let Some(tags) = args.get("tags").and_then(|v| v.as_array()) {
         let tag_names: Vec<String> = tags
             .iter()
@@ -4054,9 +4724,6 @@ fn tool_brain_context(
                 .map_err(|e| anyhow!("list_section_uids_with_tags: {e}"))?;
             let filter_tagged = |nodes: &mut Vec<nestweaver_engine::BrainNode>| {
                 nodes.retain(|item| {
-                    if item.kind.to_lowercase().contains("symbol") {
-                        return true;
-                    }
                     tagged_notes.contains(&item.uid) || tagged_sections.contains(&item.uid)
                 });
             };
@@ -4257,6 +4924,28 @@ fn tool_brain_context(
     let truncated_by = nestweaver_engine::TruncationCause::resolve(truncated, false);
     let mut resp = json!({
         "seeds_expanded": result.seeds.len(),
+        // nw-393. The SEED cap, one layer upstream of the connected-list
+        // disclosure: `seeds_resolved`/`seeds_expanded` alone cannot distinguish
+        // a name with five definitions from a name with two hundred, and
+        // `truncated_by: "limit"` misdirects because no caller-settable knob can
+        // recover a seed that was never resolved.
+        //
+        // FOUR INDEPENDENT FIELDS rather than a `truncated_by: "seed_resolution"`
+        // variant, because the two caps do not compose: `truncated_by: "limit"`
+        // stays a correct statement about `connected` even when the seed set was
+        // ALSO cut, so collapsing them into the scalar makes one of two true
+        // things unsayable. The relation label is `search_total_relation_label`'s
+        // "eq"/"gte" — `brain_search`'s spelling, not a second convention.
+        //
+        // Hand-built here because the engine computes these on
+        // `ContextResult`/`BrainContextResult` and this payload is assembled
+        // field by field; without these four lines the numbers exist and reach
+        // nobody, and the CLI's DAEMON route (which parses this very payload back
+        // into `ContextResult`) discloses only on its local fallback.
+        "seed_matches_total": result.seed_matches_total,
+        "seed_matches_total_relation": result.seed_matches_total_relation.clone(),
+        "seeds_truncated": result.seeds_truncated,
+        "seed_resolution_limit": result.seed_resolution_limit,
         "connected": connected_json,
         "returned": returned,
         "total": total,
@@ -6346,8 +7035,107 @@ fn tool_schema_brain_status() -> Value {
 fn tool_brain_status(
     store: &GraphStore,
     tantivy: Option<&TantivyIndex>,
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
 ) -> Result<Value, anyhow::Error> {
-    brain_status_json(store, tantivy)
+    let mut value = brain_status_json(store, tantivy)?;
+    scope_brain_status_to_visible_repos(store, &mut value, visible)?;
+    Ok(value)
+}
+
+/// nw-403: cut `brain_status`'s repo-derived fields down to the caller's
+/// visible repositories.
+///
+/// This is the most direct enumeration in the catalogue — `repos[]` carries
+/// each repo's URL and indexed git SHA, i.e. repo IDENTITY rather than repo
+/// CONTENT — and it was reachable by any repo-restricted bearer token.
+///
+/// It redacts the FINISHED document rather than taking `visible` into
+/// [`brain_status_json`] on purpose: that builder is the single document
+/// shared by the daemon's gRPC surface, the in-process MCP server and the
+/// CLI's direct fallback, and those routes have no `[authz]` identity to pass.
+/// Changing its signature would push an argument every other caller has to
+/// invent through three crates; redacting here keeps the scoping where the
+/// identity actually is.
+///
+/// `warnings` and `staleness_warnings` are matched by SUBSTRING against the
+/// hidden repos' urls and names because those rows are prose keyed by display
+/// name, with no uid to join on. That over-drops when one repo's name is a
+/// substring of another's — which is the safe direction: a scoped caller
+/// losing a warning about a repo they can see is a degraded answer, whereas
+/// keeping one is a disclosure.
+fn scope_brain_status_to_visible_repos(
+    store: &GraphStore,
+    value: &mut Value,
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
+) -> Result<(), anyhow::Error> {
+    let Some(nestweaver_engine::authz::VisibleRepos::Only(_)) = visible else {
+        return Ok(());
+    };
+    // Fails closed: a status document that could not be scoped is not served
+    // unscoped.
+    let repos = store
+        .list_repos(None)
+        .context("brain_status: listing repos for repository-scoped redaction")?;
+    let vaults = store
+        .list_vaults(None)
+        .context("brain_status: listing vaults for repository-scoped redaction")?;
+    let (shown, hidden): (Vec<_>, Vec<_>) = repos
+        .iter()
+        .partition(|repo| repo_is_visible(&repo.uid, visible));
+    let hidden_labels: Vec<String> = hidden
+        .iter()
+        .flat_map(|repo| {
+            [
+                Some(repo.url.clone()),
+                repo.name.clone(),
+                Some(repo.uid.clone()),
+            ]
+        })
+        .flatten()
+        .filter(|label| !label.is_empty())
+        .collect();
+
+    let Some(object) = value.as_object_mut() else {
+        return Ok(());
+    };
+    object.insert(
+        "repos".to_string(),
+        json!(
+            shown
+                .iter()
+                .map(|repo| json!({ "url": repo.url, "sha": repo.indexed_sha }))
+                .collect::<Vec<_>>()
+        ),
+    );
+    object.insert("repo_count".to_string(), json!(shown.len()));
+    for key in ["warnings", "staleness_warnings"] {
+        if let Some(rows) = object.get_mut(key).and_then(Value::as_array_mut) {
+            rows.retain(|row| {
+                let rendered = row.to_string();
+                !hidden_labels.iter().any(|label| rendered.contains(label))
+            });
+        }
+    }
+    // Rebuilt from the surviving repos plus every vault, matching how
+    // `brain_status_json` derives it. A hidden repo's instance id names the
+    // instance a hidden repo was indexed on.
+    let mut instance_ids: std::collections::BTreeSet<&str> =
+        vaults.iter().map(|v| v.instance_id.as_str()).collect();
+    instance_ids.extend(shown.iter().map(|repo| repo.instance_id.as_str()));
+    object.insert(
+        "instance_ids".to_string(),
+        json!(instance_ids.into_iter().collect::<Vec<_>>()),
+    );
+    object.insert(
+        "visibility".to_string(),
+        json!({
+            "scoped": true,
+            "repos_hidden": hidden.len(),
+            "note": "repos, repo_count, instance_ids and the warning lists are scoped to this \
+                     caller's [authz] visibility; vault and corpus counts are graph-wide.",
+        }),
+    );
+    Ok(())
 }
 
 /// Build one `vaults[]` row, and say whether its note count could be READ.
@@ -8047,6 +8835,7 @@ fn tool_flow_trace(
     store: &GraphStore,
     args: Value,
     cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
 ) -> Result<Value, anyhow::Error> {
     let symbol = args
         .get("symbol")
@@ -8071,6 +8860,15 @@ fn tool_flow_trace(
         .lookup_symbol(&resolved_uid)
         .map_err(|_| anyhow!("symbol '{symbol}' not found"))?;
 
+    // nw-403. A root in a repository this caller cannot see answers exactly as
+    // an absent symbol does. Deliberately the SAME error string as the lookup
+    // failure above: distinguishing "hidden" from "does not exist" would turn
+    // this tool into an existence oracle for the hidden repo, which is the
+    // property `brain_impact`'s ambiguity handling already protects.
+    if !repo_is_visible(&root.repo_uid, visible) {
+        return Err(anyhow!("symbol '{symbol}' not found"));
+    }
+
     let mut visited = HashSet::new();
     visited.insert(root.uid.clone());
 
@@ -8078,6 +8876,7 @@ fn tool_flow_trace(
         max_depth,
         concise,
         cancel,
+        visible,
     };
 
     // Classes don't have CALLS edges — only their methods do. When the root
@@ -8101,11 +8900,21 @@ fn tool_flow_trace(
                 s.kind == SymbolKind::Method || s.kind == SymbolKind::Function
             };
 
+            // nw-390: the THIRD undisclosed cap. The response `note` explained
+            // the class-to-methods expansion and never mentioned that the
+            // expansion stops at 20, so a 60-method class reported 20 methods
+            // with no total and no flag. `methods_total` is captured on both
+            // branches below and published beside `methods`.
             const MAX_METHODS: usize = 20;
+            // Assigned on both branches below, so it is declared without an
+            // initialiser: a placeholder zero here would be a number nobody
+            // computed, which is the shape this fix exists to remove.
+            let methods_total: usize;
             let method_trees: Vec<Value> = if !members.is_empty() {
-                members
+                let methods: Vec<_> = members.iter().filter(|s| is_method(s)).collect();
+                methods_total = methods.len();
+                methods
                     .iter()
-                    .filter(|s| is_method(s))
                     .take(MAX_METHODS)
                     .map(|s| {
                         let mut v = visited.clone();
@@ -8128,7 +8937,7 @@ fn tool_flow_trace(
                     })
                     .map(|s| (s.start_line, s.end_line))
                     .collect();
-                file_symbols
+                let methods: Vec<_> = file_symbols
                     .iter()
                     .filter(|s| {
                         s.uid != root.uid
@@ -8139,6 +8948,10 @@ fn tool_flow_trace(
                                 .iter()
                                 .any(|&(start, end)| s.start_line >= start && s.start_line <= end)
                     })
+                    .collect();
+                methods_total = methods.len();
+                methods
+                    .iter()
                     .take(MAX_METHODS)
                     .map(|s| {
                         let mut v = visited.clone();
@@ -8148,12 +8961,30 @@ fn tool_flow_trace(
                     .collect::<Result<Vec<Value>, _>>()?
             };
 
+            let methods_truncated = methods_total > method_trees.len();
             return Ok(json!({
                 "root_uid": root.uid,
                 "root_name": root.name,
                 "root_kind": "class",
                 "max_depth": max_depth,
-                "note": "Class expanded to its methods — classes have no direct CALLS edges. Methods filtered to this class only.",
+                "note": if methods_truncated {
+                    format!(
+                        "Class expanded to its methods — classes have no direct CALLS edges. \
+                         Methods filtered to this class only. Showing {} of {methods_total} \
+                         methods (cap {MAX_METHODS}); the cut is positional, not by importance.",
+                        method_trees.len()
+                    )
+                } else {
+                    "Class expanded to its methods — classes have no direct CALLS edges. \
+                     Methods filtered to this class only."
+                        .to_string()
+                },
+                // nw-390: the TOTAL, next to the returned list, so a caller can
+                // see the cut without counting the array against a cap that was
+                // never published.
+                "methods_returned": method_trees.len(),
+                "methods_total": methods_total,
+                "methods_truncated": methods_truncated,
                 "methods": method_trees,
             }));
         }
@@ -8185,6 +9016,12 @@ struct FlowTraceOpts<'a> {
     /// Cooperative cancellation flag, checked once per recursion level. See
     /// [`nestweaver_store::StoreError::Cancelled`] for the contract.
     cancel: Option<&'a std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    /// nw-403: the caller's per-repo visibility. A callee in a repository this
+    /// caller cannot see is dropped DURING the walk and counted into
+    /// `children_redacted`, rather than removed from a finished tree — a
+    /// silently deleted subtree is `children: []`, which is exactly the
+    /// "indistinguishable from a leaf" defect the rest of this function fixes.
+    visible: Option<&'a nestweaver_engine::authz::VisibleRepos>,
 }
 
 fn build_flow_tree(
@@ -8209,6 +9046,10 @@ fn build_flow_tree(
     }
 
     let mut children = Vec::new();
+    // nw-390. Three things used to make a suppressed expansion look like a
+    // genuine leaf, and all three are now stated on the node itself.
+    let mut truncated_at_depth = false;
+    let mut children_omitted = 0usize;
 
     // A failed callee lookup is NOT "this function calls nothing".
     //
@@ -8218,15 +9059,62 @@ fn build_flow_tree(
     // path a few lines above already refuses to serve a truncated tree as a
     // real answer; an unreadable one is no different, and this function
     // already returns a `Result` to say so.
-    if depth < opts.max_depth {
-        let callees = store.callees_with_edge_types_of(uid).map_err(|error| {
-            anyhow::anyhow!(
-                "flow_trace: could not read the callees of {uid}: {error}. Refusing to \
-                 report an empty call tree, which is indistinguishable from a leaf."
-            )
-        })?;
+    //
+    // nw-390: the callees are now read even AT the depth cap, where the old
+    // code returned without asking. That is one extra edge query per frontier
+    // node, and it buys the only fact that distinguishes "the cap stopped
+    // here" from "nothing is called here" — which is the whole complaint.
+    let callees = store.callees_with_edge_types_of(uid).map_err(|error| {
+        anyhow::anyhow!(
+            "flow_trace: could not read the callees of {uid}: {error}. Refusing to \
+             report an empty call tree, which is indistinguishable from a leaf."
+        )
+    })?;
+    // nw-403: attribute before anything is rendered or counted, so a hidden
+    // callee contributes to `children_redacted` and to nothing else.
+    let (callees, redacted): (Vec<_>, Vec<_>) = callees
+        .into_iter()
+        .partition(|(callee, _)| repo_is_visible(&callee.repo_uid, opts.visible));
+    let children_redacted = redacted.len();
+
+    if depth >= opts.max_depth {
+        // The cap fired. Say so, and say how many callees it hid — previously
+        // `children` simply stayed empty and was serialized as a leaf.
+        truncated_at_depth = !callees.is_empty();
+        children_omitted = callees.len();
+    } else {
         for (callee, edge_type) in &callees {
             if visited.contains(&callee.uid) {
+                // nw-390, THE non-monotonicity. `visited` is GLOBAL to the
+                // traversal, so a callee claimed by an earlier branch used to
+                // be dropped from every later parent with no marker at all —
+                // which is why raising `--max-depth` REMOVED children: at
+                // greater depth an earlier branch reaches the node first and a
+                // later parent silently loses it.
+                //
+                // A `deduped_ref` stub restores monotonicity as a property of
+                // the RESPONSE rather than of the traversal: the edge is
+                // always present and always names its target, and the subtree
+                // is expanded exactly once somewhere in the document. The
+                // alternative — expanding it twice — is exponential on a
+                // recursive graph, which is why `visited` exists.
+                let mut stub = if opts.concise {
+                    json!({ "name": callee.name, "deduped_ref": callee.uid, "children": [] })
+                } else {
+                    json!({
+                        "uid": callee.uid,
+                        "name": callee.name,
+                        "file_path": callee.file_path,
+                        "depth": depth + 1,
+                        "repo_uid": callee.repo_uid,
+                        "deduped_ref": callee.uid,
+                        "children": [],
+                    })
+                };
+                if let Some(object) = stub.as_object_mut() {
+                    object.insert("edge_type".to_string(), json!(edge_type));
+                }
+                children.push(stub);
                 continue;
             }
             visited.insert(callee.uid.clone());
@@ -8254,14 +9142,37 @@ fn build_flow_tree(
         }
     }
 
+    // nw-390: the markers ride on the node in BOTH renderings. A concise tree
+    // is read by exactly the caller who cannot afford to mistake a capped node
+    // for a leaf, and omitting them there would reproduce the bug in the
+    // compact shape. Only non-zero/true values are attached, so a genuine leaf
+    // stays byte-identical to what it always was and the flags remain
+    // falsifiable rather than decorative.
+    let attach_markers = |node: &mut Value| {
+        let Some(object) = node.as_object_mut() else {
+            return;
+        };
+        if truncated_at_depth {
+            object.insert("truncated_at_depth".to_string(), json!(true));
+        }
+        if children_omitted > 0 {
+            object.insert("children_omitted".to_string(), json!(children_omitted));
+        }
+        if children_redacted > 0 {
+            object.insert("children_redacted".to_string(), json!(children_redacted));
+        }
+    };
+
     if opts.concise {
         // The label ships in concise mode too: a caller scanning a compact tree
         // is exactly the one who cannot afford to mistake a cross-repo guess for
         // a call.
-        Ok(json!({
+        let mut node = json!({
             "name": name,
             "children": children,
-        }))
+        });
+        attach_markers(&mut node);
+        Ok(node)
     } else {
         // Look up repo_uid and canonical_id for boundary detection.
         let (repo_uid, canonical_id) = store
@@ -8274,7 +9185,7 @@ fn build_flow_tree(
                 )
             })
             .unwrap_or_default();
-        Ok(json!({
+        let mut node = json!({
             "uid": uid,
             "name": name,
             "file_path": file_path,
@@ -8282,7 +9193,9 @@ fn build_flow_tree(
             "repo_uid": repo_uid,
             "canonical_id": canonical_id,
             "children": children,
-        }))
+        });
+        attach_markers(&mut node);
+        Ok(node)
     }
 }
 
@@ -8430,15 +9343,23 @@ fn tool_detect_changes(store: &GraphStore, args: Value) -> Result<Value, anyhow:
 fn tool_schema_affected_tests() -> Value {
     json!({
         "name": "affected_tests",
-        "description": "Prioritize which test files a PR should run by mapping changed files through the call/import graph to test files. Results bucketed into priority tiers.\n\nRequires either 'changed_files' or 'base_ref' (at least one must be provided).\n\nGuidelines:\n- Provide changed_files (repo-relative) or base_ref (git ref like 'main') to diff against\n- tier_1 = directly references changed symbol, tier_2 = direct caller, tier_3 = transitive\n- For symbol-level blast radius use brain_impact; for risk scoring use detect_changes\n- `recommendation` is a machine-readable CI directive: 'run-full-suite' on any non-complete run (fail-safe widening), 'selection-usable' otherwise\n\nLimitations:\n- Static call-graph regression test selection — misses reflection, DI, codegen, and integration/e2e tests\n- 'No tests found' does NOT mean safe to skip testing. IMPORTANT: keep periodic full test runs in CI\n\nWhen queried through the hybrid client (a local daemon connected to an upstream server), returns two-tier results (local_impact + org_wide_impact) with _meta.sources indicating provenance; a raw MCP connection to a single daemon returns single-tier local results.",
+        "description": "Prioritize which test files a PR should run by mapping changed files through the call/import graph to test files. Results bucketed into priority tiers.\n\nRequires either 'changed_files' or 'base_ref' (at least one must be provided).\n\nREFUSAL: on a graph whose edges predate the running resolver this tool returns `refused: true` with `reason: \"outdated_resolver\"`, `resolver_stale_repos`, a `remedies` array, `recommendation: \"run-full-suite\"`, and NO tier keys at all — a missing edge can only make the selection SMALLER, so an under-resolved graph silently drops a regression test while the gate still reports success. Re-index every repo it names (`nestweaver index --repo <path> --force`; `--force` is required, a generation-stale repo is already at HEAD so a plain incremental index writes nothing) and call again.\n\nGuidelines:\n- Provide changed_files (repo-relative) or base_ref (git ref like 'main') to diff against\n- tier_1 = directly references changed symbol, tier_2 = direct caller, tier_3 = transitive\n- For symbol-level blast radius use brain_impact; for risk scoring use detect_changes\n- `recommendation` is a machine-readable CI directive: 'run-full-suite' on any non-complete run (fail-safe widening), 'selection-usable' otherwise\n\nLimitations:\n- Static call-graph regression test selection — misses reflection, DI, codegen, and integration/e2e tests\n- 'No tests found' does NOT mean safe to skip testing. IMPORTANT: keep periodic full test runs in CI\n\nWhen queried through the hybrid client (a local daemon connected to an upstream server), returns two-tier results (local_impact + org_wide_impact) with _meta.sources indicating provenance; a raw MCP connection to a single daemon returns single-tier local results.",
         "inputSchema": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
+                // nw-392. This is a merge-gate input: a changed file past the
+                // 1000th used to be dropped before analysis, absent from the
+                // echoed `changed_files` and from the notifications, while the
+                // run still reported `status: complete` /
+                // `recommendation: selection-usable`. A safety selector must
+                // REFUSE a request it cannot fully honour rather than answer a
+                // narrowed one, so the bound is declared and enforced.
                 "changed_files": {
                     "type": "array",
-                    "items": { "type": "string" },
-                    "description": "Changed file paths (repo-relative). Example: [\"src/auth/login.ts\"]."
+                    "items": { "type": "string", "maxLength": MAX_IDENTIFIER_LEN },
+                    "maxItems": MAX_IDENTIFIER_COUNT,
+                    "description": "Changed file paths (repo-relative). Example: [\"src/auth/login.ts\"]. At most 1000 entries of at most 512 bytes each; an oversized request is REJECTED rather than silently narrowed, because a test selection computed from a shortened change set is not a selection for that change."
                 },
                 "base_ref": {
                     "type": "string",
@@ -8454,6 +9375,16 @@ fn tool_affected_tests(
     args: Value,
     visible: Option<&nestweaver_engine::authz::VisibleRepos>,
 ) -> Result<Value, anyhow::Error> {
+    // nw-412: REFUSE before doing any work, the way `dead_code` does. On a
+    // resolver-generation-stale graph a MISSING edge makes the affected-test
+    // set SMALLER, so the regression test that should have run is silently
+    // dropped while the gate reports success. See
+    // `affected_tests_refusal_payload` for why this refuses where
+    // `blast_radius` degrades.
+    if let Some(refusal) = resolver_generation_refusal(store, visible)? {
+        return Ok(affected_tests_refusal_payload(&refusal));
+    }
+
     let owners = restricted_symbol_owners(store, visible)?;
 
     // Resolve the set of changed files: explicit list takes precedence over base_ref.
@@ -8466,7 +9397,8 @@ fn tool_affected_tests(
                     .collect()
             })
             .unwrap_or_default(),
-    );
+        "changed_files",
+    )?;
 
     let base_ref = args.get("base_ref").and_then(|v| v.as_str());
     if changed_files.is_empty()
@@ -8794,10 +9726,23 @@ fn tool_schema_stale_check() -> Value {
     })
 }
 
-fn tool_stale_check(store: &GraphStore) -> Result<Value, anyhow::Error> {
-    let repos = store
+fn tool_stale_check(
+    store: &GraphStore,
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
+) -> Result<Value, anyhow::Error> {
+    // nw-403: scoped at the SOURCE, not on the way out. Every number this tool
+    // publishes — `repo_count`, `any_stale`, `any_needs_reindex` and the three
+    // pre-summarised url lists — is derived from `repos` further down, so
+    // filtering the input is what keeps the summaries and the rows describing
+    // the same population. Filtering the output would have left
+    // `any_needs_reindex: true` with an empty `needs_reindex_repos`, which is
+    // the self-contradictory shape nw-163 and nw-370 spent two items removing.
+    let repos: Vec<_> = store
         .list_repos(None)
-        .map_err(|e| anyhow!("list_repos: {e}"))?;
+        .map_err(|e| anyhow!("list_repos: {e}"))?
+        .into_iter()
+        .filter(|repo| repo_is_visible(&repo.uid, visible))
+        .collect();
 
     // nw-370: the FOURTH rung of the ladder. `missing` / `incomplete` /
     // behind-HEAD all ask "is the input newer than the index?"; this one asks
@@ -9362,16 +10307,16 @@ fn tool_schema_project_context() -> Value {
                 "repos": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Scope results to these repos (display name, uid, or path substring). Use on a returning session to skip the broad load."
+                    "description": "Scope results to these repositories. Each entry must RESOLVE to one repo — exact repo UID, exact display name (case-insensitive), or exact clone URL / local root; an unresolvable or ambiguous entry is an ERROR rather than a filter that quietly matches nothing. Only nodes OWNED by a resolved repo are kept, so vault content (Note/Section/Heading/Tag), which belongs to a vault and not to any repository, is DROPPED when this is set. Use on a returning session to skip the broad load."
                 },
                 "path_prefix": {
                     "type": "string",
-                    "description": "Keep only nodes whose location starts with this path prefix (e.g. \"crates/nestweaver-daemon/\")."
+                    "description": "Keep only nodes whose location starts with this path prefix (e.g. \"crates/nestweaver-daemon/\"). Nodes that have NO path at all (Tag nodes carry an empty location) are exempt rather than excluded."
                 },
                 "tags": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Keep only note/section nodes tagged with any of these tags. Symbol nodes are always kept. Matching is case-insensitive and includes NESTED descendants: \"project\" matches \"project/nestweaver\" but never \"projectile\"."
+                    "description": "Keep only note/section nodes tagged with any of these tags. Symbol nodes carry no tags and are DROPPED when this is set, so a tag-scoped result can never be larger than the unscoped one. Matching is case-insensitive and includes NESTED descendants: \"project\" matches \"project/nestweaver\" but never \"projectile\"."
                 },
                 "exclude_tags": {
                     "type": "array",
@@ -9393,6 +10338,8 @@ fn tool_project_context(
     args: Value,
     embed_model: Option<&dyn EmbedQueryFn>,
     cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    // See `tool_brain_context` — same reason, same parameter.
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
 ) -> Result<Value, anyhow::Error> {
     // Reject an empty/whitespace project — otherwise the UID-substring fallback below
     // (`uid.contains(project_str)`) matches EVERY project on "" and silently resolves to the
@@ -9649,44 +10596,28 @@ fn tool_project_context(
 
     // 5b. repos + path_prefix scope filters (mirror brain_context so the two tools scope
     //     identically — the "load project_context, then narrow" handoff keeps the same params).
-    let repo_names = if filter_repos.is_some() {
-        build_repo_name_map(store)
-    } else {
-        std::collections::HashMap::new()
+    //     nw-405/406: this was a byte-for-byte COPY of brain_context's substring
+    //     predicate, which is why one grooming pass had to fix the same defect
+    //     in two places. Both now route through the shared resolver and the
+    //     shared retain helpers, so the next correction lands once.
+    let repo_scope = match filter_repos {
+        Some(ref selectors) => Some(resolve_repo_filter(store, selectors, visible)?),
+        None => None,
     };
     let apply_scope = |nodes: &mut Vec<nestweaver_engine::BrainNode>| {
-        if let Some(ref repos) = filter_repos {
-            let filter_lower: Vec<String> = repos.iter().map(|r| r.to_lowercase()).collect();
-            nodes.retain(|n| {
-                let node_repo_uid = if n.uid.starts_with("sym:") {
-                    let parts: Vec<&str> = n.uid[4..].splitn(4, ':').collect();
-                    if parts.len() >= 3 {
-                        Some(format!("{}:{}:{}", parts[0], parts[1], parts[2]))
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
-                filter_lower.iter().any(|r| {
-                    if let Some(ref repo_uid) = node_repo_uid
-                        && let Some(name) = repo_names.get(repo_uid)
-                        && name.to_lowercase().contains(r)
-                    {
-                        return true;
-                    }
-                    n.uid.to_lowercase().contains(r) || n.location.to_lowercase().contains(r)
-                })
-            });
+        if let Some(ref repo_uids) = repo_scope {
+            retain_nodes_in_repos(nodes, repo_uids);
         }
         if let Some(ref prefix) = path_prefix {
-            nodes.retain(|n| n.location.starts_with(prefix.as_str()));
+            retain_nodes_under_path_prefix(nodes, prefix.as_str());
         }
     };
     apply_scope(&mut result.seeds);
     apply_scope(&mut result.connected);
 
-    // 5c. tags filter: keep only note/section nodes tagged with any of these (symbols kept).
+    // 5c. tags filter: keep only note/section nodes tagged with any of these.
+    //     nw-407: symbols are no longer passed through unconditionally — see
+    //     the argument at brain_context's twin of this block.
     if let Some(tags) = args.get("tags").and_then(|v| v.as_array()) {
         let tag_names: Vec<String> = tags
             .iter()
@@ -9701,9 +10632,6 @@ fn tool_project_context(
                 .map_err(|e| anyhow!("list_section_uids_with_tags: {e}"))?;
             let filter_tagged = |nodes: &mut Vec<nestweaver_engine::BrainNode>| {
                 nodes.retain(|item| {
-                    if item.kind.to_lowercase().contains("symbol") {
-                        return true;
-                    }
                     tagged_notes.contains(&item.uid) || tagged_sections.contains(&item.uid)
                 });
             };
@@ -9994,12 +10922,22 @@ fn tool_dead_code(
     store: &GraphStore,
     args: Value,
     cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
 ) -> Result<Value, anyhow::Error> {
     // nw-372: REFUSE before doing any work. Every other resolver-generation
     // surface discloses and prints anyway; this one is a list of symbols to
     // delete, and a missing edge can only move a LIVE symbol onto it. See
     // `DeadCodeRefusal` for the full argument.
-    if let Some(refusal) = dead_code_refusal(store)? {
+    // nw-403 (review finding): the refusal payload is built from the STALE REPO
+    // SET, and `DeadCodeRefusal::payload()` emits `resolver_stale_repos` as a
+    // string array plus a `note` carrying one `index --repo <LOCAL PATH> --force`
+    // line per stale repo. Neither survives redaction — `row_allowed` only walks
+    // objects — so an unfiltered refusal hands a repo-scoped bearer token the
+    // UIDs *and the on-disk paths* of repos it may not see. `affected_tests` and
+    // `blast_radius` were given `visible` when nw-412 generalised this helper;
+    // `dead_code`, the ORIGINAL consumer, was left on `None`. Same bug, and the
+    // doc on `resolver_generation_refusal` already spells it out.
+    if let Some(refusal) = dead_code_refusal(store, visible)? {
         return Ok(refusal.payload());
     }
 
@@ -10268,7 +11206,7 @@ fn tool_bridge_nodes(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
 fn tool_schema_blast_radius() -> Value {
     json!({
         "name": "blast_radius",
-        "description": "Assess full blast radius of file changes: maps to symbols, traces reverse dependencies, groups by cluster, and returns risk level (Low/Medium/High) with impact scores.\n\nGuidelines:\n- Use BEFORE merging a PR; pass repo-relative changed file paths\n- Each affected symbol has impact_score (0.0-1.0) decaying through the call graph\n- For single-symbol impact use brain_impact; for cross-repo use cross_repo_contracts\n\n`cochanged_files` lists historically co-changing files (git history, Jaccard confidence) with no static edge — an advisory recall supplement; absence of co-change data is disclosed via a `cochange-unavailable` note.\n\nTrust contract (read before trusting a green result):\n- status (complete/partial/degraded/failed) + gate_state (ok/degraded-unknown/risk-flagged): a run that did NOT complete is degraded-unknown, NEVER risk-flagged — treat it as 'unknown, review manually', not 'safe'\n- coverage (repos in scope / not indexed / stale / truncated) distinguishes 'no impact' from 'incomplete coverage'\n- blind_spots: inherent static gaps (dynamic-dispatch, reflection, config-wiring, codegen) plus run-specific ones (pruned-below-threshold, depth-truncated, not-indexed)\n\nLimitations:\n- Static analysis only — misses dynamic dispatch and reflection (declared in blind_spots, not silently)\n- Response size scales with number of changed files and graph density\n\nWhen queried through the hybrid client (a local daemon connected to an upstream server), returns two-tier results (local_impact + org_wide_impact) with _meta.sources indicating provenance; a raw MCP connection to a single daemon returns single-tier local results. On an authenticated server with an [authz] policy, results are redacted to the caller's visible repos.",
+        "description": "Assess full blast radius of file changes: maps to symbols, traces reverse dependencies, groups by cluster, and returns risk level (Low/Medium/High) with impact scores.\n\nGuidelines:\n- Use BEFORE merging a PR; pass repo-relative changed file paths\n- Each affected symbol has impact_score (0.0-1.0) decaying through the call graph\n- For single-symbol impact use brain_impact; for cross-repo use cross_repo_contracts\n\n`cochanged_files` lists historically co-changing files (git history, Jaccard confidence) with no static edge — an advisory recall supplement; absence of co-change data is disclosed via a `cochange-unavailable` note.\n\nTrust contract (read before trusting a green result):\n- status (complete/partial/degraded/failed) + gate_state (ok/degraded-unknown/risk-flagged): a run that did NOT complete is degraded-unknown, NEVER risk-flagged — treat it as 'unknown, review manually', not 'safe'\n- a graph whose edges predate the running resolver DEGRADES rather than refusing: status becomes at least 'degraded', gate_state becomes 'degraded-unknown', and a `resolver.generation-stale` notification names the repos and the `nestweaver index --repo <path> --force` remedy. On such a graph a missing edge UNDERSTATES impact, so a green result there is not a green result. (`affected_tests` refuses outright on the same condition — it is a selector, and a narrowed selection cannot be widened back by its caller.)\n- coverage (repos in scope / not indexed / stale / truncated) distinguishes 'no impact' from 'incomplete coverage'\n- blind_spots: inherent static gaps (dynamic-dispatch, reflection, config-wiring, codegen) plus run-specific ones (pruned-below-threshold, depth-truncated, not-indexed)\n\nLimitations:\n- Static analysis only — misses dynamic dispatch and reflection (declared in blind_spots, not silently)\n- Response size scales with number of changed files and graph density\n\nWhen queried through the hybrid client (a local daemon connected to an upstream server), returns two-tier results (local_impact + org_wide_impact) with _meta.sources indicating provenance; a raw MCP connection to a single daemon returns single-tier local results. On an authenticated server with an [authz] policy, results are redacted to the caller's visible repos.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -10395,6 +11333,46 @@ fn tool_blast_radius(
         })?;
         nestweaver_engine::authz::redact_blast_radius_for_visibility(&mut result, v, &repos);
         nestweaver_engine::blast_radius::apply_affected_symbol_limit(&mut result, requested_limit);
+    }
+
+    // nw-412: a generation-stale graph is a run that did not complete.
+    //
+    // Applied HERE — after analysis and after the R9b redaction, before either
+    // rendering — so the SARIF leg carries it too; `pr-impact --sarif` is the
+    // merge-gate surface most likely to be read by a machine that never sees
+    // the JSON. Degrading rather than refusing is argued at
+    // `BLAST_RADIUS_RESOLVER_STALE_DESCRIPTOR`.
+    //
+    // `status` is only ever pushed DOWN (`.max` over the ordered ladder
+    // Complete < Partial < Degraded < Failed), matching nw-105's rule that a
+    // run already Degraded or Failed is never upgraded by a later finding, and
+    // `gate_state` is then forced to DegradedUnknown. That mirrors
+    // `derive_gate_state`'s "non-Complete => DegradedUnknown" without calling
+    // it (it is `pub(crate)` to the engine) and, crucially, closes the
+    // direction that made this dangerous: a stale-resolver run reported
+    // `gate_state: ok` over a shrunken affected set, and can no longer report
+    // `ok` at all.
+    if let Some(refusal) = resolver_generation_refusal(store, visible)? {
+        result.status = result
+            .status
+            .max(nestweaver_engine::blast_radius::AnalysisStatus::Degraded);
+        result.gate_state = nestweaver_engine::blast_radius::GateState::DegradedUnknown;
+        result
+            .notifications
+            .push(nestweaver_engine::blast_radius::Notification {
+                level: nestweaver_engine::blast_radius::NotificationLevel::Error,
+                message: refusal.message(),
+                descriptor: BLAST_RADIUS_RESOLVER_STALE_DESCRIPTOR.to_string(),
+            });
+        // `render_blast_summary` appends `[status: …]` for any non-Complete
+        // run and is `pub(crate)`, so the marker is restated here rather than
+        // leaving the human summary claiming a clean run. Guarded so a summary
+        // that already carries one is not double-tagged.
+        if !result.summary.contains("[status: ") {
+            result
+                .summary
+                .push_str(&format!(" [status: {}]", result.status.label()));
+        }
     }
 
     // SARIF output: emit a standard SARIF v2.1.0 run (with namespaced
@@ -12558,6 +13536,30 @@ pub fn attach_ranking_staleness(resp: &mut Value, store: &GraphStore) {
 /// binary. There is nothing there that can predate the running resolver.
 fn dead_code_refusal(
     store: &GraphStore,
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
+) -> Result<Option<nestweaver_engine::resolver_generation::DeadCodeRefusal>, anyhow::Error> {
+    resolver_generation_refusal(store, visible)
+}
+
+/// The resolver-generation verdict for the repos this caller can SEE, or
+/// `None` when every one of them is current.
+///
+/// nw-412 generalised `dead_code_refusal` (nw-372) to a second and third
+/// consumer rather than growing a parallel detector: the item's instruction is
+/// "the mechanism is already built and just not wired here — reuse both; do
+/// not invent a second mechanism". The computation underneath is still the
+/// single `ResolverGenerations::stale_repos` nw-358 collapsed everything onto.
+///
+/// `visible` narrows the repo set because `affected_tests` is
+/// `RepoScope::EnforcedInArm` — nothing redacts its response afterwards, so a
+/// refusal payload built from every repo in the graph would enumerate hidden
+/// repo UIDs to a repo-scoped bearer token, which is nw-403 exactly. It also
+/// makes the verdict CORRECT for that caller: a stale repo they cannot see can
+/// contribute no edge to an answer that is already filtered to their scope, so
+/// refusing on it would be refusing on someone else's data.
+fn resolver_generation_refusal(
+    store: &GraphStore,
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
 ) -> Result<Option<nestweaver_engine::resolver_generation::DeadCodeRefusal>, anyhow::Error> {
     let db_path = match (current_db_path(store), store.db_path()) {
         (Ok(path), _) => path,
@@ -12569,9 +13571,101 @@ fn dead_code_refusal(
     // error (and, on the CLI, the diagnostic nw-285 built for a schema-less
     // database) rather than a binder exception quoted inside a paragraph about
     // resolver generations.
-    let repos = store.list_repos(None)?;
+    let repos: Vec<nestweaver_schema::Repo> = store
+        .list_repos(None)?
+        .into_iter()
+        .filter(|repo| repo_is_visible(&repo.uid, visible))
+        .collect();
     Ok(nestweaver_engine::resolver_generation::DeadCodeRefusal::for_repos(&db_path, &repos))
 }
+
+/// Why `affected_tests` refuses a generation-stale graph instead of answering
+/// a narrower question.
+///
+/// nw-412. This is the counterpart of `WHY_DEAD_CODE_REFUSES` and it is worded
+/// separately because the ERROR DIRECTION is the opposite one and that is the
+/// whole argument. `dead-code` on a stale graph puts a LIVE symbol on a
+/// deletion list — bad, but a human reviewing the list can catch it. Here a
+/// missing edge makes the affected-test set SMALLER: the regression test that
+/// would have caught the change is never selected, the gate reports success,
+/// and there is no list for anyone to review. A test selector that refuses is
+/// safe; one that silently narrows is not.
+const WHY_AFFECTED_TESTS_REFUSES: &str = "affected-tests will not produce a selection on this graph. Its output is the set of tests a \
+     change can reach through the call/import graph, so a MISSING edge cannot make the selection \
+     safer — it can only drop a test that should have run, while `status` still reads complete. \
+     The error is one-directional and it is silent: nothing downstream can tell a test that was \
+     not selected from a test that does not exist.";
+
+/// Turn the shared resolver-generation verdict into `affected_tests`'
+/// refusal.
+///
+/// nw-412. The payload is `DeadCodeRefusal::payload()` — same `refused: true`,
+/// same `reason: "outdated_resolver"` token `stale-check` puts in a repo's
+/// `status`, same `remedies` array of ready-to-run
+/// `nestweaver index --repo <path> --force` commands, same `needs_reindex` key
+/// a CI job already gates on. Only two things are tool-specific:
+///
+///  * `note` is replaced, because `DeadCodeRefusal::message()` opens with
+///    "dead-code will not produce a list on this graph", which is the wrong
+///    sentence in front of the right remedies.
+///  * `recommendation: "run-full-suite"` is ADDED. It is the one key a CI
+///    consumer of this tool acts on, and the refusal deliberately carries no
+///    `tier_1`/`tier_2`/`tier_3` — so without it a caller that keys off "did I
+///    get tiers" would read the refusal as "no tests affected", which is the
+///    exact silent narrowing this refusal exists to prevent. It is the same
+///    fail-safe widening value the tool already emits for any non-complete
+///    run, so the vocabulary is unchanged.
+fn affected_tests_refusal_payload(
+    refusal: &nestweaver_engine::resolver_generation::DeadCodeRefusal,
+) -> Value {
+    let mut payload = refusal.payload();
+    let mut note = WHY_AFFECTED_TESTS_REFUSES.to_string();
+    for remedy in payload
+        .get("remedies")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        match remedy.get("command").and_then(Value::as_str) {
+            Some(command) => note.push_str(&format!("\n  {command}")),
+            None => note.push_str(&format!(
+                "\n  {} — indexed from a bare clone, so this machine has no working tree to \
+                 pass to `--repo`; re-index it where it lives",
+                remedy
+                    .get("uid")
+                    .and_then(Value::as_str)
+                    .unwrap_or("(unnamed repo)")
+            )),
+        }
+    }
+    payload["note"] = json!(note);
+    payload["recommendation"] = json!("run-full-suite");
+    payload
+}
+
+/// The notification `blast_radius` attaches when its graph is
+/// generation-stale.
+///
+/// nw-412 asked for a decision between refusing and degrading, per surface,
+/// and these two land differently:
+///
+///  * `affected_tests` REFUSES. It is a selector: its answer is consumed as
+///    "run exactly these", there is no field a caller can read to widen it
+///    back, and a narrowed selection is indistinguishable from a correct one.
+///  * `blast_radius` DEGRADES. It is an assessment, not a selector, and it
+///    already ships the exact contract this condition wants: `status` +
+///    `gate_state`, whose documented rule is that a run which did not complete
+///    is `degraded-unknown` and NEVER `risk-flagged` — "unknown, review
+///    manually", not "safe". A stale-resolver run IS a run that did not
+///    complete. Degrading also preserves `coverage`, `blind_spots` and the
+///    changed-file echo, which are what a human uses to decide whether to
+///    trust it, and it keeps the SARIF rendering valid; a refusal payload is
+///    not a SARIF run and would break `pr-impact --sarif` outright.
+///
+/// The direction that made nw-412 dangerous is closed either way: on a stale
+/// graph `blast_radius` used to report `gate_state: ok` with a shrunken
+/// affected set, and it can no longer report `ok` at all.
+const BLAST_RADIUS_RESOLVER_STALE_DESCRIPTOR: &str = "resolver.generation-stale";
 
 /// Attach a disclosure to a tool result without dropping one already there.
 ///
@@ -12687,7 +13781,7 @@ mod server_mode_tests {
         let store = GraphStore::in_memory().unwrap();
 
         set_server_mode(true);
-        let status = tool_brain_status(&store, None).unwrap();
+        let status = tool_brain_status(&store, None, None).unwrap();
         assert_eq!(
             status["server_mode"],
             serde_json::json!(true),
@@ -12695,7 +13789,7 @@ mod server_mode_tests {
         );
 
         set_server_mode(false);
-        let status = tool_brain_status(&store, None).unwrap();
+        let status = tool_brain_status(&store, None, None).unwrap();
         assert_eq!(
             status["server_mode"],
             serde_json::json!(false),
@@ -12874,6 +13968,7 @@ mod project_context_bug12_tests {
                 }),
                 None,
                 None,
+                None,
             )
             .unwrap();
             resp["connected"]
@@ -12982,6 +14077,7 @@ mod project_context_bug12_tests {
             json!({ "project": "Parallel Paths", "token_budget": 5000, "response_format": "detailed" }),
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -13012,6 +14108,7 @@ mod project_context_bug12_tests {
             &store,
             None,
             json!({ "seeds": ["LeafOnlySymbol"], "token_budget": 5000 }),
+            None,
             None,
             None,
         )
@@ -13054,6 +14151,7 @@ mod project_context_bug12_tests {
             json!({ "seeds": ["greet"], "token_budget": 5000, "include_seeds": true }),
             None,
             None,
+            None,
         )
         .unwrap();
         let any_body_off = off["connected"]
@@ -13074,6 +14172,7 @@ mod project_context_bug12_tests {
                 "include_bodies": true,
                 "root": root,
             }),
+            None,
             None,
             None,
         )
@@ -13374,7 +14473,7 @@ mod cache_dispatch_tests {
         set_current_db_path(db_path.clone());
         let store = GraphStore::open(&db_path).unwrap();
 
-        let value = tool_stale_check(&store).unwrap();
+        let value = tool_stale_check(&store, None).unwrap();
         for field in ["stale_repos", "needs_reindex_repos"] {
             assert!(
                 value[field].is_array(),
@@ -15727,6 +16826,7 @@ mod arg_alias_tests {
             json!({ "seeds": ["x"], "kinds": ["Banana"] }),
             None,
             None,
+            None,
         )
         .unwrap_err()
         .to_string();
@@ -15755,6 +16855,7 @@ mod arg_alias_tests {
             &store,
             None,
             json!({ "seeds": ["x"], "kinds": ["note", "SYMBOL", "Symbol/Function"] }),
+            None,
             None,
             None,
         )
@@ -16737,7 +17838,7 @@ mod stale_check_tool_tests {
         // Delete the working tree after indexing.
         std::fs::remove_dir_all(gone.path()).unwrap();
 
-        let result = tool_stale_check(&store).expect("stale check");
+        let result = tool_stale_check(&store, None).expect("stale check");
         assert_eq!(result["any_needs_reindex"], true, "{result}");
         let repo = &result["repos"][0];
         assert_eq!(repo["status"], "missing", "{result}");
@@ -16776,7 +17877,7 @@ mod stale_check_tool_tests {
             .expect("insert repo");
         std::fs::remove_dir_all(gone.path()).unwrap();
 
-        let result = tool_stale_check(&store).expect("stale check");
+        let result = tool_stale_check(&store, None).expect("stale check");
         let repo = &result["repos"][0];
         assert_eq!(repo["status"], "missing", "{result}");
         assert_eq!(repo["needs_reindex"], true, "{result}");
@@ -16818,7 +17919,7 @@ mod stale_check_tool_tests {
             })
             .expect("insert repo");
 
-        let result = tool_stale_check(&store).expect("stale check");
+        let result = tool_stale_check(&store, None).expect("stale check");
         assert_eq!(result["any_needs_reindex"], true, "{result}");
         assert_eq!(
             result["any_stale"], false,
@@ -16840,7 +17941,7 @@ mod stale_check_tool_tests {
                 content_hash: "h".to_string(),
             })
             .expect("insert file");
-        let healed = tool_stale_check(&store).expect("stale check");
+        let healed = tool_stale_check(&store, None).expect("stale check");
         assert_eq!(healed["any_stale"], false, "{healed}");
         assert_eq!(healed["any_needs_reindex"], false, "{healed}");
         assert_eq!(healed["repos"][0]["status"], "ok", "{healed}");
@@ -16899,7 +18000,7 @@ mod stale_check_tool_tests {
             .insert_vault_note_edge("vlt:1", "note:1")
             .expect("insert vault note edge");
 
-        let result = tool_stale_check(&store).expect("stale check");
+        let result = tool_stale_check(&store, None).expect("stale check");
         assert_eq!(result["any_stale"], false, "{result}");
         assert_eq!(result["repos"][0]["status"], "ok", "{result}");
     }
@@ -17713,5 +18814,1615 @@ mod detect_changes_gate_disclosure_tests {
         assert_eq!(payload["gate_state"], json!("ok"), "{payload}");
         assert_eq!(payload["status"], json!("complete"), "{payload}");
         assert_eq!(payload["notifications"], json!([]), "{payload}");
+    }
+}
+
+// ── nw-403: repository visibility, per tool ─────────────────────────────────
+
+/// nw-403 was a CRITICAL confidentiality bug whose entire shape was
+/// "somebody spot-checked one tool". `brain_search` enforced `[authz]`
+/// correctly, so the boundary looked healthy while 37 of the 42 dispatch arms
+/// never received the caller's visibility at all.
+///
+/// These tests are therefore TABLE-DRIVEN OVER EVERY TOOL. A per-tool table is
+/// the only shape in which "which arms enforce this?" has an answer, and the
+/// counterweight tests below exist so the table cannot pass vacuously — a
+/// fixture that stopped reaching the hidden repo would make every leak
+/// assertion trivially true, which is exactly how this survived.
+#[cfg(test)]
+mod repo_visibility_coverage_tests {
+    use super::*;
+    use nestweaver_engine::authz::VisibleRepos;
+    use nestweaver_schema::{EdgeType, Repo, ResolvedEdge, Symbol, SymbolKind, Visibility};
+
+    /// Tokens that appear ONLY in the hidden repo's data — never in any
+    /// argument this test sends. That distinction matters: an argument echoed
+    /// back is not a leak, and a marker a test can smuggle in through its own
+    /// input would make every assertion below meaningless.
+    const HIDDEN_MARKERS: &[&str] = &["hiddenSecret", "hidden-secret", "repo:hidden"];
+
+    /// The visible repo owns `src/alpha.py`; the hidden repo owns a symbol in
+    /// a file at the SAME repo-relative path (paths are repo-relative, so this
+    /// is the ordinary case, not a contrived one) plus a caller and a callee
+    /// of the visible symbol. Every leak route the bug report measured —
+    /// file→symbol, forward call, reverse call, repo identity — is reachable
+    /// from arguments that name only visible things.
+    fn hidden_repo_store() -> GraphStore {
+        let store = GraphStore::in_memory().expect("in_memory store");
+        let repo = |uid: &str, url: &str, name: &str| Repo {
+            uid: uid.to_string(),
+            url: url.to_string(),
+            indexed_sha: "0123456789abcdef0123456789abcdef01234567".to_string(),
+            staleness_commits_behind: 0,
+            instance_id: "inst".to_string(),
+            name: Some(name.to_string()),
+            root_path: None,
+        };
+        let symbol = |uid: &str, name: &str, repo_uid: &str, file: &str, line: u32| Symbol {
+            uid: uid.to_string(),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            repo_uid: repo_uid.to_string(),
+            file_path: file.to_string(),
+            start_line: line,
+            end_line: line,
+            signature: format!("fn {name}()"),
+            summary: None,
+            content_hash: format!("h_{uid}"),
+            embedding: None,
+            pagerank_score: Some(0.5),
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Inferred,
+            type_info: None,
+            framework_hint: None,
+            canonical_id: None,
+        };
+        store
+            .insert_repo(&repo("repo:alpha", "https://example.test/alpha", "alpha"))
+            .unwrap();
+        store
+            .insert_repo(&repo(
+                "repo:hidden",
+                "https://example.test/hidden-secret",
+                "hidden-secret",
+            ))
+            .unwrap();
+        store
+            .insert_symbol(&symbol(
+                "sym:alpha:public",
+                "alphaPublicHelper",
+                "repo:alpha",
+                "src/alpha.py",
+                1,
+            ))
+            .unwrap();
+        // Same repo-relative path, different repo: the file→symbol route.
+        store
+            .insert_symbol(&symbol(
+                "sym:hidden:twin",
+                "hiddenSecretTwin",
+                "repo:hidden",
+                "src/alpha.py",
+                2,
+            ))
+            .unwrap();
+        // Forward call route (flow_trace, code_context).
+        store
+            .insert_symbol(&symbol(
+                "sym:hidden:callee",
+                "hiddenSecretCallee",
+                "repo:hidden",
+                "secret/hidden.py",
+                3,
+            ))
+            .unwrap();
+        // Reverse call route (impact, blast_radius, dead_code reachability).
+        store
+            .insert_symbol(&symbol(
+                "sym:hidden:caller",
+                "hiddenSecretCaller",
+                "repo:hidden",
+                "secret/hidden.py",
+                4,
+            ))
+            .unwrap();
+        for (source, target) in [
+            ("sym:alpha:public", "sym:hidden:callee"),
+            ("sym:hidden:caller", "sym:alpha:public"),
+        ] {
+            store
+                .insert_edge(&ResolvedEdge {
+                    source_uid: source.to_string(),
+                    target_uid: target.to_string(),
+                    edge_type: EdgeType::Calls,
+                    confidence: 0.9,
+                    link_type: None,
+                    evidence: vec![],
+                })
+                .unwrap();
+        }
+        store
+    }
+
+    /// Every tool in the catalogue, with arguments that name ONLY visible
+    /// things. Kept as one table so a new tool that is added to
+    /// `dispatch_tool_arm` without a row here fails
+    /// `the_visibility_table_covers_every_tool` rather than going untested.
+    fn tool_call_table() -> Vec<(&'static str, Value)> {
+        vec![
+            ("brain_context", json!({ "query": "alphaPublicHelper" })),
+            ("code_context", json!({ "seeds": ["alphaPublicHelper"] })),
+            ("brain_search", json!({ "query": "alphaPublicHelper" })),
+            ("note_get", json!({ "uid": "note:absent" })),
+            ("backlinks", json!({ "uid": "note:absent" })),
+            ("brain_status", json!({})),
+            ("brain_add_source", json!({ "path": "/tmp/nw-403-absent" })),
+            ("brain_remove_source", json!({ "uid": "repo:alpha" })),
+            ("prune_stale", json!({})),
+            ("compact_embeddings", json!({ "dry_run": true })),
+            (
+                "cross_repo_contracts",
+                json!({ "name": "alphaPublicHelper" }),
+            ),
+            ("brain_impact", json!({ "symbol": "alphaPublicHelper" })),
+            ("brain_guide", json!({})),
+            ("flow_trace", json!({ "symbol": "alphaPublicHelper" })),
+            (
+                "detect_changes",
+                json!({ "changed_files": ["src/alpha.py"] }),
+            ),
+            ("clusters", json!({})),
+            ("stale_check", json!({})),
+            (
+                "set_extension",
+                json!({ "scope_uid": "repo:alpha", "key": "k", "value": "v" }),
+            ),
+            ("query_extensions", json!({ "scope_uid": "repo:alpha" })),
+            ("brain_diff", json!({})),
+            (
+                "project_context",
+                json!({ "project": "alpha", "response_format": "detailed" }),
+            ),
+            ("dead_code", json!({})),
+            ("hub_nodes", json!({})),
+            ("bridge_nodes", json!({})),
+            ("blast_radius", json!({ "changed_files": ["src/alpha.py"] })),
+            ("get_summary", json!({ "level": "file" })),
+            (
+                "read_symbols",
+                json!({ "targets": ["alphaPublicHelper"], "include_neighbors": 5 }),
+            ),
+            ("regex_search", json!({ "pattern": "Helper" })),
+            ("count_patterns", json!({ "patterns": ["Helper"] })),
+            ("brain_broken_links", json!({})),
+            ("brain_orphan_documents", json!({})),
+            ("brain_topic_clusters", json!({})),
+            ("brain_tag_graph", json!({})),
+            ("brain_doc_stats", json!({})),
+            (
+                "affected_tests",
+                json!({ "changed_files": ["src/alpha.py"] }),
+            ),
+            (
+                "investigate",
+                json!({ "question": "what calls alphaPublicHelper" }),
+            ),
+            ("investigate_expand", json!({ "card_id": "absent" })),
+            ("investigate_hydrate", json!({ "card_id": "absent" })),
+            ("contract_drift", json!({})),
+            ("brain_memory_lint", json!({})),
+            ("brain_memory_consolidate", json!({})),
+            ("brain_memory_related", json!({ "uid": "note:absent" })),
+        ]
+    }
+
+    fn rendered(result: Result<Value, anyhow::Error>) -> String {
+        match result {
+            // An error cannot leak rows, but it can still name a repo, so the
+            // message is asserted over too.
+            Err(error) => format!("{error:#}"),
+            Ok(value) => value.to_string(),
+        }
+    }
+
+    fn call(
+        store: &GraphStore,
+        name: &str,
+        args: &Value,
+        visible: Option<&VisibleRepos>,
+    ) -> String {
+        rendered(dispatch_cancellable(
+            store,
+            None,
+            name,
+            args.clone(),
+            None,
+            None,
+            visible,
+        ))
+    }
+
+    fn only_alpha() -> VisibleRepos {
+        VisibleRepos::Only(["repo:alpha".to_string()].into_iter().collect())
+    }
+
+    fn leaked(rendered: &str) -> Option<&'static str> {
+        HIDDEN_MARKERS
+            .iter()
+            .copied()
+            .find(|marker| rendered.contains(marker))
+    }
+
+    #[test]
+    fn the_visibility_table_covers_every_tool() {
+        let declared: std::collections::BTreeSet<String> = tool_list(false)["tools"]
+            .as_array()
+            .expect("tool list")
+            .iter()
+            .filter_map(|tool| tool["name"].as_str().map(str::to_string))
+            .collect();
+        let covered: std::collections::BTreeSet<String> = tool_call_table()
+            .into_iter()
+            .map(|(name, _)| name.to_string())
+            .collect();
+        assert_eq!(
+            declared, covered,
+            "every tool must have a repo-visibility row; nw-403 was 37 tools nobody had a row for"
+        );
+    }
+
+    /// The inverted default. A tool nobody wrote a disposition for must refuse
+    /// a repo-scoped caller, and every REAL tool must have one — the two halves
+    /// together are what make the default safe rather than merely documented.
+    #[test]
+    fn every_tool_declares_a_repo_scope_disposition_and_the_default_fails_closed() {
+        for (name, _) in tool_call_table() {
+            match repo_scope(name) {
+                RepoScope::FailClosed(reason) => assert_ne!(
+                    reason, UNDECLARED_TOOL_SCOPE,
+                    "{name} has no recorded repo-visibility disposition"
+                ),
+                RepoScope::NotRepoScoped(reason) => assert!(
+                    !reason.is_empty(),
+                    "{name} opts out of scoping without a justification"
+                ),
+                RepoScope::EnforcedInArm | RepoScope::RedactedAfterDispatch => {}
+            }
+        }
+        // Counterweight: the fallback really is fail-closed, so a tool added
+        // tomorrow cannot inherit the old "leak" default.
+        match repo_scope("a_tool_that_was_added_without_thinking_about_authz") {
+            RepoScope::FailClosed(reason) => assert_eq!(reason, UNDECLARED_TOOL_SCOPE),
+            other => panic!("an undeclared tool must fail closed, got {other:?}"),
+        }
+    }
+
+    /// THE bug: a bearer token authorized for `repo:alpha` only must not
+    /// receive `repo:hidden` data from ANY tool.
+    #[test]
+    fn no_tool_returns_hidden_repo_data_to_a_repo_scoped_caller() {
+        let store = hidden_repo_store();
+        let visible = only_alpha();
+        let mut offenders: Vec<String> = Vec::new();
+        for (name, args) in tool_call_table() {
+            let body = call(&store, name, &args, Some(&visible));
+            if let Some(marker) = leaked(&body) {
+                offenders.push(format!("{name} leaked {marker:?}: {body}"));
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "tools leaked hidden-repo data to a repo-scoped caller:\n{}",
+            offenders.join("\n")
+        );
+    }
+
+    /// COUNTERWEIGHT, and the most important test in this module: the
+    /// assertion above must not be passing because the fixture stopped
+    /// reaching the hidden repo. Without a policy every one of these tools
+    /// DOES surface it, which is precisely what nw-403 measured — so the
+    /// unscoped run has to leak from a broad set of tools, including the ones
+    /// the bug report named by hand.
+    #[test]
+    fn the_same_calls_do_return_hidden_repo_data_when_no_policy_is_configured() {
+        let store = hidden_repo_store();
+        let leaking: std::collections::BTreeSet<String> = tool_call_table()
+            .into_iter()
+            .filter(|(name, args)| leaked(&call(&store, name, args, None)).is_some())
+            .map(|(name, _)| name.to_string())
+            .collect();
+        // Every one of these was named in nw-403's measured leak table.
+        // `regex_search` and `count_patterns` were too, but their corpus is
+        // the trigram/posting index rather than the graph rows, so an
+        // in-memory fixture cannot reach them here; the redactor's own unit
+        // test covers a regex_search-shaped payload instead.
+        for required in [
+            "brain_status",
+            "clusters",
+            "code_context",
+            "dead_code",
+            "detect_changes",
+            "flow_trace",
+            "get_summary",
+            "hub_nodes",
+            "read_symbols",
+            "stale_check",
+        ] {
+            assert!(
+                leaking.contains(required),
+                "fixture no longer reaches the hidden repo through {required}, so the scoped \
+                 assertion for it would pass vacuously (leaking: {leaking:?})"
+            );
+        }
+    }
+
+    /// COUNTERWEIGHT: scoping must not be over-applied. A caller authorized
+    /// for BOTH repos is not restricted at all in effect, and an unconfigured
+    /// deployment (`None`) must be byte-identical to the pre-nw-403 behaviour.
+    #[test]
+    fn a_caller_authorized_for_every_repo_still_sees_every_repo() {
+        let store = hidden_repo_store();
+        let all = VisibleRepos::Only(
+            ["repo:alpha".to_string(), "repo:hidden".to_string()]
+                .into_iter()
+                .collect(),
+        );
+        let scoped = call(&store, "brain_status", &json!({}), Some(&all));
+        assert!(
+            scoped.contains("hidden-secret"),
+            "a caller authorized for repo:hidden must still see it: {scoped}"
+        );
+        let unscoped = call(&store, "brain_status", &json!({}), None);
+        assert!(unscoped.contains("hidden-secret"), "{unscoped}");
+        assert!(
+            !unscoped.contains("\"visibility\""),
+            "an unscoped caller must not receive a scoping disclosure: {unscoped}"
+        );
+    }
+
+    /// `brain_status` is called out separately because it leaks repo IDENTITY
+    /// (URL + indexed git SHA) rather than repo content, and because its
+    /// summaries have to stay consistent with the list they summarise.
+    #[test]
+    fn brain_status_scopes_the_repo_list_without_erasing_the_visible_repo() {
+        let store = hidden_repo_store();
+        let visible = only_alpha();
+        let value = dispatch_cancellable(
+            &store,
+            None,
+            "brain_status",
+            json!({}),
+            None,
+            None,
+            Some(&visible),
+        )
+        .expect("brain_status must still answer a scoped caller");
+        assert_eq!(value["repo_count"], json!(1), "{value}");
+        let repos = value["repos"].as_array().expect("repos array");
+        assert_eq!(repos.len(), 1, "{value}");
+        assert_eq!(
+            repos[0]["url"],
+            json!("https://example.test/alpha"),
+            "{value}"
+        );
+        assert_eq!(value["visibility"]["scoped"], json!(true), "{value}");
+        assert_eq!(value["visibility"]["repos_hidden"], json!(1), "{value}");
+    }
+
+    /// `stale_check` is scoped at its INPUT so its pre-summarised lists cannot
+    /// disagree with its rows — a scoped `any_needs_reindex: true` with an
+    /// empty `needs_reindex_repos` would be the self-contradictory shape
+    /// nw-163/nw-370 removed.
+    #[test]
+    fn stale_check_summaries_describe_only_the_repos_it_returned() {
+        let store = hidden_repo_store();
+        let visible = only_alpha();
+        let value = dispatch_cancellable(
+            &store,
+            None,
+            "stale_check",
+            json!({}),
+            None,
+            None,
+            Some(&visible),
+        )
+        .expect("stale_check must still answer a scoped caller");
+        assert_eq!(value["repo_count"], json!(1), "{value}");
+        assert_eq!(value["repos"].as_array().map(Vec::len), Some(1), "{value}");
+        for key in ["stale_repos", "needs_reindex_repos", "resolver_stale_repos"] {
+            for url in value[key].as_array().expect(key) {
+                assert_ne!(
+                    url.as_str(),
+                    Some("https://example.test/hidden-secret"),
+                    "{key} named a hidden repo: {value}"
+                );
+            }
+        }
+    }
+
+    /// A concise rendering drops the uid the redactor attributes rows by. It
+    /// is REFUSED rather than served unfiltered, and the message has to name
+    /// the remedy because `project_context` defaults to concise.
+    #[test]
+    fn a_concise_request_is_refused_rather_than_served_unfiltered() {
+        let store = hidden_repo_store();
+        let visible = only_alpha();
+        let error = dispatch_cancellable(
+            &store,
+            None,
+            "dead_code",
+            json!({ "response_format": "concise" }),
+            None,
+            None,
+            Some(&visible),
+        )
+        .expect_err("a concise response cannot be repo-scoped");
+        let text = format!("{error:#}");
+        assert!(text.contains("concise"), "{text}");
+        assert!(text.contains("detailed"), "{text}");
+        // Counterweight: the refusal is about SCOPING, not about concise mode.
+        // An unscoped caller keeps the concise rendering it always had.
+        assert!(
+            dispatch_cancellable(
+                &store,
+                None,
+                "dead_code",
+                json!({ "response_format": "concise" }),
+                None,
+                None,
+                None,
+            )
+            .is_ok(),
+            "concise must keep working for an unscoped caller"
+        );
+    }
+
+    /// A fail-closed tool must SAY it refused, not return an empty answer that
+    /// reads as "no findings" — that inversion is what made the original bug
+    /// invisible.
+    #[test]
+    fn a_fail_closed_tool_refuses_out_loud() {
+        let store = hidden_repo_store();
+        let visible = only_alpha();
+        let error = dispatch_cancellable(
+            &store,
+            None,
+            "get_summary",
+            json!({ "level": "file" }),
+            None,
+            None,
+            Some(&visible),
+        )
+        .expect_err("get_summary cannot be scoped");
+        let text = format!("{error:#}");
+        assert!(text.contains("repository-scoped caller"), "{text}");
+        assert!(text.contains("nw-403"), "{text}");
+    }
+
+    /// The redactor, exercised directly on a `regex_search`-shaped payload.
+    ///
+    /// `regex_search` answers out of the trigram/posting corpus rather than
+    /// the graph rows, so the in-memory fixture above cannot drive a hit
+    /// through it — and a tool whose filtering is untested because the fixture
+    /// could not reach it is the exact position nw-403 started from. This
+    /// pins the rule on the shape the tool actually returns.
+    #[test]
+    fn the_redactor_drops_hidden_rows_and_keeps_vault_rows_it_cannot_own() {
+        let store = hidden_repo_store();
+        let visible = only_alpha();
+        let mut payload = json!({
+            "results": [
+                { "uid": "sym:alpha:public", "title": "alphaPublicHelper", "location": "src/alpha.py" },
+                { "uid": "sym:hidden:twin", "title": "hiddenSecretTwin", "location": "src/alpha.py" },
+                { "uid": "sec:note:vlt:1:2:intro", "title": "Intro", "location": "notes/intro.md" },
+                { "uid": "sym:deleted:unknown", "title": "TombstonedRow", "location": "x.py" },
+            ],
+            "truncated": false,
+        });
+        redact_response_for_visibility(&store, &mut payload, Some(&visible)).unwrap();
+        let titles: Vec<&str> = payload["results"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|row| row["title"].as_str())
+            .collect();
+        // The hidden symbol goes. The vault section stays: it has no repo, so
+        // repo visibility neither permits nor forbids it.
+        assert_eq!(titles, vec!["alphaPublicHelper", "Intro"], "{payload}");
+        // A `sym:` uid the ownership scan never saw is UNATTRIBUTABLE, and
+        // unattributable is not the same as unowned — it is dropped.
+        assert_eq!(
+            payload["visibility"]["redacted_entries"],
+            json!(2),
+            "{payload}"
+        );
+        // COUNTERWEIGHT: the same payload is untouched for an unscoped caller,
+        // and carries no disclosure claiming it was scoped.
+        let mut unscoped = json!({ "results": [ { "uid": "sym:hidden:twin" } ] });
+        redact_response_for_visibility(&store, &mut unscoped, None).unwrap();
+        assert_eq!(unscoped["results"].as_array().map(Vec::len), Some(1));
+        assert!(unscoped.get("visibility").is_none(), "{unscoped}");
+    }
+}
+
+// ── nw-390: flow_trace must not render a suppressed expansion as a leaf ─────
+
+#[cfg(test)]
+mod flow_trace_truncation_tests {
+    use super::*;
+    use nestweaver_schema::{EdgeType, Repo, ResolvedEdge, Symbol, SymbolKind, Visibility};
+
+    fn symbol(uid: &str, name: &str, kind: SymbolKind, line: u32) -> Symbol {
+        Symbol {
+            uid: uid.to_string(),
+            name: name.to_string(),
+            kind,
+            repo_uid: "repo:only".to_string(),
+            file_path: "src/lib.rs".to_string(),
+            start_line: line,
+            end_line: line + 1,
+            signature: format!("fn {name}()"),
+            summary: None,
+            content_hash: format!("h_{uid}"),
+            embedding: None,
+            pagerank_score: Some(0.5),
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Inferred,
+            type_info: None,
+            framework_hint: None,
+            canonical_id: None,
+        }
+    }
+
+    fn store_with(symbols: &[Symbol], edges: &[(&str, &str, EdgeType)]) -> GraphStore {
+        let store = GraphStore::in_memory().expect("in_memory store");
+        store
+            .insert_repo(&Repo {
+                uid: "repo:only".to_string(),
+                url: "https://example.test/only".to_string(),
+                indexed_sha: String::new(),
+                staleness_commits_behind: 0,
+                instance_id: "inst".to_string(),
+                name: None,
+                root_path: None,
+            })
+            .unwrap();
+        for sym in symbols {
+            store.insert_symbol(sym).unwrap();
+        }
+        for (source, target, edge_type) in edges {
+            store
+                .insert_edge(&ResolvedEdge {
+                    source_uid: source.to_string(),
+                    target_uid: target.to_string(),
+                    edge_type: *edge_type,
+                    confidence: 0.9,
+                    link_type: None,
+                    evidence: vec![],
+                })
+                .unwrap();
+        }
+        store
+    }
+
+    /// `root -> a`, `root -> shared`, `a -> shared`.
+    ///
+    /// This is the minimal shape of the reported non-monotonicity. At
+    /// `max_depth 1` the root lists both callees. At `max_depth 2` the walk
+    /// reaches `shared` through `a` first, marks it globally visited, and the
+    /// root's own edge to `shared` used to be `continue`d away — so asking for
+    /// MORE depth returned FEWER children.
+    fn diamond_store() -> GraphStore {
+        store_with(
+            &[
+                symbol("sym:root", "rootFn", SymbolKind::Function, 1),
+                symbol("sym:a", "aFn", SymbolKind::Function, 10),
+                symbol("sym:shared", "sharedFn", SymbolKind::Function, 20),
+                symbol("sym:deep", "deepFn", SymbolKind::Function, 30),
+            ],
+            &[
+                ("sym:root", "sym:a", EdgeType::Calls),
+                ("sym:root", "sym:shared", EdgeType::Calls),
+                ("sym:a", "sym:shared", EdgeType::Calls),
+                ("sym:shared", "sym:deep", EdgeType::Calls),
+            ],
+        )
+    }
+
+    /// Every uid that appears anywhere in a rendered tree.
+    fn uids(value: &Value) -> std::collections::BTreeSet<String> {
+        let mut found = std::collections::BTreeSet::new();
+        fn walk(value: &Value, found: &mut std::collections::BTreeSet<String>) {
+            match value {
+                Value::Object(map) => {
+                    if let Some(uid) = map.get("uid").and_then(Value::as_str) {
+                        found.insert(uid.to_string());
+                    }
+                    for child in map.values() {
+                        walk(child, found);
+                    }
+                }
+                Value::Array(items) => items.iter().for_each(|item| walk(item, found)),
+                _ => {}
+            }
+        }
+        walk(value, &mut found);
+        found
+    }
+
+    fn trace(store: &GraphStore, max_depth: u64) -> Value {
+        tool_flow_trace(
+            store,
+            json!({ "symbol": "rootFn", "max_depth": max_depth }),
+            None,
+            None,
+        )
+        .expect("flow_trace")
+    }
+
+    /// THE property nw-390 asks for: the callee set at depth N+1 is a superset
+    /// of the set at depth N, for a fixed root.
+    #[test]
+    fn the_callee_set_at_depth_n_plus_one_is_a_superset_of_depth_n() {
+        let store = diamond_store();
+        let mut previous = uids(&trace(&store, 1));
+        for depth in 2..=5 {
+            let current = uids(&trace(&store, depth));
+            assert!(
+                previous.is_subset(&current),
+                "raising max_depth to {depth} REMOVED callees: {:?} vanished",
+                previous.difference(&current).collect::<Vec<_>>()
+            );
+            previous = current;
+        }
+        // COUNTERWEIGHT: monotone must not mean constant. Depth genuinely buys
+        // reach, or a walk that returned the root alone would pass above.
+        assert!(
+            uids(&trace(&store, 1)).len() < uids(&trace(&store, 5)).len(),
+            "a deeper trace must actually reach further"
+        );
+    }
+
+    /// The per-node form of the same regression, which is how it was reported:
+    /// a parent that listed two children at `--max-depth 2` listed none at 3.
+    #[test]
+    fn a_globally_visited_callee_still_appears_under_every_parent_that_calls_it() {
+        let store = diamond_store();
+        let root_children = |depth: u64| -> Vec<String> {
+            trace(&store, depth)["tree"]["children"]
+                .as_array()
+                .expect("children")
+                .iter()
+                .filter_map(|child| child["uid"].as_str().map(str::to_string))
+                .collect()
+        };
+        assert_eq!(root_children(1), root_children(2));
+        assert_eq!(root_children(2), root_children(3));
+        // The second occurrence is a REFERENCE, not a second expansion: the
+        // subtree is rendered exactly once, which is why `visited` exists.
+        let deeper = trace(&store, 3);
+        let dedup = deeper["tree"]["children"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|child| child["deduped_ref"].is_string())
+            .expect("the repeated callee must be marked, not dropped");
+        assert_eq!(dedup["deduped_ref"], json!("sym:shared"));
+        assert_eq!(dedup["children"], json!([]));
+    }
+
+    /// A node the depth cap stopped at and a node that genuinely calls nothing
+    /// used to be byte-identical.
+    #[test]
+    fn a_depth_capped_node_is_distinguishable_from_a_real_leaf() {
+        let store = diamond_store();
+        let capped = trace(&store, 1);
+        let frontier = &capped["tree"]["children"][0];
+        assert_eq!(frontier["truncated_at_depth"], json!(true), "{capped}");
+        assert!(
+            frontier["children_omitted"].as_u64().unwrap_or(0) > 0,
+            "{capped}"
+        );
+        // COUNTERWEIGHT: a genuine leaf must NOT be marked, or the flag stops
+        // distinguishing anything. `deepFn` calls nothing at any depth.
+        let full = trace(&store, 5);
+        let leaf = uids(&full);
+        assert!(leaf.contains("sym:deep"), "{full}");
+        fn find<'a>(value: &'a Value, uid: &str) -> Option<&'a Value> {
+            if value["uid"] == json!(uid) {
+                return Some(value);
+            }
+            value["children"]
+                .as_array()?
+                .iter()
+                .find_map(|child| find(child, uid))
+        }
+        let deep = find(&full["tree"], "sym:deep").expect("deepFn in the tree");
+        assert!(deep.get("truncated_at_depth").is_none(), "{deep}");
+        assert!(deep.get("children_omitted").is_none(), "{deep}");
+        assert_eq!(deep["children"], json!([]));
+    }
+
+    /// `MAX_METHODS = 20` was applied silently while the response `note`
+    /// explained the class expansion and said nothing about the cut.
+    #[test]
+    fn a_class_expansion_reports_how_many_methods_it_did_not_show() {
+        let mut symbols = vec![symbol("sym:cls", "BigClass", SymbolKind::Class, 1)];
+        let mut edges = Vec::new();
+        for index in 0..25u32 {
+            symbols.push(symbol(
+                Box::leak(format!("sym:m{index}").into_boxed_str()),
+                Box::leak(format!("method{index}").into_boxed_str()),
+                SymbolKind::Method,
+                100 + index,
+            ));
+            edges.push((
+                Box::leak(format!("sym:m{index}").into_boxed_str()) as &str,
+                "sym:cls",
+                EdgeType::MemberOf,
+            ));
+        }
+        let store = store_with(&symbols, &edges);
+        let value = tool_flow_trace(&store, json!({ "symbol": "BigClass" }), None, None).unwrap();
+        assert_eq!(value["root_kind"], json!("class"), "{value}");
+        assert_eq!(value["methods_total"], json!(25), "{value}");
+        assert_eq!(value["methods_returned"], json!(20), "{value}");
+        assert_eq!(value["methods_truncated"], json!(true), "{value}");
+        assert!(
+            value["note"].as_str().unwrap_or_default().contains("of 25"),
+            "the note must name the cut it performs: {value}"
+        );
+
+        // COUNTERWEIGHT: a class under the cap must not claim truncation.
+        let small = store_with(
+            &[
+                symbol("sym:small", "SmallClass", SymbolKind::Class, 1),
+                symbol("sym:only", "onlyMethod", SymbolKind::Method, 5),
+            ],
+            &[("sym:only", "sym:small", EdgeType::MemberOf)],
+        );
+        let value = tool_flow_trace(&small, json!({ "symbol": "SmallClass" }), None, None).unwrap();
+        assert_eq!(value["methods_total"], json!(1), "{value}");
+        assert_eq!(value["methods_truncated"], json!(false), "{value}");
+    }
+}
+
+// ── nw-392: a bounded request is rejected, never silently shortened ─────────
+
+#[cfg(test)]
+mod request_bound_tests {
+    use super::*;
+
+    fn store() -> GraphStore {
+        GraphStore::in_memory().expect("in_memory store")
+    }
+
+    fn targets(count: usize) -> Vec<String> {
+        (0..count)
+            .map(|index| format!("junkTarget{index}"))
+            .collect()
+    }
+
+    /// The exact boundary the item asks for: 1000 accepted, 1001 handled.
+    ///
+    /// The old code truncated at 1000 and then reported `truncated: false`
+    /// with an empty `dropped`, so a real symbol sent as the 1001st target
+    /// appeared in NEITHER `symbols` nor `not_found` nor `dropped`.
+    #[test]
+    fn read_symbols_accepts_one_thousand_targets_and_rejects_one_thousand_and_one() {
+        let store = store();
+        let accepted = tool_read_symbols(&store, json!({ "targets": targets(1000) }));
+        assert!(accepted.is_ok(), "1000 targets must be accepted");
+
+        let error = tool_read_symbols(&store, json!({ "targets": targets(1001) }))
+            .expect_err("1001 targets must not be silently shortened");
+        let text = format!("{error:#}");
+        assert!(text.contains("1001"), "{text}");
+        assert!(text.contains("REJECTED"), "{text}");
+        assert!(text.contains("targets"), "{text}");
+    }
+
+    /// The safety leg. `affected_tests` decides which tests a PR must run; its
+    /// contract is fail-safe WIDENING, and silently narrowing its own input
+    /// inverted that — 113 required test files were dropped while the payload
+    /// reported `status: complete` / `recommendation: selection-usable`.
+    #[test]
+    fn affected_tests_refuses_a_change_set_it_cannot_fully_honour() {
+        let store = store();
+        let files = |count: usize| -> Vec<String> {
+            (0..count).map(|index| format!("src/f{index}.rs")).collect()
+        };
+        assert!(
+            tool_affected_tests(&store, json!({ "changed_files": files(1000) }), None).is_ok(),
+            "1000 changed files must be accepted"
+        );
+        let error = tool_affected_tests(&store, json!({ "changed_files": files(1001) }), None)
+            .expect_err("a safety selector must refuse a request it cannot honour");
+        let text = format!("{error:#}");
+        assert!(text.contains("changed_files"), "{text}");
+        assert!(text.contains("REJECTED"), "{text}");
+    }
+
+    /// The second, sharper cap: a 512-byte truncation did not DROP a long FQN,
+    /// it MUTATED it into a different identifier which then reported back as
+    /// not-found — an answer about a symbol the caller never asked about.
+    #[test]
+    fn an_over_long_identifier_is_rejected_rather_than_mutated_into_another_one() {
+        let store = store();
+        let long = "a".repeat(MAX_IDENTIFIER_LEN + 1);
+        let error = tool_read_symbols(&store, json!({ "targets": [long] }))
+            .expect_err("an over-long identifier must not be silently rewritten");
+        let text = format!("{error:#}");
+        assert!(text.contains("targets[0]"), "{text}");
+        assert!(text.contains("513"), "{text}");
+
+        // COUNTERWEIGHT: exactly at the cap is a legal identifier and must
+        // still be accepted, so the bound rejects only what it must.
+        let at_cap = "a".repeat(MAX_IDENTIFIER_LEN);
+        assert!(
+            tool_read_symbols(&store, json!({ "targets": [at_cap] })).is_ok(),
+            "an identifier exactly at the cap must be accepted"
+        );
+    }
+
+    /// Both schemas must DECLARE the bound they enforce, so the oversized call
+    /// is rejected by validation at the MCP boundary rather than reaching a
+    /// handler that used to shorten it. Neither declared `maxItems` before.
+    #[test]
+    fn the_schemas_declare_the_request_bounds_they_enforce() {
+        for (tool, field) in [
+            ("read_symbols", "targets"),
+            ("read_symbols", "uids_or_fqns"),
+            ("affected_tests", "changed_files"),
+        ] {
+            let schema = all_tool_schemas_undecorated()
+                .into_iter()
+                .find(|value| value["name"] == json!(tool))
+                .unwrap_or_else(|| panic!("{tool} schema"));
+            let property = &schema["inputSchema"]["properties"][field];
+            assert_eq!(
+                property["maxItems"],
+                json!(MAX_IDENTIFIER_COUNT),
+                "{tool}.{field} must declare maxItems"
+            );
+            assert_eq!(
+                property["items"]["maxLength"],
+                json!(MAX_IDENTIFIER_LEN),
+                "{tool}.{field} must declare maxLength"
+            );
+        }
+        // And validation must actually reject on that declaration.
+        assert!(
+            validate_tool_arguments("read_symbols", &json!({ "targets": targets(1001) })).is_err(),
+            "schema validation must reject an oversized targets array"
+        );
+        assert!(
+            validate_tool_arguments("read_symbols", &json!({ "targets": targets(1000) })).is_ok(),
+            "schema validation must accept exactly 1000"
+        );
+    }
+}
+
+// ── nw-405 / nw-406 / nw-407: the scope filters actually scope ───────────────
+
+#[cfg(test)]
+mod context_scope_filter_tests {
+    use super::*;
+    use nestweaver_schema::{Note, NoteKind, Section, Symbol, SymbolKind, Tag, Vault, Visibility};
+
+    /// Two repos whose DISPLAY NAMES collide, plus a vault whose note paths
+    /// mention one of them. This is the live-graph shape all four of nw-405's
+    /// measured wrong answers came from, minimised.
+    const REPO_A: &str = "repo:default:aaaaaaaaaaaa";
+    const REPO_B: &str = "repo:default:bbbbbbbbbbbb";
+    const VAULT: &str = "vlt:default:cccccccccccc";
+
+    fn node(uid: &str, kind: &str, location: &str) -> nestweaver_engine::BrainNode {
+        nestweaver_engine::BrainNode {
+            uid: uid.to_string(),
+            kind: kind.to_string(),
+            title: uid.to_string(),
+            location: location.to_string(),
+            relevance: 1.0,
+            inline_body: None,
+            body_complete: true,
+        }
+    }
+
+    /// One node of every shape the filters have to decide, with the LOCATIONS
+    /// that made the substring predicate wrong:
+    ///  * the repo-A symbol's location is repo-relative and never contains
+    ///    "alpha" — the under-include leg;
+    ///  * the repo-B symbol's location DOES contain "alpha", so a location
+    ///    substring keeps it — the collision leg;
+    ///  * the note lives under `Workspaces/Alpha/`, so a location substring
+    ///    keeps it too even though it belongs to no repo — the vault leg.
+    fn mixed_nodes() -> Vec<nestweaver_engine::BrainNode> {
+        vec![
+            node(&format!("sym:{REPO_A}:f1:n1:10"), "Symbol", "src/lib.rs"),
+            node(
+                &format!("sym:{REPO_B}:f2:n2:20"),
+                "Symbol",
+                "vendor/alpha/shim.rs",
+            ),
+            node(
+                &format!("note:{VAULT}:n1"),
+                "Note",
+                "Workspaces/Alpha/design.md",
+            ),
+            node(
+                &format!("sec:note:{VAULT}:n1:1:abc"),
+                "Section",
+                "Workspaces/Alpha/design.md",
+            ),
+            node(&format!("tag:{VAULT}:t1"), "Tag", ""),
+        ]
+    }
+
+    fn uids(nodes: &[nestweaver_engine::BrainNode]) -> Vec<String> {
+        nodes.iter().map(|n| n.uid.clone()).collect()
+    }
+
+    /// nw-405, all three keep/drop legs at once.
+    ///
+    /// COUNTERWEIGHT: scoping to repo B must return repo B's symbol and
+    /// nothing else. Without it a filter that simply deleted everything would
+    /// pass the "no foreign rows" half of this test.
+    #[test]
+    fn a_repos_scope_keeps_the_named_repos_own_symbols_and_no_one_elses() {
+        let mut nodes = mixed_nodes();
+        retain_nodes_in_repos(&mut nodes, &HashSet::from([REPO_A.to_string()]));
+        assert_eq!(
+            uids(&nodes),
+            vec![format!("sym:{REPO_A}:f1:n1:10")],
+            "repo A's own symbol must survive despite a repo-relative location \
+             that never contains its repo name, and nothing else may"
+        );
+
+        let mut nodes = mixed_nodes();
+        retain_nodes_in_repos(&mut nodes, &HashSet::from([REPO_B.to_string()]));
+        assert_eq!(
+            uids(&nodes),
+            vec![format!("sym:{REPO_B}:f2:n2:20")],
+            "the filter must SELECT by owner, not merely delete"
+        );
+    }
+
+    /// nw-405's recorded vault decision, pinned so it cannot be reverted by
+    /// accident: `repos:` drops vault content because a note belongs to a
+    /// vault and to no repo. On a consulting vault the old behaviour returned
+    /// clientB's notes for `repos:["clientA"]`.
+    ///
+    /// COUNTERWEIGHT: an UNFILTERED list keeps every one of those rows, so the
+    /// drop is attributable to the scope argument and not to the fixture.
+    #[test]
+    fn a_repos_scope_drops_vault_content_that_merely_mentions_the_repo_in_its_path() {
+        let unfiltered = mixed_nodes();
+        assert_eq!(
+            unfiltered.len(),
+            5,
+            "the fixture must carry the vault rows this test claims are dropped"
+        );
+
+        let mut nodes = mixed_nodes();
+        retain_nodes_in_repos(&mut nodes, &HashSet::from([REPO_A.to_string()]));
+        assert!(
+            !nodes.iter().any(|n| n.uid.starts_with("note:")
+                || n.uid.starts_with("sec:")
+                || n.uid.starts_with("tag:")),
+            "vault content belongs to no repo and must not pass a repo scope: {:?}",
+            uids(&nodes)
+        );
+    }
+
+    /// The mirror image, so `vaults:` is a scope in the same sense.
+    #[test]
+    fn a_vaults_scope_keeps_that_vaults_content_and_drops_repo_symbols() {
+        let mut nodes = mixed_nodes();
+        retain_nodes_in_vaults(&mut nodes, &HashSet::from([VAULT.to_string()]));
+        assert_eq!(
+            uids(&nodes),
+            vec![
+                format!("note:{VAULT}:n1"),
+                format!("sec:note:{VAULT}:n1:1:abc"),
+                format!("tag:{VAULT}:t1"),
+            ],
+            "notes, sections and tags are vault-owned; symbols are not"
+        );
+
+        let mut nodes = mixed_nodes();
+        retain_nodes_in_vaults(
+            &mut nodes,
+            &HashSet::from(["vlt:default:999999999999".to_string()]),
+        );
+        assert!(
+            nodes.is_empty(),
+            "a vault nobody owns must select nothing, not everything"
+        );
+    }
+
+    /// nw-406. `path_prefix` must not silently delete a whole KIND it has no
+    /// way to judge.
+    ///
+    /// COUNTERWEIGHT: a node that HAS a path and does not match is still
+    /// dropped — the exemption is for "no path concept", not for everything.
+    #[test]
+    fn a_path_prefix_exempts_nodes_with_no_path_but_still_drops_non_matching_paths() {
+        let mut nodes = mixed_nodes();
+        retain_nodes_under_path_prefix(&mut nodes, "Workspaces/");
+        assert!(
+            nodes.iter().any(|n| n.uid.starts_with("tag:")),
+            "a Tag carries location \"\"; \"\".starts_with(prefix) is false, which \
+             deleted every tag in the vault: {:?}",
+            uids(&nodes)
+        );
+        assert!(
+            !nodes.iter().any(|n| n.location == "src/lib.rs"),
+            "a node with a real, non-matching path must still be dropped: {:?}",
+            uids(&nodes)
+        );
+    }
+
+    /// A UID shape the filters cannot attribute is dropped rather than kept,
+    /// matching nw-403's redactor: "I cannot tell what owns this" is not a
+    /// reason to return it under a scope argument.
+    #[test]
+    fn an_unattributable_uid_survives_no_scope_at_all() {
+        assert_eq!(node_owner("proj:default:abc"), NodeOwner::Unattributable);
+        assert_eq!(node_owner("banana"), NodeOwner::Unattributable);
+        assert_eq!(
+            node_owner(&format!("sym:{REPO_A}:f:n:1")),
+            NodeOwner::Repo(REPO_A.to_string())
+        );
+        assert_eq!(
+            node_owner(&format!("head:note:{VAULT}:n1:h:3")),
+            NodeOwner::Vault(VAULT.to_string())
+        );
+    }
+
+    fn store_with_two_repos_named_website() -> GraphStore {
+        let store = GraphStore::in_memory().unwrap();
+        for (uid, url, name) in [
+            (REPO_A, "https://github.com/coyote/website", "website"),
+            (REPO_B, "https://github.com/wavelength/website", "website"),
+        ] {
+            store
+                .insert_repo(&nestweaver_schema::Repo {
+                    uid: uid.to_string(),
+                    url: url.to_string(),
+                    indexed_sha: "deadbeef".to_string(),
+                    staleness_commits_behind: 0,
+                    instance_id: "default".to_string(),
+                    name: Some(name.to_string()),
+                    root_path: None,
+                })
+                .unwrap();
+        }
+        store
+    }
+
+    /// nw-405 legs (2) and (4): a colliding display name must FAIL naming both
+    /// candidates rather than quietly merging two tenants, and the documented
+    /// UID form must resolve — it used to return `connected: 0`.
+    #[test]
+    fn a_colliding_repo_name_is_refused_while_the_documented_uid_form_resolves() {
+        let store = store_with_two_repos_named_website();
+
+        let err = resolve_repo_filter(&store, &["website".to_string()], None)
+            .expect_err("two repos share this display name; merging them silently is the bug")
+            .to_string();
+        assert!(
+            err.contains("ambiguous") && err.contains(REPO_A) && err.contains(REPO_B),
+            "the error must name both candidates so the caller can disambiguate: {err}"
+        );
+
+        // COUNTERWEIGHT: the disambiguated form the error recommends works.
+        let resolved = resolve_repo_filter(&store, &[REPO_A.to_string()], None).unwrap();
+        assert_eq!(resolved, HashSet::from([REPO_A.to_string()]));
+    }
+
+    /// nw-405: an entry that names no repo is an ERROR. The old predicate
+    /// matched nothing and returned a confident empty result, which a caller
+    /// reads as "this repo has no relevant content" rather than "you named a
+    /// repo that is not here".
+    #[test]
+    fn an_unresolvable_repos_entry_errors_instead_of_matching_nothing() {
+        let store = store_with_two_repos_named_website();
+        let err = resolve_repo_filter(&store, &["not-a-repo".to_string()], None)
+            .expect_err("an unresolvable scope must not silently answer")
+            .to_string();
+        assert!(
+            err.contains("not-a-repo"),
+            "the error must name the entry that failed: {err}"
+        );
+    }
+
+    /// The same contract for `vaults:`, including the counterweight that a
+    /// real vault still resolves.
+    #[test]
+    fn an_unresolvable_vaults_entry_errors_while_a_real_vault_resolves() {
+        let store = GraphStore::in_memory().unwrap();
+        store
+            .insert_vault(&Vault {
+                uid: VAULT.to_string(),
+                name: "brain".to_string(),
+                root_path: "/home/k/brain".to_string(),
+                instance_id: "default".to_string(),
+            })
+            .unwrap();
+
+        let err = resolve_vault_filter(&store, &["nope".to_string()])
+            .expect_err("an unresolvable vault scope must not silently answer")
+            .to_string();
+        assert!(err.contains("nope") && err.contains("brain"), "{err}");
+
+        for selector in [VAULT, "brain", "BRAIN", "/home/k/brain"] {
+            assert_eq!(
+                resolve_vault_filter(&store, &[selector.to_string()]).unwrap(),
+                HashSet::from([VAULT.to_string()]),
+                "selector {selector:?} must resolve"
+            );
+        }
+    }
+
+    /// nw-407, end to end through the tool.
+    ///
+    /// `tags` used to keep every Symbol unconditionally, which made it an
+    /// EXPANSION: on the live graph a tag-scoped call returned MORE rows than
+    /// the unscoped one (30 -> 71) and drove the tagged share from 22/30 to
+    /// 1/71. Asserted on the `seeds` list because it is filtered by the same
+    /// `filter_tagged` closure and is deterministic on a fixture with no
+    /// edges, unlike the PPR-driven `connected` list.
+    ///
+    /// COUNTERWEIGHT: the same call WITHOUT `tags` still returns the symbol,
+    /// so the drop is attributable to the filter and not to seed resolution.
+    #[test]
+    fn a_tag_scoped_context_cannot_return_more_rows_than_the_unscoped_one() {
+        let store = GraphStore::in_memory().unwrap();
+        store
+            .insert_vault(&Vault {
+                uid: VAULT.to_string(),
+                name: "brain".to_string(),
+                root_path: "/v".to_string(),
+                instance_id: "default".to_string(),
+            })
+            .unwrap();
+        let note_uid = format!("note:{VAULT}:n1");
+        store
+            .insert_note(&Note {
+                uid: note_uid.clone(),
+                vault_uid: VAULT.to_string(),
+                file_path: "Workspaces/Sec/threat-model.md".to_string(),
+                title: "threatmodel".to_string(),
+                note_kind: NoteKind::General,
+                word_count: 10,
+                content_hash: "h1".to_string(),
+                frontmatter: None,
+                frontmatter_raw: None,
+                created_at: None,
+                modified_at: None,
+                pagerank_score: None,
+                embedding: None,
+            })
+            .unwrap();
+        let section_uid = format!("sec:{note_uid}:1:abc");
+        store
+            .insert_section(&Section {
+                uid: section_uid.clone(),
+                note_uid: note_uid.clone(),
+                heading_uid: None,
+                start_line: 1,
+                end_line: 2,
+                text_hash: "th".to_string(),
+                text_content: "threat model".to_string(),
+                word_count: 2,
+                pagerank_score: None,
+            })
+            .unwrap();
+        store
+            .batch_insert_note_section_edges(&[(note_uid.as_str(), section_uid.as_str())])
+            .unwrap();
+        let tag_uid = format!("tag:{VAULT}:security");
+        store
+            .insert_tag(&Tag {
+                uid: tag_uid.clone(),
+                vault_uid: VAULT.to_string(),
+                name: "security".to_string(),
+            })
+            .unwrap();
+        store
+            .batch_insert_note_tag_edges(&[(note_uid.as_str(), tag_uid.as_str())])
+            .unwrap();
+        store
+            .insert_symbol(&Symbol {
+                uid: format!("sym:{REPO_A}:f1:n1:1"),
+                name: "authenticate".to_string(),
+                kind: SymbolKind::Function,
+                repo_uid: REPO_A.to_string(),
+                file_path: "src/auth.rs".to_string(),
+                start_line: 1,
+                end_line: 2,
+                signature: "fn authenticate()".to_string(),
+                summary: None,
+                content_hash: "h2".to_string(),
+                embedding: None,
+                pagerank_score: None,
+                is_entry_point: false,
+                entry_point_kind: None,
+                visibility: Visibility::Public,
+                type_info: None,
+                framework_hint: None,
+                canonical_id: None,
+            })
+            .unwrap();
+
+        let seed_uids = |args: Value| -> Vec<String> {
+            let resp = tool_brain_context(&store, None, args, None, None, None).unwrap();
+            resp["seeds"]
+                .as_array()
+                .expect("include_seeds was requested")
+                .iter()
+                .filter_map(|n| n["uid"].as_str().map(String::from))
+                .collect()
+        };
+
+        let base = json!({
+            "seeds": ["authenticate", "threatmodel"],
+            "token_budget": 5000,
+            "include_seeds": true,
+        });
+        let unscoped = seed_uids(base.clone());
+        assert!(
+            unscoped.iter().any(|u| u.starts_with("sym:")),
+            "COUNTERWEIGHT: without `tags` the symbol must be present, else this \
+             test proves nothing about the filter: {unscoped:?}"
+        );
+
+        let mut tagged_args = base;
+        tagged_args["tags"] = json!(["security"]);
+        let scoped = seed_uids(tagged_args);
+        assert!(
+            !scoped.iter().any(|u| u.starts_with("sym:")),
+            "code carries no tags, so a symbol cannot satisfy a tag scope: {scoped:?}"
+        );
+        assert!(
+            scoped.len() <= unscoped.len(),
+            "a filter that grows the result is not a filter: {} -> {}",
+            unscoped.len(),
+            scoped.len()
+        );
+        assert!(
+            scoped.contains(&note_uid),
+            "the tagged note is what the caller asked for: {scoped:?}"
+        );
+    }
+}
+
+// ── nw-412: the merge-gate surfaces refuse or degrade on a stale resolver ────
+
+#[cfg(test)]
+mod resolver_stale_merge_gate_tests {
+    use super::*;
+    use std::fs;
+
+    /// Rewrite the on-disk generation sidecar so every recorded repo sits one
+    /// generation BEHIND the running binary — the exact 9.0.0 upgrade shape
+    /// (present, well-formed, behind), not the pre-nw-103 "absent" one.
+    fn downgrade(db_path: &std::path::Path) {
+        let sidecar = nestweaver_engine::sidecar_path(
+            db_path,
+            nestweaver_engine::resolver_generation::RESOLVER_GENERATION_SIDECAR,
+        );
+        let mut generations = nestweaver_engine::resolver_generation::load(db_path);
+        assert!(
+            !generations.repos.is_empty(),
+            "the fixture recorded no generations, so the downgrade would be vacuous"
+        );
+        let behind = nestweaver_engine::resolver_generation::RESOLVER_GENERATION - 1;
+        for generation in generations.repos.values_mut() {
+            *generation = behind;
+        }
+        fs::write(&sidecar, serde_json::to_string(&generations).unwrap()).unwrap();
+    }
+
+    /// nw-412. A test SELECTOR that silently narrows is the dangerous
+    /// direction: on a generation-stale graph a MISSING edge makes the
+    /// affected-test set SMALLER, so the regression test that should have run
+    /// is dropped and the gate still reports success. It refuses instead, with
+    /// `dead_code`'s vocabulary and `dead_code`'s remedy.
+    ///
+    /// COUNTERWEIGHT (required by the item): the SAME fixture at the CURRENT
+    /// generation must not refuse. A gate that always refuses is not a gate.
+    #[test]
+    fn a_resolver_stale_graph_cannot_yield_a_narrowed_affected_test_selection() {
+        let (_dir, db_path) = super::cache_dispatch_tests::index_on_disk_for_merge_guard();
+        let store = GraphStore::open(&db_path).unwrap();
+        let args = json!({ "changed_files": ["main.js"] });
+
+        // COUNTERWEIGHT first, so a fixture that never refuses cannot pass the
+        // refusal half by accident.
+        let current = tool_affected_tests(&store, args.clone(), None).unwrap();
+        assert!(
+            current.get("refused").is_none(),
+            "a generation-CURRENT graph must answer, not refuse: {current}"
+        );
+        assert!(
+            current.get("tier_1").is_some(),
+            "the current-generation answer must carry the tiers it is asked for: {current}"
+        );
+
+        downgrade(&db_path);
+        let stale = tool_affected_tests(&store, args, None).unwrap();
+        assert_eq!(stale["refused"], json!(true), "{stale}");
+        assert_eq!(stale["reason"], json!("outdated_resolver"), "{stale}");
+        assert_eq!(stale["needs_reindex"], json!(true), "{stale}");
+        assert!(
+            stale.get("tier_1").is_none()
+                && stale.get("tier_2").is_none()
+                && stale.get("tier_3").is_none(),
+            "an empty tier is a claim, and it is the wrong one — the refusal must \
+             carry no selection at all: {stale}"
+        );
+        assert_eq!(
+            stale["recommendation"],
+            json!("run-full-suite"),
+            "a CI job that only reads `recommendation` must be widened, not left \
+             to read the missing tiers as 'no tests affected': {stale}"
+        );
+        assert!(
+            stale["remedies"]
+                .as_array()
+                .is_some_and(|remedies| remedies.iter().any(|remedy| remedy["command"]
+                    .as_str()
+                    .is_some_and(|command| command.contains("--force")))),
+            "the remedy must be the one that WORKS: a generation-stale repo is \
+             already at HEAD, so a plain incremental index writes nothing: {stale}"
+        );
+        assert!(
+            stale["note"]
+                .as_str()
+                .is_some_and(|note| note.contains("affected-tests")),
+            "the refusal must explain ITSELF, not quote dead-code's paragraph: {stale}"
+        );
+    }
+
+    /// nw-412, the other half of the decision. `blast_radius` is an
+    /// assessment rather than a selector and already ships a trust contract
+    /// for "this run did not complete", so it DEGRADES: it may no longer
+    /// report `gate_state: ok` over an understated affected set, but it keeps
+    /// returning `coverage` / `blind_spots` / the SARIF rendering that a human
+    /// or a code-scanning tool uses to judge it.
+    ///
+    /// COUNTERWEIGHT: the generation-current run is untouched and still
+    /// reports a non-degraded gate.
+    #[test]
+    fn a_resolver_stale_blast_radius_cannot_report_an_ok_gate() {
+        let (_dir, db_path) = super::cache_dispatch_tests::index_on_disk_for_merge_guard();
+        let store = GraphStore::open(&db_path).unwrap();
+        let args = json!({ "changed_files": ["main.js"] });
+
+        let current = tool_blast_radius(&store, args.clone(), None, None).unwrap();
+        assert_eq!(
+            current["gate_state"],
+            json!("ok"),
+            "COUNTERWEIGHT: a generation-CURRENT graph must not be degraded: {current}"
+        );
+        assert!(
+            !current["notifications"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|n| n["descriptor"] == json!(BLAST_RADIUS_RESOLVER_STALE_DESCRIPTOR)),
+            "nothing is stale here: {current}"
+        );
+
+        downgrade(&db_path);
+        let stale = tool_blast_radius(&store, args, None, None).unwrap();
+        assert_eq!(
+            stale["gate_state"],
+            json!("degraded-unknown"),
+            "an understated blast radius must never read as a clean gate: {stale}"
+        );
+        assert_eq!(stale["status"], json!("degraded"), "{stale}");
+        assert!(
+            stale["notifications"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|n| n["descriptor"] == json!(BLAST_RADIUS_RESOLVER_STALE_DESCRIPTOR)),
+            "the degrade must be NAMED so a consumer can act on the reason: {stale}"
+        );
+        assert!(
+            stale["summary"]
+                .as_str()
+                .is_some_and(|summary| summary.contains("[status: degraded]")),
+            "the human summary must not claim a clean run: {stale}"
+        );
+        // It DEGRADES rather than refusing: the fields a reviewer judges it by
+        // survive.
+        assert!(
+            stale.get("coverage").is_some() && stale.get("blind_spots").is_some(),
+            "degrading must not strip the trust contract it degrades: {stale}"
+        );
+    }
+}
+
+// ── nw-393: the seed cap reaches the caller, on BOTH payloads ────────────────
+
+#[cfg(test)]
+mod seed_cap_disclosure_tests {
+    use super::*;
+    use nestweaver_engine::query::SEED_NAME_MATCH_LIMIT;
+    use nestweaver_schema::{Symbol, SymbolKind, Visibility};
+
+    /// `count` distinct symbols whose names all contain `validate`, plus one
+    /// control that does not — so a total that accidentally counted the whole
+    /// symbol table is caught rather than passing by coincidence. Mirrors the
+    /// engine-side fixture deliberately: this test is about the PAYLOAD, and
+    /// diverging fixtures is how a payload test comes to disagree with the
+    /// computation it is supposed to be exposing.
+    fn store_with_validate_definitions(count: usize) -> GraphStore {
+        let store = GraphStore::in_memory().unwrap();
+        let mk = |uid: &str, name: &str| Symbol {
+            uid: format!("sym:repo:default:aaaaaaaaaaaa:f:{uid}:1"),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            repo_uid: "repo:default:aaaaaaaaaaaa".to_string(),
+            file_path: "src/lib.rs".to_string(),
+            start_line: 1,
+            end_line: 2,
+            signature: format!("fn {name}()"),
+            summary: None,
+            content_hash: format!("hash-{uid}"),
+            embedding: None,
+            pagerank_score: None,
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Inferred,
+            type_info: None,
+            framework_hint: None,
+            canonical_id: None,
+        };
+        for i in 0..count {
+            store
+                .insert_symbol(&mk(&format!("v{i}"), &format!("validate{i}")))
+                .unwrap();
+        }
+        store.insert_symbol(&mk("other", "unrelated")).unwrap();
+        store
+    }
+
+    /// The two payloads under test, by the key each one already used for the
+    /// resolved-seed COUNT — the number nw-393 exists because callers were
+    /// forced to reason from.
+    fn payloads(store: &GraphStore) -> [(&'static str, Value); 2] {
+        [
+            (
+                "code_context",
+                tool_code_context(store, json!({ "seeds": ["validate"] })).unwrap(),
+            ),
+            (
+                "brain_context",
+                tool_brain_context(
+                    store,
+                    None,
+                    json!({ "seeds": ["validate"], "token_budget": 5000 }),
+                    None,
+                    None,
+                    None,
+                )
+                .unwrap(),
+            ),
+        ]
+    }
+
+    /// nw-393. The engine computes the honest seed numbers; these payloads are
+    /// hand-built field by field, so without an explicit emit the numbers exist
+    /// and reach nobody. `seeds_resolved`/`seeds_expanded` cannot carry this:
+    /// 5 of 5 and 5 of 200 are the same integer.
+    #[test]
+    fn a_capped_seed_resolution_is_disclosed_on_both_context_payloads() {
+        let store = store_with_validate_definitions(50);
+        for (tool, payload) in payloads(&store) {
+            assert_eq!(
+                payload["seed_matches_total"],
+                json!(50),
+                "{tool} must report what the name MATCHED, not what survived: {payload}"
+            );
+            assert_eq!(
+                payload["seed_matches_total_relation"],
+                json!("eq"),
+                "{tool}: 50 is far below the store's count cap, so this is a census \
+                 not a floor — and the spelling is brain_search's: {payload}"
+            );
+            assert_eq!(
+                payload["seeds_truncated"],
+                json!(true),
+                "{tool}: 45 of 50 definitions never entered the PPR seed set: {payload}"
+            );
+            assert_eq!(
+                payload["seed_resolution_limit"],
+                json!(SEED_NAME_MATCH_LIMIT),
+                "{tool}: naming the cut without naming the bound leaves the caller \
+                 unable to judge the loss: {payload}"
+            );
+            // The seed cap and the connected-list cap are INDEPENDENT: this
+            // must not have been folded into `truncated_by`, because
+            // `truncated_by: "limit"` stays a correct statement about
+            // `connected` even when the seed set was also cut.
+            assert_ne!(
+                payload["truncated_by"],
+                json!("seed_resolution"),
+                "{tool}: the two caps do not compose into one scalar: {payload}"
+            );
+        }
+    }
+
+    /// COUNTERWEIGHT. A name with exactly as many definitions as the cap
+    /// allows is complete, and must not be reported as cut — that case is
+    /// indistinguishable from the bug by seed COUNT alone, which is exactly
+    /// why the count was never a disclosure. The bound is still echoed,
+    /// because `limit: 5, truncated: false` says more than an absent field.
+    #[test]
+    fn an_uncapped_seed_resolution_is_not_reported_as_truncated() {
+        let store = store_with_validate_definitions(SEED_NAME_MATCH_LIMIT);
+        for (tool, payload) in payloads(&store) {
+            assert_eq!(
+                payload["seeds_truncated"],
+                json!(false),
+                "{tool}: a complete seed set must not be reported as cut: {payload}"
+            );
+            assert_eq!(
+                payload["seed_matches_total"],
+                json!(SEED_NAME_MATCH_LIMIT),
+                "{tool}: every definition matched: {payload}"
+            );
+            assert_eq!(
+                payload["seed_resolution_limit"],
+                json!(SEED_NAME_MATCH_LIMIT),
+                "{tool}: the bound is echoed whenever it was in force: {payload}"
+            );
+        }
+    }
+
+    /// COUNTERWEIGHT, the other direction: a seed form the cap does not bound
+    /// at all reports NOTHING rather than `0 of 0`. A second false disclosure
+    /// is not a fix.
+    #[test]
+    fn a_seed_form_the_cap_does_not_bound_discloses_nothing_on_either_payload() {
+        let store = store_with_validate_definitions(50);
+        let uid = "sym:repo:default:aaaaaaaaaaaa:f:v0:1";
+        for (tool, payload) in [
+            (
+                "code_context",
+                tool_code_context(&store, json!({ "seeds": [uid] })).unwrap(),
+            ),
+            (
+                "brain_context",
+                tool_brain_context(
+                    &store,
+                    None,
+                    json!({ "seeds": [uid], "token_budget": 5000 }),
+                    None,
+                    None,
+                    None,
+                )
+                .unwrap(),
+            ),
+        ] {
+            assert_eq!(
+                payload["seed_matches_total"],
+                Value::Null,
+                "{tool}: UID lookup is exhaustive; it has no match total: {payload}"
+            );
+            assert_eq!(payload["seeds_truncated"], Value::Null, "{tool}: {payload}");
+            assert_eq!(
+                payload["seed_resolution_limit"],
+                Value::Null,
+                "{tool}: {payload}"
+            );
+        }
     }
 }

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -341,6 +341,61 @@ fn restricted_symbol_owners(
     ))
 }
 
+/// nw-416: every STRING spelling of a repo's identity, mapped to the
+/// `repo_uid` visibility is decided by.
+///
+/// [`VisibilityRedactor::row_allowed`] early-returned `true` for any array
+/// element that was not an object, so a bare `Vec<String>` of repo identities
+/// walked straight through the redactor untouched. `hub_nodes` and
+/// `bridge_nodes` are `RedactedAfterDispatch` and both publish
+/// `attach_ranking_staleness`'s `stale_repos` — an unfiltered list of the uids
+/// of every generation-stale repo in the brain. That is the SAME enumeration
+/// that earned `brain_status` its dedicated `EnforcedInArm` treatment under
+/// nw-403: a bare list of repo identities is exactly the payload the policy
+/// withholds, whether it arrives as a row or as a string.
+///
+/// Filtering here rather than at `attach_ranking_staleness` is deliberate.
+/// That function has no `visible` argument and is `pub` for the daemon's
+/// `repo_map_json`, so scoping it would mean a signature change across a crate
+/// boundary — and it is not the only field with this shape. nw-412's
+/// `resolver_stale_repos` is a string array of repo URLs on a refusal payload,
+/// `stale_check` publishes three more. One filter at the redactor covers the
+/// field that exists today and the one somebody adds next, which is the
+/// general form the item asks for.
+///
+/// THREE spellings, because the payloads disagree about which they use:
+/// `stale_repos` carries uids, `resolver_stale_repos` carries URLs, and
+/// `DeadCodeRefusal`'s remedies carry on-disk root paths. A repo NAME is
+/// deliberately not indexed: it is not a locator, and a short one ("core",
+/// "web") would collide with ordinary strings and start deleting array
+/// elements that name nothing.
+fn restricted_repo_identities(
+    store: &GraphStore,
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
+) -> Result<HashMap<String, String>, anyhow::Error> {
+    let Some(nestweaver_engine::authz::VisibleRepos::Only(_)) = visible else {
+        return Ok(HashMap::new());
+    };
+    let repos = store
+        .list_repos(None)
+        .context("loading repo identities for repository-scoped response")?;
+    let mut identities = HashMap::new();
+    for repo in repos {
+        for spelling in [
+            Some(repo.uid.clone()),
+            Some(repo.url.clone()),
+            repo.root_path,
+        ] {
+            if let Some(spelling) = spelling
+                && !spelling.is_empty()
+            {
+                identities.insert(spelling, repo.uid.clone());
+            }
+        }
+    }
+    Ok(identities)
+}
+
 fn repo_is_visible(
     repo_uid: &str,
     visible: Option<&nestweaver_engine::authz::VisibleRepos>,
@@ -577,6 +632,10 @@ fn response_omits_identifiers(tool: &str, args: &Value) -> bool {
 /// predicate. A row it cannot attribute is dropped, not kept.
 struct VisibilityRedactor<'a> {
     owners: &'a HashMap<String, String>,
+    /// nw-416: identity string -> owning repo, for the string arrays
+    /// [`VisibilityRedactor::row_allowed`] used to wave through. See
+    /// [`restricted_repo_identities`].
+    repo_identities: &'a HashMap<String, String>,
     visible: Option<&'a nestweaver_engine::authz::VisibleRepos>,
     removed: usize,
 }
@@ -594,12 +653,36 @@ impl VisibilityRedactor<'_> {
         }
     }
 
+    /// nw-416: a bare STRING element that names an entity is filtered like a
+    /// row, because it leaks exactly what a row would.
+    ///
+    /// The predicate is deliberately narrow in the other direction: a string
+    /// that is neither a known repo identity nor a known symbol uid is KEPT.
+    /// These arrays also carry prose (`remedies`), the caller's own echoed
+    /// input (`changed_files`) and free text, and dropping an element merely
+    /// because it could not be attributed would mangle every one of them. The
+    /// asymmetry with `uid_allowed` — which drops an UNKNOWN `sym:` uid — is
+    /// intentional: there the key already asserted "this is an entity", so
+    /// unattributable means unreturnable; here nothing has asserted anything.
+    fn identity_string_allowed(&self, text: &str) -> bool {
+        if let Some(repo_uid) = self.repo_identities.get(text) {
+            return repo_is_visible(repo_uid, self.visible);
+        }
+        if let Some(repo_uid) = self.owners.get(text) {
+            return repo_is_visible(repo_uid, self.visible);
+        }
+        true
+    }
+
     /// A row with no identifying key at all is kept — it carries no entity to
     /// leak (a `{"path": ..., "count": ...}` echo of the caller's own input,
     /// a timings block). The tools routed here all emit an identifier on
     /// every ENTITY row; the concise renderings that do not are refused
     /// upstream in `dispatch_uncached` rather than silently trusted here.
     fn row_allowed(&self, row: &Value) -> bool {
+        if let Some(text) = row.as_str() {
+            return self.identity_string_allowed(text);
+        }
         let Some(object) = row.as_object() else {
             return true;
         };
@@ -655,8 +738,13 @@ fn redact_response_for_visibility(
     let Some(owners) = restricted_symbol_owners(store, visible)? else {
         return Ok(());
     };
+    // nw-416: a store error PROPAGATES here for the same reason it does above.
+    // A scoped response built without the identity map would pass every
+    // `stale_repos` entry through unfiltered, which is the bug.
+    let repo_identities = restricted_repo_identities(store, visible)?;
     let mut redactor = VisibilityRedactor {
         owners: &owners,
+        repo_identities: &repo_identities,
         visible,
         removed: 0,
     };
@@ -8869,8 +8957,11 @@ fn tool_flow_trace(
         return Err(anyhow!("symbol '{symbol}' not found"));
     }
 
-    let mut visited = HashSet::new();
-    visited.insert(root.uid.clone());
+    // nw-390: uids that must never be EXPANDED even when an edge reaches
+    // them. The class branch below renders one tree per method and none of
+    // them may re-descend into the class node that contains them.
+    let mut blocked = HashSet::new();
+    blocked.insert(root.uid.clone());
 
     let opts = FlowTraceOpts {
         max_depth,
@@ -8917,9 +9008,11 @@ fn tool_flow_trace(
                     .iter()
                     .take(MAX_METHODS)
                     .map(|s| {
-                        let mut v = visited.clone();
-                        v.insert(s.uid.clone());
-                        build_flow_tree(store, &s.uid, &s.name, &s.file_path, 0, &mut v, &opts)
+                        // Per-method frontier: the methods of one class are
+                        // independent traces and must not consume each other's
+                        // canonical expansions.
+                        let frontier = flow_frontier(store, &s.uid, &blocked, &opts)?;
+                        build_flow_tree(store, &s.uid, &s.name, &s.file_path, 0, &frontier, &opts)
                     })
                     .collect::<Result<Vec<Value>, _>>()?
             } else {
@@ -8954,9 +9047,11 @@ fn tool_flow_trace(
                     .iter()
                     .take(MAX_METHODS)
                     .map(|s| {
-                        let mut v = visited.clone();
-                        v.insert(s.uid.clone());
-                        build_flow_tree(store, &s.uid, &s.name, &s.file_path, 0, &mut v, &opts)
+                        // Per-method frontier: the methods of one class are
+                        // independent traces and must not consume each other's
+                        // canonical expansions.
+                        let frontier = flow_frontier(store, &s.uid, &blocked, &opts)?;
+                        build_flow_tree(store, &s.uid, &s.name, &s.file_path, 0, &frontier, &opts)
                     })
                     .collect::<Result<Vec<Value>, _>>()?
             };
@@ -8990,13 +9085,17 @@ fn tool_flow_trace(
         }
     }
 
+    // nw-390: depths BEFORE rendering. See `FlowFrontier` — the render pass
+    // can no longer decide which occurrence of a node is the canonical one,
+    // because DFS order was exactly what made the answer non-monotone.
+    let frontier = flow_frontier(store, &root.uid, &blocked, &opts)?;
     let tree = build_flow_tree(
         store,
         &root.uid,
         &root.name,
         &root.file_path,
         0,
-        &mut visited,
+        &frontier,
         &opts,
     )?;
 
@@ -9024,13 +9123,137 @@ struct FlowTraceOpts<'a> {
     visible: Option<&'a nestweaver_engine::authz::VisibleRepos>,
 }
 
+/// nw-390: the depth at which each reachable node is EXPANDED, computed
+/// BREADTH-first before a single node is rendered.
+///
+/// THE RESIDUAL DEFECT THIS EXISTS FOR, which disclosure alone did not fix.
+/// The walk used a depth-first `visited` set, so a node's one canonical
+/// expansion landed wherever DFS happened to reach it FIRST — which can be
+/// arbitrarily deeper than its shortest route from the root. When that first
+/// encounter landed ON the depth cap, the canonical expansion was itself a
+/// capped node (`children_omitted`, no children) and every OTHER parent —
+/// including a shallower one with budget to spare — got a `deduped_ref` stub
+/// with `children: []`. The subtree then existed nowhere in the document, and
+/// raising `--max-depth` could STILL delete it: at the smaller cap the deep
+/// path stopped short, the node was still unclaimed when the shallow parent
+/// reached it, and its children rendered. Marking the cut told the caller a
+/// cut happened; it did not make the answer monotone, which is what nw-390's
+/// DONE WHEN asks for.
+///
+/// Breadth-first assignment removes the order dependence entirely. A node is
+/// expanded at its SHORTEST distance from the root and nowhere else, so:
+///
+///  * the rendered node set is exactly `{u : dist(u) <= max_depth}`, and
+///  * the expanded (children-bearing) set is exactly `{u : dist(u) < max_depth}`.
+///
+/// Both sets are defined by `dist`, which does not depend on `max_depth` at
+/// all, so both can only GROW as the cap rises. Monotonicity is then a
+/// property of the walk rather than of whichever fixture a test happens to
+/// use — which is the difference between this and the previous attempt.
+///
+/// It also makes the `deduped_ref` claim true rather than aspirational: every
+/// reachable node is expanded EXACTLY once, so the document cannot blow up on
+/// a recursive graph, which is the reason a global visited set existed at all.
+struct FlowFrontier {
+    /// uid -> shortest distance from the root, for every node within
+    /// `max_depth` edges of it. A uid absent here is either out of reach or
+    /// deliberately blocked, and is never expanded.
+    depths: HashMap<String, usize>,
+    /// uid -> the callee rows already read while computing `depths`.
+    ///
+    /// This pass reads exactly the nodes the render pass expands, so handing
+    /// the rows over keeps the total edge-query count where it was before the
+    /// pass existed instead of doubling it. It also makes the two passes agree
+    /// by construction: a concurrent write between them cannot hand the
+    /// renderer an edge the depths were never computed over.
+    callees: HashMap<String, Vec<(nestweaver_schema::Symbol, String)>>,
+}
+
+/// One callee read, plus the cancellation check that must precede it.
+///
+/// A failed callee lookup is NOT "this function calls nothing". This was once
+/// `if let Ok(callees) = ...`, so a store error produced `"children": []` —
+/// byte-identical to a genuine leaf, with no flag and no note, on the flagship
+/// "what does this call" surface.
+fn read_flow_callees(
+    store: &GraphStore,
+    uid: &str,
+    opts: &FlowTraceOpts<'_>,
+) -> Result<Vec<(nestweaver_schema::Symbol, String)>, anyhow::Error> {
+    if opts
+        .cancel
+        .is_some_and(|c| c.load(std::sync::atomic::Ordering::Relaxed))
+    {
+        // A cancelled trace is incomplete — propagate the store's typed
+        // cancellation error so the boundary never serves (or caches) a
+        // truncated tree as a real answer.
+        return Err(anyhow::Error::new(nestweaver_store::StoreError::Cancelled(
+            nestweaver_store::CancelReason::Timeout,
+        )));
+    }
+    store.callees_with_edge_types_of(uid).map_err(|error| {
+        anyhow::anyhow!(
+            "flow_trace: could not read the callees of {uid}: {error}. Refusing to \
+             report an empty call tree, which is indistinguishable from a leaf."
+        )
+    })
+}
+
+/// Compute the [`FlowFrontier`] for one trace root.
+///
+/// `blocked` names uids that must never be expanded even when an edge reaches
+/// them — the CLASS root of a per-method trace, which the caller has already
+/// rendered as the container of the trees it is building. Recording them at
+/// depth 0 turns an edge back into them into a `deduped_ref` stub rather than
+/// a re-descent, which is what seeding the old `visited` set did.
+fn flow_frontier(
+    store: &GraphStore,
+    root_uid: &str,
+    blocked: &HashSet<String>,
+    opts: &FlowTraceOpts<'_>,
+) -> Result<FlowFrontier, anyhow::Error> {
+    let mut depths: HashMap<String, usize> =
+        blocked.iter().map(|uid| (uid.clone(), 0usize)).collect();
+    depths.insert(root_uid.to_string(), 0);
+    let mut callees: HashMap<String, Vec<(nestweaver_schema::Symbol, String)>> = HashMap::new();
+    let mut queue = std::collections::VecDeque::from([(root_uid.to_string(), 0usize)]);
+    while let Some((uid, depth)) = queue.pop_front() {
+        // A node ON the cap is rendered but not expanded, so its callees are
+        // read by the render pass instead — where they are COUNTED into
+        // `children_omitted` rather than walked. Reading them here would be a
+        // query whose result the renderer could only throw away.
+        if depth >= opts.max_depth {
+            continue;
+        }
+        let rows = read_flow_callees(store, &uid, opts)?;
+        for (callee, _) in &rows {
+            // nw-403: a callee in a repository this caller cannot see never
+            // enters the frontier, so it can neither be expanded nor claim a
+            // depth that would stub out a VISIBLE parent's edge to it. The
+            // render pass counts it into `children_redacted` and nothing else.
+            if !repo_is_visible(&callee.repo_uid, opts.visible) {
+                continue;
+            }
+            // First assignment wins, and breadth-first order means the first
+            // assignment IS the shortest distance. This is the whole fix.
+            if depths.contains_key(&callee.uid) {
+                continue;
+            }
+            depths.insert(callee.uid.clone(), depth + 1);
+            queue.push_back((callee.uid.clone(), depth + 1));
+        }
+        callees.insert(uid, rows);
+    }
+    Ok(FlowFrontier { depths, callees })
+}
+
 fn build_flow_tree(
     store: &GraphStore,
     uid: &str,
     name: &str,
     file_path: &str,
     depth: usize,
-    visited: &mut HashSet<String>,
+    frontier: &FlowFrontier,
     opts: &FlowTraceOpts<'_>,
 ) -> Result<Value, anyhow::Error> {
     if opts
@@ -9051,29 +9274,24 @@ fn build_flow_tree(
     let mut truncated_at_depth = false;
     let mut children_omitted = 0usize;
 
-    // A failed callee lookup is NOT "this function calls nothing".
-    //
-    // This was `if let Ok(callees) = ...`, so a store error produced
-    // `"children": []` — byte-identical to a genuine leaf, with no flag and no
-    // note, on the flagship "what does this call" surface. The cancellation
-    // path a few lines above already refuses to serve a truncated tree as a
-    // real answer; an unreadable one is no different, and this function
-    // already returns a `Result` to say so.
-    //
-    // nw-390: the callees are now read even AT the depth cap, where the old
-    // code returned without asking. That is one extra edge query per frontier
-    // node, and it buys the only fact that distinguishes "the cap stopped
-    // here" from "nothing is called here" — which is the whole complaint.
-    let callees = store.callees_with_edge_types_of(uid).map_err(|error| {
-        anyhow::anyhow!(
-            "flow_trace: could not read the callees of {uid}: {error}. Refusing to \
-             report an empty call tree, which is indistinguishable from a leaf."
-        )
-    })?;
+    // nw-390: the callees are read even AT the depth cap, where the old code
+    // returned without asking. That buys the only fact that distinguishes "the
+    // cap stopped here" from "nothing is called here" — which is the whole
+    // complaint — and it is the ONLY read this pass still performs, because
+    // `flow_frontier` already read every node it expands. A node on the cap is
+    // the one case the frontier pass deliberately skipped.
+    let fetched;
+    let rows: &[(nestweaver_schema::Symbol, String)] = match frontier.callees.get(uid) {
+        Some(rows) => rows,
+        None => {
+            fetched = read_flow_callees(store, uid, opts)?;
+            &fetched
+        }
+    };
     // nw-403: attribute before anything is rendered or counted, so a hidden
     // callee contributes to `children_redacted` and to nothing else.
-    let (callees, redacted): (Vec<_>, Vec<_>) = callees
-        .into_iter()
+    let (callees, redacted): (Vec<_>, Vec<_>) = rows
+        .iter()
         .partition(|(callee, _)| repo_is_visible(&callee.repo_uid, opts.visible));
     let children_redacted = redacted.len();
 
@@ -9083,21 +9301,27 @@ fn build_flow_tree(
         truncated_at_depth = !callees.is_empty();
         children_omitted = callees.len();
     } else {
-        for (callee, edge_type) in &callees {
-            if visited.contains(&callee.uid) {
-                // nw-390, THE non-monotonicity. `visited` is GLOBAL to the
-                // traversal, so a callee claimed by an earlier branch used to
-                // be dropped from every later parent with no marker at all —
+        for (callee, edge_type) in callees {
+            if frontier.depths.get(&callee.uid) != Some(&(depth + 1)) {
+                // nw-390, THE non-monotonicity. The traversal's visited set
+                // was GLOBAL, so a callee claimed by an earlier branch was
+                // dropped from every later parent with no marker at all —
                 // which is why raising `--max-depth` REMOVED children: at
                 // greater depth an earlier branch reaches the node first and a
                 // later parent silently loses it.
                 //
-                // A `deduped_ref` stub restores monotonicity as a property of
-                // the RESPONSE rather than of the traversal: the edge is
-                // always present and always names its target, and the subtree
-                // is expanded exactly once somewhere in the document. The
-                // alternative — expanding it twice — is exponential on a
-                // recursive graph, which is why `visited` exists.
+                // A `deduped_ref` stub restores the EDGE unconditionally: it is
+                // always present and always names its target. WHICH occurrence
+                // is the stub is decided by `flow_frontier`, not by DFS order —
+                // a node is expanded at its shortest distance from the root
+                // (`dist == depth + 1` here) and stubbed everywhere else. That
+                // is the half the previous fix was missing: with DFS order the
+                // single expansion could itself land on the depth cap while a
+                // shallower parent with budget to spare got the stub, so the
+                // subtree appeared nowhere and a bigger `max_depth` could still
+                // delete it. The alternative — expanding at every occurrence —
+                // is exponential on a recursive graph, which is why a canonical
+                // expansion exists at all.
                 let mut stub = if opts.concise {
                     json!({ "name": callee.name, "deduped_ref": callee.uid, "children": [] })
                 } else {
@@ -9117,14 +9341,13 @@ fn build_flow_tree(
                 children.push(stub);
                 continue;
             }
-            visited.insert(callee.uid.clone());
             let mut child = build_flow_tree(
                 store,
                 &callee.uid,
                 &callee.name,
                 &callee.file_path,
                 depth + 1,
-                visited,
+                frontier,
                 opts,
             )?;
             // Label the edge that reached this node. The traversal spans CALLS,
@@ -19344,6 +19567,214 @@ mod repo_visibility_coverage_tests {
         assert_eq!(unscoped["results"].as_array().map(Vec::len), Some(1));
         assert!(unscoped.get("visibility").is_none(), "{unscoped}");
     }
+
+    // ── nw-416: repo identity leaked as a bare string, not as a row ─────────
+
+    /// The same two repos, on DISK, with `CURRENT_DB_PATH` set.
+    ///
+    /// **THE FIXTURE IS THE POINT OF THIS TEST.** `hidden_repo_store` is
+    /// `GraphStore::in_memory()`, so `current_db_path` fails,
+    /// `attach_ranking_staleness` takes its early-bail branch and writes
+    /// `stale_repos: []` — the coverage assertions above therefore pass against
+    /// an empty array on every run and CANNOT fail for this field. An in-memory
+    /// fixture is not a weaker test of `stale_repos`; it is not a test of it.
+    ///
+    /// On disk with no `.resolver_generation.json` sidecar, every repo reads as
+    /// generation 0 (`ResolverGenerations::generation_for`), which is below
+    /// `RESOLVER_GENERATION`, so `ranking_stale_repos` returns EVERY repo uid
+    /// in the brain — including the ones this caller may not see.
+    /// Restores `CURRENT_DB_PATH` when the fixture goes out of scope.
+    ///
+    /// The thread-local outlives the test; the `TempDir` does not. Leaving the
+    /// path set would point every LATER test on this thread — most of this
+    /// module's, which are in-memory — at a database directory that no longer
+    /// exists, which is an order-dependent flake rather than a failure anybody
+    /// could read.
+    struct DbPathGuard(Option<std::path::PathBuf>);
+
+    impl Drop for DbPathGuard {
+        fn drop(&mut self) {
+            CURRENT_DB_PATH.with(|cell| *cell.borrow_mut() = self.0.take());
+        }
+    }
+
+    fn hidden_repo_store_on_disk() -> (tempfile::TempDir, DbPathGuard, GraphStore) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("nw416.lbug");
+        let store = GraphStore::open(&db_path).expect("on-disk store");
+        for (uid, url, name) in [
+            ("repo:alpha", "https://example.test/alpha", "alpha"),
+            (
+                "repo:hidden",
+                "https://example.test/hidden-secret",
+                "hidden-secret",
+            ),
+        ] {
+            store
+                .insert_repo(&Repo {
+                    uid: uid.to_string(),
+                    url: url.to_string(),
+                    indexed_sha: "0123456789abcdef0123456789abcdef01234567".to_string(),
+                    staleness_commits_behind: 0,
+                    instance_id: "inst".to_string(),
+                    name: Some(name.to_string()),
+                    root_path: None,
+                })
+                .unwrap();
+        }
+        let guard = DbPathGuard(CURRENT_DB_PATH.with(|cell| cell.borrow().clone()));
+        set_current_db_path(db_path);
+        (dir, guard, store)
+    }
+
+    fn stale_repos_from(value: &Value) -> Vec<String> {
+        value["stale_repos"]
+            .as_array()
+            .unwrap_or_else(|| panic!("stale_repos must be present: {value}"))
+            .iter()
+            .filter_map(|entry| entry.as_str().map(str::to_string))
+            .collect()
+    }
+
+    /// THE bug: `hub_nodes` and `bridge_nodes` handed a repo-scoped caller the
+    /// uid of every stale repo in the brain, through `stale_repos`.
+    ///
+    /// Both tools are `RedactedAfterDispatch`, and the redactor could not see
+    /// the field: `row_allowed` early-returned `true` for any array element
+    /// that was not an object, so a `Vec<String>` walked through untouched.
+    /// Same enumeration class that earned `brain_status` its `EnforcedInArm`
+    /// treatment — a bare list of repo identities is the payload the policy
+    /// withholds, whatever JSON shape it arrives in.
+    #[test]
+    fn a_scoped_caller_cannot_enumerate_hidden_repos_through_stale_repos() {
+        let (_dir, _db_path, store) = hidden_repo_store_on_disk();
+        let visible = only_alpha();
+        for tool in ["hub_nodes", "bridge_nodes"] {
+            let value = dispatch_cancellable(
+                &store,
+                None,
+                tool,
+                json!({ "no_cache": true }),
+                None,
+                None,
+                Some(&visible),
+            )
+            .unwrap_or_else(|error| panic!("{tool} must still answer a scoped caller: {error:#}"));
+            assert_eq!(
+                stale_repos_from(&value),
+                vec!["repo:alpha".to_string()],
+                "{tool} named a repo outside the caller's scope: {value}"
+            );
+            // The disclosure must not be silently deleted along with the row:
+            // a scoped caller whose OWN repo is stale still needs to be told.
+            assert_eq!(value["rankings_stale"], json!(true), "{tool}: {value}");
+            assert!(
+                leaked(&value.to_string()).is_none(),
+                "{tool} leaked a hidden marker: {value}"
+            );
+        }
+    }
+
+    /// COUNTERWEIGHT, and the assertion that makes the one above non-vacuous:
+    /// on THIS fixture the field is genuinely populated with both repos, so the
+    /// scoped result is a filter and not an empty array.
+    ///
+    /// If a future refactor reverts the fixture to `GraphStore::in_memory()`,
+    /// this test fails and the one above starts passing for the wrong reason —
+    /// which is exactly what the in-memory version of it did.
+    #[test]
+    fn the_same_call_does_list_every_stale_repo_when_no_policy_is_configured() {
+        let (_dir, _db_path, store) = hidden_repo_store_on_disk();
+        let value = dispatch_cancellable(
+            &store,
+            None,
+            "hub_nodes",
+            json!({ "no_cache": true }),
+            None,
+            None,
+            None,
+        )
+        .expect("hub_nodes");
+        assert_eq!(
+            stale_repos_from(&value),
+            vec!["repo:alpha".to_string(), "repo:hidden".to_string()],
+            "the fixture must actually populate stale_repos, or the scoped \
+             assertion cannot fail: {value}"
+        );
+        assert!(value.get("visibility").is_none(), "{value}");
+    }
+
+    /// COUNTERWEIGHT: string filtering must not become string DELETION.
+    ///
+    /// These payloads also carry prose, remedies and the caller's own echoed
+    /// input as string arrays. A string that names no known entity is kept —
+    /// the opposite rule from `uid_allowed`, where a key has already asserted
+    /// "this is an entity" and unattributable therefore means unreturnable.
+    #[test]
+    fn string_array_filtering_only_removes_strings_that_name_a_hidden_entity() {
+        let (_dir, _db_path, store) = hidden_repo_store_on_disk();
+        store
+            .insert_symbol(&Symbol {
+                uid: "sym:hidden:twin".to_string(),
+                name: "hiddenSecretTwin".to_string(),
+                kind: SymbolKind::Function,
+                repo_uid: "repo:hidden".to_string(),
+                file_path: "src/alpha.py".to_string(),
+                start_line: 2,
+                end_line: 2,
+                signature: "fn hiddenSecretTwin()".to_string(),
+                summary: None,
+                content_hash: "h_twin".to_string(),
+                embedding: None,
+                pagerank_score: Some(0.5),
+                is_entry_point: false,
+                entry_point_kind: None,
+                visibility: Visibility::Inferred,
+                type_info: None,
+                framework_hint: None,
+                canonical_id: None,
+            })
+            .unwrap();
+        let visible = only_alpha();
+        let mut payload = json!({
+            // nw-412's shape: repo URLs, not uids.
+            "resolver_stale_repos": [
+                "https://example.test/alpha",
+                "https://example.test/hidden-secret",
+            ],
+            "stale_repos": ["repo:alpha", "repo:hidden"],
+            "dropped_symbols": ["sym:hidden:twin"],
+            "remedies": [
+                "Re-index every repo named above with `nestweaver index --repo <path> --force`.",
+                "run-full-suite",
+            ],
+            "changed_files": ["src/alpha.py", "src/beta.py"],
+        });
+        redact_response_for_visibility(&store, &mut payload, Some(&visible)).unwrap();
+        assert_eq!(
+            payload["resolver_stale_repos"],
+            json!(["https://example.test/alpha"]),
+            "{payload}"
+        );
+        assert_eq!(payload["stale_repos"], json!(["repo:alpha"]), "{payload}");
+        assert_eq!(payload["dropped_symbols"], json!([]), "{payload}");
+        // Prose and echoed input survive untouched: they name no entity.
+        assert_eq!(
+            payload["remedies"].as_array().map(Vec::len),
+            Some(2),
+            "{payload}"
+        );
+        assert_eq!(
+            payload["changed_files"],
+            json!(["src/alpha.py", "src/beta.py"]),
+            "{payload}"
+        );
+        assert_eq!(
+            payload["visibility"]["redacted_entries"],
+            json!(3),
+            "{payload}"
+        );
+    }
 }
 
 // ── nw-390: flow_trace must not render a suppressed expansion as a leaf ─────
@@ -19431,6 +19862,74 @@ mod flow_trace_truncation_tests {
         )
     }
 
+    /// A node reachable from two parents at DIFFERENT depths, where the walk
+    /// reaches the DEEPER parent first.
+    ///
+    /// `root -CALLS-> mid -> rung -> near` and `root -IMPORTS-> near -> far`.
+    /// `callees_with_edge_types_of` returns CALLS rows before IMPORTS rows, so
+    /// the traversal order is pinned by EDGE TYPE rather than by row order: the
+    /// walk always descends the three-hop CALLS chain before it takes the
+    /// root's own one-hop edge to `near`.
+    ///
+    /// This is what `diamond_store` could not express, and why the monotonicity
+    /// test that used it PASSED AGAINST THE UNFIXED CODE. On the diamond every
+    /// uid still appeared somewhere at every depth — a `deduped_ref` stub names
+    /// its target — so a union-of-uids comparison was already monotone before
+    /// anything was fixed. The loss this fixture produces is a node no stub
+    /// names: `far`, the child of the stubbed node.
+    ///
+    ///   `--max-depth 2` — the CALLS chain stops at `rung`, `near` is still
+    ///   unclaimed when the root's own edge reaches it at depth 1, it expands,
+    ///   and `far` is in the document.
+    ///   `--max-depth 3` — the CALLS chain claims `near` at depth 3, ON the
+    ///   cap, so the one canonical expansion has no children; the root's
+    ///   shallow edge then gets a `deduped_ref` stub and `far` is GONE.
+    ///
+    /// Asking for MORE depth returned strictly LESS, which is nw-390's
+    /// headline complaint, unfixed by disclosure alone.
+    fn ladder_store() -> GraphStore {
+        store_with(
+            &[
+                symbol("sym:root", "rootFn", SymbolKind::Function, 1),
+                symbol("sym:mid", "midFn", SymbolKind::Function, 10),
+                symbol("sym:rung", "rungFn", SymbolKind::Function, 20),
+                symbol("sym:near", "nearFn", SymbolKind::Function, 30),
+                symbol("sym:far", "farFn", SymbolKind::Function, 40),
+            ],
+            &[
+                ("sym:root", "sym:mid", EdgeType::Calls),
+                ("sym:mid", "sym:rung", EdgeType::Calls),
+                ("sym:rung", "sym:near", EdgeType::Calls),
+                // Sorted AFTER the CALLS rows by `callees_with_edge_types_of`,
+                // which is what makes the deep path win the race deterministically.
+                ("sym:root", "sym:near", EdgeType::Imports),
+                ("sym:near", "sym:far", EdgeType::Calls),
+            ],
+        )
+    }
+
+    /// Every node in a rendered tree that describes `uid`, expansions and
+    /// `deduped_ref` stubs alike.
+    fn occurrences<'a>(value: &'a Value, uid: &str) -> Vec<&'a Value> {
+        let mut found = Vec::new();
+        fn walk<'a>(value: &'a Value, uid: &str, found: &mut Vec<&'a Value>) {
+            match value {
+                Value::Object(map) => {
+                    if map.get("uid").and_then(Value::as_str) == Some(uid) {
+                        found.push(value);
+                    }
+                    for child in map.values() {
+                        walk(child, uid, found);
+                    }
+                }
+                Value::Array(items) => items.iter().for_each(|item| walk(item, uid, found)),
+                _ => {}
+            }
+        }
+        walk(value, uid, &mut found);
+        found
+    }
+
     /// Every uid that appears anywhere in a rendered tree.
     fn uids(value: &Value) -> std::collections::BTreeSet<String> {
         let mut found = std::collections::BTreeSet::new();
@@ -19464,11 +19963,18 @@ mod flow_trace_truncation_tests {
 
     /// THE property nw-390 asks for: the callee set at depth N+1 is a superset
     /// of the set at depth N, for a fixed root.
+    ///
+    /// This runs on `ladder_store`, NOT on the diamond. The diamond version of
+    /// this test passed against the unfixed traversal — every uid survived as a
+    /// `deduped_ref` stub, so the union was monotone whether or not the
+    /// canonical expansion had been stranded on the depth cap. A monotonicity
+    /// test that cannot fail is worse than none: it certifies the property it
+    /// does not measure. See `ladder_store` for the shape that does measure it.
     #[test]
-    fn the_callee_set_at_depth_n_plus_one_is_a_superset_of_depth_n() {
-        let store = diamond_store();
+    fn raising_max_depth_cannot_delete_a_subtree_a_shallower_trace_showed() {
+        let store = ladder_store();
         let mut previous = uids(&trace(&store, 1));
-        for depth in 2..=5 {
+        for depth in 2..=6 {
             let current = uids(&trace(&store, depth));
             assert!(
                 previous.is_subset(&current),
@@ -19477,11 +19983,46 @@ mod flow_trace_truncation_tests {
             );
             previous = current;
         }
-        // COUNTERWEIGHT: monotone must not mean constant. Depth genuinely buys
-        // reach, or a walk that returned the root alone would pass above.
+        // The exact loss the fixture is built around, asserted by name so a
+        // regression reports WHICH node vanished rather than only that the set
+        // shrank. Under the DFS-order rule `sym:far` is present at depth 2 and
+        // absent from depth 3 onwards.
+        for depth in 2..=6 {
+            let current = uids(&trace(&store, depth));
+            assert!(
+                current.contains("sym:far"),
+                "max_depth {depth} lost farFn, the child of the stubbed node: {current:?}"
+            );
+        }
+        // COUNTERWEIGHT 1: monotone must not mean constant. Depth genuinely
+        // buys reach, or a walk that returned the root alone would pass above.
         assert!(
-            uids(&trace(&store, 1)).len() < uids(&trace(&store, 5)).len(),
+            uids(&trace(&store, 1)).len() < uids(&trace(&store, 3)).len(),
             "a deeper trace must actually reach further"
+        );
+        // COUNTERWEIGHT 2: pin the MECHANISM, not just the outcome. The one
+        // expansion of `nearFn` must sit at its shortest distance from the root
+        // (depth 1, the root's own IMPORTS edge) and carry real children — an
+        // implementation that restored monotonicity by expanding the node at
+        // every occurrence would satisfy the set comparison above while
+        // reintroducing the exponential blowup `deduped_ref` exists to prevent.
+        let deep = trace(&store, 3);
+        let near = occurrences(&deep["tree"], "sym:near");
+        let expanded: Vec<&&Value> = near
+            .iter()
+            .filter(|node| node.get("deduped_ref").is_none())
+            .collect();
+        assert_eq!(expanded.len(), 1, "exactly one expansion of nearFn: {deep}");
+        assert_eq!(expanded[0]["depth"], json!(1), "{deep}");
+        assert_eq!(
+            expanded[0]["children"][0]["uid"],
+            json!("sym:far"),
+            "{deep}"
+        );
+        assert!(
+            near.iter()
+                .any(|node| node["deduped_ref"] == json!("sym:near")),
+            "the deeper parent must still name the edge it did not expand: {deep}"
         );
     }
 
@@ -19500,17 +20041,40 @@ mod flow_trace_truncation_tests {
         };
         assert_eq!(root_children(1), root_children(2));
         assert_eq!(root_children(2), root_children(3));
-        // The second occurrence is a REFERENCE, not a second expansion: the
-        // subtree is rendered exactly once, which is why `visited` exists.
+        // The repeated callee is rendered exactly ONCE and referenced
+        // everywhere else, which is why a canonical expansion exists at all.
+        //
+        // nw-390 residual: WHICH occurrence is the expansion is now decided by
+        // shortest distance from the root, not by depth-first arrival order.
+        // `sharedFn` is one hop from the root, so the ROOT's edge carries the
+        // expansion and `aFn`'s edge carries the stub; DFS order used to put
+        // them the other way round, and that ordering is precisely what let a
+        // depth-capped occurrence become the canonical one on other shapes.
         let deeper = trace(&store, 3);
-        let dedup = deeper["tree"]["children"]
-            .as_array()
-            .unwrap()
+        let shared = occurrences(&deeper["tree"], "sym:shared");
+        assert_eq!(shared.len(), 2, "one expansion + one reference: {deeper}");
+        let expanded: Vec<&&Value> = shared
             .iter()
-            .find(|child| child["deduped_ref"].is_string())
-            .expect("the repeated callee must be marked, not dropped");
-        assert_eq!(dedup["deduped_ref"], json!("sym:shared"));
-        assert_eq!(dedup["children"], json!([]));
+            .filter(|node| node.get("deduped_ref").is_none())
+            .collect();
+        assert_eq!(expanded.len(), 1, "{deeper}");
+        assert_eq!(expanded[0]["depth"], json!(1), "{deeper}");
+        assert_eq!(
+            expanded[0]["children"][0]["uid"],
+            json!("sym:deep"),
+            "{deeper}"
+        );
+        let stub: Vec<&&Value> = shared
+            .iter()
+            .filter(|node| node.get("deduped_ref").is_some())
+            .collect();
+        assert_eq!(
+            stub.len(),
+            1,
+            "the repeated callee must be marked: {deeper}"
+        );
+        assert_eq!(stub[0]["deduped_ref"], json!("sym:shared"));
+        assert_eq!(stub[0]["children"], json!([]));
     }
 
     /// A node the depth cap stopped at and a node that genuinely calls nothing

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -479,10 +479,38 @@ fn is_stale_checkpoint_error(msg: &str) -> bool {
 /// Remove the stale checkpoint sidecars lbug's error tells us to delete — but ONLY
 /// when the shadow file is absent or empty (0 bytes), the exact signature of an
 /// aborted checkpoint. A non-empty shadow could belong to a live mid-checkpoint
-/// writer; never touch that. (Reaching the stale-checkpoint error already implies
-/// no other process holds the write lock — that would surface as a lock error
-/// instead.) Returns true if the checkpoint file was removed (worth a retry).
-fn remove_stale_checkpoint_sidecars(path: &Path) -> bool {
+/// writer; never touch that. Returns true if the checkpoint file was removed
+/// (worth a retry).
+///
+/// nw-373. THE SENTENCE THAT USED TO BE HERE IS DELETED, not softened, because
+/// it was the reasoning that produced the bug: *"Reaching the stale-checkpoint
+/// error already implies no other process holds the write lock — that would
+/// surface as a lock error instead."* That is FALSE on the path that reached it
+/// most often. A READ-ONLY open never contends for the write lock at all, so it
+/// can never surface a lock error, so the implication has no antecedent — and
+/// this function was deleting `<db>.wal.checkpoint` and `<db>.shadow` of a
+/// database another process was writing, on the strength of it. An inference
+/// about what a caller did NOT observe is not a proof of exclusivity.
+///
+/// `read_write` is the gate that replaces the inference, and it is the same one
+/// [`quarantine_orphaned_wal`] has always had — these two arms of ONE recovery
+/// disagreed about whether a read-only caller may mutate the directory, and the
+/// arm that DELETES was the ungated one. A read-write open has at least taken
+/// lbug's own write lock on the database file, which is evidence; a read-only
+/// open has taken nothing. The self-heal that motivated this recovery is
+/// unaffected: it is the daemon that crash-loops, and the daemon opens
+/// read-write.
+///
+/// HANDOFF, and the reason this is a NARROWING rather than nw-373's fix: even a
+/// read-write open only PROBED exclusivity in the past — it holds lbug's lock,
+/// not the canonical write lease, across the delete. The property nw-373 asks
+/// for is a `DbWriteLease` HELD across the whole enumerate-and-delete, and
+/// `acquire_db_write_lease` lives in `nestweaver-daemon`, which depends on this
+/// crate. See the report for the signature; do not grow a second lease here.
+fn remove_stale_checkpoint_sidecars(path: &Path, read_write: bool) -> bool {
+    if !read_write {
+        return false;
+    }
     let shadow = PathBuf::from(format!("{}.shadow", path.display()));
     let checkpoint = PathBuf::from(format!("{}.wal.checkpoint", path.display()));
     let shadow_empty = std::fs::metadata(&shadow)
@@ -700,6 +728,16 @@ fn is_orphaned_wal_error(msg: &str) -> bool {
 /// Only acts on the exact orphan signature — `.wal` present AND `.shadow`
 /// absent. A `.wal` with its `.shadow` intact is a normal recoverable log and
 /// must be left for the engine to replay.
+///
+/// nw-373, unfixed and named: the caller gates this on a read-write open, which
+/// means lbug's write lock was taken — but nothing HOLDS the canonical write
+/// lease across the rename, so this is still a check-then-act on exclusivity.
+/// A probe answers a question about the past; the rename happens in the future.
+/// The blast radius is bounded by the fact that this only ever RENAMES (see
+/// above) and only on the orphan signature, which is why it is named here rather
+/// than papered over with a second probe. The fix needs
+/// `nestweaver_daemon::lifecycle::acquire_db_write_lease`, which this crate
+/// cannot reach; see the report's HANDOFF.
 fn quarantine_orphaned_wal(path: &Path) -> Option<PathBuf> {
     let wal = PathBuf::from(format!("{}.wal", path.display()));
     let shadow = PathBuf::from(format!("{}.shadow", path.display()));
@@ -716,13 +754,52 @@ fn quarantine_orphaned_wal(path: &Path) -> Option<PathBuf> {
         .map(|()| quarantined)
 }
 
+/// Turn a failed open into a `StoreError`, consulting the write lease when — and
+/// only when — the caller could not be the process holding it.
+///
+/// nw-404. The veto (`from_engine_message_for_db`) exists because a live
+/// writer's partially-appended WAL tail and a genuinely damaged log produce the
+/// SAME engine sentence, and the remedy for the second destroys the first. But
+/// `flock` carries no holder identity, so the probe cannot tell "someone else is
+/// writing" from "I am writing": the daemon takes the lease for its whole life
+/// (`server.rs`, before it ever opens the store) and every `--no-daemon` writer
+/// takes it through `require_exclusive_store_access`. Asked blindly, the probe
+/// would answer "a live writer holds it" to the writer itself, and a genuinely
+/// corrupt database would fail daemon boot with a contention message instead of
+/// the corruption runbook — trading nw-404's false alarm for a silent one, on the
+/// exact recovery path nw-332's outage needed.
+///
+/// `read_write` is the STRUCTURAL proxy for "not the holder", and it is exact
+/// rather than approximate: lbug takes its own write lock on the database file
+/// for a read-write open, so a read-write open by a NON-holder while someone
+/// else is writing fails with "Could not set lock" and never reaches a WAL
+/// verdict at all. The only read-write opener that can arrive here with a lease
+/// held is the holder. Read-only opens are the complement — the direct
+/// `impact --repo` / `brain context --no-tests` route that filed nw-404 — and
+/// they are the ones that get the veto.
+///
+/// HANDOFF, for the exact rather than the structural answer: a self-ownership
+/// latch (the shape `lifecycle::note_local_store_write_lock` already uses to stop
+/// `db_write_lock` destroying its own lock) set by `acquire_db_write_lease`. That
+/// is a `crates/nestweaver-daemon/src/lifecycle.rs` edit.
+fn open_failure(path: &Path, message: String, read_write: bool) -> StoreError {
+    if read_write {
+        // nw-346: the frame that knows WHICH database failed attaches the path,
+        // so no caller has to guess one from prose.
+        return StoreError::from_engine_message(message).with_db_path(path);
+    }
+    StoreError::from_engine_message_for_db(message, path)
+}
+
 /// Open an lbug database, auto-recovering once from crash debris that would
 /// otherwise make it permanently unopenable.
 ///
 /// `read_write` gates the orphaned-WAL arm. Replay is inherently a write
 /// operation, so a read-only open must report the condition rather than mutate
 /// the directory to clear it — and a read-only caller quarantining a log out
-/// from under a live writer would be a genuine hazard.
+/// from under a live writer would be a genuine hazard. It also gates nw-404's
+/// writer-liveness veto; see [`open_failure`] for why the two questions share
+/// one flag.
 fn open_lbug_with_recovery(
     path: &Path,
     read_write: bool,
@@ -740,14 +817,15 @@ fn open_lbug_with_recovery(
         Ok(db) => Ok(db),
         Err(e) => {
             let msg = e.to_string();
-            if is_stale_checkpoint_error(&msg) && remove_stale_checkpoint_sidecars(path) {
+            if is_stale_checkpoint_error(&msg) && remove_stale_checkpoint_sidecars(path, read_write)
+            {
                 tracing::warn!(
                     "recovered a stale WAL checkpoint for {} (a prior crash left \
                      .wal.checkpoint/.shadow that made the DB unopenable); retrying open",
                     path.display()
                 );
                 return lbug::Database::new(path, make_config())
-                    .map_err(|e| StoreError::from(e).with_db_path(path));
+                    .map_err(|e| open_failure(path, e.to_string(), read_write));
             }
             if read_write
                 && is_orphaned_wal_error(&msg)
@@ -762,12 +840,13 @@ fn open_lbug_with_recovery(
                     quarantined.display()
                 );
                 return lbug::Database::new(path, make_config())
-                    .map_err(|e| StoreError::from(e).with_db_path(path));
+                    .map_err(|e| open_failure(path, e.to_string(), read_write));
             }
-            // nw-346. This is the frame that knows WHICH database failed; the
-            // engine's message names no path, so attaching it here is what
-            // retires the caller's need to guess one.
-            Err(StoreError::from(e).with_db_path(path))
+            // nw-346 / nw-404. This is the frame that knows WHICH database
+            // failed AND whether this open could be the one writing it — the
+            // two facts an unreadable-WAL verdict depends on and that
+            // `StoreError::from` cannot supply. See [`open_failure`].
+            Err(open_failure(path, e.to_string(), read_write))
         }
     }
 }
@@ -4099,6 +4178,40 @@ mod tests {
         ));
     }
 
+    /// nw-373. The deleted doc sentence claimed that reaching this error already
+    /// implied nobody else held the write lock. A READ-ONLY open never asks for
+    /// that lock, so it could never have observed the lock error the inference
+    /// relied on — and it was deleting `.wal.checkpoint` and `.shadow` of a
+    /// database the daemon was writing.
+    ///
+    /// The counterweight is the second half: the read-WRITE self-heal that this
+    /// recovery exists for must still fire, or the fix trades a data hazard for
+    /// the crash-loop outage it was written to end.
+    #[test]
+    fn a_read_only_open_cannot_delete_checkpoint_sidecars_it_never_locked() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("db.lbug");
+        let cp = dir.path().join("db.lbug.wal.checkpoint");
+        let shadow = dir.path().join("db.lbug.shadow");
+        std::fs::write(&cp, b"stale-checkpoint-bytes").unwrap();
+        std::fs::write(&shadow, b"").unwrap();
+
+        assert!(
+            !remove_stale_checkpoint_sidecars(&db, false),
+            "a read-only open holds nothing and must not perform sidecar surgery"
+        );
+        assert!(cp.exists(), "the checkpoint must survive a read-only open");
+        assert!(shadow.exists(), "and so must the shadow");
+
+        assert!(
+            remove_stale_checkpoint_sidecars(&db, true),
+            "the read-write self-heal is the reason this recovery exists and must \
+             still fire — gating it into uselessness would restore the crash loop"
+        );
+        assert!(!cp.exists());
+        assert!(!shadow.exists());
+    }
+
     #[test]
     fn removes_stale_checkpoint_only_when_shadow_empty() {
         let dir = tempfile::tempdir().unwrap();
@@ -4109,14 +4222,14 @@ mod tests {
         // Empty shadow + checkpoint present → recover (remove both).
         std::fs::write(&cp, b"stale-checkpoint-bytes").unwrap();
         std::fs::write(&shadow, b"").unwrap();
-        assert!(remove_stale_checkpoint_sidecars(&db));
+        assert!(remove_stale_checkpoint_sidecars(&db, true));
         assert!(!cp.exists(), "stale checkpoint should be removed");
         assert!(!shadow.exists(), "empty shadow should be removed");
 
         // Non-empty shadow (possible live writer) → do NOT touch the checkpoint.
         std::fs::write(&cp, b"stale").unwrap();
         std::fs::write(&shadow, b"live-writer-state").unwrap();
-        assert!(!remove_stale_checkpoint_sidecars(&db));
+        assert!(!remove_stale_checkpoint_sidecars(&db, true));
         assert!(
             cp.exists(),
             "must not remove checkpoint when shadow is non-empty"
@@ -5209,5 +5322,90 @@ mod git_activity_loader_tests {
 
         store.load_git_activity_sidecar(&path).unwrap();
         assert_eq!(store.git_activity_score("repo:x", "src/main.rs"), Some(0.9));
+    }
+}
+
+/// nw-404: the writer-liveness veto on an unreadable-WAL verdict, exercised
+/// through the OPEN FUNNEL rather than through the classifier alone.
+#[cfg(test)]
+mod live_writer_wal_tests {
+    use super::GraphStore;
+
+    /// nw-404. The veto belongs to the READ-ONLY open and to nothing else.
+    ///
+    /// The read-only leg is the defect: `impact --repo` / `brain context
+    /// --no-tests` bypass the daemon, open read-only, meet the daemon's
+    /// half-written WAL tail and get told the database is corrupt — with a
+    /// runbook that moves aside the `.wal` the daemon is still appending to.
+    ///
+    /// The read-write leg is the COUNTERWEIGHT, and it is not hypothetical: the
+    /// daemon holds this very lease for its whole life and then opens the store,
+    /// so a blind probe would answer "a live writer holds it" to the writer
+    /// itself and swallow the corruption diagnosis on the one path that most
+    /// needs it. Both legs are asserted here against a lease this test actually
+    /// holds, so neither can be broken without the other failing.
+    #[cfg(unix)]
+    #[test]
+    fn only_a_read_only_open_lets_a_live_writer_retract_an_unreadable_wal_verdict() {
+        use std::os::unix::io::AsRawFd;
+
+        const ENGINE: &str = "Corrupted wal file. Read out invalid WAL record type.";
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("t.lbug");
+        std::fs::write(&db, b"").unwrap();
+
+        let lease = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(format!("{}.write.lock", db.display()))
+            .unwrap();
+        assert_eq!(
+            unsafe { libc::flock(lease.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+            0,
+            "the test must actually hold the lease or it proves nothing"
+        );
+
+        assert_eq!(
+            super::open_failure(&db, ENGINE.to_string(), false).corruption_kind(),
+            None,
+            "a read-only open meeting a live writer must not report corruption, \
+             because its remedy moves aside a WAL that is still being written"
+        );
+        assert_eq!(
+            super::open_failure(&db, ENGINE.to_string(), true).corruption_kind(),
+            Some(crate::error::CorruptionKind::WalUnreadable),
+            "a read-write open holds the lease itself, so the same probe would \
+             be the writer asking about itself — it must keep the corruption \
+             verdict and its recovery runbook"
+        );
+    }
+
+    /// The narrowness half of nw-404, at the surface a user actually touches.
+    ///
+    /// A 0-byte `<db>.wal` opens and serves today — an empty log is a log with
+    /// nothing in it, not a damaged one — and the veto must not change that in
+    /// either direction: not by declining the open, and not by routing a
+    /// perfectly ordinary open through the contention arm. The veto only ever
+    /// runs on the ERROR branch of `open_lbug_with_recovery`, and this is what
+    /// pins that.
+    #[test]
+    fn a_zero_byte_write_ahead_log_still_opens_and_serves() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("t.lbug");
+        {
+            let store = GraphStore::open_or_create(&db).unwrap();
+            store.ensure_data_instance_id("2051a9da").unwrap();
+        }
+        std::fs::write(format!("{}.wal", db.display()), b"").unwrap();
+
+        let reopened = GraphStore::open_read_only(&db)
+            .expect("a 0-byte write-ahead log is an empty log, not a corrupt one");
+        assert_eq!(
+            reopened.data_instance_id().unwrap().as_deref(),
+            Some("2051a9da"),
+            "and it must still SERVE, not merely open"
+        );
     }
 }

--- a/crates/nestweaver-store/src/error.rs
+++ b/crates/nestweaver-store/src/error.rs
@@ -78,6 +78,136 @@ impl std::fmt::Display for CorruptionKind {
     }
 }
 
+/// The sentence the store attaches when it DECLINES to call a write-ahead log
+/// corrupt because a live writer holds the database's write lease.
+///
+/// nw-404. Three jobs, which is why it is a `const` and not an inline
+/// `format!`:
+///
+/// 1. It is the operator-facing disclosure. It says who to blame (another
+///    process) and what to do (nothing — retry).
+/// 2. It satisfies [`StoreError::is_lock_contention`] verbatim ("another
+///    process holds"), so every consumer that already tells "someone holds it"
+///    from "it is damaged" — `repair_open_failure`, `daemon_held_store_error` —
+///    gets the right answer with no new predicate. nw-346 built that
+///    distinction; this case simply never reached it.
+/// 3. It is the SENTINEL [`classify_engine_corruption`] looks for. The engine's
+///    verbatim words are preserved beside it (a paraphrase at this boundary is
+///    the nw-332 regression), and those words still say "corrupted wal" — so
+///    without the sentinel the prose-fallback classifier in `into_diagnostic`
+///    (`src/main.rs`, which re-classifies the RENDERED error when no type
+///    survived) would re-derive `WalUnreadable` from our own disclosure and
+///    print the move-aside runbook anyway. Evidence and veto have to travel
+///    together.
+pub const LIVE_WRITER_DISCLOSURE: &str = "another process holds the write lease";
+
+/// Path of the write-lease file for `db_path` — `<db>.write.lock`.
+///
+/// nw-404. DERIVED, not owned: the lease itself is
+/// `nestweaver_daemon::lifecycle::acquire_db_write_lease`, and this crate sits
+/// far below the daemon so it cannot call it. This function only NAMES the file
+/// that mechanism uses; it never creates it and never locks it for keeps.
+/// Keeping the two in sync is a real hazard — see the HANDOFF note on
+/// [`live_writer_holds_write_lease`].
+///
+/// The canonicalisation mirrors `lifecycle::canonical_db_path` in the shape that
+/// matters here (resolve the path, else resolve the parent and re-join the file
+/// name). The lease's own cwd-join fallback is deliberately NOT reproduced: the
+/// probe below tries the un-canonicalised name too, so a path this cannot
+/// resolve costs an extra `open` on the error path rather than a wrong answer.
+fn write_lease_path(db_path: &Path) -> PathBuf {
+    let canonical = std::fs::canonicalize(db_path).ok().or_else(|| {
+        let parent = db_path.parent()?;
+        let file_name = db_path.file_name()?;
+        Some(std::fs::canonicalize(parent).ok()?.join(file_name))
+    });
+    let mut name = canonical
+        .unwrap_or_else(|| db_path.to_path_buf())
+        .into_os_string();
+    name.push(".write.lock");
+    PathBuf::from(name)
+}
+
+/// Is `lease_path` locked RIGHT NOW by a process that is still alive?
+///
+/// nw-404. The lease is an `flock`, and `flock` is the reason this is a proof
+/// rather than an inference: the kernel drops it when the holder exits, so
+/// there is no stale state to reap and no pid to check for liveness — a held
+/// lock IS a live holder. That is the same property
+/// `nestweaver_engine::index_publication::process_is_alive` reaches for by
+/// checking `kill(pid, 0)` against the publication marker's recorded pid, with
+/// the pid-reuse caveat removed because the kernel is doing the bookkeeping.
+///
+/// A SHARED probe, and it never creates the file. Both matter:
+///
+/// * `LOCK_SH` still conflicts with the holder's `LOCK_EX`, so `EWOULDBLOCK`
+///   proves a writer holds it. Taking `LOCK_EX` to ask the same question would
+///   make a concurrent `acquire_db_write_lease` fail with `Held` for the
+///   microseconds we owned it — a probe that manufactures the contention it is
+///   asking about.
+/// * `create(false)`: an absent lease file is a real answer (nobody has ever
+///   taken a lease on this database), and creating one would leave debris in
+///   every directory a read-only open ever failed in.
+///
+/// Only reached on the corruption branch of a failed open, so the shared lock
+/// is held for microseconds on a path that already ended in an error.
+#[cfg(unix)]
+fn write_lease_is_held(lease_path: &Path) -> bool {
+    use std::os::unix::io::AsRawFd;
+
+    let Ok(file) = std::fs::OpenOptions::new().read(true).open(lease_path) else {
+        // No lease file, or we cannot read it. Either way we have not PROVED a
+        // live writer, and the counterweight says an unproved writer must not
+        // suppress a genuine corruption report.
+        return false;
+    };
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_SH | libc::LOCK_NB) } != 0 {
+        // EWOULDBLOCK is the answer we came for. Anything else (EBADF, EINTR,
+        // an unsupported filesystem) is "cannot tell", which is not proof.
+        return std::io::Error::last_os_error().kind() == std::io::ErrorKind::WouldBlock;
+    }
+    // We got the shared lock, so nobody held it exclusively. Release it at once
+    // rather than waiting for the drop, so the window cannot outlive the answer.
+    unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+    false
+}
+
+/// Non-unix fallback: there is no portable equivalent of the `flock` probe, so
+/// we cannot PROVE a live writer and therefore never claim one.
+///
+/// Note which direction this fails in, because it is the opposite of
+/// `process_is_alive`'s: that one returns `true` on non-unix so recovery
+/// DECLINES. Here `true` would suppress every WAL-corruption report on the
+/// platform, breaking the counterweight everywhere rather than in the one
+/// contended case. `false` preserves the pre-nw-404 behaviour exactly.
+#[cfg(not(unix))]
+fn write_lease_is_held(_lease_path: &Path) -> bool {
+    false
+}
+
+/// Is a live writer holding the write lease on `db_path` right now?
+///
+/// nw-404, the primitive the classifier consults before it is willing to call a
+/// write-ahead log damaged.
+///
+/// HANDOFF (out of this crate's reach): `write_lease_path` here and
+/// `nestweaver_daemon::lifecycle::write_lease_path` derive the same
+/// `<db>.write.lock` name independently, because the store cannot depend on the
+/// daemon. The lasting shape is for the daemon's to delegate to this one; that
+/// is a `crates/nestweaver-daemon/src/lifecycle.rs` edit. Until then the probe
+/// asks about BOTH the canonicalised and the literal name — a lease held under
+/// either is a live writer, and asking twice on an error path is free.
+pub fn live_writer_holds_write_lease(db_path: &Path) -> bool {
+    let canonical = write_lease_path(db_path);
+    if write_lease_is_held(&canonical) {
+        return true;
+    }
+    let mut literal = db_path.to_path_buf().into_os_string();
+    literal.push(".write.lock");
+    let literal = PathBuf::from(literal);
+    literal != canonical && write_lease_is_held(&literal)
+}
+
 /// Classify an engine message into a [`CorruptionKind`], or `None` when it
 /// describes an ordinary failure.
 ///
@@ -90,8 +220,26 @@ impl std::fmt::Display for CorruptionKind {
 /// nw-332 message ("Corrupted wal file. Read out invalid WAL record type.") is
 /// about a log that cannot be READ, and answering it with "open read-write to
 /// replay" is how the crash-restart loop starts.
+///
+/// PURE, and deliberately so: it decides from the MESSAGE alone, which is what
+/// lets `into_diagnostic` re-run it over rendered prose when no type survived.
+/// The writer-liveness question needs a database path, so it lives in
+/// [`classify_engine_corruption_for_db`] — the variant the store's open funnel
+/// calls, where a path is in hand.
 pub fn classify_engine_corruption(message: &str) -> Option<CorruptionKind> {
     let lower = message.to_lowercase();
+    // nw-404. The one exception to "decide from the message alone", and it is
+    // not a heuristic: this phrase is only ever written by
+    // `StoreError::from_engine_message_for_db` AFTER it proved a live writer
+    // holds the lease. The engine's verbatim words ride along in the same
+    // string and still say "corrupted wal", so without this the prose fallback
+    // in `into_diagnostic` re-derives `WalUnreadable` from our own disclosure
+    // and prints the move-aside-your-WAL runbook against a healthy database
+    // being written by the running daemon. A verdict must not be overturned by
+    // the evidence it was careful to preserve.
+    if lower.contains(LIVE_WRITER_DISCLOSURE) {
+        return None;
+    }
     // The engine has at least TWO phrasings for an unreadable log and they do
     // not share a word order:
     //
@@ -123,6 +271,46 @@ pub fn classify_engine_corruption(message: &str) -> Option<CorruptionKind> {
         return Some(CorruptionKind::EngineAssertion);
     }
     None
+}
+
+/// [`classify_engine_corruption`] for a caller that knows WHICH database
+/// failed, with the writer-liveness veto nw-404 exists for.
+///
+/// THE BUG: a read-only open that meets a live writer's partially-appended WAL
+/// tail gets "Corrupted wal file. Read out invalid WAL record type." from the
+/// engine — the same sentence a genuinely damaged log produces. The pure
+/// classifier cannot tell them apart, so it called a HEALTHY database corrupt
+/// and the CLI printed a runbook telling the operator to move aside `.wal`,
+/// `.wal.checkpoint`, `.shadow` and both `.checkpoint.*.lock` of a database the
+/// daemon was actively appending to. Following it discards the un-checkpointed
+/// tail. Measured on the live graph: `brain status` and `search` succeeded
+/// throughout and the `.wal` GREW 12,226,075 -> 12,817,039 bytes in 20 seconds
+/// while the direct route reported it corrupt.
+///
+/// THE VETO IS NARROW ON PURPOSE, and each narrowing is load-bearing:
+///
+/// * `WalUnreadable` ONLY. A truncated file, a C++ assertion or an
+///   unclassified corruption is not made healthy by a writer being alive, and
+///   suppressing those would trade a false alarm for a silent one.
+/// * A PROVED live holder only. An absent lease file, a lease file nobody
+///   holds, and a platform where we cannot ask all mean "no proof", and all
+///   three keep the corruption verdict. A genuinely corrupt WAL with no live
+///   writer must still be reported as corrupt — that is the counterweight, and
+///   it is what stops this fix from becoming a way to never report corruption.
+/// * The engine's own words survive into whatever the caller returns. The veto
+///   changes the VERDICT, never the evidence.
+/// * CALLER-SCOPED. `flock` carries no holder identity, so this cannot tell "someone
+///   else is writing" from "I am writing" — and the daemon takes the lease before it
+///   opens the store. The store's open funnel therefore calls this for READ-ONLY
+///   opens only; `db::open_failure` carries that reasoning and the handoff that
+///   would make the answer exact instead of structural. Anyone else calling this
+///   owes the same question.
+pub fn classify_engine_corruption_for_db(message: &str, db_path: &Path) -> Option<CorruptionKind> {
+    let kind = classify_engine_corruption(message)?;
+    if kind == CorruptionKind::WalUnreadable && live_writer_holds_write_lease(db_path) {
+        return None;
+    }
+    Some(kind)
 }
 
 /// The payload of [`StoreError::Corruption`].
@@ -257,6 +445,46 @@ impl StoreError {
         }
     }
 
+    /// [`Self::from_engine_message`] for the frame that knows WHICH database
+    /// failed — the store's open funnel.
+    ///
+    /// nw-404. Two things the path-free constructor cannot do:
+    ///
+    /// 1. It consults [`classify_engine_corruption_for_db`], so an unreadable
+    ///    WAL under a LIVE WRITER is reported as contention rather than damage.
+    /// 2. It attaches the path at construction instead of leaving an outer
+    ///    frame to add it, which is the nw-346 property `with_db_path` protects.
+    ///
+    /// The contention error is a plain [`Self::Database`] on purpose: it is the
+    /// variant [`Self::is_lock_contention`] already answers for, so no consumer
+    /// needs a new arm, and no new `CorruptionKind` (which would have to be a
+    /// corruption, which is the claim being retracted). The engine's verbatim
+    /// sentence is carried through — see [`LIVE_WRITER_DISCLOSURE`] for why
+    /// carrying it is safe only with the sentinel in front of it.
+    pub fn from_engine_message_for_db(message: impl Into<String>, db_path: &Path) -> Self {
+        let detail = message.into();
+        match classify_engine_corruption_for_db(&detail, db_path) {
+            Some(kind) => StoreError::Corruption(Box::new(EngineCorruption {
+                kind,
+                detail,
+                path: Some(db_path.to_path_buf()),
+            })),
+            None if classify_engine_corruption(&detail) == Some(CorruptionKind::WalUnreadable) => {
+                StoreError::Database(format!(
+                    "{LIVE_WRITER_DISCLOSURE} on {} and is appending to its \
+                     write-ahead log right now, so the partial record at the end \
+                     of the log is IN-FLIGHT WRITING, not damage — this database \
+                     is not known to be corrupt and must not be recovered as if \
+                     it were. Retry the read, or route it through the daemon that \
+                     owns the write lock. The storage engine's own words, kept \
+                     verbatim: {detail}",
+                    db_path.display()
+                ))
+            }
+            None => StoreError::Database(detail),
+        }
+    }
+
     /// Record corruption whose engine phrasing we do not recognise.
     ///
     /// For callers that know from CONTEXT that a database is damaged even
@@ -278,6 +506,13 @@ impl StoreError {
     /// and the CLI read funnel both need to tell "someone holds it" from "it is
     /// damaged", and they were each deciding that from a different substring of
     /// a different message. One phrase, one place.
+    ///
+    /// nw-404 added a THIRD producer and no new phrase:
+    /// [`LIVE_WRITER_DISCLOSURE`] contains "another process holds" verbatim, so
+    /// a WAL that is merely being appended to lands in the arm this predicate
+    /// already owned. That case used to fall straight through here into
+    /// corruption, which is the whole defect — the distinction existed and this
+    /// condition was never routed into it.
     pub fn is_lock_contention(&self) -> bool {
         match self {
             StoreError::Database(msg) | StoreError::Query(msg) => {
@@ -439,6 +674,191 @@ mod corruption_classification_tests {
         let benign = StoreError::from_engine_message("Could not set lock")
             .with_db_path(Path::new("/tmp/x.lbug"));
         assert!(matches!(benign, StoreError::Database(_)));
+    }
+
+    /// nw-404. The engine says the same sentence for a log that is DAMAGED and
+    /// for a log that is being APPENDED TO, so a lease held by a live writer is
+    /// the only thing that separates them.
+    ///
+    /// `flock` is per-open-file-description, so a second `open` in this very
+    /// process contends with the first exactly as a second process would —
+    /// which is what lets the holder be forked-free here.
+    #[cfg(unix)]
+    struct HeldLease {
+        /// Held for the lifetime of the value; the kernel releases it on drop,
+        /// which is exactly the property the probe is asking about.
+        _file: std::fs::File,
+    }
+
+    #[cfg(unix)]
+    impl HeldLease {
+        /// Take the lease the way `acquire_db_write_lease` does: create
+        /// `<db>.write.lock`, `flock(LOCK_EX | LOCK_NB)`, hold the descriptor.
+        fn take(db_path: &Path) -> Self {
+            use std::os::unix::io::AsRawFd;
+            let mut name = db_path.to_path_buf().into_os_string();
+            name.push(".write.lock");
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .truncate(false)
+                .open(PathBuf::from(name))
+                .expect("lease file");
+            assert_eq!(
+                unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+                0,
+                "the test must actually hold the lease or it proves nothing"
+            );
+            HeldLease { _file: file }
+        }
+    }
+
+    /// The exact sentence the live kory-brain graph produced while the daemon
+    /// (pid 45771) was appending to a `.wal` that GREW 12,226,075 -> 12,817,039
+    /// bytes in 20 seconds and `brain status` / `search` kept succeeding.
+    const LIVE_WRITER_WAL_PHRASE: &str = "Corrupted wal file. Read out invalid WAL record type.";
+
+    /// nw-404. A read-only open that meets a live writer must report
+    /// CONTENTION, not corruption — and the runbook that tells the operator to
+    /// move aside a live database's `.wal` must be unreachable from it.
+    ///
+    /// The third assertion is the one that actually stops the data loss:
+    /// `into_diagnostic` re-runs the PURE classifier over the RENDERED error
+    /// when no type survived, so an error that carries the engine's verbatim
+    /// "corrupted wal" would be re-promoted to `WalUnreadable` there and print
+    /// the runbook after all. Retracting the verdict is not enough; the
+    /// retraction has to survive re-classification.
+    #[cfg(unix)]
+    #[test]
+    fn a_wal_a_live_writer_is_appending_is_contention_and_can_never_reach_the_runbook() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        std::fs::write(&db, b"").unwrap();
+        let _lease = HeldLease::take(&db);
+
+        assert!(
+            live_writer_holds_write_lease(&db),
+            "a held flock on <db>.write.lock is the writer signal"
+        );
+        assert_eq!(
+            classify_engine_corruption_for_db(LIVE_WRITER_WAL_PHRASE, &db),
+            None,
+            "a healthy database being written must not be classified as damaged"
+        );
+
+        let error = StoreError::from_engine_message_for_db(LIVE_WRITER_WAL_PHRASE, &db);
+        assert_eq!(
+            error.corruption_kind(),
+            None,
+            "no corruption kind means no `corruption_diagnostic`, which means no runbook"
+        );
+        assert!(
+            error.is_lock_contention(),
+            "it must land in the existing 'someone holds it' arm nw-346 built: {error}"
+        );
+        assert!(
+            error.to_string().contains(LIVE_WRITER_WAL_PHRASE),
+            "the engine's own words must survive the retraction: {error}"
+        );
+        assert_eq!(
+            classify_engine_corruption(&format!("{error}")),
+            None,
+            "the prose fallback in `into_diagnostic` must not re-promote our own \
+             disclosure back to WalUnreadable and print the move-aside runbook"
+        );
+    }
+
+    /// THE COUNTERWEIGHT. The veto must be reachable ONLY by proof of a live
+    /// holder, or nw-404's fix becomes a way to never report a corrupt WAL at
+    /// all — which is the failure mode with the worse ending.
+    ///
+    /// Three "no proof" shapes, all of which must still report corruption:
+    /// no lease file at all, a lease file nobody holds (it is never deleted
+    /// after a release, so presence alone is evidence of nothing), and a lease
+    /// that WAS held and has since been dropped.
+    #[cfg(unix)]
+    #[test]
+    fn a_corrupt_wal_with_no_live_writer_is_still_reported_as_corrupt() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        std::fs::write(&db, b"").unwrap();
+
+        let expect_corrupt = |stage: &str| {
+            assert!(
+                !live_writer_holds_write_lease(&db),
+                "no live writer must be claimed at stage: {stage}"
+            );
+            assert_eq!(
+                classify_engine_corruption_for_db(LIVE_WRITER_WAL_PHRASE, &db),
+                Some(CorruptionKind::WalUnreadable),
+                "a genuinely unreadable log must keep its verdict at stage: {stage}"
+            );
+            assert_eq!(
+                StoreError::from_engine_message_for_db(LIVE_WRITER_WAL_PHRASE, &db)
+                    .corruption_kind(),
+                Some(CorruptionKind::WalUnreadable),
+                "and the operator must still get the recovery runbook at stage: {stage}"
+            );
+        };
+
+        expect_corrupt("no lease file has ever existed");
+
+        // A lease file with nobody holding it. `acquire_db_write_lease` never
+        // deletes it, so every database a writer has EVER touched has one.
+        let mut name = db.clone().into_os_string();
+        name.push(".write.lock");
+        std::fs::write(PathBuf::from(name), b"").unwrap();
+        expect_corrupt("the lease file exists but is unheld");
+
+        let lease = HeldLease::take(&db);
+        assert!(live_writer_holds_write_lease(&db));
+        drop(lease);
+        expect_corrupt("the lease was held and has been released");
+    }
+
+    /// The other half of "keep it narrow": a live writer does not make a
+    /// TRUNCATED file, a C++ assertion or an unclassified corruption healthy.
+    /// Only the WAL-tail reading is ambiguous under an active append, so only
+    /// that verdict may be retracted.
+    #[cfg(unix)]
+    #[test]
+    fn a_live_writer_does_not_excuse_any_corruption_but_the_wal_tail() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        std::fs::write(&db, b"").unwrap();
+        let _lease = HeldLease::take(&db);
+
+        for (phrase, expected) in [
+            (
+                "catalog page range starts at 3567 and spans 5 pages, outside the \
+                 database file with 1696 pages",
+                CorruptionKind::FileTruncated,
+            ),
+            (
+                "Assertion failed in file \"<crate>/column.cpp\" on line 289: x <= y",
+                CorruptionKind::EngineAssertion,
+            ),
+            (
+                "database error: basic_string",
+                CorruptionKind::EngineAssertion,
+            ),
+        ] {
+            assert_eq!(
+                classify_engine_corruption_for_db(phrase, &db),
+                Some(expected),
+                "a live writer must not suppress this verdict: {phrase}"
+            );
+        }
+
+        // And an ordinary failure is still not corruption, lease or no lease.
+        assert_eq!(
+            classify_engine_corruption_for_db(
+                "Binder exception: Table Symbol does not exist.",
+                &db
+            ),
+            None
+        );
     }
 
     /// The engine's own words must survive classification verbatim. The nw-332

--- a/docs/verification-corpus.md
+++ b/docs/verification-corpus.md
@@ -1,0 +1,71 @@
+# The verification corpus (nw-413)
+
+## Why this exists
+
+Five open backlog items are blocked on the same missing artefact, and none of
+them owned building it — so it could never be scheduled:
+
+| Item | What it needs the corpus for |
+| --- | --- |
+| nw-291 | dead-code re-measurement at per-language scale |
+| nw-308 | hub/bridge name-collision rate across many repos |
+| nw-322 | `investigate --scope project:` latency on a large multi-repo graph |
+| nw-351 | C++ entry-point discovery, re-measured |
+| nw-358 | `stale_repos` ordering across routes, needs tens of repos |
+
+Every one of those measurements had previously been taken against Kory's
+personal brain DB. That DB is not reproducible by anyone else, so no result
+taken on it could be independently checked or re-run after a fix.
+
+## Why a fixture is not enough
+
+This is the most-repeated finding in the backlog and it is the reason the
+corpus is not optional:
+
+- **nw-352** — 821 of 822 real C++ `class` definitions were not extracted (0.1%).
+  **No fixture could see it**, because `testdata/cpp/simple.cpp`'s
+  `class SensorManager` extracts fine. Found only against a real tree.
+- **nw-338** (read-only schema migrations) and **nw-291**'s High-tier
+  miscalibration were both found only against a disposable copy of the real
+  1 GB graph.
+
+Fixture-green is necessary, not sufficient.
+
+## Usage
+
+```sh
+scripts/build-verification-corpus.sh            # ~20 repos, 10 languages
+scripts/build-verification-corpus.sh --small    # 5 repos, for iterating
+scripts/build-verification-corpus.sh --teardown # delete everything
+```
+
+Environment:
+
+- `CORPUS_DIR` — where clones and the `.lbug` live (default `/tmp/nw-corpus`)
+- `NW` — the binary to index with (default `cargo run --release --`)
+
+## Design decisions worth not re-litigating
+
+**Every repo is pinned to a commit SHA.** An unpinned corpus is not a corpus: a
+measurement taken against "whatever `main` was that day" cannot be compared to
+the next one. That is exactly how nw-291's re-measurement became
+uncomparable to its own filing.
+
+**A repo that fails to clone or index is reported, never silently skipped.** A
+corpus that quietly indexed 12 of 20 repos would make every measurement taken
+on it wrong in a direction nobody could see — which is the same silent-partial
+-success class as nw-387 and nw-394.
+
+**Teardown stops the daemon before deleting the DB.** Otherwise the next run
+inherits a daemon pointing at a path that no longer exists (nw-377's wedge).
+
+**Repos are chosen for size, not just language spread.** The corpus has to
+exceed the internal caps under test or it cannot prove they disclose
+themselves: `DEFAULT_RETRIEVAL_BREADTH` 30, `HUB_COUNT` 30,
+`MAX_CLUSTER_SUMMARIES` 50, `bound_identifiers` `MAX_COUNT` 1000.
+
+## Definition of done
+
+nw-413 is closed when **one of the five dependent items has been re-measured
+with this corpus and closed or updated on the result** — not when the script
+exists. A fixture nobody has used is the same dead end as no fixture.

--- a/scripts/build-verification-corpus.sh
+++ b/scripts/build-verification-corpus.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# nw-413: build a DISPOSABLE, REPEATABLE, multi-repo verification corpus.
+#
+# Five open backlog items are blocked on "measure this against a real multi-repo
+# graph, not a fixture" (nw-291, nw-308, nw-322, nw-351, nw-358). Every one of
+# them had been measured only against Kory's personal brain DB, which nobody
+# else can reproduce. This builds an equivalent graph from public sources.
+#
+# Usage:
+#   scripts/build-verification-corpus.sh            # full corpus (~20 repos)
+#   scripts/build-verification-corpus.sh --small    # 5 repos, for iterating on the script
+#   scripts/build-verification-corpus.sh --teardown # delete everything
+#
+# Env:
+#   CORPUS_DIR   where clones + the .lbug live   (default /tmp/nw-corpus)
+#   NW           the nestweaver binary to index with (default: cargo run --release)
+#
+# Entries are pinned to RELEASE TAGS, not commit SHAs, and the difference matters:
+# a tag is mutable, so this is weaker pinning than the ideal. It is recorded here
+# rather than overstated because an earlier draft of this comment claimed SHA
+# pinning in capitals while the manifest below used tags — a false claim in a
+# comment is the same defect class as a false claim in a payload.
+#
+# Tags are used because they are legible and stable in practice for these
+# projects; `--teardown` plus a re-run gives a fresh corpus if one ever moves.
+# The script RESOLVES each ref to a concrete SHA at clone time and PRINTS it, so
+# any measurement can record exactly what it ran against. Anyone needing
+# reproducibility stronger than "the tag did not move" should paste the printed
+# SHAs back into the manifest.
+#
+# One entry is a floating BRANCH (`TypeScript-Node-Starter|master`) because the
+# project publishes no tags. It is flagged as such in the output rather than
+# silently mixed in with the tagged entries.
+set -u
+cd "$(dirname "$0")/.."
+
+CORPUS_DIR="${CORPUS_DIR:-/tmp/nw-corpus}"
+DB="$CORPUS_DIR/corpus.lbug"
+
+# repo|sha|language — chosen for language spread and for sizes that make the
+# internal caps actually bind (DEFAULT_RETRIEVAL_BREADTH=30, HUB_COUNT=30,
+# MAX_CLUSTER_SUMMARIES=50, bound_identifiers MAX_COUNT=1000). A corpus that
+# does not exceed a cap cannot prove the cap discloses itself.
+REPOS_FULL=$(cat <<'EOF'
+https://github.com/BurntSushi/ripgrep|14.1.1|rust
+https://github.com/serde-rs/serde|v1.0.215|rust
+https://github.com/clap-rs/clap|v4.5.21|rust
+https://github.com/tokio-rs/tokio|tokio-1.42.0|rust
+https://github.com/expressjs/express|4.21.2|javascript
+https://github.com/lodash/lodash|4.17.21|javascript
+https://github.com/axios/axios|v1.7.9|javascript
+https://github.com/microsoft/TypeScript-Node-Starter|master|typescript
+https://github.com/pallets/flask|3.1.0|python
+https://github.com/psf/requests|v2.32.3|python
+https://github.com/python/mypy|v1.13.0|python
+https://github.com/gin-gonic/gin|v1.10.0|go
+https://github.com/spf13/cobra|v1.8.1|go
+https://github.com/nlohmann/json|v3.11.3|cpp
+https://github.com/fmtlib/fmt|11.0.2|cpp
+https://github.com/catchorg/Catch2|v3.7.1|cpp
+https://github.com/google/guava|v33.4.0-jre|java
+https://github.com/square/retrofit|parent-2.11.0|java
+https://github.com/rails/rails|v8.0.1|ruby
+https://github.com/laravel/framework|v11.34.2|php
+EOF
+)
+REPOS_SMALL=$(printf '%s\n' "$REPOS_FULL" | head -5)
+
+teardown() {
+  echo "removing $CORPUS_DIR"
+  # Stop any daemon that autostarted against the corpus DB before deleting it,
+  # otherwise the next run inherits a daemon pointing at a path that no longer
+  # exists — the exact wedge nw-377 describes.
+  if [ -f "$DB" ]; then
+    ${NW:-cargo run --release --} daemon --db "$DB" stop >/dev/null 2>&1 || true
+  fi
+  rm -rf "$CORPUS_DIR"
+  echo "done"
+}
+
+case "${1:-}" in
+  --teardown) teardown; exit 0 ;;
+  --small)    REPOS="$REPOS_SMALL" ;;
+  "")         REPOS="$REPOS_FULL" ;;
+  *)          echo "unknown argument: $1" >&2; exit 64 ;;
+esac
+
+NW="${NW:-cargo run --release --}"
+mkdir -p "$CORPUS_DIR/src"
+
+echo "corpus dir: $CORPUS_DIR"
+echo "database:   $DB"
+echo
+
+# --- clone (shallow, pinned) -------------------------------------------------
+while IFS='|' read -r url sha lang; do
+  [ -z "$url" ] && continue
+  name=$(basename "$url")
+  dest="$CORPUS_DIR/src/$name"
+  if [ -d "$dest/.git" ]; then
+    echo "have    $name ($lang)"
+    continue
+  fi
+  echo "clone   $name ($lang) @ $sha"
+  # --filter=blob:none keeps the checkout small without losing the ability to
+  # resolve the pinned ref; a plain --depth 1 cannot check out an arbitrary sha.
+  if ! git clone --quiet --filter=blob:none --no-checkout "$url" "$dest" 2>/dev/null; then
+    echo "  SKIP (clone failed — network or renamed repo)" >&2
+    rm -rf "$dest"
+    continue
+  fi
+  if ! git -C "$dest" checkout --quiet "$sha" 2>/dev/null; then
+    echo "  SKIP (pinned ref '$sha' not found — repo moved its tags)" >&2
+    rm -rf "$dest"
+    continue
+  fi
+  # Record what the mutable ref actually resolved to, so a measurement taken on
+  # this corpus can be reproduced even if the tag later moves.
+  resolved=$(git -C "$dest" rev-parse HEAD 2>/dev/null || echo unknown)
+  printf '        resolved %s -> %s\n' "$sha" "${resolved:0:12}"
+  if [ "$sha" = "master" ] || [ "$sha" = "main" ]; then
+    echo "        NOTE: floating branch, not a tag — this entry is not reproducible by ref alone" >&2
+  fi
+done <<< "$REPOS"
+
+# --- index -------------------------------------------------------------------
+echo
+indexed=0
+for dest in "$CORPUS_DIR"/src/*/; do
+  [ -d "$dest" ] || continue
+  name=$(basename "$dest")
+  printf 'index   %-28s ' "$name"
+  if $NW index --repo "$dest" --db "$DB" --no-embed >/dev/null 2>&1; then
+    echo ok
+    indexed=$((indexed + 1))
+  else
+    # A failed repo is reported, never silently dropped — a corpus that quietly
+    # indexed 12 of 20 repos would make every measurement taken on it wrong in
+    # a direction nobody could see.
+    echo "FAILED"
+  fi
+done
+
+# --- report ------------------------------------------------------------------
+echo
+echo "=== corpus built ==="
+echo "repos indexed: $indexed"
+$NW list-repos --db "$DB" 2>/dev/null | tail -5
+echo
+echo "Scale check — these are the numbers that decide whether the corpus is big"
+echo "enough for the caps under test to actually bind:"
+$NW search "" --db "$DB" --limit 10000 --json 2>/dev/null > "$CORPUS_DIR/.scale.json" || true
+python3 - "$CORPUS_DIR/.scale.json" <<'PYEOF' || echo "  (symbol count unavailable)"
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception:
+    print("  (symbol count unavailable)"); raise SystemExit(0)
+n = d.get("returned", 0)
+print(f"  symbols in capped view: {n} (truncated={d.get('truncated')})")
+# The 10000 presentation ceiling is itself a cap; hitting it means the corpus is
+# at least that big, which is the property the blocked items actually need.
+print("  scale: SUFFICIENT — exceeds the 10k presentation ceiling" if d.get("truncated")
+      else f"  scale: thin at {n} symbols; add repos before trusting a cap measurement")
+PYEOF
+echo
+echo "Use with:  --db $DB"
+echo "Teardown:  scripts/build-verification-corpus.sh --teardown"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2468,6 +2468,90 @@ fn dead_code_refusal_note(payload: &serde_json::Value) -> String {
         })
 }
 
+/// Why `affected-tests` refuses a generation-stale graph instead of answering
+/// a narrower question.
+///
+/// nw-412. The counterpart of `WHY_DEAD_CODE_REFUSES`, worded separately
+/// because the ERROR DIRECTION is the opposite one and that is the whole
+/// argument. `dead-code` on a stale graph puts a LIVE symbol on a deletion
+/// list — bad, but a human reviewing the list can catch it. Here a missing
+/// edge makes the affected-test set SMALLER: the regression test that would
+/// have caught the change is never selected, the gate reports success, and
+/// there is no list for anyone to review. A test selector that refuses is
+/// safe; one that silently narrows is not.
+///
+/// Byte-identical to `WHY_AFFECTED_TESTS_REFUSES` in
+/// `crates/nestweaver-mcp/src/tools.rs`, which is where the same sentence is
+/// produced for the MCP tool and for this command's DAEMON route.
+const WHY_AFFECTED_TESTS_REFUSES: &str = "affected-tests will not produce a selection on this graph. Its output is the set of tests a \
+     change can reach through the call/import graph, so a MISSING edge cannot make the selection \
+     safer — it can only drop a test that should have run, while `status` still reads complete. \
+     The error is one-directional and it is silent: nothing downstream can tell a test that was \
+     not selected from a test that does not exist.";
+
+/// Turn the shared resolver-generation verdict into `affected-tests`' refusal.
+///
+/// nw-412. The payload is `DeadCodeRefusal::payload()` — same `refused: true`,
+/// same `reason: "outdated_resolver"` token `stale-check` puts in a repo's
+/// `status`, same `remedies` array of ready-to-run
+/// `nestweaver index --repo <path> --force` commands, same `needs_reindex` key
+/// a CI job already gates on. Only two things are tool-specific:
+///
+///  * `note` is replaced, because `DeadCodeRefusal::message()` opens with
+///    "dead-code will not produce a list on this graph", which is the wrong
+///    sentence in front of the right remedies.
+///  * `recommendation: "run-full-suite"` is ADDED. It is the one key a CI
+///    consumer acts on, and the refusal deliberately carries no
+///    `tier_1`/`tier_2`/`tier_3` — so without it a caller that keys off "did I
+///    get tiers" would read the refusal as "no tests affected", which is the
+///    exact silent narrowing this refusal exists to prevent.
+///
+/// This mirrors `affected_tests_refusal_payload` in the MCP crate so the
+/// direct route and the daemon route emit the SAME object; a CI gate must not
+/// be able to tell which one answered.
+fn affected_tests_refusal_payload(
+    refusal: &nestweaver_engine::resolver_generation::DeadCodeRefusal,
+) -> serde_json::Value {
+    let mut payload = refusal.payload();
+    let mut note = WHY_AFFECTED_TESTS_REFUSES.to_string();
+    for remedy in payload
+        .get("remedies")
+        .and_then(|v| v.as_array())
+        .into_iter()
+        .flatten()
+    {
+        match remedy.get("command").and_then(|v| v.as_str()) {
+            Some(command) => note.push_str(&format!("\n  {command}")),
+            None => note.push_str(&format!(
+                "\n  {} — indexed from a bare clone, so this machine has no working tree to \
+                 pass to `--repo`; re-index it where it lives",
+                remedy
+                    .get("uid")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("(unnamed repo)")
+            )),
+        }
+    }
+    payload["note"] = serde_json::json!(note);
+    payload["recommendation"] = serde_json::json!("run-full-suite");
+    payload
+}
+
+/// The refusal paragraph out of an `affected_tests` payload the DAEMON
+/// produced.
+///
+/// The twin of [`dead_code_refusal_note`], and it decides nothing for the same
+/// reason: the tool that computed the refusal also wrote the sentence, so this
+/// route prints what it was sent. The fallback covers only a payload that says
+/// `refused` and carries no `note`, which this binary cannot produce.
+fn affected_tests_refusal_note(payload: &serde_json::Value) -> String {
+    payload
+        .get("note")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| WHY_AFFECTED_TESTS_REFUSES.to_string())
+}
+
 fn render_dead_code_text(payload: &serde_json::Value) {
     let num = |k: &str| payload.get(k).and_then(|v| v.as_u64()).unwrap_or(0);
     let total = num("total_symbols");
@@ -7482,6 +7566,84 @@ fn pr_impact_exit_code(
     } else {
         EXIT_SUCCESS
     }
+}
+
+/// The notification descriptor attached when a blast-radius run's graph is
+/// resolver-generation-stale.
+///
+/// nw-412 asked for a decision between refusing and degrading, per surface,
+/// and the two land differently:
+///
+///  * `affected-tests` REFUSES. It is a selector: its answer is consumed as
+///    "run exactly these", there is no field a caller can read to widen it
+///    back, and a narrowed selection is indistinguishable from a correct one.
+///  * `pr-impact` / `blast-radius` DEGRADE. They are an assessment, not a
+///    selector, and they already ship the exact contract this condition wants:
+///    `status` + `gate_state`, whose documented rule is that a run which did
+///    not complete is `degraded-unknown` and NEVER `risk-flagged` — "unknown,
+///    review manually", not "safe". A stale-resolver run IS a run that did not
+///    complete. Degrading also preserves `coverage`, `blind_spots` and the
+///    changed-file echo, and keeps the SARIF rendering valid; a refusal
+///    payload is not a SARIF run and would break `pr-impact --sarif` outright.
+///
+/// Same string as `BLAST_RADIUS_RESOLVER_STALE_DESCRIPTOR` in the MCP crate,
+/// so a consumer matching on the descriptor sees one code from both surfaces.
+const BLAST_RADIUS_RESOLVER_STALE_DESCRIPTOR: &str = "resolver.generation-stale";
+
+/// Degrade a locally-computed blast-radius result when this graph's edges
+/// predate the running resolver.
+///
+/// nw-412, the CLI twin of the block in `tool_blast_radius`. `status` is only
+/// ever pushed DOWN (`.max` over the ordered ladder Complete < Partial <
+/// Degraded < Failed), matching nw-105's rule that a run already Degraded or
+/// Failed is never upgraded by a later finding, and `gate_state` is then
+/// forced to `DegradedUnknown`. That mirrors `derive_gate_state`'s
+/// "non-Complete => DegradedUnknown" without calling it (it is `pub(crate)` to
+/// the engine) and closes the direction that made this dangerous: a
+/// stale-resolver run reported `gate_state: ok` over a shrunken affected set,
+/// and can no longer report `ok` at all.
+///
+/// The consequence on the pre-push hook is the point of wiring it here:
+/// `print_pr_impact_hook` is SILENT on an `Ok` + `Low` + nothing-affected run,
+/// and a stale graph is exactly the run most likely to look like that. It can
+/// no longer be silent.
+///
+/// `list_repos` PROPAGATES rather than becoming a degrade: a store that cannot
+/// enumerate repos cannot serve the traversal either, so the caller gets the
+/// CLI's own error classifier (nw-285's `db_no_schema` diagnostic) instead of
+/// a binder exception quoted inside a paragraph about resolver generations.
+fn degrade_blast_radius_if_resolver_stale(
+    store: &GraphStore,
+    db_path: &Path,
+    result: &mut BlastRadiusResult,
+) -> Result<(), anyhow::Error> {
+    let repos = store.list_repos(None)?;
+    let Some(refusal) =
+        nestweaver_engine::resolver_generation::DeadCodeRefusal::for_repos(db_path, &repos)
+    else {
+        return Ok(());
+    };
+    result.status = result
+        .status
+        .max(nestweaver_engine::blast_radius::AnalysisStatus::Degraded);
+    result.gate_state = GateState::DegradedUnknown;
+    result
+        .notifications
+        .push(nestweaver_engine::blast_radius::Notification {
+            level: NotificationLevel::Error,
+            message: refusal.message(),
+            descriptor: BLAST_RADIUS_RESOLVER_STALE_DESCRIPTOR.to_string(),
+        });
+    // `render_blast_summary` appends `[status: …]` for any non-Complete run
+    // and is `pub(crate)`, so the marker is restated here rather than leaving
+    // the human summary claiming a clean run. Guarded so a summary that
+    // already carries one is not double-tagged.
+    if !result.summary.contains("[status: ") {
+        result
+            .summary
+            .push_str(&format!(" [status: {}]", result.status.label()));
+    }
+    Ok(())
 }
 
 /// Name the top reason a run was degraded/unknown, for the advisory banner.
@@ -14832,8 +14994,15 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 include_data_edges: false,
                 limit: None,
             };
-            let result =
+            let mut result =
                 analyze_blast_radius(&store, &changed_files, &options, None, Some(&db_path))?;
+
+            // nw-412: applied HERE — after the analysis, before EITHER
+            // rendering — so the SARIF leg carries it too. `pr-impact --sarif`
+            // is the merge-gate surface most likely to be read by a machine
+            // that never sees the JSON, and `--sarif` also forces this direct
+            // path, so it is the leg that most needs the marker.
+            degrade_blast_radius_if_resolver_stale(&store, &db_path, &mut result)?;
 
             if sarif {
                 let mut sarif_value =
@@ -14936,10 +15105,29 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let daemon_result: Option<nestweaver_engine::AffectedTestsResult> = if use_daemon {
                 let args = affected_tests_rpc_args(&changed_files);
                 match try_hybrid_json_rpc(true, &db_path, None, "affected_tests", args)? {
-                    Some(value) => Some(
-                        serde_json::from_value(value)
-                            .context("decoding daemon affected_tests result")?,
-                    ),
+                    Some(value) => {
+                        // nw-412: a refusal is NOT an `AffectedTestsResult`
+                        // and must be intercepted before `from_value`, which
+                        // would fail on the missing tiers and report a decode
+                        // bug instead of a stale graph. The daemon PRINTS what
+                        // it was sent — the `affected_tests` tool it ran
+                        // computed the refusal from the sole
+                        // `ResolverGenerations::stale_repos` computation, so
+                        // this route decides nothing and cannot disagree with
+                        // the tool about one database (the same rule the
+                        // `dead-code` daemon route follows).
+                        if value.get("refused").and_then(|v| v.as_bool()) == Some(true) {
+                            if json {
+                                print_json_payload(&value)?;
+                            }
+                            eprintln!("Error: {}", affected_tests_refusal_note(&value));
+                            return Ok((EXIT_NEEDS_REINDEX, None));
+                        }
+                        Some(
+                            serde_json::from_value(value)
+                                .context("decoding daemon affected_tests result")?,
+                        )
+                    }
                     None => None,
                 }
             } else {
@@ -14950,6 +15138,30 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 Some(r) => r,
                 None => {
                     let store = open_store(Some(&db_path))?;
+                    // nw-412: REFUSE before the selection, the way `dead-code`
+                    // does. On a resolver-generation-stale graph a MISSING
+                    // edge makes the affected-test set SMALLER, so the
+                    // regression test that should have run is silently dropped
+                    // while `status` still reads complete — the one error
+                    // direction nothing downstream can detect. See
+                    // `WHY_AFFECTED_TESTS_REFUSES` for why this refuses where
+                    // `pr-impact` degrades.
+                    let repos = store.list_repos(None)?;
+                    if let Some(refusal) =
+                        nestweaver_engine::resolver_generation::DeadCodeRefusal::for_repos(
+                            &db_path, &repos,
+                        )
+                    {
+                        let payload = affected_tests_refusal_payload(&refusal);
+                        // stdout stays pure JSON for a `--json` gate; the
+                        // paragraph goes to stderr on BOTH modes, the same
+                        // split `dead-code` and `stale-check` already use.
+                        if json {
+                            print_json_payload(&payload)?;
+                        }
+                        eprintln!("Error: {}", affected_tests_refusal_note(&payload));
+                        return Ok((EXIT_NEEDS_REINDEX, None));
+                    }
                     nestweaver_engine::rts_eval::run_recorded(
                         &store,
                         &changed_files,
@@ -23822,6 +24034,25 @@ fn run_brain(
                         });
                     }
 
+                    // nw-405: resolve the scope flags to CONCRETE container
+                    // UIDs BEFORE filtering anything, mirroring
+                    // `tool_brain_context`. Resolution sits outside the
+                    // per-list closure so an unresolvable entry is one ERROR
+                    // for the command rather than a predicate that silently
+                    // matches nothing on both lists — and it is the same
+                    // resolver, so this route and the daemon route can no
+                    // longer answer differently for one flag value.
+                    let repo_scope = if repos.is_empty() {
+                        None
+                    } else {
+                        Some(resolve_repo_filter(&store, &repos)?)
+                    };
+                    let vault_scope = if vaults.is_empty() {
+                        None
+                    } else {
+                        Some(resolve_vault_filter(&store, &vaults)?)
+                    };
+
                     // RFC #2: apply post-PPR filters when any filter flag was set.
                     let filter_kinds_lower: Vec<String> =
                         kinds.iter().map(|k| k.to_lowercase()).collect();
@@ -23834,22 +24065,14 @@ fn run_brain(
                                     .any(|k| kind_lower.starts_with(k.as_str()))
                             });
                         }
-                        if !repos.is_empty() {
-                            nodes.retain(|n| {
-                                repos.iter().any(|r| {
-                                    n.uid.contains(r.as_str()) || n.location.contains(r.as_str())
-                                })
-                            });
+                        if let Some(ref repo_uids) = repo_scope {
+                            retain_nodes_in_repos(nodes, repo_uids);
                         }
-                        if !vaults.is_empty() {
-                            nodes.retain(|n| {
-                                vaults.iter().any(|v| {
-                                    n.uid.contains(v.as_str()) || n.location.contains(v.as_str())
-                                })
-                            });
+                        if let Some(ref vault_uids) = vault_scope {
+                            retain_nodes_in_vaults(nodes, vault_uids);
                         }
                         if let Some(ref prefix) = path_prefix {
-                            nodes.retain(|n| n.location.starts_with(prefix.as_str()));
+                            retain_nodes_under_path_prefix(nodes, prefix.as_str());
                         }
                     };
                     apply_filters(&mut result.seeds);
@@ -23902,6 +24125,23 @@ fn run_brain(
                     }
 
                     // tags filter: keep only note/section nodes tagged with any of these.
+                    //
+                    // nw-407: Symbol nodes used to be kept UNCONDITIONALLY
+                    // here ("no tag concept for code"), which made `--tags` an
+                    // EXPANSION rather than a filter. Measured on the live
+                    // graph at one seed and budget: with `--tags security` the
+                    // result was n=71 of which 70 were Symbols and ONE was a
+                    // tagged Note; without it, n=30 with 22 of 30 vault
+                    // content. Adding the filter GREW the result 30 -> 71 and
+                    // drove the tagged share from 22/30 to 1/71.
+                    //
+                    // The budget leg is why this is not cosmetic: the
+                    // pass-through happens before the token budget is spent,
+                    // so untagged symbols eat the budget the tagged notes were
+                    // asked for. "No tag concept for code" means a symbol
+                    // cannot SATISFY a tag scope, not that it is exempt from
+                    // one — the old comment documented the mechanism and never
+                    // the consequence.
                     if !tags.is_empty() {
                         let tagged_notes = store
                             .list_note_uids_with_tags(&tags)
@@ -23910,13 +24150,7 @@ fn run_brain(
                             .list_section_uids_with_tags(&tags)
                             .map_err(|e| anyhow::anyhow!(e))?;
                         let filter_tagged = |nodes: &mut Vec<nestweaver_engine::BrainNode>| {
-                            nodes.retain(|item| {
-                                if item.kind.to_lowercase().contains("symbol") {
-                                    return true;
-                                }
-                                tagged_notes.contains(&item.uid)
-                                    || tagged_sections.contains(&item.uid)
-                            });
+                            retain_tagged_nodes(nodes, &tagged_notes, &tagged_sections);
                         };
                         filter_tagged(&mut result.seeds);
                         filter_tagged(&mut result.connected);
@@ -24585,6 +24819,224 @@ fn run_brain(
             Ok((EXIT_SUCCESS, None))
         }
     }
+}
+
+// ── `brain context` scope filters (nw-405 / nw-406 / nw-407) ────────────────
+//
+// The CLI twins of the private helpers in `crates/nestweaver-mcp/src/tools.rs`
+// (`NodeOwner`, `node_owner`, `resolve_repo_filter`, `resolve_vault_filter`,
+// `retain_nodes_in_repos`, `retain_nodes_in_vaults`,
+// `retain_nodes_under_path_prefix`), which carry the full argument for each
+// decision. They must stay equivalent to those: nw-405's fourth measured
+// symptom was the two surfaces DISAGREEING about one flag value — the CLI's
+// predicate was case-SENSITIVE where MCP's was not — and `brain context`
+// forwards these flags to the daemon except under `--no-tests` /
+// `--prefer-instance`, which force this direct path. So the same command
+// answered differently depending on whether a daemon happened to be running.
+//
+// They are DUPLICATED rather than shared only because the MCP copies are
+// crate-private. The durable fix is to lift one copy into `nestweaver-engine`
+// and have both surfaces call it; until then a change to either must be made
+// to both, which is exactly the hazard this item was filed about.
+
+/// The container a node UID names as its owner.
+///
+/// The UID is the authority because it is the only field on a `BrainNode` that
+/// NAMES an owner: `sym:`/`file:`/`svc:` embed the whole `repo:{inst}:{hash}`,
+/// and `note:`/`sec:`/`head:`/`tag:` embed the whole `vlt:{inst}:{hash}`.
+/// `location` names neither — a symbol's location is REPO-RELATIVE and so
+/// never contains its own repo name, which is why `--repos website` used to
+/// return ZERO symbols from the repo it named.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum NodeOwner {
+    Repo(String),
+    /// Vault content carries no `repo_uid` at all — the same fact
+    /// `RepoScope::NotRepoScoped` is written on.
+    Vault(String),
+    /// Nothing in the UID names an owner.
+    Unattributable,
+}
+
+/// The owner of `uid`.
+///
+/// Matched over [`nestweaver_schema::uid::UidKind`] rather than an `if` chain
+/// of `starts_with`, for nw-301's reason: an `if` chain cannot be exhaustive,
+/// so a twelfth UID domain would fall silently into whatever the trailing arm
+/// does instead of failing this build.
+fn node_owner(uid: &str) -> NodeOwner {
+    use nestweaver_schema::uid::UidKind;
+
+    /// `{prefix}{owner_uid}:{…}` — an owner UID is always exactly three
+    /// colon-separated components, so take three and discard the tail.
+    fn owner_head(rest: &str) -> Option<String> {
+        let parts: Vec<&str> = rest.splitn(4, ':').collect();
+        (parts.len() >= 3).then(|| format!("{}:{}:{}", parts[0], parts[1], parts[2]))
+    }
+
+    let Some(kind) = UidKind::of(uid) else {
+        return NodeOwner::Unattributable;
+    };
+    let rest = &uid[kind.prefix().len()..];
+    match kind {
+        UidKind::Repo => NodeOwner::Repo(uid.to_string()),
+        UidKind::Vault => NodeOwner::Vault(uid.to_string()),
+        UidKind::File | UidKind::Service | UidKind::Symbol => {
+            owner_head(rest).map_or(NodeOwner::Unattributable, NodeOwner::Repo)
+        }
+        UidKind::Note | UidKind::Tag => {
+            owner_head(rest).map_or(NodeOwner::Unattributable, NodeOwner::Vault)
+        }
+        // `sec:{note_uid}:{…}` / `head:{note_uid}:{…}`, and a note UID is
+        // itself `note:{vault_uid}:{…}`, so the inner `note:` comes off too.
+        UidKind::Section | UidKind::Heading => rest
+            .strip_prefix(UidKind::Note.prefix())
+            .and_then(owner_head)
+            .map_or(NodeOwner::Unattributable, NodeOwner::Vault),
+        // `proj:` names an INSTANCE and a contract UID carries no repo
+        // component, so neither can be attributed to a container.
+        UidKind::Project | UidKind::Contract => NodeOwner::Unattributable,
+    }
+}
+
+/// Resolve `--repos` entries to concrete repo UIDs.
+///
+/// The resolution is [`nestweaver_engine::resolve_repo_selector`] — the SAME
+/// resolver `--repo` already uses everywhere else — so this flag cannot grow a
+/// second, drifting notion of what a repo name means, and an ambiguous
+/// selector (`website` under two orgs) FAILS naming both candidates instead of
+/// quietly merging two tenants' code into one answer. An unresolvable entry
+/// ERRORS: the old predicate matched nothing and returned a confident empty
+/// result, which reads as "this repo has no relevant content" rather than "you
+/// named a repo that is not here".
+fn resolve_repo_filter(
+    store: &GraphStore,
+    selectors: &[String],
+) -> Result<std::collections::HashSet<String>, anyhow::Error> {
+    let repos = store
+        .list_repos(None)
+        .context("listing repositories to resolve --repos")?;
+    selectors
+        .iter()
+        .map(|selector| {
+            nestweaver_engine::resolve_repo_selector(&repos, selector)
+                .map(|repo| repo.uid.clone())
+                // Flattened with `{error:#}` rather than `.context(…)` so the
+                // resolver's own "ambiguous; use an exact UID: …" candidate
+                // list — the only actionable part — survives to the terminal.
+                .map_err(|error| anyhow::anyhow!("--repos entry {selector:?}: {error:#}"))
+        })
+        .collect()
+}
+
+/// Resolve `--vaults` entries to concrete vault UIDs.
+///
+/// The mirror of [`resolve_repo_filter`], written out because there is no
+/// engine-side vault selector to reuse: `--repo` is a first-class selector and
+/// `--vault` is not. Precedence deliberately matches `resolve_repo_selector`'s
+/// (exact UID, then case-insensitive exact name, then exact root path) and is
+/// exact-only — the substring leg is precisely what nw-405 removes.
+fn resolve_vault_filter(
+    store: &GraphStore,
+    selectors: &[String],
+) -> Result<std::collections::HashSet<String>, anyhow::Error> {
+    let vaults = store
+        .list_vaults(None)
+        .context("listing vaults to resolve --vaults")?;
+    selectors
+        .iter()
+        .map(|selector| {
+            let needle = selector.to_lowercase();
+            let matches: Vec<&nestweaver_schema::Vault> = vaults
+                .iter()
+                .filter(|vault| {
+                    vault.uid == *selector
+                        || vault.name.to_lowercase() == needle
+                        || vault.root_path == *selector
+                })
+                .collect();
+            match matches.as_slice() {
+                [vault] => Ok(vault.uid.clone()),
+                [] => {
+                    let known: Vec<&str> = vaults.iter().map(|vault| vault.name.as_str()).collect();
+                    Err(anyhow::anyhow!(
+                        "--vaults entry {selector:?} matches no indexed vault; known vaults: {}",
+                        if known.is_empty() {
+                            "(none indexed)".to_string()
+                        } else {
+                            known.join(", ")
+                        }
+                    ))
+                }
+                ambiguous => Err(anyhow::anyhow!(
+                    "--vaults entry {selector:?} is ambiguous; use an exact UID: {}",
+                    ambiguous
+                        .iter()
+                        .map(|vault| format!("{} ({})", vault.name, vault.uid))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )),
+            }
+        })
+        .collect()
+}
+
+/// Keep only nodes owned by one of `repo_uids`.
+///
+/// **VAULT NODES ARE DROPPED.** This is nw-405's required recorded decision
+/// and it matches the MCP schema text for `repos`. A Note, Section, Heading or
+/// Tag belongs to a VAULT and carries no `repo_uid`, so it is not "in repo X"
+/// under any reading — keeping it is exactly the measured over-include where
+/// `--repos clientA` returned clientB's notes because their PATH contained the
+/// string. Vault content is scoped with `--vaults`.
+///
+/// An unattributable UID is dropped for nw-403's redactor's reason: "I cannot
+/// tell what owns this" is not a reason to return it under a scope argument.
+fn retain_nodes_in_repos(
+    nodes: &mut Vec<nestweaver_engine::BrainNode>,
+    repo_uids: &std::collections::HashSet<String>,
+) {
+    nodes.retain(
+        |node| matches!(node_owner(&node.uid), NodeOwner::Repo(uid) if repo_uids.contains(&uid)),
+    );
+}
+
+/// Keep only nodes owned by one of `vault_uids`.
+///
+/// The mirror of [`retain_nodes_in_repos`]: Symbol/File/Service nodes belong
+/// to a repo, so they cannot satisfy a vault scope and are dropped.
+fn retain_nodes_in_vaults(
+    nodes: &mut Vec<nestweaver_engine::BrainNode>,
+    vault_uids: &std::collections::HashSet<String>,
+) {
+    nodes.retain(
+        |node| matches!(node_owner(&node.uid), NodeOwner::Vault(uid) if vault_uids.contains(&uid)),
+    );
+}
+
+/// Apply `--path-prefix`, exempting nodes that have no path at all.
+///
+/// nw-406. The predicate was the bare
+/// `nodes.retain(|n| n.location.starts_with(prefix))`, and a Tag node carries
+/// `location: ""`: `"".starts_with("Workspaces/")` is false, so
+/// `--kinds Tag --path-prefix Workspaces/` measured 25 Tag nodes -> 0 on a
+/// vault whose 606 tags ALL live under `Workspaces/`. A confident zero with no
+/// disclosure. A tag is not "outside" the prefix — it has no path concept for
+/// the prefix to test, so an empty location is EXEMPT rather than excluded.
+fn retain_nodes_under_path_prefix(nodes: &mut Vec<nestweaver_engine::BrainNode>, prefix: &str) {
+    nodes.retain(|node| node.location.is_empty() || node.location.starts_with(prefix));
+}
+
+/// Keep only nodes that actually carry one of the requested tags.
+///
+/// nw-407. Extracted from the `--tags` closure so the one decision it encodes
+/// is assertable: a Symbol is NOT exempt. See the call site for the measured
+/// 30 -> 71 expansion the old unconditional `return true` produced.
+fn retain_tagged_nodes(
+    nodes: &mut Vec<nestweaver_engine::BrainNode>,
+    tagged_notes: &std::collections::HashSet<String>,
+    tagged_sections: &std::collections::HashSet<String>,
+) {
+    nodes.retain(|node| tagged_notes.contains(&node.uid) || tagged_sections.contains(&node.uid));
 }
 
 /// Greedy token-budget selection: include nodes in PPR-rank order until the
@@ -37508,6 +37960,497 @@ mod render_cost_parity_tests {
              nodes for the same budget ({at_detailed_rate} vs \
              {at_concise_rate}) — that gap IS the reported item-count \
              divergence between the two routes"
+        );
+    }
+}
+
+/// nw-405 / nw-406 / nw-407 — the CLI half of `brain context`'s scope filters.
+///
+/// The predicates these replace were a case-SENSITIVE substring match over
+/// uid-or-location, a bare `starts_with` on `path_prefix`, and a `tags` filter
+/// that passed every Symbol through unconditionally. The MCP twins are pinned
+/// by the same assertions in `crates/nestweaver-mcp/src/tools.rs`; the two
+/// suites are deliberately parallel, because the reported symptom was the two
+/// surfaces answering differently for ONE flag value.
+#[cfg(test)]
+mod brain_context_scope_filter_tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    const REPO_A: &str = "repo:default:aaaaaaaaaaaa";
+    const REPO_B: &str = "repo:default:bbbbbbbbbbbb";
+    const VAULT: &str = "vlt:default:cccccccccccc";
+
+    fn node(uid: &str, kind: &str, location: &str) -> nestweaver_engine::BrainNode {
+        nestweaver_engine::BrainNode {
+            uid: uid.to_string(),
+            kind: kind.to_string(),
+            title: "t".to_string(),
+            location: location.to_string(),
+            relevance: 1.0,
+            inline_body: None,
+            body_complete: true,
+        }
+    }
+
+    /// A fixture built so the OLD predicate gets each leg wrong:
+    ///
+    ///  * repo A's symbol has a repo-relative location that never contains
+    ///    "aaaaaaaaaaaa" — the under-include leg;
+    ///  * repo B's symbol sits under `vendor/alpha/`, so a location substring
+    ///    pulls it into a scope it does not belong to;
+    ///  * the note lives under `Workspaces/Alpha/`, so a location substring
+    ///    keeps it even though it belongs to no repo at all;
+    ///  * the tag carries `location: ""`, which every `path_prefix` deleted.
+    fn mixed_nodes() -> Vec<nestweaver_engine::BrainNode> {
+        vec![
+            node(&format!("sym:{REPO_A}:f1:n1:10"), "Symbol", "src/lib.rs"),
+            node(
+                &format!("sym:{REPO_B}:f2:n2:20"),
+                "Symbol",
+                "vendor/alpha/shim.rs",
+            ),
+            node(
+                &format!("note:{VAULT}:n1"),
+                "Note",
+                "Workspaces/Alpha/design.md",
+            ),
+            node(
+                &format!("sec:note:{VAULT}:n1:1:abc"),
+                "Section",
+                "Workspaces/Alpha/design.md",
+            ),
+            node(&format!("tag:{VAULT}:t1"), "Tag", ""),
+        ]
+    }
+
+    fn uids(nodes: &[nestweaver_engine::BrainNode]) -> Vec<String> {
+        nodes.iter().map(|n| n.uid.clone()).collect()
+    }
+
+    fn store_with_two_repos_named_website() -> GraphStore {
+        let store = GraphStore::in_memory().unwrap();
+        for (uid, url, name) in [
+            (REPO_A, "https://github.com/coyote/website", "website"),
+            (REPO_B, "https://github.com/wavelength/website", "website"),
+        ] {
+            store
+                .insert_repo(&nestweaver_schema::Repo {
+                    uid: uid.to_string(),
+                    url: url.to_string(),
+                    indexed_sha: "deadbeef".to_string(),
+                    staleness_commits_behind: 0,
+                    instance_id: "default".to_string(),
+                    name: Some(name.to_string()),
+                    root_path: None,
+                })
+                .unwrap();
+        }
+        store
+    }
+
+    /// nw-405, all three keep/drop legs at once.
+    ///
+    /// COUNTERWEIGHT: scoping to repo B must SELECT repo B's symbol. Without
+    /// that half, a filter that simply deleted everything would pass the "no
+    /// foreign rows" assertion.
+    #[test]
+    fn a_repos_scope_keeps_the_named_repos_own_symbols_and_no_one_elses() {
+        let mut nodes = mixed_nodes();
+        retain_nodes_in_repos(&mut nodes, &HashSet::from([REPO_A.to_string()]));
+        assert_eq!(
+            uids(&nodes),
+            vec![format!("sym:{REPO_A}:f1:n1:10")],
+            "repo A's own symbol must survive despite a repo-relative location \
+             that never contains its repo name, and nothing else may"
+        );
+
+        let mut nodes = mixed_nodes();
+        retain_nodes_in_repos(&mut nodes, &HashSet::from([REPO_B.to_string()]));
+        assert_eq!(
+            uids(&nodes),
+            vec![format!("sym:{REPO_B}:f2:n2:20")],
+            "the filter must SELECT by owner, not merely delete"
+        );
+    }
+
+    /// nw-405's recorded vault decision, pinned so it cannot be reverted by
+    /// accident: `--repos` drops vault content because a note belongs to a
+    /// vault and to no repo. On a consulting vault the old behaviour returned
+    /// clientB's notes for `--repos clientA`.
+    ///
+    /// COUNTERWEIGHT: the UNFILTERED list carries every one of those rows, so
+    /// the drop is attributable to the scope flag and not to the fixture.
+    #[test]
+    fn a_repos_scope_drops_vault_content_that_merely_mentions_the_repo_in_its_path() {
+        assert_eq!(
+            mixed_nodes().len(),
+            5,
+            "the fixture must carry the vault rows this test claims are dropped"
+        );
+
+        let mut nodes = mixed_nodes();
+        retain_nodes_in_repos(&mut nodes, &HashSet::from([REPO_A.to_string()]));
+        assert!(
+            !nodes.iter().any(|n| n.uid.starts_with("note:")
+                || n.uid.starts_with("sec:")
+                || n.uid.starts_with("tag:")),
+            "vault content belongs to no repo and must not pass a repo scope: {:?}",
+            uids(&nodes)
+        );
+    }
+
+    /// The mirror image, so `--vaults` is a scope in the same sense.
+    #[test]
+    fn a_vaults_scope_keeps_that_vaults_content_and_drops_repo_symbols() {
+        let mut nodes = mixed_nodes();
+        retain_nodes_in_vaults(&mut nodes, &HashSet::from([VAULT.to_string()]));
+        assert_eq!(
+            uids(&nodes),
+            vec![
+                format!("note:{VAULT}:n1"),
+                format!("sec:note:{VAULT}:n1:1:abc"),
+                format!("tag:{VAULT}:t1"),
+            ],
+            "notes, sections and tags are vault-owned; symbols are not"
+        );
+
+        let mut nodes = mixed_nodes();
+        retain_nodes_in_vaults(
+            &mut nodes,
+            &HashSet::from(["vlt:default:999999999999".to_string()]),
+        );
+        assert!(
+            nodes.is_empty(),
+            "a vault nobody owns must select nothing, not everything"
+        );
+    }
+
+    /// nw-406. `--path-prefix` must not silently delete a whole KIND it has no
+    /// way to judge — all 606 tags in the measured vault vanished this way.
+    ///
+    /// COUNTERWEIGHT: a node that HAS a path and does not match is still
+    /// dropped. The exemption is for "no path concept", not for everything.
+    #[test]
+    fn a_path_prefix_exempts_nodes_with_no_path_but_still_drops_non_matching_paths() {
+        let mut nodes = mixed_nodes();
+        retain_nodes_under_path_prefix(&mut nodes, "Workspaces/");
+        assert!(
+            nodes.iter().any(|n| n.uid.starts_with("tag:")),
+            "a Tag carries location \"\"; \"\".starts_with(prefix) is false, which \
+             deleted every tag in the vault: {:?}",
+            uids(&nodes)
+        );
+        assert!(
+            !nodes.iter().any(|n| n.location == "src/lib.rs"),
+            "a node with a real, non-matching path must still be dropped: {:?}",
+            uids(&nodes)
+        );
+    }
+
+    /// nw-407. `--tags` is a FILTER, so a Symbol — which cannot carry a tag —
+    /// cannot satisfy it. The old `if kind.contains("symbol") { return true }`
+    /// made the flag an expansion: measured 30 -> 71 rows, of which 70 were
+    /// untagged symbols eating the token budget the tagged notes asked for.
+    ///
+    /// COUNTERWEIGHT: a tagged note is KEPT, so the filter selects rather than
+    /// merely emptying the list.
+    #[test]
+    fn a_tags_scope_drops_symbols_and_keeps_the_content_that_carries_the_tag() {
+        let mut nodes = mixed_nodes();
+        retain_tagged_nodes(
+            &mut nodes,
+            &HashSet::from([format!("note:{VAULT}:n1")]),
+            &HashSet::new(),
+        );
+        assert_eq!(
+            uids(&nodes),
+            vec![format!("note:{VAULT}:n1")],
+            "only the tagged note carries the tag; the two symbols cannot"
+        );
+    }
+
+    /// An unattributable UID is dropped rather than kept, matching nw-403's
+    /// redactor: "I cannot tell what owns this" is not a reason to return it
+    /// under a scope argument.
+    #[test]
+    fn an_unattributable_uid_survives_no_scope_at_all() {
+        assert_eq!(node_owner("proj:default:abc"), NodeOwner::Unattributable);
+        assert_eq!(node_owner("banana"), NodeOwner::Unattributable);
+        assert_eq!(
+            node_owner(&format!("sym:{REPO_A}:f:n:1")),
+            NodeOwner::Repo(REPO_A.to_string())
+        );
+        assert_eq!(
+            node_owner(&format!("head:note:{VAULT}:n1:h:3")),
+            NodeOwner::Vault(VAULT.to_string())
+        );
+    }
+
+    /// nw-405 legs (2) and (4): a colliding display name must FAIL naming both
+    /// candidates rather than quietly merging two tenants, and the documented
+    /// UID form must resolve — it used to answer `connected: 0`.
+    #[test]
+    fn a_colliding_repo_name_is_refused_while_the_documented_uid_form_resolves() {
+        let store = store_with_two_repos_named_website();
+
+        let err = resolve_repo_filter(&store, &["website".to_string()])
+            .expect_err("two repos share this display name; merging them silently is the bug")
+            .to_string();
+        assert!(
+            err.contains("ambiguous") && err.contains(REPO_A) && err.contains(REPO_B),
+            "the error must name both candidates so the caller can disambiguate: {err}"
+        );
+
+        // COUNTERWEIGHT: the disambiguated form the error recommends works.
+        assert_eq!(
+            resolve_repo_filter(&store, &[REPO_A.to_string()]).unwrap(),
+            HashSet::from([REPO_A.to_string()])
+        );
+    }
+
+    /// nw-405: an entry that names no repo is an ERROR. The old predicate
+    /// matched nothing and returned a confident empty result, which a caller
+    /// reads as "this repo has no relevant content" rather than "you named a
+    /// repo that is not here".
+    #[test]
+    fn an_unresolvable_repos_entry_errors_instead_of_matching_nothing() {
+        let store = store_with_two_repos_named_website();
+        let err = resolve_repo_filter(&store, &["not-a-repo".to_string()])
+            .expect_err("an unresolvable scope must not silently answer")
+            .to_string();
+        assert!(
+            err.contains("not-a-repo"),
+            "the error must name the entry that failed: {err}"
+        );
+    }
+
+    /// The `--vaults` contract, plus the CASE leg that made the two surfaces
+    /// disagree: the old CLI predicate was `contains`, case-SENSITIVE, while
+    /// MCP's was `to_lowercase().contains`. `--vaults BRAIN` therefore answered
+    /// one way through the daemon and another through this path, for one flag
+    /// value. Both resolvers are now case-insensitive on the name leg.
+    #[test]
+    fn an_unresolvable_vaults_entry_errors_while_a_real_vault_resolves_in_any_case() {
+        let store = GraphStore::in_memory().unwrap();
+        store
+            .insert_vault(&nestweaver_schema::Vault {
+                uid: VAULT.to_string(),
+                name: "brain".to_string(),
+                root_path: "/home/k/brain".to_string(),
+                instance_id: "default".to_string(),
+            })
+            .unwrap();
+
+        let err = resolve_vault_filter(&store, &["nope".to_string()])
+            .expect_err("an unresolvable vault scope must not silently answer")
+            .to_string();
+        assert!(
+            err.contains("nope") && err.contains("brain"),
+            "the error must name the failed entry and the known vaults: {err}"
+        );
+
+        for selector in [VAULT, "brain", "BRAIN", "/home/k/brain"] {
+            assert_eq!(
+                resolve_vault_filter(&store, &[selector.to_string()]).unwrap(),
+                HashSet::from([VAULT.to_string()]),
+                "selector {selector:?} must resolve"
+            );
+        }
+    }
+}
+
+/// nw-412 — `affected-tests` REFUSES and `pr-impact` DEGRADES on a graph whose
+/// edges predate the running resolver.
+///
+/// Both directions matter and they are different contracts: a test selector
+/// that silently narrows drops the regression test that would have caught the
+/// change, with nothing downstream able to tell that from "no tests exist".
+#[cfg(test)]
+mod resolver_generation_gate_tests {
+    use super::*;
+    use nestweaver_engine::blast_radius::{AnalysisStatus, BlastRadiusResult};
+    use nestweaver_engine::resolver_generation::{self, DeadCodeRefusal};
+
+    const REPO: &str = "repo:default:aaaaaaaaaaaa";
+
+    fn repo_row(root: &std::path::Path) -> nestweaver_schema::Repo {
+        nestweaver_schema::Repo {
+            uid: REPO.to_string(),
+            url: "https://github.com/example/demo".to_string(),
+            indexed_sha: "deadbeef".to_string(),
+            staleness_commits_behind: 0,
+            instance_id: "default".to_string(),
+            name: Some("demo".to_string()),
+            root_path: Some(root.display().to_string()),
+        }
+    }
+
+    fn store_with_one_repo(root: &std::path::Path) -> GraphStore {
+        let store = GraphStore::in_memory().unwrap();
+        store.insert_repo(&repo_row(root)).unwrap();
+        store
+    }
+
+    /// A run that reported the clean gate this item is about: `Complete`,
+    /// `Ok`, `Low`, nothing affected — the exact shape `print_pr_impact_hook`
+    /// prints NOTHING for.
+    fn clean_result() -> BlastRadiusResult {
+        BlastRadiusResult {
+            changed_symbols: Vec::new(),
+            affected_symbols: Vec::new(),
+            affected_symbol_count: 0,
+            affected_clusters: Vec::new(),
+            risk_level: RiskLevel::Low,
+            summary: "1 changed symbol, 0 affected".to_string(),
+            org_wide: None,
+            status: AnalysisStatus::Complete,
+            notifications: Vec::new(),
+            gate_state: GateState::Ok,
+            coverage: nestweaver_engine::blast_radius::Coverage::default(),
+            blind_spots: Vec::new(),
+            cochanged_files: Vec::new(),
+            analysis_direction: "over-approximate".to_string(),
+        }
+    }
+
+    /// The direction that made nw-412 dangerous: a stale graph understates
+    /// impact, and the run that understates it most is the one that looks
+    /// cleanest. After the degrade it cannot report `ok` at all, which is also
+    /// what breaks `print_pr_impact_hook`'s silence — that banner is skipped
+    /// only for `gate_state == Ok && risk_level == Low && nothing affected`,
+    /// and a stale graph is exactly the run most likely to look like that.
+    #[test]
+    fn a_generation_stale_graph_cannot_report_a_clean_blast_radius_gate() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("nestweaver.lbug");
+        let store = store_with_one_repo(tmp.path());
+        // No sidecar written: an unrecorded repo reads as generation 0, which
+        // is the "indexed before this record existed" case by definition.
+
+        let mut result = clean_result();
+        degrade_blast_radius_if_resolver_stale(&store, &db_path, &mut result).unwrap();
+
+        assert_eq!(result.status, AnalysisStatus::Degraded);
+        assert_eq!(
+            result.gate_state,
+            GateState::DegradedUnknown,
+            "a run that did not complete is `degraded-unknown`, never `ok`"
+        );
+        assert_ne!(
+            result.gate_state,
+            GateState::Ok,
+            "`print_pr_impact_hook` is silent on an Ok/Low/empty run — the whole \
+             point is that a stale graph must no longer reach that branch"
+        );
+        assert!(
+            result.notifications.iter().any(|n| {
+                n.descriptor == BLAST_RADIUS_RESOLVER_STALE_DESCRIPTOR
+                    && matches!(n.level, NotificationLevel::Error)
+            }),
+            "the reason must be a NAMED error notification, not an unexplained \
+             degrade: {:?}",
+            result.notifications
+        );
+        assert!(
+            result.summary.contains("[status: degraded]"),
+            "the human summary must not still claim a clean run: {}",
+            result.summary
+        );
+    }
+
+    /// COUNTERWEIGHT, and the assertion nw-412 explicitly requires: a
+    /// generation-CURRENT graph must NOT degrade. Without this, wiring that
+    /// degraded unconditionally would pass every test above while making the
+    /// gate useless.
+    #[test]
+    fn a_generation_current_graph_still_reports_its_own_clean_gate() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("nestweaver.lbug");
+        let store = store_with_one_repo(tmp.path());
+        resolver_generation::record(&db_path, REPO).unwrap();
+
+        let mut result = clean_result();
+        let before = result.summary.clone();
+        degrade_blast_radius_if_resolver_stale(&store, &db_path, &mut result).unwrap();
+
+        assert_eq!(result.status, AnalysisStatus::Complete);
+        assert_eq!(result.gate_state, GateState::Ok);
+        assert!(
+            result.notifications.is_empty(),
+            "a current graph must not be told it is stale: {:?}",
+            result.notifications
+        );
+        assert_eq!(result.summary, before, "the summary must not be re-tagged");
+    }
+
+    /// `affected-tests` refuses rather than degrades, and the refusal has to
+    /// be readable by the CI job that consumes it: no tiers at all (an empty
+    /// tier list is a CLAIM, and the wrong one), `needs_reindex` for the gate
+    /// that already keys on it, and `run-full-suite` as the widening a caller
+    /// acts on.
+    ///
+    /// The `note` check is the one this item names specifically: reusing
+    /// `DeadCodeRefusal::message()` verbatim would print "dead-code will not
+    /// produce a list…" in front of the right remedies.
+    #[test]
+    fn an_affected_tests_refusal_says_run_the_full_suite_and_carries_no_tiers() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("nestweaver.lbug");
+        let repos = vec![repo_row(tmp.path())];
+
+        let refusal = DeadCodeRefusal::for_repos(&db_path, &repos)
+            .expect("an unrecorded repo is generation 0 and therefore stale");
+        let payload = affected_tests_refusal_payload(&refusal);
+
+        assert_eq!(payload["refused"], serde_json::json!(true));
+        assert_eq!(payload["reason"], serde_json::json!("outdated_resolver"));
+        assert_eq!(payload["needs_reindex"], serde_json::json!(true));
+        assert_eq!(
+            payload["recommendation"],
+            serde_json::json!("run-full-suite"),
+            "a caller that keys off `did I get tiers` reads a refusal as `no \
+             tests affected` — the exact silent narrowing this prevents"
+        );
+        for tier in ["tier_1", "tier_2", "tier_3"] {
+            assert!(
+                payload.get(tier).is_none(),
+                "{tier} must be ABSENT; an empty list is a claim and it is wrong"
+            );
+        }
+
+        let note = payload["note"].as_str().unwrap();
+        assert!(
+            note.starts_with("affected-tests will not produce a selection"),
+            "the refusal must use the affected-tests wording, not dead-code's: {note}"
+        );
+        assert!(
+            !note.contains("dead-code"),
+            "dead-code's sentence is the wrong one in front of these remedies: {note}"
+        );
+        assert!(
+            note.contains("--force"),
+            "the remedy must be runnable: a plain re-index is a no-op on a \
+             generation-stale repo that is already at HEAD: {note}"
+        );
+        // The daemon route prints what it was sent; the extractor must find
+        // exactly this paragraph rather than falling back.
+        assert_eq!(affected_tests_refusal_note(&payload), note);
+    }
+
+    /// COUNTERWEIGHT for the selector: a generation-CURRENT graph produces no
+    /// refusal at all, so `affected-tests` still answers. A selector that
+    /// refuses unconditionally is safe and useless.
+    #[test]
+    fn a_generation_current_graph_produces_no_affected_tests_refusal() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("nestweaver.lbug");
+        let repos = vec![repo_row(tmp.path())];
+        resolver_generation::record(&db_path, REPO).unwrap();
+
+        assert!(
+            DeadCodeRefusal::for_repos(&db_path, &repos).is_none(),
+            "a repo recorded at the current generation must not refuse"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2407,14 +2407,60 @@ fn render_blast_radius_text(payload: &serde_json::Value) {
 /// cross-repo link rather than an observed call, and omitting the label is what
 /// let fabricated cross-language execution paths read as real ones (nw-111).
 fn render_flow_trace_text(payload: &serde_json::Value) {
+    // nw-390. The JSON payload marks every place the tree was CUT — a
+    // depth-capped node, a node whose canonical expansion lives elsewhere, and
+    // rows a visibility policy removed. The text renderer read NONE of them, so
+    // the human surface still showed a capped node as an ordinary leaf: exactly
+    // the defect nw-390 exists to close, surviving on the route the item's own
+    // reproducer uses. A marker that only the machine payload carries has not
+    // fixed the confusion for the person reading it.
+    fn cut_marker(node: &serde_json::Value) -> String {
+        let mut parts: Vec<String> = Vec::new();
+        // `deduped_ref` first: it explains WHERE the subtree went, which is the
+        // question a reader has on seeing an empty node. The uid is printed
+        // because it is the argument you would trace next.
+        if let Some(uid) = node.get("deduped_ref").and_then(|v| v.as_str()) {
+            parts.push(format!("expanded above as {uid}"));
+        }
+        if node
+            .get("truncated_at_depth")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+        {
+            match node
+                .get("children_omitted")
+                .and_then(serde_json::Value::as_u64)
+            {
+                // Distinguish "cut, and this many were dropped" from "cut, count
+                // unknown". Printing `0 callees` for the second would state a
+                // census the payload never made.
+                Some(n) if n > 0 => parts.push(format!("depth cap: {n} callee(s) not shown")),
+                _ => parts.push("depth cap: callees not shown".to_string()),
+            }
+        }
+        if let Some(n) = node
+            .get("children_redacted")
+            .and_then(serde_json::Value::as_u64)
+            .filter(|n| *n > 0)
+        {
+            parts.push(format!("{n} hidden by policy"));
+        }
+        if parts.is_empty() {
+            String::new()
+        } else {
+            format!("  [{}]", parts.join("; "))
+        }
+    }
+
     fn walk(node: &serde_json::Value, depth: usize) {
         let name = node.get("name").and_then(|v| v.as_str()).unwrap_or("?");
         let edge = node.get("edge_type").and_then(|v| v.as_str());
         let path = node.get("file_path").and_then(|v| v.as_str()).unwrap_or("");
         let indent = "  ".repeat(depth + 1);
+        let cut = cut_marker(node);
         match edge {
-            Some(e) => println!("{indent}{name}  [{e}]  {path}"),
-            None => println!("{indent}{name}  {path}"),
+            Some(e) => println!("{indent}{name}  [{e}]  {path}{cut}"),
+            None => println!("{indent}{name}  {path}{cut}"),
         }
         for child in node
             .get("children")
@@ -2434,7 +2480,38 @@ fn render_flow_trace_text(payload: &serde_json::Value) {
     println!("Flow trace from '{root_name}':");
 
     // A class root expands to one tree per method.
-    if let Some(trees) = payload.get("method_trees").and_then(|v| v.as_array()) {
+    //
+    // KEY FIX, and it was silent: this looked ONLY for `method_trees`, while the
+    // tool emits `methods`. So a class root fell through to the single-tree arm
+    // below and its per-method trees were never rendered at all on the text
+    // route. Both spellings are accepted rather than just swapped, because the
+    // daemon and direct routes are independently versioned and a payload built
+    // by an older peer must not silently render nothing.
+    if let Some(trees) = payload
+        .get("methods")
+        .or_else(|| payload.get("method_trees"))
+        .and_then(|v| v.as_array())
+    {
+        // nw-390's third cap: the class-to-methods expansion is capped at
+        // MAX_METHODS and the payload says so. Silence here would misreport a
+        // partial method list as the whole class.
+        if payload
+            .get("methods_truncated")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+        {
+            let shown = payload
+                .get("methods_returned")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(trees.len() as u64);
+            match payload
+                .get("methods_total")
+                .and_then(serde_json::Value::as_u64)
+            {
+                Some(total) => println!("  (showing {shown} of {total} methods)"),
+                None => println!("  (method list truncated)"),
+            }
+        }
         for tree in trees {
             walk(tree, 0);
         }
@@ -20368,7 +20445,23 @@ fn resolve_uid_with_repo_filter(
 
 /// Print a human-readable representation of a `ContextResult`.
 fn print_context_text(result: &ContextResult) {
-    println!("Seeds ({} resolved):", result.seeds.len());
+    // nw-393: `Seeds (5 resolved):` was printed for a bare-name input that
+    // matched 200 symbols, so the human reader had no way to tell an arbitrary
+    // 5-of-200 seeding from a name with five definitions — while the JSON twin
+    // beside it already carried `seed_matches_total` / `seeds_truncated`.
+    // `ContextResult` has no semantic seed leg, so the provenance half of
+    // `seed_header` is always zero here; the shared function is used anyway so
+    // this line and `brain context`'s cannot describe the same cap differently.
+    println!(
+        "{}",
+        seed_header(
+            result.seeds.len(),
+            0,
+            result.seed_matches_total,
+            result.seed_matches_total_relation.as_deref(),
+            result.seeds_truncated,
+        )
+    );
     for node in &result.seeds {
         println!(
             "  {}  {}  {}:{}",
@@ -25480,12 +25573,63 @@ fn print_clusters_output_with_total(
 /// "blast radius" fails a direct lookup against the symbol `blast_radius` yet
 /// its semantic hits are excellent, so labelling them guesses would understate
 /// them exactly as counting them as direct matches overstated them.
-fn seed_header(total_seeds: usize, semantic_seeds: usize) -> String {
+///
+/// nw-393: the header also carries the SEED-RESOLUTION disclosure, because
+/// `Seeds (5 resolved)` for a name that matched 200 symbols is
+/// indistinguishable from a name that genuinely has five definitions. The
+/// machine payloads (`seed_matches_total`, `seed_matches_total_relation`,
+/// `seeds_truncated`, `seed_resolution_limit`) already say the set was cut; a
+/// human line that does not is the human-vs-machine split nw-259(a) ruled
+/// against — the prose must not claim something the payload contradicts.
+/// Shared with `print_context_text` rather than given a second spelling: two
+/// surfaces drifting apart about the same query is the failure mode being
+/// fixed, not a shape to reproduce.
+fn seed_header(
+    total_seeds: usize,
+    semantic_seeds: usize,
+    seed_matches_total: Option<usize>,
+    seed_matches_total_relation: Option<&str>,
+    seeds_truncated: Option<bool>,
+) -> String {
     let matched = total_seeds.saturating_sub(semantic_seeds);
-    if semantic_seeds > 0 {
-        format!("Seeds ({matched} matched directly, {semantic_seeds} via semantic search):")
+    // Annotate ONLY when the cap actually BIT. `Some(false)` — a name with
+    // exactly `SEED_NAME_MATCH_LIMIT` definitions, all of them resolved — and
+    // `None` — no bare-name input reached symbol search at all, e.g. a `sym:`
+    // UID or note-title seed, where the cap was never in force — both leave
+    // the line byte-identical to before. "5 of 5" is noise and "0 of 0" is a
+    // false cut claim about an exhaustive seed form; either one trains the
+    // reader to skip the clause that matters.
+    let (of_total, cap) = if seeds_truncated == Some(true) {
+        let of_total = match (seed_matches_total, seed_matches_total_relation) {
+            // `gte` means the counted search stopped at
+            // `SYMBOL_SEARCH_COUNT_CAP`, so the number is a LOWER BOUND and
+            // printing it as exact would replace one false precision with
+            // another. Same wording `brain search` already uses for a `gte`
+            // total ("N of at least M result(s)"), so there is one human
+            // spelling of "this count is a floor", not two.
+            (Some(total), Some("gte")) => format!(" of at least {total}"),
+            (Some(total), _) => format!(" of {total}"),
+            // Flag set, count absent: a producer that predates the count, or a
+            // daemon payload that carried one field and not the other. Name the
+            // cut — it is the load-bearing half — but do not invent a total.
+            (None, _) => String::new(),
+        };
+        (of_total, ", seed-resolution cap")
     } else {
-        format!("Seeds ({matched} resolved):")
+        (String::new(), "")
+    };
+    if semantic_seeds > 0 {
+        // The cap bounds the DIRECT name-match leg only; semantic hits are
+        // injected by KNN and are not subject to it, so the `of N` rides on the
+        // "matched directly" count and never on the semantic one.
+        format!(
+            "Seeds ({matched}{of_total} matched directly, \
+             {semantic_seeds} via semantic search{cap}):"
+        )
+    } else if of_total.is_empty() {
+        format!("Seeds ({matched} resolved{cap}):")
+    } else {
+        format!("Seeds ({matched}{of_total}{cap}):")
     }
 }
 
@@ -25506,9 +25650,19 @@ fn print_brain_context_text(
     // both as "resolved" made the output contradict itself: a nonsense query
     // printed `Seeds (5 resolved)` while ALSO listing that same query under
     // `Unresolved seeds (1)`. Report the two separately.
+    // nw-393 rides on the same line: the seed set is also cut by the
+    // per-input name-match cap, and this route resolves seeds through its own
+    // loop, so the disclosure has to be attached here too or `brain context`
+    // and `context` would disagree about an identical query.
     println!(
         "{}",
-        seed_header(result.seeds.len(), result.semantic_seed_count)
+        seed_header(
+            result.seeds.len(),
+            result.semantic_seed_count,
+            result.seed_matches_total,
+            result.seed_matches_total_relation.as_deref(),
+            result.seeds_truncated,
+        )
     );
     for n in &result.seeds {
         if n.location.is_empty() {
@@ -33809,7 +33963,7 @@ credential_method = "ssh"
     #[test]
     fn seed_header_never_counts_semantic_hits_as_resolved() {
         // The reported case: nothing matched, five nearest neighbours injected.
-        let h = seed_header(5, 5);
+        let h = seed_header(5, 5, None, None, None);
         assert!(h.contains("0 matched directly"), "{h}");
         assert!(h.contains("5 via semantic search"), "{h}");
         assert!(
@@ -33818,10 +33972,10 @@ credential_method = "ssh"
         );
 
         // Genuine direct matches, no semantic leg.
-        assert_eq!(seed_header(3, 0), "Seeds (3 resolved):");
+        assert_eq!(seed_header(3, 0, None, None, None), "Seeds (3 resolved):");
 
         // Mixed: two direct, three semantic.
-        let m = seed_header(5, 3);
+        let m = seed_header(5, 3, None, None, None);
         assert!(
             m.contains("2 matched directly") && m.contains("3 via semantic search"),
             "{m}"
@@ -33832,8 +33986,80 @@ credential_method = "ssh"
     /// older payload must not underflow the subtraction.
     #[test]
     fn seed_header_does_not_underflow_on_inconsistent_counts() {
-        let h = seed_header(2, 9);
+        let h = seed_header(2, 9, None, None, None);
         assert!(h.contains("0 matched directly"), "{h}");
+    }
+
+    /// nw-393: the human line must not claim something the machine payload
+    /// beside it contradicts. `search validate --limit 200` reports >=200
+    /// symbols named `validate`, the seed cap keeps 5, and the JSON twin says
+    /// so via `seed_matches_total` / `seeds_truncated` — the text renderer
+    /// printed a bare `Seeds (5 resolved):`, which reads exactly like a name
+    /// that genuinely has five definitions.
+    #[test]
+    fn a_cut_seed_set_cannot_print_as_an_exhaustive_one() {
+        let h = seed_header(5, 0, Some(200), Some("eq"), Some(true));
+        assert_eq!(h, "Seeds (5 of 200, seed-resolution cap):");
+        assert!(
+            !h.contains("5 resolved"),
+            "a cut seed set must not read as a resolved-in-full one: {h}"
+        );
+
+        // The mixed case: the cap bounds the DIRECT leg only, so the `of N`
+        // must ride on the matched-directly count, never on the semantic one.
+        let m = seed_header(5, 3, Some(200), Some("eq"), Some(true));
+        assert_eq!(
+            m,
+            "Seeds (2 of 200 matched directly, 3 via semantic search, seed-resolution cap):"
+        );
+    }
+
+    /// nw-393: past `SYMBOL_SEARCH_COUNT_CAP` the store stops counting and
+    /// reports `gte`, so the total is a LOWER BOUND. Printing it as exact
+    /// would swap one false precision for another.
+    #[test]
+    fn a_lower_bound_seed_total_is_never_printed_as_an_exact_count() {
+        let h = seed_header(5, 0, Some(200), Some("gte"), Some(true));
+        assert_eq!(h, "Seeds (5 of at least 200, seed-resolution cap):");
+        assert!(
+            !h.contains("of 200"),
+            "a gte total must not be stated as an exact one: {h}"
+        );
+    }
+
+    /// COUNTERWEIGHT for nw-393, both halves. The disclosure must not
+    /// over-apply: when the cap did not bite, and when the cap was never in
+    /// force at all, the line is byte-identical to what it printed before.
+    #[test]
+    fn a_seed_set_the_cap_did_not_cut_prints_the_unchanged_line() {
+        // Cap IN FORCE and did not reach — a name with exactly
+        // `SEED_NAME_MATCH_LIMIT` definitions, all five resolved. "5 of 5" is
+        // noise, so the wording is unchanged.
+        assert_eq!(
+            seed_header(5, 0, Some(5), Some("eq"), Some(false)),
+            "Seeds (5 resolved):"
+        );
+
+        // Cap NOT APPLICABLE — a `sym:` UID seed never reaches the name
+        // search, so all three fields are absent. This is the case that must
+        // never print "0 of 0" about an exhaustive seed form.
+        assert_eq!(seed_header(2, 0, None, None, None), "Seeds (2 resolved):");
+        assert_eq!(seed_header(0, 0, None, None, None), "Seeds (0 resolved):");
+
+        // Semantic provenance (nw-102) survives untouched in both.
+        assert_eq!(
+            seed_header(5, 3, Some(5), Some("eq"), Some(false)),
+            "Seeds (2 matched directly, 3 via semantic search):"
+        );
+    }
+
+    /// Defensive twin of the underflow test: a daemon payload that carried the
+    /// flag but not the count must still disclose the cut, and must not invent
+    /// a total to do it.
+    #[test]
+    fn a_cut_seed_set_without_a_total_names_the_cap_without_inventing_a_number() {
+        let h = seed_header(5, 0, None, None, Some(true));
+        assert_eq!(h, "Seeds (5 resolved, seed-resolution cap):");
     }
 
     /// nw-123: the impact envelope's key set must not depend on which

--- a/src/main.rs
+++ b/src/main.rs
@@ -471,11 +471,16 @@ enum CliDiagnostic {
     },
 
     /// nw-285. A zero-length `.lbug`, or one that was created but never
-    /// indexed. `require_openable_db` passes a zero-byte file on purpose (it
-    /// is what the store itself initialises), and a read-only open does not
-    /// run `init_schema`, so the first query fails in the engine's binder with
-    /// `Table <X> does not exist` — an internal sentence with no remedy, for a
-    /// condition whose remedy is obvious and safe to name.
+    /// indexed.
+    ///
+    /// STALE UNTIL nw-385, corrected here: this used to say
+    /// `require_openable_db` "passes a zero-byte file on purpose". It no longer
+    /// does — passing it is what let a READ command initialise a store over a
+    /// user's 0-byte file, create four sidecars and spawn a daemon, all at exit
+    /// 0. The guard now RAISES this variant directly, so this diagnostic is
+    /// reached from the guard rather than from the binder failure downstream of
+    /// it. The binder arm below is kept because a database can still reach a
+    /// query with no schema by other routes.
     ///
     /// This is the one database-shaped diagnostic that MAY prescribe a write:
     /// `read_path_diagnostics_never_prescribe_a_write` bars a write when the
@@ -781,6 +786,18 @@ fn into_diagnostic(err: anyhow::Error) -> miette::Report {
                 }
                 .into()
             }
+            // nw-385. `require_openable_db` raises this one directly, so it
+            // needs an arm: without it the `_` fallback below renders the
+            // sentence and DROPS `nestweaver::db_no_schema`, and a read
+            // against a zero-byte `--db` would report the right words with no
+            // code for `error_remedy_test` — or any operator's grep — to key
+            // on. The text arm at the top of this function still produces the
+            // same variant for the binder-exception route.
+            CliDiagnostic::DatabaseNoSchema { path, detail } => CliDiagnostic::DatabaseNoSchema {
+                path: path.clone(),
+                detail: detail.clone(),
+            }
+            .into(),
             // Every other variant is currently produced BY this function rather
             // than raised as an error, so there is nothing to pass through.
             // A variant that starts being raised directly adds its arm here.
@@ -848,10 +865,16 @@ fn into_diagnostic(err: anyhow::Error) -> miette::Report {
         return corruption_diagnostic(kind, path, message);
     }
 
-    // nw-285. A zero-length `.lbug` passes `require_openable_db` by design, and
-    // `open_read_only` does not run `init_schema`, so the first query dies in
-    // the binder. `Table Symbol does not exist` / `Table Vault does not exist`
-    // is an internal sentence for a condition with an obvious remedy.
+    // nw-285. `open_read_only` does not run `init_schema`, so a query against a
+    // schema-less database dies in the binder. `Table Symbol does not exist` /
+    // `Table Vault does not exist` is an internal sentence for a condition with
+    // an obvious remedy.
+    //
+    // NOTE, corrected under nw-385: this comment used to say a zero-length
+    // `.lbug` "passes `require_openable_db` by design". That is no longer true —
+    // the guard refuses it up front. This arm is now the BACKSTOP for a
+    // schema-less database that reached a query some other way, not the primary
+    // path for the zero-byte case.
     if lower.contains("does not exist")
         && (lower.contains("binder exception") || lower.contains("table "))
     {
@@ -7966,9 +7989,17 @@ fn open_store(db: Option<&Path>) -> anyhow::Result<GraphStore> {
     // `sidecar_path(db, ".pagerank.json")`; the old `with_extension` idiom
     // yielded `<db>.pagerank.json`, so a direct (non-daemon) `ui`/query never
     // warm-loaded ranks. Mirror the daemon's idiom (server.rs).
-    nestweaver_engine::migrate_sidecar(path, "pagerank.json", ".pagerank.json");
-    let pr_path = nestweaver_engine::sidecar_path(path, ".pagerank.json");
-    let _ = store.load_pagerank_cache(&pr_path);
+    //
+    // nw-391: and SAY SO when the loader refuses it. This was
+    // `let _ = store.load_pagerank_cache(&pr_path);` — one of three sites that
+    // discarded a fully composed, correct diagnostic, so a stale or foreign
+    // sidecar degraded every ranked surface at exit 0 with no output at all.
+    // stderr, not stdout: `--json` consumers parse stdout, and this is exactly
+    // the split `warn_stale_resolver_rankings` already uses for the same class
+    // of ranking-provenance warning.
+    if let Some(disclosure) = nestweaver_mcp::warm_pagerank_from_sidecar(&store, path) {
+        eprintln!("Warning: {disclosure}");
+    }
 
     // Load interaction memory scores so PPR can apply a small bias toward
     // frequently-accessed nodes.
@@ -9971,9 +10002,15 @@ const LBUG_FILE_MAGIC: &[u8; 4] = b"LBUG";
 /// same answer to the caller and were being given wildly different service.
 ///
 /// Deliberately a cheap header probe and NOT an open: an open is what costs,
-/// and this runs before every daemon-routed read. It is also deliberately
-/// conservative — an empty file passes, because a zero-byte `.lbug` is what
-/// the store itself initialises.
+/// and this runs before every daemon-routed read.
+///
+/// nw-385: this is a READ guard, and every one of its callers is a read —
+/// `open_store` (which only ever performs `open_read_only`) and
+/// `try_hybrid_json_rpc_checked` (the daemon-routed read funnel, which `index`
+/// deliberately does not route through). It used to exempt a zero-byte file
+/// "because the store initialises it", which is a statement about the CREATE
+/// path and was therefore an exemption for a caller that has never existed.
+/// See the `Ok(0)` arm for what that cost.
 ///
 /// This does NOT claim to detect corruption. A `.lbug` whose header is intact
 /// and whose index region is not still passes here, by construction; see
@@ -9999,9 +10036,37 @@ fn require_openable_db(db_path: &std::path::Path) -> anyhow::Result<()> {
              at a database you can read.",
             db_path.display()
         ),
-        // A zero-byte file is what an interrupted create leaves; the store
-        // initialises it. Not this guard's business.
-        Ok(0) => Ok(()),
+        // nw-385. A `--db` that yields NO bytes is REFUSED on the read path,
+        // and the exemption this arm replaces is the whole bug.
+        //
+        // The old arm read: "a zero-byte file is what an interrupted create
+        // leaves; the store initialises it. Not this guard's business." Every
+        // clause of that is true of a CREATE path, and no create path calls
+        // this guard — `index` opens read-write directly and never funnels
+        // through either call site. So the exemption protected nobody while
+        // admitting the entire READ surface to the route whose very next step
+        // is "the store initialises it", against a file the USER created.
+        //
+        // MEASURED: `nestweaver search --db ./important-notes.txt user`
+        // overwrote a 0-byte `important-notes.txt` with a 4096-byte LadybugDB
+        // header, created `.publications/`, `.tantivy/`, `.wal` and
+        // `.write.lock` beside it, left a persistent daemon running against
+        // it, printed "No symbols found matching 'user'." and exited 0. A read
+        // command destroyed the file it was pointed at and called it success.
+        //
+        // `index` keeps today's behaviour BY CONSTRUCTION rather than by
+        // exception: it does not consult this guard, and the store still
+        // initialises a zero-byte file on the create path — pinned by
+        // `the_create_path_still_initialises_a_zero_byte_database` so the
+        // justification the old comment gave is asserted where it is actually
+        // true instead of where it was actually harmful.
+        //
+        // Refusing HERE, before the dial, is also what fixes the adjacent leg:
+        // `--db /dev/null` reads EOF, so it took this arm and then paid the
+        // full 30s `NESTWEAVER_DAEMON_BOOT_TIMEOUT_SECS` ceiling and
+        // registered a launchd instance directory for `/dev/null` — exactly
+        // the cost nw-309 (see above) exists to eliminate.
+        Ok(0) => Err(no_bytes_refusal(db_path)),
         Ok(_) if header == *LBUG_FILE_MAGIC => Ok(()),
         Ok(_) => anyhow::bail!(
             "{} is not a NestWeaver database (its header is not `LBUG`). \
@@ -10010,6 +10075,43 @@ fn require_openable_db(db_path: &std::path::Path) -> anyhow::Result<()> {
             db_path.display()
         ),
     }
+}
+
+/// The refusal for a `--db` that opens but yields no bytes at all (nw-385).
+///
+/// Two different shapes reach it and they have earned two different sentences.
+///
+/// A zero-byte REGULAR file is nw-285's `db_no_schema`: an interrupted create,
+/// or a file the user made with `touch` / `: >`. That variant already states
+/// the size, already names `nestweaver index` as the remedy, and is the one
+/// database diagnostic explicitly ALLOWED to prescribe a write, because a file
+/// with no schema demonstrably holds no data (see the variant's own doc). It is
+/// raised as the typed `CliDiagnostic` rather than as prose so the code survives
+/// to `into_diagnostic` instead of being re-derived from a sentence — the shrink
+/// -the-domain move nw-360 added the pass-through for.
+///
+/// A path that reads EOF but is NOT a regular file — `/dev/null`, the reported
+/// case, and any fifo or device — can never hold a database however often it is
+/// indexed, so prescribing `index` against it would be a remedy nobody can
+/// follow to a good end. It gets the same "not a NestWeaver database" sentence
+/// the non-`LBUG` header arm gives, which points at a different `--db` instead.
+fn no_bytes_refusal(db_path: &std::path::Path) -> anyhow::Error {
+    let regular_file = std::fs::metadata(db_path).is_ok_and(|meta| meta.is_file());
+    if !regular_file {
+        return anyhow::anyhow!(
+            "{} is not a NestWeaver database (it is not a regular file, and it \
+             yields no bytes to read). Point --db at a `.lbug` file, or run \
+             `nestweaver index --repo <path> --db <new path>` to create one.",
+            db_path.display()
+        );
+    }
+    anyhow::Error::new(CliDiagnostic::DatabaseNoSchema {
+        path: db_path.display().to_string(),
+        detail: format!(
+            "{} is 0 bytes — an interrupted create leaves exactly this.",
+            db_path.display()
+        ),
+    })
 }
 
 /// Stable machine name for a recovery outcome, for `--json` consumers.
@@ -26493,17 +26595,195 @@ lbug-0.19.1/lbug-src/src/storage/table/column.cpp\" on line 289: \
         let error = require_openable_db(&directory).unwrap_err().to_string();
         assert!(error.contains("is a directory"), "{error}");
 
-        // A zero-byte file is what an interrupted create leaves and what the
-        // store itself initialises. Refusing it would break creation.
+        // nw-385: a zero-byte file is now REFUSED, because every caller of
+        // this guard is a read and "the store initialises it" is precisely
+        // what a read must never do. Fully asserted in
+        // `a_zero_byte_db_is_refused_on_the_read_path_without_writing_to_it`;
+        // named here so this inventory of shapes stays complete.
         let empty = dir.path().join("empty.lbug");
         std::fs::write(&empty, b"").unwrap();
-        require_openable_db(&empty).expect("an empty file is the store's business");
+        let error = require_openable_db(&empty).unwrap_err().to_string();
+        assert!(error.contains("no graph schema"), "{error}");
 
         // And a real header passes, so the guard cannot be satisfied by
         // rejecting everything.
         let real = dir.path().join("real.lbug");
         std::fs::write(&real, b"LBUG\x00\x00\x00\x00").unwrap();
         require_openable_db(&real).expect("a real LadybugDB header must pass");
+    }
+
+    /// nw-385. A READ command WROTE, and what it wrote over was a file the
+    /// user had made themselves.
+    ///
+    /// Reproduced verbatim before the fix: `: > important-notes.txt` then
+    /// `nestweaver search --db ./important-notes.txt user` turned the 0-byte
+    /// file into a 4096-byte LadybugDB, dropped `.publications/`, `.tantivy/`,
+    /// `.wal` and `.write.lock` next to it, left a daemon running against it,
+    /// and exited **0** with "No symbols found matching 'user'." The guard was
+    /// the one thing standing between a read and that route, and it waved the
+    /// file through on purpose.
+    ///
+    /// So this asserts all three halves of the DONE WHEN — refused, named
+    /// `db_no_schema`, and the file byte-for-byte untouched — plus the
+    /// counterweights that keep the other `--db` shapes exactly as they were.
+    #[test]
+    fn a_zero_byte_db_is_refused_on_the_read_path_without_writing_to_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let notes = dir.path().join("important-notes.txt");
+        std::fs::write(&notes, b"").unwrap();
+
+        let error = require_openable_db(&notes).unwrap_err();
+
+        // The typed variant, not a lookalike sentence: `into_diagnostic`
+        // renders `nestweaver::db_no_schema` from the TYPE, and
+        // `error_remedy_test::a_zero_length_database_says_what_to_run` greps
+        // stderr for that code.
+        let diagnostic = error
+            .downcast_ref::<CliDiagnostic>()
+            .expect("the refusal must carry its code, not just its words");
+        assert!(
+            matches!(diagnostic, CliDiagnostic::DatabaseNoSchema { .. }),
+            "expected db_no_schema, got {diagnostic:?}"
+        );
+        let message = format!("{error:#}");
+        assert!(message.contains("no graph schema"), "{message}");
+
+        // What the operator actually sees. The size is the diagnosis and the
+        // remedy has to be runnable — the same two facts
+        // `error_remedy_test::a_zero_length_database_says_what_to_run` greps
+        // for, asserted here so the wiring cannot rot silently between the
+        // guard, the pass-through arm and the rendered report.
+        let rendered = format!("{:?}", into_diagnostic(error));
+        assert!(rendered.contains("nestweaver::db_no_schema"), "{rendered}");
+        assert!(rendered.contains("0 bytes"), "{rendered}");
+        assert!(rendered.contains("nestweaver index"), "{rendered}");
+
+        // The point of the item: the file is still the user's empty file.
+        let after = std::fs::metadata(&notes).unwrap();
+        assert_eq!(after.len(), 0, "a read guard must not have written a byte");
+
+        // …and no sidecar was materialised beside it. `.tantivy`,
+        // `.publications`, `.wal` and `.write.lock` are the four the repro
+        // produced; asserting the directory is otherwise empty catches any
+        // fifth a future route might add.
+        let siblings: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        assert_eq!(
+            siblings.len(),
+            1,
+            "a refused read left artifacts behind: {siblings:?}"
+        );
+
+        // COUNTERWEIGHT 1 — the refusal must not swallow the whole read
+        // surface. A real database still passes the guard untouched.
+        let real = dir.path().join("real.lbug");
+        std::fs::write(&real, b"LBUG\x00\x00\x00\x00").unwrap();
+        require_openable_db(&real).expect("a real LadybugDB header must still pass");
+
+        // COUNTERWEIGHT 2 — the four shapes nw-385 explicitly says are handled
+        // WELL today keep their own accurate, distinct sentences. A single
+        // catch-all refusal would pass the assertions above and destroy these.
+        let missing = dir.path().join("nope.lbug");
+        assert!(
+            require_openable_db(&missing)
+                .unwrap_err()
+                .to_string()
+                .contains("not found")
+        );
+        let text = dir.path().join("fake.lbug");
+        std::fs::write(&text, b"hello not a db").unwrap();
+        assert!(
+            require_openable_db(&text)
+                .unwrap_err()
+                .to_string()
+                .contains("not a NestWeaver database")
+        );
+        let directory = dir.path().join("adir.lbug");
+        std::fs::create_dir(&directory).unwrap();
+        assert!(
+            require_openable_db(&directory)
+                .unwrap_err()
+                .to_string()
+                .contains("is a directory")
+        );
+    }
+
+    /// nw-385, the adjacent leg. `--db /dev/null` reads EOF, so it took the
+    /// zero-byte exemption and then paid the FULL 30s daemon-boot ceiling
+    /// before failing — the exact cost nw-309 was written to eliminate — and
+    /// registered a launchd instance directory for `/dev/null` on the way.
+    ///
+    /// It is refused by shape now, before any dial. `/dev/null` is not a
+    /// regular file, so it earns the "point --db somewhere else" sentence
+    /// rather than an `index` invocation that could never help it.
+    #[cfg(unix)]
+    #[test]
+    fn a_character_device_db_is_refused_by_shape_rather_than_by_daemon_timeout() {
+        let error = require_openable_db(std::path::Path::new("/dev/null"))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("not a NestWeaver database"), "{error}");
+        assert!(error.contains("not a regular file"), "{error}");
+    }
+
+    /// nw-385 COUNTERWEIGHT for the create path, which must keep today's
+    /// behaviour.
+    ///
+    /// The exemption that was removed justified itself with "the store
+    /// initialises it", and that sentence is TRUE — it is just true of the
+    /// create path, which never consulted the guard. Asserted here, where it
+    /// holds, so a future change that breaks `index` against an interrupted
+    /// create fails a test instead of the user.
+    #[test]
+    fn the_create_path_still_initialises_a_zero_byte_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let empty = dir.path().join("interrupted.lbug");
+        std::fs::write(&empty, b"").unwrap();
+
+        // This is what `index` does with a zero-byte `--db`: a read-write open,
+        // no guard in front of it.
+        let store = GraphStore::open(&empty).expect("the store initialises a zero-byte file");
+        drop(store);
+
+        assert!(
+            std::fs::metadata(&empty).unwrap().len() > 0,
+            "the create path must still turn a zero-byte file into a database"
+        );
+        require_openable_db(&empty)
+            .expect("and the database it created is then readable by the guard");
+    }
+
+    /// nw-385. The daemon leg, which is where the damage actually happened:
+    /// `try_hybrid_json_rpc_checked` autostarts a daemon, and an autostarted
+    /// daemon opens the store READ-WRITE, which is what materialised a database
+    /// on top of the user's file. The guard has to fire before the dial, not
+    /// after it.
+    #[test]
+    fn a_zero_byte_db_is_refused_before_any_daemon_can_be_dialled() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("zero.lbug");
+        std::fs::write(&db, b"").unwrap();
+
+        let error = try_hybrid_json_rpc_checked(
+            true,
+            &db,
+            None,
+            "search_symbols",
+            serde_json::json!({ "query": "user" }),
+        )
+        .expect_err("a zero-byte --db must not reach the daemon route");
+        assert!(
+            format!("{error:#}").contains("no graph schema"),
+            "{error:#}"
+        );
+
+        // The daemon opens read-write; if one had been dialled and started,
+        // the file would no longer be empty and its sidecars would exist.
+        assert_eq!(std::fs::metadata(&db).unwrap().len(), 0);
+        assert!(!dir.path().join("zero.lbug.tantivy").exists());
+        assert!(!dir.path().join("zero.lbug.publications").exists());
     }
 
     /// S1/T1 — the cheap FLOOR, and explicitly not evidence of anything else.
@@ -27269,6 +27549,34 @@ fn brain_context_json_value(
         "degraded_components": result.degraded_components,
     });
 
+    // nw-393. The SEED cap, one layer upstream of the connected-list disclosure
+    // above. `seeds_expanded` alone cannot distinguish a name with five
+    // definitions from a name with two hundred, and `truncated_by: "limit"`
+    // MISDIRECTS here, because no caller-settable knob can recover a seed that
+    // was never resolved.
+    //
+    // Independent fields rather than a `truncated_by: "seed_resolution"`
+    // variant, deliberately: the two caps do NOT compose. `truncated_by:
+    // "limit"` stays a correct, actionable statement about `connected` even
+    // when the seed set was separately cut, so folding them into one scalar
+    // would have to discard one true answer to state the other.
+    //
+    // Emitted only when the cap was IN FORCE (a uid-form seed is exhaustive and
+    // reports nothing), so a "0 of 0" is never printed for a seed form the cap
+    // cannot bound.
+    if let Some(total) = result.seed_matches_total {
+        resp["seed_matches_total"] = serde_json::json!(total);
+    }
+    if let Some(relation) = result.seed_matches_total_relation.as_deref() {
+        resp["seed_matches_total_relation"] = serde_json::json!(relation);
+    }
+    if let Some(t) = result.seeds_truncated {
+        resp["seeds_truncated"] = serde_json::json!(t);
+    }
+    if let Some(l) = result.seed_resolution_limit {
+        resp["seed_resolution_limit"] = serde_json::json!(l);
+    }
+
     if !result.unresolved_seeds.is_empty() {
         resp["unresolved_seeds"] = serde_json::json!(result.unresolved_seeds);
     }
@@ -27303,6 +27611,14 @@ mod context_json_renderer_tests {
             semantic_applied: false,
             semantic_seed_count: 0,
             degraded_components: vec!["semantic".to_string()],
+            // nw-393 added the seed-cap disclosure to `BrainContextResult`.
+            // This fixture is about the SEMANTIC degradation contract, so the
+            // cap fields stay at their "no bare-name seed was capped" values —
+            // the disclosure has its own tests.
+            seed_matches_total: None,
+            seed_matches_total_relation: None,
+            seeds_truncated: None,
+            seed_resolution_limit: None,
         }
     }
 


### PR DESCRIPTION
Twelve `ready` critical/high backlog items in one branch. Batched deliberately: CI time is the scarce resource and these share test surface — several were caught only by each other's tests.

**Local gate (mirrors `.github/workflows/ci.yml` exactly):** `fmt` · `--locked` metadata · `build` · `config validate` · `check --benches` · `clippy --workspace --all-targets -D warnings` · `test --workspace` · daemon integration suite — **8/8, 4,412 tests, 0 failed.** `Cargo.lock` untouched.

## Fully closed

| Item | |
|---|---|
| **nw-403** (CRITICAL, security) | `visible` reached only **5 of 42** MCP dispatch arms. Default now **inverted**: `repo_scope` classifies all 42, fallback arm is `FailClosed`, so a new tool refuses a scoped call until classified. **Inert for non-`[authz]` installs** — dispatch short-circuits on anything not `Only(_)`. |
| **nw-391** | Three callers discarded the PageRank sidecar's own error with `let _ =`; now one shared `warm_pagerank_from_sidecar`. |
| **nw-392** | `bound_identifiers` silently truncated the caller's **request** at 1000 — dropping 113 required test files while reporting `selection-usable`. Now rejects; both schemas declare `maxItems`. |
| **nw-387** | The prune-disclosure channel nw-325 promised was **dead code** — `skipped_dirs()`'s only caller was the test asserting it. A pruned `vendor/` now degrades coverage and fails `--fail-on-skip`. |
| **nw-385** | `search --db <0-byte file>` initialised a store **over that file**, made four sidecars, spawned a daemon, exited 0. `--db /dev/null`: 30s → 40ms. |
| **nw-384** | `investigate` ignored the publication fail-closed guard on all three entry paths, including the BM25 fallback that had no check at all. |

## Advanced, with the remaining route named

An independent reviewer found these; they are **not** claimed as closed.

- **nw-405/406/407** — fixed on MCP; **CLI twin at `src/main.rs:23826-23842` still has the substring predicate.** The same command can now answer differently depending on whether a daemon is running.
- **nw-412** — `affected_tests` refuses and `blast_radius` degrades on MCP; **`pr-impact` and CLI `affected-tests` call the engine directly** and bypass both.
- **nw-390** — markers emitted, but a capped node can still be the single canonical expansion, so monotonicity is disclosed rather than achieved. Its headline test would survive a revert.
- **nw-386** — normalisation is correct in `FilesystemReader`; **`GitBareReader` (server/bare-clone path) is unpatched.**
- **nw-387** — the drain reaches `IndexResult` only under `--force`; a plain incremental `index` still reports `complete`.
- **nw-393** — machine routes agree; the two human CLI renderers still print a bare seed count.

## Not attempted

**nw-373.** `acquire_db_write_lease` lives in `nestweaver-daemon`, which *depends on* `nestweaver-store` — the dependency runs backwards, so the store cannot reach the lease. Correct fix is to move it down into `nestweaver-store` (verified: `engine → store`, `engine ↛ daemon`, so that reaches all four instances *and* closes nw-404's caveat). That's a crate-structure change and belongs in its own branch.

A real narrowing did ship: `remove_stale_checkpoint_sidecars` was deleting another process's `.wal.checkpoint` and `.shadow` on a **false inference** — its comment claimed "reaching this error implies no other process holds the write lock," which is untrue on the path that reached it most often, since a read-only open never contends for that lock. Two arms of one recovery disagreed about whether a read-only caller may mutate the directory, **and the arm that DELETES was the ungated one.**

## Known flake (pre-existing, not from this branch)

`macos_autostart_normal_db_is_owned_by_launchd` failed once under parallel execution (`cleanup must boot out …`) and **passes in isolation**. `#[cfg(target_os = "macos")]`-gated, so the ubuntu `build-and-check` job never runs it. Test-isolation weakness against real launchd state, worth its own item.

## Corrections made to the backlog's own claims

- **nw-391's headline is false.** Reproduced independently: tampering `source_graph_generation` leaves ranks byte-identical (`0.4651/0.4651/0.0698`), not flat 1/N. The loader invalidates the cache *before* validating, so recompute happens. The real defect is the **silence**, which is what's fixed; severity was overstated.
- **nw-413's script** claimed SHA pinning in capitals while using mutable tags. Corrected to state what it does, and it now resolves and prints each SHA so a measurement is reproducible if a tag moves.
