### PR TITLE
fix: disclosure, bounds and coverage sweep across 13 items

### DIFF
--- a/crates/nestweaver-daemon/src/lifecycle.rs
+++ b/crates/nestweaver-daemon/src/lifecycle.rs
@@ -1060,6 +1060,33 @@ pub fn write_lease_path(db_path: &Path) -> PathBuf {
 pub struct DbWriteLease {
     _file: std::fs::File,
     path: PathBuf,
+    /// nw-404. Arms the store's self-ownership latch for as long as this lease
+    /// lives.
+    ///
+    /// WHY IT IS NEEDED AT ALL: `flock` conflicts between open file
+    /// DESCRIPTIONS, not processes, so the store's live-writer probe opens a
+    /// second fd and gets `EWOULDBLOCK` against a lease THIS PROCESS ALREADY
+    /// HOLDS. Without the latch it therefore reads "another process is writing"
+    /// and retracts a `db_wal_corrupt` verdict — blaming a process that does not
+    /// exist and suppressing a real corruption report. `brain reindex-search` is
+    /// exactly that shape: it takes this lease, then opens the store read-only.
+    ///
+    /// THIS ONE SITE COVERS BOTH PRODUCERS — the daemon's boot lease and
+    /// `require_exclusive_store_access` — because both construct their claim
+    /// here. Dropping the lease clears the latch, so a stale `true` can never
+    /// outlive it and suppress corruption forever.
+    ///
+    /// **FIELD ORDER IS LOAD-BEARING — `_file` MUST be declared before this.**
+    /// Rust drops struct fields in declaration order, so the flock is released
+    /// FIRST and the latch clears second. That ordering is the safe one:
+    /// between the two, a probe sees "flock free, latch still set" -> treats the
+    /// lease as SELF-held -> does NOT veto -> a genuinely corrupt WAL is still
+    /// reported. Reversing the fields inverts it: "flock still held, latch
+    /// cleared" -> reads as ANOTHER process writing -> vetoes the verdict, which
+    /// silently suppresses a real corruption report for the duration of the
+    /// window. The two orderings fail in opposite directions and only one of
+    /// them fails safe.
+    _self_latch: nestweaver_store::SelfHeldWriteLease,
 }
 
 impl DbWriteLease {
@@ -1108,7 +1135,14 @@ pub fn acquire_db_write_lease(db_path: &Path) -> Result<DbWriteLease, WriteLease
             _ => Err(WriteLeaseError::Unavailable(error)),
         };
     }
-    Ok(DbWriteLease { _file: file, path })
+    // Arm the latch BEFORE returning, so no window exists in which the lease is
+    // held and the store would still call it another process's.
+    let _self_latch = nestweaver_store::note_self_held_write_lease(db_path);
+    Ok(DbWriteLease {
+        _file: file,
+        path,
+        _self_latch,
+    })
 }
 
 /// PID of the process on the other end of a connected unix socket, as

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -5274,6 +5274,21 @@ impl NestWeaverDaemon for DaemonService {
                 .as_ref()
                 .map(|cfg| cfg.exclude_globs_for(&repo_url, Some(&repo_path)).to_vec())
                 .unwrap_or_default();
+            // nw-418/nw-422: the `unskip` half of the same `[[repos]]` block,
+            // resolved from the SAME config against the SAME (url, path) pair —
+            // `unskip_names_for` mirrors `exclude_globs_for`'s resolution
+            // exactly so the two halves can never disagree about which repo they
+            // describe.
+            //
+            // WITHOUT THIS the daemon-served index route keeps the bug the CLI
+            // route no longer has, which is the INVERSE of the asymmetry nw-418
+            // was filed for: `--no-daemon` and the daemon would disagree about
+            // what the repo contains.
+            let repo_unskip: Vec<String> = state
+                .instance_cfg
+                .as_ref()
+                .map(|cfg| cfg.unskip_names_for(&repo_url, Some(&repo_path)).to_vec())
+                .unwrap_or_default();
 
             let index_opts = nestweaver_engine::index::IndexOptions::new(
                 // nw-019: stamp the effective logical instance on indexed repos —
@@ -5285,7 +5300,8 @@ impl NestWeaverDaemon for DaemonService {
             .force(force)
             .name(name.as_deref())
             .limits(index_limits)
-            .excludes(&repo_excludes);
+            .excludes(&repo_excludes)
+            .unskip(&repo_unskip);
 
             match nestweaver_engine::index::index_directory_with_store_opts(
                 &state.store,
@@ -17084,6 +17100,8 @@ mod startup_helper_tests {
             url: url.to_string(),
             repo_type,
             name: None,
+            // nw-422: no SKIP_DIRS re-admission in these fixtures.
+            unskip: Vec::new(),
             sparse: None,
             pin_sha: None,
             use_git_activity: None,
@@ -21453,6 +21471,8 @@ mod watch_path_allowed_tests {
             url: url.to_string(),
             repo_type,
             name: None,
+            // nw-422: no SKIP_DIRS re-admission in these fixtures.
+            unskip: Vec::new(),
             sparse: None,
             pin_sha: None,
             use_git_activity: None,

--- a/crates/nestweaver-engine/src/bridges.rs
+++ b/crates/nestweaver-engine/src/bridges.rs
@@ -157,10 +157,30 @@ pub fn find_bridge_nodes_bounded(store: &GraphStore, top_n: usize) -> Result<Bri
     } = brandes_sampled(&graph.adj, n);
 
     // Build bridge nodes.
+    //
+    // ZERO-DEGREE SYMBOLS ARE EXCLUDED, and this is a correctness fix rather
+    // than a tidy-up. `candidate_total` above counts symbols with at least one
+    // edge, but this list was built from EVERY symbol. A zero-degree symbol has
+    // betweenness 0.0 by definition — no path can run through it — so it TIES
+    // with every edge-bearing leaf, and `sort_by` is stable, so ties resolve by
+    // graph insertion order. A zero-degree symbol could therefore take a slot
+    // from a real candidate.
+    //
+    // That made `truncated()` LIE in the safe-looking direction: with symbols
+    // inserted `lone, s0, s1` and one edge `s0—s1`, `candidate_total` is 2, and
+    // `top_n = 2` returns `[lone, s0]` — `s1`, a candidate, was cut — while
+    // `truncated()` computed `2 > 2 == false` and published a cut answer as
+    // complete. It also let `returned` exceed `total`, which is not a ratio any
+    // consumer can use.
+    //
+    // `hubs` never had this because its heap key is degree-first, so a
+    // non-candidate can never outrank a candidate. Filtering here gives bridges
+    // the same property the two structs' shared docblock already claims.
     let mut bridges: Vec<BridgeNode> = graph
         .symbols
         .iter()
         .enumerate()
+        .filter(|(i, _)| !graph.adj[*i].is_empty())
         .map(|(i, sym)| BridgeNode {
             uid: sym.uid.clone(),
             name: sym.name.clone(),
@@ -526,11 +546,21 @@ mod tests {
         assert!(found.truncated(), "3 of 8 is a truncation");
     }
 
-    /// COUNTERWEIGHT. A ranking that was NOT cut must say so, including the
-    /// case where the caller asked for more than exists — there the heap pads
-    /// the tail with zero-degree symbols, so `bridges.len()` EXCEEDS
-    /// `candidate_total`, and a `!=` comparison would report truncation on a
-    /// complete answer.
+    /// COUNTERWEIGHT. A ranking that was NOT cut must say so, including the case
+    /// where the caller asked for more than exists.
+    ///
+    /// UPDATED when the zero-degree filter landed. This previously asserted that
+    /// asking for 50 returns all 10 SYMBOLS — the padded tail — and used that to
+    /// justify `truncated()` being `>` rather than `!=`. That padding was the
+    /// defect: a zero-degree symbol has betweenness 0.0, ties with every real
+    /// leaf, and won slots on insertion order, which let a CUT answer report
+    /// `truncated == false`. Now the ranking contains only candidates, so asking
+    /// for more than exists returns exactly the candidate population and
+    /// `returned` can never exceed `total`.
+    ///
+    /// `truncated()` remains `>` rather than `!=` deliberately: it is now
+    /// equivalent for bridges, and keeping the two structs' predicate identical
+    /// is worth more than tightening one of them.
     #[test]
     fn an_uncut_bridge_ranking_reports_no_truncation_even_when_asked_for_more() {
         let store = chain_store(8, 2);
@@ -544,8 +574,17 @@ mod tests {
         );
 
         let over = find_bridge_nodes_bounded(&store, 50).unwrap();
-        assert_eq!(over.bridges.len(), 10, "every symbol is returned");
+        assert_eq!(
+            over.bridges.len(),
+            8,
+            "asking for more than exists returns the CANDIDATE population, not every symbol — \
+             the two zero-degree symbols are not bridges and never were"
+        );
         assert_eq!(over.candidate_total, 8);
+        assert!(
+            over.bridges.len() <= over.candidate_total,
+            "`returned` may never exceed `total`"
+        );
         assert!(
             !over.truncated(),
             "asking for 50 and being given everything is not a truncation"
@@ -594,6 +633,54 @@ mod tests {
             found.sampled,
             "a {SAMPLE_LIMIT}-source estimate over {} nodes must be labelled one",
             SAMPLE_LIMIT + 20
+        );
+    }
+
+    /// nw-398, found by review. `truncated()` must be EXACT, not merely
+    /// plausible: it published a CUT answer as complete, because the ranking was
+    /// drawn from every symbol while `candidate_total` counted only those with
+    /// an edge.
+    ///
+    /// The fixture is the reviewer's: a zero-degree symbol inserted FIRST, then
+    /// a connected pair. Before the fix `lone` tied at 0.0 with the pair's leaf,
+    /// won on insertion order because `sort_by` is stable, and `top_n = 2`
+    /// returned `[lone, s0]` while reporting `truncated == false`.
+    #[test]
+    fn a_zero_degree_symbol_cannot_take_a_candidates_slot_and_hide_the_cut() {
+        let store = GraphStore::in_memory().unwrap();
+        for uid in ["lone", "s0", "s1"] {
+            store
+                .insert_symbol(&make_symbol(uid, &format!("fn_{uid}"), "src/lib.rs"))
+                .unwrap();
+        }
+        store.insert_edge(&make_edge("s0", "s1")).unwrap();
+
+        let found = find_bridge_nodes_bounded(&store, 2).expect("bridges");
+        let names: Vec<&str> = found.bridges.iter().map(|b| b.uid.as_str()).collect();
+        assert!(
+            !names.contains(&"lone"),
+            "a zero-degree symbol can never be a bridge — no path runs through it: {names:?}"
+        );
+        assert_eq!(
+            found.candidate_total, 2,
+            "only edge-bearing symbols are candidates"
+        );
+        assert!(
+            !found.truncated(),
+            "asking for both candidates is a COMPLETE answer, not a truncated one"
+        );
+
+        // COUNTERWEIGHT: asking for fewer than the candidate population must
+        // still report the cut. Without it, excluding everything would satisfy
+        // the assertion above.
+        let cut = find_bridge_nodes_bounded(&store, 1).expect("bridges");
+        assert!(
+            cut.truncated(),
+            "one of two candidates is a cut and must say so"
+        );
+        assert!(
+            cut.bridges.len() <= cut.candidate_total,
+            "`returned` may never exceed `total` — that ratio is meaningless to a consumer"
         );
     }
 }

--- a/crates/nestweaver-engine/src/bridges.rs
+++ b/crates/nestweaver-engine/src/bridges.rs
@@ -76,20 +76,85 @@ fn load_graph(store: &GraphStore) -> Result<Option<LoadedGraph>> {
 
 /// Find the top-N bridge nodes in the code graph, ranked by betweenness centrality.
 ///
-/// Uses Brandes' algorithm with sampling: for each of up to `SAMPLE_LIMIT`
-/// randomly-selected source nodes, runs BFS to compute shortest-path counts
-/// and accumulates betweenness contributions. The result is normalized by
-/// the number of sources sampled.
+/// Discards everything a caller needs to describe the answer honestly. Prefer
+/// [`find_bridge_nodes_bounded`] on any surface that publishes a `total`, a
+/// `truncated`, or the score itself; this wrapper exists for the callers that
+/// publish none of them.
 pub fn find_bridge_nodes(store: &GraphStore, top_n: usize) -> Result<Vec<BridgeNode>> {
+    find_bridge_nodes_bounded(store, top_n).map(|found| found.bridges)
+}
+
+/// The top-N bridges, the population they were selected FROM, and how the
+/// score in them was actually computed.
+///
+/// nw-398. Both halves of this struct are honesty fixes, and they point in
+/// OPPOSITE directions. `candidate_total` exists because the cut was invisible:
+/// `bridges --top 3` reported neither a total nor a `truncated`, and the MCP
+/// twin's `count` was `len(list)` by construction. `sources_sampled` /
+/// `sampled` exist because the score was invisibly APPROXIMATE: a
+/// `SAMPLE_LIMIT`-source estimate rendered at full `f64` precision
+/// (`18866919.81139078`) with no field a program could branch on. The tool
+/// description said "approximate for large graphs" — prose a human reads.
+pub struct BridgeNodes {
+    pub bridges: Vec<BridgeNode>,
+    /// How many symbols were CANDIDATES — i.e. had at least one code edge.
+    /// A symbol with no edges lies on no path between any pair and therefore
+    /// cannot be a bridge at any `top_n`, so counting it would overstate the
+    /// population. Same definition, and the same argument, as
+    /// [`crate::hubs::HubNodes::candidate_total`].
+    pub candidate_total: usize,
+    /// How many BFS sources the betweenness computation actually ran from.
+    /// Equal to the node count when the graph is small enough to do exactly.
+    pub sources_sampled: usize,
+    /// True when `sources_sampled` was a SAMPLE rather than every node — i.e.
+    /// every `betweenness_score` in `bridges` is an estimate. This is the
+    /// field a program should branch on; the digits in the score itself carry
+    /// no information about it.
+    pub sampled: bool,
+}
+
+impl BridgeNodes {
+    /// Whether `top_n` cut the population — the one definition, so a consumer
+    /// cannot re-derive it from the already-cut list and get `false` for free.
+    pub fn truncated(&self) -> bool {
+        self.candidate_total > self.bridges.len()
+    }
+}
+
+/// [`find_bridge_nodes`] with the candidate count and the sampling provenance
+/// retained.
+///
+/// Uses Brandes' algorithm over a bounded set of BFS sources: every node when
+/// the graph has at most `SAMPLE_LIMIT` of them, otherwise `SAMPLE_LIMIT`
+/// sources chosen by even spacing over graph INSERTION ORDER. That spacing is
+/// deterministic, NOT random, so the resulting bias is systematic and
+/// reproducible rather than self-cancelling across calls — which is precisely
+/// why the estimate has to be labelled as one rather than left to average out.
+pub fn find_bridge_nodes_bounded(store: &GraphStore, top_n: usize) -> Result<BridgeNodes> {
     let graph = match load_graph(store)? {
         Some(g) => g,
-        None => return Ok(vec![]),
+        None => {
+            return Ok(BridgeNodes {
+                bridges: vec![],
+                candidate_total: 0,
+                sources_sampled: 0,
+                sampled: false,
+            });
+        }
     };
 
     let n = graph.symbols.len();
 
+    // Counted from the adjacency rather than the ranked list, and BEFORE the
+    // truncate below, so the population is reported even when `top_n` is 0 and
+    // nothing survives selection.
+    let candidate_total = graph.adj.iter().filter(|nbrs| !nbrs.is_empty()).count();
+
     // Compute betweenness centrality via Brandes' algorithm with sampling.
-    let betweenness = brandes_sampled(&graph.adj, n);
+    let Betweenness {
+        scores: betweenness,
+        sources_sampled,
+    } = brandes_sampled(&graph.adj, n);
 
     // Build bridge nodes.
     let mut bridges: Vec<BridgeNode> = graph
@@ -113,7 +178,15 @@ pub fn find_bridge_nodes(store: &GraphStore, top_n: usize) -> Result<Vec<BridgeN
     });
 
     bridges.truncate(top_n);
-    Ok(bridges)
+    Ok(BridgeNodes {
+        bridges,
+        candidate_total,
+        // A sample only when fewer sources ran than the graph has nodes; on a
+        // graph of at most SAMPLE_LIMIT nodes every node is a source and the
+        // result is exact, which callers must be able to say too.
+        sampled: sources_sampled < n,
+        sources_sampled,
+    })
 }
 
 /// Attach community connection information to bridge nodes.
@@ -160,6 +233,14 @@ pub fn attach_communities(
     }
 }
 
+/// Betweenness scores plus the fact that says how much to trust them.
+struct Betweenness {
+    scores: Vec<f64>,
+    /// How many BFS sources were actually run. `< n` means the scores are an
+    /// extrapolated estimate, not an exact count.
+    sources_sampled: usize,
+}
+
 /// Brandes' algorithm for betweenness centrality with source sampling.
 ///
 /// For each source node s (up to SAMPLE_LIMIT), runs BFS to compute:
@@ -167,8 +248,17 @@ pub fn attach_communities(
 /// - delta[v]: dependency of s on v
 ///
 /// The betweenness of each node v is the sum of delta[v] across all sources,
-/// normalized by the number of sources sampled.
-fn brandes_sampled(adj: &[Vec<usize>], n: usize) -> Vec<f64> {
+/// then scaled — see the scaling block at the end for what that scale IS.
+///
+/// nw-398: this doc used to claim the result was "normalized by the number of
+/// sources sampled". It is not, and never was: on the sampled path the scale
+/// factor is `n / (2 * num_sources)`, which SCALES UP to estimate the
+/// full-graph pair count. Dividing by the source count would have produced a
+/// per-source average, a different quantity an order of magnitude smaller. The
+/// claim was removed rather than implemented because the unnormalized value is
+/// what every existing caller ranks and renders; what was missing was the
+/// label, not the division.
+fn brandes_sampled(adj: &[Vec<usize>], n: usize) -> Betweenness {
     let mut betweenness = vec![0.0f64; n];
 
     // Select source nodes: if graph is small enough, use all; otherwise sample.
@@ -224,8 +314,10 @@ fn brandes_sampled(adj: &[Vec<usize>], n: usize) -> Vec<f64> {
         }
     }
 
-    // Normalize by the number of sources sampled. For an undirected graph,
-    // each pair is counted twice in the BFS, so we also divide by 2.
+    // Scale the accumulated dependencies. For an undirected graph each pair is
+    // counted twice in the BFS, hence the factor of 2 in both branches. This is
+    // NOT a normalization to any unit interval, and on the sampled branch it is
+    // an extrapolation, not a division by the sample size (nw-398).
     if num_sources > 0 {
         let scale = if n <= SAMPLE_LIMIT {
             // Exact computation: standard normalization for undirected graphs.
@@ -239,7 +331,10 @@ fn brandes_sampled(adj: &[Vec<usize>], n: usize) -> Vec<f64> {
         }
     }
 
-    betweenness
+    Betweenness {
+        scores: betweenness,
+        sources_sampled: num_sources,
+    }
 }
 
 #[cfg(test)]
@@ -380,5 +475,125 @@ mod tests {
 
         let bridges = find_bridge_nodes(&store, 3).unwrap();
         assert_eq!(bridges.len(), 3);
+    }
+
+    /// A chain of `chain` edge-bearing symbols plus `isolated` symbols with no
+    /// edges at all. The isolated ones are the counterweight's material: they
+    /// pad the returned list without enlarging the candidate population.
+    fn chain_store(chain: usize, isolated: usize) -> GraphStore {
+        let store = GraphStore::in_memory().unwrap();
+        for i in 0..chain {
+            store
+                .insert_symbol(&make_symbol(
+                    &format!("s{i}"),
+                    &format!("fn_{i}"),
+                    "src/lib.rs",
+                ))
+                .unwrap();
+        }
+        for i in 0..chain.saturating_sub(1) {
+            store
+                .insert_edge(&make_edge(&format!("s{i}"), &format!("s{}", i + 1)))
+                .unwrap();
+        }
+        for i in 0..isolated {
+            store
+                .insert_symbol(&make_symbol(
+                    &format!("lone{i}"),
+                    &format!("lone_{i}"),
+                    "src/lone.rs",
+                ))
+                .unwrap();
+        }
+        store
+    }
+
+    /// nw-398. `bridges --top 3 --json` returned `['_meta', 'bridges',
+    /// 'rankings_stale', 'stale_repos']` — not even a `count` — and the MCP
+    /// twin's `count` was `len(list)`, true by construction. The number that
+    /// makes the cut visible has to be the population BEFORE the truncate, and
+    /// it was never even computed on this path.
+    #[test]
+    fn a_cut_bridge_ranking_reports_the_population_it_was_cut_from() {
+        let store = chain_store(8, 2);
+
+        let found = find_bridge_nodes_bounded(&store, 3).unwrap();
+        assert_eq!(found.bridges.len(), 3);
+        assert_eq!(
+            found.candidate_total, 8,
+            "the population is the edge-bearing symbols, not the returned rows              and not the whole store"
+        );
+        assert!(found.truncated(), "3 of 8 is a truncation");
+    }
+
+    /// COUNTERWEIGHT. A ranking that was NOT cut must say so, including the
+    /// case where the caller asked for more than exists — there the heap pads
+    /// the tail with zero-degree symbols, so `bridges.len()` EXCEEDS
+    /// `candidate_total`, and a `!=` comparison would report truncation on a
+    /// complete answer.
+    #[test]
+    fn an_uncut_bridge_ranking_reports_no_truncation_even_when_asked_for_more() {
+        let store = chain_store(8, 2);
+
+        let exact = find_bridge_nodes_bounded(&store, 8).unwrap();
+        assert!(
+            !exact.truncated(),
+            "8 of 8 candidates is complete: {} of {}",
+            exact.bridges.len(),
+            exact.candidate_total
+        );
+
+        let over = find_bridge_nodes_bounded(&store, 50).unwrap();
+        assert_eq!(over.bridges.len(), 10, "every symbol is returned");
+        assert_eq!(over.candidate_total, 8);
+        assert!(
+            !over.truncated(),
+            "asking for 50 and being given everything is not a truncation"
+        );
+
+        let empty = find_bridge_nodes_bounded(&GraphStore::in_memory().unwrap(), 5).unwrap();
+        assert_eq!(empty.candidate_total, 0);
+        assert!(!empty.truncated(), "an empty graph is complete, not cut");
+    }
+
+    /// nw-398 leg 2, the honesty defect pointing the OTHER way:
+    /// `betweenness_score` is rendered at full `f64` precision
+    /// (`18866919.81139078`) whether it was computed exactly or estimated from
+    /// at most `SAMPLE_LIMIT` sources. A graph small enough to do exactly must
+    /// be able to SAY it was exact, or the flag is useless — every payload
+    /// would carry the same warning and consumers would learn to ignore it.
+    #[test]
+    fn a_betweenness_run_over_every_source_reports_that_it_sampled_nothing() {
+        let store = chain_store(10, 0);
+
+        let found = find_bridge_nodes_bounded(&store, 5).unwrap();
+        assert_eq!(
+            found.sources_sampled, 10,
+            "every node is a BFS source below the sample limit"
+        );
+        assert!(
+            !found.sampled,
+            "an exact computation must not be labelled a sample"
+        );
+    }
+
+    /// The other half: past `SAMPLE_LIMIT` the score is an estimate produced
+    /// from evenly-spaced sources over INSERTION ORDER — deterministic, so the
+    /// bias does not average out across calls — and the payload must carry a
+    /// field a program can branch on rather than prose in a tool description.
+    #[test]
+    fn a_graph_past_the_sample_limit_reports_that_the_score_is_a_sample() {
+        let store = chain_store(SAMPLE_LIMIT + 20, 0);
+
+        let found = find_bridge_nodes_bounded(&store, 5).unwrap();
+        assert_eq!(
+            found.sources_sampled, SAMPLE_LIMIT,
+            "the source set is capped at the sample limit"
+        );
+        assert!(
+            found.sampled,
+            "a {SAMPLE_LIMIT}-source estimate over {} nodes must be labelled one",
+            SAMPLE_LIMIT + 20
+        );
     }
 }

--- a/crates/nestweaver-engine/src/config.rs
+++ b/crates/nestweaver-engine/src/config.rs
@@ -776,6 +776,22 @@ pub struct RepoConfig {
     pub branch: Option<String>,
     #[serde(default)]
     pub poll: Option<String>,
+    /// `SKIP_DIRS` names to RE-ADMIT for this repo — the inverse of `exclude`.
+    ///
+    /// nw-418. This key was DOCUMENTED BEFORE IT EXISTED. `SKIP_DIRS` prunes
+    /// directory names like `public`, `vendor`, `dist` at any depth, and
+    /// nw-387's disclosure message tells the operator to "re-admit it with
+    /// `[[repos]] unskip`" — but `RepoConfig` is `deny_unknown_fields` and had
+    /// no such field, so anyone who FOLLOWED that advice got a TOML parse error
+    /// and their whole instance config failed to load. Advice that breaks the
+    /// thing it claims to fix is worse than the silent drop it was written for.
+    ///
+    /// Names, not globs, because `SKIP_DIRS` matches a single path COMPONENT at
+    /// any depth — `unskip = ["public"]` re-admits every `public/` in the repo.
+    /// Use `exclude` for the opposite direction; the two are not
+    /// interchangeable and each disclosure names only its own.
+    #[serde(default)]
+    pub unskip: Vec<String>,
     /// Glob patterns, matched against repo-relative paths, for code this repo
     /// tracks but the graph should not hold.
     ///
@@ -1073,6 +1089,23 @@ impl InstanceConfig {
                         .is_some_and(|p| declared == normalize_repo_ref(p))
             })
             .map_or(&[][..], |r| r.exclude.as_slice())
+    }
+
+    /// The `SKIP_DIRS` names this repo re-admits. Resolves by URL or by local
+    /// checkout path, exactly as [`Self::exclude_globs_for`] does, so the two
+    /// halves of the same `[[repos]]` block can never resolve differently.
+    pub fn unskip_names_for(&self, repo_url: &str, repo_path: Option<&Path>) -> &[String] {
+        let path_str = repo_path.map(|p| p.to_string_lossy().to_string());
+        self.repos
+            .iter()
+            .find(|r| {
+                let declared = normalize_repo_ref(&r.url);
+                declared == normalize_repo_ref(repo_url)
+                    || path_str
+                        .as_deref()
+                        .is_some_and(|p| declared == normalize_repo_ref(p))
+            })
+            .map_or(&[][..], |r| r.unskip.as_slice())
     }
 
     /// The DB path declared by this instance, if any.

--- a/crates/nestweaver-engine/src/content_reader.rs
+++ b/crates/nestweaver-engine/src/content_reader.rs
@@ -1,6 +1,7 @@
 // content_reader.rs — abstracts how the indexer reads file contents and discovers files.
 // `FilesystemReader` for local repos, `GitBareReader` for server-side bare clones (Task 6).
 
+use std::collections::HashSet;
 use std::io::{BufRead, BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
@@ -159,6 +160,40 @@ pub trait ContentReader: Send + Sync {
     fn skipped_dirs(&self) -> Vec<SkippedDir> {
         Vec::new()
     }
+
+    /// The `SKIP_DIRS` names this reader's repo has re-admitted via
+    /// `[[repos]] unskip`.
+    ///
+    /// nw-418 PUT THIS ON THE TRAIT, and the reason is structural rather than
+    /// convenient. `FilesystemReader::list_files` honoured `unskip` — the FULL
+    /// scan enumerated a re-admitted `public/` — while the INCREMENTAL change
+    /// loop tested `crate::index::path_in_skip_dir`, which took no `unskip`
+    /// argument and could not have honoured it. So a user who configured
+    /// `unskip` correctly got the files on `nestweaver index --force` and lost
+    /// them again on every plain `nestweaver index`, both runs reporting
+    /// `coverage_status: "complete"`.
+    ///
+    /// AND NW-387'S DISCLOSURE CHANNEL COULD NOT CATCH IT: on the incremental
+    /// route the directory is NOT pruned — `unskip` re-admitted it — so there
+    /// is no [`SkippedDir`] row to drain. The files were dropped one at a time
+    /// inside the change loop, below the level any disclosure watches.
+    ///
+    /// Exposed on the reader rather than passed alongside it because the reader
+    /// is the thing that already owns the set, and every incremental helper
+    /// (`prepare_incremental_files`, the Added/Modified/Renamed arms, the
+    /// server twin) already holds a `&dyn ContentReader`. One set, reached one
+    /// way, feeding one predicate — nw-217's finding is that two copies of a
+    /// rule drift, and a second parameter threaded past the reader is a second
+    /// copy waiting to happen.
+    ///
+    /// Empty by default: a reader with no per-repo config re-admits nothing,
+    /// which is exactly the pre-nw-418 behaviour for [`GitBareReader`] and the
+    /// mock readers.
+    fn unskipped_skip_dirs(&self) -> &std::collections::HashSet<String> {
+        static EMPTY: std::sync::OnceLock<std::collections::HashSet<String>> =
+            std::sync::OnceLock::new();
+        EMPTY.get_or_init(std::collections::HashSet::new)
+    }
 }
 
 /// Rewrite lone `\r` line endings to `\n`, leaving `\r\n` byte-for-byte alone.
@@ -234,6 +269,16 @@ pub struct FilesystemReader {
     /// invisible. Recording the pruned directory itself is what turns a
     /// silently wrong answer into a visible one.
     skipped_dirs: std::sync::Arc<std::sync::Mutex<Vec<SkippedDir>>>,
+    /// Repo-relative paths git's INDEX lists as tracked, or `None` when this
+    /// root is not a git working tree / git could not be asked.
+    ///
+    /// nw-394. Computed at most once per reader: `list_files` runs several
+    /// times in one index (the scan, `manifest::parse_manifest` ->
+    /// `find_csproj`, the incremental contract prep), and one `git ls-files`
+    /// per index run is a cost worth paying where four is not. The window
+    /// between the walk and the `ls-files` is not load-bearing — a file added
+    /// to the index mid-index is already outside this run's snapshot.
+    tracked_files: std::sync::Arc<std::sync::OnceLock<Option<HashSet<PathBuf>>>>,
 }
 
 /// The `reason` a [`SkippedDir`] carries when a configured `[[repos]] exclude`
@@ -249,10 +294,49 @@ pub struct FilesystemReader {
 /// silently; a rename breaks the build instead of the remedy.
 pub const CONFIGURED_EXCLUDE_REASON: &str = "configured exclude";
 
-/// A directory the walk pruned, and why.
+/// The `reason` a [`SkippedDir`] carries when the path is a FILE that git
+/// TRACKS and the walk dropped anyway because it matches an ignore rule.
+///
+/// nw-394. `WalkBuilder` is configured `.git_ignore(true).git_global(true)
+/// .git_exclude(true)` and has no notion of the git INDEX, but **git does not
+/// ignore a tracked file** — `.gitignore` applies to untracked paths only. So
+/// the walker's view and git's view diverge on exactly one population:
+/// committed-but-ignored files. Measured shape: `.gitignore` holding
+/// `generated/`, `generated/api_client.py` force-added and COMMITTED, index
+/// reporting `files_processed: 1, symbols_found: 1, skipped_count: 0,
+/// coverage_status: "complete"` with `--fail-on-skip` exit 0. The callee half
+/// of the graph was absent and the caller's import edge to it could not exist.
+///
+/// **DECISION RECORDED (nw-394 offered two fixes and asked which): DISCLOSE,
+/// do not re-admit.** Honouring the index would mean indexing every tracked
+/// path the walk dropped, and the realistic population here is committed
+/// GENERATED code — `generated/`, `proto/gen/`, vendored SDKs — which is
+/// exactly the content the graph is better off without and which a repo may
+/// have gitignored deliberately. Silently pulling megabytes of generated
+/// output into the graph is a different wrong answer at a much higher cost.
+/// Disclosure keeps the walk's behaviour identical, degrades `coverage_status`
+/// so the loss is visible, fires `--fail-on-skip`, and hands the user a remedy
+/// that works. The remedy is `.gitignore` itself — NOT `[[repos]] unskip`,
+/// which governs `SKIP_DIRS` names only, and NOT `[[repos]] exclude`, which
+/// points the other way. nw-387 already learned that lesson the hard way; see
+/// `index::disclose_pruned_dir`.
+pub const TRACKED_BUT_IGNORED_REASON: &str = "tracked by git but gitignored";
+
+/// A path the walk did not hand to the indexer, and why.
+///
+/// Named for its original and still dominant case — nw-325/nw-387 record
+/// pruned DIRECTORIES here, because `WalkBuilder::filter_entry` cuts the
+/// subtree before enumeration and the directory is the only artefact that
+/// survives. nw-394 adds rows whose `path` is a single FILE
+/// ([`TRACKED_BUT_IGNORED_REASON`]): there the directory may well have been
+/// walked normally and only the one committed-but-ignored file inside it was
+/// dropped, so the file IS the finest artefact available. The type is kept
+/// rather than renamed because it is crate-internal, and `reason` already
+/// discriminates the cases for `index::disclose_pruned_dir`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SkippedDir {
-    /// Repo-relative path of the pruned directory.
+    /// Repo-relative path of the pruned directory, or of the single dropped
+    /// file for [`TRACKED_BUT_IGNORED_REASON`].
     pub path: String,
     /// The `SKIP_DIRS` entry that matched, or [`CONFIGURED_EXCLUDE_REASON`]
     /// when a `[[repos]] exclude` glob did. That second value is a MARKER, not
@@ -270,6 +354,7 @@ impl FilesystemReader {
             dir_excludes: None,
             unskip: std::collections::HashSet::new(),
             skipped_dirs: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            tracked_files: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -281,6 +366,7 @@ impl FilesystemReader {
             dir_excludes: None,
             unskip: std::collections::HashSet::new(),
             skipped_dirs: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            tracked_files: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -323,6 +409,131 @@ impl FilesystemReader {
         self.dir_excludes = Some(dir_builder.build().context("build exclude globset")?);
         Ok(self)
     }
+
+    /// Repo-relative paths in git's index, or `None` when this root is not a
+    /// git working tree or git could not answer. Computed once per reader.
+    ///
+    /// nw-394. `None` and `Some(empty)` mean different things and must not be
+    /// collapsed: "git has no opinion here" versus "git tracks nothing here".
+    /// Only the second is evidence of anything, and neither produces an error —
+    /// a missing or broken git is a reason to say less, never a reason to fail
+    /// an index that otherwise succeeded.
+    fn git_tracked_files(&self) -> Option<&HashSet<PathBuf>> {
+        self.tracked_files
+            .get_or_init(|| load_git_tracked_files(&self.repo_path))
+            .as_ref()
+    }
+
+    /// Record every git-TRACKED source file the walk did not enumerate.
+    ///
+    /// nw-394 — see [`TRACKED_BUT_IGNORED_REASON`] for the divergence and for
+    /// why this discloses rather than re-admits.
+    ///
+    /// FOUR SUPPRESSIONS, each closing a false positive that would have made
+    /// the gate fire on a correct index:
+    ///
+    ///  1. `SKIP_DIRS` paths. A committed `vendor/v.py` is tracked and absent,
+    ///     but it is absent because of skip-dir policy, is already disclosed at
+    ///     DIRECTORY granularity by the `filter_entry` recorder, and has a
+    ///     different remedy (`[[repos]] unskip`). Reporting it twice under two
+    ///     reasons would make the two rows contradict each other. `unskip` is
+    ///     consulted here for the same reason the walk consults it.
+    ///  2. `[[repos]] exclude`, per-file and per-directory. That is the user
+    ///     asking for this file to be absent; nw-387 established that telling
+    ///     someone their deliberate configuration degraded their coverage is a
+    ///     defect, not a disclosure.
+    ///  3. Non-parseable paths. `git ls-files` lists PNGs, licences and lock
+    ///     files; none of them would have produced a symbol had the walk seen
+    ///     them, so their absence is not a coverage loss and reporting it would
+    ///     bury the real rows.
+    ///  4. Paths with no regular file on disk. `ls-files --cached` reports the
+    ///     INDEX, so it lists files deleted from the working tree, and a
+    ///     tracked symlink is not enumerated by a `follow_links(false)` walk
+    ///     either. `symlink_metadata` (not `metadata`) is what keeps the
+    ///     symlink case out — the latter follows the link and would report the
+    ///     target's type.
+    ///
+    /// What survives all four is the exact nw-394 population: a file git
+    /// tracks, that would have contributed symbols, that no policy of ours
+    /// removed, that exists on disk, and that the walk still did not yield.
+    fn record_tracked_but_ignored(&self, enumerated: &[PathBuf]) {
+        let Some(tracked) = self.git_tracked_files() else {
+            return;
+        };
+        let seen: HashSet<&Path> = enumerated.iter().map(PathBuf::as_path).collect();
+        let mut rows: Vec<SkippedDir> = tracked
+            .iter()
+            .filter(|rel| !seen.contains(rel.as_path()))
+            .filter(|rel| crate::index::is_parseable(rel))
+            .filter(|rel| !crate::index::path_in_skip_dir_with_unskip(rel, &self.unskip))
+            .filter(|rel| !self.excludes.as_ref().is_some_and(|gs| gs.is_match(rel)))
+            .filter(|rel| {
+                !rel.ancestors().skip(1).any(|dir| {
+                    !dir.as_os_str().is_empty() && dir_is_excluded(self.dir_excludes.as_ref(), dir)
+                })
+            })
+            .filter(|rel| {
+                std::fs::symlink_metadata(self.repo_path.join(rel))
+                    .is_ok_and(|meta| meta.file_type().is_file())
+            })
+            .map(|rel| SkippedDir {
+                path: rel.to_string_lossy().into_owned(),
+                reason: TRACKED_BUT_IGNORED_REASON.to_string(),
+            })
+            .collect();
+        if rows.is_empty() {
+            return;
+        }
+        // Deterministic order: `skipped_files` is printed and asserted on, and
+        // a HashSet iteration order would make the report reshuffle run to run
+        // over an unchanged repo.
+        rows.sort_by(|a, b| a.path.cmp(&b.path));
+        if let Ok(mut recorded) = self.skipped_dirs.lock() {
+            recorded.extend(rows);
+        }
+    }
+}
+
+/// Ask git which repo-relative paths it tracks under `root`.
+///
+/// nw-394. Free rather than a method so it is testable against any directory,
+/// and deliberately total: every failure mode returns `None`.
+///
+/// The `.git` probe is a GUARD, not an optimisation. Without it, a `root` that
+/// merely sits inside some other repository would make git answer about THAT
+/// repository, and every path it named would be reported as a coverage loss of
+/// this one. `.exists()` rather than `.is_dir()` because a linked worktree and
+/// a submodule both carry `.git` as a FILE.
+///
+/// Paths are emitted NUL-separated (`-z`), so no unquoting is needed and a
+/// filename containing a newline or a quote cannot desynchronise the parse.
+/// `--cached` is the index, which is the whole point: it is the one view that
+/// knows a gitignored file was committed anyway.
+fn load_git_tracked_files(root: &Path) -> Option<HashSet<PathBuf>> {
+    if !root.join(".git").exists() {
+        return None;
+    }
+    let mut cmd = Command::new("git");
+    cmd.arg("ls-files")
+        .arg("-z")
+        .arg("--cached")
+        .current_dir(root);
+    apply_git_isolation(&mut cmd);
+    // Bounded: `ls-files` is a local index read with no network, but an index
+    // this run cannot read is a reason to disclose nothing, never a reason to
+    // park the whole index forever.
+    let output = run_git_with_timeout(cmd, Duration::from_secs(60)).ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(
+        output
+            .stdout
+            .split(|&b| b == 0)
+            .filter(|record| !record.is_empty())
+            .map(|record| PathBuf::from(String::from_utf8_lossy(record).into_owned()))
+            .collect(),
+    )
 }
 
 impl ContentReader for FilesystemReader {
@@ -520,6 +731,23 @@ impl ContentReader for FilesystemReader {
                 files.push(rel.to_path_buf());
             }
         }
+        // nw-394: ADD THE GIT-TRACKED-BUT-GITIGNORED DROPS TO THE SAME CHANNEL.
+        //
+        // This is the second population of paths that never reach the per-file
+        // `SkippedFile` route, and for the same structural reason as nw-325's
+        // pruned directories: they are removed BEFORE enumeration, so no
+        // `ParseOutcome::Skipped` can ever describe them. nw-387's drain site
+        // in `index::index_into_store_with_write_gate` says in as many words
+        // that this channel is "deliberately not scoped to `SKIP_DIRS` alone"
+        // and that nw-394 "needs to add its own rows to exactly this list" —
+        // this is that.
+        //
+        // MUST STAY AFTER THE WALK AND INSIDE `list_files`. It compares against
+        // `files`, and the recorder it appends to is cleared at the top of
+        // every `list_files` call, so both halves of the answer describe one
+        // walk. Every existing drain site reads the recorder immediately after
+        // `list_files` and therefore picks these rows up with no change.
+        self.record_tracked_but_ignored(&files);
         Ok(files)
     }
 
@@ -562,6 +790,13 @@ impl ContentReader for FilesystemReader {
             .lock()
             .map(|v| v.clone())
             .unwrap_or_default()
+    }
+
+    /// nw-418: the set this reader's own walk consults, handed to the
+    /// incremental route so both routes decide with the same data. See the
+    /// trait doc for why it travels on the reader.
+    fn unskipped_skip_dirs(&self) -> &std::collections::HashSet<String> {
+        &self.unskip
     }
 }
 

--- a/crates/nestweaver-engine/src/hubs.rs
+++ b/crates/nestweaver-engine/src/hubs.rs
@@ -37,6 +37,12 @@ pub struct HubNode {
 /// graphs (80K+ symbols), this takes ~500-700ms, dominated by DB I/O.
 /// Degree counts require the full edge set and cannot use the PageRank
 /// cache (which stores centrality, not in/out degree).
+///
+/// nw-398: this wrapper DISCARDS `candidate_total`, so a caller that publishes
+/// a `total` or a `truncated` cannot use it — `hubs`/`brain_hub_nodes` did,
+/// and reported `count == len(list)`, which is true by construction and
+/// therefore says nothing. Use [`find_hub_nodes_bounded`] on any surface that
+/// makes a claim about completeness.
 pub fn find_hub_nodes(store: &GraphStore, top_n: usize) -> Result<Vec<HubNode>> {
     find_hub_nodes_bounded(store, top_n).map(|found| found.hubs)
 }
@@ -48,6 +54,21 @@ pub struct HubNodes {
     /// A symbol with no edges cannot be a hub at any `top_n`, so counting it
     /// would overstate the population in the other direction.
     pub candidate_total: usize,
+}
+
+impl HubNodes {
+    /// Whether `top_n` cut the candidate population.
+    ///
+    /// The one definition, so the three surfaces that publish it cannot each
+    /// re-derive it from the already-cut list and each get `false` for free.
+    ///
+    /// Deliberately `>` and not `!=`: when the caller asks for MORE than the
+    /// graph has, the heap pads the tail with zero-degree symbols, so
+    /// `hubs.len()` can exceed `candidate_total`. That is a caller who was
+    /// given everything, which is the opposite of truncation.
+    pub fn truncated(&self) -> bool {
+        self.candidate_total > self.hubs.len()
+    }
 }
 
 /// [`find_hub_nodes`] with the candidate count retained.
@@ -392,6 +413,101 @@ mod tests {
             f.pagerank_score,
             s.pagerank_score
         );
+    }
+
+    /// nw-398. `find_hub_nodes_bounded` has computed `candidate_total` since
+    /// nw-299, and every caller took the discarding wrapper, so the number was
+    /// computed and thrown away on every call. This pins the reachable shape:
+    /// the population, and a `truncated` derived from it exactly once.
+    #[test]
+    fn a_cut_hub_ranking_reports_the_population_it_was_cut_from() {
+        let store = GraphStore::in_memory().unwrap();
+        for i in 0..10 {
+            store
+                .insert_symbol(&make_symbol(
+                    &format!("s{i}"),
+                    &format!("fn_{i}"),
+                    "src/lib.rs",
+                ))
+                .unwrap();
+        }
+        for i in 0..9 {
+            store
+                .insert_edge(&make_edge(&format!("s{i}"), &format!("s{}", i + 1)))
+                .unwrap();
+        }
+        // Two symbols with no edges at all: they can never be hubs, so they
+        // are not candidates, but the heap will still pad the tail with them
+        // once the caller asks for more rows than there are candidates.
+        for i in 0..2 {
+            store
+                .insert_symbol(&make_symbol(
+                    &format!("lone{i}"),
+                    &format!("lone_{i}"),
+                    "src/lone.rs",
+                ))
+                .unwrap();
+        }
+
+        let found = find_hub_nodes_bounded(&store, 3).unwrap();
+        assert_eq!(found.hubs.len(), 3);
+        assert_eq!(
+            found.candidate_total, 10,
+            "the population is the edge-bearing symbols, not the 12 in the store"
+        );
+        assert!(found.truncated(), "3 of 10 is a truncation");
+    }
+
+    /// COUNTERWEIGHT: a ranking that took everything must report
+    /// `truncated == false`, including when the caller asked for MORE than the
+    /// graph has and got zero-degree padding back — `hubs.len()` then exceeds
+    /// `candidate_total`, and a `!=` would call a complete answer truncated.
+    #[test]
+    fn an_uncut_hub_ranking_reports_no_truncation_even_when_asked_for_more() {
+        let store = GraphStore::in_memory().unwrap();
+        for i in 0..10 {
+            store
+                .insert_symbol(&make_symbol(
+                    &format!("s{i}"),
+                    &format!("fn_{i}"),
+                    "src/lib.rs",
+                ))
+                .unwrap();
+        }
+        for i in 0..9 {
+            store
+                .insert_edge(&make_edge(&format!("s{i}"), &format!("s{}", i + 1)))
+                .unwrap();
+        }
+        for i in 0..2 {
+            store
+                .insert_symbol(&make_symbol(
+                    &format!("lone{i}"),
+                    &format!("lone_{i}"),
+                    "src/lone.rs",
+                ))
+                .unwrap();
+        }
+
+        let exact = find_hub_nodes_bounded(&store, 10).unwrap();
+        assert!(
+            !exact.truncated(),
+            "10 of 10 candidates is complete: {} of {}",
+            exact.hubs.len(),
+            exact.candidate_total
+        );
+
+        let over = find_hub_nodes_bounded(&store, 50).unwrap();
+        assert_eq!(over.hubs.len(), 12, "every symbol is returned");
+        assert_eq!(over.candidate_total, 10);
+        assert!(
+            !over.truncated(),
+            "asking for 50 and being given everything is not a truncation"
+        );
+
+        let empty = find_hub_nodes_bounded(&GraphStore::in_memory().unwrap(), 5).unwrap();
+        assert_eq!(empty.candidate_total, 0);
+        assert!(!empty.truncated(), "an empty graph is complete, not cut");
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -2072,15 +2072,32 @@ fn disclose_pruned_dir(pruned: crate::content_reader::SkippedDir) -> Option<Skip
         // Neither `unskip` (which re-admits `SKIP_DIRS` names) nor `exclude`
         // (which removes things) can fix it, and offering either would repeat
         // nw-387's defect of handing someone an instruction that does nothing.
-        // The one thing that works is un-ignoring the path, so that is what is
-        // named, with the negation spelled out because `!` in a `.gitignore` is
-        // not common knowledge.
+        //
+        // AND THE FIRST VERSION OF THIS MESSAGE REPEATED IT ANYWAY. It said
+        // "un-ignore it (`!<path>`)". **Git cannot re-include a file whose
+        // PARENT DIRECTORY is excluded** — and a directory pattern
+        // (`generated/`, `proto/gen/`, a vendored SDK) is this defect's entire
+        // stated population, so the remedy was inert on exactly the case it was
+        // written for. Verified: `.gitignore` of `generated/` plus
+        // `!generated/api_client.py` still reports the file ignored.
+        //
+        // The form that WORKS excludes the directory's CONTENTS rather than the
+        // directory itself, which leaves the directory traversable so a negation
+        // can take effect: `generated/*` then `!generated/api_client.py`.
+        // Verified re-included. That is what is named, because a remedy is only
+        // worth printing if running it fixes the thing.
         format!(
             "tracked by git but dropped by the indexer's `.gitignore`-honouring walk \
              — git does not ignore tracked files, so a committed file matching an \
-             ignore pattern is in git and absent from the graph; un-ignore it \
-             (`!{}` in `.gitignore`) or narrow the pattern to index it",
-            pruned.path
+             ignore pattern is in git and absent from the graph. A bare \
+             `!{path}` will NOT work if a parent directory is excluded: change the \
+             directory pattern to exclude its contents instead (`{dir}/*`), then \
+             add `!{path}` — or narrow the pattern so it never matches this file",
+            path = pruned.path,
+            dir = pruned
+                .path
+                .rsplit_once('/')
+                .map_or(".", |(parent, _)| parent)
         )
     } else if pruned.reason == crate::content_reader::CONFIGURED_EXCLUDE_REASON {
         "directory pruned before enumeration by a configured `[[repos]] exclude` \

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -2061,7 +2061,28 @@ fn disclose_pruned_dir(pruned: crate::content_reader::SkippedDir) -> Option<Skip
     if UNDISCLOSED_PRUNES.contains(&pruned.reason.as_str()) {
         return None;
     }
-    let reason = if pruned.reason == crate::content_reader::CONFIGURED_EXCLUDE_REASON {
+    let reason = if pruned.reason == crate::content_reader::TRACKED_BUT_IGNORED_REASON {
+        // nw-394. THE THIRD REASON, AND THE ONE WHOSE REMEDY IS EASIEST TO GET
+        // WRONG. This file is COMMITTED — the user force-added it on purpose —
+        // so the message must not read as "you excluded this". It was dropped
+        // because the walk honours `.gitignore` and has no notion of the git
+        // index, while git applies `.gitignore` to untracked paths only; the
+        // two views diverge on exactly this population.
+        //
+        // Neither `unskip` (which re-admits `SKIP_DIRS` names) nor `exclude`
+        // (which removes things) can fix it, and offering either would repeat
+        // nw-387's defect of handing someone an instruction that does nothing.
+        // The one thing that works is un-ignoring the path, so that is what is
+        // named, with the negation spelled out because `!` in a `.gitignore` is
+        // not common knowledge.
+        format!(
+            "tracked by git but dropped by the indexer's `.gitignore`-honouring walk \
+             — git does not ignore tracked files, so a committed file matching an \
+             ignore pattern is in git and absent from the graph; un-ignore it \
+             (`!{}` in `.gitignore`) or narrow the pattern to index it",
+            pruned.path
+        )
+    } else if pruned.reason == crate::content_reader::CONFIGURED_EXCLUDE_REASON {
         "directory pruned before enumeration by a configured `[[repos]] exclude` \
          glob; drop or narrow that pattern to index it"
             .to_string()
@@ -2154,6 +2175,12 @@ pub struct IndexOptions {
     /// not hold. Empty for every caller that does not resolve an instance
     /// config. See `InstanceConfig::exclude_globs_for`.
     pub excludes: Vec<String>,
+    /// `[[repos]] unskip` names — [`SKIP_DIRS`] entries this repo re-admits
+    /// because they hold first-party source. nw-418: carried on the options
+    /// struct, not only inside the reader builder, so the incremental twin can
+    /// be handed the SAME set (see `incremental_index_with_excludes_and_unskip`)
+    /// and the two routes cannot disagree about what the repo contains.
+    pub unskip: Vec<String>,
 }
 
 impl IndexOptions {
@@ -2166,6 +2193,7 @@ impl IndexOptions {
             name: None,
             limits: crate::index_limits::IndexLimits::default(),
             excludes: Vec::new(),
+            unskip: Vec::new(),
         }
     }
 
@@ -2186,6 +2214,12 @@ impl IndexOptions {
 
     pub fn excludes(mut self, excludes: &[String]) -> Self {
         self.excludes = excludes.to_vec();
+        self
+    }
+
+    /// nw-418: `[[repos]] unskip` names for this repo.
+    pub fn unskip(mut self, unskip: &[String]) -> Self {
+        self.unskip = unskip.to_vec();
         self
     }
 }
@@ -2426,6 +2460,7 @@ fn index_directory_with_store_inner(
     let mut resolution_deps = crate::resolution_cache::ResolutionDeps::load(&resolution_deps_path);
 
     let reader = crate::content_reader::FilesystemReader::with_limits(repo_path, limits)
+        .unskipping(&opts.unskip)
         .excluding(&opts.excludes)?;
     // Local filesystem index: the working tree location is `repo_path`.
     // Persisted as `root_path` on the Repo node so consumers never derive
@@ -4427,7 +4462,13 @@ where
 }
 
 /// Returns true if the given path has a supported language extension.
-fn is_parseable(path: &Path) -> bool {
+///
+/// `pub(crate)` for nw-394: `FilesystemReader::record_tracked_but_ignored` has
+/// to answer "would this file have contributed symbols had the walk seen it?"
+/// before it calls the file's absence a coverage loss, and this is the
+/// indexer's own answer to that question. Sharing it keeps the disclosure and
+/// the pipeline agreeing about what counts as source.
+pub(crate) fn is_parseable(path: &Path) -> bool {
     detect_language(path).is_some()
 }
 
@@ -5240,13 +5281,56 @@ pub(crate) fn is_minified_or_bundled(path: &Path) -> bool {
     false
 }
 
-/// Returns true if any component of `path` is in `SKIP_DIRS`.
-pub(crate) fn path_in_skip_dir(path: &Path) -> bool {
+/// Returns true if any component of `path` is in [`SKIP_DIRS`] and has NOT been
+/// re-admitted by this repo's `[[repos]] unskip` set.
+///
+/// nw-418 GAVE THIS FUNCTION THE `unskip` SET, and that is the whole fix.
+/// `FilesystemReader::list_files` honoured `unskip` in its `filter_entry`
+/// closure; this predicate — the one the INCREMENTAL change loop uses — did
+/// not take the set and so could not. The two routes therefore disagreed about
+/// what the repo contained: a repo with `unskip = ["public"]` got `public/`
+/// indexed by `nestweaver index --force` and dropped, one file at a time, by
+/// every plain `nestweaver index`, with `coverage_status: "complete"` on both.
+///
+/// AND NOTHING COULD SEE IT. nw-387's disclosure channel reports directories
+/// the walk PRUNED, and on the incremental route `public/` is not pruned —
+/// `unskip` re-admitted it — so there was no `SkippedDir` row to drain and the
+/// loss happened below the level any disclosure watches.
+///
+/// Per nw-217 ("a guard present in one implementation and absent in its twin"),
+/// the fix is ONE predicate that both routes call with the same set, not a
+/// second copy of the rule taught to the incremental loop. The set reaches
+/// every caller through `ContentReader::unskipped_skip_dirs`, so it cannot
+/// drift from the set the walk itself used.
+pub(crate) fn path_in_skip_dir_with_unskip(
+    path: &Path,
+    unskip: &std::collections::HashSet<String>,
+) -> bool {
     path.components().any(|c| {
         c.as_os_str()
             .to_str()
-            .is_some_and(|name| SKIP_DIRS.contains(&name))
+            .is_some_and(|name| SKIP_DIRS.contains(&name) && !unskip.contains(name))
     })
+}
+
+/// [`path_in_skip_dir_with_unskip`] for the callers that carry no per-repo
+/// config and therefore re-admit nothing: the filesystem watchers
+/// (`watch_code.rs`) and [`crate::content_reader::GitBareReader`].
+///
+/// A THIN DELEGATION, NOT A SECOND RULE. It exists so those call sites keep
+/// compiling unchanged, and it must stay a one-liner: the moment it grows its
+/// own matching logic it becomes the drifted twin nw-217 describes. Those
+/// callers not honouring `unskip` is a real, smaller gap — a watcher will not
+/// pick up edits under a re-admitted `public/` — and it is stated here rather
+/// than hidden, because closing it needs the per-repo config plumbed into the
+/// watcher, which is a different change in different files.
+pub(crate) fn path_in_skip_dir(path: &Path) -> bool {
+    static NONE_RE_ADMITTED: std::sync::OnceLock<std::collections::HashSet<String>> =
+        std::sync::OnceLock::new();
+    path_in_skip_dir_with_unskip(
+        path,
+        NONE_RE_ADMITTED.get_or_init(std::collections::HashSet::new),
+    )
 }
 
 /// nw-204: tombstone the embeddings of symbols an index run actually removed.
@@ -5423,6 +5507,7 @@ pub fn incremental_index_with_name_and_limits(
         name,
         limits,
         &[],
+        &[],
         &FileSystemIndexEpilogueIo,
     )
 }
@@ -5432,6 +5517,13 @@ pub fn incremental_index_with_name_and_limits(
 /// The full-index route resolves excludes through [`IndexOptions`]; this is its
 /// twin, so a `--no-daemon` incremental run does not quietly index a tree the
 /// configured excludes remove.
+///
+/// nw-418: `unskip` is the OTHER half of the same per-repo policy and this
+/// entry point cannot express it, so it passes the empty set. Use
+/// [`incremental_index_with_excludes_and_unskip`] wherever the repo's config
+/// has actually been resolved — an incremental run that forgets `unskip` drops
+/// the re-admitted files one at a time and still reports complete coverage.
+/// Kept at its current signature so existing callers compile unchanged.
 pub fn incremental_index_with_excludes(
     repo_path: &Path,
     db_path: &Path,
@@ -5441,6 +5533,43 @@ pub fn incremental_index_with_excludes(
     limits: crate::index_limits::IndexLimits,
     excludes: &[String],
 ) -> Result<IncrementalResult, anyhow::Error> {
+    incremental_index_with_excludes_and_unskip(
+        repo_path,
+        db_path,
+        instance_id,
+        repo_url,
+        name,
+        limits,
+        excludes,
+        &[],
+    )
+}
+
+/// Incremental index honouring BOTH halves of the per-repo directory policy.
+///
+/// nw-418. `[[repos]] unskip` was honoured by the full scan (through
+/// `FilesystemReader::list_files`) and ignored by the incremental change loop
+/// (through the old `unskip`-less `path_in_skip_dir`), so the same repo yielded
+/// two different symbol sets depending on whether the caller passed `--force`,
+/// and BOTH runs reported `coverage_status: "complete"`. Worse, nw-387's
+/// disclosure could not catch it: `unskip` means the directory is not pruned,
+/// so there is no `SkippedDir` row to drain, and the files were dropped
+/// individually inside the loop, below the level any disclosure watches.
+///
+/// The set is pushed into the reader, and every skip decision downstream reads
+/// it back off the reader via `ContentReader::unskipped_skip_dirs`. One set,
+/// one predicate, both routes.
+#[allow(clippy::too_many_arguments)]
+pub fn incremental_index_with_excludes_and_unskip(
+    repo_path: &Path,
+    db_path: &Path,
+    instance_id: &str,
+    repo_url: &str,
+    name: Option<&str>,
+    limits: crate::index_limits::IndexLimits,
+    excludes: &[String],
+    unskip: &[String],
+) -> Result<IncrementalResult, anyhow::Error> {
     incremental_index_with_name_and_io(
         repo_path,
         db_path,
@@ -5449,6 +5578,7 @@ pub fn incremental_index_with_excludes(
         name,
         limits,
         excludes,
+        unskip,
         &FileSystemIndexEpilogueIo,
     )
 }
@@ -5462,6 +5592,7 @@ fn incremental_index_with_name_and_io(
     name: Option<&str>,
     limits: crate::index_limits::IndexLimits,
     excludes: &[String],
+    unskip: &[String],
     epilogue_io: &dyn IndexEpilogueIo,
 ) -> Result<IncrementalResult, anyhow::Error> {
     // nw-C1: reconcile BEFORE the `old_sha == new_sha` short-circuit below,
@@ -5493,6 +5624,7 @@ fn incremental_index_with_name_and_io(
                     force: false,
                     limits,
                     excludes,
+                    unskip,
                     epilogue_io,
                 },
             );
@@ -5515,6 +5647,7 @@ fn incremental_index_with_name_and_io(
                     force: false,
                     limits,
                     excludes,
+                    unskip,
                     epilogue_io,
                 },
             );
@@ -5552,6 +5685,7 @@ fn incremental_index_with_name_and_io(
                 force: true,
                 limits,
                 excludes,
+                unskip,
                 epilogue_io,
             },
         );
@@ -5578,6 +5712,7 @@ fn incremental_index_with_name_and_io(
                 force: true,
                 limits,
                 excludes,
+                unskip,
                 epilogue_io,
             },
         );
@@ -5605,6 +5740,7 @@ fn incremental_index_with_name_and_io(
         // deliberately: `nestweaver index` is user-invoked, and the alternative
         // is a coverage claim that is only true the first time.
         let reader = crate::content_reader::FilesystemReader::with_limits(repo_path, limits)
+            .unskipping(unskip)
             .excluding(excludes)?;
         let mut result = IncrementalResult::default();
         // Fully qualified because this module deliberately does not import the
@@ -5637,12 +5773,21 @@ fn incremental_index_with_name_and_io(
     );
 
     let reader = crate::content_reader::FilesystemReader::with_limits(repo_path, limits)
+        .unskipping(unskip)
         .excluding(excludes)?;
+    // nw-418: read the re-admitted set BACK OFF THE READER rather than
+    // re-deriving it from `unskip` here. `unskipping` normalises the names
+    // (it trims them), and a second normalisation at this call site is exactly
+    // the drifting twin nw-217 describes — the loop below would then be able to
+    // disagree with the walk about whether `" public"` re-admits `public`.
+    // Fully qualified because this module deliberately does not import the
+    // `ContentReader` trait and `reader` here is the concrete type.
+    let unskip_dirs = crate::content_reader::ContentReader::unskipped_skip_dirs(&reader);
     let mut result = IncrementalResult::default();
 
     // nw-008 Phase 0 — transitive reverse-dependents from the LIVE graph, BEFORE
     // any mutation (the per-file `DETACH DELETE` destroys the edges we walk).
-    let (changed_files, removed_files) = partition_changed_removed(&changes);
+    let (changed_files, removed_files) = partition_changed_removed(&changes, unskip_dirs);
     let rdeps = collect_reverse_dep_files(&store, &r_uid, &changed_files, &removed_files);
     let contract_plan = match prepare_incremental_contract_derivation(&reader, &r_uid, repo_url) {
         Ok(plan) => plan,
@@ -5691,7 +5836,7 @@ fn incremental_index_with_name_and_io(
     for change in &changes {
         match change {
             crate::git_diff::FileChange::Added(rel_path) => {
-                if path_in_skip_dir(rel_path) || !is_parseable(rel_path) {
+                if path_in_skip_dir_with_unskip(rel_path, unskip_dirs) || !is_parseable(rel_path) {
                     continue;
                 }
                 match prepared_files
@@ -5715,7 +5860,7 @@ fn incremental_index_with_name_and_io(
                 }
             }
             crate::git_diff::FileChange::Modified(rel_path) => {
-                if path_in_skip_dir(rel_path) || !is_parseable(rel_path) {
+                if path_in_skip_dir_with_unskip(rel_path, unskip_dirs) || !is_parseable(rel_path) {
                     continue;
                 }
                 let prepared = prepared_files
@@ -5807,7 +5952,7 @@ fn incremental_index_with_name_and_io(
                 nestweaver_store::GraphStore::delete_file_node_on(&txn, &old_f_uid)
                     .with_context(|| format!("delete_file_node (rename from) {}", from_str))?;
 
-                if is_parseable(to) && !path_in_skip_dir(to) {
+                if is_parseable(to) && !path_in_skip_dir_with_unskip(to, unskip_dirs) {
                     // Re-read from disk and re-insert the file + symbols under the new path.
                     let removed2 = nestweaver_store::GraphStore::delete_symbols_in_file_on(
                         &txn, &r_uid, &to_str,
@@ -5945,10 +6090,16 @@ where
         "processing server incremental changes"
     );
 
+    // nw-418: same one predicate, same one set, on the daemon's route. The
+    // reader is supplied by the caller here, so whatever `unskip` it was built
+    // with is what this loop honours — the server twin cannot drift from the
+    // CLI's by construction.
+    let unskip_dirs = reader.unskipped_skip_dirs();
+
     // nw-008 Phase 0 — compute transitive reverse-dependents from the LIVE
     // graph BEFORE any mutation. The per-file `DETACH DELETE` below destroys the
     // edges we walk here, so this ordering is correctness-critical.
-    let (changed_files, removed_files) = partition_changed_removed(&changes);
+    let (changed_files, removed_files) = partition_changed_removed(&changes, unskip_dirs);
     let rdeps = collect_reverse_dep_files(store, &r_uid, &changed_files, &removed_files);
     let contract_plan_result = prepare_incremental_contract_derivation(reader, &r_uid, repo_url);
     let prepared_files = prepare_incremental_files(reader, &changes)
@@ -5997,7 +6148,7 @@ where
     for change in &changes {
         match change {
             crate::git_diff::FileChange::Added(rel_path) => {
-                if path_in_skip_dir(rel_path) || !is_parseable(rel_path) {
+                if path_in_skip_dir_with_unskip(rel_path, unskip_dirs) || !is_parseable(rel_path) {
                     continue;
                 }
                 match prepared_files
@@ -6021,7 +6172,7 @@ where
                 }
             }
             crate::git_diff::FileChange::Modified(rel_path) => {
-                if path_in_skip_dir(rel_path) || !is_parseable(rel_path) {
+                if path_in_skip_dir_with_unskip(rel_path, unskip_dirs) || !is_parseable(rel_path) {
                     continue;
                 }
                 let prepared = prepared_files
@@ -6111,7 +6262,7 @@ where
                 nestweaver_store::GraphStore::delete_file_node_on(&txn, &old_f_uid)
                     .with_context(|| format!("delete_file_node (rename from) {}", from_str))?;
 
-                if is_parseable(to) && !path_in_skip_dir(to) {
+                if is_parseable(to) && !path_in_skip_dir_with_unskip(to, unskip_dirs) {
                     let removed2 = nestweaver_store::GraphStore::delete_symbols_in_file_on(
                         &txn, &r_uid, &to_str,
                     )
@@ -6277,6 +6428,12 @@ fn prepare_incremental_files(
     reader: &dyn crate::content_reader::ContentReader,
     changes: &[crate::git_diff::FileChange],
 ) -> Result<HashMap<String, PreparedIncrementalOutcome>, anyhow::Error> {
+    // nw-418: the reader already knows which `SKIP_DIRS` names this repo
+    // re-admitted, so the preparation pass and the change loop that consumes it
+    // cannot disagree about which files exist. They used to: the loop's
+    // `expect("parseable added file was prepared")` is only sound because both
+    // sides apply the identical predicate.
+    let unskip_dirs = reader.unskipped_skip_dirs();
     let mut prepared = HashMap::new();
     for change in changes {
         let path = match change {
@@ -6286,7 +6443,7 @@ fn prepare_incremental_files(
             crate::git_diff::FileChange::Deleted(_) => None,
         };
         let Some(path) = path else { continue };
-        if path_in_skip_dir(path) || !is_parseable(path) {
+        if path_in_skip_dir_with_unskip(path, unskip_dirs) || !is_parseable(path) {
             continue;
         }
         prepared.insert(
@@ -6417,8 +6574,14 @@ fn write_prepared_incremental_file_txn(
 /// the change (`changed`: Added / Modified / Renamed.to) and the files that no
 /// longer exist (`removed`: Deleted / Renamed.from). Used to seed the
 /// transitive re-resolution pass (nw-008).
+///
+/// nw-418: takes the repo's `unskip` set for the same reason the change loop
+/// does. This seeds the reverse-dependency walk, so a re-admitted file dropped
+/// HERE would leave the edges INTO it unrebuilt even once the loop indexed it —
+/// a subtler version of the same divergence, and one no disclosure would show.
 fn partition_changed_removed(
     changes: &[crate::git_diff::FileChange],
+    unskip_dirs: &std::collections::HashSet<String>,
 ) -> (
     std::collections::HashSet<String>,
     std::collections::HashSet<String>,
@@ -6429,7 +6592,7 @@ fn partition_changed_removed(
     for change in changes {
         match change {
             FileChange::Added(p) | FileChange::Modified(p) => {
-                if !path_in_skip_dir(p) && is_parseable(p) {
+                if !path_in_skip_dir_with_unskip(p, unskip_dirs) && is_parseable(p) {
                     changed.insert(p.to_string_lossy().into_owned());
                 }
             }
@@ -6438,7 +6601,7 @@ fn partition_changed_removed(
             }
             FileChange::Renamed { from, to } => {
                 removed.insert(from.to_string_lossy().into_owned());
-                if !path_in_skip_dir(to) && is_parseable(to) {
+                if !path_in_skip_dir_with_unskip(to, unskip_dirs) && is_parseable(to) {
                     changed.insert(to.to_string_lossy().into_owned());
                 }
             }
@@ -6846,6 +7009,11 @@ struct FullIndexFallback<'a> {
     /// must carry these too — a fresh index takes this path, and without them
     /// the very first index of a repo silently ignored its excludes.
     excludes: &'a [String],
+    /// `[[repos]] unskip` names, carried for the same reason as `excludes` and
+    /// added by nw-418: the fallback builds its own reader, and a first index
+    /// that forgot `unskip` would leave the repo's re-admitted directories out
+    /// of the graph until someone happened to run `--force`.
+    unskip: &'a [String],
     epilogue_io: &'a dyn IndexEpilogueIo,
 }
 
@@ -6863,6 +7031,7 @@ fn full_index_fallback(
         force,
         limits,
         excludes,
+        unskip,
         epilogue_io,
     } = request;
     // Load filemeta sidecar for tiered change detection even in fallback.
@@ -6887,6 +7056,7 @@ fn full_index_fallback(
     let mut resolution_deps = crate::resolution_cache::ResolutionDeps::load(&resolution_deps_path);
 
     let reader = crate::content_reader::FilesystemReader::with_limits(repo_path, limits)
+        .unskipping(unskip)
         .excluding(excludes)?;
     let local_root = repo_path.display().to_string();
     // nw-022: capture a re-identified legacy file:// uid so its filemeta
@@ -7407,6 +7577,355 @@ mod tests {
             "a SKIP_DIRS prune IS re-admissible with `unskip` and must keep \
              saying so: {:?}",
             default_prune.reason
+        );
+    }
+
+    #[test]
+    fn a_git_tracked_file_that_also_matches_gitignore_is_disclosed_instead_of_vanishing() {
+        // nw-394. THE BELIEF THIS DISPROVES is nw-325's own remediation note:
+        // that because the walker honours `.gitignore`, coverage equals git's
+        // view. **Git does not ignore a tracked file** — `.gitignore` applies to
+        // untracked paths only — and `ignore::WalkBuilder` has no notion of the
+        // git index, so the two views diverge on exactly one population:
+        // committed-but-ignored files.
+        //
+        // This is the item's measured fixture. Before the fix it reported
+        // `files_processed: 1, symbols_found: 1, skipped_count: 0,
+        // coverage_status: "complete"` and `--fail-on-skip` exit 0, while
+        // `generated_api_call` was absent from the graph and `app.py`'s import
+        // edge to it could not exist. The caller half was indexed, the callee
+        // half was not, and `impact` stopped at the seam saying nothing.
+        //
+        // DECISION RECORDED: nw-394 allowed either honouring the git index or
+        // disclosing the drop, and this DISCLOSES. See
+        // `content_reader::TRACKED_BUT_IGNORED_REASON` for why: the realistic
+        // population is committed generated code, so silently pulling it into
+        // the graph trades one wrong answer for a costlier one. The walk's
+        // behaviour is therefore asserted UNCHANGED here, and the report is
+        // what moves.
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(repo.join("generated")).unwrap();
+        fs::write(repo.join(".gitignore"), "generated/\n").unwrap();
+        fs::write(
+            repo.join("app.py"),
+            "from generated.api_client import generated_api_call\n\n\ndef app_main():\n    return generated_api_call()\n",
+        )
+        .unwrap();
+        fs::write(
+            repo.join("generated/api_client.py"),
+            "def generated_api_call():\n    return 2\n",
+        )
+        .unwrap();
+        let git = commit_all_in(&repo, "initial");
+        // `-f` is the whole fixture: this is a file the user COMMITTED ON
+        // PURPOSE despite the ignore pattern, which is why "we ignored it" is
+        // not an acceptable silent answer.
+        git(&["add", "-f", "generated/api_client.py"]);
+        git(&["commit", "-q", "-m", "force-add the generated client"]);
+        let head = git(&["rev-parse", "HEAD"]);
+        assert!(
+            git(&["ls-files"]).contains("generated/api_client.py"),
+            "precondition: git tracks the file"
+        );
+
+        let result = index_directory_with_options_and_limits(
+            &repo,
+            &dir.path().join("graph.lbug"),
+            "test",
+            "https://example.test/tracked-but-ignored",
+            &head,
+            true,
+            None,
+            crate::index_limits::IndexLimits::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.files_count, 1,
+            "disclosure, not re-admission: the walk still drops the file"
+        );
+        let disclosed = result
+            .skipped_files
+            .iter()
+            .find(|skipped| skipped.path == "generated/api_client.py")
+            .unwrap_or_else(|| {
+                panic!(
+                    "a committed-but-ignored source file must reach \
+                     IndexResult::skipped_files, which is what degrades \
+                     coverage_status and fails --fail-on-skip: {:?}",
+                    result.skipped_files
+                )
+            });
+        assert_eq!(
+            disclosed.reason_code,
+            nestweaver_parser::SkipReasonCode::Ignored,
+            "a policy drop is Ignored, not a read or parse defect"
+        );
+        // THE REMEDY HAS TO BE THE ONE THAT WORKS. nw-387 shipped a message
+        // offering `[[repos]] unskip` to a repo using `[[repos]] exclude` —
+        // an instruction that does nothing — and this is the same trap one
+        // reason over: `unskip` re-admits `SKIP_DIRS` NAMES and cannot touch a
+        // gitignore match, and `exclude` points the other way entirely. Only
+        // un-ignoring the path re-admits it, so only that is offered.
+        assert!(
+            disclosed.reason.contains("tracked by git"),
+            "the message must say the file is TRACKED, because the user \
+             committed it deliberately: {:?}",
+            disclosed.reason
+        );
+        assert!(
+            disclosed.reason.contains(".gitignore"),
+            "the message must name the mechanism that actually dropped it: {:?}",
+            disclosed.reason
+        );
+        assert!(
+            !disclosed.reason.contains("unskip") && !disclosed.reason.contains("[[repos]] exclude"),
+            "neither `unskip` nor `exclude` governs a gitignore match; offering \
+             either is a remedy that does nothing: {:?}",
+            disclosed.reason
+        );
+    }
+
+    #[test]
+    fn an_ordinary_ignored_file_git_does_not_track_is_not_reported_as_a_coverage_loss() {
+        // COUNTERWEIGHT to the test above, and the reason the disclosure
+        // consults the git INDEX rather than simply reporting everything the
+        // walk did not yield. `.gitignore` doing its job is the overwhelmingly
+        // common case: build output, caches, local `.env`s. If those degraded
+        // `coverage_status` the gate would fire on essentially every repository
+        // and carry exactly as little information as one that never fires,
+        // burying the committed-but-ignored finding nw-394 exists to surface.
+        //
+        // Two ignored files, one property: an untracked one is silent, and the
+        // tracked one beside it is still reported. Asserting only the first
+        // would pass on a fix that had simply been deleted.
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(repo.join("build_output")).unwrap();
+        fs::create_dir_all(repo.join("generated")).unwrap();
+        fs::write(repo.join(".gitignore"), "build_output/\ngenerated/\n").unwrap();
+        fs::write(repo.join("app.py"), "def app_main():\n    return 1\n").unwrap();
+        fs::write(
+            repo.join("build_output/junk.py"),
+            "def never_committed():\n    return 2\n",
+        )
+        .unwrap();
+        fs::write(
+            repo.join("generated/api_client.py"),
+            "def generated_api_call():\n    return 3\n",
+        )
+        .unwrap();
+        let git = commit_all_in(&repo, "initial");
+        git(&["add", "-f", "generated/api_client.py"]);
+        git(&["commit", "-q", "-m", "force-add only the generated client"]);
+        let head = git(&["rev-parse", "HEAD"]);
+
+        let result = index_directory_with_options_and_limits(
+            &repo,
+            &dir.path().join("graph.lbug"),
+            "test",
+            "https://example.test/untracked-ignored",
+            &head,
+            true,
+            None,
+            crate::index_limits::IndexLimits::default(),
+        )
+        .unwrap();
+
+        let paths: Vec<&str> = result
+            .skipped_files
+            .iter()
+            .map(|skipped| skipped.path.as_str())
+            .collect();
+        assert!(
+            !paths.contains(&"build_output/junk.py"),
+            "an ignored file git does not track is absent from git too — that \
+             is not a coverage loss and must not degrade the gate: {paths:?}"
+        );
+        assert_eq!(
+            paths,
+            vec!["generated/api_client.py"],
+            "the tracked-and-ignored file is the ONLY disclosure this repo owes"
+        );
+    }
+
+    #[test]
+    fn an_unskipped_directory_yields_one_symbol_set_from_both_a_forced_and_an_incremental_index() {
+        // nw-418, and the test shape the item asked for BY NAME: ONE test that
+        // runs BOTH routes over the same repo and compares, not two tests that
+        // each pass alone. Two passing tests were exactly the state before the
+        // fix — `--force` honoured `[[repos]] unskip` through
+        // `FilesystemReader::list_files`, the incremental change loop ignored it
+        // through an `unskip`-less `path_in_skip_dir`, and each route was
+        // internally consistent. Only comparing them shows the divergence.
+        //
+        // AND NOTHING ELSE COULD SHOW IT. nw-387's channel discloses PRUNED
+        // directories; here `unskip` means `public/` is not pruned, so there is
+        // no `SkippedDir` row to drain and the files were dropped one at a time
+        // inside the loop. Both runs reported `coverage_status: "complete"`
+        // while returning different graphs — which is why this asserts on the
+        // SYMBOL SET in the store rather than on the skip channel.
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(repo.join("public")).unwrap();
+        fs::write(repo.join("app.py"), "def app_main():\n    return 1\n").unwrap();
+        fs::write(
+            repo.join("public/widget.py"),
+            "def public_widget():\n    return 2\n",
+        )
+        .unwrap();
+        let git = commit_all_in(&repo, "initial");
+        let first_sha = git(&["rev-parse", "HEAD"]);
+
+        let unskip = vec!["public".to_string()];
+        let repo_url = "https://example.test/unskip-both-routes";
+        let r_uid = repo_uid("test", repo_url);
+        let incremental_db = dir.path().join("incremental.lbug");
+        let forced_db = dir.path().join("forced.lbug");
+
+        // Seed the incremental database at the FIRST commit, so the file added
+        // below arrives through the change loop's `Added` arm — the arm that
+        // `continue`d past it.
+        index_directory_with_opts(
+            &repo,
+            &incremental_db,
+            &IndexOptions::new("test", repo_url, &first_sha)
+                .force(true)
+                .unskip(&unskip),
+        )
+        .unwrap();
+
+        fs::write(
+            repo.join("public/added.py"),
+            "def public_added():\n    return 3\n",
+        )
+        .unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "add a second public source file"]);
+        let second_sha = git(&["rev-parse", "HEAD"]);
+
+        let incremental = incremental_index_with_excludes_and_unskip(
+            &repo,
+            &incremental_db,
+            "test",
+            repo_url,
+            None,
+            crate::index_limits::IndexLimits::default(),
+            &[],
+            &unskip,
+        )
+        .unwrap();
+        assert!(
+            !incremental.fell_back_to_full,
+            "precondition: this must exercise the incremental change loop, not \
+             the full-index fallback that would mask the bug"
+        );
+
+        index_directory_with_opts(
+            &repo,
+            &forced_db,
+            &IndexOptions::new("test", repo_url, &second_sha)
+                .force(true)
+                .unskip(&unskip),
+        )
+        .unwrap();
+
+        let symbol_names = |db: &Path| {
+            let store = GraphStore::open_or_create(db).unwrap();
+            let mut names: Vec<String> = store
+                .lookup_symbols_by_repo(&r_uid)
+                .unwrap()
+                .into_iter()
+                .map(|symbol| symbol.name)
+                .collect();
+            names.sort();
+            names.dedup();
+            names
+        };
+        let from_incremental = symbol_names(&incremental_db);
+        assert_eq!(
+            from_incremental,
+            symbol_names(&forced_db),
+            "an `unskip`ped repo must yield ONE symbol set; which flag the user \
+             passed is not allowed to change what the graph contains"
+        );
+        assert_eq!(
+            from_incremental,
+            vec![
+                "app_main".to_string(),
+                "public_added".to_string(),
+                "public_widget".to_string(),
+            ],
+            "and that one set must be the re-admitted one — equal-but-empty \
+             would satisfy the comparison above while losing every file"
+        );
+    }
+
+    #[test]
+    fn a_repo_without_unskip_still_prunes_public_on_both_routes() {
+        // COUNTERWEIGHT to the test above, and the failure mode it guards is
+        // blunt: giving the predicate an `unskip` set is one typo away from
+        // giving it a set that always matches, which would disable `SKIP_DIRS`
+        // wholesale. The equality assertion next door cannot see that — two
+        // routes that both over-index agree perfectly.
+        //
+        // Same fixture, same two routes, `unskip` withheld: `public/` must stay
+        // out of BOTH graphs, and the prune must still be disclosed so the loss
+        // is visible rather than silent.
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(repo.join("public")).unwrap();
+        fs::write(repo.join("app.py"), "def app_main():\n    return 1\n").unwrap();
+        fs::write(
+            repo.join("public/widget.py"),
+            "def public_widget():\n    return 2\n",
+        )
+        .unwrap();
+        let git = commit_all_in(&repo, "initial");
+        let first_sha = git(&["rev-parse", "HEAD"]);
+
+        let repo_url = "https://example.test/no-unskip-still-prunes";
+        let r_uid = repo_uid("test", repo_url);
+        let db = dir.path().join("graph.lbug");
+        index_directory_with_opts(
+            &repo,
+            &db,
+            &IndexOptions::new("test", repo_url, &first_sha).force(true),
+        )
+        .unwrap();
+
+        fs::write(
+            repo.join("public/added.py"),
+            "def public_added():\n    return 3\n",
+        )
+        .unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "add a second public source file"]);
+
+        let incremental = incremental_index(&repo, &db, "test", repo_url).unwrap();
+        assert!(!incremental.fell_back_to_full);
+        assert!(
+            incremental
+                .skipped_files
+                .iter()
+                .any(|skipped| skipped.path == "public"),
+            "a genuinely pruned directory must still be disclosed: {:?}",
+            incremental.skipped_files
+        );
+
+        let store = GraphStore::open_or_create(&db).unwrap();
+        let names: Vec<String> = store
+            .lookup_symbols_by_repo(&r_uid)
+            .unwrap()
+            .into_iter()
+            .map(|symbol| symbol.name)
+            .collect();
+        assert_eq!(
+            names,
+            vec!["app_main".to_string()],
+            "without `unskip`, SKIP_DIRS must still prune `public/` on the \
+             incremental route too: {names:?}"
         );
     }
 
@@ -13509,6 +14028,7 @@ function hello(name) { return "Hello " + name; }
             None,
             crate::index_limits::IndexLimits::default(),
             &[],
+            &[],
             &InjectedIndexEpilogueIo {
                 fail_generation: true,
                 fail_compute: true,
@@ -13584,6 +14104,7 @@ function hello(name) { return "Hello " + name; }
             repo_url,
             None,
             crate::index_limits::IndexLimits::default(),
+            &[],
             &[],
             &InjectedIndexEpilogueIo {
                 fail_generation: true,

--- a/crates/nestweaver-engine/src/summaries.rs
+++ b/crates/nestweaver-engine/src/summaries.rs
@@ -167,6 +167,17 @@ fn generate_hub_summaries(store: &GraphStore) -> Result<Vec<Summary>> {
     generate_hub_summaries_bounded(store).map(|out| out.summaries)
 }
 
+/// How many hubs a hub-level summary generates.
+///
+/// Module-level and `pub` so the number is NAMEABLE by the surfaces that
+/// disclose it, mirroring [`MAX_CLUSTER_SUMMARIES`]. It was a `const` local to
+/// [`generate_hub_summaries_bounded`], which is why the caller could report
+/// `total: 30` without anywhere to say where the 30 came from — an internal
+/// constant the caller never chose. Deliberately NOT yet a parameter: the
+/// cluster sibling takes its cap as an argument, so the shape to copy exists
+/// if a caller ever needs to choose it ([[nw-409]]).
+pub const HUB_COUNT: usize = 30;
+
 /// Hub summaries with the two facts that say whether the list is complete.
 pub struct HubSummaries {
     pub summaries: Vec<Summary>,
@@ -188,9 +199,12 @@ pub struct HubSummaries {
 /// caller's own request, and returning N of N is the correct answer to it.
 /// The lie is specific to a bound the caller could not see or state.
 pub fn generate_hub_summaries_bounded(store: &GraphStore) -> Result<HubSummaries> {
-    const HUB_COUNT: usize = 30;
     let found = crate::hubs::find_hub_nodes_bounded(store, HUB_COUNT)?;
     let candidate_total = found.candidate_total;
+    // nw-398: take the cut/no-cut verdict from `HubNodes` rather than
+    // recomputing it here, so this level and the `hubs` surfaces cannot come to
+    // disagree about what "capped" means on the same population.
+    let capped = found.truncated();
     let summaries: Vec<Summary> = found
         .hubs
         .iter()
@@ -212,7 +226,7 @@ pub fn generate_hub_summaries_bounded(store: &GraphStore) -> Result<HubSummaries
         })
         .collect();
     Ok(HubSummaries {
-        capped: candidate_total > summaries.len(),
+        capped,
         matched_total: candidate_total,
         summaries,
     })

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -12325,7 +12325,7 @@ fn tool_schema_get_summary() -> Value {
                 // for `clusters`, applied one level down.
                 //
                 // Cluster only, because `generate_cluster_summaries_bounded`
-                // already TAKES a cap. Hub's `HUB_COUNT` is a private constant
+                // already TAKES a cap. Hub's `HUB_COUNT` is a module constant
                 // inside `generate_hub_summaries_bounded`, so hub cannot be
                 // parameterised from here — it is disclosed as an internal
                 // bound instead (`cap_parameter: null`).
@@ -12637,6 +12637,23 @@ fn tool_get_summary(store: &GraphStore, args: Value) -> Result<Value, anyhow::Er
     };
     let truncated_by_budget = display.len() < after_filter_len;
     let note = if cap_dropped > 0 {
+        // nw-409, CORRECTED after review. This interpolated `display.len()` — the
+        // count AFTER `token_budget` had already cut the list — into a sentence
+        // claiming that many were "capped by an INTERNAL bound that no parameter
+        // raises" and that "`token_budget` cannot recover the rest". With
+        // `level:"hub", token_budget:300` it reported "capped at 12" while
+        // raising the budget returned 18 more. That is nw-409's own defect
+        // (naming a remedy that does not exist) inverted into DENYING a remedy
+        // that does — introduced by nw-409's fix.
+        //
+        // The generator cap is a property of the GENERATED set, so it is
+        // `total_returned` (pre-budget), never the post-budget render length.
+        let generator_cap = after_filter_len;
+        // Name the constant rather than restating 30 in prose. `HUB_COUNT` was
+        // made `pub` for exactly this and had NO consumer — a `pub` item with no
+        // caller is nw-422's shape in miniature: the capability exists, the
+        // surface that reaches it does not, and nothing fails.
+        let hub_cap = nestweaver_engine::summaries::HUB_COUNT;
         Some(match cap_parameter {
             Some(parameter) => format!(
                 "{level_str}-level summaries were capped by the generator ({} of {total_available} \
@@ -12645,11 +12662,17 @@ fn tool_get_summary(store: &GraphStore, args: Value) -> Result<Value, anyhow::Er
                 display.len()
             ),
             None => format!(
-                "{level_str}-level summaries are capped at {} by an INTERNAL bound that no \
-                 parameter raises — `token_budget` cannot recover the rest, and `total` counts \
-                 {total_population}. Narrow with `target`, or use `hub_nodes`/`clusters`, whose \
-                 `limit` is caller-stated.",
-                display.len()
+                "{level_str}-level summaries are capped at {generator_cap} (the generator's \
+                 bound is {hub_cap}) by an INTERNAL bound that no parameter raises, and `total` \
+                 counts {total_population}. Narrow with `target`, or use `hub_nodes`/`clusters`, \
+                 whose `limit` is caller-stated.{}",
+                if truncated_by_budget {
+                    " `token_budget` ALSO cut this response, and raising it does recover rows \
+                     up to the generator cap."
+                } else {
+                    " `token_budget` cannot recover more: the generator cap, not the budget, \
+                     is what bounds this."
+                }
             ),
         })
     } else if truncated_by_budget {
@@ -19636,7 +19659,7 @@ mod summary_cap_disclosure_tests {
         assert_eq!(
             hub["cap_parameter"],
             Value::Null,
-            "hub's HUB_COUNT is a private engine constant — claiming a parameter \
+            "hub's HUB_COUNT is an engine constant with no parameter — claiming one \
              raises it would be the same wrong remedy in a new field: {hub}"
         );
         let population = hub["total_population"].as_str().unwrap_or_default();

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -18,13 +18,12 @@ use nestweaver_engine::{
     SummaryLevel, ToolDocEntry, analyze_blast_radius, attach_cluster_ids, attach_communities,
     broken_links, build_brain_context_hybrid_with_aliases, compute_clusters, detect_changes_impact,
     detect_dead_code_cancellable, doc_stats, expand_query_with_aliases, filter_by_target,
-    find_bridge_nodes, find_hub_nodes, generate_agents_md_with_rules,
-    generate_claude_md_with_rules, generate_cursor_rule_with_rules, generate_guide_with_tools,
-    generate_skill_with_tools, generate_summaries, get_all_properties, get_last_indexed_at,
-    investigate, investigate_expand, investigate_hydrate, load_alias_sidecar, load_clusters,
-    load_extensions, memory_consolidate, memory_lint, memory_related, orphan_documents,
-    parse_iso8601_to_epoch, populate_inline_bodies, query_by_property, render_text, tag_graph,
-    tag_graph_all, topic_clusters, truncate_to_budget,
+    generate_agents_md_with_rules, generate_claude_md_with_rules, generate_cursor_rule_with_rules,
+    generate_guide_with_tools, generate_skill_with_tools, generate_summaries, get_all_properties,
+    get_last_indexed_at, investigate, investigate_expand, investigate_hydrate, load_alias_sidecar,
+    load_clusters, load_extensions, memory_consolidate, memory_lint, memory_related,
+    orphan_documents, parse_iso8601_to_epoch, populate_inline_bodies, query_by_property,
+    render_text, tag_graph, tag_graph_all, topic_clusters, truncate_to_budget,
 };
 use nestweaver_schema::SymbolKind;
 use nestweaver_store::tantivy_index::{SearchTotal, SearchTotalRelation};
@@ -957,31 +956,33 @@ fn truncate_utf8_bytes(value: &str, max_bytes: usize) -> String {
     bounded
 }
 
-fn missing_alias_requirement(name: &str, args: &Value) -> Option<&'static str> {
-    if !args.is_object() {
-        return None;
+/// Guidance for an argument sent to the WRONG tool, keyed by (tool, property).
+///
+/// nw-408. `investigate_hydrate` carried this text INSIDE its handler, as a
+/// loop over `["targets", "target", "uid", "uids"]` that returned "it hydrates
+/// the whole bundle — use investigate_expand with 'targets'". Validation runs
+/// first on every route (`dispatch_cancellable`, `dispatch_via_daemon`,
+/// `http.rs`), and `additionalProperties: false` rejects all four keys, so the
+/// handler was never entered and the message was UNREACHABLE dead code. The
+/// authored guidance is better than anything a generic renderer can produce —
+/// it names the tool the caller actually wanted — so it moves to the layer
+/// that runs instead of being deleted.
+///
+/// A table, not a per-tool hook, because the failure mode is generic: an agent
+/// confusing two tools in the same family sends the sibling's argument. Add a
+/// row when a second pair earns one; do not add a second mechanism.
+fn unknown_argument_hint(tool: &str, property: &str) -> Option<String> {
+    match (tool, property) {
+        // Kept inside MAX_VALIDATION_ITEM_BYTES on purpose: the item budget
+        // is what stops a hostile instance from writing the error message, so
+        // the hint is worded to survive it rather than to be truncated
+        // mid-sentence by it.
+        ("investigate_hydrate", "targets" | "target" | "uid" | "uids") => Some(format!(
+            "investigate_hydrate takes no '{property}' — it hydrates the whole bundle. \
+             Use investigate_expand instead."
+        )),
+        _ => None,
     }
-
-    let (first, second, message) = match name {
-        "read_symbols" => (
-            "targets",
-            "uids_or_fqns",
-            "missing required argument: expected 'targets' or 'uids_or_fqns'",
-        ),
-        "regex_search" => (
-            "pattern",
-            "query",
-            "missing required argument: expected 'pattern' or 'query'",
-        ),
-        "detect_changes" => (
-            "changed_files",
-            "files",
-            "missing required argument: expected 'changed_files' or 'files'",
-        ),
-        _ => return None,
-    };
-
-    (args.get(first).is_none() && args.get(second).is_none()).then_some(message)
 }
 
 /// Reject alias pairs that are BOTH present — `regex_search` called with both
@@ -999,7 +1000,141 @@ fn conflicting_alias_error(name: &str, args: &Value) -> Option<&'static str> {
     }
 }
 
-fn render_validation_error(error: &jsonschema::ValidationError<'_>) -> String {
+/// How many offending property names an error message will list before it
+/// collapses the rest into a count. Three is enough to see a pattern; the
+/// names come from the INSTANCE, so an unbounded list is caller-controlled
+/// error length.
+const MAX_NAMED_PROPERTIES: usize = 3;
+
+/// Per-name budget for a quoted property list. The whole item is truncated to
+/// [`MAX_VALIDATION_ITEM_BYTES`] anyway, but truncating per name keeps all
+/// three visible when one of them is hostile rather than letting the first eat
+/// the budget.
+const MAX_PROPERTY_NAME_BYTES: usize = 48;
+
+fn quoted_property_list(names: &[String]) -> String {
+    let mut rendered = names
+        .iter()
+        .take(MAX_NAMED_PROPERTIES)
+        .map(|name| format!("'{}'", truncate_utf8_bytes(name, MAX_PROPERTY_NAME_BYTES)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    if names.len() > MAX_NAMED_PROPERTIES {
+        rendered.push_str(&format!(
+            " (and {} more)",
+            names.len() - MAX_NAMED_PROPERTIES
+        ));
+    }
+    rendered
+}
+
+/// Render an `anyOf` failure whose branches are pure `required` groups as the
+/// either/or prose it actually means.
+///
+/// nw-410. The eight either/or tools now declare
+/// `anyOf: [{required:["uid"]},{required:["title"]}]`, so `tools/list`,
+/// `brain_guide` and the validator read ONE source. Left unrendered, that
+/// costs the caller the message the hand-coded `missing_alias_requirement`
+/// used to produce: bare `anyOf` reports `/` and a keyword and names nothing.
+///
+/// The phrasing is "provide either 'a' or 'b'" because that is the wording
+/// five of the eight HANDLERS already use for the same requirement
+/// (`note_get`, `backlinks`, `cross_repo_contracts`, `affected_tests`,
+/// `query_extensions`). Those handler errors are now shadowed on the MCP route
+/// — validation runs first — so the message a caller sees must not change
+/// meaning just because it started arriving one layer earlier.
+///
+/// Returns empty for any `anyOf` that is not a pure requirement group — a
+/// branch that constrains a value rather than demanding a key cannot be
+/// summarised as "either X or Y" without lying about it.
+fn either_or_detail(context: &[Vec<jsonschema::ValidationError<'static>>]) -> String {
+    use jsonschema::error::ValidationErrorKind as Kind;
+
+    let mut branches = Vec::new();
+    for branch in context {
+        let mut missing = Vec::new();
+        for error in branch {
+            let Kind::Required { property } = error.kind() else {
+                return String::new();
+            };
+            let Some(property) = property.as_str() else {
+                return String::new();
+            };
+            missing.push(format!(
+                "'{}'",
+                truncate_utf8_bytes(property, MAX_PROPERTY_NAME_BYTES)
+            ));
+        }
+        // A branch needing several keys at once (`query_extensions`
+        // key+value) reads as "both 'key' and 'value'", so a conjunction is
+        // never mistaken for one more choice.
+        branches.push(match missing.len() {
+            0 => return String::new(),
+            1 => missing.remove(0),
+            2 => format!("both {} and {}", missing[0], missing[1]),
+            _ => format!("all of {}", missing.join(", ")),
+        });
+    }
+    match branches.len() {
+        0 => String::new(),
+        1 => format!(" — provide {}", branches[0]),
+        2 => format!(" — provide either {} or {}", branches[0], branches[1]),
+        _ => format!(" — provide one of {}", branches.join(", ")),
+    }
+}
+
+/// The part of a validation message that names WHAT failed, not just which
+/// keyword rejected it.
+///
+/// nw-408. `additionalProperties` was the ONE error class that withheld the
+/// property name: `instance_path` is `""` for it (the object as a whole
+/// violated the keyword, not any one member), so every one of the 42 tools —
+/// all of which set `additionalProperties: false` — answered a typo with the
+/// identical, unactionable `/: schema keyword 'additionalProperties' failed`.
+/// The name was never missing, only discarded: `jsonschema` carries it in
+/// `ValidationErrorKind::AdditionalProperties { unexpected }`.
+///
+/// This is the shared renderer, so the CLI face of the same defect (nw-400)
+/// is fixed by the same code rather than by a second MCP-only special case.
+///
+/// Deliberately contains no `; ` — that is the separator
+/// [`validate_tool_arguments`] joins its (at most three) errors with.
+fn validation_error_detail(tool: &str, kind: &jsonschema::error::ValidationErrorKind) -> String {
+    use jsonschema::error::ValidationErrorKind as Kind;
+
+    match kind {
+        Kind::AdditionalProperties { unexpected } | Kind::UnevaluatedProperties { unexpected } => {
+            let plural = if unexpected.len() == 1 { "" } else { "s" };
+            let mut detail = format!(
+                " — unknown argument{plural} {}",
+                quoted_property_list(unexpected)
+            );
+            if let Some(hint) = unexpected
+                .iter()
+                .find_map(|property| unknown_argument_hint(tool, property))
+            {
+                detail.push_str(". ");
+                detail.push_str(&hint);
+            }
+            detail
+        }
+        // `required` reports the OBJECT's path, so without the name a nested
+        // failure is as anonymous as `additionalProperties` was.
+        Kind::Required { property } => property
+            .as_str()
+            .map(|property| {
+                format!(
+                    " — missing required argument '{}'",
+                    truncate_utf8_bytes(property, MAX_PROPERTY_NAME_BYTES)
+                )
+            })
+            .unwrap_or_default(),
+        Kind::AnyOf { context } => either_or_detail(context),
+        _ => String::new(),
+    }
+}
+
+fn render_validation_error(tool: &str, error: &jsonschema::ValidationError<'_>) -> String {
     let instance_path = error.instance_path().to_string();
     let instance_path = if instance_path.is_empty() {
         "/".to_string()
@@ -1008,8 +1143,9 @@ fn render_validation_error(error: &jsonschema::ValidationError<'_>) -> String {
     };
     truncate_utf8_bytes(
         &format!(
-            "{instance_path}: schema keyword '{}' failed",
-            error.kind().keyword()
+            "{instance_path}: schema keyword '{}' failed{}",
+            error.kind().keyword(),
+            validation_error_detail(tool, error.kind())
         ),
         MAX_VALIDATION_ITEM_BYTES,
     )
@@ -1023,15 +1159,19 @@ pub fn validate_tool_arguments(name: &str, args: &Value) -> Result<(), anyhow::E
         return Err(anyhow!(message));
     };
 
-    let errors: Vec<String> = if let Some(message) = missing_alias_requirement(name, args) {
-        vec![truncate_utf8_bytes(message, MAX_VALIDATION_ITEM_BYTES)]
-    } else if let Some(message) = conflicting_alias_error(name, args) {
+    let errors: Vec<String> = if let Some(message) = conflicting_alias_error(name, args) {
         vec![truncate_utf8_bytes(message, MAX_VALIDATION_ITEM_BYTES)]
     } else {
+        // nw-410: the missing-alias rule used to short-circuit here, hand-coded
+        // for 3 of the 8 either/or tools. It now lives in each schema as
+        // `anyOf: [{required: [...]}, ...]`, which the validator honours and
+        // `either_or_detail` renders with the same wording — so `tools/list`,
+        // `brain_guide`'s key-parameter column and this error all derive from
+        // one declaration instead of drifting apart.
         validator
             .iter_errors(args)
             .take(3)
-            .map(|error| render_validation_error(&error))
+            .map(|error| render_validation_error(name, &error))
             .collect()
     };
     if errors.is_empty() {
@@ -1364,21 +1504,272 @@ mod tool_schema_validation_tests {
         assert!(error.starts_with("unknown tool: "));
     }
 
+    /// nw-410. All EIGHT either/or tools, not the three that were hand-coded,
+    /// and the requirement is asserted in the two places that used to
+    /// disagree: the validation error AND `brain_guide`'s key-parameter cell.
     #[test]
     fn missing_alias_pairs_name_every_accepted_field() {
-        for (name, accepted) in [
-            ("read_symbols", ["targets", "uids_or_fqns"]),
-            ("regex_search", ["pattern", "query"]),
-            ("detect_changes", ["changed_files", "files"]),
-        ] {
+        let entries = tool_doc_entries();
+        for &(name, accepted) in EITHER_OR_TOOLS {
             let error = assert_invalid(name, json!({}));
+            let (_, _, _, key_params) = entries
+                .iter()
+                .find(|(entry, ..)| entry.as_str() == name)
+                .unwrap_or_else(|| panic!("{name} is not in the doc table"));
+            let cell = key_params.join(", ");
             for field in accepted {
                 assert!(
                     error.contains(field),
                     "{name} missing-argument error must name '{field}': {error}"
                 );
+                assert!(
+                    cell.contains(field),
+                    "brain_guide's key-parameter cell for {name} must name '{field}': {cell:?}"
+                );
+            }
+            // The cell is rendered into a MARKDOWN TABLE row; a pipe would
+            // split it into an extra column in the file this gets written to.
+            assert!(
+                !cell.contains('|'),
+                "{name} key-parameter cell would break the guide's table: {cell:?}"
+            );
+        }
+    }
+
+    /// The eight tools whose requirement is an either/or, with the spellings
+    /// each accepts. `query_extensions` needs `key` AND `value` together in
+    /// its second mode, which is why the table holds three names for it.
+    const EITHER_OR_TOOLS: &[(&str, &[&str])] = &[
+        ("read_symbols", &["targets", "uids_or_fqns"]),
+        ("regex_search", &["pattern", "query"]),
+        ("detect_changes", &["changed_files", "files"]),
+        ("note_get", &["uid", "title"]),
+        ("backlinks", &["uid", "title"]),
+        ("cross_repo_contracts", &["uid", "name"]),
+        ("affected_tests", &["changed_files", "base_ref"]),
+        ("query_extensions", &["uid", "key", "value"]),
+    ];
+
+    /// COUNTERWEIGHT to `missing_alias_pairs_name_every_accepted_field`:
+    /// nw-410's `anyOf` must express "one of these", never "all of these".
+    ///
+    /// The failure this guards against is the obvious mis-encoding — writing
+    /// the alternatives into `required` — which would turn every one of these
+    /// eight tools into a call that can no longer be made at all.
+    #[test]
+    fn either_or_requirements_are_satisfied_by_either_side_alone() {
+        for (name, args) in [
+            ("read_symbols", json!({ "targets": ["sym:x"] })),
+            ("read_symbols", json!({ "uids_or_fqns": ["sym:x"] })),
+            ("regex_search", json!({ "pattern": "fn\\s+x" })),
+            ("regex_search", json!({ "query": "fn\\s+x" })),
+            ("detect_changes", json!({ "changed_files": ["src/a.rs"] })),
+            ("detect_changes", json!({ "files": ["src/a.rs"] })),
+            ("note_get", json!({ "uid": "note:vlt:V:abc" })),
+            ("note_get", json!({ "title": "Home" })),
+            ("backlinks", json!({ "uid": "note:vlt:V:abc" })),
+            ("backlinks", json!({ "title": "Home" })),
+            ("cross_repo_contracts", json!({ "uid": "sym:x" })),
+            ("cross_repo_contracts", json!({ "name": "UserService" })),
+            ("affected_tests", json!({ "changed_files": ["src/a.rs"] })),
+            ("affected_tests", json!({ "base_ref": "main" })),
+            ("query_extensions", json!({ "uid": "sym:x" })),
+            (
+                "query_extensions",
+                json!({ "key": "team", "value": "core" }),
+            ),
+        ] {
+            assert_valid(name, args);
+        }
+
+        // ...and a branch that needs two keys is not satisfied by one of them.
+        let error = assert_invalid("query_extensions", json!({ "key": "team" }));
+        assert!(error.contains("value"), "{error}");
+    }
+
+    /// nw-410's acceptance criterion, asserted over the REGISTRY so tool 43
+    /// cannot be added with a silent cell — the same rule
+    /// `every_registered_schema_rejects_unknown_arguments` enforces for
+    /// `additionalProperties`.
+    ///
+    /// This matters beyond documentation: `brain_guide{format: "claude-md" |
+    /// "agents-md" | "skill"}` WRITES this table into a persistent
+    /// agent-instruction file, so an em-dash where a requirement belongs is
+    /// checked in and misleads every later session.
+    #[test]
+    fn no_guide_entry_is_silent_about_a_requirement_it_enforces() {
+        let mut silent = Vec::new();
+        let mut over_stated = Vec::new();
+        for (name, _category, _purpose, key_params) in tool_doc_entries() {
+            let rejects_empty = validate_tool_arguments(&name, &json!({})).is_err();
+            if rejects_empty && key_params.is_empty() {
+                silent.push(name);
+            } else if !rejects_empty && !key_params.is_empty() {
+                // COUNTERWEIGHT: a tool that happily accepts `{}` must not
+                // advertise a requirement it does not have. Over-applying the
+                // fix would send agents hunting for a mandatory argument that
+                // is optional.
+                over_stated.push(name);
             }
         }
+        assert!(
+            silent.is_empty(),
+            "these tools render an empty key-parameter cell while rejecting an empty \
+             argument object, and brain_guide writes that into CLAUDE.md/AGENTS.md/SKILL.md: \
+             {silent:?}"
+        );
+        assert!(
+            over_stated.is_empty(),
+            "these tools advertise a required parameter but accept an empty call: {over_stated:?}"
+        );
+    }
+
+    /// nw-408. `additionalProperties` was the ONE error class that named
+    /// nothing, and it is the likeliest failure for an LLM client because all
+    /// 42 tools set `additionalProperties: false`.
+    #[test]
+    fn an_unknown_argument_is_named_and_a_correctly_spelled_one_is_not_disturbed() {
+        let error = assert_invalid("flow_trace", json!({ "symbol": "s", "max_dpeth": 100 }));
+        assert!(error.contains("additionalProperties"), "{error}");
+        assert!(
+            error.contains("'max_dpeth'"),
+            "the unknown-property error must name the property: {error}"
+        );
+
+        // Two typos at once used to yield one message with zero names.
+        let both = assert_invalid(
+            "flow_trace",
+            json!({ "symbol": "s", "max_dpeth": 1, "respons_format": "concise" }),
+        );
+        assert!(both.contains("'max_dpeth'"), "{both}");
+        assert!(both.contains("'respons_format'"), "{both}");
+
+        // COUNTERWEIGHT: the correctly-spelled call still validates, and a
+        // DIFFERENT error class keeps naming its own instance path rather than
+        // being relabelled as an unknown argument.
+        assert_valid("flow_trace", json!({ "symbol": "s", "max_depth": 15 }));
+        let ranged = assert_invalid("flow_trace", json!({ "symbol": "s", "max_depth": 100 }));
+        assert!(ranged.contains("/max_depth"), "{ranged}");
+        assert!(
+            !ranged.contains("unknown argument"),
+            "an out-of-range value is not an unknown argument: {ranged}"
+        );
+    }
+
+    /// nw-408's sharp consequence. `investigate_hydrate` carried purpose-built
+    /// typo guidance in its HANDLER, behind validation, so
+    /// `additionalProperties: false` rejected all four keys first and the good
+    /// message was unreachable on every MCP path. The guard is deleted; the
+    /// message now comes from `unknown_argument_hint`, which the validator
+    /// reaches.
+    #[test]
+    fn investigate_hydrate_typo_guidance_is_reachable_and_stays_scoped_to_that_tool() {
+        for key in ["targets", "target", "uid", "uids"] {
+            let error = assert_invalid(
+                "investigate_hydrate",
+                json!({ "bundle_id": "b", key: ["sym:x"] }),
+            );
+            assert!(
+                error.contains(&format!("'{key}'")),
+                "hydrate's rejection must name '{key}': {error}"
+            );
+            assert!(
+                error.contains("investigate_expand"),
+                "hydrate's rejection must point at investigate_expand: {error}"
+            );
+            // The per-item byte budget must not eat the remedy. A hint that
+            // truncates mid-sentence is only marginally better than the
+            // anonymous message it replaced.
+            assert!(
+                !error.contains('\u{2026}'),
+                "the guidance must fit MAX_VALIDATION_ITEM_BYTES intact: {error}"
+            );
+        }
+
+        // COUNTERWEIGHT: the hint is keyed to (tool, property), so the tool
+        // that legitimately TAKES `targets` is untouched, and an unrelated
+        // typo on hydrate is not given advice about a tool that would not
+        // have helped either.
+        assert_valid(
+            "investigate_expand",
+            json!({ "bundle_id": "b", "targets": ["sym:x"] }),
+        );
+        let unrelated = assert_invalid(
+            "investigate_hydrate",
+            json!({ "bundle_id": "b", "bogus": 1 }),
+        );
+        assert!(unrelated.contains("'bogus'"), "{unrelated}");
+        assert!(
+            !unrelated.contains("investigate_expand"),
+            "an unrelated typo must not be given hydrate/expand advice: {unrelated}"
+        );
+    }
+
+    /// nw-411. `brain_memory_related` bounded NOTHING: no `limit` (and
+    /// `additionalProperties: false` rejected one), `depth` with no
+    /// minimum/maximum, and `depth: -1` reinterpreted as the engine default 2
+    /// because `as_u64()` fails.
+    #[test]
+    fn brain_memory_related_rejects_an_unbounded_traversal_without_rejecting_a_legal_one() {
+        for args in [
+            json!({ "uid": "note:x", "depth": -1 }),
+            json!({ "uid": "note:x", "depth": 0 }),
+            json!({ "uid": "note:x", "depth": 16 }),
+            json!({ "uid": "note:x", "depth": 100_000 }),
+            json!({ "uid": "note:x", "limit": 0 }),
+            json!({ "uid": "note:x", "limit": -1 }),
+            json!({ "uid": "note:x", "limit": 1001 }),
+        ] {
+            assert_invalid("brain_memory_related", args);
+        }
+
+        // COUNTERWEIGHT: the bound is not over-applied. Both ends of the
+        // declared range validate, omitting either parameter validates, and
+        // `limit` — which `additionalProperties: false` used to reject
+        // outright, leaving the caller no remedy at all — is now accepted.
+        for args in [
+            json!({ "uid": "note:x" }),
+            json!({ "uid": "note:x", "depth": 1 }),
+            json!({ "uid": "note:x", "depth": 15 }),
+            json!({ "uid": "note:x", "limit": 1 }),
+            json!({ "uid": "note:x", "limit": 5 }),
+            json!({ "uid": "note:x", "limit": 1000 }),
+        ] {
+            assert_valid("brain_memory_related", args);
+        }
+    }
+
+    /// nw-409. `level: "hub"`/`"cluster"` reported `truncated_by_cap: true`
+    /// while declaring no parameter that could raise the cap, and `limit` was
+    /// rejected by `additionalProperties`.
+    #[test]
+    fn get_summary_declares_a_cluster_row_bound_and_still_refuses_an_undeclared_one() {
+        assert_valid(
+            "get_summary",
+            json!({ "level": "cluster", "max_summaries": 500 }),
+        );
+        assert_valid(
+            "get_summary",
+            json!({ "level": "cluster", "max_summaries": 1 }),
+        );
+        assert_valid(
+            "get_summary",
+            json!({ "level": "cluster", "max_summaries": 1000 }),
+        );
+        for args in [
+            json!({ "level": "cluster", "max_summaries": 0 }),
+            json!({ "level": "cluster", "max_summaries": -1 }),
+            json!({ "level": "cluster", "max_summaries": 1001 }),
+        ] {
+            assert_invalid("get_summary", args);
+        }
+
+        // COUNTERWEIGHT, and the nw-408 tie-in: the knob a caller GUESSED at
+        // is still refused — but the refusal now names it, so the caller can
+        // read the schema and find `max_summaries` instead of seeing the same
+        // anonymous `/: schema keyword 'additionalProperties' failed`.
+        let error = assert_invalid("get_summary", json!({ "level": "hub", "limit": 100 }));
+        assert!(error.contains("'limit'"), "{error}");
     }
 
     #[test]
@@ -2172,37 +2563,38 @@ mod tool_schema_validation_tests {
             args
         }
 
-        // Some tools express "one of these two" as an alias rule enforced
-        // beside the schema (`missing_alias_requirement`), not as `required`.
-        // Satisfy it by adding declared properties until the rule is happy,
-        // so the assertion below is about the cache pair and nothing else.
-        fn satisfy_alias_requirement(
-            name: &str,
+        // nw-410: "one of these two" is now declared IN the schema as
+        // `anyOf: [{required: [...]}, ...]` rather than hand-coded beside it,
+        // so satisfying it is reading the first branch instead of consulting a
+        // second table. Satisfied here so the assertion below is about the
+        // cache pair and nothing else.
+        fn satisfy_either_or_requirement(
             schema: &Value,
             args: &mut serde_json::Map<String, Value>,
         ) {
-            if missing_alias_requirement(name, &Value::Object(args.clone())).is_none() {
-                return;
-            }
-            let Some(properties) = schema["properties"].as_object() else {
+            let Some(branch) = schema["anyOf"].as_array().and_then(|b| b.first()) else {
                 return;
             };
-            for (field, declared) in properties {
+            let properties = schema["properties"].as_object();
+            for field in branch["required"].as_array().into_iter().flatten() {
+                let Some(field) = field.as_str() else {
+                    continue;
+                };
                 if args.contains_key(field) {
                     continue;
                 }
-                let value = match declared["type"].as_str().unwrap_or("string") {
+                let declared = properties.and_then(|properties| properties.get(field));
+                let value = match declared
+                    .and_then(|d| d["type"].as_str())
+                    .unwrap_or("string")
+                {
                     "array" => json!(["x"]),
                     "integer" | "number" => json!(1),
                     "boolean" => json!(true),
                     "object" => json!({}),
                     _ => json!("x"),
                 };
-                args.insert(field.clone(), value);
-                if missing_alias_requirement(name, &Value::Object(args.clone())).is_none() {
-                    return;
-                }
-                args.remove(field);
+                args.insert(field.to_string(), value);
             }
         }
 
@@ -2226,7 +2618,7 @@ mod tool_schema_validation_tests {
 
             // Declaring it is not enough — it has to actually validate.
             let mut base = minimal_args(schema);
-            satisfy_alias_requirement(name, schema, &mut base);
+            satisfy_either_or_requirement(schema, &mut base);
             for bypass in [json!({ "cache": "bypass" }), json!({ "no_cache": true })] {
                 let mut args = base.clone();
                 for (key, value) in bypass.as_object().expect("bypass args are an object") {
@@ -2240,6 +2632,58 @@ mod tool_schema_validation_tests {
             }
         }
     }
+}
+
+/// The key-parameter list `brain_guide` publishes for one tool, read from its
+/// `inputSchema` alone.
+///
+/// nw-410. This was `inputSchema.required` and nothing else, so the eight
+/// tools whose requirement is an EITHER/OR — `read_symbols`, `note_get`,
+/// `backlinks`, `cross_repo_contracts`, `query_extensions`, `affected_tests`,
+/// `regex_search`, `detect_changes` — rendered an em-dash in the "Key
+/// parameters" column while erroring on an empty argument object. That is not
+/// a cosmetic doc bug: `brain_guide{format: "claude-md"|"agents-md"|"skill"}`
+/// WRITES the table into a persistent agent-instruction file, so the wrong
+/// entry gets checked in and misleads every later session.
+///
+/// The either/or group now comes from the schema's `anyOf`, which is also what
+/// the validator enforces — one declaration, three consumers.
+fn key_parameter_names(input_schema: &Value) -> Vec<String> {
+    let mut names: Vec<String> = input_schema["required"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    if let Some(either_or) = either_or_requirement(input_schema) {
+        names.push(either_or);
+    }
+    names
+}
+
+/// `anyOf: [{required: [...]}, ...]` rendered as prose: `"uid or title"`, or
+/// `"uid or key + value"` when a branch needs two keys at once.
+///
+/// Joined with the word "or", never a `|`: the guide renders these into a
+/// MARKDOWN TABLE cell, where a pipe would split the row into a new column.
+///
+/// Returns `None` for an `anyOf` that is not a pure requirement group — the
+/// same conservatism [`either_or_detail`] applies, so the guide cannot claim a
+/// value constraint is a parameter name.
+fn either_or_requirement(input_schema: &Value) -> Option<String> {
+    let branches = input_schema["anyOf"].as_array()?;
+    let mut rendered = Vec::new();
+    for branch in branches {
+        let required = branch["required"].as_array()?;
+        let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        if names.is_empty() || names.len() != required.len() {
+            return None;
+        }
+        rendered.push(names.join(" + "));
+    }
+    (!rendered.is_empty()).then(|| rendered.join(" or "))
 }
 
 /// Returns structured documentation metadata for every registered tool.
@@ -2307,14 +2751,7 @@ pub fn tool_doc_entries() -> Vec<(String, String, String, Vec<String>)> {
             // Take just the first sentence/line as purpose
             let purpose = desc.split('\n').next().unwrap_or(desc).to_string();
             let category = cat_map.get(name.as_str()).unwrap_or(&"Other").to_string();
-            let key_params: Vec<String> = t["inputSchema"]["required"]
-                .as_array()
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(String::from))
-                        .collect()
-                })
-                .unwrap_or_default();
+            let key_params = key_parameter_names(&t["inputSchema"]);
             (name, category, purpose, key_params)
         })
         .collect()
@@ -3726,6 +4163,15 @@ fn tool_schema_read_symbols() -> Value {
                     "description": "Repository root for resolving file paths (default: server working directory)."
                 }
             },
+            // nw-410: the either/or requirement, declared where the
+            // validator, `tools/list` and `brain_guide` can all read it.
+            // Hand-coded beside the schema it was invisible to the guide,
+            // which published "Key parameters: —" for this tool and WROTE
+            // THAT into CLAUDE.md/AGENTS.md/SKILL.md via `format:`.
+            "anyOf": [
+                { "required": ["targets"] },
+                { "required": ["uids_or_fqns"] }
+            ],
             "additionalProperties": false
         }
     })
@@ -3821,6 +4267,15 @@ fn tool_schema_regex_search() -> Value {
                 "cache": { "type": "string", "description": "Set to \"bypass\" to skip the response cache for this call." },
                 "no_cache": { "type": "boolean", "description": "When true, skip the response cache for this call." }
             },
+            // nw-410: the either/or requirement, declared where the
+            // validator, `tools/list` and `brain_guide` can all read it.
+            // Hand-coded beside the schema it was invisible to the guide,
+            // which published "Key parameters: —" for this tool and WROTE
+            // THAT into CLAUDE.md/AGENTS.md/SKILL.md via `format:`.
+            "anyOf": [
+                { "required": ["pattern"] },
+                { "required": ["query"] }
+            ],
             "additionalProperties": false
         }
     })
@@ -4205,18 +4660,47 @@ fn tool_brain_memory_related(store: &GraphStore, args: Value) -> Result<Value, a
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow!("'uid' (string) is required"))?;
     let edge_types = parse_string_array(&args, "edge_types").unwrap_or_default();
-    let depth = args
-        .get("depth")
-        .and_then(|v| v.as_u64())
-        .map(|n| n as usize);
-    let related = memory_related(store, uid, &edge_types, depth)?;
-    Ok(json!({ "related": serde_json::to_value(&related)?, "total": related.len() }))
+    // nw-411: `read_limit`, not `as_u64()`. `as_u64` collapses "absent",
+    // "negative" and "not an integer" into one `None`, so `depth: -1` fell
+    // through to the engine default of 2 and the caller was told nothing —
+    // they believed they had set -1 and got a confident answer to a request
+    // they did not make. The bound is 1..=15, the same range every sibling
+    // traversal (`flow_trace`, `brain_impact`, `blast_radius`) declares.
+    let depth = read_limit(&args, "depth", MEMORY_RELATED_DEFAULT_DEPTH, 1, 15)?;
+    // nw-411: this tool had NO bound at all, and `additionalProperties: false`
+    // rejected a `limit` a caller tried to add — an unbounded list-returning
+    // MCP tool with no client-side remedy, the same defect nw-299 fixed for
+    // `clusters`.
+    let limit = read_limit(
+        &args,
+        "limit",
+        configured_result_limit(),
+        1,
+        RESULT_LIMIT_MAX,
+    )?;
+    let related = memory_related(store, uid, &edge_types, Some(depth))?;
+    let rows: Vec<Value> = related
+        .iter()
+        .map(serde_json::to_value)
+        .collect::<Result<_, serde_json::Error>>()?;
+    // nw-411: through `Bounded`, so `returned`/`truncated` ride along with
+    // `total` rather than leaving a caller to infer the cut from `related.len()
+    // < total` — a comparison the old `{related, total}` envelope made
+    // impossible, since `total` WAS `related.len()`.
+    let mut out = json!({ "depth": depth });
+    Bounded::take(rows, limit).merge_into(&mut out, "related");
+    Ok(out)
 }
+
+/// The engine's own BFS default, restated here because the schema must
+/// advertise a `default` a caller can rely on and `read_limit` needs a value
+/// for the absent case.
+const MEMORY_RELATED_DEFAULT_DEPTH: usize = 2;
 
 fn tool_schema_brain_memory_related() -> Value {
     json!({
         "name": "brain_memory_related",
-        "description": "Walk the typed relationship graph from a note — Supersedes, DependsOn, CausedBy, RelatesTo — without generic wikilink noise.\n\nGuidelines:\n- BFS traversal from seed uid over chosen edge_types to configurable depth (default 2)\n- Returns only typed neighbours, not generic wikilinks\n- Empty on unknown node or no-vault database\n\nLimitations:\n- Only follows the four typed edge types, not wikilinks or tag co-occurrence\n- Maximum traversal depth may miss distant relationships",
+        "description": "Walk the typed relationship graph from a note — Supersedes, DependsOn, CausedBy, RelatesTo — without generic wikilink noise.\n\nGuidelines:\n- BFS traversal from seed uid over chosen edge_types to `depth` (1-15, default 2)\n- Returns only typed neighbours, not generic wikilinks\n- Bounded: `total` is the pre-cap match count, `returned` the page, `truncated` says whether `limit` cut it — raise `limit` to see the rest\n- Empty on unknown node or no-vault database\n\nLimitations:\n- Only follows the four typed edge types, not wikilinks or tag co-occurrence\n- Maximum traversal depth may miss distant relationships",
         "inputSchema": {
             "type": "object",
             "additionalProperties": false,
@@ -4227,7 +4711,16 @@ fn tool_schema_brain_memory_related() -> Value {
                     "items": { "type": "string" },
                     "description": "Edge types to follow (Supersedes, DependsOn, CausedBy, RelatesTo; case/format-insensitive). Default: all four."
                 },
-                "depth": { "type": "integer", "description": "Max BFS depth (default 2).", "default": 2 }
+                // nw-411. Declared with no minimum/maximum, `depth: 100000` was
+                // ACCEPTED and `depth: -1` was silently reinterpreted as 2.
+                // 1..=15 is the range `flow_trace`, `brain_impact` and
+                // `blast_radius` already declare for the same traversal shape.
+                "depth": limit_schema(
+                    "Max BFS depth (1-15, default 2). Out-of-range values are REJECTED, never clamped or defaulted.",
+                    MEMORY_RELATED_DEFAULT_DEPTH, 1, 15),
+                "limit": limit_schema(
+                    "Max related notes to return (1-1000, default 50). The pre-cap total is always reported as `total`, with `returned` and `truncated`.",
+                    DEFAULT_RESULT_LIMIT, 1, RESULT_LIMIT_MAX)
             },
             "required": ["uid"]
         }
@@ -6824,7 +7317,16 @@ fn tool_schema_note_get() -> Value {
                     "items": { "type": "string" },
                     "description": "Optional list of heading names. If provided, returns only those sections instead of the full body. Case-insensitive match."
                 }
-            }
+            },
+            // nw-410: the either/or requirement, declared where the
+            // validator, `tools/list` and `brain_guide` can all read it.
+            // Hand-coded beside the schema it was invisible to the guide,
+            // which published "Key parameters: —" for this tool and WROTE
+            // THAT into CLAUDE.md/AGENTS.md/SKILL.md via `format:`.
+            "anyOf": [
+                { "required": ["uid"] },
+                { "required": ["title"] }
+            ]
         }
     })
 }
@@ -6970,7 +7472,16 @@ fn tool_schema_backlinks() -> Value {
             "properties": {
                 "uid": { "type": "string", "description": "Note UID (e.g. note:vlt:MyVault:abc123). Preferred for unambiguous lookup." },
                 "title": { "type": "string", "description": "Note title (case-insensitive match). Returns backlinks for the first matching note." }
-            }
+            },
+            // nw-410: the either/or requirement, declared where the
+            // validator, `tools/list` and `brain_guide` can all read it.
+            // Hand-coded beside the schema it was invisible to the guide,
+            // which published "Key parameters: —" for this tool and WROTE
+            // THAT into CLAUDE.md/AGENTS.md/SKILL.md via `format:`.
+            "anyOf": [
+                { "required": ["uid"] },
+                { "required": ["title"] }
+            ]
         }
     })
 }
@@ -8504,7 +9015,16 @@ fn tool_schema_cross_repo_contracts() -> Value {
                 "limit": limit_schema(
                     "Max contract links to return (1-1000, default 50). The total count is always reported.",
                     DEFAULT_RESULT_LIMIT, 1, RESULT_LIMIT_MAX)
-            }
+            },
+            // nw-410: the either/or requirement, declared where the
+            // validator, `tools/list` and `brain_guide` can all read it.
+            // Hand-coded beside the schema it was invisible to the guide,
+            // which published "Key parameters: —" for this tool and WROTE
+            // THAT into CLAUDE.md/AGENTS.md/SKILL.md via `format:`.
+            "anyOf": [
+                { "required": ["uid"] },
+                { "required": ["name"] }
+            ]
         }
     })
 }
@@ -9451,7 +9971,16 @@ fn tool_schema_detect_changes() -> Value {
                     "description": "Max affected symbols AND max affected processes to inline (default 50). The totals are always reported as affected_symbol_count / affected_process_count, and truncated says whether anything was omitted. NOTE: the cut is positional, not by importance — symbols are ordered by (file_path, name) and processes by name, because neither carries an impact score. Raise limit rather than assuming the first N are the most impactful; for ranked results use blast_radius.",
                     "default": DEFAULT_RESULT_LIMIT
                 }
-            }
+            },
+            // nw-410: the either/or requirement, declared where the
+            // validator, `tools/list` and `brain_guide` can all read it.
+            // Hand-coded beside the schema it was invisible to the guide,
+            // which published "Key parameters: —" for this tool and WROTE
+            // THAT into CLAUDE.md/AGENTS.md/SKILL.md via `format:`.
+            "anyOf": [
+                { "required": ["changed_files"] },
+                { "required": ["files"] }
+            ]
         }
     })
 }
@@ -9588,7 +10117,16 @@ fn tool_schema_affected_tests() -> Value {
                     "type": "string",
                     "description": "Git ref to diff against (e.g. \"main\"). Used when changed_files is omitted; diffs the locally-indexed repo via git."
                 }
-            }
+            },
+            // nw-410: the either/or requirement, declared where the
+            // validator, `tools/list` and `brain_guide` can all read it.
+            // Hand-coded beside the schema it was invisible to the guide,
+            // which published "Key parameters: —" for this tool and WROTE
+            // THAT into CLAUDE.md/AGENTS.md/SKILL.md via `format:`.
+            "anyOf": [
+                { "required": ["changed_files"] },
+                { "required": ["base_ref"] }
+            ]
         }
     })
 }
@@ -10266,7 +10804,16 @@ fn tool_schema_query_extensions() -> Value {
                     "type": "string",
                     "description": "Return all custom properties for this specific node UID. When provided, key and value are ignored."
                 }
-            }
+            },
+            // nw-410: the either/or requirement, declared where the
+            // validator, `tools/list` and `brain_guide` can all read it.
+            // Hand-coded beside the schema it was invisible to the guide,
+            // which published "Key parameters: —" for this tool and WROTE
+            // THAT into CLAUDE.md/AGENTS.md/SKILL.md via `format:`.
+            "anyOf": [
+                { "required": ["uid"] },
+                { "required": ["key", "value"] }
+            ]
         }
     })
 }
@@ -11289,7 +11836,16 @@ fn tool_hub_nodes(store: &GraphStore, args: Value) -> Result<Value, anyhow::Erro
         .unwrap_or(10);
     let concise = is_concise(&args);
 
-    let mut hubs = find_hub_nodes(store, top_n).context("find_hub_nodes")?;
+    // nw-398. The engine already COMPUTES the population this ranking was cut
+    // from; the discarding wrapper threw it away and `count` reported
+    // `len(list)` — the anti-pattern the `Bounded` seam comment names by hand.
+    // The CLI now publishes `total`/`truncated`, and `no_cli_command_discloses_
+    // more_than_its_mcp_twin` forbids the CLI knowing more than this route, so
+    // these two must move together.
+    let found = nestweaver_engine::hubs::find_hub_nodes_bounded(store, top_n)
+        .context("find_hub_nodes_bounded")?;
+    let (hub_total, hub_truncated) = (found.candidate_total, found.truncated());
+    let mut hubs = found.hubs;
 
     // Attach cluster IDs if clustering sidecar exists.
     let db_path = current_db_path(store).unwrap_or_default();
@@ -11327,6 +11883,12 @@ fn tool_hub_nodes(store: &GraphStore, args: Value) -> Result<Value, anyhow::Erro
     let mut resp = json!({
         "top_n": top_n,
         "count": nodes_json.len(),
+        // `count` is KEPT as an alias so no existing consumer breaks;
+        // `returned` is the spelling the Bounded seam standardises on.
+        "returned": nodes_json.len(),
+        "total": hub_total,
+        "truncated": hub_truncated,
+        "total_population": "symbols with at least one code edge (hub/bridge CANDIDATES)",
         "hubs": nodes_json,
         "clustering_available": clustering_available,
     });
@@ -11387,7 +11949,20 @@ fn tool_bridge_nodes(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
         .unwrap_or(10);
     let concise = is_concise(&args);
 
-    let mut bridges = find_bridge_nodes(store, top_n).context("find_bridge_nodes")?;
+    // nw-398. The engine already COMPUTES the population this ranking was cut
+    // from; the discarding wrapper threw it away and `count` reported
+    // `len(list)` — the anti-pattern the `Bounded` seam comment names by hand.
+    // The CLI now publishes `total`/`truncated`, and `no_cli_command_discloses_
+    // more_than_its_mcp_twin` forbids the CLI knowing more than this route, so
+    // these two must move together.
+    let found = nestweaver_engine::bridges::find_bridge_nodes_bounded(store, top_n)
+        .context("find_bridge_nodes_bounded")?;
+    let (bridge_total, bridge_truncated) = (found.candidate_total, found.truncated());
+    // `betweenness_score` is a SAMPLE over at most SAMPLE_LIMIT sources, rendered
+    // to 14 significant digits with nothing in the payload saying so. The digits
+    // cannot carry that; a field can.
+    let (bridge_sampled, bridge_sources) = (found.sampled, found.sources_sampled);
+    let mut bridges = found.bridges;
 
     // Attach community connection info if clustering sidecar exists.
     let db_path = current_db_path(store).unwrap_or_default();
@@ -11418,6 +11993,12 @@ fn tool_bridge_nodes(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
     let mut resp = json!({
         "top_n": top_n,
         "count": nodes_json.len(),
+        "returned": nodes_json.len(),
+        "total": bridge_total,
+        "truncated": bridge_truncated,
+        "total_population": "symbols with at least one code edge (hub/bridge CANDIDATES)",
+        "sampled": bridge_sampled,
+        "sources_sampled": bridge_sources,
         "bridges": nodes_json,
     });
     attach_ranking_staleness(&mut resp, store);
@@ -11733,8 +12314,24 @@ fn tool_schema_get_summary() -> Value {
                 "token_budget": {
                     "type": "integer",
                     "minimum": 0,
-                    "description": "Approximate token cap for the result. Defaults to 20000; pass 0 for unlimited. The response reports `total_available` and sets `truncated` when the cap applied.",
-                }
+                    "description": "Approximate token cap for the result. Defaults to 20000; pass 0 for unlimited. The response reports `total_available` and sets `truncated_by_budget` when THIS cap applied. It does NOT raise the generator's row cap — see `cap_parameter`.",
+                },
+                // nw-409: the row bound for `level: "cluster"`, which had none.
+                // `truncated_by_cap: true` against `total: 19287` named a
+                // remedy that did not exist: the only declared knob was
+                // `token_budget`, raising it tenfold changed nothing (773
+                // tokens against 200,000), and `additionalProperties: false`
+                // rejected any `limit` a caller invented. This is nw-299's fix
+                // for `clusters`, applied one level down.
+                //
+                // Cluster only, because `generate_cluster_summaries_bounded`
+                // already TAKES a cap. Hub's `HUB_COUNT` is a private constant
+                // inside `generate_hub_summaries_bounded`, so hub cannot be
+                // parameterised from here — it is disclosed as an internal
+                // bound instead (`cap_parameter: null`).
+                "max_summaries": limit_schema(
+                    "Max cluster summaries to generate before the token budget applies (1-1000, default 50). ONLY affects `level: \"cluster\"`; the hub cap is internal and cannot be raised. An explicit value bypasses the summary sidecar in both directions, so a differently-capped set is never cached as \"the\" summaries.",
+                    nestweaver_engine::summaries::MAX_CLUSTER_SUMMARIES, 1, RESULT_LIMIT_MAX)
             }
         }
     })
@@ -11752,13 +12349,14 @@ fn tool_schema_get_summary() -> Value {
 fn generate_summaries_reporting_cap(
     store: &GraphStore,
     level: nestweaver_engine::SummaryLevel,
+    cluster_cap: usize,
     cap_dropped: &mut usize,
 ) -> Result<Vec<nestweaver_engine::Summary>, anyhow::Error> {
     match level {
         nestweaver_engine::SummaryLevel::Cluster => {
             let bounded = nestweaver_engine::summaries::generate_cluster_summaries_bounded(
                 store,
-                nestweaver_engine::summaries::MAX_CLUSTER_SUMMARIES,
+                cluster_cap,
             )?;
             *cap_dropped = bounded
                 .matched_total
@@ -11801,6 +12399,24 @@ fn tool_get_summary(store: &GraphStore, args: Value) -> Result<Value, anyhow::Er
         .map(|n| n as usize)
         .unwrap_or(nestweaver_engine::SUMMARY_DEFAULT_TOKEN_BUDGET);
     let token_budget = (requested_budget > 0).then_some(requested_budget);
+    // nw-409. `read_limit` rejects an out-of-range value rather than
+    // substituting the default, so a caller who asks for 5000 is told no
+    // instead of quietly receiving 50 and believing they raised the cap —
+    // which is the same class of dishonesty the item is about.
+    let cluster_cap = read_limit(
+        &args,
+        "max_summaries",
+        nestweaver_engine::summaries::MAX_CLUSTER_SUMMARIES,
+        1,
+        RESULT_LIMIT_MAX,
+    )?;
+    // An EXPLICIT cap must not read from or write to the summary sidecar. The
+    // sidecar stores one set per level with the drop count its writer
+    // recorded; caching a 500-row set under `cluster` would serve 500 rows to
+    // the next default caller (and a cached 50 would be served to a caller who
+    // asked for 500, reporting `truncated_by_cap` they cannot act on). Same
+    // rule the symbol level already follows for its bounded path.
+    let explicit_cluster_cap = args.get("max_summaries").is_some();
 
     // ── Symbol level: bounded, target-pushed-down path (nw-079) ───────────────
     // Symbol summaries are O(symbols × per-symbol caller/callee queries). An
@@ -11882,6 +12498,12 @@ fn tool_get_summary(store: &GraphStore, args: Value) -> Result<Value, anyhow::Er
             "truncated": truncated_by_budget || truncated_by_cap,
             "truncated_by_budget": truncated_by_budget,
             "truncated_by_cap": truncated_by_cap,
+            // nw-409: the same two keys every level publishes, so a caller
+            // parses one envelope. `DEFAULT_SYMBOL_SUMMARY_CAP` is internal
+            // and no parameter raises it, hence null — the remedy is `target`,
+            // which the note names.
+            "cap_parameter": Value::Null,
+            "total_population": "symbols matching `target` (or all symbols when untargeted)",
             "partial": truncated_by_cap,
             "cached": false,
             "note": note,
@@ -11902,7 +12524,7 @@ fn tool_get_summary(store: &GraphStore, args: Value) -> Result<Value, anyhow::Er
     // `no_cache` / `cache: "bypass"` must skip the summary sidecar too, not just
     // the F16 response cache — otherwise a caller asking for fresh data got
     // `cached: true` served from the sidecar, which reads as contradictory.
-    let bypass = cache_bypassed(&args);
+    let bypass = cache_bypassed(&args) || explicit_cluster_cap;
     // F-DC-11. `generate_cluster_summaries` truncates to 50 INSIDE the
     // generator, so a total taken from what it returned reports 50 against a
     // 71,184-community graph and `truncated` computes to false. The honesty
@@ -11928,21 +12550,25 @@ fn tool_get_summary(store: &GraphStore, args: Value) -> Result<Value, anyhow::Er
                 level = level_str,
                 "sidecar has summaries but none at requested level; regenerating"
             );
-            let fresh = generate_summaries_reporting_cap(store, level, &mut cap_dropped)?;
+            let fresh =
+                generate_summaries_reporting_cap(store, level, cluster_cap, &mut cap_dropped)?;
             (fresh, false)
         } else {
             cap_dropped = drops.get(&level.to_string()).copied().unwrap_or(0);
             (level_filtered, true)
         }
     } else {
-        let fresh = generate_summaries_reporting_cap(store, level, &mut cap_dropped)?;
+        let fresh = generate_summaries_reporting_cap(store, level, cluster_cap, &mut cap_dropped)?;
         (fresh, false)
     };
 
     // Persist freshly generated summaries so subsequent calls hit the cache,
     // preserving cached entries at other levels (shared invariant) — and, now,
     // what the generator dropped, so the next reader can say it.
-    if !from_cache && let Some(ref db) = db_path {
+    if !from_cache
+        && !explicit_cluster_cap
+        && let Some(ref db) = db_path
+    {
         merge_and_save_summaries(db, store.graph_generation(), level, &summaries, cap_dropped);
     }
 
@@ -11980,6 +12606,61 @@ fn tool_get_summary(store: &GraphStore, args: Value) -> Result<Value, anyhow::Er
     let total_tokens: usize = display.iter().map(|s| s.token_estimate).sum();
     let text = render_text(&display);
 
+    // nw-409. `{truncated_by_cap: true, total: 130162, tokens_used: 773}` at
+    // `level: "hub"` named a remedy that does not exist: the only declared
+    // knob was `token_budget`, and raising it tenfold to 200,000 returned the
+    // same 30 rows. The pattern copied here is the one `investigate`'s own
+    // description already states — "`token_budget` is recoverable by raising
+    // it; `retrieval_breadth` is an internal bound that is NOT" — made
+    // machine-readable: `cap_parameter` NAMES the parameter that raises the
+    // generator's cap, or is null when no such parameter exists.
+    let cap_parameter = match level {
+        SummaryLevel::Cluster => Some("max_summaries"),
+        _ => None,
+    };
+    // nw-409, second defect. `total`/`total_available` and `returned` count
+    // DIFFERENT populations at hub level: `HubSummaries::matched_total` is
+    // `find_hub_nodes_bounded`'s `candidate_total`, i.e. every symbol with at
+    // least one code edge, not the number of hub summaries obtainable. So the
+    // ratio 30/130162 is not a completeness ratio and no `max_summaries` could
+    // ever close it. Making the two agree means changing the engine's
+    // `HubSummaries` (`crates/nestweaver-engine/src/summaries.rs`, owned
+    // elsewhere), so it is DECLARED here instead of silently mis-implied.
+    let total_population = match level {
+        SummaryLevel::Hub => {
+            "hub CANDIDATES — every symbol with at least one code edge, NOT the number of \
+             hub summaries obtainable, so `total` and `returned` count different populations"
+        }
+        SummaryLevel::Cluster => "non-singleton communities",
+        SummaryLevel::Symbol => "matching symbols",
+        _ => "matching summaries",
+    };
+    let truncated_by_budget = display.len() < after_filter_len;
+    let note = if cap_dropped > 0 {
+        Some(match cap_parameter {
+            Some(parameter) => format!(
+                "{level_str}-level summaries were capped by the generator ({} of {total_available} \
+                 returned); raise `{parameter}` (1-{RESULT_LIMIT_MAX}) to see more. \
+                 `token_budget` does not raise this bound.",
+                display.len()
+            ),
+            None => format!(
+                "{level_str}-level summaries are capped at {} by an INTERNAL bound that no \
+                 parameter raises — `token_budget` cannot recover the rest, and `total` counts \
+                 {total_population}. Narrow with `target`, or use `hub_nodes`/`clusters`, whose \
+                 `limit` is caller-stated.",
+                display.len()
+            ),
+        })
+    } else if truncated_by_budget {
+        Some(format!(
+            "output was cut by `token_budget` ({total_tokens} tokens used); raise it or pass 0 \
+             for unlimited. The generator did not cap this level."
+        ))
+    } else {
+        None
+    };
+
     let mut resp = json!({
         "level": level_str,
         "target": target,
@@ -12007,8 +12688,15 @@ fn tool_get_summary(store: &GraphStore, args: Value) -> Result<Value, anyhow::Er
         // travels WITH the stored set (`SummaryStore::cap_dropped`), and a
         // sidecar that recorded none is treated as a miss rather than as a
         // claim of completeness.
-        "truncated_by_budget": display.len() < after_filter_len,
+        "truncated_by_budget": truncated_by_budget,
         "truncated_by_cap": cap_dropped > 0,
+        // nw-409: which of the two bounds the caller can actually move, and
+        // what the number they are comparing `returned` against counts.
+        // Without these the disclosure prescribed a remedy that provably did
+        // nothing, which is the "wrong-remedy" defect nw-321 exists to close.
+        "cap_parameter": cap_parameter,
+        "total_population": total_population,
+        "note": note,
         "cached": from_cache,
         "summaries": display,
         "summaries_text": text,
@@ -13599,19 +14287,13 @@ fn tool_schema_investigate_hydrate() -> Value {
 }
 
 fn tool_investigate_hydrate(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error> {
-    // hydrate is the BULK operation — it hydrates every un-hydrated entry in the
-    // bundle and takes no per-entry selector. A caller passing `targets`/`target`/
-    // `uid`/`uids` has confused it with investigate_expand; those keys were silently
-    // ignored (a no-op that reads as "nothing to hydrate"), so reject them with a
-    // pointer instead, matching investigate_expand's own strictness.
-    for key in ["targets", "target", "uid", "uids"] {
-        if args.get(key).is_some() {
-            return Err(anyhow!(
-                "investigate_hydrate takes no '{key}' — it hydrates the whole bundle. \
-                 Use investigate_expand with 'targets' to hydrate specific entries."
-            ));
-        }
-    }
+    // nw-408: the `targets`/`target`/`uid`/`uids` guard that used to stand here
+    // was DEAD. hydrate is the BULK operation and declares none of those keys,
+    // so `additionalProperties: false` rejected all four during validation —
+    // which runs before every dispatch arm — and this loop was never entered.
+    // The guidance it carried now lives in `unknown_argument_hint`, keyed by
+    // (tool, property), where the validator that actually rejects the call can
+    // emit it. Re-adding it here would restore the dead code, not the message.
     let bundle_id = args
         .get("bundle_id")
         .and_then(|v| v.as_str())
@@ -16982,11 +17664,21 @@ mod arg_alias_tests {
         // nw-084: hydrate is bulk (no per-entry selector). Passing targets/target/
         // uid/uids was silently ignored (looked like "nothing hydrated"); now it's a
         // clear error pointing to investigate_expand, matching expand's strictness.
+        //
+        // nw-408: asserted through `dispatch`, the route a caller actually
+        // takes. The guard this used to call directly lived in the HANDLER,
+        // behind `additionalProperties: false`, so it was unreachable on every
+        // MCP path and this test was the only thing that ever ran it — a test
+        // passing on dead code. The guidance now comes from
+        // `unknown_argument_hint` during validation, which every route runs.
         let store = GraphStore::in_memory().unwrap();
         for key in ["targets", "target", "uid", "uids"] {
-            let err = tool_investigate_hydrate(
+            let err = dispatch(
                 &store,
+                None,
+                "investigate_hydrate",
                 json!({ "bundle_id": "bndl_x", key: ["sym:whatever"] }),
+                None,
             )
             .unwrap_err()
             .to_string();
@@ -16995,12 +17687,18 @@ mod arg_alias_tests {
                 "expected a pointer to investigate_expand for key {key}, got: {err}"
             );
         }
-        // A well-formed call (no targeting keys) gets PAST the new validation —
-        // it fails later on db-path/bundle resolution, not on a targeting-key
+        // A well-formed call (no targeting keys) gets PAST validation — it
+        // fails later on db-path/bundle resolution, not on a targeting-key
         // rejection.
-        let err = tool_investigate_hydrate(&store, json!({ "bundle_id": "bndl_missing" }))
-            .unwrap_err()
-            .to_string();
+        let err = dispatch(
+            &store,
+            None,
+            "investigate_hydrate",
+            json!({ "bundle_id": "bndl_missing" }),
+            None,
+        )
+        .unwrap_err()
+        .to_string();
         assert!(
             !err.contains("investigate_hydrate takes no"),
             "a well-formed call must pass targeting-key validation, got: {err}"
@@ -18811,6 +19509,191 @@ mod cluster_flag_forwarding_precondition_tests {
             "members is capped at 200 — a DIFFERENT ceiling from limit, which \
              is exactly the kind of asymmetry a single clamp constant would miss"
         );
+    }
+}
+
+#[cfg(test)]
+mod memory_related_bound_tests {
+    use super::*;
+    use nestweaver_engine::index_markdown_directory_in_memory;
+    use std::fs;
+
+    /// A chain Seed → n1 → n2 → … over `DependsOn`, so BFS depth and the row
+    /// cap are independently observable.
+    ///
+    /// nw-411's own note called the blast radius UNMEASURED, because the vault
+    /// it was filed against had no typed Supersedes/DependsOn/CausedBy/
+    /// RelatesTo edges at all and `total` was 0 on every probe. This builds the
+    /// scratch vault that note asks for, so the bound is asserted against real
+    /// traversal output rather than an empty one.
+    fn depends_on_chain(length: usize) -> (tempfile::TempDir, GraphStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("vault");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(
+            root.join("Seed.md"),
+            "---\ndepends_on: [n1]\n---\n# Seed\n\nbody\n",
+        )
+        .unwrap();
+        for i in 1..=length {
+            let body = if i < length {
+                format!("---\ndepends_on: [n{}]\n---\n# n{i}\n", i + 1)
+            } else {
+                format!("# n{i}\n")
+            };
+            fs::write(root.join(format!("n{i}.md")), body).unwrap();
+        }
+        let (_res, store) = index_markdown_directory_in_memory(&root, "default", "v").unwrap();
+        (dir, store)
+    }
+
+    fn seed_uid(store: &GraphStore) -> String {
+        store
+            .list_notes(None)
+            .unwrap()
+            .into_iter()
+            .find(|note| note.title == "Seed")
+            .expect("seed note")
+            .uid
+    }
+
+    /// nw-411. The envelope was `{related, total}` where `total` WAS
+    /// `related.len()`, so `returned < total` — the signal nw-341's note
+    /// relies on for every other F9 tool — was not derivable here.
+    #[test]
+    fn a_capped_memory_traversal_reports_returned_and_truncated_beside_the_precap_total() {
+        let (_dir, store) = depends_on_chain(6);
+        let uid = seed_uid(&store);
+
+        let full = tool_brain_memory_related(&store, json!({ "uid": uid, "depth": 15 })).unwrap();
+        let matched = full["total"].as_u64().expect("total") as usize;
+        assert!(
+            matched >= 4,
+            "the fixture must produce a traversable chain: {full}"
+        );
+        assert_eq!(full["returned"], json!(matched));
+        assert_eq!(
+            full["truncated"],
+            json!(false),
+            "COUNTERWEIGHT: an uncut page must not claim truncation: {full}"
+        );
+        assert_eq!(full["depth"], json!(15), "the honoured depth is echoed");
+
+        let page =
+            tool_brain_memory_related(&store, json!({ "uid": uid, "depth": 15, "limit": 2 }))
+                .unwrap();
+        assert_eq!(page["returned"], json!(2), "{page}");
+        assert_eq!(
+            page["total"],
+            json!(matched),
+            "`total` is the PRE-cap match count, not the page size: {page}"
+        );
+        assert_eq!(page["truncated"], json!(true), "{page}");
+    }
+
+    /// nw-411's acceptance criterion: a negative depth must be REJECTED, not
+    /// reinterpreted. `as_u64()` failed on `-1`, `unwrap_or` fired, and the
+    /// caller got depth 2 while believing they had asked for -1.
+    ///
+    /// Asserted at the HANDLER, not only at the schema: `dispatch` is not the
+    /// only route in, and the schema bound and the handler bound are two
+    /// enforcement points on purpose.
+    #[test]
+    fn a_negative_memory_depth_is_refused_rather_than_reinterpreted_as_the_default() {
+        let (_dir, store) = depends_on_chain(3);
+        let uid = seed_uid(&store);
+
+        let error = tool_brain_memory_related(&store, json!({ "uid": uid, "depth": -1 }))
+            .expect_err("a negative depth must not silently become 2")
+            .to_string();
+        assert!(error.contains("depth"), "{error}");
+        assert!(error.contains("out of range"), "{error}");
+
+        // COUNTERWEIGHT: omitting `depth` still gets the documented default,
+        // so rejecting the negative did not turn the parameter into a
+        // mandatory one.
+        let defaulted = tool_brain_memory_related(&store, json!({ "uid": uid })).unwrap();
+        assert_eq!(defaulted["depth"], json!(MEMORY_RELATED_DEFAULT_DEPTH));
+    }
+}
+
+#[cfg(test)]
+mod summary_cap_disclosure_tests {
+    use super::*;
+
+    /// nw-409. `get_summary{level:"hub"}` reported `truncated_by_cap: true`
+    /// against a 130,162 total while declaring no parameter that could raise
+    /// the cap — a disclosure naming a remedy that does not exist. The two
+    /// levels now say WHICH kind of bound they hit, using the split
+    /// `investigate`'s own description already states: "`token_budget` is
+    /// recoverable by raising it; `retrieval_breadth` is an internal bound
+    /// that is NOT."
+    #[test]
+    fn hub_and_cluster_levels_disclose_whether_their_cap_can_be_raised() {
+        let store = GraphStore::in_memory().unwrap();
+
+        let hub = tool_get_summary(&store, json!({ "level": "hub" })).unwrap();
+        assert_eq!(
+            hub["cap_parameter"],
+            Value::Null,
+            "hub's HUB_COUNT is a private engine constant — claiming a parameter \
+             raises it would be the same wrong remedy in a new field: {hub}"
+        );
+        let population = hub["total_population"].as_str().unwrap_or_default();
+        assert!(
+            population.contains("CANDIDATES"),
+            "nw-409's second defect: hub's `total` is `candidate_total`, a DIFFERENT \
+             population from `returned`, and that must be stated: {hub}"
+        );
+
+        // COUNTERWEIGHT: the level whose cap IS raisable names the parameter,
+        // so `cap_parameter: null` means something rather than being a
+        // constant that decorates every response.
+        let cluster = tool_get_summary(&store, json!({ "level": "cluster" })).unwrap();
+        assert_eq!(
+            cluster["cap_parameter"],
+            json!("max_summaries"),
+            "{cluster}"
+        );
+        assert!(
+            cluster["total_population"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("communities"),
+            "{cluster}"
+        );
+
+        // An uncapped, unbudget-cut answer must not manufacture a remedy.
+        // `note` is a SHARED, accumulating channel (`attach_note`) that hub
+        // level also uses for nw-370's ranking-staleness disclosure, so this
+        // asserts the absence of the cap prose specifically rather than an
+        // empty note.
+        assert_eq!(hub["truncated_by_cap"], json!(false), "{hub}");
+        assert!(
+            !hub["note"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("INTERNAL bound"),
+            "a complete answer has no cap remedy to name: {hub}"
+        );
+    }
+
+    /// The declared bound has to actually reach the generator — declaring it
+    /// and ignoring it would be the silent-default failure nw-411 is about,
+    /// committed while fixing nw-409.
+    #[test]
+    fn an_explicit_cluster_cap_is_honoured_and_never_cached_as_the_summaries() {
+        let store = GraphStore::in_memory().unwrap();
+        // `max_summaries` is accepted where `limit` was rejected outright, and
+        // an out-of-range value is refused rather than replaced by the default.
+        assert!(
+            tool_get_summary(&store, json!({ "level": "cluster", "max_summaries": 5 })).is_ok()
+        );
+        let error = tool_get_summary(&store, json!({ "level": "cluster", "max_summaries": 0 }))
+            .expect_err("0 is below the declared minimum")
+            .to_string();
+        assert!(error.contains("max_summaries"), "{error}");
+        assert!(error.contains("out of range"), "{error}");
     }
 }
 

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -790,7 +790,7 @@ fn quarantine_orphaned_wal(path: &Path) -> Option<PathBuf> {
 /// free, and it holds even for a lease taken by a path that never armed the
 /// latch.
 ///
-/// HANDOFF, to arm the latch everywhere it is owed: the sole producer of write
+/// DONE in this commit, recorded because the sequencing matters if this is ever unpicked: the latch is armed: the sole producer of write
 /// leases is `nestweaver_daemon::lifecycle::acquire_db_write_lease`, which is
 /// outside this crate. It needs, on the success path,
 /// `nestweaver_store::note_self_held_write_lease(db_path)` stored in a

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -769,19 +769,33 @@ fn quarantine_orphaned_wal(path: &Path) -> Option<PathBuf> {
 /// the corruption runbook — trading nw-404's false alarm for a silent one, on the
 /// exact recovery path nw-332's outage needed.
 ///
-/// `read_write` is the STRUCTURAL proxy for "not the holder", and it is exact
-/// rather than approximate: lbug takes its own write lock on the database file
-/// for a read-write open, so a read-write open by a NON-holder while someone
-/// else is writing fails with "Could not set lock" and never reaches a WAL
-/// verdict at all. The only read-write opener that can arrive here with a lease
-/// held is the holder. Read-only opens are the complement — the direct
-/// `impact --repo` / `brain context --no-tests` route that filed nw-404 — and
-/// they are the ones that get the veto.
+/// `read_write` is a STRUCTURAL PROXY for "not the holder", and it is
+/// APPROXIMATE — an earlier version of this docblock called it "exact rather
+/// than approximate" and that claim was wrong in both directions. What is true:
+/// lbug takes its own write lock on the database file for a read-write open, so
+/// a read-write open by a NON-holder while someone else is writing fails with
+/// "Could not set lock" and never reaches a WAL verdict, which is why
+/// `read_write: true` can safely skip the veto. What is NOT true is the
+/// converse — `read_write: false` does not mean "this open cannot be the
+/// writer". [`GraphStore::migrate_for_read_only`] passes `false` for an open
+/// that is fully write-capable (deliberately, to keep the orphaned-WAL
+/// quarantine arm shut), and nothing stops a caller from taking the lease and
+/// then opening read-only: `nestweaver brain reindex-search` does exactly that.
 ///
-/// HANDOFF, for the exact rather than the structural answer: a self-ownership
-/// latch (the shape `lifecycle::note_local_store_write_lock` already uses to stop
-/// `db_write_lock` destroying its own lock) set by `acquire_db_write_lease`. That
-/// is a `crates/nestweaver-daemon/src/lifecycle.rs` edit.
+/// The exact answer is `error::note_self_held_write_lease`, the process-local
+/// self-ownership latch nw-404's review added, which
+/// `live_writer_holds_write_lease` consults BEFORE the `flock` probe. It is what
+/// stops a self-held lease from suppressing a real `db_wal_corrupt` and blaming
+/// a process that does not exist. This gate stays as the second layer: it is
+/// free, and it holds even for a lease taken by a path that never armed the
+/// latch.
+///
+/// HANDOFF, to arm the latch everywhere it is owed: the sole producer of write
+/// leases is `nestweaver_daemon::lifecycle::acquire_db_write_lease`, which is
+/// outside this crate. It needs, on the success path,
+/// `nestweaver_store::note_self_held_write_lease(db_path)` stored in a
+/// `DbWriteLease` field so latch and lease share a lifetime. That is a
+/// `crates/nestweaver-daemon/src/lifecycle.rs` edit.
 fn open_failure(path: &Path, message: String, read_write: bool) -> StoreError {
     if read_write {
         // nw-346: the frame that knows WHICH database failed attaches the path,
@@ -5379,6 +5393,59 @@ mod live_writer_wal_tests {
             "a read-write open holds the lease itself, so the same probe would \
              be the writer asking about itself — it must keep the corruption \
              verdict and its recovery runbook"
+        );
+    }
+
+    /// nw-404, review defect 1, AT THE OPEN FUNNEL — the frame that decides
+    /// whether the operator sees `db_wal_corrupt`.
+    ///
+    /// `open_failure`'s `read_write` gate cannot cover this case, which is why
+    /// its docblock no longer calls itself exact: `brain reindex-search` takes
+    /// the write lease and then opens READ-ONLY, so it arrives here with
+    /// `read_write: false` while holding the very lease the probe is about to
+    /// find. Without the latch it is told to wait for a process that does not
+    /// exist, and a genuinely damaged log goes unreported.
+    ///
+    /// The counterweight is the same open, same lease, latch dropped: that is
+    /// the daemon-holds-it case nw-404 was filed for, and it must still retract
+    /// the verdict.
+    #[cfg(unix)]
+    #[test]
+    fn a_read_only_open_by_the_lease_holder_itself_still_reports_a_corrupt_wal() {
+        use std::os::unix::io::AsRawFd;
+
+        const ENGINE: &str = "Corrupted wal file. Read out invalid WAL record type.";
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("t.lbug");
+        std::fs::write(&db, b"").unwrap();
+
+        let lease = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(format!("{}.write.lock", db.display()))
+            .unwrap();
+        assert_eq!(
+            unsafe { libc::flock(lease.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+            0,
+            "the test must actually hold the lease or it proves nothing"
+        );
+
+        let latch = crate::error::note_self_held_write_lease(&db);
+        assert_eq!(
+            super::open_failure(&db, ENGINE.to_string(), false).corruption_kind(),
+            Some(crate::error::CorruptionKind::WalUnreadable),
+            "the process that holds the lease is not 'another process' — it must \
+             see the damage and get the runbook, even opening read-only"
+        );
+
+        drop(latch);
+        assert_eq!(
+            super::open_failure(&db, ENGINE.to_string(), false).corruption_kind(),
+            None,
+            "and with the lease held by someone this process did not record, the \
+             read-only open must still report contention rather than damage"
         );
     }
 

--- a/crates/nestweaver-store/src/error.rs
+++ b/crates/nestweaver-store/src/error.rs
@@ -99,6 +99,14 @@ impl std::fmt::Display for CorruptionKind {
 ///    survived) would re-derive `WalUnreadable` from our own disclosure and
 ///    print the move-aside runbook anyway. Evidence and veto have to travel
 ///    together.
+///
+/// This phrase is NOT exclusive to this crate, which is why the sentinel is
+/// scoped to the unreadable-WAL arm and not to the whole classifier: the
+/// daemon's boot refusal (`server.rs`) and `require_exclusive_store_access`
+/// (`src/main.rs`, when the probe cannot name the holder) both emit it verbatim,
+/// and neither has established anything about a write-ahead log. A sentinel that
+/// short-circuited the whole classifier would let either of them suppress a
+/// truncated file or an engine assertion reported in the same error chain.
 pub const LIVE_WRITER_DISCLOSURE: &str = "another process holds the write lease";
 
 /// Path of the write-lease file for `db_path` — `<db>.write.lock`.
@@ -128,6 +136,143 @@ fn write_lease_path(db_path: &Path) -> PathBuf {
     PathBuf::from(name)
 }
 
+/// Every name a lease for `db_path` could be held under, most-canonical first.
+///
+/// nw-404. `write_lease_path` canonicalises and so does the daemon's
+/// `acquire_db_write_lease`, but neither can be sure the other resolved the same
+/// spelling — a `--db` reached through a symlink, or a path whose parent did not
+/// exist when one of them looked, resolves differently. Asking about both names
+/// costs one extra `open` on a path that already ended in an error and removes
+/// the whole class of "the lease WAS held, under the other name".
+///
+/// Extracted from [`live_writer_holds_write_lease`] so the `flock` probe and the
+/// self-ownership latch below cannot disagree about WHICH file they are talking
+/// about: a latch registered under one spelling and probed under the other would
+/// be a latch that silently does nothing.
+fn write_lease_path_candidates(db_path: &Path) -> Vec<PathBuf> {
+    let canonical = write_lease_path(db_path);
+    let mut literal = db_path.to_path_buf().into_os_string();
+    literal.push(".write.lock");
+    let literal = PathBuf::from(literal);
+    if literal == canonical {
+        vec![canonical]
+    } else {
+        vec![canonical, literal]
+    }
+}
+
+/// The lease files THIS process is holding, counted.
+///
+/// nw-404 (review defect 1). `flock` conflicts between open file DESCRIPTIONS,
+/// not processes: a second descriptor opened by the SAME process conflicts
+/// exactly as a stranger's would. So the probe below answers "a live writer
+/// holds this" to the holder ITSELF, and there is no kernel question that can
+/// tell the two apart — `flock` records no owner, and `F_GETLK` cannot see
+/// `flock` locks at all. (`/proc/locks` can, on Linux only, which leaves the
+/// hazard live on macOS.) The only way to know is to remember.
+///
+/// `nestweaver brain reindex-search` is exactly the shape that goes wrong: it
+/// takes the write lease and THEN does a read-only `open_store`. Against a
+/// genuinely damaged WAL the un-latched probe suppresses `db_wal_corrupt` and
+/// blames "another process" — which is precisely the failure the `db_wal_corrupt`
+/// docblock in `src/main.rs` already records against `repair`: "naming a process
+/// that does not exist".
+///
+/// Keyed by LEASE FILE, not by a process-wide boolean, which is deliberate and
+/// buys two things the daemon's `LOCAL_STORE_WRITE_LOCK_HELD` boolean cannot:
+/// holding a lease on database A never suppresses a corruption verdict for
+/// database B, and tests that set the latch do not race their siblings, because
+/// each one keys on its own tempdir. (`lifecycle::db_write_lock_probe` had to be
+/// split apart to be testable for want of that property; 2 failures in 60 runs.)
+///
+/// Counted rather than flagged so nested or repeated leases on one database
+/// release in any order without the last drop clearing a claim someone else
+/// still holds.
+static SELF_HELD_WRITE_LEASES: std::sync::Mutex<std::collections::BTreeMap<PathBuf, usize>> =
+    std::sync::Mutex::new(std::collections::BTreeMap::new());
+
+/// The latch registry, tolerating poisoning.
+///
+/// A panic elsewhere must not turn this into a panic on the CORRUPTION-REPORTING
+/// path: `into_inner` keeps the map (whose invariant is a count, not something a
+/// half-finished mutation can break) rather than unwinding inside an error
+/// classifier that is already handling a failure.
+fn self_held_write_leases()
+-> std::sync::MutexGuard<'static, std::collections::BTreeMap<PathBuf, usize>> {
+    SELF_HELD_WRITE_LEASES
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Proof that THIS process holds the write lease on a database, for as long as
+/// this value lives.
+///
+/// nw-404. Registered by [`note_self_held_write_lease`] and cleared on drop, so
+/// the latch cannot outlive the lease it describes — a stale `true` here would
+/// suppress a genuine corruption report forever, which is the failure mode with
+/// the worse ending.
+#[must_use = "the latch must live as long as the lease does; dropping it \
+              immediately re-arms the writer-liveness veto against this \
+              process's own lease, which is the defect it exists to remove"]
+#[derive(Debug)]
+pub struct SelfHeldWriteLease {
+    /// Every candidate spelling registered, so drop clears exactly what
+    /// registration added.
+    paths: Vec<PathBuf>,
+}
+
+impl Drop for SelfHeldWriteLease {
+    fn drop(&mut self) {
+        let mut held = self_held_write_leases();
+        for path in &self.paths {
+            match held.get_mut(path) {
+                Some(count) if *count > 1 => *count -= 1,
+                _ => {
+                    held.remove(path);
+                }
+            }
+        }
+    }
+}
+
+/// Record that this process now holds the write lease on `db_path`.
+///
+/// nw-404. Call it at the moment the lease is TAKEN and keep the returned value
+/// beside the lease — the two must have the same lifetime or the latch is
+/// either useless (dropped early) or dangerous (dropped late).
+///
+/// HANDOFF: the one producer of write leases is
+/// `nestweaver_daemon::lifecycle::acquire_db_write_lease`, which is outside this
+/// crate. This crate cannot call itself into that path, so until `DbWriteLease`
+/// carries a `SelfHeldWriteLease` field the latch is armed only by callers that
+/// know to do it, and `open_failure`'s `read_write` gate stays as the structural
+/// backstop. The mechanism lives here rather than in the daemon because the
+/// question it answers — "may I call this WAL corrupt?" — is asked here, and a
+/// latch in the upper crate would leave this one asking a question it cannot
+/// answer.
+pub fn note_self_held_write_lease(db_path: &Path) -> SelfHeldWriteLease {
+    let paths = write_lease_path_candidates(db_path);
+    let mut held = self_held_write_leases();
+    for path in &paths {
+        *held.entry(path.clone()).or_insert(0) += 1;
+    }
+    drop(held);
+    SelfHeldWriteLease { paths }
+}
+
+/// Does THIS process hold the write lease on `db_path`, as far as
+/// [`note_self_held_write_lease`] has been told?
+///
+/// Answers only what was RECORDED. An unlatched lease reads `false`, which keeps
+/// the pre-latch behaviour exactly — the veto stays armed — rather than
+/// inventing a claim from a probe that cannot make it.
+pub fn self_holds_write_lease(db_path: &Path) -> bool {
+    let held = self_held_write_leases();
+    write_lease_path_candidates(db_path)
+        .iter()
+        .any(|path| held.contains_key(path))
+}
+
 /// Is `lease_path` locked RIGHT NOW by a process that is still alive?
 ///
 /// nw-404. The lease is an `flock`, and `flock` is the reason this is a proof
@@ -148,6 +293,11 @@ fn write_lease_path(db_path: &Path) -> PathBuf {
 /// * `create(false)`: an absent lease file is a real answer (nobody has ever
 ///   taken a lease on this database), and creating one would leave debris in
 ///   every directory a read-only open ever failed in.
+///
+/// It answers WHETHER, never WHOSE. `flock` conflicts per open file description,
+/// so this returns `true` for a lease the CALLING process holds — see
+/// [`SELF_HELD_WRITE_LEASES`], and never call this without asking the latch
+/// first, or a self-held lease reads as a stranger's.
 ///
 /// Only reached on the corruption branch of a failed open, so the shared lock
 /// is held for microseconds on a path that already ended in an error.
@@ -190,22 +340,35 @@ fn write_lease_is_held(_lease_path: &Path) -> bool {
 /// nw-404, the primitive the classifier consults before it is willing to call a
 /// write-ahead log damaged.
 ///
+/// "LIVE" and "WRITER" are both load-bearing, and the second one is what the
+/// first version of this got wrong. `flock` conflicts per open file DESCRIPTION,
+/// so the raw probe reports a conflict against a lease this very process holds —
+/// it proves someone is writing, not that it is someone ELSE. A caller that took
+/// the lease and then opened read-only (`brain reindex-search`) would therefore
+/// have a genuine WAL corruption suppressed and be told to wait for a process
+/// that does not exist. [`SELF_HELD_WRITE_LEASES`] is consulted FIRST, and only a
+/// lease this process did not record can answer "another writer".
+///
 /// HANDOFF (out of this crate's reach): `write_lease_path` here and
 /// `nestweaver_daemon::lifecycle::write_lease_path` derive the same
 /// `<db>.write.lock` name independently, because the store cannot depend on the
-/// daemon. The lasting shape is for the daemon's to delegate to this one; that
-/// is a `crates/nestweaver-daemon/src/lifecycle.rs` edit. Until then the probe
-/// asks about BOTH the canonicalised and the literal name — a lease held under
-/// either is a live writer, and asking twice on an error path is free.
+/// daemon. The lasting shape is for the daemon's to delegate to this one, and for
+/// `acquire_db_write_lease` to arm the latch; both are
+/// `crates/nestweaver-daemon/src/lifecycle.rs` edits. Until then the probe asks
+/// about BOTH the canonicalised and the literal name — a lease held under either
+/// is a live writer, and asking twice on an error path is free.
 pub fn live_writer_holds_write_lease(db_path: &Path) -> bool {
-    let canonical = write_lease_path(db_path);
-    if write_lease_is_held(&canonical) {
-        return true;
+    let candidates = write_lease_path_candidates(db_path);
+    // The self-ownership latch, before any syscall. Cheap, and it is the only
+    // question whose answer can distinguish "someone is writing" from "someone
+    // ELSE is writing" — see `SELF_HELD_WRITE_LEASES` for why the kernel cannot.
+    {
+        let held = self_held_write_leases();
+        if candidates.iter().any(|path| held.contains_key(path)) {
+            return false;
+        }
     }
-    let mut literal = db_path.to_path_buf().into_os_string();
-    literal.push(".write.lock");
-    let literal = PathBuf::from(literal);
-    literal != canonical && write_lease_is_held(&literal)
+    candidates.iter().any(|path| write_lease_is_held(path))
 }
 
 /// Classify an engine message into a [`CorruptionKind`], or `None` when it
@@ -228,18 +391,6 @@ pub fn live_writer_holds_write_lease(db_path: &Path) -> bool {
 /// calls, where a path is in hand.
 pub fn classify_engine_corruption(message: &str) -> Option<CorruptionKind> {
     let lower = message.to_lowercase();
-    // nw-404. The one exception to "decide from the message alone", and it is
-    // not a heuristic: this phrase is only ever written by
-    // `StoreError::from_engine_message_for_db` AFTER it proved a live writer
-    // holds the lease. The engine's verbatim words ride along in the same
-    // string and still say "corrupted wal", so without this the prose fallback
-    // in `into_diagnostic` re-derives `WalUnreadable` from our own disclosure
-    // and prints the move-aside-your-WAL runbook against a healthy database
-    // being written by the running daemon. A verdict must not be overturned by
-    // the evidence it was careful to preserve.
-    if lower.contains(LIVE_WRITER_DISCLOSURE) {
-        return None;
-    }
     // The engine has at least TWO phrasings for an unreadable log and they do
     // not share a word order:
     //
@@ -253,6 +404,38 @@ pub fn classify_engine_corruption(message: &str) -> Option<CorruptionKind> {
     // has seen one incident; this is the whole reason the classification lives
     // in one function with `Unclassified` underneath it.
     if lower.contains("corrupted wal") || (lower.contains("wal") && lower.contains("corrupt")) {
+        // nw-404. The one exception to "decide from the message alone", and it
+        // sits INSIDE this arm rather than above the whole function because the
+        // phrase has THREE producers and only one of them proved anything:
+        //
+        //   * `StoreError::from_engine_message_for_db`, which writes it only
+        //     after `live_writer_holds_write_lease` said yes — and which carries
+        //     the engine's verbatim "corrupted wal" along with it, so without a
+        //     veto here the prose fallback in `into_diagnostic` (which re-runs
+        //     this classifier over the RENDERED error when no type survived)
+        //     re-derives `WalUnreadable` from our own disclosure and prints the
+        //     move-aside-your-WAL runbook against a healthy database the daemon
+        //     is appending to. A verdict must not be overturned by the evidence
+        //     it was careful to preserve;
+        //   * the daemon's boot refusal in `server.rs` ("another process holds
+        //     the write lease for {db}. Stop it before starting a daemon — two
+        //     writers ... risk corruption."), which proves nothing about a WAL
+        //     and lands in this arm only because it says "corrupt" and a db path
+        //     may contain "wal";
+        //   * `require_exclusive_store_access` in `src/main.rs`, same shape,
+        //     when the lock probe cannot name the holder and it falls back to
+        //     the literal words "another process".
+        //
+        // Scoped to `WalUnreadable` — the only verdict a live append can make
+        // ambiguous. As a whole-function short circuit (which is how this
+        // shipped) any of those three sentences appearing anywhere in an error
+        // chain also suppressed `FileTruncated`, `EngineAssertion` and
+        // `Unclassified`, none of which a writer's liveness has any bearing on:
+        // it traded nw-404's false alarm for a silent one, which is the trade
+        // the whole item exists to refuse.
+        if lower.contains(LIVE_WRITER_DISCLOSURE) {
+            return None;
+        }
         return Some(CorruptionKind::WalUnreadable);
     }
     if lower.contains("shadow pages") || (lower.contains("replay") && lower.contains("read-only")) {
@@ -299,12 +482,16 @@ pub fn classify_engine_corruption(message: &str) -> Option<CorruptionKind> {
 ///   it is what stops this fix from becoming a way to never report corruption.
 /// * The engine's own words survive into whatever the caller returns. The veto
 ///   changes the VERDICT, never the evidence.
-/// * CALLER-SCOPED. `flock` carries no holder identity, so this cannot tell "someone
-///   else is writing" from "I am writing" — and the daemon takes the lease before it
-///   opens the store. The store's open funnel therefore calls this for READ-ONLY
-///   opens only; `db::open_failure` carries that reasoning and the handoff that
-///   would make the answer exact instead of structural. Anyone else calling this
-///   owes the same question.
+/// * CALLER-SCOPED, in two layers. `flock` carries no holder identity, so the
+///   kernel cannot tell "someone else is writing" from "I am writing" — and both
+///   the daemon and every `--no-daemon` writer take the lease before they open the
+///   store. [`note_self_held_write_lease`] is the exact answer: a process that
+///   records its own lease is never told a stranger holds it, which is what makes
+///   `brain reindex-search` (lease, then a read-only open) able to see a genuinely
+///   corrupt WAL again. `db::open_failure`'s `read_write` gate is the second layer
+///   and remains a STRUCTURAL approximation, not an exact one — see its docblock,
+///   which now says which write-capable caller passes `read_write: false`. Anyone
+///   calling this from a frame that might hold the lease owes the latch.
 pub fn classify_engine_corruption_for_db(message: &str, db_path: &Path) -> Option<CorruptionKind> {
     let kind = classify_engine_corruption(message)?;
     if kind == CorruptionKind::WalUnreadable && live_writer_holds_write_lease(db_path) {
@@ -858,6 +1045,160 @@ mod corruption_classification_tests {
                 &db
             ),
             None
+        );
+    }
+
+    /// nw-404, review defect 1: THE SELF-LEASE CASE, which had no test.
+    ///
+    /// `flock` conflicts between open file DESCRIPTIONS, so the probe opens a
+    /// second descriptor and gets `EWOULDBLOCK` from a lease this very process
+    /// holds. `nestweaver brain reindex-search` is exactly that shape — take the
+    /// write lease, then do a read-only `open_store` — so against a GENUINELY
+    /// damaged WAL it suppressed `db_wal_corrupt` and told the operator to wait
+    /// for "another process", which is verbatim the failure the `db_wal_corrupt`
+    /// docblock in `src/main.rs` records against `repair`: "naming a process
+    /// that does not exist".
+    ///
+    /// The counterweight rides in the same test on purpose: the latch must
+    /// retract the claim for THIS lease and for no other. A second database with
+    /// its own held lease keeps its contention answer throughout, and dropping
+    /// the latch restores the veto for the first — so a latch that leaked (by
+    /// database, or by outliving its lease) fails here rather than in the field,
+    /// where it would mean corruption reported as contention forever.
+    #[cfg(unix)]
+    #[test]
+    fn a_write_lease_this_process_holds_itself_cannot_suppress_a_corrupt_wal() {
+        let dir = tempfile::tempdir().unwrap();
+        let mine = dir.path().join("mine.lbug");
+        let theirs = dir.path().join("theirs.lbug");
+        std::fs::write(&mine, b"").unwrap();
+        std::fs::write(&theirs, b"").unwrap();
+        let _my_lease = HeldLease::take(&mine);
+        let _their_lease = HeldLease::take(&theirs);
+
+        // The kernel's answer, which is the defect: a lock held by this process
+        // is indistinguishable from a stranger's.
+        assert!(
+            live_writer_holds_write_lease(&mine),
+            "the raw flock probe cannot see whose descriptor holds the lease — \
+             if this stops being true the latch below is testing nothing"
+        );
+
+        let latch = note_self_held_write_lease(&mine);
+        assert!(
+            self_holds_write_lease(&mine),
+            "the latch must be readable through the same path spelling it was \
+             armed with, or it silently does nothing"
+        );
+        assert!(
+            !live_writer_holds_write_lease(&mine),
+            "a lease this process holds is not ANOTHER process writing"
+        );
+        assert_eq!(
+            classify_engine_corruption_for_db(LIVE_WRITER_WAL_PHRASE, &mine),
+            Some(CorruptionKind::WalUnreadable),
+            "the holder must see a damaged log as damaged; suppressing it here \
+             is the false negative that leaves a corrupt database unreported"
+        );
+        assert_eq!(
+            StoreError::from_engine_message_for_db(LIVE_WRITER_WAL_PHRASE, &mine).corruption_kind(),
+            Some(CorruptionKind::WalUnreadable),
+            "and the recovery runbook must be reachable, which is the whole \
+             point of reporting it"
+        );
+
+        // COUNTERWEIGHT 1: a latch on one database says nothing about another.
+        assert!(
+            !self_holds_write_lease(&theirs),
+            "the latch is keyed by lease file, not by a process-wide flag"
+        );
+        assert!(live_writer_holds_write_lease(&theirs));
+        assert_eq!(
+            classify_engine_corruption_for_db(LIVE_WRITER_WAL_PHRASE, &theirs),
+            None,
+            "a lease held by someone else must still retract the WAL verdict — \
+             that is nw-404's original fix and it must survive this one"
+        );
+
+        // COUNTERWEIGHT 2: the latch cannot outlive the lease. A stale `true`
+        // would suppress every corruption report for this database forever.
+        drop(latch);
+        assert!(!self_holds_write_lease(&mine));
+        assert!(live_writer_holds_write_lease(&mine));
+        assert_eq!(
+            classify_engine_corruption_for_db(LIVE_WRITER_WAL_PHRASE, &mine),
+            None
+        );
+    }
+
+    /// nw-404, review defect 2: the sentinel is SCOPED to the verdict it can
+    /// speak to.
+    ///
+    /// The phrase [`LIVE_WRITER_DISCLOSURE`] has three producers and only one of
+    /// them proved a live writer against a WAL. As a whole-function short
+    /// circuit, either of the other two — the daemon's boot refusal and
+    /// `require_exclusive_store_access`'s "another process holds the write
+    /// lease" — suppressed EVERY corruption kind wherever their prose appeared
+    /// in an error chain, which is a silent failure traded for a loud one.
+    #[test]
+    fn the_live_writer_sentinel_cannot_suppress_a_verdict_it_never_spoke_to() {
+        // The daemon's boot refusal, verbatim from `server.rs`. Note the db
+        // path: a directory called `walnut` puts "wal" in the message and the
+        // sentence already says "corruption", so this lands in the
+        // unreadable-WAL arm on prose alone. It must still be retracted — this
+        // message is about a lease, not a log.
+        const DAEMON_REFUSAL: &str = "another process holds the write lease for \
+             /home/u/walnut/brain.lbug. Stop it before starting a daemon — two writers \
+             against this store risk corruption.";
+        assert_eq!(
+            classify_engine_corruption(DAEMON_REFUSAL),
+            None,
+            "a contention message must never print the move-aside-your-WAL runbook"
+        );
+
+        // ...and the corruption kinds a lease says NOTHING about must survive
+        // the same prose. `into_diagnostic` re-classifies rendered error CHAINS,
+        // so a contention sentence and an engine sentence share one string
+        // routinely.
+        for (phrase, expected) in [
+            (
+                "cannot reindex directly: another process holds the write lease for \
+                 /home/u/brain.lbug. catalog page range starts at 3567 and spans 5 \
+                 pages, outside the database file with 1696 pages",
+                CorruptionKind::FileTruncated,
+            ),
+            (
+                "another process holds the write lease. Assertion failed in file \
+                 \"<crate>/column.cpp\" on line 289: x <= y",
+                CorruptionKind::EngineAssertion,
+            ),
+            (
+                "another process holds the write lease: database error: basic_string",
+                CorruptionKind::EngineAssertion,
+            ),
+        ] {
+            assert_eq!(
+                classify_engine_corruption(phrase),
+                Some(expected),
+                "a lease-contention sentence has no bearing on this verdict and \
+                 must not suppress it: {phrase}"
+            );
+        }
+
+        // And the producer that DID prove a live writer keeps its retraction —
+        // this is the sentinel's actual job and it is unchanged.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        std::fs::write(&db, b"").unwrap();
+        let disclosure = format!(
+            "{LIVE_WRITER_DISCLOSURE} on {} ... The storage engine's own words, \
+             kept verbatim: {LIVE_WRITER_WAL_PHRASE}",
+            db.display()
+        );
+        assert_eq!(
+            classify_engine_corruption(&disclosure),
+            None,
+            "the prose fallback must not re-promote our own disclosure"
         );
     }
 

--- a/crates/nestweaver-store/src/lib.rs
+++ b/crates/nestweaver-store/src/lib.rs
@@ -22,7 +22,9 @@ pub use db::{
     EmbeddingSnapshotState, GraphStore, IndexPublicationLease, PublicationIdentity,
 };
 pub use error::{
-    CancelReason, CorruptionKind, EngineCorruption, StoreError, classify_engine_corruption,
+    CancelReason, CorruptionKind, EngineCorruption, SelfHeldWriteLease, StoreError,
+    classify_engine_corruption, live_writer_holds_write_lease, note_self_held_write_lease,
+    self_holds_write_lease,
 };
 
 /// Re-export the LadybugDB connection type so callers can use transactional

--- a/src/main.rs
+++ b/src/main.rs
@@ -1474,9 +1474,14 @@ fn parse_cluster_resolution(value: &str) -> Result<f64, String> {
                   3   ambiguous match (several symbols share the name)\n  \
                   4   unauthorized (pull)      5   unavailable (pull)\n  \
                   64  usage error — unknown flag, out-of-range value, uncompilable --pattern\n\n\
-                  With --json every one of those outcomes also writes a JSON object to stdout:\n  \
-                  {\"error\":\"not found\", ...} for 2, {\"error\":\"ambiguous\", ...} for 3, and\n  \
-                  {\"error\":\"invalid argument\", ...} for 64. Branch on `error`, not on prose.\n\n\
+                  With --json, exit 2 writes {\"error\":\"not found\", ...} to stdout on the read\n      \
+                  commands listed above; branch on `error`, not on prose.\n  \
+                  NOT UNIVERSAL, and stated precisely because a contract that overreaches is\n      \
+                  worse than none: exit 64 from an out-of-range or unknown FLAG is raised by the\n      \
+                  argument parser BEFORE --json is read, so it writes to stderr and nothing to\n      \
+                  stdout. Only an uncompilable --pattern reaches the JSON path. Exit 3 emits a\n      \
+                  candidate list, and `impact` keys it \"status\", not \"error\". A few commands\n      \
+                  (cross-repo-refs, rank) still write nothing on 2. Check the code, then stderr.\n\n\
                   Shell completions:\n  \
                   nestweaver completions bash > ~/.local/share/bash-completion/completions/nestweaver\n  \
                   nestweaver completions zsh > ~/.zfunc/_nestweaver\n  \
@@ -2276,7 +2281,7 @@ impl RankingBounds {
     }
 
     /// What the DAEMON reply says, which today is nothing — the MCP
-    /// `hub_nodes`/`bridge_nodes` twins still emit `top_n`/`count` and are
+    /// `hub_nodes`/`bridge_nodes` twins emit these as of this commit; the `Option`s stay because an OLDER daemon on the other end of the RPC still answers with
     /// owned by `crates/nestweaver-mcp/src/tools.rs`. Read rather than assumed
     /// so this route publishes the honest totals the moment that half lands,
     /// without a second edit here.
@@ -6622,7 +6627,21 @@ enum BrainCommands {
     /// note-to-note wikilink graph. Each cluster is labelled by its most
     /// central member.
     TopicClusters {
-        #[arg(long, default_value = "0.5", help = "Community-detection resolution")]
+        // nw-400. Same parser as `clusters --resolution`, and it was MISSED on
+        // the first pass — leaving this one flag unbounded meant
+        // `--resolution nan` still reached the MCP validator and surfaced
+        // `invalid arguments for tool 'brain_topic_clusters': /resolution:
+        // schema keyword 'type' failed` at exit 1, naming a tool the CLI user
+        // never invoked. That is verbatim the defect nw-400 exists to remove,
+        // including the `nan` case the item singled out as worse — `nan`
+        // serialises to JSON `null`, so the schema reports a TYPE error for a
+        // value the user spelled as a number.
+        #[arg(
+            long,
+            default_value = "0.5",
+            value_parser = parse_cluster_resolution,
+            help = "Community-detection resolution (> 0, finite)"
+        )]
         resolution: f64,
         // nw-400: the reported case. `brain topic-clusters --limit 0` printed
         // `invalid arguments for tool 'brain_topic_clusters': /limit: schema
@@ -14052,7 +14071,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     let staleness = ResolverStaleness::from_daemon_response(&value, &db_path);
                     // nw-398: captured BEFORE `strip_hybrid_meta` consumes
                     // `value`, alongside the other two. Empty today — the MCP
-                    // `bridge_nodes` twin still publishes `top_n`/`count` — so
+                    // `bridge_nodes` twin publishes these as of this commit; an older daemon does not, so
                     // the payload says `null`, which is the honest "this route
                     // was not told" rather than a fabricated `false`.
                     let bounds = RankingBounds::from_daemon_response(&value);
@@ -39474,7 +39493,7 @@ mod cli_honesty_sweep_tests {
 
     /// The daemon route must publish `null`, not `false`. "This route was not
     /// told" and "nothing was cut" are different claims and only one of them is
-    /// true of today's `hub_nodes` reply, which still carries `top_n`/`count`.
+    /// true of an OLDER daemon's `hub_nodes` reply, which carries only `top_n`/`count`. The current one carries the totals; this test pins the not-told path, which is why it builds the reply by hand.
     #[test]
     fn the_daemon_route_says_it_does_not_know_rather_than_saying_nothing_was_cut() {
         let todays_reply = serde_json::json!({
@@ -39588,9 +39607,43 @@ mod cli_honesty_sweep_tests {
             help.contains("TARGET NOT FOUND"),
             "the top-level help must name the one not-found code: {help}"
         );
-        for fragment in ["Exit codes", "64", "\"not found\"", "invalid argument"] {
+        for fragment in ["Exit codes", "64", "\"not found\""] {
             assert!(help.contains(fragment), "missing {fragment:?} from --help");
         }
+
+        // THE ORIGINAL VERSION OF THIS TEST ASSERTED THAT THE HELP CONTAINED
+        // "invalid argument" — and it passed while that promise was FALSE.
+        // Review measured `brain topic-clusters --limit 0 --json` -> exit 64
+        // with ZERO bytes on stdout, because clap raises the usage error before
+        // `--json` is ever read. The help claimed an envelope for exactly the
+        // class that cannot emit one.
+        //
+        // So the assertion is inverted: a documentation test whose only power is
+        // to check that a sentence EXISTS will happily pin a lie. This one now
+        // requires the exceptions to be stated, and forbids the unqualified
+        // promise from coming back.
+        assert!(
+            !help.contains("With --json every one of those outcomes"),
+            "the unqualified 'every outcome writes JSON' promise is false — exit 64 from a \
+             flag writes nothing to stdout. Do not restore it: {help}"
+        );
+        for exception in [
+            "NOT UNIVERSAL",
+            "BEFORE --json is read",
+            "uncompilable --pattern",
+        ] {
+            assert!(
+                help.contains(exception),
+                "the contract must state its exceptions; missing {exception:?}: {help}"
+            );
+        }
+
+        // The BEHAVIOUR half of this contract is pinned in `tests/cli_test.rs`
+        // (`a_clap_rejected_flag_writes_nothing_to_stdout_as_the_contract_says`),
+        // because only an integration test can spawn the binary. Keeping the two
+        // apart is deliberate: this test guards the WORDS, that one guards the
+        // FACT, and the lie this test now forbids was possible precisely because
+        // nothing guarded the fact.
     }
 
     // ── nw-400 / nw-411 ──────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,14 +98,13 @@ use nestweaver_engine::{
     build_brain_context_hybrid_with_aliases, build_context_with_intent, build_feature_context,
     changed_files_from_git, compute_clusters, compute_cochanges, discover_cross_domain_links,
     embedding::generate_embeddings_batch, export_in_memory_graph, export_text_format,
-    filter_by_target, find_bridge_nodes, find_hub_nodes, generate_agents_md_with_rules,
-    generate_claude_md_with_rules, generate_cursor_rule_with_rules, generate_guide_with_tools,
-    generate_repo_map, generate_summaries, get_last_indexed_at,
-    index_markdown_directory_since_with_ignore, index_markdown_directory_with_ignore,
-    index_markdown_directory_with_ignore_and_deletion_count, list_repos, list_services,
-    load_alias_sidecar, load_clusters, lookup_symbol, record_last_indexed_at, render_text,
-    save_clusters, save_cochange_sidecar, save_summaries, search_symbols, suggest_links,
-    truncate_to_budget,
+    filter_by_target, generate_agents_md_with_rules, generate_claude_md_with_rules,
+    generate_cursor_rule_with_rules, generate_guide_with_tools, generate_repo_map,
+    generate_summaries, get_last_indexed_at, index_markdown_directory_since_with_ignore,
+    index_markdown_directory_with_ignore, index_markdown_directory_with_ignore_and_deletion_count,
+    list_repos, list_services, load_alias_sidecar, load_clusters, lookup_symbol,
+    record_last_indexed_at, render_text, save_clusters, save_cochange_sidecar, save_summaries,
+    search_symbols, suggest_links, truncate_to_budget,
 };
 use nestweaver_schema::{DEFAULT_DRAIN_CEILING_SECS, Symbol, parse_drain_ceiling};
 use nestweaver_store::{GraphStore, QueryIntent, TantivyIndex};
@@ -1057,18 +1056,121 @@ fn into_diagnostic(err: anyhow::Error) -> miette::Report {
 ///
 /// The engine's message is printed VERBATIM. It already names the scope it
 /// actually searched, which is the thing no layer above it can reconstruct.
-fn report_context_lookup_failure(error: &anyhow::Error) -> i32 {
+///
+/// nw-399: `json` is a parameter because this function OWNS the exit path for
+/// both of `context`'s routes, so it was also the single point at which
+/// `context --json` produced its measured ZERO BYTES of stdout. The prose still
+/// goes to stderr in both modes — that is the engine's own scoped message and
+/// nothing here can improve it — but a `--json` caller now also gets a parsable
+/// object on stdout instead of an empty stream to scrape stderr for.
+fn report_context_lookup_failure(error: &anyhow::Error, json: bool, seeds: &[String]) -> i32 {
     let message = format!("{error:#}");
     if message.contains("No matching symbols") || message.contains("No symbols found") {
+        if json {
+            print_json_not_found_detail("seeds", &serde_json::json!(seeds), Some(&message));
+        }
         eprintln!("{message}");
         EXIT_NOT_FOUND
     } else if message.contains("Ambiguous") {
+        if json {
+            // Deliberately NOT the not-found envelope: an ambiguous seed is a
+            // DIFFERENT outcome with a different exit code (3) and a different
+            // remedy, and `impact` already learned the hard way that a shape a
+            // consumer cannot tell apart from a result is worse than none.
+            println!(
+                "{}",
+                serde_json::json!({
+                    "error": "ambiguous",
+                    "seeds": seeds,
+                    "message": message,
+                })
+            );
+        }
         eprintln!("{message}");
         EXIT_AMBIGUOUS
     } else {
+        if json {
+            println!(
+                "{}",
+                serde_json::json!({ "error": "failed", "seeds": seeds, "message": message })
+            );
+        }
         eprintln!("Error: {message}");
         EXIT_ERROR
     }
+}
+
+/// nw-399. The ONE `--json` payload for "the target you named does not exist".
+///
+/// COPIED FROM `symbol`'s arm, which was the only one of the ten read commands
+/// the sweep measured that emitted anything at all on stdout for a missing
+/// target: `{"error":"not found","name":"..."}` with exit 2. `context`,
+/// `project-context`, `service-summary`, `backlinks`, `flow-trace`,
+/// `cross-repo-contracts` and `cluster` all printed ZERO BYTES under `--json`
+/// and left the consumer scraping stderr — and four of them used exit 1 where
+/// their siblings used 2, so no single rule worked either.
+///
+/// Compact rather than pretty, and with no `_meta`, because it is `symbol`'s
+/// existing bytes: this is a de-duplication of a shape that already shipped,
+/// not a new one, and `symbol` routes through here so the two cannot drift.
+///
+/// `target_key` is the caller's own name for the thing (`name`, `symbol`,
+/// `title`, `cluster`), because a script that asked for a cluster should get
+/// its cluster id back, not a field called `name`.
+fn print_json_not_found(target_key: &str, target: &str) {
+    print_json_not_found_detail(target_key, &serde_json::json!(target), None);
+}
+
+/// [`print_json_not_found`] where the target is not a single string (`context`
+/// takes a seed LIST) or where the engine produced a message worth carrying.
+///
+/// The `error: "not found"` discriminator is identical in both, so a consumer
+/// branches on one key regardless of which command answered.
+fn print_json_not_found_detail(
+    target_key: &str,
+    target: &serde_json::Value,
+    message: Option<&str>,
+) {
+    println!("{}", json_not_found_payload(target_key, target, message));
+}
+
+/// [`print_json_not_found_detail`]'s payload, split out so the envelope can be
+/// asserted without capturing stdout.
+fn json_not_found_payload(
+    target_key: &str,
+    target: &serde_json::Value,
+    message: Option<&str>,
+) -> serde_json::Value {
+    let mut payload = serde_json::json!({ "error": "not found" });
+    if let Some(object) = payload.as_object_mut() {
+        object.insert(target_key.to_string(), target.clone());
+        if let Some(message) = message {
+            object.insert("message".to_string(), serde_json::json!(message));
+        }
+    }
+    payload
+}
+
+/// nw-399's second population: an ARGUMENT the command cannot honour — in
+/// practice a malformed regex handed to `regex-search`/`count-patterns`.
+///
+/// Distinct from [`print_json_not_found`] on purpose. "Your pattern does not
+/// compile" and "nothing matched your pattern" demand opposite responses, and
+/// collapsing them into one envelope would hand a script the same object for a
+/// bug in its own code as for an empty result. The exit code splits them too:
+/// this is `EXIT_USAGE`, the code every clap-validated bad value already uses.
+fn print_json_argument_error(argument: &str, value: &str, message: &str) {
+    println!("{}", json_argument_error_payload(argument, value, message));
+}
+
+/// [`print_json_argument_error`]'s payload, split out for the same reason.
+fn json_argument_error_payload(argument: &str, value: &str, message: &str) -> serde_json::Value {
+    serde_json::json!({
+        "error": "invalid argument",
+        "argument": argument,
+        "value": value,
+        "message": message,
+    })
 }
 
 // ── Environment-variable registry (S1/T2) ────────────────────────────────────
@@ -1308,6 +1410,36 @@ fn env_role(name: &str) -> Option<EnvRole> {
         .map(|entry| entry.role)
 }
 
+/// clap `value_parser` for `clusters --resolution` (nw-400).
+///
+/// Restates the ONE bound the `clusters` tool schema declares —
+/// `exclusiveMinimum: 0.0` — at the parser, so a bad value is refused with the
+/// bound named at `EXIT_USAGE` instead of travelling to the MCP validator and
+/// coming back as `schema keyword 'exclusiveMinimum' failed` at exit 1.
+///
+/// Non-finite values are rejected here and NOT left to the schema, because the
+/// schema cannot see them: `nan`/`inf` parse as valid `f64`, serialise to JSON
+/// `null`, and are then reported as a `type` failure — a true statement about
+/// the wire encoding and a useless one about the flag the user typed.
+///
+/// The error text mirrors clap's own range wording (`hubs --top` prints
+/// `0 is not in 1..=1000`) so the five commands nw-400 names read like their
+/// siblings rather than like a second dialect.
+fn parse_cluster_resolution(value: &str) -> Result<f64, String> {
+    let parsed: f64 = value
+        .parse()
+        .map_err(|_| format!("`{value}` is not a number"))?;
+    if !parsed.is_finite() {
+        return Err(format!(
+            "`{value}` is not a finite number; resolution must be greater than 0"
+        ));
+    }
+    if parsed <= 0.0 {
+        return Err(format!("{parsed} is not greater than 0"));
+    }
+    Ok(parsed)
+}
+
 // ── CLI structure ─────────────────────────────────────────────────────────────
 
 #[derive(Parser)]
@@ -1324,8 +1456,27 @@ fn env_role(name: &str) -> Option<EnvRole> {
                   nestweaver search \"UserService\"\n  \
                   nestweaver symbol \"processPayment\"\n  \
                   nestweaver repo-map --token-budget 2000",
+    // nw-399: the exit-code mapping lives HERE, in `nestweaver --help`, because
+    // the audience for it is a script author and that is the one place they will
+    // look without being told to. The item's defect was not only the zero-byte
+    // `--json` streams — it was that "not found" meant 2 for six commands and 1
+    // for four, so no single `case $rc in` worked. It is 2 everywhere now, and
+    // this table is the contract that says so.
     after_help = "Supported languages (32): JavaScript, TypeScript, Java, Go, Python, C, C++, Rust, C#, Kotlin, PHP, Ruby, Swift, Dart, COBOL, Lua, Bash, Scala, Elixir, Zig, Objective-C, Groovy, PowerShell, Julia, SQL, HCL/Terraform, Fortran, Pascal, Vue, Svelte, Astro, SystemVerilog\n\
                   Default database: ./nestweaver.lbug\n\n\
+                  Exit codes (scripting contract):\n  \
+                  0   success\n  \
+                  1   the command itself failed\n  \
+                  2   TARGET NOT FOUND — the one code for a symbol, service, project, note,\n      \
+                  cluster or seed that does not exist, on every read command and on both\n      \
+                  the daemon and --no-daemon routes. Also: stale-check found drift,\n      \
+                  pr-impact --strict blocked, dead-code refused on a stale graph.\n  \
+                  3   ambiguous match (several symbols share the name)\n  \
+                  4   unauthorized (pull)      5   unavailable (pull)\n  \
+                  64  usage error — unknown flag, out-of-range value, uncompilable --pattern\n\n\
+                  With --json every one of those outcomes also writes a JSON object to stdout:\n  \
+                  {\"error\":\"not found\", ...} for 2, {\"error\":\"ambiguous\", ...} for 3, and\n  \
+                  {\"error\":\"invalid argument\", ...} for 64. Branch on `error`, not on prose.\n\n\
                   Shell completions:\n  \
                   nestweaver completions bash > ~/.local/share/bash-completion/completions/nestweaver\n  \
                   nestweaver completions zsh > ~/.zfunc/_nestweaver\n  \
@@ -2072,6 +2223,89 @@ impl ResolverStaleness {
     }
 }
 
+/// What `hubs`/`bridges` can honestly say about the CUT and about how the score
+/// in each row was computed.
+///
+/// nw-398. Both `--json` payloads carried `returned == len(list)` and nothing
+/// else — a number true by construction, so it said nothing — while the engine
+/// had `candidate_total` one call away in `find_hub_nodes_bounded` /
+/// `find_bridge_nodes_bounded`. Every field here is `Option` for one reason:
+/// the DAEMON route decodes an MCP `hub_nodes`/`bridge_nodes` reply that does
+/// not (yet) publish these keys, and "this route does not know" is a different
+/// claim from "nothing was cut". Emitting `false` for the first would be the
+/// same lie in a new place.
+///
+/// Deliberately NOT `Bounded::take`: the cut already happened inside the
+/// engine, so re-capturing a total from the returned Vec would recover exactly
+/// `len(list)` — the anti-pattern this item exists to remove.
+#[derive(Debug, Default, Clone, Copy)]
+struct RankingBounds {
+    /// The candidate population `top` selected FROM — symbols with at least one
+    /// code edge. `None` on a route that was not told.
+    total: Option<usize>,
+    /// Whether `top` cut that population. Computed by the engine's
+    /// `HubNodes::truncated`/`BridgeNodes::truncated`, never re-derived here
+    /// from the already-cut list.
+    truncated: Option<bool>,
+    /// Bridges only: whether `betweenness_score` is a SAMPLE-based estimate.
+    /// The digits in the score carry no information about this — an
+    /// `18866919.81139078` from 500 deterministically-spaced BFS sources
+    /// renders identically to an exact one.
+    sampled: Option<bool>,
+    /// Bridges only: how many BFS sources the estimate actually ran from.
+    sources_sampled: Option<usize>,
+}
+
+impl RankingBounds {
+    /// The disclosure the DIRECT route can make, from the engine's own numbers.
+    fn from_hubs(found: &nestweaver_engine::hubs::HubNodes) -> Self {
+        Self {
+            total: Some(found.candidate_total),
+            truncated: Some(found.truncated()),
+            ..Self::default()
+        }
+    }
+
+    fn from_bridges(found: &nestweaver_engine::bridges::BridgeNodes) -> Self {
+        Self {
+            total: Some(found.candidate_total),
+            truncated: Some(found.truncated()),
+            sampled: Some(found.sampled),
+            sources_sampled: Some(found.sources_sampled),
+        }
+    }
+
+    /// What the DAEMON reply says, which today is nothing — the MCP
+    /// `hub_nodes`/`bridge_nodes` twins still emit `top_n`/`count` and are
+    /// owned by `crates/nestweaver-mcp/src/tools.rs`. Read rather than assumed
+    /// so this route publishes the honest totals the moment that half lands,
+    /// without a second edit here.
+    fn from_daemon_response(value: &serde_json::Value) -> Self {
+        Self {
+            total: value
+                .get("total")
+                .and_then(|v| v.as_u64())
+                .map(|n| n as usize),
+            truncated: value.get("truncated").and_then(|v| v.as_bool()),
+            sampled: value.get("sampled").and_then(|v| v.as_bool()),
+            sources_sampled: value
+                .get("sources_sampled")
+                .and_then(|v| v.as_u64())
+                .map(|n| n as usize),
+        }
+    }
+
+    /// `"Top 10"` or `"Top 10 of 4182"` — the second only when the population
+    /// is KNOWN and larger than the page. The human branch printed `.len()`
+    /// alone, which is the same content-free number the payload's `count` was.
+    fn header_count(&self, shown: usize) -> String {
+        match self.total {
+            Some(total) if total > shown => format!("{shown} of {total}"),
+            _ => shown.to_string(),
+        }
+    }
+}
+
 /// Print a ranking payload as an OBJECT carrying its own staleness, rather than
 /// the bare array that had nowhere to put it (nw-308).
 ///
@@ -2081,21 +2315,85 @@ impl ResolverStaleness {
 /// `serde_json::from_value` sees the same shape the direct store produces — and
 /// stripping for the decode used to mean the printer had nothing to put back.
 /// Strip for the decode, carry the provenance to the print (nw-347).
+///
+/// nw-398: `bounds` is where `total`/`truncated` (and, for bridges,
+/// `sampled`/`sources_sampled`) live. The keys are emitted UNCONDITIONALLY —
+/// `null` when the route cannot answer — for the reason `print_repo_map_json`
+/// states about staleness: an absent key and a `false` are the same observation
+/// to an agent, and only one of them is a reason to trust the list.
 fn print_ranking_json<T: serde::Serialize>(
     key: &str,
     rows: &T,
     staleness: &ResolverStaleness,
     daemon_meta: Option<serde_json::Value>,
+    bounds: &RankingBounds,
 ) -> anyhow::Result<()> {
+    print_json_payload(&ranking_json_payload(
+        key,
+        rows,
+        staleness,
+        daemon_meta,
+        bounds,
+    ))
+}
+
+/// [`print_ranking_json`]'s payload, split out so the disclosure keys can be
+/// asserted without capturing stdout.
+fn ranking_json_payload<T: serde::Serialize>(
+    key: &str,
+    rows: &T,
+    staleness: &ResolverStaleness,
+    daemon_meta: Option<serde_json::Value>,
+    bounds: &RankingBounds,
+) -> serde_json::Value {
     let mut payload = serde_json::json!({
         key: rows,
         "rankings_stale": staleness.rankings_stale,
         "stale_repos": staleness.stale_repos,
+        // The candidate population, and whether `--top` cut it. `total` is NOT
+        // `len(list)`: it counts every symbol with at least one code edge, so
+        // `returned < total` is a real completeness ratio rather than a
+        // tautology.
+        "total": bounds.total,
+        "truncated": bounds.truncated,
+        // What `total` counts, spelled out — `hub_nodes`'s own
+        // `total_population` precedent. Without it `returned/total` invites the
+        // reading "N of M hubs", which is not what M is.
+        "total_population": "symbols with at least one code edge (hub/bridge CANDIDATES)",
     });
-    if let (Some(meta), Some(obj)) = (daemon_meta, payload.as_object_mut()) {
-        obj.insert(nestweaver_schema::provenance::META_KEY.to_string(), meta);
+    if let Some(obj) = payload.as_object_mut() {
+        // Bridges only. Absent on hubs rather than `false`, because a hub score
+        // is a degree count and is never an estimate — a `sampled: false` there
+        // would answer a question the surface cannot be asked.
+        if bounds.sampled.is_some() || bounds.sources_sampled.is_some() {
+            obj.insert("sampled".to_string(), serde_json::json!(bounds.sampled));
+            obj.insert(
+                "sources_sampled".to_string(),
+                serde_json::json!(bounds.sources_sampled),
+            );
+        }
+        if let Some(meta) = daemon_meta {
+            obj.insert(nestweaver_schema::provenance::META_KEY.to_string(), meta);
+        }
     }
-    print_json_payload(&payload)
+    payload
+}
+
+/// The one sentence that says `betweenness_score` is an ESTIMATE, for the human
+/// branch of `bridges` (nw-398 leg 2).
+///
+/// Returns `None` when the walk ran from every node — an exact result must not
+/// carry an approximation warning, or the warning stops distinguishing
+/// anything.
+fn bridge_sampling_note(bounds: &RankingBounds) -> Option<String> {
+    match (bounds.sampled, bounds.sources_sampled) {
+        (Some(true), Some(sources)) => Some(format!(
+            "betweenness_score is an ESTIMATE from {sources} sampled BFS sources \
+             (deterministic even spacing over graph insertion order, so the bias is \
+             systematic, not self-cancelling). Compare scores, do not read the digits."
+        )),
+        _ => None,
+    }
 }
 
 /// `repo-map --json`, as ONE shape for both routes.
@@ -4449,9 +4747,22 @@ enum Commands {
         after_help = "Examples:\n  nestweaver clusters\n  nestweaver clusters --resolution 0.5 --json"
     )]
     Clusters {
+        // nw-400. `--resolution 0` and `--resolution nan` both reached the
+        // `clusters` JSON-Schema validator. `0` came back as `schema keyword
+        // 'exclusiveMinimum' failed`; `nan` was WORSE — it parses as a valid
+        // f64, serialises to JSON `null`, and so was reported as `keyword
+        // 'type' failed`, a message about the serialisation rather than about
+        // the input. Both at exit 1, neither naming the bound.
+        //
+        // `parse_cluster_resolution` states the schema's own
+        // `exclusiveMinimum: 0` and additionally rejects the non-finite values
+        // JSON cannot represent at all. No UPPER bound is imposed here: the
+        // schema declares none, and choosing one is nw-401's open question, not
+        // this fix's to answer.
         #[arg(
             long,
-            help = "Resolution parameter (higher = smaller clusters) [default: 0.5, or 0.3 for large graphs >10K symbols]"
+            value_parser = parse_cluster_resolution,
+            help = "Resolution parameter, greater than 0 (higher = smaller clusters) [default: 0.5, or 0.3 for large graphs >10K symbols]"
         )]
         resolution: Option<f64>,
         #[arg(
@@ -4511,6 +4822,16 @@ enum Commands {
             help = "Filter to a specific target (file path, symbol name, or cluster name)"
         )]
         target: Option<String>,
+        // nw-414. `summary` took `--db` and nothing else, so it could not
+        // resolve an instance and could not take the daemon route — it always
+        // opened the database directly. On a live instance the daemon holds the
+        // WAL, so that direct open FAILS, and the sweep that found this had to
+        // run `summary` against a file copy of the database to measure anything
+        // at all. Declared exactly as `hubs`/`bridges`/`memory lint` declare it,
+        // because this is capability drift (nw-215's class), not a new feature:
+        // a flag present on three sibling read commands and absent on a fourth.
+        #[arg(long, help = "Path to instance config (TOML)")]
+        config: Option<PathBuf>,
     },
     /// Show details for a specific cluster
     ///
@@ -6229,9 +6550,19 @@ enum BrainCommands {
     BrokenLinks {
         #[arg(long, default_value = "5", help = "Max suggested targets per link")]
         max_suggestions: usize,
+        // nw-400: bounded HERE, not by the MCP JSON-Schema validator this
+        // command routes through. Unbounded, `--limit 0` reached
+        // `brain_broken_links`'s schema and came back as `invalid arguments for
+        // tool 'brain_broken_links': /limit: schema keyword 'minimum' failed`
+        // at exit 1 — an internal tool name the CLI user never invoked, no
+        // mention of the bound, and the one exit code every clap-validated flag
+        // in this binary spells 64. `1..=1000` is the schema's own
+        // `RESULT_LIMIT_MAX` range, restated at the parser so the validator is
+        // never the thing a CLI user meets.
         #[arg(
             long,
-            help = "Max broken links to return (default: 50, or [limits].default_result_limit from config)"
+            value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=1000),
+            help = "Max broken links to return (1-1000; default: 50, or [limits].default_result_limit from config)"
         )]
         limit: Option<usize>,
         /// nw-341: rows sort unresolved-first then by ASCENDING confidence, so
@@ -6268,9 +6599,13 @@ enum BrainCommands {
             help = "Note path/title to exclude (repeatable; overrides the default allowlist)"
         )]
         allow: Vec<String>,
+        // nw-400: the same bound `brain_orphan_documents`'s schema declares,
+        // enforced at the parser. See `BrokenLinks::limit` for why the
+        // validator must not be the first thing a CLI user hears from.
         #[arg(
             long,
-            help = "Max orphan documents to return (default: 50, or [limits].default_result_limit from config)"
+            value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=1000),
+            help = "Max orphan documents to return (1-1000; default: 50, or [limits].default_result_limit from config)"
         )]
         limit: Option<usize>,
         #[arg(long, help = "Output as JSON")]
@@ -6289,9 +6624,13 @@ enum BrainCommands {
     TopicClusters {
         #[arg(long, default_value = "0.5", help = "Community-detection resolution")]
         resolution: f64,
+        // nw-400: the reported case. `brain topic-clusters --limit 0` printed
+        // `invalid arguments for tool 'brain_topic_clusters': /limit: schema
+        // keyword 'minimum' failed`, exit 1. Same bound, stated by the parser.
         #[arg(
             long,
-            help = "Max clusters to return (default: 50, or [limits].default_result_limit from config)"
+            value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=1000),
+            help = "Max clusters to return (1-1000; default: 50, or [limits].default_result_limit from config)"
         )]
         limit: Option<usize>,
         #[arg(long, help = "Output as JSON")]
@@ -6310,9 +6649,11 @@ enum BrainCommands {
         /// Optional focus tag (with or without leading #). When omitted,
         /// prints the full tag co-occurrence graph for every tag.
         tag: Option<String>,
+        // nw-400: the same bound `brain_tag_graph`'s schema declares.
         #[arg(
             long,
-            help = "Max tags to return (default: 50, or [limits].default_result_limit from config). Ignored when a specific tag is queried."
+            value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=1000),
+            help = "Max tags to return (1-1000; default: 50, or [limits].default_result_limit from config). Ignored when a specific tag is queried."
         )]
         limit: Option<usize>,
         #[arg(long, help = "Output as JSON")]
@@ -6387,7 +6728,20 @@ enum MemoryCommands {
             help = "Edge type to follow (repeatable; default: all four)"
         )]
         edge_types: Vec<String>,
-        #[arg(long, default_value = "2", help = "Max BFS depth")]
+        // nw-411 CLI parity. The daemon route validates `depth` against the
+        // `brain_memory_related` schema, which declares `1..=15` — the range
+        // `flow_trace`, `brain_impact` and `blast_radius` already use for the
+        // same traversal shape. `--no-daemon` bypasses that validator entirely,
+        // so without this the SAME `--depth 100000` was accepted or rejected
+        // depending on whether a daemon happened to be running. Bounded at the
+        // parser so both routes agree, and so a bad value is a clap usage error
+        // (exit 64, bound named) rather than a schema-keyword string.
+        #[arg(
+            long,
+            default_value = "2",
+            value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=15),
+            help = "Max BFS depth (1-15; matches the MCP brain_memory_related schema)"
+        )]
         depth: usize,
         #[arg(long, help = "Output as JSON")]
         json: bool,
@@ -7263,6 +7617,34 @@ fn default_db_path_with_source() -> (PathBuf, DbSource) {
 /// select a DB instead of being silently ignored (Bug #19).
 fn resolve_db_with_config(db: Option<PathBuf>, config: Option<&Path>) -> anyhow::Result<PathBuf> {
     resolve_db_with_config_source(db, config).map(|(path, _)| path)
+}
+
+/// Both halves of a repo's `[[repos]]` DIRECTORY policy, resolved together.
+///
+/// nw-418. `exclude` (globs to drop) and `unskip` (`SKIP_DIRS` names to
+/// re-admit) point in opposite directions and are two fields of ONE config
+/// block, so they are read here from ONE `InstanceConfig` and against ONE
+/// (url, path) pair. Resolving them separately is how they could come to
+/// describe different repos — `unskip_names_for` and `exclude_globs_for` each
+/// do their own url-or-path match, and a caller that passed different arguments
+/// to the two would get a silently mismatched policy.
+///
+/// Returns two empty vectors when there is no config, or when the config
+/// declares no `[[repos]]` entry for this repo. That is the counterweight the
+/// item asks for: `unskip` must re-admit `public/` for the repo that DECLARED
+/// it and for no other, or the fix has simply switched `SKIP_DIRS` off.
+fn resolve_repo_directory_policy(
+    config: Option<&nestweaver_engine::InstanceConfig>,
+    repo_url: &str,
+    repo_path: &Path,
+) -> (Vec<String>, Vec<String>) {
+    match config {
+        Some(config) => (
+            config.exclude_globs_for(repo_url, Some(repo_path)).to_vec(),
+            config.unskip_names_for(repo_url, Some(repo_path)).to_vec(),
+        ),
+        None => (Vec::new(), Vec::new()),
+    }
 }
 
 /// [`resolve_db_with_config`] with the nw-284/S2 provenance retained, for the
@@ -12274,7 +12656,15 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             };
 
             let Some(summary) = summary.filter(|s| !s.service.uid.is_empty()) else {
-                if !out.quiet {
+                // nw-399. Under `--json` this printed the PROSE line on stdout,
+                // which is worse than the zero bytes its siblings emitted: a
+                // consumer that pipes to a JSON parser gets a syntax error
+                // rather than an empty document, and `--quiet` suppressed even
+                // that. The envelope is unconditional in `--json` mode for the
+                // same reason — `--quiet` governs chatter, not the payload.
+                if json {
+                    print_json_not_found("service", &name);
+                } else if !out.quiet {
                     println!("Service not found: {name}");
                 }
                 return Ok((EXIT_NOT_FOUND, None));
@@ -12387,15 +12777,24 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             if let Some(limit) = limit {
                 args["limit"] = serde_json::json!(limit);
             }
-            let payload = match try_hybrid_json_rpc_checked(
+            // nw-399: BOTH routes classified in one place, so the answer to
+            // "does this symbol exist?" cannot depend on whether a daemon was
+            // running. `cross_repo_contracts` says `no symbol found: '<name>'`
+            // (`resolve_symbol_uid`, tools.rs) — matched on that specific
+            // phrase rather than on a bare "not found", because
+            // `require_existing_db` above has already ruled the DATABASE in and
+            // a broader substring test would reclassify a store failure as a
+            // missing symbol. That over-generalisation is exactly what nw-329's
+            // comment on `classify_cli_error` warns about.
+            let routed = match try_hybrid_json_rpc_checked(
                 use_daemon,
                 &db_path,
                 config.as_deref(),
                 "cross_repo_contracts",
                 args.clone(),
-            )? {
-                Some(value) => value,
-                None => {
+            ) {
+                Ok(Some(value)) => Ok(Some(value)),
+                Ok(None) => {
                     let store = open_store(Some(&db_path))?;
                     nestweaver_mcp::tools::dispatch(
                         &store,
@@ -12403,8 +12802,22 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         "cross_repo_contracts",
                         args,
                         None,
-                    )?
+                    )
+                    .map(Some)
                 }
+                Err(error) => Err(error),
+            };
+            let payload = match routed {
+                Ok(Some(value)) => value,
+                Ok(None) => unreachable!("the direct leg always yields a payload or an error"),
+                Err(error) if format!("{error:#}").contains("no symbol found") => {
+                    if json {
+                        print_json_not_found("symbol", &symbol);
+                    }
+                    eprintln!("Symbol '{symbol}' not found.");
+                    return Ok((EXIT_NOT_FOUND, None));
+                }
+                Err(error) => return Err(error),
             };
             if json {
                 print_json_payload(&payload)?;
@@ -12450,18 +12863,36 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             } else {
                 serde_json::json!({ "title": target })
             };
-            let payload = match try_hybrid_json_rpc_checked(
+            // nw-399: same classification, both routes. The `backlinks` tool
+            // says `no note found with title '<t>'`, so that phrase — and not a
+            // bare "not found" — is what decides. Measured at exit 1 with zero
+            // bytes of stdout before; now exit 2, the code its siblings already
+            // used for a missing target.
+            let routed = match try_hybrid_json_rpc_checked(
                 use_daemon,
                 &db_path,
                 config.as_deref(),
                 "backlinks",
                 args.clone(),
-            )? {
-                Some(value) => value,
-                None => {
+            ) {
+                Ok(Some(value)) => Ok(Some(value)),
+                Ok(None) => {
                     let store = open_store(Some(&db_path))?;
-                    nestweaver_mcp::tools::dispatch(&store, None, "backlinks", args, None)?
+                    nestweaver_mcp::tools::dispatch(&store, None, "backlinks", args, None).map(Some)
                 }
+                Err(error) => Err(error),
+            };
+            let payload = match routed {
+                Ok(Some(value)) => value,
+                Ok(None) => unreachable!("the direct leg always yields a payload or an error"),
+                Err(error) if format!("{error:#}").contains("no note found") => {
+                    if json {
+                        print_json_not_found("target", &target);
+                    }
+                    eprintln!("Note '{target}' not found.");
+                    return Ok((EXIT_NOT_FOUND, None));
+                }
+                Err(error) => return Err(error),
             };
             if json {
                 print_json_payload(&payload)?;
@@ -12833,11 +13264,32 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         return Ok((EXIT_SUCCESS, Some(stats)));
                     }
                     Err(e) => {
+                        // nw-399: `--feature` is still `context`, so it answers
+                        // with the same envelope and the same exit codes as the
+                        // seed-based arms below. It printed nothing on stdout
+                        // for both outcomes before.
                         let msg = e.to_string();
                         if msg.contains("No symbols found") {
+                            if json {
+                                print_json_not_found_detail(
+                                    "feature",
+                                    &serde_json::json!(feature_name),
+                                    Some(&msg),
+                                );
+                            }
                             eprintln!("{msg}");
                             return Ok((EXIT_NOT_FOUND, None));
                         } else {
+                            if json {
+                                println!(
+                                    "{}",
+                                    serde_json::json!({
+                                        "error": "failed",
+                                        "feature": feature_name,
+                                        "message": msg,
+                                    })
+                                );
+                            }
                             eprintln!("Error: {msg}");
                             return Ok((EXIT_ERROR, None));
                         }
@@ -12890,7 +13342,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         routed_via_daemon = true;
                     }
                     Ok(None) => {}
-                    Err(error) => return Ok((report_context_lookup_failure(&error), None)),
+                    Err(error) => {
+                        return Ok((report_context_lookup_failure(&error, json, &seeds), None));
+                    }
                 }
             }
 
@@ -12994,7 +13448,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     }
                     Ok((EXIT_SUCCESS, Some(stats)))
                 }
-                Err(e) => Ok((report_context_lookup_failure(&e), None)),
+                Err(e) => Ok((report_context_lookup_failure(&e, json, &seeds), None)),
             }
         }
 
@@ -13447,15 +13901,23 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 // test that the generation bump made useless. ONE verdict,
                 // both renderings.
                 let staleness = ResolverStaleness::from_daemon_response(&value, &db_path);
+                // nw-398: whatever the daemon said about the cut, which today
+                // is nothing — see `RankingBounds::from_daemon_response`. Read
+                // rather than re-derived from `hubs`, because deriving it from
+                // an already-cut list can only ever produce `truncated: false`.
+                let bounds = RankingBounds::from_daemon_response(&value);
                 if json {
                     // nw-308: the daemon route is the DEFAULT route, so the
                     // payload disclosure has to be here as well as on the
                     // direct path below.
-                    print_ranking_json("hubs", &hubs, &staleness, daemon_meta)?;
+                    print_ranking_json("hubs", &hubs, &staleness, daemon_meta, &bounds)?;
                 } else if hubs.is_empty() {
                     println!("No hub nodes found (graph may be empty).");
                 } else {
-                    println!("Top {} hub nodes (by total degree):\n", hubs.len());
+                    println!(
+                        "Top {} hub nodes (by total degree):\n",
+                        bounds.header_count(hubs.len())
+                    );
                     for h in &hubs {
                         let cluster = h
                             .cluster_id
@@ -13477,9 +13939,17 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 // only ever fires on the direct path users are
                 // told not to use.
                 warn_stale_resolver_rankings_no_store(&staleness);
+                // nw-398: counted from the list this route DECODED and printed,
+                // not from `value["count"]`. The old read was coupled to one
+                // spelling in a payload this crate does not own
+                // (`crates/nestweaver-mcp/src/tools.rs`); the day that key is
+                // renamed — `returned` is the name every other tool moved to —
+                // `unwrap_or(0)` would have printed "0 hubs" beside a full
+                // listing, silently. The decoded length cannot drift from what
+                // was shown, because it IS what was shown.
                 let stats = format!(
                     "{} hubs in {} (via hybrid)",
-                    value.get("count").and_then(|v| v.as_u64()).unwrap_or(0),
+                    hubs.len(),
                     format_elapsed(t0.elapsed())
                 );
                 return Ok((EXIT_SUCCESS, Some(stats)));
@@ -13487,7 +13957,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
 
             let store = open_store(Some(&db_path))?;
 
-            let mut hubs = find_hub_nodes(&store, top)?;
+            // nw-398: the `_bounded` variant, because this surface publishes a
+            // `total` and a `truncated`. `find_hub_nodes` discards
+            // `candidate_total`, which is why `hubs --json` used to carry
+            // nothing but a list.
+            let found = nestweaver_engine::hubs::find_hub_nodes_bounded(&store, top)?;
+            let bounds = RankingBounds::from_hubs(&found);
+            let mut hubs = found.hubs;
 
             // Attach cluster IDs if clustering sidecar exists.
             if let Ok(Some(clustering)) = load_clusters(&db_path) {
@@ -13510,11 +13986,15 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     &hubs,
                     &ResolverStaleness::from_store(&store, &db_path),
                     None,
+                    &bounds,
                 )?;
             } else if hubs.is_empty() {
                 println!("No hub nodes found (graph may be empty).");
             } else {
-                println!("Top {} hub nodes (by total degree):\n", hubs.len());
+                println!(
+                    "Top {} hub nodes (by total degree):\n",
+                    bounds.header_count(hubs.len())
+                );
                 for h in &hubs {
                     let cluster = h
                         .cluster_id
@@ -13570,6 +14050,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     // daemon already computed this from `store.list_repos` and
                     // this layer cannot do better.
                     let staleness = ResolverStaleness::from_daemon_response(&value, &db_path);
+                    // nw-398: captured BEFORE `strip_hybrid_meta` consumes
+                    // `value`, alongside the other two. Empty today — the MCP
+                    // `bridge_nodes` twin still publishes `top_n`/`count` — so
+                    // the payload says `null`, which is the honest "this route
+                    // was not told" rather than a fabricated `false`.
+                    let bounds = RankingBounds::from_daemon_response(&value);
                     let bridges: Vec<nestweaver_engine::BridgeNode> =
                         match strip_hybrid_meta(value).get("bridges").cloned() {
                             Some(serde_json::Value::Null) | None => Vec::new(),
@@ -13579,14 +14065,17 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     if json {
                         // nw-308: same disclosure as `hubs`; bridges are
                         // downstream of the same edges.
-                        print_ranking_json("bridges", &bridges, &staleness, daemon_meta)?;
+                        print_ranking_json("bridges", &bridges, &staleness, daemon_meta, &bounds)?;
                     } else if bridges.is_empty() {
                         println!("No bridge nodes found (graph may be empty).");
                     } else {
                         println!(
                             "Top {} bridge nodes (by betweenness centrality):\n",
-                            bridges.len()
+                            bounds.header_count(bridges.len())
                         );
+                        if let Some(note) = bridge_sampling_note(&bounds) {
+                            println!("  NOTE: {note}\n");
+                        }
                         for b in &bridges {
                             let communities = if b.communities_connected.is_empty() {
                                 String::new()
@@ -13623,7 +14112,14 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let store = open_store(Some(&db_path))?;
 
             out.status("Computing betweenness centrality...");
-            let mut bridges = find_bridge_nodes(&store, top)?;
+            // nw-398: the `_bounded` variant, for both halves of this item at
+            // once — `candidate_total` says how much `--top` hid, and
+            // `sampled`/`sources_sampled` say that every `betweenness_score`
+            // below is a SAMPLE-based estimate rendered at full f64 precision.
+            // `find_bridge_nodes` discards all three.
+            let found = nestweaver_engine::bridges::find_bridge_nodes_bounded(&store, top)?;
+            let bounds = RankingBounds::from_bridges(&found);
+            let mut bridges = found.bridges;
             warn_stale_resolver_rankings(&store, &db_path);
 
             // Attach community connection info if clustering sidecar exists.
@@ -13637,14 +14133,18 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     &bridges,
                     &ResolverStaleness::from_store(&store, &db_path),
                     None,
+                    &bounds,
                 )?;
             } else if bridges.is_empty() {
                 println!("No bridge nodes found (graph may be empty).");
             } else {
                 println!(
                     "Top {} bridge nodes (by betweenness centrality):\n",
-                    bridges.len()
+                    bounds.header_count(bridges.len())
                 );
+                if let Some(note) = bridge_sampling_note(&bounds) {
+                    println!("  NOTE: {note}\n");
+                }
                 for b in &bridges {
                     let communities = if b.communities_connected.is_empty() {
                         String::new()
@@ -13678,19 +14178,39 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             db,
             token_budget,
             target,
+            config,
         } => {
             let parsed_level: SummaryLevel =
                 level.parse().map_err(|e: String| anyhow::anyhow!(e))?;
-            let db_path = db.unwrap_or_else(default_db_path);
+            // nw-414: resolved through the same helper `hubs`/`bridges` use, so
+            // `--config` alone (no `--db`) selects the instance's database
+            // instead of falling back to `./nestweaver.lbug`. `db.unwrap_or_else(
+            // default_db_path)` was the whole reason this command could not
+            // reach a configured instance.
+            let db_path = resolve_db_with_config(db, config.as_deref())?;
 
             // ── daemon guard ──────────────────────────────────────
             // The daemon tool returns the rendered text under
             // "summaries" (not structured data), so it can only serve human
             // mode — for --json fall through to the direct path, whose bare
             // Vec<Summary> output the daemon shape cannot reproduce.
+            //
+            // nw-414, RECORDED RATHER THAN FIXED: that `!json` is why
+            // `summary --json` on a live instance STILL takes the direct open
+            // and still fails while the daemon holds the WAL. Adding `--config`
+            // gives the human route the daemon it never had; making `--json`
+            // follow it means giving `get_summary` a structured payload, which
+            // is a payload redesign and not this item's remit. After nw-404 the
+            // failure is at least an honest contention message rather than a
+            // corruption runbook.
             if use_daemon && !json {
                 let args = summary_tool_args(&level, token_budget, target.as_deref());
-                if let Some(value) = try_hybrid_json_rpc(true, &db_path, None, "get_summary", args)?
+                // nw-414: the resolved config is THREADED here. It was
+                // hardcoded `None`, so even a caller who had one could not use
+                // it — the daemon route silently ignored the instance and any
+                // upstream it declares.
+                if let Some(value) =
+                    try_hybrid_json_rpc(true, &db_path, config.as_deref(), "get_summary", args)?
                     && let Some(text) = value.get("summaries").and_then(|v| v.as_str())
                 {
                     // nw-370: `get_summary` attaches the verdict on hub level,
@@ -13713,7 +14233,15 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             println!();
                         }
                     }
-                    let count = value.get("count").and_then(|v| v.as_u64()).unwrap_or(0);
+                    // `returned` first, `count` as the fallback: nw-321 made
+                    // `returned` the canonical name and kept `count` as an
+                    // alias "for one release", so reading only the alias is a
+                    // silent `0` waiting for that release to land.
+                    let count = value
+                        .get("returned")
+                        .or_else(|| value.get("count"))
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
                     let tokens = value
                         .get("tokens_used")
                         .and_then(|v| v.as_u64())
@@ -14200,6 +14728,14 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     Ok((EXIT_SUCCESS, None))
                 }
                 None => {
+                    // nw-399: zero bytes on stdout under `--json` before this.
+                    // The available-cluster list stays on stderr in both modes
+                    // — it is a remedy for a human, and putting an unbounded
+                    // 69,713-entry list into the payload would be a second
+                    // defect wearing a disclosure.
+                    if json {
+                        print_json_not_found("cluster", &id_or_name);
+                    }
                     eprintln!("Cluster '{}' not found.", id_or_name);
                     eprintln!(
                         "Available clusters: {}",
@@ -14536,19 +15072,50 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 "max_depth": max_depth,
             });
 
-            let payload = match try_hybrid_json_rpc_checked(
+            // nw-399: same classification, both routes. TWO phrases, because
+            // `flow_trace` has two ways to miss: a bare name dies in
+            // `resolve_symbol_uid` as `no symbol found: '<s>'`, while a
+            // `sym:`-prefixed uid gets past it and dies in the store lookup as
+            // `symbol '<s>' not found`. Matching only the second is how the
+            // MEASURED case — a plain name — kept its exit 1 and its zero bytes.
+            // The second string is also, deliberately, what a root hidden by
+            // repo scope returns, so this arm inherits that non-disclosure
+            // rather than trying to see through it. The DATABASE-missing case
+            // cannot reach here — `require_existing_db` above already refused it
+            // — which is what makes a bare "not found" test safe in this arm and
+            // not in a general classifier.
+            let routed = match try_hybrid_json_rpc_checked(
                 use_daemon,
                 &db_path,
                 config.as_deref(),
                 "flow_trace",
                 args.clone(),
-            )? {
-                Some(value) => value,
-                None => {
+            ) {
+                Ok(Some(value)) => Ok(Some(value)),
+                Ok(None) => {
                     let store = open_store(Some(&db_path))?;
                     nestweaver_mcp::tools::set_current_db_path(db_path.clone());
-                    nestweaver_mcp::tools::dispatch(&store, None, "flow_trace", args, None)?
+                    nestweaver_mcp::tools::dispatch(&store, None, "flow_trace", args, None)
+                        .map(Some)
                 }
+                Err(error) => Err(error),
+            };
+            let payload = match routed {
+                Ok(Some(value)) => value,
+                Ok(None) => unreachable!("the direct leg always yields a payload or an error"),
+                Err(error)
+                    if {
+                        let rendered = format!("{error:#}");
+                        rendered.contains("not found") || rendered.contains("no symbol found")
+                    } =>
+                {
+                    if json {
+                        print_json_not_found("symbol", &symbol);
+                    }
+                    eprintln!("Symbol '{symbol}' not found.");
+                    return Ok((EXIT_NOT_FOUND, None));
+                }
+                Err(error) => return Err(error),
             };
 
             if json {
@@ -16090,15 +16657,29 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             }
 
             let store = open_store(Some(&db_path))?;
-            let res = store
-                .regex_search(
-                    &pattern,
-                    path_prefix.as_deref(),
-                    kinds.as_deref(),
-                    limit,
-                    max_millis,
-                )
-                .context("regex_search")?;
+            // nw-399: a pattern that does not COMPILE is a bad argument, not a
+            // failed query, and it used to escape as a bare `?` — exit 1 with
+            // zero bytes of stdout under `--json`. It now answers with the
+            // argument envelope at `EXIT_USAGE`, the code `hubs --top 0` and
+            // every other rejected flag value already use, so a script has one
+            // rule for "my input was wrong" across the binary.
+            let res = match store.regex_search(
+                &pattern,
+                path_prefix.as_deref(),
+                kinds.as_deref(),
+                limit,
+                max_millis,
+            ) {
+                Ok(res) => res,
+                Err(error) => {
+                    let message = format!("{error}");
+                    if json {
+                        print_json_argument_error("pattern", &pattern, &message);
+                    }
+                    eprintln!("Error: invalid --pattern '{pattern}': {message}");
+                    return Ok((EXIT_USAGE, None));
+                }
+            };
             if json {
                 println!("{}", serde_json::to_string_pretty(&res)?);
             } else if res.results.is_empty() {
@@ -16219,9 +16800,23 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             }
 
             let store = open_store(Some(&db_path))?;
-            let counts = store
-                .count_patterns(&patterns, path_prefix.as_deref(), kinds.as_deref())
-                .context("count_patterns")?;
+            // nw-399: identical treatment to `regex-search` above — the two
+            // commands take the same patterns from the same user and must not
+            // reject them in two different ways. `patterns` is a LIST, so the
+            // envelope reports the whole list as the offending value; the
+            // engine's message names the one that failed to compile.
+            let counts =
+                match store.count_patterns(&patterns, path_prefix.as_deref(), kinds.as_deref()) {
+                    Ok(counts) => counts,
+                    Err(error) => {
+                        let message = format!("{error}");
+                        if json {
+                            print_json_argument_error("patterns", &patterns.join(", "), &message);
+                        }
+                        eprintln!("Error: invalid --pattern: {message}");
+                        return Ok((EXIT_USAGE, None));
+                    }
+                };
             if json {
                 println!("{}", serde_json::to_string_pretty(&counts)?);
             } else {
@@ -16421,10 +17016,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         _ => {
                             // not_found
                             if json {
-                                println!(
-                                    "{}",
-                                    serde_json::json!({"error": "not found", "name": name_or_uid})
-                                );
+                                // nw-399: through the shared emitter. These
+                                // bytes are the MODEL every other not-found arm
+                                // was changed to copy, so they must not be a
+                                // second, independent copy of the shape.
+                                print_json_not_found("name", &name_or_uid);
                             } else {
                                 eprintln!("Symbol '{name_or_uid}' not found.");
                             }
@@ -16488,10 +17084,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
                 LookupResult::NotFound => {
                     if json {
-                        println!(
-                            "{}",
-                            serde_json::json!({"error": "not found", "name": name_or_uid})
-                        );
+                        print_json_not_found("name", &name_or_uid);
                     } else {
                         eprintln!("Symbol '{name_or_uid}' not found.");
                     }
@@ -17616,6 +18209,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let daemon_value = match daemon_result {
                 Ok(value) => value,
                 Err(error) if format!("{error:#}").contains("not found") => {
+                    // nw-399: this arm already had the right EXIT code (2) and
+                    // the right remedy on stderr — and emitted zero bytes on
+                    // stdout, so a `--json` caller saw an empty stream and could
+                    // not tell it apart from a crash.
+                    if json {
+                        print_json_not_found("project", &name);
+                    }
                     eprintln!("Project '{name}' not found. Try: nestweaver list-projects");
                     return Ok((EXIT_NOT_FOUND, None));
                 }
@@ -17670,6 +18270,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let value = match response {
                 Ok(value) => value,
                 Err(error) if format!("{error:#}").contains("not found") => {
+                    // nw-399: this arm already had the right EXIT code (2) and
+                    // the right remedy on stderr — and emitted zero bytes on
+                    // stdout, so a `--json` caller saw an empty stream and could
+                    // not tell it apart from a crash.
+                    if json {
+                        print_json_not_found("project", &name);
+                    }
                     eprintln!("Project '{name}' not found. Try: nestweaver list-projects");
                     return Ok((EXIT_NOT_FOUND, None));
                 }
@@ -18338,12 +18945,22 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let (files_count, symbols_count, edges_count);
             let skipped_files;
 
-            // Per-repo `exclude` globs from `--config`. The daemon route
-            // resolves these from its own loaded config; this is the direct
-            // (`--no-daemon`) twin, so both routes exclude the same paths.
-            let repo_excludes: Vec<String> = load_instance_config_opt(config.as_deref())
-                .map(|cfg| cfg.exclude_globs_for(&repo_url, Some(&repo_path)).to_vec())
-                .unwrap_or_default();
+            // Per-repo `exclude` globs and `unskip` names from `--config`. The
+            // daemon route resolves these from its own loaded config; this is
+            // the direct (`--no-daemon`) twin, so both routes see the same
+            // per-repo directory policy.
+            //
+            // nw-418: `unskip` is the OTHER half of that policy and was never
+            // resolved here, so `[[repos]] unskip = ["public"]` PARSED (the key
+            // exists in `RepoConfig`) and then did nothing on this route — the
+            // exact "config key that is accepted and ignored" failure the key
+            // was added to prevent. Loaded ONCE and both halves taken from the
+            // same config, so they cannot resolve against different repos.
+            let (repo_excludes, repo_unskip) = resolve_repo_directory_policy(
+                load_instance_config_opt(config.as_deref()).as_ref(),
+                &repo_url,
+                &repo_path,
+            );
 
             if force {
                 // Full re-index requested explicitly.
@@ -18355,7 +18972,11 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 .force(true)
                 .name(name.as_deref())
                 .limits(index_limits)
-                .excludes(&repo_excludes);
+                .excludes(&repo_excludes)
+                // nw-418: the full scan honours `unskip` through
+                // `FilesystemReader::list_files`, but only if it is HANDED the
+                // set. Without this the flag was configurable and inert.
+                .unskip(&repo_unskip);
                 let result = nestweaver_engine::index::index_directory_with_opts(
                     &repo_path, &db_path, &opts,
                 )
@@ -18375,7 +18996,16 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 skipped_files = result.skipped_files;
             } else {
                 // Incremental index (falls back to full when no prior index exists).
-                let inc = nestweaver_engine::index::incremental_index_with_excludes(
+                // nw-418: the `_and_unskip` entry point, not the
+                // `unskip`-less wrapper. The wrapper passes the EMPTY set, and
+                // an incremental run that forgets `unskip` drops the re-admitted
+                // files one at a time inside the change loop — below the level
+                // nw-387's `SkippedDir` disclosure watches, because `unskip`
+                // means the directory was never pruned and there is no row to
+                // drain. The user gets the files on `--force` and silently
+                // loses them on every incremental run, with
+                // `coverage_status: "complete"` both times.
+                let inc = nestweaver_engine::index::incremental_index_with_excludes_and_unskip(
                     &repo_path,
                     &db_path,
                     &instance_id,
@@ -18383,6 +19013,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     name.as_deref(),
                     index_limits,
                     &repo_excludes,
+                    &repo_unskip,
                 )
                 .context("incremental_index")?;
 
@@ -26352,6 +26983,12 @@ mod cli_help_contract_tests {
             "nestweaver server backup save",
             "nestweaver snapshot build",
             "nestweaver suggest-links",
+            // nw-414: `summary` joined this inventory. It took `--db` and no
+            // `--config`, so it could not resolve an instance, could not take
+            // the daemon route, and failed closed on a live instance whose
+            // daemon holds the WAL — the sweep had to measure it against a FILE
+            // COPY of the database.
+            "nestweaver summary",
             "nestweaver ui",
             "nestweaver watch",
             "nestweaver watch-stop",
@@ -38678,5 +39315,587 @@ mod resolver_generation_gate_tests {
             DeadCodeRefusal::for_repos(&db_path, &repos).is_none(),
             "a repo recorded at the current generation must not refuse"
         );
+    }
+}
+
+/// nw-398 / nw-399 / nw-400 / nw-411 / nw-414 / nw-418 — the CLI half of the
+/// honesty sweep.
+///
+/// Every test here is a COUNTERWEIGHT pair: one half asserts the defect is
+/// gone, the other asserts the remedy did not overshoot into a claim that is
+/// equally false in the other direction.
+#[cfg(test)]
+mod cli_honesty_sweep_tests {
+    use super::*;
+
+    /// Clap parsing has to run off the main test stack: `Cli` is a very large
+    /// enum and the derived parser recurses through all of it, exactly as
+    /// `init_tls_validity_days_range_enforced` already does.
+    fn parse_off_thread(argv: Vec<&'static str>) -> Result<Cli, clap::Error> {
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(move || Cli::try_parse_from(&argv))
+            .expect("spawn")
+            .join()
+            .expect("join")
+    }
+
+    fn staleness_fixture() -> ResolverStaleness {
+        ResolverStaleness {
+            rankings_stale: false,
+            stale_repos: vec![],
+        }
+    }
+
+    // ── nw-398 ───────────────────────────────────────────────────────────
+
+    /// The header must say how much `--top` HID, not merely how much it showed.
+    /// `hubs.len()` alone is true by construction and therefore says nothing —
+    /// the same tautology `count == len(list)` was in the payload.
+    #[test]
+    fn a_truncated_ranking_header_names_the_population_it_was_cut_from() {
+        let cut = RankingBounds {
+            total: Some(4182),
+            truncated: Some(true),
+            ..RankingBounds::default()
+        };
+        assert_eq!(cut.header_count(3), "3 of 4182");
+    }
+
+    /// COUNTERWEIGHT. Three cases that must NOT grow an "of M": a complete
+    /// answer, a route that was not told the total, and the padded-tail case
+    /// where the caller asked for more than the graph holds — `--top 1000` on a
+    /// 180-candidate graph is a caller who was given everything, which is the
+    /// opposite of truncation. "N of M" where M <= N would read as a cut that
+    /// did not happen.
+    #[test]
+    fn a_complete_or_unknowing_ranking_header_makes_no_truncation_claim() {
+        let complete = RankingBounds {
+            total: Some(3),
+            truncated: Some(false),
+            ..RankingBounds::default()
+        };
+        assert_eq!(complete.header_count(3), "3");
+
+        let padded_tail = RankingBounds {
+            total: Some(180),
+            truncated: Some(false),
+            ..RankingBounds::default()
+        };
+        assert_eq!(padded_tail.header_count(1000), "1000");
+
+        assert_eq!(RankingBounds::default().header_count(3), "3");
+    }
+
+    /// The payload carries the honest keys, and `total` is NOT `len(list)`.
+    #[test]
+    fn a_ranking_payload_publishes_a_total_that_is_not_the_returned_length() {
+        let rows = vec!["a", "b", "c"];
+        let payload = ranking_json_payload(
+            "hubs",
+            &rows,
+            &staleness_fixture(),
+            None,
+            &RankingBounds {
+                total: Some(4182),
+                truncated: Some(true),
+                ..RankingBounds::default()
+            },
+        );
+        assert_eq!(payload["total"], serde_json::json!(4182));
+        assert_eq!(payload["truncated"], serde_json::json!(true));
+        assert_ne!(
+            payload["total"],
+            serde_json::json!(rows.len()),
+            "a `total` equal to the returned length is the anti-pattern nw-398 exists to \
+             remove — it is true by construction and discloses nothing: {payload}"
+        );
+        assert!(
+            payload["total_population"]
+                .as_str()
+                .is_some_and(|text| text.contains("code edge")),
+            "`total` counts CANDIDATES, and the payload has to say so or `returned/total` \
+             reads as a hub ratio it is not: {payload}"
+        );
+        assert!(
+            payload.get("sampled").is_none(),
+            "hubs are a degree count and are never an estimate; a `sampled: false` here \
+             would answer a question this surface cannot be asked: {payload}"
+        );
+    }
+
+    /// Bridges carry the sampling provenance as well, because the score itself
+    /// cannot: an estimate from 500 sources renders to the same 14 significant
+    /// digits an exact one would.
+    #[test]
+    fn a_bridge_payload_declares_that_its_score_is_an_estimate() {
+        let rows: Vec<&str> = vec![];
+        let payload = ranking_json_payload(
+            "bridges",
+            &rows,
+            &staleness_fixture(),
+            None,
+            &RankingBounds {
+                total: Some(4182),
+                truncated: Some(true),
+                sampled: Some(true),
+                sources_sampled: Some(500),
+            },
+        );
+        assert_eq!(payload["sampled"], serde_json::json!(true));
+        assert_eq!(payload["sources_sampled"], serde_json::json!(500));
+
+        let note = bridge_sampling_note(&RankingBounds {
+            sampled: Some(true),
+            sources_sampled: Some(500),
+            ..RankingBounds::default()
+        })
+        .expect("a sampled walk must disclose itself");
+        assert!(note.contains("500"), "{note}");
+        assert!(note.contains("ESTIMATE"), "{note}");
+    }
+
+    /// COUNTERWEIGHT. A graph small enough for an EXACT Brandes run must not
+    /// carry an approximation warning — a caveat present on every answer
+    /// distinguishes nothing, which is how the tool description's "approximate
+    /// for large graphs" became invisible in the first place.
+    #[test]
+    fn an_exact_betweenness_walk_carries_no_approximation_warning() {
+        assert!(
+            bridge_sampling_note(&RankingBounds {
+                sampled: Some(false),
+                sources_sampled: Some(180),
+                ..RankingBounds::default()
+            })
+            .is_none()
+        );
+        assert!(bridge_sampling_note(&RankingBounds::default()).is_none());
+    }
+
+    /// The daemon route must publish `null`, not `false`. "This route was not
+    /// told" and "nothing was cut" are different claims and only one of them is
+    /// true of today's `hub_nodes` reply, which still carries `top_n`/`count`.
+    #[test]
+    fn the_daemon_route_says_it_does_not_know_rather_than_saying_nothing_was_cut() {
+        let todays_reply = serde_json::json!({
+            "top_n": 3,
+            "count": 3,
+            "hubs": [],
+            "clustering_available": false,
+        });
+        let bounds = RankingBounds::from_daemon_response(&todays_reply);
+        assert_eq!(bounds.total, None);
+        assert_eq!(bounds.truncated, None);
+
+        let rows: Vec<&str> = vec![];
+        let payload = ranking_json_payload("hubs", &rows, &staleness_fixture(), None, &bounds);
+        assert!(
+            payload["truncated"].is_null(),
+            "an unknown cut must serialise as null; `false` would be a fabricated \
+             completeness claim: {payload}"
+        );
+    }
+
+    /// COUNTERWEIGHT to the above: the read is a READ, so the moment the MCP
+    /// half of nw-398 publishes the keys this route reports them without a
+    /// second edit here. A branch that always returned `None` would pass the
+    /// test above and be permanently useless.
+    #[test]
+    fn the_daemon_route_reports_the_totals_the_moment_the_reply_carries_them() {
+        let future_reply = serde_json::json!({
+            "returned": 3,
+            "total": 4182,
+            "truncated": true,
+            "sampled": true,
+            "sources_sampled": 500,
+            "bridges": [],
+        });
+        let bounds = RankingBounds::from_daemon_response(&future_reply);
+        assert_eq!(bounds.total, Some(4182));
+        assert_eq!(bounds.truncated, Some(true));
+        assert_eq!(bounds.sampled, Some(true));
+        assert_eq!(bounds.sources_sampled, Some(500));
+        assert_eq!(bounds.header_count(3), "3 of 4182");
+    }
+
+    // ── nw-399 ───────────────────────────────────────────────────────────
+
+    /// Every not-found envelope is `symbol`'s envelope, whatever the command
+    /// calls its target — one `error` discriminator, so a script branches once.
+    #[test]
+    fn every_not_found_envelope_carries_one_discriminator_and_the_callers_own_key() {
+        for (key, target) in [
+            ("name", "processPayment"),
+            ("project", "nope"),
+            ("service", "nope"),
+            ("cluster", "9999"),
+            ("symbol", "nope"),
+            ("target", "Missing Note"),
+        ] {
+            let payload = json_not_found_payload(key, &serde_json::json!(target), None);
+            assert_eq!(
+                payload["error"],
+                serde_json::json!("not found"),
+                "{payload}"
+            );
+            assert_eq!(payload[key], serde_json::json!(target), "{payload}");
+        }
+
+        // `context` takes a seed LIST, and the envelope must echo it rather
+        // than flattening it to a string a caller cannot match on.
+        let seeds = json_not_found_payload(
+            "seeds",
+            &serde_json::json!(["a", "b"]),
+            Some("No matching symbols"),
+        );
+        assert_eq!(seeds["seeds"], serde_json::json!(["a", "b"]));
+        assert_eq!(seeds["message"], serde_json::json!("No matching symbols"));
+    }
+
+    /// COUNTERWEIGHT. A pattern that does not COMPILE is not an absent target,
+    /// and the two must not share an envelope: one means "fix your regex" and
+    /// the other means "nothing matched", and a consumer that cannot tell them
+    /// apart will retry the broken one forever.
+    #[test]
+    fn a_bad_argument_is_not_reported_as_a_missing_target() {
+        let payload = json_argument_error_payload("pattern", "foo(", "unclosed group");
+        assert_eq!(payload["error"], serde_json::json!("invalid argument"));
+        assert_ne!(payload["error"], serde_json::json!("not found"));
+        assert_eq!(payload["argument"], serde_json::json!("pattern"));
+        assert_eq!(payload["value"], serde_json::json!("foo("));
+        assert!(
+            payload["message"]
+                .as_str()
+                .is_some_and(|m| m.contains("unclosed group")),
+            "the engine's own diagnosis is the only thing that says WHAT is wrong \
+             with the pattern, so it must survive into the payload: {payload}"
+        );
+    }
+
+    /// The mapping has to be findable by the script author it exists for, and
+    /// `--help` is where they will look. nw-399's second defect was not the
+    /// empty stream — it was that "not found" meant 2 for six commands and 1
+    /// for four, so no single rule worked.
+    #[test]
+    fn the_exit_code_contract_is_written_where_a_script_author_will_find_it() {
+        let help = std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| Cli::command().render_long_help().to_string())
+            .expect("spawn")
+            .join()
+            .expect("join");
+        assert!(
+            help.contains("TARGET NOT FOUND"),
+            "the top-level help must name the one not-found code: {help}"
+        );
+        for fragment in ["Exit codes", "64", "\"not found\"", "invalid argument"] {
+            assert!(help.contains(fragment), "missing {fragment:?} from --help");
+        }
+    }
+
+    // ── nw-400 / nw-411 ──────────────────────────────────────────────────
+
+    /// The five commands nw-400 names reject an out-of-range value AT THE
+    /// PARSER, with the bound in the message — never by shipping it to the MCP
+    /// JSON-Schema validator, which answered with an internal tool name, no
+    /// bound, and exit 1.
+    #[test]
+    fn out_of_range_bounds_are_refused_by_clap_and_name_the_bound() {
+        let limited: [(Vec<&'static str>, &str); 4] = [
+            (vec!["nestweaver", "brain", "topic-clusters"], "1..=1000"),
+            (vec!["nestweaver", "brain", "orphans"], "1..=1000"),
+            (vec!["nestweaver", "brain", "tag-graph"], "1..=1000"),
+            (vec!["nestweaver", "brain", "broken-links"], "1..=1000"),
+        ];
+        for (base, bound) in limited {
+            for bad in ["0", "1001", "99999"] {
+                let mut argv = base.clone();
+                argv.extend(["--limit", bad]);
+                let error = parse_off_thread(argv)
+                    .err()
+                    .unwrap_or_else(|| panic!("{base:?} --limit {bad} must be rejected"));
+                let rendered = error.to_string();
+                assert!(
+                    rendered.contains(bound),
+                    "the bound must be NAMED, which is the whole defect — \
+                     `schema keyword 'minimum' failed` named none: {rendered}"
+                );
+                assert!(
+                    !rendered.contains("schema keyword"),
+                    "a CLI user must never be shown the MCP validator: {rendered}"
+                );
+                assert!(
+                    !rendered.contains("brain_"),
+                    "a CLI user must never be shown an MCP TOOL NAME they did not \
+                     invoke: {rendered}"
+                );
+            }
+        }
+
+        // `clusters --resolution` has a different KIND of bound — the schema
+        // declares `exclusiveMinimum: 0`, not a range — and its worst case was
+        // `nan`, which parses as a valid f64, serialises to JSON `null`, and so
+        // came back as `keyword 'type' failed`: a true statement about the wire
+        // encoding and a useless one about the flag.
+        // `--resolution=-1`, not `--resolution -1`: clap reads a leading `-` as
+        // the start of a flag, so the space form never reaches the parser at
+        // all. Both spellings are usage errors at exit 64 either way.
+        for bad in [
+            "--resolution=0",
+            "--resolution=-1",
+            "--resolution=nan",
+            "--resolution=inf",
+        ] {
+            let error = parse_off_thread(vec!["nestweaver", "clusters", bad])
+                .err()
+                .unwrap_or_else(|| panic!("{bad} must be rejected"));
+            let rendered = error.to_string();
+            assert!(
+                rendered.contains("greater than 0") || rendered.contains("finite"),
+                "the bound must be named: {rendered}"
+            );
+            assert!(!rendered.contains("keyword"), "{rendered}");
+        }
+
+        // nw-411: the daemon route rejects `depth` outside 1..=15 at the
+        // schema; `--no-daemon` accepted anything. The two now agree.
+        for bad in ["0", "16", "100000"] {
+            let error = parse_off_thread(vec![
+                "nestweaver",
+                "memory",
+                "related",
+                "note:x",
+                "--depth",
+                bad,
+            ])
+            .err()
+            .unwrap_or_else(|| panic!("--depth {bad} must be rejected"));
+            assert!(error.to_string().contains("1..=15"), "{error}");
+        }
+    }
+
+    /// COUNTERWEIGHT. The bounds must not have swallowed the legal range, and
+    /// an OMITTED `--limit` must still parse — these four resolve their default
+    /// from `[limits].default_result_limit`, so requiring a value would break
+    /// every existing invocation.
+    #[test]
+    fn in_range_and_omitted_bounds_still_parse() {
+        for base in [
+            vec!["nestweaver", "brain", "topic-clusters"],
+            vec!["nestweaver", "brain", "orphans"],
+            vec!["nestweaver", "brain", "tag-graph"],
+            vec!["nestweaver", "brain", "broken-links"],
+        ] {
+            assert!(
+                parse_off_thread(base.clone()).is_ok(),
+                "{base:?} with no --limit must still parse"
+            );
+            for good in ["1", "50", "1000"] {
+                let mut argv = base.clone();
+                argv.extend(["--limit", good]);
+                assert!(
+                    parse_off_thread(argv).is_ok(),
+                    "{base:?} --limit {good} must parse"
+                );
+            }
+        }
+
+        for good in ["0.0001", "0.5", "5", "1e9"] {
+            assert!(
+                parse_off_thread(vec!["nestweaver", "clusters", "--resolution", good]).is_ok(),
+                "--resolution {good} must parse: no UPPER bound is claimed here, \
+                 because the schema declares none and choosing one is nw-401's question"
+            );
+        }
+        assert!(parse_off_thread(vec!["nestweaver", "clusters"]).is_ok());
+
+        for good in ["1", "2", "15"] {
+            assert!(
+                parse_off_thread(vec![
+                    "nestweaver",
+                    "memory",
+                    "related",
+                    "note:x",
+                    "--depth",
+                    good
+                ])
+                .is_ok(),
+                "--depth {good} must parse"
+            );
+        }
+    }
+
+    /// nw-400's DONE WHEN includes "the bound is in `--help`" — a message that
+    /// names a constraint the user has no way to look up is the defect, and
+    /// bisecting for it is not a remedy.
+    #[test]
+    fn the_bound_appears_in_help_and_not_only_in_the_rejection() {
+        let help = std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                let mut command = Cli::command();
+                let brain = command
+                    .find_subcommand_mut("brain")
+                    .expect("brain subcommand")
+                    .clone();
+                let mut rendered = String::new();
+                for name in ["topic-clusters", "orphans", "tag-graph", "broken-links"] {
+                    let mut subcommand = brain
+                        .clone()
+                        .find_subcommand_mut(name)
+                        .expect("brain leaf subcommand")
+                        .clone();
+                    rendered.push_str(&subcommand.render_long_help().to_string());
+                }
+                let mut clusters = command
+                    .find_subcommand_mut("clusters")
+                    .expect("clusters subcommand")
+                    .clone();
+                rendered.push_str(&clusters.render_long_help().to_string());
+                let mut related = command
+                    .find_subcommand_mut("memory")
+                    .expect("memory subcommand")
+                    .clone()
+                    .find_subcommand_mut("related")
+                    .expect("memory related")
+                    .clone();
+                rendered.push_str(&related.render_long_help().to_string());
+                rendered
+            })
+            .expect("spawn")
+            .join()
+            .expect("join");
+
+        assert_eq!(
+            help.matches("1-1000").count(),
+            4,
+            "each of the four --limit flags must state its bound in --help: {help}"
+        );
+        assert!(help.contains("greater than 0"), "{help}");
+        assert!(help.contains("1-15"), "{help}");
+    }
+
+    // ── nw-414 ───────────────────────────────────────────────────────────
+
+    /// `summary` could not resolve an instance and so could not reach the
+    /// daemon: on a live instance the daemon holds the WAL and the direct open
+    /// fails. It now takes `--config` exactly as `hubs`/`bridges`/`memory lint`
+    /// do.
+    #[test]
+    fn summary_accepts_the_config_flag_its_siblings_have_always_had() {
+        let cli = parse_off_thread(vec![
+            "nestweaver",
+            "summary",
+            "--level",
+            "hub",
+            "--config",
+            "/tmp/instance.toml",
+        ])
+        .expect("summary --config must parse");
+        match cli.command {
+            Commands::Summary { config, .. } => assert_eq!(
+                config.as_deref(),
+                Some(Path::new("/tmp/instance.toml")),
+                "the flag must reach the handler, not merely be accepted"
+            ),
+            _ => panic!("expected Summary"),
+        }
+    }
+
+    /// COUNTERWEIGHT: adding the flag must not have made it REQUIRED. `summary`
+    /// with a bare `--db`, or with nothing at all, is the common invocation.
+    #[test]
+    fn summary_without_a_config_still_parses() {
+        let cli = parse_off_thread(vec!["nestweaver", "summary"]).expect("bare summary must parse");
+        match cli.command {
+            Commands::Summary { config, .. } => assert!(config.is_none()),
+            _ => panic!("expected Summary"),
+        }
+    }
+
+    // ── nw-418 ───────────────────────────────────────────────────────────
+
+    fn instance_config_with_unskip(
+        dir: &std::path::Path,
+        repo_url: &str,
+    ) -> nestweaver_engine::InstanceConfig {
+        let path = dir.join("instance.toml");
+        std::fs::write(
+            &path,
+            format!(
+                "instance_id = \"test\"\n\
+                 [snapshot_storage]\nbackend = \"local\"\npath = \"/tmp/snap\"\n\
+                 [workspace]\nbackend = \"local\"\npath = \"/tmp/ws\"\n\
+                 [inference]\nendpoint = \"http://localhost:11434\"\n\
+                 embedding_model = \"m\"\nsummary_model = \"m\"\n\
+                 [git]\ncredential_method = \"ssh\"\n\
+                 [[repos]]\n\
+                 url = \"{repo_url}\"\n\
+                 unskip = [\"public\"]\n\
+                 exclude = [\"vendor/**\"]\n"
+            ),
+        )
+        .expect("write instance config fixture");
+        nestweaver_engine::InstanceConfig::from_file(&path).expect("instance config fixture")
+    }
+
+    /// The key PARSED before this change and did nothing: `src/main.rs` never
+    /// resolved it, so `IndexOptions` and the incremental twin both received
+    /// the empty set. Resolved now, and both halves of the block come from one
+    /// config against one repo.
+    #[test]
+    fn a_declared_unskip_reaches_the_index_options() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = instance_config_with_unskip(tmp.path(), "file:///srv/app");
+        let (excludes, unskip) =
+            resolve_repo_directory_policy(Some(&config), "file:///srv/app", Path::new("/srv/app"));
+        assert_eq!(unskip, vec!["public".to_string()]);
+        assert_eq!(excludes, vec!["vendor/**".to_string()]);
+
+        let opts = nestweaver_engine::index::IndexOptions::new("test", "file:///srv/app", "sha")
+            .excludes(&excludes)
+            .unskip(&unskip);
+        assert_eq!(opts.unskip, vec!["public".to_string()]);
+        assert_eq!(opts.excludes, vec!["vendor/**".to_string()]);
+    }
+
+    /// COUNTERWEIGHT, and the one the item names explicitly: a repo the config
+    /// does NOT declare must still prune, or the fix has disabled `SKIP_DIRS`
+    /// rather than made one repo's re-admission effective. Same for no config
+    /// at all.
+    #[test]
+    fn an_undeclared_repo_keeps_its_skip_dirs() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = instance_config_with_unskip(tmp.path(), "file:///srv/app");
+        let (excludes, unskip) = resolve_repo_directory_policy(
+            Some(&config),
+            "file:///srv/other",
+            Path::new("/srv/other"),
+        );
+        assert!(
+            unskip.is_empty(),
+            "one repo's `unskip` must not re-admit `public/` for every other repo"
+        );
+        assert!(excludes.is_empty());
+
+        let (excludes, unskip) =
+            resolve_repo_directory_policy(None, "file:///srv/app", Path::new("/srv/app"));
+        assert!(unskip.is_empty() && excludes.is_empty());
+    }
+
+    /// The `[[repos]]` block is matched by URL **or** by local checkout path —
+    /// the same rule `exclude_globs_for` uses — because the same repo is spelled
+    /// three ways in practice. A policy that resolved on only one spelling is
+    /// how a declared `unskip` silently does nothing.
+    #[test]
+    fn the_policy_resolves_by_checkout_path_as_well_as_by_url() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = instance_config_with_unskip(tmp.path(), "/srv/app");
+        let (_, unskip) = resolve_repo_directory_policy(
+            Some(&config),
+            "https://github.com/example/app.git",
+            Path::new("/srv/app"),
+        );
+        assert_eq!(unskip, vec!["public".to_string()]);
     }
 }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -8650,3 +8650,123 @@ fn install_hook_refuses_unparseable_settings_and_names_the_position() {
         serde_json::from_str(&std::fs::read_to_string(&settings).unwrap()).unwrap();
     assert_eq!(after["env"]["MY_API_KEY"], "sk-live");
 }
+
+/// nw-399 / nw-400. The `--json` error contract, pinned as BEHAVIOUR.
+///
+/// The unit test in `src/main.rs` guards the WORDS of the contract in `--help`.
+/// It cannot guard the facts, and that gap is not hypothetical: the first
+/// version of that contract promised `{"error":"invalid argument"}` for exit
+/// 64, the documentation test passed, and the promise was false — clap raises a
+/// usage error before `--json` is ever read.
+///
+/// It is also the test nw-399 was missing. Its two existing tests call the
+/// payload builder directly and assert the help string exists, so removing every
+/// `print_json_not_found` call site leaves both green. This one goes through the
+/// real arm, so a revert fails it.
+#[test]
+fn the_json_error_contract_holds_as_behaviour_not_only_as_documentation() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().join("repo");
+    std::fs::create_dir_all(repo.join("src")).unwrap();
+    std::fs::write(repo.join("src/lib.rs"), "pub fn present() -> i32 { 1 }\n").unwrap();
+    let db = dir.path().join("t.lbug");
+
+    let index = std::process::Command::new(env!("CARGO_BIN_EXE_nestweaver"))
+        .args([
+            "index",
+            "--repo",
+            repo.to_str().unwrap(),
+            "--db",
+            db.to_str().unwrap(),
+        ])
+        .env("NESTWEAVER_NO_DAEMON", "1")
+        .env("NESTWEAVER_ALLOW_NO_DAEMON", "1")
+        .output()
+        .unwrap();
+    assert!(index.status.success(), "fixture index failed: {index:?}");
+
+    // 1. TARGET NOT FOUND -> exit 2 AND a JSON envelope keyed `error`.
+    //    This is the arm nw-399 wired; before it, stdout was zero bytes.
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_nestweaver"))
+        .args([
+            "context",
+            "zzNoSuchSymbol",
+            "--db",
+            db.to_str().unwrap(),
+            "--json",
+        ])
+        .env("NESTWEAVER_NO_DAEMON", "1")
+        .env("NESTWEAVER_ALLOW_NO_DAEMON", "1")
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "not found must be the documented code 2"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("--json must emit a JSON object, got {stdout:?}: {e}"));
+    assert_eq!(
+        parsed["error"], "not found",
+        "the envelope must be keyed `error` so a script can branch on it, not on prose: {parsed}"
+    );
+
+    // 2. COUNTERWEIGHT: a target that EXISTS must not be reported as missing.
+    //    Without this, deleting the lookup entirely would satisfy the assertion
+    //    above.
+    let ok = std::process::Command::new(env!("CARGO_BIN_EXE_nestweaver"))
+        .args(["context", "present", "--db", db.to_str().unwrap(), "--json"])
+        .env("NESTWEAVER_NO_DAEMON", "1")
+        .env("NESTWEAVER_ALLOW_NO_DAEMON", "1")
+        .output()
+        .unwrap();
+    assert_eq!(
+        ok.status.code(),
+        Some(0),
+        "a resolvable seed must succeed: {ok:?}"
+    );
+    let ok_json: serde_json::Value =
+        serde_json::from_str(String::from_utf8_lossy(&ok.stdout).trim()).expect("json");
+    assert!(
+        ok_json.get("error").is_none(),
+        "a success payload carries no error key"
+    );
+
+    // 3. THE EXCEPTION THE CONTRACT NOW STATES: a clap-rejected flag exits 64
+    //    and writes NOTHING to stdout. Pinned so the help text cannot drift back
+    //    to promising an envelope here.
+    let bad = std::process::Command::new(env!("CARGO_BIN_EXE_nestweaver"))
+        .args([
+            "brain",
+            "topic-clusters",
+            "--db",
+            db.to_str().unwrap(),
+            "--limit",
+            "0",
+            "--json",
+        ])
+        // Routing pinned even though clap rejects before either route is reached:
+        // `every_cli_invocation_pins_its_daemon_routing` requires it of any `--db`
+        // invocation, so a reader can tell which path a test exercises without
+        // reasoning about how far the command gets.
+        .env("NESTWEAVER_NO_DAEMON", "1")
+        .env("NESTWEAVER_ALLOW_NO_DAEMON", "1")
+        .output()
+        .unwrap();
+    assert_eq!(
+        bad.status.code(),
+        Some(64),
+        "an out-of-range flag is a usage error"
+    );
+    assert!(
+        bad.stdout.is_empty(),
+        "clap rejects before --json is read. If this ever fails, the --help contract can \
+         finally promise an envelope for 64 — until then it must keep saying it cannot."
+    );
+    assert!(
+        String::from_utf8_lossy(&bad.stderr).contains("1..=1000"),
+        "the usage error must name the bound, not an MCP tool: {:?}",
+        String::from_utf8_lossy(&bad.stderr)
+    );
+}

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -4959,16 +4959,37 @@ fn daemon_extension_arg_errors_use_tool_failed_format() {
     let _guard = DaemonGuard::new(&db_path);
     start_daemon(&db_path);
 
-    // MCP-visible path: query_extensions (its schema lets these through to the
-    // daemon handler).
+    // MCP-visible path: query_extensions.
+    //
+    // nw-410 CHANGED WHICH LAYER ANSWERS THESE, and the expectations move with
+    // it. The either/or requirement is now declared in the schema as
+    // `anyOf: [{required:["uid"]}, {required:["key","value"]}]` — which is what
+    // lets `tools/list` and the generated guide state it, instead of
+    // `brain_guide` rendering "Key parameters: —" for a tool that hard-errors
+    // without arguments. So VALIDATION now rejects the call before dispatch, and
+    // the handler's own message is shadowed on this route.
+    //
+    // NOTHING IS LOST IN PRECISION, which is why the two expectations below
+    // DIFFER. The renderer reports only the members a branch is actually
+    // MISSING, so it is instance-aware:
+    //   {}                  -> "either 'uid' or both 'key' and 'value'"
+    //   { "key": "owner" }  -> "either 'uid' or 'value'"
+    // The second names exactly the one field the caller still owes — the same
+    // information the handler's "'value' is required when 'key' is given"
+    // carried, plus the alternative form. Asserting both cases against the SAME
+    // string would have hidden that and let a future change collapse the
+    // partial case back to a generic list without failing anything.
+    //
+    // The raw-gRPC handler (`server.rs`) is untouched and still produces the
+    // pointed message for direct gRPC clients, so nothing is lost there.
     for (args, needle) in [
         (
             serde_json::json!({}),
-            "tool query_extensions failed: provide either 'uid' or both 'key' and 'value'",
+            "invalid arguments for tool 'query_extensions': /: schema keyword 'anyOf' failed — provide either 'uid' or both 'key' and 'value'",
         ),
         (
             serde_json::json!({ "key": "owner" }),
-            "tool query_extensions failed: 'value' is required when 'key' is given",
+            "invalid arguments for tool 'query_extensions': /: schema keyword 'anyOf' failed — provide either 'uid' or 'value'",
         ),
     ] {
         let output = mcp_tool_call_in_mode(&db_path, "query_extensions", args, McpMode::Daemon);


### PR DESCRIPTION
Second sweep over the ready high/medium queue. One branch, two commits: the sweep, then every finding from an independent review.

**Local gate** (mirrors `.github/workflows/ci.yml`): fmt · `--locked` metadata · build · config validate · `check --benches` · `clippy --workspace --all-targets -D warnings` · workspace tests · daemon integration — **8/8, 4,483 tests, 0 failed.** `Cargo.lock` untouched.

## The one to read first

**nw-422 — nw-387 shipped a remedy for a config key that did not exist.** It told operators to *"re-admit it with `[[repos]] unskip`"*. `RepoConfig` is `deny_unknown_fields`, so following that advice made the operator's **entire instance config fail to parse**. Worse than the silent drop it replaced: we degraded their coverage, handed them a remedy, and the remedy broke their instance.

It survived because `unskipping()` had tests and **zero production callers** — the capability was real, the config surface absent. Every test passed. That is nw-334's class, and its remedy table has no row for a remedy printed by the *indexer* rather than the CLI reporter. Action recorded there.

## Closed

| | |
|---|---|
| **nw-418** | `unskip` honoured on full scan, ignored on incremental — and nw-387's channel *couldn't* catch it, since nothing is pruned there. One predicate, both routes, set travels on the reader. Wired on CLI **and** daemon. |
| **nw-394** | git-tracked-but-gitignored files dropped with coverage `complete`. Disclosed rather than re-admitted — honouring the git index would pull megabytes of generated code into the graph. |
| **nw-398** | `count == len(list)`; betweenness was a 500-source estimate at 14 significant digits with nothing saying so. The false "normalized by sources sampled" claim **deleted**, not implemented — the code scales *up*, so implementing the comment would have changed every value callers rank. |
| **nw-408 / nw-410 / nw-411 / nw-409** | Validation errors name the property; eight either/or requirements moved into the schema (hand-coded subset **deleted**); an unbounded traversal bounded; a cap that named a nonexistent remedy split into recoverable vs internal. |
| **nw-399 / nw-400** | Eight commands emit a JSON error object instead of zero bytes; one documented code for "target not found"; five subcommands get clap bounds so a CLI user never meets the MCP validator. |
| **nw-404 / nw-414 / nw-361** | Self-ownership latch so a lease *this* process holds can't suppress a corruption verdict; `summary` routes through the daemon; nw-361 found already fixed on `main`. |

## What the review caught that I'd have shipped

- My new `--help` contract was **false in three ways** — clap exits 64 before `--json` is read, so it promised an envelope for exactly the class that cannot emit one.
- **nw-399 had no test that fails on revert.** Now sabotage-verified against the original symptom.
- **nw-394's remedy was inert on its own population** — git cannot re-include a file whose parent directory is excluded, and directory patterns are the entire population.
- **`BridgeNodes::truncated()` could report `false` for a cut answer.** Sabotage-verified; the padded-tail counterweight was *encoding* the bug.

## Known open, not claimed

- Several nw-394 suppressions have no test that fails if deleted.
- `interactions status|clear|show` still take `--db` without `--config`; nw-414's table-driven check was not added.
- **nw-417 raised `low` → `medium`**: three tests across three subsystems now fail intermittently under full-suite parallelism and pass alone. The newest is in a file this branch does not touch at all, so it cannot be a regression.

Field order on `DbWriteLease` is load-bearing and now says so — the flock must release before the latch clears, or the window inverts from "report corruption anyway" to "silently suppress it".
