### PR TITLE
fix: harden high-priority safety contracts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,14 @@
-* @korykehl
+* @kory-io
+
+# Release and enforcement policy is executable supply-chain code. Keep these
+# explicit even though the repository-wide owner currently resolves identically;
+# release-policy review requests must always route to the maintainer.
+/.github/workflows/** @kory-io
+/.github/CODEOWNERS @kory-io
+/.release-please-manifest.json @kory-io
+/release-please-config.json @kory-io
+/scripts/observe-release-visibility.sh @kory-io
+/scripts/verify-release-*.sh @kory-io
+/scripts/verify-release-install.js @kory-io
+/scripts/verify-required-ci.sh @kory-io
+/CONTRIBUTING.md @kory-io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,18 +383,22 @@ jobs:
         if: failure()
         shell: bash
         run: |
+          OUTPUT_DIR="${OUTPUT_DIR:-$RUNNER_TEMP/nestweaver-metal-evidence-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}}"
           mkdir -p "$OUTPUT_DIR"
           BIN="$PWD/target/release/nestweaver"
           "$BIN" diagnostics capabilities --json \
             >"$OUTPUT_DIR/capabilities.json" 2>"$OUTPUT_DIR/capabilities.stderr" || true
-          "$BIN" daemon --db "$TARGET_DB" status \
-            >"$OUTPUT_DIR/daemon-status.txt" 2>"$OUTPUT_DIR/daemon-status.stderr" || true
-          DAEMON_LOG="$RUNTIME_DIR/daemon.log"
-          if [ -f "$DAEMON_LOG" ]; then
-            cp "$DAEMON_LOG" "$OUTPUT_DIR/daemon.log"
+          if [ -n "${TARGET_DB:-}" ]; then
+            "$BIN" daemon --db "$TARGET_DB" status \
+              >"$OUTPUT_DIR/daemon-status.txt" 2>"$OUTPUT_DIR/daemon-status.stderr" || true
           fi
-          launchctl print "gui/$(id -u)/io.kehl.nestweaver.$INSTANCE_ID" \
-            >"$OUTPUT_DIR/launchd.txt" 2>&1 || true
+          if [ -n "${RUNTIME_DIR:-}" ] && [ -f "$RUNTIME_DIR/daemon.log" ]; then
+            cp "$RUNTIME_DIR/daemon.log" "$OUTPUT_DIR/daemon.log"
+          fi
+          if [ -n "${INSTANCE_ID:-}" ]; then
+            launchctl print "gui/$(id -u)/io.kehl.nestweaver.$INSTANCE_ID" \
+              >"$OUTPUT_DIR/launchd.txt" 2>&1 || true
+          fi
       - name: Upload Metal smoke evidence
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main, staging]
+  # A PR created with the repository GITHUB_TOKEN may not emit a pull_request
+  # workflow event at all. Maintainers can explicitly run CI from that PR's
+  # latest branch head; the Required CI check remains bound to github.sha.
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 # Cancel a PR's earlier run when a new commit supersedes it.
 #
@@ -38,18 +45,25 @@ env:
 jobs:
   # Detect what actually changed so we don't recompile the entire Rust
   # workspace (~50 min) for a frontend-only PR, or run the frontend/e2e
-  # stack for a pure-Rust change. There are no branch-protection required
-  # checks, so skipped jobs are safe — they don't deadlock merges.
+  # stack for a pure-Rust change. Branch protection requires only the stable
+  # `Required CI` aggregate below; that job interprets these conditional skips
+  # instead of asking GitHub to require job names that may not be created.
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       metal: ${{ steps.filter.outputs.metal }}
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         id: filter
         with:
           filters: |
@@ -60,6 +74,14 @@ jobs:
               - '.cargo/**'
               - '.github/workflows/ci.yml'
               - '.github/workflows/release-please.yml'
+              - '.github/CODEOWNERS'
+              - 'CONTRIBUTING.md'
+              - 'release-please-config.json'
+              - 'scripts/observe-release-visibility.sh'
+              - 'scripts/verify-release-canary-pr.sh'
+              - 'scripts/verify-release-bundle.sh'
+              - 'scripts/verify-release-package.sh'
+              - 'scripts/verify-required-ci.sh'
               - 'examples/**'
               - 'instance.toml'
               - 'INSTALL.md'
@@ -107,9 +129,12 @@ jobs:
       - name: Verify native Apple Silicon runner
         shell: bash
         run: test "$(uname -m)" = "arm64"
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-09-02
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           cache-on-failure: true
           shared-key: metal-smoke
@@ -199,7 +224,7 @@ jobs:
           done
       - name: Upload macOS crash reports
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: macos-crash-reports-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/crash-reports
@@ -372,7 +397,7 @@ jobs:
             >"$OUTPUT_DIR/launchd.txt" 2>&1 || true
       - name: Upload Metal smoke evidence
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: metal-smoke-evidence
           path: ${{ runner.temp }}/nestweaver-metal-evidence-${{ github.run_id }}-${{ github.run_attempt }}-metal-smoke
@@ -415,8 +440,11 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-09-02
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -437,11 +465,14 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
           sudo apt-get clean
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-09-02
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           cache-on-failure: true
           shared-key: build
@@ -458,7 +489,7 @@ jobs:
         # lbug (C++ graph DB, built from source) and vendored OpenSSL dominate
         # cold-build time. Keyed on their package versions (not Cargo.lock as a
         # whole) so they survive release-please lockfile churn.
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             target/**/build/lbug-*/out
@@ -504,11 +535,14 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
           sudo apt-get clean
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-09-02
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           cache-on-failure: true
           shared-key: build
@@ -522,7 +556,7 @@ jobs:
           RUSTC_VER=$(rustc --version | awk '{print $2}')
           echo "key=${LBUG_VER}-${OSSL_VER}-rustc${RUSTC_VER}" >> "$GITHUB_OUTPUT"
       - name: Cache native build outputs (lbug C++, OpenSSL)
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             target/**/build/lbug-*/out
@@ -550,9 +584,12 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
           sudo apt-get clean
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-09-02
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           cache-on-failure: true
           shared-key: build
@@ -569,7 +606,7 @@ jobs:
         # lbug (C++ graph DB, built from source) and vendored OpenSSL dominate
         # cold-build time. Keyed on their package versions (not Cargo.lock as a
         # whole) so they survive release-please lockfile churn.
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             target/**/build/lbug-*/out
@@ -606,16 +643,21 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
           sudo apt-get clean
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-09-02
         with:
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           cache-on-failure: true
           key: coverage
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@2af88edc33c2d5ff8a473fd1c5ab83052f77afee # cargo-llvm-cov 2026-09-02
+        with:
+          tool: cargo-llvm-cov
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
       - name: Compute native dependency cache key
@@ -629,7 +671,7 @@ jobs:
         # lbug (C++ graph DB, built from source) and vendored OpenSSL dominate
         # cold-build time. Keyed on their package versions (not Cargo.lock as a
         # whole) so they survive release-please lockfile churn.
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             target/**/build/lbug-*/out
@@ -655,7 +697,7 @@ jobs:
           NESTWEAVER_ALLOW_NO_DAEMON: "1"
           NESTWEAVER_NO_DAEMON: "1"
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report
           path: lcov.info
@@ -700,12 +742,14 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
           sudo apt-get clean
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
           # `--in-diff` needs the base commit to diff against.
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-09-02
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           cache-on-failure: true
           # Share the `build` cache the other Rust jobs populate, instead of a
@@ -718,7 +762,7 @@ jobs:
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake g++ libssl-dev libzstd-dev pkg-config protobuf-compiler mold
       - name: Install cargo-mutants
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@0758d235715de2f3551eacc980d9ae8fce9342c3 # v2
         with:
           tool: cargo-mutants
       - name: Compute the PR diff
@@ -926,7 +970,7 @@ jobs:
           fi
       - name: Upload mutants report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mutants-report
           path: mutants.out/
@@ -938,12 +982,17 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-09-02
       # Prebuilt binary via install-action instead of `cargo install cargo-audit`
       # (which compiles it from source on every run, ~3 min).
       - name: Install cargo-audit
-        uses: taiki-e/install-action@cargo-audit
+        uses: taiki-e/install-action@8e38755317fb11cc24a0cd3b573a64008362d207 # cargo-audit 2026-09-02
+        with:
+          tool: cargo-audit
       # No `|| true`. This check is displayed as "Security Audit" on every pull
       # request in a public repo, which reads as an enforced supply-chain gate —
       # suppressing the exit code made that a false claim. Verified clean on
@@ -963,8 +1012,10 @@ jobs:
     # any file type, including ones no language filter matches.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
           # Full history. This repo is public, so a secret that was committed and
           # later removed is still disclosed and still needs rotating — scanning
           # only the tip would miss exactly the case that matters most.
@@ -976,8 +1027,10 @@ jobs:
         run: |
           set -euo pipefail
           VERSION=8.30.1
+          EXPECTED_SHA256=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
           curl -sSfL -o /tmp/gitleaks.tar.gz \
             "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz"
+          printf '%s  %s\n' "$EXPECTED_SHA256" /tmp/gitleaks.tar.gz | sha256sum -c -
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
           sudo install /tmp/gitleaks /usr/local/bin/gitleaks
           gitleaks version
@@ -1021,13 +1074,16 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
           sudo apt-get clean
           df -h /
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-09-02
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           cache-on-failure: true
           shared-key: build
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           cache: "npm"
@@ -1048,7 +1104,7 @@ jobs:
         # lbug (C++ graph DB, built from source) and vendored OpenSSL dominate
         # cold-build time. Keyed on their package versions (not Cargo.lock as a
         # whole) so they survive release-please lockfile churn.
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             target/**/build/lbug-*/out
@@ -1072,7 +1128,82 @@ jobs:
         run: npx playwright test
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-report
           path: crates/nestweaver-web/frontend/playwright-report/
+
+  required-ci:
+    name: Required CI
+    # `always()` is essential: a failed, cancelled, or unexpectedly skipped
+    # prerequisite must be reduced to a failing conclusion, not skip the one
+    # check the main-branch ruleset requires.
+    if: always()
+    needs:
+      - changes
+      - metal-smoke
+      - fmt
+      - build-and-check
+      - clippy
+      - daemon-tests
+      - audit
+      - secret-scan
+      - e2e
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the exact candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - name: Prove exact SHA and reduce required results
+        env:
+          EXPECTED_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          ACTUAL_SHA="$(git rev-parse HEAD)"
+          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::error::Required CI checked out $ACTUAL_SHA, expected $EXPECTED_SHA" >&2
+            exit 1
+          fi
+
+          bash scripts/verify-required-ci.sh --self-test
+          bash scripts/verify-release-bundle.sh --self-test
+          bash scripts/verify-release-package.sh --self-test
+          bash -n scripts/observe-release-visibility.sh \
+            scripts/verify-release-canary-pr.sh
+          uses_key=uses
+          at_sign=@
+          unpinned_actions="$({
+            grep -REn "${uses_key}:[[:space:]]+[^[:space:]]+${at_sign}" \
+              .github/workflows || true
+          } | grep -Ev '@[0-9a-f]{40}([[:space:]]|$)' || true)"
+          if [ -n "$unpinned_actions" ]; then
+            echo "::error::every external action must be pinned to a full commit SHA" >&2
+            printf '%s\n' "$unpinned_actions" >&2
+            exit 1
+          fi
+          printf '%s\n' "$NEEDS_JSON" | bash scripts/verify-required-ci.sh -
+          {
+            echo "Required non-advisory CI passed."
+            echo ""
+            echo "Exact candidate SHA: \`$ACTUAL_SHA\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Validate GitHub Actions workflow syntax
+        if: always()
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/actionlint.tar.gz"
+          tool_dir="$RUNNER_TEMP/actionlint"
+          mkdir -p "$tool_dir"
+          curl --fail-with-body --silent --show-error --location \
+            --retry 3 --retry-all-errors \
+            --output "$archive" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          printf '%s  %s\n' "$ACTIONLINT_SHA256" "$archive" | sha256sum -c -
+          tar -xzf "$archive" -C "$tool_dir" actionlint
+          "$tool_dir/actionlint" .github/workflows/*.yml

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -474,9 +474,11 @@ jobs:
           fi
 
           echo "located release PR: ${NUM:-<none>} (${BRANCH:-<none>} @ ${HEAD_SHA:-<none>})"
-          echo "number=$NUM" >> "$GITHUB_OUTPUT"
-          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
-          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          {
+            echo "number=$NUM"
+            echo "branch=$BRANCH"
+            echo "head_sha=$HEAD_SHA"
+          } >> "$GITHUB_OUTPUT"
 
   prepare-release-lockfile:
     name: Prepare release lockfile without write authority

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,31 +3,374 @@ name: Release Please
 on:
   push:
     branches: [main]
-  # A release artifact is materially different from the ordinary CI binary:
-  # it is built on the compatibility runner, with the release linker and the
-  # exact runtime layout users download. Allow that contract to be exercised
-  # before cutting another public tag when a platform-specific failure needs
-  # diagnosis. A manual run builds and verifies the matrix but cannot publish.
+  # Manual runs either exercise the complete gate or recover one exact private
+  # draft/public package. Every mutating recovery input is bound to an explicit
+  # commit, tag, release id, and (for resume) source workflow run.
   workflow_dispatch:
+    inputs:
+      operation:
+        description: Release-gate operation
+        required: true
+        default: dry-run
+        type: choice
+        options: [dry-run, resume, cleanup-draft, recover-npm]
+      candidate_sha:
+        description: Exact release commit SHA (dry-run defaults to the workflow SHA)
+        required: false
+        type: string
+      release_id:
+        description: Exact GitHub release id for resume, cleanup, or npm recovery
+        required: false
+        type: string
+      release_tag:
+        description: Exact vX.Y.Z tag for resume, cleanup, or npm recovery
+        required: false
+        type: string
+      source_run_id:
+        description: Completed release workflow run containing all release artifacts for resume or npm recovery
+        required: false
+        type: string
+      fault_mode:
+        description: Negative-control behavior for one matrix target
+        required: true
+        default: none
+        type: choice
+        options: [none, fail, omit]
+      fault_target:
+        description: Matrix target used when fault_mode is fail or omit
+        required: true
+        default: x86_64-unknown-linux-gnu
+        type: choice
+        options:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
 
-permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
-  attestations: write
+# A second main push must not ask Release Please to inspect history while the
+# previous run still owns a deliberately tagless private draft. Resume,
+# cleanup, and npm recovery share that mutation lane so two exact-id operators
+# cannot race each other or the automatic publisher. Read-only dry-run probes
+# remain independent.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && inputs.operation == 'dry-run' && github.run_id || 'main' }}
+  cancel-in-progress: false
+
+permissions: {}
 
 jobs:
   release-please:
+    # Manual verification must be publication-side-effect free. This literal
+    # condition is also guarded by the release-workflow contract test.
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      release_sha: ${{ steps.release.outputs.sha }}
+      upload_url: ${{ steps.release.outputs.upload_url }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      # Release creation and next-PR generation are deliberately separate.
+      # With `draft: true`, GitHub does not create a tag until publication. A
+      # single Release Please invocation can then fail its second pass while it
+      # looks for that intentionally absent tag, stranding an unreachable draft.
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
         with:
+          # The built-in token deliberately leaves automation-authored PRs
+          # behind the repository's explicit Actions/manual-dispatch gate.
+          token: ${{ github.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          skip-github-pull-request: true
+
+  release-context:
+    name: Bind exact release identity
+    needs: release-please
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      active: ${{ steps.context.outputs.active }}
+      mode: ${{ steps.context.outputs.mode }}
+      release_sha: ${{ steps.context.outputs.release_sha }}
+      tag_name: ${{ steps.context.outputs.tag_name }}
+      release_id: ${{ steps.context.outputs.release_id }}
+      upload_url: ${{ steps.context.outputs.upload_url }}
+      source_run_id: ${{ steps.context.outputs.source_run_id }}
+      dry_run_version: ${{ steps.context.outputs.dry_run_version }}
+    steps:
+      - name: Validate immutable release context
+        id: context
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          OPERATION: ${{ inputs.operation }}
+          INPUT_SHA: ${{ inputs.candidate_sha }}
+          INPUT_RELEASE_ID: ${{ inputs.release_id }}
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+          INPUT_SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_JOB_RESULT: ${{ needs.release-please.result }}
+          RELEASE_CREATED: ${{ needs.release-please.outputs.release_created }}
+          RELEASE_SHA: ${{ needs.release-please.outputs.release_sha }}
+          RELEASE_TAG: ${{ needs.release-please.outputs.tag_name }}
+          RELEASE_UPLOAD_URL: ${{ needs.release-please.outputs.upload_url }}
+          WORKFLOW_REF: ${{ github.ref }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          output() { printf '%s=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"; }
+          require_sha() {
+            [[ "$1" =~ ^[0-9a-f]{40}$ ]] || {
+              echo "::error::release SHA must be 40 lowercase hexadecimal characters" >&2
+              exit 1
+            }
+          }
+          require_tag() {
+            [[ "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]] || {
+              echo "::error::release tag must be an exact vX.Y.Z semantic version: $1" >&2
+              exit 1
+            }
+          }
+          assert_tag_absent() {
+            local encoded status
+            encoded="$(jq -rn --arg value "$1" '$value | @uri')"
+            set +e
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$encoded" >/dev/null 2> tag-error.txt
+            status=$?
+            set -e
+            if [ "$status" -eq 0 ] || ! grep -q 'HTTP 404' tag-error.txt; then
+              echo "::error::could not prove that tag $1 is absent" >&2
+              cat tag-error.txt >&2
+              exit 1
+            fi
+          }
+          validate_release() {
+            local expected_draft=$1 release_json
+            release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")"
+            jq -e \
+              --arg tag "$RELEASE_TAG" \
+              --arg sha "$RELEASE_SHA" \
+              --argjson draft "$expected_draft" \
+              '.draft == $draft and .tag_name == $tag and .target_commitish == $sha' \
+              <<< "$release_json" >/dev/null
+            if [ "$expected_draft" = false ]; then
+              jq -e '.immutable == true' <<< "$release_json" >/dev/null || {
+                echo "::error::public release $RELEASE_ID is mutable; refusing recovery or npm publication" >&2
+                exit 1
+              }
+            fi
+            RELEASE_UPLOAD_URL="$(jq -er '.upload_url' <<< "$release_json")"
+          }
+
+          output active false
+          output mode none
+          output release_sha ""
+          output tag_name ""
+          output release_id ""
+          output upload_url ""
+          output source_run_id ""
+          output dry_run_version ""
+
+          if [ "$EVENT_NAME" = push ]; then
+            if [ "$RELEASE_JOB_RESULT" != success ]; then
+              echo "::error::Release Please did not complete successfully" >&2
+              exit 1
+            fi
+            if [ "$RELEASE_CREATED" != true ]; then
+              exit 0
+            fi
+            require_sha "$RELEASE_SHA"
+            require_tag "$RELEASE_TAG"
+            RELEASE_ID="$(sed -E 's#^.*/releases/([0-9]+)/assets.*#\1#' <<< "$RELEASE_UPLOAD_URL")"
+            [[ "$RELEASE_ID" =~ ^[0-9]+$ ]] || {
+              echo "::error::could not derive the draft release id" >&2
+              exit 1
+            }
+            validate_release true
+            assert_tag_absent "$RELEASE_TAG"
+            output active true
+            output mode publish
+            output release_sha "$RELEASE_SHA"
+            output tag_name "$RELEASE_TAG"
+            output release_id "$RELEASE_ID"
+            output upload_url "$RELEASE_UPLOAD_URL"
+            output source_run_id "$GITHUB_RUN_ID"
+            exit 0
+          fi
+
+          expected_workflow_ref="refs/heads/$DEFAULT_BRANCH"
+          [ "$WORKFLOW_REF" = "$expected_workflow_ref" ] || {
+            echo "::error::manual release operations must run from $expected_workflow_ref" >&2
+            exit 1
+          }
+          current_default_sha="$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" --jq '.object.sha')"
+          [ "$WORKFLOW_SHA" = "$current_default_sha" ] || {
+            echo "::error::manual release policy $WORKFLOW_SHA is not current $DEFAULT_BRANCH tip $current_default_sha" >&2
+            exit 1
+          }
+
+          case "$OPERATION" in
+            dry-run)
+              RELEASE_SHA="${INPUT_SHA:-$GITHUB_SHA}"
+              require_sha "$RELEASE_SHA"
+              if [ "$RELEASE_SHA" != "$GITHUB_SHA" ]; then
+                echo "::error::dry-run SHA must equal the selected workflow ref SHA" >&2
+                exit 1
+              fi
+              RELEASE_TAG="dry-run-${RELEASE_SHA:0:12}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+              output active true
+              output mode dry-run
+              output release_sha "$RELEASE_SHA"
+              output tag_name "$RELEASE_TAG"
+              output dry_run_version "0.0.0-release-gate.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"
+              ;;
+            resume|cleanup-draft|recover-npm)
+              RELEASE_SHA="$INPUT_SHA"
+              RELEASE_ID="$INPUT_RELEASE_ID"
+              RELEASE_TAG="$INPUT_RELEASE_TAG"
+              require_sha "$RELEASE_SHA"
+              require_tag "$RELEASE_TAG"
+              [[ "$RELEASE_ID" =~ ^[0-9]+$ ]] || {
+                echo "::error::release_id must be numeric" >&2
+                exit 1
+              }
+
+              if [ "$OPERATION" = recover-npm ]; then
+                validate_release false
+                tag_json="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG")"
+                tag_sha="$(jq -er '.object.sha' <<< "$tag_json")"
+                tag_type="$(jq -er '.object.type' <<< "$tag_json")"
+                if [ "$tag_type" = tag ]; then
+                  tag_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$tag_sha" --jq '.object.sha')"
+                fi
+                [ "$tag_sha" = "$RELEASE_SHA" ] || {
+                  echo "::error::$RELEASE_TAG resolves to $tag_sha, expected $RELEASE_SHA" >&2
+                  exit 1
+                }
+                expected_assets="$(mktemp)"
+                actual_assets="$(mktemp)"
+                for target in \
+                  aarch64-apple-darwin aarch64-unknown-linux-gnu \
+                  x86_64-apple-darwin x86_64-unknown-linux-gnu; do
+                  archive="nestweaver-${RELEASE_TAG}-${target}.tar.gz"
+                  printf '%s\n%s\n' "$archive" "$archive.sha256" >> "$expected_assets"
+                done
+                sort -o "$expected_assets" "$expected_assets"
+                assets_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets?per_page=100")"
+                jq -r '.[].name' <<< "$assets_json" | sort > "$actual_assets"
+                diff -u "$expected_assets" "$actual_assets"
+                jq -e 'length == 8 and all(.[];
+                  .state == "uploaded" and (.digest | startswith("sha256:")))' \
+                  <<< "$assets_json" >/dev/null
+                rm -f "$expected_assets" "$actual_assets"
+              else
+                validate_release true
+                assert_tag_absent "$RELEASE_TAG"
+              fi
+
+              if [ "$OPERATION" = resume ] || [ "$OPERATION" = recover-npm ]; then
+                [[ "$INPUT_SOURCE_RUN_ID" =~ ^[0-9]+$ ]] || {
+                  echo "::error::source_run_id must be numeric for $OPERATION" >&2
+                  exit 1
+                }
+                source_run="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$INPUT_SOURCE_RUN_ID")"
+                jq -e \
+                  --arg sha "$RELEASE_SHA" \
+                  --arg branch "$DEFAULT_BRANCH" \
+                  '.head_sha == $sha and .event == "push" and
+                   .head_branch == $branch and
+                   .path == ".github/workflows/release-please.yml" and
+                   .status == "completed"' <<< "$source_run" >/dev/null
+              fi
+
+              output active true
+              output mode "$OPERATION"
+              output release_sha "$RELEASE_SHA"
+              output tag_name "$RELEASE_TAG"
+              output release_id "$RELEASE_ID"
+              output upload_url "$RELEASE_UPLOAD_URL"
+              output source_run_id "$INPUT_SOURCE_RUN_ID"
+              ;;
+            *)
+              echo "::error::unknown release operation: $OPERATION" >&2
+              exit 1
+              ;;
+          esac
+
+  cleanup-draft:
+    name: Delete exact private draft
+    needs: release-context
+    if: ${{ needs.release-context.outputs.mode == 'cleanup-draft' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Revalidate and delete only the bound tagless draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.release-context.outputs.release_id }}
+          RELEASE_SHA: ${{ needs.release-context.outputs.release_sha }}
+          RELEASE_TAG: ${{ needs.release-context.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          release="$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")"
+          jq -e --arg tag "$RELEASE_TAG" --arg sha "$RELEASE_SHA" \
+            '.draft == true and .tag_name == $tag and .target_commitish == $sha' \
+            <<< "$release" >/dev/null
+          set +e
+          gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" \
+            >/dev/null 2> tag-error.txt
+          tag_status=$?
+          set -e
+          if [ "$tag_status" -eq 0 ] || ! grep -q 'HTTP 404' tag-error.txt; then
+            echo "::error::could not prove the cleanup target has no visible tag" >&2
+            cat tag-error.txt >&2
+            exit 1
+          fi
+          gh api --method DELETE "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" --silent
+          set +e
+          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            >/dev/null 2> release-error.txt
+          release_status=$?
+          set -e
+          if [ "$release_status" -eq 0 ] || ! grep -q 'HTTP 404' release-error.txt; then
+            echo "::error::could not prove draft release $RELEASE_ID was deleted" >&2
+            cat release-error.txt >&2
+            exit 1
+          fi
+
+  release-pr:
+    # On an ordinary push this creates or updates the pending release PR. When
+    # a release was drafted, it waits until publication creates the tag before
+    # asking Release Please for the next PR; otherwise Release Please's tag
+    # lookup can fail against the intentionally tagless private draft.
+    needs: [release-please, publish-release]
+    if: ${{ always() && github.event_name == 'push' && needs.release-please.result == 'success' && (needs.release-please.outputs.release_created != 'true' || needs.publish-release.result == 'success') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      number: ${{ steps.release_pr.outputs.number }}
+      branch: ${{ steps.release_pr.outputs.branch }}
+      head_sha: ${{ steps.release_pr.outputs.head_sha }}
+    steps:
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+        id: release
+        with:
+          token: ${{ github.token }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          skip-github-release: true
       # Find the open release PR by LABEL, not by `prs_created`.
       #
       # `prs_created` is true only when release-please CREATES the PR. When it
@@ -37,8 +380,8 @@ jobs:
       # `cargo build --locked` refuses outright (verified: exit 101, "cannot
       # update the lock file ... because --locked was passed"). Merging it would
       # have CUT THE TAG and then failed every one of the four binary builds,
-      # publishing a release with no artifacts -- and the release PR is the one
-      # PR in this repo that gets no CI, so nothing would have caught it.
+      # publishing a release with no artifacts -- and the release PR was the
+      # one PR in this repo that got no CI, so nothing caught it at the time.
       #
       # `autorelease: pending` is release-please's own label on an open release
       # PR and is present however the PR got there.
@@ -47,11 +390,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ACTION_PR: ${{ steps.release.outputs.pr }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           PRS_CREATED: ${{ steps.release.outputs.prs_created }}
         run: |
           set -euo pipefail
           NUM=""
-          BRANCH=""
+          ACTION_BRANCH=""
+          EXPECTED_BRANCH="release-please--branches--${DEFAULT_BRANCH}--components--nestweaver"
 
           # PREFER THE ACTION'S OWN OUTPUT. When release-please has just CREATED
           # the PR, its `autorelease: pending` label is not attached yet: PR #338
@@ -61,7 +406,7 @@ jobs:
           # The action's output is populated in-process and cannot race.
           if [ -n "${ACTION_PR:-}" ] && [ "$ACTION_PR" != "null" ]; then
             NUM="$(jq -r '.number // empty' <<< "$ACTION_PR")"
-            BRANCH="$(jq -r '.headBranchName // empty' <<< "$ACTION_PR")"
+            ACTION_BRANCH="$(jq -r '.headBranchName // empty' <<< "$ACTION_PR")"
           fi
 
           # FALL BACK TO THE LABEL for a PR that already existed and was merely
@@ -71,9 +416,14 @@ jobs:
           if [ -z "$NUM" ]; then
             for attempt in 1 2 3; do
               PR_JSON="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
-                --label 'autorelease: pending' --json number,headRefName --limit 1)"
+                --label 'autorelease: pending' --json number --limit 100)"
+              match_count="$(jq 'length' <<< "$PR_JSON")"
+              if [ "$match_count" -gt 1 ]; then
+                echo "::error::multiple open autorelease: pending PRs exist; refusing to choose a privileged mutation target" >&2
+                jq . <<< "$PR_JSON" >&2
+                exit 1
+              fi
               NUM="$(jq -r '.[0].number // empty' <<< "$PR_JSON")"
-              BRANCH="$(jq -r '.[0].headRefName // empty' <<< "$PR_JSON")"
               [ -n "$NUM" ] && break
               echo "no open release PR yet (attempt $attempt/3); retrying in 5s"
               sleep 5
@@ -88,51 +438,195 @@ jobs:
             exit 1
           fi
 
-          echo "located release PR: ${NUM:-<none>} (${BRANCH:-<none>})"
-          echo "number=$NUM" >> "$GITHUB_OUTPUT"
-          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
-      - name: Check out release PR
-        if: steps.release_pr.outputs.number != ''
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ steps.release_pr.outputs.branch }}
-      - name: Install Rust toolchain
-        if: steps.release_pr.outputs.number != ''
-        uses: dtolnay/rust-toolchain@stable
-      - name: Synchronize release lockfile
-        if: steps.release_pr.outputs.number != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_PR_NUMBER: ${{ steps.release_pr.outputs.number }}
-          RELEASE_PR_BRANCH: ${{ steps.release_pr.outputs.branch }}
-        run: |
-          set -euo pipefail
-
-          cargo update --workspace
-
-          if ! git diff --quiet -- Cargo.lock; then
-            git add Cargo.lock
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git commit -m "chore: synchronize Cargo.lock for release"
-            git push origin "HEAD:$RELEASE_PR_BRANCH"
+          if [ -n "$NUM" ]; then
+            [[ "$NUM" =~ ^[0-9]+$ ]] || {
+              echo "::error::release PR number is not numeric" >&2
+              exit 1
+            }
+            PR_JSON="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$NUM")"
+            jq -e \
+              --arg base "$DEFAULT_BRANCH" \
+              --arg branch "$EXPECTED_BRANCH" \
+              --arg repo "$GITHUB_REPOSITORY" '
+                .state == "open" and
+                .base.ref == $base and
+                .head.ref == $branch and
+                .head.repo.full_name == $repo and
+                .head.repo.fork == false and
+                .user.login == "github-actions[bot]"
+              ' <<< "$PR_JSON" >/dev/null || {
+                echo "::error::candidate release PR failed trusted base/head/repository/author validation" >&2
+                jq '{number, state, author: .user.login, base: .base.ref,
+                     head: .head.ref, head_repo: .head.repo.full_name,
+                     head_repo_fork: .head.repo.fork}' <<< "$PR_JSON" >&2
+                exit 1
+              }
+            BRANCH="$(jq -er '.head.ref' <<< "$PR_JSON")"
+            HEAD_SHA="$(jq -er '.head.sha' <<< "$PR_JSON")"
+            [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+            if [ -n "$ACTION_BRANCH" ] && [ "$ACTION_BRANCH" != "$BRANCH" ]; then
+              echo "::error::release-please output branch $ACTION_BRANCH disagrees with validated PR branch $BRANCH" >&2
+              exit 1
+            fi
+          else
+            BRANCH=""
+            HEAD_SHA=""
           fi
 
-          # Prove the state we are about to let someone merge actually builds.
-          # `cargo update --workspace` exiting 0 is not that proof: it says the
-          # lock was refreshed, not that --locked now accepts it, and --locked
-          # is what the build job uses.
-          cargo metadata --locked --format-version 1 > /dev/null
+          echo "located release PR: ${NUM:-<none>} (${BRANCH:-<none>} @ ${HEAD_SHA:-<none>})"
+          echo "number=$NUM" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
-          if [ "$(gh pr view "$RELEASE_PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')" = "true" ]; then
+  prepare-release-lockfile:
+    name: Prepare release lockfile without write authority
+    needs: release-pr
+    if: ${{ needs.release-pr.outputs.number != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # This job executes Cargo against the release PR, so it deliberately has
+      # no write token. The following job receives only two inert data files
+      # and never checks out or executes the PR tree.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.release-pr.outputs.head_sha }}
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-09-02
+      - name: Resolve and validate the lockfile
+        env:
+          RELEASE_PR_HEAD_SHA: ${{ needs.release-pr.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          original_blob="$(git rev-parse HEAD:Cargo.lock)"
+          [[ "$original_blob" =~ ^[0-9a-f]{40}$ ]]
+          cargo update --workspace
+          cargo metadata --locked --format-version 1 > /dev/null
+          changed=false
+          if ! git diff --quiet -- Cargo.lock; then
+            changed=true
+          fi
+          unexpected="$(git status --porcelain --untracked-files=all | grep -vE '^ M Cargo\.lock$' || true)"
+          if [ -n "$unexpected" ]; then
+            echo "::error::lockfile preparation modified files outside Cargo.lock" >&2
+            printf '%s\n' "$unexpected" >&2
+            exit 1
+          fi
+          sha256="$(sha256sum Cargo.lock | awk '{print $1}')"
+          jq -n \
+            --arg head_sha "$RELEASE_PR_HEAD_SHA" \
+            --arg original_blob "$original_blob" \
+            --arg sha256 "$sha256" \
+            --argjson changed "$changed" \
+            '{head_sha: $head_sha, original_blob: $original_blob,
+              sha256: $sha256, changed: $changed}' > lockfile-state.json
+      - name: Transfer only inert lockfile data
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-lockfile-${{ needs.release-pr.outputs.number }}
+          path: |
+            Cargo.lock
+            lockfile-state.json
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-release-lockfile:
+    name: Publish validated release lockfile without executing PR code
+    needs: [release-pr, prepare-release-lockfile]
+    if: ${{ needs.prepare-release-lockfile.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: release-lockfile-${{ needs.release-pr.outputs.number }}
+          path: lockfile-artifact
+      - name: Revalidate identity and publish Cargo.lock with an exact-head lease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_PR_BRANCH: ${{ needs.release-pr.outputs.branch }}
+          RELEASE_PR_HEAD_SHA: ${{ needs.release-pr.outputs.head_sha }}
+          RELEASE_PR_NUMBER: ${{ needs.release-pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          files="$(find lockfile-artifact -maxdepth 1 -type f -printf '%f\n' | sort)"
+          [ "$files" = $'Cargo.lock\nlockfile-state.json' ]
+          test "$(stat -c '%s' lockfile-artifact/Cargo.lock)" -le 10485760
+          jq -e \
+            --arg head "$RELEASE_PR_HEAD_SHA" \
+            '.head_sha == $head and
+             (.original_blob | test("^[0-9a-f]{40}$")) and
+             (.sha256 | test("^[0-9a-f]{64}$")) and
+             (.changed | type == "boolean")' \
+            lockfile-artifact/lockfile-state.json >/dev/null
+          expected_sha256="$(jq -er '.sha256' lockfile-artifact/lockfile-state.json)"
+          [ "$(sha256sum lockfile-artifact/Cargo.lock | awk '{print $1}')" = "$expected_sha256" ]
+
+          pr="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$RELEASE_PR_NUMBER")"
+          jq -e \
+            --arg branch "$RELEASE_PR_BRANCH" \
+            --arg head "$RELEASE_PR_HEAD_SHA" \
+            --arg repo "$GITHUB_REPOSITORY" '
+              .state == "open" and .base.ref == "main" and
+              .head.ref == $branch and .head.sha == $head and
+              .head.repo.full_name == $repo and .head.repo.fork == false and
+              .user.login == "github-actions[bot]"
+            ' <<< "$pr" >/dev/null
+
+          current_lock="$(gh api \
+            "repos/$GITHUB_REPOSITORY/contents/Cargo.lock?ref=$RELEASE_PR_BRANCH")"
+          original_blob="$(jq -er '.original_blob' lockfile-artifact/lockfile-state.json)"
+          [ "$(jq -er '.sha' <<< "$current_lock")" = "$original_blob" ]
+          changed="$(jq -er '.changed' lockfile-artifact/lockfile-state.json)"
+          expected_head="$RELEASE_PR_HEAD_SHA"
+          if [ "$changed" = true ]; then
+            branch_head="$(gh api \
+              "repos/$GITHUB_REPOSITORY/git/ref/heads/$RELEASE_PR_BRANCH" \
+              --jq '.object.sha')"
+            [ "$branch_head" = "$RELEASE_PR_HEAD_SHA" ]
+            base_tree="$(gh api \
+              "repos/$GITHUB_REPOSITORY/git/commits/$RELEASE_PR_HEAD_SHA" \
+              --jq '.tree.sha')"
+            blob="$(base64 -w 0 lockfile-artifact/Cargo.lock | \
+              jq -Rs '{content: ., encoding: "base64"}' | \
+              gh api --method POST \
+                "repos/$GITHUB_REPOSITORY/git/blobs" --input - --jq '.sha')"
+            tree="$(jq -n \
+              --arg base_tree "$base_tree" --arg blob "$blob" \
+              '{base_tree: $base_tree, tree: [{path: "Cargo.lock", mode: "100644", type: "blob", sha: $blob}]}' | \
+              gh api --method POST \
+                "repos/$GITHUB_REPOSITORY/git/trees" --input - --jq '.sha')"
+            expected_head="$(jq -n \
+              --arg message 'chore: synchronize Cargo.lock for release' \
+              --arg tree "$tree" --arg parent "$RELEASE_PR_HEAD_SHA" \
+              '{message: $message, tree: $tree, parents: [$parent]}' | \
+              gh api --method POST \
+                "repos/$GITHUB_REPOSITORY/git/commits" --input - --jq '.sha')"
+            jq -n --arg sha "$expected_head" '{sha: $sha, force: false}' | \
+              gh api --method PATCH \
+                "repos/$GITHUB_REPOSITORY/git/refs/heads/$RELEASE_PR_BRANCH" \
+                --input - >/dev/null
+          fi
+          actual_head="$(gh api \
+            "repos/$GITHUB_REPOSITORY/pulls/$RELEASE_PR_NUMBER" --jq '.head.sha')"
+          [ "$actual_head" = "$expected_head" ]
+          if [ "$(jq -r '.draft' <<< "$pr")" = true ]; then
             gh pr ready "$RELEASE_PR_NUMBER" --repo "$GITHUB_REPOSITORY"
           fi
 
   build:
     name: Build ${{ matrix.target }}
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created || github.event_name == 'workflow_dispatch' }}
+    needs: [release-context, dry-run-baseline]
+    if: ${{ always() && (needs.release-context.outputs.mode == 'publish' || (needs.release-context.outputs.mode == 'dry-run' && needs.dry-run-baseline.result == 'success')) }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -177,11 +671,45 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
           sudo apt-get clean
           df -h /
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Check out exact release candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.release-context.outputs.release_sha }}
+          persist-credentials: false
+      - name: Bind the immutable release identity
+        id: candidate
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ needs.release-context.outputs.release_sha }}
+          RELEASE_TAG: ${{ needs.release-context.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          ACTUAL_SHA="$(git rev-parse HEAD)"
+          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::error::checked out $ACTUAL_SHA, expected exact release candidate $EXPECTED_SHA" >&2
+            exit 1
+          fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "$ACTUAL_SHA" != "${{ github.sha }}" ]; then
+            echo "::error::manual candidate $ACTUAL_SHA differs from workflow SHA ${{ github.sha }}; dispatch the workflow from the candidate ref so provenance binds to the tested source" >&2
+            exit 1
+          fi
+          if [ "${{ github.event_name }}" != "workflow_dispatch" ] && [ "$ACTUAL_SHA" != "${{ github.sha }}" ]; then
+            echo "::error::Release Please selected $ACTUAL_SHA, but the reviewed main push is ${{ github.sha }}" >&2
+            exit 1
+          fi
+          if [ -z "$RELEASE_TAG" ]; then
+            RELEASE_TAG="dry-run-${ACTUAL_SHA:0:12}"
+          fi
+          {
+            echo "RELEASE_SHA=$ACTUAL_SHA"
+            echo "RELEASE_TAG=$RELEASE_TAG"
+          } >> "$GITHUB_ENV"
+          echo "sha=$ACTUAL_SHA" >> "$GITHUB_OUTPUT"
+          echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-09-02
         with:
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           cache-targets: false
           cache-on-failure: true
@@ -268,7 +796,7 @@ jobs:
       # LadybugDB opened a database. The same GCC 13 source build linked with
       # GNU ld passes that operation, and native upstream Ladybug builds also
       # use the system linker. Link speed is not an artifact requirement.
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: npm
@@ -299,7 +827,7 @@ jobs:
         # Keyed on package versions (not Cargo.lock) so the cache survives
         # release lockfile churn; per-target and per-native-toolchain so an
         # incomplete GCC 12 build cannot poison the GCC 13 repair job.
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             target/**/build/lbug-*/out
@@ -451,41 +979,7 @@ jobs:
             fi
           fi
 
-          HOST="$(uname -s)-$(uname -m)"
-          case "$HOST:$TARGET" in
-            Linux-x86_64:x86_64-unknown-linux-gnu|Linux-aarch64:aarch64-unknown-linux-gnu|Darwin-x86_64:x86_64-apple-darwin|Darwin-arm64:aarch64-apple-darwin)
-              "$BIN" --version
-              SMOKE_DIR="$(mktemp -d "$RUNNER_TEMP/nestweaver-release-smoke.XXXXXX")"
-              trap 'rm -rf "$SMOKE_DIR"' EXIT
-              if NESTWEAVER_ALLOW_NO_DAEMON=1 NESTWEAVER_NO_DAEMON=1 \
-                "$BIN" index \
-                    --repo "$GITHUB_WORKSPACE/crates/nestweaver-parser/tests" \
-                    --name release-artifact-smoke \
-                    --db "$SMOKE_DIR/smoke.lbug" \
-                    --no-embed \
-                    --with-trigrams \
-                    --json; then
-                :
-              else
-                SMOKE_STATUS=$?
-                if [ "${{ runner.os }}" = "Linux" ]; then
-                  DEBUG_DIR="$(mktemp -d "$RUNNER_TEMP/nestweaver-release-debug.XXXXXX")"
-                  NESTWEAVER_ALLOW_NO_DAEMON=1 NESTWEAVER_NO_DAEMON=1 \
-                    gdb --batch --quiet \
-                      -ex run \
-                      -ex 'thread apply all backtrace' \
-                      --args "$BIN" index \
-                        --repo "$GITHUB_WORKSPACE/crates/nestweaver-parser/tests" \
-                        --name release-artifact-debug \
-                        --db "$DEBUG_DIR/debug.lbug" \
-                        --no-embed \
-                        --with-trigrams \
-                        --json || true
-                fi
-                exit "$SMOKE_STATUS"
-              fi
-              ;;
-          esac
+          "$BIN" --version
       - name: Verify Apple Metal capability
         if: runner.os == 'macOS'
         shell: bash
@@ -497,12 +991,11 @@ jobs:
           printf '%s\n' "$CAPABILITIES"
           jq -e '.metal_compiled == true' <<< "$CAPABILITIES"
       - name: Package binary
-        if: github.event_name != 'workflow_dispatch'
         shell: bash
         env:
           TARGET: ${{ matrix.target }}
         run: |
-          ARCHIVE="nestweaver-${{ needs.release-please.outputs.tag_name }}-$TARGET.tar.gz"
+          ARCHIVE="nestweaver-${RELEASE_TAG}-$TARGET.tar.gz"
           if [[ "$TARGET" == *-unknown-linux-gnu ]]; then
             tar czf "$ARCHIVE" -C "target/$TARGET/release" nestweaver lib
           else
@@ -510,36 +1003,718 @@ jobs:
           fi
           echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
       - name: Generate SHA-256 checksum
-        if: github.event_name != 'workflow_dispatch'
         run: shasum -a 256 "$ARCHIVE" > "$ARCHIVE.sha256"
+      - name: Extract and smoke the consumer archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          shasum -a 256 -c "$ARCHIVE.sha256"
+          EXTRACT_DIR="$(mktemp -d "$RUNNER_TEMP/nestweaver-release-extract.XXXXXX")"
+          SMOKE_DIR="$(mktemp -d "$RUNNER_TEMP/nestweaver-release-smoke.XXXXXX")"
+          DEBUG_DIR=""
+          trap 'rm -rf "$EXTRACT_DIR" "$SMOKE_DIR" "${DEBUG_DIR:-}"' EXIT
+          tar xzf "$ARCHIVE" -C "$EXTRACT_DIR"
+          BIN="$EXTRACT_DIR/nestweaver"
+          test -x "$BIN"
+          "$BIN" --version
+
+          if NESTWEAVER_ALLOW_NO_DAEMON=1 NESTWEAVER_NO_DAEMON=1 \
+            "$BIN" index \
+              --repo "$GITHUB_WORKSPACE/crates/nestweaver-parser/tests" \
+              --name release-artifact-smoke \
+              --db "$SMOKE_DIR/smoke.lbug" \
+              --no-embed \
+              --with-trigrams \
+              --json; then
+            :
+          else
+            SMOKE_STATUS=$?
+            if [ "${{ runner.os }}" = "Linux" ]; then
+              DEBUG_DIR="$(mktemp -d "$RUNNER_TEMP/nestweaver-release-debug.XXXXXX")"
+              NESTWEAVER_ALLOW_NO_DAEMON=1 NESTWEAVER_NO_DAEMON=1 \
+                gdb --batch --quiet \
+                  -ex run \
+                  -ex 'thread apply all backtrace' \
+                  --args "$BIN" index \
+                    --repo "$GITHUB_WORKSPACE/crates/nestweaver-parser/tests" \
+                    --name release-artifact-debug \
+                    --db "$DEBUG_DIR/debug.lbug" \
+                    --no-embed \
+                    --with-trigrams \
+                    --json || true
+            fi
+            exit "$SMOKE_STATUS"
+          fi
+      - name: Exercise a failed target
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.fault_mode == 'fail' && inputs.fault_target == matrix.target }}
+        run: |
+          echo "::error::deliberately failing ${{ matrix.target }} before it can enter the publication bundle"
+          exit 1
       - name: Attest build provenance
-        if: github.event_name != 'workflow_dispatch'
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
         with:
           subject-path: ${{ env.ARCHIVE }}
-      - name: Upload release artifact
-        if: github.event_name != 'workflow_dispatch'
-        uses: softprops/action-gh-release@v3
+      - name: Stage verified target for the all-or-nothing gate
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.fault_mode != 'omit' || inputs.fault_target != matrix.target }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          tag_name: ${{ needs.release-please.outputs.tag_name }}
-          files: |
+          name: release-bundle-${{ matrix.target }}
+          path: |
             ${{ env.ARCHIVE }}
             ${{ env.ARCHIVE }}.sha256
+          if-no-files-found: error
+          retention-days: 7
 
-  publish-npm:
-    name: Publish npm wrapper
-    needs: [release-please, build]
-    if: ${{ needs.release-please.outputs.release_created }}
+  dry-run-baseline:
+    name: Capture dry-run visibility baseline
+    needs: release-context
+    if: ${{ needs.release-context.outputs.mode == 'dry-run' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      visibility: ${{ steps.observe.outputs.visibility }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.release-context.outputs.release_sha }}
+          persist-credentials: false
+      - name: Observe tag, release, and npm absence before the matrix
+        id: observe
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.release-context.outputs.tag_name }}
+          DRY_RUN_VERSION: ${{ needs.release-context.outputs.dry_run_version }}
+        run: |
+          set -euo pipefail
+          visibility="$(bash scripts/observe-release-visibility.sh \
+            "$GITHUB_REPOSITORY" "$RELEASE_TAG" nestweaver "$DRY_RUN_VERSION")"
+          jq -e '.all_absent == true' <<< "$visibility" >/dev/null
+          echo "visibility=$(jq -c . <<< "$visibility")" >> "$GITHUB_OUTPUT"
+
+  preflight-package:
+    name: Preflight release package
+    needs: [release-context, build]
+    if: ${{ always() && needs.release-context.outputs.active == 'true' && ((needs.release-context.outputs.mode == 'publish' && needs.build.result == 'success') || needs.release-context.outputs.mode == 'resume' || needs.release-context.outputs.mode == 'recover-npm') }}
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      actions: read
+      attestations: write
+      contents: read
+      id-token: write
+    outputs:
+      name: ${{ steps.package.outputs.name }}
+      version: ${{ steps.package.outputs.version }}
+      integrity: ${{ steps.package.outputs.integrity }}
+      filename: ${{ steps.package.outputs.filename }}
+      sha256: ${{ steps.package.outputs.sha256 }}
+      already_published: ${{ steps.registry.outputs.already_published }}
+    steps:
+      - name: Check out exact release candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.release-context.outputs.release_sha }}
+          persist-credentials: false
+      - name: Check out current release policy for recovery
+        if: ${{ needs.release-context.outputs.mode == 'resume' || needs.release-context.outputs.mode == 'recover-npm' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          path: .release-policy
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
+      - name: Recover exact package from the bound source run
+        if: ${{ needs.release-context.outputs.mode == 'resume' || needs.release-context.outputs.mode == 'recover-npm' }}
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: release-npm-package
+          path: ${{ runner.temp }}/npm-package
+          run-id: ${{ needs.release-context.outputs.source_run_id }}
+          github-token: ${{ github.token }}
+      - name: Verify Cargo, manifest, npm, tag, and package contents
+        id: package
+        env:
+          RELEASE_MODE: ${{ needs.release-context.outputs.mode }}
+          RELEASE_TAG: ${{ needs.release-context.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          policy_root="$GITHUB_WORKSPACE"
+          if [ "$RELEASE_MODE" = resume ] || [ "$RELEASE_MODE" = recover-npm ]; then
+            policy_root="$GITHUB_WORKSPACE/.release-policy"
+          fi
+          package_dir="$RUNNER_TEMP/npm-package"
+          mkdir -p "$package_dir"
+          if [ "$RELEASE_MODE" = publish ]; then
+            package="$(bash "$policy_root/scripts/verify-release-package.sh" \
+              "$GITHUB_WORKSPACE" "$RELEASE_TAG" "$package_dir")"
+            printf '%s\n' "$package" > "$package_dir/release-package.json"
+            package="$(bash "$policy_root/scripts/verify-release-package.sh" \
+              --verify-artifact "$GITHUB_WORKSPACE" "$RELEASE_TAG" "$package_dir")"
+          else
+            package="$(bash "$policy_root/scripts/verify-release-package.sh" \
+              --verify-artifact "$GITHUB_WORKSPACE" "$RELEASE_TAG" "$package_dir")"
+          fi
+          for field in name version integrity filename sha256; do
+            echo "$field=$(jq -er --arg field "$field" '.[$field]' <<< "$package")" \
+              >> "$GITHUB_OUTPUT"
+          done
+      - name: Attest the exact npm tarball
+        if: ${{ needs.release-context.outputs.mode == 'publish' }}
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
+        with:
+          subject-path: ${{ runner.temp }}/npm-package/${{ steps.package.outputs.filename }}
+      - name: Revalidate recovered package provenance
+        if: ${{ needs.release-context.outputs.mode == 'resume' || needs.release-context.outputs.mode == 'recover-npm' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACKAGE_FILENAME: ${{ steps.package.outputs.filename }}
+          RELEASE_SHA: ${{ needs.release-context.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+          gh attestation verify "$RUNNER_TEMP/npm-package/$PACKAGE_FILENAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release-please.yml" \
+            --source-digest "$RELEASE_SHA"
+      - name: Preserve the exact package for publication or recovery
+        if: ${{ needs.release-context.outputs.mode == 'publish' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-npm-package
+          path: ${{ runner.temp }}/npm-package
+          if-no-files-found: error
+          retention-days: 7
+      - name: Prove npm authorization and exact-version visibility
+        id: registry
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PACKAGE_INTEGRITY: ${{ steps.package.outputs.integrity }}
+          PACKAGE_NAME: ${{ steps.package.outputs.name }}
+          PACKAGE_VERSION: ${{ steps.package.outputs.version }}
+          RELEASE_SHA: ${{ needs.release-context.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::error::NPM_TOKEN is unavailable in the protected release environment" >&2
+            exit 1
+          fi
+          npm whoami --registry=https://registry.npmjs.org >/dev/null
+
+          set +e
+          npm view "$PACKAGE_NAME@$PACKAGE_VERSION" \
+            name version gitHead dist.integrity --json \
+            > registry-version.json 2> registry-error.txt
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            jq -e \
+              --arg name "$PACKAGE_NAME" \
+              --arg version "$PACKAGE_VERSION" \
+              --arg sha "$RELEASE_SHA" \
+              --arg integrity "$PACKAGE_INTEGRITY" \
+              '.name == $name and .version == $version and .gitHead == $sha and
+               .["dist.integrity"] == $integrity' registry-version.json >/dev/null
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+          elif grep -Eq 'E404|404 Not Found' registry-error.txt; then
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          else
+            cat registry-error.txt >&2
+            echo "::error::could not establish npm version visibility" >&2
+            exit 1
+          fi
+
+  publish-release:
+    name: Publish complete release
+    needs: [release-context, build, preflight-package]
+    if: ${{ always() && needs.preflight-package.result == 'success' && ((needs.release-context.outputs.mode == 'publish' && needs.build.result == 'success') || needs.release-context.outputs.mode == 'resume') }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      attestations: read
+      contents: write
+    steps:
+      - name: Check out exact release candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.release-context.outputs.release_sha }}
+          persist-credentials: false
+      - name: Check out current release policy for resume
+        if: ${{ needs.release-context.outputs.mode == 'resume' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          path: .release-policy
+          persist-credentials: false
+      - name: Require successful main CI on the exact release SHA
+        timeout-minutes: 90
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ needs.release-context.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+          DEADLINE=$((SECONDS + 5100))
+          while true; do
+            RUNS="$(gh api \
+              "repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs?head_sha=$RELEASE_SHA&event=push&per_page=20")"
+            RUN="$(jq -c --arg sha "$RELEASE_SHA" \
+              '[.workflow_runs[] | select(.head_sha == $sha and .event == "push")]
+               | sort_by(.id) | last // empty' <<< "$RUNS")"
+
+            if [ -n "$RUN" ]; then
+              RUN_ID="$(jq -r '.id' <<< "$RUN")"
+              RUN_STATUS="$(jq -r '.status' <<< "$RUN")"
+              RUN_CONCLUSION="$(jq -r '.conclusion // "pending"' <<< "$RUN")"
+              RUN_URL="$(jq -r '.html_url' <<< "$RUN")"
+              if [ "$RUN_STATUS" = completed ]; then
+                [ "$RUN_CONCLUSION" = success ] || {
+                  echo "::error::exact-SHA CI concluded $RUN_CONCLUSION: $RUN_URL" >&2
+                  exit 1
+                }
+                JOBS="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/jobs?per_page=100")"
+                jq -e --arg sha "$RELEASE_SHA" \
+                  'any(.jobs[]; .name == "Required CI" and .head_sha == $sha and
+                    .status == "completed" and .conclusion == "success")' \
+                  <<< "$JOBS" >/dev/null || {
+                    echo "::error::successful CI run $RUN_ID lacks exact-SHA Required CI" >&2
+                    exit 1
+                  }
+                echo "exact-SHA main CI passed: $RUN_URL"
+                break
+              fi
+              echo "exact-SHA CI is $RUN_STATUS; waiting: $RUN_URL"
+            else
+              echo "no main CI run is visible yet for $RELEASE_SHA; waiting"
+            fi
+            [ "$SECONDS" -lt "$DEADLINE" ] || {
+              echo "::error::timed out waiting for exact-SHA main CI" >&2
+              exit 1
+            }
+            sleep 15
+          done
+      - name: Download all four artifacts from the bound source run
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          pattern: release-bundle-*
+          path: release-bundle
+          merge-multiple: true
+          run-id: ${{ needs.release-context.outputs.source_run_id }}
+          github-token: ${{ github.token }}
+      - name: Verify complete checksum-bound bundle and attestations
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_MODE: ${{ needs.release-context.outputs.mode }}
+          RELEASE_TAG: ${{ needs.release-context.outputs.tag_name }}
+          RELEASE_SHA: ${{ needs.release-context.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          policy_root="$GITHUB_WORKSPACE"
+          if [ "$RELEASE_MODE" = resume ]; then
+            policy_root="$GITHUB_WORKSPACE/.release-policy"
+          fi
+          bash "$policy_root/scripts/verify-release-bundle.sh" \
+            release-bundle "$RELEASE_TAG"
+
+          for archive in release-bundle/*.tar.gz; do
+            verified=false
+            for attempt in 1 2 3 4 5; do
+              if gh attestation verify "$archive" \
+                --repo "$GITHUB_REPOSITORY" \
+                --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release-please.yml" \
+                --source-digest "$RELEASE_SHA"; then
+                verified=true
+                break
+              fi
+              echo "attestation not visible yet for $archive (attempt $attempt/5)"
+              sleep 10
+            done
+            [ "$verified" = true ] || {
+              echo "::error::no valid release-workflow attestation for $archive" >&2
+              exit 1
+            }
+          done
+      - name: Replace private assets by exact release id and verify remote digests
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.release-context.outputs.release_id }}
+          RELEASE_TAG: ${{ needs.release-context.outputs.tag_name }}
+          RELEASE_SHA: ${{ needs.release-context.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+          release="$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")"
+          jq -e --arg tag "$RELEASE_TAG" --arg sha "$RELEASE_SHA" \
+            '.draft == true and .tag_name == $tag and .target_commitish == $sha' \
+            <<< "$release" >/dev/null
+          upload_template="$(jq -er '.upload_url' <<< "$release")"
+          expected_template="https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets{?name,label}"
+          [ "$upload_template" = "$expected_template" ] || {
+            echo "::error::release upload URL is not bound to exact release id $RELEASE_ID" >&2
+            exit 1
+          }
+          upload_base="${upload_template%%\{*}"
+
+          set +e
+          gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" \
+            >/dev/null 2> tag-error.txt
+          tag_status=$?
+          set -e
+          if [ "$tag_status" -eq 0 ] || ! grep -q 'HTTP 404' tag-error.txt; then
+            echo "::error::could not prove that $RELEASE_TAG remains absent" >&2
+            exit 1
+          fi
+
+          existing_assets="$(gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets?per_page=100")"
+          jq -r '.[][] | .id' <<< "$existing_assets" | while read -r asset_id; do
+              [ -z "$asset_id" ] || gh api --method DELETE \
+                "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id" --silent
+            done
+
+          for file in release-bundle/*; do
+            name="${file##*/}"
+            encoded_name="$(jq -rn --arg value "$name" '$value | @uri')"
+            local_size="$(stat -c '%s' "$file")"
+            local_digest="sha256:$(sha256sum "$file" | awk '{print $1}')"
+            uploaded="$(curl --fail-with-body --silent --show-error --location \
+              --request POST \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H 'Content-Type: application/octet-stream' \
+              "$upload_base?name=$encoded_name" \
+              --data-binary "@$file")"
+            jq -e \
+              --arg name "$name" \
+              --argjson size "$local_size" \
+              --arg digest "$local_digest" \
+              '.name == $name and .state == "uploaded" and
+               .size == $size and .digest == $digest' <<< "$uploaded" >/dev/null
+          done
+
+          find release-bundle -maxdepth 1 -type f -printf '%f\n' | sort > expected-assets.txt
+          assets="$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets?per_page=100")"
+          jq -r '.[].name' <<< "$assets" | sort > remote-assets.txt
+          diff -u expected-assets.txt remote-assets.txt
+
+          for file in release-bundle/*; do
+            name="${file##*/}"
+            local_size="$(stat -c '%s' "$file")"
+            local_digest="sha256:$(sha256sum "$file" | awk '{print $1}')"
+            asset_id="$(jq -er --arg name "$name" \
+              '[.[] | select(.name == $name)] |
+               if length == 1 then .[0].id else error("asset name is not unique") end' \
+              <<< "$assets")"
+            [[ "$asset_id" =~ ^[0-9]+$ ]]
+            jq -e \
+              --arg name "$name" \
+              --argjson size "$local_size" \
+              --arg digest "$local_digest" \
+              'any(.[]; .name == $name and .state == "uploaded" and
+                .size == $size and .digest == $digest)' <<< "$assets" >/dev/null
+
+            remote_file="$RUNNER_TEMP/release-asset-$asset_id"
+            curl --fail-with-body --silent --show-error --location \
+              --retry 3 --retry-all-errors \
+              -H 'Accept: application/octet-stream' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              --output "$remote_file" \
+              "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/assets/$asset_id"
+            cmp --silent "$file" "$remote_file" || {
+              echo "::error::remote bytes differ for exact asset id $asset_id ($name)" >&2
+              exit 1
+            }
+            [ "$(stat -c '%s' "$remote_file")" = "$local_size" ]
+            [ "sha256:$(sha256sum "$remote_file" | awk '{print $1}')" = "$local_digest" ]
+            rm -f -- "$remote_file"
+          done
+      - name: Publish the complete draft and create its exact-SHA tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.release-context.outputs.release_id }}
+          RELEASE_TAG: ${{ needs.release-context.outputs.tag_name }}
+          RELEASE_SHA: ${{ needs.release-context.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+          published="$(gh api --method PATCH \
+            "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" -F draft=false)"
+          for attempt in 1 2 3 4 5 6; do
+            published="$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")"
+            if jq -e --arg tag "$RELEASE_TAG" --arg sha "$RELEASE_SHA" '
+              .draft == false and .immutable == true and
+              .tag_name == $tag and .target_commitish == $sha
+            ' <<< "$published" >/dev/null; then
+              break
+            fi
+            if [ "$attempt" -eq 6 ]; then
+              echo "::error::published release did not become immutable; npm publication is forbidden" >&2
+              jq '{id, draft, immutable, tag_name, target_commitish}' <<< "$published" >&2
+              exit 1
+            fi
+            sleep 5
+          done
+
+          tag_object="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG")"
+          tag_type="$(jq -r '.object.type' <<< "$tag_object")"
+          tag_sha="$(jq -r '.object.sha' <<< "$tag_object")"
+          if [ "$tag_type" = tag ]; then
+            tag_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$tag_sha" --jq '.object.sha')"
+          fi
+          [ "$tag_sha" = "$RELEASE_SHA" ] || {
+            echo "::error::published tag $RELEASE_TAG points to $tag_sha, expected $RELEASE_SHA" >&2
+            exit 1
+          }
+
+  verify-dry-run:
+    name: Verify release dry run
+    needs: [release-context, dry-run-baseline, build]
+    if: ${{ always() && needs.release-context.outputs.mode == 'dry-run' && needs.dry-run-baseline.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: read
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out dry-run candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.release-context.outputs.release_sha }}
+          persist-credentials: false
+      - name: Download staged targets
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          pattern: release-bundle-*
+          path: release-bundle
+          merge-multiple: true
+      - name: Prove matrix rejection, external visibility, and automation PR enforcement
+        env:
+          BASELINE_VISIBILITY: ${{ needs.dry-run-baseline.outputs.visibility }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          CANDIDATE_SHA: ${{ needs.release-context.outputs.release_sha }}
+          DRY_RUN_VERSION: ${{ needs.release-context.outputs.dry_run_version }}
+          FAULT_MODE: ${{ inputs.fault_mode }}
+          FAULT_TARGET: ${{ inputs.fault_target }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.release-context.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$CANDIDATE_SHA"
+          test "$CANDIDATE_SHA" = "${{ github.sha }}"
+
+          set +e
+          bash scripts/verify-release-bundle.sh release-bundle "$RELEASE_TAG"
+          VERIFY_STATUS=$?
+          set -e
+
+          case "$FAULT_MODE" in
+            none)
+              test "$BUILD_RESULT" = success
+              test "$VERIFY_STATUS" -eq 0
+              ;;
+            fail)
+              test "$BUILD_RESULT" = failure
+              test "$VERIFY_STATUS" -ne 0
+              ;;
+            omit)
+              test "$BUILD_RESULT" = success
+              test "$VERIFY_STATUS" -ne 0
+              ;;
+            *)
+              echo "::error::unknown fault mode: $FAULT_MODE" >&2
+              exit 1
+              ;;
+          esac
+
+          final_visibility="$(bash scripts/observe-release-visibility.sh \
+            "$GITHUB_REPOSITORY" "$RELEASE_TAG" nestweaver "$DRY_RUN_VERSION")"
+          jq -e '.all_absent == true' <<< "$BASELINE_VISIBILITY" >/dev/null
+          jq -e '.all_absent == true' <<< "$final_visibility" >/dev/null
+
+          canary="$(bash scripts/verify-release-canary-pr.sh \
+            "$GITHUB_REPOSITORY" "$CANDIDATE_SHA")"
+
+          jq -n \
+            --arg candidate_sha "$CANDIDATE_SHA" \
+            --arg tag "$RELEASE_TAG" \
+            --arg fault_mode "$FAULT_MODE" \
+            --arg fault_target "$FAULT_TARGET" \
+            --arg build_result "$BUILD_RESULT" \
+            --argjson verifier_status "$VERIFY_STATUS" \
+            --argjson before "$BASELINE_VISIBILITY" \
+            --argjson after "$final_visibility" \
+            --argjson canary "$canary" \
+            '{candidate_sha: $candidate_sha, tag: $tag, fault_mode: $fault_mode,
+              fault_target: $fault_target, build_result: $build_result,
+              bundle_verifier_status: $verifier_status, visibility_before: $before,
+              visibility_after: $after, automation_pr: $canary}' \
+            > release-gate-evidence.json
+          cat release-gate-evidence.json >> "$GITHUB_STEP_SUMMARY"
+      - name: Preserve dry-run evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-gate-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          path: release-gate-evidence.json
+          if-no-files-found: error
+          retention-days: 30
+
+  cleanup-canary:
+    name: Clean release-gate canary
+    needs: [release-context, verify-dry-run]
+    if: ${{ always() && needs.release-context.outputs.mode == 'dry-run' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Close canary PR and delete its exact branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          branch="release-gate-canary-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          gh pr list --repo "$GITHUB_REPOSITORY" --state open --head "$branch" \
+            --json number --jq '.[].number' | while read -r pr_number; do
+              [ -z "$pr_number" ] || gh pr close "$pr_number" \
+                --repo "$GITHUB_REPOSITORY"
+            done
+
+          set +e
+          gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$branch" \
+            >/dev/null 2> ref-error.txt
+          ref_status=$?
+          set -e
+          if [ "$ref_status" -eq 0 ]; then
+            gh api --method DELETE \
+              "repos/$GITHUB_REPOSITORY/git/refs/heads/$branch" --silent
+          elif ! grep -q 'HTTP 404' ref-error.txt; then
+            cat ref-error.txt >&2
+            echo "::error::could not establish canary branch state" >&2
+            exit 1
+          fi
+
+          test "$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+            --head "$branch" --json number --jq 'length')" -eq 0
+          set +e
+          gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$branch" \
+            >/dev/null 2> final-ref-error.txt
+          final_status=$?
+          set -e
+          if [ "$final_status" -eq 0 ] || ! grep -q 'HTTP 404' final-ref-error.txt; then
+            echo "::error::canary branch cleanup was not proven" >&2
+            cat final-ref-error.txt >&2
+            exit 1
+          fi
+
+  publish-npm:
+    name: Publish npm wrapper
+    needs: [release-context, preflight-package, publish-release]
+    if: ${{ always() && needs.preflight-package.result == 'success' && (((needs.release-context.outputs.mode == 'publish' || needs.release-context.outputs.mode == 'resume') && needs.publish-release.result == 'success') || needs.release-context.outputs.mode == 'recover-npm') }}
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      actions: read
+      attestations: read
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.release-context.outputs.release_sha }}
+          persist-credentials: false
+      - name: Check out current release policy for recovery
+        if: ${{ needs.release-context.outputs.mode == 'resume' || needs.release-context.outputs.mode == 'recover-npm' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          path: .release-policy
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      - name: Download the exact attested npm package
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: release-npm-package
+          path: ${{ runner.temp }}/npm-package
+          run-id: ${{ needs.release-context.outputs.source_run_id }}
+          github-token: ${{ github.token }}
+      - name: Revalidate public remote bytes, checksums, and provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.release-context.outputs.release_id }}
+          RELEASE_MODE: ${{ needs.release-context.outputs.mode }}
+          RELEASE_SHA: ${{ needs.release-context.outputs.release_sha }}
+          RELEASE_TAG: ${{ needs.release-context.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          release="$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")"
+          jq -e --arg tag "$RELEASE_TAG" --arg sha "$RELEASE_SHA" \
+            '.draft == false and .immutable == true and .tag_name == $tag and .target_commitish == $sha' \
+            <<< "$release" >/dev/null
+
+          tag_object="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG")"
+          tag_type="$(jq -er '.object.type' <<< "$tag_object")"
+          tag_sha="$(jq -er '.object.sha' <<< "$tag_object")"
+          if [ "$tag_type" = tag ]; then
+            tag_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$tag_sha" --jq '.object.sha')"
+          fi
+          [ "$tag_sha" = "$RELEASE_SHA" ]
+
+          mkdir release-bundle
+          assets="$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets?per_page=100")"
+          expected_assets="$(mktemp)"
+          actual_assets="$(mktemp)"
+          for target in \
+            aarch64-apple-darwin aarch64-unknown-linux-gnu \
+            x86_64-apple-darwin x86_64-unknown-linux-gnu; do
+            archive="nestweaver-${RELEASE_TAG}-${target}.tar.gz"
+            printf '%s\n%s\n' "$archive" "$archive.sha256" >> "$expected_assets"
+          done
+          sort -o "$expected_assets" "$expected_assets"
+          jq -r '.[].name' <<< "$assets" | sort > "$actual_assets"
+          diff -u "$expected_assets" "$actual_assets"
+          rm -f -- "$expected_assets" "$actual_assets"
+
+          jq -r '.[] | [.id, .name, .size, .digest] | @tsv' <<< "$assets" |
+            while IFS=$'\t' read -r asset_id name expected_size expected_digest; do
+              [[ "$asset_id" =~ ^[0-9]+$ ]]
+              [[ "$expected_size" =~ ^[0-9]+$ ]]
+              [[ "$expected_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+              remote_file="release-bundle/$name"
+              curl --fail-with-body --silent --show-error --location \
+                --retry 3 --retry-all-errors \
+                -H 'Accept: application/octet-stream' \
+                -H 'X-GitHub-Api-Version: 2022-11-28' \
+                -H "Authorization: Bearer $GH_TOKEN" \
+                --output "$remote_file" \
+                "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/assets/$asset_id"
+              [ "$(stat -c '%s' "$remote_file")" = "$expected_size" ]
+              actual_digest="sha256:$(sha256sum "$remote_file" | awk '{print $1}')"
+              [ "$actual_digest" = "$expected_digest" ]
+            done
+
+          policy_root="$GITHUB_WORKSPACE"
+          if [ "$RELEASE_MODE" = resume ] || [ "$RELEASE_MODE" = recover-npm ]; then
+            policy_root="$GITHUB_WORKSPACE/.release-policy"
+          fi
+          bash "$policy_root/scripts/verify-release-bundle.sh" \
+            release-bundle "$RELEASE_TAG"
+          for archive in release-bundle/*.tar.gz; do
+            gh attestation verify "$archive" \
+              --repo "$GITHUB_REPOSITORY" \
+              --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release-please.yml" \
+              --source-digest "$RELEASE_SHA"
+          done
       # The wrapper's postinstall downloads the matching release binary, so it
-      # must publish only after the `build` job has uploaded the assets for
-      # this tag.
+      # must publish only after the complete draft has become public and its
+      # exact-SHA tag and eight-asset inventory have been verified.
       #
       # This step FAILS rather than skips when the token is absent. It used to
       # exit 0 with a "skipping" message so releases stayed green before the
@@ -549,30 +1724,65 @@ jobs:
       # (nw-115). A release job that cannot publish must say so.
       - name: Publish to npm
         working-directory: npm
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PACKAGE_INTEGRITY: ${{ needs.preflight-package.outputs.integrity }}
+          PACKAGE_FILENAME: ${{ needs.preflight-package.outputs.filename }}
+          PACKAGE_NAME: ${{ needs.preflight-package.outputs.name }}
+          PACKAGE_SHA256: ${{ needs.preflight-package.outputs.sha256 }}
+          PACKAGE_VERSION: ${{ needs.preflight-package.outputs.version }}
+          RELEASE_ID: ${{ needs.release-context.outputs.release_id }}
+          RELEASE_SHA: ${{ needs.release-context.outputs.release_sha }}
+          RELEASE_TAG: ${{ needs.release-context.outputs.tag_name }}
         run: |
           set -euo pipefail
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
-            echo "::error::NPM_TOKEN is not set, so the npm wrapper cannot be published." >&2
-            echo "Add the NPM_TOKEN repository secret. A release must not report" >&2
-            echo "success while silently dropping a distribution channel (nw-115)." >&2
-            exit 1
+          release="$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")"
+          jq -e --arg tag "$RELEASE_TAG" --arg sha "$RELEASE_SHA" \
+            '.draft == false and .immutable == true and .tag_name == $tag and .target_commitish == $sha' \
+            <<< "$release" >/dev/null
+
+          [[ "$PACKAGE_FILENAME" =~ ^nestweaver-[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?\.tgz$ ]]
+          package_tarball="$RUNNER_TEMP/npm-package/$PACKAGE_FILENAME"
+          test -f "$package_tarball"
+          test -f "$package_tarball.sha256"
+          (cd "$RUNNER_TEMP/npm-package" && sha256sum -c "$PACKAGE_FILENAME.sha256")
+          actual_sha256="$(sha256sum "$package_tarball" | awk '{print $1}')"
+          [ "$actual_sha256" = "$PACKAGE_SHA256" ]
+          gh attestation verify "$package_tarball" \
+            --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release-please.yml" \
+            --source-digest "$RELEASE_SHA"
+
+          verify_registry() {
+            local metadata
+            metadata="$(npm view "$PACKAGE_NAME@$PACKAGE_VERSION" \
+              name version gitHead dist.integrity --json 2>/dev/null)" || return 1
+            jq -e \
+              --arg name "$PACKAGE_NAME" \
+              --arg version "$PACKAGE_VERSION" \
+              --arg sha "$RELEASE_SHA" \
+              --arg integrity "$PACKAGE_INTEGRITY" \
+              '.name == $name and .version == $version and .gitHead == $sha and
+               .["dist.integrity"] == $integrity' <<< "$metadata" >/dev/null
+          }
+
+          if verify_registry; then
+            echo "Verified existing immutable $PACKAGE_NAME@$PACKAGE_VERSION; nothing to republish."
+            exit 0
           fi
-          NAME=$(node -p "require('./package.json').name")
-          VERSION=$(node -p "require('./package.json').version")
-          npm publish --access public
-          # Read it back. `npm publish` exiting 0 is a claim, not evidence: a
-          # publish that is not resolvable from the registry did not happen, and
-          # trusting the exit code is the exact failure this step is here to
-          # stop. Retry only for registry propagation lag.
-          for attempt in 1 2 3 4 5; do
-            if [ "$(npm view "$NAME@$VERSION" version 2>/dev/null || true)" = "$VERSION" ]; then
-              echo "Verified $NAME@$VERSION is resolvable from the registry."
+
+          set +e
+          npm publish "$package_tarball" --ignore-scripts --access public
+          publish_status=$?
+          set -e
+          for attempt in 1 2 3 4 5 6; do
+            if verify_registry; then
+              echo "Verified exact $PACKAGE_NAME@$PACKAGE_VERSION from $RELEASE_SHA."
               exit 0
             fi
-            echo "Registry has not caught up (attempt $attempt/5); retrying in 10s."
+            echo "Registry has not caught up (attempt $attempt/6); retrying in 10s."
             sleep 10
           done
-          echo "::error::npm publish exited 0 but $NAME@$VERSION is not resolvable." >&2
+          echo "::error::npm publish status $publish_status did not produce the exact expected immutable package." >&2
           exit 1
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,117 @@ One consequence worth expecting either way: switching a working tree between
 `-p` and `--workspace` re-resolves features, which re-fingerprints the build and
 forces a full `lbug` C++ rebuild. Pick one shape per tree and stay with it.
 
+## Release gate
+
+Release Please intentionally uses the workflow's `GITHUB_TOKEN`. GitHub may
+suppress the resulting `pull_request` event entirely or hold its workflow in
+`action_required` with zero jobs. This repository uses that as an explicit gate
+rather than adding another long-lived credential. After the release workflow
+has finished synchronizing the lockfile and marked the PR ready, a maintainer
+must approve a held CI run or explicitly dispatch `CI` from the release PR's
+latest branch. For example, after checking the current PR head:
+
+```sh
+PR=123
+HEAD_REF=$(gh pr view "$PR" --json headRefName --jq .headRefName)
+HEAD_SHA=$(gh pr view "$PR" --json headRefOid --jq .headRefOid)
+gh workflow run ci.yml --ref "$HEAD_REF"
+# Before merge, require the successful Required CI check to report HEAD_SHA.
+printf 'expected release PR head: %s\n' "$HEAD_SHA"
+```
+
+Do not approve, dispatch, or merge against an earlier head; another automation
+commit dismisses approval and makes that CI evidence stale.
+
+Protect `main` with a ruleset that requires pull requests, a CODEOWNER approval,
+and the **Required CI** check from the GitHub Actions app. Require the branch to
+be up to date, dismiss approvals after every push, and give neither admins nor
+the release automation actor a bypass. Conditional jobs such as Rustfmt and
+Cold Metal must not be named individually in the ruleset: `Required CI` fails
+closed when any applicable non-advisory job is failed, cancelled, missing, or
+unexpectedly skipped. A workflow held in `action_required`, a workflow that
+creates zero jobs, and an invalid workflow all leave `Required CI` absent, so
+the ruleset must treat the missing check as blocking. If repository Actions
+policy still holds the trusted automation actor for approval, approve that run
+explicitly; never merge around the absent check.
+
+Also protect `v*` tags from update and deletion, and restrict creation to the
+release automation identity. Require full-SHA action pins in repository Actions
+settings. Create a protected `release` environment, allow only `main`, require a
+maintainer reviewer, and expose `NPM_TOKEN` only there. These repository rules,
+environment protections, and Actions approval settings live in GitHub; the
+workflow file cannot install them by itself. The dry-run canary refuses to pass
+unless the applied branch rules include PR review, CODEOWNER review, strict
+up-to-date checks, and the `Required CI` check from a specific GitHub App.
+
+The public release is intentionally last. Release Please first creates a
+private draft without a tag. The workflow then checks out the exact release
+SHA, waits for that SHA's successful `CI` push run and `Required CI` job, builds
+all four targets, checksums each archive, extracts and smoke-tests the consumer
+layout, creates provenance attestations, and validates the exact eight-file
+bundle. Before publication, a protected-environment job proves Cargo, manifest,
+npm, and tag versions agree, validates the exact npm tarball contents and
+integrity, authenticates to npm, and observes whether the immutable version is
+already present. The publication job then replaces assets through the validated
+release ID, compares every remote size and SHA-256 digest, and downloads each
+exact asset ID for a byte-for-byte check against the verified local files. Only
+then does it publish the draft and create the tag. npm publication is idempotent
+and depends on that completed transition; immediately before npm publication it
+downloads the public assets again and rechecks the four checksum pairs and
+provenance. A failed or absent target leaves only a private draft and cannot
+publish npm.
+
+Run the lightweight local policy checks with:
+
+```sh
+bash scripts/verify-required-ci.sh --self-test
+bash scripts/verify-release-bundle.sh --self-test
+bash scripts/verify-release-package.sh --self-test
+bash -n scripts/observe-release-visibility.sh scripts/verify-release-canary-pr.sh
+```
+
+The release workflow also has positive and negative controls. They build and
+attest artifacts but never call Release Please, create a tag/release, or publish
+npm. Each run creates a temporary automation-authored canary branch and PR,
+observes that the real ruleset blocks it while `Required CI` is absent or held
+in `action_required`, then closes the PR and deletes the branch. It also queries
+GitHub tags, public/private releases, and the exact synthetic npm version before
+and after the matrix; the evidence is observed state, not a skipped-job claim:
+
+```sh
+SHA=$(git rev-parse origin/main)
+gh workflow run release-please.yml --ref main -f operation=dry-run -f candidate_sha="$SHA" -f fault_mode=none
+gh workflow run release-please.yml --ref main -f operation=dry-run -f candidate_sha="$SHA" -f fault_mode=fail -f fault_target=x86_64-unknown-linux-gnu
+gh workflow run release-please.yml --ref main -f operation=dry-run -f candidate_sha="$SHA" -f fault_mode=omit -f fault_target=aarch64-apple-darwin
+```
+
+Preserve the `release-gate-evidence-*` artifact from each run. The `none` run
+must validate all eight files. The `fail` and `omit` runs must show that an
+incomplete matrix is rejected while the exact synthetic tag, release, and npm
+version remain absent. The evidence must also contain the canary PR's blocked
+merge state and absent/`action_required` workflow observation.
+
+A private draft can be resumed only from the completed release workflow run
+whose artifacts and attestations belong to the same exact SHA. Resume deletes
+and deterministically replaces only that release ID's private assets. If that
+source run is incomplete, delete only the explicitly bound private draft and
+then repair/re-run Release Please; cleanup refuses a public release or visible
+tag. If GitHub publication succeeded but npm did not, the npm-only recovery
+revalidates the public release, exact tag/SHA, eight remote digests, package
+contents, and registry identity before publishing or accepting an already
+identical immutable version:
+
+```sh
+gh workflow run release-please.yml --ref main -f operation=resume \
+  -f candidate_sha="$SHA" -f release_id="$RELEASE_ID" \
+  -f release_tag="$TAG" -f source_run_id="$SOURCE_RUN_ID"
+gh workflow run release-please.yml --ref main -f operation=cleanup-draft \
+  -f candidate_sha="$SHA" -f release_id="$RELEASE_ID" -f release_tag="$TAG"
+gh workflow run release-please.yml --ref main -f operation=recover-npm \
+  -f candidate_sha="$SHA" -f release_id="$RELEASE_ID" \
+  -f release_tag="$TAG" -f source_run_id="$SOURCE_RUN_ID"
+```
+
 ### Code conventions
 
 - `thiserror` for all public error types in library crates

--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -44,6 +44,17 @@ pub struct DaemonClient {
     inner: NestWeaverDaemonClient<Channel>,
 }
 
+fn require_embedding_identity_repair_capability(
+    health: &nestweaver_proto::HealthCheckResponse,
+) -> Result<()> {
+    anyhow::ensure!(
+        health.embedding_identity_repair,
+        "the running daemon does not advertise embedding identity repair; restart it with \
+         `nestweaver daemon --db <path> restart` before retrying --repair-identity"
+    );
+    Ok(())
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RestartConfig {
     Configured(PathBuf),
@@ -1479,6 +1490,7 @@ impl DaemonClient {
                 scope: scope.to_string(),
                 force,
                 batch_size: 0,
+                repair_identity: false,
             })
             .await
             .context("plan_embed RPC failed")?;
@@ -1486,18 +1498,42 @@ impl DaemonClient {
     }
 
     /// Run bulk embedding on the daemon using its configured embedding backend.
+    ///
+    /// This preserves the established source-compatible API. Identity repair
+    /// uses a separate method because it requires explicit capability
+    /// negotiation before the mutating RPC is sent.
     pub async fn embed(
         &mut self,
         scope: &str,
         force: bool,
         batch_size: u32,
     ) -> Result<nestweaver_proto::EmbedResponse> {
+        self.embed_with_identity_repair(scope, force, batch_size, false)
+            .await
+    }
+
+    /// Run bulk embedding with optional unreadable-identity repair.
+    pub async fn embed_with_identity_repair(
+        &mut self,
+        scope: &str,
+        force: bool,
+        batch_size: u32,
+        repair_identity: bool,
+    ) -> Result<nestweaver_proto::EmbedResponse> {
+        if repair_identity {
+            let health = self
+                .health_check()
+                .await
+                .context("negotiate daemon embedding repair capability")?;
+            require_embedding_identity_repair_capability(&health)?;
+        }
         let resp = self
             .inner
             .embed(nestweaver_proto::EmbedRequest {
                 scope: scope.to_string(),
                 force,
                 batch_size,
+                repair_identity,
             })
             .await
             .context("embed RPC failed")?;
@@ -1564,6 +1600,22 @@ mod status_rendering_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn repair_capability_is_required_before_the_mutating_rpc() {
+        let mut legacy = nestweaver_proto::HealthCheckResponse::default();
+        let error = require_embedding_identity_repair_capability(&legacy)
+            .expect_err("an older daemon's default-false field must fail closed");
+        assert!(
+            error
+                .to_string()
+                .contains("does not advertise embedding identity repair")
+        );
+
+        legacy.embedding_identity_repair = true;
+        require_embedding_identity_repair_capability(&legacy)
+            .expect("a current daemon advertises repair explicitly");
+    }
 
     fn valid_config(dir: &tempfile::TempDir, name: &str) -> PathBuf {
         let path = dir.path().join(name);

--- a/crates/nestweaver-daemon/src/lifecycle.rs
+++ b/crates/nestweaver-daemon/src/lifecycle.rs
@@ -447,71 +447,7 @@ impl std::error::Error for EffectiveConfigBindingError {
 /// directory and append the original filename. This keeps socket IDs stable for
 /// paths such as macOS `/tmp/...` and `/private/tmp/...`.
 pub fn canonical_db_path(db_path: &Path) -> PathBuf {
-    if let Ok(canonical) = std::fs::canonicalize(db_path) {
-        return canonical;
-    }
-
-    if let (Some(parent), Some(file_name)) = (db_path.parent(), db_path.file_name())
-        && let Ok(canonical_parent) = std::fs::canonicalize(parent)
-    {
-        return canonical_parent.join(file_name);
-    }
-
-    // A relative path whose parent does not resolve — most importantly a BARE
-    // `nestweaver.lbug`, where `parent()` is `Some("")` and also fails to
-    // canonicalize — used to be returned unchanged, hashing to a DIFFERENT
-    // instance id than the same database gets once the file exists:
-    //
-    //   before creation: canonicalize fails -> id = hash("nestweaver.lbug")
-    //   after creation:  canonicalize wins  -> id = hash("/cwd/nestweaver.lbug")
-    //
-    // So the first `daemon start` in a fresh directory bound one identity, and
-    // every command after the database existed looked for another — leaving a
-    // daemon holding the write lock that the CLI could no longer address by
-    // name. Joining the cwd makes the pre-creation answer agree with the
-    // post-creation one, which is what `database_path_fingerprint` already did
-    // for the same reason; this function simply never got the same treatment.
-    //
-    // The join is LEXICALLY NORMALIZED. `cwd.join("sub/../nw.lbug")` yields
-    // `/cwd/sub/../nw.lbug`, which hashes differently from the `/cwd/nw.lbug`
-    // that `canonicalize` returns once the file exists — the same fork, one
-    // path shape further out.
-    if db_path.is_relative()
-        && let Ok(cwd) = std::env::current_dir()
-    {
-        return lexically_normalize(&cwd.join(db_path));
-    }
-
-    db_path.to_path_buf()
-}
-
-/// Collapse `.` and `..` without touching the filesystem.
-///
-/// `Path::join` is purely textual, so a relative `--db` containing `..` would
-/// otherwise produce a path that never equals the canonicalized form.
-/// Deliberately lexical: the point is to agree with `canonicalize` for paths
-/// that do not exist YET, so it cannot resolve symlinks — and on the platforms
-/// this runs on, a `..` crossing a symlinked directory is the only case where
-/// the two disagree, which no `--db` argument in practice exercises.
-fn lexically_normalize(path: &Path) -> PathBuf {
-    let mut out = PathBuf::new();
-    for component in path.components() {
-        match component {
-            std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => {
-                // Never pop past the root; `/..` is `/`.
-                if out
-                    .components()
-                    .next_back()
-                    .is_some_and(|c| matches!(c, std::path::Component::Normal(_)))
-                {
-                    out.pop();
-                }
-            }
-            other => out.push(other.as_os_str()),
-        }
-    }
-    out
+    nestweaver_store::canonical_db_path(db_path)
 }
 
 /// Reproduce the PRE-nw-208 canonicalization exactly.
@@ -1016,101 +952,18 @@ pub fn checkpoint_artifacts(db_path: &Path) -> CheckpointArtifacts {
     CheckpointArtifacts::Debris { artifacts }
 }
 
-/// Path of the dedicated write-lease file for a database.
+/// Canonical writer and destructive-namespace authority primitives.
 ///
-/// A SEPARATE file, deliberately. The obvious choice — lock the database file
-/// itself — is unsafe with POSIX record locks, and `db_write_lock` above
-/// documents why: `fcntl` locks are held per PROCESS, so closing ANY
-/// descriptor to that file drops every lock this process holds on it. A lease
-/// taken on the database would be destroyed by the store's own routine
-/// open/close, silently admitting a second writer. Nothing but the lease
-/// opens this file, so nothing can drop it by accident.
-pub fn write_lease_path(db_path: &Path) -> PathBuf {
-    let canonical = canonical_db_path(db_path);
-    let mut name = canonical.as_os_str().to_owned();
-    name.push(".write.lock");
-    PathBuf::from(name)
-}
-
-/// An exclusive claim on a database's write access, held for as long as the
-/// value lives and released by the kernel when the process exits.
-///
-/// `flock`, not `fcntl`: `flock` is per-DESCRIPTOR, so it survives unrelated
-/// opens and closes of the database, and the kernel drops it on exit with no
-/// stale state to reap. That is the property a pidfile does not have and the
-/// reason this can be trusted where a probe cannot.
-///
-/// A probe answers "was anyone holding this a moment ago". Only a held lease
-/// answers "is anyone holding this for as long as I am writing", which is the
-/// question a check-then-write cannot ask. Every comparable embedded store —
-/// SQLite, RocksDB, LMDB, DuckDB, Kuzu — holds a lock for the lifetime of the
-/// handle for exactly this reason.
-// nw-274: `#[must_use]` on the TYPE, not only on the helper that returns it.
-//
-// The single `#[must_use]` guarding this lived on `require_exclusive_store_access`
-// in `main.rs`, and an unrelated function inserted above it silently detached
-// the attribute — the fifth docblock detachment this release. A per-function
-// attribute protects one function and can be separated from it by an edit
-// elsewhere; on the type it covers every present and future producer, and
-// nothing can come between them.
-#[must_use = "the lease must be HELD for the duration of the write; dropping it \
-              immediately reduces this to a probe, which is the check-then-act \
-              race it exists to remove"]
-#[derive(Debug)]
-pub struct DbWriteLease {
-    _file: std::fs::File,
-    path: PathBuf,
-}
-
-impl DbWriteLease {
-    /// The lease file this claim is held on.
-    pub fn path(&self) -> &Path {
-        &self.path
-    }
-}
-
-/// Why a write lease could not be taken.
-#[derive(Debug)]
-pub enum WriteLeaseError {
-    /// Someone else holds it. They are writing right now.
-    Held,
-    /// The lease file itself could not be created or locked.
-    Unavailable(std::io::Error),
-}
-
-/// Take an exclusive, non-blocking write lease on `db_path`.
-///
-/// Non-blocking on purpose: a caller that would block has a live writer to
-/// report, and telling the operator who holds the database is more useful than
-/// hanging. Callers that genuinely want to wait can retry.
-pub fn acquire_db_write_lease(db_path: &Path) -> Result<DbWriteLease, WriteLeaseError> {
-    use std::os::unix::io::AsRawFd;
-
-    let path = write_lease_path(db_path);
-    if let Some(parent) = path.parent()
-        && !parent.exists()
-    {
-        std::fs::create_dir_all(parent).map_err(WriteLeaseError::Unavailable)?;
-    }
-    let file = std::fs::OpenOptions::new()
-        .create(true)
-        .read(true)
-        .write(true)
-        .truncate(false)
-        .open(&path)
-        .map_err(WriteLeaseError::Unavailable)?;
-
-    // LOCK_NB so a contended lease fails immediately instead of hanging.
-    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
-        let error = std::io::Error::last_os_error();
-        return match error.kind() {
-            std::io::ErrorKind::WouldBlock => Err(WriteLeaseError::Held),
-            _ => Err(WriteLeaseError::Unavailable(error)),
-        };
-    }
-    Ok(DbWriteLease { _file: file, path })
-}
-
+/// The writer lease deliberately holds three compatible claims for its full
+/// lifetime: lbug's POSIX database-lock class (to exclude older writers), a
+/// descriptor-scoped database flock (to exclude duplicate same-process
+/// authorities), and the stable sidecar flock (to survive database cutover).
+/// It is acquired before the store and dropped after the store, so routine
+/// store descriptors cannot shorten the authority lifetime.
+pub use nestweaver_store::{
+    DbNamespaceLease, DbWriteLease, WriteLeaseError, acquire_db_namespace_lease,
+    acquire_db_write_lease, acquire_db_write_lease_under_namespace, write_lease_path,
+};
 /// PID of the process on the other end of a connected unix socket, as
 /// reported by the kernel. Unlike the pidfile (whose contents can be
 /// overwritten while the daemon still holds its flock), this cannot be faked

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -214,6 +214,24 @@ struct ConnectionGuard {
     counter: Arc<AtomicU32>,
 }
 
+fn try_admit_write_with<F>(
+    active_writes: &AtomicU32,
+    shutdown_started: &AtomicBool,
+    after_increment: F,
+) -> bool
+where
+    F: FnOnce(),
+{
+    active_writes.fetch_add(1, Ordering::SeqCst);
+    after_increment();
+    if shutdown_started.load(Ordering::SeqCst) {
+        active_writes.fetch_sub(1, Ordering::SeqCst);
+        false
+    } else {
+        true
+    }
+}
+
 impl ConnectionGuard {
     fn read(state: &DaemonState) -> Self {
         state.active_reads.fetch_add(1, Ordering::Relaxed);
@@ -226,10 +244,10 @@ impl ConnectionGuard {
     /// Admit a write, or refuse it because shutdown has begun.
     ///
     /// THIS REFUSAL IS WHAT MAKES THE DRAIN TERMINATE. `active_writes` is the
-    /// drain's exit condition and this constructor is its ONLY incrementer (the
-    /// web admin crate holds the same `Arc` but never adds to it), so gating
-    /// here — and only here — makes the count monotonically non-increasing once
-    /// shutdown starts.
+    /// drain's exit condition. This constructor and the web admin mutation
+    /// admission guard are its only incrementers; both use the same
+    /// increment-before-shutdown-check ordering, so the count is monotonically
+    /// non-increasing once shutdown starts.
     ///
     /// Without it the drain is not merely slow, it is not guaranteed to
     /// terminate at all. The old SIGTERM broadcast closed every listener, which
@@ -252,19 +270,19 @@ impl ConnectionGuard {
     /// extend the drain, and continuing to serve them for the whole drain is
     /// the point of this design.
     fn write(state: &DaemonState) -> Result<Self, Status> {
-        // Ordering: this load pairs with the `swap` in `begin_shutdown_drain`.
-        // `Relaxed` matches every other access to this flag; the race window it
-        // leaves is one already-admitted write, which the drain then waits for
-        // exactly as it would have anyway. What must not happen — an unbounded
-        // stream of new writes — is closed regardless of ordering.
-        if state.shutdown_started.load(Ordering::Relaxed) {
+        // Increment first, then recheck shutdown. With SeqCst this gives the
+        // drain and admission one total order: an increment before shutdown is
+        // visible to the drain; an increment after shutdown rolls itself back
+        // and never reaches mutation work. Check-then-increment allowed the
+        // drain to observe zero between those two operations and finish before
+        // a late writer.
+        if !try_admit_write_with(&state.active_writes, &state.shutdown_started, || {}) {
             return Err(Status::unavailable(
                 "daemon is shutting down and is not accepting new writes; it is \
                  finishing the writes already in flight and still serving reads. \
                  Retry against the daemon that starts next.",
             ));
         }
-        state.active_writes.fetch_add(1, Ordering::Relaxed);
         state.idle_notify.notify_one();
         Ok(Self {
             counter: Arc::clone(&state.active_writes),
@@ -274,8 +292,18 @@ impl ConnectionGuard {
 
 impl Drop for ConnectionGuard {
     fn drop(&mut self) {
-        self.counter.fetch_sub(1, Ordering::Relaxed);
+        self.counter.fetch_sub(1, Ordering::Release);
     }
+}
+
+/// Exact-worker ownership with deliberate drop order.
+///
+/// Rust drops struct fields in declaration order. Releasing the process write
+/// gate before decrementing `active_writes` prevents even a tiny interval in
+/// which shutdown observes zero writers while the gate is still held.
+struct MutationWorkerOwnership {
+    _write_lease: WriteLease,
+    _connection_guard: ConnectionGuard,
 }
 
 /// Compose shutdown admission and the process-wide writer gate in the only
@@ -295,7 +323,10 @@ fn daemon_mutation_lease_factory(
             }
         })?;
         let write = state.write_gate.blocking_lock(label);
-        Ok(Box::new((guard, write)))
+        Ok(Box::new(MutationWorkerOwnership {
+            _write_lease: write,
+            _connection_guard: guard,
+        }))
     })
 }
 
@@ -390,11 +421,33 @@ fn request_is_applying(args_json: &str) -> bool {
         .unwrap_or(false)
 }
 
+#[cfg(any(feature = "embed", test))]
 fn settle_embed_counts(succeeded: u32, failed: u32, flush_ok: bool) -> (u32, u32) {
     if flush_ok {
         return (succeeded, failed);
     }
     (0, failed.saturating_add(succeeded))
+}
+
+/// Publish one embed pass in identity-before-vector order.
+///
+/// The `?` on the metadata stamp is a security boundary, not shorthand: if
+/// the database keeps its old pipeline, flushing same-dimension vectors from a
+/// replacement model would label those vectors with the old fingerprint. A
+/// stamp failure therefore prevents the flush from being attempted at all.
+#[cfg(feature = "embed")]
+fn persist_embed_output(
+    store: &GraphStore,
+    pipeline: Option<&nestweaver_schema::EmbeddingPipelineV2>,
+    succeeded: u32,
+) -> Result<(), nestweaver_store::StoreError> {
+    if let Some(pipeline) = pipeline {
+        store.set_embedding_pipeline(pipeline)?;
+    }
+    if succeeded > 0 {
+        store.flush_embedding_index()?;
+    }
+    Ok(())
 }
 
 fn unix_now_seconds() -> i64 {
@@ -414,15 +467,13 @@ impl EmbedProgress {
     /// Claim the reporting slot for a starting pass. `total` is 0 until
     /// preflight finishes, which is reported honestly rather than guessed at.
     ///
-    /// Returns a guard that is INERT when a pass is already running. The write
-    /// lease is owned by the RPC future while the pass itself runs on a
-    /// blocking task, so a client that disconnects releases the lock while its
-    /// pass keeps embedding; a re-issued `embed` then acquires the gate with
-    /// the first pass still in flight. Without this claim its `begin` would
-    /// zero the shared counters and whichever guard dropped first would report
-    /// `pass_active: false` during a live embed — precisely the class of
-    /// status lie this work exists to remove. The second pass therefore
-    /// reports nothing rather than corrupting the first pass's numbers.
+    /// Returns a guard that is INERT when a pass is already running. The unary
+    /// mutation helper now moves write ownership into this exact blocking
+    /// worker, so a disconnected client cannot admit a second pass. The
+    /// independent progress claim remains a defense against callers outside
+    /// that RPC path and against future wiring mistakes: a second pass reports
+    /// nothing rather than zeroing or prematurely clearing the first pass's
+    /// counters.
     #[must_use]
     pub fn begin(self: &Arc<Self>, scope: &str) -> EmbedProgressGuard {
         let mut slot = self.lock();
@@ -445,18 +496,22 @@ impl EmbedProgress {
         EmbedProgressGuard(Some(Arc::clone(self)))
     }
 
+    #[cfg(any(feature = "embed", test))]
     fn set_total(&self, total: u64) {
         if let Some(state) = self.lock().as_mut() {
             state.total = total;
         }
     }
 
+    #[cfg(any(feature = "embed", test))]
     fn advance(&self, by: u64) {
         if let Some(state) = self.lock().as_mut() {
             state.processed = state.processed.saturating_add(by);
         }
     }
 
+    #[cfg(any(feature = "embed", test))]
+    #[cfg_attr(all(test, not(feature = "embed")), allow(dead_code))]
     fn processed(&self) -> u64 {
         self.lock().as_ref().map(|s| s.processed).unwrap_or(0)
     }
@@ -495,23 +550,28 @@ const EMBED_PASS_LOG_INTERVAL: Duration = Duration::from_secs(60);
 pub struct EmbedProgressGuard(Option<Arc<EmbedProgress>>);
 
 impl EmbedProgressGuard {
+    #[cfg(any(feature = "embed", test))]
     fn set_total(&self, total: u64) {
         if let Some(progress) = &self.0 {
             progress.set_total(total);
         }
     }
 
+    #[cfg(any(feature = "embed", test))]
     fn advance(&self, by: u64) {
         if let Some(progress) = &self.0 {
             progress.advance(by);
         }
     }
 
+    #[cfg(any(feature = "embed", test))]
+    #[cfg_attr(all(test, not(feature = "embed")), allow(dead_code))]
     fn processed(&self) -> u64 {
         self.0.as_ref().map(|p| p.processed()).unwrap_or(0)
     }
 
     /// Whether this pass owns the reporting slot.
+    #[cfg(any(feature = "embed", test))]
     fn reports(&self) -> bool {
         self.0.is_some()
     }
@@ -543,6 +603,161 @@ enum SearchIndexReconciliation {
 /// a restart and long enough to be invisible.
 const SEARCH_REOPEN_RETRY_INTERVAL: Duration = Duration::from_secs(60);
 
+/// Durable proof that the graph may be newer than the BM25 sidecar.
+///
+/// The marker is established before a vault mutation enters the engine. It is
+/// intentionally conservative: a failed graph operation may have committed a
+/// prefix, so only a successful full rebuild, a proven no-op, or an
+/// intentionally disabled writer may clear it.
+const SEARCH_RECONCILIATION_DEBT_SUFFIX: &str = ".search-reconciliation.json";
+const SEARCH_RECONCILIATION_DEBT_VERSION: u32 = 1;
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+struct SearchReconciliationDebt {
+    version: u32,
+    operation: String,
+    created_at_unix: i64,
+    graph_generation_before: u64,
+    attempts: u64,
+    #[serde(default)]
+    last_error: String,
+}
+
+fn search_reconciliation_debt_path(db_path: &Path) -> PathBuf {
+    nestweaver_engine::sidecar_path(db_path, SEARCH_RECONCILIATION_DEBT_SUFFIX)
+}
+
+fn load_search_reconciliation_debt(
+    db_path: &Path,
+) -> Result<Option<SearchReconciliationDebt>, anyhow::Error> {
+    let path = search_reconciliation_debt_path(db_path);
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(anyhow::anyhow!(
+                "read durable search-reconciliation debt {}: {error}",
+                path.display()
+            ));
+        }
+    };
+    let debt: SearchReconciliationDebt = serde_json::from_slice(&bytes).with_context(|| {
+        format!(
+            "decode durable search-reconciliation debt {}",
+            path.display()
+        )
+    })?;
+    anyhow::ensure!(
+        debt.version == SEARCH_RECONCILIATION_DEBT_VERSION,
+        "unsupported search-reconciliation debt version {} in {} (expected {})",
+        debt.version,
+        path.display(),
+        SEARCH_RECONCILIATION_DEBT_VERSION
+    );
+    anyhow::ensure!(
+        !debt.operation.trim().is_empty(),
+        "search-reconciliation debt {} has an empty operation",
+        path.display()
+    );
+    Ok(Some(debt))
+}
+
+fn write_search_reconciliation_debt(
+    db_path: &Path,
+    debt: &SearchReconciliationDebt,
+) -> Result<(), anyhow::Error> {
+    let path = search_reconciliation_debt_path(db_path);
+    let bytes = serde_json::to_vec_pretty(debt)?;
+    nestweaver_store::durable_sidecar::atomic_replace_file(&path, |file| {
+        use std::io::Write as _;
+        file.write_all(&bytes)?;
+        file.write_all(b"\n")
+    })
+    .with_context(|| {
+        format!(
+            "durably publish search-reconciliation debt {}",
+            path.display()
+        )
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SearchDebtAdmission {
+    had_existing_debt: bool,
+}
+
+fn establish_search_reconciliation_debt(
+    state: &DaemonState,
+    operation: &str,
+) -> Result<SearchDebtAdmission, anyhow::Error> {
+    let existing = load_search_reconciliation_debt(&state.db_path)?;
+    let had_existing_debt = existing.is_some();
+    let debt = match existing {
+        Some(mut debt) => {
+            // Preserve the earliest possible divergence point. The latest
+            // operation remains useful in diagnostics, while the generation
+            // and timestamp continue to describe how long the corpus may have
+            // been stale.
+            debt.operation = operation.to_string();
+            debt
+        }
+        None => SearchReconciliationDebt {
+            version: SEARCH_RECONCILIATION_DEBT_VERSION,
+            operation: operation.to_string(),
+            created_at_unix: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs() as i64,
+            graph_generation_before: state.store.graph_generation(),
+            attempts: 0,
+            last_error: String::new(),
+        },
+    };
+    write_search_reconciliation_debt(&state.db_path, &debt)?;
+    Ok(SearchDebtAdmission { had_existing_debt })
+}
+
+fn record_search_reconciliation_failure(
+    state: &DaemonState,
+    operation: &str,
+    error: &anyhow::Error,
+) -> Result<(), anyhow::Error> {
+    let mut debt =
+        load_search_reconciliation_debt(&state.db_path)?.unwrap_or(SearchReconciliationDebt {
+            version: SEARCH_RECONCILIATION_DEBT_VERSION,
+            operation: operation.to_string(),
+            created_at_unix: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs() as i64,
+            graph_generation_before: state.store.graph_generation(),
+            attempts: 0,
+            last_error: String::new(),
+        });
+    debt.operation = operation.to_string();
+    debt.attempts = debt.attempts.saturating_add(1);
+    debt.last_error = format!("{error:#}");
+    write_search_reconciliation_debt(&state.db_path, &debt)
+}
+
+fn clear_search_reconciliation_debt(db_path: &Path) -> Result<(), anyhow::Error> {
+    let path = search_reconciliation_debt_path(db_path);
+    nestweaver_store::durable_sidecar::remove_file_durable_if_exists(&path)
+        .with_context(|| {
+            format!(
+                "durably clear search-reconciliation debt {}",
+                path.display()
+            )
+        })
+        .map(|_| ())
+}
+
+#[derive(Clone)]
+struct SearchRecoveryContext {
+    state: std::sync::Weak<DaemonState>,
+    runtime: tokio::runtime::Handle,
+}
+
 /// The daemon's full-text search capability, re-establishable.
 ///
 /// This is the `tantivy` + `search_reconciliation` pair that used to sit
@@ -570,6 +785,12 @@ pub struct SearchRuntime {
     /// Guards the re-open attempt itself, so a burst of concurrent queries
     /// against a broken sidecar performs ONE open, not one per query.
     next_attempt: std::sync::Mutex<Instant>,
+    /// Installed after [`DaemonState`] is assembled. Weak ownership avoids a
+    /// state → runtime → state cycle while still letting a recovered writer
+    /// enqueue the exact-worker reconciliation that makes it safe to clear a
+    /// durable debt.
+    recovery_context: std::sync::OnceLock<SearchRecoveryContext>,
+    recovery_in_flight: Arc<AtomicBool>,
 }
 
 /// Readiness and the exact usable handle as one value, so a caller can never
@@ -631,7 +852,101 @@ impl SearchRuntime {
             retry_interval,
             inner: std::sync::RwLock::new(snapshot),
             next_attempt: std::sync::Mutex::new(Instant::now()),
+            recovery_context: std::sync::OnceLock::new(),
+            recovery_in_flight: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    fn attach_recovery_context(&self, state: &Arc<DaemonState>) {
+        let _ = self.recovery_context.set(SearchRecoveryContext {
+            state: Arc::downgrade(state),
+            runtime: tokio::runtime::Handle::current(),
+        });
+    }
+
+    fn current_snapshot(&self) -> SearchRuntimeSnapshot {
+        self.inner
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn debt_is_pending(&self) -> bool {
+        self.recovery_context
+            .get()
+            .and_then(|context| context.state.upgrade())
+            .is_some_and(|state| {
+                matches!(load_search_reconciliation_debt(&state.db_path), Ok(Some(_)))
+            })
+    }
+
+    /// Schedule a debt repair under the same exact-worker ownership as every
+    /// other daemon writer. A query may discover that the Tantivy writer has
+    /// recovered, but the query itself must never perform the rebuild or clear
+    /// the durable marker outside the write gate.
+    fn schedule_debt_reconciliation(&self, tantivy: Arc<TantivyIndex>) {
+        if !self.debt_is_pending()
+            || self
+                .recovery_in_flight
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_err()
+        {
+            return;
+        }
+        let Some(context) = self.recovery_context.get().cloned() else {
+            self.recovery_in_flight.store(false, Ordering::Release);
+            return;
+        };
+        let SearchRecoveryContext {
+            state: weak_state,
+            runtime,
+        } = context;
+        let in_flight = Arc::clone(&self.recovery_in_flight);
+        runtime.spawn(async move {
+            let Some(state) = weak_state.upgrade() else {
+                in_flight.store(false, Ordering::Release);
+                return;
+            };
+            let guard = match ConnectionGuard::write(&state) {
+                Ok(guard) => guard,
+                Err(status) => {
+                    tracing::debug!(
+                        error = %status,
+                        "search-reconciliation recovery was refused during shutdown"
+                    );
+                    in_flight.store(false, Ordering::Release);
+                    return;
+                }
+            };
+            let lease = state.write_gate.lock("search_debt_recovery").await;
+            let repair_state = Arc::clone(&state);
+            let result = tokio::task::spawn_blocking(move || {
+                let _ownership = MutationWorkerOwnership {
+                    _write_lease: lease,
+                    _connection_guard: guard,
+                };
+                reconcile_pending_search_debt(
+                    &repair_state,
+                    SearchIndexReconciliation::Available(tantivy),
+                    "search_writer_recovery",
+                )
+            })
+            .await;
+            match result {
+                Ok(Ok(())) => tracing::info!(
+                    "reconciled durable search debt after the Tantivy writer recovered"
+                ),
+                Ok(Err(error)) => tracing::warn!(
+                    error = %error,
+                    "search debt remains pending after writer recovery"
+                ),
+                Err(error) => tracing::error!(
+                    error = %error,
+                    "search-debt recovery worker panicked; durable debt remains"
+                ),
+            }
+            in_flight.store(false, Ordering::Release);
+        });
     }
 
     /// The current search state, re-establishing it first if it is degraded
@@ -643,6 +958,9 @@ impl SearchRuntime {
                 .read()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             if current.is_healthy() {
+                if let SearchIndexReconciliation::Available(tantivy) = &current.reconciliation {
+                    self.schedule_debt_reconciliation(Arc::clone(tantivy));
+                }
                 return current.clone();
             }
         }
@@ -683,7 +1001,10 @@ impl SearchRuntime {
         *self
             .inner
             .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = candidate;
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = candidate.clone();
+        if let SearchIndexReconciliation::Available(tantivy) = candidate.reconciliation {
+            self.schedule_debt_reconciliation(tantivy);
+        }
     }
 
     /// Replace the reconciliation verdict. Used by the deletion-reconciliation
@@ -732,6 +1053,32 @@ pub struct WatcherRegistration {
     owner_pid: Option<i32>,
 }
 
+/// A retained watcher worker. The id ties the otherwise-unstructured join
+/// handle back to its registration, so an explicit stop can signal and await
+/// the exact blocking worker instead of merely hoping shutdown catches it.
+pub struct WatcherTask {
+    id: u64,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+/// A watcher started as part of a ServeUI session.
+///
+/// ServeUI shares the daemon's single canonical watcher slot with WatchCode
+/// and WatchVault. Recording the registration id here lets StopUI stop only
+/// the watcher it owns; it must never tear down an unrelated replacement.
+struct UiWatcherBinding {
+    id: u64,
+    repo_path: PathBuf,
+    instance_id: String,
+}
+
+/// Resources owned by one ServeUI session.
+pub struct UiServerRegistration {
+    port: u16,
+    handle: tokio::task::JoinHandle<()>,
+    watcher: Option<UiWatcherBinding>,
+}
+
 #[derive(Debug, Clone, Default)]
 struct EmbeddingRuntimeStatus {
     state: String,
@@ -742,6 +1089,173 @@ struct EmbeddingRuntimeStatus {
     error: String,
     metal_compiled: bool,
     fallback_used: bool,
+}
+
+const EMBEDDING_IDENTITY_REMEDIATION: &str = "repair or restore the recorded embedding model/pipeline metadata, or intentionally rebuild all embeddings from a verified source; --force cannot bypass an unreadable identity";
+
+fn embedding_identity_unreadable_status(
+    mut status: EmbeddingRuntimeStatus,
+    error: impl std::fmt::Display,
+) -> EmbeddingRuntimeStatus {
+    status.state = "identity_unreadable".to_string();
+    status.selected_device.clear();
+    status.error = format!("{error}");
+    status
+}
+
+fn embedding_status_with_store_identity(
+    status: EmbeddingRuntimeStatus,
+    store: &GraphStore,
+) -> EmbeddingRuntimeStatus {
+    match store.embedding_identity_error() {
+        Some(error) => embedding_identity_unreadable_status(status, error),
+        None => status,
+    }
+}
+
+fn embedding_identity_fields(
+    store: &GraphStore,
+    status: &EmbeddingRuntimeStatus,
+) -> (&'static str, String, &'static str) {
+    match store
+        .embedding_identity_error()
+        .or_else(|| (status.state == "identity_unreadable").then(|| status.error.clone()))
+    {
+        Some(error) => ("unreadable", error, EMBEDDING_IDENTITY_REMEDIATION),
+        None => ("verified", String::new(), ""),
+    }
+}
+
+fn require_verified_embedding_identity(store: &GraphStore, operation: &str) -> Result<(), Status> {
+    store
+        .require_verified_embedding_identity()
+        .map_err(|error| embedding_identity_precondition_status(operation, &error))
+}
+
+fn embedding_identity_precondition_status(
+    operation: &str,
+    error: &dyn std::fmt::Display,
+) -> Status {
+    Status::failed_precondition(format!(
+        "{operation} refused because the persisted embedding identity is unreadable. \
+         Source error: {error}. Remediation: {EMBEDDING_IDENTITY_REMEDIATION}."
+    ))
+}
+
+fn require_verified_embedding_runtime_identity(
+    store: &GraphStore,
+    runtime_status: &EmbeddingRuntimeStatus,
+    operation: &str,
+) -> Result<(), Status> {
+    require_verified_embedding_identity(store, operation)?;
+    if runtime_status.state == "identity_unreadable" {
+        return Err(embedding_identity_precondition_status(
+            operation,
+            &runtime_status.error,
+        ));
+    }
+    Ok(())
+}
+
+/// Whether this invocation actually requests a semantic/rerank operation.
+/// Pure lexical `brain_search` stays available and is annotated as degraded;
+/// callers that ask for reranking or a semantic hybrid leg fail closed.
+fn embedding_identity_operation(
+    tool_name: &str,
+    args: &serde_json::Value,
+    instance_cfg: Option<&nestweaver_engine::InstanceConfig>,
+) -> Option<&'static str> {
+    let rerank = args
+        .get("rerank")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    if rerank {
+        return Some("rerank");
+    }
+    match tool_name {
+        "brain_context" => {
+            let defaults = instance_cfg
+                .map(|config| config.embedding.clone())
+                .unwrap_or_default();
+            let ppr = args
+                .get("weight_ppr")
+                .and_then(serde_json::Value::as_f64)
+                .unwrap_or(defaults.weight_ppr)
+                .max(0.0);
+            let bm25 = args
+                .get("weight_bm25")
+                .and_then(serde_json::Value::as_f64)
+                .unwrap_or(defaults.weight_bm25)
+                .max(0.0);
+            let semantic = args
+                .get("weight_semantic")
+                .and_then(serde_json::Value::as_f64)
+                .unwrap_or(defaults.weight_semantic)
+                .max(0.0);
+            let semantic = if ppr == 0.0 && bm25 == 0.0 && semantic == 0.0 {
+                defaults.weight_semantic.max(0.0)
+            } else {
+                semantic
+            };
+            (semantic > 0.0).then_some("semantic brain_context")
+        }
+        // Project context has no per-request semantic knob but does honor the
+        // instance default. Investigate currently constructs the engine's
+        // semantic-on HybridSearchConfig directly, so it always requests the
+        // leg when routed through a daemon model.
+        "project_context"
+            if instance_cfg
+                .map(|config| config.embedding.weight_semantic)
+                .unwrap_or_else(|| {
+                    nestweaver_engine::config::EmbeddingConfig::default().weight_semantic
+                })
+                > 0.0 =>
+        {
+            Some("semantic project_context")
+        }
+        "investigate" => Some("semantic investigate"),
+        "compact_embeddings"
+            if !args
+                .get("dry_run")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false) =>
+        {
+            Some("embedding compaction write")
+        }
+        _ => None,
+    }
+}
+
+fn annotate_lexical_identity_degradation(
+    tool_name: &str,
+    identity_error: Option<&str>,
+    value: &mut serde_json::Value,
+) {
+    if tool_name != "brain_search" || identity_error.is_none() {
+        return;
+    }
+    if let Some(object) = value.as_object_mut() {
+        object.insert("semantic_applied".to_string(), serde_json::json!(false));
+        let degraded = object
+            .entry("degraded_components")
+            .or_insert_with(|| serde_json::json!([]));
+        if let Some(components) = degraded.as_array_mut()
+            && !components
+                .iter()
+                .any(|component| component.as_str() == Some("semantic"))
+        {
+            components.push(serde_json::json!("semantic"));
+        }
+        object.insert(
+            "semantic_unavailable".to_string(),
+            serde_json::json!({
+                "cause": "embedding_identity",
+                "reason": "embedding_identity_unreadable",
+                "error": identity_error.unwrap_or_default(),
+                "remediation": EMBEDDING_IDENTITY_REMEDIATION,
+            }),
+        );
+    }
 }
 
 #[derive(Clone)]
@@ -944,7 +1458,10 @@ fn embedding_status_proto(
     status: &EmbeddingRuntimeStatus,
     progress: &EmbedProgressSnapshot,
     occupancy: nestweaver_store::EmbeddingIndexOccupancy,
+    store: &GraphStore,
 ) -> nestweaver_proto::EmbeddingStatus {
+    let (identity_state, identity_error, identity_remediation) =
+        embedding_identity_fields(store, status);
     nestweaver_proto::EmbeddingStatus {
         state: effective_embedding_state(status, progress),
         backend: status.backend.clone(),
@@ -962,6 +1479,9 @@ fn embedding_status_proto(
         index_live: occupancy.live as u64,
         index_tombstoned: occupancy.tombstoned as u64,
         index_stored: occupancy.stored as u64,
+        identity_state: identity_state.to_string(),
+        identity_error,
+        identity_remediation: identity_remediation.to_string(),
     }
 }
 
@@ -969,7 +1489,10 @@ fn embedding_status_json(
     status: &EmbeddingRuntimeStatus,
     progress: &EmbedProgressSnapshot,
     occupancy: nestweaver_store::EmbeddingIndexOccupancy,
+    store: &GraphStore,
 ) -> serde_json::Value {
+    let (identity_state, identity_error, identity_remediation) =
+        embedding_identity_fields(store, status);
     serde_json::json!({
         "state": effective_embedding_state(status, progress),
         "backend": status.backend,
@@ -987,6 +1510,9 @@ fn embedding_status_json(
         "index_live": occupancy.live,
         "index_tombstoned": occupancy.tombstoned,
         "index_stored": occupancy.stored,
+        "identity_state": identity_state,
+        "identity_error": identity_error,
+        "identity_remediation": identity_remediation,
     })
 }
 
@@ -1239,12 +1765,8 @@ pub struct DaemonState {
     /// Retained for exactly the reason stated above, which this task violated
     /// by being spawned detached: it performs the same kind of unabortable
     /// blocking store write on a `spawn_blocking` thread. The write gate
-    /// covers the common case, but `ConnectionGuard::write` reads
-    /// `shutdown_started` with `Relaxed` and then increments `active_writes`
-    /// — a pass that slips between those two steps is invisible to the drain,
-    /// so teardown could remove the socket, the pidfile and the INSTANCE LOCK
-    /// while the outgoing process was still rewriting the sidecar, letting a
-    /// successor daemon open the same database concurrently.
+    /// covers each mutation; the retained handle is the second line of
+    /// defence that lets teardown await the loop itself after admission closes.
     pub embedding_reconciler_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
     /// Join handles for every watcher task this daemon has spawned.
     ///
@@ -1259,15 +1781,13 @@ pub struct DaemonState {
     /// A Vec rather than an Option because a FORCE-RETIRED watcher is still
     /// draining: `register_watcher(force)` stops the incumbent and immediately
     /// registers a replacement, so at shutdown there may be several tasks
-    /// winding down. Awaiting the collection covers them without any extra
-    /// bookkeeping.
-    pub watcher_tasks: std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>,
-    /// Handle to the `serve_ui` web-server task plus the port it is bound
-    /// to, aborted by `stop_ui` so the listen port is released when the CLI
-    /// exits (LOW: ui port leak). The port is tracked so a repeated
-    /// `serve_ui` can report the ACTUAL running port instead of echoing the
-    /// requested one (which would send the CLI to a dead URL).
-    pub ui_server: std::sync::Mutex<Option<(u16, tokio::task::JoinHandle<()>)>>,
+    /// winding down. Each handle is paired with its registration id so an
+    /// explicit watcher/UI stop can await its exact worker too.
+    pub watcher_tasks: std::sync::Mutex<Vec<WatcherTask>>,
+    /// Handle to the `serve_ui` web-server task, its bound port, and its
+    /// optional canonical watcher registration. `stop_ui` aborts the server
+    /// and stops/drains only the watcher this UI session owns.
+    pub ui_server: std::sync::Mutex<Option<UiServerRegistration>>,
 }
 
 impl DaemonState {
@@ -1704,7 +2224,7 @@ fn begin_shutdown_drain(state: Arc<DaemonState>, trigger: &'static str) {
     // listener mid-drain. An operator who runs `daemon restart` and then
     // `daemon stop` now gets one drain that keeps serving reads, and the CLI
     // reports honestly instead of the second signal cutting the first one short.
-    if state.shutdown_started.swap(true, Ordering::Relaxed) {
+    if state.shutdown_started.swap(true, Ordering::SeqCst) {
         tracing::info!(
             trigger,
             "shutdown already in progress — not starting a second drain"
@@ -2143,6 +2663,47 @@ fn clear_watcher_registration(state: &DaemonState, id: u64) {
     }
 }
 
+/// Whether `id` is still the daemon's canonical active watcher.
+fn watcher_registration_is_active(state: &DaemonState, id: u64) -> bool {
+    state
+        .watcher_stop
+        .lock()
+        .ok()
+        .and_then(|guard| guard.as_ref().map(|registration| registration.id == id))
+        .unwrap_or(false)
+}
+
+/// Remove the retained worker for `id`, if it is still tracked.
+///
+/// The mutex is released before callers await the handle. The watcher worker
+/// clears its registration as it exits and therefore must never be awaited
+/// while either registry lock is held.
+fn take_watcher_task(state: &DaemonState, id: u64) -> Option<tokio::task::JoinHandle<()>> {
+    let mut tasks = state
+        .watcher_tasks
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let position = tasks.iter().position(|task| task.id == id)?;
+    Some(tasks.swap_remove(position).handle)
+}
+
+/// Signal `id` only if it still owns the canonical slot.
+fn stop_watcher_registration(state: &DaemonState, id: u64) -> bool {
+    let Ok(mut guard) = state.watcher_stop.lock() else {
+        return false;
+    };
+    let Some(registration) = guard.as_ref() else {
+        return false;
+    };
+    if registration.id != id {
+        return false;
+    }
+    let registration = guard.take().expect("registration checked above");
+    tracing::info!(watcher_id = id, "stopping registered watcher");
+    registration.handle.stop();
+    true
+}
+
 /// The gRPC service implementation. Wraps shared state in an `Arc`.
 pub struct DaemonService {
     state: Arc<DaemonState>,
@@ -2162,6 +2723,101 @@ impl DaemonService {
         Self { state }
     }
 
+    /// Run a unary mutation with ownership held by the exact blocking worker.
+    ///
+    /// Dropping a Tokio `JoinHandle` does not cancel `spawn_blocking`. Keeping
+    /// either guard in the RPC future therefore creates a dangerous split: a
+    /// disconnected client drops the guards while the worker continues to
+    /// mutate, allowing a conflicting writer or shutdown to overlap it. Both
+    /// guards are moved into the closure here, so `active_writes`, holder
+    /// reporting, writer exclusion, and shutdown draining all describe the
+    /// real lifetime of the work.
+    #[allow(clippy::result_large_err)]
+    async fn run_unary_mutation<T, F>(&self, label: &'static str, task: F) -> Result<T, Status>
+    where
+        T: Send + 'static,
+        F: FnOnce() -> Result<T, Status> + Send + 'static,
+    {
+        // Admission precedes queueing, preserving the immediate UNAVAILABLE
+        // shutdown refusal instead of waiting behind a write that is draining.
+        let guard = ConnectionGuard::write(&self.state)?;
+        let write_gate = self.state.write_gate.clone();
+        tokio::task::spawn_blocking(move || {
+            let _ownership = MutationWorkerOwnership {
+                _write_lease: write_gate.blocking_lock(label),
+                _connection_guard: guard,
+            };
+            task()
+        })
+        .await
+        .map_err(|error| Status::internal(format!("{label} task panicked: {error}")))?
+    }
+
+    /// Construct, register, retain, and run a CodeWatcher through the daemon's
+    /// one canonical lifecycle. Used by both WatchCode and ServeUI.
+    fn start_registered_code_watcher(
+        &self,
+        repo_path: PathBuf,
+        instance_id: String,
+        force: bool,
+        owner_pid: Option<i32>,
+    ) -> Result<u64, Status> {
+        let limits = self
+            .state
+            .instance_cfg
+            .as_ref()
+            .map(|config| config.indexing.limits())
+            .unwrap_or_default();
+        let mut watcher =
+            nestweaver_engine::CodeWatcher::new(&self.state.db_path, &repo_path, &instance_id)
+                .with_limits(limits);
+        let shutdown_handle = watcher.shutdown_handle();
+
+        // Refuse shutdown before mutating the registry. This admission guard
+        // covers registration only; each actual watcher batch obtains its own
+        // exact-worker lease from the factory below.
+        let admission_guard = ConnectionGuard::write(&self.state)?;
+        let watcher_id = register_watcher(&self.state, shutdown_handle, force, owner_pid)?;
+
+        watcher =
+            watcher.with_mutation_lease_factory(daemon_mutation_lease_factory(self.state.clone()));
+        let state = self.state.clone();
+        let store = self.state.store.clone();
+        let on_change = Self::make_embed_on_change(
+            self.state.embedding_runtime.clone(),
+            self.state.store.clone(),
+        );
+        let watcher_task = tokio::task::spawn_blocking(move || {
+            tracing::info!(repo = %repo_path.display(), watcher_id, "code watcher thread started");
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                watcher.run_with_store(store, on_change)
+            }));
+            match result {
+                Ok(Ok(())) => tracing::info!(watcher_id, "code watcher exited cleanly"),
+                Ok(Err(error)) => {
+                    tracing::error!(%error, watcher_id, "code watcher exited with error")
+                }
+                Err(_) => tracing::error!(watcher_id, "code watcher thread panicked"),
+            }
+            clear_watcher_registration(&state, watcher_id);
+        });
+
+        let mut tasks = self
+            .state
+            .watcher_tasks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        tasks.retain(|task| !task.handle.is_finished());
+        tasks.push(WatcherTask {
+            id: watcher_id,
+            handle: watcher_task,
+        });
+        // Admission includes handle publication. Shutdown cannot observe this
+        // registration as finished until teardown owns the spawned task.
+        drop(admission_guard);
+        Ok(watcher_id)
+    }
+
     /// Generic JSON pass-through dispatch. Maps every read RPC to the
     /// corresponding MCP tool via `nestweaver_mcp::tools::dispatch`.
     /// Runs the blocking dispatch on a dedicated thread to avoid
@@ -2174,6 +2830,31 @@ impl DaemonService {
         tool_name: &str,
         args_json: &str,
         visible: nestweaver_engine::authz::VisibleRepos,
+    ) -> Result<Response<JsonResponse>, Status> {
+        self.dispatch_json_tool_with_ownership(tool_name, args_json, visible, None)
+            .await
+    }
+
+    /// Mutating JSON dispatch whose admission guard is transferred to the
+    /// exact blocking dispatch worker.
+    async fn dispatch_json_mutation(
+        &self,
+        tool_name: &str,
+        args_json: &str,
+        visible: nestweaver_engine::authz::VisibleRepos,
+        label: &'static str,
+    ) -> Result<Response<JsonResponse>, Status> {
+        let guard = ConnectionGuard::write(&self.state)?;
+        self.dispatch_json_tool_with_ownership(tool_name, args_json, visible, Some((guard, label)))
+            .await
+    }
+
+    async fn dispatch_json_tool_with_ownership(
+        &self,
+        tool_name: &str,
+        args_json: &str,
+        visible: nestweaver_engine::authz::VisibleRepos,
+        mutation: Option<(ConnectionGuard, &'static str)>,
     ) -> Result<Response<JsonResponse>, Status> {
         let started = std::time::Instant::now();
         // Increment gRPC request counter for this tool/method.
@@ -2188,7 +2869,8 @@ impl DaemonService {
         // `with_safeguard_cancellable` on timeout and observed by the
         // `spawn_blocking` dispatch (e.g. brain_context's vector fan-out).
         let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let handler = self.dispatch_json_tool_inner(tool_name, args_json, cancel.clone(), visible);
+        let handler =
+            self.dispatch_json_tool_inner(tool_name, args_json, cancel.clone(), visible, mutation);
 
         let response = if self.state.server_mode {
             with_safeguard_cancellable(&tool, safeguards, None, cancel, handler).await
@@ -2220,9 +2902,15 @@ impl DaemonService {
         args_json: &str,
         cancel: std::sync::Arc<std::sync::atomic::AtomicBool>,
         visible: nestweaver_engine::authz::VisibleRepos,
+        mutation: Option<(ConnectionGuard, &'static str)>,
     ) -> Result<Response<JsonResponse>, Status> {
         let t0 = std::time::Instant::now();
-        let _guard = ConnectionGuard::read(&self.state);
+        // Read dispatches retain their historical request-scoped accounting.
+        // Mutations transfer their write accounting into the blocking worker
+        // below, where cancellation cannot release it prematurely.
+        let _read_guard = mutation
+            .is_none()
+            .then(|| ConnectionGuard::read(&self.state));
         // Trip the cancel flag if this request future is dropped (client cancel
         // / disconnect), the same flag the timeout path sets.
         let _disconnect_guard = arm_disconnect_cancel(cancel.clone());
@@ -2239,6 +2927,11 @@ impl DaemonService {
 
         #[allow(clippy::result_large_err)]
         let result = tokio::task::spawn_blocking(move || -> Result<String, Status> {
+            let has_authoritative_writer = mutation.is_some();
+            let _mutation_scope = mutation.map(|(guard, label)| MutationWorkerOwnership {
+                _write_lease: state.write_gate.blocking_lock(label),
+                _connection_guard: guard,
+            });
             let t_parse = std::time::Instant::now();
             let args: serde_json::Value = serde_json::from_str(&args_json)
                 .map_err(|e| Status::invalid_argument(format!("invalid JSON in args_json: {e}")))?;
@@ -2306,6 +2999,20 @@ impl DaemonService {
             };
 
             let embed_ref = embed_arc.as_deref();
+            if let Some(operation) =
+                embedding_identity_operation(&tool_name, &args, state.instance_cfg.as_deref())
+            {
+                require_verified_embedding_runtime_identity(
+                    &state.store,
+                    &state.embedding_runtime.status(),
+                    operation,
+                )?;
+            }
+            let runtime_status = state.embedding_runtime.status();
+            let identity_error = state.store.embedding_identity_error().or_else(|| {
+                (runtime_status.state == "identity_unreadable")
+                    .then(|| runtime_status.error.clone())
+            });
             tracing::debug!(
                 has_model = embed_ref.is_some(),
                 "dispatch_json_tool embed_model status"
@@ -2313,21 +3020,36 @@ impl DaemonService {
 
             let t_dispatch = std::time::Instant::now();
             let dispatch_tantivy = state.tantivy();
-            let mut value = nestweaver_mcp::tools::dispatch_cancellable(
-                &state.store,
-                dispatch_tantivy.as_deref(),
-                &tool_name,
-                args,
-                embed_ref,
-                Some(&cancel),
-                // R9/R9b: scope blast_radius output to the caller's visible
-                // repos. `visible` was resolved from the request's Identity
-                // extension before the request was consumed. With no `[authz]`
-                // config this is `VisibleRepos::All`, so redaction is a no-op
-                // (zero behavior change); every non-blast_radius tool ignores it.
-                Some(&visible),
-            )
+            let dispatch = || {
+                nestweaver_mcp::tools::dispatch_cancellable(
+                    &state.store,
+                    dispatch_tantivy.as_deref(),
+                    &tool_name,
+                    args,
+                    embed_ref,
+                    Some(&cancel),
+                    // Repository visibility was resolved from the request's
+                    // identity before it was consumed. The tool registry now
+                    // requires every producer to enforce, fail closed, or be
+                    // explicitly global.
+                    Some(&visible),
+                )
+            };
+            // The memory-consolidation apply guard is thread-local. Install it
+            // only inside the exact blocking worker that owns both daemon write
+            // admission and the write gate; wrapping the future outside this
+            // closure would bless the wrong thread and release too early.
+            let mut value = if has_authoritative_writer {
+                nestweaver_mcp::tools::with_authoritative_writer_ownership(dispatch)
+            } else {
+                dispatch()
+            }
             .map_err(|e| dispatch_err_to_status(&tool_name, e))?;
+            annotate_lexical_identity_degradation(
+                &tool_name,
+                identity_error.as_deref(),
+                &mut value,
+            );
             tracing::debug!(
                 tool = %tool_name,
                 elapsed_ms = t_dispatch.elapsed().as_millis(),
@@ -2448,26 +3170,41 @@ impl DaemonService {
             nestweaver_mcp::tools::set_server_mode(state.server_mode);
 
             let embed_ref = embed_arc.as_deref();
+            if let Some(operation) =
+                embedding_identity_operation(&tool_name, &args, state.instance_cfg.as_deref())
+            {
+                require_verified_embedding_runtime_identity(
+                    &state.store,
+                    &state.embedding_runtime.status(),
+                    operation,
+                )?;
+            }
+            let runtime_status = state.embedding_runtime.status();
+            let identity_error = state.store.embedding_identity_error().or_else(|| {
+                (runtime_status.state == "identity_unreadable")
+                    .then(|| runtime_status.error.clone())
+            });
 
             let t_dispatch = std::time::Instant::now();
             let dispatch_tantivy = state.tantivy();
-            let value = nestweaver_mcp::tools::dispatch_cancellable(
+            let mut value = nestweaver_mcp::tools::dispatch_cancellable(
                 &state.store,
                 dispatch_tantivy.as_deref(),
                 &tool_name,
                 args,
                 embed_ref,
                 Some(&cancel),
-                // R9/R9b: scope tool output to the caller's visible repos
-                // (`visible`, resolved from the request Identity by the typed
-                // handler). With no `[authz]` config this is
-                // `VisibleRepos::All` ⇒ redaction is a no-op. Enforcement
-                // applies to blast_radius and to the repo-scoped search tools
-                // (brain_search, brain_impact, affected_tests); other tools
-                // ignore it.
+                // Scope or fail closed according to the canonical tool
+                // visibility registry. With no `[authz]` config this is
+                // `VisibleRepos::All` and preserves single-domain behavior.
                 Some(&visible),
             )
             .map_err(|e| dispatch_err_to_status(&tool_name, e))?;
+            annotate_lexical_identity_degradation(
+                &tool_name,
+                identity_error.as_deref(),
+                &mut value,
+            );
             tracing::debug!(
                 tool = %tool_name,
                 elapsed_ms = t_dispatch.elapsed().as_millis(),
@@ -2565,6 +3302,19 @@ impl DaemonService {
                     return;
                 }
                 st.last_pass = Some(std::time::Instant::now());
+            }
+            if let Err(error) = require_verified_embedding_runtime_identity(
+                &store,
+                &embedding_runtime.status(),
+                "watcher embedding write",
+            ) {
+                tracing::warn!(
+                    error = %error,
+                    remediation = EMBEDDING_IDENTITY_REMEDIATION,
+                    "watcher embedding pass refused because persisted embedding identity is unreadable"
+                );
+                state.lock().unwrap().disabled = true;
+                return;
             }
             let model = embedding_runtime.current_model();
             let Some(model) = model else { return };
@@ -2785,9 +3535,10 @@ macro_rules! json_rpc {
         // R9/R9b: resolve the caller's per-repo visibility from the request's
         // Identity extension BEFORE consuming the request. This covers the
         // generic `/mcp` tool path and every typed RPC routed through this
-        // macro (including `blast_radius`), so their output is redacted to the
-        // caller's visible repos. No `[authz]` config ⇒ `VisibleRepos::All` ⇒
-        // no-op redaction (backward compatible).
+        // macro, so authorization-aware tools receive the caller's induced
+        // repository scope and unsupported repo-owned analyses fail closed at
+        // the common tool boundary. No `[authz]` config ⇒ `VisibleRepos::All`
+        // (backward compatible).
         let visible = $self.state.visible_repos_for($request.extensions())?;
         let req = $request.into_inner();
         $self
@@ -3012,7 +3763,7 @@ fn finalize_node_graph_deletion(
     failures
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct IndexedSearchDocument {
     uid: String,
     kind: &'static str,
@@ -3162,9 +3913,21 @@ fn indexed_search_rows_before(
     })
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum IndexedSearchMutationScope {
+    /// The operation mutates only graph rows. Equal projections therefore
+    /// prove that the indexed corpus did not change.
+    GraphOnly,
+    /// The operation may have changed vault files before the graph preflight.
+    /// Equal graph projections cannot prove that Tantivy already has the new
+    /// on-disk body.
+    MayIncludeVaultFiles,
+}
+
 fn indexed_search_mutation(
     before: Option<Result<std::collections::HashSet<IndexedSearchDocument>, anyhow::Error>>,
     store: &GraphStore,
+    scope: IndexedSearchMutationScope,
 ) -> IndexedSearchMutation {
     match before {
         None => IndexedSearchMutation::Unchanged,
@@ -3176,7 +3939,16 @@ fn indexed_search_mutation(
             IndexedSearchMutation::Unknown
         }
         Some(Ok(before)) => match indexed_search_rows(store) {
-            Ok(after) if before == after => IndexedSearchMutation::Unchanged,
+            // The preflight graph can already observe a newly-written vault
+            // file, so equality is not proof that the existing Tantivy index
+            // contains that body (notably legacy empty-section rows). Preserve
+            // that conservative verdict for vault indexing while allowing
+            // graph-only cleanup operations to prove that the corpus stayed
+            // unchanged.
+            Ok(after) if before == after => match scope {
+                IndexedSearchMutationScope::GraphOnly => IndexedSearchMutation::Unchanged,
+                IndexedSearchMutationScope::MayIncludeVaultFiles => IndexedSearchMutation::Unknown,
+            },
             Ok(_) => IndexedSearchMutation::Changed,
             Err(error) => {
                 tracing::warn!(
@@ -3209,6 +3981,174 @@ fn reconcile_search_index(
             anyhow::bail!("configured Tantivy index unavailable: {reason}")
         }
     }
+}
+
+/// Finish a graph mutation's durable search contract through the canonical
+/// full-corpus reconciler. The debt is cleared only after the rebuild (or a
+/// proven no-op / intentional Disabled state) succeeds. Recording a failure is
+/// itself part of the error path: if refreshing the marker fails, the caller
+/// sees both failures and must not report Done.
+fn finish_search_reconciliation(
+    state: &DaemonState,
+    mutation: IndexedSearchMutation,
+    operation: &str,
+    admission: SearchDebtAdmission,
+) -> Result<(), anyhow::Error> {
+    let reconciliation = state.search_reconciliation();
+    // A prior failed mutation owns the earliest divergence point. A later
+    // no-op may not clear that debt; it must retry a full reconciliation.
+    let mutation = if admission.had_existing_debt {
+        IndexedSearchMutation::Unknown
+    } else {
+        mutation
+    };
+    match reconcile_search_index(&reconciliation, &state.store, mutation, operation) {
+        Ok(()) => clear_search_reconciliation_debt(&state.db_path),
+        Err(error) => {
+            if let Err(marker_error) =
+                record_search_reconciliation_failure(state, operation, &error)
+            {
+                return Err(anyhow::anyhow!(
+                    "{error:#}; additionally failed to preserve durable search-reconciliation debt: {marker_error:#}"
+                ));
+            }
+            Err(error)
+        }
+    }
+}
+
+/// Retry a previously established debt. Durable debt means the precise graph
+/// delta is unknown, so recovery always chooses the safe full rebuild.
+fn reconcile_pending_search_debt(
+    state: &DaemonState,
+    reconciliation: SearchIndexReconciliation,
+    operation: &str,
+) -> Result<(), anyhow::Error> {
+    let Some(_) = load_search_reconciliation_debt(&state.db_path)? else {
+        return Ok(());
+    };
+    match reconcile_search_index(
+        &reconciliation,
+        &state.store,
+        IndexedSearchMutation::Unknown,
+        operation,
+    ) {
+        Ok(()) => clear_search_reconciliation_debt(&state.db_path),
+        Err(error) => {
+            if let Err(marker_error) =
+                record_search_reconciliation_failure(state, operation, &error)
+            {
+                return Err(anyhow::anyhow!(
+                    "{error:#}; additionally failed to update durable search-reconciliation debt: {marker_error:#}"
+                ));
+            }
+            Err(error)
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct SearchCapabilityStatus {
+    reader_available: bool,
+    writer_available: bool,
+    current: bool,
+    reconciliation_debt: bool,
+    error: String,
+    debt_operation: String,
+    debt_created_at: i64,
+}
+
+fn search_capability_status(state: &DaemonState) -> SearchCapabilityStatus {
+    let snapshot = state.search.snapshot();
+    let reader_available = snapshot.tantivy.is_some();
+    let (writer_available, writer_error) = match &snapshot.reconciliation {
+        SearchIndexReconciliation::Available(_) => (true, String::new()),
+        SearchIndexReconciliation::Disabled => (false, String::new()),
+        SearchIndexReconciliation::Unavailable(error) => (false, error.clone()),
+    };
+    match load_search_reconciliation_debt(&state.db_path) {
+        Ok(Some(debt)) => SearchCapabilityStatus {
+            reader_available,
+            writer_available,
+            current: false,
+            reconciliation_debt: true,
+            error: if debt.last_error.is_empty() {
+                writer_error
+            } else if writer_error.is_empty() {
+                debt.last_error
+            } else {
+                format!("{writer_error}; {}", debt.last_error)
+            },
+            debt_operation: debt.operation,
+            debt_created_at: debt.created_at_unix,
+        },
+        Ok(None) => SearchCapabilityStatus {
+            reader_available,
+            writer_available,
+            current: true,
+            reconciliation_debt: false,
+            error: writer_error,
+            debt_operation: String::new(),
+            debt_created_at: 0,
+        },
+        Err(error) => SearchCapabilityStatus {
+            reader_available,
+            writer_available,
+            current: false,
+            reconciliation_debt: true,
+            error: format!(
+                "durable search-reconciliation debt is unreadable and cannot be cleared safely: {error:#}"
+            ),
+            debt_operation: String::new(),
+            debt_created_at: 0,
+        },
+    }
+}
+
+fn search_status_proto(status: &SearchCapabilityStatus) -> nestweaver_proto::SearchStatus {
+    nestweaver_proto::SearchStatus {
+        reader_available: status.reader_available,
+        writer_available: status.writer_available,
+        current: status.current,
+        reconciliation_debt: status.reconciliation_debt,
+        error: status.error.clone(),
+        debt_operation: status.debt_operation.clone(),
+        debt_created_at: status.debt_created_at,
+    }
+}
+
+fn search_status_json(status: &SearchCapabilityStatus) -> serde_json::Value {
+    serde_json::json!({
+        "reader_available": status.reader_available,
+        "writer_available": status.writer_available,
+        "current": status.current,
+        "reconciliation_debt": status.reconciliation_debt,
+        "error": status.error,
+        "debt_operation": status.debt_operation,
+        "debt_created_at": status.debt_created_at,
+    })
+}
+
+async fn retry_search_reconciliation_debt_at_startup(
+    state: &Arc<DaemonState>,
+) -> Result<(), anyhow::Error> {
+    if state.read_only || load_search_reconciliation_debt(&state.db_path)?.is_none() {
+        return Ok(());
+    }
+    let reconciliation = state.search.current_snapshot().reconciliation;
+    let guard =
+        ConnectionGuard::write(state).map_err(|status| anyhow::anyhow!(status.to_string()))?;
+    let lease = state.write_gate.lock("search_debt_startup").await;
+    let recovery_state = Arc::clone(state);
+    tokio::task::spawn_blocking(move || {
+        let _ownership = MutationWorkerOwnership {
+            _write_lease: lease,
+            _connection_guard: guard,
+        };
+        reconcile_pending_search_debt(&recovery_state, reconciliation, "daemon_startup")
+    })
+    .await
+    .map_err(|error| anyhow::anyhow!("startup search-debt worker panicked: {error}"))?
 }
 
 fn open_search_index(
@@ -3593,7 +4533,11 @@ where
     };
     reconcile_deleted_extension_uids(state, &removed_vault_uids, &mut failures);
     let search_mutation = if changed {
-        indexed_search_mutation(search_rows_before, &state.store)
+        indexed_search_mutation(
+            search_rows_before,
+            &state.store,
+            IndexedSearchMutationScope::GraphOnly,
+        )
     } else {
         IndexedSearchMutation::Unchanged
     };
@@ -3682,7 +4626,11 @@ where
             reconcile_deleted_extension_uids(state, &vault_uids, &mut failures);
             reconcile_deleted_project_extensions(state, &project_uids, &mut failures);
             let search_mutation = if changed {
-                indexed_search_mutation(search_rows_before, &state.store)
+                indexed_search_mutation(
+                    search_rows_before,
+                    &state.store,
+                    IndexedSearchMutationScope::GraphOnly,
+                )
             } else {
                 IndexedSearchMutation::Unchanged
             };
@@ -3706,7 +4654,11 @@ where
             };
             reconcile_deleted_extension_uids(state, &vault_uids, &mut failures);
             reconcile_deleted_project_extensions(state, &project_uids, &mut failures);
-            let search_mutation = indexed_search_mutation(search_rows_before, &state.store);
+            let search_mutation = indexed_search_mutation(
+                search_rows_before,
+                &state.store,
+                IndexedSearchMutationScope::GraphOnly,
+            );
             if search_mutation != IndexedSearchMutation::Unchanged {
                 append_search_reconciliation(
                     &mut failures,
@@ -4075,7 +5027,11 @@ where
                 Vec::new()
             });
             let search_mutation = if changed {
-                indexed_search_mutation(search_rows_before, &state.store)
+                indexed_search_mutation(
+                    search_rows_before,
+                    &state.store,
+                    IndexedSearchMutationScope::GraphOnly,
+                )
             } else {
                 IndexedSearchMutation::Unchanged
             };
@@ -4097,7 +5053,11 @@ where
             } else {
                 finalize_code_graph_deletion(state, &repo_uids)
             };
-            let search_mutation = indexed_search_mutation(search_rows_before, &state.store);
+            let search_mutation = indexed_search_mutation(
+                search_rows_before,
+                &state.store,
+                IndexedSearchMutationScope::GraphOnly,
+            );
             if search_mutation != IndexedSearchMutation::Unchanged {
                 append_search_reconciliation(
                     &mut failures,
@@ -4131,7 +5091,11 @@ fn run_remove_vault_with_projection(
     if !confirmed_noop {
         failures = finalize_node_graph_deletion(state, "remove_vault");
         reconcile_deleted_extension_uids(state, &[vault_uid.to_string()], &mut failures);
-        let search_mutation = indexed_search_mutation(search_rows_before, &state.store);
+        let search_mutation = indexed_search_mutation(
+            search_rows_before,
+            &state.store,
+            IndexedSearchMutationScope::GraphOnly,
+        );
         if search_mutation != IndexedSearchMutation::Unchanged {
             append_search_reconciliation(
                 &mut failures,
@@ -4229,6 +5193,57 @@ fn plan_embeddings(store: &GraphStore, scope: &str, force: bool) -> Result<Embed
     })
 }
 
+fn degraded_graph_publication_message(
+    operation: &str,
+    publication: &nestweaver_engine::manifest::GraphMutationPublicationOutcome,
+) -> Option<String> {
+    use nestweaver_engine::manifest::GraphMutationPublicationDisposition;
+
+    if publication.disposition != GraphMutationPublicationDisposition::CommittedDegraded {
+        return None;
+    }
+    let warnings = if publication.warnings.is_empty() {
+        "unspecified publication stage".to_string()
+    } else {
+        publication
+            .warnings
+            .iter()
+            .map(|warning| format!("{}: {}", warning.stage, warning.message))
+            .collect::<Vec<_>>()
+            .join("; ")
+    };
+    Some(format!(
+        "{operation} committed graph changes (generation {} -> {}), but publication reconciliation is degraded: {warnings}. The graph was NOT rolled back; repair the named stage(s) before treating derived artifacts as current.",
+        publication.generation_before, publication.generation_after,
+    ))
+}
+
+fn materialize_projects_terminal_progress(
+    result: &nestweaver_engine::ProjectMaterializationResult,
+) -> IndexProgress {
+    let degraded = degraded_graph_publication_message("MaterializeProjects", &result.publication);
+    let message = if let Some(message) = &degraded {
+        message.clone()
+    } else {
+        format!(
+            "Done — {} projects, {} note edges, {} symbol edges, {} component edges",
+            result.projects_created, result.note_edges, result.symbol_edges, result.component_edges,
+        )
+    };
+    IndexProgress {
+        phase: if degraded.is_some() {
+            Phase::Error as i32
+        } else {
+            Phase::Done as i32
+        },
+        message,
+        files_processed: result.projects_created as u64,
+        files_total: result.projects_created as u64,
+        symbols_found: result.symbol_edges as u64,
+        ..Default::default()
+    }
+}
+
 #[tonic::async_trait]
 impl NestWeaverDaemon for DaemonService {
     // ── Lifecycle ───────────────────────────────────────────────────
@@ -4249,6 +5264,7 @@ impl NestWeaverDaemon for DaemonService {
             // The daemon's own PID, so the CLI can cross-check a pidfile
             // PID against the socket-reported PID before signaling it.
             pid: std::process::id(),
+            embedding_identity_repair: true,
         }))
     }
 
@@ -4305,27 +5321,17 @@ impl NestWeaverDaemon for DaemonService {
             },
         };
 
-        // Stage the backup while HOLDING the write lock. Quiesce == lock-held:
-        // no writer touches the files mid-copy, and the RAII guard releases the
-        // lock on drop/panic — there is no persistent quiesce flag to leak.
-        let staged = {
-            // Guard BEFORE the write gate: during a drain the gate is held by the
-            // in-flight write for as long as it runs, so taking it first meant this
-            // request queued for minutes and only then learned it was refused. A
-            // client with a deadline saw DEADLINE_EXCEEDED instead of the
-            // explanatory UNAVAILABLE, which defeats the point of the message.
-            let _guard = ConnectionGuard::write(&self.state)?;
-            let _write_lock = self.state.write_gate.lock("backup").await;
-            let store = self.state.store.clone();
-            let cfg = config.clone();
-            tracing::info!("backup: staging under write lock");
-            tokio::task::spawn_blocking(move || {
+        // Stage under exact-worker ownership. Packaging below is detached from
+        // the live database and deliberately does not retain the write lease.
+        let store = self.state.store.clone();
+        let cfg = config.clone();
+        let staged = self
+            .run_unary_mutation("backup", move || {
+                tracing::info!("backup: staging under write lock");
                 nestweaver_engine::stage_backup_from_store(&store, &cfg)
+                    .map_err(|error| Status::internal(format!("backup staging failed: {error}")))
             })
-            .await
-            .map_err(|e| Status::internal(format!("backup staging panicked: {e}")))?
-            .map_err(|e| Status::internal(format!("backup staging failed: {e}")))?
-        }; // write lock released here — writers resume while we package below
+            .await?;
 
         let cfg = config.clone();
         let result =
@@ -4445,9 +5451,6 @@ impl NestWeaverDaemon for DaemonService {
             }
             Err(e) => return Err(e),
         };
-        // Registration is admitted as one short mutation. The endless service
-        // must not remain an active write while it is merely waiting for files.
-        drop(admission_guard);
         let state = self.state.clone();
         let mutation_factory = daemon_mutation_lease_factory(self.state.clone());
         watcher = watcher.with_mutation_lease_factory(mutation_factory);
@@ -4475,13 +5478,23 @@ impl NestWeaverDaemon for DaemonService {
         // Retained so shutdown can AWAIT it before releasing the socket,
         // pidfile and instance lock — a watcher write that outlives teardown
         // is the hazard the reconcile loops already guard against.
-        if let Ok(mut tasks) = self.state.watcher_tasks.lock() {
-            // Drop handles for tasks that already finished, so a long-lived
-            // daemon that starts and stops many watchers does not accumulate
-            // them.
-            tasks.retain(|task| !task.is_finished());
-            tasks.push(watcher_task);
-        }
+        let mut tasks = self
+            .state
+            .watcher_tasks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Drop handles for tasks that already finished, so a long-lived
+        // daemon that starts and stops many watchers does not accumulate
+        // them.
+        tasks.retain(|task| !task.handle.is_finished());
+        tasks.push(WatcherTask {
+            id: watcher_id,
+            handle: watcher_task,
+        });
+        // Registration, spawn, and handle retention are one admitted unit.
+        // Only now may the drain observe it as complete; later watcher batches
+        // take their own exact-worker leases.
+        drop(admission_guard);
 
         Ok(Response::new(WatchVaultResponse {
             ok: true,
@@ -4529,34 +5542,11 @@ impl NestWeaverDaemon for DaemonService {
             false,
         )?;
 
-        let db_path = self.state.db_path.clone();
-
-        let limits = self
-            .state
-            .instance_cfg
-            .as_ref()
-            .map(|config| config.indexing.limits())
-            .unwrap_or_default();
-        let mut watcher = nestweaver_engine::CodeWatcher::new(&db_path, &repo_path, &instance_id)
-            .with_limits(limits);
-        let shutdown_handle = watcher.shutdown_handle();
-
-        // Refuse BEFORE registering — and here the ordering matters more than in
-        // `watch_vault`, because `force` is passed through. With the guard
-        // second, `nestweaver watch --force` during a drain would STOP THE
-        // RUNNING INCUMBENT WATCHER and then refuse the request that replaced
-        // it, leaving no watcher at all plus a registration pointing at a
-        // dropped `CodeWatcher`. Destroying live state on behalf of a rejected
-        // request is not something a refusal is allowed to do.
-        let admission_guard = ConnectionGuard::write(&self.state)?;
-
-        // register_watcher holds the lock across check + store (TOCTOU-safe).
-        // With `force`, an already-running watcher whose owner is ALIVE is
-        // stopped and replaced. nw-302: one orphaned by a kill -9'd `watch`
-        // CLI no longer needs `force` — its owner pid is recorded, so the
-        // reclaim is automatic.
-        let watcher_id = match register_watcher(&self.state, shutdown_handle, force, owner_pid) {
-            Ok(id) => id,
+        // ServeUI and WatchCode use this same constructor, so registration,
+        // per-batch ownership, task retention, and shutdown behavior cannot
+        // drift between the two entry points.
+        match self.start_registered_code_watcher(repo_path, instance_id, force, owner_pid) {
+            Ok(_) => {}
             Err(e) if e.code() == tonic::Code::AlreadyExists => {
                 return Ok(Response::new(WatchCodeResponse {
                     ok: false,
@@ -4566,41 +5556,6 @@ impl NestWeaverDaemon for DaemonService {
                 }));
             }
             Err(e) => return Err(e),
-        };
-        drop(admission_guard);
-        let state = self.state.clone();
-        let mutation_factory = daemon_mutation_lease_factory(self.state.clone());
-        watcher = watcher.with_mutation_lease_factory(mutation_factory);
-        let store = self.state.store.clone();
-        let on_change = Self::make_embed_on_change(
-            self.state.embedding_runtime.clone(),
-            self.state.store.clone(),
-        );
-
-        let watcher_task = tokio::task::spawn_blocking(move || {
-            tracing::info!(repo = %repo_path.display(), "code watcher thread started");
-
-            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                watcher.run_with_store(store, on_change)
-            }));
-
-            match result {
-                Ok(Ok(())) => tracing::info!("code watcher exited cleanly"),
-                Ok(Err(e)) => tracing::error!(error = %e, "code watcher exited with error"),
-                Err(_) => tracing::error!("code watcher thread panicked"),
-            }
-
-            clear_watcher_registration(&state, watcher_id);
-        });
-        // Retained so shutdown can AWAIT it before releasing the socket,
-        // pidfile and instance lock — a watcher write that outlives teardown
-        // is the hazard the reconcile loops already guard against.
-        if let Ok(mut tasks) = self.state.watcher_tasks.lock() {
-            // Drop handles for tasks that already finished, so a long-lived
-            // daemon that starts and stops many watchers does not accumulate
-            // them.
-            tasks.retain(|task| !task.is_finished());
-            tasks.push(watcher_task);
         }
 
         Ok(Response::new(WatchCodeResponse {
@@ -4618,15 +5573,19 @@ impl NestWeaverDaemon for DaemonService {
         {
             return Err(Status::permission_denied("admin token required"));
         }
-        let mut guard = self
+        let watcher_id = self
             .state
             .watcher_stop
             .lock()
-            .map_err(|e| Status::internal(format!("watcher_stop lock poisoned: {e}")))?;
+            .map_err(|e| Status::internal(format!("watcher_stop lock poisoned: {e}")))?
+            .as_ref()
+            .map(|registration| registration.id);
 
-        if let Some(reg) = guard.take() {
-            tracing::info!(watcher_id = reg.id, "stop_watch: stopping active watcher");
-            reg.handle.stop();
+        if let Some(watcher_id) = watcher_id {
+            stop_watcher_registration(&self.state, watcher_id);
+            if let Some(task) = take_watcher_task(&self.state, watcher_id) {
+                let _ = task.await;
+            }
             Ok(Response::new(StopWatchResponse { ok: true }))
         } else {
             Ok(Response::new(StopWatchResponse { ok: false }))
@@ -4786,7 +5745,29 @@ impl NestWeaverDaemon for DaemonService {
         }
         let req = request.into_inner();
         let state = self.state.clone();
-        let watch_instance = resolve_effective_instance_id(&req.watch_instance_id, &state)?;
+        let requested_watch = if req.watch && !req.watch_repo_path.is_empty() {
+            let repo_path =
+                PathBuf::from(&req.watch_repo_path)
+                    .canonicalize()
+                    .map_err(|error| {
+                        Status::invalid_argument(format!(
+                            "cannot canonicalize watched repo path: {error}"
+                        ))
+                    })?;
+            watch_path_allowed(
+                state
+                    .instance_cfg
+                    .as_ref()
+                    .map(|config| config.repos.as_slice()),
+                &repo_path,
+                "repo",
+                false,
+            )?;
+            let instance_id = resolve_effective_instance_id(&req.watch_instance_id, &state)?;
+            Some((repo_path, instance_id))
+        } else {
+            None
+        };
 
         let app_state = nestweaver_web::state::AppState::new_with_arc_tantivy(
             state.store.clone(),
@@ -4820,48 +5801,79 @@ impl NestWeaverDaemon for DaemonService {
         // is a no-op success, but a FOREIGN process bound to the port must be a
         // clear error — the old code spawned a task whose bind failure was only
         // logged, and reported ok:true regardless.
-        {
-            let guard = self
+        let stale_watcher = {
+            let mut guard = self
                 .state
                 .ui_server
                 .lock()
                 .map_err(|e| Status::internal(format!("ui_server lock poisoned: {e}")))?;
-            if let Some((running_port, handle)) = guard.as_ref()
-                && !handle.is_finished()
+            if let Some(running) = guard.as_mut()
+                && !running.handle.is_finished()
             {
-                // A watch request must not be silently dropped just because
-                // the UI is already served — start the watcher here too.
-                if req.watch && !req.watch_repo_path.is_empty() {
-                    let watch_db = state.db_path.clone();
-                    let watch_repo = std::path::PathBuf::from(&req.watch_repo_path);
-                    let watch_store = state.store.clone();
-                    let watch_instance = watch_instance.clone();
-                    let watch_limits = state
-                        .instance_cfg
-                        .as_ref()
-                        .map(|config| config.indexing.limits())
-                        .unwrap_or_default();
-
-                    tokio::task::spawn_blocking(move || {
-                        let watcher = nestweaver_engine::CodeWatcher::new(
-                            &watch_db,
-                            &watch_repo,
-                            &watch_instance,
-                        )
-                        .with_limits(watch_limits);
-                        if let Err(e) = watcher.run_with_store(watch_store, None) {
-                            tracing::error!("CodeWatcher failed: {e}");
+                if let Some((watch_repo, watch_instance)) = requested_watch.as_ref() {
+                    if let Some(binding) = running.watcher.as_ref()
+                        && watcher_registration_is_active(&state, binding.id)
+                    {
+                        if binding.repo_path == *watch_repo
+                            && binding.instance_id == *watch_instance
+                        {
+                            return Ok(Response::new(ServeUiResponse {
+                                ok: true,
+                                message: format!(
+                                    "UI server already running on port {}; watcher already running for {}",
+                                    running.port,
+                                    watch_repo.display()
+                                ),
+                                port: u32::from(running.port),
+                                error: String::new(),
+                            }));
                         }
+                        return Ok(Response::new(ServeUiResponse {
+                            ok: false,
+                            message: format!(
+                                "UI server is already watching {} for instance {}; stop it before watching {} for instance {}",
+                                binding.repo_path.display(),
+                                binding.instance_id,
+                                watch_repo.display(),
+                                watch_instance
+                            ),
+                            port: u32::from(running.port),
+                            error: "watcher_conflict".to_string(),
+                        }));
+                    }
+
+                    let watcher_id = match self.start_registered_code_watcher(
+                        watch_repo.clone(),
+                        watch_instance.clone(),
+                        false,
+                        None,
+                    ) {
+                        Ok(id) => id,
+                        Err(error) if error.code() == tonic::Code::AlreadyExists => {
+                            return Ok(Response::new(ServeUiResponse {
+                                ok: false,
+                                message: "another daemon watcher is already running; stop it before enabling the UI watcher".to_string(),
+                                port: u32::from(running.port),
+                                error: "watcher_conflict".to_string(),
+                            }));
+                        }
+                        Err(error) => return Err(error),
+                    };
+                    running.watcher = Some(UiWatcherBinding {
+                        id: watcher_id,
+                        repo_path: watch_repo.clone(),
+                        instance_id: watch_instance.clone(),
                     });
                     // Report the ACTUAL running port, not the requested one —
                     // the CLI prints this port in the URL it shows the user.
                     return Ok(Response::new(ServeUiResponse {
                         ok: true,
                         message: format!(
-                            "UI server already running on port {running_port}; watcher started for {}",
-                            req.watch_repo_path
+                            "UI server already running on port {}; watcher started for {}",
+                            running.port,
+                            watch_repo.display()
                         ),
-                        port: u32::from(*running_port),
+                        port: u32::from(running.port),
                         error: String::new(),
                     }));
                 }
@@ -4869,10 +5881,17 @@ impl NestWeaverDaemon for DaemonService {
                 // the CLI prints this port in the URL it shows the user.
                 return Ok(Response::new(ServeUiResponse {
                     ok: true,
-                    message: format!("UI server already running on port {running_port}"),
-                    port: u32::from(*running_port),
+                    message: format!("UI server already running on port {}", running.port),
+                    port: u32::from(running.port),
                     error: String::new(),
                 }));
+            }
+            guard.take().and_then(|registration| registration.watcher)
+        };
+        if let Some(watcher) = stale_watcher {
+            stop_watcher_registration(&self.state, watcher.id);
+            if let Some(task) = take_watcher_task(&self.state, watcher.id) {
+                let _ = task.await;
             }
         }
         if std::net::TcpListener::bind(("127.0.0.1", port)).is_err() {
@@ -4897,6 +5916,37 @@ impl NestWeaverDaemon for DaemonService {
             tracing::info!("admin API also mounted on web UI server");
         }
 
+        // Register the optional watcher before publishing the UI registration.
+        // It uses the same canonical slot and retained task path as WatchCode;
+        // a competing watcher refuses the request instead of spawning an
+        // unobservable duplicate.
+        let watcher = if let Some((watch_repo, watch_instance)) = requested_watch.as_ref() {
+            let watcher_id = match self.start_registered_code_watcher(
+                watch_repo.clone(),
+                watch_instance.clone(),
+                false,
+                None,
+            ) {
+                Ok(id) => id,
+                Err(error) if error.code() == tonic::Code::AlreadyExists => {
+                    return Ok(Response::new(ServeUiResponse {
+                        ok: false,
+                        message: "another daemon watcher is already running; stop it before enabling the UI watcher".to_string(),
+                        port: 0,
+                        error: "watcher_conflict".to_string(),
+                    }));
+                }
+                Err(error) => return Err(error),
+            };
+            Some(UiWatcherBinding {
+                id: watcher_id,
+                repo_path: watch_repo.clone(),
+                instance_id: watch_instance.clone(),
+            })
+        } else {
+            None
+        };
+
         // Spawn web server as a background task inside the daemon. The handle
         // is tracked so `stop_ui` can abort it and release the listen port
         // (LOW: ui port leak).
@@ -4917,27 +5967,10 @@ impl NestWeaverDaemon for DaemonService {
                 .ui_server
                 .lock()
                 .map_err(|e| Status::internal(format!("ui_server lock poisoned: {e}")))?;
-            *guard = Some((port, handle));
-        }
-
-        // If watch mode requested, spawn a CodeWatcher.
-        if req.watch && !req.watch_repo_path.is_empty() {
-            let watch_db = state.db_path.clone();
-            let watch_repo = std::path::PathBuf::from(&req.watch_repo_path);
-            let watch_store = state.store.clone();
-            let watch_limits = state
-                .instance_cfg
-                .as_ref()
-                .map(|config| config.indexing.limits())
-                .unwrap_or_default();
-
-            tokio::task::spawn_blocking(move || {
-                let watcher =
-                    nestweaver_engine::CodeWatcher::new(&watch_db, &watch_repo, &watch_instance)
-                        .with_limits(watch_limits);
-                if let Err(e) = watcher.run_with_store(watch_store, None) {
-                    tracing::error!("CodeWatcher failed: {e}");
-                }
+            *guard = Some(UiServerRegistration {
+                port,
+                handle,
+                watcher,
             });
         }
 
@@ -4967,12 +6000,25 @@ impl NestWeaverDaemon for DaemonService {
             guard.take()
         };
         match handle {
-            Some((_port, handle)) if !handle.is_finished() => {
-                // Aborting the task drops the axum listener, releasing the port.
-                handle.abort();
+            Some(registration) => {
+                let server_was_running = !registration.handle.is_finished();
+                if server_was_running {
+                    // Aborting the task drops the axum listener, releasing the port.
+                    registration.handle.abort();
+                }
+                if let Some(watcher) = registration.watcher {
+                    stop_watcher_registration(&self.state, watcher.id);
+                    if let Some(task) = take_watcher_task(&self.state, watcher.id) {
+                        let _ = task.await;
+                    }
+                }
                 Ok(Response::new(StopUiResponse {
                     ok: true,
-                    message: "UI server stopped".to_string(),
+                    message: if server_was_running {
+                        "UI server stopped".to_string()
+                    } else {
+                        "UI server had exited; its watcher was stopped and drained".to_string()
+                    },
                 }))
             }
             _ => Ok(Response::new(StopUiResponse {
@@ -5116,8 +6162,10 @@ impl NestWeaverDaemon for DaemonService {
         let cancel_for_index = cancel;
 
         tokio::task::spawn_blocking(move || {
-            let _write_lock = write_lock.blocking_lock("index_repo");
-            let _guard = guard;
+            let _ownership = MutationWorkerOwnership {
+                _write_lease: write_lock.blocking_lock("index_repo"),
+                _connection_guard: guard,
+            };
             // Dropped when the index task ends → fires the watchdog's `done_rx`
             // so it releases its stream sender and the response can terminate.
             let _done = done_tx;
@@ -5424,8 +6472,10 @@ impl NestWeaverDaemon for DaemonService {
         let guard = ConnectionGuard::write(&self.state)?;
         let write_lock = self.state.write_gate.clone();
         tokio::task::spawn_blocking(move || {
-            let _write_lock = write_lock.blocking_lock("index_vault");
-            let _guard = guard;
+            let _ownership = MutationWorkerOwnership {
+                _write_lease: write_lock.blocking_lock("index_vault"),
+                _connection_guard: guard,
+            };
             let _ = tx.blocking_send(Ok(IndexProgress {
                 phase: Phase::Discovering as i32,
                 message: format!("Scanning vault {}", vault_path.display()),
@@ -5434,6 +6484,22 @@ impl NestWeaverDaemon for DaemonService {
                 symbols_found: 0,
                 ..Default::default()
             }));
+
+            let indexed_before = indexed_search_rows_before(&state);
+            let search_admission = match establish_search_reconciliation_debt(&state, "index_vault")
+            {
+                Ok(admission) => admission,
+                Err(error) => {
+                    let _ = tx.blocking_send(Ok(IndexProgress {
+                            phase: Phase::Error as i32,
+                            message: format!(
+                                "IndexVault refused before graph mutation because durable search-reconciliation debt could not be established: {error:#}"
+                            ),
+                            ..Default::default()
+                        }));
+                    return;
+                }
+            };
 
             let index_result =
                 nestweaver_engine::index_markdown_directory_with_store_and_deletion_count(
@@ -5471,63 +6537,46 @@ impl NestWeaverDaemon for DaemonService {
                         trigram_refresh: None,
                     }));
 
-                    // Rebuild Tantivy search index so BM25 search reflects
-                    // the freshly indexed vault content.
-                    //
-                    // nw-249: when there is NO writer this whole block was
-                    // skipped and the DONE phase below still reported a full
-                    // set of counts — so an index that could not touch the
-                    // search index at all looked identical to one that
-                    // rebuilt it. Unlike a failed rebuild, this is not an
-                    // error: a read-only replica legitimately has no writer.
-                    // So it is disclosed rather than failed, and the phrasing
-                    // says which of the two happened.
-                    let search_index_rebuilt =
-                        state.tantivy().is_some_and(|tantivy| tantivy.has_writer());
-                    if !search_index_rebuilt {
+                    let mutation = indexed_search_mutation(
+                        indexed_before,
+                        &state.store,
+                        IndexedSearchMutationScope::MayIncludeVaultFiles,
+                    );
+                    if let Err(error) = finish_search_reconciliation(
+                        &state,
+                        mutation,
+                        "index_vault",
+                        search_admission,
+                    ) {
+                        tracing::error!(error = %error, "search reconciliation failed after vault indexing");
                         let _ = tx.blocking_send(Ok(IndexProgress {
-                            message: "note: the graph was updated but the BM25 search index \
-                                      was NOT rebuilt (this daemon holds no search-index \
-                                      writer), so `brain search` will not reflect this \
-                                      index until one does"
-                                .to_string(),
+                            phase: Phase::Error as i32,
+                            message: format!(
+                                "IndexVault committed graph changes but BM25 search reconciliation failed and remains durably pending: {error:#}"
+                            ),
+                            files_processed: result.index.notes_count as u64,
+                            files_total: result.index.notes_count as u64,
+                            symbols_found: result.index.headings_count as u64,
                             ..Default::default()
                         }));
+                        return;
                     }
-                    if let Some(tantivy) = state.tantivy()
-                        && tantivy.has_writer()
+
+                    if let Some(message) =
+                        degraded_graph_publication_message("IndexVault", &result.publication)
                     {
-                        match tantivy.reindex_from_store(&state.store) {
-                            Ok(n) => {
-                                tracing::info!(docs = n, "Tantivy reindexed after vault indexing")
-                            }
-                            // Report the failure instead of walking into the
-                            // DONE phase below with a full set of counts.
-                            //
-                            // `refresh_vault_since` — the sibling roughly 80
-                            // lines down, doing the same rebuild after the same
-                            // kind of commit — already emits Phase::Error and
-                            // returns. This one warned to the log and then told
-                            // the user it was finished, so a vault re-index
-                            // looked clean while BM25 search kept serving the
-                            // PRE-INDEX corpus. The graph write did land, which
-                            // is why the message says so explicitly rather than
-                            // implying the whole operation failed.
-                            Err(error) => {
-                                tracing::error!(error = %error, "Tantivy reindex failed after vault indexing");
-                                let _ = tx.blocking_send(Ok(IndexProgress {
-                                    phase: Phase::Error as i32,
-                                    message: format!(
-                                        "IndexVault committed graph changes but Tantivy rebuild failed: {error:#}"
-                                    ),
-                                    files_processed: result.index.notes_count as u64,
-                                    files_total: result.index.notes_count as u64,
-                                    symbols_found: result.index.headings_count as u64,
-                                    ..Default::default()
-                                }));
-                                return;
-                            }
-                        }
+                        let _ = tx.blocking_send(Ok(IndexProgress {
+                            phase: Phase::Error as i32,
+                            message,
+                            files_processed: result.index.notes_count as u64,
+                            files_total: result.index.notes_count as u64,
+                            symbols_found: result.index.headings_count as u64,
+                            skipped_count: skipped_count as u64,
+                            skipped_files,
+                            coverage_status,
+                            trigram_refresh: None,
+                        }));
+                        return;
                     }
 
                     // DONE phase
@@ -5546,6 +6595,15 @@ impl NestWeaverDaemon for DaemonService {
                     }));
                 }
                 Err(e) => {
+                    let error = anyhow::anyhow!("IndexVault graph mutation failed: {e:#}");
+                    if let Err(marker_error) =
+                        record_search_reconciliation_failure(&state, "index_vault", &error)
+                    {
+                        tracing::error!(
+                            error = %marker_error,
+                            "failed to update durable search debt after IndexVault error"
+                        );
+                    }
                     let _ = tx.blocking_send(Ok(IndexProgress {
                         phase: Phase::Error as i32,
                         message: format!("IndexVault failed: {e:#}"),
@@ -5588,8 +6646,10 @@ impl NestWeaverDaemon for DaemonService {
         let guard = ConnectionGuard::write(&self.state)?;
         let write_lock = self.state.write_gate.clone();
         tokio::task::spawn_blocking(move || {
-            let _write_lock = write_lock.blocking_lock("refresh_vault_since");
-            let _guard = guard;
+            let _ownership = MutationWorkerOwnership {
+                _write_lease: write_lock.blocking_lock("refresh_vault_since"),
+                _connection_guard: guard,
+            };
             let _ = tx.blocking_send(Ok(IndexProgress {
                 phase: Phase::Discovering as i32,
                 message: format!(
@@ -5603,6 +6663,24 @@ impl NestWeaverDaemon for DaemonService {
                 ..Default::default()
             }));
 
+            let indexed_before = indexed_search_rows_before(&state);
+            let search_admission = match establish_search_reconciliation_debt(
+                &state,
+                "refresh_vault_since",
+            ) {
+                Ok(admission) => admission,
+                Err(error) => {
+                    let _ = tx.blocking_send(Ok(IndexProgress {
+                            phase: Phase::Error as i32,
+                            message: format!(
+                                "RefreshVaultSince refused before graph mutation because durable search-reconciliation debt could not be established: {error:#}"
+                            ),
+                            ..Default::default()
+                        }));
+                    return;
+                }
+            };
+
             match nestweaver_engine::index_markdown_directory_since_with_store_and_ignore(
                 &state.store,
                 &vault_path,
@@ -5612,20 +6690,40 @@ impl NestWeaverDaemon for DaemonService {
                 &extra_patterns,
             ) {
                 Ok(result) => {
-                    if let Some(tantivy) = state.tantivy()
-                        && tantivy.has_writer()
-                        && let Err(error) = tantivy.reindex_from_store(&state.store)
-                    {
+                    let mutation = indexed_search_mutation(
+                        indexed_before,
+                        &state.store,
+                        IndexedSearchMutationScope::MayIncludeVaultFiles,
+                    );
+                    if let Err(error) = finish_search_reconciliation(
+                        &state,
+                        mutation,
+                        "refresh_vault_since",
+                        search_admission,
+                    ) {
                         let _ = tx.blocking_send(Ok(IndexProgress {
                                 phase: Phase::Error as i32,
                                 message: format!(
-                                    "RefreshVaultSince committed graph changes but Tantivy rebuild failed: {error:#}"
+                                    "RefreshVaultSince committed graph changes but BM25 search reconciliation failed and remains durably pending: {error:#}"
                                 ),
                                 files_processed: result.files_checked as u64,
                                 files_total: result.files_checked as u64,
                                 symbols_found: result.headings_count as u64,
                                 ..Default::default()
                             }));
+                        return;
+                    }
+                    if let Some(message) =
+                        degraded_graph_publication_message("RefreshVaultSince", &result.publication)
+                    {
+                        let _ = tx.blocking_send(Ok(IndexProgress {
+                            phase: Phase::Error as i32,
+                            message,
+                            files_processed: result.files_checked as u64,
+                            files_total: result.files_checked as u64,
+                            symbols_found: result.headings_count as u64,
+                            ..Default::default()
+                        }));
                         return;
                     }
                     let vault_uid = nestweaver_schema::vault_uid(
@@ -5659,6 +6757,18 @@ impl NestWeaverDaemon for DaemonService {
                     }));
                 }
                 Err(error) => {
+                    let debt_error =
+                        anyhow::anyhow!("RefreshVaultSince graph mutation failed: {error:#}");
+                    if let Err(marker_error) = record_search_reconciliation_failure(
+                        &state,
+                        "refresh_vault_since",
+                        &debt_error,
+                    ) {
+                        tracing::error!(
+                            error = %marker_error,
+                            "failed to update durable search debt after RefreshVaultSince error"
+                        );
+                    }
                     let _ = tx.blocking_send(Ok(IndexProgress {
                         phase: Phase::Error as i32,
                         message: format!("RefreshVaultSince failed: {error:#}"),
@@ -5741,20 +6851,7 @@ impl NestWeaverDaemon for DaemonService {
                 Some(mutation_factory),
             ) {
                 Ok(result) => {
-                    let _ = tx.blocking_send(Ok(IndexProgress {
-                        phase: Phase::Done as i32,
-                        message: format!(
-                            "Done — {} projects, {} note edges, {} symbol edges, {} component edges",
-                            result.projects_created,
-                            result.note_edges,
-                            result.symbol_edges,
-                            result.component_edges,
-                        ),
-                        files_processed: result.projects_created as u64,
-                        files_total: result.projects_created as u64,
-                        symbols_found: result.symbol_edges as u64,
-                        ..Default::default()
-                    }));
+                    let _ = tx.blocking_send(Ok(materialize_projects_terminal_progress(&result)));
                 }
                 Err(e) => {
                     let _ = tx.blocking_send(Ok(IndexProgress {
@@ -5783,26 +6880,14 @@ impl NestWeaverDaemon for DaemonService {
         {
             return Err(Status::permission_denied("admin token required"));
         }
-        // Guard BEFORE the write gate: during a drain the gate is held by the
-        // in-flight write for as long as it runs, so taking it first meant this
-        // request queued for minutes and only then learned it was refused. A
-        // client with a deadline saw DEADLINE_EXCEEDED instead of the
-        // explanatory UNAVAILABLE, which defeats the point of the message.
-        let _guard = ConnectionGuard::write(&self.state)?;
-        let _write_lock = self.state.write_gate.lock("remove_vault").await;
-
         let req = request.into_inner();
         let state = self.state.clone();
-
-        #[allow(clippy::result_large_err)]
-        let result = tokio::task::spawn_blocking(move || {
+        self.run_unary_mutation("remove_vault", move || {
             let search_rows_before = indexed_search_rows_before(&state);
             run_remove_vault_with_projection(&state, &req.vault_uid, search_rows_before)
         })
         .await
-        .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
-
-        result.map(Response::new)
+        .map(Response::new)
     }
 
     async fn remove_repo(
@@ -5814,19 +6899,9 @@ impl NestWeaverDaemon for DaemonService {
         {
             return Err(Status::permission_denied("admin token required"));
         }
-        // Guard BEFORE the write gate: during a drain the gate is held by the
-        // in-flight write for as long as it runs, so taking it first meant this
-        // request queued for minutes and only then learned it was refused. A
-        // client with a deadline saw DEADLINE_EXCEEDED instead of the
-        // explanatory UNAVAILABLE, which defeats the point of the message.
-        let _guard = ConnectionGuard::write(&self.state)?;
-        let _write_lock = self.state.write_gate.lock("remove_repo").await;
-
         let req = request.into_inner();
         let state = self.state.clone();
-
-        #[allow(clippy::result_large_err)]
-        let result = tokio::task::spawn_blocking(move || {
+        self.run_unary_mutation("remove_repo", move || {
             run_remove_repo_with(
                 &state,
                 &req.repo_uid,
@@ -5843,9 +6918,7 @@ impl NestWeaverDaemon for DaemonService {
             )
         })
         .await
-        .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
-
-        result.map(Response::new)
+        .map(Response::new)
     }
 
     async fn remove_project(
@@ -5857,19 +6930,9 @@ impl NestWeaverDaemon for DaemonService {
         {
             return Err(Status::permission_denied("admin token required"));
         }
-        // Guard BEFORE the write gate: during a drain the gate is held by the
-        // in-flight write for as long as it runs, so taking it first meant this
-        // request queued for minutes and only then learned it was refused. A
-        // client with a deadline saw DEADLINE_EXCEEDED instead of the
-        // explanatory UNAVAILABLE, which defeats the point of the message.
-        let _guard = ConnectionGuard::write(&self.state)?;
-        let _write_lock = self.state.write_gate.lock("remove_project").await;
-
         let req = request.into_inner();
         let state = self.state.clone();
-
-        #[allow(clippy::result_large_err)]
-        let result = tokio::task::spawn_blocking(move || {
+        self.run_unary_mutation("remove_project", move || {
             run_remove_project_with(
                 &state,
                 &req.project_uid,
@@ -5880,9 +6943,7 @@ impl NestWeaverDaemon for DaemonService {
             )
         })
         .await
-        .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
-
-        result.map(Response::new)
+        .map(Response::new)
     }
 
     async fn prune_stale(
@@ -5894,19 +6955,9 @@ impl NestWeaverDaemon for DaemonService {
         {
             return Err(Status::permission_denied("admin token required"));
         }
-        // Guard BEFORE the write gate: during a drain the gate is held by the
-        // in-flight write for as long as it runs, so taking it first meant this
-        // request queued for minutes and only then learned it was refused. A
-        // client with a deadline saw DEADLINE_EXCEEDED instead of the
-        // explanatory UNAVAILABLE, which defeats the point of the message.
-        let _guard = ConnectionGuard::write(&self.state)?;
-        let _write_lock = self.state.write_gate.lock("prune_stale").await;
-
         let _req = request.into_inner();
         let state = self.state.clone();
-
-        #[allow(clippy::result_large_err)]
-        let result = tokio::task::spawn_blocking(move || {
+        self.run_unary_mutation("prune_stale", move || {
             run_prune_stale_with(
                 &state,
                 delete_repo_cascade,
@@ -5920,9 +6971,7 @@ impl NestWeaverDaemon for DaemonService {
             )
         })
         .await
-        .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
-
-        result.map(Response::new)
+        .map(Response::new)
     }
 
     /// nw-204. Reclaim embedding vectors for nodes that no longer exist.
@@ -5945,21 +6994,7 @@ impl NestWeaverDaemon for DaemonService {
         let dry_run = request.into_inner().dry_run;
         let state = self.state.clone();
 
-        // A dry run writes NOTHING, so it must not take the write gate: doing so
-        // would let a purely informational query block indexing and the watcher,
-        // and be refused outright during a drain. The real run takes the guard
-        // BEFORE the gate, matching every other write RPC — during a drain the
-        // gate is held for as long as the in-flight write runs, so taking it
-        // first would queue this behind a write it is about to be refused after.
-        let _write_scope = if dry_run {
-            None
-        } else {
-            let guard = ConnectionGuard::write(&self.state)?;
-            let lease = self.state.write_gate.lock("compact_embeddings").await;
-            Some((guard, lease))
-        };
-
-        let response = tokio::task::spawn_blocking(move || {
+        let compact = move || {
             let sidecar = nestweaver_engine::sidecar_path(&state.db_path, ".embeddings.bin");
             let bytes_of = |path: &std::path::Path| {
                 std::fs::metadata(path).map(|meta| meta.len()).unwrap_or(0)
@@ -5969,7 +7004,7 @@ impl NestWeaverDaemon for DaemonService {
             let bytes_before = bytes_of(&sidecar);
 
             if dry_run {
-                return Ok::<_, nestweaver_store::StoreError>(CompactEmbeddingsResponse {
+                return Ok::<_, Status>(CompactEmbeddingsResponse {
                     stored_before: before.stored as u64,
                     tombstoned_before: before.tombstoned as u64,
                     stored_after: before.stored as u64,
@@ -5981,13 +7016,24 @@ impl NestWeaverDaemon for DaemonService {
                 });
             }
 
+            require_verified_embedding_runtime_identity(
+                &state.store,
+                &state.embedding_runtime.status(),
+                "embedding compaction write",
+            )?;
+
             // Reconcile FIRST, always. Compaction rewrites the base without
             // tombstoned rows, so running it alone on a brain whose orphans
             // were never tombstoned reclaims exactly nothing — which is the
             // state every pre-fix brain is in.
-            state.store.reconcile_embedding_index()?;
+            state
+                .store
+                .reconcile_embedding_index()
+                .map_err(|error| Status::internal(format!("compact embeddings failed: {error}")))?;
             if state.store.embedding_index_occupancy().tombstoned > 0 {
-                state.store.compact_embedding_index()?;
+                state.store.compact_embedding_index().map_err(|error| {
+                    Status::internal(format!("compact embeddings failed: {error}"))
+                })?;
             }
 
             let after = state.store.embedding_index_occupancy();
@@ -5997,10 +7043,20 @@ impl NestWeaverDaemon for DaemonService {
                 bytes_before,
                 bytes_of(&sidecar),
             ))
-        })
-        .await
-        .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?
-        .map_err(|e| Status::internal(format!("compact embeddings failed: {e}")))?;
+        };
+
+        // A dry run writes nothing and remains outside write admission. The
+        // applying path transfers ownership into the exact worker.
+        let response = if dry_run {
+            tokio::task::spawn_blocking(compact)
+                .await
+                .map_err(|error| {
+                    Status::internal(format!("compact_embeddings task panicked: {error}"))
+                })??
+        } else {
+            self.run_unary_mutation("compact_embeddings", compact)
+                .await?
+        };
 
         Ok(Response::new(response))
     }
@@ -6022,18 +7078,8 @@ impl NestWeaverDaemon for DaemonService {
                 "source and target instance IDs must differ",
             ));
         }
-        // Guard BEFORE the write gate: during a drain the gate is held by the
-        // in-flight write for as long as it runs, so taking it first meant this
-        // request queued for minutes and only then learned it was refused. A
-        // client with a deadline saw DEADLINE_EXCEEDED instead of the
-        // explanatory UNAVAILABLE, which defeats the point of the message.
-        let _guard = ConnectionGuard::write(&self.state)?;
-        let _write_lock = self.state.write_gate.lock("merge_instance").await;
-
         let state = self.state.clone();
-
-        #[allow(clippy::result_large_err)]
-        let result = tokio::task::spawn_blocking(move || {
+        self.run_unary_mutation("merge_instance", move || {
             let result = run_merge_instance_with(
                 &state,
                 &from_id,
@@ -6067,9 +7113,7 @@ impl NestWeaverDaemon for DaemonService {
             })
         })
         .await
-        .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
-
-        result.map(Response::new)
+        .map(Response::new)
     }
 
     type PurgeInstanceStream = ProgressStream;
@@ -6092,8 +7136,10 @@ impl NestWeaverDaemon for DaemonService {
         let guard = ConnectionGuard::write(&self.state)?;
         let write_lock = self.state.write_gate.clone();
         tokio::task::spawn_blocking(move || {
-            let _write_lock = write_lock.blocking_lock("purge_instance");
-            let _guard = guard;
+            let _ownership = MutationWorkerOwnership {
+                _write_lease: write_lock.blocking_lock("purge_instance"),
+                _connection_guard: guard,
+            };
             let _ = tx.blocking_send(Ok(IndexProgress {
                 phase: Phase::Writing as i32,
                 message: format!("Purging instance {instance_id}"),
@@ -6168,36 +7214,25 @@ impl NestWeaverDaemon for DaemonService {
         {
             return Err(Status::permission_denied("admin token required"));
         }
-        // Rebuilding the Tantivy index is a mutation: it must run under the
-        // write gate so it serializes against a `backup`'s sidecar staging
-        // (which copies under the same lock) and is visible to the shutdown
-        // drain / idle timeout via `active_writes` — mirroring `prune_stale`
-        // and `purge_instance`.
-        // Guard BEFORE the write gate: during a drain the gate is held by the
-        // in-flight write for as long as it runs, so taking it first meant this
-        // request queued for minutes and only then learned it was refused. A
-        // client with a deadline saw DEADLINE_EXCEEDED instead of the
-        // explanatory UNAVAILABLE, which defeats the point of the message.
-        let _guard = ConnectionGuard::write(&self.state)?;
-        let _write_lock = self.state.write_gate.lock("reindex_search").await;
-
         let state = self.state.clone();
-        #[allow(clippy::result_large_err)]
-        let result = tokio::task::spawn_blocking(move || {
+        self.run_unary_mutation("reindex_search", move || {
             let tantivy = state.tantivy().filter(|t| t.has_writer()).ok_or_else(|| {
                 Status::failed_precondition("daemon has no writer-mode Tantivy index")
             })?;
             let count = tantivy
                 .reindex_from_store(&state.store)
                 .map_err(|e| Status::internal(format!("reindex failed: {e:#}")))?;
+            clear_search_reconciliation_debt(&state.db_path).map_err(|error| {
+                Status::internal(format!(
+                    "search index rebuilt, but durable reconciliation debt could not be cleared: {error:#}"
+                ))
+            })?;
             Ok::<_, Status>(ReindexSearchResponse {
                 document_count: count as i32,
             })
         })
         .await
-        .map_err(|e| Status::internal(format!("spawn_blocking failed: {e}")))?;
-
-        result.map(Response::new)
+        .map(Response::new)
     }
 
     // ── Read RPCs — typed hot-path ─────────────────────────────────
@@ -6327,6 +7362,45 @@ impl NestWeaverDaemon for DaemonService {
         let truncated = explicit_truncated
             || total_matches_relation != "eq"
             || returned_matches < total_matches;
+        let semantic_applied = value
+            .get("semantic_applied")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        let degraded_components = value
+            .get("degraded_components")
+            .and_then(serde_json::Value::as_array)
+            .map(|components| {
+                components
+                    .iter()
+                    .filter_map(|component| component.as_str().map(ToOwned::to_owned))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let semantic_unavailable = value
+            .get("semantic_unavailable")
+            .and_then(serde_json::Value::as_object)
+            .map(|detail| SemanticUnavailable {
+                cause: detail
+                    .get("cause")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                reason: detail
+                    .get("reason")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                error: detail
+                    .get("error")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                remediation: detail
+                    .get("remediation")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+            });
 
         Ok(Response::new(BrainSearchResponse {
             query: query_echo,
@@ -6337,10 +7411,13 @@ impl NestWeaverDaemon for DaemonService {
             returned_matches,
             total_matches_relation,
             truncated,
-            // `brain_search` is keyword/BM25-only; it must not claim a
-            // semantic leg was requested or degraded.
-            semantic_applied: false,
-            degraded_components: Vec::new(),
+            // `brain_search` remains keyword/BM25-only. A semantic-identity
+            // failure is nevertheless reported as an unavailable optional
+            // capability so lexical success cannot be mistaken for full
+            // semantic readiness.
+            semantic_applied,
+            degraded_components,
+            semantic_unavailable,
         }))
     }
 
@@ -6362,6 +7439,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<BrainContextRequest>,
     ) -> Result<Response<BrainContextResponse>, Status> {
+        let visible = self.state.visible_repos_for(r.extensions())?;
         let req = r.into_inner();
         let mut args = serde_json::json!({
             "seeds": req.seeds,
@@ -6419,13 +7497,11 @@ impl NestWeaverDaemon for DaemonService {
             args["recency_half_life_days"] = serde_json::json!(req.recency_half_life_days);
         }
 
-        // Fixed non-blast_radius tool — see brain_search above.
+        // The common tool boundary either executes on an authorization-safe
+        // induced subgraph or refuses before traversal. The typed route must
+        // pass the request-derived scope just like generic JSON-RPC.
         let value = self
-            .dispatch_tool_json(
-                "brain_context",
-                args,
-                nestweaver_engine::authz::VisibleRepos::All,
-            )
+            .dispatch_tool_json("brain_context", args, visible)
             .await?;
         let result_json = serde_json::to_string(&value)
             .map_err(|e| Status::internal(format!("failed to serialize result: {e}")))?;
@@ -6455,6 +7531,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<ProjectContextRequest>,
     ) -> Result<Response<ProjectContextResponse>, Status> {
+        let visible = self.state.visible_repos_for(r.extensions())?;
         let req = r.into_inner();
         let mut args = serde_json::json!({
             "project": req.project,
@@ -6500,13 +7577,8 @@ impl NestWeaverDaemon for DaemonService {
             args["exclude_tags"] = serde_json::json!(req.exclude_tags);
         }
 
-        // Fixed non-blast_radius tool — see brain_search above.
         let value = self
-            .dispatch_tool_json(
-                "project_context",
-                args,
-                nestweaver_engine::authz::VisibleRepos::All,
-            )
+            .dispatch_tool_json("project_context", args, visible)
             .await?;
         let result_json = serde_json::to_string(&value)
             .map_err(|e| Status::internal(format!("failed to serialize result: {e}")))?;
@@ -6617,16 +7689,12 @@ impl NestWeaverDaemon for DaemonService {
 
     async fn brain_status(
         &self,
-        _r: Request<BrainStatusRequest>,
+        r: Request<BrainStatusRequest>,
     ) -> Result<Response<BrainStatusResponse>, Status> {
+        let visible = self.state.visible_repos_for(r.extensions())?;
         let args = serde_json::json!({});
-        // Fixed non-blast_radius tool — see brain_search above.
         let value = self
-            .dispatch_tool_json(
-                "brain_status",
-                args,
-                nestweaver_engine::authz::VisibleRepos::All,
-            )
+            .dispatch_tool_json("brain_status", args, visible)
             .await?;
 
         let indexing_active = self.state.indexing_active.load(Ordering::Relaxed);
@@ -6636,11 +7704,17 @@ impl NestWeaverDaemon for DaemonService {
             String::new()
         };
         let queue_depth = self.state.indexing_queue_depth.load(Ordering::Relaxed) as i32;
+        let embedding_runtime_status = embedding_status_with_store_identity(
+            self.state.embedding_runtime.status(),
+            &self.state.store,
+        );
         let embedding_status = embedding_status_proto(
-            &self.state.embedding_runtime.status(),
+            &embedding_runtime_status,
             &self.state.embed_progress.snapshot(),
             self.state.store.embedding_index_occupancy(),
+            &self.state.store,
         );
+        let search_status = search_capability_status(&self.state);
         let write_queue_depth = self.state.write_gate.waiting() as i32;
         let (write_holder, write_holder_seconds) = self
             .state
@@ -6679,6 +7753,7 @@ impl NestWeaverDaemon for DaemonService {
             write_queue_depth,
             write_holder,
             write_holder_seconds,
+            search_status: Some(search_status_proto(&search_status)),
         }))
     }
 
@@ -6686,6 +7761,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<HubNodesRequest>,
     ) -> Result<Response<HubNodesResponse>, Status> {
+        let visible = self.state.visible_repos_for(r.extensions())?;
         let req = r.into_inner();
         let mut args = serde_json::json!({});
         if req.top_n > 0 {
@@ -6695,14 +7771,7 @@ impl NestWeaverDaemon for DaemonService {
             args["response_format"] = serde_json::json!(req.response_format);
         }
 
-        // Fixed non-blast_radius tool — see brain_search above.
-        let value = self
-            .dispatch_tool_json(
-                "hub_nodes",
-                args,
-                nestweaver_engine::authz::VisibleRepos::All,
-            )
-            .await?;
+        let value = self.dispatch_tool_json("hub_nodes", args, visible).await?;
         let result_json = serde_json::to_string(&value)
             .map_err(|e| Status::internal(format!("failed to serialize result: {e}")))?;
 
@@ -6713,14 +7782,10 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<JsonRequest>,
     ) -> Result<Response<JsonResponse>, Status> {
+        let visible = self.state.visible_repos_for(r.extensions())?;
         let req = r.into_inner();
-        // Fixed non-blast_radius tool — pass `VisibleRepos::All` (no scoping).
         let resp = self
-            .dispatch_json_tool(
-                "brain_status",
-                &req.args_json,
-                nestweaver_engine::authz::VisibleRepos::All,
-            )
+            .dispatch_json_tool("brain_status", &req.args_json, visible)
             .await?;
         // Inject server-side indexing status into the JSON response so
         // AI agents see it via the MCP tool path as well.
@@ -6753,12 +7818,17 @@ impl NestWeaverDaemon for DaemonService {
                 .unwrap_or_else(|| (String::new(), 0));
             value["write_holder"] = serde_json::json!(write_holder);
             value["write_holder_seconds"] = serde_json::json!(write_holder_seconds);
-            let embedding_status = self.state.embedding_runtime.status();
+            let embedding_status = embedding_status_with_store_identity(
+                self.state.embedding_runtime.status(),
+                &self.state.store,
+            );
             value["embedding_status"] = embedding_status_json(
                 &embedding_status,
                 &self.state.embed_progress.snapshot(),
                 self.state.store.embedding_index_occupancy(),
+                &self.state.store,
             );
+            value["search_status"] = search_status_json(&search_capability_status(&self.state));
             // Daemon-side witness counter in the `cache` block (the
             // `hit_rate_pct` session-counter precedent): an adopted client
             // proves the answer came from THIS daemon because the counter
@@ -6778,8 +7848,9 @@ impl NestWeaverDaemon for DaemonService {
 
     async fn repo_states(
         &self,
-        _request: Request<RepoStatesRequest>,
+        request: Request<RepoStatesRequest>,
     ) -> Result<Response<RepoStatesResponse>, Status> {
+        let visible = self.state.visible_repos_for(request.extensions())?;
         let _guard = ConnectionGuard::read(&self.state);
         let state = self.state.clone();
 
@@ -6787,7 +7858,10 @@ impl NestWeaverDaemon for DaemonService {
             let repos = state
                 .store
                 .list_repos(None)
-                .map_err(|e| Status::internal(format!("list_repos failed: {e:#}")))?;
+                .map_err(|e| Status::internal(format!("list_repos failed: {e:#}")))?
+                .into_iter()
+                .filter(|repo| visible.allows(&repo.uid))
+                .collect::<Vec<_>>();
 
             // `unwrap_or(0)` made a failed read indistinguishable from a repo
             // that genuinely has no symbols — which reads as "this repo was
@@ -7025,15 +8099,22 @@ impl NestWeaverDaemon for DaemonService {
             return json_rpc!(self, r, "brain_memory_consolidate");
         }
 
-        // Guard BEFORE the gate, for the reason spelled out on `set_extension`:
-        // during a drain the gate is held for as long as the in-flight write
-        // runs, so taking it first means the caller waits minutes only to learn
-        // it was refused, and sees DEADLINE_EXCEEDED instead of the explanatory
-        // UNAVAILABLE.
-        let _guard = ConnectionGuard::write(&self.state)?;
-        let _write_lock = self.state.write_gate.lock("brain_memory_consolidate").await;
-
-        json_rpc!(self, r, "brain_memory_consolidate")
+        if let Some(crate::auth::IsAdmin(false)) | None =
+            r.extensions().get::<crate::auth::IsAdmin>()
+        {
+            return Err(Status::permission_denied(
+                "tool 'brain_memory_consolidate' is mutating and requires the admin token",
+            ));
+        }
+        let visible = self.state.visible_repos_for(r.extensions())?;
+        let req = r.into_inner();
+        self.dispatch_json_mutation(
+            "brain_memory_consolidate",
+            &req.args_json,
+            visible,
+            "brain_memory_consolidate",
+        )
+        .await
     }
 
     async fn brain_memory_related(
@@ -7106,29 +8187,13 @@ impl NestWeaverDaemon for DaemonService {
                 "tool 'set_extension' is mutating and requires the admin token",
             ));
         }
-        // Read-modify-write of the `.extensions.json` sidecar, which is part of
-        // the backup sidecar set. It must run under the write gate — write_mutex
-        // + ConnectionGuard::write — so it serializes against a `backup`'s
-        // sidecar staging (which copies under the same lock), is visible to the
-        // shutdown drain / idle timeout, and two concurrent callers cannot lose
-        // updates (last-writer-wins). This is the single gated write path: the
-        // MCP `tool_set_extension` routes here rather than mutating directly.
-        // Guard BEFORE the write gate: during a drain the gate is held by the
-        // in-flight write for as long as it runs, so taking it first meant this
-        // request queued for minutes and only then learned it was refused. A
-        // client with a deadline saw DEADLINE_EXCEEDED instead of the
-        // explanatory UNAVAILABLE, which defeats the point of the message.
-        let _guard = ConnectionGuard::write(&self.state)?;
-        let _write_lock = self.state.write_gate.lock("set_extension").await;
-
         let req = r.into_inner();
         let db_path = self.state.db_path.clone();
 
         // Errors are wrapped in the standard `tool <name> failed:` format (see
         // dispatch_err_to_status) so MCP clients don't mislabel tool argument
         // errors as gRPC transport failures.
-        #[allow(clippy::result_large_err)]
-        let result = tokio::task::spawn_blocking(move || {
+        self.run_unary_mutation("set_extension", move || {
             let args: serde_json::Value = serde_json::from_str(&req.args_json).map_err(|e| {
                 Status::invalid_argument(format!(
                     "tool set_extension failed: invalid JSON in args_json: {e}"
@@ -7160,9 +8225,7 @@ impl NestWeaverDaemon for DaemonService {
             Ok::<_, Status>(JsonResponse { result_json })
         })
         .await
-        .map_err(|e| Status::internal(format!("tool set_extension failed: spawn_blocking: {e}")))?;
-
-        result.map(Response::new)
+        .map(Response::new)
     }
 
     async fn query_extensions(
@@ -7555,34 +8618,92 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<JsonRequest>,
     ) -> Result<Response<JsonResponse>, Status> {
-        let _guard = ConnectionGuard::read(&self.state);
+        let is_admin = matches!(
+            r.extensions().get::<crate::auth::IsAdmin>(),
+            Some(crate::auth::IsAdmin(true))
+        );
         let state = self.state.clone();
         let args: serde_json::Value = serde_json::from_str(&r.into_inner().args_json)
             .map_err(|e| Status::invalid_argument(format!("invalid args JSON: {e}")))?;
+        let vault_path = args
+            .get("vault")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| Status::invalid_argument("missing 'vault' argument"))?;
+        let vault = PathBuf::from(vault_path);
+        let canonical = std::fs::canonicalize(&vault).unwrap_or_else(|_| vault.clone());
+        let requested_instance = args
+            .get("instance_id")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default();
+        let instance_id = resolve_effective_instance_id(requested_instance, &state)?;
+        let vault_uid = nestweaver_schema::vault_uid(&instance_id, &canonical.to_string_lossy());
+        let dry_run = args
+            .get("dry_run")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        if state.read_only && !dry_run {
+            return Err(Status::failed_precondition(
+                "this daemon serves a read-only snapshot replica; detect_implicit_projects requires dry_run=true",
+            ));
+        }
+        if !dry_run && !is_admin {
+            return Err(Status::permission_denied(
+                "detect_implicit_projects is mutating and requires the admin token",
+            ));
+        }
 
-        let result = tokio::task::spawn_blocking(move || {
-            let vault_path = args
-                .get("vault")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| Status::invalid_argument("missing 'vault' argument"))?;
-            let vault = std::path::PathBuf::from(vault_path);
-            let canonical = std::fs::canonicalize(&vault).unwrap_or_else(|_| vault.clone());
-            let instance_id = "default";
-            let vault_uid = nestweaver_schema::vault_uid(instance_id, &canonical.to_string_lossy());
-            let detected = nestweaver_engine::detect_implicit_projects(
+        let detect = move || {
+            let detected = nestweaver_engine::project::detect_implicit_projects_with_publication(
                 &state.store,
                 &vault,
                 &vault_uid,
-                instance_id,
+                &instance_id,
+                dry_run,
             )
-            .map_err(|e| Status::internal(format!("detect_implicit_projects failed: {e:#}")))?;
-            serde_json::to_string(&detected)
-                .map_err(|e| Status::internal(format!("serialization failed: {e:#}")))
-        })
-        .await
-        .map_err(|e| Status::internal(format!("spawn_blocking panicked: {e}")))?;
-
-        result.map(|j| Response::new(JsonResponse { result_json: j }))
+            .map_err(|error| {
+                Status::internal(format!("detect_implicit_projects failed: {error:#}"))
+            })?;
+            let disposition = match detected.publication.disposition {
+                nestweaver_engine::manifest::GraphMutationPublicationDisposition::ConfirmedNoChange => {
+                    "confirmed_no_change"
+                }
+                nestweaver_engine::manifest::GraphMutationPublicationDisposition::CommittedComplete => {
+                    "committed_complete"
+                }
+                nestweaver_engine::manifest::GraphMutationPublicationDisposition::CommittedDegraded => {
+                    "committed_degraded"
+                }
+            };
+            let payload = serde_json::json!({
+                "projects": detected.projects,
+                "publication": {
+                    "disposition": disposition,
+                    "generation_before": detected.publication.generation_before,
+                    "generation_after": detected.publication.generation_after,
+                    "warnings": detected.publication.warnings.into_iter().map(|warning| {
+                        serde_json::json!({
+                            "stage": warning.stage,
+                            "message": warning.message,
+                        })
+                    }).collect::<Vec<_>>(),
+                },
+            });
+            serde_json::to_string(&payload)
+                .map_err(|error| Status::internal(format!("serialization failed: {error:#}")))
+        };
+        let result = if dry_run {
+            tokio::task::spawn_blocking(detect)
+                .await
+                .map_err(|error| {
+                    Status::internal(format!("detect_implicit_projects task panicked: {error}"))
+                })??
+        } else {
+            self.run_unary_mutation("detect_implicit_projects", detect)
+                .await?
+        };
+        Ok(Response::new(JsonResponse {
+            result_json: result,
+        }))
     }
 
     #[allow(clippy::result_large_err)]
@@ -7599,6 +8720,11 @@ impl NestWeaverDaemon for DaemonService {
         // loudly (Unavailable, after one retry inside `visible_repos_for`)
         // instead of silently redacting everything.
         let visible = self.state.visible_repos_for(r.extensions())?;
+        if matches!(visible, nestweaver_engine::authz::VisibleRepos::Only(_)) {
+            return Err(Status::permission_denied(
+                "pr_impact is unavailable for a repository-restricted identity: blast-radius traversal cannot yet be computed on an authorization-induced subgraph",
+            ));
+        }
         let args: serde_json::Value = serde_json::from_str(&r.into_inner().args_json)
             .map_err(|e| Status::invalid_argument(format!("invalid args JSON: {e}")))?;
 
@@ -7629,20 +8755,31 @@ impl NestWeaverDaemon for DaemonService {
             depth
         };
 
-        let changed_files: Vec<std::path::PathBuf> = args
+        let provided_files = args
             .get("files")
             .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(std::path::PathBuf::from))
-                    .collect()
+            .ok_or_else(|| Status::invalid_argument("missing or invalid 'files' array argument"))?;
+        // Never filter invalid elements out of an analysis request. Doing so
+        // turns a malformed N-file diff into a green result for a smaller
+        // diff, which is more dangerous than rejecting it. Decode the whole
+        // array first, then apply the shared CLI/MCP/engine path contract.
+        let raw_files: Vec<String> = provided_files
+            .iter()
+            .enumerate()
+            .map(|(index, value)| {
+                value.as_str().map(str::to_string).ok_or_else(|| {
+                    Status::invalid_argument(format!(
+                        "invalid files[{index}]: expected a repository-relative path string"
+                    ))
+                })
             })
-            .unwrap_or_default();
-        if changed_files.is_empty() {
-            return Err(Status::invalid_argument(
-                "missing or empty 'files' array argument",
-            ));
-        }
+            .collect::<Result<_, _>>()?;
+        let changed_files: Vec<PathBuf> =
+            nestweaver_engine::changed_files::require_changed_files(&raw_files)
+                .map_err(|error| Status::invalid_argument(error.to_string()))?
+                .into_iter()
+                .map(PathBuf::from)
+                .collect();
 
         let cancel_for_task = cancel.clone();
         let handler = async move {
@@ -7737,14 +8874,6 @@ impl NestWeaverDaemon for DaemonService {
         {
             return Err(Status::permission_denied("admin token required"));
         }
-        // Guard BEFORE the write gate: during a drain the gate is held by the
-        // in-flight write for as long as it runs, so taking it first meant this
-        // request queued for minutes and only then learned it was refused. A
-        // client with a deadline saw DEADLINE_EXCEEDED instead of the
-        // explanatory UNAVAILABLE, which defeats the point of the message.
-        let _guard = ConnectionGuard::write(&self.state)?;
-        let _write_lock = self.state.write_gate.lock("embed").await;
-
         #[cfg(not(feature = "embed"))]
         {
             let _ = request;
@@ -7757,7 +8886,8 @@ impl NestWeaverDaemon for DaemonService {
         {
             let req = request.into_inner();
             let scope = req.scope.clone();
-            let force = req.force;
+            let repair_identity = req.repair_identity;
+            let force = req.force || repair_identity;
             let batch_size = if req.batch_size == 0 {
                 32
             } else {
@@ -7765,6 +8895,13 @@ impl NestWeaverDaemon for DaemonService {
             };
 
             let scopes = embedding_scopes(&scope)?;
+            if !repair_identity {
+                require_verified_embedding_runtime_identity(
+                    &self.state.store,
+                    &self.state.embedding_runtime.status(),
+                    "embedding write",
+                )?;
+            }
             let do_symbols = scopes.symbols;
             let do_notes = scopes.notes;
             let do_headings = scopes.headings;
@@ -7772,6 +8909,27 @@ impl NestWeaverDaemon for DaemonService {
             let (status, model) = self.state.embedding_runtime.snapshot();
             let model = match model {
                 Some(model) => model,
+                None if repair_identity => {
+                    let store = self.state.store.clone();
+                    let discarded = self
+                        .run_unary_mutation("repair_embedding_identity", move || {
+                            store
+                                .reset_embedding_space_for_identity_repair()
+                                .map(|count| count as u64)
+                                .map_err(|error| {
+                                    Status::internal(format!(
+                                        "reset unreadable embedding identity: {error}"
+                                    ))
+                                })
+                        })
+                        .await?;
+                    return Ok(Response::new(EmbedResponse {
+                        identity_repaired: true,
+                        restart_required: true,
+                        discarded_embeddings: discarded,
+                        ..EmbedResponse::default()
+                    }));
+                }
                 None => {
                     // nw-139: the daemon is the single writer, and since 6.3.0
                     // the CLI refuses `embed --local` while the daemon holds
@@ -7783,26 +8941,15 @@ impl NestWeaverDaemon for DaemonService {
                     //
                     // Seed it here instead. This is safe precisely because it
                     // is NOT the startup path: the request is operator-
-                    // initiated, already admin-authenticated, and already holds
-                    // the write gate above, so no lock ever changes hands.
+                    // initiated, already admin-authenticated, and the cache
+                    // seed below runs inside the same exact-worker write lease,
+                    // so no lock ever changes hands.
                     // Startup stays CacheOnly, so booting never depends on
                     // network reachability.
                     //
                     // A complete cache makes DownloadMissing a no-op, so a
                     // failure for any other reason simply reproduces itself
                     // below and reports the original diagnosis.
-                    tracing::info!(
-                        state = %status.state,
-                        "embedding model unavailable; seeding the configured artifact cache"
-                    );
-                    // Download the missing artifacts ONLY. Constructing the
-                    // model here would run it on a tokio worker, and a local
-                    // backend must be loaded on the main block_on thread or
-                    // MTLCompilerService is unreachable and Metal silently
-                    // degrades to CPU — the regression `load_embedding_model`
-                    // documents and asserts against. Seeding is pure network
-                    // and disk I/O, so it is safe from any thread.
-                    let outcome = seed_embedding_artifact_cache(&self.state);
                     let detail = if status.error.is_empty() {
                         format!("embedding is not ready (state: {})", status.state)
                     } else {
@@ -7811,16 +8958,33 @@ impl NestWeaverDaemon for DaemonService {
                             status.state, status.error
                         )
                     };
-                    return Err(Status::failed_precondition(match outcome {
-                        Ok(cache_dir) => format!(
-                            "{detail}. The missing model artifacts have now been downloaded \
-                             into {} by the daemon itself, so the write lock never changed \
-                             hands. Restart the daemon to load them \
-                             (`nestweaver daemon restart`), then re-run this command.",
-                            cache_dir.display()
-                        ),
-                        Err(error) => format!("{detail}. Seeding the cache failed: {error:#}"),
-                    }));
+                    let state = self.state.clone();
+                    return self
+                        .run_unary_mutation("embed", move || {
+                            tracing::info!(
+                                state = %status.state,
+                                "embedding model unavailable; seeding the configured artifact cache"
+                            );
+                            // Cache writes are part of this unary mutation too:
+                            // a disconnect must not make shutdown claim the
+                            // daemon is idle while downloads are still being
+                            // published.
+                            let outcome = seed_embedding_artifact_cache(&state);
+                            Err::<EmbedResponse, _>(Status::failed_precondition(match outcome {
+                                Ok(cache_dir) => format!(
+                                    "{detail}. The missing model artifacts have now been downloaded \
+                                     into {} by the daemon itself, so the write lock never changed \
+                                     hands. Restart the daemon to load them \
+                                     (`nestweaver daemon restart`), then re-run this command.",
+                                    cache_dir.display()
+                                ),
+                                Err(error) => {
+                                    format!("{detail}. Seeding the cache failed: {error:#}")
+                                }
+                            }))
+                        })
+                        .await
+                        .map(Response::new);
                 }
             };
             // The model the daemon actually loaded (startup preference: the
@@ -7831,7 +8995,18 @@ impl NestWeaverDaemon for DaemonService {
             let progress = Arc::clone(&self.state.embed_progress);
             let progress_scope = scope.clone();
 
-            let result = tokio::task::spawn_blocking(move || {
+            self.run_unary_mutation("embed", move || {
+                let discarded_embeddings = if repair_identity {
+                    store
+                        .reset_embedding_space_for_identity_repair()
+                        .map_err(|error| {
+                            Status::internal(format!(
+                                "reset unreadable embedding identity: {error}"
+                            ))
+                        })? as u64
+                } else {
+                    0
+                };
                 // Owned by the blocking task, not by the RPC future: a client
                 // that disconnects does not stop the pass, so progress must
                 // keep reporting `active` until the work actually ends. The
@@ -8084,24 +9259,16 @@ impl NestWeaverDaemon for DaemonService {
                 //
                 // Only from vectors this run produced: an embed that produced
                 // nothing must not invent or overwrite metadata.
-                if let Some(pipeline) = produced_pipeline.as_ref()
-                    && let Err(e) = store.set_embedding_pipeline(pipeline)
-                {
-                    tracing::warn!("failed to record embedding model metadata: {e}");
-                }
-
-                let flush = if succeeded > 0 {
-                    store.flush_embedding_index()
-                } else {
-                    Ok(())
-                };
-                if let Err(e) = &flush {
+                let persistence =
+                    persist_embed_output(&store, produced_pipeline.as_ref(), succeeded);
+                if let Err(e) = &persistence {
                     tracing::error!(
-                        "failed to flush embedding index, reporting {succeeded} \
+                        "failed to stamp or flush embedding index, reporting {succeeded} \
                          unpersisted vector(s) as failures: {e}"
                     );
                 }
-                let (succeeded, failed) = settle_embed_counts(succeeded, failed, flush.is_ok());
+                let (succeeded, failed) =
+                    settle_embed_counts(succeeded, failed, persistence.is_ok());
 
                 log_pass_progress(true);
                 tracing::info!(
@@ -8118,12 +9285,13 @@ impl NestWeaverDaemon for DaemonService {
                     scoped,
                     eligible,
                     skipped: scoped.saturating_sub(eligible),
+                    identity_repaired: repair_identity,
+                    restart_required: false,
+                    discarded_embeddings,
                 })
             })
             .await
-            .map_err(|e| Status::internal(format!("embed task panicked: {e}")))?;
-
-            result.map(Response::new)
+            .map(Response::new)
         }
     }
 }
@@ -8389,6 +9557,8 @@ const READ_ONLY_ALLOWED_METHODS: &[&str] = &[
     "CrossRepoContracts",
     "DeadCode",
     "DetectChanges",
+    // Payload-gated: `dry_run=true` is a pure read; the handler rejects the
+    // mutating form explicitly on a replica.
     "DetectImplicitProjectsJson",
     "EmbeddingDimension",
     "ExportGraph",
@@ -9994,6 +11164,19 @@ async fn load_embedding_model_with_mode(
     state: &std::sync::Arc<DaemonState>,
     mode: nestweaver_embed::ArtifactMode,
 ) {
+    if let Err(error) = state.store.require_verified_embedding_identity() {
+        let status = embedding_identity_unreadable_status(
+            state.embedding_runtime.status(),
+            format!("{error}. Remediation: {EMBEDDING_IDENTITY_REMEDIATION}."),
+        );
+        state.embedding_runtime.publish_unavailable(status);
+        tracing::warn!(
+            error = %error,
+            remediation = EMBEDDING_IDENTITY_REMEDIATION,
+            "embedding model load skipped because persisted identity is unreadable; graph and lexical service remain available"
+        );
+        return;
+    }
     let cfg = state
         .instance_cfg
         .as_ref()
@@ -10020,12 +11203,22 @@ async fn load_embedding_model_with_mode(
     // model regardless of the compiled default or config — it must match the stored vectors,
     // or semantic search is disabled on a dimension mismatch. This lets the shipped default
     // stay light while a given instance uses whatever it was actually embedded with.
-    let stored_model_id = state
-        .store
-        .get_embedding_metadata()
-        .ok()
-        .flatten()
-        .map(|(model_id, _)| model_id);
+    let stored_model_id = match state.store.get_embedding_metadata() {
+        Ok(metadata) => metadata.map(|(model_id, _)| model_id),
+        Err(error) => {
+            let status = embedding_identity_unreadable_status(
+                state.embedding_runtime.status(),
+                format!("{error}. Remediation: {EMBEDDING_IDENTITY_REMEDIATION}."),
+            );
+            state.embedding_runtime.publish_unavailable(status);
+            tracing::warn!(
+                error = %error,
+                remediation = EMBEDDING_IDENTITY_REMEDIATION,
+                "embedding metadata became unreadable during model load; semantic service remains disabled"
+            );
+            return;
+        }
+    };
     if let Some(stored_model_id) = stored_model_id.as_deref() {
         let configured_model = if cfg.external_endpoint.is_some() {
             cfg.external_model.as_deref().unwrap_or_default()
@@ -10149,8 +11342,13 @@ async fn load_embedding_model_with_mode(
 /// recover on a read-write boot), with
 /// `read_write_daemon_boot_recovers_the_abandoned_publication` pinning the
 /// call-site binding end to end.
-fn reconcile_index_publication_before_ppr_warm(store: &GraphStore, read_only: bool) {
-    nestweaver_engine::index::recover_abandoned_index_publication_best_effort(store, !read_only);
+fn reconcile_index_publication_before_ppr_warm(
+    store: &GraphStore,
+    authority: Option<&nestweaver_store::DbWriteLease>,
+) {
+    if let Some(authority) = authority {
+        nestweaver_engine::index::recover_abandoned_index_publication_best_effort(store, authority);
+    }
     match store.warm_ppr_cache() {
         Ok(()) => tracing::info!("PPR adjacency cache warmed"),
         // nw-C2: this specific failure used to be swallowed as a generic warn,
@@ -10250,6 +11448,24 @@ pub async fn run_server(
         nestweaver_engine::publication::resolve_selected_database(&base_db_path)?
     };
 
+    // Parse the asserted identity before writer-authority acquisition. The
+    // authority deliberately creates a missing database file so it can close
+    // the create/open race; when expected_brain_uuid is configured, however,
+    // absence is a refusal and no database may be materialized at all.
+    let (instance_cfg, effective_config) =
+        load_daemon_instance_config(config_path, server_opts.is_some())?;
+    if !snapshot_replica
+        && !db_path.exists()
+        && let Some(expected) = instance_cfg
+            .as_ref()
+            .and_then(|config| config.expected_brain_uuid.as_deref())
+    {
+        anyhow::bail!(
+            "instance config expects brain {expected}, but no database exists at {}; refusing to create a different brain. Restore or rebuild the expected brain explicitly, or remove the assertion only when intentionally creating a new brain",
+            db_path.display()
+        );
+    }
+
     let instance_id = lifecycle::instance_id_from_db_path(&db_path);
     let instance_label = lifecycle::instance_label_from_db_path(&db_path);
     // nw-019: two identities. `instance_id` (db-path hash) is for RUNTIME paths
@@ -10291,82 +11507,47 @@ pub async fn run_server(
     // launcher's lock instead of trying to acquire a conflicting second flock.
     let _pid_guard = claim_instance_lock(&instance_id)?;
 
-    // The WRITE LEASE, held for the daemon's whole life. This is what makes a
+    // The WRITE LEASE, held for a read-write daemon's whole life. This is what makes a
     // direct CLI write safe to refuse: without the daemon participating, a
     // CLI-side lease would only exclude other CLI writers and the daemon —
     // the writer that actually matters — would be invisible to it.
     //
     // Deliberately a different claim from the pidfile lock above. That one is
-    // about instance identity and lives on an inode an operator's `rm` can
-    // erase; this one is about who may write this database, and nothing but
-    // the lease ever opens its file.
+    // about instance identity; this one is dual-anchored on the database and
+    // its stable lease sidecar so replacing either one alone cannot mint a
+    // second authority.
     //
     // A daemon that cannot take it must not start: something else is already
     // writing, and two writers against a store that is not crash-safe is the
     // failure this exists to prevent.
-    let _write_lease = match lifecycle::acquire_db_write_lease(&db_path) {
-        Ok(lease) => lease,
-        Err(lifecycle::WriteLeaseError::Held) => {
-            anyhow::bail!(
-                "another process holds the write lease for {}. Stop it before starting a \
-                 daemon — two writers against this store risk corruption.",
-                db_path.display()
-            );
-        }
-        Err(lifecycle::WriteLeaseError::Unavailable(error)) => {
-            anyhow::bail!(
-                "could not take the write lease for {}: {error}. Refusing to start rather \
-                 than write without exclusivity.",
-                db_path.display()
-            );
-        }
+    let write_authority = if snapshot_replica {
+        None
+    } else {
+        Some(match lifecycle::acquire_db_write_lease(&db_path) {
+            Ok(lease) => Arc::new(lease),
+            Err(lifecycle::WriteLeaseError::Held) => {
+                anyhow::bail!(
+                    "another process holds the write lease for {}. Stop it before starting a \
+                     daemon — two writers against this store risk corruption.",
+                    db_path.display()
+                );
+            }
+            Err(lifecycle::WriteLeaseError::Unavailable(error)) => {
+                anyhow::bail!(
+                    "could not take the write lease for {}: {error}. Refusing to start rather \
+                     than write without exclusivity.",
+                    db_path.display()
+                );
+            }
+        })
     };
 
-    // The pidfile lock is NOT sufficient proof of ownership. It is held on an
-    // inode: if anyone unlinked `daemon.pid` (which is exactly what an operator
-    // does while recovering a stuck instance), the live owner keeps its lock on
-    // a now-unlinked inode and the claim above succeeds against a brand-new
-    // file with no contention at all. Continuing from here would delete the
-    // live daemon's effective-config binding and, further down, unlink its
-    // socket before binding — leaving a healthy daemon that no client can
-    // reach. Corroborate with the database write lock, which lives on the
-    // database file itself and no recovery step removes.
-    //
-    // Read-only snapshot replicas are exempt: they never take the write lock
-    // (lbug sets it only when `!readOnly`; see storage_manager.cpp), so a held
-    // lock says nothing about them.
-    //
-    // State only what the kernel actually told us. The lock proves a process
-    // holds THIS DATABASE — not that it is a daemon, and not that anyone
-    // deleted a pidfile: `embed --local`, an index run, and every `--no-daemon`
-    // command hold the same lock for their duration.
-    //
-    // Matching only `Held` — and so proceeding on `Unknown` — is the one
-    // deliberate exception to the "treat Unknown as possibly-owned" rule every
-    // other caller follows. This probe runs BEFORE this process opens the
-    // store, so the self-probe guard cannot fire here, and if the lock really
-    // is held, `GraphStore::open_or_create` below fails on lbug's own lock a
-    // moment later. Failing closed here would instead refuse to boot whenever
-    // the database is merely unreadable-by-probe, which is a worse trade for
-    // the one caller whose next action already fails safely.
-    let serves_snapshot = server_opts
-        .as_ref()
-        .and_then(|o| o.snapshot.as_ref())
-        .is_some();
-    if !serves_snapshot
-        && let lifecycle::DbWriteLock::Held { pid } = lifecycle::db_write_lock(&db_path)
-    {
-        let owner = pid
-            .map(|pid| format!("PID {pid}"))
-            .unwrap_or_else(|| "another process".to_string());
-        anyhow::bail!(
-            "refusing to start instance {instance_label}: {owner} holds the write lock on {}. \
-             This daemon claimed the instance pidfile lock ({}) anyway, so that lock is not \
-             evidence of ownership here — check what {owner} is before doing anything to it.",
-            db_path.display(),
-            lifecycle::pidfile_path(&instance_id).display()
-        );
-    }
+    // The pidfile is not ownership proof. The write authority above already
+    // took lbug's real whole-database POSIX lock class before the store open,
+    // so a pre-upgrade writer that knows nothing about the sidecar is excluded
+    // without a second check-then-act probe. Do not call `db_write_lock` here:
+    // opening and closing another descriptor would release this process's
+    // POSIX record lock before GraphStore replaces it with its own.
 
     // We now exclusively own this instance's pidfile lock, so any binding left
     // by a crashed predecessor is stale. Clear it before fallible startup work;
@@ -10374,12 +11555,6 @@ pub async fn run_server(
     lifecycle::remove_effective_config_binding(&instance_id).with_context(|| {
         format!("remove stale effective-config binding for instance {instance_id}")
     })?;
-
-    // Parse explicit config before snapshot compatibility checks. Core-schema
-    // snapshots deliberately support configless replicas; extension snapshots
-    // require this config so their effective schema can be mediated.
-    let (instance_cfg, effective_config) =
-        load_daemon_instance_config(config_path, server_opts.is_some())?;
 
     // Snapshot replica: materialize the snapshot into a private working copy and
     // serve it read-only. `read_only` gates out the write RPCs (via the
@@ -10414,23 +11589,6 @@ pub async fn run_server(
     } else {
         db_path
     };
-
-    // An expected brain UUID is an assertion, never an instruction to assign
-    // identity to a new empty database. Refuse before `open_or_create` can
-    // materialize a different brain at a mistyped/missing path. Snapshot
-    // replicas have already materialized a verified graph above and are
-    // checked against the assertion immediately after opening it.
-    if !read_only
-        && !db_path.exists()
-        && let Some(expected) = instance_cfg
-            .as_ref()
-            .and_then(|config| config.expected_brain_uuid.as_deref())
-    {
-        anyhow::bail!(
-            "instance config expects brain {expected}, but no database exists at {}; refusing to create a different brain. Restore or rebuild the expected brain explicitly, or remove the assertion only when intentionally creating a new brain",
-            db_path.display()
-        );
-    }
 
     // Open the graph store: read-only for a snapshot replica, read-write
     // otherwise (the daemon is the sole DB owner).
@@ -10727,17 +11885,36 @@ pub async fn run_server(
         .as_ref()
         .map(|config| config.embedding.clone())
         .unwrap_or_default();
-    let stored_embedding_model = store
-        .get_embedding_metadata()
-        .ok()
-        .flatten()
-        .map(|(model_id, _)| model_id);
-    let embedding_status = initial_embedding_status(
+    let (stored_embedding_model, embedding_identity_error) =
+        match store.require_verified_embedding_identity() {
+            Ok(()) => match store.get_embedding_metadata() {
+                Ok(metadata) => (metadata.map(|(model_id, _)| model_id), None),
+                Err(error) => (None, Some(error.to_string())),
+            },
+            Err(error) => (
+                None,
+                store
+                    .embedding_identity_error()
+                    .or_else(|| Some(error.to_string())),
+            ),
+        };
+    let mut embedding_status = initial_embedding_status(
         &embedding_cfg,
         stored_embedding_model.as_deref(),
         cfg!(feature = "embed"),
         daemon_metal_compiled(),
     );
+    if let Some(error) = embedding_identity_error {
+        embedding_status = embedding_identity_unreadable_status(
+            embedding_status,
+            format!("{error}. Remediation: {EMBEDDING_IDENTITY_REMEDIATION}."),
+        );
+        tracing::warn!(
+            error = %error,
+            remediation = EMBEDDING_IDENTITY_REMEDIATION,
+            "persisted embedding identity is unreadable; daemon will serve graph and lexical operations with semantic service disabled"
+        );
+    }
     let embedding_probe_ms = embedding_probe_started.elapsed().as_millis() as u64;
     let state = Arc::new(DaemonState {
         store: Arc::new(store),
@@ -10779,6 +11956,24 @@ pub async fn run_server(
         watcher_tasks: std::sync::Mutex::new(Vec::new()),
         ui_server: std::sync::Mutex::new(None),
     });
+    state.search.attach_recovery_context(&state);
+
+    // Retry durable graph→search debt before the socket is exposed, but do
+    // not make graph/lexical service availability depend on the writer. A
+    // failed retry remains durable and is surfaced through SearchStatus; a
+    // later successful writer re-open schedules the same exact-worker repair.
+    match retry_search_reconciliation_debt_at_startup(&state).await {
+        Ok(())
+            if load_search_reconciliation_debt(&state.db_path).is_ok_and(|debt| debt.is_none()) =>
+        {
+            tracing::debug!("startup search-reconciliation debt is clear")
+        }
+        Ok(()) => {}
+        Err(error) => tracing::warn!(
+            error = %error,
+            "startup could not reconcile durable search-index debt; graph and lexical service remain available and status is degraded"
+        ),
+    }
 
     // nw-119: two instrumentation passes narrowed the unattributed boot time to
     // the span between the Tantivy open and the bind — 253s of a 268s boot,
@@ -10814,13 +12009,19 @@ pub async fn run_server(
 
     let extension_reconcile_ms = reconcile_started.elapsed().as_millis() as u64;
 
-    // Pre-warm PPR adjacency cache so the first PPR query after startup
-    // hits the cache instead of spending ~350ms rebuilding from the DB.
+    // Recover any interrupted index publication, then pre-warm the PPR
+    // adjacency cache before any listener can serve. This work may write and
+    // spawn_blocking cannot be cancelled; awaiting it here ensures an
+    // immediate shutdown can never let the task outlive run_server (and its
+    // DbWriteLease) or expose the pre-recovery graph to a request.
     {
         let store = state.store.clone();
+        let write_authority = write_authority.clone();
         tokio::task::spawn_blocking(move || {
-            reconcile_index_publication_before_ppr_warm(&store, read_only)
-        });
+            reconcile_index_publication_before_ppr_warm(&store, write_authority.as_deref())
+        })
+        .await
+        .context("boot publication recovery/PPR warm task panicked")?;
     }
 
     // Spawn periodic rate limiter cleanup (every 10 minutes).
@@ -10884,7 +12085,6 @@ pub async fn run_server(
     if let Some(timeout) = idle_timeout {
         let notify = idle_notify.clone();
         let active = state.clone();
-        let tx = shutdown_tx.clone();
         tokio::spawn(async move {
             loop {
                 tokio::select! {
@@ -10899,13 +12099,12 @@ pub async fn run_server(
                                 timeout_secs = timeout.as_secs(),
                                 "idle timeout reached — shutting down"
                             );
-                            // Symmetry with the SIGTERM handler: this
-                            // broadcasts immediately, so a Shutdown RPC
-                            // arriving afterwards has nothing left to drain
-                            // and should not spawn a loop that would only
-                            // re-broadcast.
-                            active.shutdown_started.store(true, Ordering::Relaxed);
-                            let _ = tx.send(true);
+                            // A write may be admitted after the idle counters
+                            // were observed but before shutdown is marked. The
+                            // shared drain establishes the SeqCst admission
+                            // boundary, then waits for that write instead of
+                            // tearing listeners and ownership down beneath it.
+                            begin_shutdown_drain(Arc::clone(&active), "idle_timeout");
                             return;
                         }
                     }
@@ -11016,6 +12215,11 @@ pub async fn run_server(
     // admin API (dashboard "connected clients") and the metrics task
     // (`MCP_SESSIONS` gauge). `None` outside server mode.
     let mut mcp_session_gauge_opt: Option<std::sync::Arc<std::sync::atomic::AtomicU32>> = None;
+
+    // Public listeners own service clones (and therefore GraphStore Arcs).
+    // Retain their roots so graceful shutdown can prove the complete network
+    // task trees are gone before socket/pid/DbWriteLease cleanup.
+    let mut network_tasks: Vec<(&'static str, tokio::task::JoinHandle<()>)> = Vec::new();
 
     // MCP-over-HTTP server — spawned alongside the gRPC servers.
     // Binds to grpc_port + 1 when server mode is active, or a separate OS-assigned
@@ -11246,6 +12450,7 @@ pub async fn run_server(
                 start_time: state.start_time,
                 active_reads: state.active_reads.clone(),
                 active_writes: state.active_writes.clone(),
+                shutdown_started: state.shutdown_started.clone(),
                 mcp_sessions: mcp_session_gauge_opt
                     .clone()
                     .unwrap_or_else(|| std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0))),
@@ -11493,58 +12698,63 @@ pub async fn run_server(
         // Store the MCP port — written alongside the gRPC port below.
         let mcp_port_for_file = mcp_actual_addr.port();
 
+        // Finish every fallible public-listener setup step before spawning
+        // either server. Otherwise a TCP bind/port-file error would return
+        // from run_server while a detached MCP task still owned the store.
+        let tcp_listener = tokio::net::TcpListener::bind(&opts.bind_addr)
+            .await
+            .with_context(|| format!("bind TCP: {}", opts.bind_addr))?;
+        let actual_addr = tcp_listener.local_addr()?;
+        tracing::info!(%actual_addr, "TCP server listening");
+        eprintln!("[daemon] TCP server listening on {}", actual_addr);
+        if let Some(ref pf) = opts.port_file {
+            // Write gRPC port on line 1, MCP HTTP port on line 2.
+            let contents = format!("{}\n{}", actual_addr.port(), mcp_port_for_file);
+            std::fs::write(pf, contents)?;
+        }
+        let tcp_stream = tokio_stream::wrappers::TcpListenerStream::new(tcp_listener);
+
         let mcp_tls_acceptor = tls_config.as_ref().map(|(_, a)| a.clone());
         let mut mcp_shutdown_rx = shutdown_tx.subscribe();
-        let mut mcp_accept_shutdown_rx = shutdown_tx.subscribe();
-        tokio::spawn(async move {
+        let mcp_task = tokio::spawn(async move {
             if let Some(acceptor) = mcp_tls_acceptor {
                 // B3: run each TLS handshake in its OWN task under a timeout and
-                // funnel only completed handshakes through a channel, so a peer
-                // that connects and never sends a ClientHello can't stall accepts
-                // for every other client on this public listener. A semaphore caps
-                // in-flight handshakes so a silent-client flood can't exhaust
-                // resources, and the accept task exits on shutdown so it doesn't
-                // leak the listener / spawn doomed handshakes.
+                // retain every handshake and connection in JoinSets. The shutdown
+                // path aborts+awaits pre-HTTP handshakes, gracefully closes+awaits
+                // HTTP connections, and only then lets this server root release
+                // its router/store ownership.
                 let (handshake_tx, mut handshake_rx) = tokio::sync::mpsc::channel::<
                     tokio_rustls::server::TlsStream<tokio::net::TcpStream>,
                 >(256);
                 let handshake_sem =
                     std::sync::Arc::new(tokio::sync::Semaphore::new(MAX_INFLIGHT_HANDSHAKES));
-                tokio::spawn(async move {
-                    loop {
-                        let (stream, _addr) = tokio::select! {
-                            _ = mcp_accept_shutdown_rx.changed() => break,
-                            res = mcp_listener.accept() => match res {
-                                Ok(v) => v,
-                                Err(e) => {
-                                    tracing::debug!("MCP TCP accept failed: {e}");
-                                    continue;
-                                }
-                            },
-                        };
-                        // Backpressure: wait for a handshake permit before spawning.
-                        let permit = tokio::select! {
-                            _ = mcp_accept_shutdown_rx.changed() => break,
-                            res = handshake_sem.clone().acquire_owned() => match res {
-                                Ok(p) => p,
-                                Err(_) => break,
-                            },
-                        };
-                        let acceptor = acceptor.clone();
-                        let handshake_tx = handshake_tx.clone();
-                        tokio::spawn(drive_capped_handshake(
-                            permit,
-                            acceptor,
-                            stream,
-                            TLS_HANDSHAKE_TIMEOUT,
-                            handshake_tx,
-                            "MCP",
-                        ));
-                    }
-                });
-                let mut shutdown = Box::pin(mcp_shutdown_rx.changed());
+                let mut handshakes = tokio::task::JoinSet::new();
+                let mut connections = tokio::task::JoinSet::new();
                 loop {
                     tokio::select! {
+                        biased;
+                        _ = mcp_shutdown_rx.changed() => break,
+                        accepted = mcp_listener.accept(), if handshakes.len() < MAX_INFLIGHT_HANDSHAKES => {
+                            let (stream, _addr) = match accepted {
+                                Ok(value) => value,
+                                Err(error) => {
+                                    tracing::debug!("MCP TCP accept failed: {error}");
+                                    continue;
+                                }
+                            };
+                            let Ok(permit) = handshake_sem.clone().try_acquire_owned() else {
+                                tracing::debug!("MCP handshake permit unavailable despite JoinSet cap");
+                                continue;
+                            };
+                            handshakes.spawn(drive_capped_handshake(
+                                permit,
+                                acceptor.clone(),
+                                stream,
+                                TLS_HANDSHAKE_TIMEOUT,
+                                handshake_tx.clone(),
+                                "MCP",
+                            ));
+                        }
                         Some(stream) = handshake_rx.recv() => {
                             // Serving the router directly via hyper here does not
                             // populate `ConnectInfo<SocketAddr>`, so the nested
@@ -11557,19 +12767,47 @@ pub async fn run_server(
                             // MCP limiter's documented TLS fallback below. Terminate
                             // TLS at a trusted proxy that sets XFF for per-IP fidelity.
                             let svc = mcp_router.clone();
-                            tokio::spawn(async move {
-                                let hyper_svc = hyper_util::service::TowerToHyperService::new(svc);
+                            let mut connection_shutdown = mcp_shutdown_rx.clone();
+                            connections.spawn(async move {
+                                let hyper_svc =
+                                    hyper_util::service::TowerToHyperService::new(svc);
                                 let io = hyper_util::rt::TokioIo::new(stream);
-                                let _ = hyper_util::server::conn::auto::Builder::new(
+                                let builder = hyper_util::server::conn::auto::Builder::new(
                                     hyper_util::rt::TokioExecutor::new(),
-                                )
-                                .serve_connection(io, hyper_svc)
-                                .await;
+                                );
+                                let connection = builder.serve_connection(io, hyper_svc);
+                                tokio::pin!(connection);
+                                tokio::select! {
+                                    _ = connection.as_mut() => {}
+                                    _ = connection_shutdown.changed() => {
+                                        connection.as_mut().graceful_shutdown();
+                                        let _ = connection.await;
+                                    }
+                                }
                             });
                         }
-                        _ = &mut shutdown => break,
+                        Some(result) = handshakes.join_next(), if !handshakes.is_empty() => {
+                            if let Err(error) = result {
+                                tracing::debug!("MCP TLS handshake task failed: {error}");
+                            }
+                        }
+                        Some(result) = connections.join_next(), if !connections.is_empty() => {
+                            if let Err(error) = result {
+                                tracing::debug!("MCP HTTP connection task failed: {error}");
+                            }
+                        }
                     }
                 }
+
+                // Handshakes have not entered application code, so cancellation
+                // is safe; nevertheless await every aborted task before dropping
+                // the listener. Existing HTTP work receives a graceful signal and
+                // is fully awaited so its router/GraphStore Arc cannot escape.
+                handshakes.abort_all();
+                while handshakes.join_next().await.is_some() {}
+                drop(handshake_tx);
+                while handshake_rx.try_recv().is_ok() {}
+                while connections.join_next().await.is_some() {}
             } else {
                 // `into_make_service_with_connect_info` populates
                 // `ConnectInfo<SocketAddr>` so the MCP rate limiter can key
@@ -11589,23 +12827,10 @@ pub async fn run_server(
                 .ok();
             }
         });
+        network_tasks.push(("MCP HTTP", mcp_task));
 
         // TCP listener for server mode — spawned before the blocking UDS serve.
         {
-            let tcp_listener = tokio::net::TcpListener::bind(&opts.bind_addr)
-                .await
-                .with_context(|| format!("bind TCP: {}", opts.bind_addr))?;
-            let actual_addr = tcp_listener.local_addr()?;
-            tracing::info!(%actual_addr, "TCP server listening");
-            eprintln!("[daemon] TCP server listening on {}", actual_addr);
-
-            if let Some(ref pf) = opts.port_file {
-                // Write gRPC port on line 1, MCP HTTP port on line 2.
-                let contents = format!("{}\n{}", actual_addr.port(), mcp_port_for_file);
-                std::fs::write(pf, contents)?;
-            }
-
-            let tcp_stream = tokio_stream::wrappers::TcpListenerStream::new(tcp_listener);
             let mut tcp_shutdown_rx = shutdown_tx.subscribe();
             let mut grpc_accept_shutdown_rx = shutdown_tx.subscribe();
 
@@ -11619,7 +12844,7 @@ pub async fn run_server(
             let tcp_svc =
                 tonic::service::interceptor::InterceptedService::new(svc.clone(), interceptor);
 
-            tokio::spawn(async move {
+            let tcp_task = tokio::spawn(async move {
                 let mut builder = tonic::transport::Server::builder();
                 let shutdown = async move {
                     let _ = tcp_shutdown_rx.changed().await;
@@ -11656,41 +12881,44 @@ pub async fn run_server(
                         let handshake_sem = std::sync::Arc::new(tokio::sync::Semaphore::new(
                             MAX_INFLIGHT_HANDSHAKES,
                         ));
-                        tokio::spawn(async move {
+                        let accept_task = tokio::spawn(async move {
                             let mut tcp = tcp_stream;
+                            let mut handshakes = tokio::task::JoinSet::new();
                             loop {
-                                let conn = tokio::select! {
+                                tokio::select! {
+                                    biased;
                                     _ = grpc_accept_shutdown_rx.changed() => break,
-                                    c = tcp.next() => match c {
-                                        Some(c) => c,
-                                        None => break,
-                                    },
-                                };
-                                let tcp_conn = match conn {
-                                    Ok(c) => c,
-                                    Err(e) => {
-                                        tracing::debug!("gRPC TCP accept failed: {e}");
-                                        continue;
+                                    conn = tcp.next(), if handshakes.len() < MAX_INFLIGHT_HANDSHAKES => {
+                                        let Some(conn) = conn else { break };
+                                        let tcp_conn = match conn {
+                                            Ok(connection) => connection,
+                                            Err(error) => {
+                                                tracing::debug!("gRPC TCP accept failed: {error}");
+                                                continue;
+                                            }
+                                        };
+                                        let Ok(permit) = handshake_sem.clone().try_acquire_owned() else {
+                                            tracing::debug!("gRPC handshake permit unavailable despite JoinSet cap");
+                                            continue;
+                                        };
+                                        handshakes.spawn(drive_capped_handshake(
+                                            permit,
+                                            acme_acceptor.clone(),
+                                            tcp_conn,
+                                            TLS_HANDSHAKE_TIMEOUT,
+                                            tls_tx.clone(),
+                                            "gRPC",
+                                        ));
                                     }
-                                };
-                                let permit = tokio::select! {
-                                    _ = grpc_accept_shutdown_rx.changed() => break,
-                                    res = handshake_sem.clone().acquire_owned() => match res {
-                                        Ok(p) => p,
-                                        Err(_) => break,
-                                    },
-                                };
-                                let acme_acceptor = acme_acceptor.clone();
-                                let tls_tx = tls_tx.clone();
-                                tokio::spawn(drive_capped_handshake(
-                                    permit,
-                                    acme_acceptor,
-                                    tcp_conn,
-                                    TLS_HANDSHAKE_TIMEOUT,
-                                    tls_tx,
-                                    "gRPC",
-                                ));
+                                    Some(result) = handshakes.join_next(), if !handshakes.is_empty() => {
+                                        if let Err(error) = result {
+                                            tracing::debug!("gRPC TLS handshake task failed: {error}");
+                                        }
+                                    }
+                                }
                             }
+                            handshakes.abort_all();
+                            while handshakes.join_next().await.is_some() {}
                         });
                         // tonic wants a stream of `Result<conn, E>`; our channel
                         // carries only successfully-handshaked streams.
@@ -11700,6 +12928,7 @@ pub async fn run_server(
                             .add_service(tcp_svc)
                             .serve_with_incoming_shutdown(tls_incoming, shutdown)
                             .await;
+                        let _ = accept_task.await;
                     }
                     // Plain TCP (loopback / no TLS).
                     None => {
@@ -11710,6 +12939,7 @@ pub async fn run_server(
                     }
                 }
             });
+            network_tasks.push(("TCP gRPC", tcp_task));
         }
 
         // Spawn the worker pool to consume index jobs from the SQLite queue.
@@ -12184,10 +13414,29 @@ pub async fn run_server(
         }
     }
 
-    uds_serve
+    let uds_result = uds_serve
         .await
-        .context("UDS serve task panicked")?
-        .context("gRPC server error")?;
+        .context("UDS serve task panicked")
+        .and_then(|result| result.context("gRPC server error"));
+
+    // A serve error/panic can end UDS without a Shutdown RPC or signal. Enter
+    // the same admission-closing drain in that case; otherwise retained public
+    // servers would wait forever (or have to be detached) while writers could
+    // still be admitted.
+    if !state.shutdown_started.load(Ordering::SeqCst) {
+        begin_shutdown_drain(Arc::clone(&state), "uds_server_exit");
+    }
+
+    // The shutdown broadcast has stopped accepts and initiated each server's
+    // graceful drain. Await the retained roots before any filesystem/lease
+    // cleanup: their complete task trees own the public service clones, and a
+    // dropped JoinHandle would merely detach those GraphStore Arcs.
+    for (label, task) in network_tasks {
+        tracing::info!(server = label, "draining public network server before exit");
+        if let Err(error) = task.await {
+            tracing::error!(server = label, %error, "public network server task failed");
+        }
+    }
 
     // Cleanup — runs on graceful shutdown (not skipped like process::exit would).
     tracing::info!("daemon shutting down, cleaning up");
@@ -12251,7 +13500,7 @@ pub async fn run_server(
             "draining watcher task(s) before exit"
         );
         for task in watcher_tasks {
-            let _ = task.await;
+            let _ = task.handle.await;
         }
     }
 
@@ -12281,7 +13530,7 @@ pub async fn run_server(
     // is inside.
     lifecycle::remove_instance_dirs_for_temp_db(&db_path, &instance_id);
 
-    Ok(())
+    uds_result
 }
 
 // ── FlowTraceContinue implementation ────────────────────────────────────
@@ -12758,6 +14007,49 @@ fn probe_remote_sha(
 mod startup_helper_tests {
     use super::*;
     use nestweaver_engine::{RepoConfig, RepoType};
+
+    #[tokio::test]
+    async fn expected_brain_uuid_refuses_a_missing_database_before_writer_authority_creates_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("missing.lbug");
+        let config_path = dir.path().join("instance.toml");
+        std::fs::write(
+            &config_path,
+            r#"instance_id = "expected-brain"
+expected_brain_uuid = "11111111-1111-4111-8111-111111111111"
+
+[snapshot_storage]
+backend = "local"
+path = "/tmp/nestweaver-test-snapshots"
+
+[workspace]
+backend = "local"
+path = "/tmp/nestweaver-test-workspace"
+
+[inference]
+endpoint = "http://localhost:11434"
+embedding_model = "nomic-embed-text"
+summary_model = "qwen2.5-coder:7b"
+
+[git]
+credential_method = "gh"
+"#,
+        )
+        .unwrap();
+
+        let error = run_server(&db_path, None, Some(&config_path), None)
+            .await
+            .expect_err("an asserted identity must never initialize a missing database");
+        assert!(
+            error.to_string().contains("refusing to create"),
+            "{error:#}"
+        );
+        assert!(!db_path.exists(), "the refusal created a database file");
+        assert!(
+            !nestweaver_store::write_lease_path(&db_path).exists(),
+            "the refusal created a writer sidecar before validating identity"
+        );
+    }
 
     /// Helper: init a git repo with one commit and return its path.
     fn init_repo(dir: &std::path::Path) {
@@ -14933,6 +16225,7 @@ mod startup_helper_tests {
                 "deterministic preflight projection failure"
             ))),
             &store,
+            IndexedSearchMutationScope::GraphOnly,
         );
 
         assert_eq!(comparison, IndexedSearchMutation::Unknown);
@@ -14949,6 +16242,32 @@ mod startup_helper_tests {
                 .unwrap()
                 .is_empty(),
             "available search must repair after an unknown preflight projection"
+        );
+    }
+
+    #[test]
+    fn equal_search_projections_are_proven_only_for_graph_only_mutations() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = GraphStore::open_or_create(&dir.path().join("test.lbug")).unwrap();
+        let before = indexed_search_rows(&store).unwrap();
+
+        assert_eq!(
+            indexed_search_mutation(
+                Some(Ok(before.clone())),
+                &store,
+                IndexedSearchMutationScope::GraphOnly,
+            ),
+            IndexedSearchMutation::Unchanged,
+            "equal graph projections prove a graph-only cleanup did not change Tantivy rows"
+        );
+        assert_eq!(
+            indexed_search_mutation(
+                Some(Ok(before)),
+                &store,
+                IndexedSearchMutationScope::MayIncludeVaultFiles,
+            ),
+            IndexedSearchMutation::Unknown,
+            "vault files may already differ from Tantivy even when graph projections are equal"
         );
     }
 
@@ -15124,6 +16443,163 @@ mod startup_helper_tests {
         assert!(
             Arc::ptr_eq(&first_handle, &second_handle),
             "a healthy runtime must hand back the SAME handle, not re-open"
+        );
+    }
+
+    #[test]
+    fn search_debt_clears_only_after_a_proven_noop_or_successful_rebuild() {
+        let state = test_state_with_writer();
+        let admission = establish_search_reconciliation_debt(&state, "index_vault").unwrap();
+        state
+            .search
+            .set_reconciliation(SearchIndexReconciliation::Unavailable(
+                "writer lock held".to_string(),
+            ));
+
+        finish_search_reconciliation(
+            &state,
+            IndexedSearchMutation::Unchanged,
+            "index_vault",
+            admission,
+        )
+        .expect("a newly established proven no-op needs no writer and may clear debt");
+        assert!(
+            load_search_reconciliation_debt(&state.db_path)
+                .unwrap()
+                .is_none()
+        );
+
+        let admission =
+            establish_search_reconciliation_debt(&state, "refresh_vault_since").unwrap();
+        let error = finish_search_reconciliation(
+            &state,
+            IndexedSearchMutation::Changed,
+            "refresh_vault_since",
+            admission,
+        )
+        .expect_err("a changed corpus without a writer must remain degraded");
+        assert!(format!("{error:#}").contains("writer lock held"));
+        let debt = load_search_reconciliation_debt(&state.db_path)
+            .unwrap()
+            .expect("failed reconciliation remains durable");
+        assert_eq!(debt.operation, "refresh_vault_since");
+        assert_eq!(debt.attempts, 1);
+
+        let status = search_capability_status(&state);
+        assert!(status.reader_available);
+        assert!(!status.writer_available);
+        assert!(!status.current);
+        assert!(status.reconciliation_debt);
+        assert!(status.error.contains("writer lock held"));
+    }
+
+    #[test]
+    fn a_later_noop_cannot_clear_an_earlier_failed_search_reconciliation() {
+        let state = test_state_with_writer();
+        let first = establish_search_reconciliation_debt(&state, "index_vault").unwrap();
+        state
+            .search
+            .set_reconciliation(SearchIndexReconciliation::Unavailable(
+                "writer lock held".to_string(),
+            ));
+        finish_search_reconciliation(&state, IndexedSearchMutation::Changed, "index_vault", first)
+            .expect_err("the first failed rebuild must leave durable debt");
+
+        let second = establish_search_reconciliation_debt(&state, "refresh_vault_since").unwrap();
+        assert!(second.had_existing_debt);
+        finish_search_reconciliation(
+            &state,
+            IndexedSearchMutation::Unchanged,
+            "refresh_vault_since",
+            second,
+        )
+        .expect_err("a later no-op must retry, not erase, the earlier debt");
+        assert!(
+            load_search_reconciliation_debt(&state.db_path)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn startup_retries_durable_search_debt_under_writer_ownership() {
+        let state = test_state_with_writer();
+        establish_search_reconciliation_debt(&state, "index_vault").unwrap();
+        assert!(
+            load_search_reconciliation_debt(&state.db_path)
+                .unwrap()
+                .is_some()
+        );
+
+        retry_search_reconciliation_debt_at_startup(&state)
+            .await
+            .expect("healthy startup writer rebuilds the corpus");
+
+        assert!(
+            load_search_reconciliation_debt(&state.db_path)
+                .unwrap()
+                .is_none(),
+            "successful startup rebuild is the clearing proof"
+        );
+        assert!(search_capability_status(&state).current);
+        assert_eq!(state.active_writes.load(Ordering::Relaxed), 0);
+        assert!(state.write_gate.holder_snapshot().is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_live_writer_schedules_durable_debt_recovery_under_the_write_gate() {
+        let state = test_state_with_writer();
+        state.search.attach_recovery_context(&state);
+        establish_search_reconciliation_debt(&state, "index_vault").unwrap();
+
+        let held = state.write_gate.mutex().lock_owned().await;
+        assert!(
+            state.tantivy().is_some(),
+            "reader remains usable while debt waits"
+        );
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while state.active_writes.load(Ordering::Relaxed) == 0 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("debt recovery must enter write admission before waiting");
+        assert!(
+            load_search_reconciliation_debt(&state.db_path)
+                .unwrap()
+                .is_some(),
+            "the marker cannot clear before the recovery owns the writer gate"
+        );
+
+        drop(held);
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if load_search_reconciliation_debt(&state.db_path)
+                    .unwrap()
+                    .is_none()
+                    && state.active_writes.load(Ordering::Relaxed) == 0
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("recovered writer must rebuild and clear durable debt");
+    }
+
+    #[test]
+    fn unreadable_search_debt_never_reports_the_corpus_current() {
+        let state = test_state_with_writer();
+        std::fs::write(search_reconciliation_debt_path(&state.db_path), b"not-json").unwrap();
+
+        let status = search_capability_status(&state);
+        assert!(!status.current);
+        assert!(status.reconciliation_debt);
+        assert!(status.error.contains("unreadable"));
+        assert!(
+            establish_search_reconciliation_debt(&state, "index_vault").is_err(),
+            "a corrupt marker must refuse the graph mutation, never be overwritten"
         );
     }
 
@@ -16401,6 +17877,271 @@ mod startup_helper_tests {
         );
     }
 
+    #[test]
+    fn degraded_project_materialization_is_a_committed_error_not_done() {
+        use nestweaver_engine::manifest::{
+            GraphMutationPublicationDisposition, GraphMutationPublicationOutcome,
+            GraphMutationPublicationWarning,
+        };
+
+        let mut result = nestweaver_engine::ProjectMaterializationResult {
+            projects_created: 2,
+            note_edges: 3,
+            symbol_edges: 5,
+            component_edges: 1,
+            wiki_notes_ingested: 0,
+            wiki_fetch_errors: 0,
+            publication: GraphMutationPublicationOutcome {
+                disposition: GraphMutationPublicationDisposition::CommittedDegraded,
+                generation_before: 40,
+                generation_after: 41,
+                warnings: vec![GraphMutationPublicationWarning {
+                    stage: "persist-generation".to_string(),
+                    message: "disk full".to_string(),
+                }],
+            },
+        };
+        let terminal = materialize_projects_terminal_progress(&result);
+        assert_eq!(terminal.phase, Phase::Error as i32);
+        assert!(terminal.message.contains("committed graph changes"));
+        assert!(terminal.message.contains("generation 40 -> 41"));
+        assert!(terminal.message.contains("persist-generation: disk full"));
+        assert!(terminal.message.contains("NOT rolled back"));
+
+        result.publication.disposition = GraphMutationPublicationDisposition::CommittedComplete;
+        result.publication.warnings.clear();
+        assert_eq!(
+            materialize_projects_terminal_progress(&result).phase,
+            Phase::Done as i32
+        );
+        result.publication.disposition = GraphMutationPublicationDisposition::ConfirmedNoChange;
+        assert_eq!(
+            materialize_projects_terminal_progress(&result).phase,
+            Phase::Done as i32
+        );
+    }
+
+    /// Implicit-project detection is a graph writer on apply, despite its
+    /// read-sounding name. The daemon must stamp its configured identity and
+    /// retain write ownership after the requesting future is cancelled; the
+    /// explicit dry-run remains able to complete without the write gate.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn implicit_project_detection_uses_daemon_identity_and_exact_worker_ownership() {
+        let mut state = test_state_with_writer();
+        {
+            let state = Arc::get_mut(&mut state).expect("sole test-state owner");
+            state.data_instance_id = "configured-brain".to_string();
+            state.instance_stated_by_config = true;
+        }
+        let vault = tempfile::tempdir().unwrap();
+        let project_dir = vault.path().join("Projects").join("owned-project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(project_dir.join("owned-project.md"), "# Owned\n").unwrap();
+
+        let held_gate = state.write_gate.mutex().lock_owned().await;
+        let service = DaemonService::new(state.clone());
+        let mut request = Request::new(JsonRequest {
+            args_json: serde_json::json!({
+                "vault": vault.path().to_string_lossy(),
+                "instance_id": "",
+            })
+            .to_string(),
+        });
+        request.extensions_mut().insert(crate::auth::IsAdmin(true));
+        let rpc = tokio::spawn(async move { service.detect_implicit_projects_json(request).await });
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while state.active_writes.load(Ordering::Relaxed) == 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("implicit-project worker must be admitted before it queues");
+        rpc.abort();
+        let _ = rpc.await;
+        assert_eq!(
+            state.active_writes.load(Ordering::Relaxed),
+            1,
+            "disconnect must not hide the queued blocking writer"
+        );
+
+        drop(held_gate);
+        let uid = nestweaver_schema::project_uid("configured-brain", "owned-project");
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if state.store.project_exists(&uid).unwrap_or(false)
+                    && state.active_writes.load(Ordering::Relaxed) == 0
+                {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("cancelled implicit-project writer must finish under configured identity");
+        assert!(
+            !state
+                .store
+                .project_exists(&nestweaver_schema::project_uid("default", "owned-project"))
+                .unwrap(),
+            "daemon detection must not hard-code the default namespace"
+        );
+
+        let explicit_dir = vault.path().join("Projects").join("explicit-project");
+        std::fs::create_dir_all(&explicit_dir).unwrap();
+        std::fs::write(explicit_dir.join("explicit-project.md"), "# Explicit\n").unwrap();
+        let mut explicit_request = Request::new(JsonRequest {
+            args_json: serde_json::json!({
+                "vault": vault.path().to_string_lossy(),
+                "instance_id": "explicit-brain",
+                "dry_run": false,
+            })
+            .to_string(),
+        });
+        explicit_request
+            .extensions_mut()
+            .insert(crate::auth::IsAdmin(true));
+        let explicit = DaemonService::new(state.clone())
+            .detect_implicit_projects_json(explicit_request)
+            .await
+            .expect("an exact request identity remains authoritative")
+            .into_inner();
+        let explicit: serde_json::Value =
+            serde_json::from_str(&explicit.result_json).expect("publication-aware JSON");
+        assert!(explicit["projects"].as_array().is_some_and(|projects| {
+            projects
+                .iter()
+                .any(|name| name.as_str() == Some("explicit-project"))
+        }));
+        assert!(explicit["publication"]["disposition"].is_string());
+        assert!(
+            state
+                .store
+                .project_exists(&nestweaver_schema::project_uid(
+                    "explicit-brain",
+                    "explicit-project"
+                ))
+                .unwrap(),
+            "a non-empty request identity must be stamped exactly"
+        );
+
+        let preview_dir = vault.path().join("Workspaces").join("preview-project");
+        std::fs::create_dir_all(&preview_dir).unwrap();
+        std::fs::write(preview_dir.join("_Overview.md"), "# Preview\n").unwrap();
+        let held_gate = state.write_gate.mutex().lock_owned().await;
+        let preview = DaemonService::new(state.clone())
+            .detect_implicit_projects_json(Request::new(JsonRequest {
+                args_json: serde_json::json!({
+                    "vault": vault.path().to_string_lossy(),
+                    "dry_run": true,
+                })
+                .to_string(),
+            }))
+            .await
+            .expect("dry-run must not wait for write ownership");
+        drop(held_gate);
+        let preview: serde_json::Value = serde_json::from_str(&preview.into_inner().result_json)
+            .expect("dry-run publication-aware JSON");
+        assert!(preview["projects"].as_array().is_some_and(|projects| {
+            projects
+                .iter()
+                .any(|name| name.as_str() == Some("preview-project"))
+        }));
+        assert_eq!(preview["publication"]["disposition"], "confirmed_no_change");
+        assert!(
+            !state
+                .store
+                .project_exists(&nestweaver_schema::project_uid(
+                    "configured-brain",
+                    "preview-project"
+                ))
+                .unwrap(),
+            "dry-run must not mutate the graph"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_only_replica_allows_implicit_project_preview_but_rejects_apply() {
+        let mut state = test_state_with_writer();
+        Arc::get_mut(&mut state).unwrap().read_only = true;
+        let vault = tempfile::tempdir().unwrap();
+        let project_dir = vault.path().join("Workspaces").join("preview");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(project_dir.join("_Overview.md"), "# Preview\n").unwrap();
+        let service = DaemonService::new(state);
+
+        assert!(
+            read_only_rejection(
+                true,
+                "/nestweaver.daemon.v1.NestWeaverDaemon/DetectImplicitProjectsJson"
+            )
+            .is_none(),
+            "the transport must let the payload-aware handler inspect dry_run"
+        );
+        service
+            .detect_implicit_projects_json(Request::new(JsonRequest {
+                args_json: serde_json::json!({
+                    "vault": vault.path().to_string_lossy(),
+                    "dry_run": true,
+                })
+                .to_string(),
+            }))
+            .await
+            .expect("preview is a read and must remain available on a replica");
+
+        let mut apply = Request::new(JsonRequest {
+            args_json: serde_json::json!({
+                "vault": vault.path().to_string_lossy(),
+                "dry_run": false,
+            })
+            .to_string(),
+        });
+        apply.extensions_mut().insert(crate::auth::IsAdmin(true));
+        let error = service
+            .detect_implicit_projects_json(apply)
+            .await
+            .expect_err("the mutating form must still fail closed");
+        assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    }
+
+    /// The daemon proxy must reject a malformed PR file set atomically. The
+    /// former `filter_map` silently discarded bad entries and analyzed a
+    /// smaller diff, allowing a partial-input result to look authoritative.
+    #[tokio::test]
+    async fn pr_impact_rejects_every_invalid_file_array_without_filtering() {
+        let service = DaemonService::new(test_state_with_writer());
+        for (files, expected) in [
+            (serde_json::json!([]), "at least one"),
+            (serde_json::json!(["src/lib.rs", 17]), "invalid files[1]"),
+            (serde_json::json!(["src/lib.rs", "  "]), "changed_files[1]"),
+            (serde_json::json!(["/tmp/lib.rs"]), "changed_files[0]"),
+            (
+                serde_json::json!(["src/lib.rs", "../outside.rs"]),
+                "changed_files[1]",
+            ),
+            (
+                serde_json::json!(vec!["src/lib.rs"; 1001]),
+                "maximum is 1000",
+            ),
+            (
+                serde_json::json!(["src/lib.rs", format!("src/{}", "a".repeat(509))]),
+                "maximum is 512",
+            ),
+        ] {
+            let error = service
+                .pr_impact_json(Request::new(JsonRequest {
+                    args_json: serde_json::json!({ "files": files }).to_string(),
+                }))
+                .await
+                .expect_err("invalid changed-file array must be rejected before analysis");
+            assert_eq!(error.code(), tonic::Code::InvalidArgument);
+            assert!(
+                error.message().contains(expected),
+                "expected {expected:?} in {error:?}"
+            );
+        }
+    }
+
     /// A per-request `--instance` still beats the recorded identity: the
     /// request is the most explicit statement of intent there is, and
     /// `instance merge --from/--to` (the documented remedy for an already
@@ -17403,7 +19144,10 @@ mod startup_helper_tests {
             open_browser: false,
             watch: false,
             watch_repo_path: String::new(),
-            watch_instance_id: "default".to_string(),
+            // Empty delegates to the daemon's exact live DB/config identity;
+            // a test helper must not smuggle a literal default into every UI
+            // request and mask identity regressions.
+            watch_instance_id: String::new(),
         });
         request.extensions_mut().insert(crate::auth::IsAdmin(true));
         request
@@ -17467,6 +19211,93 @@ mod startup_helper_tests {
         assert_eq!(resp.error, "port_in_use");
         assert_eq!(resp.port, 0);
         drop(blocker);
+    }
+
+    /// ServeUI watchers use the same canonical registration and retained-task
+    /// path as WatchCode. Repeating an equivalent request is idempotent, the
+    /// daemon's configured identity is retained, and StopUI drains the exact
+    /// watcher it created.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn serve_ui_watcher_is_registered_idempotent_and_drained() {
+        let mut state = test_state_with_writer();
+        {
+            let state = Arc::get_mut(&mut state).expect("sole test-state owner");
+            state.data_instance_id = "configured-brain".to_string();
+            state.instance_stated_by_config = true;
+        }
+        let service = DaemonService::new(state.clone());
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::write(repo.path().join("seed.rs"), "fn seed() {}\n").unwrap();
+        let repo_path = repo.path().canonicalize().unwrap();
+        let port = free_port();
+
+        let request = |requested_port: u16| {
+            let mut request = Request::new(ServeUiRequest {
+                port: u32::from(requested_port),
+                open_browser: false,
+                watch: true,
+                watch_repo_path: repo_path.to_string_lossy().into_owned(),
+                // Empty means the daemon owns identity resolution.
+                watch_instance_id: String::new(),
+            });
+            request.extensions_mut().insert(crate::auth::IsAdmin(true));
+            request
+        };
+
+        let first = service.serve_ui(request(port)).await.unwrap().into_inner();
+        assert!(first.ok, "first ServeUI failed: {}", first.message);
+        let watcher_id = {
+            let ui = state.ui_server.lock().unwrap();
+            let binding = ui
+                .as_ref()
+                .and_then(|registration| registration.watcher.as_ref())
+                .expect("ServeUI watcher binding");
+            assert_eq!(binding.instance_id, "configured-brain");
+            binding.id
+        };
+
+        let second = service
+            .serve_ui(request(free_port()))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(second.ok, "repeated ServeUI failed: {}", second.message);
+        assert_eq!(second.port, u32::from(port));
+        assert_eq!(
+            state
+                .ui_server
+                .lock()
+                .unwrap()
+                .as_ref()
+                .and_then(|registration| registration.watcher.as_ref())
+                .map(|binding| binding.id),
+            Some(watcher_id),
+            "an equivalent ServeUI request must not create a second watcher"
+        );
+        assert_eq!(
+            state
+                .watcher_tasks
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|task| task.id == watcher_id)
+                .count(),
+            1
+        );
+
+        let mut stop = Request::new(StopUiRequest {});
+        stop.extensions_mut().insert(crate::auth::IsAdmin(true));
+        assert!(service.stop_ui(stop).await.unwrap().into_inner().ok);
+        assert!(!watcher_registration_is_active(&state, watcher_id));
+        assert!(
+            state
+                .watcher_tasks
+                .lock()
+                .unwrap()
+                .iter()
+                .all(|task| task.id != watcher_id),
+            "StopUI must await and remove its retained watcher task"
+        );
     }
 
     /// nw-258(a). The daemon writes this sidecar and never reloaded it, so
@@ -17725,6 +19556,11 @@ credential_method = "gh"
             response.effective_config.unwrap().source,
             Some(effective_config::Source::CompiledDefaults(_))
         ));
+        let search = response.search_status.expect("structured search status");
+        assert!(search.reader_available);
+        assert!(search.writer_available);
+        assert!(search.current);
+        assert!(!search.reconciliation_debt);
         let typed = response
             .embedding_status
             .expect("structured embedding status");
@@ -17733,6 +19569,8 @@ credential_method = "gh"
         assert_eq!(typed.selected_device, "");
         assert!(typed.error.contains("Metal"));
         assert!(!typed.fallback_used);
+        assert_eq!(typed.identity_state, "verified");
+        assert!(typed.identity_error.is_empty());
 
         let json = service
             .brain_status_json(Request::new(JsonRequest {
@@ -17747,6 +19585,11 @@ credential_method = "gh"
         assert_eq!(value["embedding_status"]["requested_device"], "metal");
         assert_eq!(value["embedding_status"]["selected_device"], "");
         assert_eq!(value["embedding_status"]["fallback_used"], false);
+        assert_eq!(value["embedding_status"]["identity_state"], "verified");
+        assert_eq!(value["search_status"]["reader_available"], true);
+        assert_eq!(value["search_status"]["writer_available"], true);
+        assert_eq!(value["search_status"]["current"], true);
+        assert_eq!(value["search_status"]["reconciliation_debt"], false);
         assert!(
             value.get("effective_config").is_none(),
             "effective config provenance must remain typed-only so Combined federation cannot backfill it"
@@ -17849,6 +19692,137 @@ credential_method = "gh"
             ..EmbeddingRuntimeStatus::default()
         };
         assert_eq!(effective_embedding_state(&failed, &running), "failed");
+    }
+
+    #[test]
+    fn unreadable_embedding_identity_is_typed_and_force_is_not_an_override() {
+        let status = embedding_identity_precondition_status(
+            "embedding write",
+            &"metadata row could not be decoded",
+        );
+        assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+        assert!(status.message().contains("embedding write"));
+        assert!(
+            status
+                .message()
+                .contains("metadata row could not be decoded")
+        );
+        assert!(status.message().contains("--force cannot bypass"));
+
+        let runtime = embedding_identity_unreadable_status(
+            EmbeddingRuntimeStatus {
+                state: "ready".to_string(),
+                selected_device: "metal".to_string(),
+                ..EmbeddingRuntimeStatus::default()
+            },
+            "bad identity",
+        );
+        assert_eq!(runtime.state, "identity_unreadable");
+        assert!(runtime.selected_device.is_empty());
+        assert_eq!(runtime.error, "bad identity");
+    }
+
+    #[tokio::test]
+    async fn typed_brain_search_round_trips_malformed_embedding_identity_details() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("malformed-search-identity.lbug");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        store.set_embedding_metadata("recorded-model", 3).unwrap();
+        {
+            let conn = store.begin_transaction().unwrap();
+            conn.query("MATCH (m:Meta {key: 'embedding'}) SET m.value = '{not-json'")
+                .unwrap();
+            store.commit_transaction(&conn).unwrap();
+        }
+        drop(store);
+        let degraded = Arc::new(GraphStore::open(&db_path).unwrap());
+        assert!(degraded.embedding_identity_error().is_some());
+        let service = DaemonService::new(test_state_with_authz(
+            degraded,
+            build_daemon_permission_source(None),
+        ));
+
+        let response = service
+            .search(Request::new(BrainSearchRequest {
+                query: "needle".to_string(),
+                limit: 10,
+                response_format: None,
+                include_bodies: false,
+                prf: false,
+                rerank: false,
+                root: None,
+            }))
+            .await
+            .expect("lexical search remains available")
+            .into_inner();
+
+        assert_eq!(response.degraded_components, ["semantic"]);
+        let detail = response
+            .semantic_unavailable
+            .expect("typed response must preserve structured degradation");
+        assert_eq!(detail.cause, "embedding_identity");
+        assert_eq!(detail.reason, "embedding_identity_unreadable");
+        assert!(detail.error.contains("embedding"), "{}", detail.error);
+        assert!(
+            detail.remediation.contains("repair"),
+            "{}",
+            detail.remediation
+        );
+    }
+
+    #[test]
+    fn only_requested_semantic_or_rerank_routes_require_verified_identity() {
+        assert_eq!(
+            embedding_identity_operation("brain_context", &serde_json::json!({}), None,),
+            Some("semantic brain_context")
+        );
+        assert_eq!(
+            embedding_identity_operation(
+                "brain_context",
+                &serde_json::json!({
+                    "weight_ppr": 1.0,
+                    "weight_bm25": 0.0,
+                    "weight_semantic": 0.0,
+                }),
+                None,
+            ),
+            None,
+            "an explicitly nonzero lexical/graph leg plus zero semantic is a usable non-semantic query"
+        );
+        assert_eq!(
+            embedding_identity_operation(
+                "brain_search",
+                &serde_json::json!({ "rerank": true }),
+                None,
+            ),
+            Some("rerank")
+        );
+        assert_eq!(
+            embedding_identity_operation(
+                "brain_search",
+                &serde_json::json!({ "rerank": false }),
+                None,
+            ),
+            None
+        );
+
+        let mut lexical = serde_json::json!({
+            "semantic_applied": false,
+            "degraded_components": [],
+        });
+        annotate_lexical_identity_degradation(
+            "brain_search",
+            Some("identity metadata unreadable"),
+            &mut lexical,
+        );
+        assert_eq!(
+            lexical["degraded_components"],
+            serde_json::json!(["semantic"])
+        );
+        assert_eq!(
+            lexical["semantic_unavailable"]["reason"],
+            "embedding_identity_unreadable"
+        );
     }
 
     /// A pass that ends — normally, by panic, or by cancellation — must not
@@ -18128,6 +20102,7 @@ credential_method = "gh"
             scope: "all".to_string(),
             force: false,
             batch_size: 0,
+            repair_identity: false,
         });
         request.extensions_mut().insert(crate::auth::IsAdmin(true));
 
@@ -18146,6 +20121,49 @@ credential_method = "gh"
 
     #[cfg(feature = "embed")]
     #[tokio::test]
+    async fn explicit_daemon_identity_repair_discards_unverified_space() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("malformed-embedding.lbug");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        store.set_embedding_metadata("old-model", 3).unwrap();
+        assert!(store.add_embedding("symbol:old", vec![0.1, 0.2, 0.3]));
+        store.flush_embedding_index().unwrap();
+        let embedding_path = store.embedding_sidecar_path().unwrap();
+        {
+            let conn = store.begin_transaction().unwrap();
+            conn.query("MATCH (m:Meta {key: 'embedding'}) SET m.value = '{not-json'")
+                .unwrap();
+            store.commit_transaction(&conn).unwrap();
+        }
+        drop(store);
+        let degraded = Arc::new(GraphStore::open(&db_path).unwrap());
+        assert!(degraded.embedding_identity_error().is_some());
+
+        let mut state = test_state_with_writer();
+        let state_mut = Arc::get_mut(&mut state).expect("test state must be uniquely owned");
+        state_mut.store = Arc::clone(&degraded);
+        state_mut.db_path = db_path;
+        let service = DaemonService::new(state);
+        let mut request = Request::new(EmbedRequest {
+            scope: "all".to_string(),
+            force: true,
+            batch_size: 1,
+            repair_identity: true,
+        });
+        request.extensions_mut().insert(crate::auth::IsAdmin(true));
+
+        let response = service.embed(request).await.unwrap().into_inner();
+        assert!(response.identity_repaired);
+        assert!(response.restart_required);
+        assert_eq!(response.discarded_embeddings, 1);
+        assert_eq!(degraded.embedding_identity_error(), None);
+        assert_eq!(degraded.get_embedding_pipeline().unwrap(), None);
+        assert_eq!(degraded.embedding_count(), 0);
+        assert!(!embedding_path.exists());
+    }
+
+    #[cfg(feature = "embed")]
+    #[tokio::test]
     async fn embed_plan_reports_all_missing_nodes_as_eligible() {
         let state = test_state_with_writer();
         insert_unembedded_nodes_for_every_scope(&state.store, "plan-missing");
@@ -18156,6 +20174,7 @@ credential_method = "gh"
                 scope: "all".to_string(),
                 force: false,
                 batch_size: 0,
+                repair_identity: false,
             }))
             .await
             .unwrap()
@@ -18181,6 +20200,7 @@ credential_method = "gh"
                 scope: "all".to_string(),
                 force: false,
                 batch_size: 0,
+                repair_identity: false,
             }))
             .await
             .unwrap()
@@ -18206,6 +20226,7 @@ credential_method = "gh"
                 scope: "all".to_string(),
                 force: true,
                 batch_size: 0,
+                repair_identity: false,
             }))
             .await
             .unwrap()
@@ -18226,6 +20247,7 @@ credential_method = "gh"
                 scope: "unknown".to_string(),
                 force: false,
                 batch_size: 0,
+                repair_identity: false,
             }))
             .await
             .unwrap_err();
@@ -18261,6 +20283,7 @@ credential_method = "gh"
             scope: "all".to_string(),
             force: false,
             batch_size: 1,
+            repair_identity: false,
         });
         request.extensions_mut().insert(crate::auth::IsAdmin(true));
         let response = service.embed(request).await.unwrap().into_inner();
@@ -18469,6 +20492,7 @@ external_model = "unavailable-test-model"
                 scope: "symbols".to_string(),
                 force: true,
                 batch_size: 1,
+                repair_identity: false,
             });
             request.extensions_mut().insert(crate::auth::IsAdmin(true));
             if let Err(error) = service.embed(request).await {
@@ -18489,6 +20513,7 @@ external_model = "unavailable-test-model"
             scope: "symbols".to_string(),
             force: true,
             batch_size: 1,
+            repair_identity: false,
         });
         final_request
             .extensions_mut()
@@ -18541,6 +20566,7 @@ external_model = "unavailable-test-model"
             scope: "symbols".to_string(),
             force: false,
             batch_size: 8,
+            repair_identity: false,
         });
         request.extensions_mut().insert(crate::auth::IsAdmin(true));
         let response = DaemonService::new(state.clone())
@@ -18591,6 +20617,7 @@ external_model = "unavailable-test-model"
             scope: "symbols".to_string(),
             force: false,
             batch_size: 8,
+            repair_identity: false,
         });
         request.extensions_mut().insert(crate::auth::IsAdmin(true));
         let response = DaemonService::new(state.clone())
@@ -18699,6 +20726,73 @@ external_model = "unavailable-test-model"
         );
     }
 
+    #[tokio::test]
+    async fn typed_context_routes_propagate_restricted_visibility_to_the_tool_boundary() {
+        use nestweaver_engine::authz::{Identity, StaticConfigPermissionSource};
+
+        let store = Arc::new(GraphStore::in_memory().unwrap());
+        for repo in [
+            test_repo("repo:visible", "https://github.com/acme/visible.git", None),
+            test_repo("repo:hidden", "https://github.com/acme/hidden.git", None),
+        ] {
+            store.insert_repo(&repo).unwrap();
+        }
+        let token = "typed-context-scope";
+        let source = Arc::new(StaticConfigPermissionSource::new(
+            [(token.to_string(), vec!["repo:visible".to_string()])]
+                .into_iter()
+                .collect(),
+        ));
+        let service = DaemonService::new(test_state_with_authz(store, source));
+
+        let mut context = Request::new(BrainContextRequest {
+            seeds: vec!["seed".to_string()],
+            ..Default::default()
+        });
+        context
+            .extensions_mut()
+            .insert(Identity::Token(token.to_string()));
+        let error = service.get_context(context).await.unwrap_err();
+        assert!(
+            error.message().contains("repository-restricted identity"),
+            "typed context must pass request visibility to the common fail-closed boundary: {error}"
+        );
+
+        let mut project = Request::new(ProjectContextRequest {
+            project: "project".to_string(),
+            ..Default::default()
+        });
+        project
+            .extensions_mut()
+            .insert(Identity::Token(token.to_string()));
+        let error = service.get_project_context(project).await.unwrap_err();
+        assert!(
+            error.message().contains("repository-restricted identity"),
+            "typed project context must pass request visibility to the common fail-closed boundary: {error}"
+        );
+
+        let mut hubs = Request::new(HubNodesRequest::default());
+        hubs.extensions_mut()
+            .insert(Identity::Token(token.to_string()));
+        let error = service.hub_nodes(hubs).await.unwrap_err();
+        assert!(error.message().contains("repository-restricted identity"));
+
+        let mut status = Request::new(BrainStatusRequest {});
+        status
+            .extensions_mut()
+            .insert(Identity::Token(token.to_string()));
+        let error = service.brain_status(status).await.unwrap_err();
+        assert!(error.message().contains("repository-restricted identity"));
+
+        let mut repos = Request::new(RepoStatesRequest {});
+        repos
+            .extensions_mut()
+            .insert(Identity::Token(token.to_string()));
+        let repos = service.repo_states(repos).await.unwrap().into_inner();
+        assert_eq!(repos.repos.len(), 1);
+        assert_eq!(repos.repos[0].repo_uid, "repo:visible");
+    }
+
     /// nw-050: a UDS trusted-admin request must see ALL repos under an enabled
     /// `[authz]` policy. The UDS interceptor is the trusted-local-admin
     /// boundary; before the fix it attached only `IsAdmin(true)` and no
@@ -18763,6 +20857,91 @@ external_model = "unavailable-test-model"
     /// must block until the gate is released. An ungated implementation returns
     /// immediately — the RED failure this test guards against.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn disconnected_unary_worker_retains_write_ownership_until_it_finishes() {
+        let state = test_state_with_writer();
+        let started = Arc::new(AtomicBool::new(false));
+        let release = Arc::new(AtomicBool::new(false));
+        let service = DaemonService::new(state.clone());
+        let worker_started = started.clone();
+        let worker_release = release.clone();
+
+        let request = tokio::spawn(async move {
+            service
+                .run_unary_mutation("disconnect_probe", move || {
+                    worker_started.store(true, Ordering::Release);
+                    while !worker_release.load(Ordering::Acquire) {
+                        std::thread::sleep(std::time::Duration::from_millis(2));
+                    }
+                    Ok::<_, Status>(())
+                })
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while !started.load(Ordering::Acquire) {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("first blocking worker must start");
+
+        // Simulate a client disconnect. The JoinHandle owned by the RPC future
+        // is dropped, but spawn_blocking itself continues.
+        request.abort();
+        let _ = request.await;
+        assert_eq!(state.active_writes.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            state.write_gate.holder_snapshot().map(|(label, _)| label),
+            Some("disconnect_probe".to_string())
+        );
+
+        let competitor_entered = Arc::new(AtomicBool::new(false));
+        let competitor_flag = competitor_entered.clone();
+        let competing_service = DaemonService::new(state.clone());
+        let competitor = tokio::spawn(async move {
+            competing_service
+                .run_unary_mutation("competing_probe", move || {
+                    competitor_flag.store(true, Ordering::Release);
+                    Ok::<_, Status>(())
+                })
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while state.write_gate.waiting() == 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("competing worker must queue behind the disconnected worker");
+        assert!(!competitor_entered.load(Ordering::Acquire));
+
+        let mut shutdown = state.shutdown_tx.subscribe();
+        begin_shutdown_drain(state.clone(), "disconnect_test");
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), shutdown.changed())
+                .await
+                .is_err(),
+            "shutdown must not broadcast while the disconnected worker is live"
+        );
+
+        release.store(true, Ordering::Release);
+        competitor
+            .await
+            .expect("competitor task")
+            .expect("competitor mutation");
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while state.active_writes.load(Ordering::Relaxed) != 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("both exact workers must release write ownership");
+        tokio::time::timeout(std::time::Duration::from_secs(5), shutdown.changed())
+            .await
+            .expect("shutdown broadcasts after the workers finish")
+            .expect("shutdown sender remains live");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn reindex_search_holds_write_gate() {
         let state = test_state_with_writer();
         let service = DaemonService::new(state.clone());
@@ -18786,6 +20965,13 @@ external_model = "unavailable-test-model"
         );
 
         drop(gate);
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while state.active_writes.load(Ordering::Relaxed) != 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("cancelled reindex worker must finish after the gate is released");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -18809,6 +20995,13 @@ external_model = "unavailable-test-model"
             "remove_project must serialize with the daemon write gate"
         );
         drop(gate);
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while state.active_writes.load(Ordering::Relaxed) != 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("cancelled remove-project worker must finish after gate release");
     }
 
     /// The admin `set_extension` RPC does a read-modify-write of the
@@ -18819,8 +21012,8 @@ external_model = "unavailable-test-model"
     ///
     /// Probed the same way as `reindex_search_holds_write_gate`: while the
     /// test holds `write_mutex`, a gated `set_extension` must block until the
-    /// gate is released. The `json_rpc!`-dispatched implementation runs under
-    /// a *read* guard and returns immediately — the RED failure this guards.
+    /// gate is released. An implementation that falls back to ordinary
+    /// read-dispatch returns immediately — the RED failure this guards.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn set_extension_holds_write_gate() {
         let state = test_state_with_writer();
@@ -18846,6 +21039,13 @@ external_model = "unavailable-test-model"
         );
 
         drop(gate);
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while state.active_writes.load(Ordering::Relaxed) != 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("cancelled extension worker must finish after gate release");
     }
 
     /// nw-244: PR #308 wired `brain_memory_consolidate` to the write gate ONLY
@@ -18900,6 +21100,32 @@ external_model = "unavailable-test-model"
         );
 
         drop(gate);
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while state.active_writes.load(Ordering::Relaxed) != 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("cancelled applying consolidation must finish after gate release");
+
+        // The MCP leaf defaults to refusing apply unless its synchronous host
+        // attests authoritative ownership on the SAME thread. Reaching a
+        // successful empty-store apply through the daemon proves the scope is
+        // installed inside (and only for) the exact blocking worker above.
+        let mut owned_apply = Request::new(JsonRequest {
+            args_json: serde_json::json!({ "apply": true }).to_string(),
+        });
+        owned_apply
+            .extensions_mut()
+            .insert(crate::auth::IsAdmin(true));
+        let result = service
+            .brain_memory_consolidate(owned_apply)
+            .await
+            .expect("daemon-owned apply must satisfy MCP authoritative-writer guard")
+            .into_inner();
+        let result: serde_json::Value =
+            serde_json::from_str(&result.result_json).expect("valid consolidation JSON");
+        assert_eq!(result["dry_run"], false);
     }
 
     /// T6.2: the Shutdown RPC MUST set `state.drained` synchronously — before
@@ -19172,6 +21398,61 @@ external_model = "unavailable-test-model"
             state.drained.load(Ordering::Relaxed),
             "the worker must stop claiming new jobs on every shutdown route"
         );
+    }
+
+    #[test]
+    fn shutdown_between_write_increment_and_recheck_rolls_admission_back() {
+        let active = AtomicU32::new(0);
+        let shutdown = AtomicBool::new(false);
+
+        let admitted = try_admit_write_with(&active, &shutdown, || {
+            assert_eq!(active.load(Ordering::SeqCst), 1);
+            shutdown.store(true, Ordering::SeqCst);
+        });
+
+        assert!(!admitted);
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn a_write_increment_ordered_before_shutdown_remains_visible_to_the_drain() {
+        let active = AtomicU32::new(0);
+        let shutdown = AtomicBool::new(false);
+
+        assert!(try_admit_write_with(&active, &shutdown, || {}));
+        shutdown.store(true, Ordering::SeqCst);
+        assert_eq!(active.load(Ordering::Acquire), 1);
+    }
+
+    /// A writer admitted after idle observed zero but before it begins
+    /// shutdown must be drained. Broadcasting directly from the idle task
+    /// closed listeners and ownership while this unabortable write continued.
+    #[tokio::test]
+    async fn idle_shutdown_drains_a_write_admitted_after_the_idle_observation() {
+        let state = test_state_with_writer();
+        let mut shutdown_rx = state.shutdown_tx.subscribe();
+        assert!(is_idle(
+            state.active_reads.load(Ordering::Relaxed)
+                + state.active_writes.load(Ordering::Relaxed),
+            state.indexing_active.load(Ordering::Relaxed),
+        ));
+
+        let admitted = ConnectionGuard::write(&state)
+            .expect("write enters after the idle task's zero-counter observation");
+        begin_shutdown_drain(Arc::clone(&state), "idle_timeout");
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(750), shutdown_rx.changed())
+                .await
+                .is_err(),
+            "idle shutdown broadcast while the newly admitted write was in flight"
+        );
+        drop(admitted);
+        tokio::time::timeout(Duration::from_secs(5), shutdown_rx.changed())
+            .await
+            .expect("idle drain must finish after the write")
+            .expect("shutdown channel closed");
+        assert!(*shutdown_rx.borrow());
     }
 
     /// The contract change, at the unit level: a SIGTERM-triggered shutdown must
@@ -19842,7 +22123,8 @@ external_model = "unavailable-test-model"
         );
     }
 
-    /// health_check must report the daemon process's own PID so the CLI
+    /// health_check must report the daemon process's own PID and destructive
+    /// repair capability so the CLI can negotiate before mutation. The PID
     /// can cross-check a pidfile PID against the socket-reported PID before
     /// signaling it (a foreign PID planted in the pidfile fails that check).
     #[tokio::test]
@@ -19855,6 +22137,7 @@ external_model = "unavailable-test-model"
             .expect("health check ok")
             .into_inner();
         assert_eq!(resp.pid, std::process::id());
+        assert!(resp.embedding_identity_repair);
     }
 
     /// A second watcher registration is refused without force; with
@@ -20527,7 +22810,7 @@ mod boot_reconciliation_tests {
         // Open exactly as the snapshot-replica boot does, then run the boot
         // reconciliation with the same `read_only` the boot computes.
         let store = GraphStore::open_read_only(&db_path).unwrap();
-        reconcile_index_publication_before_ppr_warm(&store, true);
+        reconcile_index_publication_before_ppr_warm(&store, None);
 
         assert_eq!(
             std::fs::read(&marker_path).unwrap(),
@@ -20567,7 +22850,8 @@ mod boot_reconciliation_tests {
         // Open exactly as the read-write boot does, then run the boot
         // reconciliation with the same `read_only` the boot computes.
         let store = GraphStore::open_or_create(&db_path).unwrap();
-        reconcile_index_publication_before_ppr_warm(&store, false);
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
+        reconcile_index_publication_before_ppr_warm(&store, Some(&authority));
 
         assert!(
             !marker_path.exists(),
@@ -20606,7 +22890,7 @@ mod boot_reconciliation_tests {
     // would buy nothing.
     #[allow(clippy::await_holding_lock)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn read_write_daemon_boot_recovers_the_abandoned_publication() {
+    async fn read_write_daemon_boot_recovers_before_immediate_shutdown() {
         // Resolve env-dependent paths (socket, pidfile, log/runtime dirs) for
         // the daemon's whole lifetime under the same lock the sibling e2e
         // tests hold while swapping XDG vars.
@@ -20639,22 +22923,15 @@ mod boot_reconciliation_tests {
         }
         let mut client = client.expect("daemon socket did not come up within 10s");
 
-        // The boot reconciliation needs no RPC: it runs on a blocking thread
-        // during startup and must retire the marker on its own.
-        let mut retired = false;
-        for _ in 0..300 {
-            if !marker_path.exists() {
-                retired = true;
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        }
+        // The socket is a readiness boundary: publication recovery/PPR warm
+        // must already be complete, so an immediate shutdown cannot race a
+        // detached boot writer or release its DbWriteLease first.
         assert!(
-            retired,
-            "a read-write daemon boot must recover the abandoned publication \
-             (retire the marker) within 30s of startup"
+            !marker_path.exists(),
+            "a read-write daemon must retire the abandoned marker before serving"
         );
 
+        // Deliberately issue shutdown as the first RPC after connect.
         client
             .shutdown(nestweaver_proto::ShutdownRequest {})
             .await
@@ -21337,7 +23614,42 @@ mod watcher_e2e_tests {
 /// nw-212: the daemon must not report success for work that did not persist.
 #[cfg(test)]
 mod daemon_honesty_tests {
+    #[cfg(feature = "embed")]
+    use super::persist_embed_output;
     use super::settle_embed_counts;
+
+    #[cfg(feature = "embed")]
+    #[test]
+    fn metadata_stamp_failure_prevents_the_vector_flush() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("stamp-failure.lbug");
+        let first = nestweaver_schema::EmbeddingPipelineV2::external("provider", "model-a", 2);
+        let replacement =
+            nestweaver_schema::EmbeddingPipelineV2::external("provider", "model-b", 2);
+        let writer = nestweaver_store::GraphStore::open_or_create(&db_path).unwrap();
+        writer.set_embedding_pipeline(&first).unwrap();
+        assert!(writer.add_embedding_with_pipeline(
+            "symbol:preserved",
+            vec![1.0, 0.0],
+            &first,
+            false,
+        ));
+        writer.flush_embedding_index().unwrap();
+        let sidecar = writer.embedding_sidecar_path().unwrap();
+        let original_base = std::fs::read(&sidecar).unwrap();
+        drop(writer);
+
+        // A read-only store makes the metadata stamp fail deterministically.
+        // Its existing base has no pending deltas and would flush successfully,
+        // so returning that success would prove the stamp error was swallowed
+        // and the flush was still attempted.
+        let read_only = nestweaver_store::GraphStore::open_read_only(&db_path).unwrap();
+        let error = persist_embed_output(&read_only, Some(&replacement), 1)
+            .expect_err("metadata failure must terminate persistence before flush");
+        assert!(error.to_string().contains("read-only"));
+        assert_eq!(std::fs::read(&sidecar).unwrap(), original_base);
+        assert_eq!(read_only.get_embedding_pipeline().unwrap(), Some(first));
+    }
 
     /// The fsyncgate case. The CLI's embed path already zeroed its success
     /// count on a failed flush; the daemon route returned the count unchanged,

--- a/crates/nestweaver-engine/src/affected_tests.rs
+++ b/crates/nestweaver-engine/src/affected_tests.rs
@@ -95,6 +95,10 @@ pub struct AffectedTestsResult {
     /// Machine-readable reasons the selection was incomplete or degraded.
     #[serde(default)]
     pub notifications: Vec<Notification>,
+    /// Repositories whose persisted edges were not produced by the exact
+    /// resolver generation this binary understands.
+    #[serde(default)]
+    pub resolver_stale_repos: Vec<String>,
     /// Machine-readable CI directive derived from `status` (TIA-style
     /// fail-safe widening): any non-Complete run says "run-full-suite" so a
     /// pipeline can act on degradation without parsing notifications.
@@ -145,7 +149,22 @@ pub(crate) fn derive_recommendation(status: AnalysisStatus) -> &'static str {
 ///   4. bucket by traversal depth (tier_1 = depth 1, etc.), ordering within a
 ///      tier by edge confidence.
 pub fn affected_tests(store: &GraphStore, changed_files: &[String]) -> Result<AffectedTestsResult> {
-    affected_tests_within(store, changed_files, None)
+    let changed_files = crate::changed_files::require_changed_files(changed_files)?;
+    affected_tests_within(store, &changed_files, None)
+}
+
+/// Compute affected tests for a file list derived from a trusted VCS diff.
+///
+/// Unlike [`affected_tests`], this deliberately permits an empty list because
+/// `base_ref == HEAD` is a valid, proven empty diff. Transport/user input must
+/// never use this entry point merely to turn an omitted list into a green
+/// selection.
+pub fn affected_tests_for_derived_diff(
+    store: &GraphStore,
+    changed_files: &[String],
+) -> Result<AffectedTestsResult> {
+    let changed_files = crate::changed_files::validate_changed_file_entries(changed_files)?;
+    affected_tests_within(store, &changed_files, None)
 }
 
 /// Compute affected tests inside an induced symbol subgraph.
@@ -158,7 +177,18 @@ pub fn affected_tests_scoped(
     changed_files: &[String],
     allowed_symbols: &HashSet<String>,
 ) -> Result<AffectedTestsResult> {
-    affected_tests_within(store, changed_files, Some(allowed_symbols))
+    let changed_files = crate::changed_files::require_changed_files(changed_files)?;
+    affected_tests_within(store, &changed_files, Some(allowed_symbols))
+}
+
+/// Scoped twin of [`affected_tests_for_derived_diff`].
+pub fn affected_tests_scoped_for_derived_diff(
+    store: &GraphStore,
+    changed_files: &[String],
+    allowed_symbols: &HashSet<String>,
+) -> Result<AffectedTestsResult> {
+    let changed_files = crate::changed_files::validate_changed_file_entries(changed_files)?;
+    affected_tests_within(store, &changed_files, Some(allowed_symbols))
 }
 
 fn affected_tests_within(
@@ -170,6 +200,15 @@ fn affected_tests_within(
     // consumer runs the full suite instead of trusting an incomplete subset.
     let mut status = AnalysisStatus::Complete;
     let mut notifications: Vec<Notification> = Vec::new();
+    let resolver_stale_repos = crate::resolver_generation::incompatible_repos_for_store(store)?;
+    if !resolver_stale_repos.is_empty() {
+        status = status.max(AnalysisStatus::Degraded);
+        notifications.push(Notification {
+            level: NotificationLevel::Error,
+            message: crate::resolver_generation::incompatibility_message(&resolver_stale_repos),
+            descriptor: crate::resolver_generation::INCOMPATIBLE_RESOLVER_DESCRIPTOR.to_string(),
+        });
+    }
 
     // Step 1: changed files → changed symbols, via direct per-file lookup.
     //
@@ -439,6 +478,7 @@ fn affected_tests_within(
         recommendation: derive_recommendation(status).to_string(),
         status,
         notifications,
+        resolver_stale_repos,
         measured: None,
     })
 }
@@ -642,6 +682,18 @@ mod tests {
             link_type: None,
             evidence: vec![],
         }
+    }
+
+    #[test]
+    fn explicit_api_rejects_empty_while_derived_empty_diff_is_complete() {
+        let store = GraphStore::in_memory().expect("store");
+        let error = affected_tests(&store, &[]).unwrap_err().to_string();
+        assert!(error.contains("at least one"), "{error}");
+
+        let derived = affected_tests_for_derived_diff(&store, &[]).unwrap();
+        assert!(derived.changed_files.is_empty());
+        assert_eq!(derived.status, AnalysisStatus::Complete);
+        assert_eq!(derived.recommendation, "selection-usable");
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/authz.rs
+++ b/crates/nestweaver-engine/src/authz.rs
@@ -241,6 +241,9 @@ pub fn redact_blast_radius_for_visibility(
         .coverage
         .stale_repos
         .retain(|sr| visible_only.allows(&sr.repo_uid));
+    result
+        .resolver_stale_repos
+        .retain(|uid| visible_only.allows(uid));
 
     // affected_clusters is a graph-wide (potentially cross-repo) aggregate: each
     // cluster's `total_count` is its full size and `name` can be derived from a
@@ -608,6 +611,7 @@ mod tests {
             }),
             status: Default::default(),
             notifications: vec![],
+            resolver_stale_repos: vec!["repo:b".to_string()],
             gate_state: Default::default(),
             coverage: Coverage {
                 repos_in_scope: vec!["repo:a".to_string(), "repo:b".to_string()],
@@ -750,6 +754,7 @@ mod tests {
         assert_eq!(result.coverage.repos_in_scope, vec!["repo:a".to_string()]);
         assert!(result.coverage.repos_not_indexed.is_empty());
         assert!(result.coverage.stale_repos.is_empty());
+        assert!(result.resolver_stale_repos.is_empty());
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/blast_radius.rs
+++ b/crates/nestweaver-engine/src/blast_radius.rs
@@ -228,6 +228,10 @@ pub struct BlastRadiusResult {
     /// Machine-readable reasons the analysis was incomplete or degraded.
     #[serde(default)]
     pub notifications: Vec<Notification>,
+    /// Repositories whose edge semantics cannot be trusted by this resolver.
+    /// Kept separate from `coverage.stale_repos`, which means behind-git-HEAD.
+    #[serde(default)]
+    pub resolver_stale_repos: Vec<String>,
     /// The gate verdict, derived from `status` + `risk_level`. Never emits
     /// `RiskFlagged` from a degraded run (that would be an over-approximation);
     /// a degraded run is `DegradedUnknown` so a consumer treats it as unknown.
@@ -384,6 +388,7 @@ pub fn analyze_blast_radius(
     cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
     db_path: Option<&Path>,
 ) -> Result<BlastRadiusResult> {
+    let changed_files = crate::changed_files::require_changed_paths(changed_files)?;
     let target_repo = options.target_repo.as_deref();
     let max_depth = options.max_depth;
     let include_data_edges = options.include_data_edges;
@@ -392,6 +397,15 @@ pub fn analyze_blast_radius(
     // not. A failed/partial query must NOT be reported as "nothing affected".
     let mut status = AnalysisStatus::Complete;
     let mut notifications: Vec<Notification> = Vec::new();
+    let resolver_stale_repos = crate::resolver_generation::incompatible_repos_for_store(store)?;
+    if !resolver_stale_repos.is_empty() {
+        status = status.max(AnalysisStatus::Degraded);
+        notifications.push(Notification {
+            level: NotificationLevel::Error,
+            message: crate::resolver_generation::incompatibility_message(&resolver_stale_repos),
+            descriptor: crate::resolver_generation::INCOMPATIBLE_RESOLVER_DESCRIPTOR.to_string(),
+        });
+    }
 
     // Resolve repo_uid -> display name (repo URL when available, else the uid)
     // for org-wide impact reporting. Fetched up front so the changed-file loop
@@ -432,7 +446,7 @@ pub fn analyze_blast_radius(
     let mut files_ok: usize = 0;
     let mut files_errored: usize = 0;
 
-    for file in changed_files {
+    for file in &changed_files {
         let file_str = file.to_string_lossy();
         // In a unified multi-repo graph, scope resolution to the repo under
         // review so identical relative paths don't conflate across repos.
@@ -1089,6 +1103,7 @@ pub fn analyze_blast_radius(
         org_wide,
         status,
         notifications,
+        resolver_stale_repos,
         gate_state,
         coverage,
         blind_spots,
@@ -1341,13 +1356,12 @@ mod tests {
     }
 
     #[test]
-    fn empty_diff_on_empty_store_is_not_degraded() {
-        // No changed files → nothing to assess → the empty-index guard must not
-        // fire (an empty diff is a legitimate clean no-op, not a degraded run).
+    fn empty_changed_file_input_is_rejected_before_analysis() {
         let store = GraphStore::in_memory().expect("in_memory store");
-        let result = analyze_blast_radius(&store, &[], &opts(None, 3, false), None, None).unwrap();
-        assert_eq!(result.status, AnalysisStatus::Complete);
-        assert_eq!(result.gate_state, GateState::Ok);
+        let error = analyze_blast_radius(&store, &[], &opts(None, 3, false), None, None)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("at least one"), "{error}");
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/blast_radius_sarif.rs
+++ b/crates/nestweaver-engine/src/blast_radius_sarif.rs
@@ -305,6 +305,7 @@ mod tests {
             org_wide: None,
             status: AnalysisStatus::Complete,
             notifications: vec![],
+            resolver_stale_repos: vec![],
             gate_state: GateState::Ok,
             coverage: Coverage::default(),
             cochanged_files: Vec::new(),

--- a/crates/nestweaver-engine/src/brain_memory.rs
+++ b/crates/nestweaver-engine/src/brain_memory.rs
@@ -2639,7 +2639,7 @@ mod tests {
 
         let entries = load_consolidation_journals(&vaults, &vault_roots).unwrap();
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].path, journal_path);
+        assert_eq!(entries[0].path, fs::canonicalize(&journal_path).unwrap());
         assert_eq!(entries[0].vault_root, fs::canonicalize(&root).unwrap());
     }
 

--- a/crates/nestweaver-engine/src/brain_memory.rs
+++ b/crates/nestweaver-engine/src/brain_memory.rs
@@ -30,7 +30,8 @@
 //! | RelatesTo   | `skos:related`        |
 
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::path::Path;
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
 
 use anyhow::Result;
 use nestweaver_store::GraphStore;
@@ -667,8 +668,54 @@ pub struct ConsolidationManifest {
     pub dry_run: bool,
     pub applied: bool,
     pub proposals: Vec<ConsolidationProposal>,
-    /// Warnings (e.g. that `--apply` is not yet implemented).
+    /// Apply summaries, recovery locations, and re-index guidance.
     pub warnings: Vec<String>,
+}
+
+const CONSOLIDATION_JOURNAL_VERSION: u32 = 1;
+const CONSOLIDATION_JOURNAL_DIR: &str = ".nestweaver-consolidation-journal";
+
+/// A durable checkpoint for one promotion. Journals intentionally live in the
+/// affected vault: recovering a note move must not depend on the graph DB or
+/// on database-side backup/snapshot policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+enum ConsolidationPhase {
+    Prepared,
+    DestinationPublished,
+    SourceRemoved,
+    RewritesApplied,
+    Complete,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ConsolidationJournal {
+    version: u32,
+    journal_id: String,
+    vault_uid: String,
+    proposal: ConsolidationProposal,
+    source_path: String,
+    destination_path: String,
+    source_byte_len: u64,
+    source_blake3: String,
+    rewrite_paths: Vec<String>,
+    old_link_stem: String,
+    new_link_stem: String,
+    phase: ConsolidationPhase,
+}
+
+#[derive(Debug)]
+struct JournalEntry {
+    vault_root: PathBuf,
+    path: PathBuf,
+    journal: ConsolidationJournal,
+}
+
+#[derive(Debug)]
+struct ApplyProposalsOutcome {
+    all_succeeded: bool,
+    had_work: bool,
+    summaries: Vec<String>,
+    proposals: Vec<ConsolidationProposal>,
 }
 
 /// Number of distinct idea-note referrers a daily log needs to be promoted.
@@ -694,7 +741,7 @@ pub fn memory_consolidate(
 ) -> Result<ConsolidationManifest> {
     let notes = store.list_notes(None).map_err(|e| anyhow::anyhow!(e))?;
     let mut warnings = Vec::new();
-    if notes.is_empty() {
+    if notes.is_empty() && !apply {
         return Ok(ConsolidationManifest {
             dry_run: !apply,
             applied: false,
@@ -813,11 +860,11 @@ pub fn memory_consolidate(
             .then(a.promote_to.cmp(&b.promote_to))
     });
 
-    if apply && !proposals.is_empty() {
+    if apply {
         match apply_proposals(store, &proposals, &notes) {
-            Ok((success, summaries)) => {
-                warnings.extend(summaries);
-                if success {
+            Ok(outcome) => {
+                warnings.extend(outcome.summaries);
+                if outcome.all_succeeded && outcome.had_work {
                     warnings.push(
                         "Re-index the vault to update the graph: \
                          nestweaver brain refresh <vault-path>"
@@ -826,8 +873,8 @@ pub fn memory_consolidate(
                 }
                 return Ok(ConsolidationManifest {
                     dry_run: false,
-                    applied: success,
-                    proposals,
+                    applied: outcome.all_succeeded && outcome.had_work,
+                    proposals: outcome.proposals,
                     warnings,
                 });
             }
@@ -851,209 +898,1140 @@ pub fn memory_consolidate(
     })
 }
 
-/// Execute the file moves described by `proposals`, returning
-/// `(all_succeeded, summaries)`.
+/// Recover every incomplete vault-local journal, then execute newly discovered
+/// proposals. New proposals are completely preflighted before the first
+/// Prepared journal is written. Once a journal exists, its captured plan is
+/// authoritative even when a re-run's graph no longer discovers the proposal.
 fn apply_proposals(
     store: &GraphStore,
     proposals: &[ConsolidationProposal],
     notes: &[nestweaver_schema::Note],
-) -> Result<(bool, Vec<String>)> {
+) -> Result<ApplyProposalsOutcome> {
     let vaults = store.list_vaults(None).map_err(|e| anyhow::anyhow!(e))?;
-
-    let vault_roots: HashMap<&str, &str> = vaults
+    let vault_roots: HashMap<&str, &Path> = vaults
         .iter()
-        .map(|v| (v.uid.as_str(), v.root_path.as_str()))
+        .map(|v| (v.uid.as_str(), Path::new(v.root_path.as_str())))
         .collect();
-
     let note_by_uid: HashMap<&str, &nestweaver_schema::Note> =
         notes.iter().map(|n| (n.uid.as_str(), n)).collect();
 
+    // Loading and validating every existing journal is part of preflight. A
+    // corrupt or foreign journal must stop application before any new note is
+    // moved.
+    let mut entries = load_consolidation_journals(&vaults)?;
+    // Prepare every fresh proposal in memory first. This catches ambiguous
+    // same-source/same-destination batches and all current read/path failures
+    // before publishing even the first Prepared checkpoint.
+    let mut new_entries = Vec::new();
+    for proposal in proposals {
+        let note = note_by_uid
+            .get(proposal.source_uid.as_str())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "cannot prepare consolidation for missing note uid '{}'",
+                    proposal.source_uid
+                )
+            })?;
+        let vault_root = vault_roots.get(note.vault_uid.as_str()).ok_or_else(|| {
+            anyhow::anyhow!(
+                "cannot prepare consolidation for '{}': vault uid '{}' is unavailable",
+                proposal.source_path,
+                note.vault_uid
+            )
+        })?;
+        let source_relative = validate_vault_relative_path(Path::new(&proposal.source_path))?;
+        let destination_relative = destination_relative_path(proposal)?;
+        let id = consolidation_journal_id(
+            &note.vault_uid,
+            &proposal.source_uid,
+            &path_to_slash_string(&source_relative),
+            &path_to_slash_string(&destination_relative),
+        );
+        let path = consolidation_journal_path(vault_root, &id);
+        if let Some(existing) = entries
+            .iter()
+            .chain(new_entries.iter())
+            .find(|entry| entry.path == path)
+        {
+            validate_journal_for_proposal(&existing.journal, proposal, note, &path)?;
+            continue;
+        }
+        let journal = prepare_consolidation_journal(proposal, note, vault_root, &note_by_uid)?;
+        new_entries.push(JournalEntry {
+            vault_root: (*vault_root).to_path_buf(),
+            path,
+            journal,
+        });
+    }
+
+    validate_non_conflicting_journals(entries.iter().chain(new_entries.iter()))?;
+
+    // Only now does application begin. Each Prepared write is independently
+    // durable, so even failure while preparing a later proposal leaves an
+    // exact recovery point and no unjournaled note mutation.
+    for entry in &new_entries {
+        ensure_journal_directory(&entry.vault_root)?;
+        write_consolidation_journal(&entry.vault_root, &entry.path, &entry.journal)?;
+    }
+    entries.extend(new_entries);
+    entries.sort_by(|a, b| a.path.cmp(&b.path));
+
     let mut summaries = Vec::new();
     let mut all_ok = true;
+    let mut had_work = false;
+    let mut result_proposals: Vec<_> = proposals
+        .iter()
+        .filter(|proposal| {
+            !entries.iter().any(|entry| {
+                entry.journal.phase == ConsolidationPhase::Complete
+                    && entry.journal.proposal.source_uid == proposal.source_uid
+                    && entry.journal.proposal.promote_to == proposal.promote_to
+            })
+        })
+        .cloned()
+        .collect();
 
-    for p in proposals {
-        // Resolve the vault root for this note.
-        let note = match note_by_uid.get(p.source_uid.as_str()) {
-            Some(n) => *n,
-            None => {
-                summaries.push(format!(
-                    "SKIP: note uid '{}' not found in store",
-                    p.source_uid
-                ));
+    for entry in &mut entries {
+        if entry.journal.phase == ConsolidationPhase::Complete {
+            if let Err(error) =
+                validate_retained_complete_journal(&entry.vault_root, &entry.journal)
+            {
                 all_ok = false;
-                continue;
-            }
-        };
-        let vault_root = match vault_roots.get(note.vault_uid.as_str()) {
-            Some(r) => std::path::Path::new(*r),
-            None => {
                 summaries.push(format!(
-                    "SKIP: vault uid '{}' not found for note '{}'",
-                    note.vault_uid, p.source_path
+                    "FAILED: completed consolidation '{}' is inconsistent in {}: {error}",
+                    entry.journal.journal_id,
+                    entry.path.display()
                 ));
-                all_ok = false;
-                continue;
             }
-        };
-
-        let src = vault_root.join(&p.source_path);
-        if !src.exists() {
-            summaries.push(format!("SKIP: source does not exist: {}", src.display()));
-            all_ok = false;
             continue;
         }
+        had_work = true;
+        if !result_proposals.iter().any(|proposal| {
+            proposal.source_uid == entry.journal.proposal.source_uid
+                && proposal.promote_to == entry.journal.proposal.promote_to
+        }) {
+            result_proposals.push(entry.journal.proposal.clone());
+        }
 
-        // Determine the destination path.
-        let file_name = match src.file_name() {
-            Some(f) => f,
-            None => {
+        match apply_consolidation_journal(entry) {
+            Ok(rewrite_count) => {
+                let source = entry.vault_root.join(&entry.journal.source_path);
+                let destination = entry.vault_root.join(&entry.journal.destination_path);
                 summaries.push(format!(
-                    "SKIP: cannot extract filename from '{}'",
-                    src.display()
+                    "MOVED: {} → {}",
+                    source.display(),
+                    destination.display()
                 ));
-                all_ok = false;
-                continue;
-            }
-        };
-
-        let dest_dir = if p.promote_to == "_ideas" {
-            vault_root.join("_ideas")
-        } else if p.promote_to.starts_with("project-file (") {
-            // Extract the project dir from "project-file (<dir>)".
-            let inner = p
-                .promote_to
-                .strip_prefix("project-file (")
-                .and_then(|s| s.strip_suffix(')'));
-            match inner {
-                Some(proj_dir) => vault_root.join(proj_dir),
-                None => {
-                    summaries.push(format!(
-                        "SKIP: cannot parse project dir from promote_to '{}'",
-                        p.promote_to
-                    ));
-                    all_ok = false;
-                    continue;
-                }
-            }
-        } else {
-            summaries.push(format!(
-                "SKIP: unknown promote_to target '{}'",
-                p.promote_to
-            ));
-            all_ok = false;
-            continue;
-        };
-
-        let dest = dest_dir.join(file_name);
-
-        if dest.exists() {
-            summaries.push(format!(
-                "SKIP: destination already exists: {}",
-                dest.display()
-            ));
-            all_ok = false;
-            continue;
-        }
-
-        // Ensure destination directory exists.
-        if let Err(e) = std::fs::create_dir_all(&dest_dir) {
-            summaries.push(format!(
-                "SKIP: cannot create dir '{}': {e}",
-                dest_dir.display()
-            ));
-            all_ok = false;
-            continue;
-        }
-
-        // Move the file: try rename first, fall back to copy + delete for
-        // cross-filesystem moves.
-        let moved = match std::fs::rename(&src, &dest) {
-            Ok(()) => true,
-            Err(_rename_err) => match std::fs::copy(&src, &dest) {
-                Ok(_) => {
-                    if let Err(e) = std::fs::remove_file(&src) {
-                        summaries.push(format!(
-                            "WARN: copied to '{}' but failed to remove source '{}': {e}",
-                            dest.display(),
-                            src.display(),
-                        ));
-                    }
-                    true
-                }
-                Err(e) => {
-                    summaries.push(format!(
-                        "SKIP: failed to move '{}' → '{}': {e}",
-                        src.display(),
-                        dest.display(),
-                    ));
-                    all_ok = false;
-                    false
-                }
-            },
-        };
-
-        if moved {
-            summaries.push(format!("MOVED: {} → {}", src.display(), dest.display()));
-
-            // Rewrite path-based wikilinks in notes that reference this file.
-            let old_stem = Path::new(&p.source_path)
-                .with_extension("")
-                .to_string_lossy()
-                .replace('\\', "/");
-            let new_rel = dest
-                .strip_prefix(vault_root)
-                .unwrap_or(&dest)
-                .with_extension("")
-                .to_string_lossy()
-                .replace('\\', "/");
-
-            if old_stem != new_rel {
-                let rewrite_count =
-                    rewrite_wikilinks(vault_root, &note_by_uid, &p.evidence, &old_stem, &new_rel);
                 if rewrite_count > 0 {
                     summaries.push(format!(
-                        "  REWRITE: updated [[{old_stem}]] → [[{new_rel}]] in {rewrite_count} file(s)"
+                        "  REWRITE: updated [[{}]] → [[{}]] in {rewrite_count} file(s)",
+                        entry.journal.old_link_stem, entry.journal.new_link_stem
+                    ));
+                }
+            }
+            Err(error) => {
+                all_ok = false;
+                summaries.push(format!(
+                    "FAILED: consolidation '{}' remains recoverable at {:?} in {}: {error}",
+                    entry.journal.journal_id,
+                    entry.journal.phase,
+                    entry.path.display()
+                ));
+            }
+        }
+    }
+
+    result_proposals.sort_by(|a, b| {
+        a.source_uid
+            .cmp(&b.source_uid)
+            .then(a.promote_to.cmp(&b.promote_to))
+    });
+    result_proposals.dedup_by(|a, b| a.source_uid == b.source_uid && a.promote_to == b.promote_to);
+
+    Ok(ApplyProposalsOutcome {
+        all_succeeded: all_ok,
+        had_work,
+        summaries,
+        proposals: result_proposals,
+    })
+}
+
+fn prepare_consolidation_journal(
+    proposal: &ConsolidationProposal,
+    source_note: &nestweaver_schema::Note,
+    vault_root: &Path,
+    note_by_uid: &HashMap<&str, &nestweaver_schema::Note>,
+) -> Result<ConsolidationJournal> {
+    let source_relative = validate_vault_relative_path(Path::new(&proposal.source_path))?;
+    if source_note.file_path != proposal.source_path {
+        anyhow::bail!(
+            "proposal source path '{}' does not match stored note path '{}'",
+            proposal.source_path,
+            source_note.file_path
+        );
+    }
+    let destination_relative = destination_relative_path(proposal)?;
+    if source_relative == destination_relative {
+        anyhow::bail!(
+            "consolidation source and destination are identical: {}",
+            source_relative.display()
+        );
+    }
+
+    let source = validated_vault_path(vault_root, &source_relative, "consolidation source")?;
+    let destination = validated_vault_path(
+        vault_root,
+        &destination_relative,
+        "consolidation destination",
+    )?;
+    let metadata = std::fs::symlink_metadata(&source).map_err(|error| {
+        anyhow::anyhow!("read consolidation source {}: {error}", source.display())
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        anyhow::bail!("consolidation source is not a file: {}", source.display());
+    }
+    match std::fs::symlink_metadata(&destination) {
+        Ok(_) => anyhow::bail!(
+            "consolidation destination already exists without a journal: {}",
+            destination.display()
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(anyhow::anyhow!(
+                "inspect consolidation destination {}: {error}",
+                destination.display()
+            ));
+        }
+    }
+    let source_bytes = std::fs::read(&source).map_err(|error| {
+        anyhow::anyhow!("read consolidation source {}: {error}", source.display())
+    })?;
+
+    let mut rewrite_paths = Vec::new();
+    for uid in &proposal.evidence {
+        let note = note_by_uid.get(uid.as_str()).ok_or_else(|| {
+            anyhow::anyhow!(
+                "cannot prepare wikilink rewrite: evidence note uid '{uid}' is unavailable"
+            )
+        })?;
+        if note.vault_uid != source_note.vault_uid {
+            anyhow::bail!(
+                "cannot rewrite cross-vault evidence note '{}' for source '{}'",
+                note.file_path,
+                proposal.source_path
+            );
+        }
+        let relative = validate_vault_relative_path(Path::new(&note.file_path))?;
+        let path = validated_vault_path(vault_root, &relative, "wikilink rewrite target")?;
+        let metadata = std::fs::symlink_metadata(&path).map_err(|error| {
+            anyhow::anyhow!("preflight wikilink rewrite {}: {error}", path.display())
+        })?;
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            anyhow::bail!(
+                "preflight wikilink rewrite target is not a regular file: {}",
+                path.display()
+            );
+        }
+        let bytes = std::fs::read(&path).map_err(|error| {
+            anyhow::anyhow!("preflight wikilink rewrite {}: {error}", path.display())
+        })?;
+        std::str::from_utf8(&bytes).map_err(|error| {
+            anyhow::anyhow!(
+                "preflight wikilink rewrite {} as UTF-8: {error}",
+                path.display()
+            )
+        })?;
+        rewrite_paths.push(path_to_slash_string(&relative));
+    }
+    rewrite_paths.sort();
+    rewrite_paths.dedup();
+
+    let source_path = path_to_slash_string(&source_relative);
+    let destination_path = path_to_slash_string(&destination_relative);
+    let old_link_stem = path_to_slash_string(&source_relative.with_extension(""));
+    let new_link_stem = path_to_slash_string(&destination_relative.with_extension(""));
+    let journal_id = consolidation_journal_id(
+        &source_note.vault_uid,
+        &proposal.source_uid,
+        &source_path,
+        &destination_path,
+    );
+    let mut captured_proposal = proposal.clone();
+    captured_proposal.source_path = source_path.clone();
+
+    Ok(ConsolidationJournal {
+        version: CONSOLIDATION_JOURNAL_VERSION,
+        journal_id,
+        vault_uid: source_note.vault_uid.clone(),
+        proposal: captured_proposal,
+        source_path,
+        destination_path,
+        source_byte_len: source_bytes.len() as u64,
+        source_blake3: crate::hash::blake3_hex_bytes(&source_bytes),
+        rewrite_paths,
+        old_link_stem,
+        new_link_stem,
+        phase: ConsolidationPhase::Prepared,
+    })
+}
+
+fn destination_relative_path(proposal: &ConsolidationProposal) -> Result<PathBuf> {
+    let source = validate_vault_relative_path(Path::new(&proposal.source_path))?;
+    let file_name = source.file_name().ok_or_else(|| {
+        anyhow::anyhow!(
+            "cannot extract a filename from consolidation source '{}'",
+            proposal.source_path
+        )
+    })?;
+    let parent = if proposal.promote_to == "_ideas" {
+        PathBuf::from("_ideas")
+    } else if let Some(project) = proposal
+        .promote_to
+        .strip_prefix("project-file (")
+        .and_then(|value| value.strip_suffix(')'))
+    {
+        validate_vault_relative_path(Path::new(project))?
+    } else {
+        anyhow::bail!("unknown consolidation target '{}'", proposal.promote_to);
+    };
+    validate_vault_relative_path(&parent.join(file_name))
+}
+
+fn validate_vault_relative_path(path: &Path) -> Result<PathBuf> {
+    if path.as_os_str().is_empty() || path.is_absolute() {
+        anyhow::bail!(
+            "vault path must be non-empty and relative: {}",
+            path.display()
+        );
+    }
+    if !path
+        .components()
+        .all(|component| matches!(component, Component::Normal(_)))
+    {
+        anyhow::bail!(
+            "vault path contains a non-normal component: {}",
+            path.display()
+        );
+    }
+    Ok(path.to_path_buf())
+}
+
+fn validate_vault_root(vault_root: &Path) -> Result<()> {
+    let absolute = if vault_root.is_absolute() {
+        vault_root.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|error| anyhow::anyhow!("resolve current directory: {error}"))?
+            .join(vault_root)
+    };
+    let mut current = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::Prefix(prefix) => current.push(prefix.as_os_str()),
+            Component::RootDir => current.push(Path::new(std::path::MAIN_SEPARATOR_STR)),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !current.pop() {
+                    anyhow::bail!(
+                        "vault root escapes its filesystem root: {}",
+                        vault_root.display()
+                    );
+                }
+            }
+            Component::Normal(name) => {
+                current.push(name);
+                let metadata = std::fs::symlink_metadata(&current).map_err(|error| {
+                    anyhow::anyhow!(
+                        "inspect vault root component {}: {error}",
+                        current.display()
+                    )
+                })?;
+                if metadata.file_type().is_symlink() {
+                    anyhow::bail!("vault root component is a symlink: {}", current.display());
+                }
+                if !metadata.is_dir() {
+                    anyhow::bail!(
+                        "vault root component is not a directory: {}",
+                        current.display()
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Resolve one validated vault-relative path after rejecting symlinks and
+/// non-directories in every existing parent component. The leaf may be absent,
+/// but an existing leaf is never allowed to be a symlink.
+fn validated_vault_path(vault_root: &Path, relative: &Path, label: &str) -> Result<PathBuf> {
+    let relative = validate_vault_relative_path(relative)?;
+    validate_vault_root(vault_root)?;
+    let mut current = vault_root.to_path_buf();
+    if let Some(parent) = relative.parent() {
+        for component in parent.components() {
+            let Component::Normal(name) = component else {
+                unreachable!("validated path contains only normal components");
+            };
+            current.push(name);
+            match std::fs::symlink_metadata(&current) {
+                Ok(metadata) if metadata.file_type().is_symlink() => {
+                    anyhow::bail!("{label} parent is a symlink: {}", current.display())
+                }
+                Ok(metadata) if metadata.is_dir() => {}
+                Ok(_) => anyhow::bail!("{label} parent is not a directory: {}", current.display()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => break,
+                Err(error) => {
+                    return Err(anyhow::anyhow!(
+                        "inspect {label} parent {}: {error}",
+                        current.display()
                     ));
                 }
             }
         }
     }
-
-    Ok((all_ok, summaries))
+    let path = vault_root.join(relative);
+    match std::fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            anyhow::bail!("{label} is a symlink: {}", path.display())
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(anyhow::anyhow!(
+                "inspect {label} {}: {error}",
+                path.display()
+            ));
+        }
+    }
+    Ok(path)
 }
 
-/// Rewrite `[[old_stem]]` → `[[new_stem]]` in the files identified by `evidence_uids`.
-/// Returns the number of files actually modified.
-fn rewrite_wikilinks(
-    vault_root: &Path,
-    note_by_uid: &HashMap<&str, &nestweaver_schema::Note>,
-    evidence_uids: &[String],
-    old_stem: &str,
-    new_stem: &str,
-) -> usize {
-    let old_link = format!("[[{old_stem}]]");
-    let new_link = format!("[[{new_stem}]]");
-    // Also handle display-text links: [[path|display]]
-    let old_link_prefix = format!("[[{old_stem}|");
-    let new_link_prefix = format!("[[{new_stem}|");
+fn path_to_slash_string(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
 
+fn consolidation_journal_id(
+    vault_uid: &str,
+    source_uid: &str,
+    source_path: &str,
+    destination_path: &str,
+) -> String {
+    crate::hash::blake3_hex(&format!(
+        "v1\0{vault_uid}\0{source_uid}\0{source_path}\0{destination_path}"
+    ))
+}
+
+fn consolidation_journal_path(vault_root: &Path, journal_id: &str) -> PathBuf {
+    vault_root
+        .join(CONSOLIDATION_JOURNAL_DIR)
+        .join(format!("{journal_id}.json"))
+}
+
+fn ensure_journal_directory(vault_root: &Path) -> Result<()> {
+    ensure_vault_directory(vault_root, Path::new(CONSOLIDATION_JOURNAL_DIR))
+}
+
+fn ensure_vault_directory(vault_root: &Path, relative: &Path) -> Result<()> {
+    let relative = validate_vault_relative_path(relative)?;
+    validate_vault_root(vault_root)?;
+    let mut current = vault_root.to_path_buf();
+    for component in relative.components() {
+        let Component::Normal(name) = component else {
+            unreachable!("validated path contains only normal components");
+        };
+        current.push(name);
+        match std::fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => anyhow::bail!(
+                "required consolidation directory is a symlink: {}",
+                current.display()
+            ),
+            Ok(metadata) if metadata.is_dir() => {}
+            Ok(_) => anyhow::bail!(
+                "required consolidation directory is not a directory: {}",
+                current.display()
+            ),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                std::fs::create_dir(&current).map_err(|error| {
+                    anyhow::anyhow!(
+                        "create consolidation directory {}: {error}",
+                        current.display()
+                    )
+                })?;
+            }
+            Err(error) => {
+                return Err(anyhow::anyhow!(
+                    "inspect consolidation directory {}: {error}",
+                    current.display()
+                ));
+            }
+        }
+        let metadata = std::fs::symlink_metadata(&current).map_err(|error| {
+            anyhow::anyhow!(
+                "re-inspect consolidation directory {}: {error}",
+                current.display()
+            )
+        })?;
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            anyhow::bail!(
+                "required consolidation directory changed into a symlink or non-directory: {}",
+                current.display()
+            );
+        }
+        // Sync even when the directory was already visible: a prior attempt
+        // may have created it and then failed the parent sync.
+        nestweaver_store::durable_sidecar::sync_parent_directory_durable(&current).map_err(
+            |error| {
+                anyhow::anyhow!(
+                    "publish consolidation directory {} durably: {error}",
+                    current.display()
+                )
+            },
+        )?;
+    }
+    Ok(())
+}
+
+fn write_consolidation_journal(
+    vault_root: &Path,
+    path: &Path,
+    journal: &ConsolidationJournal,
+) -> Result<()> {
+    let relative = path.strip_prefix(vault_root).map_err(|_| {
+        anyhow::anyhow!(
+            "consolidation journal path escapes vault root: {}",
+            path.display()
+        )
+    })?;
+    let path = validated_vault_path(vault_root, relative, "consolidation journal")?;
+    let mut bytes = serde_json::to_vec_pretty(journal)?;
+    bytes.push(b'\n');
+    nestweaver_store::durable_sidecar::atomic_replace_file(&path, |file| file.write_all(&bytes))
+        .map_err(|error| {
+            anyhow::anyhow!(
+                "write consolidation journal {} durably: {error}",
+                path.display()
+            )
+        })
+}
+
+fn load_consolidation_journals(vaults: &[nestweaver_schema::Vault]) -> Result<Vec<JournalEntry>> {
+    let mut entries = Vec::new();
+    for vault in vaults {
+        let vault_root = Path::new(&vault.root_path);
+        let directory = validated_vault_path(
+            vault_root,
+            Path::new(CONSOLIDATION_JOURNAL_DIR),
+            "consolidation journal directory",
+        )?;
+        let read_dir = match std::fs::symlink_metadata(&directory) {
+            Ok(metadata) if metadata.file_type().is_symlink() => anyhow::bail!(
+                "consolidation journal directory is a symlink: {}",
+                directory.display()
+            ),
+            Ok(metadata) if !metadata.is_dir() => anyhow::bail!(
+                "consolidation journal path is not a directory: {}",
+                directory.display()
+            ),
+            Ok(_) => std::fs::read_dir(&directory).map_err(|error| {
+                anyhow::anyhow!(
+                    "read consolidation journal directory {}: {error}",
+                    directory.display()
+                )
+            })?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(anyhow::anyhow!(
+                    "inspect consolidation journal directory {}: {error}",
+                    directory.display()
+                ));
+            }
+        };
+        let mut paths = Vec::new();
+        for item in read_dir {
+            let path = item
+                .map_err(|error| {
+                    anyhow::anyhow!(
+                        "enumerate consolidation journal directory {}: {error}",
+                        directory.display()
+                    )
+                })?
+                .path();
+            if path.extension().and_then(|value| value.to_str()) == Some("json") {
+                paths.push(path);
+            }
+        }
+        paths.sort();
+        for path in paths {
+            let relative = path.strip_prefix(vault_root).map_err(|_| {
+                anyhow::anyhow!(
+                    "consolidation journal path escapes vault root: {}",
+                    path.display()
+                )
+            })?;
+            let path = validated_vault_path(vault_root, relative, "consolidation journal")?;
+            let metadata = std::fs::symlink_metadata(&path).map_err(|error| {
+                anyhow::anyhow!("inspect consolidation journal {}: {error}", path.display())
+            })?;
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                anyhow::bail!(
+                    "consolidation journal is not a regular file: {}",
+                    path.display()
+                );
+            }
+            // A prior atomic replacement may have returned after the rename but
+            // before its directory sync. Confirm that namespace change before
+            // trusting the checkpoint.
+            nestweaver_store::durable_sidecar::sync_parent_directory_durable(&path).map_err(
+                |error| {
+                    anyhow::anyhow!(
+                        "confirm consolidation journal {} durably: {error}",
+                        path.display()
+                    )
+                },
+            )?;
+            let bytes = std::fs::read(&path).map_err(|error| {
+                anyhow::anyhow!("read consolidation journal {}: {error}", path.display())
+            })?;
+            let journal: ConsolidationJournal =
+                serde_json::from_slice(&bytes).map_err(|error| {
+                    anyhow::anyhow!("parse consolidation journal {}: {error}", path.display())
+                })?;
+            validate_loaded_journal(&journal, &vault.uid, vault_root, &path)?;
+            entries.push(JournalEntry {
+                vault_root: vault_root.to_path_buf(),
+                path,
+                journal,
+            });
+        }
+    }
+    entries.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(entries)
+}
+
+fn validate_loaded_journal(
+    journal: &ConsolidationJournal,
+    vault_uid: &str,
+    vault_root: &Path,
+    path: &Path,
+) -> Result<()> {
+    if journal.version != CONSOLIDATION_JOURNAL_VERSION {
+        anyhow::bail!(
+            "unsupported consolidation journal version {} in {}",
+            journal.version,
+            path.display()
+        );
+    }
+    if journal.vault_uid != vault_uid {
+        anyhow::bail!(
+            "consolidation journal {} belongs to vault '{}' rather than '{}'",
+            path.display(),
+            journal.vault_uid,
+            vault_uid
+        );
+    }
+    let source = validate_vault_relative_path(Path::new(&journal.source_path))?;
+    let destination = validate_vault_relative_path(Path::new(&journal.destination_path))?;
+    if path_to_slash_string(&source) != journal.source_path
+        || path_to_slash_string(&destination) != journal.destination_path
+    {
+        anyhow::bail!(
+            "non-canonical path in consolidation journal {}",
+            path.display()
+        );
+    }
+    if journal.proposal.source_path != journal.source_path {
+        anyhow::bail!(
+            "proposal/source mismatch in consolidation journal {}",
+            path.display()
+        );
+    }
+    let derived_destination = destination_relative_path(&journal.proposal)?;
+    if derived_destination != destination {
+        anyhow::bail!(
+            "proposal/destination mismatch in consolidation journal {}",
+            path.display()
+        );
+    }
+    if journal.old_link_stem != path_to_slash_string(&source.with_extension(""))
+        || journal.new_link_stem != path_to_slash_string(&destination.with_extension(""))
+    {
+        anyhow::bail!(
+            "wikilink stem mismatch in consolidation journal {}",
+            path.display()
+        );
+    }
+    let mut normalized_rewrites = Vec::with_capacity(journal.rewrite_paths.len());
+    for rewrite in &journal.rewrite_paths {
+        let normalized = validate_vault_relative_path(Path::new(rewrite))?;
+        normalized_rewrites.push(path_to_slash_string(&normalized));
+    }
+    let mut sorted_rewrites = normalized_rewrites.clone();
+    sorted_rewrites.sort();
+    sorted_rewrites.dedup();
+    if normalized_rewrites != sorted_rewrites {
+        anyhow::bail!(
+            "rewrite paths are not canonical, sorted, and unique in consolidation journal {}",
+            path.display()
+        );
+    }
+    if journal.source_blake3.len() != 64
+        || !journal
+            .source_blake3
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+    {
+        anyhow::bail!(
+            "invalid source digest in consolidation journal {}",
+            path.display()
+        );
+    }
+    let expected_id = consolidation_journal_id(
+        vault_uid,
+        &journal.proposal.source_uid,
+        &journal.source_path,
+        &journal.destination_path,
+    );
+    if journal.journal_id != expected_id
+        || path != consolidation_journal_path(vault_root, &expected_id)
+    {
+        anyhow::bail!(
+            "identity mismatch in consolidation journal {}",
+            path.display()
+        );
+    }
+    validate_journal_vault_paths(vault_root, journal, path)?;
+    Ok(())
+}
+
+fn validate_journal_vault_paths(
+    vault_root: &Path,
+    journal: &ConsolidationJournal,
+    journal_path: &Path,
+) -> Result<()> {
+    validated_vault_path(
+        vault_root,
+        Path::new(&journal.source_path),
+        "consolidation source",
+    )?;
+    validated_vault_path(
+        vault_root,
+        Path::new(&journal.destination_path),
+        "consolidation destination",
+    )?;
+    for rewrite in &journal.rewrite_paths {
+        validated_vault_path(vault_root, Path::new(rewrite), "wikilink rewrite target")?;
+    }
+    let journal_relative = journal_path.strip_prefix(vault_root).map_err(|_| {
+        anyhow::anyhow!(
+            "consolidation journal path escapes vault root: {}",
+            journal_path.display()
+        )
+    })?;
+    validated_vault_path(vault_root, journal_relative, "consolidation journal")?;
+    Ok(())
+}
+
+fn validate_journal_for_proposal(
+    existing: &ConsolidationJournal,
+    proposal: &ConsolidationProposal,
+    note: &nestweaver_schema::Note,
+    path: &Path,
+) -> Result<()> {
+    let proposal_source = path_to_slash_string(&validate_vault_relative_path(Path::new(
+        &proposal.source_path,
+    ))?);
+    if existing.vault_uid != note.vault_uid
+        || existing.proposal.source_uid != proposal.source_uid
+        || existing.source_path != proposal_source
+        || existing.proposal.promote_to != proposal.promote_to
+    {
+        anyhow::bail!(
+            "fresh proposal conflicts with durable consolidation journal {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+fn validate_non_conflicting_journals<'a>(
+    entries: impl Iterator<Item = &'a JournalEntry>,
+) -> Result<()> {
+    let active: Vec<&JournalEntry> = entries
+        .filter(|entry| entry.journal.phase != ConsolidationPhase::Complete)
+        .collect();
+    let mut sources: HashMap<(PathBuf, String), String> = HashMap::new();
+    let mut destinations: HashMap<(PathBuf, String), String> = HashMap::new();
+    for entry in &active {
+        let source_key = (entry.vault_root.clone(), entry.journal.source_path.clone());
+        if let Some(other) = sources.insert(source_key, entry.journal.journal_id.clone())
+            && other != entry.journal.journal_id
+        {
+            anyhow::bail!(
+                "conflicting consolidation journals '{other}' and '{}' share source '{}'",
+                entry.journal.journal_id,
+                entry.journal.source_path
+            );
+        }
+        let destination_key = (
+            entry.vault_root.clone(),
+            entry.journal.destination_path.clone(),
+        );
+        if let Some(other) = destinations.insert(destination_key, entry.journal.journal_id.clone())
+            && other != entry.journal.journal_id
+        {
+            anyhow::bail!(
+                "conflicting consolidation journals '{other}' and '{}' share destination '{}'",
+                entry.journal.journal_id,
+                entry.journal.destination_path
+            );
+        }
+    }
+    for entry in &active {
+        for rewrite in &entry.journal.rewrite_paths {
+            if let Some(source_journal) = sources.get(&(entry.vault_root.clone(), rewrite.clone()))
+            {
+                anyhow::bail!(
+                    "consolidation journal '{}' would rewrite source '{}' owned by journal '{}'",
+                    entry.journal.journal_id,
+                    rewrite,
+                    source_journal
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn apply_consolidation_journal(entry: &mut JournalEntry) -> Result<usize> {
+    let mut rewrite_count = 0;
+    loop {
+        validate_journal_vault_paths(&entry.vault_root, &entry.journal, &entry.path)?;
+        match entry.journal.phase {
+            ConsolidationPhase::Prepared => {
+                publish_consolidation_destination(&entry.vault_root, &entry.journal)?;
+                advance_consolidation_phase(entry, ConsolidationPhase::DestinationPublished)?;
+            }
+            ConsolidationPhase::DestinationPublished => {
+                remove_consolidation_source(&entry.vault_root, &entry.journal)?;
+                advance_consolidation_phase(entry, ConsolidationPhase::SourceRemoved)?;
+            }
+            ConsolidationPhase::SourceRemoved => {
+                rewrite_count += rewrite_journal_wikilinks(&entry.vault_root, &entry.journal)?;
+                advance_consolidation_phase(entry, ConsolidationPhase::RewritesApplied)?;
+            }
+            ConsolidationPhase::RewritesApplied => {
+                // Validate the exact captured bytes and rewrites before the
+                // durable Complete checkpoint. Once Complete is published,
+                // later user edits to the destination are legitimate and the
+                // retained journal must not freeze them forever.
+                validate_consolidation_completion(&entry.vault_root, &entry.journal)?;
+                advance_consolidation_phase(entry, ConsolidationPhase::Complete)?;
+            }
+            ConsolidationPhase::Complete => {
+                validate_retained_complete_journal(&entry.vault_root, &entry.journal)?;
+                return Ok(rewrite_count);
+            }
+        }
+    }
+}
+
+fn advance_consolidation_phase(entry: &mut JournalEntry, phase: ConsolidationPhase) -> Result<()> {
+    let mut next = entry.journal.clone();
+    next.phase = phase;
+    write_consolidation_journal(&entry.vault_root, &entry.path, &next)?;
+    entry.journal = next;
+    Ok(())
+}
+
+fn publish_consolidation_destination(
+    vault_root: &Path,
+    journal: &ConsolidationJournal,
+) -> Result<()> {
+    let source_relative = Path::new(&journal.source_path);
+    let source = validated_vault_path(vault_root, source_relative, "consolidation source")?;
+    let destination_relative = Path::new(&journal.destination_path);
+    let destination = validated_vault_path(
+        vault_root,
+        destination_relative,
+        "consolidation destination",
+    )?;
+    match std::fs::symlink_metadata(&destination) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            anyhow::bail!(
+                "published consolidation destination is not a regular file: {}",
+                destination.display()
+            );
+        }
+        Ok(_) => {
+            validate_journal_file(&destination, journal)?;
+            nestweaver_store::durable_sidecar::sync_parent_directory_durable(&destination)
+                .map_err(|error| {
+                    anyhow::anyhow!(
+                        "confirm published consolidation destination {}: {error}",
+                        destination.display()
+                    )
+                })?;
+            return Ok(());
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(anyhow::anyhow!(
+                "inspect consolidation destination {}: {error}",
+                destination.display()
+            ));
+        }
+    }
+
+    validate_journal_file(&source, journal)?;
+    let parent_relative = destination_relative.parent().ok_or_else(|| {
+        anyhow::anyhow!(
+            "consolidation destination has no parent: {}",
+            destination.display()
+        )
+    })?;
+    ensure_vault_directory(vault_root, parent_relative)?;
+    let source = validated_vault_path(vault_root, source_relative, "consolidation source")?;
+    let destination = validated_vault_path(
+        vault_root,
+        destination_relative,
+        "consolidation destination",
+    )?;
+    let mut input = std::fs::File::open(&source).map_err(|error| {
+        anyhow::anyhow!("open consolidation source {}: {error}", source.display())
+    })?;
+    nestweaver_store::durable_sidecar::atomic_replace_file(&destination, |output| {
+        std::io::copy(&mut input, output).map(|_| ())
+    })
+    .map_err(|error| {
+        anyhow::anyhow!(
+            "publish consolidation destination {}: {error}",
+            destination.display()
+        )
+    })?;
+    validate_journal_file(&destination, journal)
+}
+
+fn validate_journal_file(path: &Path, journal: &ConsolidationJournal) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        anyhow::anyhow!("inspect consolidation file {}: {error}", path.display())
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        anyhow::bail!(
+            "consolidation file is not a regular file: {}",
+            path.display()
+        );
+    }
+    let bytes = std::fs::read(path)
+        .map_err(|error| anyhow::anyhow!("read consolidation file {}: {error}", path.display()))?;
+    let digest = crate::hash::blake3_hex_bytes(&bytes);
+    if bytes.len() as u64 != journal.source_byte_len || digest != journal.source_blake3 {
+        anyhow::bail!(
+            "consolidation file {} no longer matches journaled source bytes",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+fn remove_consolidation_source(vault_root: &Path, journal: &ConsolidationJournal) -> Result<()> {
+    let source = validated_vault_path(
+        vault_root,
+        Path::new(&journal.source_path),
+        "consolidation source",
+    )?;
+    match std::fs::symlink_metadata(&source) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                anyhow::bail!(
+                    "refuse to unlink non-file consolidation source {}",
+                    source.display()
+                );
+            }
+            validate_journal_file(&source, journal)?;
+            nestweaver_store::durable_sidecar::remove_file_durable(&source).map_err(|error| {
+                anyhow::anyhow!("remove consolidation source {}: {error}", source.display())
+            })?;
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            // The unlink may have happened before a prior attempt failed its
+            // parent sync. Syncing now turns observed absence into durable
+            // proof before the phase advances.
+            nestweaver_store::durable_sidecar::sync_parent_directory_durable(&source).map_err(
+                |error| {
+                    anyhow::anyhow!(
+                        "confirm removed consolidation source {}: {error}",
+                        source.display()
+                    )
+                },
+            )?;
+        }
+        Err(error) => {
+            return Err(anyhow::anyhow!(
+                "inspect consolidation source {}: {error}",
+                source.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn rewrite_journal_wikilinks(vault_root: &Path, journal: &ConsolidationJournal) -> Result<usize> {
+    if journal.old_link_stem == journal.new_link_stem {
+        return Ok(0);
+    }
+    let old_link = format!("[[{}]]", journal.old_link_stem);
+    let new_link = format!("[[{}]]", journal.new_link_stem);
+    let old_link_prefix = format!("[[{}|", journal.old_link_stem);
+    let new_link_prefix = format!("[[{}|", journal.new_link_stem);
     let mut count = 0;
-    for uid in evidence_uids {
-        let Some(note) = note_by_uid.get(uid.as_str()) else {
-            continue;
-        };
-        let path = vault_root.join(&note.file_path);
-        let Ok(content) = std::fs::read_to_string(&path) else {
-            continue;
-        };
+
+    for relative in &journal.rewrite_paths {
+        let relative = validate_vault_relative_path(Path::new(relative))?;
+        let path = validated_vault_path(vault_root, &relative, "wikilink rewrite target")?;
+        let metadata = std::fs::symlink_metadata(&path).map_err(|error| {
+            anyhow::anyhow!(
+                "inspect wikilink rewrite target {}: {error}",
+                path.display()
+            )
+        })?;
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            anyhow::bail!(
+                "wikilink rewrite target is not a regular file: {}",
+                path.display()
+            );
+        }
+        let bytes = std::fs::read(&path).map_err(|error| {
+            anyhow::anyhow!("read wikilink rewrite target {}: {error}", path.display())
+        })?;
+        let content = std::str::from_utf8(&bytes).map_err(|error| {
+            anyhow::anyhow!(
+                "read wikilink rewrite target {} as UTF-8: {error}",
+                path.display()
+            )
+        })?;
         let updated = content
             .replace(&old_link, &new_link)
             .replace(&old_link_prefix, &new_link_prefix);
-        if updated != content && std::fs::write(&path, &updated).is_ok() {
-            count += 1;
+        if updated == content {
+            // This can be an idempotent retry after rename succeeded but its
+            // parent sync failed. Re-sync before treating the rewrite as done.
+            nestweaver_store::durable_sidecar::sync_parent_directory_durable(&path).map_err(
+                |error| {
+                    anyhow::anyhow!(
+                        "confirm unchanged/idempotent wikilink target {}: {error}",
+                        path.display()
+                    )
+                },
+            )?;
+            continue;
+        }
+        let path = validated_vault_path(vault_root, &relative, "wikilink rewrite target")?;
+        nestweaver_store::durable_sidecar::atomic_replace_file(&path, |file| {
+            file.write_all(updated.as_bytes())
+        })
+        .map_err(|error| {
+            anyhow::anyhow!("rewrite wikilinks in {} durably: {error}", path.display())
+        })?;
+        count += 1;
+    }
+    Ok(count)
+}
+
+fn validate_consolidation_completion(
+    vault_root: &Path,
+    journal: &ConsolidationJournal,
+) -> Result<()> {
+    let source = validated_vault_path(
+        vault_root,
+        Path::new(&journal.source_path),
+        "consolidation source",
+    )?;
+    match std::fs::symlink_metadata(&source) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Ok(_) => anyhow::bail!(
+            "completed consolidation source unexpectedly exists: {}",
+            source.display()
+        ),
+        Err(error) => {
+            return Err(anyhow::anyhow!(
+                "inspect completed consolidation source {}: {error}",
+                source.display()
+            ));
         }
     }
-    count
+    let destination = validated_vault_path(
+        vault_root,
+        Path::new(&journal.destination_path),
+        "consolidation destination",
+    )?;
+    validate_journal_file(&destination, journal)?;
+
+    let old_link = format!("[[{}]]", journal.old_link_stem);
+    let old_link_prefix = format!("[[{}|", journal.old_link_stem);
+    for relative in &journal.rewrite_paths {
+        let path = validated_vault_path(
+            vault_root,
+            &validate_vault_relative_path(Path::new(relative))?,
+            "wikilink rewrite target",
+        )?;
+        let content = std::fs::read_to_string(&path).map_err(|error| {
+            anyhow::anyhow!(
+                "validate completed wikilink target {}: {error}",
+                path.display()
+            )
+        })?;
+        if content.contains(&old_link) || content.contains(&old_link_prefix) {
+            anyhow::bail!(
+                "completed consolidation still has an old wikilink in {}",
+                path.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_retained_complete_journal(
+    vault_root: &Path,
+    journal: &ConsolidationJournal,
+) -> Result<()> {
+    let source = validated_vault_path(
+        vault_root,
+        Path::new(&journal.source_path),
+        "consolidation source",
+    )?;
+    match std::fs::symlink_metadata(&source) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Ok(_) => anyhow::bail!(
+            "completed consolidation source unexpectedly exists: {}",
+            source.display()
+        ),
+        Err(error) => {
+            return Err(anyhow::anyhow!(
+                "inspect completed consolidation source {}: {error}",
+                source.display()
+            ));
+        }
+    }
+
+    let destination = validated_vault_path(
+        vault_root,
+        Path::new(&journal.destination_path),
+        "consolidation destination",
+    )?;
+    let metadata = std::fs::symlink_metadata(&destination).map_err(|error| {
+        anyhow::anyhow!(
+            "inspect completed consolidation destination {}: {error}",
+            destination.display()
+        )
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        anyhow::bail!(
+            "completed consolidation destination is not a file: {}",
+            destination.display()
+        );
+    }
+    Ok(())
 }
 
 /// True when `path_lc` (lowercased, forward-slash) is inside a directory named
@@ -1537,6 +2515,305 @@ mod tests {
         assert!(
             !idea_a.contains("[[_logs/2025-01-01]]"),
             "idea-a.md should not have old wikilink"
+        );
+    }
+
+    fn prepared_log_promotion_journal(store: &GraphStore, root: &Path) -> ConsolidationJournal {
+        let manifest = memory_consolidate(store, false, 4_000_000_000.0).unwrap();
+        let proposal = manifest
+            .proposals
+            .into_iter()
+            .find(|proposal| proposal.source_path == "_logs/2025-01-01.md")
+            .expect("log promotion proposal");
+        let notes = store.list_notes(None).unwrap();
+        let source_note = notes
+            .iter()
+            .find(|note| note.uid == proposal.source_uid)
+            .unwrap();
+        let note_by_uid: HashMap<&str, &nestweaver_schema::Note> =
+            notes.iter().map(|note| (note.uid.as_str(), note)).collect();
+        prepare_consolidation_journal(&proposal, source_note, root, &note_by_uid).unwrap()
+    }
+
+    fn journal_fixture() -> (tempfile::TempDir, PathBuf, GraphStore, ConsolidationJournal) {
+        let (dir, root) = make_vault(&[
+            (
+                "_logs/2025-01-01.md",
+                "# Log Jan 1\n\nA recurring idea worth promoting.\n",
+            ),
+            (
+                "_ideas/idea-a.md",
+                "# Idea A\n\nSee [[_logs/2025-01-01]].\n",
+            ),
+            (
+                "_ideas/idea-b.md",
+                "# Idea B\n\nRefs [[_logs/2025-01-01]].\n",
+            ),
+            (
+                "_ideas/idea-c.md",
+                "# Idea C\n\nAlso [[_logs/2025-01-01]].\n",
+            ),
+        ]);
+        let (_res, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+        let journal = prepared_log_promotion_journal(&store, &root);
+        (dir, root, store, journal)
+    }
+
+    fn persist_test_journal(root: &Path, journal: &ConsolidationJournal) -> PathBuf {
+        ensure_journal_directory(root).unwrap();
+        let path = consolidation_journal_path(root, &journal.journal_id);
+        write_consolidation_journal(root, &path, journal).unwrap();
+        path
+    }
+
+    fn read_test_journal(path: &Path) -> ConsolidationJournal {
+        serde_json::from_slice(&fs::read(path).unwrap()).unwrap()
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn consolidate_rejects_symlinked_destination_parent_before_any_mutation() {
+        use std::os::unix::fs::symlink;
+
+        let (dir, root, store, journal) = journal_fixture();
+        let source = root.join(&journal.source_path);
+        let source_before = fs::read(&source).unwrap();
+        fs::rename(root.join("_ideas"), root.join("idea-evidence")).unwrap();
+        let outside = dir.path().join("outside-destination");
+        fs::create_dir(&outside).unwrap();
+        fs::write(outside.join("sentinel.txt"), "outside must stay unchanged").unwrap();
+        symlink(&outside, root.join("_ideas")).unwrap();
+
+        let manifest = memory_consolidate(&store, true, 4_000_000_000.0).unwrap();
+
+        assert!(!manifest.applied);
+        assert!(
+            manifest
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("symlink")),
+            "warnings: {:?}",
+            manifest.warnings
+        );
+        assert_eq!(fs::read(&source).unwrap(), source_before);
+        assert_eq!(
+            fs::read_to_string(outside.join("sentinel.txt")).unwrap(),
+            "outside must stay unchanged"
+        );
+        assert!(!outside.join("2025-01-01.md").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn consolidate_rejects_symlinked_rewrite_parent_before_any_mutation() {
+        use std::os::unix::fs::symlink;
+
+        let (dir, root, store, mut journal) = journal_fixture();
+        let source = root.join(&journal.source_path);
+        let source_before = fs::read(&source).unwrap();
+        let rewrite_parent = root.join("rewrites");
+        fs::create_dir(&rewrite_parent).unwrap();
+        fs::write(
+            rewrite_parent.join("link.md"),
+            "[[_logs/2025-01-01]] inside vault",
+        )
+        .unwrap();
+        journal.rewrite_paths = vec!["rewrites/link.md".to_string()];
+        let _journal_path = persist_test_journal(&root, &journal);
+        fs::remove_dir_all(&rewrite_parent).unwrap();
+        let outside = dir.path().join("outside-rewrites");
+        fs::create_dir(&outside).unwrap();
+        let outside_rewrite = outside.join("link.md");
+        let outside_before = "[[_logs/2025-01-01]] outside vault";
+        fs::write(&outside_rewrite, outside_before).unwrap();
+        symlink(&outside, &rewrite_parent).unwrap();
+
+        let manifest = memory_consolidate(&store, true, 0.0).unwrap();
+
+        assert!(!manifest.applied);
+        assert!(
+            manifest
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("symlink")),
+            "warnings: {:?}",
+            manifest.warnings
+        );
+        assert_eq!(fs::read(&source).unwrap(), source_before);
+        assert!(!root.join(&journal.destination_path).exists());
+        assert_eq!(fs::read_to_string(outside_rewrite).unwrap(), outside_before);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn consolidate_rejects_symlinked_journal_directory_before_any_mutation() {
+        use std::os::unix::fs::symlink;
+
+        let (dir, root, store, journal) = journal_fixture();
+        let source = root.join(&journal.source_path);
+        let source_before = fs::read(&source).unwrap();
+        let outside = dir.path().join("outside-journals");
+        fs::create_dir(&outside).unwrap();
+        let sentinel = outside.join("sentinel.txt");
+        fs::write(&sentinel, "not a journal").unwrap();
+        symlink(&outside, root.join(CONSOLIDATION_JOURNAL_DIR)).unwrap();
+
+        let manifest = memory_consolidate(&store, true, 4_000_000_000.0).unwrap();
+
+        assert!(!manifest.applied);
+        assert!(
+            manifest
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("symlink")),
+            "warnings: {:?}",
+            manifest.warnings
+        );
+        assert_eq!(fs::read(&source).unwrap(), source_before);
+        assert!(!root.join(&journal.destination_path).exists());
+        assert_eq!(fs::read_to_string(&sentinel).unwrap(), "not a journal");
+        assert_eq!(fs::read_dir(&outside).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn consolidate_recovers_existing_journal_when_discovery_is_empty() {
+        let (_dir, root, store, journal) = journal_fixture();
+        let journal_path = persist_test_journal(&root, &journal);
+        // Simulate interruption after the atomic destination rename but before
+        // Prepared could be advanced to DestinationPublished.
+        publish_consolidation_destination(&root, &journal).unwrap();
+
+        // `now=0` makes the indexed log too young, so fresh discovery is empty.
+        // Recovery must still use the captured journal plan.
+        let manifest = memory_consolidate(&store, true, 0.0).unwrap();
+        assert!(manifest.applied, "warnings: {:?}", manifest.warnings);
+        assert_eq!(manifest.proposals.len(), 1, "recovered work stays visible");
+        assert!(!root.join("_logs/2025-01-01.md").exists());
+        assert!(root.join("_ideas/2025-01-01.md").exists());
+        assert_eq!(
+            read_test_journal(&journal_path).phase,
+            ConsolidationPhase::Complete
+        );
+
+        // A retained Complete journal is not new work once discovery is empty.
+        let second = memory_consolidate(&store, true, 0.0).unwrap();
+        assert!(!second.applied);
+        assert!(second.proposals.is_empty());
+
+        // A retained Complete journal is a transaction receipt, not a
+        // permanent content lock. The stale graph can rediscover the removed
+        // source, and users may legitimately edit the promoted destination.
+        fs::write(
+            root.join(&journal.destination_path),
+            "# Promoted and subsequently edited\n",
+        )
+        .unwrap();
+        let stale_graph_retry = memory_consolidate(&store, true, 4_000_000_000.0).unwrap();
+        assert!(!stale_graph_retry.applied);
+        assert!(stale_graph_retry.proposals.is_empty());
+        assert!(
+            stale_graph_retry
+                .warnings
+                .iter()
+                .all(|warning| !warning.contains("FAILED")),
+            "warnings: {:?}",
+            stale_graph_retry.warnings
+        );
+    }
+
+    #[test]
+    fn consolidate_failed_unlink_stays_destination_published_and_is_not_applied() {
+        let (_dir, root, store, mut journal) = journal_fixture();
+        publish_consolidation_destination(&root, &journal).unwrap();
+        journal.phase = ConsolidationPhase::DestinationPublished;
+        let source = root.join(&journal.source_path);
+        fs::remove_file(&source).unwrap();
+        fs::create_dir(&source).unwrap();
+        let journal_path = persist_test_journal(&root, &journal);
+
+        let manifest = memory_consolidate(&store, true, 0.0).unwrap();
+        assert!(!manifest.applied);
+        assert!(
+            manifest
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("non-file consolidation source")),
+            "warnings: {:?}",
+            manifest.warnings
+        );
+        assert_eq!(
+            read_test_journal(&journal_path).phase,
+            ConsolidationPhase::DestinationPublished
+        );
+        assert!(root.join(&journal.destination_path).exists());
+        assert!(source.is_dir());
+    }
+
+    #[test]
+    fn consolidate_failed_rewrite_stays_source_removed_and_is_not_applied() {
+        let (_dir, root, store, mut journal) = journal_fixture();
+        publish_consolidation_destination(&root, &journal).unwrap();
+        nestweaver_store::durable_sidecar::remove_file_durable(&root.join(&journal.source_path))
+            .unwrap();
+        journal.phase = ConsolidationPhase::SourceRemoved;
+        journal.rewrite_paths = vec!["missing-rewrite-target.md".to_string()];
+        let journal_path = persist_test_journal(&root, &journal);
+
+        let manifest = memory_consolidate(&store, true, 0.0).unwrap();
+        assert!(!manifest.applied);
+        assert!(
+            manifest
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("wikilink rewrite target")),
+            "warnings: {:?}",
+            manifest.warnings
+        );
+        assert_eq!(
+            read_test_journal(&journal_path).phase,
+            ConsolidationPhase::SourceRemoved
+        );
+        assert!(root.join(&journal.destination_path).exists());
+    }
+
+    #[test]
+    fn consolidate_applies_multiple_independent_proposals_as_one_recoverable_batch() {
+        let (_dir, root) = make_vault(&[
+            ("_logs/2025-01-01.md", "# First log\n"),
+            ("_logs/2025-01-02.md", "# Second log\n"),
+            (
+                "_ideas/idea-a.md",
+                "[[_logs/2025-01-01]] and [[_logs/2025-01-02]]\n",
+            ),
+            (
+                "_ideas/idea-b.md",
+                "[[_logs/2025-01-01]] and [[_logs/2025-01-02]]\n",
+            ),
+            (
+                "_ideas/idea-c.md",
+                "[[_logs/2025-01-01]] and [[_logs/2025-01-02]]\n",
+            ),
+        ]);
+        let (_res, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+
+        let manifest = memory_consolidate(&store, true, 4_000_000_000.0).unwrap();
+        assert!(manifest.applied, "warnings: {:?}", manifest.warnings);
+        assert_eq!(manifest.proposals.len(), 2);
+        assert!(root.join("_ideas/2025-01-01.md").exists());
+        assert!(root.join("_ideas/2025-01-02.md").exists());
+        let idea = fs::read_to_string(root.join("_ideas/idea-a.md")).unwrap();
+        assert!(idea.contains("[[_ideas/2025-01-01]]"));
+        assert!(idea.contains("[[_ideas/2025-01-02]]"));
+
+        let journals: Vec<_> = fs::read_dir(root.join(CONSOLIDATION_JOURNAL_DIR))
+            .unwrap()
+            .map(|entry| read_test_journal(&entry.unwrap().path()))
+            .collect();
+        assert_eq!(journals.len(), 2);
+        assert!(
+            journals
+                .iter()
+                .all(|journal| journal.phase == ConsolidationPhase::Complete)
         );
     }
 

--- a/crates/nestweaver-engine/src/brain_memory.rs
+++ b/crates/nestweaver-engine/src/brain_memory.rs
@@ -908,17 +908,19 @@ fn apply_proposals(
     notes: &[nestweaver_schema::Note],
 ) -> Result<ApplyProposalsOutcome> {
     let vaults = store.list_vaults(None).map_err(|e| anyhow::anyhow!(e))?;
-    let vault_roots: HashMap<&str, &Path> = vaults
+    let vault_roots: HashMap<&str, PathBuf> = vaults
         .iter()
-        .map(|v| (v.uid.as_str(), Path::new(v.root_path.as_str())))
-        .collect();
+        .map(|v| {
+            validate_vault_root(Path::new(v.root_path.as_str())).map(|root| (v.uid.as_str(), root))
+        })
+        .collect::<Result<_>>()?;
     let note_by_uid: HashMap<&str, &nestweaver_schema::Note> =
         notes.iter().map(|n| (n.uid.as_str(), n)).collect();
 
     // Loading and validating every existing journal is part of preflight. A
     // corrupt or foreign journal must stop application before any new note is
     // moved.
-    let mut entries = load_consolidation_journals(&vaults)?;
+    let mut entries = load_consolidation_journals(&vaults, &vault_roots)?;
     // Prepare every fresh proposal in memory first. This catches ambiguous
     // same-source/same-destination batches and all current read/path failures
     // before publishing even the first Prepared checkpoint.
@@ -958,7 +960,7 @@ fn apply_proposals(
         }
         let journal = prepare_consolidation_journal(proposal, note, vault_root, &note_by_uid)?;
         new_entries.push(JournalEntry {
-            vault_root: (*vault_root).to_path_buf(),
+            vault_root: vault_root.clone(),
             path,
             journal,
         });
@@ -1216,7 +1218,7 @@ fn validate_vault_relative_path(path: &Path) -> Result<PathBuf> {
     Ok(path.to_path_buf())
 }
 
-fn validate_vault_root(vault_root: &Path) -> Result<()> {
+fn validate_vault_root(vault_root: &Path) -> Result<PathBuf> {
     let absolute = if vault_root.is_absolute() {
         vault_root.to_path_buf()
     } else {
@@ -1224,41 +1226,26 @@ fn validate_vault_root(vault_root: &Path) -> Result<()> {
             .map_err(|error| anyhow::anyhow!("resolve current directory: {error}"))?
             .join(vault_root)
     };
-    let mut current = PathBuf::new();
-    for component in absolute.components() {
-        match component {
-            Component::Prefix(prefix) => current.push(prefix.as_os_str()),
-            Component::RootDir => current.push(Path::new(std::path::MAIN_SEPARATOR_STR)),
-            Component::CurDir => {}
-            Component::ParentDir => {
-                if !current.pop() {
-                    anyhow::bail!(
-                        "vault root escapes its filesystem root: {}",
-                        vault_root.display()
-                    );
-                }
-            }
-            Component::Normal(name) => {
-                current.push(name);
-                let metadata = std::fs::symlink_metadata(&current).map_err(|error| {
-                    anyhow::anyhow!(
-                        "inspect vault root component {}: {error}",
-                        current.display()
-                    )
-                })?;
-                if metadata.file_type().is_symlink() {
-                    anyhow::bail!("vault root component is a symlink: {}", current.display());
-                }
-                if !metadata.is_dir() {
-                    anyhow::bail!(
-                        "vault root component is not a directory: {}",
-                        current.display()
-                    );
-                }
-            }
-        }
+    // `symlink_metadata("alias/")` follows `alias` on POSIX because the
+    // trailing separator requires directory traversal. Rebuild the lexical
+    // spelling from components first so the final component is always checked
+    // without a trailing separator or terminal `/.` bypass.
+    let lexical_root: PathBuf = absolute.components().collect();
+    let metadata = std::fs::symlink_metadata(&lexical_root).map_err(|error| {
+        anyhow::anyhow!("inspect vault root {}: {error}", lexical_root.display())
+    })?;
+    if metadata.file_type().is_symlink() {
+        anyhow::bail!("vault root is a symlink: {}", lexical_root.display());
     }
-    Ok(())
+    if !metadata.is_dir() {
+        anyhow::bail!("vault root is not a directory: {}", lexical_root.display());
+    }
+    std::fs::canonicalize(&lexical_root).map_err(|error| {
+        anyhow::anyhow!(
+            "canonicalize vault root {}: {error}",
+            lexical_root.display()
+        )
+    })
 }
 
 /// Resolve one validated vault-relative path after rejecting symlinks and
@@ -1266,8 +1253,8 @@ fn validate_vault_root(vault_root: &Path) -> Result<()> {
 /// but an existing leaf is never allowed to be a symlink.
 fn validated_vault_path(vault_root: &Path, relative: &Path, label: &str) -> Result<PathBuf> {
     let relative = validate_vault_relative_path(relative)?;
-    validate_vault_root(vault_root)?;
-    let mut current = vault_root.to_path_buf();
+    let vault_root = validate_vault_root(vault_root)?;
+    let mut current = vault_root.clone();
     if let Some(parent) = relative.parent() {
         for component in parent.components() {
             let Component::Normal(name) = component else {
@@ -1334,8 +1321,7 @@ fn ensure_journal_directory(vault_root: &Path) -> Result<()> {
 
 fn ensure_vault_directory(vault_root: &Path, relative: &Path) -> Result<()> {
     let relative = validate_vault_relative_path(relative)?;
-    validate_vault_root(vault_root)?;
-    let mut current = vault_root.to_path_buf();
+    let mut current = validate_vault_root(vault_root)?;
     for component in relative.components() {
         let Component::Normal(name) = component else {
             unreachable!("validated path contains only normal components");
@@ -1415,10 +1401,18 @@ fn write_consolidation_journal(
         })
 }
 
-fn load_consolidation_journals(vaults: &[nestweaver_schema::Vault]) -> Result<Vec<JournalEntry>> {
+fn load_consolidation_journals(
+    vaults: &[nestweaver_schema::Vault],
+    vault_roots: &HashMap<&str, PathBuf>,
+) -> Result<Vec<JournalEntry>> {
     let mut entries = Vec::new();
     for vault in vaults {
-        let vault_root = Path::new(&vault.root_path);
+        let vault_root = vault_roots.get(vault.uid.as_str()).ok_or_else(|| {
+            anyhow::anyhow!(
+                "cannot load consolidation journals: vault uid '{}' has no snapshotted root",
+                vault.uid
+            )
+        })?;
         let directory = validated_vault_path(
             vault_root,
             Path::new(CONSOLIDATION_JOURNAL_DIR),
@@ -1499,7 +1493,7 @@ fn load_consolidation_journals(vaults: &[nestweaver_schema::Vault]) -> Result<Ve
                 })?;
             validate_loaded_journal(&journal, &vault.uid, vault_root, &path)?;
             entries.push(JournalEntry {
-                vault_root: vault_root.to_path_buf(),
+                vault_root: vault_root.clone(),
                 path,
                 journal,
             });
@@ -2568,6 +2562,85 @@ mod tests {
 
     fn read_test_journal(path: &Path) -> ConsolidationJournal {
         serde_json::from_slice(&fs::read(path).unwrap()).unwrap()
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn vault_root_canonicalizes_platform_ancestor_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let real_parent = dir.path().join("real-parent");
+        let real_vault = real_parent.join("vault");
+        fs::create_dir_all(&real_vault).unwrap();
+        fs::write(real_vault.join("note.md"), "# Note\n").unwrap();
+        let alias_parent = dir.path().join("platform-alias");
+        symlink(&real_parent, &alias_parent).unwrap();
+
+        let resolved = validated_vault_path(
+            &alias_parent.join("vault"),
+            Path::new("note.md"),
+            "fixture note",
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolved,
+            fs::canonicalize(real_vault.join("note.md")).unwrap()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn vault_root_rejects_a_final_symlink_even_with_a_trailing_separator() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let real_vault = dir.path().join("real-vault");
+        fs::create_dir(&real_vault).unwrap();
+        let alias = dir.path().join("vault-alias");
+        symlink(&real_vault, &alias).unwrap();
+        let trailing = PathBuf::from(format!("{}/", alias.display()));
+
+        let error = validate_vault_root(&trailing).unwrap_err();
+        assert!(error.to_string().contains("vault root is a symlink"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn journal_recovery_uses_one_snapshotted_physical_vault_root() {
+        use std::os::unix::fs::symlink;
+
+        let (dir, root, store, journal) = journal_fixture();
+        let journal_path = persist_test_journal(&root, &journal);
+        let root_name = root.file_name().unwrap();
+        let alias_parent = dir.path().join("platform-alias");
+        symlink(dir.path(), &alias_parent).unwrap();
+        let configured_root = alias_parent.join(root_name);
+
+        let mut vaults = store.list_vaults(None).unwrap();
+        assert_eq!(vaults.len(), 1);
+        vaults[0].root_path = configured_root.display().to_string();
+        let vault_roots: HashMap<&str, PathBuf> = vaults
+            .iter()
+            .map(|vault| {
+                (
+                    vault.uid.as_str(),
+                    validate_vault_root(Path::new(&vault.root_path)).unwrap(),
+                )
+            })
+            .collect();
+
+        fs::remove_file(&alias_parent).unwrap();
+        let other_parent = dir.path().join("other-parent");
+        fs::create_dir(&other_parent).unwrap();
+        fs::create_dir(other_parent.join(root_name)).unwrap();
+        symlink(&other_parent, &alias_parent).unwrap();
+
+        let entries = load_consolidation_journals(&vaults, &vault_roots).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].path, journal_path);
+        assert_eq!(entries[0].vault_root, fs::canonicalize(&root).unwrap());
     }
 
     #[cfg(unix)]

--- a/crates/nestweaver-engine/src/changed_files.rs
+++ b/crates/nestweaver-engine/src/changed_files.rs
@@ -1,0 +1,170 @@
+//! Canonical validation for file lists that drive edge-dependent analysis.
+//!
+//! These inputs cross CLI, MCP, daemon-proxy, and direct engine boundaries.
+//! Keeping validation here prevents a transport from silently dropping a bad
+//! element and then reporting a green result for the smaller list.
+
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{Result, bail};
+
+/// Maximum number of paths accepted by any public changed-file analysis.
+pub const MAX_CHANGED_FILES: usize = 1000;
+/// Maximum UTF-8 byte length of one repository-relative changed-file path.
+pub const MAX_CHANGED_FILE_LEN: usize = 512;
+
+/// Validate and trim changed-file entries while permitting a genuinely empty
+/// diff (used by `affected-tests --base-ref HEAD`).
+pub fn validate_changed_file_entries(changed_files: &[String]) -> Result<Vec<String>> {
+    if changed_files.len() > MAX_CHANGED_FILES {
+        bail!(
+            "'changed_files' contains {} entries; maximum is {MAX_CHANGED_FILES}",
+            changed_files.len()
+        );
+    }
+    changed_files
+        .iter()
+        .enumerate()
+        .map(|(index, raw)| validate_changed_file(raw, index))
+        .collect()
+}
+
+/// Validate a user-supplied list that must contain at least one changed file.
+pub fn require_changed_files(changed_files: &[String]) -> Result<Vec<String>> {
+    if changed_files.is_empty() {
+        bail!("'changed_files' must contain at least one repository-relative path");
+    }
+    validate_changed_file_entries(changed_files)
+}
+
+/// Path-buffer twin used by blast-radius's public engine API.
+pub fn require_changed_paths(changed_files: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    if changed_files.is_empty() {
+        bail!("'changed_files' must contain at least one repository-relative path");
+    }
+    if changed_files.len() > MAX_CHANGED_FILES {
+        bail!(
+            "'changed_files' contains {} entries; maximum is {MAX_CHANGED_FILES}",
+            changed_files.len()
+        );
+    }
+    let encoded: Vec<String> = changed_files
+        .iter()
+        .enumerate()
+        .map(|(index, path)| {
+            path.to_str().map(str::to_string).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "invalid changed_files[{index}] {path:?}: paths must be valid UTF-8"
+                )
+            })
+        })
+        .collect::<Result<_>>()?;
+    Ok(require_changed_files(&encoded)?
+        .into_iter()
+        .map(PathBuf::from)
+        .collect())
+}
+
+fn validate_changed_file(raw: &str, index: usize) -> Result<String> {
+    let value = raw.trim();
+    if value.is_empty() {
+        bail!("invalid changed_files[{index}] {raw:?}: path must not be blank or whitespace-only");
+    }
+    if value.len() > MAX_CHANGED_FILE_LEN {
+        bail!(
+            "invalid changed_files[{index}]: path is {} bytes; maximum is {MAX_CHANGED_FILE_LEN}",
+            value.len()
+        );
+    }
+
+    let path = Path::new(value);
+    let windows_prefix = value
+        .as_bytes()
+        .get(0..2)
+        .is_some_and(|prefix| prefix[0].is_ascii_alphabetic() && prefix[1] == b':')
+        || value.starts_with("\\\\");
+    let mut has_file_component = false;
+    let mut invalid_component = false;
+    for component in path.components() {
+        match component {
+            Component::Normal(_) => has_file_component = true,
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                invalid_component = true
+            }
+        }
+    }
+    if path.is_absolute() || windows_prefix || invalid_component || !has_file_component {
+        bail!(
+            "invalid changed_files[{index}] {raw:?}: expected a repository-relative file path without '..'"
+        );
+    }
+
+    Ok(value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trims_valid_paths_and_preserves_missing_new_files() {
+        assert_eq!(
+            require_changed_files(&[
+                "  src/lib.rs  ".to_string(),
+                "new/not-indexed.rs".to_string(),
+            ])
+            .unwrap(),
+            vec!["src/lib.rs", "new/not-indexed.rs"]
+        );
+    }
+
+    #[test]
+    fn rejects_empty_blank_mixed_absolute_and_parent_paths_as_a_whole() {
+        assert!(require_changed_files(&[]).is_err());
+        for (files, invalid_index) in [
+            (vec!["".to_string()], 0),
+            (vec![" \t\n".to_string()], 0),
+            (vec!["src/lib.rs".to_string(), "  ".to_string()], 1),
+            (vec!["/tmp/lib.rs".to_string()], 0),
+            (vec!["../outside.rs".to_string()], 0),
+            (vec!["src/../outside.rs".to_string()], 0),
+            (vec!["C:\\tmp\\lib.rs".to_string()], 0),
+        ] {
+            let error = require_changed_files(&files).unwrap_err().to_string();
+            assert!(
+                error.contains(&format!("changed_files[{invalid_index}]")),
+                "the invalid element must be named: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_empty_derived_diff_can_be_validated_without_becoming_user_input() {
+        assert_eq!(
+            validate_changed_file_entries(&Vec::<String>::new()).unwrap(),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn rejects_oversized_lists_and_overlong_paths_at_the_shared_boundary() {
+        let too_many = vec!["src/lib.rs".to_string(); MAX_CHANGED_FILES + 1];
+        let error = validate_changed_file_entries(&too_many)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("maximum is 1000"), "{error}");
+        let too_many_paths = vec![PathBuf::from("src/lib.rs"); MAX_CHANGED_FILES + 1];
+        let error = require_changed_paths(&too_many_paths)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("maximum is 1000"), "{error}");
+
+        let overlong = format!("src/{}", "a".repeat(MAX_CHANGED_FILE_LEN));
+        let error = require_changed_files(&["src/ok.rs".to_string(), overlong])
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("changed_files[1]"), "{error}");
+        assert!(error.contains("maximum is 512"), "{error}");
+    }
+}

--- a/crates/nestweaver-engine/src/drain.rs
+++ b/crates/nestweaver-engine/src/drain.rs
@@ -115,7 +115,7 @@ pub async fn run_drain(signals: DrainSignals, ceiling: u64) {
     let mut next_over_ceiling_report = ceiling_at;
 
     loop {
-        let writes = signals.active_writes.load(Ordering::Relaxed);
+        let writes = signals.active_writes.load(Ordering::Acquire);
         // Index jobs bump `indexing_active`, not `active_writes`, so the
         // drain must wait on both — otherwise a shutdown could proceed
         // while the worker is mid-write.

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -1286,12 +1286,21 @@ pub enum IndexPublicationRecovery {
     /// Fails closed: "cannot tell" is not "abandoned".
     Undeterminable { detail: String },
     /// The marker records a writer that is still alive. A live publication is
-    /// never recovered out from under its writer.
+    /// reported by a read-only caller that cannot prove database ownership.
     WriterAlive { pid: i32 },
+    /// The marker records a writer PID whose liveness could not be classified,
+    /// and this read-only caller cannot prove database ownership.
+    WriterLivenessUnknown { pid: i32 },
     /// The marker records no pid we can attribute (an older binary, a
     /// truncated write, or a hand-created marker). Auto-heal declines; the
     /// operator escape hatch can still be pointed at it explicitly.
     WriterUnattributed,
+    /// The caller did not supply the exact canonical writer authority, or the
+    /// store itself was constructed read-only. No publication bytes changed.
+    WriterAuthorityRequired { detail: String },
+    /// The marker changed between triage and the process-local publication
+    /// lease. Decline rather than guessing which publication it represents.
+    MarkerChanged,
     /// A live in-process publisher holds the lease, so this publication is
     /// in flight rather than abandoned.
     LeaseHeld,
@@ -1336,10 +1345,24 @@ impl IndexPublicationRecovery {
                  failing closed rather than assuming it was abandoned"
             ),
             IndexPublicationRecovery::WriterAlive { pid } => format!(
-                "index publication is in flight; writer pid {pid} is alive — not recovering"
+                "index publication marker names live pid {pid}; this caller does not own the \
+                 database writer lock — not recovering"
+            ),
+            IndexPublicationRecovery::WriterLivenessUnknown { pid } => format!(
+                "index publication marker names pid {pid}, whose liveness could not be \
+                 determined; this caller does not own the database writer lock — not recovering"
             ),
             IndexPublicationRecovery::WriterUnattributed => {
                 "index publication marker records no writer pid; not recovering automatically"
+                    .to_string()
+            }
+            IndexPublicationRecovery::WriterAuthorityRequired { detail } => format!(
+                "index publication recovery requires the exact held database writer lease \
+                 and a read-write store ({detail}); not recovering"
+            ),
+            IndexPublicationRecovery::MarkerChanged => {
+                "index publication marker changed while recovery was acquiring ownership; not \
+                 recovering this observation"
                     .to_string()
             }
             IndexPublicationRecovery::LeaseHeld => {
@@ -1358,7 +1381,7 @@ impl IndexPublicationRecovery {
                 was_cancelled_run,
             } => {
                 let who = match abandoned_writer_pid {
-                    Some(pid) => format!("dead writer pid {pid}"),
+                    Some(pid) => format!("marker pid {pid} (diagnostic only)"),
                     None => "an unattributable writer (forced repair)".to_string(),
                 };
                 let base = format!(
@@ -1429,38 +1452,45 @@ impl IndexPublicationRecovery {
 /// store read-only, so it must never be the process performing repair.
 pub fn recover_abandoned_index_publication(
     store: &GraphStore,
-    read_write: bool,
+    authority: &nestweaver_store::DbWriteLease,
 ) -> Result<IndexPublicationRecovery, DeletionReconciliationError> {
-    recover_abandoned_index_publication_with_io(
-        store,
-        read_write,
-        false,
-        &FileSystemIndexEpilogueIo,
-    )
+    recover_abandoned_index_publication_with_io(store, authority, false, &FileSystemIndexEpilogueIo)
 }
 
-/// Operator-forced recovery: proceeds on the two cases the automatic predicate
-/// must decline — a marker with no attributable writer, and one whose state
-/// cannot be read.
+/// Operator-forced recovery: proceeds when the marker state cannot be read.
+/// A readable marker needs no PID attribution once the caller holds the exact
+/// database authority and the in-process publication lease.
 ///
-/// `force` never overrides a writer we can prove is ALIVE, and never overrides
-/// an in-process lease holder; those remain hard declines. What it overrides is
-/// only "cannot prove dead", which is the automatic predicate's conservatism,
-/// not a safety property. The real protection against clobbering a live writer
-/// is that every recovery path holds a read-write `GraphStore`, and lbug's
-/// exclusive write lock means no other process can hold one at the same time;
-/// the pid and lease checks are defence in depth on top of that.
+/// `force` never overrides the database writer lock or an in-process
+/// publication lease. Marker PID liveness is diagnostic rather than
+/// authoritative because PID reuse is normal: every recovery path holds a
+/// read-write `GraphStore`, and lbug's exclusive write lock means no other
+/// process can own this database writer at the same time.
 pub fn force_recover_index_publication(
     store: &GraphStore,
+    authority: &nestweaver_store::DbWriteLease,
 ) -> Result<IndexPublicationRecovery, DeletionReconciliationError> {
-    recover_abandoned_index_publication_with_io(store, true, true, &FileSystemIndexEpilogueIo)
+    recover_abandoned_index_publication_with_io(store, authority, true, &FileSystemIndexEpilogueIo)
 }
 
 pub(crate) fn recover_abandoned_index_publication_with_io(
     store: &GraphStore,
-    read_write: bool,
+    authority: &nestweaver_store::DbWriteLease,
     force: bool,
     io: &dyn IndexEpilogueIo,
+) -> Result<IndexPublicationRecovery, DeletionReconciliationError> {
+    recover_abandoned_index_publication_with_io_and_marker_hook(store, authority, force, io, |_| {})
+}
+
+/// Recovery implementation with a narrow between-read seam. Production uses
+/// a no-op callback; tests use it to deterministically replace the marker
+/// after the process-local publication lease is held but before confirmation.
+fn recover_abandoned_index_publication_with_io_and_marker_hook(
+    store: &GraphStore,
+    authority: &nestweaver_store::DbWriteLease,
+    force: bool,
+    io: &dyn IndexEpilogueIo,
+    between_marker_reads: impl FnOnce(&Path),
 ) -> Result<IndexPublicationRecovery, DeletionReconciliationError> {
     const OPERATION: &str = "recover abandoned index publication";
 
@@ -1478,7 +1508,7 @@ pub(crate) fn recover_abandoned_index_publication_with_io(
         nestweaver_store::index_publication::MarkerState::Undeterminable(detail) => {
             // "Cannot tell" is not "abandoned" — never automatically. An
             // operator who has looked at the directory can still override.
-            if !(force && read_write) {
+            if !force {
                 return Ok(IndexPublicationRecovery::Undeterminable {
                     detail: detail.clone(),
                 });
@@ -1490,44 +1520,26 @@ pub(crate) fn recover_abandoned_index_publication_with_io(
         }
         nestweaver_store::index_publication::MarkerState::Present(_) => {}
     }
-    let record = state.record();
-    let was_cancelled_run = record.is_some_and(|r| r.is_deliberately_dirty());
-    // `pid` is `None` for an unattributed or undeterminable marker. Automatic
-    // recovery declines; a forced one proceeds.
-    let pid = match record.and_then(|r| r.writer_pid) {
-        Some(pid) => {
-            if crate::index_publication::process_is_alive(pid) {
-                // Never overridden, not even by `force`.
-                return Ok(IndexPublicationRecovery::WriterAlive { pid });
-            }
-            Some(pid)
-        }
-        None => {
-            if !(force && read_write) {
-                return Ok(IndexPublicationRecovery::WriterUnattributed);
-            }
-            None
-        }
-    };
-    if !read_write {
-        // Report, never clear. Same rule, and the same reason, as the
-        // read-only arm of `open_lbug_with_recovery`: "a read-only caller
-        // quarantining a log out from under a live writer would be a genuine
-        // hazard". The MCP server opens the store read-only and can be a
-        // different process from the daemon, so it lands here. A read-only
-        // handle also does not hold lbug's exclusive write lock, which is what
-        // actually keeps a live writer safe.
-        return Ok(match pid {
-            Some(pid) => IndexPublicationRecovery::ReadOnlyStore {
-                abandoned_writer_pid: pid,
-            },
-            // Unreachable in practice: a pid-less marker only gets past the
-            // match above when `force && read_write`, and `read_write` is false
-            // here. Written totally rather than unwrapped so it cannot become a
-            // panic if that gating ever changes.
-            None => IndexPublicationRecovery::WriterUnattributed,
+    if !store.is_read_write() {
+        return Ok(IndexPublicationRecovery::WriterAuthorityRequired {
+            detail: "the GraphStore was opened read-only".to_string(),
         });
     }
+    if !authority.authorizes(&db_path) {
+        return Ok(IndexPublicationRecovery::WriterAuthorityRequired {
+            detail: format!(
+                "lease {} does not authorize {}",
+                authority.path().display(),
+                db_path.display()
+            ),
+        });
+    }
+    let record = state.record();
+    let was_cancelled_run = record.is_some_and(|r| r.is_deliberately_dirty());
+    // PID is diagnostic only. Exact cross-process database authority plus the
+    // in-process publication lease below prove that no writer can still
+    // finish this readable marker, including legacy pid-less markers.
+    let pid = record.and_then(|r| r.writer_pid);
 
     // Second half of the abandoned predicate: no in-process publisher owns the
     // lease. Acquired non-blockingly — queueing behind a live publisher would
@@ -1551,22 +1563,11 @@ pub(crate) fn recover_abandoned_index_publication_with_io(
     // Re-read under the lease. Between the triage read and here, a fresh
     // publisher in another process could have established a new marker with a
     // live pid; recovering that would clear a marker out from under its writer.
+    let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
+    between_marker_reads(&marker_path);
     let confirmed = nestweaver_store::index_publication::read_marker(&db_path);
-    match (confirmed.record().and_then(|r| r.writer_pid), pid) {
-        // A different pid appeared: a fresh publisher established a new marker
-        // between the triage read and here. Recovering it would clear a marker
-        // out from under its writer.
-        (Some(current), Some(original)) if current != original => {
-            return Ok(IndexPublicationRecovery::WriterAlive { pid: current });
-        }
-        // A forced recovery of a pid-less marker that has since GAINED a pid is
-        // likewise a new publisher; decline if that publisher is alive.
-        (Some(current), None) if crate::index_publication::process_is_alive(current) => {
-            return Ok(IndexPublicationRecovery::WriterAlive { pid: current });
-        }
-        (Some(_), _) => {}
-        (None, Some(_)) => return Ok(IndexPublicationRecovery::WriterUnattributed),
-        (None, None) => {}
+    if confirmed != state {
+        return Ok(IndexPublicationRecovery::MarkerChanged);
     }
 
     // The `u64::MAX` arm. When `.generation` is missing or unparseable while
@@ -1659,10 +1660,22 @@ pub(crate) fn recover_abandoned_index_publication_with_io(
 /// watchers); the daemon reconciles separately at startup. Read-only openers —
 /// notably the MCP server, which commonly runs in a different process from the
 /// daemon — deliberately do NOT have an equivalent and must never repair.
-pub fn open_store_for_writing_with_recovery(db_path: &Path) -> Result<GraphStore, anyhow::Error> {
+/// Open through an already-held exact writer authority. This is the path for
+/// CLI/daemon owners whose mutation lifetime is wider than the store open.
+pub(crate) fn open_store_for_writing_with_authority(
+    db_path: &Path,
+    authority: &nestweaver_store::DbWriteLease,
+) -> Result<GraphStore, anyhow::Error> {
+    if !authority.authorizes(db_path) {
+        anyhow::bail!(
+            "writer lease {} does not authorize database {}",
+            authority.path().display(),
+            db_path.display()
+        );
+    }
     let store = GraphStore::open_or_create(db_path)
         .with_context(|| format!("open/create store at {}", db_path.display()))?;
-    recover_abandoned_index_publication_best_effort(&store, true);
+    recover_abandoned_index_publication_best_effort(&store, authority);
     Ok(store)
 }
 
@@ -1671,9 +1684,9 @@ pub fn open_store_for_writing_with_recovery(db_path: &Path) -> Result<GraphStore
 /// best-effort improvement and must never be able to fail the caller.
 pub fn recover_abandoned_index_publication_best_effort(
     store: &GraphStore,
-    read_write: bool,
+    authority: &nestweaver_store::DbWriteLease,
 ) -> Option<IndexPublicationRecovery> {
-    match recover_abandoned_index_publication(store, read_write) {
+    match recover_abandoned_index_publication(store, authority) {
         Ok(outcome) => {
             if outcome.recovered() {
                 tracing::warn!("{}", outcome.describe());
@@ -2116,7 +2129,21 @@ pub fn index_directory_with_opts(
     db_path: &Path,
     opts: &IndexOptions,
 ) -> Result<IndexResult, anyhow::Error> {
-    let store = open_store_for_writing_with_recovery(db_path)?;
+    let authority = nestweaver_store::acquire_db_write_lease(db_path)
+        .map_err(|error| anyhow::anyhow!("cannot index {}: {error:?}", db_path.display()))?;
+    let store = open_store_for_writing_with_authority(db_path, &authority)?;
+    index_directory_with_store_inner(&store, repo_path, db_path, opts, None)
+}
+
+/// [`index_directory_with_opts`] under an exact authority already held by the
+/// caller for a wider mutation lifetime.
+pub fn index_directory_with_opts_and_write_lease(
+    repo_path: &Path,
+    db_path: &Path,
+    opts: &IndexOptions,
+    authority: &nestweaver_store::DbWriteLease,
+) -> Result<IndexResult, anyhow::Error> {
+    let store = open_store_for_writing_with_authority(db_path, authority)?;
     index_directory_with_store_inner(&store, repo_path, db_path, opts, None)
 }
 
@@ -2147,7 +2174,9 @@ pub fn index_directory_with_options_and_limits(
     // nw-C1: reconcile an abandoned publication before indexing. A crashed
     // predecessor's `.index-dirty` otherwise wedges every ranked query, and the
     // fail-closed `u64::MAX` generation base can block this run's own preflight.
-    let store = open_store_for_writing_with_recovery(db_path)?;
+    let authority = nestweaver_store::acquire_db_write_lease(db_path)
+        .map_err(|error| anyhow::anyhow!("cannot index {}: {error:?}", db_path.display()))?;
+    let store = open_store_for_writing_with_authority(db_path, &authority)?;
     index_directory_with_store_and_limits(
         &store,
         repo_path,
@@ -5301,6 +5330,32 @@ pub fn incremental_index_with_excludes(
     )
 }
 
+/// [`incremental_index_with_excludes`] under the caller's already-held exact
+/// database writer authority.
+#[allow(clippy::too_many_arguments)]
+pub fn incremental_index_with_excludes_and_write_lease(
+    repo_path: &Path,
+    db_path: &Path,
+    instance_id: &str,
+    repo_url: &str,
+    name: Option<&str>,
+    limits: crate::index_limits::IndexLimits,
+    excludes: &[String],
+    authority: &nestweaver_store::DbWriteLease,
+) -> Result<IncrementalResult, anyhow::Error> {
+    incremental_index_with_name_and_io_and_authority(
+        repo_path,
+        db_path,
+        instance_id,
+        repo_url,
+        name,
+        limits,
+        excludes,
+        &FileSystemIndexEpilogueIo,
+        authority,
+    )
+}
+
 #[allow(clippy::too_many_arguments)]
 fn incremental_index_with_name_and_io(
     repo_path: &Path,
@@ -5316,7 +5371,38 @@ fn incremental_index_with_name_and_io(
     // which returns early without ever establishing a marker. Without this, an
     // idle repo could never clear an abandoned publication however often it was
     // re-indexed.
-    let store = open_store_for_writing_with_recovery(db_path)?;
+    let authority = nestweaver_store::acquire_db_write_lease(db_path).map_err(|error| {
+        anyhow::anyhow!(
+            "cannot index {} without exact writer authority: {error:?}",
+            db_path.display()
+        )
+    })?;
+    incremental_index_with_name_and_io_and_authority(
+        repo_path,
+        db_path,
+        instance_id,
+        repo_url,
+        name,
+        limits,
+        excludes,
+        epilogue_io,
+        &authority,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn incremental_index_with_name_and_io_and_authority(
+    repo_path: &Path,
+    db_path: &Path,
+    instance_id: &str,
+    repo_url: &str,
+    name: Option<&str>,
+    limits: crate::index_limits::IndexLimits,
+    excludes: &[String],
+    epilogue_io: &dyn IndexEpilogueIo,
+    authority: &nestweaver_store::DbWriteLease,
+) -> Result<IncrementalResult, anyhow::Error> {
+    let store = open_store_for_writing_with_authority(db_path, authority)?;
 
     let r_uid = nestweaver_schema::repo_uid(instance_id, repo_url);
 
@@ -7089,7 +7175,8 @@ mod tests {
         assert!(marker_path.exists(), "the crash must leave the marker set");
 
         // The whole point: an ordinary read-write open, nothing else.
-        let store = open_store_for_writing_with_recovery(&db_path).unwrap();
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
+        let store = open_store_for_writing_with_authority(&db_path, &authority).unwrap();
 
         assert!(
             !marker_path.exists(),
@@ -7150,14 +7237,15 @@ mod tests {
         let db_path = dir.path().join("test.lbug");
         let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
 
-        let (dead_pid, _) = abandon_publication_after_commit(&db_path, "readonly");
+        let (_dead_pid, _) = abandon_publication_after_commit(&db_path, "readonly");
 
         let store = GraphStore::open_read_only(&db_path).unwrap();
-        let outcome = recover_abandoned_index_publication(&store, false).unwrap();
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
+        let outcome = recover_abandoned_index_publication(&store, &authority).unwrap();
         assert_eq!(
             outcome,
-            IndexPublicationRecovery::ReadOnlyStore {
-                abandoned_writer_pid: dead_pid
+            IndexPublicationRecovery::WriterAuthorityRequired {
+                detail: "the GraphStore was opened read-only".to_string()
             },
             "a read-only caller must report, never repair"
         );
@@ -7170,6 +7258,87 @@ mod tests {
             store.is_index_publication_dirty(),
             "a read-only open must keep failing closed"
         );
+    }
+
+    #[test]
+    fn a_wrong_database_authority_cannot_mutate_any_publication_artifact() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let sibling = dir.path().join("sibling.lbug");
+        let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
+        let generation_path = crate::sidecar_path(&db_path, ".generation");
+        let pagerank_path = crate::sidecar_path(&db_path, ".pagerank.json");
+        abandon_publication_after_commit(&db_path, "wrong-authority");
+        let before = [
+            std::fs::read(&marker_path).unwrap(),
+            std::fs::read(&generation_path).unwrap(),
+            std::fs::read(&pagerank_path).unwrap(),
+        ];
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        let wrong = nestweaver_store::acquire_db_write_lease(&sibling).unwrap();
+        let outcome = force_recover_index_publication(&store, &wrong).unwrap();
+        assert!(matches!(
+            outcome,
+            IndexPublicationRecovery::WriterAuthorityRequired { .. }
+        ));
+        assert_eq!(std::fs::read(&marker_path).unwrap(), before[0]);
+        assert_eq!(std::fs::read(&generation_path).unwrap(), before[1]);
+        assert_eq!(std::fs::read(&pagerank_path).unwrap(), before[2]);
+    }
+
+    #[test]
+    fn marker_change_declines_first_repair_and_second_repair_converges() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
+        let generation_path = crate::sidecar_path(&db_path, ".generation");
+        let pagerank_path = crate::sidecar_path(&db_path, ".pagerank.json");
+        let (_original_pid, canonical) =
+            abandon_publication_after_commit(&db_path, "marker-changed");
+
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
+        let replacement_pid = reaped_child_pid();
+        let replacement_marker = nestweaver_store::index_publication::format_marker_payload(
+            replacement_pid as u32,
+            42,
+            Some(nestweaver_store::index_publication::MARKER_REASON_CANCELLED),
+        );
+        let generation_before = std::fs::read(&generation_path).unwrap();
+        let pagerank_before = std::fs::read(&pagerank_path).unwrap();
+
+        let first = recover_abandoned_index_publication_with_io_and_marker_hook(
+            &store,
+            &authority,
+            false,
+            &FileSystemIndexEpilogueIo,
+            |path| std::fs::write(path, &replacement_marker).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(first, IndexPublicationRecovery::MarkerChanged);
+        assert_eq!(
+            std::fs::read(&marker_path).unwrap(),
+            replacement_marker.as_bytes(),
+            "the declined repair must not overwrite or retire the new publisher's marker"
+        );
+        assert_eq!(std::fs::read(&generation_path).unwrap(), generation_before);
+        assert_eq!(std::fs::read(&pagerank_path).unwrap(), pagerank_before);
+
+        let second = recover_abandoned_index_publication(&store, &authority).unwrap();
+        assert_eq!(
+            second,
+            IndexPublicationRecovery::Recovered {
+                abandoned_writer_pid: Some(replacement_pid),
+                generation: canonical + 2,
+                was_cancelled_run: true,
+            }
+        );
+        assert!(!marker_path.exists());
+        assert_eq!(store.graph_generation(), canonical + 2);
+        let scores = store.pagerank_scores().unwrap();
+        assert!(scores.contains_key("sym:publisher-marker-changed:source"));
+        assert!(scores.contains_key("note:marker-changed:one"));
     }
 
     #[test]
@@ -7191,16 +7360,12 @@ mod tests {
         )
         .unwrap();
         let dirty_generation = store.graph_generation();
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
 
-        // The marker names THIS process, which is alive: liveness alone must
-        // stop recovery, before the lease is even consulted.
-        let outcome = recover_abandoned_index_publication(&store, true).unwrap();
-        assert_eq!(
-            outcome,
-            IndexPublicationRecovery::WriterAlive {
-                pid: std::process::id() as i32
-            }
-        );
+        // PID liveness is diagnostic only. The in-process publication lease is
+        // the authoritative proof that this writer is genuinely active.
+        let outcome = recover_abandoned_index_publication(&store, &authority).unwrap();
+        assert_eq!(outcome, IndexPublicationRecovery::LeaseHeld);
         assert!(marker_path.exists());
         assert_eq!(store.graph_generation(), dirty_generation);
 
@@ -7208,7 +7373,7 @@ mod tests {
         // the second half of the predicate must decline too.
         write_marker_with_pid(&marker_path, reaped_child_pid(), None);
         assert_eq!(
-            recover_abandoned_index_publication(&store, true).unwrap(),
+            recover_abandoned_index_publication(&store, &authority).unwrap(),
             IndexPublicationRecovery::LeaseHeld,
             "a held lease means the publication is in flight, not abandoned"
         );
@@ -7242,7 +7407,8 @@ mod tests {
         std::fs::create_dir(&marker_path).unwrap();
 
         let store = GraphStore::open_or_create(&db_path).unwrap();
-        let outcome = recover_abandoned_index_publication(&store, true).unwrap();
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
+        let outcome = recover_abandoned_index_publication(&store, &authority).unwrap();
         assert!(
             matches!(outcome, IndexPublicationRecovery::Undeterminable { .. }),
             "cannot tell is not abandoned: {outcome:?}"
@@ -7252,7 +7418,7 @@ mod tests {
     }
 
     #[test]
-    fn an_unattributed_marker_is_not_auto_recovered() {
+    fn an_unattributed_marker_is_auto_recovered_under_exact_authority() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("test.lbug");
         let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
@@ -7264,11 +7430,19 @@ mod tests {
         std::fs::write(&marker_path, b"dirty").unwrap();
 
         let store = GraphStore::open_or_create(&db_path).unwrap();
-        assert_eq!(
-            recover_abandoned_index_publication(&store, true).unwrap(),
-            IndexPublicationRecovery::WriterUnattributed
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
+        let outcome = recover_abandoned_index_publication(&store, &authority).unwrap();
+        assert!(
+            matches!(
+                outcome,
+                IndexPublicationRecovery::Recovered {
+                    abandoned_writer_pid: None,
+                    ..
+                }
+            ),
+            "readable legacy marker should recover without PID attribution: {outcome:?}"
         );
-        assert!(marker_path.exists());
+        assert!(!marker_path.exists());
     }
 
     #[test]
@@ -7306,7 +7480,8 @@ mod tests {
             );
         }
 
-        let store = open_store_for_writing_with_recovery(&db_path).unwrap();
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
+        let store = open_store_for_writing_with_authority(&db_path, &authority).unwrap();
         assert!(
             !marker_path.exists(),
             "recovery must re-derive rather than add to u64::MAX"
@@ -7365,21 +7540,11 @@ mod tests {
             "the deliberate hold must be recorded in the marker payload"
         );
 
-        // Still owned by a live process → never recovered.
-        assert_eq!(
-            recover_abandoned_index_publication(&store, true).unwrap(),
-            IndexPublicationRecovery::WriterAlive {
-                pid: std::process::id() as i32
-            }
-        );
-        drop(store);
-
-        // Once that writer is gone, the publication IS reconciled — the
-        // sidecars really do predate the commit either way — but the outcome
-        // says so, so the `index --force` guidance is not silently lost.
-        write_marker_with_pid(&marker_path, reaped_child_pid(), Some("cancelled"));
-        let store = GraphStore::open_or_create(&db_path).unwrap();
-        let outcome = recover_abandoned_index_publication(&store, true).unwrap();
+        // The publisher released its lease when it deliberately left the
+        // marker dirty. This process still being alive cannot veto recovery:
+        // the writable store and unowned lease prove exclusive ownership.
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
+        let outcome = recover_abandoned_index_publication(&store, &authority).unwrap();
         assert!(outcome.recovered());
         assert!(
             matches!(
@@ -7469,7 +7634,7 @@ mod tests {
     }
 
     #[test]
-    fn force_recovers_an_unattributed_marker_that_auto_heal_must_decline() {
+    fn auto_recovery_of_an_unattributed_marker_rebuilds_unified_ranks() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("test.lbug");
         let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
@@ -7482,14 +7647,8 @@ mod tests {
         std::fs::write(&marker_path, b"dirty").unwrap();
 
         let store = GraphStore::open_or_create(&db_path).unwrap();
-        assert_eq!(
-            recover_abandoned_index_publication(&store, true).unwrap(),
-            IndexPublicationRecovery::WriterUnattributed,
-            "auto-heal must still decline what it cannot prove abandoned"
-        );
-        assert!(marker_path.exists());
-
-        let outcome = force_recover_index_publication(&store).unwrap();
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
+        let outcome = recover_abandoned_index_publication(&store, &authority).unwrap();
         assert!(outcome.recovered(), "{outcome:?}");
         assert!(
             matches!(
@@ -7499,7 +7658,7 @@ mod tests {
                     ..
                 }
             ),
-            "a forced recovery names no pid because there was none: {outcome:?}"
+            "automatic recovery names no pid because there was none: {outcome:?}"
         );
         assert!(!marker_path.exists());
         assert!(!store.is_index_publication_dirty());
@@ -7509,21 +7668,42 @@ mod tests {
     }
 
     #[test]
-    fn force_never_overrides_a_live_writer() {
+    fn a_live_but_unrelated_marker_pid_does_not_veto_owned_recovery() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("test.lbug");
         let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
         let store = GraphStore::open_or_create(&db_path).unwrap();
+        insert_publication_graph(&store, "pid-reuse");
         write_marker_with_pid(&marker_path, std::process::id() as i32, None);
 
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
+        let outcome = force_recover_index_publication(&store, &authority).unwrap();
+        assert!(outcome.recovered(), "{outcome:?}");
+        assert!(!marker_path.exists());
+    }
+
+    #[test]
+    fn force_never_overrides_a_genuine_in_process_publisher() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        let lease = establish_index_publication_marker_with_io(
+            &store,
+            Some(&db_path),
+            "live forced publisher",
+            &FileSystemIndexEpilogueIo,
+        )
+        .unwrap();
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
+
         assert_eq!(
-            force_recover_index_publication(&store).unwrap(),
-            IndexPublicationRecovery::WriterAlive {
-                pid: std::process::id() as i32
-            },
-            "--force overrides 'cannot prove dead', never 'provably alive'"
+            force_recover_index_publication(&store, &authority).unwrap(),
+            IndexPublicationRecovery::LeaseHeld,
+            "--force never overrides authoritative in-process ownership"
         );
         assert!(marker_path.exists());
+        drop(lease);
     }
 
     #[test]
@@ -7538,14 +7718,15 @@ mod tests {
         std::fs::create_dir(&marker_path).unwrap();
 
         let store = GraphStore::open_or_create(&db_path).unwrap();
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
         // Auto-heal always declines: "cannot tell" is never "abandoned".
         assert!(matches!(
-            recover_abandoned_index_publication(&store, true).unwrap(),
+            recover_abandoned_index_publication(&store, &authority).unwrap(),
             IndexPublicationRecovery::Undeterminable { .. }
         ));
         // Forced, it proceeds — and honestly reports the failure to remove a
         // directory rather than pretending the publication is clean.
-        let forced = force_recover_index_publication(&store);
+        let forced = force_recover_index_publication(&store, &authority);
         assert!(
             forced.is_err(),
             "clearing a directory-shaped marker must fail loudly: {forced:?}"
@@ -7559,13 +7740,14 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("test.lbug");
         let store = GraphStore::open_or_create(&db_path).unwrap();
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
         assert_eq!(
-            recover_abandoned_index_publication(&store, true).unwrap(),
+            recover_abandoned_index_publication(&store, &authority).unwrap(),
             IndexPublicationRecovery::Clean
         );
         let memory = GraphStore::in_memory().unwrap();
         assert_eq!(
-            recover_abandoned_index_publication(&memory, true).unwrap(),
+            recover_abandoned_index_publication(&memory, &authority).unwrap(),
             IndexPublicationRecovery::NotFileBacked
         );
     }
@@ -10049,6 +10231,7 @@ function hello(name) { return "Hello " + name; }
     fn deletion_finalizer_removes_phantom_manifest_suggestions_and_preserves_survivors() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("test.lbug");
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
         let repos = [
             (
                 "app",
@@ -10075,7 +10258,9 @@ function hello(name) { return "Hello " + name; }
             )
             .unwrap();
             fs::write(root.join("package.json"), manifest).unwrap();
-            index_directory(&root, &db_path, "test", url, "sha").unwrap();
+            let options = IndexOptions::new("test", url, "sha");
+            index_directory_with_opts_and_write_lease(&root, &db_path, &options, &authority)
+                .unwrap();
         }
 
         let removed_uid = nestweaver_schema::repo_uid("test", "https://example.com/removed");
@@ -11104,7 +11289,8 @@ function hello(name) { return "Hello " + name; }
         // After reconciliation the healed ranks must not contain the stale score.
         let marker_path = crate::sidecar_path(&db_path, ".index-dirty");
         write_marker_with_pid(&marker_path, reaped_child_pid(), None);
-        let outcome = recover_abandoned_index_publication(&store, true).unwrap();
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
+        let outcome = recover_abandoned_index_publication(&store, &authority).unwrap();
         assert!(
             outcome.recovered(),
             "the dirty publication must reconcile: {}",
@@ -11166,7 +11352,8 @@ function hello(name) { return "Hello " + name; }
             "a failed PageRank refresh must leave the publication dirty"
         );
         write_marker_with_pid(&marker_path, reaped_child_pid(), None);
-        let outcome = recover_abandoned_index_publication(&store, true).unwrap();
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
+        let outcome = recover_abandoned_index_publication(&store, &authority).unwrap();
         assert!(
             outcome.recovered(),
             "the dirty publication must reconcile: {}",
@@ -11283,7 +11470,8 @@ function hello(name) { return "Hello " + name; }
         if marker_path.exists() {
             // Dirty is acceptable: recovery self-heals it right here.
             write_marker_with_pid(&marker_path, reaped_child_pid(), None);
-            let outcome = recover_abandoned_index_publication(&reopened, true).unwrap();
+            let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
+            let outcome = recover_abandoned_index_publication(&reopened, &authority).unwrap();
             assert!(
                 outcome.recovered(),
                 "a marker present after the crash must reconcile: {}",
@@ -11322,7 +11510,8 @@ function hello(name) { return "Hello " + name; }
         );
         write_marker_with_pid(&marker_path, reaped_child_pid(), None);
         let reopened = GraphStore::open_or_create(&db_path).unwrap();
-        let outcome = recover_abandoned_index_publication(&reopened, true).unwrap();
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
+        let outcome = recover_abandoned_index_publication(&reopened, &authority).unwrap();
         assert!(
             outcome.recovered(),
             "the dirty publication must reconcile: {}",
@@ -11392,7 +11581,8 @@ function hello(name) { return "Hello " + name; }
         // And it recovers on the next open — with note ranks, not just code.
         write_marker_with_pid(&marker_path, reaped_child_pid(), None);
         let reopened = GraphStore::open_or_create(&db_path).unwrap();
-        let outcome = recover_abandoned_index_publication(&reopened, true).unwrap();
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
+        let outcome = recover_abandoned_index_publication(&reopened, &authority).unwrap();
         assert!(
             outcome.recovered(),
             "the dirty publication must reconcile: {}",
@@ -12227,6 +12417,7 @@ function hello(name) { return "Hello " + name; }
         let removed_repo = dir.path().join("removed-repo");
         let surviving_repo = dir.path().join("surviving-repo");
         let db_path = dir.path().join("test.lbug");
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
         fs::create_dir_all(&removed_repo).unwrap();
         fs::create_dir_all(&surviving_repo).unwrap();
         let removed_file = removed_repo.join("removed.js");
@@ -12237,32 +12428,29 @@ function hello(name) { return "Hello " + name; }
         )
         .unwrap();
 
-        index_directory(
+        index_directory_with_opts_and_write_lease(
             &removed_repo,
             &db_path,
-            "test",
-            "https://example.com/removed",
-            "abc123",
+            &IndexOptions::new("test", "https://example.com/removed", "abc123"),
+            &authority,
         )
         .unwrap();
-        index_directory(
+        index_directory_with_opts_and_write_lease(
             &surviving_repo,
             &db_path,
-            "test",
-            "https://example.com/surviving",
-            "abc123",
+            &IndexOptions::new("test", "https://example.com/surviving", "abc123"),
+            &authority,
         )
         .unwrap();
 
         let pagerank_before = persisted_pagerank(&db_path);
         fs::remove_file(&removed_file).unwrap();
 
-        let result = index_directory(
+        let result = index_directory_with_opts_and_write_lease(
             &removed_repo,
             &db_path,
-            "test",
-            "https://example.com/removed",
-            "abc123",
+            &IndexOptions::new("test", "https://example.com/removed", "abc123"),
+            &authority,
         )
         .unwrap();
 
@@ -13985,9 +14173,24 @@ function hello(name) { return "Hello " + name; }
         fs::create_dir_all(&src).unwrap();
         fs::write(src.join("main.js"), "function a() { return 1; }\n").unwrap();
 
+        // This regression isolates the fallback's filemeta hand-off, not
+        // writer-authority reacquisition. Model the daemon's real lifetime:
+        // one caller-owned exact authority spans both successive publications.
+        // `IncrementalResult` contains only counters/vectors and owns no lease.
+        let authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
         let local_root = src.display().to_string();
         let file_url = format!("file://{local_root}");
-        let r1 = incremental_index_with_name(&src, &db_path, "test", &file_url, None).unwrap();
+        let r1 = incremental_index_with_excludes_and_write_lease(
+            &src,
+            &db_path,
+            "test",
+            &file_url,
+            None,
+            crate::index_limits::IndexLimits::default(),
+            &[],
+            &authority,
+        )
+        .unwrap();
         assert!(r1.fell_back_to_full, "non-git dir must fall back to full");
 
         let old_uid = repo_uid("test", &file_url);
@@ -14000,7 +14203,17 @@ function hello(name) { return "Hello " + name; }
         );
 
         let origin_url = "https://example.com/acme/demo.git";
-        let r2 = incremental_index_with_name(&src, &db_path, "test", origin_url, None).unwrap();
+        let r2 = incremental_index_with_excludes_and_write_lease(
+            &src,
+            &db_path,
+            "test",
+            origin_url,
+            None,
+            crate::index_limits::IndexLimits::default(),
+            &[],
+            &authority,
+        )
+        .unwrap();
         assert!(r2.fell_back_to_full);
 
         let new_uid = repo_uid("test", origin_url);

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -74,6 +74,7 @@ pub struct MarkdownIndexResult {
 pub struct MarkdownRefreshResult {
     pub index: MarkdownIndexResult,
     pub notes_deleted: usize,
+    pub publication: crate::manifest::GraphMutationPublicationOutcome,
 }
 
 /// Canonical full-refresh summary shared by direct CLI and daemon progress.
@@ -409,6 +410,7 @@ pub struct MarkdownSinceResult {
     /// actually CHANGED — a fifth population, and the narrowest of them. It is
     /// not comparable with a full index's `resolved_link_edges`.
     pub changed_note_link_edges: usize,
+    pub publication: crate::manifest::GraphMutationPublicationOutcome,
 }
 
 /// Incrementally refresh only the files in `vault_root` whose filesystem
@@ -663,6 +665,7 @@ fn index_markdown_since_with_reader(
             sections_count: 0,
             tags_count: 0,
             changed_note_link_edges: 0,
+            publication: crate::manifest::finalize_committed_graph_mutation(store, false),
         });
     }
 
@@ -1053,6 +1056,8 @@ fn index_markdown_since_with_reader(
         .flatten()
         .collect();
 
+    let graph_publication =
+        crate::manifest::begin_graph_mutation_publication(store, "incremental vault refresh")?;
     store
         .incremental_vault_refresh_atomically(
             &Vault {
@@ -1082,19 +1087,7 @@ fn index_markdown_since_with_reader(
         )
         .context("atomic incremental vault refresh")?;
 
-    // Advance + persist the graph generation when any note was mutated.
-    // An in-place edit deletes and recreates the note's sections, leaving the
-    // candidate-node count unchanged — the generation bump is the only signal
-    // that stales the trigram posting table (mirrors `index.rs` and the full
-    // vault index above).
-    //
-    // nw-289: wrapped so the code manifest cache is carried across the
-    // boundary. A VAULT index advances the generation that `.manifests.json`
-    // is bound to, while being incapable of changing anything the manifest
-    // describes.
-    crate::manifest::advancing_generation_rebinding_manifests(store, || {
-        store.bump_and_persist_generation();
-    });
+    let publication = graph_publication.finish(true)?;
 
     // Best-effort and AFTER the commit, like the symbol epilogue: a
     // tombstoning failure must not fail a refresh that already succeeded.
@@ -1124,6 +1117,7 @@ fn index_markdown_since_with_reader(
         sections_count: total_sections,
         tags_count: total_tags,
         changed_note_link_edges: changed_wikilinks,
+        publication,
     })
 }
 
@@ -2082,6 +2076,11 @@ where
         .len();
 
     // 3 & 4. Flush all nodes and edges for this vault in one transaction.
+    // The durable dirty marker is established immediately before the first
+    // possible graph write and remains until generation/artifact publication
+    // has completed.
+    let graph_publication =
+        crate::manifest::begin_graph_mutation_publication(store, "full vault refresh")?;
     let notes_deleted = {
         let vault_note_refs: Vec<(&str, &str)> = edge_pairs
             .iter()
@@ -2182,20 +2181,7 @@ where
         record_repo_indexed_sha(store, instance_id, vault_name, sha)?;
     }
 
-    // Advance + persist the graph generation for this vault mutation,
-    // mirroring the code path (`index.rs`). Without it the trigram posting
-    // table's staleness check is blind to an in-place vault edit: a section
-    // delete+recreate keeps the candidate-node count identical, so
-    // `regex_search` would trust stale postings and silently drop new/edited
-    // note content. `bump_and_persist_generation` persists to the
-    // `<db>.generation` sidecar for persistent stores and just bumps for
-    // in-memory ones.
-    //
-    // nw-289: wrapped for the same reason as the incremental path — see
-    // `advancing_generation_rebinding_manifests`.
-    crate::manifest::advancing_generation_rebinding_manifests(store, || {
-        store.bump_and_persist_generation();
-    });
+    let publication = graph_publication.finish(true)?;
 
     // ── Summary ───────────────────────────────────────────────────────────
     let elapsed = started.elapsed();
@@ -2225,6 +2211,7 @@ where
             skipped,
         },
         notes_deleted,
+        publication,
     })
 }
 
@@ -4954,6 +4941,77 @@ sub b body
         assert!(
             g2 > g1,
             "the since refresh must advance and persist the graph generation ({g1} -> {g2})"
+        );
+    }
+
+    #[test]
+    fn vault_refreshes_invalidate_live_and_durable_pagerank() {
+        let (_dir, root) = make_vault(&[("a.md", "# A\n\nalpha body\n")]);
+        let db_path = root.join("brain.lbug");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        index_markdown_directory_with_store(&store, &root, &db_path, "default", "v", &[]).unwrap();
+        store
+            .compute_pagerank(
+                nestweaver_store::ranking::PAGERANK_DAMPING,
+                nestweaver_store::ranking::PAGERANK_ITERATIONS,
+                &nestweaver_store::ranking::GraphScope::unified(),
+            )
+            .unwrap();
+        let pagerank_path = crate::sidecar_path(&db_path, ".pagerank.json");
+        store.save_pagerank_cache(&pagerank_path).unwrap();
+        let computed_before = store.pagerank_generation();
+        assert!(pagerank_path.exists());
+
+        fs::write(root.join("a.md"), "# A\n\nbeta body rewritten\n").unwrap();
+        let result = index_markdown_directory_since_with_store_and_ignore(
+            &store,
+            &root,
+            "default",
+            "v",
+            std::time::UNIX_EPOCH,
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.publication.disposition,
+            crate::manifest::GraphMutationPublicationDisposition::CommittedComplete
+        );
+        assert!(
+            !pagerank_path.exists(),
+            "the pre-refresh PageRank envelope must be retired"
+        );
+        let _ = store.pagerank_scores().unwrap();
+        assert!(
+            store.pagerank_generation() > computed_before,
+            "the first ranked read after refresh must recompute rather than serve the live old cache"
+        );
+
+        store.save_pagerank_cache(&pagerank_path).unwrap();
+        let computed_after_incremental = store.pagerank_generation();
+        assert!(pagerank_path.exists());
+        fs::write(root.join("a.md"), "# A\n\ngamma body rewritten again\n").unwrap();
+        let full = index_markdown_directory_with_store_and_deletion_count(
+            &store,
+            &root,
+            &db_path,
+            "default",
+            "v",
+            &[],
+        )
+        .unwrap();
+        assert_eq!(
+            full.publication.disposition,
+            crate::manifest::GraphMutationPublicationDisposition::CommittedComplete
+        );
+        assert!(
+            !pagerank_path.exists(),
+            "full vault replacement must also retire the pre-mutation PageRank envelope"
+        );
+        let _ = store.pagerank_scores().unwrap();
+        assert!(
+            store.pagerank_generation() > computed_after_incremental,
+            "ranked reads after full vault replacement must not reuse the live old cache"
         );
     }
 

--- a/crates/nestweaver-engine/src/index_publication.rs
+++ b/crates/nestweaver-engine/src/index_publication.rs
@@ -8,11 +8,11 @@
 //!
 //! Two rules govern everything here.
 //!
-//! **A publication is abandoned only when the recorded pid is dead AND the
-//! in-process lease is unowned.** The pid half is cross-process (the writer is
-//! commonly the daemon or a one-shot `nestweaver index`); the lease half closes
-//! the case where the writer is *this* process and simply has not finished yet.
-//! Either half alone is insufficient.
+//! **Writer ownership, not PID liveness, is authoritative.** A writable
+//! [`GraphStore`] proves that no other process owns lbug's exclusive database
+//! writer lock; the in-process publication lease proves that no publisher in
+//! this process owns the publication. Marker PIDs remain useful diagnostics,
+//! but may be recycled and therefore cannot veto recovery by a proven writer.
 //!
 //! **"Cannot tell" is not "abandoned".** An `EACCES`/`EIO` on the sidecar
 //! directory reads as permanently dirty by design and is tested that way
@@ -32,33 +32,51 @@ use nestweaver_store::index_publication::{MarkerRecord, MarkerState, read_marker
 /// can point at, is a diagnosis worth surfacing.
 pub const WEDGED_MARKER_AGE: Duration = Duration::from_secs(60);
 
-/// Whether `pid` names a live process.
+/// Best-effort process-liveness evidence carried only for diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessLiveness {
+    Alive,
+    Dead,
+    Unknown,
+}
+
+/// Classify whether `pid` names a live process.
 ///
 /// `kill(pid, 0)` performs the permission and existence checks without
 /// delivering a signal — the established idiom in this tree (`src/main.rs`
 /// daemon liveness probes). `EPERM` means the process exists but belongs to
 /// another user, which is still *alive*; only `ESRCH` proves it is gone.
 ///
-/// Pid reuse is possible in principle. It is not load-bearing here: a recycled
-/// pid can only make this return `true`, which makes recovery *decline*. The
-/// failure mode is a missed auto-heal, recoverable with `nestweaver repair`,
-/// never a marker cleared out from under a live writer.
+/// PID reuse is expected and this result is deliberately not an ownership
+/// predicate. Writable recovery is authorized by the database writer lock and
+/// the in-process publication lease; this value only enriches status output.
 #[cfg(unix)]
-pub fn process_is_alive(pid: i32) -> bool {
+pub fn process_liveness(pid: i32) -> ProcessLiveness {
     if pid <= 0 {
-        return false;
+        return ProcessLiveness::Dead;
     }
     if unsafe { libc::kill(pid, 0) } == 0 {
-        return true;
+        return ProcessLiveness::Alive;
     }
-    std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+    match std::io::Error::last_os_error().raw_os_error() {
+        Some(libc::ESRCH) => ProcessLiveness::Dead,
+        // POSIX specifies EPERM only when the target exists but cannot be
+        // signalled by this caller, so it is positive liveness evidence.
+        Some(libc::EPERM) => ProcessLiveness::Alive,
+        _ => ProcessLiveness::Unknown,
+    }
 }
 
-/// Non-unix fallback: we cannot prove the writer is dead, so we never claim it.
-/// Auto-heal declines and the operator escape hatch still applies.
+/// Non-unix fallback: the marker PID supplies no trustworthy ownership proof.
 #[cfg(not(unix))]
-pub fn process_is_alive(_pid: i32) -> bool {
-    true
+pub fn process_liveness(_pid: i32) -> ProcessLiveness {
+    ProcessLiveness::Unknown
+}
+
+/// Compatibility predicate for diagnostic callers. Unknown remains
+/// fail-closed and therefore reads as possibly alive.
+pub fn process_is_alive(pid: i32) -> bool {
+    process_liveness(pid) != ProcessLiveness::Dead
 }
 
 /// File-derived publication state, suitable for reporting on the direct
@@ -72,8 +90,13 @@ pub struct IndexPublicationStatus {
     /// Pid recorded in the marker payload, when it parsed.
     pub writer_pid: Option<i32>,
     /// Whether that pid still names a live process. `None` when there is no
-    /// pid to check.
+    /// pid to check or liveness is indeterminate.
     pub writer_alive: Option<bool>,
+    /// True when a marker PID exists but the platform could not classify it.
+    pub writer_liveness_unknown: bool,
+    /// Whether the canonical `<db>.write.lock` is currently held. This is the
+    /// ownership signal; marker PID liveness above is diagnostic only.
+    pub writer_authority_held: Option<bool>,
     /// Seconds since the marker was established, per its own payload.
     pub marker_age_s: Option<u64>,
     /// Reason recorded by the writer, when it recorded one (see
@@ -98,47 +121,29 @@ impl IndexPublicationStatus {
         if !self.determinable {
             return true;
         }
-        match self.writer_alive {
-            // A live writer is a publication in flight, not a wedge.
+        match self.writer_authority_held {
             Some(true) => false,
-            // A dead writer cannot finish. Wedged regardless of age.
+            // A free canonical lease proves no writer can finish this marker,
+            // even when its diagnostic PID has since been recycled.
             Some(false) => true,
-            None => match self.marker_age_s {
-                Some(age) => Duration::from_secs(age) >= WEDGED_MARKER_AGE,
-                // Nothing attributable at all: no pid to probe, no timestamp to
-                // age out. A marker written by an older binary, truncated by a
-                // crash, or hand-created with `touch` lands here, and NOTHING
-                // can clear it on its own — auto-heal declines because it
-                // cannot prove the writer is dead. Reporting it as merely
-                // transient would promise a recovery that never arrives, and
-                // would leave every caller paying the bounded wait forever.
-                // Call it wedged so the operator is told to run `repair
-                // --force`, which is the one thing that does resolve it.
-                None => true,
-            },
+            // Unknown ownership remains fail-closed and needs operator
+            // attention; PID liveness cannot turn it into verified ownership.
+            None => true,
         }
     }
 
-    /// True when the wedge can only be cleared by an explicit operator
-    /// override — the marker is present but carries no writer we can prove
-    /// dead, so the automatic predicate must decline.
-    ///
-    /// The [`is_wedged`](Self::is_wedged) gate is INTRINSIC, not something each
-    /// call site must remember: a young, timestamped, pid-less marker is a
-    /// publication in flight, not a wedge, and it does not need repair at all —
-    /// so it must never produce a `repair --force` suggestion, even for a
-    /// caller that reaches for [`repair_command_for`](Self::repair_command_for)
-    /// without checking `is_wedged()` first.
+    /// True when the marker bytes themselves cannot be determined and an
+    /// operator must explicitly authorize discarding unknown state. A readable
+    /// PID-less marker does not require force: exact database authority and the
+    /// process-local publication lease are the ownership proof.
     pub fn needs_forced_repair(&self) -> bool {
-        self.is_wedged() && (!self.determinable || self.writer_pid.is_none())
+        self.is_wedged() && !self.determinable
     }
 
     /// The operator escape hatch to name in a wedged-state message.
     ///
-    /// A marker carrying no writer we can prove dead needs the explicit
-    /// override, so name it. Printing the bare command for a case that is
-    /// guaranteed to decline would send the operator round the same loop the
-    /// automatic predicate already lost.
+    /// Only unreadable/undeterminable marker state needs the explicit override;
+    /// readable markers are reconciled under exact writer authority.
     pub fn repair_command(db_path: &Path) -> String {
         format!("nestweaver repair --db {}", db_path.display())
     }
@@ -164,12 +169,19 @@ pub fn status_from(db_path: &Path, state: MarkerState) -> IndexPublicationStatus
     let marker_path = nestweaver_store::index_publication::marker_path(db_path)
         .display()
         .to_string();
+    let writer_authority_held = match nestweaver_store::write_lease_state(db_path) {
+        nestweaver_store::WriteLeaseState::Held => Some(true),
+        nestweaver_store::WriteLeaseState::Free => Some(false),
+        nestweaver_store::WriteLeaseState::Unknown => None,
+    };
     match state {
         MarkerState::Absent => IndexPublicationStatus {
             dirty: false,
             determinable: true,
             writer_pid: None,
             writer_alive: None,
+            writer_liveness_unknown: false,
+            writer_authority_held,
             marker_age_s: None,
             writer_reason: None,
             marker_path,
@@ -179,19 +191,30 @@ pub fn status_from(db_path: &Path, state: MarkerState) -> IndexPublicationStatus
             determinable: false,
             writer_pid: None,
             writer_alive: None,
+            writer_liveness_unknown: false,
+            writer_authority_held,
             marker_age_s: None,
             writer_reason: None,
             marker_path,
         },
-        MarkerState::Present(record) => IndexPublicationStatus {
-            dirty: true,
-            determinable: true,
-            writer_pid: record.writer_pid,
-            writer_alive: record.writer_pid.map(process_is_alive),
-            marker_age_s: record.age().map(|age| age.as_secs()),
-            writer_reason: record.reason.clone(),
-            marker_path,
-        },
+        MarkerState::Present(record) => {
+            let liveness = record.writer_pid.map(process_liveness);
+            IndexPublicationStatus {
+                dirty: true,
+                determinable: true,
+                writer_pid: record.writer_pid,
+                writer_alive: match liveness {
+                    Some(ProcessLiveness::Alive) => Some(true),
+                    Some(ProcessLiveness::Dead) => Some(false),
+                    Some(ProcessLiveness::Unknown) | None => None,
+                },
+                writer_liveness_unknown: liveness == Some(ProcessLiveness::Unknown),
+                writer_authority_held,
+                marker_age_s: record.age().map(|age| age.as_secs()),
+                writer_reason: record.reason.clone(),
+                marker_path,
+            }
+        }
     }
 }
 
@@ -204,7 +227,7 @@ pub fn status_from(db_path: &Path, state: MarkerState) -> IndexPublicationStatus
 pub fn abandoned_writer_pid(state: &MarkerState) -> Option<i32> {
     let record: &MarkerRecord = state.record()?;
     let pid = record.writer_pid?;
-    (!process_is_alive(pid)).then_some(pid)
+    (process_liveness(pid) == ProcessLiveness::Dead).then_some(pid)
 }
 
 /// The full abandoned-publication predicate: a dead recorded writer AND an
@@ -243,6 +266,22 @@ mod tests {
     fn a_nonpositive_pid_is_never_alive() {
         assert!(!process_is_alive(0));
         assert!(!process_is_alive(-1));
+    }
+
+    #[test]
+    fn live_marker_pid_is_diagnostic_and_free_authority_is_wedged() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let state = present(Some(std::process::id() as i32), None);
+        let status = status_from(&db_path, state);
+        assert_eq!(status.writer_alive, Some(true));
+        assert_eq!(status.writer_authority_held, Some(false));
+        assert!(status.is_wedged());
+
+        let _authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
+        let held = status_from(&db_path, present(Some(std::process::id() as i32), None));
+        assert_eq!(held.writer_authority_held, Some(true));
+        assert!(!held.is_wedged());
     }
 
     #[test]
@@ -291,6 +330,7 @@ mod tests {
             format_marker_payload(std::process::id(), 1, None),
         )
         .unwrap();
+        let _authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
         let status = status(&db_path);
         assert_eq!(status.writer_alive, Some(true));
         assert!(!status.is_wedged(), "a live publication is not wedged");
@@ -331,7 +371,7 @@ mod tests {
     }
 
     #[test]
-    fn an_unattributed_marker_is_wedged_not_transient() {
+    fn an_unattributed_marker_is_wedged_but_needs_no_force() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("test.lbug");
         // The legacy / `touch`-created marker: present, but nothing to attribute.
@@ -347,8 +387,8 @@ mod tests {
              transient promises a recovery that never arrives"
         );
         assert!(
-            status.needs_forced_repair(),
-            "and the only thing that resolves it is an explicit override"
+            !status.needs_forced_repair(),
+            "exact writer authority can reconcile a readable marker without PID attribution"
         );
     }
 
@@ -359,10 +399,10 @@ mod tests {
 
         std::fs::write(marker_path(&db_path), b"dirty").unwrap();
         assert!(
-            status(&db_path)
+            !status(&db_path)
                 .repair_command_for(&db_path)
                 .ends_with("--force"),
-            "an unattributable marker must be told to use --force"
+            "a readable unattributed marker needs exact authority, not an override"
         );
 
         let dead = {
@@ -405,25 +445,28 @@ mod tests {
             format_marker_payload(std::process::id(), 1, None),
         )
         .unwrap();
+        let _authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
         let status = status(&db_path);
         assert!(!status.is_wedged());
         assert!(!status.needs_forced_repair());
     }
 
     #[test]
-    fn a_young_timestamped_marker_without_a_pid_is_still_transient() {
+    fn a_young_timestamped_marker_without_authority_is_already_wedged() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("test.lbug");
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        // No pid, but a fresh timestamp: age-based classification still applies.
+        // A fresh timestamp and PID are diagnostic only. With the canonical
+        // authority free, no writer can complete this publication.
         std::fs::write(marker_path(&db_path), format!("x:{now}\n")).unwrap();
         let status = status(&db_path);
         assert_eq!(status.writer_pid, None);
         assert!(status.marker_age_s.is_some());
-        assert!(!status.is_wedged(), "a young marker is transient");
+        assert!(status.is_wedged());
+        assert!(!status.needs_forced_repair());
     }
 
     #[test]
@@ -439,6 +482,7 @@ mod tests {
             .unwrap()
             .as_nanos();
         std::fs::write(marker_path(&db_path), format!("x:{now}\n")).unwrap();
+        let _authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
         let status = status(&db_path);
         assert_eq!(status.writer_pid, None);
         assert!(status.marker_age_s.is_some());
@@ -454,10 +498,9 @@ mod tests {
     }
 
     #[test]
-    fn an_aged_out_pidless_marker_still_needs_forced_repair() {
-        // The narrowing must not go too far: once the same pid-less marker is
-        // older than WEDGED_MARKER_AGE it IS wedged, and the explicit override
-        // remains the only thing that resolves it.
+    fn an_aged_out_pidless_marker_is_wedged_but_still_needs_no_force() {
+        // Once the same pid-less marker is old it is wedged, but readable bytes
+        // plus exact database authority remain sufficient for automatic repair.
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("test.lbug");
         let old = std::time::SystemTime::now()
@@ -469,8 +512,8 @@ mod tests {
         let status = status(&db_path);
         assert_eq!(status.writer_pid, None);
         assert!(status.is_wedged(), "an aged-out pid-less marker is wedged");
-        assert!(status.needs_forced_repair());
-        assert!(status.repair_command_for(&db_path).ends_with("--force"));
+        assert!(!status.needs_forced_repair());
+        assert!(!status.repair_command_for(&db_path).ends_with("--force"));
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/investigate.rs
+++ b/crates/nestweaver-engine/src/investigate.rs
@@ -578,7 +578,10 @@ pub fn investigate(
             );
             nodes
         }
-        Err(_) => bm25_fallback(store, tantivy, query, DEFAULT_RETRIEVAL_BREADTH),
+        Err(error) if is_no_seed_resolution_error(&error) => {
+            bm25_fallback(store, tantivy, query, DEFAULT_RETRIEVAL_BREADTH)
+        }
+        Err(error) => return Err(error),
     };
     if let Some(ref filter) = scope_filter {
         connected.retain(|n| node_in_scope(store, n, filter));
@@ -1059,6 +1062,16 @@ fn bm25_fallback(
     nodes
 }
 
+/// The hybrid query's unresolved-seed outcome is the one benign failure for
+/// which `investigate` can still produce an honest lexical map. Everything
+/// else is an operational or integrity failure and must retain its typed error
+/// instead of being mistaken for an empty semantic result.
+fn is_no_seed_resolution_error(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.to_string().starts_with("No seeds resolved."))
+}
+
 /// Whether a node survives the scope filter. Only symbol nodes are scoped;
 /// non-symbol nodes (notes/sections/tags) are vault-global and pass through
 /// unfiltered — this mirrors the long-standing `repo:` notes handling.
@@ -1394,6 +1407,31 @@ mod tests {
     use super::*;
     use crate::index::index_directory_in_memory;
     use std::fs;
+
+    #[test]
+    fn investigate_fallback_does_not_swallow_unreadable_embedding_identity() {
+        let no_seeds = anyhow::anyhow!(
+            "No seeds resolved. Tried as UIDs, note titles, tags, symbol names, and semantic search."
+        )
+        .context("hybrid retrieval");
+        assert!(is_no_seed_resolution_error(&no_seeds));
+
+        let identity_error =
+            anyhow::Error::new(nestweaver_store::StoreError::EmbeddingIdentityUnreadable {
+                detail: "injected malformed embedding metadata".to_string(),
+            })
+            .context("hybrid retrieval");
+        assert!(!is_no_seed_resolution_error(&identity_error));
+        assert!(
+            identity_error
+                .downcast_ref::<nestweaver_store::StoreError>()
+                .is_some_and(|error| matches!(
+                    error,
+                    nestweaver_store::StoreError::EmbeddingIdentityUnreadable { .. }
+                )),
+            "the fail-closed store error must remain typed through context"
+        );
+    }
 
     fn make_store() -> (tempfile::TempDir, std::path::PathBuf, GraphStore) {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -349,6 +349,7 @@ pub mod brain_docgraph;
 pub mod brain_memory;
 pub mod brainignore;
 pub mod bridges;
+pub mod changed_files;
 pub mod circuit_breaker;
 pub mod cluster_dispatch;
 pub mod clustering;
@@ -539,15 +540,19 @@ pub use investigate::{
     load_bundle, load_bundle_store, save_bundle_store,
 };
 pub use manifest::{
-    ManifestInfo, load_manifest_cache, load_manifest_cache_for_db, manifest_cache_path,
-    parse_manifest, save_manifest_cache, save_manifest_cache_for_db,
+    GraphMutationPublicationDisposition, GraphMutationPublicationGuard,
+    GraphMutationPublicationOutcome, GraphMutationPublicationWarning, ManifestInfo,
+    begin_graph_mutation_publication, finalize_committed_graph_mutation, load_manifest_cache,
+    load_manifest_cache_for_db, manifest_cache_path, parse_manifest, save_manifest_cache,
+    save_manifest_cache_for_db,
 };
 pub use process::{
     AffectedProcess, AffectedSymbol, ChangeImpact, ProcessMember, ProcessResult, RiskLevel,
     detect_changes_impact, trace_processes,
 };
 pub use project::{
-    ProjectMaterializationResult, detect_implicit_projects, detect_implicit_projects_with_mode,
+    ImplicitProjectDetectionResult, ProjectMaterializationResult, detect_implicit_projects,
+    detect_implicit_projects_with_mode, detect_implicit_projects_with_publication,
     materialize_projects, materialize_projects_with_lease,
 };
 pub use publication::*;

--- a/crates/nestweaver-engine/src/manifest.rs
+++ b/crates/nestweaver-engine/src/manifest.rs
@@ -93,6 +93,312 @@ pub fn load_manifest_cache_for_db(
     .unwrap_or_default())
 }
 
+/// Publication status for a graph mutation that has already committed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GraphMutationPublicationDisposition {
+    /// The store proved that no graph state changed.
+    ConfirmedNoChange,
+    /// The mutation and every required derived-artifact reconciliation step
+    /// completed.
+    CommittedComplete,
+    /// The graph mutation committed, but one or more reconciliation steps
+    /// failed and require operator repair.
+    CommittedDegraded,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GraphMutationPublicationWarning {
+    pub stage: String,
+    pub message: String,
+}
+
+/// Complete publication result for a graph mutation.
+///
+/// A committed graph write is never turned back into a plain `Err` merely
+/// because generation persistence or sidecar reconciliation subsequently
+/// failed. Callers can therefore report the truthful committed-but-degraded
+/// state instead of implying that the graph rolled back.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GraphMutationPublicationOutcome {
+    pub disposition: GraphMutationPublicationDisposition,
+    pub generation_before: u64,
+    pub generation_after: u64,
+    pub warnings: Vec<GraphMutationPublicationWarning>,
+}
+
+/// Crash fence for a non-index graph mutation.
+///
+/// Unlike a full index publication this guard does not reserve dirty N+1 and
+/// clean N+2 generations: the materialization contract requires exactly one
+/// successor generation. The durable marker still brackets the graph commit,
+/// so interruption before post-commit reconciliation leaves every ranked read
+/// and snapshot fail-closed until normal abandoned-publication repair runs.
+pub struct GraphMutationPublicationGuard<'a> {
+    lease: Option<nestweaver_store::IndexPublicationLease<'a>>,
+    marker_path: Option<PathBuf>,
+    operation: String,
+}
+
+impl<'a> GraphMutationPublicationGuard<'a> {
+    /// Finish a bracketed operation. A confirmed no-op retires the marker
+    /// without advancing generation; a commit publishes exactly once.
+    pub fn finish(
+        mut self,
+        changed: bool,
+    ) -> Result<GraphMutationPublicationOutcome, anyhow::Error> {
+        let store = self
+            .lease
+            .as_ref()
+            .expect("publication guard always owns its lease until finish")
+            .store();
+        let mut outcome = finalize_committed_graph_mutation(store, changed);
+
+        if !outcome.is_degraded()
+            && let Some(marker_path) = &self.marker_path
+            && let Err(error) = store.with_index_publication_rank_barrier(|| {
+                nestweaver_store::durable_sidecar::remove_file_durable_if_exists(marker_path)
+            })
+        {
+            if changed {
+                outcome.record_warning(
+                    "retire-graph-publication-marker",
+                    format!(
+                        "{} committed clean state but could not retire {}: {error}",
+                        self.operation,
+                        marker_path.display()
+                    ),
+                );
+            } else {
+                anyhow::bail!(
+                    "{} made no graph change but could not retire publication marker {}: {error}",
+                    self.operation,
+                    marker_path.display()
+                );
+            }
+        }
+
+        if let Some(lease) = self.lease.take()
+            && let Err(error) = lease.release()
+        {
+            if changed {
+                outcome.record_warning(
+                    "release-graph-publication-lease",
+                    format!(
+                        "{} committed but could not release its publication lease: {error}",
+                        self.operation
+                    ),
+                );
+            } else {
+                return Err(anyhow::anyhow!(
+                    "{} made no graph change but could not release its publication lease: {error}",
+                    self.operation
+                ));
+            }
+        }
+        Ok(outcome)
+    }
+}
+
+/// Durably mark a graph publication dirty before its first possible write.
+///
+/// The returned guard must span the graph commit and post-commit finalizer.
+/// Dropping it early intentionally releases only live ownership; the durable
+/// marker remains so a crash or ambiguous write cannot make old derived data
+/// authoritative.
+pub fn begin_graph_mutation_publication<'a>(
+    store: &'a nestweaver_store::GraphStore,
+    operation: impl Into<String>,
+) -> Result<GraphMutationPublicationGuard<'a>, anyhow::Error> {
+    let operation = operation.into();
+    let lease = store
+        .acquire_index_publication_lease()
+        .map_err(|error| anyhow::anyhow!("{operation}: acquire publication lease: {error}"))?;
+    lease.ensure_clean_for_snapshot().map_err(|error| {
+        anyhow::anyhow!("{operation}: refusing to overwrite a dirty publication: {error}")
+    })?;
+
+    let marker_path = if let Some(db_path) = store.db_path() {
+        lease.preflight_generation().map_err(|error| {
+            anyhow::anyhow!("{operation}: preflight successor generation: {error}")
+        })?;
+        let marker_path = crate::sidecar_path(db_path, ".index-dirty");
+        let payload = nestweaver_store::index_publication::format_marker_payload(
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos(),
+            None,
+        );
+        store
+            .with_index_publication_rank_barrier(|| {
+                nestweaver_store::durable_sidecar::atomic_replace_file(&marker_path, |file| {
+                    file.write_all(payload.as_bytes())
+                })
+            })
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "{operation}: publish graph mutation marker {}: {error}",
+                    marker_path.display()
+                )
+            })?;
+        Some(marker_path)
+    } else {
+        lease.preflight_transient_generation().map_err(|error| {
+            anyhow::anyhow!("{operation}: preflight in-memory successor generation: {error}")
+        })?;
+        None
+    };
+
+    Ok(GraphMutationPublicationGuard {
+        lease: Some(lease),
+        marker_path,
+        operation,
+    })
+}
+
+impl GraphMutationPublicationOutcome {
+    pub fn changed(&self) -> bool {
+        self.disposition != GraphMutationPublicationDisposition::ConfirmedNoChange
+    }
+
+    pub fn is_degraded(&self) -> bool {
+        self.disposition == GraphMutationPublicationDisposition::CommittedDegraded
+    }
+
+    pub fn record_warning(&mut self, stage: impl Into<String>, message: impl Into<String>) {
+        self.warnings.push(GraphMutationPublicationWarning {
+            stage: stage.into(),
+            message: message.into(),
+        });
+        if self.disposition == GraphMutationPublicationDisposition::CommittedComplete {
+            self.disposition = GraphMutationPublicationDisposition::CommittedDegraded;
+        }
+    }
+}
+
+/// Publish one already-committed graph mutation.
+///
+/// A confirmed no-op leaves every generation and derived artifact untouched.
+/// A change invalidates both live and durable PageRank, advances generation
+/// exactly once, persists it, and rebinds a valid repository-manifest cache to
+/// the successor generation. Post-commit failures are accumulated instead of
+/// being returned as rollback-looking errors.
+pub fn finalize_committed_graph_mutation(
+    store: &nestweaver_store::GraphStore,
+    changed: bool,
+) -> GraphMutationPublicationOutcome {
+    let generation_before = store.graph_generation();
+    if !changed {
+        return GraphMutationPublicationOutcome {
+            disposition: GraphMutationPublicationDisposition::ConfirmedNoChange,
+            generation_before,
+            generation_after: generation_before,
+            warnings: Vec::new(),
+        };
+    }
+
+    let db_path = store.db_path().map(Path::to_path_buf);
+    let mut outcome = GraphMutationPublicationOutcome {
+        disposition: GraphMutationPublicationDisposition::CommittedComplete,
+        generation_before,
+        generation_after: generation_before,
+        warnings: Vec::new(),
+    };
+    let carried_manifests = db_path.as_ref().and_then(|db_path| {
+        let path = manifest_cache_path(db_path);
+        if !path.exists() {
+            return None;
+        }
+        match load_manifest_cache_for_db(store, db_path) {
+            Ok(manifests) => Some(manifests),
+            Err(error) => {
+                outcome.record_warning(
+                    "load-manifest-cache",
+                    format!(
+                        "could not carry the repository manifest cache across publication: {error:#}"
+                    ),
+                );
+                None
+            }
+        }
+    });
+
+    // Clear live scores before exposing the new generation. The durable copy
+    // is removed as well, so a process restart cannot reload pre-mutation
+    // ranking even if a later publication step is degraded.
+    store.invalidate_pagerank();
+    if let Some(db_path) = &db_path {
+        let pagerank_path = crate::sidecar_path(db_path, ".pagerank.json");
+        if let Err(error) =
+            nestweaver_store::durable_sidecar::remove_file_durable_if_exists(&pagerank_path)
+        {
+            outcome.record_warning(
+                "invalidate-pagerank-sidecar",
+                format!(
+                    "could not durably remove stale PageRank sidecar {}: {error}",
+                    pagerank_path.display()
+                ),
+            );
+        }
+    }
+
+    let generation_after = match store.try_bump_graph_generation() {
+        Ok(generation) => generation,
+        Err(error) => {
+            outcome.record_warning(
+                "advance-graph-generation",
+                format!("committed graph mutation could not advance generation: {error}"),
+            );
+            outcome.generation_after = store.graph_generation();
+            return outcome;
+        }
+    };
+    outcome.generation_after = generation_after;
+
+    let generation_persisted = if let Some(db_path) = &db_path {
+        let generation_path = crate::sidecar_path(db_path, ".generation");
+        match store.save_graph_generation(&generation_path) {
+            Ok(()) => true,
+            Err(error) => {
+                outcome.record_warning(
+                    "persist-graph-generation",
+                    format!(
+                        "generation {generation_after} is live but could not be durably published to {}: {error}",
+                        generation_path.display()
+                    ),
+                );
+                false
+            }
+        }
+    } else {
+        true
+    };
+
+    if generation_persisted
+        && let (Some(db_path), Some(manifests)) = (&db_path, carried_manifests)
+        && let Err(error) = save_manifest_cache_for_db(&manifests, store, db_path)
+    {
+        outcome.record_warning(
+            "rebind-manifest-cache",
+            format!(
+                "could not rebind the repository manifest cache to generation {generation_after}: {error:#}"
+            ),
+        );
+    }
+
+    for warning in &outcome.warnings {
+        tracing::warn!(
+            stage = %warning.stage,
+            message = %warning.message,
+            generation_before,
+            generation_after = outcome.generation_after,
+            "graph mutation committed with degraded publication reconciliation"
+        );
+    }
+    outcome
+}
+
 /// Advance the graph generation while carrying the manifest cache across the
 /// boundary.
 ///
@@ -955,6 +1261,160 @@ dependencies = ["requests>=2.28", "pydantic>=2.0"]
                 .contains("foreign artifact identity"),
             "{foreign_error}"
         );
+    }
+
+    #[test]
+    fn committed_graph_publication_advances_once_and_reconciles_derived_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("brain.lbug");
+        let store = nestweaver_store::GraphStore::create(&db_path).unwrap();
+        let manifests = HashMap::from([("repo:stable".to_string(), ManifestInfo::default())]);
+        save_manifest_cache_for_db(&manifests, &store, &db_path).unwrap();
+        store
+            .compute_pagerank(
+                0.85,
+                20,
+                &nestweaver_store::ranking::GraphScope::code_only(),
+            )
+            .unwrap();
+        let pagerank_path = crate::sidecar_path(&db_path, ".pagerank.json");
+        store.save_pagerank_cache(&pagerank_path).unwrap();
+
+        let unchanged = finalize_committed_graph_mutation(&store, false);
+        assert_eq!(
+            unchanged.disposition,
+            GraphMutationPublicationDisposition::ConfirmedNoChange
+        );
+        assert_eq!(unchanged.generation_before, unchanged.generation_after);
+        assert!(pagerank_path.exists());
+
+        let changed = finalize_committed_graph_mutation(&store, true);
+        assert_eq!(
+            changed.disposition,
+            GraphMutationPublicationDisposition::CommittedComplete
+        );
+        assert_eq!(changed.generation_after, changed.generation_before + 1);
+        assert_eq!(store.graph_generation(), changed.generation_after);
+        assert_eq!(
+            std::fs::read_to_string(crate::sidecar_path(&db_path, ".generation"))
+                .unwrap()
+                .parse::<u64>()
+                .unwrap(),
+            changed.generation_after
+        );
+        assert!(!pagerank_path.exists());
+        assert!(
+            load_manifest_cache_for_db(&store, &db_path)
+                .unwrap()
+                .contains_key("repo:stable")
+        );
+
+        let repeated_noop = finalize_committed_graph_mutation(&store, false);
+        assert_eq!(repeated_noop.generation_after, changed.generation_after);
+    }
+
+    #[test]
+    fn committed_graph_publication_reports_reconciliation_degradation() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("brain.lbug");
+        let store = nestweaver_store::GraphStore::create(&db_path).unwrap();
+        let pagerank_path = crate::sidecar_path(&db_path, ".pagerank.json");
+        std::fs::create_dir(&pagerank_path).unwrap();
+
+        let publication =
+            begin_graph_mutation_publication(&store, "injected reconciliation failure").unwrap();
+        let outcome = publication.finish(true).unwrap();
+
+        assert_eq!(
+            outcome.disposition,
+            GraphMutationPublicationDisposition::CommittedDegraded
+        );
+        assert_eq!(outcome.generation_after, outcome.generation_before + 1);
+        assert!(
+            outcome
+                .warnings
+                .iter()
+                .any(|warning| warning.stage == "invalidate-pagerank-sidecar")
+        );
+        assert!(
+            crate::sidecar_path(&db_path, ".index-dirty").exists(),
+            "degraded reconciliation must retain the crash fence"
+        );
+
+        let backup_config = crate::backup::BackupConfig {
+            db_path: db_path.clone(),
+            output_path: dir.path().join("backup.nwsnap.zst"),
+            include_clones: false,
+            instance_id: "test".to_string(),
+            workspace_path: None,
+        };
+        let backup_error = crate::backup::stage_backup_from_store(&store, &backup_config)
+            .err()
+            .expect("backup must fail closed on committed-but-degraded publication")
+            .to_string();
+        assert!(
+            backup_error.contains("dirty index publication"),
+            "{backup_error}"
+        );
+
+        let snapshot_dir = dir.path().join("snapshot");
+        let snapshot_stamp = crate::snapshot::Stamp {
+            format_version: 0,
+            capabilities: Vec::new(),
+            instance_id: "test".to_string(),
+            brain_uuid: String::new(),
+            publication_uuid: String::new(),
+            engine_version: env!("CARGO_PKG_VERSION").to_string(),
+            min_compatible_engine: crate::snapshot::MIN_SNAPSHOT_READER_VERSION.to_string(),
+            schema_hash_core: nestweaver_schema::core_schema_hash(),
+            schema_hash_extensions: "none".to_string(),
+            schema_hash_effective: "schema".to_string(),
+            embedding_model_id: "model".to_string(),
+            embedding_dimension: 0,
+            embedding_count: 0,
+            built_at: "2026-09-02T00:00:00Z".to_string(),
+            repos: Vec::new(),
+        };
+        let snapshot_manifest = crate::snapshot::Manifest { repos: Vec::new() };
+        let snapshot_error = crate::snapshot::build_snapshot_from_store(
+            &snapshot_dir,
+            &snapshot_stamp,
+            &snapshot_manifest,
+            &store,
+        )
+        .expect_err("snapshot must fail closed on committed-but-degraded publication")
+        .to_string();
+        assert!(
+            snapshot_error.contains("dirty index publication"),
+            "{snapshot_error}"
+        );
+    }
+
+    #[test]
+    fn interrupted_bracketed_mutation_retains_fail_closed_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("brain.lbug");
+        let store = nestweaver_store::GraphStore::create(&db_path).unwrap();
+        let publication = begin_graph_mutation_publication(&store, "interrupted mutation").unwrap();
+        store
+            .insert_project(&nestweaver_schema::Project {
+                uid: "proj:test:interrupted".to_string(),
+                name: "interrupted".to_string(),
+                summary: None,
+                instance_id: "test".to_string(),
+            })
+            .unwrap();
+
+        // Model interruption after the graph commit but before `finish`.
+        drop(publication);
+
+        assert!(crate::sidecar_path(&db_path, ".index-dirty").exists());
+        assert_eq!(store.graph_generation(), 0);
+        let error = store
+            .ensure_pagerank_loaded()
+            .expect_err("ranked reads must fail closed across the interruption window")
+            .to_string();
+        assert!(error.contains("dirty index publication"), "{error}");
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/process.rs
+++ b/crates/nestweaver-engine/src/process.rs
@@ -43,6 +43,8 @@ pub struct ChangeImpact {
     #[serde(default)]
     pub notifications: Vec<Notification>,
     #[serde(default)]
+    pub resolver_stale_repos: Vec<String>,
+    #[serde(default)]
     pub gate_state: GateState,
 }
 
@@ -343,14 +345,25 @@ pub fn detect_changes_impact(
     changed_files: &[String],
     max_depth: u32,
 ) -> Result<ChangeImpact> {
+    let changed_files = crate::changed_files::require_changed_files(changed_files)?;
+
     // Step 1: collect all symbols in changed files.
     let mut affected_symbols = Vec::new();
     let mut affected_uids: HashSet<String> = HashSet::new();
     let mut status = AnalysisStatus::Complete;
     let mut notifications = Vec::new();
     let mut unassessed = Vec::new();
+    let resolver_stale_repos = crate::resolver_generation::incompatible_repos_for_store(store)?;
+    if !resolver_stale_repos.is_empty() {
+        status = status.max(AnalysisStatus::Degraded);
+        notifications.push(Notification {
+            level: NotificationLevel::Error,
+            message: crate::resolver_generation::incompatibility_message(&resolver_stale_repos),
+            descriptor: crate::resolver_generation::INCOMPATIBLE_RESOLVER_DESCRIPTOR.to_string(),
+        });
+    }
 
-    for file_path in changed_files {
+    for file_path in &changed_files {
         let syms = match store.symbols_in_file(file_path) {
             Ok(syms) => syms,
             Err(e) => {
@@ -402,6 +415,7 @@ pub fn detect_changes_impact(
             blast_radius: 0,
             status,
             notifications,
+            resolver_stale_repos,
             gate_state,
         });
     }
@@ -518,6 +532,7 @@ pub fn detect_changes_impact(
         blast_radius,
         status,
         notifications,
+        resolver_stale_repos,
         gate_state,
     })
 }

--- a/crates/nestweaver-engine/src/project.rs
+++ b/crates/nestweaver-engine/src/project.rs
@@ -1,15 +1,22 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use nestweaver_schema::{
     Heading, Note, NoteKind, Project, Section, heading_uid, note_uid, project_uid, section_uid,
     truncated_hash,
 };
-use nestweaver_store::GraphStore;
+use nestweaver_store::write::{
+    ReplaceMaterializedProjectsError, ReplaceMaterializedProjectsOutcome,
+};
+use nestweaver_store::{GraphStore, ProjectMutationDisposition};
 
 use crate::config::InstanceConfig;
 use crate::extensions::{load_extensions, save_extensions, set_property};
 use crate::html_to_md::maybe_convert_html_to_markdown;
+use crate::manifest::{
+    GraphMutationPublicationGuard, GraphMutationPublicationOutcome,
+    begin_graph_mutation_publication, finalize_committed_graph_mutation,
+};
 use crate::mcp_client::McpClient;
 use crate::repo_display_name;
 
@@ -20,6 +27,47 @@ pub struct ProjectMaterializationResult {
     pub component_edges: usize,
     pub wiki_notes_ingested: usize,
     pub wiki_fetch_errors: usize,
+    pub publication: GraphMutationPublicationOutcome,
+}
+
+pub struct ImplicitProjectDetectionResult {
+    pub projects: Vec<String>,
+    pub publication: GraphMutationPublicationOutcome,
+}
+
+fn resolve_project_replacement<'a>(
+    publication: GraphMutationPublicationGuard<'a>,
+    replacement: Result<ReplaceMaterializedProjectsOutcome, ReplaceMaterializedProjectsError>,
+) -> Result<
+    (
+        GraphMutationPublicationGuard<'a>,
+        ReplaceMaterializedProjectsOutcome,
+    ),
+    anyhow::Error,
+> {
+    match replacement {
+        Ok(outcome) => Ok((publication, outcome)),
+        Err(error)
+            if matches!(
+                error.disposition,
+                ProjectMutationDisposition::ConfirmedUnchanged
+                    | ProjectMutationDisposition::ConfirmedRolledBack
+            ) =>
+        {
+            if let Err(finish_error) = publication.finish(false) {
+                return Err(anyhow::anyhow!(
+                    "{error}; additionally failed to retire the no-change publication: {finish_error:#}"
+                ));
+            }
+            Err(error.into())
+        }
+        Err(error) => {
+            // Changed/ambiguous failures retain the durable crash fence. The
+            // guard drop releases live ownership only; readers stay fail-closed.
+            drop(publication);
+            Err(error.into())
+        }
+    }
 }
 
 /// Heuristic patterns that indicate an MCP tool response is an error message
@@ -197,6 +245,7 @@ pub fn materialize_projects_with_lease(
     let mut symbol_edges: Vec<(String, String)> = Vec::new();
     let mut component_edges: Vec<(String, String)> = Vec::new();
     let mut parent_edges: Vec<(String, String)> = Vec::new();
+    let mut wiki_project_uids: HashMap<String, Vec<String>> = HashMap::new();
 
     for project_cfg in &config.projects {
         let uid = project_uid(instance_id, &project_cfg.name);
@@ -222,24 +271,21 @@ pub fn materialize_projects_with_lease(
         }
 
         // A transient wiki fetch failure must not erase the last successfully
-        // materialized membership. Successful sources are re-linked after
-        // their Note replacement below; failed sources preserve an existing
-        // Note edge if that Note is still present.
+        // materialized membership. Existing successful sources belong in the
+        // desired replacement too: omitting them here deleted and re-created
+        // the same edge on every run, so an identical wiki response could
+        // never be a true graph no-op.
         for ws in &project_cfg.wiki_sources {
-            let key = (
-                project_cfg.name.clone(),
-                ws.mcp_server.clone(),
-                ws.tool.clone(),
-                ws.label.clone(),
+            let wiki_note_uid = note_uid(
+                &format!("wiki:{}", ws.mcp_server),
+                &format!("{}/{}", ws.tool, ws.label),
             );
-            if !prepared_wiki_contents.contains_key(&key) {
-                let wiki_note_uid = note_uid(
-                    &format!("wiki:{}", ws.mcp_server),
-                    &format!("{}/{}", ws.tool, ws.label),
-                );
-                if all_notes.iter().any(|note| note.uid == wiki_note_uid) {
-                    note_edges.push((uid.clone(), wiki_note_uid));
-                }
+            wiki_project_uids
+                .entry(wiki_note_uid.clone())
+                .or_default()
+                .push(uid.clone());
+            if all_notes.iter().any(|note| note.uid == wiki_note_uid) {
+                note_edges.push((uid.clone(), wiki_note_uid));
             }
         }
 
@@ -293,24 +339,36 @@ pub fn materialize_projects_with_lease(
             parent_edges.push((uid.clone(), parent_uid));
         }
     }
+    for project_uids in wiki_project_uids.values_mut() {
+        project_uids.sort();
+        project_uids.dedup();
+    }
 
     // One transaction replaces the complete configured Project subgraph.
     // Relationship COPY turns the 139k-edge hot path from one execute per edge
     // into four bounded bulk loads, and rollback preserves the old graph if
     // any replacement step fails.
-    store.replace_materialized_projects(
-        &projects,
-        &note_edges,
-        &symbol_edges,
-        &component_edges,
-        &parent_edges,
+    let graph_publication =
+        begin_graph_mutation_publication(store, "explicit Project materialization")?;
+    let (graph_publication, replacement) = resolve_project_replacement(
+        graph_publication,
+        store.replace_materialized_projects(
+            &projects,
+            &note_edges,
+            &symbol_edges,
+            &component_edges,
+            &parent_edges,
+        ),
     )?;
+    let mut graph_changed = replacement.changed();
 
     let projects_created = projects.len();
     let total_note_edges = note_edges.len();
     let total_symbol_edges = symbol_edges.len();
     let total_component_edges = component_edges.len();
     let mut total_wiki_notes_ingested = 0usize;
+    let mut wiki_mutation_errors = Vec::new();
+    let mut reconciled_wiki_notes = HashSet::new();
 
     for project_cfg in &config.projects {
         let uid = project_uid(instance_id, &project_cfg.name);
@@ -372,6 +430,9 @@ pub fn materialize_projects_with_lease(
                     &format!("wiki:{}", ws.mcp_server),
                     &format!("{}/{}", ws.tool, ws.label),
                 );
+                if reconciled_wiki_notes.contains(&wiki_note_uid) {
+                    continue;
+                }
 
                 let note = Note {
                     uid: wiki_note_uid.clone(),
@@ -391,122 +452,122 @@ pub fn materialize_projects_with_lease(
                     embedding: None,
                 };
 
-                if let Err(e) = store.upsert_note(&note) {
-                    tracing::warn!(
-                        label = ws.label,
-                        error = %e,
-                        "failed to upsert wiki note"
-                    );
-                    continue;
-                }
-
-                // Decompose the wiki note into headings and sections.
-                if let Ok(parsed) = nestweaver_parser::parse_markdown(
+                // Decompose the complete desired wiki topology before the
+                // store transaction. Parse failure therefore cannot publish a
+                // replacement Note with missing children.
+                let parsed = match nestweaver_parser::parse_markdown(
                     &format!("{}/{}", ws.tool, ws.label),
                     &content,
                 ) {
-                    // Build heading UIDs so sections can reference them.
-                    let heading_uids: Vec<String> = parsed
-                        .headings
-                        .iter()
-                        .map(|h| heading_uid(&wiki_note_uid, &h.slug, h.start_line))
-                        .collect();
-
-                    let headings: Vec<Heading> = parsed
-                        .headings
-                        .iter()
-                        .enumerate()
-                        .map(|(idx, h)| Heading {
-                            uid: heading_uids[idx].clone(),
+                    Ok(parsed) => parsed,
+                    Err(error) => {
+                        wiki_mutation_errors.push(format!(
+                            "wiki source '{}' could not be parsed before graph mutation: {error:#}",
+                            ws.label
+                        ));
+                        continue;
+                    }
+                };
+                let heading_uids: Vec<String> = parsed
+                    .headings
+                    .iter()
+                    .map(|heading| heading_uid(&wiki_note_uid, &heading.slug, heading.start_line))
+                    .collect();
+                let headings: Vec<Heading> = parsed
+                    .headings
+                    .iter()
+                    .enumerate()
+                    .map(|(index, heading)| Heading {
+                        uid: heading_uids[index].clone(),
+                        note_uid: wiki_note_uid.clone(),
+                        level: heading.level,
+                        text: heading.text.clone(),
+                        slug: heading.slug.clone(),
+                        start_line: heading.start_line,
+                        end_line: heading.end_line,
+                        content_hash: truncated_hash(&heading.text),
+                        embedding: None,
+                    })
+                    .collect();
+                let sections: Vec<Section> = parsed
+                    .sections
+                    .iter()
+                    .map(|section| {
+                        let text_hash = truncated_hash(&section.text);
+                        Section {
+                            uid: section_uid(&wiki_note_uid, section.start_line, &text_hash),
                             note_uid: wiki_note_uid.clone(),
-                            level: h.level,
-                            text: h.text.clone(),
-                            slug: h.slug.clone(),
-                            start_line: h.start_line,
-                            end_line: h.end_line,
-                            content_hash: truncated_hash(&h.text),
-                            embedding: None,
-                        })
-                        .collect();
-
-                    if !headings.is_empty() {
-                        if let Err(e) = store.batch_insert_headings(&headings) {
-                            tracing::warn!(
-                                label = ws.label,
-                                error = %e,
-                                "failed to insert wiki note headings"
-                            );
-                        } else {
-                            let nh_edges: Vec<(&str, &str)> = heading_uids
-                                .iter()
-                                .map(|h| (wiki_note_uid.as_str(), h.as_str()))
-                                .collect();
-                            let _ = store.batch_insert_note_heading_edges(&nh_edges);
+                            heading_uid: section
+                                .heading_idx
+                                .and_then(|index| heading_uids.get(index))
+                                .cloned(),
+                            start_line: section.start_line,
+                            end_line: section.end_line,
+                            text_hash,
+                            text_content: section.text.clone(),
+                            word_count: u32::try_from(section.text.split_whitespace().count())
+                                .unwrap_or(u32::MAX),
+                            pagerank_score: None,
                         }
+                    })
+                    .collect();
+
+                let project_uids = wiki_project_uids
+                    .get(&wiki_note_uid)
+                    .expect("configured wiki source has planned Project memberships");
+                match store.replace_project_wiki_note_memberships(
+                    project_uids,
+                    &note,
+                    &headings,
+                    &sections,
+                ) {
+                    Ok(outcome) => {
+                        reconciled_wiki_notes.insert(wiki_note_uid);
+                        graph_changed |= outcome.changed();
+                        total_wiki_notes_ingested += 1;
+                        tracing::info!(
+                            label = ws.label,
+                            project = project_cfg.name,
+                            changed = outcome.changed(),
+                            "reconciled wiki source"
+                        );
                     }
-
-                    let sections: Vec<Section> = parsed
-                        .sections
-                        .iter()
-                        .map(|sec| {
-                            let text_hash = truncated_hash(&sec.text);
-                            let s_uid = section_uid(&wiki_note_uid, sec.start_line, &text_hash);
-                            let heading_link =
-                                sec.heading_idx.and_then(|i| heading_uids.get(i)).cloned();
-                            let word_count = u32::try_from(sec.text.split_whitespace().count())
-                                .unwrap_or(u32::MAX);
-                            Section {
-                                uid: s_uid,
-                                note_uid: wiki_note_uid.clone(),
-                                heading_uid: heading_link,
-                                start_line: sec.start_line,
-                                end_line: sec.end_line,
-                                text_hash,
-                                text_content: sec.text.clone(),
-                                word_count,
-                                pagerank_score: None,
-                            }
-                        })
-                        .collect();
-
-                    if !sections.is_empty() {
-                        if let Err(e) = store.batch_upsert_sections(&sections) {
-                            tracing::warn!(
-                                label = ws.label,
-                                error = %e,
-                                "failed to upsert wiki note sections"
-                            );
-                        } else {
-                            let ns_edges: Vec<(&str, &str)> = sections
-                                .iter()
-                                .map(|s| (wiki_note_uid.as_str(), s.uid.as_str()))
-                                .collect();
-                            let _ = store.batch_insert_note_section_edges(&ns_edges);
-                        }
-                    }
+                    Err(error) => wiki_mutation_errors.push(format!(
+                        "wiki source '{}' topology transaction failed: {error:#}",
+                        ws.label
+                    )),
                 }
-
-                let edge = (uid.as_str(), wiki_note_uid.as_str());
-                if let Err(e) = store.batch_insert_project_note_edges(&[edge]) {
-                    tracing::warn!(
-                        label = ws.label,
-                        error = %e,
-                        "failed to link wiki note to project"
-                    );
-                }
-
-                total_wiki_notes_ingested += 1;
-                tracing::info!(
-                    label = ws.label,
-                    project = project_cfg.name,
-                    "ingested wiki source"
-                );
             }
         }
     }
 
     // Persist the extension sidecar once after all projects are processed.
-    save_extensions(db_path, &ext_store)?;
+    let extension_save_error = save_extensions(db_path, &ext_store).err();
+    let mut publication = graph_publication.finish(graph_changed)?;
+    if !wiki_mutation_errors.is_empty() {
+        if graph_changed {
+            for error in wiki_mutation_errors {
+                publication.record_warning("materialize-project-wiki", error);
+            }
+        } else {
+            anyhow::bail!(
+                "project wiki materialization failed before any graph change: {}",
+                wiki_mutation_errors.join("; ")
+            );
+        }
+    }
+    if let Some(error) = extension_save_error {
+        if graph_changed {
+            publication.record_warning(
+                "save-project-extensions",
+                format!(
+                    "graph materialization committed but the project extension sidecar was not published: {error:#}"
+                ),
+            );
+        } else {
+            return Err(error);
+        }
+    }
 
     Ok(ProjectMaterializationResult {
         projects_created,
@@ -515,16 +576,15 @@ pub fn materialize_projects_with_lease(
         component_edges: total_component_edges,
         wiki_notes_ingested: total_wiki_notes_ingested,
         wiki_fetch_errors: total_wiki_fetch_errors,
+        publication,
     })
 }
 
 /// Walk `vault_root/Projects/` and auto-detect project folders whose entry
 /// note exists at `Projects/<slug>/<slug>.md`.
 ///
-/// For each detected project:
-/// 1. A Project node is created (or silently skipped on duplicate-UID errors).
-/// 2. All notes whose path starts with `Projects/<slug>/` are linked via
-///    PROJECT_INCLUDES_NOTE edges.
+/// All detected Project nodes and their `PROJECT_INCLUDES_NOTE` relationships
+/// are planned first, then replaced atomically as one graph mutation.
 ///
 /// Returns the list of detected project slugs (folder names).
 /// Vault folders that hold one directory per project.
@@ -554,10 +614,9 @@ pub fn detect_implicit_projects(
 
 /// [`detect_implicit_projects`] with an explicit write mode.
 ///
-/// nw-161: this function WRITES — `upsert_project` and
-/// `batch_insert_project_note_edges` — despite a read-sounding name, and
-/// nothing in `--help` signalled it. `dry_run` reports what would be created
-/// without touching the graph.
+/// nw-161: this function WRITES despite a read-sounding name, and nothing in
+/// `--help` signalled it. `dry_run` reports what would be created without
+/// touching the graph.
 pub fn detect_implicit_projects_with_mode(
     store: &GraphStore,
     vault_root: &Path,
@@ -565,33 +624,95 @@ pub fn detect_implicit_projects_with_mode(
     instance_id: &str,
     dry_run: bool,
 ) -> Result<Vec<String>, anyhow::Error> {
-    let mut detected: Vec<String> = Vec::new();
+    Ok(detect_implicit_projects_with_publication(
+        store,
+        vault_root,
+        vault_uid,
+        instance_id,
+        dry_run,
+    )?
+    .projects)
+}
+
+/// Detect implicit projects and return the complete graph-publication result.
+///
+/// Callers that expose mutation status should use this form so a committed
+/// graph update followed by degraded generation/artifact reconciliation is not
+/// flattened into ordinary success.
+pub fn detect_implicit_projects_with_publication(
+    store: &GraphStore,
+    vault_root: &Path,
+    vault_uid: &str,
+    instance_id: &str,
+    dry_run: bool,
+) -> Result<ImplicitProjectDetectionResult, anyhow::Error> {
+    let mut detected: Vec<(String, String)> = Vec::new();
     for container in PROJECT_CONTAINER_DIRS {
         let projects_dir = vault_root.join(container);
         if !projects_dir.is_dir() {
             continue;
         }
-        detect_in_container(
-            store,
-            &projects_dir,
-            container,
-            vault_uid,
-            instance_id,
-            dry_run,
-            &mut detected,
-        )?;
+        detect_in_container(&projects_dir, container, &mut detected)?;
     }
-    Ok(detected)
+
+    let mut project_names = Vec::new();
+    let mut unique_names = std::collections::HashSet::new();
+    for (slug, _) in &detected {
+        if unique_names.insert(slug.clone()) {
+            project_names.push(slug.clone());
+        }
+    }
+
+    if dry_run || detected.is_empty() {
+        return Ok(ImplicitProjectDetectionResult {
+            projects: project_names,
+            publication: finalize_committed_graph_mutation(store, false),
+        });
+    }
+
+    // Plan every node and relationship before the single atomic store write.
+    // This prevents a later filesystem/read failure from leaving earlier
+    // Projects committed without a generation publication.
+    let all_notes = store.list_notes(Some(vault_uid))?;
+    let projects = project_names
+        .iter()
+        .map(|slug| Project {
+            uid: project_uid(instance_id, slug),
+            name: slug.clone(),
+            summary: None,
+            instance_id: instance_id.to_string(),
+        })
+        .collect::<Vec<_>>();
+    let mut note_edges = Vec::new();
+    for (slug, container) in &detected {
+        let uid = project_uid(instance_id, slug);
+        let prefix = format!("{container}/{slug}/");
+        note_edges.extend(
+            all_notes
+                .iter()
+                .filter(|note| note.file_path.starts_with(&prefix))
+                .map(|note| (uid.clone(), note.uid.clone())),
+        );
+    }
+    note_edges.sort();
+    note_edges.dedup();
+
+    let graph_publication = begin_graph_mutation_publication(store, "implicit Project detection")?;
+    let (graph_publication, replacement) = resolve_project_replacement(
+        graph_publication,
+        store.replace_implicit_project_note_memberships(&projects, &note_edges),
+    )?;
+    let publication = graph_publication.finish(replacement.changed())?;
+    Ok(ImplicitProjectDetectionResult {
+        projects: project_names,
+        publication,
+    })
 }
 
 fn detect_in_container(
-    store: &GraphStore,
     projects_dir: &Path,
     container: &str,
-    vault_uid: &str,
-    instance_id: &str,
-    dry_run: bool,
-    detected: &mut Vec<String>,
+    detected: &mut Vec<(String, String)>,
 ) -> Result<(), anyhow::Error> {
     let read_dir = std::fs::read_dir(projects_dir)?;
     for entry in read_dir {
@@ -609,42 +730,7 @@ fn detect_in_container(
         if !is_entry_note(&path, &slug) {
             continue;
         }
-        if dry_run {
-            detected.push(slug);
-            continue;
-        }
-
-        // Generate UID and create the Project node. If the node already
-        // exists the store will return a duplicate-key error; skip gracefully.
-        let uid = project_uid(instance_id, &slug);
-        let project = Project {
-            uid: uid.clone(),
-            name: slug.clone(),
-            summary: None,
-            instance_id: instance_id.to_string(),
-        };
-        if let Err(e) = store.upsert_project(&project) {
-            tracing::debug!(
-                "detect_implicit_projects: skipping '{}' (upsert_project failed: {e})",
-                slug
-            );
-            // Still wire up edges even if the upsert failed.
-            let _ = e;
-        }
-
-        // Attach all notes under <container>/<slug>/ via vault-relative paths.
-        let prefix = format!("{container}/{slug}/");
-        let all_notes = store.list_notes(Some(vault_uid))?;
-        let edges: Vec<(&str, &str)> = all_notes
-            .iter()
-            .filter(|n| n.file_path.starts_with(&prefix))
-            .map(|n| (uid.as_str(), n.uid.as_str()))
-            .collect();
-        if !edges.is_empty() {
-            store.batch_insert_project_note_edges(&edges)?;
-        }
-
-        detected.push(slug);
+        detected.push((slug, container.to_string()));
     }
 
     Ok(())
@@ -698,6 +784,101 @@ components = ["child-b"]
             err.to_string().contains("\"dup\""),
             "error must name the duplicate project, got: {err}"
         );
+    }
+
+    #[test]
+    fn invalid_configured_project_topology_retires_marker_without_advancing_generation() {
+        for (case, topology) in [
+            ("component", "components = [\"missing\"]"),
+            ("parent", "parent = \"missing\""),
+        ] {
+            let toml = format!(
+                r#"
+instance_id = "test-instance"
+
+[snapshot_storage]
+backend = "local"
+path = "/tmp/snapshots"
+
+[workspace]
+backend = "local"
+path = "/tmp/workspace"
+
+[inference]
+endpoint = "http://localhost:8080"
+embedding_model = "text-embedding-3-small"
+summary_model = "gpt-4o-mini"
+
+[git]
+credential_method = "ssh"
+
+[[projects]]
+name = "configured"
+{topology}
+"#
+            );
+            let config = crate::config::InstanceConfig::from_toml_str(&toml).unwrap();
+            let dir = tempfile::tempdir().unwrap();
+            let db_path = dir.path().join(format!("{case}.lbug"));
+            let store = nestweaver_store::GraphStore::create(&db_path).unwrap();
+            let generation_before = store.graph_generation();
+
+            let error = super::materialize_projects(&store, &config, "test-instance", &db_path)
+                .err()
+                .expect("an undeclared Project endpoint must fail preflight");
+
+            assert!(error.to_string().contains("not configured"), "{error:#}");
+            assert_eq!(store.graph_generation(), generation_before);
+            assert!(
+                !crate::sidecar_path(&db_path, ".index-dirty").exists(),
+                "proven {case} preflight failure must retire the publication marker"
+            );
+        }
+    }
+
+    #[test]
+    fn typed_project_replacement_failure_retires_only_proven_restored_marker() {
+        for (case, disposition, marker_expected) in [
+            (
+                "restored",
+                nestweaver_store::ProjectMutationDisposition::ConfirmedRolledBack,
+                false,
+            ),
+            (
+                "ambiguous",
+                nestweaver_store::ProjectMutationDisposition::Ambiguous,
+                true,
+            ),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let db_path = dir.path().join(format!("{case}.lbug"));
+            let store = nestweaver_store::GraphStore::create(&db_path).unwrap();
+            let generation_before = store.graph_generation();
+            let publication = crate::manifest::begin_graph_mutation_publication(
+                &store,
+                format!("injected {case} Project replacement"),
+            )
+            .unwrap();
+            let injected = nestweaver_store::write::ReplaceMaterializedProjectsError {
+                disposition,
+                primary: nestweaver_store::StoreError::Query(format!(
+                    "injected {case} Project replacement failure"
+                )),
+            };
+
+            let error = match super::resolve_project_replacement(publication, Err(injected)) {
+                Ok(_) => panic!("injected replacement must remain an operation failure"),
+                Err(error) => error,
+            };
+
+            assert!(error.to_string().contains("injected"), "{error:#}");
+            assert_eq!(store.graph_generation(), generation_before);
+            assert_eq!(
+                crate::sidecar_path(&db_path, ".index-dirty").exists(),
+                marker_expected,
+                "{case} disposition retained the wrong publication-marker state"
+            );
+        }
     }
 
     #[test]
@@ -779,6 +960,244 @@ args = { page = "123" }
             vec![wiki_note_uid],
             "a transient remote failure must preserve the last good wiki membership"
         );
+    }
+
+    #[test]
+    fn explicit_project_materialization_versions_change_but_not_exact_noop() {
+        let toml = r#"
+instance_id = "test-instance"
+
+[snapshot_storage]
+backend = "local"
+path = "/tmp/snapshots"
+
+[workspace]
+backend = "local"
+path = "/tmp/workspace"
+
+[inference]
+endpoint = "http://localhost:8080"
+embedding_model = "text-embedding-3-small"
+summary_model = "gpt-4o-mini"
+
+[git]
+credential_method = "ssh"
+
+[[projects]]
+name = "stable"
+description = "Stable project"
+"#;
+        let config = crate::config::InstanceConfig::from_toml_str(toml).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("brain.lbug");
+        let store = nestweaver_store::GraphStore::create(&db_path).unwrap();
+
+        let changed =
+            super::materialize_projects(&store, &config, "test-instance", &db_path).unwrap();
+        assert_eq!(
+            changed.publication.disposition,
+            crate::manifest::GraphMutationPublicationDisposition::CommittedComplete
+        );
+        assert_eq!(
+            changed.publication.generation_after,
+            changed.publication.generation_before + 1
+        );
+
+        let unchanged =
+            super::materialize_projects(&store, &config, "test-instance", &db_path).unwrap();
+        assert_eq!(
+            unchanged.publication.disposition,
+            crate::manifest::GraphMutationPublicationDisposition::ConfirmedNoChange
+        );
+        assert_eq!(
+            unchanged.publication.generation_after,
+            changed.publication.generation_after
+        );
+        assert!(
+            !crate::sidecar_path(&db_path, ".index-dirty").exists(),
+            "clean and no-op publications must both retire the crash fence"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_wiki_source_keeps_all_project_memberships_and_repeats_as_exact_noop() {
+        use nestweaver_schema::{note_uid, project_uid};
+
+        let dir = tempfile::tempdir().unwrap();
+        let server_path = dir.path().join("mock-mcp.sh");
+        std::fs::write(
+            &server_path,
+            r##"while IFS= read -r request; do
+  case "$request" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{}}'
+      ;;
+    *'"method":"tools/call"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"# Shared Wiki\nOne canonical document."}],"isError":false}}'
+      ;;
+  esac
+done
+"##,
+        )
+        .unwrap();
+        let toml = format!(
+            r#"
+instance_id = "test-instance"
+
+[snapshot_storage]
+backend = "local"
+path = "/tmp/snapshots"
+
+[workspace]
+backend = "local"
+path = "/tmp/workspace"
+
+[inference]
+endpoint = "http://localhost:8080"
+embedding_model = "text-embedding-3-small"
+summary_model = "gpt-4o-mini"
+
+[git]
+credential_method = "ssh"
+
+[[projects]]
+name = "alpha"
+
+[[projects.wiki_sources]]
+label = "Architecture"
+mcp_server = "mock"
+tool = "get_page"
+args = {{ page = "shared" }}
+
+[[projects]]
+name = "beta"
+
+[[projects.wiki_sources]]
+label = "Architecture"
+mcp_server = "mock"
+tool = "get_page"
+args = {{ page = "shared" }}
+
+[[mcp_servers]]
+name = "mock"
+command = "/bin/sh"
+args = ["{}"]
+timeout_secs = 5
+"#,
+            server_path.display()
+        );
+        let config = crate::config::InstanceConfig::from_toml_str(&toml).unwrap();
+        let db_path = dir.path().join("brain.lbug");
+        let store = nestweaver_store::GraphStore::create(&db_path).unwrap();
+
+        let first =
+            super::materialize_projects(&store, &config, "test-instance", &db_path).unwrap();
+        let alpha_uid = project_uid("test-instance", "alpha");
+        let beta_uid = project_uid("test-instance", "beta");
+        let shared_note_uid = note_uid("wiki:mock", "get_page/Architecture");
+        for project_uid in [&alpha_uid, &beta_uid] {
+            assert_eq!(
+                store.list_project_note_uids(project_uid).unwrap(),
+                vec![shared_note_uid.clone()],
+                "the shared wiki Note must remain attached to every configured Project"
+            );
+        }
+        assert_eq!(
+            store
+                .list_notes(None)
+                .unwrap()
+                .into_iter()
+                .filter(|note| note.uid == shared_note_uid)
+                .count(),
+            1,
+            "shared Project membership must use one canonical wiki Note"
+        );
+        assert_eq!(first.wiki_notes_ingested, 1);
+
+        let second =
+            super::materialize_projects(&store, &config, "test-instance", &db_path).unwrap();
+        assert_eq!(
+            second.publication.disposition,
+            crate::manifest::GraphMutationPublicationDisposition::ConfirmedNoChange
+        );
+        assert_eq!(
+            second.publication.generation_after, first.publication.generation_after,
+            "an identical shared-source rerun must not advance graph generation"
+        );
+    }
+
+    #[test]
+    fn implicit_project_detection_versions_atomic_change_and_dry_run_is_noop() {
+        use nestweaver_schema::{Note, NoteKind};
+
+        let dir = tempfile::tempdir().unwrap();
+        let vault_root = dir.path().join("vault");
+        let project_dir = vault_root.join("Workspaces/alpha");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(project_dir.join("_Overview.md"), "# Alpha").unwrap();
+        let db_path = dir.path().join("brain.lbug");
+        let store = nestweaver_store::GraphStore::create(&db_path).unwrap();
+        store
+            .insert_note(&Note {
+                uid: "note:vault:alpha".to_string(),
+                vault_uid: "vault:test".to_string(),
+                file_path: "Workspaces/alpha/_Overview.md".to_string(),
+                title: "Alpha".to_string(),
+                note_kind: NoteKind::General,
+                word_count: 1,
+                content_hash: "alpha".to_string(),
+                frontmatter: None,
+                frontmatter_raw: None,
+                created_at: None,
+                modified_at: None,
+                pagerank_score: None,
+                embedding: None,
+            })
+            .unwrap();
+
+        let dry_run = super::detect_implicit_projects_with_publication(
+            &store,
+            &vault_root,
+            "vault:test",
+            "test-instance",
+            true,
+        )
+        .unwrap();
+        assert_eq!(dry_run.projects, vec!["alpha"]);
+        assert_eq!(
+            dry_run.publication.disposition,
+            crate::manifest::GraphMutationPublicationDisposition::ConfirmedNoChange
+        );
+        assert_eq!(store.graph_generation(), 0);
+
+        let changed = super::detect_implicit_projects_with_publication(
+            &store,
+            &vault_root,
+            "vault:test",
+            "test-instance",
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            changed.publication.disposition,
+            crate::manifest::GraphMutationPublicationDisposition::CommittedComplete
+        );
+        assert_eq!(changed.publication.generation_after, 1);
+
+        let unchanged = super::detect_implicit_projects_with_publication(
+            &store,
+            &vault_root,
+            "vault:test",
+            "test-instance",
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            unchanged.publication.disposition,
+            crate::manifest::GraphMutationPublicationDisposition::ConfirmedNoChange
+        );
+        assert_eq!(store.graph_generation(), 1);
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/publication.rs
+++ b/crates/nestweaver-engine/src/publication.rs
@@ -734,6 +734,42 @@ pub fn default_publication_root(db_path: &Path) -> PathBuf {
     crate::sidecar_path(db_path, ".publications")
 }
 
+/// POSIX record locks do not conflict with another descriptor in the same
+/// process. Claim the canonical root before opening its lock file so a second
+/// in-process publication operation cannot slip past that compatibility gate.
+/// Spawned children are expected to exec before entering NestWeaver code; a
+/// fork-only child inherits a stale copy of this process-local registry.
+static PROCESS_PUBLICATION_ROOTS: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashSet<PathBuf>>,
+> = std::sync::OnceLock::new();
+
+#[derive(Debug)]
+struct ProcessPublicationRootClaim {
+    path: PathBuf,
+}
+
+impl ProcessPublicationRootClaim {
+    fn acquire(path: &Path) -> Option<Self> {
+        let mut claimed = PROCESS_PUBLICATION_ROOTS
+            .get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        claimed.insert(path.to_path_buf()).then(|| Self {
+            path: path.to_path_buf(),
+        })
+    }
+}
+
+impl Drop for ProcessPublicationRootClaim {
+    fn drop(&mut self) {
+        PROCESS_PUBLICATION_ROOTS
+            .get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(&self.path);
+    }
+}
+
 /// Cross-process exclusion for one publication root.
 ///
 /// The `IndexPublicationLease` is an in-process coordinator — a `Mutex` plus a
@@ -752,15 +788,21 @@ pub fn default_publication_root(db_path: &Path) -> PathBuf {
 #[derive(Debug)]
 pub struct PublicationRootLock {
     _file: std::fs::File,
+    root: PathBuf,
     path: PathBuf,
+    // Declared last so the OS lock closes before another thread in this
+    // process can claim the root.
+    _process_claim: ProcessPublicationRootClaim,
 }
 
 impl PublicationRootLock {
     /// Take the lock, or fail fast if another operation holds it.
     ///
-    /// Deliberately non-blocking: a publication rebuild can run for minutes, and
-    /// a CLI that silently hangs behind one is worse than a CLI that says who is
-    /// holding it and exits.
+    /// A live external owner is refused without queueing: a publication rebuild
+    /// can run for minutes, and a CLI must report that contention rather than
+    /// silently wait. On Unix, acquisition may retry for at most 500 ms after a
+    /// non-inherited POSIX lock proves that the only remaining contention is a
+    /// stale flock description in another thread's fork-before-exec window.
     pub fn acquire(publication_root: &Path) -> anyhow::Result<Self> {
         std::fs::create_dir_all(publication_root).with_context(|| {
             format!(
@@ -768,7 +810,16 @@ impl PublicationRootLock {
                 publication_root.display()
             )
         })?;
-        let path = publication_root.join("LOCK");
+        let canonical_root = std::fs::canonicalize(publication_root).with_context(|| {
+            format!(
+                "resolve publication root {} for locking",
+                publication_root.display()
+            )
+        })?;
+        let path = canonical_root.join("LOCK");
+        let process_claim = ProcessPublicationRootClaim::acquire(&path).ok_or_else(|| {
+            publication_lock_contention(&path, std::io::ErrorKind::WouldBlock.into())
+        })?;
         let file = std::fs::OpenOptions::new()
             .create(true)
             .read(true)
@@ -776,20 +827,92 @@ impl PublicationRootLock {
             .truncate(false)
             .open(&path)
             .with_context(|| format!("open publication lock {}", path.display()))?;
-        file.try_lock().map_err(|error| {
-            anyhow::anyhow!(
-                "another publication operation holds {} ({error}); wait for it to finish, \
-                 or check `nestweaver publication status`",
-                path.display()
-            )
-        })?;
-        Ok(Self { _file: file, path })
+        lock_publication_file(&file).map_err(|error| publication_lock_contention(&path, error))?;
+        Ok(Self {
+            _file: file,
+            root: canonical_root,
+            path,
+            _process_claim: process_claim,
+        })
     }
 
     /// The lock file backing this guard, for diagnostics.
     pub fn path(&self) -> &Path {
         &self.path
     }
+
+    /// Whether this guard covers exactly this publication root after resolving
+    /// relative paths and symlink aliases.
+    pub fn authorizes(&self, publication_root: &Path) -> bool {
+        std::fs::canonicalize(publication_root).is_ok_and(|root| root == self.root)
+    }
+
+    fn ensure_authorizes(&self, publication_root: &Path) -> anyhow::Result<&Path> {
+        if self.authorizes(publication_root) {
+            Ok(&self.root)
+        } else {
+            anyhow::bail!(
+                "publication root lock for {} does not authorize {}",
+                self.root.display(),
+                publication_root.display()
+            )
+        }
+    }
+}
+
+fn publication_lock_contention(path: &Path, error: std::io::Error) -> anyhow::Error {
+    anyhow::anyhow!(
+        "another publication operation holds {} ({error}); wait for it to finish, \
+         or check `nestweaver publication status`",
+        path.display()
+    )
+}
+
+#[cfg(unix)]
+fn lock_publication_file(file: &std::fs::File) -> std::io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+
+    // A POSIX record lock is not inherited across fork. It therefore remains
+    // the fail-fast authority for a live external process even when a child
+    // briefly retains the previous owner's flock description before exec.
+    let mut record_lock: libc::flock = unsafe { std::mem::zeroed() };
+    record_lock.l_type = libc::F_WRLCK as libc::c_short;
+    record_lock.l_whence = libc::SEEK_SET as libc::c_short;
+    if unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETLK, &record_lock) } != 0 {
+        let error = std::io::Error::last_os_error();
+        return if error
+            .raw_os_error()
+            .is_some_and(|code| code == libc::EACCES || code == libc::EAGAIN)
+        {
+            Err(std::io::ErrorKind::WouldBlock.into())
+        } else {
+            Err(error)
+        };
+    }
+
+    // `flock` is tied to the open file description and that description is
+    // inherited by fork. Rust descriptors are CLOEXEC, but another thread's
+    // child can keep a just-dropped owner's lock alive until exec. Retry only
+    // after the non-inherited POSIX authority above succeeds; a genuine live
+    // external owner still fails immediately at that first gate.
+    for attempt in 0..=100 {
+        match file.try_lock() {
+            Ok(()) => return Ok(()),
+            Err(std::fs::TryLockError::WouldBlock) if attempt < 100 => {
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
+            Err(std::fs::TryLockError::WouldBlock) => {
+                return Err(std::io::ErrorKind::WouldBlock.into());
+            }
+            Err(std::fs::TryLockError::Error(error)) => return Err(error),
+        }
+    }
+    unreachable!("bounded publication flock retry always returns")
+}
+
+#[cfg(not(unix))]
+fn lock_publication_file(file: &std::fs::File) -> std::io::Result<()> {
+    file.try_lock().map_err(Into::into)
 }
 
 /// One slot considered by [`prune_slots`].
@@ -872,10 +995,10 @@ pub fn prune_slots(
     // discard — and what stops a cutover landing between the CURRENT read below
     // and the deletes further down, which would reclaim the slot that cutover
     // had just selected.
-    debug_assert!(
-        lock.path().starts_with(publication_root),
-        "the lock must guard the root being pruned"
-    );
+    // Continue through the canonical root held by the guard. Besides making
+    // authorization exact in release builds, this keeps a symlink alias from
+    // being retargeted between the coverage check and the filesystem work.
+    let publication_root = lock.ensure_authorizes(publication_root)?;
     let slots_dir = publication_root.join("slots");
     let entries = match std::fs::read_dir(&slots_dir) {
         Ok(entries) => entries,
@@ -1380,8 +1503,9 @@ pub fn rollback_current_under_lock(
     publication_root: &Path,
     lease: &nestweaver_store::IndexPublicationLease<'_>,
     expected_current: &str,
-    _root_lock: &PublicationRootLock,
+    root_lock: &PublicationRootLock,
 ) -> anyhow::Result<Option<CurrentPublicationPointer>> {
+    let publication_root = root_lock.ensure_authorizes(publication_root)?;
     lease
         .ensure_clean_for_snapshot()
         .map_err(|error| anyhow::anyhow!("refusing CURRENT rollback from dirty graph: {error}"))?;
@@ -2112,29 +2236,138 @@ mod tests {
             "the refusal must name the contention: {error}"
         );
 
-        // Cross-PROCESS, not merely cross-handle: a child that tries the same
-        // root must also be refused while this process holds it.
-        let probe = std::process::Command::new("/bin/sh")
-            .arg("-c")
-            .arg(format!(
-                "exec 9>>'{}' && flock -n 9 && echo FREE || echo HELD",
-                root.join("LOCK").display()
-            ))
-            .output();
-        if let Ok(probe) = probe {
-            let observed = String::from_utf8_lossy(&probe.stdout);
-            // `flock(1)` is absent on macOS; only assert where it exists.
-            if observed.contains("HELD") || observed.contains("FREE") {
-                assert!(
-                    observed.contains("HELD"),
-                    "another process must observe the lock as held: {observed}"
-                );
-            }
-        }
+        // Cross-PROCESS, through the production API rather than a platform
+        // shell utility: exec a fresh copy of this test binary and have its
+        // focused child test attempt the same canonical root.
+        let probe = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("publication::tests::publication_root_lock_child_probe")
+            .arg("--exact")
+            .arg("--nocapture")
+            .env("NESTWEAVER_PUBLICATION_LOCK_PROBE_ROOT", &root)
+            .output()
+            .expect("run publication lock child probe");
+        assert!(
+            probe.status.success(),
+            "another process must observe the production lock as held\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&probe.stdout),
+            String::from_utf8_lossy(&probe.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&probe.stdout).contains("running 1 test"),
+            "the exact child probe must actually run\nstdout:\n{}",
+            String::from_utf8_lossy(&probe.stdout)
+        );
 
         drop(held);
         PublicationRootLock::acquire(&root)
             .expect("the lock must be released when its guard drops");
+    }
+
+    #[test]
+    fn publication_root_lock_child_probe() {
+        let Some(root) = std::env::var_os("NESTWEAVER_PUBLICATION_LOCK_PROBE_ROOT") else {
+            return;
+        };
+        let error = PublicationRootLock::acquire(Path::new(&root))
+            .expect_err("the parent process must retain publication-root ownership");
+        assert!(
+            error.to_string().contains("another publication operation"),
+            "the production API must report cross-process contention: {error}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_inherited_lock_description_does_not_outlive_publication_ownership() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("brain.lbug.publications");
+        std::fs::create_dir(&root).unwrap();
+        let path = root.join("LOCK");
+        let owner = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&path)
+            .unwrap();
+        lock_publication_file(&owner).unwrap();
+
+        // A cloned descriptor shares the same open file description, exactly
+        // as a forked child does before exec. Closing `owner` releases the
+        // process-scoped POSIX lock, but the clone keeps flock alive briefly.
+        let inherited = owner.try_clone().unwrap();
+        drop(owner);
+        let child_window = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            drop(inherited);
+        });
+
+        let replacement = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        lock_publication_file(&replacement)
+            .expect("a stale inherited flock must not manufacture live publication contention");
+        child_window.join().unwrap();
+    }
+
+    #[test]
+    fn publication_root_authorization_is_canonical_and_exact() {
+        let relative_parent = tempfile::Builder::new()
+            .prefix("publication-relative-")
+            .tempdir_in(".")
+            .unwrap();
+        let relative_root = relative_parent
+            .path()
+            .strip_prefix(std::env::current_dir().unwrap())
+            .unwrap()
+            .join("publications");
+        assert!(
+            relative_root.is_relative(),
+            "fixture must exercise a relative root"
+        );
+        std::fs::create_dir(&relative_root).unwrap();
+        let lock = PublicationRootLock::acquire(&relative_root).unwrap();
+        assert!(lock.authorizes(&relative_root));
+        assert!(
+            prune_slots(&relative_root, &lock, true)
+                .unwrap()
+                .slots
+                .is_empty()
+        );
+
+        let unrelated = relative_parent.path().join("unrelated-publications");
+        std::fs::create_dir(&unrelated).unwrap();
+        assert!(!lock.authorizes(&unrelated));
+        let error = prune_slots(&unrelated, &lock, true).unwrap_err();
+        assert!(
+            error.to_string().contains("does not authorize"),
+            "wrong-root prune must fail closed: {error}"
+        );
+        let store = nestweaver_store::GraphStore::in_memory().unwrap();
+        let lease = store.acquire_index_publication_lease().unwrap();
+        let error = rollback_current_under_lock(&unrelated, &lease, "unused", &lock).unwrap_err();
+        assert!(
+            error.to_string().contains("does not authorize"),
+            "wrong-root rollback must fail before inspecting the target: {error}"
+        );
+        lease.release().unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn publication_root_authorization_accepts_a_symlink_alias() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("publications");
+        let alias = dir.path().join("publications-alias");
+        std::fs::create_dir(&root).unwrap();
+        std::os::unix::fs::symlink(&root, &alias).unwrap();
+
+        let lock = PublicationRootLock::acquire(&alias).unwrap();
+        assert!(lock.authorizes(&alias));
+        assert!(lock.authorizes(&root));
+        assert!(prune_slots(&alias, &lock, true).unwrap().slots.is_empty());
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/publication.rs
+++ b/crates/nestweaver-engine/src/publication.rs
@@ -800,9 +800,9 @@ impl PublicationRootLock {
     ///
     /// A live external owner is refused without queueing: a publication rebuild
     /// can run for minutes, and a CLI must report that contention rather than
-    /// silently wait. On Unix, acquisition may retry for at most 500 ms after a
-    /// non-inherited POSIX lock proves that the only remaining contention is a
-    /// stale flock description in another thread's fork-before-exec window.
+    /// silently wait. On Unix, acquisition may retry for at most 500 ms so a
+    /// stale flock description in another thread's fork-before-exec window
+    /// cannot manufacture durable contention.
     pub fn acquire(publication_root: &Path) -> anyhow::Result<Self> {
         std::fs::create_dir_all(publication_root).with_context(|| {
             format!(
@@ -870,31 +870,17 @@ fn publication_lock_contention(path: &Path, error: std::io::Error) -> anyhow::Er
 
 #[cfg(unix)]
 fn lock_publication_file(file: &std::fs::File) -> std::io::Result<()> {
-    use std::os::unix::io::AsRawFd;
-
-    // A POSIX record lock is not inherited across fork. It therefore remains
-    // the fail-fast authority for a live external process even when a child
-    // briefly retains the previous owner's flock description before exec.
-    let mut record_lock: libc::flock = unsafe { std::mem::zeroed() };
-    record_lock.l_type = libc::F_WRLCK as libc::c_short;
-    record_lock.l_whence = libc::SEEK_SET as libc::c_short;
-    if unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETLK, &record_lock) } != 0 {
-        let error = std::io::Error::last_os_error();
-        return if error
-            .raw_os_error()
-            .is_some_and(|code| code == libc::EACCES || code == libc::EAGAIN)
-        {
-            Err(std::io::ErrorKind::WouldBlock.into())
-        } else {
-            Err(error)
-        };
-    }
-
-    // `flock` is tied to the open file description and that description is
-    // inherited by fork. Rust descriptors are CLOEXEC, but another thread's
-    // child can keep a just-dropped owner's lock alive until exec. Retry only
-    // after the non-inherited POSIX authority above succeeds; a genuine live
-    // external owner still fails immediately at that first gate.
+    // Keep this inode on one lock interface. Linux treats flock and POSIX
+    // record locks independently, while macOS makes them cooperate; layering
+    // both on one descriptor can therefore contend with this process's own
+    // lock. Publication roots have always coordinated through flock, so that
+    // is also the protocol compatible with a live pre-upgrade process. The
+    // process-local claim closes the same-process duplicate-descriptor gap.
+    //
+    // A flock is inherited across fork. Rust descriptors are CLOEXEC, but
+    // another thread's child can briefly keep a just-dropped owner's open file
+    // description alive until exec, so bound the retry instead of turning that
+    // window into false durable contention.
     for attempt in 0..=100 {
         match file.try_lock() {
             Ok(()) => return Ok(()),
@@ -2294,7 +2280,7 @@ mod tests {
 
         // A cloned descriptor shares the same open file description, exactly
         // as a forked child does before exec. Closing `owner` releases the
-        // process-scoped POSIX lock, but the clone keeps flock alive briefly.
+        // lock owner's description, so the clone keeps flock alive briefly.
         let inherited = owner.try_clone().unwrap();
         drop(owner);
         let child_window = std::thread::spawn(move || {

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -1764,6 +1764,13 @@ pub fn build_brain_context_hybrid_with_aliases(
     // relevant neighborhoods even when the textual seeds miss them. The full
     // hit list is passed to weighted_score_fuse as the semantic signal.
     let semantic_requested = config.weight_semantic > 0.0;
+    // Identity corruption is not an ordinary unavailable-model condition.
+    // Guard at the transport-independent core boundary, before the empty-index
+    // fast path or model inference can silently turn a requested semantic leg
+    // into a successful lexical/PPR-only response.
+    if semantic_requested {
+        store.require_verified_embedding_identity()?;
+    }
     let mut semantic_applied = false;
     let mut semantic_seed_count: usize = 0;
     let mut semantic_hits: Vec<(String, f64)> = Vec::new();

--- a/crates/nestweaver-engine/src/resolver_generation.rs
+++ b/crates/nestweaver-engine/src/resolver_generation.rs
@@ -19,7 +19,9 @@
 //! existed has no entry — which is exactly the "predates the fix" answer we
 //! want, at zero migration cost.
 
+use anyhow::Context;
 use nestweaver_schema::Repo;
+use nestweaver_store::GraphStore;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -97,7 +99,8 @@ impl ResolverGenerations {
         self.repos.get(repo_uid).copied().unwrap_or(0)
     }
 
-    /// Repo uids whose edges predate [`RESOLVER_GENERATION`], SORTED.
+    /// Repo uids whose edges were not produced by exactly
+    /// [`RESOLVER_GENERATION`], SORTED.
     ///
     /// nw-358. This is the sole computation behind every route's
     /// `stale_repos` — the CLI's two staleness constructors, `hub_nodes` /
@@ -116,7 +119,7 @@ impl ResolverGenerations {
     pub fn stale_repos<'a, I: IntoIterator<Item = &'a str>>(&self, known: I) -> Vec<String> {
         let mut stale: Vec<String> = known
             .into_iter()
-            .filter(|uid| self.generation_for(uid) < RESOLVER_GENERATION)
+            .filter(|uid| self.generation_for(uid) != RESOLVER_GENERATION)
             .map(|uid| uid.to_string())
             .collect();
         stale.sort_unstable();
@@ -134,6 +137,38 @@ pub fn load(db_path: &Path) -> ResolverGenerations {
         .ok()
         .and_then(|s| serde_json::from_str(&s).ok())
         .unwrap_or_default()
+}
+
+/// Stable descriptor carried by every edge-dependent analysis that cannot
+/// trust the resolver generation recorded for its graph.
+pub const INCOMPATIBLE_RESOLVER_DESCRIPTOR: &str = "resolver-generation-incompatible";
+
+/// Return every repository whose persisted edges are incompatible with the
+/// running resolver.
+///
+/// In-memory stores have no persisted sidecar and are used heavily by pure
+/// analysis tests, so there is no disk generation to prove or reject. Every
+/// disk-backed store is checked, including absent and unreadable sidecars:
+/// [`load`] maps both to generation zero, which is deliberately incompatible.
+pub fn incompatible_repos_for_store(store: &GraphStore) -> anyhow::Result<Vec<String>> {
+    let Some(db_path) = store.db_path() else {
+        return Ok(Vec::new());
+    };
+    let repos = store
+        .list_repos(None)
+        .context("list repositories for resolver-generation compatibility")?;
+    Ok(load(db_path).stale_repos(repos.iter().map(|repo| repo.uid.as_str())))
+}
+
+/// One shared diagnostic for affected-tests, detect-changes, and blast-radius.
+pub fn incompatibility_message(repos: &[String]) -> String {
+    format!(
+        "edge-dependent analysis cannot trust repositories with a resolver generation that \
+         differs from the running generation {}: {}. Re-index each repository with \
+         `nestweaver index --repo <path> --force`",
+        RESOLVER_GENERATION,
+        repos.join(", ")
+    )
 }
 
 /// Record that `repo_uid` was just indexed by the current resolver.
@@ -174,7 +209,7 @@ pub fn staleness_note(db_path: &Path, repo_uids: &[String]) -> Option<String> {
 /// drift from this one the first time either is edited.
 ///
 /// `total` is `None` where the population is genuinely unknown. It is rendered
-/// as a floor ("N repo(s) are known to have been") rather than by inventing a
+/// as a floor ("N repo(s) are known to be incompatible") rather than by inventing a
 /// denominator, because on that route `stale_repos` can UNDER-count: the
 /// sidecar fallback for a pre-`attach_ranking_staleness` daemon sees only the
 /// repos the sidecar records, and a repo present in the graph but absent from
@@ -196,13 +231,14 @@ pub fn staleness_note_for(stale: &[String], total: Option<usize>) -> Option<Stri
     }
     let scope = match total {
         Some(total) => format!("{} of {total} repo(s) were", stale.len()),
-        None => format!("{} repo(s) are known to have been", stale.len()),
+        None => format!("{} repo(s) are known to be", stale.len()),
     };
     Some(format!(
-        "{scope} indexed by an older resolver, so their edges are the ones that \
-         resolver wrote: rankings over them are wrong, and edge families added since \
-         (C/C++ MEMBER_OF, C++ IMPORTS) are absent entirely. Upgrading the binary does \
-         not repair data already on disk. Re-index each one with \
+        "{scope} incompatible with this resolver. This includes repositories indexed by an \
+         older resolver, repositories with missing or unreadable generation metadata, and \
+         repositories claiming a future generation this binary cannot understand. Their edges \
+         cannot be trusted: rankings may be wrong, and edge families may be absent entirely. \
+         Upgrading the binary does not repair data already on disk. Re-index each one with \
          `nestweaver index --repo <path> --force`."
     ))
 }
@@ -443,12 +479,105 @@ mod tests {
     }
 
     #[test]
-    fn only_repos_below_the_current_generation_are_stale() {
+    fn only_the_exact_current_generation_is_compatible() {
         let mut g = ResolverGenerations::default();
         g.repos.insert("fresh".into(), RESOLVER_GENERATION);
         g.repos.insert("ancient".into(), 0);
-        let stale = g.stale_repos(vec!["fresh", "ancient", "unrecorded"]);
-        assert_eq!(stale, vec!["ancient".to_string(), "unrecorded".to_string()]);
+        g.repos.insert("future".into(), RESOLVER_GENERATION + 1);
+        let stale = g.stale_repos(vec!["fresh", "future", "ancient", "unrecorded"]);
+        assert_eq!(
+            stale,
+            vec![
+                "ancient".to_string(),
+                "future".to_string(),
+                "unrecorded".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn corrupt_and_missing_sidecars_fail_closed_for_known_repositories() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("g.lbug");
+        let known = ["repo:a"];
+
+        assert_eq!(load(&db).stale_repos(known), vec!["repo:a"]);
+        std::fs::write(
+            crate::sidecar_path(&db, RESOLVER_GENERATION_SIDECAR),
+            "not-json",
+        )
+        .unwrap();
+        assert_eq!(load(&db).stale_repos(known), vec!["repo:a"]);
+    }
+
+    #[test]
+    fn all_changed_file_engines_share_the_same_incompatible_repo_preflight() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("g.lbug");
+        let store = GraphStore::open_or_create(&db).unwrap();
+        let repo = Repo {
+            uid: "repo:default:future".into(),
+            url: "file:///tmp/future".into(),
+            indexed_sha: "deadbeef".into(),
+            staleness_commits_behind: 0,
+            instance_id: "default".into(),
+            name: None,
+            root_path: Some("/tmp/future".into()),
+        };
+        store.insert_repo(&repo).unwrap();
+        record(&db, &repo.uid).unwrap();
+
+        let files = vec!["src/new.rs".to_string()];
+        assert!(
+            crate::affected_tests::affected_tests(&store, &files)
+                .unwrap()
+                .resolver_stale_repos
+                .is_empty()
+        );
+
+        let mut generations = load(&db);
+        generations
+            .repos
+            .insert(repo.uid.clone(), RESOLVER_GENERATION + 1);
+        std::fs::write(
+            crate::sidecar_path(&db, RESOLVER_GENERATION_SIDECAR),
+            serde_json::to_string(&generations).unwrap(),
+        )
+        .unwrap();
+
+        let affected = crate::affected_tests::affected_tests(&store, &files).unwrap();
+        assert_eq!(affected.resolver_stale_repos, vec![repo.uid.clone()]);
+        assert_eq!(affected.recommendation, "run-full-suite");
+
+        let detected = crate::process::detect_changes_impact(&store, &files, 3).unwrap();
+        assert_eq!(detected.resolver_stale_repos, vec![repo.uid.clone()]);
+        assert_eq!(
+            detected.gate_state,
+            crate::blast_radius::GateState::DegradedUnknown
+        );
+
+        let blast = crate::blast_radius::analyze_blast_radius(
+            &store,
+            &[std::path::PathBuf::from("src/new.rs")],
+            &crate::blast_radius::BlastRadiusOptions::default(),
+            None,
+            Some(&db),
+        )
+        .unwrap();
+        assert_eq!(blast.resolver_stale_repos, vec![repo.uid]);
+        assert_eq!(
+            blast.gate_state,
+            crate::blast_radius::GateState::DegradedUnknown
+        );
+        for notifications in [
+            &affected.notifications,
+            &detected.notifications,
+            &blast.notifications,
+        ] {
+            assert!(notifications.iter().any(|notification| {
+                notification.descriptor == INCOMPATIBLE_RESOLVER_DESCRIPTOR
+            }));
+        }
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/rts_eval.rs
+++ b/crates/nestweaver-engine/src/rts_eval.rs
@@ -614,7 +614,26 @@ pub fn run_recorded(
     changed_files: &[String],
     db_path: Option<&Path>,
 ) -> Result<AffectedTestsResult> {
-    let mut result = crate::affected_tests::affected_tests(store, changed_files)?;
+    let result = crate::affected_tests::affected_tests(store, changed_files)?;
+    attach_recording(store, result, db_path)
+}
+
+/// Recorded affected-test selection for a trusted VCS-derived diff, including
+/// the valid zero-change case.
+pub fn run_recorded_derived_diff(
+    store: &nestweaver_store::GraphStore,
+    changed_files: &[String],
+    db_path: Option<&Path>,
+) -> Result<AffectedTestsResult> {
+    let result = crate::affected_tests::affected_tests_for_derived_diff(store, changed_files)?;
+    attach_recording(store, result, db_path)
+}
+
+fn attach_recording(
+    store: &nestweaver_store::GraphStore,
+    mut result: AffectedTestsResult,
+    db_path: Option<&Path>,
+) -> Result<AffectedTestsResult> {
     let Some(db) = db_path else {
         return Ok(result);
     };
@@ -775,6 +794,7 @@ mod tests {
             disclaimer: String::new(),
             status: AnalysisStatus::Complete,
             notifications: Vec::new(),
+            resolver_stale_repos: Vec::new(),
             recommendation: "selection-usable".to_string(),
             measured: None,
         }

--- a/crates/nestweaver-engine/src/snapshot.rs
+++ b/crates/nestweaver-engine/src/snapshot.rs
@@ -406,6 +406,49 @@ fn sync_directory_tree(root: &Path) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// Copy a rebuildable, generation-bound sidecar into a snapshot only when its
+/// full identity/schema/fingerprint/payload contract is valid for the graph
+/// being captured.
+///
+/// Generation staleness is the one recoverable case: the graph is healthy and
+/// the optional artifact can be recomputed, so omit it with a warning. Every
+/// other validation failure remains fatal rather than laundering a foreign or
+/// corrupt artifact into an apparently valid snapshot.
+fn copy_optional_generation_bound_sidecar(
+    logical_path: &str,
+    source: &Path,
+    destination: &Path,
+    stamp: &Stamp,
+    source_graph_generation: u64,
+) -> Result<bool, anyhow::Error> {
+    match artifact_contract_for_path(logical_path, source, stamp, source_graph_generation) {
+        Ok(_) => {}
+        Err(error) => {
+            let message = format!("{error:#}");
+            if nestweaver_store::artifact_envelope::is_stale_artifact_generation(&message) {
+                tracing::warn!(
+                    artifact = logical_path,
+                    source = %source.display(),
+                    reason = %message,
+                    "omitting generation-stale optional artifact from snapshot; rebuild it after restore"
+                );
+                return Ok(false);
+            }
+            return Err(anyhow::anyhow!(
+                "snapshot refused optional artifact {logical_path} at {}: {message}",
+                source.display()
+            ));
+        }
+    }
+    std::fs::copy(source, destination).map_err(|error| {
+        anyhow::anyhow!(
+            "failed to copy validated optional artifact {logical_path} from {}: {error}",
+            source.display()
+        )
+    })?;
+    Ok(true)
+}
+
 fn build_snapshot_files(
     output_dir: &Path,
     stamp: &Stamp,
@@ -426,12 +469,13 @@ fn build_snapshot_files(
     // ── Sidecars ────────────────────────────────────────────────────────────
     let pagerank_src = crate::sidecar_path(db_path, &format!(".{SIDECAR_PAGERANK}"));
     if pagerank_src.exists() {
-        std::fs::copy(&pagerank_src, output_dir.join(SIDECAR_PAGERANK)).map_err(|e| {
-            anyhow::anyhow!(
-                "failed to copy pagerank sidecar {}: {e}",
-                pagerank_src.display()
-            )
-        })?;
+        copy_optional_generation_bound_sidecar(
+            SIDECAR_PAGERANK,
+            &pagerank_src,
+            &output_dir.join(SIDECAR_PAGERANK),
+            stamp,
+            source_graph_generation,
+        )?;
     } else {
         tracing::debug!(
             src = %pagerank_src.display(),
@@ -441,12 +485,13 @@ fn build_snapshot_files(
 
     let manifests_src = crate::sidecar_path(db_path, &format!(".{SIDECAR_MANIFESTS}"));
     if manifests_src.exists() {
-        std::fs::copy(&manifests_src, output_dir.join(SIDECAR_MANIFESTS)).map_err(|e| {
-            anyhow::anyhow!(
-                "failed to copy manifests sidecar {}: {e}",
-                manifests_src.display()
-            )
-        })?;
+        copy_optional_generation_bound_sidecar(
+            SIDECAR_MANIFESTS,
+            &manifests_src,
+            &output_dir.join(SIDECAR_MANIFESTS),
+            stamp,
+            source_graph_generation,
+        )?;
     } else {
         tracing::debug!(
             src = %manifests_src.display(),
@@ -1564,6 +1609,149 @@ mod tests {
             .is_err(),
             "an incompatible snapshot must refuse to materialize"
         );
+    }
+
+    #[test]
+    fn build_omits_only_generation_stale_optional_derived_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let snap_dir = dir.path().join("snapshot");
+        let db = make_test_db(dir.path());
+        let store = nestweaver_store::GraphStore::open(&db).unwrap();
+        store
+            .compute_pagerank(
+                nestweaver_store::ranking::PAGERANK_DAMPING,
+                nestweaver_store::ranking::PAGERANK_ITERATIONS,
+                &nestweaver_store::ranking::GraphScope::code_only(),
+            )
+            .unwrap();
+        store
+            .save_pagerank_cache(&crate::sidecar_path(&db, ".pagerank.json"))
+            .unwrap();
+        crate::save_manifest_cache_for_db(&std::collections::HashMap::new(), &store, &db).unwrap();
+        store.bump_and_persist_graph_generation(&crate::sidecar_path(&db, ".generation"));
+        drop(store);
+
+        build_snapshot(
+            &snap_dir,
+            &make_stamp(env!("CARGO_PKG_VERSION"), "0.1.0", "schema-hash", "model"),
+            &make_manifest(),
+            &db,
+        )
+        .unwrap();
+
+        assert!(!snap_dir.join(SIDECAR_PAGERANK).exists());
+        assert!(!snap_dir.join(SIDECAR_MANIFESTS).exists());
+        verify_snapshot(&snap_dir).unwrap();
+    }
+
+    #[test]
+    fn build_refuses_corrupt_optional_derived_artifact_instead_of_omitting_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let snap_dir = dir.path().join("snapshot");
+        let db = make_test_db(dir.path());
+        let pagerank_path = crate::sidecar_path(&db, ".pagerank.json");
+        std::fs::write(&pagerank_path, b"not an artifact envelope").unwrap();
+
+        let error = build_snapshot(
+            &snap_dir,
+            &make_stamp(env!("CARGO_PKG_VERSION"), "0.1.0", "schema-hash", "model"),
+            &make_manifest(),
+            &db,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("snapshot refused optional artifact pagerank.json"));
+        assert!(!snap_dir.exists(), "failed snapshot must not be published");
+    }
+
+    #[test]
+    fn build_refuses_foreign_optional_derived_artifact_instead_of_omitting_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let foreign_dir = tempfile::tempdir().unwrap();
+        let snap_dir = dir.path().join("snapshot");
+        let db = make_test_db(dir.path());
+        let foreign_db = make_test_db(foreign_dir.path());
+        let foreign = nestweaver_store::GraphStore::open(&foreign_db).unwrap();
+        foreign
+            .compute_pagerank(
+                nestweaver_store::ranking::PAGERANK_DAMPING,
+                nestweaver_store::ranking::PAGERANK_ITERATIONS,
+                &nestweaver_store::ranking::GraphScope::code_only(),
+            )
+            .unwrap();
+        let foreign_pagerank = crate::sidecar_path(&foreign_db, ".pagerank.json");
+        foreign.save_pagerank_cache(&foreign_pagerank).unwrap();
+        std::fs::copy(
+            &foreign_pagerank,
+            crate::sidecar_path(&db, ".pagerank.json"),
+        )
+        .unwrap();
+
+        let error = build_snapshot(
+            &snap_dir,
+            &make_stamp(env!("CARGO_PKG_VERSION"), "0.1.0", "schema-hash", "model"),
+            &make_manifest(),
+            &db,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("foreign artifact identity"), "{error}");
+        assert!(!snap_dir.exists(), "failed snapshot must not be published");
+    }
+
+    #[test]
+    fn optional_derived_artifact_schema_and_fingerprint_mismatch_remain_fatal() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = make_test_db(dir.path());
+        let store = nestweaver_store::GraphStore::open(&db).unwrap();
+        store
+            .compute_pagerank(
+                nestweaver_store::ranking::PAGERANK_DAMPING,
+                nestweaver_store::ranking::PAGERANK_ITERATIONS,
+                &nestweaver_store::ranking::GraphScope::code_only(),
+            )
+            .unwrap();
+        let pagerank_path = crate::sidecar_path(&db, ".pagerank.json");
+        store.save_pagerank_cache(&pagerank_path).unwrap();
+        let identity = store.publication_identity().unwrap().unwrap();
+        let mut stamp = make_stamp(env!("CARGO_PKG_VERSION"), "0.1.0", "schema-hash", "model");
+        stamp.brain_uuid = identity.brain_uuid;
+        stamp.publication_uuid = identity.publication_uuid;
+        let valid: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&pagerank_path).unwrap()).unwrap();
+
+        for (field, replacement, expected) in [
+            (
+                "artifact_schema_version",
+                serde_json::json!(nestweaver_store::ranking::PAGERANK_ARTIFACT_SCHEMA_VERSION + 1),
+                "incompatible artifact",
+            ),
+            (
+                "algorithm_fingerprint",
+                serde_json::json!("foreign-fingerprint"),
+                "fingerprint",
+            ),
+        ] {
+            let mut mismatched = valid.clone();
+            mismatched[field] = replacement;
+            std::fs::write(&pagerank_path, serde_json::to_vec(&mismatched).unwrap()).unwrap();
+            let error = copy_optional_generation_bound_sidecar(
+                SIDECAR_PAGERANK,
+                &pagerank_path,
+                &dir.path().join(format!("copied-{field}.json")),
+                &stamp,
+                store.graph_generation(),
+            )
+            .unwrap_err()
+            .to_string();
+            assert!(error.contains(expected), "{field}: {error}");
+            assert!(
+                !nestweaver_store::artifact_envelope::is_stale_artifact_generation(&error),
+                "{field} mismatch must not be misclassified as rebuildable staleness"
+            );
+        }
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/watch_code.rs
+++ b/crates/nestweaver-engine/src/watch_code.rs
@@ -161,8 +161,26 @@ impl CodeWatcher {
     pub fn run(self) -> Result<(), anyhow::Error> {
         // nw-C1: this watcher is a writer, so it reconciles an abandoned
         // publication left by a crashed indexer instead of inheriting the wedge.
-        let store = Arc::new(crate::index::open_store_for_writing_with_recovery(
+        let authority =
+            nestweaver_store::acquire_db_write_lease(&self.db_path).map_err(|error| {
+                anyhow::anyhow!("cannot start code watcher without writer authority: {error:?}")
+            })?;
+        let store = Arc::new(crate::index::open_store_for_writing_with_authority(
             &self.db_path,
+            &authority,
+        )?);
+        self.run_inner(store, None)
+    }
+
+    /// Run under an exact writer authority already held by the caller for the
+    /// watcher's complete lifetime.
+    pub fn run_with_write_lease(
+        self,
+        authority: &nestweaver_store::DbWriteLease,
+    ) -> Result<(), anyhow::Error> {
+        let store = Arc::new(crate::index::open_store_for_writing_with_authority(
+            &self.db_path,
+            authority,
         )?);
         self.run_inner(store, None)
     }

--- a/crates/nestweaver-engine/src/watcher.rs
+++ b/crates/nestweaver-engine/src/watcher.rs
@@ -301,8 +301,26 @@ impl BrainWatcher {
     pub fn run(self) -> Result<(), anyhow::Error> {
         // nw-C1: this watcher is a writer, so it reconciles an abandoned
         // publication left by a crashed indexer instead of inheriting the wedge.
-        let store = Arc::new(crate::index::open_store_for_writing_with_recovery(
+        let authority =
+            nestweaver_store::acquire_db_write_lease(&self.db_path).map_err(|error| {
+                anyhow::anyhow!("cannot start brain watcher without writer authority: {error:?}")
+            })?;
+        let store = Arc::new(crate::index::open_store_for_writing_with_authority(
             &self.db_path,
+            &authority,
+        )?);
+        self.run_inner(store, None)
+    }
+
+    /// Run under an exact writer authority already held by the caller for the
+    /// watcher's complete lifetime.
+    pub fn run_with_write_lease(
+        self,
+        authority: &nestweaver_store::DbWriteLease,
+    ) -> Result<(), anyhow::Error> {
+        let store = Arc::new(crate::index::open_store_for_writing_with_authority(
+            &self.db_path,
+            authority,
         )?);
         self.run_inner(store, None)
     }

--- a/crates/nestweaver-federation/src/dispatch.rs
+++ b/crates/nestweaver-federation/src/dispatch.rs
@@ -184,7 +184,7 @@ fn brain_search_response_to_json(
     };
     let truncated =
         response.truncated || relation != "eq" || returned_matches < response.total_matches;
-    serde_json::json!({
+    let mut value = serde_json::json!({
         "query": response.query,
         "engine": response.engine,
         "total_matches": response.total_matches,
@@ -195,7 +195,16 @@ fn brain_search_response_to_json(
         "expansion_terms": response.expansion_terms,
         "semantic_applied": response.semantic_applied,
         "degraded_components": response.degraded_components,
-    })
+    });
+    if let Some(detail) = &response.semantic_unavailable {
+        value["semantic_unavailable"] = serde_json::json!({
+            "cause": detail.cause,
+            "reason": detail.reason,
+            "error": detail.error,
+            "remediation": detail.remediation,
+        });
+    }
+    value
 }
 
 /// Typed dispatch for `brain_search` -> `Search` RPC.
@@ -565,6 +574,7 @@ mod tests {
             truncated: false,
             semantic_applied: false,
             degraded_components: Vec::new(),
+            semantic_unavailable: None,
         };
 
         let value = brain_search_response_to_json(&response, false);

--- a/crates/nestweaver-federation/src/results.rs
+++ b/crates/nestweaver-federation/src/results.rs
@@ -298,6 +298,17 @@ fn merge_honesty_fields(local: &Value, server: &Value, response: &mut Value) {
 
     response["semantic_applied"] = Value::Bool(semantic_applied);
     response["degraded_components"] = serde_json::json!(degraded);
+    // The typed daemon transport carries the structured explanation beside
+    // `degraded_components`. Preserve it through the JSON merge as well;
+    // otherwise a daemon-routed MCP response would lose the actionable cause
+    // as soon as it was combined with a local tier. Local-first matches the
+    // surrounding provenance/encounter-order convention.
+    if let Some(detail) = tiers
+        .iter()
+        .find_map(|value| value.get("semantic_unavailable"))
+    {
+        response["semantic_unavailable"] = detail.clone();
+    }
 }
 
 /// Count the number of result items in a JSON response.
@@ -2225,6 +2236,28 @@ mod tests {
             merged["degraded_components"],
             json!(["semantic", "reranker", "expansion"]),
             "union in local-then-server encounter order, deduplicated"
+        );
+    }
+
+    #[test]
+    fn merge_preserves_structured_semantic_unavailability() {
+        let local = brain_search_tier("a", false, &[]);
+        let mut server = brain_search_tier("b", false, &["semantic"]);
+        server["semantic_unavailable"] = json!({
+            "cause": "embedding_identity",
+            "reason": "embedding_identity_unreadable",
+            "error": "malformed persisted metadata",
+            "remediation": "repair the identity",
+        });
+
+        let merged = merge_json_results(&local, &server);
+        assert_eq!(
+            merged["semantic_unavailable"]["reason"],
+            "embedding_identity_unreadable"
+        );
+        assert_eq!(
+            merged["semantic_unavailable"]["error"],
+            "malformed persisted metadata"
         );
     }
 

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -37,6 +37,57 @@ use nestweaver_engine::{index_markdown_directory, save_extensions, set_property}
 
 // ── Shared helpers ──────────────────────────────────────────────────────────
 
+const EMBEDDING_IDENTITY_REMEDIATION: &str = "repair or restore the recorded embedding model/pipeline metadata, or intentionally rebuild all embeddings from a verified source; --force cannot bypass an unreadable identity";
+
+fn rerank_requested(args: &Value) -> bool {
+    args.get("rerank").and_then(Value::as_bool).unwrap_or(false)
+}
+
+fn require_verified_embedding_identity_for_rerank(
+    store: &GraphStore,
+    args: &Value,
+) -> Result<(), anyhow::Error> {
+    if rerank_requested(args) {
+        store.require_verified_embedding_identity()?;
+    }
+    Ok(())
+}
+
+/// Keep lexical search available while reporting why semantic facilities are
+/// unavailable. This mirrors the daemon envelope exactly; callers should not
+/// have to infer degradation from a warning string or from transport choice.
+fn annotate_lexical_embedding_identity_degradation(
+    identity_error: Option<&str>,
+    value: &mut Value,
+) {
+    let Some(identity_error) = identity_error else {
+        return;
+    };
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+    object.insert("semantic_applied".to_string(), json!(false));
+    let degraded_components = object
+        .entry("degraded_components")
+        .or_insert_with(|| json!([]));
+    if let Some(components) = degraded_components.as_array_mut()
+        && !components
+            .iter()
+            .any(|component| component.as_str() == Some("semantic"))
+    {
+        components.push(json!("semantic"));
+    }
+    object.insert(
+        "semantic_unavailable".to_string(),
+        json!({
+            "cause": "embedding_identity",
+            "reason": "embedding_identity_unreadable",
+            "error": identity_error,
+            "remediation": EMBEDDING_IDENTITY_REMEDIATION,
+        }),
+    );
+}
+
 /// Resolve a symbol name to a UID. When multiple symbols share the name,
 /// pick the most likely canonical definition using a composite heuristic:
 /// PageRank score (if computed), then source-path priority (src/ over tests/),
@@ -133,6 +184,141 @@ fn repo_is_visible(
         }
         _ => true,
     }
+}
+
+/// Resolve only inside the caller's visible repositories. Hidden and unknown
+/// UIDs deliberately collapse to the same not-found error.
+fn resolve_visible_symbol_uid(
+    store: &GraphStore,
+    name_or_uid: &str,
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
+) -> Result<String, anyhow::Error> {
+    if name_or_uid.contains(':') {
+        let symbol = store
+            .lookup_symbol(name_or_uid)
+            .map_err(|_| anyhow!("no symbol found: '{name_or_uid}'"))?;
+        if !repo_is_visible(&symbol.repo_uid, visible) {
+            anyhow::bail!("no symbol found: '{name_or_uid}'");
+        }
+        return Ok(symbol.uid);
+    }
+
+    let mut matches = store
+        .lookup_symbols_by_name(name_or_uid)
+        .map_err(|e| anyhow!("lookup_symbols_by_name: {e}"))?;
+    matches.retain(|symbol| repo_is_visible(&symbol.repo_uid, visible));
+    let best = matches.into_iter().max_by(|a, b| {
+        let pr_a = a.pagerank_score.unwrap_or(0.0);
+        let pr_b = b.pagerank_score.unwrap_or(0.0);
+        if (pr_a - pr_b).abs() > f64::EPSILON {
+            return pr_a.partial_cmp(&pr_b).unwrap_or(std::cmp::Ordering::Equal);
+        }
+        let non_src = |path: &str| {
+            let path = path.to_lowercase();
+            path.starts_with("test") || path.contains("__tests__") || path.starts_with("migrations")
+        };
+        let a_test = non_src(&a.file_path);
+        let b_test = non_src(&b.file_path);
+        if a_test != b_test {
+            return b_test.cmp(&a_test);
+        }
+        b.start_line.cmp(&a.start_line)
+    });
+    best.map(|symbol| symbol.uid)
+        .ok_or_else(|| anyhow!("no symbol found: '{name_or_uid}'"))
+}
+
+/// Repository-visibility contract for every public tool.
+///
+/// `Scoped` handlers either constrain traversal to the caller's induced symbol
+/// subgraph or redact before computing response totals. `FailClosed` tools
+/// produce repository-owned data but do not yet have an induced-subgraph
+/// engine API; restricted callers are refused before cache lookup or analysis
+/// rather than receiving a post-filtered result whose ranking/counts leak the
+/// hidden graph. `Global` tools operate only on vault/global/admin state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ToolVisibilityContract {
+    Global,
+    Scoped,
+    FailClosed,
+}
+
+fn tool_visibility_contract(name: &str) -> Option<ToolVisibilityContract> {
+    use ToolVisibilityContract::{FailClosed, Global, Scoped};
+    Some(match name {
+        // Authorization-aware producers.
+        "brain_search"
+        | "brain_impact"
+        | "cross_repo_contracts"
+        | "flow_trace"
+        | "detect_changes"
+        | "brain_diff"
+        | "affected_tests" => Scoped,
+
+        // Repository/symbol/topology producers which currently lack a safe
+        // induced-subgraph computation. The common boundary refuses these for
+        // restricted identities before any seed resolution or traversal.
+        "brain_context"
+        | "code_context"
+        | "brain_status"
+        | "brain_guide"
+        | "clusters"
+        | "stale_check"
+        | "project_context"
+        | "dead_code"
+        | "hub_nodes"
+        | "bridge_nodes"
+        | "blast_radius"
+        | "get_summary"
+        | "read_symbols"
+        | "regex_search"
+        | "count_patterns"
+        | "investigate"
+        | "investigate_expand"
+        | "investigate_hydrate"
+        | "contract_drift"
+        | "set_extension"
+        | "query_extensions" => FailClosed,
+
+        // Vault-only reads, global maintenance and memory-note tools.
+        "note_get"
+        | "backlinks"
+        | "brain_add_source"
+        | "brain_remove_source"
+        | "prune_stale"
+        | "compact_embeddings"
+        | "brain_broken_links"
+        | "brain_orphan_documents"
+        | "brain_topic_clusters"
+        | "brain_tag_graph"
+        | "brain_doc_stats"
+        | "brain_memory_lint"
+        | "brain_memory_consolidate"
+        | "brain_memory_related" => Global,
+        _ => return None,
+    })
+}
+
+fn enforce_repo_visibility_contract(
+    name: &str,
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
+) -> Result<(), anyhow::Error> {
+    let contract = tool_visibility_contract(name)
+        .ok_or_else(|| anyhow!("tool '{name}' has no repository-visibility classification"))?;
+    if matches!(
+        (contract, visible),
+        (
+            ToolVisibilityContract::FailClosed,
+            Some(nestweaver_engine::authz::VisibleRepos::Only(_))
+        )
+    ) {
+        anyhow::bail!(
+            "tool '{name}' is unavailable for a repository-restricted identity: its analysis \
+             cannot yet be computed on an authorization-induced subgraph; refusing before \
+             seed resolution or traversal"
+        );
+    }
+    Ok(())
 }
 
 // ── Tool catalogue ──────────────────────────────────────────────────────────
@@ -503,6 +689,43 @@ mod tool_schema_validation_tests {
     }
 
     #[test]
+    fn every_registered_tool_has_one_repository_visibility_contract() {
+        let names: Vec<String> = all_tool_schemas()
+            .into_iter()
+            .map(|tool| tool["name"].as_str().unwrap().to_string())
+            .collect();
+        let missing: Vec<&str> = names
+            .iter()
+            .map(String::as_str)
+            .filter(|name| tool_visibility_contract(name).is_none())
+            .collect();
+        assert!(missing.is_empty(), "unclassified tools: {missing:?}");
+        assert_eq!(
+            names.len(),
+            names.iter().collect::<BTreeSet<_>>().len(),
+            "duplicate tool registration would make visibility classification ambiguous"
+        );
+    }
+
+    #[test]
+    fn changed_file_schemas_publish_the_shared_boundary_limits() {
+        for (tool, property) in [
+            ("detect_changes", "changed_files"),
+            ("detect_changes", "files"),
+            ("affected_tests", "changed_files"),
+            ("blast_radius", "changed_files"),
+        ] {
+            let schema = all_tool_schemas()
+                .into_iter()
+                .find(|candidate| candidate["name"] == tool)
+                .unwrap();
+            let files = &schema["inputSchema"]["properties"][property];
+            assert_eq!(files["maxItems"], json!(1000), "{tool}.{property}");
+            assert_eq!(files["items"]["maxLength"], json!(512), "{tool}.{property}");
+        }
+    }
+
+    #[test]
     fn explicit_tool_selection_is_transport_aware_and_never_silently_empty() {
         validate_tool_selection(
             Some(&["brain_context".to_string(), "brain_search".to_string()]),
@@ -771,6 +994,11 @@ mod tool_schema_validation_tests {
         for (name, args) in [
             ("read_symbols", json!({ "uids_or_fqns": [] })),
             ("detect_changes", json!({ "files": [] })),
+            ("affected_tests", json!({ "changed_files": [] })),
+            ("blast_radius", json!({ "changed_files": [] })),
+            ("detect_changes", json!({ "changed_files": [""] })),
+            ("affected_tests", json!({ "changed_files": [""] })),
+            ("blast_radius", json!({ "changed_files": [""] })),
         ] {
             assert_invalid(name, args);
         }
@@ -1390,6 +1618,7 @@ mod tool_schema_validation_tests {
             truncated: false,
             semantic_applied: false,
             degraded_components: Vec::new(),
+            semantic_unavailable: None,
         };
 
         let value = daemon_brain_search_response_to_json(&response, false);
@@ -1404,6 +1633,30 @@ mod tool_schema_validation_tests {
         let concise = daemon_brain_search_response_to_json(&response, true);
         assert_eq!(concise["results"][0]["uid"], "sym:needle");
         assert_eq!(concise["results"][0]["canonical_id"], "canonical-needle");
+    }
+
+    #[cfg(feature = "daemon")]
+    #[test]
+    fn daemon_brain_search_json_preserves_structured_semantic_unavailability() {
+        let response = nestweaver_proto::BrainSearchResponse {
+            semantic_applied: false,
+            degraded_components: vec!["semantic".to_string()],
+            semantic_unavailable: Some(nestweaver_proto::SemanticUnavailable {
+                cause: "embedding_identity".to_string(),
+                reason: "embedding_identity_unreadable".to_string(),
+                error: "malformed persisted metadata".to_string(),
+                remediation: "repair the recorded identity".to_string(),
+            }),
+            ..Default::default()
+        };
+
+        let value = daemon_brain_search_response_to_json(&response, false);
+        assert_eq!(value["degraded_components"], json!(["semantic"]));
+        assert_eq!(value["semantic_unavailable"]["cause"], "embedding_identity");
+        assert_eq!(
+            value["semantic_unavailable"]["error"],
+            "malformed persisted metadata"
+        );
     }
 
     #[cfg(feature = "daemon")]
@@ -1464,6 +1717,7 @@ mod tool_schema_validation_tests {
             truncated: false,
             semantic_applied: false,
             degraded_components: Vec::new(),
+            semantic_unavailable: None,
         };
 
         let value = daemon_brain_search_response_to_json(&response, false);
@@ -1813,9 +2067,10 @@ pub fn dispatch(
 /// `visible` carries the caller's per-repo visibility, resolved by the
 /// HTTP boundary from the bearer identity. `None` (and `Some(VisibleRepos::All)`)
 /// means no scoping — the backward-compatible single-trust-domain default, in
-/// which repo-scoped authorization is a no-op. `brain_search`, `brain_impact`,
-/// `blast_radius`, and `affected_tests` enforce it; tools whose data is not
-/// repo-scoped ignore it.
+/// which repo-scoped authorization is a no-op. Every registered tool has a
+/// [`ToolVisibilityContract`]: authorization-aware tools enforce the induced
+/// visible subgraph, repo-owned tools without such an engine path fail closed,
+/// and vault/global tools ignore repository scope by explicit classification.
 pub fn dispatch_cancellable(
     store: &GraphStore,
     tantivy: Option<&TantivyIndex>,
@@ -1829,6 +2084,19 @@ pub fn dispatch_cancellable(
     enforce_tool_allowed(name)?;
 
     validate_tool_arguments(name, &args)?;
+    // Security boundary: classification is mandatory for every registered
+    // tool, and unsupported repo-owned analyses fail before cache lookup and
+    // before any graph computation. This prevents a cached unrestricted
+    // answer or a post-filtered global rank from crossing an auth boundary.
+    enforce_repo_visibility_contract(name, visible)?;
+
+    // Reranking consumes persisted embedding-derived similarity signals even
+    // when the primary retrieval request is lexical-only. Guard before the
+    // response cache so a prior successful response cannot bypass a newly
+    // unreadable durable embedding identity.
+    if matches!(name, "brain_context" | "brain_search") {
+        require_verified_embedding_identity_for_rerank(store, &args)?;
+    }
 
     // nw-C2: a query landing inside a normal index-publication window used to
     // fail outright with an internal-looking assertion string. Wait it out
@@ -1869,7 +2137,17 @@ pub fn dispatch_cancellable(
     // process cannot compute without I/O), so its richer stamp wins. What this
     // layer can say honestly is that the answer came from the local graph, and
     // saying that is what makes the absence of a richer verdict legible.
-    let result = result.map(|value| provenance_seam::stamp(Unstamped::new(value)));
+    let result = result.map(|mut value| {
+        // A cache hit predating identity degradation bypasses the tool body.
+        // Annotate at the common in-process transport seam as well as at the
+        // producer so every lexical brain_search response reflects current
+        // semantic availability.
+        if name == "brain_search" {
+            let identity_error = store.embedding_identity_error();
+            annotate_lexical_embedding_identity_degradation(identity_error.as_deref(), &mut value);
+        }
+        provenance_seam::stamp(Unstamped::new(value))
+    });
 
     // Tools that do not consult PageRank still succeed during a dirty
     // publication, so the classification is applied to the ERROR rather than
@@ -1946,9 +2224,16 @@ fn classify_index_publication_error(store: &GraphStore, error: anyhow::Error) ->
     if !status.dirty {
         return error;
     }
-    let writer = match (status.writer_pid, status.writer_alive) {
-        (Some(pid), Some(true)) => format!("writer pid {pid} is running"),
-        (Some(pid), _) => format!("writer pid {pid} is NOT running"),
+    let writer = match (
+        status.writer_pid,
+        status.writer_alive,
+        status.writer_liveness_unknown,
+    ) {
+        (Some(pid), Some(true), _) => {
+            format!("diagnostic marker pid {pid} is running but does not prove ownership")
+        }
+        (Some(pid), _, true) => format!("writer pid {pid} has unknown liveness"),
+        (Some(pid), _, false) => format!("writer pid {pid} is NOT running"),
         _ => "no writer pid recorded in the marker".to_string(),
     };
     let age = status
@@ -1956,13 +2241,18 @@ fn classify_index_publication_error(store: &GraphStore, error: anyhow::Error) ->
         .map(|s| format!("{s}s"))
         .unwrap_or_else(|| "unknown".to_string());
     let waited_ms = index_publication_wait().as_millis();
+    let ownership = match status.writer_authority_held {
+        Some(true) => "the canonical writer lease is held",
+        Some(false) => "the canonical writer lease is free",
+        None => "canonical writer-lease ownership is unknown",
+    };
     let preamble = "This is an index PUBLICATION window, not a dirty git working tree — \
                     editing files in a repo does not cause it.";
     if status.is_wedged() {
         let repair = status.repair_command_for(&db_path);
         anyhow!(
             "index publication WEDGED: ranked queries are failing closed because {} exists \
-             and {writer} (marker age {age}). {preamble} The PageRank and generation sidecars \
+             and {writer}; {ownership} (marker age {age}). {preamble} The PageRank and generation sidecars \
              may predate the committed graph, so serving them would return wrong ranks. \
              A HUMAN must recover with (there is no MCP tool for this): {repair}{}",
             status.marker_path,
@@ -2007,11 +2297,11 @@ fn dispatch_uncached(
         "brain_remove_source" => tool_brain_remove_source(store, args),
         "prune_stale" => tool_prune_stale(store),
         "compact_embeddings" => tool_compact_embeddings(store, args),
-        "cross_repo_contracts" => tool_cross_repo_contracts(store, args),
+        "cross_repo_contracts" => tool_cross_repo_contracts(store, args, visible),
         "brain_impact" => tool_brain_impact(store, args, cancel, visible),
         "brain_guide" => tool_brain_guide(store, args),
-        "flow_trace" => tool_flow_trace(store, args, cancel),
-        "detect_changes" => tool_detect_changes(store, args),
+        "flow_trace" => tool_flow_trace(store, args, cancel, visible),
+        "detect_changes" => tool_detect_changes_scoped(store, args, visible),
         "clusters" => tool_clusters(store, args),
         "stale_check" => tool_stale_check(store),
         "set_extension" => tool_set_extension(args),
@@ -2311,7 +2601,7 @@ fn semantic_cache_salt(name: &str, embed_model: Option<&dyn EmbedQueryFn>) -> u6
 }
 
 fn semantic_response_is_degraded(name: &str, value: &Value) -> bool {
-    matches!(name, "brain_context" | "project_context")
+    matches!(name, "brain_context" | "project_context" | "brain_search")
         && value
             .get("degraded_components")
             .and_then(Value::as_array)
@@ -3377,6 +3667,9 @@ fn tool_schema_brain_memory_lint() -> Value {
 
 fn tool_brain_memory_consolidate(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error> {
     let apply = args.get("apply").and_then(|v| v.as_bool()).unwrap_or(false);
+    if apply {
+        require_authoritative_writer_ownership("apply memory consolidation")?;
+    }
     let limit = read_limit(
         &args,
         "limit",
@@ -3424,6 +3717,75 @@ fn tool_schema_brain_memory_consolidate() -> Value {
             }
         }
     })
+}
+
+#[cfg(test)]
+mod memory_consolidation_ownership_tests {
+    use super::*;
+
+    #[test]
+    fn in_process_dispatch_refuses_apply_without_host_writer_ownership() {
+        let store = GraphStore::in_memory().unwrap();
+
+        let error = dispatch(
+            &store,
+            None,
+            "brain_memory_consolidate",
+            json!({ "apply": true }),
+            None,
+        )
+        .expect_err("an unowned in-process apply must fail closed")
+        .to_string();
+        assert!(error.contains("authoritative writer ownership"), "{error}");
+
+        let dry_run = dispatch(
+            &store,
+            None,
+            "brain_memory_consolidate",
+            json!({ "apply": false }),
+            None,
+        )
+        .expect("dry-run is read-only and needs no writer lease");
+        assert_eq!(dry_run["dry_run"], json!(true));
+    }
+
+    #[test]
+    fn host_owned_scope_allows_apply_and_does_not_leak_to_the_next_request() {
+        let store = GraphStore::in_memory().unwrap();
+        let result = with_authoritative_writer_ownership(|| {
+            dispatch(
+                &store,
+                None,
+                "brain_memory_consolidate",
+                json!({ "apply": true }),
+                None,
+            )
+        })
+        .expect("host-attested apply reaches the engine");
+        assert_eq!(result["dry_run"], json!(false));
+
+        let error = dispatch(
+            &store,
+            None,
+            "brain_memory_consolidate",
+            json!({ "apply": true }),
+            None,
+        )
+        .expect_err("ownership must end with the scoped dispatch")
+        .to_string();
+        assert!(error.contains("authoritative writer ownership"), "{error}");
+    }
+
+    #[test]
+    fn host_owned_scope_restores_default_deny_after_panic() {
+        let _ = std::panic::catch_unwind(|| {
+            with_authoritative_writer_ownership(|| panic!("fixture panic"));
+        });
+        let error = require_authoritative_writer_ownership("apply memory consolidation")
+            .expect_err("panic cleanup must restore default deny")
+            .to_string();
+        assert!(error.contains("authoritative writer ownership"), "{error}");
+    }
 }
 
 fn tool_brain_memory_related(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error> {
@@ -3820,6 +4182,7 @@ fn tool_brain_context(
     embed_model: Option<&dyn EmbedQueryFn>,
     cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
 ) -> Result<Value, anyhow::Error> {
+    require_verified_embedding_identity_for_rerank(store, &args)?;
     let seeds: Vec<String> = args
         .get("seeds")
         .and_then(|v| v.as_array())
@@ -4164,10 +4527,7 @@ fn tool_brain_context(
     // heuristic (NOT a validated nDCG win); an optional `<db>.rerank.json`
     // learned-weights file is used if present and version-matched. Reranking
     // only reorders an already-retrieved set; recall is unchanged.
-    let do_rerank = args
-        .get("rerank")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let do_rerank = rerank_requested(&args);
     if do_rerank {
         let reranker = nestweaver_engine::select_reranker(Some(&db_path));
         nestweaver_engine::rerank(
@@ -4457,7 +4817,7 @@ fn authorized_symbol_total(
 fn tool_schema_brain_search() -> Value {
     json!({
         "name": "brain_search",
-        "description": "Find notes, headings, sections, tags, and code symbols by keyword or phrase using BM25 full-text search.\n\nGuidelines:\n- Use for keyword/phrase lookup; for structural context ('what's connected to X') use brain_context instead\n- Returns both notes and code symbols in a single call, with UIDs for follow-up queries; note rows also carry vault_uid and matched_headings (matched_headings is omitted when empty)\n- Use response_format 'concise' for scanning many results; limit is applied per-kind\n- total_matches counts distinct note/tag and symbol entities independently of the display limit; total_matches_relation 'gte' marks a stable lower bound from bounded counting\n- returned_matches is the actual response length, and truncated is true for every lower bound or when fewer rows are returned than total_matches\n- semantic_applied is always false and degraded_components always empty: this tool is keyword/BM25-only and never runs a semantic leg, so ranking is lexical. The fields are reported rather than omitted so their absence is never mistaken for an older server\n\nLimitations:\n- Does not read full note bodies — use note_get after finding the note here\n- Falls back to substring matching when the Tantivy BM25 index is unavailable\n- Keyword matching only — it will not find conceptually related wording that shares no terms with the query",
+        "description": "Find notes, headings, sections, tags, and code symbols by keyword or phrase using BM25 full-text search.\n\nGuidelines:\n- Use for keyword/phrase lookup; for structural context ('what's connected to X') use brain_context instead\n- Returns both notes and code symbols in a single call, with UIDs for follow-up queries; note rows also carry vault_uid and matched_headings (matched_headings is omitted when empty)\n- Use response_format 'concise' for scanning many results; limit is applied per-kind\n- total_matches counts distinct note/tag and symbol entities independently of the display limit; total_matches_relation 'gte' marks a stable lower bound from bounded counting\n- returned_matches is the actual response length, and truncated is true for every lower bound or when fewer rows are returned than total_matches\n- semantic_applied is always false because this tool's retrieval is keyword/BM25-only. When the recorded embedding identity is unreadable, lexical results remain available and the response reports degraded_components: [\"semantic\"] plus semantic_unavailable reason, error, and remediation; otherwise degraded_components is empty. The fields are reported rather than omitted so their absence is never mistaken for an older server\n\nLimitations:\n- Does not read full note bodies — use note_get after finding the note here\n- Falls back to substring matching when the Tantivy BM25 index is unavailable\n- Keyword matching only — it will not find conceptually related wording that shares no terms with the query",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -4529,6 +4889,7 @@ fn tool_brain_search(
     args: Value,
     visible: Option<&nestweaver_engine::authz::VisibleRepos>,
 ) -> Result<Value, anyhow::Error> {
+    require_verified_embedding_identity_for_rerank(store, &args)?;
     let raw_query = args
         .get("query")
         .and_then(|v| v.as_str())
@@ -4838,10 +5199,7 @@ fn tool_brain_search(
     // heuristic, NOT a validated nDCG win; an optional `<db>.rerank.json`
     // learned-weights file is used if present and version-matched. Reranking
     // only reorders an already-retrieved set; recall is unchanged.
-    let do_rerank = args
-        .get("rerank")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let do_rerank = rerank_requested(&args);
     if do_rerank && !concise {
         // Build BrainNodes mirroring the JSON rows (UID-keyed; rows without a
         // UID — none in detailed mode — are dropped from the reorder set).
@@ -5033,11 +5391,12 @@ fn tool_brain_search(
         "total_matches_relation": search_total_relation_label(total.relation),
         "returned_matches": returned_matches,
         "truncated": truncated,
-        // `brain_search` is keyword/BM25-only; it must not claim a
-        // semantic leg was requested or degraded. Emitted unconditionally
-        // (and on both the bm25 and substring branches, which converge
-        // here) so callers can tell "no semantic leg" apart from "field
-        // not implemented on this path".
+        // `brain_search` is keyword/BM25-only, so it never claims that a
+        // semantic leg was applied. Emitted unconditionally (and on both the
+        // bm25 and substring branches, which converge here) so callers can
+        // tell "no semantic leg" apart from "field not implemented on this
+        // path". An unreadable durable embedding identity is annotated below:
+        // lexical results still succeed, but semantic capability is degraded.
         //
         // Other sites that must stay in agreement when a semantic leg is
         // added. This list is not a claim that they currently agree:
@@ -5071,6 +5430,8 @@ fn tool_brain_search(
         "semantic_applied": false,
         "degraded_components": [],
     });
+    let identity_error = store.embedding_identity_error();
+    annotate_lexical_embedding_identity_degradation(identity_error.as_deref(), &mut response);
     if engine == "substring" {
         response["engine_warning"] = json!(
             "tantivy_unavailable: BM25 index could not be opened (another process may hold the writer lock, or it has not been built yet). Results are substring matches only. Run `nestweaver brain reindex-search` to build the index."
@@ -5233,6 +5594,53 @@ mod brain_search_total_contract_tests {
 
     const QUERY: &str = "searchneedle";
 
+    #[test]
+    fn lexical_search_reports_unreadable_semantic_identity_without_failing() {
+        let mut response = json!({
+            "semantic_applied": false,
+            "degraded_components": [],
+            "results": [],
+        });
+        annotate_lexical_embedding_identity_degradation(
+            Some("embedding identity is unreadable: injected malformed metadata"),
+            &mut response,
+        );
+
+        assert_eq!(response["semantic_applied"], json!(false));
+        assert_eq!(response["degraded_components"], json!(["semantic"]));
+        assert_eq!(
+            response["semantic_unavailable"]["reason"],
+            "embedding_identity_unreadable"
+        );
+        assert_eq!(
+            response["semantic_unavailable"]["error"],
+            "embedding identity is unreadable: injected malformed metadata"
+        );
+        assert_eq!(
+            response["semantic_unavailable"]["remediation"],
+            EMBEDDING_IDENTITY_REMEDIATION
+        );
+
+        // The transport seam may see an already-annotated producer response;
+        // annotation is deliberately idempotent.
+        annotate_lexical_embedding_identity_degradation(
+            Some("embedding identity is unreadable: injected malformed metadata"),
+            &mut response,
+        );
+        assert_eq!(response["degraded_components"], json!(["semantic"]));
+    }
+
+    #[test]
+    fn lexical_search_keeps_clean_semantic_honesty_when_identity_is_verified() {
+        let mut response = json!({
+            "semantic_applied": false,
+            "degraded_components": [],
+        });
+        annotate_lexical_embedding_identity_degradation(None, &mut response);
+        assert_eq!(response["degraded_components"], json!([]));
+        assert!(response.get("semantic_unavailable").is_none());
+    }
+
     fn note(uid: &str, title: &str) -> Note {
         Note {
             uid: uid.to_string(),
@@ -5330,7 +5738,8 @@ mod brain_search_total_contract_tests {
         assert_eq!(drift["contracts_status"], json!("degraded"));
         assert_eq!(drift["degraded_repos"], json!(["repo:broken"]));
 
-        let cross = tool_cross_repo_contracts(&store, json!({ "uid": "sym:absent" })).unwrap();
+        let cross =
+            tool_cross_repo_contracts(&store, json!({ "uid": "sym:absent" }), None).unwrap();
         assert_eq!(cross["contracts_status"], json!("degraded"), "{cross}");
         assert_eq!(cross["degraded_repos"], json!(["repo:broken"]));
     }
@@ -5346,7 +5755,8 @@ mod brain_search_total_contract_tests {
         assert_eq!(drift["contracts_status"], json!("complete"));
         assert_eq!(drift["degraded_repos"], json!([]));
 
-        let cross = tool_cross_repo_contracts(&store, json!({ "uid": "sym:absent" })).unwrap();
+        let cross =
+            tool_cross_repo_contracts(&store, json!({ "uid": "sym:absent" }), None).unwrap();
         assert_eq!(cross["contracts_status"], json!("complete"), "{cross}");
         assert_eq!(cross["degraded_repos"], json!([]));
     }
@@ -5976,6 +6386,7 @@ mod brain_search_total_contract_tests {
             truncated: false,
             semantic_applied: false,
             degraded_components: Vec::new(),
+            semantic_unavailable: None,
         };
 
         // 2. Daemon-routed MCP: forwards the proto fields verbatim.
@@ -6334,7 +6745,7 @@ fn tool_backlinks(store: &GraphStore, args: Value) -> Result<Value, anyhow::Erro
 fn tool_schema_brain_status() -> Value {
     json!({
         "name": "brain_status",
-        "description": "Show what knowledge sources are indexed: vault/repo counts, note/tag/wikilink totals, staleness warnings, and search engine availability. No parameters required.\n\nGuidelines:\n- Call at session start to verify expected vaults and repos are loaded\n- Surfaces staleness warnings when repos are behind git HEAD\n- If counts are zero, use brain_add_source to index content — but a count of `null` means it could NOT BE READ, which is NOT zero and is not a reason to re-index. Check `unavailable` (and `counts_complete`) before acting on any count\n\nLimitations:\n- Metadata-only — does not search content (use brain_search for that)\n- For detailed per-repo staleness, use stale_check\n\nServer-mode and daemon-runtime fields (server_mode, indexing_active, indexing_repo, queue_depth, write_queue_depth, write_holder, write_holder_seconds, embedding_status) are ALWAYS present in the document. `write_queue_depth` counts write RPCs blocked on the daemon write lock — a different population from `queue_depth`, which counts index jobs. Inside `embedding_status`, `pass_active` / `pass_processed` / `pass_total` / `pass_started_at` / `pass_scope` describe an in-flight embedding pass. While a pass runs, `state` reads `embedding` rather than `ready` — a strictly narrower `ready`, so the daemon can still answer semantic queries; prefer the boolean `pass_active` over matching the state string. `pass_total` is 0 until the eligibility preflight finishes, which means \"not yet counted\", not \"nothing to do\". Only a live daemon can answer the daemon-owned fields honestly (`server_mode` is the exception — a bool that is simply `false` off-daemon): they carry live values on the daemon's gRPC surface and explicit nulls when no daemon serves the answer (direct `--no-daemon`, MCP-over-HTTP, in-process MCP — nothing was bypassed there, so `degraded_components` stays empty). The CLI's daemon-bypassed fallback additionally marks the nulls via `degraded_components: [\"daemon_runtime\"]` and a `daemon_bypassed` warning.",
+        "description": "Show what knowledge sources are indexed: vault/repo counts, note/tag/wikilink totals, staleness warnings, and search engine availability. No parameters required.\n\nGuidelines:\n- Call at session start to verify expected vaults and repos are loaded\n- Surfaces staleness warnings when repos are behind git HEAD\n- If counts are zero, use brain_add_source to index content — but a count of `null` means it could NOT BE READ, which is NOT zero and is not a reason to re-index. Check `unavailable` (and `counts_complete`) before acting on any count\n\nLimitations:\n- Metadata-only — does not search content (use brain_search for that)\n- For detailed per-repo staleness, use stale_check\n\nServer-mode and daemon-runtime fields (server_mode, indexing_active, indexing_repo, queue_depth, write_queue_depth, write_holder, write_holder_seconds, embedding_status, search_status) are ALWAYS present in the document. `write_queue_depth` counts write RPCs blocked on the daemon write lock — a different population from `queue_depth`, which counts index jobs. Inside `embedding_status`, `pass_active` / `pass_processed` / `pass_total` / `pass_started_at` / `pass_scope` describe an in-flight embedding pass. While a pass runs, `state` reads `embedding` rather than `ready` — a strictly narrower `ready`, so the daemon can still answer semantic queries; prefer the boolean `pass_active` over matching the state string. `pass_total` is 0 until the eligibility preflight finishes, which means \"not yet counted\", not \"nothing to do\". Only a live daemon can answer the daemon-owned fields honestly (`server_mode` is the exception — a bool that is simply `false` off-daemon): they carry live values on the daemon's gRPC surface and explicit nulls when no daemon serves the answer (direct `--no-daemon`, MCP-over-HTTP, in-process MCP — nothing was bypassed there, so `degraded_components` stays empty). The CLI's daemon-bypassed fallback additionally marks the nulls via `degraded_components: [\"daemon_runtime\"]` and a `daemon_bypassed` warning.",
         "inputSchema": {
             "type": "object",
             "additionalProperties": false,
@@ -6506,8 +6917,8 @@ fn counts_disclosure(
 /// Fields only a live daemon can answer honestly — see
 /// [`DAEMON_RUNTIME_STATUS_FIELDS`] — are ALWAYS present, so a
 /// `--json 2>/dev/null` consumer can never silently receive a different
-/// schema on the direct path. The seven daemon-owned runtime fields are
-/// explicit nulls here (the daemon's gRPC handler overwrites them with live
+/// schema on the direct path. The daemon-owned runtime fields are explicit
+/// nulls here (the daemon's gRPC handler overwrites them with live
 /// values); the two tantivy fields are derived from the builder's own
 /// `tantivy` argument, and the CLI's direct fallback re-nulls even those via
 /// [`mark_brain_status_daemon_bypassed`] — a process without the daemon's
@@ -6704,6 +7115,8 @@ pub fn brain_status_json(
             "marker_age_s": status.marker_age_s,
             "writer_pid": status.writer_pid,
             "writer_alive": status.writer_alive,
+            "writer_liveness_unknown": status.writer_liveness_unknown,
+            "writer_authority_held": status.writer_authority_held,
             "writer_reason": status.writer_reason,
             "wedged": status.is_wedged(),
             "marker_path": status.marker_path,
@@ -6773,12 +7186,14 @@ pub fn brain_status_json(
         // fields (a process without the daemon's index open cannot claim
         // `false`/`0` honestly) and marks the document degraded.
         "embedding_status": Value::Null,
+        "search_status": Value::Null,
         "indexing_active": Value::Null,
         "indexing_repo": Value::Null,
         "queue_depth": Value::Null,
         "write_queue_depth": Value::Null,
         "write_holder": Value::Null,
         "write_holder_seconds": Value::Null,
+        "search_status": Value::Null,
         // The `brain_search` precedent: always present, empty unless a
         // component was bypassed. The direct fallback sets
         // ["daemon_runtime"] via `mark_brain_status_daemon_bypassed`.
@@ -6793,12 +7208,14 @@ pub fn brain_status_json(
 /// silently receive a different schema.
 pub const DAEMON_RUNTIME_STATUS_FIELDS: &[&str] = &[
     "embedding_status",
+    "search_status",
     "indexing_active",
     "indexing_repo",
     "queue_depth",
     "write_queue_depth",
     "write_holder",
     "write_holder_seconds",
+    "search_status",
     "tantivy_available",
     "tantivy_doc_count",
 ];
@@ -6844,7 +7261,7 @@ pub fn mark_brain_status_daemon_bypassed(value: &mut Value, cause: &str) {
         warnings.push(json!({
             "kind": "daemon_bypassed",
             "warning": "answered by the read-only direct path; daemon-runtime fields \
-                        (embedding_status, write/index queue, tantivy stats) are null",
+                        (embedding/search status, write/index queue, tantivy stats) are null",
             "cause": cause,
         }));
     }
@@ -6975,6 +7392,16 @@ fn brain_status_warnings_for(
                  I/O error on the sidecar directory); ranked queries fail closed."
             },
             "action": status.repair_command_for(p),
+        }));
+    }
+
+    if let Some(error) = store.embedding_identity_error() {
+        warnings.push(json!({
+            "kind": "embedding_identity_unreadable",
+            "warning": format!(
+                "embedding metadata could not be read or validated ({error}); graph and lexical reads remain available, but semantic search, reranking, and embedding writes are disabled"
+            ),
+            "action": "repair or restore verified embedding model/pipeline metadata, or intentionally rebuild all embeddings from a verified source; --force does not bypass unreadable identity",
         }));
     }
 
@@ -7633,11 +8060,33 @@ fn tool_schema_cross_repo_contracts() -> Value {
     })
 }
 
-fn tool_cross_repo_contracts(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error> {
+fn tool_cross_repo_contracts(
+    store: &GraphStore,
+    args: Value,
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
+) -> Result<Value, anyhow::Error> {
+    let restricted = matches!(
+        visible,
+        Some(nestweaver_engine::authz::VisibleRepos::Only(_))
+    );
     let uid = if let Some(uid) = args.get("uid").and_then(|v| v.as_str()) {
-        uid.to_string()
+        if restricted {
+            let symbol = store
+                .lookup_symbol(uid)
+                .map_err(|_| anyhow!("no symbol found: '{uid}'"))?;
+            if !repo_is_visible(&symbol.repo_uid, visible) {
+                anyhow::bail!("no symbol found: '{uid}'");
+            }
+            symbol.uid
+        } else {
+            uid.to_string()
+        }
     } else if let Some(name) = args.get("name").and_then(|v| v.as_str()) {
-        resolve_symbol_uid(store, name)?
+        if restricted {
+            resolve_visible_symbol_uid(store, name, visible)?
+        } else {
+            resolve_symbol_uid(store, name)?
+        }
     } else {
         return Err(anyhow!("provide either 'uid' or 'name'"));
     };
@@ -7653,8 +8102,19 @@ fn tool_cross_repo_contracts(store: &GraphStore, args: Value) -> Result<Value, a
         .cross_repo_links(&uid)
         .map_err(|e| anyhow!("cross_repo_links: {e}"))?;
 
+    let owners = restricted_symbol_owners(store, visible)?;
+    let uid_is_visible = |candidate: &str| {
+        owners.as_ref().is_none_or(|owners| {
+            owners
+                .get(candidate)
+                .is_some_and(|repo_uid| repo_is_visible(repo_uid, visible))
+        })
+    };
     let mut rows: Vec<Value> = refs
         .iter()
+        // Scope both endpoints before totals/truncation. Unknown ownership is
+        // dropped under restriction rather than treated as globally visible.
+        .filter(|r| uid_is_visible(&r.source_uid) && uid_is_visible(&r.target_uid))
         .map(|r| {
             json!({
                 "source_uid": r.source_uid,
@@ -7693,9 +8153,10 @@ fn tool_cross_repo_contracts(store: &GraphStore, args: Value) -> Result<Value, a
     // to the symbol's repo: contract UIDs carry no repo component, so the rows
     // above cannot be attributed to one repo, and a degraded repo anywhere can
     // cost this symbol a link.
-    let degraded_repos = store
+    let mut degraded_repos = store
         .contract_derivation_failures(None)
         .map_err(|e| anyhow!("contract_derivation_failures: {e}"))?;
+    degraded_repos.retain(|repo_uid| repo_is_visible(repo_uid, visible));
     let contracts_status = if degraded_repos.is_empty() {
         "complete"
     } else {
@@ -7810,6 +8271,26 @@ fn tool_brain_impact(
                 .is_some_and(|repo_uid| repo_is_visible(repo_uid, visible))
         })
     };
+
+    // Reverse-impact depends entirely on resolver-produced edges. Refuse
+    // before symbol resolution/traversal when any repository the caller can
+    // see was indexed by an incompatible resolver generation. Hidden stale
+    // repositories are filtered first so their UIDs/count cannot leak into an
+    // otherwise healthy restricted response.
+    let mut resolver_stale_repos =
+        nestweaver_engine::resolver_generation::incompatible_repos_for_store(store)?;
+    resolver_stale_repos.retain(|repo_uid| repo_is_visible(repo_uid, visible));
+    if !resolver_stale_repos.is_empty() {
+        // A tool error is deliberate here. Existing CLI consumers treat every
+        // unknown success status as an ordinary empty impact set; returning a
+        // degraded success envelope would therefore print a confident "No
+        // impact found". Erroring preserves fail-closed semantics on every
+        // transport until all clients understand a structured refusal.
+        anyhow::bail!(
+            "brain_impact refused: {}",
+            nestweaver_engine::resolver_generation::incompatibility_message(&resolver_stale_repos)
+        );
+    }
 
     // Resolve with an explicit status so the CLI can honor the not-found/ambiguous exit-code
     // contract in daemon mode, instead of the daemon path silently returning the best of
@@ -8047,6 +8528,7 @@ fn tool_flow_trace(
     store: &GraphStore,
     args: Value,
     cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
 ) -> Result<Value, anyhow::Error> {
     let symbol = args
         .get("symbol")
@@ -8065,7 +8547,19 @@ fn tool_flow_trace(
         .clamp(1, 15);
     let concise = is_concise(&args);
 
-    let resolved_uid = resolve_symbol_uid(store, symbol)?;
+    let owners = restricted_symbol_owners(store, visible)?;
+    let allowed_symbols: Option<HashSet<String>> = owners.as_ref().map(|owners| {
+        owners
+            .iter()
+            .filter(|(_, repo_uid)| repo_is_visible(repo_uid, visible))
+            .map(|(uid, _)| uid.clone())
+            .collect()
+    });
+    let resolved_uid = if allowed_symbols.is_some() {
+        resolve_visible_symbol_uid(store, symbol, visible)?
+    } else {
+        resolve_symbol_uid(store, symbol)?
+    };
 
     let root = store
         .lookup_symbol(&resolved_uid)
@@ -8078,6 +8572,7 @@ fn tool_flow_trace(
         max_depth,
         concise,
         cancel,
+        allowed_symbols: allowed_symbols.as_ref(),
     };
 
     // Classes don't have CALLS edges — only their methods do. When the root
@@ -8091,7 +8586,12 @@ fn tool_flow_trace(
         let direct_callees = store
             .callees_of(&root.uid)
             .map_err(|e| anyhow!("callees_of: {e}"))?;
-        if direct_callees.is_empty() {
+        let has_visible_direct_callee = direct_callees.iter().any(|callee| {
+            allowed_symbols
+                .as_ref()
+                .is_none_or(|allowed| allowed.contains(&callee.uid))
+        });
+        if !has_visible_direct_callee {
             // Prefer MEMBER_OF edges — these correctly scope inner-class methods.
             let members = store
                 .members_of(&root.uid)
@@ -8105,7 +8605,12 @@ fn tool_flow_trace(
             let method_trees: Vec<Value> = if !members.is_empty() {
                 members
                     .iter()
-                    .filter(|s| is_method(s))
+                    .filter(|s| {
+                        is_method(s)
+                            && allowed_symbols
+                                .as_ref()
+                                .is_none_or(|allowed| allowed.contains(&s.uid))
+                    })
                     .take(MAX_METHODS)
                     .map(|s| {
                         let mut v = visited.clone();
@@ -8123,6 +8628,9 @@ fn tool_flow_trace(
                     .filter(|s| {
                         s.kind == SymbolKind::Class
                             && s.uid != root.uid
+                            && allowed_symbols
+                                .as_ref()
+                                .is_none_or(|allowed| allowed.contains(&s.uid))
                             && s.start_line > root.start_line
                             && s.end_line < root.end_line
                     })
@@ -8132,6 +8640,9 @@ fn tool_flow_trace(
                     .iter()
                     .filter(|s| {
                         s.uid != root.uid
+                            && allowed_symbols
+                                .as_ref()
+                                .is_none_or(|allowed| allowed.contains(&s.uid))
                             && is_method(s)
                             && s.start_line > root.start_line
                             && s.start_line <= root.end_line
@@ -8185,6 +8696,9 @@ struct FlowTraceOpts<'a> {
     /// Cooperative cancellation flag, checked once per recursion level. See
     /// [`nestweaver_store::StoreError::Cancelled`] for the contract.
     cancel: Option<&'a std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    /// Positive authorization set. Traversal never visits an endpoint outside
+    /// this induced symbol subgraph.
+    allowed_symbols: Option<&'a HashSet<String>>,
 }
 
 fn build_flow_tree(
@@ -8226,6 +8740,12 @@ fn build_flow_tree(
             )
         })?;
         for (callee, edge_type) in &callees {
+            if opts
+                .allowed_symbols
+                .is_some_and(|allowed| !allowed.contains(&callee.uid))
+            {
+                continue;
+            }
             if visited.contains(&callee.uid) {
                 continue;
             }
@@ -8298,14 +8818,16 @@ fn tool_schema_detect_changes() -> Value {
             "properties": {
                 "changed_files": {
                     "type": "array",
-                    "items": { "type": "string" },
+                    "items": { "type": "string", "minLength": 1, "maxLength": nestweaver_engine::changed_files::MAX_CHANGED_FILE_LEN },
                     "minItems": 1,
+                    "maxItems": nestweaver_engine::changed_files::MAX_CHANGED_FILES,
                     "description": "List of changed file paths (repo-relative). Example: [\"src/auth/login.ts\", \"src/utils/validate.ts\"]. One of 'changed_files' or 'files' is required."
                 },
                 "files": {
                     "type": "array",
-                    "items": { "type": "string" },
+                    "items": { "type": "string", "minLength": 1, "maxLength": nestweaver_engine::changed_files::MAX_CHANGED_FILE_LEN },
                     "minItems": 1,
+                    "maxItems": nestweaver_engine::changed_files::MAX_CHANGED_FILES,
                     "description": "Backward-compatible alias for changed_files."
                 },
                 "limit": {
@@ -8320,19 +8842,30 @@ fn tool_schema_detect_changes() -> Value {
     })
 }
 
+#[cfg(test)]
 fn tool_detect_changes(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error> {
+    tool_detect_changes_scoped(store, args, None)
+}
+
+fn tool_detect_changes_scoped(
+    store: &GraphStore,
+    args: Value,
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
+) -> Result<Value, anyhow::Error> {
     let files: Vec<String> = args
         .get("changed_files")
         .or_else(|| args.get("files"))
         .and_then(|v| v.as_array())
         .ok_or_else(|| anyhow!("'changed_files' must be an array of strings"))?
         .iter()
-        .filter_map(|v| v.as_str().map(String::from))
-        .collect();
-
-    if files.is_empty() {
-        return Err(anyhow!("'files' must contain at least one path"));
-    }
+        .enumerate()
+        .map(|(index, value)| {
+            value.as_str().map(String::from).ok_or_else(|| {
+                anyhow!("'changed_files[{index}]' must be a repository-relative path string")
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    let files = nestweaver_engine::changed_files::require_changed_files(&files)?;
 
     // nw-174: this tool inlined EVERY affected symbol and process. On a
     // high-fanout file that was 156 KB (~39K tokens) with 416 processes in one
@@ -8346,6 +8879,73 @@ fn tool_detect_changes(store: &GraphStore, args: Value) -> Result<Value, anyhow:
         .map(|n| n as usize)
         .unwrap_or(DEFAULT_RESULT_LIMIT)
         .clamp(1, 1000);
+
+    // The process engine currently has no authorization-induced traversal.
+    // For restricted callers, compute only the visible changed-file seeds and
+    // stop before the global process graph is loaded. This is intentionally a
+    // degraded-unknown answer: it is useful for locating visible changed
+    // symbols but cannot be mistaken for a complete risk assessment.
+    if matches!(
+        visible,
+        Some(nestweaver_engine::authz::VisibleRepos::Only(_))
+    ) {
+        let owners = restricted_symbol_owners(store, visible)?.unwrap_or_default();
+        let mut symbols = Vec::new();
+        let mut seen = HashSet::new();
+        for file in &files {
+            let candidates = store
+                .symbols_in_file(file)
+                .with_context(|| format!("mapping changed file {file} to visible symbols"))?;
+            for symbol in candidates {
+                if seen.insert(symbol.uid.clone())
+                    && owners.get(&symbol.uid).is_some_and(|repo_uid| {
+                        repo_uid == &symbol.repo_uid && repo_is_visible(repo_uid, visible)
+                    })
+                {
+                    symbols.push(symbol);
+                }
+            }
+        }
+        symbols.sort_by(|a, b| a.file_path.cmp(&b.file_path).then(a.name.cmp(&b.name)));
+        let total = symbols.len();
+        let affected_symbols: Vec<Value> = symbols
+            .iter()
+            .take(limit)
+            .map(|symbol| {
+                json!({
+                    "uid": symbol.uid,
+                    "name": symbol.name,
+                    "file_path": symbol.file_path,
+                })
+            })
+            .collect();
+        let symbols_omitted = total.saturating_sub(affected_symbols.len());
+        let mut resolver_stale_repos =
+            nestweaver_engine::resolver_generation::incompatible_repos_for_store(store)?;
+        resolver_stale_repos.retain(|repo_uid| repo_is_visible(repo_uid, visible));
+        return Ok(json!({
+            "files": files,
+            "risk": Value::Null,
+            "status": "degraded",
+            "gate_state": "degraded-unknown",
+            "notifications": [{
+                "level": "warning",
+                "descriptor": "authz.process-analysis-unavailable",
+                "message": "process impact is unavailable for repository-restricted analysis because process records lack authoritative repository ownership"
+            }],
+            "resolver_stale_repos": resolver_stale_repos,
+            "blast_radius": total,
+            "affected_symbols": affected_symbols,
+            "affected_symbol_count": total,
+            "affected_processes": [],
+            "affected_process_count": 0,
+            "process_analysis_unavailable": true,
+            "limit": limit,
+            "truncated": symbols_omitted > 0,
+            "symbols_omitted": symbols_omitted,
+            "processes_omitted": 0,
+        }));
+    }
 
     let impact = detect_changes_impact(store, &files, 10).context("detect_changes_impact")?;
 
@@ -8410,6 +9010,7 @@ fn tool_detect_changes(store: &GraphStore, args: Value) -> Result<Value, anyhow:
         "status": serde_json::to_value(impact.status)?,
         "gate_state": serde_json::to_value(impact.gate_state)?,
         "notifications": serde_json::to_value(&impact.notifications)?,
+        "resolver_stale_repos": impact.resolver_stale_repos,
         "blast_radius": impact.blast_radius,
         "affected_symbols": affected_symbols,
         // The TOTAL, not the returned length — so `affected_symbol_count`
@@ -8418,6 +9019,7 @@ fn tool_detect_changes(store: &GraphStore, args: Value) -> Result<Value, anyhow:
         "affected_symbol_count": impact.affected_symbols.len(),
         "affected_processes": affected_processes,
         "affected_process_count": impact.affected_processes.len(),
+        "process_analysis_unavailable": false,
         "limit": limit,
         "truncated": symbols_omitted > 0 || processes_omitted > 0,
         "symbols_omitted": symbols_omitted,
@@ -8437,7 +9039,9 @@ fn tool_schema_affected_tests() -> Value {
             "properties": {
                 "changed_files": {
                     "type": "array",
-                    "items": { "type": "string" },
+                    "items": { "type": "string", "minLength": 1, "maxLength": nestweaver_engine::changed_files::MAX_CHANGED_FILE_LEN },
+                    "minItems": 1,
+                    "maxItems": nestweaver_engine::changed_files::MAX_CHANGED_FILES,
                     "description": "Changed file paths (repo-relative). Example: [\"src/auth/login.ts\"]."
                 },
                 "base_ref": {
@@ -8454,24 +9058,33 @@ fn tool_affected_tests(
     args: Value,
     visible: Option<&nestweaver_engine::authz::VisibleRepos>,
 ) -> Result<Value, anyhow::Error> {
-    let owners = restricted_symbol_owners(store, visible)?;
-
     // Resolve the set of changed files: explicit list takes precedence over base_ref.
-    let mut changed_files: Vec<String> = bound_identifiers(
-        args.get("changed_files")
-            .and_then(|v| v.as_array())
-            .map(|a| {
-                a.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect()
-            })
-            .unwrap_or_default(),
-    );
+    let explicit_changed_files = args
+        .get("changed_files")
+        .map(|value| {
+            let values = value
+                .as_array()
+                .ok_or_else(|| anyhow!("'changed_files' must be an array of strings"))?;
+            let files: Vec<String> = values
+                .iter()
+                .enumerate()
+                .map(|(index, value)| {
+                    let path = value.as_str().ok_or_else(|| {
+                        anyhow!(
+                            "'changed_files[{index}]' must be a repository-relative path string"
+                        )
+                    })?;
+                    Ok::<String, anyhow::Error>(String::from(path))
+                })
+                .collect::<Result<_, _>>()?;
+            nestweaver_engine::changed_files::require_changed_files(&files)
+        })
+        .transpose()?;
+    let explicit_input = explicit_changed_files.is_some();
+    let mut changed_files: Vec<String> = explicit_changed_files.unwrap_or_default();
 
     let base_ref = args.get("base_ref").and_then(|v| v.as_str());
-    if changed_files.is_empty()
-        && let Some(base_ref) = base_ref
-    {
+    if !explicit_input && let Some(base_ref) = base_ref {
         let repo_path = scoped_local_repo_path(store, visible)?.unwrap_or_else(|| ".".to_string());
         let files =
             nestweaver_engine::changed_files_from_git(Path::new(&repo_path), Some(base_ref))
@@ -8480,6 +9093,8 @@ fn tool_affected_tests(
             .iter()
             .map(|p| p.to_string_lossy().into_owned())
             .collect();
+        changed_files =
+            nestweaver_engine::changed_files::validate_changed_file_entries(&changed_files)?;
     }
 
     // Only a genuine "no input" (neither changed_files nor base_ref) is an error.
@@ -8494,6 +9109,8 @@ fn tool_affected_tests(
         ));
     }
 
+    let owners = restricted_symbol_owners(store, visible)?;
+
     // nw-037: route through the recorded wrapper so every selection feeds the
     // measured-recall loop and carries the in-band `measured` disclosure.
     let mut result = if let Some(owners) = &owners {
@@ -8502,16 +9119,41 @@ fn tool_affected_tests(
             .filter(|(_, repo_uid)| repo_is_visible(repo_uid, visible))
             .map(|(uid, _)| uid.clone())
             .collect();
-        nestweaver_engine::affected_tests::affected_tests_scoped(store, &changed_files, &allowed)
+        if explicit_input {
+            nestweaver_engine::affected_tests::affected_tests_scoped(
+                store,
+                &changed_files,
+                &allowed,
+            )
             .context("affected_tests")?
+        } else {
+            nestweaver_engine::affected_tests::affected_tests_scoped_for_derived_diff(
+                store,
+                &changed_files,
+                &allowed,
+            )
+            .context("affected_tests")?
+        }
     } else {
         let db_path = current_db_path(store).ok();
-        nestweaver_engine::rts_eval::run_recorded(store, &changed_files, db_path.as_deref())
+        if explicit_input {
+            nestweaver_engine::rts_eval::run_recorded(store, &changed_files, db_path.as_deref())
+                .context("affected_tests")?
+        } else {
+            nestweaver_engine::rts_eval::run_recorded_derived_diff(
+                store,
+                &changed_files,
+                db_path.as_deref(),
+            )
             .context("affected_tests")?
+        }
     };
 
     if let Some(owners) = owners {
         let mut ownership_unproven = false;
+        result
+            .resolver_stale_repos
+            .retain(|repo_uid| repo_is_visible(repo_uid, visible));
         result.changed_symbols.retain(|symbol| {
             let repo_uid = if symbol.repo_uid.is_empty() {
                 owners.get(&symbol.uid).map(String::as_str)
@@ -9265,6 +9907,13 @@ fn tool_brain_diff(
     for file_path in &changed_paths {
         if let Ok(syms) = store.symbols_in_file(file_path) {
             for sym in syms {
+                // File paths are repository-relative and therefore collide
+                // across repositories. The selected visible repo is the
+                // authoritative owner; never attach same-path symbols from a
+                // hidden or merely different repository.
+                if sym.repo_uid != repo.uid || !repo_is_visible(&sym.repo_uid, visible) {
+                    continue;
+                }
                 affected_symbols.push(json!({
                     "uid": sym.uid,
                     "name": sym.name,
@@ -10268,13 +10917,15 @@ fn tool_bridge_nodes(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
 fn tool_schema_blast_radius() -> Value {
     json!({
         "name": "blast_radius",
-        "description": "Assess full blast radius of file changes: maps to symbols, traces reverse dependencies, groups by cluster, and returns risk level (Low/Medium/High) with impact scores.\n\nGuidelines:\n- Use BEFORE merging a PR; pass repo-relative changed file paths\n- Each affected symbol has impact_score (0.0-1.0) decaying through the call graph\n- For single-symbol impact use brain_impact; for cross-repo use cross_repo_contracts\n\n`cochanged_files` lists historically co-changing files (git history, Jaccard confidence) with no static edge — an advisory recall supplement; absence of co-change data is disclosed via a `cochange-unavailable` note.\n\nTrust contract (read before trusting a green result):\n- status (complete/partial/degraded/failed) + gate_state (ok/degraded-unknown/risk-flagged): a run that did NOT complete is degraded-unknown, NEVER risk-flagged — treat it as 'unknown, review manually', not 'safe'\n- coverage (repos in scope / not indexed / stale / truncated) distinguishes 'no impact' from 'incomplete coverage'\n- blind_spots: inherent static gaps (dynamic-dispatch, reflection, config-wiring, codegen) plus run-specific ones (pruned-below-threshold, depth-truncated, not-indexed)\n\nLimitations:\n- Static analysis only — misses dynamic dispatch and reflection (declared in blind_spots, not silently)\n- Response size scales with number of changed files and graph density\n\nWhen queried through the hybrid client (a local daemon connected to an upstream server), returns two-tier results (local_impact + org_wide_impact) with _meta.sources indicating provenance; a raw MCP connection to a single daemon returns single-tier local results. On an authenticated server with an [authz] policy, results are redacted to the caller's visible repos.",
+        "description": "Assess full blast radius of file changes: maps to symbols, traces reverse dependencies, groups by cluster, and returns risk level (Low/Medium/High) with impact scores.\n\nGuidelines:\n- Use BEFORE merging a PR; pass repo-relative changed file paths\n- Each affected symbol has impact_score (0.0-1.0) decaying through the call graph\n- For single-symbol impact use brain_impact; for cross-repo use cross_repo_contracts\n\n`cochanged_files` lists historically co-changing files (git history, Jaccard confidence) with no static edge — an advisory recall supplement; absence of co-change data is disclosed via a `cochange-unavailable` note.\n\nTrust contract (read before trusting a green result):\n- status (complete/partial/degraded/failed) + gate_state (ok/degraded-unknown/risk-flagged): a run that did NOT complete is degraded-unknown, NEVER risk-flagged — treat it as 'unknown, review manually', not 'safe'\n- coverage (repos in scope / not indexed / stale / truncated) distinguishes 'no impact' from 'incomplete coverage'\n- blind_spots: inherent static gaps (dynamic-dispatch, reflection, config-wiring, codegen) plus run-specific ones (pruned-below-threshold, depth-truncated, not-indexed)\n\nLimitations:\n- Static analysis only — misses dynamic dispatch and reflection (declared in blind_spots, not silently)\n- Response size scales with number of changed files and graph density\n- Authenticated repository-restricted callers are refused before traversal until blast-radius analysis supports an authorization-induced subgraph; post-filtering global scores would leak hidden topology\n\nWhen queried through the hybrid client (a local daemon connected to an upstream server), returns two-tier results (local_impact + org_wide_impact) with _meta.sources indicating provenance; a raw MCP connection to a single daemon returns single-tier local results.",
         "inputSchema": {
             "type": "object",
             "properties": {
                 "changed_files": {
                     "type": "array",
-                    "items": { "type": "string" },
+                    "items": { "type": "string", "minLength": 1, "maxLength": nestweaver_engine::changed_files::MAX_CHANGED_FILE_LEN },
+                    "minItems": 1,
+                    "maxItems": nestweaver_engine::changed_files::MAX_CHANGED_FILES,
                     "description": "List of changed file paths (repo-relative). Example: [\"src/auth/login.ts\", \"src/utils/validate.ts\"]."
                 },
                 "max_depth": {
@@ -10324,17 +10975,23 @@ fn tool_blast_radius(
     cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
     visible: Option<&nestweaver_engine::authz::VisibleRepos>,
 ) -> Result<Value, anyhow::Error> {
-    let files: Vec<std::path::PathBuf> = args
+    let files: Vec<String> = args
         .get("changed_files")
         .and_then(|v| v.as_array())
         .ok_or_else(|| anyhow!("'changed_files' must be an array of strings"))?
         .iter()
-        .filter_map(|v| v.as_str().map(std::path::PathBuf::from))
-        .collect();
-
-    if files.is_empty() {
-        return Err(anyhow!("'changed_files' must contain at least one path"));
-    }
+        .enumerate()
+        .map(|(index, value)| {
+            value.as_str().map(String::from).ok_or_else(|| {
+                anyhow!("'changed_files[{index}]' must be a repository-relative path string")
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    let files: Vec<std::path::PathBuf> =
+        nestweaver_engine::changed_files::require_changed_files(&files)?
+            .into_iter()
+            .map(std::path::PathBuf::from)
+            .collect();
 
     let max_depth = args
         .get("max_depth")
@@ -10485,6 +11142,7 @@ fn tool_blast_radius(
         "status": status_json,
         "gate_state": gate_state_json,
         "notifications": notifications_json,
+        "resolver_stale_repos": result.resolver_stale_repos,
         "changed_symbols": changed_json,
         "changed_symbol_count": changed_json.len(),
         "affected_symbols": affected_json,
@@ -10873,6 +11531,13 @@ thread_local! {
     static TRACK_INTERACTIONS: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
     static SERVER_MODE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
     static DIRECT_READ_ONLY: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    // Explicit host attestation that the CURRENT synchronous dispatch runs
+    // while the daemon/direct caller still holds its authoritative writer
+    // lease. Default-deny is deliberate: an in-process HTTP/MCP route that
+    // forgets the host hook must refuse consolidation apply, not become a
+    // second writer.
+    static AUTHORITATIVE_WRITER_OWNERSHIP_DEPTH: std::cell::Cell<u32> =
+        const { std::cell::Cell::new(0) };
     // F16 response cache: size cap (MiB) and per-session hit/miss counters.
     static CACHE_MAX_SIZE_MB: std::cell::Cell<u64> =
         const { std::cell::Cell::new(nestweaver_store::cache::DEFAULT_MAX_SIZE_MB) };
@@ -11256,6 +11921,49 @@ pub fn is_direct_read_only() -> bool {
     DIRECT_READ_ONLY.with(|value| value.get())
 }
 
+/// Run one synchronous tool dispatch while the HOST attests that it holds the
+/// canonical writer lease for the full closure lifetime.
+///
+/// This is an assertion boundary, not a lock implementation. The daemon must
+/// enter it only inside its existing write-gated mutation closure; a direct
+/// host must enter it only while its cross-process DB write lease is alive.
+/// Keeping it closure-scoped and thread-local prevents ownership from leaking
+/// to a later request on a reused blocking worker. Do not hold this scope
+/// across `.await`; enter it on the same blocking thread that calls
+/// [`dispatch`] or [`dispatch_cancellable`].
+pub fn with_authoritative_writer_ownership<T>(operation: impl FnOnce() -> T) -> T {
+    struct Restore(u32);
+
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            AUTHORITATIVE_WRITER_OWNERSHIP_DEPTH.with(|depth| depth.set(self.0));
+        }
+    }
+
+    AUTHORITATIVE_WRITER_OWNERSHIP_DEPTH.with(|depth| {
+        let previous = depth.get();
+        depth.set(
+            previous
+                .checked_add(1)
+                .expect("authoritative writer ownership nesting overflow"),
+        );
+        let restore = Restore(previous);
+        let result = operation();
+        drop(restore);
+        result
+    })
+}
+
+fn require_authoritative_writer_ownership(operation: &str) -> Result<(), anyhow::Error> {
+    let owned = AUTHORITATIVE_WRITER_OWNERSHIP_DEPTH.with(|depth| depth.get() > 0);
+    if !owned {
+        anyhow::bail!(
+            "refusing to {operation}: authoritative writer ownership was not established by the MCP host"
+        );
+    }
+    Ok(())
+}
+
 pub fn set_allowed_tools(names: Vec<String>) {
     ALLOWED_TOOLS.with(|c| *c.borrow_mut() = Some(names));
 }
@@ -11383,6 +12091,14 @@ fn daemon_brain_search_response_to_json(
     });
     if !response.expansion_terms.is_empty() {
         value["expansion_terms"] = json!(response.expansion_terms);
+    }
+    if let Some(detail) = &response.semantic_unavailable {
+        value["semantic_unavailable"] = json!({
+            "cause": detail.cause,
+            "reason": detail.reason,
+            "error": detail.error,
+            "remediation": detail.remediation,
+        });
     }
     value
 }
@@ -13101,6 +13817,7 @@ mod cache_dispatch_tests {
     /// source dir (kept alive by the returned tempdir).
     /// Shared with the federated round-trip guard, which needs a real store to
     /// get real tool output.
+    #[cfg(feature = "daemon")]
     pub(super) fn index_on_disk_for_merge_guard() -> (tempfile::TempDir, std::path::PathBuf) {
         index_on_disk()
     }
@@ -14311,6 +15028,7 @@ mod cache_dispatch_tests {
         reset_session();
         let (_dir, db_path) = index_on_disk();
         set_current_db_path(db_path.clone());
+        let _writer_authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
         write_marker(&db_path, std::process::id(), None);
         let store = GraphStore::open(&db_path).unwrap();
 
@@ -14368,18 +15086,21 @@ mod cache_dispatch_tests {
         let (_dir, db_path) = index_on_disk();
         set_current_db_path(db_path.clone());
         let marker = nestweaver_engine::sidecar_path(&db_path, ".index-dirty");
+        let writer_authority = nestweaver_store::acquire_db_write_lease(&db_path).unwrap();
         write_marker(&db_path, std::process::id(), None);
         let store = GraphStore::open(&db_path).unwrap();
 
-        // The clearer touches ONLY the marker file — it never acquires or
-        // releases the publication lease, so the in-process condvar is never
-        // notified. This is what an out-of-process writer looks like from
-        // here, and it is why the wait must poll the file.
+        // The clearer owns canonical writer authority but never acquires or
+        // releases the in-process publication lease, so the condvar is never
+        // notified. This preserves the out-of-process marker-clear behavior
+        // that makes the wait poll the file while proving a real writer can
+        // finish and release its authority.
         let clearer = std::thread::spawn({
             let marker = marker.clone();
             move || {
                 std::thread::sleep(std::time::Duration::from_millis(80));
                 fs::remove_file(&marker).unwrap();
+                drop(writer_authority);
             }
         });
 
@@ -15566,11 +16287,160 @@ mod arg_alias_tests {
     fn detect_changes_accepts_changed_files_and_files_alias() {
         let store = GraphStore::in_memory().unwrap();
         let via_new =
-            tool_detect_changes(&store, json!({ "changed_files": ["src/a.rs"] })).unwrap();
+            tool_detect_changes(&store, json!({ "changed_files": ["  src/a.rs  "] })).unwrap();
         assert_eq!(via_new["files"], json!(["src/a.rs"]));
         let via_alias = tool_detect_changes(&store, json!({ "files": ["src/b.rs"] })).unwrap();
         assert_eq!(via_alias["files"], json!(["src/b.rs"]));
         assert!(tool_detect_changes(&store, json!({})).is_err());
+    }
+
+    #[test]
+    fn every_changed_file_handler_rejects_blank_and_mixed_lists_before_analysis() {
+        let store = GraphStore::in_memory().unwrap();
+        for files in [json!(["  "]), json!(["src/ok.rs", "\t"])] {
+            let detect = tool_detect_changes(&store, json!({ "changed_files": files.clone() }))
+                .unwrap_err()
+                .to_string();
+            assert!(detect.contains("changed_files["), "{detect}");
+
+            let affected =
+                tool_affected_tests(&store, json!({ "changed_files": files.clone() }), None)
+                    .unwrap_err()
+                    .to_string();
+            assert!(affected.contains("changed_files["), "{affected}");
+
+            let blast = tool_blast_radius(&store, json!({ "changed_files": files }), None, None)
+                .unwrap_err()
+                .to_string();
+            assert!(blast.contains("changed_files["), "{blast}");
+        }
+    }
+
+    #[test]
+    fn changed_file_tools_reject_explicit_oversized_and_overlong_lists_atomically() {
+        let store = GraphStore::in_memory().unwrap();
+
+        let empty = tool_affected_tests(&store, json!({ "changed_files": [] }), None)
+            .unwrap_err()
+            .to_string();
+        assert!(empty.contains("at least one"), "{empty}");
+
+        let too_many = vec!["src/lib.rs"; 1001];
+        let count_error = tool_affected_tests(&store, json!({ "changed_files": too_many }), None)
+            .unwrap_err()
+            .to_string();
+        assert!(count_error.contains("1001"), "{count_error}");
+        assert!(count_error.contains("maximum is 1000"), "{count_error}");
+        for error in [
+            tool_detect_changes(&store, json!({ "changed_files": vec!["src/lib.rs"; 1001] }))
+                .unwrap_err()
+                .to_string(),
+            tool_blast_radius(
+                &store,
+                json!({ "changed_files": vec!["src/lib.rs"; 1001] }),
+                None,
+                None,
+            )
+            .unwrap_err()
+            .to_string(),
+        ] {
+            assert!(error.contains("maximum is 1000"), "{error}");
+        }
+
+        let too_long = format!("src/{}", "a".repeat(509));
+        assert!(too_long.len() > 512);
+        let length_error = tool_affected_tests(
+            &store,
+            json!({ "changed_files": ["src/valid.rs", too_long] }),
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(length_error.contains("changed_files[1]"), "{length_error}");
+        assert!(length_error.contains("maximum is 512"), "{length_error}");
+        for error in [
+            tool_detect_changes(
+                &store,
+                json!({ "changed_files": ["src/valid.rs", format!("src/{}", "a".repeat(509))] }),
+            )
+            .unwrap_err()
+            .to_string(),
+            tool_blast_radius(
+                &store,
+                json!({ "changed_files": ["src/valid.rs", format!("src/{}", "a".repeat(509))] }),
+                None,
+                None,
+            )
+            .unwrap_err()
+            .to_string(),
+        ] {
+            assert!(error.contains("changed_files[1]"), "{error}");
+            assert!(error.contains("maximum is 512"), "{error}");
+        }
+    }
+
+    #[test]
+    fn changed_file_tools_serialize_one_shared_future_generation_refusal() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("future.lbug");
+        let store = GraphStore::open_or_create(&db).unwrap();
+        let repo_uid = "repo:default:future";
+        store
+            .insert_repo(&nestweaver_schema::Repo {
+                uid: repo_uid.to_string(),
+                url: "file:///tmp/future".to_string(),
+                indexed_sha: "deadbeef".to_string(),
+                staleness_commits_behind: 0,
+                instance_id: "default".to_string(),
+                name: None,
+                root_path: Some("/tmp/future".to_string()),
+            })
+            .unwrap();
+        nestweaver_engine::resolver_generation::record(&db, repo_uid).unwrap();
+        let mut generations = nestweaver_engine::resolver_generation::load(&db);
+        generations.repos.insert(
+            repo_uid.to_string(),
+            nestweaver_engine::resolver_generation::RESOLVER_GENERATION + 1,
+        );
+        std::fs::write(
+            nestweaver_engine::sidecar_path(
+                &db,
+                nestweaver_engine::resolver_generation::RESOLVER_GENERATION_SIDECAR,
+            ),
+            serde_json::to_string(&generations).unwrap(),
+        )
+        .unwrap();
+
+        let detect =
+            tool_detect_changes(&store, json!({ "changed_files": ["src/new.rs"] })).unwrap();
+        let affected =
+            tool_affected_tests(&store, json!({ "changed_files": ["src/new.rs"] }), None).unwrap();
+        let blast = tool_blast_radius(
+            &store,
+            json!({ "changed_files": ["src/new.rs"] }),
+            None,
+            None,
+        )
+        .unwrap();
+
+        for payload in [&detect, &affected, &blast] {
+            assert_eq!(payload["resolver_stale_repos"], json!([repo_uid]));
+            assert!(
+                payload["notifications"]
+                    .as_array()
+                    .is_some_and(|notifications| {
+                        notifications.iter().any(|notification| {
+                            notification["descriptor"]
+                                == json!(
+                            nestweaver_engine::resolver_generation::INCOMPATIBLE_RESOLVER_DESCRIPTOR
+                        )
+                        })
+                    })
+            );
+        }
+        assert_eq!(detect["gate_state"], json!("degraded-unknown"));
+        assert_eq!(blast["gate_state"], json!("degraded-unknown"));
+        assert_eq!(affected["recommendation"], json!("run-full-suite"));
     }
 
     #[test]
@@ -16080,6 +16950,137 @@ mod blast_radius_visibility_tests {
             scoped["org_wide"].is_null(),
             "org_wide collapses to null once its only item (repo:client) is hidden"
         );
+    }
+
+    #[test]
+    fn restricted_symbol_topology_tools_never_cross_a_two_repo_boundary() {
+        let store = cross_repo_store();
+        let api_only = VisibleRepos::Only(["repo:api".to_string()].into_iter().collect());
+        let client_only = VisibleRepos::Only(["repo:client".to_string()].into_iter().collect());
+
+        let contracts =
+            tool_cross_repo_contracts(&store, json!({ "uid": "api" }), Some(&api_only)).unwrap();
+        let contracts_json = serde_json::to_string(&contracts).unwrap();
+        assert!(!contracts_json.contains("repo:client"), "{contracts_json}");
+        assert!(!contracts_json.contains("Caller"), "{contracts_json}");
+
+        let flow = tool_flow_trace(
+            &store,
+            json!({ "symbol": "Caller", "max_depth": 3 }),
+            None,
+            Some(&client_only),
+        )
+        .unwrap();
+        let flow_json = serde_json::to_string(&flow).unwrap();
+        assert!(!flow_json.contains("repo:api"), "{flow_json}");
+        assert!(!flow_json.contains("Handler"), "{flow_json}");
+        assert!(
+            tool_flow_trace(
+                &store,
+                json!({ "symbol": "Handler" }),
+                None,
+                Some(&client_only),
+            )
+            .is_err(),
+            "a hidden seed must look absent"
+        );
+    }
+
+    #[test]
+    fn detect_changes_recomputes_visible_counts_and_suppresses_unowned_process_details() {
+        let store = cross_repo_store();
+        let mut hidden = store.lookup_symbol("client").unwrap();
+        hidden.uid = "hidden-same-path".to_string();
+        hidden.name = "HiddenSamePath".to_string();
+        hidden.file_path = "src/api.rs".to_string();
+        store.insert_symbol(&hidden).unwrap();
+
+        let visible = VisibleRepos::Only(["repo:api".to_string()].into_iter().collect());
+        let result = tool_detect_changes_scoped(
+            &store,
+            json!({ "changed_files": ["src/api.rs"] }),
+            Some(&visible),
+        )
+        .unwrap();
+        let encoded = serde_json::to_string(&result).unwrap();
+        assert!(!encoded.contains("HiddenSamePath"), "{encoded}");
+        assert!(!encoded.contains("repo:client"), "{encoded}");
+        assert_eq!(result["affected_symbol_count"], 1);
+        assert_eq!(result["affected_process_count"], 0);
+        assert_eq!(result["gate_state"], "degraded-unknown");
+        assert_eq!(result["risk"], Value::Null);
+        assert_eq!(result["process_analysis_unavailable"], true);
+    }
+
+    #[test]
+    fn restricted_edge_tools_redact_hidden_resolver_staleness_and_fail_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = GraphStore::open_or_create(&dir.path().join("resolver-scope.lbug")).unwrap();
+        let repo = |uid: &str| Repo {
+            uid: uid.to_string(),
+            url: format!("https://example.test/{uid}"),
+            indexed_sha: String::new(),
+            staleness_commits_behind: 0,
+            instance_id: "inst".to_string(),
+            name: None,
+            root_path: None,
+        };
+        for uid in ["repo:visible", "repo:hidden"] {
+            store.insert_repo(&repo(uid)).unwrap();
+        }
+        let symbol = |uid: &str, name: &str, repo_uid: &str| Symbol {
+            uid: uid.to_string(),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            repo_uid: repo_uid.to_string(),
+            file_path: "src/shared.rs".to_string(),
+            start_line: 1,
+            end_line: 2,
+            signature: format!("fn {name}()"),
+            summary: None,
+            content_hash: format!("hash:{uid}"),
+            embedding: None,
+            pagerank_score: None,
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: Visibility::Public,
+            type_info: None,
+            framework_hint: None,
+            canonical_id: None,
+        };
+        store
+            .insert_symbol(&symbol("visible-symbol", "VisibleSymbol", "repo:visible"))
+            .unwrap();
+        store
+            .insert_symbol(&symbol("hidden-symbol", "HiddenSymbol", "repo:hidden"))
+            .unwrap();
+
+        // No resolver-generation sidecar: both repositories are incompatible,
+        // but the restricted caller must see only its own stale UID.
+        let visible = VisibleRepos::Only(["repo:visible".to_string()].into_iter().collect());
+        let detect = tool_detect_changes_scoped(
+            &store,
+            json!({ "changed_files": ["src/shared.rs"] }),
+            Some(&visible),
+        )
+        .unwrap();
+        let detect_json = serde_json::to_string(&detect).unwrap();
+        assert!(detect_json.contains("repo:visible"), "{detect_json}");
+        assert!(!detect_json.contains("repo:hidden"), "{detect_json}");
+        assert!(!detect_json.contains("HiddenSymbol"), "{detect_json}");
+
+        let impact = tool_brain_impact(
+            &store,
+            json!({ "symbol": "VisibleSymbol" }),
+            None,
+            Some(&visible),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(impact.contains("brain_impact refused"), "{impact}");
+        assert!(impact.contains("repo:visible"), "{impact}");
+        assert!(!impact.contains("repo:hidden"), "{impact}");
+        assert!(impact.contains("--force"), "{impact}");
     }
 
     #[test]

--- a/crates/nestweaver-schema/src/edges.rs
+++ b/crates/nestweaver-schema/src/edges.rs
@@ -63,6 +63,35 @@ pub const ALL_SYMBOL_EDGE_TYPES: &[EdgeType] = &[
     EdgeType::MemberOf,
 ];
 
+/// Every typed relationship that can be declared in an artifact contract.
+///
+/// This is deliberately separate from [`ALL_SYMBOL_EDGE_TYPES`]. The latter is
+/// a traversal inventory for code-symbol queries; widening it would make
+/// symbol-only callers start considering note, project, and contract edges.
+/// Artifact readers need the exhaustive vocabulary because unified graph
+/// scopes legitimately declare typed cross-domain relationships.
+pub const ALL_EDGE_TYPES: &[EdgeType] = &[
+    EdgeType::Calls,
+    EdgeType::Imports,
+    EdgeType::Extends,
+    EdgeType::Implements,
+    EdgeType::Includes,
+    EdgeType::Uses,
+    EdgeType::Accesses,
+    EdgeType::MemberOf,
+    EdgeType::Contains,
+    EdgeType::CrossRepoLink,
+    EdgeType::ProjectIncludesSymbol,
+    EdgeType::ProjectIncludesNote,
+    EdgeType::ProjectHasComponent,
+    EdgeType::ProjectHasParent,
+    EdgeType::ImplementsContract,
+    EdgeType::Supersedes,
+    EdgeType::DependsOn,
+    EdgeType::CausedBy,
+    EdgeType::RelatesTo,
+];
+
 impl EdgeType {
     /// Return the Cypher relationship table name used in the graph store.
     ///
@@ -104,6 +133,19 @@ impl EdgeType {
             .find(|et| et.rel_table_name() == name)
             .copied()
     }
+
+    /// Reverse lookup over the complete typed relationship vocabulary.
+    ///
+    /// Use this for self-describing artifact contracts and other unified-graph
+    /// declarations. Code-symbol traversals should continue to use
+    /// [`Self::from_rel_table_name`], whose intentionally narrower contract is
+    /// preserved.
+    pub fn from_any_rel_table_name(name: &str) -> Option<EdgeType> {
+        ALL_EDGE_TYPES
+            .iter()
+            .find(|edge_type| edge_type.rel_table_name() == name)
+            .copied()
+    }
 }
 
 impl fmt::Display for EdgeType {
@@ -129,6 +171,39 @@ impl fmt::Display for EdgeType {
             EdgeType::CausedBy => write!(f, "CAUSED_BY"),
             EdgeType::RelatesTo => write!(f, "RELATES_TO"),
         }
+    }
+}
+
+#[cfg(test)]
+mod edge_type_tests {
+    use super::{ALL_EDGE_TYPES, ALL_SYMBOL_EDGE_TYPES, EdgeType};
+
+    #[test]
+    fn exhaustive_relationship_names_round_trip_without_widening_symbol_lookup() {
+        for edge_type in ALL_EDGE_TYPES {
+            assert_eq!(
+                EdgeType::from_any_rel_table_name(edge_type.rel_table_name()),
+                Some(*edge_type),
+                "{} is missing from the exhaustive reverse map",
+                edge_type.rel_table_name()
+            );
+        }
+
+        for edge_type in ALL_SYMBOL_EDGE_TYPES {
+            assert_eq!(
+                EdgeType::from_rel_table_name(edge_type.rel_table_name()),
+                Some(*edge_type)
+            );
+        }
+        assert_eq!(
+            EdgeType::from_rel_table_name(EdgeType::ProjectIncludesNote.rel_table_name()),
+            None,
+            "the symbol-only lookup must remain symbol-only"
+        );
+        assert_eq!(
+            EdgeType::from_any_rel_table_name("NOT_A_RELATIONSHIP"),
+            None
+        );
     }
 }
 

--- a/crates/nestweaver-schema/src/lib.rs
+++ b/crates/nestweaver-schema/src/lib.rs
@@ -11,7 +11,9 @@ pub mod uid;
 pub mod version;
 
 pub use confidence::{Language, MatchType, confidence_score};
-pub use edges::{ALL_SYMBOL_EDGE_TYPES, CrossRepoLinkType, EdgeEvidence, EdgeType, ResolvedEdge};
+pub use edges::{
+    ALL_EDGE_TYPES, ALL_SYMBOL_EDGE_TYPES, CrossRepoLinkType, EdgeEvidence, EdgeType, ResolvedEdge,
+};
 pub use embedding::{
     EMBEDDING_PIPELINE_SCHEMA_VERSION, EmbeddingBackend, EmbeddingPipelineV2, EmbeddingPoolingMode,
     EmbeddingQuantization, EmbeddingSimilarity, EmbeddingTruncation,

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -266,6 +266,7 @@ impl Drop for IndexPublicationLease<'_> {
 /// given that Connection<'a> borrows &'a Database.
 pub struct GraphStore {
     pub(crate) db: lbug::Database,
+    access_mode: GraphStoreAccessMode,
     pub(crate) pagerank_cache: Mutex<Option<HashMap<String, f64>>>,
     /// Algorithm and scope fingerprint for the scores currently held in
     /// `pagerank_cache`. It is persisted with the scores so a loader cannot
@@ -357,10 +358,21 @@ pub struct GraphStore {
     /// LadybugDB (which has no float-array column type). Loaded on open,
     /// saved on mutation via `flush_embedding_index`.
     pub(crate) embedding_index: Mutex<crate::search::EmbeddingIndex>,
+    /// Why the database-owned semantic identity could not be verified at
+    /// open. Graph traversal and lexical search remain usable, but every
+    /// semantic read/write must fail closed until metadata is repaired.
+    embedding_identity_error: Mutex<Option<String>>,
     /// LRU cache for PPR result vectors keyed by a hash of
     /// `(sorted seed_uids, damping, max_iterations, scope_hash, intent, graph_generation)`.
     /// Repeated queries with the same seeds skip the iterative PPR computation entirely.
     pub(crate) ppr_result_cache: Mutex<lru::LruCache<u64, Vec<(String, f64)>>>,
+}
+
+/// Capability fixed by the constructor that opened a [`GraphStore`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphStoreAccessMode {
+    ReadWrite,
+    ReadOnly,
 }
 
 /// Persistent identity of one NestWeaver brain and its current publication
@@ -979,6 +991,7 @@ impl GraphStore {
         let db = open_lbug_with_recovery(path, true, hardened_system_config)?;
         let store = GraphStore {
             db,
+            access_mode: GraphStoreAccessMode::ReadWrite,
             pagerank_cache: Mutex::new(None),
             pagerank_artifact_fingerprint: Mutex::new(None),
             pagerank_declared_parameters: Mutex::new(None),
@@ -998,6 +1011,7 @@ impl GraphStore {
             impact_snapshot_cache: Mutex::new(None),
             impact_snapshot_compute_lock: Mutex::new(()),
             embedding_index: Mutex::new(Self::load_embedding_index(path)),
+            embedding_identity_error: Mutex::new(None),
             ppr_result_cache: Mutex::new(lru::LruCache::new(
                 std::num::NonZeroUsize::new(128).unwrap(),
             )),
@@ -1032,6 +1046,7 @@ impl GraphStore {
         let db = open_lbug_with_recovery(path, true, hardened_system_config)?;
         let store = GraphStore {
             db,
+            access_mode: GraphStoreAccessMode::ReadWrite,
             pagerank_cache: Mutex::new(None),
             pagerank_artifact_fingerprint: Mutex::new(None),
             pagerank_declared_parameters: Mutex::new(None),
@@ -1051,6 +1066,7 @@ impl GraphStore {
             impact_snapshot_cache: Mutex::new(None),
             impact_snapshot_compute_lock: Mutex::new(()),
             embedding_index: Mutex::new(Self::load_embedding_index(path)),
+            embedding_identity_error: Mutex::new(None),
             ppr_result_cache: Mutex::new(lru::LruCache::new(
                 std::num::NonZeroUsize::new(128).unwrap(),
             )),
@@ -1069,6 +1085,7 @@ impl GraphStore {
         let db = open_lbug_with_recovery(path, true, hardened_system_config)?;
         let store = GraphStore {
             db,
+            access_mode: GraphStoreAccessMode::ReadWrite,
             pagerank_cache: Mutex::new(None),
             pagerank_artifact_fingerprint: Mutex::new(None),
             pagerank_declared_parameters: Mutex::new(None),
@@ -1088,6 +1105,7 @@ impl GraphStore {
             impact_snapshot_cache: Mutex::new(None),
             impact_snapshot_compute_lock: Mutex::new(()),
             embedding_index: Mutex::new(Self::load_embedding_index(path)),
+            embedding_identity_error: Mutex::new(None),
             ppr_result_cache: Mutex::new(lru::LruCache::new(
                 std::num::NonZeroUsize::new(128).unwrap(),
             )),
@@ -1148,6 +1166,7 @@ impl GraphStore {
         }
         let store = GraphStore {
             db,
+            access_mode: GraphStoreAccessMode::ReadOnly,
             pagerank_cache: Mutex::new(None),
             pagerank_artifact_fingerprint: Mutex::new(None),
             pagerank_declared_parameters: Mutex::new(None),
@@ -1167,6 +1186,7 @@ impl GraphStore {
             impact_snapshot_cache: Mutex::new(None),
             impact_snapshot_compute_lock: Mutex::new(()),
             embedding_index: Mutex::new(Self::load_embedding_index(path)),
+            embedding_identity_error: Mutex::new(None),
             ppr_result_cache: Mutex::new(lru::LruCache::new(
                 std::num::NonZeroUsize::new(128).unwrap(),
             )),
@@ -1212,6 +1232,7 @@ impl GraphStore {
             .map_err(|error| StoreError::Query(format!("create in-memory regex root: {error}")))?;
         let store = GraphStore {
             db,
+            access_mode: GraphStoreAccessMode::ReadWrite,
             pagerank_cache: Mutex::new(None),
             pagerank_artifact_fingerprint: Mutex::new(None),
             pagerank_declared_parameters: Mutex::new(None),
@@ -1231,6 +1252,7 @@ impl GraphStore {
             impact_snapshot_cache: Mutex::new(None),
             impact_snapshot_compute_lock: Mutex::new(()),
             embedding_index: Mutex::new(crate::search::EmbeddingIndex::new()),
+            embedding_identity_error: Mutex::new(None),
             ppr_result_cache: Mutex::new(lru::LruCache::new(
                 std::num::NonZeroUsize::new(128).unwrap(),
             )),
@@ -1246,6 +1268,16 @@ impl GraphStore {
     /// only after the in-memory cache is reloaded from the sidecar.
     pub fn pagerank_generation(&self) -> u64 {
         self.pagerank_generation.load(Ordering::Acquire)
+    }
+
+    /// Access capability derived from the constructor; callers cannot upgrade
+    /// a read-only handle with a boolean argument.
+    pub fn access_mode(&self) -> GraphStoreAccessMode {
+        self.access_mode
+    }
+
+    pub fn is_read_write(&self) -> bool {
+        self.access_mode == GraphStoreAccessMode::ReadWrite
     }
 
     /// True if the caller's observed generation is older than the current
@@ -2031,21 +2063,26 @@ impl GraphStore {
     /// Hand the embedding index the model id recorded in the database's
     /// embedding metadata, so `add_embedding_with_force` can refuse a
     /// same-dimension write from a different model. Read once here — never
-    /// per-add — and kept current by `set_embedding_metadata`. Absent or
-    /// unreadable metadata means unknown: the model guard stays off and the
-    /// dimension guard alone applies.
+    /// per-add — and kept current by `set_embedding_metadata`. A successfully
+    /// queried absent row means unconfigured. Any read/decode/validation error
+    /// records a degraded semantic identity and disables every semantic
+    /// operation while leaving graph and lexical reads available.
     fn load_recorded_embedding_model_into_index(&self) {
+        let mut identity_errors = Vec::new();
         let recorded = match self.get_embedding_metadata() {
             Ok(recorded) => recorded.map(|(model_id, _)| model_id),
-            Err(e) => {
-                tracing::warn!(
-                    "could not read embedding metadata; the recorded-model write guard is \
-                     disabled for this store: {e}"
-                );
+            Err(error) => {
+                identity_errors.push(format!("read embedding metadata: {error}"));
                 None
             }
         };
-        let pipeline = self.get_embedding_pipeline().ok().flatten();
+        let pipeline = match self.get_embedding_pipeline() {
+            Ok(pipeline) => pipeline,
+            Err(error) => {
+                identity_errors.push(format!("read embedding pipeline: {error}"));
+                None
+            }
+        };
         let pipeline_fingerprint = pipeline
             .as_ref()
             .and_then(|pipeline| pipeline.fingerprint().ok());
@@ -2082,13 +2119,60 @@ impl GraphStore {
             if let Err(error) = index.replay_journal_v2(&journal, &identity, &pipeline) {
                 tracing::warn!(%error, "embedding journal is invalid; semantic search is unavailable until a full re-embed");
                 index.clear();
+                identity_errors.push(format!("replay embedding journal: {error}"));
             }
         }
-        index.set_recorded_model_id(recorded);
-        index.set_recorded_pipeline_fingerprint(pipeline_fingerprint);
-        if let Some(pipeline) = pipeline {
-            index.set_similarity(pipeline.similarity);
+        if identity_errors.is_empty() {
+            *self
+                .embedding_identity_error
+                .lock()
+                .unwrap_or_else(|error| error.into_inner()) = None;
+            index.set_recorded_model_id(recorded);
+            index.set_recorded_pipeline_fingerprint(pipeline_fingerprint);
+            if let Some(pipeline) = pipeline {
+                index.set_similarity(pipeline.similarity);
+            }
+        } else {
+            let message = format!(
+                "embedding identity is unreadable: {}; repair or re-embed from verified database metadata before semantic search or embedding writes",
+                identity_errors.join("; ")
+            );
+            tracing::warn!(%message, "semantic subsystem is degraded");
+            *self
+                .embedding_identity_error
+                .lock()
+                .unwrap_or_else(|error| error.into_inner()) = Some(message);
+            index.clear();
+            index.set_recorded_model_id(None);
+            index.set_recorded_pipeline_fingerprint(None);
         }
+    }
+
+    /// Current semantic-identity degradation, if metadata could not be read or
+    /// validated. This is intentionally separate from store-open health so a
+    /// daemon can continue serving graph traversal and lexical search.
+    pub fn embedding_identity_error(&self) -> Option<String> {
+        self.embedding_identity_error
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone()
+    }
+
+    /// Fail a semantic operation under unverified database identity.
+    pub fn require_verified_embedding_identity(&self) -> Result<(), StoreError> {
+        match self.embedding_identity_error() {
+            Some(detail) => Err(StoreError::EmbeddingIdentityUnreadable { detail }),
+            None => Ok(()),
+        }
+    }
+
+    /// Mark the semantic identity verified after a valid metadata pipeline has
+    /// been durably written and the in-memory guards have been synchronized.
+    pub(crate) fn clear_embedding_identity_error(&self) {
+        *self
+            .embedding_identity_error
+            .lock()
+            .unwrap_or_else(|error| error.into_inner()) = None;
     }
 
     /// Compute the legacy JSON sidecar path for a given database path.
@@ -2148,6 +2232,9 @@ impl GraphStore {
     /// [`add_embedding_with_force`]: GraphStore::add_embedding_with_force
     #[must_use = "a false return means the dimension guard rejected the embedding"]
     pub fn add_embedding(&self, uid: &str, embedding: Vec<f32>) -> bool {
+        if self.require_verified_embedding_identity().is_err() {
+            return false;
+        }
         let mut idx = self
             .embedding_index
             .lock()
@@ -2167,6 +2254,9 @@ impl GraphStore {
         model_id: &str,
         force: bool,
     ) -> bool {
+        if self.require_verified_embedding_identity().is_err() {
+            return false;
+        }
         let mut idx = self
             .embedding_index
             .lock()
@@ -2182,6 +2272,9 @@ impl GraphStore {
         pipeline: &nestweaver_schema::EmbeddingPipelineV2,
         force: bool,
     ) -> bool {
+        if self.require_verified_embedding_identity().is_err() {
+            return false;
+        }
         let mut index = self
             .embedding_index
             .lock()
@@ -2212,6 +2305,7 @@ impl GraphStore {
     /// Persist the in-memory embedding index to the binary sidecar file.
     /// No-op for in-memory stores.
     pub fn flush_embedding_index(&self) -> Result<(), StoreError> {
+        self.require_verified_embedding_identity()?;
         let mut idx = self
             .embedding_index
             .lock()
@@ -2229,6 +2323,22 @@ impl GraphStore {
                         .to_string(),
                 )
             })?;
+            let persisted_fingerprint = pipeline.fingerprint().map_err(|error| {
+                StoreError::Query(format!(
+                    "fingerprint persisted embedding pipeline before flush: {error}"
+                ))
+            })?;
+            let producer_fingerprint = idx.recorded_pipeline_fingerprint().ok_or_else(|| {
+                StoreError::Query(
+                    "embedding index producer pipeline is unverified; refusing to persist vectors"
+                        .to_string(),
+                )
+            })?;
+            if producer_fingerprint != persisted_fingerprint.as_str() {
+                return Err(StoreError::Query(format!(
+                    "embedding index producer pipeline fingerprint {producer_fingerprint} does not match persisted database fingerprint {persisted_fingerprint}; refusing to persist vectors under stale metadata"
+                )));
+            }
             let db_path = self
                 .db_path
                 .as_ref()
@@ -2309,6 +2419,7 @@ impl GraphStore {
     /// Fold the append journal into a complete sibling-safe base snapshot.
     /// Backup/cutover paths use this to package one self-contained artifact.
     pub fn compact_embedding_index(&self) -> Result<(), StoreError> {
+        self.require_verified_embedding_identity()?;
         let mut index = self
             .embedding_index
             .lock()
@@ -2354,6 +2465,7 @@ impl GraphStore {
         &self,
         destination: &Path,
     ) -> Result<EmbeddingSnapshotLease<'_>, StoreError> {
+        self.require_verified_embedding_identity()?;
         let idx = self
             .embedding_index
             .lock()
@@ -2683,6 +2795,7 @@ impl GraphStore {
         limit: usize,
         cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
     ) -> Result<Vec<(String, f64)>, StoreError> {
+        self.require_verified_embedding_identity()?;
         let idx = self
             .embedding_index
             .lock()
@@ -2699,6 +2812,7 @@ impl GraphStore {
         limit: usize,
         uid_prefix: Option<&str>,
     ) -> Result<Vec<(String, f64)>, StoreError> {
+        self.require_verified_embedding_identity()?;
         let idx = self
             .embedding_index
             .lock()
@@ -3709,6 +3823,26 @@ mod tests {
     use super::*;
 
     #[test]
+    fn constructors_fix_the_store_access_capability() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mode.lbug");
+        let created = GraphStore::create(&path).unwrap();
+        assert_eq!(created.access_mode(), GraphStoreAccessMode::ReadWrite);
+        drop(created);
+        let read_only = GraphStore::open_read_only(&path).unwrap();
+        assert_eq!(read_only.access_mode(), GraphStoreAccessMode::ReadOnly);
+        drop(read_only);
+        assert_eq!(
+            GraphStore::open(&path).unwrap().access_mode(),
+            GraphStoreAccessMode::ReadWrite
+        );
+        assert_eq!(
+            GraphStore::in_memory().unwrap().access_mode(),
+            GraphStoreAccessMode::ReadWrite
+        );
+    }
+
+    #[test]
     fn publication_identity_is_created_once_and_survives_reopen() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("identity.lbug");
@@ -4579,6 +4713,211 @@ mod tests {
             reopened.try_vector_search(&[1.0, 0.0], 1),
             Err(StoreError::EmbeddingArtifactCorrupt)
         ));
+    }
+
+    #[test]
+    fn unreadable_embedding_identity_degrades_only_semantic_operations() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.lbug");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        store.set_embedding_metadata("verified-model", 2).unwrap();
+        assert!(store.add_embedding("symbol:old-space", vec![1.0, 0.0]));
+        store.flush_embedding_index().unwrap();
+        let embedding_path = store.embedding_sidecar_path().unwrap();
+        assert!(embedding_path.is_file());
+
+        // Model an interrupted/manual metadata edit at the durable boundary.
+        // Reopening must not reinterpret this row as an unconfigured semantic
+        // space, because that would permit vectors from an unrelated model.
+        let conn = store.conn().unwrap();
+        let mut statement = conn
+            .prepare("MATCH (m:Meta {key: $key}) SET m.value = $value")
+            .unwrap();
+        conn.execute(
+            &mut statement,
+            vec![
+                ("key", lbug::Value::String("embedding".to_string())),
+                ("value", lbug::Value::String("{not-json".to_string())),
+            ],
+        )
+        .unwrap();
+        drop(conn);
+        drop(store);
+
+        let degraded = GraphStore::open(&db_path).unwrap();
+        let identity_error = degraded
+            .embedding_identity_error()
+            .expect("malformed durable metadata must be a typed degradation");
+        assert!(identity_error.contains("embedding identity is unreadable"));
+        assert!(degraded.get_embedding_metadata().is_err());
+        assert!(!degraded.add_embedding("symbol:rejected", vec![1.0, 0.0]));
+        assert!(!degraded.add_embedding_with_force(
+            "symbol:force-cannot-bypass",
+            vec![1.0, 0.0],
+            "replacement-model",
+            true,
+        ));
+        assert!(degraded.try_vector_search(&[1.0, 0.0], 1).is_err());
+        assert!(degraded.flush_embedding_index().is_err());
+
+        // Graph/lexical capability remains available while semantic identity
+        // awaits explicit repair.
+        assert!(
+            degraded
+                .hybrid_search(
+                    "no-match",
+                    None,
+                    None,
+                    10,
+                    &crate::ranking::SeedResolutionConfig::default(),
+                )
+                .unwrap()
+                .is_empty()
+        );
+
+        assert_eq!(
+            degraded
+                .reset_embedding_space_for_identity_repair()
+                .unwrap(),
+            1
+        );
+        assert_eq!(degraded.embedding_identity_error(), None);
+        assert_eq!(degraded.get_embedding_pipeline().unwrap(), None);
+        assert_eq!(degraded.embedding_count(), 0);
+        assert!(!embedding_path.exists());
+
+        degraded
+            .set_embedding_metadata("verified-replacement", 2)
+            .unwrap();
+        assert!(degraded.add_embedding("symbol:accepted-after-explicit-repair", vec![1.0, 0.0],));
+        drop(degraded);
+
+        let repaired = GraphStore::open(&db_path).unwrap();
+        repaired.require_verified_embedding_identity().unwrap();
+        assert_eq!(
+            repaired.get_embedding_pipeline().unwrap().unwrap().model_id,
+            "verified-replacement"
+        );
+    }
+
+    #[test]
+    fn forced_pipeline_switch_publishes_a_complete_base_that_survives_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("pipeline-switch.lbug");
+        let first = nestweaver_schema::EmbeddingPipelineV2::external("provider", "model-a", 2);
+        let second = nestweaver_schema::EmbeddingPipelineV2::external("provider", "model-b", 2);
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        store.set_embedding_pipeline(&first).unwrap();
+        assert!(store.add_embedding_with_pipeline(
+            "symbol:old-space",
+            vec![1.0, 0.0],
+            &first,
+            false,
+        ));
+        store.flush_embedding_index().unwrap();
+
+        store.reset_embedding_force_guard();
+        assert!(store.add_embedding_with_pipeline(
+            "symbol:new-space",
+            vec![0.0, 1.0],
+            &second,
+            true,
+        ));
+        assert!(!store.has_embedding("symbol:old-space"));
+        store.set_embedding_pipeline(&second).unwrap();
+        store.flush_embedding_index().unwrap();
+        drop(store);
+
+        let reopened = GraphStore::open_read_only(&db_path).unwrap();
+        assert_eq!(reopened.get_embedding_pipeline().unwrap(), Some(second));
+        assert!(reopened.has_embedding("symbol:new-space"));
+        assert!(
+            !reopened.has_embedding("symbol:old-space"),
+            "the old semantic space must not reappear after publication"
+        );
+    }
+
+    #[test]
+    fn flush_refuses_vectors_whose_producer_differs_from_database_pipeline() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("pipeline-mismatch.lbug");
+        let first = nestweaver_schema::EmbeddingPipelineV2::external("provider", "model-a", 2);
+        let second = nestweaver_schema::EmbeddingPipelineV2::external("provider", "model-b", 2);
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        store.set_embedding_pipeline(&first).unwrap();
+        assert!(store.add_embedding_with_pipeline(
+            "symbol:old-space",
+            vec![1.0, 0.0],
+            &first,
+            false,
+        ));
+        store.flush_embedding_index().unwrap();
+        let sidecar = store.embedding_sidecar_path().unwrap();
+        let original_base = std::fs::read(&sidecar).unwrap();
+
+        store.reset_embedding_force_guard();
+        assert!(store.add_embedding_with_pipeline(
+            "symbol:new-space",
+            vec![0.0, 1.0],
+            &second,
+            true,
+        ));
+        let error = store
+            .flush_embedding_index()
+            .expect_err("stale database metadata must block vector persistence");
+        assert!(
+            error
+                .to_string()
+                .contains("does not match persisted database fingerprint"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            std::fs::read(&sidecar).unwrap(),
+            original_base,
+            "a rejected flush must leave the authoritative base untouched"
+        );
+        drop(store);
+
+        let reopened = GraphStore::open_read_only(&db_path).unwrap();
+        assert_eq!(reopened.get_embedding_pipeline().unwrap(), Some(first));
+        assert!(reopened.has_embedding("symbol:old-space"));
+        assert!(!reopened.has_embedding("symbol:new-space"));
+    }
+
+    #[test]
+    fn read_only_identity_repair_refuses_before_touching_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("read-only-repair.lbug");
+        let pipeline = nestweaver_schema::EmbeddingPipelineV2::external("provider", "model-a", 2);
+        let writer = GraphStore::open_or_create(&db_path).unwrap();
+        writer.set_embedding_pipeline(&pipeline).unwrap();
+        assert!(writer.add_embedding_with_pipeline(
+            "symbol:preserved",
+            vec![1.0, 0.0],
+            &pipeline,
+            false,
+        ));
+        writer.flush_embedding_index().unwrap();
+        let sidecar = writer.embedding_sidecar_path().unwrap();
+        let original_base = std::fs::read(&sidecar).unwrap();
+        drop(writer);
+
+        let read_only = GraphStore::open_read_only(&db_path).unwrap();
+        let error = read_only
+            .reset_embedding_space_for_identity_repair()
+            .expect_err("a read-only handle must not repair semantic identity");
+        assert!(error.to_string().contains("requires a read-write store"));
+        assert_eq!(std::fs::read(&sidecar).unwrap(), original_base);
+        assert_eq!(
+            read_only.get_embedding_pipeline().unwrap(),
+            Some(pipeline.clone())
+        );
+        assert!(read_only.has_embedding("symbol:preserved"));
+        drop(read_only);
+
+        let reopened = GraphStore::open_read_only(&db_path).unwrap();
+        assert_eq!(reopened.get_embedding_pipeline().unwrap(), Some(pipeline));
+        assert!(reopened.has_embedding("symbol:preserved"));
     }
 
     #[test]

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -2137,7 +2137,15 @@ impl GraphStore {
                 "embedding identity is unreadable: {}; repair or re-embed from verified database metadata before semantic search or embedding writes",
                 identity_errors.join("; ")
             );
-            tracing::warn!(%message, "semantic subsystem is degraded");
+            // Keep the exact source chain available to typed semantic
+            // operations, but do not spray backend binder/parser text during
+            // an otherwise unrelated graph-only command. That output can
+            // contain implementation details and can obscure the command's
+            // own classified database diagnostic (for example, a schema-less
+            // zero-byte database).
+            tracing::warn!(
+                "semantic subsystem is degraded; typed semantic operations will return repair guidance"
+            );
             *self
                 .embedding_identity_error
                 .lock()

--- a/crates/nestweaver-store/src/error.rs
+++ b/crates/nestweaver-store/src/error.rs
@@ -174,6 +174,14 @@ pub enum StoreError {
     /// empty graph.
     #[error("PageRank unavailable during dirty index publication")]
     RankingUnavailable,
+    /// Persisted embedding metadata exists but cannot be parsed or validated.
+    ///
+    /// This must remain distinct from an ordinary query failure: semantic
+    /// callers are allowed to tolerate model/network availability failures,
+    /// but must never turn an unverified database identity into a successful
+    /// lexical-only answer.
+    #[error("embedding identity is unreadable: {detail}")]
+    EmbeddingIdentityUnreadable { detail: String },
     #[error("not found")]
     NotFound,
     #[error("presentation limit {limit} exceeds maximum {max}")]
@@ -216,6 +224,7 @@ impl StoreError {
                     || lower.contains("constraint")
             }
             StoreError::Corruption(_)
+            | StoreError::EmbeddingIdentityUnreadable { .. }
             | StoreError::NotFound
             | StoreError::RankingUnavailable
             | StoreError::PresentationLimitExceeded { .. }

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -15,11 +15,13 @@ pub mod search;
 pub mod tantivy_index;
 pub mod traverse;
 pub mod write;
+pub mod write_lease;
 pub mod zstd;
 
 pub use db::{
     EmbeddingIndexOccupancy, EmbeddingIndexReconciliation, EmbeddingSnapshotLease,
-    EmbeddingSnapshotState, GraphStore, IndexPublicationLease, PublicationIdentity,
+    EmbeddingSnapshotState, GraphStore, GraphStoreAccessMode, IndexPublicationLease,
+    PublicationIdentity,
 };
 pub use error::{
     CancelReason, CorruptionKind, EngineCorruption, StoreError, classify_engine_corruption,
@@ -64,6 +66,11 @@ pub use write::{
     InstanceUidRemap, InstanceUidRemapPlanState, InstanceVaultRecovery, MergeResult,
     MutationDisposition, MutationFailure, MutationOutcome, ProjectMutationDisposition,
     PurgeInstanceResult,
+};
+pub use write_lease::{
+    DbNamespaceLease, DbWriteLease, WriteLeaseError, WriteLeaseState, acquire_db_namespace_lease,
+    acquire_db_write_lease, acquire_db_write_lease_under_namespace, canonical_db_path,
+    write_lease_path, write_lease_state,
 };
 
 #[cfg(test)]

--- a/crates/nestweaver-store/src/ranking.rs
+++ b/crates/nestweaver-store/src/ranking.rs
@@ -108,7 +108,7 @@ pub fn pagerank_fingerprint_from_declared(parameters: &serde_json::Value) -> Opt
         let query = edge.get("query")?.as_str()?.to_string();
         let edge_type = match edge.get("edge_type") {
             Some(serde_json::Value::Null) | None => None,
-            Some(value) => Some(nestweaver_schema::EdgeType::from_rel_table_name(
+            Some(value) => Some(nestweaver_schema::EdgeType::from_any_rel_table_name(
                 value.as_str()?,
             )?),
         };
@@ -757,6 +757,10 @@ impl GraphScope {
         scope.edge_queries.push(ScopedEdgeQuery {
             query: "MATCH (p:Project)-[r:PROJECT_HAS_COMPONENT]->(q:Project) RETURN p.uid, q.uid, r.confidence".to_string(),
             edge_type: Some(EdgeType::ProjectHasComponent),
+        });
+        scope.edge_queries.push(ScopedEdgeQuery {
+            query: "MATCH (p:Project)-[r:PROJECT_HAS_PARENT]->(q:Project) RETURN p.uid, q.uid, r.confidence".to_string(),
+            edge_type: Some(EdgeType::ProjectHasParent),
         });
         scope
     }
@@ -1760,6 +1764,90 @@ mod tests {
             framework_hint: None,
             canonical_id: None,
         }
+    }
+
+    #[test]
+    fn every_supported_pagerank_scope_round_trips_its_declared_fingerprint() {
+        for (name, scope) in [
+            ("code-only", GraphScope::code_only()),
+            ("notes-only", GraphScope::notes_only()),
+            ("unified", GraphScope::unified()),
+        ] {
+            let declared = super::pagerank_declared_parameters(
+                super::PAGERANK_DAMPING,
+                super::PAGERANK_ITERATIONS,
+                &scope,
+            );
+            assert_eq!(
+                super::pagerank_fingerprint_from_declared(&declared),
+                Some(super::pagerank_algorithm_fingerprint(
+                    super::PAGERANK_DAMPING,
+                    super::PAGERANK_ITERATIONS,
+                    &scope,
+                )),
+                "the {name} scope must accept the declaration it produced"
+            );
+        }
+    }
+
+    #[test]
+    fn pagerank_presets_cover_every_typed_note_and_project_relationship() {
+        let notes = GraphScope::notes_only();
+        for relation in crate::read::VAULT_RELATIONS
+            .iter()
+            .filter(|relation| relation.in_notes_scope)
+        {
+            assert!(
+                notes
+                    .edge_queries
+                    .iter()
+                    .any(|edge| edge.query.contains(&format!(":{}]", relation.rel))),
+                "notes PageRank omitted inventory relationship {}",
+                relation.rel
+            );
+        }
+        for relationship in ["SUPERSEDES", "DEPENDS_ON", "CAUSED_BY", "RELATES_TO"] {
+            assert!(
+                crate::read::VAULT_RELATIONS
+                    .iter()
+                    .any(|relation| relation.rel == relationship && relation.in_notes_scope),
+                "typed Note relationship {relationship} is absent from the shared vault inventory"
+            );
+        }
+
+        let unified = GraphScope::unified();
+        for edge_type in nestweaver_schema::ALL_EDGE_TYPES
+            .iter()
+            .copied()
+            .filter(|edge_type| edge_type.rel_table_name().starts_with("PROJECT_"))
+        {
+            assert!(
+                unified
+                    .edge_queries
+                    .iter()
+                    .any(|edge| edge.edge_type == Some(edge_type)),
+                "unified PageRank omitted {}",
+                edge_type.rel_table_name()
+            );
+        }
+    }
+
+    #[test]
+    fn pagerank_declaration_rejects_an_unknown_typed_relationship() {
+        let mut declared = super::pagerank_declared_parameters(
+            super::PAGERANK_DAMPING,
+            super::PAGERANK_ITERATIONS,
+            &GraphScope::unified(),
+        );
+        let typed_edge = declared["edge_queries"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|edge| !edge["edge_type"].is_null())
+            .expect("unified scope declares typed project edges");
+        typed_edge["edge_type"] = serde_json::json!("UNKNOWN_RELATIONSHIP");
+
+        assert_eq!(super::pagerank_fingerprint_from_declared(&declared), None);
     }
 
     fn make_calls_edge(src: &str, tgt: &str) -> ResolvedEdge {

--- a/crates/nestweaver-store/src/read.rs
+++ b/crates/nestweaver-store/src/read.rs
@@ -120,6 +120,34 @@ pub const VAULT_RELATIONS: &[VaultRelation] = &[
         scored: false,
         in_notes_scope: true,
     },
+    VaultRelation {
+        rel: "SUPERSEDES",
+        from: "Note",
+        to: "Note",
+        scored: true,
+        in_notes_scope: true,
+    },
+    VaultRelation {
+        rel: "DEPENDS_ON",
+        from: "Note",
+        to: "Note",
+        scored: true,
+        in_notes_scope: true,
+    },
+    VaultRelation {
+        rel: "CAUSED_BY",
+        from: "Note",
+        to: "Note",
+        scored: true,
+        in_notes_scope: true,
+    },
+    VaultRelation {
+        rel: "RELATES_TO",
+        from: "Note",
+        to: "Note",
+        scored: true,
+        in_notes_scope: true,
+    },
 ];
 
 /// The cross-domain bridges. Without these a "code + vault" export is two
@@ -3493,33 +3521,34 @@ impl GraphStore {
 
     /// Read the stored embedding metadata (model ID and dimension).
     ///
-    /// Returns `Some((model_id, dimension))` when a record has been written
-    /// by [`GraphStore::set_embedding_metadata`], or `None` if the Meta table
-    /// does not exist yet (old DB) or the `"embedding"` key has never been set.
+    /// Returns `Some((model_id, dimension))` when a valid record has been
+    /// written by [`GraphStore::set_embedding_metadata`], or `None` only when
+    /// the query completed successfully and no `"embedding"` row exists.
+    /// Prepare/execute/extract/decode/validation failures are errors: callers
+    /// must never confuse unreadable identity with a fresh semantic space.
     pub fn get_embedding_metadata(&self) -> Result<Option<(String, u32)>, StoreError> {
         let conn = self.conn()?;
         let q = "MATCH (m:Meta {key: $k}) RETURN m.value";
-        let mut stmt = match conn.prepare(q) {
-            Ok(s) => s,
-            Err(_) => {
-                // Meta table doesn't exist on older databases — treat as absent.
-                return Ok(None);
-            }
-        };
-        let mut result = match conn.execute(
-            &mut stmt,
-            vec![("k", Value::String("embedding".to_string()))],
-        ) {
-            Ok(r) => r,
-            Err(_) => return Ok(None),
-        };
+        let mut stmt = conn.prepare(q).map_err(|error| {
+            StoreError::Query(format!("prepare embedding metadata read: {error}"))
+        })?;
+        let mut result = conn
+            .execute(
+                &mut stmt,
+                vec![("k", Value::String("embedding".to_string()))],
+            )
+            .map_err(|error| {
+                StoreError::Query(format!("execute embedding metadata read: {error}"))
+            })?;
         let row = match result.next() {
             Some(r) => r,
             None => return Ok(None),
         };
         let value = extract_string(&row, 0)?;
         if value.is_empty() {
-            return Ok(None);
+            return Err(StoreError::Query(
+                "validate embedding metadata: stored value is empty".to_string(),
+            ));
         }
         // Parse the JSON value stored by set_embedding_metadata.
         // Expected format: {"model_id":"<id>","dimension":<n>}
@@ -3528,16 +3557,29 @@ impl GraphStore {
         let model_id = parsed
             .get("model_id")
             .and_then(|v| v.as_str())
-            .unwrap_or("")
+            .filter(|model_id| !model_id.trim().is_empty())
+            .ok_or_else(|| {
+                StoreError::Query(
+                    "validate embedding metadata: model_id is missing or empty".to_string(),
+                )
+            })?
             .to_string();
-        let dimension = parsed
+        let dimension_u64 = parsed
             .get("dimension")
             .or_else(|| parsed.get("produced_dimension"))
             .and_then(|v| v.as_u64())
-            .unwrap_or(0) as u32;
-        if model_id.is_empty() || dimension == 0 {
-            return Ok(None);
-        }
+            .filter(|dimension| *dimension > 0)
+            .ok_or_else(|| {
+                StoreError::Query(
+                    "validate embedding metadata: dimension is missing, zero, or invalid"
+                        .to_string(),
+                )
+            })?;
+        let dimension = u32::try_from(dimension_u64).map_err(|_| {
+            StoreError::Query(format!(
+                "validate embedding metadata: dimension {dimension_u64} exceeds u32"
+            ))
+        })?;
         Ok(Some((model_id, dimension)))
     }
 
@@ -3548,17 +3590,19 @@ impl GraphStore {
         &self,
     ) -> Result<Option<nestweaver_schema::EmbeddingPipelineV2>, StoreError> {
         let conn = self.conn()?;
-        let mut statement = match conn.prepare("MATCH (m:Meta {key: $k}) RETURN m.value") {
-            Ok(statement) => statement,
-            Err(_) => return Ok(None),
-        };
-        let mut rows = match conn.execute(
-            &mut statement,
-            vec![("k", Value::String("embedding".to_string()))],
-        ) {
-            Ok(rows) => rows,
-            Err(_) => return Ok(None),
-        };
+        let mut statement = conn
+            .prepare("MATCH (m:Meta {key: $k}) RETURN m.value")
+            .map_err(|error| {
+                StoreError::Query(format!("prepare embedding pipeline read: {error}"))
+            })?;
+        let mut rows = conn
+            .execute(
+                &mut statement,
+                vec![("k", Value::String("embedding".to_string()))],
+            )
+            .map_err(|error| {
+                StoreError::Query(format!("execute embedding pipeline read: {error}"))
+            })?;
         let Some(row) = rows.next() else {
             return Ok(None);
         };

--- a/crates/nestweaver-store/src/search.rs
+++ b/crates/nestweaver-store/src/search.rs
@@ -412,6 +412,25 @@ impl EmbeddingIndex {
         self.recorded_pipeline_fingerprint = fingerprint;
     }
 
+    pub(crate) fn recorded_pipeline_fingerprint(&self) -> Option<&str> {
+        self.recorded_pipeline_fingerprint.as_deref()
+    }
+
+    fn require_recorded_pipeline(
+        &self,
+        pipeline: &nestweaver_schema::EmbeddingPipelineV2,
+    ) -> Result<String, anyhow::Error> {
+        let persisted = pipeline.fingerprint().map_err(anyhow::Error::msg)?;
+        let producer = self.recorded_pipeline_fingerprint().ok_or_else(|| {
+            anyhow::anyhow!("embedding index producer pipeline is unverified; refusing persistence")
+        })?;
+        anyhow::ensure!(
+            producer == persisted.as_str(),
+            "embedding index producer pipeline fingerprint {producer} does not match persistence fingerprint {persisted}"
+        );
+        Ok(persisted)
+    }
+
     pub fn set_similarity(&mut self, similarity: nestweaver_schema::EmbeddingSimilarity) {
         self.similarity = similarity;
     }
@@ -466,6 +485,15 @@ impl EmbeddingIndex {
                 self.embeddings.clear();
                 self.base = None;
                 self.deleted_base_uids.clear();
+                // The mapped base belongs to `recorded`, while every vector
+                // after this Clear belongs to `incoming`. Retaining its
+                // envelope makes `GraphStore::flush_embedding_index` append a
+                // new-pipeline journal to an old-pipeline base. The next open
+                // then rejects the base before it can replay that journal and
+                // silently loses the completed force re-embed. Invalidating
+                // trust forces the checkpoint to publish one complete new
+                // base and retire the old journal instead.
+                self.artifact_envelope = None;
                 self.pending_deltas.push(EmbeddingDelta::Clear);
                 self.force_cleared = true;
             } else {
@@ -738,7 +766,7 @@ impl EmbeddingIndex {
         pipeline: &nestweaver_schema::EmbeddingPipelineV2,
     ) -> Result<EmbeddingArtifactEnvelopeV2, anyhow::Error> {
         use std::io::Write;
-        pipeline.validate().map_err(anyhow::Error::msg)?;
+        self.require_recorded_pipeline(pipeline)?;
         // nw-184: the base checksum is verified lazily on read, but the write
         // path must stay fail-closed — re-publishing an unverified base would
         // launder corruption into a freshly computed checksum that then looks
@@ -1032,7 +1060,7 @@ impl EmbeddingIndex {
         if self.pending_deltas.is_empty() {
             return Ok(0);
         }
-        let fingerprint = pipeline.fingerprint().map_err(anyhow::Error::msg)?;
+        let fingerprint = self.require_recorded_pipeline(pipeline)?;
         let mut journal = match std::fs::read(path) {
             Ok(bytes) => bytes,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -1839,6 +1867,9 @@ impl GraphStore {
         seed_resolution: &SeedResolutionConfig,
         cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
     ) -> Result<Vec<SearchResult>, StoreError> {
+        if query_embedding.is_some() && embedding_index.is_some() {
+            self.require_verified_embedding_identity()?;
+        }
         // 1. Text search
         let text_results = self.search_symbols_by_name(text_query, limit * 2, seed_resolution)?;
 
@@ -2499,6 +2530,75 @@ mod tests {
             .unwrap();
         assert!(!results.is_empty());
         assert_eq!(results[0].name, "greet");
+    }
+
+    #[test]
+    fn hybrid_search_requires_verified_identity_only_for_two_sided_vector_input() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("hybrid-identity.lbug");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        store.insert_symbol(&make_symbol("sym:1", "greet")).unwrap();
+        store.set_embedding_metadata("verified-model", 2).unwrap();
+
+        let conn = store.conn().unwrap();
+        let mut statement = conn
+            .prepare("MATCH (m:Meta {key: $key}) SET m.value = $value")
+            .unwrap();
+        conn.execute(
+            &mut statement,
+            vec![
+                ("key", lbug::Value::String("embedding".to_string())),
+                ("value", lbug::Value::String("{not-json".to_string())),
+            ],
+        )
+        .unwrap();
+        drop(conn);
+        drop(store);
+
+        let degraded = GraphStore::open(&db_path).unwrap();
+        assert!(degraded.embedding_identity_error().is_some());
+        let query = [1.0_f32, 0.0];
+        let mut index = EmbeddingIndex::new();
+        assert!(index.add("sym:1", query.to_vec(), false));
+
+        for (label, query_embedding, embedding_index) in [
+            ("neither", None, None),
+            ("query only", Some(query.as_slice()), None),
+            ("index only", None, Some(&index)),
+        ] {
+            let results = degraded
+                .hybrid_search_cancellable(
+                    "greet",
+                    query_embedding,
+                    embedding_index,
+                    10,
+                    &empty_seed_resolution(),
+                    None,
+                )
+                .unwrap_or_else(|error| {
+                    panic!("{label} must retain lexical search under unreadable identity: {error}")
+                });
+            assert_eq!(
+                results.first().map(|result| result.uid.as_str()),
+                Some("sym:1"),
+                "{label} must return the lexical match"
+            );
+        }
+
+        let error = degraded
+            .hybrid_search_cancellable(
+                "greet",
+                Some(&query),
+                Some(&index),
+                10,
+                &empty_seed_resolution(),
+                None,
+            )
+            .expect_err("two-sided vector input must require verified identity");
+        assert!(matches!(
+            error,
+            StoreError::EmbeddingIdentityUnreadable { .. }
+        ));
     }
 
     #[test]

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -63,6 +63,42 @@ fn validate_edge_pairs(
     Ok(())
 }
 
+fn same_materialized_note(existing: &Note, desired: &Note) -> bool {
+    existing.uid == desired.uid
+        && existing.vault_uid == desired.vault_uid
+        && existing.file_path == desired.file_path
+        && existing.title == desired.title
+        && existing.note_kind == desired.note_kind
+        && existing.word_count == desired.word_count
+        && existing.content_hash == desired.content_hash
+        && existing.frontmatter == desired.frontmatter
+        && existing.frontmatter_raw == desired.frontmatter_raw
+        && existing.created_at == desired.created_at
+        && existing.modified_at == desired.modified_at
+}
+
+fn same_materialized_heading(existing: &Heading, desired: &Heading) -> bool {
+    existing.uid == desired.uid
+        && existing.note_uid == desired.note_uid
+        && existing.level == desired.level
+        && existing.text == desired.text
+        && existing.slug == desired.slug
+        && existing.start_line == desired.start_line
+        && existing.end_line == desired.end_line
+        && existing.content_hash == desired.content_hash
+}
+
+fn same_materialized_section(existing: &Section, desired: &Section) -> bool {
+    existing.uid == desired.uid
+        && existing.note_uid == desired.note_uid
+        && existing.heading_uid == desired.heading_uid
+        && existing.start_line == desired.start_line
+        && existing.end_line == desired.end_line
+        && existing.text_hash == desired.text_hash
+        && existing.text_content == desired.text_content
+        && existing.word_count == desired.word_count
+}
+
 /// `Meta.key` prefix for the per-repo contract-derivation failure marker.
 ///
 /// The full key is `<prefix><repo_uid>`. Contract derivation is best-effort at
@@ -142,6 +178,71 @@ pub enum ProjectMutationDisposition {
     /// The database may have committed or a required rollback could not be
     /// confirmed. Callers must reconcile against graph liveness.
     Ambiguous,
+}
+
+/// Whether an atomic Project-subgraph replacement published new graph state.
+///
+/// The engine uses this proof to publish exactly one new graph generation for
+/// a committed materialization, while keeping an idempotent rerun at the
+/// current generation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReplaceMaterializedProjectsOutcome {
+    pub disposition: ProjectMutationDisposition,
+}
+
+impl ReplaceMaterializedProjectsOutcome {
+    pub fn changed(self) -> bool {
+        self.disposition == ProjectMutationDisposition::Changed
+    }
+}
+
+/// A failed materialized-Project replacement together with the strongest
+/// final-state proof available to publication callers.
+#[derive(Debug)]
+pub struct ReplaceMaterializedProjectsError {
+    pub disposition: ProjectMutationDisposition,
+    pub primary: StoreError,
+}
+
+impl ReplaceMaterializedProjectsError {
+    fn unchanged(primary: StoreError) -> Self {
+        Self {
+            disposition: ProjectMutationDisposition::ConfirmedUnchanged,
+            primary,
+        }
+    }
+
+    fn restored(primary: StoreError) -> Self {
+        Self {
+            disposition: ProjectMutationDisposition::ConfirmedRolledBack,
+            primary,
+        }
+    }
+
+    fn ambiguous(primary: StoreError) -> Self {
+        Self {
+            disposition: ProjectMutationDisposition::Ambiguous,
+            primary,
+        }
+    }
+}
+
+impl std::fmt::Display for ReplaceMaterializedProjectsError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Project materialization ({:?}) failed: {}",
+            self.disposition, self.primary
+        )
+    }
+}
+
+impl std::error::Error for ReplaceMaterializedProjectsError {}
+
+impl From<StoreError> for ReplaceMaterializedProjectsError {
+    fn from(primary: StoreError) -> Self {
+        Self::unchanged(primary)
+    }
 }
 
 /// Confirmed result of an atomic Project cascade.
@@ -4192,6 +4293,7 @@ impl GraphStore {
     /// to disk. For batch operations, prefer `add_embedding` +
     /// `flush_embedding_index` to avoid O(n^2) writes.
     pub fn update_note_embedding(&self, uid: &str, embedding: &[f32]) -> Result<(), StoreError> {
+        self.require_verified_embedding_identity()?;
         // A dimension-guard rejection is logged by the index; nothing was
         // inserted, so skip the flush.
         if self.add_embedding(uid, embedding.to_vec()) {
@@ -4206,6 +4308,7 @@ impl GraphStore {
     /// to disk. For batch operations, prefer `add_embedding` +
     /// `flush_embedding_index` to avoid O(n^2) writes.
     pub fn update_heading_embedding(&self, uid: &str, embedding: &[f32]) -> Result<(), StoreError> {
+        self.require_verified_embedding_identity()?;
         if self.add_embedding(uid, embedding.to_vec()) {
             self.flush_embedding_index()?;
         }
@@ -4218,6 +4321,7 @@ impl GraphStore {
     /// to disk. For batch operations, prefer `add_embedding` +
     /// `flush_embedding_index` to avoid O(n^2) writes.
     pub fn update_symbol_embedding(&self, uid: &str, embedding: &[f32]) -> Result<(), StoreError> {
+        self.require_verified_embedding_identity()?;
         if self.add_embedding(uid, embedding.to_vec()) {
             self.flush_embedding_index()?;
         }
@@ -5309,7 +5413,7 @@ impl GraphStore {
         symbol_edges: &[(String, String)],
         component_edges: &[(String, String)],
         parent_edges: &[(String, String)],
-    ) -> Result<(), StoreError> {
+    ) -> Result<ReplaceMaterializedProjectsOutcome, ReplaceMaterializedProjectsError> {
         let target_uids = projects
             .iter()
             .map(|project| project.uid.as_str())
@@ -5324,7 +5428,8 @@ impl GraphStore {
             {
                 return Err(StoreError::Query(format!(
                     "{relationship} source Project {source} is not configured"
-                )));
+                ))
+                .into());
             }
         }
         for (relationship, edges) in [
@@ -5337,7 +5442,8 @@ impl GraphStore {
             {
                 return Err(StoreError::Query(format!(
                     "{relationship} source Project {source} is not configured"
-                )));
+                ))
+                .into());
             }
             if let Some((_, target)) = edges
                 .iter()
@@ -5345,7 +5451,8 @@ impl GraphStore {
             {
                 return Err(StoreError::Query(format!(
                     "{relationship} target Project {target} is not configured"
-                )));
+                ))
+                .into());
             }
         }
 
@@ -5374,6 +5481,389 @@ impl GraphStore {
         )
     }
 
+    /// Atomically reconcile Projects discovered from vault folders and only
+    /// their note memberships.
+    ///
+    /// Implicit detection is not authoritative for configured repository,
+    /// component, or parent topology. Feeding empty arrays for those
+    /// relationship kinds to [`Self::replace_materialized_projects`] would
+    /// therefore erase valid configured edges. This narrow entry point carries
+    /// the incumbent non-note relationships into the replacement transaction
+    /// unchanged while retaining its rollback/recovery guarantees.
+    pub fn replace_implicit_project_note_memberships(
+        &self,
+        projects: &[Project],
+        note_edges: &[(String, String)],
+    ) -> Result<ReplaceMaterializedProjectsOutcome, ReplaceMaterializedProjectsError> {
+        let target_uids = projects
+            .iter()
+            .map(|project| project.uid.as_str())
+            .collect::<std::collections::HashSet<_>>();
+        if let Some((source, _)) = note_edges
+            .iter()
+            .find(|(source, _)| !target_uids.contains(source.as_str()))
+        {
+            return Err(StoreError::Query(format!(
+                "PROJECT_INCLUDES_NOTE source Project {source} was not implicitly detected"
+            ))
+            .into());
+        }
+
+        let existing = self.list_projects()?;
+        // Folder detection only knows the synthetic identity it would use for
+        // a new implicit Project. When that UID is already configured, its
+        // authored metadata remains authoritative; implicit detection owns
+        // only the Project's note membership.
+        let reconciled_projects = projects
+            .iter()
+            .map(|detected| {
+                existing
+                    .iter()
+                    .find(|project| project.uid == detected.uid)
+                    .cloned()
+                    .unwrap_or_else(|| detected.clone())
+            })
+            .collect::<Vec<_>>();
+        let target_names = projects
+            .iter()
+            .map(|project| project.name.to_lowercase())
+            .collect::<std::collections::HashSet<_>>();
+        let stale_uids = existing
+            .iter()
+            .filter(|project| {
+                target_names.contains(&project.name.to_lowercase())
+                    && !target_uids.contains(project.uid.as_str())
+            })
+            .map(|project| project.uid.clone())
+            .collect::<Vec<_>>();
+
+        // Passing the complete incumbent sets makes them desired state for
+        // this transaction, so only PROJECT_INCLUDES_NOTE is reconciled for
+        // the detected Projects.
+        let symbol_edges = self
+            .list_project_edge_pairs("PROJECT_INCLUDES_SYMBOL")?
+            .into_iter()
+            .collect::<Vec<_>>();
+        let component_edges = self
+            .list_project_edge_pairs("PROJECT_HAS_COMPONENT")?
+            .into_iter()
+            .collect::<Vec<_>>();
+        let parent_edges = self
+            .list_project_edge_pairs("PROJECT_HAS_PARENT")?
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        self.replace_materialized_projects_transaction(
+            &reconciled_projects,
+            note_edges,
+            &symbol_edges,
+            &component_edges,
+            &parent_edges,
+            &stale_uids,
+            true,
+        )
+    }
+
+    /// Replace one externally-fetched wiki Note and its complete structural
+    /// topology in a single transaction, then attach it to its Project.
+    ///
+    /// The old materializer performed Note, Heading, Section, and edge writes
+    /// independently and ignored several failures. A successful return could
+    /// consequently describe a partially-published document. This operation
+    /// either leaves an already-identical topology untouched or publishes the
+    /// complete replacement atomically.
+    pub fn replace_project_wiki_note(
+        &self,
+        project_uid: &str,
+        note: &Note,
+        headings: &[Heading],
+        sections: &[Section],
+    ) -> Result<ReplaceMaterializedProjectsOutcome, StoreError> {
+        self.replace_project_wiki_note_memberships(
+            &[project_uid.to_string()],
+            note,
+            headings,
+            sections,
+        )
+    }
+
+    /// Replace one externally-fetched wiki Note and attach its complete set of
+    /// configured Project memberships in the same transaction.
+    pub fn replace_project_wiki_note_memberships(
+        &self,
+        project_uids: &[String],
+        note: &Note,
+        headings: &[Heading],
+        sections: &[Section],
+    ) -> Result<ReplaceMaterializedProjectsOutcome, StoreError> {
+        let desired_project_uid_refs = unique_uid_set(
+            "wiki Project membership",
+            project_uids.iter().map(String::as_str),
+        )?;
+        if desired_project_uid_refs.is_empty() {
+            return Err(StoreError::Query(format!(
+                "wiki Note {} has no configured Project membership",
+                note.uid
+            )));
+        }
+        let desired_project_uids = desired_project_uid_refs
+            .into_iter()
+            .map(str::to_string)
+            .collect::<std::collections::HashSet<_>>();
+        let existing_project_uids = self
+            .list_projects()?
+            .into_iter()
+            .map(|project| project.uid)
+            .collect::<std::collections::HashSet<_>>();
+        if let Some(project_uid) = desired_project_uids
+            .iter()
+            .find(|project_uid| !existing_project_uids.contains(*project_uid))
+        {
+            return Err(StoreError::Query(format!(
+                "wiki Note {} references missing Project {project_uid}",
+                note.uid
+            )));
+        }
+        let heading_uids = unique_uid_set(
+            "wiki Heading",
+            headings.iter().map(|heading| heading.uid.as_str()),
+        )?;
+        let _section_uids = unique_uid_set(
+            "wiki Section",
+            sections.iter().map(|section| section.uid.as_str()),
+        )?;
+        for heading in headings {
+            if heading.note_uid != note.uid {
+                return Err(StoreError::Query(format!(
+                    "wiki Heading {} belongs to {}, expected {}",
+                    heading.uid, heading.note_uid, note.uid
+                )));
+            }
+        }
+        for section in sections {
+            if section.note_uid != note.uid
+                || section
+                    .heading_uid
+                    .as_deref()
+                    .is_some_and(|uid| !heading_uids.contains(uid))
+            {
+                return Err(StoreError::Query(format!(
+                    "wiki Section {} references an endpoint outside Note {} replacement input",
+                    section.uid, note.uid
+                )));
+            }
+        }
+
+        if self.project_wiki_note_matches(&desired_project_uids, note, headings, sections)? {
+            return Ok(ReplaceMaterializedProjectsOutcome {
+                disposition: ProjectMutationDisposition::ConfirmedUnchanged,
+            });
+        }
+
+        let note_heading_edges = headings
+            .iter()
+            .map(|heading| (note.uid.as_str(), heading.uid.as_str()))
+            .collect::<Vec<_>>();
+        let note_section_edges = sections
+            .iter()
+            .map(|section| (note.uid.as_str(), section.uid.as_str()))
+            .collect::<Vec<_>>();
+        let heading_section_edges = sections
+            .iter()
+            .filter_map(|section| {
+                section
+                    .heading_uid
+                    .as_deref()
+                    .map(|heading_uid| (heading_uid, section.uid.as_str()))
+            })
+            .collect::<Vec<_>>();
+        let project_note_edges = project_uids
+            .iter()
+            .map(|project_uid| (project_uid.as_str(), note.uid.as_str()))
+            .collect::<Vec<_>>();
+
+        let conn = self.begin_transaction()?;
+        let mutation = (|| {
+            Self::delete_note_cascade_on(&conn, &note.uid)?;
+            Self::batch_insert_notes_on(&conn, std::slice::from_ref(note))?;
+            Self::batch_insert_headings_on(&conn, headings)?;
+            Self::batch_insert_sections_on(&conn, sections)?;
+            Self::batch_insert_note_heading_edges_on(&conn, &note_heading_edges)?;
+            Self::batch_insert_note_section_edges_on(&conn, &note_section_edges)?;
+            Self::batch_insert_heading_section_edges_on(&conn, &heading_section_edges)?;
+            Self::batch_insert_project_note_edges_on(&conn, &project_note_edges)?;
+            Self::mark_regex_scope_dirty_on(&conn, &note.vault_uid, false)?;
+            Ok(())
+        })();
+        if let Err(error) = mutation {
+            return match self.rollback_transaction(&conn) {
+                Ok(()) => Err(error),
+                Err(rollback) => Err(StoreError::Query(format!(
+                    "{error}; atomic wiki Note replacement rollback failed: {rollback}"
+                ))),
+            };
+        }
+        if let Err(error) = self.commit_transaction(&conn) {
+            return Err(StoreError::Query(format!(
+                "atomic wiki Note replacement commit failed: {error}"
+            )));
+        }
+        Ok(ReplaceMaterializedProjectsOutcome {
+            disposition: ProjectMutationDisposition::Changed,
+        })
+    }
+
+    fn project_wiki_note_matches(
+        &self,
+        desired_project_uids: &std::collections::HashSet<String>,
+        desired_note: &Note,
+        desired_headings: &[Heading],
+        desired_sections: &[Section],
+    ) -> Result<bool, StoreError> {
+        let existing_note = match self.lookup_note(&desired_note.uid) {
+            Ok(note) => note,
+            Err(StoreError::NotFound) => return Ok(false),
+            Err(error) => return Err(error),
+        };
+        if !same_materialized_note(&existing_note, desired_note) {
+            return Ok(false);
+        }
+
+        let mut existing_headings = self
+            .list_all_headings()?
+            .into_iter()
+            .filter(|heading| heading.note_uid == desired_note.uid)
+            .collect::<Vec<_>>();
+        let mut desired_headings = desired_headings.iter().collect::<Vec<_>>();
+        existing_headings.sort_by(|left, right| left.uid.cmp(&right.uid));
+        desired_headings.sort_by(|left, right| left.uid.cmp(&right.uid));
+        if existing_headings.len() != desired_headings.len()
+            || existing_headings
+                .iter()
+                .zip(&desired_headings)
+                .any(|(existing, desired)| !same_materialized_heading(existing, desired))
+        {
+            return Ok(false);
+        }
+
+        let mut existing_sections = self
+            .list_all_sections()?
+            .into_iter()
+            .filter(|section| section.note_uid == desired_note.uid)
+            .collect::<Vec<_>>();
+        let mut desired_sections = desired_sections.iter().collect::<Vec<_>>();
+        existing_sections.sort_by(|left, right| left.uid.cmp(&right.uid));
+        desired_sections.sort_by(|left, right| left.uid.cmp(&right.uid));
+        if existing_sections.len() != desired_sections.len()
+            || existing_sections
+                .iter()
+                .zip(&desired_sections)
+                .any(|(existing, desired)| !same_materialized_section(existing, desired))
+        {
+            return Ok(false);
+        }
+
+        let conn = self.conn()?;
+        let actual_project_notes = Self::list_string_targets_on(
+            &conn,
+            "MATCH (p:Project)-[:PROJECT_INCLUDES_NOTE]->(n:Note {uid: $uid}) RETURN p.uid",
+            &desired_note.uid,
+            "wiki Project membership",
+        )?;
+        if &actual_project_notes != desired_project_uids {
+            return Ok(false);
+        }
+        let actual_heading_uids = Self::list_string_targets_on(
+            &conn,
+            "MATCH (n:Note {uid: $uid})-[:NOTE_HAS_HEADING]->(h:Heading) RETURN h.uid",
+            &desired_note.uid,
+            "wiki Note headings",
+        )?;
+        let desired_heading_uids = desired_headings
+            .iter()
+            .map(|heading| heading.uid.clone())
+            .collect::<std::collections::HashSet<_>>();
+        if actual_heading_uids != desired_heading_uids {
+            return Ok(false);
+        }
+        let actual_section_uids = Self::list_string_targets_on(
+            &conn,
+            "MATCH (n:Note {uid: $uid})-[:NOTE_HAS_SECTION]->(s:Section) RETURN s.uid",
+            &desired_note.uid,
+            "wiki Note sections",
+        )?;
+        let desired_section_uids = desired_sections
+            .iter()
+            .map(|section| section.uid.clone())
+            .collect::<std::collections::HashSet<_>>();
+        if actual_section_uids != desired_section_uids {
+            return Ok(false);
+        }
+
+        let actual_heading_sections = Self::list_string_pairs_on(
+            &conn,
+            "MATCH (h:Heading {note_uid: $uid})-[:HEADING_HAS_SECTION]->(s:Section) RETURN h.uid, s.uid",
+            &desired_note.uid,
+            "wiki heading sections",
+        )?;
+        let desired_heading_sections = desired_sections
+            .iter()
+            .filter_map(|section| {
+                section
+                    .heading_uid
+                    .as_ref()
+                    .map(|heading_uid| (heading_uid.clone(), section.uid.clone()))
+            })
+            .collect::<std::collections::HashSet<_>>();
+        Ok(actual_heading_sections == desired_heading_sections)
+    }
+
+    fn list_string_targets_on(
+        conn: &lbug::Connection<'_>,
+        query: &str,
+        uid: &str,
+        stage: &str,
+    ) -> Result<std::collections::HashSet<String>, StoreError> {
+        let mut statement = conn
+            .prepare(query)
+            .map_err(|error| StoreError::Query(format!("prepare {stage}: {error}")))?;
+        let rows = conn
+            .execute(
+                &mut statement,
+                vec![("uid", lbug::Value::String(uid.to_string()))],
+            )
+            .map_err(|error| StoreError::Query(format!("execute {stage}: {error}")))?;
+        rows.map(|row| match row.first() {
+            Some(lbug::Value::String(value)) => Ok(value.clone()),
+            _ => Err(StoreError::Query(format!("{stage}: malformed target uid"))),
+        })
+        .collect()
+    }
+
+    fn list_string_pairs_on(
+        conn: &lbug::Connection<'_>,
+        query: &str,
+        uid: &str,
+        stage: &str,
+    ) -> Result<std::collections::HashSet<(String, String)>, StoreError> {
+        let mut statement = conn
+            .prepare(query)
+            .map_err(|error| StoreError::Query(format!("prepare {stage}: {error}")))?;
+        let rows = conn
+            .execute(
+                &mut statement,
+                vec![("uid", lbug::Value::String(uid.to_string()))],
+            )
+            .map_err(|error| StoreError::Query(format!("execute {stage}: {error}")))?;
+        rows.map(|row| match (row.first(), row.get(1)) {
+            (Some(lbug::Value::String(source)), Some(lbug::Value::String(target))) => {
+                Ok((source.clone(), target.clone()))
+            }
+            _ => Err(StoreError::Query(format!("{stage}: malformed edge"))),
+        })
+        .collect()
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn replace_materialized_projects_transaction(
         &self,
@@ -5384,7 +5874,7 @@ impl GraphStore {
         parent_edges: &[(String, String)],
         stale_uids: &[String],
         recover_on_failure: bool,
-    ) -> Result<(), StoreError> {
+    ) -> Result<ReplaceMaterializedProjectsOutcome, ReplaceMaterializedProjectsError> {
         let existing_note_edges = self.list_project_edge_pairs("PROJECT_INCLUDES_NOTE")?;
         let existing_symbol_edges = self.list_project_edge_pairs("PROJECT_INCLUDES_SYMBOL")?;
         let existing_component_edges = self.list_project_edge_pairs("PROJECT_HAS_COMPONENT")?;
@@ -5419,6 +5909,17 @@ impl GraphStore {
             .iter()
             .map(|project| project.uid.clone())
             .collect::<std::collections::HashSet<_>>();
+
+        let projects_changed = projects.iter().any(|desired| {
+            existing_projects
+                .iter()
+                .find(|existing| existing.uid == desired.uid)
+                .is_none_or(|existing| {
+                    existing.name != desired.name
+                        || existing.summary != desired.summary
+                        || existing.instance_id != desired.instance_id
+                })
+        });
 
         let note_additions = desired_note_edges
             .difference(&existing_note_edges)
@@ -5468,6 +5969,22 @@ impl GraphStore {
             })
             .cloned()
             .collect::<Vec<_>>();
+
+        if !projects_changed
+            && stale_uids.is_empty()
+            && note_additions.is_empty()
+            && symbol_additions.is_empty()
+            && component_additions.is_empty()
+            && parent_additions.is_empty()
+            && obsolete_note_edges.is_empty()
+            && obsolete_symbol_edges.is_empty()
+            && obsolete_component_edges.is_empty()
+            && obsolete_parent_edges.is_empty()
+        {
+            return Ok(ReplaceMaterializedProjectsOutcome {
+                disposition: ProjectMutationDisposition::ConfirmedUnchanged,
+            });
+        }
 
         let conn = self.begin_transaction()?;
         let mutation = (|| {
@@ -5530,11 +6047,13 @@ impl GraphStore {
             Err(error) => Err(error),
         };
         let Err(error) = publication else {
-            return Ok(());
+            return Ok(ReplaceMaterializedProjectsOutcome {
+                disposition: ProjectMutationDisposition::Changed,
+            });
         };
         let primary = Self::rollback_project_transaction(&conn, error, "Project materialization");
         if !recover_on_failure {
-            return Err(primary);
+            return Err(ReplaceMaterializedProjectsError::ambiguous(primary));
         }
 
         let snapshot_note_edges = existing_note_edges.into_iter().collect::<Vec<_>>();
@@ -5546,7 +6065,12 @@ impl GraphStore {
             .map(|project| project.uid.as_str())
             .collect::<std::collections::HashSet<_>>();
         let introduced_uids = self
-            .list_projects()?
+            .list_projects()
+            .map_err(|probe| {
+                ReplaceMaterializedProjectsError::ambiguous(StoreError::Query(format!(
+                    "{primary}; Project materialization recovery inventory failed: {probe}"
+                )))
+            })?
             .into_iter()
             .filter(|project| !snapshot_uids.contains(project.uid.as_str()))
             .map(|project| project.uid)
@@ -5560,10 +6084,13 @@ impl GraphStore {
             &introduced_uids,
             false,
         ) {
-            Ok(()) => Err(primary),
-            Err(recovery) => Err(StoreError::Query(format!(
-                "{primary}; Project materialization recovery failed: {recovery}"
-            ))),
+            Ok(_) => Err(ReplaceMaterializedProjectsError::restored(primary)),
+            Err(recovery) => Err(ReplaceMaterializedProjectsError::ambiguous(
+                StoreError::Query(format!(
+                    "{primary}; Project materialization recovery failed: {}",
+                    recovery.primary
+                )),
+            )),
         }
     }
 
@@ -7570,6 +8097,80 @@ impl GraphStore {
 
     // ── DB-level metadata ───────────────────────────────────────────────────
 
+    /// Intentionally discard an unreadable semantic space so it can be rebuilt.
+    ///
+    /// This is the only supported escape hatch from fail-closed embedding
+    /// identity degradation. It never adopts or guesses the malformed
+    /// metadata: every vector artifact is durably removed first, then the
+    /// authoritative Meta row is deleted in one transaction. If artifact
+    /// retirement fails, the unreadable database identity remains in place and
+    /// semantic reads/writes stay refused.
+    pub fn reset_embedding_space_for_identity_repair(&self) -> Result<usize, StoreError> {
+        // Sidecar retirement is an ordinary filesystem unlink and therefore
+        // is not protected by lbug's read-only connection. Refuse on the
+        // constructor-derived capability before touching any artifact; doing
+        // this only when the metadata transaction begins would return a
+        // read-only error after the durable vector index was already gone.
+        if !self.is_read_write() {
+            return Err(StoreError::Query(
+                "embedding identity repair requires a read-write store; no artifacts were modified"
+                    .to_string(),
+            ));
+        }
+        let mut embedding_index = self
+            .embedding_index
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let mut removed = embedding_index.len();
+
+        if let Some(db_path) = self.db_path.as_ref() {
+            for suffix in [".embeddings.journal", ".embeddings.bin", ".embeddings"] {
+                let mut path = db_path.as_os_str().to_owned();
+                path.push(suffix);
+                let path = std::path::PathBuf::from(path);
+                if suffix == ".embeddings.bin"
+                    && let Ok(index) = crate::search::EmbeddingIndex::load_binary_v2(&path)
+                {
+                    removed = removed.max(index.len());
+                }
+                crate::durable_sidecar::remove_file_durable_if_exists(&path).map_err(|error| {
+                    StoreError::Query(format!(
+                        "retire embedding artifact {} during identity repair: {error}",
+                        path.display()
+                    ))
+                })?;
+            }
+        }
+
+        let conn = self.conn()?;
+        conn.query("BEGIN TRANSACTION").map_err(|error| {
+            StoreError::Query(format!("begin embedding identity reset: {error}"))
+        })?;
+        let result = (|| {
+            exec_params(
+                &conn,
+                "MATCH (m:Meta {key: $k}) DETACH DELETE m",
+                vec![("k", lbug::Value::String("embedding".to_string()))],
+            )?;
+            conn.query("COMMIT").map_err(|error| {
+                StoreError::Query(format!("commit embedding identity reset: {error}"))
+            })?;
+            Ok(())
+        })();
+        if result.is_err() {
+            let _ = conn.query("ROLLBACK");
+            return result.map(|()| removed);
+        }
+
+        embedding_index.clear();
+        embedding_index.set_recorded_model_id(None);
+        embedding_index.set_recorded_pipeline_fingerprint(None);
+        embedding_index.set_similarity(nestweaver_schema::EmbeddingSimilarity::Cosine);
+        embedding_index.reset_force_guard();
+        self.clear_embedding_identity_error();
+        Ok(removed)
+    }
+
     /// Persist the embedding model ID and vector dimension as a singleton
     /// `Meta` node in the database. lbug does not support MERGE or SET, so
     /// we use the established delete-then-create upsert pattern. The node
@@ -7603,23 +8204,36 @@ impl GraphStore {
         let conn = self.conn()?;
         let value = serde_json::to_string(pipeline)
             .map_err(|error| StoreError::Query(format!("serialize embedding pipeline: {error}")))?;
-        let _ = exec_params(
-            &conn,
-            "MATCH (m:Meta {key: $k}) DETACH DELETE m",
-            vec![("k", lbug::Value::String("embedding".to_string()))],
-        );
-        let result = exec_params(
-            &conn,
-            "CREATE (:Meta {key: $k, value: $v})",
-            vec![
-                ("k", lbug::Value::String("embedding".to_string())),
-                ("v", lbug::Value::String(value)),
-            ],
-        );
+        conn.query("BEGIN TRANSACTION").map_err(|error| {
+            StoreError::Query(format!("begin embedding pipeline update: {error}"))
+        })?;
+        let result = (|| {
+            exec_params(
+                &conn,
+                "MATCH (m:Meta {key: $k}) DETACH DELETE m",
+                vec![("k", lbug::Value::String("embedding".to_string()))],
+            )?;
+            exec_params(
+                &conn,
+                "CREATE (:Meta {key: $k, value: $v})",
+                vec![
+                    ("k", lbug::Value::String("embedding".to_string())),
+                    ("v", lbug::Value::String(value)),
+                ],
+            )?;
+            conn.query("COMMIT").map_err(|error| {
+                StoreError::Query(format!("commit embedding pipeline update: {error}"))
+            })?;
+            Ok(())
+        })();
+        if result.is_err() {
+            let _ = conn.query("ROLLBACK");
+        }
         if result.is_ok() {
             embedding_index.set_recorded_pipeline_fingerprint(Some(fingerprint));
             embedding_index.set_recorded_model_id(Some(pipeline.model_id.clone()));
             embedding_index.set_similarity(pipeline.similarity.clone());
+            self.clear_embedding_identity_error();
         }
         result
     }
@@ -7783,6 +8397,52 @@ impl GraphStore {
                 lbug::Value::String(format!("{CONTRACT_DERIVATION_DEBT_PREFIX}{repo_uid}")),
             )],
         )
+    }
+}
+
+#[cfg(test)]
+mod embedding_write_identity_tests {
+    use super::*;
+
+    #[test]
+    fn direct_embedding_updates_propagate_unreadable_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("embedding-write-identity.lbug");
+        let store = GraphStore::open_or_create(&db_path).unwrap();
+        store.set_embedding_metadata("verified-model", 2).unwrap();
+
+        let conn = store.conn().unwrap();
+        let mut statement = conn
+            .prepare("MATCH (m:Meta {key: $key}) SET m.value = $value")
+            .unwrap();
+        conn.execute(
+            &mut statement,
+            vec![
+                ("key", lbug::Value::String("embedding".to_string())),
+                ("value", lbug::Value::String("{not-json".to_string())),
+            ],
+        )
+        .unwrap();
+        drop(conn);
+        drop(store);
+
+        let degraded = GraphStore::open(&db_path).unwrap();
+        for error in [
+            degraded
+                .update_note_embedding("note:rejected", &[1.0, 0.0])
+                .unwrap_err(),
+            degraded
+                .update_heading_embedding("heading:rejected", &[1.0, 0.0])
+                .unwrap_err(),
+            degraded
+                .update_symbol_embedding("symbol:rejected", &[1.0, 0.0])
+                .unwrap_err(),
+        ] {
+            assert!(
+                matches!(error, StoreError::EmbeddingIdentityUnreadable { .. }),
+                "direct embedding update returned the wrong error: {error}"
+            );
+        }
     }
 }
 
@@ -10202,6 +10862,307 @@ mod tests {
     }
 
     #[test]
+    fn materialized_project_replacement_distinguishes_change_from_exact_noop() {
+        use nestweaver_schema::Project;
+
+        let store = GraphStore::in_memory().unwrap();
+        let project = Project {
+            uid: "proj:test:stable".to_string(),
+            name: "stable".to_string(),
+            summary: Some("same summary".to_string()),
+            instance_id: "test".to_string(),
+        };
+
+        let changed = store
+            .replace_materialized_projects(std::slice::from_ref(&project), &[], &[], &[], &[])
+            .unwrap();
+        assert_eq!(changed.disposition, ProjectMutationDisposition::Changed);
+
+        let unchanged = store
+            .replace_materialized_projects(std::slice::from_ref(&project), &[], &[], &[], &[])
+            .unwrap();
+        assert_eq!(
+            unchanged.disposition,
+            ProjectMutationDisposition::ConfirmedUnchanged
+        );
+
+        let mut revised = project;
+        revised.summary = Some("revised summary".to_string());
+        let revised = store
+            .replace_materialized_projects(std::slice::from_ref(&revised), &[], &[], &[], &[])
+            .unwrap();
+        assert_eq!(revised.disposition, ProjectMutationDisposition::Changed);
+    }
+
+    #[test]
+    fn implicit_project_replacement_preserves_configured_non_note_topology() {
+        use nestweaver_schema::{Note, NoteKind, Project, Symbol, SymbolKind, Visibility};
+
+        let store = GraphStore::in_memory().unwrap();
+        let detected = Project {
+            uid: "proj:test:implicit".to_string(),
+            name: "implicit".to_string(),
+            summary: None,
+            instance_id: "test".to_string(),
+        };
+        let implicit = Project {
+            uid: detected.uid.clone(),
+            name: "Configured display name".to_string(),
+            summary: Some("Configured summary".to_string()),
+            instance_id: "configured-instance".to_string(),
+        };
+        let related = Project {
+            uid: "proj:test:related".to_string(),
+            name: "related".to_string(),
+            summary: None,
+            instance_id: "test".to_string(),
+        };
+        store.insert_project(&implicit).unwrap();
+        store.insert_project(&related).unwrap();
+        for (uid, title) in [("note:old", "Old"), ("note:new", "New")] {
+            store
+                .insert_note(&Note {
+                    uid: uid.to_string(),
+                    vault_uid: "vault:test".to_string(),
+                    file_path: format!("Workspaces/implicit/{title}.md"),
+                    title: title.to_string(),
+                    note_kind: NoteKind::General,
+                    word_count: 1,
+                    content_hash: title.to_lowercase(),
+                    frontmatter: None,
+                    frontmatter_raw: None,
+                    created_at: None,
+                    modified_at: None,
+                    pagerank_score: None,
+                    embedding: None,
+                })
+                .unwrap();
+        }
+        let symbol_uid = "sym:test:configured".to_string();
+        store
+            .insert_symbol(&Symbol {
+                uid: symbol_uid.clone(),
+                name: "configured".to_string(),
+                kind: SymbolKind::Function,
+                repo_uid: "repo:test".to_string(),
+                file_path: "src/lib.rs".to_string(),
+                start_line: 1,
+                end_line: 1,
+                signature: "fn configured()".to_string(),
+                summary: None,
+                content_hash: "configured".to_string(),
+                embedding: None,
+                pagerank_score: None,
+                is_entry_point: false,
+                entry_point_kind: None,
+                visibility: Visibility::Public,
+                type_info: None,
+                framework_hint: None,
+                canonical_id: None,
+            })
+            .unwrap();
+        store
+            .batch_insert_project_note_edges(&[(&implicit.uid, "note:old")])
+            .unwrap();
+        store
+            .batch_insert_project_symbol_edges(
+                &implicit.uid,
+                std::slice::from_ref(&symbol_uid),
+                1.0,
+            )
+            .unwrap();
+        store
+            .insert_project_component_edge(&implicit.uid, &related.uid, 1.0)
+            .unwrap();
+        store
+            .insert_project_parent_edge(&implicit.uid, &related.uid, 1.0)
+            .unwrap();
+
+        let changed = store
+            .replace_implicit_project_note_memberships(
+                std::slice::from_ref(&detected),
+                &[(implicit.uid.clone(), "note:new".to_string())],
+            )
+            .unwrap();
+        assert_eq!(changed.disposition, ProjectMutationDisposition::Changed);
+        assert_eq!(
+            store.list_project_note_uids(&implicit.uid).unwrap(),
+            vec!["note:new".to_string()]
+        );
+        assert_eq!(
+            store.list_project_symbol_uids(&implicit.uid).unwrap(),
+            vec![symbol_uid]
+        );
+        assert_eq!(
+            store.list_project_component_uids(&implicit.uid).unwrap(),
+            vec![related.uid.clone()]
+        );
+        let conn = store.conn().unwrap();
+        assert_eq!(
+            conn.query(
+                "MATCH (p:Project {uid: 'proj:test:implicit'})-[:PROJECT_HAS_PARENT]->\
+                 (q:Project {uid: 'proj:test:related'}) RETURN q.uid"
+            )
+            .unwrap()
+            .count(),
+            1,
+            "implicit note discovery must preserve the configured parent relationship"
+        );
+        let preserved = store
+            .list_projects()
+            .unwrap()
+            .into_iter()
+            .find(|project| project.uid == implicit.uid)
+            .unwrap();
+        assert_eq!(preserved.name, implicit.name);
+        assert_eq!(preserved.summary, implicit.summary);
+        assert_eq!(preserved.instance_id, implicit.instance_id);
+
+        let unchanged = store
+            .replace_implicit_project_note_memberships(
+                std::slice::from_ref(&detected),
+                &[(implicit.uid.clone(), "note:new".to_string())],
+            )
+            .unwrap();
+        assert_eq!(
+            unchanged.disposition,
+            ProjectMutationDisposition::ConfirmedUnchanged
+        );
+    }
+
+    #[test]
+    fn shared_project_wiki_note_replacement_is_atomic_and_exact_noop() {
+        use nestweaver_schema::{Heading, Note, NoteKind, Project, Section};
+
+        let store = GraphStore::in_memory().unwrap();
+        let project = Project {
+            uid: "proj:test:wiki".to_string(),
+            name: "wiki".to_string(),
+            summary: None,
+            instance_id: "test".to_string(),
+        };
+        store.insert_project(&project).unwrap();
+        let peer = Project {
+            uid: "proj:test:wiki-peer".to_string(),
+            name: "wiki-peer".to_string(),
+            summary: None,
+            instance_id: "test".to_string(),
+        };
+        store.insert_project(&peer).unwrap();
+        let project_uids = vec![project.uid.clone(), peer.uid.clone()];
+        let note = Note {
+            uid: "note:wiki:test".to_string(),
+            vault_uid: "wiki:test".to_string(),
+            file_path: "get_page/Test".to_string(),
+            title: "Test".to_string(),
+            note_kind: NoteKind::General,
+            word_count: 2,
+            content_hash: "wiki-note-hash".to_string(),
+            frontmatter: None,
+            frontmatter_raw: None,
+            created_at: None,
+            modified_at: None,
+            pagerank_score: None,
+            embedding: None,
+        };
+        let heading = Heading {
+            uid: "heading:wiki:test".to_string(),
+            note_uid: note.uid.clone(),
+            level: 1,
+            text: "Test".to_string(),
+            slug: "test".to_string(),
+            start_line: 1,
+            end_line: 2,
+            content_hash: "heading-hash".to_string(),
+            embedding: None,
+        };
+        let section = Section {
+            uid: "section:wiki:test".to_string(),
+            note_uid: note.uid.clone(),
+            heading_uid: Some(heading.uid.clone()),
+            start_line: 1,
+            end_line: 2,
+            text_hash: "section-hash".to_string(),
+            text_content: "# Test".to_string(),
+            word_count: 2,
+            pagerank_score: None,
+        };
+
+        let changed = store
+            .replace_project_wiki_note_memberships(
+                &project_uids,
+                &note,
+                std::slice::from_ref(&heading),
+                std::slice::from_ref(&section),
+            )
+            .unwrap();
+        assert_eq!(changed.disposition, ProjectMutationDisposition::Changed);
+        assert_eq!(
+            store.list_project_note_uids(&project.uid).unwrap(),
+            vec![note.uid.clone()]
+        );
+        assert_eq!(
+            store.list_project_note_uids(&peer.uid).unwrap(),
+            vec![note.uid.clone()],
+            "one shared wiki Note must retain every configured Project membership"
+        );
+        assert_eq!(
+            store
+                .list_notes(None)
+                .unwrap()
+                .into_iter()
+                .filter(|candidate| candidate.uid == note.uid)
+                .count(),
+            1,
+            "shared membership must not duplicate the wiki Note"
+        );
+
+        let unchanged = store
+            .replace_project_wiki_note_memberships(
+                &project_uids,
+                &note,
+                std::slice::from_ref(&heading),
+                std::slice::from_ref(&section),
+            )
+            .unwrap();
+        assert_eq!(
+            unchanged.disposition,
+            ProjectMutationDisposition::ConfirmedUnchanged
+        );
+
+        let invalid_section = Section {
+            heading_uid: Some("heading:missing".to_string()),
+            text_content: "replacement that must not publish".to_string(),
+            ..section
+        };
+        assert!(
+            store
+                .replace_project_wiki_note_memberships(
+                    &project_uids,
+                    &note,
+                    std::slice::from_ref(&heading),
+                    std::slice::from_ref(&invalid_section),
+                )
+                .is_err()
+        );
+        assert_eq!(
+            store.lookup_note(&note.uid).unwrap().content_hash,
+            note.content_hash
+        );
+        assert_eq!(
+            store
+                .list_all_sections()
+                .unwrap()
+                .into_iter()
+                .find(|candidate| candidate.uid == "section:wiki:test")
+                .unwrap()
+                .text_content,
+            "# Test",
+            "invalid replacement input must leave the complete incumbent topology"
+        );
+    }
+
+    #[test]
     fn disk_backed_late_project_copy_failure_restores_previous_graph() {
         use nestweaver_schema::{Note, NoteKind, Project};
 
@@ -10291,6 +11252,11 @@ mod tests {
             true,
         );
         let error = result.expect_err("the late component COPY must fail");
+        assert_eq!(
+            error.disposition,
+            ProjectMutationDisposition::ConfirmedRolledBack,
+            "successful snapshot restoration must be exposed to publication callers"
+        );
         assert!(error.to_string().contains("PROJECT_HAS_COMPONENT"));
         assert!(
             !error.to_string().contains("rollback failed"),
@@ -10355,6 +11321,10 @@ mod tests {
                 &[],
             )
             .unwrap_err();
+        assert_eq!(
+            error.disposition,
+            ProjectMutationDisposition::ConfirmedUnchanged
+        );
         assert!(error.to_string().contains("is not configured"));
         assert_eq!(
             store.list_project_note_uids(&project.uid).unwrap(),

--- a/crates/nestweaver-store/src/write_lease.rs
+++ b/crates/nestweaver-store/src/write_lease.rs
@@ -103,6 +103,10 @@ pub fn write_lease_path(db_path: &Path) -> PathBuf {
 #[must_use = "the lease must be held for the complete mutation"]
 #[derive(Debug)]
 pub struct DbWriteLease {
+    // System scratch roots such as /tmp cannot be destructively restored by
+    // NestWeaver, so a database directly below one needs only the exact
+    // database and sidecar authorities. Every replaceable data directory also
+    // holds this shared namespace descriptor.
     _namespace_file: Option<std::fs::File>,
     _db_file: std::fs::File,
     _lease_file: std::fs::File,
@@ -186,12 +190,11 @@ pub fn acquire_db_namespace_lease(data_dir: &Path) -> Result<DbNamespaceLease, W
         .truncate(false)
         .open(&lease_path)
         .map_err(WriteLeaseError::Unavailable)?;
-    // The POSIX record lock is not inherited across fork. Take it first so a
-    // live external namespace owner still fails immediately, while the flock
-    // retry below can be limited to same-process ownership or the brief
-    // fork-before-exec interval of an otherwise finished owner.
-    lock_posix_nonblocking(&file, libc::F_WRLCK as libc::c_short)?;
-    lock_flock_after_posix_authority(&file, libc::LOCK_EX)?;
+    // Namespace coordination is an upgraded-writer protocol, so one
+    // descriptor-scoped flock is sufficient. Do not layer a POSIX record lock
+    // onto this same inode: macOS makes flock/fcntl locks cooperate and
+    // explicitly permits only one of those interfaces per file in a process.
+    lock_flock_with_inheritance_retry(&file, libc::LOCK_EX)?;
     Ok(DbNamespaceLease {
         _file: file,
         data_dir,
@@ -199,6 +202,12 @@ pub fn acquire_db_namespace_lease(data_dir: &Path) -> Result<DbNamespaceLease, W
 }
 
 fn namespace_lease_path(data_dir: &Path) -> Result<PathBuf, WriteLeaseError> {
+    if is_system_scratch_data_dir(data_dir) {
+        return Err(WriteLeaseError::Unavailable(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "system scratch directories cannot be destructively replaced as database namespaces",
+        )));
+    }
     let parent = data_dir.parent().ok_or_else(|| {
         WriteLeaseError::Unavailable(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
@@ -215,6 +224,23 @@ fn namespace_lease_path(data_dir: &Path) -> Result<PathBuf, WriteLeaseError> {
     lock_name.push(name);
     lock_name.push(".nestweaver-write-namespace.lock");
     Ok(parent.join(lock_name))
+}
+
+/// Direct scratch databases are valid, but replacing the system scratch root
+/// itself is not. Keeping that distinction explicit prevents `/tmp/x.lbug`
+/// from trying to create its shared namespace lock in `/`, while every exact
+/// database writer still holds the database inode and stable sidecar locks.
+///
+/// The paths are fixed rather than derived from `TMPDIR`: an untrusted ambient
+/// environment variable must not be able to opt an ordinary data directory out
+/// of restore coordination. Canonicalisation covers macOS aliases such as
+/// `/tmp -> /private/tmp`.
+fn is_system_scratch_data_dir(data_dir: &Path) -> bool {
+    let data_dir = canonical_db_path(data_dir);
+    [Path::new("/tmp"), Path::new("/var/tmp")]
+        .into_iter()
+        .map(canonical_db_path)
+        .any(|scratch| scratch == data_dir)
 }
 
 fn acquire_db_write_lease_inner(
@@ -236,22 +262,25 @@ fn acquire_db_write_lease_inner(
                 "database path has no stable namespace ancestor",
             ))
         })?;
-        if let Some(stable_parent) = data_dir.parent()
-            && !stable_parent.exists()
-        {
-            std::fs::create_dir_all(stable_parent).map_err(WriteLeaseError::Unavailable)?;
+        if is_system_scratch_data_dir(&data_dir) {
+            None
+        } else {
+            if let Some(stable_parent) = data_dir.parent()
+                && !stable_parent.exists()
+            {
+                std::fs::create_dir_all(stable_parent).map_err(WriteLeaseError::Unavailable)?;
+            }
+            let lease_path = namespace_lease_path(&data_dir)?;
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .truncate(false)
+                .open(lease_path)
+                .map_err(WriteLeaseError::Unavailable)?;
+            lock_flock_with_inheritance_retry(&file, libc::LOCK_SH)?;
+            Some(file)
         }
-        let lease_path = namespace_lease_path(&data_dir)?;
-        let file = std::fs::OpenOptions::new()
-            .create(true)
-            .read(true)
-            .write(true)
-            .truncate(false)
-            .open(lease_path)
-            .map_err(WriteLeaseError::Unavailable)?;
-        lock_posix_nonblocking(&file, libc::F_RDLCK as libc::c_short)?;
-        lock_flock_after_posix_authority(&file, libc::LOCK_SH)?;
-        Some(file)
     };
     // The data directory may have been absent, or restore may have renamed it
     // away immediately before this acquisition. Recreate it only after the
@@ -278,10 +307,10 @@ fn acquire_db_write_lease_inner(
     // knows nothing about the sidecar: successful authority acquisition must
     // exclude it, not merely exclude other upgraded NestWeaver processes.
     lock_posix_write_nonblocking(&db_file)?;
-    // POSIX locks are process-scoped, so a second descriptor in this process
-    // would not conflict with the first. The additional flock is descriptor-
-    // scoped and closes that same-process duplicate-authority hole.
-    lock_flock_after_posix_authority(&db_file, libc::LOCK_EX)?;
+    // Never flock this same inode as well. Linux keeps the two lock families
+    // independent, while macOS makes them cooperate and a second interface can
+    // contend with this process's own record lock. The process claim and the
+    // distinct sidecar flock below close the same-process duplicate hole.
 
     let lease_file = std::fs::OpenOptions::new()
         .create(true)
@@ -290,7 +319,7 @@ fn acquire_db_write_lease_inner(
         .truncate(false)
         .open(&lease_path)
         .map_err(WriteLeaseError::Unavailable)?;
-    lock_flock_after_posix_authority(&lease_file, libc::LOCK_EX)?;
+    lock_flock_with_inheritance_retry(&lease_file, libc::LOCK_EX)?;
     Ok(DbWriteLease {
         _namespace_file: namespace_file,
         _db_file: db_file,
@@ -306,7 +335,7 @@ fn data_dir_for_db(db_path: &Path) -> Option<PathBuf> {
     canonical.parent().map(Path::to_path_buf)
 }
 
-fn lock_flock_after_posix_authority(
+fn lock_flock_with_inheritance_retry(
     file: &std::fs::File,
     operation: libc::c_int,
 ) -> Result<(), WriteLeaseError> {
@@ -314,10 +343,11 @@ fn lock_flock_after_posix_authority(
 
     // `flock` follows the open file description across fork. Rust marks these
     // descriptors CLOEXEC, but a child created by another thread can retain a
-    // just-dropped owner's description until exec completes. The preceding
-    // POSIX record lock is not inherited, so a live external canonical owner
-    // normally fails at that first gate. Bounded retry here covers inherited
-    // descriptions and retains the flock fallback for same-process authority.
+    // just-dropped owner's description until exec completes. Bounded retry
+    // covers that transient inheritance window. A live upgraded owner keeps
+    // the flock past the bound and is reported as Held; an exact database
+    // writer is also excluded first by the non-inherited POSIX lock on the
+    // separate database inode.
     for attempt in 0..=100 {
         if unsafe { libc::flock(file.as_raw_fd(), operation | libc::LOCK_NB) } == 0 {
             return Ok(());
@@ -457,9 +487,11 @@ mod tests {
 
     fn await_write_lease_free(db: &Path) {
         for _ in 0..100 {
-            let namespace_free = data_dir_for_db(db)
-                .and_then(|data_dir| namespace_lease_path(&data_dir).ok())
-                .is_some_and(|path| probe_flock_state(&path) == WriteLeaseState::Free);
+            let namespace_free = data_dir_for_db(db).is_some_and(|data_dir| {
+                namespace_lease_path(&data_dir)
+                    .map(|path| probe_flock_state(&path) == WriteLeaseState::Free)
+                    .unwrap_or(true)
+            });
             if write_lease_state(db) == WriteLeaseState::Free && namespace_free {
                 return;
             }
@@ -471,10 +503,39 @@ mod tests {
         }
         assert_eq!(write_lease_state(db), WriteLeaseState::Free);
         let data_dir = data_dir_for_db(db).expect("database path has a data directory");
-        assert_eq!(
-            probe_flock_state(&namespace_lease_path(&data_dir).unwrap()),
-            WriteLeaseState::Free
-        );
+        if let Ok(namespace_path) = namespace_lease_path(&data_dir) {
+            assert_eq!(probe_flock_state(&namespace_path), WriteLeaseState::Free);
+        }
+    }
+
+    #[test]
+    fn a_database_directly_in_system_scratch_does_not_require_a_root_lock() {
+        let scratch_root = Path::new("/tmp");
+        if !scratch_root.is_dir() {
+            return;
+        }
+        assert!(is_system_scratch_data_dir(scratch_root));
+        assert!(matches!(
+            namespace_lease_path(scratch_root),
+            Err(WriteLeaseError::Unavailable(error))
+                if error.kind() == std::io::ErrorKind::InvalidInput
+        ));
+
+        let scratch_db = tempfile::Builder::new()
+            .prefix("nestweaver-write-lease-")
+            .suffix(".lbug")
+            .tempfile_in(scratch_root)
+            .unwrap();
+        let db_path = scratch_db.path().to_path_buf();
+        let sidecar = write_lease_path(&db_path);
+        let authority = acquire_db_write_lease(&db_path)
+            .expect("an exact scratch database lease must not need write access to /");
+        assert!(authority.authorizes(&db_path));
+        assert_eq!(write_lease_state(&db_path), WriteLeaseState::Held);
+
+        drop(authority);
+        await_write_lease_free(&db_path);
+        std::fs::remove_file(sidecar).unwrap();
     }
 
     #[test]

--- a/crates/nestweaver-store/src/write_lease.rs
+++ b/crates/nestweaver-store/src/write_lease.rs
@@ -114,19 +114,20 @@ pub struct DbWriteLease {
 }
 
 /// Exclusive authority over creation/removal of databases below one stable
-/// directory namespace. Destructive directory replacement (restore) takes
-/// this before enumeration; ordinary database writers take a shared lock on
-/// the same ancestor as part of [`acquire_db_write_lease`].
+/// data-directory namespace. Destructive directory replacement (restore)
+/// takes this before enumeration; ordinary database writers take a shared
+/// lock on the same stable per-directory file as part of
+/// [`acquire_db_write_lease`].
 #[must_use = "the namespace lease must be held across enumeration and cutover"]
 #[derive(Debug)]
 pub struct DbNamespaceLease {
     _file: std::fs::File,
-    root: PathBuf,
+    data_dir: PathBuf,
 }
 
 impl DbNamespaceLease {
     pub fn authorizes(&self, db_path: &Path) -> bool {
-        namespace_root_for_db(db_path).is_some_and(|root| root == self.root)
+        data_dir_for_db(db_path).is_some_and(|data_dir| data_dir == self.data_dir)
     }
 }
 
@@ -147,7 +148,9 @@ pub enum WriteLeaseError {
     Unavailable(std::io::Error),
 }
 
-/// Acquire the canonical exclusive writer authority without blocking.
+/// Acquire the canonical exclusive writer authority without queueing behind a
+/// live external canonical owner. Acquisition may briefly retry an inherited
+/// `flock` left in the fork-before-exec window of another thread.
 pub fn acquire_db_write_lease(db_path: &Path) -> Result<DbWriteLease, WriteLeaseError> {
     acquire_db_write_lease_inner(db_path, None)
 }
@@ -169,55 +172,96 @@ pub fn acquire_db_write_lease_under_namespace(
 }
 
 /// Exclusively close the database-creation namespace for a destructive
-/// replacement of `data_dir`. The locked inode is the stable parent of the
-/// directory being replaced, so renaming `data_dir` cannot swap the lock out
-/// from under the operation.
+/// replacement of `data_dir`. The locked file lives in the stable parent and
+/// is keyed by the directory being replaced, so renaming `data_dir` cannot
+/// swap the lock out from under the operation and unrelated sibling data
+/// directories do not block one another.
 pub fn acquire_db_namespace_lease(data_dir: &Path) -> Result<DbNamespaceLease, WriteLeaseError> {
-    let canonical = canonical_db_path(data_dir);
-    let root = canonical.parent().ok_or_else(|| {
+    let data_dir = canonical_db_path(data_dir);
+    let lease_path = namespace_lease_path(&data_dir)?;
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lease_path)
+        .map_err(WriteLeaseError::Unavailable)?;
+    // The POSIX record lock is not inherited across fork. Take it first so a
+    // live external namespace owner still fails immediately, while the flock
+    // retry below can be limited to same-process ownership or the brief
+    // fork-before-exec interval of an otherwise finished owner.
+    lock_posix_nonblocking(&file, libc::F_WRLCK as libc::c_short)?;
+    lock_flock_after_posix_authority(&file, libc::LOCK_EX)?;
+    Ok(DbNamespaceLease {
+        _file: file,
+        data_dir,
+    })
+}
+
+fn namespace_lease_path(data_dir: &Path) -> Result<PathBuf, WriteLeaseError> {
+    let parent = data_dir.parent().ok_or_else(|| {
         WriteLeaseError::Unavailable(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             "database directory has no stable parent namespace",
         ))
     })?;
-    let file = std::fs::File::open(root).map_err(WriteLeaseError::Unavailable)?;
-    lock_flock_nonblocking(&file, libc::LOCK_EX)?;
-    Ok(DbNamespaceLease {
-        _file: file,
-        root: root.to_path_buf(),
-    })
+    let name = data_dir.file_name().ok_or_else(|| {
+        WriteLeaseError::Unavailable(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "database directory has no stable namespace name",
+        ))
+    })?;
+    let mut lock_name = std::ffi::OsString::from(".");
+    lock_name.push(name);
+    lock_name.push(".nestweaver-write-namespace.lock");
+    Ok(parent.join(lock_name))
 }
 
 fn acquire_db_write_lease_inner(
     db_path: &Path,
     namespace: Option<&DbNamespaceLease>,
 ) -> Result<DbWriteLease, WriteLeaseError> {
-    use std::os::unix::io::AsRawFd;
-
     let db_path = canonical_db_path(db_path);
     // This must precede every database open. See PROCESS_DB_LEASES: even a
     // descriptor that never called F_SETLK would release the incumbent
     // process's record lock when the failed acquisition closed it.
     let process_claim = ProcessDbLeaseClaim::acquire(&db_path)?;
     let lease_path = write_lease_path(&db_path);
-    if let Some(parent) = db_path.parent()
-        && !parent.exists()
-    {
-        std::fs::create_dir_all(parent).map_err(WriteLeaseError::Unavailable)?;
-    }
     let namespace_file = if namespace.is_some() {
         None
     } else {
-        let root = namespace_root_for_db(&db_path).ok_or_else(|| {
+        let data_dir = data_dir_for_db(&db_path).ok_or_else(|| {
             WriteLeaseError::Unavailable(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 "database path has no stable namespace ancestor",
             ))
         })?;
-        let file = std::fs::File::open(root).map_err(WriteLeaseError::Unavailable)?;
-        lock_flock_nonblocking(&file, libc::LOCK_SH)?;
+        if let Some(stable_parent) = data_dir.parent()
+            && !stable_parent.exists()
+        {
+            std::fs::create_dir_all(stable_parent).map_err(WriteLeaseError::Unavailable)?;
+        }
+        let lease_path = namespace_lease_path(&data_dir)?;
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(lease_path)
+            .map_err(WriteLeaseError::Unavailable)?;
+        lock_posix_nonblocking(&file, libc::F_RDLCK as libc::c_short)?;
+        lock_flock_after_posix_authority(&file, libc::LOCK_SH)?;
         Some(file)
     };
+    // The data directory may have been absent, or restore may have renamed it
+    // away immediately before this acquisition. Recreate it only after the
+    // shared namespace authority is held so a losing writer cannot leave an
+    // empty destination that obstructs restore cutover.
+    if let Some(parent) = db_path.parent()
+        && !parent.exists()
+    {
+        std::fs::create_dir_all(parent).map_err(WriteLeaseError::Unavailable)?;
+    }
     // The database descriptor is part of the authority, not merely a probe.
     // Open it first so every cooperating contender has the same lock order.
     // `create(true)` preserves the pre-open use case: callers intentionally
@@ -237,7 +281,7 @@ fn acquire_db_write_lease_inner(
     // POSIX locks are process-scoped, so a second descriptor in this process
     // would not conflict with the first. The additional flock is descriptor-
     // scoped and closes that same-process duplicate-authority hole.
-    lock_exclusive_nonblocking(&db_file)?;
+    lock_flock_after_posix_authority(&db_file, libc::LOCK_EX)?;
 
     let lease_file = std::fs::OpenOptions::new()
         .create(true)
@@ -246,13 +290,7 @@ fn acquire_db_write_lease_inner(
         .truncate(false)
         .open(&lease_path)
         .map_err(WriteLeaseError::Unavailable)?;
-    if unsafe { libc::flock(lease_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
-        let error = std::io::Error::last_os_error();
-        return match error.kind() {
-            std::io::ErrorKind::WouldBlock => Err(WriteLeaseError::Held),
-            _ => Err(WriteLeaseError::Unavailable(error)),
-        };
-    }
+    lock_flock_after_posix_authority(&lease_file, libc::LOCK_EX)?;
     Ok(DbWriteLease {
         _namespace_file: namespace_file,
         _db_file: db_file,
@@ -263,36 +301,47 @@ fn acquire_db_write_lease_inner(
     })
 }
 
-fn namespace_root_for_db(db_path: &Path) -> Option<PathBuf> {
+fn data_dir_for_db(db_path: &Path) -> Option<PathBuf> {
     let canonical = canonical_db_path(db_path);
-    canonical.parent()?.parent().map(Path::to_path_buf)
+    canonical.parent().map(Path::to_path_buf)
 }
 
-fn lock_flock_nonblocking(
+fn lock_flock_after_posix_authority(
     file: &std::fs::File,
     operation: libc::c_int,
 ) -> Result<(), WriteLeaseError> {
     use std::os::unix::io::AsRawFd;
 
-    if unsafe { libc::flock(file.as_raw_fd(), operation | libc::LOCK_NB) } == 0 {
-        return Ok(());
+    // `flock` follows the open file description across fork. Rust marks these
+    // descriptors CLOEXEC, but a child created by another thread can retain a
+    // just-dropped owner's description until exec completes. The preceding
+    // POSIX record lock is not inherited, so a live external canonical owner
+    // normally fails at that first gate. Bounded retry here covers inherited
+    // descriptions and retains the flock fallback for same-process authority.
+    for attempt in 0..=100 {
+        if unsafe { libc::flock(file.as_raw_fd(), operation | libc::LOCK_NB) } == 0 {
+            return Ok(());
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::WouldBlock {
+            return Err(WriteLeaseError::Unavailable(error));
+        }
+        if attempt == 100 {
+            return Err(WriteLeaseError::Held);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
     }
-    let error = std::io::Error::last_os_error();
-    match error.kind() {
-        std::io::ErrorKind::WouldBlock => Err(WriteLeaseError::Held),
-        _ => Err(WriteLeaseError::Unavailable(error)),
-    }
+    unreachable!("bounded flock retry always returns")
 }
 
-fn lock_exclusive_nonblocking(file: &std::fs::File) -> Result<(), WriteLeaseError> {
-    lock_flock_nonblocking(file, libc::LOCK_EX)
-}
-
-fn lock_posix_write_nonblocking(file: &std::fs::File) -> Result<(), WriteLeaseError> {
+fn lock_posix_nonblocking(
+    file: &std::fs::File,
+    lock_type: libc::c_short,
+) -> Result<(), WriteLeaseError> {
     use std::os::unix::io::AsRawFd;
 
     let mut lock: libc::flock = unsafe { std::mem::zeroed() };
-    lock.l_type = libc::F_WRLCK as libc::c_short;
+    lock.l_type = lock_type;
     lock.l_whence = libc::SEEK_SET as libc::c_short;
     lock.l_start = 0;
     lock.l_len = 0;
@@ -308,6 +357,10 @@ fn lock_posix_write_nonblocking(file: &std::fs::File) -> Result<(), WriteLeaseEr
     } else {
         Err(WriteLeaseError::Unavailable(error))
     }
+}
+
+fn lock_posix_write_nonblocking(file: &std::fs::File) -> Result<(), WriteLeaseError> {
+    lock_posix_nonblocking(file, libc::F_WRLCK as libc::c_short)
 }
 
 /// Non-mutating best-effort view of canonical writer ownership.
@@ -402,6 +455,28 @@ fn probe_posix_write_lock_state(path: &Path) -> WriteLeaseState {
 mod tests {
     use super::*;
 
+    fn await_write_lease_free(db: &Path) {
+        for _ in 0..100 {
+            let namespace_free = data_dir_for_db(db)
+                .and_then(|data_dir| namespace_lease_path(&data_dir).ok())
+                .is_some_and(|path| probe_flock_state(&path) == WriteLeaseState::Free);
+            if write_lease_state(db) == WriteLeaseState::Free && namespace_free {
+                return;
+            }
+            // Another parallel test may be between fork and exec. The forked
+            // child briefly inherits the open-file description; CLOEXEC drops
+            // it at exec, but an immediate probe can observe that real,
+            // transient ownership after the parent lease is dropped.
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert_eq!(write_lease_state(db), WriteLeaseState::Free);
+        let data_dir = data_dir_for_db(db).expect("database path has a data directory");
+        assert_eq!(
+            probe_flock_state(&namespace_lease_path(&data_dir).unwrap()),
+            WriteLeaseState::Free
+        );
+    }
+
     #[test]
     fn exact_authority_rejects_a_sibling_and_state_tracks_its_lifetime() {
         let dir = tempfile::tempdir().unwrap();
@@ -413,7 +488,107 @@ mod tests {
         assert!(!authority.authorizes(&sibling));
         assert_eq!(write_lease_state(&db), WriteLeaseState::Held);
         drop(authority);
-        assert_eq!(write_lease_state(&db), WriteLeaseState::Free);
+        await_write_lease_free(&db);
+    }
+
+    #[test]
+    fn destructive_namespaces_are_isolated_per_data_directory() {
+        let root = tempfile::tempdir().unwrap();
+        let first_dir = root.path().join("first");
+        let second_dir = root.path().join("second");
+        std::fs::create_dir_all(&first_dir).unwrap();
+        std::fs::create_dir_all(&second_dir).unwrap();
+
+        let first = acquire_db_namespace_lease(&first_dir).unwrap();
+        let second = acquire_db_namespace_lease(&second_dir).unwrap();
+        assert!(matches!(
+            acquire_db_write_lease(&first_dir.join("blocked.lbug")),
+            Err(WriteLeaseError::Held)
+        ));
+        let second_db = second_dir.join("brain.lbug");
+        let second_writer = acquire_db_write_lease_under_namespace(&second_db, &second).unwrap();
+
+        assert!(first.authorizes(&first_dir.join("brain.lbug")));
+        assert!(!first.authorizes(&second_db));
+        assert!(second_writer.authorizes(&second_db));
+    }
+
+    #[test]
+    fn blocked_writer_does_not_recreate_a_restore_destination() {
+        let root = tempfile::tempdir().unwrap();
+        let data_dir = root.path().join("data");
+        let renamed = root.path().join("data-before-restore");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let namespace = acquire_db_namespace_lease(&data_dir).unwrap();
+        std::fs::rename(&data_dir, &renamed).unwrap();
+        assert!(matches!(
+            acquire_db_write_lease(&data_dir.join("brain.lbug")),
+            Err(WriteLeaseError::Held)
+        ));
+
+        assert!(namespace.authorizes(&data_dir.join("brain.lbug")));
+        assert!(
+            !data_dir.exists(),
+            "a writer that loses namespace admission must not obstruct restore cutover"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_forked_child_cannot_create_false_writer_contention_after_owner_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("fork-inheritance.lbug");
+        let authority = acquire_db_write_lease(&db).unwrap();
+
+        let child = unsafe { libc::fork() };
+        assert!(child >= 0, "fork fixture failed");
+        if child == 0 {
+            // Keep every inherited flock description alive long enough for
+            // the parent to drop and reacquire its authority.
+            unsafe {
+                libc::usleep(50_000);
+                libc::_exit(0);
+            }
+        }
+
+        drop(authority);
+        let replacement = acquire_db_write_lease(&db).unwrap();
+        assert!(replacement.authorizes(&db));
+        drop(replacement);
+
+        let mut status = 0;
+        assert_eq!(unsafe { libc::waitpid(child, &mut status, 0) }, child);
+        assert!(libc::WIFEXITED(status));
+        assert_eq!(libc::WEXITSTATUS(status), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_forked_child_cannot_create_false_namespace_contention_after_owner_drop() {
+        let root = tempfile::tempdir().unwrap();
+        let data_dir = root.path().join("data");
+        std::fs::create_dir(&data_dir).unwrap();
+        let namespace = acquire_db_namespace_lease(&data_dir).unwrap();
+
+        let child = unsafe { libc::fork() };
+        assert!(child >= 0, "fork fixture failed");
+        if child == 0 {
+            unsafe {
+                libc::usleep(50_000);
+                libc::_exit(0);
+            }
+        }
+
+        drop(namespace);
+        let replacement = acquire_db_namespace_lease(&data_dir).unwrap();
+        assert!(replacement.authorizes(&data_dir.join("brain.lbug")));
+        drop(replacement);
+
+        let mut status = 0;
+        assert_eq!(unsafe { libc::waitpid(child, &mut status, 0) }, child);
+        assert!(libc::WIFEXITED(status));
+        assert_eq!(libc::WEXITSTATUS(status), 0);
     }
 
     #[cfg(unix)]
@@ -445,6 +620,19 @@ mod tests {
         ));
 
         drop(authority);
+        await_write_lease_free(&db);
+        let canonical = canonical_db_path(&db);
+        assert!(!ProcessDbLeaseClaim::is_held(&canonical));
+        assert_eq!(
+            probe_flock_state(&namespace_lease_path(dir.path()).unwrap()),
+            WriteLeaseState::Free
+        );
+        assert_eq!(probe_flock_state(&db), WriteLeaseState::Free);
+        assert_eq!(probe_posix_write_lock_state(&db), WriteLeaseState::Free);
+        assert_eq!(
+            probe_flock_state(&write_lease_path(&db)),
+            WriteLeaseState::Free
+        );
         let replacement = acquire_db_write_lease(&db).unwrap();
         assert!(replacement.authorizes(&db));
     }

--- a/crates/nestweaver-store/src/write_lease.rs
+++ b/crates/nestweaver-store/src/write_lease.rs
@@ -51,20 +51,28 @@ impl Drop for ProcessDbLeaseClaim {
 
 /// Canonicalize a database path even before the file exists.
 pub fn canonical_db_path(db_path: &Path) -> PathBuf {
-    if let Ok(canonical) = std::fs::canonicalize(db_path) {
-        return canonical;
+    let absolute = if db_path.is_relative() {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(db_path))
+            .unwrap_or_else(|_| db_path.to_path_buf())
+    } else {
+        db_path.to_path_buf()
+    };
+    // Resolve the deepest ancestor that exists, then retain the unresolved
+    // suffix. Canonicalizing only the immediate parent loses aliases whenever
+    // more than one component is absent (for example while restore has renamed
+    // a data directory), allowing two spellings of one future database to
+    // bypass the pre-open process claim.
+    for ancestor in absolute.ancestors() {
+        if let Ok(mut canonical) = std::fs::canonicalize(ancestor) {
+            let suffix = absolute
+                .strip_prefix(ancestor)
+                .expect("an ancestor must prefix its path");
+            canonical.push(suffix);
+            return lexical_normalize(&canonical);
+        }
     }
-    if let (Some(parent), Some(file_name)) = (db_path.parent(), db_path.file_name())
-        && let Ok(canonical_parent) = std::fs::canonicalize(parent)
-    {
-        return canonical_parent.join(file_name);
-    }
-    if db_path.is_relative()
-        && let Ok(cwd) = std::env::current_dir()
-    {
-        return lexical_normalize(&cwd.join(db_path));
-    }
-    db_path.to_path_buf()
+    lexical_normalize(&absolute)
 }
 
 fn lexical_normalize(path: &Path) -> PathBuf {
@@ -418,11 +426,12 @@ pub fn write_lease_state(db_path: &Path) -> WriteLeaseState {
     if sidecar_state == WriteLeaseState::Held {
         return WriteLeaseState::Held;
     }
-    let states = [
-        sidecar_state,
-        probe_flock_state(&db_path),
-        probe_posix_write_lock_state(&db_path),
-    ];
+    // The database inode belongs exclusively to the POSIX compatibility
+    // protocol. Probing it with flock as well is harmless on Linux, where the
+    // lock families are independent, but on macOS that flock can conflict with
+    // a POSIX lock held by this very process and falsely report an external
+    // writer. Upgraded writers are already visible through the stable sidecar.
+    let states = [sidecar_state, probe_posix_write_lock_state(&db_path)];
     if states.contains(&WriteLeaseState::Held) {
         WriteLeaseState::Held
     } else if states.contains(&WriteLeaseState::Unknown) {
@@ -667,6 +676,44 @@ mod tests {
         assert_eq!(write_lease_path(&alias_db), write_lease_path(&canonical_db));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn canonical_aliases_survive_multiple_missing_path_components() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        let alias = dir.path().join("alias");
+        std::os::unix::fs::symlink(&real, &alias).unwrap();
+        let canonical_db = std::fs::canonicalize(&real)
+            .unwrap()
+            .join("missing")
+            .join("nested")
+            .join("brain.lbug");
+        let alias_db = alias.join("missing").join("nested").join("brain.lbug");
+
+        assert_eq!(canonical_db_path(&alias_db), canonical_db);
+        assert_eq!(write_lease_path(&alias_db), write_lease_path(&canonical_db));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn namespace_authority_follows_a_symlinked_database_target() {
+        let root = tempfile::tempdir().unwrap();
+        let apparent_dir = root.path().join("apparent");
+        let target_dir = root.path().join("target");
+        std::fs::create_dir(&apparent_dir).unwrap();
+        std::fs::create_dir(&target_dir).unwrap();
+        let target_db = target_dir.join("brain.lbug");
+        std::fs::write(&target_db, b"database").unwrap();
+        let alias_db = apparent_dir.join("brain.lbug");
+        std::os::unix::fs::symlink(&target_db, &alias_db).unwrap();
+
+        let apparent = acquire_db_namespace_lease(&apparent_dir).unwrap();
+        assert!(!apparent.authorizes(&alias_db));
+        let target = acquire_db_namespace_lease(&target_dir).unwrap();
+        assert!(target.authorizes(&alias_db));
+    }
+
     #[test]
     fn unlinking_and_recreating_the_sidecar_cannot_mint_a_second_authority() {
         let dir = tempfile::tempdir().unwrap();
@@ -696,6 +743,36 @@ mod tests {
         );
         let replacement = acquire_db_write_lease(&db).unwrap();
         assert!(replacement.authorizes(&db));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_lease_state_does_not_cross_probe_a_same_process_posix_lock() {
+        use std::os::unix::io::AsRawFd as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&db)
+            .unwrap();
+        let mut lock: libc::flock = unsafe { std::mem::zeroed() };
+        lock.l_type = libc::F_WRLCK as libc::c_short;
+        lock.l_whence = libc::SEEK_SET as libc::c_short;
+        assert_eq!(
+            unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETLK, &lock) },
+            0
+        );
+
+        // This synthetic unclaimed lock is not a supported writer lifecycle:
+        // closing the probe descriptor also releases same-process POSIX locks.
+        // It exists only to prove the state query does not add a cross-family
+        // flock probe that self-contends on macOS. Production writers hold the
+        // process claim, so write_lease_state returns Held before opening here.
+        assert_eq!(write_lease_state(&db), WriteLeaseState::Free);
     }
 
     #[cfg(unix)]

--- a/crates/nestweaver-store/src/write_lease.rs
+++ b/crates/nestweaver-store/src/write_lease.rs
@@ -1,0 +1,577 @@
+//! Canonical cross-process authority for database mutations.
+
+use std::collections::HashSet;
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+/// POSIX record locks are process-scoped and closing *any* descriptor for the
+/// same file releases every record lock that process holds on it. Reject a
+/// same-process duplicate before it can open (and later close) another
+/// database descriptor, or that failed attempt could silently discard the
+/// incumbent lease's compatibility lock against pre-upgrade writers.
+static PROCESS_DB_LEASES: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
+
+#[derive(Debug)]
+struct ProcessDbLeaseClaim {
+    db_path: PathBuf,
+}
+
+impl ProcessDbLeaseClaim {
+    fn acquire(db_path: &Path) -> Result<Self, WriteLeaseError> {
+        let mut claimed = PROCESS_DB_LEASES
+            .get_or_init(|| Mutex::new(HashSet::new()))
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !claimed.insert(db_path.to_path_buf()) {
+            return Err(WriteLeaseError::Held);
+        }
+        Ok(Self {
+            db_path: db_path.to_path_buf(),
+        })
+    }
+
+    fn is_held(db_path: &Path) -> bool {
+        PROCESS_DB_LEASES
+            .get_or_init(|| Mutex::new(HashSet::new()))
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .contains(db_path)
+    }
+}
+
+impl Drop for ProcessDbLeaseClaim {
+    fn drop(&mut self) {
+        PROCESS_DB_LEASES
+            .get_or_init(|| Mutex::new(HashSet::new()))
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(&self.db_path);
+    }
+}
+
+/// Canonicalize a database path even before the file exists.
+pub fn canonical_db_path(db_path: &Path) -> PathBuf {
+    if let Ok(canonical) = std::fs::canonicalize(db_path) {
+        return canonical;
+    }
+    if let (Some(parent), Some(file_name)) = (db_path.parent(), db_path.file_name())
+        && let Ok(canonical_parent) = std::fs::canonicalize(parent)
+    {
+        return canonical_parent.join(file_name);
+    }
+    if db_path.is_relative()
+        && let Ok(cwd) = std::env::current_dir()
+    {
+        return lexical_normalize(&cwd.join(db_path));
+    }
+    db_path.to_path_buf()
+}
+
+fn lexical_normalize(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+/// Dedicated per-database lease path.
+///
+/// The authority also locks the database inode itself. Holding both locks is
+/// intentional: the stable sidecar survives publication/restore replacement
+/// of the database, while the database lock prevents unlinking and recreating
+/// only the sidecar from manufacturing a second authority.
+pub fn write_lease_path(db_path: &Path) -> PathBuf {
+    let canonical = canonical_db_path(db_path);
+    let mut name = canonical.as_os_str().to_owned();
+    name.push(".write.lock");
+    PathBuf::from(name)
+}
+
+/// Held writer authority for one canonical database.
+///
+/// Acquire this before opening a read-write [`crate::GraphStore`] and keep it
+/// alive until after the store is dropped. POSIX record locks are process-
+/// scoped: dropping the database descriptor while a store remains open could
+/// otherwise shorten the store's own lock lifetime.
+#[must_use = "the lease must be held for the complete mutation"]
+#[derive(Debug)]
+pub struct DbWriteLease {
+    _namespace_file: Option<std::fs::File>,
+    _db_file: std::fs::File,
+    _lease_file: std::fs::File,
+    db_path: PathBuf,
+    lease_path: PathBuf,
+    // Declared last so every OS lock descriptor closes before another thread
+    // in this process can claim the path.
+    _process_claim: ProcessDbLeaseClaim,
+}
+
+/// Exclusive authority over creation/removal of databases below one stable
+/// directory namespace. Destructive directory replacement (restore) takes
+/// this before enumeration; ordinary database writers take a shared lock on
+/// the same ancestor as part of [`acquire_db_write_lease`].
+#[must_use = "the namespace lease must be held across enumeration and cutover"]
+#[derive(Debug)]
+pub struct DbNamespaceLease {
+    _file: std::fs::File,
+    root: PathBuf,
+}
+
+impl DbNamespaceLease {
+    pub fn authorizes(&self, db_path: &Path) -> bool {
+        namespace_root_for_db(db_path).is_some_and(|root| root == self.root)
+    }
+}
+
+impl DbWriteLease {
+    pub fn path(&self) -> &Path {
+        &self.lease_path
+    }
+
+    /// Prove this authority belongs to the exact canonical database.
+    pub fn authorizes(&self, db_path: &Path) -> bool {
+        self.db_path == canonical_db_path(db_path)
+    }
+}
+
+#[derive(Debug)]
+pub enum WriteLeaseError {
+    Held,
+    Unavailable(std::io::Error),
+}
+
+/// Acquire the canonical exclusive writer authority without blocking.
+pub fn acquire_db_write_lease(db_path: &Path) -> Result<DbWriteLease, WriteLeaseError> {
+    acquire_db_write_lease_inner(db_path, None)
+}
+
+/// Acquire one database authority while an exclusive namespace authority is
+/// already held. Used by restore so it can close the enumerate/create race
+/// without deadlocking against its own ordinary shared namespace lock.
+pub fn acquire_db_write_lease_under_namespace(
+    db_path: &Path,
+    namespace: &DbNamespaceLease,
+) -> Result<DbWriteLease, WriteLeaseError> {
+    if !namespace.authorizes(db_path) {
+        return Err(WriteLeaseError::Unavailable(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "namespace authority does not cover this database",
+        )));
+    }
+    acquire_db_write_lease_inner(db_path, Some(namespace))
+}
+
+/// Exclusively close the database-creation namespace for a destructive
+/// replacement of `data_dir`. The locked inode is the stable parent of the
+/// directory being replaced, so renaming `data_dir` cannot swap the lock out
+/// from under the operation.
+pub fn acquire_db_namespace_lease(data_dir: &Path) -> Result<DbNamespaceLease, WriteLeaseError> {
+    let canonical = canonical_db_path(data_dir);
+    let root = canonical.parent().ok_or_else(|| {
+        WriteLeaseError::Unavailable(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "database directory has no stable parent namespace",
+        ))
+    })?;
+    let file = std::fs::File::open(root).map_err(WriteLeaseError::Unavailable)?;
+    lock_flock_nonblocking(&file, libc::LOCK_EX)?;
+    Ok(DbNamespaceLease {
+        _file: file,
+        root: root.to_path_buf(),
+    })
+}
+
+fn acquire_db_write_lease_inner(
+    db_path: &Path,
+    namespace: Option<&DbNamespaceLease>,
+) -> Result<DbWriteLease, WriteLeaseError> {
+    use std::os::unix::io::AsRawFd;
+
+    let db_path = canonical_db_path(db_path);
+    // This must precede every database open. See PROCESS_DB_LEASES: even a
+    // descriptor that never called F_SETLK would release the incumbent
+    // process's record lock when the failed acquisition closed it.
+    let process_claim = ProcessDbLeaseClaim::acquire(&db_path)?;
+    let lease_path = write_lease_path(&db_path);
+    if let Some(parent) = db_path.parent()
+        && !parent.exists()
+    {
+        std::fs::create_dir_all(parent).map_err(WriteLeaseError::Unavailable)?;
+    }
+    let namespace_file = if namespace.is_some() {
+        None
+    } else {
+        let root = namespace_root_for_db(&db_path).ok_or_else(|| {
+            WriteLeaseError::Unavailable(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "database path has no stable namespace ancestor",
+            ))
+        })?;
+        let file = std::fs::File::open(root).map_err(WriteLeaseError::Unavailable)?;
+        lock_flock_nonblocking(&file, libc::LOCK_SH)?;
+        Some(file)
+    };
+    // The database descriptor is part of the authority, not merely a probe.
+    // Open it first so every cooperating contender has the same lock order.
+    // `create(true)` preserves the pre-open use case: callers intentionally
+    // claim writer authority before GraphStore creates a new database.
+    let db_file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&db_path)
+        .map_err(WriteLeaseError::Unavailable)?;
+    // Take the same whole-file POSIX record-lock class used by lbug itself.
+    // This is the compatibility bridge for a live pre-upgrade writer that
+    // knows nothing about the sidecar: successful authority acquisition must
+    // exclude it, not merely exclude other upgraded NestWeaver processes.
+    lock_posix_write_nonblocking(&db_file)?;
+    // POSIX locks are process-scoped, so a second descriptor in this process
+    // would not conflict with the first. The additional flock is descriptor-
+    // scoped and closes that same-process duplicate-authority hole.
+    lock_exclusive_nonblocking(&db_file)?;
+
+    let lease_file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lease_path)
+        .map_err(WriteLeaseError::Unavailable)?;
+    if unsafe { libc::flock(lease_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        let error = std::io::Error::last_os_error();
+        return match error.kind() {
+            std::io::ErrorKind::WouldBlock => Err(WriteLeaseError::Held),
+            _ => Err(WriteLeaseError::Unavailable(error)),
+        };
+    }
+    Ok(DbWriteLease {
+        _namespace_file: namespace_file,
+        _db_file: db_file,
+        _lease_file: lease_file,
+        db_path,
+        lease_path,
+        _process_claim: process_claim,
+    })
+}
+
+fn namespace_root_for_db(db_path: &Path) -> Option<PathBuf> {
+    let canonical = canonical_db_path(db_path);
+    canonical.parent()?.parent().map(Path::to_path_buf)
+}
+
+fn lock_flock_nonblocking(
+    file: &std::fs::File,
+    operation: libc::c_int,
+) -> Result<(), WriteLeaseError> {
+    use std::os::unix::io::AsRawFd;
+
+    if unsafe { libc::flock(file.as_raw_fd(), operation | libc::LOCK_NB) } == 0 {
+        return Ok(());
+    }
+    let error = std::io::Error::last_os_error();
+    match error.kind() {
+        std::io::ErrorKind::WouldBlock => Err(WriteLeaseError::Held),
+        _ => Err(WriteLeaseError::Unavailable(error)),
+    }
+}
+
+fn lock_exclusive_nonblocking(file: &std::fs::File) -> Result<(), WriteLeaseError> {
+    lock_flock_nonblocking(file, libc::LOCK_EX)
+}
+
+fn lock_posix_write_nonblocking(file: &std::fs::File) -> Result<(), WriteLeaseError> {
+    use std::os::unix::io::AsRawFd;
+
+    let mut lock: libc::flock = unsafe { std::mem::zeroed() };
+    lock.l_type = libc::F_WRLCK as libc::c_short;
+    lock.l_whence = libc::SEEK_SET as libc::c_short;
+    lock.l_start = 0;
+    lock.l_len = 0;
+    if unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETLK, &lock) } == 0 {
+        return Ok(());
+    }
+    let error = std::io::Error::last_os_error();
+    if error
+        .raw_os_error()
+        .is_some_and(|code| code == libc::EACCES || code == libc::EAGAIN)
+    {
+        Err(WriteLeaseError::Held)
+    } else {
+        Err(WriteLeaseError::Unavailable(error))
+    }
+}
+
+/// Non-mutating best-effort view of canonical writer ownership.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteLeaseState {
+    Free,
+    Held,
+    Unknown,
+}
+
+pub fn write_lease_state(db_path: &Path) -> WriteLeaseState {
+    let db_path = canonical_db_path(db_path);
+    // Never probe the database inode while this process owns its POSIX lock:
+    // closing the probe descriptor would release that lock even though the
+    // probe did not acquire it. The process-local claim is exact authority for
+    // this case and survives sidecar unlink/replacement.
+    if ProcessDbLeaseClaim::is_held(&db_path) {
+        return WriteLeaseState::Held;
+    }
+    // Probe the sidecar first. An upgraded writer always holds it, and an
+    // early Held return avoids opening/closing the database descriptor. That
+    // matters because closing any descriptor drops this process's POSIX record
+    // locks on the file.
+    let sidecar_state = probe_flock_state(&write_lease_path(&db_path));
+    if sidecar_state == WriteLeaseState::Held {
+        return WriteLeaseState::Held;
+    }
+    let states = [
+        sidecar_state,
+        probe_flock_state(&db_path),
+        probe_posix_write_lock_state(&db_path),
+    ];
+    if states.contains(&WriteLeaseState::Held) {
+        WriteLeaseState::Held
+    } else if states.contains(&WriteLeaseState::Unknown) {
+        WriteLeaseState::Unknown
+    } else {
+        WriteLeaseState::Free
+    }
+}
+
+fn probe_flock_state(path: &Path) -> WriteLeaseState {
+    use std::os::unix::io::AsRawFd;
+
+    let file = match std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return WriteLeaseState::Free;
+        }
+        Err(_) => return WriteLeaseState::Unknown,
+    };
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+        let _ = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+        WriteLeaseState::Free
+    } else if std::io::Error::last_os_error().kind() == std::io::ErrorKind::WouldBlock {
+        WriteLeaseState::Held
+    } else {
+        WriteLeaseState::Unknown
+    }
+}
+
+fn probe_posix_write_lock_state(path: &Path) -> WriteLeaseState {
+    use std::os::unix::io::AsRawFd;
+
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return WriteLeaseState::Free;
+        }
+        Err(_) => return WriteLeaseState::Unknown,
+    };
+    let mut probe: libc::flock = unsafe { std::mem::zeroed() };
+    probe.l_type = libc::F_WRLCK as libc::c_short;
+    probe.l_whence = libc::SEEK_SET as libc::c_short;
+    probe.l_start = 0;
+    probe.l_len = 0;
+    if unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETLK, &mut probe) } != 0 {
+        return WriteLeaseState::Unknown;
+    }
+    if probe.l_type == libc::F_UNLCK as libc::c_short {
+        WriteLeaseState::Free
+    } else {
+        WriteLeaseState::Held
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_authority_rejects_a_sibling_and_state_tracks_its_lifetime() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        let sibling = dir.path().join("sibling.lbug");
+        assert_eq!(write_lease_state(&db), WriteLeaseState::Free);
+        let authority = acquire_db_write_lease(&db).unwrap();
+        assert!(authority.authorizes(&db));
+        assert!(!authority.authorizes(&sibling));
+        assert_eq!(write_lease_state(&db), WriteLeaseState::Held);
+        drop(authority);
+        assert_eq!(write_lease_state(&db), WriteLeaseState::Free);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonical_aliases_share_one_authority() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        let alias = dir.path().join("alias");
+        std::os::unix::fs::symlink(&real, &alias).unwrap();
+        let canonical_db = real.join("brain.lbug");
+        let alias_db = alias.join("brain.lbug");
+        let authority = acquire_db_write_lease(&alias_db).unwrap();
+        assert!(authority.authorizes(&canonical_db));
+        assert_eq!(write_lease_path(&alias_db), write_lease_path(&canonical_db));
+    }
+
+    #[test]
+    fn unlinking_and_recreating_the_sidecar_cannot_mint_a_second_authority() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        let authority = acquire_db_write_lease(&db).unwrap();
+        std::fs::remove_file(write_lease_path(&db)).unwrap();
+
+        assert_eq!(write_lease_state(&db), WriteLeaseState::Held);
+        assert!(matches!(
+            acquire_db_write_lease(&db),
+            Err(WriteLeaseError::Held)
+        ));
+
+        drop(authority);
+        let replacement = acquire_db_write_lease(&db).unwrap();
+        assert!(replacement.authorizes(&db));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_rejected_same_process_duplicate_preserves_the_posix_compatibility_lock() {
+        use std::os::unix::io::AsRawFd as _;
+
+        const CHILD_ENV: &str = "NW_TEST_PROBE_POSIX_DB_LOCK";
+        if let Some(db) = std::env::var_os(CHILD_ENV) {
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .truncate(false)
+                .open(db)
+                .unwrap();
+            let mut lock: libc::flock = unsafe { std::mem::zeroed() };
+            lock.l_type = libc::F_WRLCK as libc::c_short;
+            lock.l_whence = libc::SEEK_SET as libc::c_short;
+            lock.l_start = 0;
+            lock.l_len = 0;
+            let result = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETLK, &lock) };
+            if result == 0 {
+                println!("legacy-posix-lock-free");
+            } else {
+                let error = std::io::Error::last_os_error();
+                assert!(
+                    error
+                        .raw_os_error()
+                        .is_some_and(|code| code == libc::EACCES || code == libc::EAGAIN),
+                    "unexpected POSIX lock error: {error}"
+                );
+                println!("legacy-posix-lock-held");
+            }
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        let authority = acquire_db_write_lease(&db).unwrap();
+        assert!(matches!(
+            acquire_db_write_lease(&db),
+            Err(WriteLeaseError::Held)
+        ));
+
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "write_lease::tests::a_rejected_same_process_duplicate_preserves_the_posix_compatibility_lock",
+                "--nocapture",
+            ])
+            .env(CHILD_ENV, &db)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("legacy-posix-lock-held"),
+            "a failed duplicate acquisition released the incumbent POSIX lock: {stdout}"
+        );
+        drop(authority);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_pre_upgrade_posix_database_writer_blocks_new_authority() {
+        use std::io::{BufRead as _, Write as _};
+        use std::os::unix::io::AsRawFd as _;
+
+        const CHILD_ENV: &str = "NW_TEST_LEGACY_DB_LOCK";
+        if let Some(db) = std::env::var_os(CHILD_ENV) {
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .truncate(false)
+                .open(db)
+                .unwrap();
+            let mut lock: libc::flock = unsafe { std::mem::zeroed() };
+            lock.l_type = libc::F_WRLCK as libc::c_short;
+            lock.l_whence = libc::SEEK_SET as libc::c_short;
+            lock.l_start = 0;
+            lock.l_len = 0;
+            assert_eq!(
+                unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETLK, &lock) },
+                0
+            );
+            println!("legacy-lock-held");
+            std::io::stdout().flush().unwrap();
+            std::thread::sleep(std::time::Duration::from_secs(30));
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        std::fs::write(&db, b"legacy database").unwrap();
+        let executable = std::env::current_exe().unwrap();
+        let mut child = std::process::Command::new(executable)
+            .args([
+                "--exact",
+                "write_lease::tests::a_pre_upgrade_posix_database_writer_blocks_new_authority",
+                "--nocapture",
+            ])
+            .env(CHILD_ENV, &db)
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+        let mut reader = std::io::BufReader::new(child.stdout.take().unwrap());
+        let mut transcript = String::new();
+        loop {
+            let mut line = String::new();
+            if reader.read_line(&mut line).unwrap() == 0 {
+                panic!("legacy-lock child exited before readiness: {transcript}");
+            }
+            transcript.push_str(&line);
+            if line.contains("legacy-lock-held") {
+                break;
+            }
+        }
+
+        assert!(matches!(
+            acquire_db_write_lease(&db),
+            Err(WriteLeaseError::Held)
+        ));
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}

--- a/crates/nestweaver-web/src/routes/admin.rs
+++ b/crates/nestweaver-web/src/routes/admin.rs
@@ -19,6 +19,37 @@ use crate::state::{AdminState, PendingDevice};
 use nestweaver_engine::jobs::JobQueue;
 use std::sync::Mutex;
 
+/// Shutdown-visible admission for an admin mutation.
+///
+/// Increment-before-check with sequential consistency gives the daemon drain
+/// and this request a single order: either the drain observes this writer, or
+/// this request observes shutdown and refuses before its first mutation.
+struct AdminMutationAdmission {
+    active_writes: Arc<std::sync::atomic::AtomicU32>,
+}
+
+impl AdminMutationAdmission {
+    fn admit(state: &AdminState) -> Result<Self, (StatusCode, String)> {
+        state.active_writes.fetch_add(1, Ordering::SeqCst);
+        if state.shutdown_started.load(Ordering::SeqCst) {
+            state.active_writes.fetch_sub(1, Ordering::SeqCst);
+            return Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                "daemon is shutting down and is not accepting new admin mutations; retry against the daemon that starts next".to_string(),
+            ));
+        }
+        Ok(Self {
+            active_writes: Arc::clone(&state.active_writes),
+        })
+    }
+}
+
+impl Drop for AdminMutationAdmission {
+    fn drop(&mut self) {
+        self.active_writes.fetch_sub(1, Ordering::Release);
+    }
+}
+
 // ── Shared job-queue access ────────────────────────────────────────────
 
 /// RAII handle to a job-queue connection for an admin operation. Wraps either
@@ -446,6 +477,30 @@ pub async fn remove_repo(
     _auth: AdminAuth,
     State(state): State<Arc<AdminState>>,
     Path(repo_uid): Path<String>,
+) -> Result<Json<MessageResponse>, (StatusCode, String)> {
+    // Admission must precede queue/config/scheduler as well as graph mutation:
+    // all are durable parts of this operation and none may outlive shutdown.
+    // The task owns the admission (and the entire mutation) independently of
+    // the HTTP request future: dropping an axum request drops its JoinHandle,
+    // not the spawned task, so a disconnected/aborted client cannot make the
+    // drain counter reach zero while spawn_blocking still owns graph work.
+    let admission = AdminMutationAdmission::admit(&state)?;
+    tokio::spawn(async move {
+        let _admission = admission;
+        remove_repo_owned(state, repo_uid).await
+    })
+    .await
+    .map_err(|error| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("admin repo removal task panicked: {error}"),
+        )
+    })?
+}
+
+async fn remove_repo_owned(
+    state: Arc<AdminState>,
+    repo_uid: String,
 ) -> Result<Json<MessageResponse>, (StatusCode, String)> {
     let store = state.daemon_store.clone();
     let uid = repo_uid.clone();
@@ -1659,6 +1714,77 @@ mod tests {
         admin_state_with_auth(Some("test-query-token".to_string()))
     }
 
+    #[test]
+    fn admin_mutation_admission_is_shutdown_visible_and_fail_closed() {
+        let state = test_admin_state();
+        let admission = AdminMutationAdmission::admit(&state).expect("admit before shutdown");
+        assert_eq!(state.active_writes.load(Ordering::SeqCst), 1);
+
+        state.shutdown_started.store(true, Ordering::SeqCst);
+        let error = AdminMutationAdmission::admit(&state)
+            .err()
+            .expect("new admin mutation must be refused after shutdown");
+        assert_eq!(error.0, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(state.active_writes.load(Ordering::SeqCst), 1);
+
+        drop(admission);
+        assert_eq!(state.active_writes.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn aborted_remove_request_keeps_admission_until_blocked_writer_finishes() {
+        let gate = nestweaver_engine::write_gate::WriteGate::new();
+        let blocker = gate.lock("test_block_admin_remove").await;
+        let mut state = test_admin_state();
+        Arc::get_mut(&mut state)
+            .expect("test owns the only state Arc")
+            .write_gate = Some(gate.clone());
+        let active_writes = Arc::clone(&state.active_writes);
+        let app = Router::new()
+            .route("/admin/api/repos/{id}", delete(remove_repo))
+            .with_state(state);
+
+        let request = tokio::spawn(
+            app.oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/admin/api/repos/missing-repo")
+                    .header("Authorization", "Bearer test-admin-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            ),
+        );
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while gate.waiting() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("admin graph worker must block on the held write gate");
+        assert_eq!(active_writes.load(Ordering::SeqCst), 1);
+
+        request.abort();
+        let _ = request.await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            active_writes.load(Ordering::SeqCst),
+            1,
+            "request cancellation must not release the mutation admission"
+        );
+        assert_eq!(gate.waiting(), 1, "the owned mutation must still be alive");
+
+        drop(blocker);
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while active_writes.load(Ordering::SeqCst) != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("owned mutation must finish and release admission");
+        assert_eq!(gate.waiting(), 0);
+    }
+
     fn admin_state_with_auth(auth_token: Option<String>) -> Arc<AdminState> {
         let dir = tempfile::tempdir().expect("create tempdir");
         let db_path = dir.path().join("test.lbug");
@@ -1677,6 +1803,7 @@ mod tests {
             start_time: std::time::Instant::now(),
             active_reads: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             active_writes: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            shutdown_started: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             mcp_sessions: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             drained: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             indexing_queue_depth: Arc::new(std::sync::atomic::AtomicU32::new(0)),
@@ -1935,6 +2062,7 @@ url = "https://github.com/example/existing"
             start_time: std::time::Instant::now(),
             active_reads: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             active_writes: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            shutdown_started: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             mcp_sessions: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             drained: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             indexing_queue_depth: Arc::new(std::sync::atomic::AtomicU32::new(0)),
@@ -2069,6 +2197,7 @@ url = "https://github.com/example/existing"
             start_time: std::time::Instant::now(),
             active_reads: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             active_writes: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            shutdown_started: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             mcp_sessions: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             drained: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             indexing_queue_depth: Arc::new(std::sync::atomic::AtomicU32::new(0)),

--- a/crates/nestweaver-web/src/routes/impact.rs
+++ b/crates/nestweaver-web/src/routes/impact.rs
@@ -300,6 +300,7 @@ fn empty_affected_tests(
         // not "no tests are affected". Reporting Complete would read as "safe to
         // skip all tests" — exactly the false-safe the trust core (D3) forbids.
         status: nestweaver_engine::AnalysisStatus::Degraded,
+        resolver_stale_repos: Vec::new(),
         // Degraded hints => fail-safe widening (nw-060): CI must not narrow.
         recommendation: "run-full-suite".to_string(),
         measured: None,

--- a/crates/nestweaver-web/src/state.rs
+++ b/crates/nestweaver-web/src/state.rs
@@ -112,6 +112,10 @@ pub struct AdminState {
     pub start_time: Instant,
     pub active_reads: Arc<AtomicU32>,
     pub active_writes: Arc<AtomicU32>,
+    /// Once set, new admin mutations must be refused. This is the daemon's
+    /// shutdown-admission flag, paired with `active_writes` so the drain cannot
+    /// observe zero and finish while an HTTP admin mutation starts behind it.
+    pub shutdown_started: Arc<AtomicBool>,
     /// Live count of active MCP-over-HTTP sessions, shared with the MCP handler
     /// (which republishes `sessions.len()` on insert/expiry). Surfaced as the
     /// dashboard's "connected MCP clients". Zero when server mode is off.

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const { execSync } = require("child_process");
+const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 
@@ -13,14 +13,20 @@ const PLATFORM_MAP = {
 
 const key = `${process.platform}-${process.arch}`;
 const target = PLATFORM_MAP[key];
+const binDir = path.join(__dirname, ".nestweaver-bin");
+const binaryPath = path.join(binDir, "nestweaver");
+fs.mkdirSync(binDir, { recursive: true });
+// Never let a failed upgrade leave the newly installed wrapper executing a
+// binary from an older package version.
+fs.rmSync(binaryPath, { force: true });
 
 if (!target) {
-  console.warn(`Unsupported platform: ${key}`);
-  console.warn("Supported: darwin-x64, darwin-arm64, linux-x64, linux-arm64");
-  console.warn(
+  console.error(`Unsupported platform: ${key}`);
+  console.error("Supported: darwin-x64, darwin-arm64, linux-x64, linux-arm64");
+  console.error(
     "Unsupported platform. Install a verified GitHub Release archive for a supported target, or from a source checkout: cargo install --locked --path .",
   );
-  process.exit(0); // Don't break npm install
+  process.exit(1);
 }
 
 const version = require("./package.json").version;
@@ -32,51 +38,72 @@ const tag = `v${version}`;
 const archive = `nestweaver-${tag}-${target}.tar.gz`;
 const base = `https://github.com/${repo}/releases/download/${tag}`;
 const url = `${base}/${archive}`;
+const releaseApiUrl = `https://api.github.com/repos/${repo}/releases/tags/${tag}`;
 
-const binDir = path.join(__dirname, ".nestweaver-bin");
-fs.mkdirSync(binDir, { recursive: true });
 const archivePath = path.join(binDir, archive);
 
 console.log(`Downloading NestWeaver v${version} for ${target}...`);
 
 try {
-  execSync(`curl -fsSL "${url}" -o "${archivePath}"`, { stdio: "inherit" });
+  const release = JSON.parse(
+    execFileSync("curl", [
+      "-fsSL",
+      "-H",
+      "Accept: application/vnd.github+json",
+      "-H",
+      "X-GitHub-Api-Version: 2026-03-10",
+      releaseApiUrl,
+    ]).toString(),
+  );
+  if (release.immutable !== true || release.tag_name !== tag) {
+    throw new Error(
+      `GitHub Release ${tag} is not immutable; refusing a checksum that could be replaced with its archive`,
+    );
+  }
+  execFileSync("curl", ["-fsSL", url, "-o", archivePath], {
+    stdio: "inherit",
+  });
 
   // Verify the SHA-256 the release ships alongside the archive — a mismatch
-  // means a corrupted or tampered download, which must fail loudly.
-  try {
-    const expected = execSync(`curl -fsSL "${url}.sha256"`)
-      .toString()
-      .trim()
-      .split(/\s+/)[0];
-    const actual = execSync(`shasum -a 256 "${archivePath}"`)
-      .toString()
-      .trim()
-      .split(/\s+/)[0];
-    if (expected && actual && expected !== actual) {
-      throw new Error(
-        `checksum mismatch: expected ${expected}, got ${actual}`,
-      );
-    }
-  } catch (checksumErr) {
-    if (String(checksumErr.message || "").includes("checksum mismatch")) {
-      throw checksumErr; // integrity failure — do not install
-    }
-    // Missing/unreadable .sha256 is not fatal; proceed with the download.
+  // means a corrupted or tampered download. Missing, unreadable, or malformed
+  // checksum evidence is equally non-authoritative and must fail closed.
+  const expected = execFileSync("curl", ["-fsSL", `${url}.sha256`])
+    .toString()
+    .trim()
+    .split(/\s+/)[0];
+  const actual = execFileSync("shasum", ["-a", "256", archivePath])
+    .toString()
+    .trim()
+    .split(/\s+/)[0];
+  if (!/^[0-9a-f]{64}$/i.test(expected) || !/^[0-9a-f]{64}$/i.test(actual)) {
+    throw new Error("release checksum evidence is missing or malformed");
+  }
+  if (expected.toLowerCase() !== actual.toLowerCase()) {
+    throw new Error(`checksum mismatch: expected ${expected}, got ${actual}`);
   }
 
-  execSync(`tar xz -C "${binDir}" -f "${archivePath}"`, { stdio: "inherit" });
+  execFileSync("tar", ["xz", "-C", binDir, "-f", archivePath], {
+    stdio: "inherit",
+  });
+  if (!fs.existsSync(binaryPath) || !fs.statSync(binaryPath).isFile()) {
+    throw new Error("verified archive did not contain the nestweaver executable");
+  }
   fs.rmSync(archivePath, { force: true });
-  fs.chmodSync(path.join(binDir, "nestweaver"), 0o755);
+  fs.chmodSync(binaryPath, 0o755);
+  execFileSync(binaryPath, ["--version"], { stdio: "inherit" });
   console.log("NestWeaver installed successfully.");
   console.log(
     "Upgrading an existing pre-publication brain? Stop its daemon and run `nestweaver publication rebuild --config /path/to/instance.toml`; the incumbent remains recoverable until validated cutover.",
   );
 } catch (err) {
-  console.warn(`Failed to install NestWeaver binary: ${err.message}`);
-  console.warn(`  URL: ${url}`);
-  console.warn(
+  fs.rmSync(archivePath, { force: true });
+  // Extraction and the runtime smoke test happen after checksum validation.
+  // A failure there must not leave a candidate binary that npm would expose.
+  fs.rmSync(binaryPath, { force: true });
+  console.error(`Failed to install NestWeaver binary: ${err.message}`);
+  console.error(`  URL: ${url}`);
+  console.error(
     "Download a verified GitHub Release archive, or build from a source checkout: cargo install --locked --path .",
   );
-  process.exit(0); // Don't break npm install on transient/network failures
+  process.exit(1);
 }

--- a/npm/package.json
+++ b/npm/package.json
@@ -21,6 +21,9 @@
     "x64",
     "arm64"
   ],
+  "libc": [
+    "glibc"
+  ],
   "keywords": [
     "mcp",
     "code-graph",

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -17,6 +17,9 @@ message HealthCheckResponse {
   // The daemon's own OS PID. Lets the CLI cross-check a pidfile PID against
   // the socket-reported PID before signaling it (B-1: pidfile PID hole).
   uint32 pid = 7;
+  // Explicit mutation capability negotiation. An older daemon decodes as
+  // false, so clients can refuse repair before sending a destructive Embed.
+  bool embedding_identity_repair = 8;
 }
 
 message ShutdownRequest {}
@@ -346,6 +349,13 @@ message BrainSearchResponse {
   bool truncated = 8;
   bool semantic_applied = 9;
   repeated string degraded_components = 10;
+  optional SemanticUnavailable semantic_unavailable = 11;
+}
+message SemanticUnavailable {
+  string cause = 1;
+  string reason = 2;
+  string error = 3;
+  string remediation = 4;
 }
 message SearchResultItem {
   string uid = 1;
@@ -363,7 +373,7 @@ message SearchResultItem {
 // brain_status
 message BrainStatusRequest {}
 message EmbeddingStatus {
-  // disabled | loading | ready | failed | embedding
+  // disabled | loading | ready | failed | embedding | identity_unreadable
   //
   // `embedding` was added in 4.2 and is reported INSTEAD of `ready` while a
   // daemon-route embedding pass is in flight. It implies the model is loaded
@@ -413,6 +423,39 @@ message EmbeddingStatus {
   uint64 index_live = 14;
   uint64 index_tombstoned = 15;
   uint64 index_stored = 16;
+
+  // ── Persisted identity verification (added 9.x) ─────────────────
+  // verified | unreadable. An unreadable identity is deliberately narrower
+  // than a generic model-load failure: graph traversal and lexical search
+  // remain available, but semantic/rerank operations and embedding writes
+  // fail closed until the recorded model/pipeline metadata is repaired.
+  string identity_state = 17;
+  // The source metadata read/validation failure. Empty when verified.
+  string identity_error = 18;
+  // Safe operator action. `--force` is explicitly not an identity override.
+  string identity_remediation = 19;
+}
+
+message SearchStatus {
+  // A Tantivy reader is serving BM25 queries. False means lexical search is
+  // using the graph-store substring fallback.
+  bool reader_available = 1;
+  // This daemon currently owns a Tantivy writer and can reconcile graph
+  // mutations into the search sidecar.
+  bool writer_available = 2;
+  // No durable graph-to-search reconciliation debt is outstanding.
+  bool current = 3;
+  // A committed (or conservatively possibly committed) graph mutation still
+  // requires a full search-index rebuild.
+  bool reconciliation_debt = 4;
+  // Writer/open/rebuild/debt-read diagnosis. Empty only when no such failure
+  // is currently known.
+  string error = 5;
+  // Operation that first/currently established the durable debt.
+  string debt_operation = 6;
+  // Unix seconds when the debt was first established; 0 when absent or when
+  // an unreadable debt artifact cannot be decoded safely.
+  int64 debt_created_at = 7;
 }
 message EffectiveConfig {
   // The daemon's effective configuration source. Absence of EffectiveConfig
@@ -465,6 +508,11 @@ message BrainStatusResponse {
   // How long the current holder has held the write lock, in seconds; 0 when
   // the lock is free.
   int64 write_holder_seconds = 17;
+
+  // Reader, writer and corpus-currentness are separate facts. In particular,
+  // a reader-only fallback may still serve the PRE-mutation corpus while a
+  // durable reconciliation debt waits for the configured writer to recover.
+  SearchStatus search_status = 18;
 }
 
 // repo_states — per-repo indexed SHA and metadata for staleness comparison
@@ -620,6 +668,10 @@ message EmbedRequest {
   string scope = 1;    // "all", "symbols", "notes", "headings"
   bool force = 2;
   uint32 batch_size = 3;
+  // Explicitly discard every existing vector plus unreadable embedding
+  // metadata before rebuilding. This is destructive and is never implied by
+  // force, which cannot authorize adopting an unverified semantic identity.
+  bool repair_identity = 4;
 }
 
 message EmbedResponse {
@@ -634,6 +686,9 @@ message EmbedResponse {
   uint64 eligible = 5;
   // Scoped nodes omitted because their authoritative sidecar embedding exists.
   uint64 skipped = 6;
+  bool identity_repaired = 7;
+  bool restart_required = 8;
+  uint64 discarded_embeddings = 9;
 }
 
 // ─── Impact Analysis (Phase 4) ──────────────────────────────────────

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,8 @@
     ".": {
       "release-type": "simple",
       "draft-pull-request": true,
+      "draft": true,
+      "force-tag-creation": false,
       "component": "nestweaver",
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,

--- a/scripts/observe-release-visibility.sh
+++ b/scripts/observe-release-visibility.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# Observe, rather than infer, whether an exact tag, GitHub release (including a
+# private draft), or npm version exists. The dry-run gate captures this JSON
+# before and after deliberately incomplete matrices.
+
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "usage: $0 <owner/repo> <tag> <npm-package> <npm-version>" >&2
+  exit 64
+fi
+
+repo=$1
+tag=$2
+npm_package=$3
+npm_version=$4
+
+if [[ ! "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  echo "invalid GitHub repository: $repo" >&2
+  exit 64
+fi
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  echo "GH_TOKEN is required to observe private draft releases" >&2
+  exit 64
+fi
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf -- "$tmp_dir"' EXIT
+
+encoded_tag=$(jq -rn --arg value "$tag" '$value | @uri')
+tag_status=$(curl --silent --show-error \
+  --output "$tmp_dir/tag.json" --write-out '%{http_code}' \
+  -H "Authorization: Bearer $GH_TOKEN" \
+  -H 'Accept: application/vnd.github+json' \
+  -H 'X-GitHub-Api-Version: 2022-11-28' \
+  "https://api.github.com/repos/$repo/git/ref/tags/$encoded_tag")
+case "$tag_status" in
+  200) tag_visible=true ;;
+  404) tag_visible=false ;;
+  *)
+    echo "GitHub tag observation returned HTTP $tag_status" >&2
+    cat "$tmp_dir/tag.json" >&2
+    exit 1
+    ;;
+esac
+
+releases_json=$(gh api --paginate --slurp "repos/$repo/releases?per_page=100")
+release_counts=$(jq -c --arg tag "$tag" '
+  [ .[][] | select(.tag_name == $tag) ] |
+  {release_count: length,
+   draft_count: ([.[] | select(.draft == true)] | length),
+   public_count: ([.[] | select(.draft == false)] | length)}
+' <<< "$releases_json")
+
+encoded_package=$(jq -rn --arg value "$npm_package" '$value | @uri')
+encoded_version=$(jq -rn --arg value "$npm_version" '$value | @uri')
+npm_status=$(curl --silent --show-error \
+  --output "$tmp_dir/npm.json" --write-out '%{http_code}' \
+  -H 'Accept: application/json' \
+  "https://registry.npmjs.org/$encoded_package/$encoded_version")
+case "$npm_status" in
+  200) npm_visible=true ;;
+  404) npm_visible=false ;;
+  *)
+    echo "npm visibility observation returned HTTP $npm_status" >&2
+    cat "$tmp_dir/npm.json" >&2
+    exit 1
+    ;;
+esac
+
+jq -n \
+  --arg tag "$tag" \
+  --arg npm_package "$npm_package" \
+  --arg npm_version "$npm_version" \
+  --argjson tag_visible "$tag_visible" \
+  --argjson npm_visible "$npm_visible" \
+  --argjson release_counts "$release_counts" \
+  '{tag: $tag, tag_visible: $tag_visible,
+    release_count: $release_counts.release_count,
+    draft_count: $release_counts.draft_count,
+    public_count: $release_counts.public_count,
+    npm_package: $npm_package, npm_version: $npm_version,
+    npm_visible: $npm_visible,
+    all_absent: (($tag_visible | not) and
+      $release_counts.release_count == 0 and ($npm_visible | not))}'

--- a/scripts/verify-release-bundle.sh
+++ b/scripts/verify-release-bundle.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+# Verify the complete, checksum-bound NestWeaver release bundle before a draft
+# release can become public. This intentionally accepts only the four supported
+# targets and their matching checksum files; an extra, duplicate, or missing
+# consumer artifact is a release failure.
+
+set -euo pipefail
+
+readonly TARGETS=(
+  aarch64-apple-darwin
+  aarch64-unknown-linux-gnu
+  x86_64-apple-darwin
+  x86_64-unknown-linux-gnu
+)
+
+verify_bundle() {
+  local bundle_dir=$1
+  local tag=$2
+  local expected_file actual_file target archive checksum referenced
+
+  if [[ ! -d "$bundle_dir" ]]; then
+    echo "release bundle directory does not exist: $bundle_dir" >&2
+    return 1
+  fi
+  if [[ -z "$tag" || "$tag" == */* ]]; then
+    echo "release tag must be non-empty and may not contain '/': $tag" >&2
+    return 1
+  fi
+
+  expected_file=$(mktemp)
+  actual_file=$(mktemp)
+
+  for target in "${TARGETS[@]}"; do
+    archive="nestweaver-${tag}-${target}.tar.gz"
+    printf '%s\n%s\n' "$archive" "$archive.sha256" >> "$expected_file"
+  done
+  sort -o "$expected_file" "$expected_file"
+
+  find "$bundle_dir" -maxdepth 1 -type f -printf '%f\n' | sort > "$actual_file"
+  if ! diff -u "$expected_file" "$actual_file"; then
+    echo "release bundle must contain exactly four archives and four checksums" >&2
+    rm -f "$expected_file" "$actual_file"
+    return 1
+  fi
+
+  for target in "${TARGETS[@]}"; do
+    archive="nestweaver-${tag}-${target}.tar.gz"
+    checksum="$archive.sha256"
+    referenced=$(awk 'NF { print $2 }' "$bundle_dir/$checksum")
+    if [[ "$referenced" != "$archive" ]]; then
+      echo "$checksum must reference only $archive, found: ${referenced:-<empty>}" >&2
+      rm -f "$expected_file" "$actual_file"
+      return 1
+    fi
+    if ! (cd "$bundle_dir" && shasum -a 256 -c "$checksum"); then
+      rm -f "$expected_file" "$actual_file"
+      return 1
+    fi
+  done
+
+  rm -f "$expected_file" "$actual_file"
+}
+
+self_test() {
+  local fixture tag missing checksum extra
+  fixture=$(mktemp -d)
+  # Expand the path while the local exists; an EXIT trap that references the
+  # local by name trips `set -u` after this function returns.
+  # Expansion here is the safety property described above.
+  # shellcheck disable=SC2064
+  trap "rm -rf -- $(printf '%q' "$fixture")" EXIT
+  tag=v0.0.0-policy-test
+
+  for target in "${TARGETS[@]}"; do
+    printf 'archive for %s\n' "$target" > "$fixture/nestweaver-${tag}-${target}.tar.gz"
+    (
+      cd "$fixture"
+      shasum -a 256 "nestweaver-${tag}-${target}.tar.gz" \
+        > "nestweaver-${tag}-${target}.tar.gz.sha256"
+    )
+  done
+
+  verify_bundle "$fixture" "$tag"
+
+  missing="$fixture/nestweaver-${tag}-aarch64-apple-darwin.tar.gz"
+  mv "$missing" "$missing.omitted"
+  if verify_bundle "$fixture" "$tag" >/dev/null 2>&1; then
+    echo "self-test failed: a missing target was accepted" >&2
+    return 1
+  fi
+  mv "$missing.omitted" "$missing"
+
+  checksum="$fixture/nestweaver-${tag}-aarch64-unknown-linux-gnu.tar.gz.sha256"
+  printf '%064d  %s\n' 0 "nestweaver-${tag}-aarch64-unknown-linux-gnu.tar.gz" > "$checksum"
+  if verify_bundle "$fixture" "$tag" >/dev/null 2>&1; then
+    echo "self-test failed: a corrupt checksum was accepted" >&2
+    return 1
+  fi
+  (
+    cd "$fixture"
+    shasum -a 256 "nestweaver-${tag}-aarch64-unknown-linux-gnu.tar.gz" > "${checksum##*/}"
+  )
+
+  extra="$fixture/nestweaver-${tag}-unsupported.tar.gz"
+  : > "$extra"
+  if verify_bundle "$fixture" "$tag" >/dev/null 2>&1; then
+    echo "self-test failed: an extra target was accepted" >&2
+    return 1
+  fi
+  rm -f "$extra"
+
+  verify_bundle "$fixture" "$tag" >/dev/null
+  rm -rf "$fixture"
+  trap - EXIT
+  echo "release bundle verifier self-test passed"
+}
+
+case "${1:-}" in
+  --self-test)
+    self_test
+    ;;
+  "")
+    echo "usage: $0 <bundle-dir> <tag> | --self-test" >&2
+    exit 64
+    ;;
+  *)
+    if [[ $# -ne 2 ]]; then
+      echo "usage: $0 <bundle-dir> <tag> | --self-test" >&2
+      exit 64
+    fi
+    verify_bundle "$1" "$2"
+    ;;
+esac

--- a/scripts/verify-release-canary-pr.sh
+++ b/scripts/verify-release-canary-pr.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+
+# Create an automation-authored canary PR with GITHUB_TOKEN, prove the applied
+# main-branch rules block it while Required CI is absent/action_required, and
+# always close the PR and delete its temporary branch.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <owner/repo> <exact-base-sha>" >&2
+  exit 64
+fi
+
+repo=$1
+base_sha=$2
+base_branch=${BASE_BRANCH:-main}
+run_id=${GITHUB_RUN_ID:-local}
+run_attempt=${GITHUB_RUN_ATTEMPT:-1}
+branch="release-gate-canary-${run_id}-${run_attempt}"
+canary_path=".release-gate-canary/${run_id}-${run_attempt}.txt"
+pr_number=""
+cleanup_failed=false
+
+if [[ ! "$base_sha" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "canary base must be a full commit SHA: $base_sha" >&2
+  exit 64
+fi
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  echo "GH_TOKEN is required" >&2
+  exit 64
+fi
+
+cleanup() {
+  local original_status=$?
+  trap - EXIT
+  set +e
+  if [[ -n "$pr_number" ]]; then
+    if ! gh api --method PATCH "repos/$repo/pulls/$pr_number" \
+      -f state=closed --silent; then
+      echo "failed to close canary PR #$pr_number" >&2
+      cleanup_failed=true
+    fi
+  fi
+  if ! gh api --method DELETE "repos/$repo/git/refs/heads/$branch" \
+    --silent 2>/dev/null; then
+    echo "failed to delete canary branch $branch" >&2
+    cleanup_failed=true
+  fi
+  if [[ "$cleanup_failed" == true && $original_status -eq 0 ]]; then
+    exit 1
+  fi
+  exit "$original_status"
+}
+trap cleanup EXIT
+
+rules=$(gh api "repos/$repo/rules/branches/$base_branch")
+jq -e '
+  any(.[]; .type == "pull_request" and
+    (.parameters.required_approving_review_count // 0) >= 1 and
+    (.parameters.require_code_owner_review // false) == true and
+    (.parameters.dismiss_stale_reviews_on_push // false) == true) and
+  any(.[]; .type == "required_status_checks" and
+    (.parameters.strict_required_status_checks_policy // false) == true and
+    any(.parameters.required_status_checks[]?;
+      .context == "Required CI" and .integration_id == 15368))
+' <<< "$rules" >/dev/null || {
+  echo "main lacks the enforced PR/CODEOWNER/up-to-date Required CI rules" >&2
+  exit 1
+}
+
+current_base=$(gh api "repos/$repo/git/ref/heads/$base_branch" --jq '.object.sha')
+if [[ "$current_base" != "$base_sha" ]]; then
+  echo "main advanced from dry-run SHA $base_sha to $current_base; refusing stale canary evidence" >&2
+  exit 1
+fi
+
+base_commit=$(gh api "repos/$repo/git/commits/$base_sha")
+base_tree=$(jq -er '.tree.sha' <<< "$base_commit")
+blob_payload=$(jq -n \
+  --arg content "release gate canary for workflow run $run_id attempt $run_attempt" \
+  '{content: $content, encoding: "utf-8"}')
+blob_sha=$(gh api --method POST "repos/$repo/git/blobs" \
+  --input - --jq '.sha' <<< "$blob_payload")
+tree_payload=$(jq -n \
+  --arg base_tree "$base_tree" \
+  --arg path "$canary_path" \
+  --arg sha "$blob_sha" \
+  '{base_tree: $base_tree,
+    tree: [{path: $path, mode: "100644", type: "blob", sha: $sha}]}')
+tree_sha=$(gh api --method POST "repos/$repo/git/trees" \
+  --input - --jq '.sha' <<< "$tree_payload")
+commit_payload=$(jq -n \
+  --arg message "test: release gate canary" \
+  --arg tree "$tree_sha" \
+  --arg parent "$base_sha" \
+  '{message: $message, tree: $tree, parents: [$parent]}')
+canary_sha=$(gh api --method POST "repos/$repo/git/commits" \
+  --input - --jq '.sha' <<< "$commit_payload")
+ref_payload=$(jq -n \
+  --arg ref "refs/heads/$branch" \
+  --arg sha "$canary_sha" \
+  '{ref: $ref, sha: $sha}')
+gh api --method POST "repos/$repo/git/refs" --input - \
+  --silent <<< "$ref_payload"
+
+pr_payload=$(jq -n \
+  --arg title "test: release gate canary $run_id/$run_attempt" \
+  --arg head "$branch" \
+  --arg base "$base_branch" \
+  --arg body "Temporary automation-authored release-gate proof. This PR is closed automatically." \
+  '{title: $title, head: $head, base: $base, body: $body, draft: false}')
+pr_json=$(gh api --method POST "repos/$repo/pulls" --input - <<< "$pr_payload")
+pr_number=$(jq -er '.number' <<< "$pr_json")
+
+run_state=absent
+run_id_observed=""
+job_count=0
+for _ in $(seq 1 18); do
+  runs=$(gh api "repos/$repo/actions/workflows/ci.yml/runs?head_sha=$canary_sha&event=pull_request&per_page=20")
+  run=$(jq -c --arg sha "$canary_sha" '
+    [.workflow_runs[] | select(.head_sha == $sha and .event == "pull_request")]
+    | sort_by(.id) | last // empty
+  ' <<< "$runs")
+  if [[ -n "$run" ]]; then
+    run_id_observed=$(jq -er '.id' <<< "$run")
+    run_state=$(jq -r '.conclusion // .status' <<< "$run")
+    if [[ "$run_state" == action_required ]]; then
+      jobs=$(gh api "repos/$repo/actions/runs/$run_id_observed/jobs?per_page=100")
+      job_count=$(jq -er '.total_count' <<< "$jobs")
+      [[ "$job_count" -eq 0 ]] || {
+        echo "action_required canary run unexpectedly created $job_count jobs" >&2
+        exit 1
+      }
+      break
+    fi
+    if [[ "$run_state" != queued && "$run_state" != in_progress && "$run_state" != requested && "$run_state" != waiting ]]; then
+      echo "canary workflow reached unexpected state $run_state" >&2
+      exit 1
+    fi
+  fi
+  sleep 5
+done
+if [[ "$run_state" != action_required && "$run_state" != absent ]]; then
+  echo "canary workflow never reached action_required or a stable absent state" >&2
+  exit 1
+fi
+
+checks=$(gh api -H 'Accept: application/vnd.github+json' \
+  "repos/$repo/commits/$canary_sha/check-runs?per_page=100")
+required_successes=$(jq '[.check_runs[] |
+  select(.name == "Required CI" and .conclusion == "success")] | length' <<< "$checks")
+[[ "$required_successes" -eq 0 ]] || {
+  echo "canary unexpectedly received a successful Required CI check" >&2
+  exit 1
+}
+
+merge_state=unknown
+mergeable=""
+for _ in $(seq 1 12); do
+  pr_json=$(gh api "repos/$repo/pulls/$pr_number")
+  merge_state=$(jq -r '.mergeable_state // "unknown"' <<< "$pr_json")
+  mergeable=$(jq -r '.mergeable | tostring' <<< "$pr_json")
+  [[ "$merge_state" != unknown ]] && break
+  sleep 5
+done
+[[ "$merge_state" == blocked ]] || {
+  echo "canary PR was not blocked by the applied rules (state: $merge_state)" >&2
+  exit 1
+}
+final_base=$(gh api "repos/$repo/git/ref/heads/$base_branch" --jq '.object.sha')
+[[ "$final_base" == "$base_sha" ]] || {
+  echo "main advanced during the canary; the blocked state is not exact-SHA evidence" >&2
+  exit 1
+}
+
+jq -n \
+  --argjson pr_number "$pr_number" \
+  --arg branch "$branch" \
+  --arg base_sha "$base_sha" \
+  --arg canary_sha "$canary_sha" \
+  --arg run_state "$run_state" \
+  --arg run_id "$run_id_observed" \
+  --argjson job_count "$job_count" \
+  --arg merge_state "$merge_state" \
+  --arg mergeable "$mergeable" \
+  '{pr_number: $pr_number, branch: $branch, base_sha: $base_sha,
+    canary_sha: $canary_sha, workflow_state: $run_state,
+    workflow_run_id: $run_id, workflow_job_count: $job_count,
+    required_ci_success_count: 0, merge_state: $merge_state,
+    mergeable: $mergeable, cleanup: "completed-on-process-exit"}'

--- a/scripts/verify-release-install.js
+++ b/scripts/verify-release-install.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+// Behavioral release gate for the npm postinstall wrapper. It runs the real
+// candidate install.js against deterministic fake curl/checksum/tar tools so
+// success, missing-checksum, and checksum-mismatch behavior are verified
+// without touching the network.
+
+const crypto = require("crypto");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const sourcePackage = path.resolve(process.argv[2] || "npm");
+if (!fs.existsSync(path.join(sourcePackage, "install.js"))) {
+  throw new Error(`candidate npm package is missing install.js: ${sourcePackage}`);
+}
+
+const archiveBytes = Buffer.from("verified-release-archive\n");
+const archiveSha = crypto.createHash("sha256").update(archiveBytes).digest("hex");
+const fixtureTool = `#!/usr/bin/env node
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+const tool = path.basename(process.argv[1]);
+const args = process.argv.slice(2);
+const bytes = Buffer.from("verified-release-archive\\n");
+const sha = crypto.createHash("sha256").update(bytes).digest("hex");
+if (tool === "curl") {
+  if (args.some((arg) => arg.includes("api.github.com/repos/") && arg.includes("/releases/tags/"))) {
+    const immutable = process.env.NW_INSTALL_TEST_MODE !== "mutable-release";
+    const version = JSON.parse(fs.readFileSync(path.join(process.cwd(), "package.json"))).version;
+    process.stdout.write(JSON.stringify({ immutable, tag_name: "v" + version }));
+    process.exit(0);
+  }
+  const outputAt = args.indexOf("-o");
+  if (outputAt >= 0) {
+    fs.writeFileSync(args[outputAt + 1], bytes);
+    process.exit(0);
+  }
+  if (process.env.NW_INSTALL_TEST_MODE === "missing-checksum") process.exit(22);
+  const rendered = process.env.NW_INSTALL_TEST_MODE === "checksum-mismatch"
+    ? "0".repeat(64)
+    : sha;
+  process.stdout.write(rendered + "  archive.tar.gz\\n");
+  process.exit(0);
+}
+if (tool === "shasum") {
+  process.stdout.write(sha + "  archive.tar.gz\\n");
+  process.exit(0);
+}
+if (tool === "tar") {
+  const destination = args[args.indexOf("-C") + 1];
+  const exitCode = process.env.NW_INSTALL_TEST_MODE === "runtime-failure" ? 7 : 0;
+  fs.writeFileSync(
+    path.join(destination, "nestweaver"),
+    "#!/bin/sh\\nexit " + exitCode + "\\n",
+    { mode: 0o755 },
+  );
+  process.exit(0);
+}
+throw new Error("unexpected fixture tool: " + tool);
+`;
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "nestweaver-install-gate-"));
+try {
+  const fakeBin = path.join(root, "bin");
+  fs.mkdirSync(fakeBin);
+  for (const tool of ["curl", "shasum", "tar"]) {
+    fs.writeFileSync(path.join(fakeBin, tool), fixtureTool, { mode: 0o755 });
+  }
+
+  function runCase(mode, expectedSuccess) {
+    const candidate = path.join(root, mode);
+    fs.cpSync(sourcePackage, candidate, { recursive: true });
+    const binary = path.join(candidate, ".nestweaver-bin", "nestweaver");
+    fs.mkdirSync(path.dirname(binary), { recursive: true });
+    fs.writeFileSync(binary, "stale binary from an older package\n", { mode: 0o755 });
+    const result = spawnSync(process.execPath, [path.join(candidate, "install.js")], {
+      cwd: candidate,
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ""}`,
+        NW_INSTALL_TEST_MODE: mode,
+      },
+      encoding: "utf8",
+    });
+    if (expectedSuccess) {
+      if (result.status !== 0 || !fs.existsSync(binary)) {
+        throw new Error(
+          `postinstall success case failed (status ${result.status}):\n${result.stdout}\n${result.stderr}`,
+        );
+      }
+      if ((fs.statSync(binary).mode & 0o111) === 0) {
+        throw new Error("postinstall success did not leave an executable binary");
+      }
+    } else if (result.status === 0 || fs.existsSync(binary)) {
+      throw new Error(
+        `postinstall ${mode} case did not fail closed (status ${result.status}):\n${result.stdout}\n${result.stderr}`,
+      );
+    }
+  }
+
+  runCase("success", true);
+  runCase("missing-checksum", false);
+  runCase("checksum-mismatch", false);
+  runCase("mutable-release", false);
+  runCase("runtime-failure", false);
+  process.stdout.write(`npm postinstall behavioral gate passed (${archiveSha})\n`);
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}

--- a/scripts/verify-release-package.sh
+++ b/scripts/verify-release-package.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+
+# Validate the local npm wrapper and its version contract before either the
+# GitHub release or npm package becomes public. The JSON emitted on stdout is
+# consumed by the release workflow; diagnostics go to stderr.
+
+set -euo pipefail
+
+verify_release_package() {
+  local repo_root=$1
+  local release_tag=$2
+  local package_dir=$3
+  local cargo_version manifest_version npm_name npm_version pack_json
+  local expected_files actual_files package_filename package_path package_sha256
+
+  if [[ ! -d "$repo_root/npm" || ! -f "$repo_root/Cargo.toml" ]]; then
+    echo "repository root is missing Cargo.toml or npm/: $repo_root" >&2
+    return 1
+  fi
+  mkdir -p -- "$package_dir"
+  package_dir=$(cd "$package_dir" && pwd)
+  if [[ ! "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+    echo "release tag is not a supported semantic version tag: $release_tag" >&2
+    return 1
+  fi
+
+  cargo_version=$(
+    awk '
+      /^\[workspace\.package\]$/ { in_package = 1; next }
+      /^\[/ { in_package = 0 }
+      in_package && /^version[[:space:]]*=/ {
+        value = $0
+        sub(/^[^=]*=[[:space:]]*"/, "", value)
+        sub(/"[[:space:]]*$/, "", value)
+        print value
+        exit
+      }
+    ' "$repo_root/Cargo.toml"
+  )
+  manifest_version=$(jq -er '.["."]' "$repo_root/.release-please-manifest.json")
+  npm_name=$(jq -er '.name' "$repo_root/npm/package.json")
+  npm_version=$(jq -er '.version' "$repo_root/npm/package.json")
+
+  if [[ -z "$cargo_version" ]]; then
+    echo "Cargo.toml has no workspace.package version" >&2
+    return 1
+  fi
+  if [[ "$npm_name" != nestweaver ]]; then
+    echo "npm package name is $npm_name, expected nestweaver" >&2
+    return 1
+  fi
+  if [[ "$cargo_version" != "$npm_version" || "$manifest_version" != "$npm_version" ]]; then
+    echo "release versions disagree: Cargo=$cargo_version manifest=$manifest_version npm=$npm_version" >&2
+    return 1
+  fi
+  if [[ "$release_tag" != "v$npm_version" ]]; then
+    echo "release tag $release_tag does not match package version v$npm_version" >&2
+    return 1
+  fi
+
+  jq -e '
+    .bin.nestweaver == "bin/nestweaver" and
+    .scripts.postinstall == "node install.js" and
+    (.files | sort) == ["README.md", "bin/", "install.js"] and
+    (.os | sort) == ["darwin", "linux"] and
+    (.cpu | sort) == ["arm64", "x64"] and
+    .libc == ["glibc"]
+  ' "$repo_root/npm/package.json" >/dev/null
+
+  node "$(dirname "$0")/verify-release-install.js" "$repo_root/npm" >&2
+
+  # Build the one immutable tarball that will be attested and published. A
+  # dry-run proves only metadata for bytes npm may repack differently later.
+  pack_json=$(cd "$repo_root/npm" && npm pack --ignore-scripts --json \
+    --pack-destination "$package_dir")
+  jq -e --arg version "$npm_version" '
+    length == 1 and
+    .[0].name == "nestweaver" and
+    .[0].version == $version and
+    (.[0].integrity | startswith("sha512-")) and
+    ([.[0].files[].path] | sort) ==
+      ["README.md", "bin/nestweaver", "install.js", "package.json"] and
+    any(.[0].files[]; .path == "bin/nestweaver" and .mode == 493)
+  ' <<< "$pack_json" >/dev/null
+
+  expected_files=$(mktemp)
+  actual_files=$(mktemp)
+  printf '%s\n' README.md bin/nestweaver install.js package.json | sort > "$expected_files"
+  jq -r '.[0].files[].path' <<< "$pack_json" | sort > "$actual_files"
+  if ! diff -u "$expected_files" "$actual_files" >&2; then
+    rm -f -- "$expected_files" "$actual_files"
+    echo "npm package contents differ from the exact release wrapper inventory" >&2
+    return 1
+  fi
+  rm -f -- "$expected_files" "$actual_files"
+
+  package_filename=$(jq -er '.[0].filename' <<< "$pack_json")
+  package_path="$package_dir/$package_filename"
+  if [[ ! -f "$package_path" ]]; then
+    echo "npm pack reported $package_filename but did not create it" >&2
+    return 1
+  fi
+  package_sha256=$(sha256sum "$package_path" | awk '{print $1}')
+  [[ "$package_sha256" =~ ^[0-9a-f]{64}$ ]]
+  printf '%s  %s\n' "$package_sha256" "$package_filename" \
+    > "$package_path.sha256"
+
+  jq -n \
+    --arg name "$npm_name" \
+    --arg version "$npm_version" \
+    --arg tag "$release_tag" \
+    --arg integrity "$(jq -er '.[0].integrity' <<< "$pack_json")" \
+    --arg filename "$package_filename" \
+    --arg sha256 "$package_sha256" \
+    '{name: $name, version: $version, tag: $tag,
+      integrity: $integrity, filename: $filename, sha256: $sha256}'
+}
+
+verify_release_package_artifact() {
+  local repo_root=$1
+  local release_tag=$2
+  local package_dir=$3
+  local manifest="$package_dir/release-package.json"
+  local package_filename package_path package_sha256 package_integrity
+  local cargo_version manifest_version package_version extract_dir
+  local expected_files actual_files
+  local -a package_files
+
+  if [[ ! -d "$repo_root/npm" || ! -f "$repo_root/Cargo.toml" ]]; then
+    echo "repository root is missing Cargo.toml or npm/: $repo_root" >&2
+    return 1
+  fi
+  if [[ ! "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+    echo "release tag is not a supported semantic version tag: $release_tag" >&2
+    return 1
+  fi
+  if [[ ! -f "$manifest" ]]; then
+    echo "release package artifact has no release-package.json" >&2
+    return 1
+  fi
+
+  mapfile -t package_files < <(
+    find "$package_dir" -maxdepth 1 -type f -name '*.tgz' -printf '%f\n' | sort
+  )
+  if [[ ${#package_files[@]} -ne 1 ]]; then
+    echo "release package artifact must contain exactly one npm tarball" >&2
+    return 1
+  fi
+  package_filename=${package_files[0]}
+  [[ "$package_filename" =~ ^nestweaver-[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?\.tgz$ ]] || {
+    echo "unexpected npm package filename: $package_filename" >&2
+    return 1
+  }
+  package_path="$package_dir/$package_filename"
+  if [[ ! -f "$package_path.sha256" ]]; then
+    echo "release package artifact has no checksum for $package_filename" >&2
+    return 1
+  fi
+
+  expected_files=$(mktemp)
+  actual_files=$(mktemp)
+  printf '%s\n' \
+    "$package_filename" "$package_filename.sha256" release-package.json \
+    | sort > "$expected_files"
+  find "$package_dir" -maxdepth 1 -type f -printf '%f\n' | sort > "$actual_files"
+  if ! diff -u "$expected_files" "$actual_files" >&2; then
+    rm -f -- "$expected_files" "$actual_files"
+    echo "release package artifact inventory is not exact" >&2
+    return 1
+  fi
+  rm -f -- "$expected_files" "$actual_files"
+
+  (cd "$package_dir" && sha256sum -c -- "$package_filename.sha256") >&2
+  package_sha256=$(sha256sum "$package_path" | awk '{print $1}')
+  package_integrity=$(node -e '
+    const crypto = require("crypto");
+    const fs = require("fs");
+    const bytes = fs.readFileSync(process.argv[1]);
+    process.stdout.write("sha512-" + crypto.createHash("sha512").update(bytes).digest("base64"));
+  ' "$package_path")
+  package_version=$(jq -er '.version' "$repo_root/npm/package.json")
+  cargo_version=$(
+    awk '
+      /^\[workspace\.package\]$/ { in_package = 1; next }
+      /^\[/ { in_package = 0 }
+      in_package && /^version[[:space:]]*=/ {
+        value = $0
+        sub(/^[^=]*=[[:space:]]*"/, "", value)
+        sub(/"[[:space:]]*$/, "", value)
+        print value
+        exit
+      }
+    ' "$repo_root/Cargo.toml"
+  )
+  manifest_version=$(jq -er '.["."]' "$repo_root/.release-please-manifest.json")
+  [[ "$package_version" = "$cargo_version" && "$package_version" = "$manifest_version" ]] || {
+    echo "release versions disagree: Cargo=$cargo_version manifest=$manifest_version npm=$package_version" >&2
+    return 1
+  }
+  [[ "$release_tag" = "v$package_version" ]] || {
+    echo "release tag $release_tag does not match package version v$package_version" >&2
+    return 1
+  }
+  jq -e \
+    --arg name nestweaver \
+    --arg version "$package_version" \
+    --arg tag "$release_tag" \
+    --arg integrity "$package_integrity" \
+    --arg filename "$package_filename" \
+    --arg sha256 "$package_sha256" '
+      .name == $name and .version == $version and .tag == $tag and
+      .integrity == $integrity and .filename == $filename and
+      .sha256 == $sha256
+    ' "$manifest" >/dev/null
+
+  expected_files=$(mktemp)
+  actual_files=$(mktemp)
+  printf '%s\n' \
+    package/README.md package/bin/nestweaver package/install.js package/package.json \
+    | sort > "$expected_files"
+  tar -tzf "$package_path" | sort > "$actual_files"
+  if ! diff -u "$expected_files" "$actual_files" >&2; then
+    rm -f -- "$expected_files" "$actual_files"
+    echo "npm tarball inventory is not exact" >&2
+    return 1
+  fi
+  rm -f -- "$expected_files" "$actual_files"
+
+  extract_dir=$(mktemp -d)
+  tar -xzf "$package_path" -C "$extract_dir"
+  test -x "$extract_dir/package/bin/nestweaver"
+  cmp "$repo_root/npm/README.md" "$extract_dir/package/README.md"
+  cmp "$repo_root/npm/bin/nestweaver" "$extract_dir/package/bin/nestweaver"
+  cmp "$repo_root/npm/install.js" "$extract_dir/package/install.js"
+  cmp "$repo_root/npm/package.json" "$extract_dir/package/package.json"
+  node "$(dirname "$0")/verify-release-install.js" "$extract_dir/package" >&2
+  rm -rf -- "$extract_dir"
+
+  jq -c . "$manifest"
+}
+
+case "${1:-}" in
+  --self-test)
+    repo_root=${2:-$(cd "$(dirname "$0")/.." && pwd)}
+    version=$(jq -er '.version' "$repo_root/npm/package.json")
+    package_dir=$(mktemp -d)
+    trap 'rm -rf -- "$package_dir"' EXIT
+    verify_release_package "$repo_root" "v$version" "$package_dir" \
+      > "$package_dir/release-package.json"
+    verify_release_package_artifact \
+      "$repo_root" "v$version" "$package_dir" >/dev/null
+    echo "release package verifier self-test passed"
+    ;;
+  "")
+    echo "usage: $0 <repo-root> <release-tag> <package-dir> | --verify-artifact <repo-root> <release-tag> <package-dir> | --self-test [repo-root]" >&2
+    exit 64
+    ;;
+  --verify-artifact)
+    if [[ $# -ne 4 ]]; then
+      echo "usage: $0 --verify-artifact <repo-root> <release-tag> <package-dir>" >&2
+      exit 64
+    fi
+    verify_release_package_artifact "$2" "$3" "$4"
+    ;;
+  *)
+    if [[ $# -ne 3 ]]; then
+      echo "usage: $0 <repo-root> <release-tag> <package-dir> | --verify-artifact <repo-root> <release-tag> <package-dir> | --self-test [repo-root]" >&2
+      exit 64
+    fi
+    verify_release_package "$1" "$2" "$3"
+    ;;
+esac

--- a/scripts/verify-required-ci.sh
+++ b/scripts/verify-required-ci.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+# Reduce path-filtered CI jobs to one stable, branch-protectable conclusion.
+# The workflow supplies GitHub's `needs` object. Any absent, cancelled, failed,
+# or unexpectedly skipped job that should have run rejects the candidate.
+
+set -euo pipefail
+
+verify_required_ci() {
+  local needs_json=$1
+  local rust metal frontend
+
+  result() {
+    jq -er --arg job "$1" '.[$job].result // "missing"' <<< "$needs_json"
+  }
+
+  require_success() {
+    local job=$1
+    local actual
+    actual=$(result "$job") || return 1
+    if [[ "$actual" != success ]]; then
+      echo "required CI job '$job' was $actual, expected success" >&2
+      return 1
+    fi
+  }
+
+  flag() {
+    local name=$1
+    local value
+    value=$(jq -er --arg name "$name" '.changes.outputs[$name] // "missing"' <<< "$needs_json")
+    if [[ "$value" != true && "$value" != false ]]; then
+      echo "change detector output '$name' was $value, expected true or false" >&2
+      return 1
+    fi
+    printf '%s' "$value"
+  }
+
+  require_success changes || return 1
+  require_success secret-scan || return 1
+
+  rust=$(flag rust) || return 1
+  metal=$(flag metal) || return 1
+  frontend=$(flag frontend) || return 1
+
+  if [[ "$rust" == true ]]; then
+    require_success fmt || return 1
+    require_success build-and-check || return 1
+    require_success clippy || return 1
+    require_success daemon-tests || return 1
+    require_success audit || return 1
+  fi
+  if [[ "$metal" == true ]]; then
+    require_success metal-smoke || return 1
+  fi
+  if [[ "$rust" == true || "$frontend" == true ]]; then
+    require_success e2e || return 1
+  fi
+}
+
+self_test() {
+  local baseline failed missing malformed
+  baseline='{
+    "changes": {"result":"success", "outputs":{"rust":"true", "metal":"true", "frontend":"true"}},
+    "secret-scan": {"result":"success"},
+    "fmt": {"result":"success"},
+    "build-and-check": {"result":"success"},
+    "clippy": {"result":"success"},
+    "daemon-tests": {"result":"success"},
+    "audit": {"result":"success"},
+    "metal-smoke": {"result":"success"},
+    "e2e": {"result":"success"}
+  }'
+
+  verify_required_ci "$baseline"
+
+  # A no-code-change run legitimately skips conditional jobs, but the change
+  # detector and unconditional secret scan must still succeed.
+  verify_required_ci "$(jq '.changes.outputs = {rust:"false", metal:"false", frontend:"false"}
+    | .fmt.result = "skipped"
+    | .["build-and-check"].result = "skipped"
+    | .clippy.result = "skipped"
+    | .["daemon-tests"].result = "skipped"
+    | .audit.result = "skipped"
+    | .["metal-smoke"].result = "skipped"
+    | .e2e.result = "skipped"' <<< "$baseline")"
+
+  failed=$(jq '.clippy.result = "failure"' <<< "$baseline")
+  if verify_required_ci "$failed" >/dev/null 2>&1; then
+    echo "self-test failed: a failed required job was accepted" >&2
+    return 1
+  fi
+
+  missing=$(jq 'del(.e2e)' <<< "$baseline")
+  if verify_required_ci "$missing" >/dev/null 2>&1; then
+    echo "self-test failed: a missing required job was accepted" >&2
+    return 1
+  fi
+
+  malformed=$(jq '.changes.outputs.rust = ""' <<< "$baseline")
+  if verify_required_ci "$malformed" >/dev/null 2>&1; then
+    echo "self-test failed: an absent change-detector output was accepted" >&2
+    return 1
+  fi
+
+  echo "required CI verifier self-test passed"
+}
+
+case "${1:-}" in
+  --self-test)
+    self_test
+    ;;
+  -)
+    verify_required_ci "$(cat)"
+    ;;
+  "")
+    echo "usage: $0 <needs-json-file> | - | --self-test" >&2
+    exit 64
+    ;;
+  *)
+    if [[ $# -ne 1 || ! -f "$1" ]]; then
+      echo "usage: $0 <needs-json-file> | - | --self-test" >&2
+      exit 64
+    fi
+    verify_required_ci "$(<"$1")"
+    ;;
+esac

--- a/src/main.rs
+++ b/src/main.rs
@@ -2639,6 +2639,18 @@ fn format_embedding_status(status: &nestweaver_proto::EmbeddingStatus) -> String
             ));
         }
     }
+    if !status.identity_state.is_empty() {
+        lines.push(format!("  Identity:         {}", status.identity_state));
+    }
+    if !status.identity_error.is_empty() {
+        lines.push(format!("  Identity error:   {}", status.identity_error));
+    }
+    if !status.identity_remediation.is_empty() {
+        lines.push(format!(
+            "  Identity repair:  {}",
+            status.identity_remediation
+        ));
+    }
     if !status.error.is_empty() {
         lines.push(format!("  Error:            {}", status.error));
     }
@@ -2665,6 +2677,40 @@ fn embedding_status_from_json(value: &serde_json::Value) -> nestweaver_proto::Em
         index_live: value["index_live"].as_u64().unwrap_or(0),
         index_tombstoned: value["index_tombstoned"].as_u64().unwrap_or(0),
         index_stored: value["index_stored"].as_u64().unwrap_or(0),
+        identity_state: value["identity_state"].as_str().unwrap_or("").to_string(),
+        identity_error: value["identity_error"].as_str().unwrap_or("").to_string(),
+        identity_remediation: value["identity_remediation"]
+            .as_str()
+            .unwrap_or("")
+            .to_string(),
+    }
+}
+
+fn format_search_status(status: &nestweaver_proto::SearchStatus) -> String {
+    let mut lines = vec![
+        format!("  Reader available: {}", status.reader_available),
+        format!("  Writer available: {}", status.writer_available),
+        format!("  Corpus current:   {}", status.current),
+        format!("  Rebuild debt:     {}", status.reconciliation_debt),
+    ];
+    if !status.debt_operation.is_empty() {
+        lines.push(format!("  Debt operation:   {}", status.debt_operation));
+    }
+    if !status.error.is_empty() {
+        lines.push(format!("  Error:            {}", status.error));
+    }
+    lines.join("\n")
+}
+
+fn search_status_from_json(value: &serde_json::Value) -> nestweaver_proto::SearchStatus {
+    nestweaver_proto::SearchStatus {
+        reader_available: value["reader_available"].as_bool().unwrap_or(false),
+        writer_available: value["writer_available"].as_bool().unwrap_or(false),
+        current: value["current"].as_bool().unwrap_or(false),
+        reconciliation_debt: value["reconciliation_debt"].as_bool().unwrap_or(false),
+        error: value["error"].as_str().unwrap_or("").to_string(),
+        debt_operation: value["debt_operation"].as_str().unwrap_or("").to_string(),
+        debt_created_at: value["debt_created_at"].as_i64().unwrap_or(0),
     }
 }
 
@@ -2964,6 +3010,12 @@ fn format_daemon_status_response(
             } else {
                 lines.push("  State:            unknown (older daemon)".to_string());
             }
+            lines.push("Search index:".to_string());
+            if let Some(search) = status.search_status.as_ref() {
+                lines.push(format_search_status(search));
+            } else {
+                lines.push("  State:            unknown (older daemon)".to_string());
+            }
             lines.join("\n")
         }
         Err(error) => [
@@ -2971,6 +3023,8 @@ fn format_daemon_status_response(
             "Embedding:".to_string(),
             "  State:            unavailable (daemon booting or unreachable)".to_string(),
             format!("  Error:            {error}"),
+            "Search index:".to_string(),
+            "  State:            unavailable (daemon booting or unreachable)".to_string(),
         ]
         .join("\n"),
     }
@@ -3097,7 +3151,10 @@ mod daemon_status_renderer_tests {
         let output = format_daemon_status_response(Err("transport refused"));
         assert!(output.starts_with("Config: unknown (daemon unreachable)\nEmbedding:\n"));
         assert!(output.contains("unavailable (daemon booting or unreachable)"));
-        assert!(output.ends_with("  Error:            transport refused"));
+        assert!(output.contains("  Error:            transport refused\nSearch index:\n"));
+        assert!(output.ends_with(
+            "Search index:\n  State:            unavailable (daemon booting or unreachable)"
+        ));
     }
 
     #[test]
@@ -3333,16 +3390,16 @@ enum Commands {
     ///
     /// Recovery is not a delete: the stale PageRank sidecar is removed and the
     /// generation advanced and persisted BEFORE the marker is cleared, then
-    /// PageRank is recomputed against the committed graph. A publication whose
-    /// writer process is still alive is left strictly alone.
+    /// PageRank is recomputed against the committed graph. The database writer
+    /// lock and in-process publication lease are never overridden.
     ///
     /// Without --force this refuses any marker it cannot prove was abandoned:
     /// one carrying no writer pid (written by an older release, truncated by a
     /// crash, or created by hand) and one whose state cannot be read at all.
-    /// --force overrides exactly that conservatism. It never overrides a writer
-    /// that is demonstrably alive.
+    /// --force overrides exactly that conservatism. A marker PID alone is not
+    /// ownership because PIDs are recyclable.
     #[command(
-        after_help = "Examples:\n  nestweaver repair\n  nestweaver repair --db ~/brain/.nestweaver/brain.lbug\n  nestweaver repair --json\n  nestweaver repair --force        # marker carries no usable writer pid\n\nExits 0 when the publication is clean or was recovered, 1 when it is dirty\nand could not be recovered. A live writer is never overridden, even with\n--force; stop that process first."
+        after_help = "Examples:\n  nestweaver repair\n  nestweaver repair --db ~/brain/.nestweaver/brain.lbug\n  nestweaver repair --json\n  nestweaver repair --force        # marker carries no usable writer pid\n\nExits 0 when the publication is clean or was recovered, 1 when it is dirty\nand could not be recovered. Database/publication ownership is never overridden,\neven with --force; stop that process first."
     )]
     Repair {
         #[arg(
@@ -3356,7 +3413,7 @@ enum Commands {
         dry_run: bool,
         #[arg(
             long,
-            help = "Recover a marker that carries no usable writer pid, or whose state cannot be read. Never overrides a live writer."
+            help = "Recover a marker that carries no usable writer pid, or whose state cannot be read. Never overrides database/publication ownership."
         )]
         force: bool,
     },
@@ -4593,7 +4650,7 @@ enum Commands {
     /// about every 5 minutes and once at the end of the pass, so interrupting
     /// a run keeps only the work completed up to the last checkpoint.
     #[command(
-        after_help = "Examples:\n  nestweaver embed                           # local model, all node types\n  nestweaver embed --scope symbols           # only symbols\n  nestweaver embed --local --cache-dir /path/to/cache  # populate a configured daemon cache\n  nestweaver embed --endpoint https://api.openai.com --model text-embedding-3-small\n  nestweaver embed --force --stats            # re-embed everything, print timing"
+        after_help = "Examples:\n  nestweaver embed                           # local model, all node types\n  nestweaver embed --scope symbols           # only symbols\n  nestweaver embed --local --cache-dir /path/to/cache  # populate a configured daemon cache\n  nestweaver embed --endpoint https://api.openai.com --model text-embedding-3-small\n  nestweaver embed --force --stats            # re-embed everything, print timing\n  nestweaver embed --force --repair-identity  # discard an unreadable semantic space and rebuild"
     )]
     Embed {
         #[arg(long, help = "Path to the database file [env: NESTWEAVER_DB]")]
@@ -4641,6 +4698,12 @@ enum Commands {
         scope: String,
         #[arg(long, help = "Re-embed nodes that already have embeddings")]
         force: bool,
+        #[arg(
+            long,
+            requires = "force",
+            help = "Destructively discard all vectors and unreadable embedding metadata before rebuilding; requires --force"
+        )]
+        repair_identity: bool,
         #[arg(long, help = "Print timing and statistics")]
         stats: bool,
     },
@@ -10022,7 +10085,10 @@ fn repair_outcome_name(
         R::NotFileBacked => "not_file_backed",
         R::Undeterminable { .. } => "undeterminable",
         R::WriterAlive { .. } => "writer_alive",
+        R::WriterLivenessUnknown { .. } => "writer_liveness_unknown",
         R::WriterUnattributed => "writer_unattributed",
+        R::WriterAuthorityRequired { .. } => "writer_authority_required",
+        R::MarkerChanged => "marker_changed",
         R::LeaseHeld => "lease_held",
         R::ReadOnlyStore { .. } => "read_only_store",
         R::Recovered { .. } => "recovered",
@@ -10137,12 +10203,15 @@ fn run_repair_index_publication(
     let mut open_error: Option<anyhow::Error> = None;
 
     if status.dirty && !dry_run {
+        let authority = require_exclusive_store_access(db_path, "repair index publication")?;
         match nestweaver_store::GraphStore::open(db_path) {
             Ok(store) => {
                 outcome = Some(if force {
-                    nestweaver_engine::index::force_recover_index_publication(&store)?
+                    nestweaver_engine::index::force_recover_index_publication(&store, &authority)?
                 } else {
-                    nestweaver_engine::index::recover_abandoned_index_publication(&store, true)?
+                    nestweaver_engine::index::recover_abandoned_index_publication(
+                        &store, &authority,
+                    )?
                 });
             }
             Err(error) => open_error = Some(repair_open_failure(db_path, error)),
@@ -10198,6 +10267,8 @@ fn run_repair_index_publication(
                 "determinable": status.determinable,
                 "writer_pid": status.writer_pid,
                 "writer_alive": status.writer_alive,
+                "writer_liveness_unknown": status.writer_liveness_unknown,
+                "writer_authority_held": status.writer_authority_held,
                 "marker_age_s": status.marker_age_s,
                 "writer_reason": status.writer_reason,
                 "wedged": status.is_wedged(),
@@ -10233,7 +10304,7 @@ fn run_repair_index_publication(
         return Ok(exit);
     }
     println!(
-        "Index publication is DIRTY (writer_pid={}, writer_alive={}, marker_age={}, wedged={}).",
+        "Index publication is DIRTY (writer_pid={}, writer_alive={}, writer_authority_held={}, marker_age={}, wedged={}).",
         status
             .writer_pid
             .map(|p| p.to_string())
@@ -10241,6 +10312,10 @@ fn run_repair_index_publication(
         status
             .writer_alive
             .map(|a| a.to_string())
+            .unwrap_or_else(|| "unknown".into()),
+        status
+            .writer_authority_held
+            .map(|held| held.to_string())
             .unwrap_or_else(|| "unknown".into()),
         status
             .marker_age_s
@@ -10270,10 +10345,11 @@ fn run_repair_index_publication(
                  re-run with --force:\n    nestweaver repair --db {} --force",
                 db_path.display()
             );
-        } else if after.writer_alive == Some(true) {
+        } else if after.writer_authority_held == Some(true) {
             eprintln!(
-                "A live writer (pid {}) owns this publication. Wait for it to finish or stop \
-                 that process; --force will not override it.",
+                "The canonical writer lease is held, so a writer owns this publication. \
+                 Diagnostic marker pid: {}. Wait for the lease owner to finish or stop it; \
+                 --force will not override writer authority.",
                 after.writer_pid.unwrap_or(0)
             );
         }
@@ -11184,10 +11260,11 @@ fn resolve_track_interactions(force_on: bool, force_off: bool, config_enabled: b
 /// write. Eight write paths honoured that answer and opened the store
 /// read-write with no check for a running daemon at all.
 ///
-/// The lock is the only thing that can answer the question that matters: is
-/// someone else holding this database RIGHT NOW. It lives on the database file
-/// itself, so unlike the pidfile an operator's `rm` cannot erase it, and the
-/// kernel releases it on process exit so there is no stale state to reap.
+/// The authority is the only thing that can answer the question that matters:
+/// is someone else holding this database RIGHT NOW. It combines lbug's real
+/// POSIX database-lock class with descriptor-scoped database and stable-
+/// sidecar flocks. Removing only a pidfile or sidecar cannot mint a competing
+/// authority, and the kernel releases every claim on process exit.
 ///
 /// `Unknown` fails CLOSED. A lock state we could not read is not evidence of
 /// freedom, and the cost of being wrong is two writers on a store that is not
@@ -14044,6 +14121,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             batch_size,
             scope,
             force,
+            repair_identity,
             stats,
         } => run_embed(
             db.as_deref(),
@@ -14056,6 +14134,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             batch_size,
             &scope,
             force,
+            repair_identity,
             stats,
             use_daemon,
             load_cli_local_embedder,
@@ -14072,6 +14151,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             db,
             config,
         } => {
+            let files = match nestweaver_engine::changed_files::require_changed_files(&files) {
+                Ok(files) => files,
+                Err(error) => {
+                    eprintln!("Error: {error}");
+                    return Ok((EXIT_USAGE, None));
+                }
+            };
             let db_path = resolve_db_with_config(db, config.as_deref())?;
             require_existing_db(&db_path)?;
 
@@ -14115,7 +14201,15 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             } else {
                 render_blast_radius_text(&payload);
             }
-            Ok((EXIT_SUCCESS, None))
+            let exit = if payload["resolver_stale_repos"]
+                .as_array()
+                .is_some_and(|repos| !repos.is_empty())
+            {
+                EXIT_NEEDS_REINDEX
+            } else {
+                EXIT_SUCCESS
+            };
+            Ok((exit, None))
         }
 
         Commands::DetectChanges {
@@ -14125,6 +14219,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             db,
             config,
         } => {
+            let files = match nestweaver_engine::changed_files::require_changed_files(&files) {
+                Ok(files) => files,
+                Err(error) => {
+                    eprintln!("Error: {error}");
+                    return Ok((EXIT_USAGE, None));
+                }
+            };
             let db_path = resolve_db_with_config(db, config.as_deref())?;
             require_existing_db(&db_path)?;
             // nw-174 added a default cap to the underlying tool. Without a flag
@@ -14177,7 +14278,15 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     }
                 }
             }
-            Ok((EXIT_SUCCESS, None))
+            let exit = if payload["resolver_stale_repos"]
+                .as_array()
+                .is_some_and(|repos| !repos.is_empty())
+            {
+                EXIT_NEEDS_REINDEX
+            } else {
+                EXIT_SUCCESS
+            };
+            Ok((exit, None))
         }
 
         Commands::FlowTrace {
@@ -14660,6 +14769,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         coverage: nestweaver_engine::blast_radius::Coverage::default(),
                         blind_spots: Vec::new(),
                         cochanged_files: Vec::new(),
+                        resolver_stale_repos: Vec::new(),
                         analysis_direction: "over-approximate".to_string(),
                     };
                     let mut payload = serde_json::to_value(&empty)?;
@@ -14786,27 +14896,42 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // Computed up front so the daemon path can send a proper
             // `changed_files` array (the tool never accepted the raw --files
             // string under the legacy `files` key).
-            let changed_files: Vec<String> = if let Some(files_str) = files {
-                files_str
-                    .split(',')
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
-                    .collect()
-            } else if let Some(base) = base_ref {
-                let repo_root = detect_repo_root();
-                out.status(&format!("Detecting changed files via git diff {base}..."));
-                changed_files_from_git(&repo_root, Some(&base))
-                    .context("git diff")?
-                    .iter()
-                    .map(|p| p.to_string_lossy().into_owned())
-                    .collect()
+            let (changed_files, explicitly_named): (Vec<String>, bool) =
+                if let Some(files_str) = files {
+                    (
+                        files_str.split(',').map(ToString::to_string).collect(),
+                        true,
+                    )
+                } else if let Some(base) = base_ref {
+                    let repo_root = detect_repo_root();
+                    out.status(&format!("Detecting changed files via git diff {base}..."));
+                    (
+                        changed_files_from_git(&repo_root, Some(&base))
+                            .context("git diff")?
+                            .iter()
+                            .map(|p| p.to_string_lossy().into_owned())
+                            .collect(),
+                        false,
+                    )
+                } else {
+                    // nw-252: a USAGE error, so EXIT_USAGE (64, EX_USAGE from
+                    // sysexits.h) — the same code clap's own parse failures
+                    // return. Exiting 1 made "you invoked this wrong" and "the
+                    // operation failed" indistinguishable to a caller.
+                    eprintln!("Error: provide either --files or --base-ref");
+                    return Ok((EXIT_USAGE, None));
+                };
+
+            let changed_files = if explicitly_named {
+                match nestweaver_engine::changed_files::require_changed_files(&changed_files) {
+                    Ok(files) => files,
+                    Err(error) => {
+                        eprintln!("Error: {error}");
+                        return Ok((EXIT_USAGE, None));
+                    }
+                }
             } else {
-                // nw-252: a USAGE error, so EXIT_USAGE (64, EX_USAGE from
-                // sysexits.h) — the same code clap's own parse failures
-                // return. Exiting 1 made "you invoked this wrong" and "the
-                // operation failed" indistinguishable to a caller.
-                eprintln!("Error: provide either --files or --base-ref");
-                return Ok((EXIT_USAGE, None));
+                changed_files
             };
 
             if changed_files.is_empty() {
@@ -14910,7 +15035,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             }
 
             let stats = format!("{} in {}", result.summary, format_elapsed(t0.elapsed()));
-            Ok((EXIT_SUCCESS, Some(stats)))
+            let exit = if result.resolver_stale_repos.is_empty() {
+                EXIT_SUCCESS
+            } else {
+                EXIT_NEEDS_REINDEX
+            };
+            Ok((exit, Some(stats)))
         }
 
         Commands::WatchStop { db, config } => {
@@ -15128,7 +15258,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // Held for the whole watch, which is the point — the lease's
             // lifetime has to cover the writes, not just the decision to
             // start.
-            let _write_lease = require_exclusive_store_access(&db_path, "watch")?;
+            let write_lease = require_exclusive_store_access(&db_path, "watch")?;
 
             let watcher =
                 CodeWatcher::new(&db_path, &repo_path, &instance_id).with_limits(index_limits);
@@ -15202,7 +15332,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 repo_path.display(),
                 db_path.display()
             );
-            if let Err(e) = watcher.run() {
+            if let Err(e) = watcher.run_with_write_lease(&write_lease) {
                 // A lock failure here means another process (usually a
                 // live daemon) holds the DB — name the remedy.
                 let msg = format!("{e:#}");
@@ -17567,6 +17697,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
 
         Commands::DetectImplicitProjects { vault, dry_run, db } => {
             let db_path = db.unwrap_or_else(default_db_path);
+            require_existing_db(&db_path)?;
 
             if !vault.exists() || !vault.is_dir() {
                 eprintln!("Error: vault path is not a directory: {}", vault.display());
@@ -17584,17 +17715,17 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             }
 
             // ── daemon guard ──────────────────────────────────────
-            // nw-161: NOT taken for --dry-run. The daemon RPC has no dry-run
-            // parameter, so routing a preview through it would perform the very
-            // writes the flag exists to avoid — the same shape as nw-186, where
-            // a daemon branch silently ignored the caller's flags. The local
-            // path opens read-only, so a preview cannot write by construction.
-            if use_daemon && !dry_run {
+            // Route apply and preview through the same identity resolver. The
+            // daemon treats dry_run as a read and keeps it outside the write
+            // funnel; apply acquires its exact worker-owned writer lease.
+            if use_daemon {
                 // Absolute path: the daemon runs with CWD=/ and would otherwise resolve
                 // a client-relative vault path against the wrong directory.
                 let vault_abs = abs_for_daemon(&vault);
                 let args = serde_json::json!({
                     "vault": vault_abs.to_string_lossy(),
+                    "instance_id": "",
+                    "dry_run": dry_run,
                 });
                 if let Some(value) =
                     try_hybrid_json_rpc(true, &db_path, None, "detect_implicit_projects", args)?
@@ -17602,9 +17733,17 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     // nw-271: a decode failure must not print "No implicit
                     // projects detected" — that is a claim about the vault,
                     // made from a failure to read the response.
-                    let detected: Vec<String> =
-                        serde_json::from_value(unwrap_hybrid_payload(value))
-                            .context("decode detected implicit projects from the daemon")?;
+                    let payload = unwrap_hybrid_payload(value);
+                    let detected: Vec<String> = if payload.is_array() {
+                        // Backward compatibility with pre-publication-outcome
+                        // daemons.
+                        serde_json::from_value(payload.clone())
+                            .context("decode detected implicit projects from the daemon")?
+                    } else {
+                        serde_json::from_value(payload["projects"].clone())
+                            .context("decode detected implicit projects from the daemon")?
+                    };
+                    let publication = payload.get("publication");
                     if detected.is_empty() {
                         println!("No implicit projects detected in {}", vault.display());
                     } else {
@@ -17613,26 +17752,58 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             println!("  {slug}");
                         }
                     }
-                    return Ok((EXIT_SUCCESS, None));
+                    let degraded = publication.and_then(|value| value["disposition"].as_str())
+                        == Some("committed_degraded");
+                    if let Some(warnings) =
+                        publication.and_then(|value| value["warnings"].as_array())
+                    {
+                        for warning in warnings {
+                            eprintln!(
+                                "Warning: graph mutation committed, but publication stage '{}' is degraded: {}",
+                                warning["stage"].as_str().unwrap_or("unknown"),
+                                warning["message"].as_str().unwrap_or("unknown failure")
+                            );
+                        }
+                    }
+                    return Ok((if degraded { EXIT_ERROR } else { EXIT_SUCCESS }, None));
                 }
             }
 
-            let store = open_store(Some(&db_path))?;
+            // A preview is structurally read-only. Apply is a graph writer and
+            // must hold the same cross-process lease as every other direct
+            // mutation before opening a writable store.
+            let _write_lease = if dry_run {
+                None
+            } else {
+                Some(require_exclusive_store_access(
+                    &db_path,
+                    "detect and materialize implicit projects",
+                )?)
+            };
+            let store = if dry_run {
+                open_store(Some(&db_path))?
+            } else {
+                GraphStore::open(&db_path)
+                    .map_err(|error| daemon_held_store_error(&db_path, error))?
+            };
 
             // Resolve vault UID the same way the indexer does.
             let canonical = abs_for_daemon(&vault);
-            let instance_id = "default";
-            let vault_uid = nestweaver_schema::vault_uid(instance_id, &canonical.to_string_lossy());
+            let instance_id = store
+                .data_instance_id()?
+                .unwrap_or_else(|| "default".to_string());
+            let vault_uid =
+                nestweaver_schema::vault_uid(&instance_id, &canonical.to_string_lossy());
 
-            let detected = nestweaver_engine::detect_implicit_projects_with_mode(
+            let detected = nestweaver_engine::project::detect_implicit_projects_with_publication(
                 &store,
                 &vault,
                 &vault_uid,
-                instance_id,
+                &instance_id,
                 dry_run,
             )?;
 
-            if detected.is_empty() {
+            if detected.projects.is_empty() {
                 println!(
                     "No implicit projects detected in {} (looked under {})",
                     vault.display(),
@@ -17641,19 +17812,29 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             } else if dry_run {
                 println!(
                     "Would create {} implicit project(s) (dry run — nothing written):",
-                    detected.len()
+                    detected.projects.len()
                 );
-                for slug in &detected {
+                for slug in &detected.projects {
                     println!("  {slug}");
                 }
             } else {
-                println!("Detected {} implicit project(s):", detected.len());
-                for slug in &detected {
+                println!("Detected {} implicit project(s):", detected.projects.len());
+                for slug in &detected.projects {
                     println!("  {slug}");
                 }
             }
-
-            Ok((EXIT_SUCCESS, None))
+            for warning in &detected.publication.warnings {
+                eprintln!(
+                    "Warning: graph mutation committed, but publication stage '{}' is degraded: {}",
+                    warning.stage, warning.message
+                );
+            }
+            let exit = if detected.publication.is_degraded() {
+                EXIT_ERROR
+            } else {
+                EXIT_SUCCESS
+            };
+            Ok((exit, None))
         }
 
         Commands::Index {
@@ -17942,7 +18123,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // filemeta, resolution deps, parsed cache, pagerank, git activity,
             // cochange and the trigram rebuild below. Dropping it here would
             // make this a probe again.
-            let _write_lease = require_exclusive_store_access(&db_path, "index")?;
+            let write_lease = require_exclusive_store_access(&db_path, "index")?;
 
             let (files_count, symbols_count, edges_count);
             let skipped_files;
@@ -17965,8 +18146,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 .name(name.as_deref())
                 .limits(index_limits)
                 .excludes(&repo_excludes);
-                let result = nestweaver_engine::index::index_directory_with_opts(
-                    &repo_path, &db_path, &opts,
+                let result = nestweaver_engine::index::index_directory_with_opts_and_write_lease(
+                    &repo_path,
+                    &db_path,
+                    &opts,
+                    &write_lease,
                 )
                 .context("index_directory")?;
 
@@ -17984,16 +18168,18 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 skipped_files = result.skipped_files;
             } else {
                 // Incremental index (falls back to full when no prior index exists).
-                let inc = nestweaver_engine::index::incremental_index_with_excludes(
-                    &repo_path,
-                    &db_path,
-                    &instance_id,
-                    &repo_url,
-                    name.as_deref(),
-                    index_limits,
-                    &repo_excludes,
-                )
-                .context("incremental_index")?;
+                let inc =
+                    nestweaver_engine::index::incremental_index_with_excludes_and_write_lease(
+                        &repo_path,
+                        &db_path,
+                        &instance_id,
+                        &repo_url,
+                        name.as_deref(),
+                        index_limits,
+                        &repo_excludes,
+                        &write_lease,
+                    )
+                    .context("incremental_index")?;
 
                 files_count = inc.files_added + inc.files_modified;
                 symbols_count = inc.symbols_added;
@@ -20552,6 +20738,32 @@ fn now_epoch_secs() -> f64 {
         .unwrap_or(0.0)
 }
 
+fn require_complete_graph_publication(
+    operation: &str,
+    publication: &nestweaver_engine::manifest::GraphMutationPublicationOutcome,
+) -> anyhow::Result<()> {
+    use nestweaver_engine::manifest::GraphMutationPublicationDisposition;
+
+    if publication.disposition != GraphMutationPublicationDisposition::CommittedDegraded {
+        return Ok(());
+    }
+    let warnings = if publication.warnings.is_empty() {
+        "unspecified publication stage".to_string()
+    } else {
+        publication
+            .warnings
+            .iter()
+            .map(|warning| format!("{}: {}", warning.stage, warning.message))
+            .collect::<Vec<_>>()
+            .join("; ")
+    };
+    anyhow::bail!(
+        "{operation} committed graph changes (generation {} -> {}), but publication reconciliation is degraded: {warnings}. The graph was NOT rolled back; repair the named stage(s) before treating derived artifacts as current",
+        publication.generation_before,
+        publication.generation_after,
+    )
+}
+
 fn run_memory(
     command: MemoryCommands,
     t0: std::time::Instant,
@@ -20654,10 +20866,44 @@ fn run_memory(
                     args,
                 )? {
                     println!("{}", serde_json::to_string_pretty(&value)?);
+                    let failed_apply = apply
+                        && !value
+                            .get("applied")
+                            .and_then(|applied| applied.as_bool())
+                            .unwrap_or(false)
+                        && value
+                            .get("proposals_total")
+                            .and_then(|total| total.as_u64())
+                            .or_else(|| {
+                                value
+                                    .get("proposals")
+                                    .and_then(|items| items.as_array())
+                                    .map(|items| items.len() as u64)
+                            })
+                            .unwrap_or(0)
+                            > 0;
+                    if failed_apply {
+                        anyhow::bail!(
+                            "memory consolidation apply did not complete; the JSON manifest above contains recovery warnings"
+                        );
+                    }
                     return Ok((EXIT_SUCCESS, None));
                 }
             }
-            let store = open_store(Some(&db_path))?;
+            let _write_lease = if apply {
+                Some(require_exclusive_store_access(
+                    &db_path,
+                    "apply memory consolidation",
+                )?)
+            } else {
+                None
+            };
+            let store = if apply {
+                GraphStore::open(&db_path)
+                    .map_err(|error| daemon_held_store_error(&db_path, error))?
+            } else {
+                open_store(Some(&db_path))?
+            };
             let manifest = nestweaver_engine::memory_consolidate(&store, apply, now_epoch_secs())?;
             if json {
                 println!("{}", serde_json::to_string_pretty(&manifest)?);
@@ -20683,6 +20929,11 @@ fn run_memory(
                 manifest.proposals.len(),
                 format_elapsed(t0.elapsed())
             );
+            if apply && !manifest.applied && !manifest.proposals.is_empty() {
+                anyhow::bail!(
+                    "memory consolidation apply did not complete; review the warnings above and recover the durable journal before retrying"
+                );
+            }
             Ok((EXIT_SUCCESS, Some(stats)))
         }
 
@@ -21835,6 +22086,12 @@ fn run_brain(
                             format_embedding_status(&embedding_status_from_json(embedding))
                         );
                     }
+                    if let Some(search) =
+                        value.get("search_status").filter(|value| !value.is_null())
+                    {
+                        println!("Search index:");
+                        println!("{}", format_search_status(&search_status_from_json(search)));
+                    }
                     // Interaction tracking — local check (not in MCP response).
                     // The sidecar is created (empty) by `InteractionTracker::new`
                     // when an MCP/daemon starts with --track-interactions, so:
@@ -22640,7 +22897,7 @@ fn run_brain(
             // it cannot survive PID reuse and an operator's `rm` erases it.
             //
             // Held for the whole watch.
-            let _write_lease = require_exclusive_store_access(&db_path, "brain watch")?;
+            let write_lease = require_exclusive_store_access(&db_path, "brain watch")?;
 
             let tantivy_sidecar = tantivy_sidecar_path_for(&db_path);
             let manifests_path = nestweaver_engine::manifest_cache_path(&db_path);
@@ -22728,7 +22985,7 @@ fn run_brain(
                 path.display(),
                 db_path.display()
             ));
-            if let Err(e) = watcher.run() {
+            if let Err(e) = watcher.run_with_write_lease(&write_lease) {
                 // A lock failure here means another process (usually a
                 // live daemon) holds the DB — name the remedy.
                 let msg = format!("{e:#}");
@@ -22965,6 +23222,10 @@ fn run_brain(
                     &extra_patterns,
                 )
                 .context("index_markdown_directory_since")?;
+                require_complete_graph_publication(
+                    "incremental vault refresh",
+                    &result.publication,
+                )?;
 
                 // Record the indexer run timestamp.
                 if let Err(e) = record_last_indexed_at(&db_path, &v_uid) {
@@ -23000,6 +23261,7 @@ fn run_brain(
                     &extra_patterns,
                 )
                 .context("index_markdown_directory")?;
+                require_complete_graph_publication("full vault refresh", &result.publication)?;
 
                 // Record the indexer run timestamp.
                 if let Err(e) = record_last_indexed_at(&db_path, &v_uid) {
@@ -23643,6 +23905,11 @@ fn run_brain(
             }
 
             let store = open_store(Some(&db_path))?;
+            if rerank {
+                store.require_verified_embedding_identity().context(
+                    "verify the database embedding identity before direct context reranking",
+                )?;
+            }
             let tantivy_path = tantivy_sidecar_path_for(&db_path);
             let tantivy = TantivyIndex::open_reader_only(&tantivy_path).ok();
 
@@ -25090,6 +25357,15 @@ fn brain_search_result_item_json(item: &nestweaver_proto::SearchResultItem) -> s
     value
 }
 
+fn semantic_unavailable_json(detail: &nestweaver_proto::SemanticUnavailable) -> serde_json::Value {
+    serde_json::json!({
+        "cause": detail.cause,
+        "reason": detail.reason,
+        "error": detail.error,
+        "remediation": detail.remediation,
+    })
+}
+
 fn render_brain_search_response(
     resp: &nestweaver_proto::BrainSearchResponse,
     json: bool,
@@ -25118,8 +25394,18 @@ fn render_brain_search_response(
         if !resp.expansion_terms.is_empty() {
             payload["expansion_terms"] = serde_json::json!(resp.expansion_terms);
         }
+        if let Some(detail) = &resp.semantic_unavailable {
+            payload["semantic_unavailable"] = semantic_unavailable_json(detail);
+        }
         print_json_payload(&payload)?;
         return Ok(());
+    }
+
+    if let Some(detail) = &resp.semantic_unavailable {
+        println!(
+            "Warning: semantic search unavailable ({}): {}\n  Remediation: {}",
+            detail.reason, detail.error, detail.remediation
+        );
     }
 
     if resp.results.is_empty() {
@@ -26983,6 +27269,7 @@ mod brain_search_renderer_tests {
             truncated: false,
             semantic_applied: false,
             degraded_components: Vec::new(),
+            semantic_unavailable: None,
         };
 
         let metadata = brain_search_display_metadata(&response);
@@ -26994,6 +27281,21 @@ mod brain_search_renderer_tests {
             brain_search_result_item_json(&response.results[0])["canonical_id"],
             "canonical-needle"
         );
+    }
+
+    #[test]
+    fn typed_semantic_unavailability_keeps_all_structured_fields() {
+        let detail = nestweaver_proto::SemanticUnavailable {
+            cause: "embedding_identity".to_string(),
+            reason: "embedding_identity_unreadable".to_string(),
+            error: "malformed persisted metadata".to_string(),
+            remediation: "repair the identity".to_string(),
+        };
+        let value = semantic_unavailable_json(&detail);
+        assert_eq!(value["cause"], "embedding_identity");
+        assert_eq!(value["reason"], "embedding_identity_unreadable");
+        assert_eq!(value["error"], "malformed persisted metadata");
+        assert_eq!(value["remediation"], "repair the identity");
     }
 
     #[test]
@@ -27336,6 +27638,7 @@ fn run_embed<Load>(
     batch_size: usize,
     scope: &str,
     force: bool,
+    repair_identity: bool,
     stats: bool,
     use_daemon: bool,
     local_model_loader: Load,
@@ -27358,6 +27661,7 @@ where
         batch_size,
         scope,
         force,
+        repair_identity,
         stats,
         use_daemon,
         local_model_loader,
@@ -27377,6 +27681,7 @@ fn run_embed_with_cancel<Load>(
     batch_size: usize,
     scope: &str,
     force: bool,
+    repair_identity: bool,
     stats: bool,
     use_daemon: bool,
     local_model_loader: Load,
@@ -27411,6 +27716,12 @@ where
     if batch_size == 0 {
         anyhow::bail!("--batch-size must be at least 1");
     }
+    let do_symbols = scope == "all" || scope == "symbols";
+    let do_notes = scope == "all" || scope == "notes";
+    let do_headings = scope == "all" || scope == "headings";
+    if !do_symbols && !do_notes && !do_headings {
+        anyhow::bail!("unknown --scope '{scope}': expected one of: all, symbols, notes, headings");
+    }
 
     let t0 = std::time::Instant::now();
     let default = default_db_path();
@@ -27432,16 +27743,22 @@ where
         // to the default (that is what the daemon would load); a DB that
         // exists but cannot be read gets a warning, because comparing against
         // the default could then produce a spurious "cannot honor" error.
-        let recorded_model = match nestweaver_store::GraphStore::open_read_only(path) {
-            Ok(store) => store.get_embedding_metadata().ok().flatten(),
-            Err(e) => {
-                if path.exists() {
-                    eprintln!(
-                        "Warning: could not read the recorded embedding model ({e:#}); \
-                         assuming the default model"
-                    );
+        let recorded_model = if repair_identity {
+            None
+        } else {
+            match nestweaver_store::GraphStore::open_read_only(path) {
+                Ok(store) => store
+                    .get_embedding_metadata()
+                    .context("read the database embedding identity before daemon embedding")?,
+                Err(e) => {
+                    if path.exists() {
+                        eprintln!(
+                            "Warning: could not read the recorded embedding model ({e:#}); \
+                             assuming the default model"
+                        );
+                    }
+                    None
                 }
-                None
             }
         };
         let recorded_model = recorded_model
@@ -27453,31 +27770,33 @@ where
         let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
         match rt.block_on(nestweaver_client::DaemonClient::connect(path, None)) {
             Ok(mut client) => {
-                match rt.block_on(client.plan_embed(scope, force)) {
-                    Ok(plan) => {
-                        eprintln!(
-                            "Embedding plan: {} eligible, {} already embedded, {} scoped node(s).",
-                            plan.eligible, plan.skipped, plan.scoped
-                        );
-                        if plan.eligible == 0 {
+                if !repair_identity {
+                    match rt.block_on(client.plan_embed(scope, force)) {
+                        Ok(plan) => {
                             eprintln!(
-                                "No embedding work required; every scoped node already has an authoritative sidecar embedding."
+                                "Embedding plan: {} eligible, {} already embedded, {} scoped node(s).",
+                                plan.eligible, plan.skipped, plan.scoped
                             );
-                            return Ok(EXIT_SUCCESS);
+                            if plan.eligible == 0 {
+                                eprintln!(
+                                    "No embedding work required; every scoped node already has an authoritative sidecar embedding."
+                                );
+                                return Ok(EXIT_SUCCESS);
+                            }
                         }
-                    }
-                    Err(error) => {
-                        // A same-version daemon from before PlanEmbed can survive a binary
-                        // upgrade. Keep the legacy route usable, but make the lost preflight
-                        // visible and tell the operator how to enable it.
-                        if daemon_lacks_embedding_preflight(&error) {
-                            eprintln!(
-                                "Daemon does not support embedding preflight; restart it with \
+                        Err(error) => {
+                            // A same-version daemon from before PlanEmbed can survive a binary
+                            // upgrade. Keep the legacy route usable, but make the lost preflight
+                            // visible and tell the operator how to enable it.
+                            if daemon_lacks_embedding_preflight(&error) {
+                                eprintln!(
+                                    "Daemon does not support embedding preflight; restart it with \
                                  `nestweaver daemon --db {} restart` to enable eligibility reporting.",
-                                path.display()
-                            );
-                        } else {
-                            return Err(error).context("daemon embedding preflight failed");
+                                    path.display()
+                                );
+                            } else {
+                                return Err(error).context("daemon embedding preflight failed");
+                            }
                         }
                     }
                 }
@@ -27495,10 +27814,35 @@ where
                         "nestweaver embed",
                         nestweaver_client::progress::NoticeKind::EmbedProgress,
                     );
-                    client.embed(scope, force, batch_size as u32).await
+                    client
+                        .embed_with_identity_repair(
+                            scope,
+                            force,
+                            batch_size as u32,
+                            repair_identity,
+                        )
+                        .await
                 }) {
                     Ok(resp) => {
                         let elapsed = t0.elapsed();
+                        if repair_identity && !resp.identity_repaired {
+                            anyhow::bail!(
+                                "daemon returned without confirming embedding identity repair; \
+                                 restart it and retry --repair-identity"
+                            );
+                        }
+                        if resp.identity_repaired {
+                            eprintln!(
+                                "Discarded {} embedding(s) and removed the unreadable semantic identity.",
+                                resp.discarded_embeddings
+                            );
+                        }
+                        if resp.restart_required {
+                            eprintln!(
+                                "Restart the daemon to load the configured embedding model, then run `nestweaver embed --force`."
+                            );
+                            return Ok(EXIT_SUCCESS);
+                        }
                         if resp.rejected > 0 {
                             eprintln!(
                                 "Error: {} embedding(s) rejected by the embedding guards \
@@ -27584,15 +27928,22 @@ where
             path.display()
         )
     })?;
-    store.reset_embedding_force_guard();
-
-    let do_symbols = scope == "all" || scope == "symbols";
-    let do_notes = scope == "all" || scope == "notes";
-    let do_headings = scope == "all" || scope == "headings";
-
-    if !do_symbols && !do_notes && !do_headings {
-        anyhow::bail!("unknown --scope '{scope}': expected one of: all, symbols, notes, headings");
+    if repair_identity {
+        let discarded = store
+            .reset_embedding_space_for_identity_repair()
+            .context("discard the unreadable semantic space before direct embedding")?;
+        eprintln!(
+            "Discarded {discarded} embedding(s) and removed the unreadable semantic identity; rebuilding from the requested model."
+        );
     }
+    // Validate the complete persisted pipeline before model loading, network
+    // calls, or local inference. `--force` may replace a verified identity; it
+    // must never authorize spending work against an unreadable one.
+    store
+        .require_verified_embedding_identity()
+        .context("verify the database embedding identity before direct embedding")?;
+    store.reset_embedding_force_guard();
+    let force = force || repair_identity;
 
     // The direct paths (--local / --endpoint) resolve their model from flags
     // alone and bypass the daemon route's recorded-model guard at the top of
@@ -27601,10 +27952,9 @@ where
     // conflicting explicit model requires --force. Absent metadata means the
     // database was never stamped: unknown, so proceed (first embed).
     let recorded_model_id = store
-        .get_embedding_metadata()
-        .ok()
-        .flatten()
-        .map(|(model_id, _)| model_id);
+        .get_embedding_pipeline()
+        .context("read the complete database embedding pipeline before direct embedding")?
+        .map(|pipeline| pipeline.model_id);
     if !force && let Some(recorded) = recorded_model_id.as_deref() {
         // On the endpoint branch the comparison operand is the endpoint's
         // model (--model, defaulting to the external default), never
@@ -28128,13 +28478,15 @@ where
                 success_count = 0;
             }
         }
-    } else if let Some(requested) = (if endpoint.is_some() { model } else { model_id })
-        && let Ok(Some((recorded, _))) = store.get_embedding_metadata()
+    } else if let Some(requested) = if endpoint.is_some() { model } else { model_id }
+        && let Some((recorded, _)) = store
+            .get_embedding_metadata()
+            .context("read the database embedding identity after a zero-work embed")?
         && recorded != requested
     {
-        // Zero-work path with an explicit model mismatch: name it, or the run
-        // ends with "Done: 0 embedding(s)" and no hint that the requested
-        // model was never applied.
+        // Zero-work path with an explicit model mismatch: name it, or the
+        // run ends with "Done: 0 embedding(s)" and no hint that the
+        // requested model was never applied.
         eprintln!(
             "No embeddings were produced; the database remains embedded with '{recorded}'. \
              Re-run with --force to re-embed everything with '{requested}'."
@@ -28768,7 +29120,7 @@ fn run_instance(command: InstanceCommands, use_daemon: bool) -> anyhow::Result<i
             // Offline recovery: operate on the sidecar journals directly (the
             // daemon is wedged and won't boot). nw-091 / Bug 3B.
             let db_path = db.unwrap_or_else(default_db_path);
-            match nestweaver_engine::abort_instance_extension_migration(&db_path, force)? {
+            match abort_instance_migration_offline(&db_path, force)? {
                 nestweaver_engine::AbortMigrationOutcome::NothingToAbort => {
                     println!("No pending instance-migration journal — nothing to abort.");
                 }
@@ -28795,6 +29147,23 @@ fn run_instance(command: InstanceCommands, use_daemon: bool) -> anyhow::Result<i
             Ok(EXIT_SUCCESS)
         }
     }
+}
+
+/// Abort recovery is an offline mutation of the same durable journal a live
+/// daemon merge advances. Hold the canonical database write lease before even
+/// inspecting that journal, and retain it through durable removal. `--force`
+/// changes phase policy only; it never bypasses ownership.
+fn abort_instance_migration_offline(
+    db_path: &Path,
+    force: bool,
+) -> anyhow::Result<nestweaver_engine::AbortMigrationOutcome> {
+    require_existing_db(db_path)?;
+    let _lease = require_exclusive_store_access_with_remedy(
+        db_path,
+        "abort an instance-migration recovery journal",
+        ExclusivityRemedy::StopTheHolder,
+    )?;
+    nestweaver_engine::abort_instance_extension_migration(db_path, force)
 }
 
 /// Guidance for vaults whose notes were discarded by a merge collision.
@@ -29083,14 +29452,14 @@ fn run_backup(command: BackupCommands) -> anyhow::Result<i32> {
             // cleanup. The pidfile above permits absent, empty and stale
             // states; none of those is evidence that nobody is writing, and
             // this is what supplies that evidence.
-            let _restore_leases = require_exclusive_restore_access(&data_dir)?;
-
             let config = nestweaver_engine::RestoreConfig {
                 snapshot_path: path,
                 data_dir: data_dir.clone(),
             };
 
-            let result = nestweaver_engine::backup_restore(&config)?;
+            let result = with_exclusive_restore_access(&data_dir, || {
+                nestweaver_engine::backup_restore(&config)
+            })?;
             let m = &result.manifest;
 
             eprintln!("Backup restored to {}", data_dir.display());
@@ -29211,11 +29580,51 @@ fn find_lbug_in_dir(dir: &Path) -> Option<PathBuf> {
 /// holds its lease on the inode that now lives under `.restoring`. Looking
 /// only at `data_dir` would create a brand-new, trivially-free lease file
 /// beside a partial copy and conclude that nobody was writing.
-fn restore_lease_targets(data_dir: &Path) -> Vec<PathBuf> {
-    [data_dir.to_path_buf(), data_dir.with_extension("restoring")]
-        .iter()
-        .filter_map(|dir| find_lbug_in_dir(dir))
-        .collect()
+fn restore_lease_targets(data_dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    let mut targets = Vec::new();
+
+    for dir in [data_dir.to_path_buf(), data_dir.with_extension("restoring")] {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                anyhow::bail!(
+                    "cannot enumerate incumbent databases in {} before destructive restore: {error}",
+                    dir.display()
+                )
+            }
+        };
+
+        for entry in entries {
+            let entry = entry.with_context(|| {
+                format!(
+                    "cannot enumerate every incumbent database in {} before destructive restore",
+                    dir.display()
+                )
+            })?;
+            let path = entry.path();
+            if path.extension().and_then(|extension| extension.to_str()) != Some("lbug") {
+                continue;
+            }
+
+            let metadata = std::fs::metadata(&path).with_context(|| {
+                format!(
+                    "cannot inspect possible incumbent database {} before destructive restore",
+                    path.display()
+                )
+            })?;
+            if metadata.is_file() {
+                targets.push(nestweaver_daemon::lifecycle::canonical_db_path(&path));
+            }
+        }
+    }
+
+    // Every restore takes leases in the same canonical order, so two recovery
+    // attempts cannot deadlock by discovering directory entries differently.
+    // Canonicalisation also collapses symlink aliases to one lock identity.
+    targets.sort();
+    targets.dedup();
+    Ok(targets)
 }
 
 /// Hold the canonical database write lease over every database a restore is
@@ -29233,11 +29642,11 @@ fn restore_lease_targets(data_dir: &Path) -> Vec<PathBuf> {
 /// brain, and the loss of the current data.
 ///
 /// The lease is the same one `index`, `watch`, `embed`, `brain watch`, the
-/// vault commands, the Tantivy rebuild and the daemon itself take — an
-/// `flock` on `<db>.write.lock`, per-DESCRIPTOR so it survives the store's own
-/// open/close, released by the kernel on process exit so there is no stale
-/// state to reap. `snapshot build` already corroborates its pidfile check with
-/// the database write lock, for exactly this reason; restore did not.
+/// vault commands, the Tantivy rebuild and the daemon itself take. It combines
+/// lbug-compatible database ownership with descriptor-scoped database and
+/// sidecar locks, while restore additionally closes the stable parent
+/// namespace before enumeration. The kernel releases every claim on process
+/// exit, so there is no stale ownership record to reap.
 ///
 /// A probe answers "was anyone holding this a moment ago". Only a HELD lease
 /// answers "is anyone holding this for as long as I am deleting their data",
@@ -29246,19 +29655,89 @@ fn restore_lease_targets(data_dir: &Path) -> Vec<PathBuf> {
               immediately reduces this to a probe, and the window that reopens \
               is precisely the one in which the data directory is renamed aside \
               and unlinked"]
-fn require_exclusive_restore_access(
-    data_dir: &Path,
-) -> anyhow::Result<Vec<nestweaver_daemon::lifecycle::DbWriteLease>> {
-    restore_lease_targets(data_dir)
+fn require_exclusive_restore_access(data_dir: &Path) -> anyhow::Result<RestoreWriteAuthority> {
+    // Close the namespace before the first enumeration. Every upgraded
+    // database creator takes a shared claim on this stable parent inode before
+    // creating/opening its database; restore takes the exclusive form. Unlike
+    // a lock on `data_dir` itself, renaming that directory cannot swap this
+    // authority onto an obsolete inode.
+    let namespace = match nestweaver_daemon::lifecycle::acquire_db_namespace_lease(data_dir) {
+        Ok(lease) => lease,
+        Err(nestweaver_daemon::lifecycle::WriteLeaseError::Held) => anyhow::bail!(
+            "cannot restore a backup over {}: a writer holds the database namespace write lease; stop every writer and retry",
+            data_dir.display()
+        ),
+        Err(nestweaver_daemon::lifecycle::WriteLeaseError::Unavailable(error)) => {
+            anyhow::bail!(
+                "cannot prove exclusive ownership of the database namespace containing {}: {error}; refusing destructive restore",
+                data_dir.display()
+            )
+        }
+    };
+    let targets = restore_lease_targets(data_dir)?;
+    let leases = targets
         .iter()
         .map(|db| {
-            require_exclusive_store_access_with_remedy(
+            match nestweaver_daemon::lifecycle::acquire_db_write_lease_under_namespace(
                 db,
-                "restore a backup over this data directory",
-                ExclusivityRemedy::StopTheHolder,
-            )
+                &namespace,
+            ) {
+                Ok(lease) => Ok(lease),
+                Err(nestweaver_daemon::lifecycle::WriteLeaseError::Held) => anyhow::bail!(
+                    "cannot restore a backup over this data directory: another process holds the write lease for {}. Stop the holder first, then retry.",
+                    db.display()
+                ),
+                Err(nestweaver_daemon::lifecycle::WriteLeaseError::Unavailable(error)) => {
+                    anyhow::bail!(
+                        "cannot take the write lease for {} before destructive restore: {error}",
+                        db.display()
+                    )
+                }
+            }
         })
-        .collect()
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    // Re-enumerate as an invariant check. Unlike the previous check-only
+    // scheme, the exclusive namespace authority remains held after this read
+    // and through cutover, so an upgraded late creator cannot enter after it.
+    let observed = restore_lease_targets(data_dir)?;
+    anyhow::ensure!(
+        observed == targets,
+        "the incumbent database set changed while restore write leases were being acquired — refusing destructive restore; stop every writer and retry"
+    );
+
+    Ok(RestoreWriteAuthority {
+        _namespace: namespace,
+        _leases: leases,
+    })
+}
+
+#[must_use = "dropping this authority reopens the restore namespace"]
+#[derive(Debug)]
+struct RestoreWriteAuthority {
+    // Drop database leases before the enclosing namespace authority.
+    _leases: Vec<nestweaver_daemon::lifecycle::DbWriteLease>,
+    _namespace: nestweaver_daemon::lifecycle::DbNamespaceLease,
+}
+
+/// Run the destructive restore phase under exact database and namespace
+/// authority, then release that authority before the caller performs any
+/// post-restore work such as `--start` daemon launch.
+fn with_exclusive_restore_access<T>(
+    data_dir: &Path,
+    restore: impl FnOnce() -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    let authority = require_exclusive_restore_access(data_dir)?;
+    let result = restore();
+    drop(authority);
+    result
+}
+
+impl RestoreWriteAuthority {
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self._leases.len()
+    }
 }
 
 /// Refuse a restore while a live daemon serves the target data directory.
@@ -30332,12 +30811,24 @@ fn run_publication_rebuild(
                         }
                     }
                     let store = GraphStore::open(&target_db)?;
-                    nestweaver_engine::project::materialize_projects(
+                    let projects = nestweaver_engine::project::materialize_projects(
                         &store,
                         &config,
                         &config.instance_id,
                         &target_db,
                     )?;
+                    if projects.publication.is_degraded() {
+                        let details = projects
+                            .publication
+                            .warnings
+                            .iter()
+                            .map(|warning| format!("{}: {}", warning.stage, warning.message))
+                            .collect::<Vec<_>>()
+                            .join("; ");
+                        anyhow::bail!(
+                            "project graph committed but its derived-artifact publication is degraded; refusing to publish the staged brain: {details}"
+                        );
+                    }
                     if let Some(links) = config.links.as_deref() {
                         nestweaver_engine::materialize_declared_links(&store, links)?;
                     }
@@ -30422,6 +30913,7 @@ fn run_publication_rebuild(
                         batch_size,
                         "all",
                         true,
+                        false,
                         true,
                         false,
                         load_cli_local_embedder,
@@ -32066,6 +32558,106 @@ mod restore_guard_tests {
             .expect_err("the restore must still be HOLDING the lease, not have dropped it");
     }
 
+    /// `backup restore --start` enters daemon startup only after the restore
+    /// scope returns. That boundary must release the exclusive namespace and
+    /// database claims or the restored daemon rejects its own writer lease.
+    #[test]
+    fn completed_restore_scope_releases_authority_before_start_phase() {
+        let rt = tempfile::tempdir().unwrap();
+        let _env = RuntimeDirGuard::set(rt.path());
+        let (data_dir, db, _sidecar, _pidfile) = fixture();
+
+        let value = with_exclusive_restore_access(data_dir.path(), || {
+            require_exclusive_store_access(&db, "probe during restore")
+                .expect_err("the destructive phase must still hold exact authority");
+            Ok(17)
+        })
+        .expect("a free fixture authorizes the restore scope");
+        assert_eq!(value, 17);
+
+        let _daemon_start_authority = require_exclusive_store_access(&db, "daemon start phase")
+            .expect("post-restore daemon startup must be able to claim writer authority");
+    }
+
+    #[test]
+    fn restore_namespace_blocks_a_late_sibling_creator_until_cutover_finishes() {
+        let rt = tempfile::tempdir().unwrap();
+        let _env = RuntimeDirGuard::set(rt.path());
+        let (data_dir, _db, _sidecar, _pidfile) = fixture();
+
+        let authority = require_exclusive_restore_access(data_dir.path())
+            .expect("the restore must close its namespace before enumeration");
+        let late = data_dir.path().join("late.lbug");
+        let error = require_exclusive_store_access(&late, "create a late sibling")
+            .expect_err("a late creator must not enter the closed restore namespace");
+        assert!(error.to_string().contains("write lease"));
+        assert!(
+            !late.exists(),
+            "the namespace refusal must happen before database creation"
+        );
+
+        drop(authority);
+        let _late_authority = require_exclusive_store_access(&late, "create after restore")
+            .expect("the namespace reopens only after restore authority drops");
+    }
+
+    /// Directory iteration order is not an ownership policy. A writer holding
+    /// the second sibling database must refuse restore just as surely as the
+    /// lexically first database covered by `restore_refuses_while_the_write_lease_is_held`.
+    #[test]
+    fn restore_refuses_when_a_later_sibling_database_is_held() {
+        let rt = tempfile::tempdir().unwrap();
+        let _env = RuntimeDirGuard::set(rt.path());
+        let (data_dir, first_db, _sidecar, _pidfile) = fixture();
+        let later_db = data_dir.path().join("zeta.lbug");
+        std::fs::write(&later_db, b"second database").unwrap();
+
+        let _held = require_exclusive_store_access(&later_db, "hold the later sibling database")
+            .expect("the sibling lease starts free");
+        let before = dir_fingerprint(data_dir.path());
+
+        let error = require_exclusive_restore_access(data_dir.path())
+            .expect_err("a held later sibling must stop destructive restore");
+        assert!(
+            error.to_string().contains("write lease"),
+            "err was: {error}"
+        );
+        assert_eq!(
+            before,
+            dir_fingerprint(data_dir.path()),
+            "refusal must preserve every sibling byte"
+        );
+        assert!(!data_dir.path().with_extension("restoring").exists());
+
+        // The earlier sibling was not the source of the refusal.
+        let _available =
+            require_exclusive_store_access(&first_db, "prove the first sibling stayed free")
+                .expect("the first sibling lease must remain available");
+    }
+
+    /// All live and interrupted-cutover databases are canonicalized,
+    /// deterministically ordered, and returned exactly once before leasing.
+    #[test]
+    fn restore_lease_targets_include_every_sibling_in_canonical_order() {
+        let (data_dir, first_db, _sidecar, _pidfile) = fixture();
+        let live_later = data_dir.path().join("zeta.lbug");
+        std::fs::write(&live_later, b"live sibling").unwrap();
+
+        let restoring = data_dir.path().with_extension("restoring");
+        std::fs::create_dir_all(&restoring).unwrap();
+        let aside_db = restoring.join("aside.lbug");
+        std::fs::write(&aside_db, b"aside sibling").unwrap();
+
+        let mut expected = vec![first_db, live_later, aside_db]
+            .into_iter()
+            .map(|path| nestweaver_daemon::lifecycle::canonical_db_path(&path))
+            .collect::<Vec<_>>();
+        expected.sort();
+        expected.dedup();
+
+        assert_eq!(restore_lease_targets(data_dir.path()).unwrap(), expected);
+    }
+
     /// No pidfile state — absent, empty, whitespace-only or stale — may stand
     /// in for lock proof, in either direction.
     ///
@@ -32124,7 +32716,7 @@ mod restore_guard_tests {
             drop(held);
 
             // With the lease free, the same pidfile state is fine.
-            require_exclusive_restore_access(data_dir.path())
+            let _authority = require_exclusive_restore_access(data_dir.path())
                 .unwrap_or_else(|error| panic!("{label}: a free lease must authorize: {error}"));
         }
     }
@@ -32259,6 +32851,39 @@ mod restore_guard_tests {
         assert_eq!(
             direct, daemon_aware,
             "both entry paths must hand the same Restore payload to run_backup"
+        );
+    }
+}
+
+#[cfg(test)]
+mod abort_migration_ownership_tests {
+    use super::*;
+
+    /// Neither the ordinary recovery path nor `--force` may inspect/remove the
+    /// migration journal while the daemon merge worker owns the database.
+    #[test]
+    fn abort_migration_refuses_without_write_ownership_even_when_forced() {
+        let temp = tempfile::tempdir().unwrap();
+        let db = temp.path().join("graph.lbug");
+        drop(nestweaver_store::GraphStore::create(&db).unwrap());
+
+        let _held = require_exclusive_store_access(&db, "simulate a live merge owner")
+            .expect("fixture lease starts free");
+        for force in [false, true] {
+            let error = abort_instance_migration_offline(&db, force)
+                .expect_err("abort must not bypass the live writer");
+            assert!(
+                error.to_string().contains("write lease"),
+                "force={force}: err was {error}"
+            );
+        }
+
+        let mut journal = db.as_os_str().to_owned();
+        journal.push(".extensions.migration.json");
+        let journal = PathBuf::from(journal);
+        assert!(
+            !journal.exists(),
+            "the ownership refusal must not create or mutate the journal"
         );
     }
 }
@@ -34914,6 +35539,9 @@ mod diagnostics_cli_tests {
             error: "Metal probe failed".to_string(),
             metal_compiled: true,
             fallback_used: false,
+            identity_state: "unreadable".to_string(),
+            identity_error: "parse embedding metadata failed".to_string(),
+            identity_remediation: "restore verified metadata or re-embed".to_string(),
             ..Default::default()
         };
         let text = format_embedding_status(&status);
@@ -34921,6 +35549,9 @@ mod diagnostics_cli_tests {
         assert!(text.contains("Device:           metal -> unavailable"));
         assert!(text.contains("Fallback used:    false"));
         assert!(text.contains("Metal probe failed"));
+        assert!(text.contains("Identity:         unreadable"));
+        assert!(text.contains("parse embedding metadata failed"));
+        assert!(text.contains("restore verified metadata or re-embed"));
     }
 }
 
@@ -36325,6 +36956,39 @@ mod embed_metadata_truth_tests {
     }
 
     #[test]
+    fn invalid_repair_scope_is_rejected_before_discarding_embeddings() {
+        let (_dir, db_path) = seed_embed_db(&["seeded"], &[], Some((RECORDED_MODEL, 3)));
+        let loader = StubLoader::new(3);
+
+        let error = run_embed(
+            Some(&db_path),
+            true,
+            None,
+            None,
+            Some(RECORDED_MODEL),
+            None,
+            None,
+            8,
+            "typo",
+            true,
+            true,
+            false,
+            false,
+            loader.closure(),
+        )
+        .expect_err("invalid scope must fail before identity repair");
+
+        assert!(error.to_string().contains("unknown --scope 'typo'"));
+        assert_eq!(loader.call_count(), 0);
+        let store = nestweaver_store::GraphStore::open_read_only(&db_path).unwrap();
+        assert!(store.has_embedding("sym:seeded"));
+        assert_eq!(
+            store.get_embedding_metadata().unwrap(),
+            Some((RECORDED_MODEL.to_string(), 3))
+        );
+    }
+
+    #[test]
     fn publication_embed_cancellation_stops_before_loading_the_model() {
         let (_dir, db_path) = seed_embed_db(&[], &["pending"], None);
         let loader = StubLoader::new(3);
@@ -36339,6 +37003,7 @@ mod embed_metadata_truth_tests {
             8,
             "all",
             true,
+            false,
             false,
             false,
             loader.closure(),
@@ -36389,6 +37054,7 @@ mod embed_metadata_truth_tests {
             8,
             "symbols",
             false, // no --force
+            false,
             false,
             false, // direct path
             loader.closure(),
@@ -36442,6 +37108,7 @@ mod embed_metadata_truth_tests {
             false,
             false,
             false,
+            false,
             loader.closure(),
         )
         .expect("a rejected run still returns an exit code");
@@ -36490,6 +37157,7 @@ mod embed_metadata_truth_tests {
             false,
             false,
             false,
+            false,
             loader.closure(),
         )
         .expect("a rejected run still returns an exit code");
@@ -36529,6 +37197,7 @@ mod embed_metadata_truth_tests {
             true, // --force
             false,
             false,
+            false,
             loader.closure(),
         )
         .expect("a forced re-embed must run");
@@ -36564,6 +37233,7 @@ mod embed_metadata_truth_tests {
             false,
             false,
             false,
+            false,
             loader.closure(),
         )
         .expect("a matching model id must not bail");
@@ -36595,6 +37265,7 @@ mod embed_metadata_truth_tests {
             8,
             "all",
             true, // --force, so the mismatch guard does not bail
+            false,
             false,
             false,
             loader.closure(),
@@ -36637,6 +37308,7 @@ mod embed_metadata_truth_tests {
             false,
             false,
             false,
+            false,
             loader.closure(),
         )
         .expect("the local --model-id must not bail the endpoint branch");
@@ -36674,6 +37346,7 @@ mod embed_metadata_truth_tests {
             None,
             8,
             "symbols",
+            false,
             false,
             false,
             false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -29644,9 +29644,10 @@ fn restore_lease_targets(data_dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
 /// The lease is the same one `index`, `watch`, `embed`, `brain watch`, the
 /// vault commands, the Tantivy rebuild and the daemon itself take. It combines
 /// lbug-compatible database ownership with descriptor-scoped database and
-/// sidecar locks, while restore additionally closes the stable parent
-/// namespace before enumeration. The kernel releases every claim on process
-/// exit, so there is no stale ownership record to reap.
+/// sidecar locks, while restore additionally closes the stable namespaces for
+/// both the live and rename-aside data directories before enumeration. The
+/// kernel releases every claim on process exit, so there is no stale ownership
+/// record to reap.
 ///
 /// A probe answers "was anyone holding this a moment ago". Only a HELD lease
 /// answers "is anyone holding this for as long as I am deleting their data",
@@ -29656,31 +29657,45 @@ fn restore_lease_targets(data_dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
               is precisely the one in which the data directory is renamed aside \
               and unlinked"]
 fn require_exclusive_restore_access(data_dir: &Path) -> anyhow::Result<RestoreWriteAuthority> {
-    // Close the namespace before the first enumeration. Every upgraded
-    // database creator takes a shared claim on this stable parent inode before
-    // creating/opening its database; restore takes the exclusive form. Unlike
-    // a lock on `data_dir` itself, renaming that directory cannot swap this
-    // authority onto an obsolete inode.
-    let namespace = match nestweaver_daemon::lifecycle::acquire_db_namespace_lease(data_dir) {
-        Ok(lease) => lease,
-        Err(nestweaver_daemon::lifecycle::WriteLeaseError::Held) => anyhow::bail!(
-            "cannot restore a backup over {}: a writer holds the database namespace write lease; stop every writer and retry",
-            data_dir.display()
-        ),
-        Err(nestweaver_daemon::lifecycle::WriteLeaseError::Unavailable(error)) => {
-            anyhow::bail!(
-                "cannot prove exclusive ownership of the database namespace containing {}: {error}; refusing destructive restore",
-                data_dir.display()
-            )
+    // Close both namespaces before the first enumeration. Every upgraded
+    // database creator takes a shared claim on a stable lock file in its data
+    // directory's parent before creating/opening a database; restore takes the
+    // exclusive form for both the live directory and the `.restoring`
+    // rename-aside directory it reconciles. Each file is keyed by the exact
+    // data-directory name, so unrelated siblings remain independent.
+    let mut namespaces = Vec::with_capacity(2);
+    for namespace_dir in [data_dir.to_path_buf(), data_dir.with_extension("restoring")] {
+        match nestweaver_daemon::lifecycle::acquire_db_namespace_lease(&namespace_dir) {
+            Ok(lease) => namespaces.push(lease),
+            Err(nestweaver_daemon::lifecycle::WriteLeaseError::Held) => anyhow::bail!(
+                "cannot restore a backup over {}: a writer holds the database namespace write lease for {}; stop every writer and retry",
+                data_dir.display(),
+                namespace_dir.display()
+            ),
+            Err(nestweaver_daemon::lifecycle::WriteLeaseError::Unavailable(error)) => {
+                anyhow::bail!(
+                    "cannot prove exclusive ownership of the database namespace containing {}: {error}; refusing destructive restore",
+                    namespace_dir.display()
+                )
+            }
         }
-    };
+    }
     let targets = restore_lease_targets(data_dir)?;
     let leases = targets
         .iter()
         .map(|db| {
+            let namespace = namespaces
+                .iter()
+                .find(|namespace| namespace.authorizes(db))
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "no held restore namespace covers incumbent database {}",
+                        db.display()
+                    )
+                })?;
             match nestweaver_daemon::lifecycle::acquire_db_write_lease_under_namespace(
                 db,
-                &namespace,
+                namespace,
             ) {
                 Ok(lease) => Ok(lease),
                 Err(nestweaver_daemon::lifecycle::WriteLeaseError::Held) => anyhow::bail!(
@@ -29707,7 +29722,7 @@ fn require_exclusive_restore_access(data_dir: &Path) -> anyhow::Result<RestoreWr
     );
 
     Ok(RestoreWriteAuthority {
-        _namespace: namespace,
+        _namespaces: namespaces,
         _leases: leases,
     })
 }
@@ -29715,9 +29730,9 @@ fn require_exclusive_restore_access(data_dir: &Path) -> anyhow::Result<RestoreWr
 #[must_use = "dropping this authority reopens the restore namespace"]
 #[derive(Debug)]
 struct RestoreWriteAuthority {
-    // Drop database leases before the enclosing namespace authority.
+    // Drop database leases before the enclosing namespace authorities.
     _leases: Vec<nestweaver_daemon::lifecycle::DbWriteLease>,
-    _namespace: nestweaver_daemon::lifecycle::DbNamespaceLease,
+    _namespaces: Vec<nestweaver_daemon::lifecycle::DbNamespaceLease>,
 }
 
 /// Run the destructive restore phase under exact database and namespace
@@ -32734,7 +32749,7 @@ mod restore_guard_tests {
         let restoring = data_dir.path().with_extension("restoring");
         std::fs::create_dir_all(&restoring).unwrap();
         std::fs::write(restoring.join("graph.lbug"), b"aside").unwrap();
-        let _held = require_exclusive_store_access(
+        let held = require_exclusive_store_access(
             &restoring.join("graph.lbug"),
             "hold the aside database",
         )
@@ -32743,6 +32758,25 @@ mod restore_guard_tests {
         let error = require_exclusive_restore_access(data_dir.path())
             .expect_err("a writer on the aside copy must stop the restore");
         assert!(error.to_string().contains("write lease"), "err: {error}");
+
+        drop(held);
+        let authority = require_exclusive_restore_access(data_dir.path())
+            .expect("a free aside database must be covered by restore authority");
+        assert_eq!(
+            authority.len(),
+            2,
+            "restore must lease the live fixture database and the free aside database"
+        );
+        let late_db = restoring.join("late.lbug");
+        assert!(matches!(
+            nestweaver_daemon::lifecycle::acquire_db_write_lease(&late_db),
+            Err(nestweaver_daemon::lifecycle::WriteLeaseError::Held)
+        ));
+        assert!(
+            !late_db.exists(),
+            "a late aside creator must lose namespace admission before file creation"
+        );
+        drop(authority);
 
         let _ = std::fs::remove_dir_all(&restoring);
     }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1695,6 +1695,7 @@ fn ci_metal_smoke_gates_offline_cold_and_warm_daemon_inference() {
     let evidence = workflow_step(job, "Collect Metal smoke evidence");
     for required in [
         "if: failure()",
+        "OUTPUT_DIR=\"${OUTPUT_DIR:-$RUNNER_TEMP/nestweaver-metal-evidence-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}}\"",
         "diagnostics capabilities --json",
         "daemon.log",
     ] {
@@ -1708,6 +1709,7 @@ fn ci_metal_smoke_gates_offline_cold_and_warm_daemon_inference() {
         "if: failure()",
         "actions/upload-artifact@",
         "metal-smoke-evidence",
+        "${{ runner.temp }}/nestweaver-metal-evidence-${{ github.run_id }}-${{ github.run_attempt }}-metal-smoke",
     ] {
         assert!(
             upload.contains(required),

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1202,18 +1202,22 @@ fn release_workflow_pins_a_portable_linux_cxx20_toolchain() {
     );
     assert!(
         workflow.contains("workflow_dispatch:")
-            && workflow.contains("github.event_name == 'workflow_dispatch'")
+            && workflow.contains("operation:")
+            && workflow.contains("options: [dry-run, resume, cleanup-draft, recover-npm]")
+            && workflow.contains("needs.release-context.outputs.mode == 'dry-run'")
+            && workflow.contains("needs.release-context.outputs.mode == 'publish'")
+            && workflow.contains("verify-dry-run:")
+            && workflow.contains("cleanup-canary:")
+            && workflow.contains("scripts/observe-release-visibility.sh")
+            && workflow.contains("scripts/verify-release-canary-pr.sh")
             && workflow.contains("CFLAGS: \"-DZSTD_DISABLE_ASM\"")
             && !workflow.contains("fuse-ld=mold")
             && workflow.contains("zstdnoasm-gnuld")
             && workflow.contains("thread apply all backtrace")
-            && workflow
-                .matches("if: github.event_name != 'workflow_dispatch'")
-                .count()
-                == 4,
-        "release artifacts must be manually verifiable before tagging; Linux must use \
-         the system linker and the same zstd native-code contract as normal CI, with a \
-         backtrace on functional-smoke failure, without uploading to a release"
+            && workflow.contains("visibility_after: $after, automation_pr: $canary"),
+        "release dry-run must be mode-isolated and preserve observed tag/release/npm plus \
+         automation-PR evidence; Linux must use the system linker and the same zstd \
+         native-code contract as normal CI, with a backtrace on functional-smoke failure"
     );
 }
 
@@ -1252,10 +1256,62 @@ fn release_workflow_syncs_the_lockfile_however_the_release_pr_got_there() {
     let workflow =
         std::fs::read_to_string(repo_root.join(".github/workflows/release-please.yml")).unwrap();
 
+    let release_pr = workflow
+        .split_once("\n  release-pr:\n")
+        .expect("release workflow must define release-pr")
+        .1
+        .split_once("\n  prepare-release-lockfile:\n")
+        .expect("release-pr must precede the read-only lockfile job")
+        .0;
+    for output in [
+        "number: ${{ steps.release_pr.outputs.number }}",
+        "branch: ${{ steps.release_pr.outputs.branch }}",
+        "head_sha: ${{ steps.release_pr.outputs.head_sha }}",
+    ] {
+        assert!(
+            release_pr.contains(output),
+            "release-pr must export `{output}` across the job boundary"
+        );
+    }
+
+    let prepare = workflow
+        .split_once("\n  prepare-release-lockfile:\n")
+        .expect("release workflow must define prepare-release-lockfile")
+        .1
+        .split_once("\n  publish-release-lockfile:\n")
+        .expect("the read-only lockfile job must precede its publisher")
+        .0;
     assert!(
-        workflow.contains("Synchronize release lockfile"),
-        "the release job must synchronize Cargo.lock; without it a version bump \
-         ships a lockfile the build refuses"
+        prepare.contains("permissions:\n      contents: read")
+            && !prepare.contains("contents: write")
+            && prepare.contains("cargo update --workspace")
+            && prepare.contains("cargo metadata --locked"),
+        "untrusted release-PR Cargo execution must remain in the read-only preparation job"
+    );
+
+    let publisher = workflow
+        .split_once("\n  publish-release-lockfile:\n")
+        .expect("release workflow must define publish-release-lockfile")
+        .1
+        .split_once("\n  build:\n")
+        .expect("the lockfile publisher must precede release builds")
+        .0;
+    for lease_contract in [
+        "repos/$GITHUB_REPOSITORY/git/commits/$RELEASE_PR_HEAD_SHA",
+        "parents: [$parent]",
+        "{sha: $sha, force: false}",
+        "repos/$GITHUB_REPOSITORY/git/refs/heads/$RELEASE_PR_BRANCH",
+    ] {
+        assert!(
+            publisher.contains(lease_contract),
+            "lockfile publication must preserve exact-head lease contract `{lease_contract}`"
+        );
+    }
+    assert!(
+        !publisher.contains("actions/checkout")
+            && !publisher.contains("cargo ")
+            && !publisher.contains("--method PUT"),
+        "the write-capable publisher must neither execute PR code nor use a blob-only Contents API lease"
     );
     // Assert on the GATES, not on the file text: the comments above these steps
     // name `prs_created` deliberately, to explain why it is the wrong condition.
@@ -1293,8 +1349,8 @@ fn release_workflow_syncs_the_lockfile_however_the_release_pr_got_there() {
          sync is how a release reaches `cargo build --locked` with a stale lock"
     );
     assert!(
-        workflow.contains("cargo metadata --locked"),
-        "the job must PROVE --locked accepts the synchronized tree; \
+        prepare.contains("cargo metadata --locked"),
+        "the read-only job must PROVE --locked accepts the synchronized tree; \
          `cargo update` exiting 0 says the lock was refreshed, not that the \
          build job's --locked will accept it"
     );

--- a/tests/error_remedy_test.rs
+++ b/tests/error_remedy_test.rs
@@ -791,9 +791,12 @@ fn repair_still_names_a_lock_that_is_genuinely_held() {
 
     let output = direct().args(["repair", "--db"]).arg(&db).output().unwrap();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let border_free = stderr.replace('│', " ");
+    let normalized = border_free.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(!output.status.success(), "a held writer must refuse repair");
     assert!(
-        stderr.contains("write lock"),
-        "a genuinely held lock must still be reported as one: {stderr}"
+        normalized.contains("holds the write lease for"),
+        "a genuinely held writer authority must still be reported: {stderr}"
     );
     drop(dir);
 }

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -300,6 +300,7 @@ async fn server_exposes_read_only_embed_plan_rpc() {
                 scope: "all".to_string(),
                 force: false,
                 batch_size: 0,
+                repair_identity: false,
             }),
             PathAndQuery::from_static("/nestweaver.daemon.v1.NestWeaverDaemon/PlanEmbed"),
             tonic_prost::ProstCodec::default(),
@@ -1262,7 +1263,7 @@ async fn server_mcp_http_read_symbols_takes_server_path() {
 /// totals before applying `limit`. A query-scoped caller must never receive the
 /// larger admin-visible total or any hidden repo identifiers.
 #[tokio::test]
-async fn server_mcp_http_blast_count_is_exact_within_visible_scope() {
+async fn server_mcp_http_blast_radius_fails_closed_for_restricted_identity() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("authz").join("test.lbug");
     let visible_repo = dir.path().join("visible_repo");
@@ -1399,34 +1400,24 @@ credential_method = "ssh"
     let query_body: Value = query_response.json().await.unwrap();
     assert_eq!(
         query_body["result"]["isError"],
-        json!(false),
-        "query-scoped blast_radius failed: {query_body}"
+        json!(true),
+        "restricted blast_radius must refuse global-score traversal: {query_body}"
     );
-    let visible = &query_body["result"]["structuredContent"];
 
     let admin_total = admin["affected_symbol_count"]
         .as_u64()
         .expect("admin affected_symbol_count");
-    let visible_total = visible["affected_symbol_count"]
-        .as_u64()
-        .expect("visible affected_symbol_count");
     assert_eq!(
         admin_total, 5,
         "admin fixture should include two visible and three hidden affected symbols: {admin}"
     );
-    assert_eq!(
-        visible_total, 2,
-        "restricted total must count only the two visible affected symbols: {visible}"
-    );
-    assert_eq!(
-        visible["returned_affected_symbol_count"],
-        json!(1),
-        "small limit should return one visible row: {visible}"
-    );
-    assert_eq!(
-        visible["affected_symbols_truncated"],
-        json!(true),
-        "restricted total should remain exact when the visible rows are truncated: {visible}"
+    let refusal = query_body["result"]["content"][0]["text"]
+        .as_str()
+        .expect("restricted refusal text");
+    assert!(
+        refusal.contains("authorization-induced subgraph")
+            && refusal.contains("refusing before seed resolution or traversal"),
+        "restricted refusal must explain the safe boundary: {query_body}"
     );
 
     let admin_serialized = admin.to_string();
@@ -1434,7 +1425,7 @@ credential_method = "ssh"
         admin_serialized.contains("hiddencaller"),
         "admin fixture must prove hidden affected rows exist: {admin}"
     );
-    let visible_serialized = visible.to_string();
+    let visible_serialized = query_body.to_string();
     for hidden_marker in [
         "hidden_repo",
         "hidden_callers.js",
@@ -1443,7 +1434,7 @@ credential_method = "ssh"
     ] {
         assert!(
             !visible_serialized.contains(hidden_marker),
-            "query-scoped output leaked {hidden_marker}: {visible}"
+            "query-scoped refusal leaked {hidden_marker}: {query_body}"
         );
     }
 }
@@ -3348,25 +3339,16 @@ export function hiddenfederationcaller() { return hiddenfederationcanary(); }
     assert_eq!(restricted_response.status(), 200);
     let restricted_body: Value = restricted_response.json().await.expect("restricted JSON");
     assert_eq!(
-        restricted_body["result"]["isError"], false,
-        "restricted request failed: {restricted_body}"
+        restricted_body["result"]["isError"], true,
+        "restricted blast_radius must fail closed: {restricted_body}"
     );
-
-    let structured = &restricted_body["result"]["structuredContent"];
-    assert_eq!(structured["tier"], "two_tier");
+    let refusal = restricted_body["result"]["content"][0]["text"]
+        .as_str()
+        .expect("restricted refusal text");
     assert!(
-        structured["local_impact"]
-            .to_string()
-            .contains("visiblefederationcanary"),
-        "authorized local tier must remain available: {structured}"
-    );
-    let org = &structured["org_wide_impact"];
-    assert_eq!(org["status"], "withheld");
-    assert_eq!(org["reason"], "authorization-unproven");
-    assert_eq!(
-        org.as_object().expect("org status object").len(),
-        2,
-        "withheld org tier must expose no rows, paths, sources, or counts: {org}"
+        refusal.contains("authorization-induced subgraph")
+            && refusal.contains("refusing before seed resolution or traversal"),
+        "restricted refusal must explain why traversal was not attempted: {restricted_body}"
     );
 
     let serialized = restricted_body.to_string();
@@ -3387,15 +3369,6 @@ export function hiddenfederationcaller() { return hiddenfederationcanary(); }
             "restricted response leaked hidden upstream marker {hidden_marker}: {restricted_body}"
         );
     }
-    let meta = &restricted_body["result"]["structuredContent"]["_meta"];
-    assert_eq!(meta["sources"], json!(["daemon"]));
-    assert_eq!(meta["scope"], "single-node");
-    assert_eq!(
-        meta["stale_repos"],
-        json!([]),
-        "global staleness cache must not leak repo URLs across caller scope"
-    );
-
     // The unrestricted local tier proves both local repositories participate
     // in impact traversal. The restricted HTTP route must remove hidden local
     // rows before computing totals and before the federation envelope is


### PR DESCRIPTION
## Summary

Closes the 15 ready HIGH regression/hardening bundles found and independently validated against v9.0.5. No ready CRITICAL item was found. All work is intentionally batched in one branch to share compilation and CI time.

Follow-up adversarial review also found and fixed blocking defects in Git revision handling, direct gRPC authorization, caller-controlled source roots, investigate publication consistency, and hybrid affected-test parsing. The final head is based on the current `main` SHA.

### Release integrity

- bind publication to the exact reviewed SHA and reduce required CI truthfully
- build, checksum, extract, smoke, attest, and observe the complete archive set before public visibility
- make npm installation verify immutable release state, checksums, executable presence, and runtime version
- split release-PR preparation from privileged Git Data publication

### Input, authorization, and analysis trust

- reject malformed, blank, absolute, oversized, and mixed changed-file sets before analysis
- resolve untrusted Git revisions to verified commit OIDs before diffing, with option termination and strict output handling
- fail edge-dependent gates closed on missing, corrupt, older, or future resolver generations
- enforce fail-closed authorization before global graph traversal and expose typed semantic degradation
- enforce request policy on direct public gRPC routes, including status and read-only side channels
- prevent repository-scoped callers from pairing authorized UIDs with caller-selected filesystem roots
- strictly parse two-tier affected-test payloads and fail safely on malformed, unavailable, or withheld results

### Writer ownership and publication

- lease every sibling database before destructive restore cutover
- retain and drain disconnected unary mutation workers and ServeUI watchers
- admit implicit project detection and migration recovery as authoritative writers
- version project, vault, memory, removal, and other non-code mutations through a shared publication finalizer
- make memory consolidation journaled, preflighted, atomic, symlink-safe, and honestly recoverable
- bind dirty-publication repair to authoritative lease ownership rather than PID liveness alone
- refuse investigate persistence when the durable published generation changes during analysis

### Derived artifacts and search

- validate unified PageRank declarations across every supported relationship type
- distinguish missing embedding identity from unreadable/mismatched identity and require capability-negotiated repair
- persist and reconcile vault search-writer debt instead of reporting false success

## Backlog owners

1. Gate releases on exact-SHA checks and complete artifacts
2. Reject blank changed-file inputs before impact analysis
3. Fail edge-dependent gates closed on incompatible resolver generations
4. Lease every sibling database before destructive restore
5. Retain ownership for disconnected unary mutation tasks
6. Register, identify, and drain ServeUI watcher tasks
7. Admit implicit-project detection as a daemon writer
8. Version Project materialization mutations and invalidate stale ranking
9. Refuse online instance-migration aborts without write ownership
10. Make applied memory consolidation atomic, honest, and write-owned
11. Keep backup and snapshot artifacts valid after non-code graph mutations
12. Bind dirty-publication recovery to writer ownership
13. Let publication rebuild validate its own unified PageRank artifact
14. Fail when embedding fingerprint metadata is unreadable
15. Report vault reconciliation failure when the configured search writer is unavailable

## Review

Independent semantic/project, release, writer/lifecycle/embedding, concurrency, CLI/transport, and security reviewers challenged the implementation. Review findings were reproduced, fixed, regression-tested, and re-reviewed. The final concurrency, CLI/transport, and security passes granted signoff with no remaining code-level CRITICAL or HIGH blocker.

NestWeaver classifies the change as HIGH risk with a truncated 14,033-node blast radius, so broad validation was used. Full graph context timed out for this checkout; targeted graph investigation and local impact checks were used, and that partial graph result is disclosed rather than treated as green.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets --features embed -- -D warnings`
- full workspace library suite with `embed`: algorithms 28, client 79, daemon 348, embed 25, engine 1,412 passed/4 ignored, federation 182, MCP 295, parser 547, resolver 226, schema 79, storage 10, store 520, web 46
- final security-focused rebuilds: MCP 263/263 and daemon-with-embed 349/349
- final root-package rebuild: 301 unit, 169 CLI integration, 60 daemon integration, 10 remedy, 58 parity, 36 server, and 3 trigram-ownership tests
- affected-test parser regressions: 11/11
- actionlint v1.7.12 with the CI-pinned archive checksum
- required-CI, release-bundle, and release-package self-tests
- strict brain audit: 224 notes, 0 errors, 0 warnings

## Groomed nonblocking follow-ups (MEDIUM)

- constrain implicit-project previews to registered vaults
- scope BrainStatus host/config/embedding metadata under repository authorization
- recompute or refuse graph aggregates for repository-scoped callers
- check resolver trust before empty affected-test shortcuts
- move `NPM_TOKEN` to a least-privilege protected environment and add a package-write authorization probe stronger than `npm whoami`
- add an explicit unauthenticated GitHub API rate-limit fallback for installer immutable-release checks
- deprecate producer-less raw embedding write APIs in favor of explicit verified-pipeline APIs
- do not enable required CODEOWNER approval until a second eligible owner exists; the current one-owner topology would deadlock release automation

Future immutable GitHub releases have already been enabled at the repository level. The deferred macOS Cold Metal SIGSEGV remains outside this ready implementation set.
