### PR TITLE
fix: close nw-373, advance nw-316, and land nw-217's remaining legs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,46 @@ For security vulnerabilities, see [SECURITY.md](.github/SECURITY.md) instead.
 PRs should be focused — one feature or fix per PR. If a change touches
 multiple crates, that's fine as long as it's one logical change.
 
+## Review rule: sibling gaps
+
+**When the same property must hold in two places, make the second place CALL
+the first, or make the property a TYPE. Do not write it twice and remember to
+check the twin.**
+
+"Remember to check the twin" has failed at least ten times in this repo. Every
+instance of this class that has stayed fixed was fixed structurally; every one
+patched by mirroring came back. This is a review rule rather than a lint
+because the two legs it covers are not syntactically expressible — "these two
+functions should agree" is not a pattern a checker can match, and a semantic
+divergence between routes is what the parity harness exists for. Where the
+property *can* be checked mechanically it already is (see the CLI/MCP bounds
+sweep in `src/main.rs`, which probes every declared bound through the real
+parser).
+
+### The canon
+
+Worked examples that shipped, so this is a canon rather than an exhortation:
+
+| Example | The shape |
+| --- | --- |
+| `render_cost` | The CLI's twin was DELETED and the function made `pub` so the CLI calls it. The copy had drifted to the wrong branch and was charging a concise response at the detailed rate. |
+| `property_matches` | The CLI calls the MCP predicate instead of restating it. |
+| `repo_head` | One implementation behind both `stale-check` routes. |
+| `DbWriteLease` | `#[must_use]` moved onto the TYPE rather than each producer, so no caller can forget it. |
+| `provenance_seam::Unstamped` | The field is private to its module, so `stamp` is the only way to construct the stamped form — the property is unforgeable rather than remembered. |
+| `PublicationRootLock` | Destructive routes take the lock BY REFERENCE and continue through its canonical root, so a route cannot hold a lock that does not cover what it deletes. |
+| `render_optional_count`, `MAX_IMPACT_DEPTH` | Shared renderer and shared constant, rather than two spellings of one number. |
+
+### The caveat that saves you from a regression
+
+**"Sibling A has a guard sibling B lacks" does not always mean B should take it.**
+Blindly mirroring a sibling's write-gate onto `brain_memory_consolidate` would
+have made every dry-run PREVIEW queue behind in-flight writes — a guard that is
+correct for the mutating path and wrong for the read-only one. Establish that
+the property genuinely belongs in both places before unifying; sometimes the
+honest answer is that the twins legitimately differ, and then the divergence
+belongs in a comment rather than in a shared function.
+
 ## Architecture
 
 See [CLAUDE.md](CLAUDE.md) for the crate dependency diagram and conventions.

--- a/crates/nestweaver-engine/src/publication.rs
+++ b/crates/nestweaver-engine/src/publication.rs
@@ -847,7 +847,7 @@ impl PublicationRootLock {
         std::fs::canonicalize(publication_root).is_ok_and(|root| root == self.root)
     }
 
-    fn ensure_authorizes(&self, publication_root: &Path) -> anyhow::Result<&Path> {
+    pub(crate) fn ensure_authorizes(&self, publication_root: &Path) -> anyhow::Result<&Path> {
         if self.authorizes(publication_root) {
             Ok(&self.root)
         } else {
@@ -2337,6 +2337,32 @@ mod tests {
         assert!(
             error.to_string().contains("does not authorize"),
             "wrong-root rollback must fail before inspecting the target: {error}"
+        );
+        // nw-373: `discard` is the third destructive publication route, and it
+        // took a root lock it never USED -- the binding was `_root_lock`, so
+        // nothing proved the lock covered the root being mutated. It must fail
+        // closed on a wrong root exactly like its two siblings above, and
+        // BEFORE it loads or inspects any journal.
+        let error = crate::publication_operation::discard_operation(
+            &unrelated,
+            "00000000-0000-4000-8000-000000000001",
+            0,
+            &lock,
+        )
+        .unwrap_err();
+        assert!(
+            error.to_string().contains("does not authorize"),
+            "wrong-root discard must fail before inspecting the journal: {error}"
+        );
+        let error = crate::publication_operation::discard_invalid_operation(
+            &unrelated,
+            "00000000-0000-4000-8000-000000000001",
+            &lock,
+        )
+        .unwrap_err();
+        assert!(
+            error.to_string().contains("does not authorize"),
+            "wrong-root invalid-discard must fail closed too: {error}"
         );
         lease.release().unwrap();
     }

--- a/crates/nestweaver-engine/src/publication_operation.rs
+++ b/crates/nestweaver-engine/src/publication_operation.rs
@@ -659,11 +659,31 @@ pub fn resume_operation(
 /// renamed out of the active UUID namespace before recursive deletion. A crash
 /// at any point therefore leaves either an inspectable active operation or an
 /// ignored `.discarded-*` tombstone, never a half-deleted selectable slot.
+/// Discard a cancelled or failed staging operation, removing its journal and
+/// any slot it staged.
+///
+/// nw-373 asked whether this route should hold the canonical DB write lease
+/// across its renames, as `backup restore` now does. IT SHOULD NOT, and the
+/// reason is recorded in `prune_slots`' own comment: an `IndexPublicationLease`
+/// "looked like exclusion but is not -- that lease is an in-process
+/// Mutex/Condvar owned by one GraphStore, so a rebuild in another process holds
+/// an unrelated one." The primitive that actually serializes rebuild, rollback
+/// AND discard is the root lock, anchored to the root being mutated.
+///
+/// What was genuinely missing is that this route took a root lock and never
+/// USED it -- the CLI bound it as `_root_lock` and it never reached here, so
+/// nothing proved the lock covered the root being mutated. That is the same
+/// dead-parameter defect already fixed in `prune_slots` and
+/// `rollback_current_under_lock`; taking the lock by reference and continuing
+/// through its canonical root closes it the same way, and keeps a symlink alias
+/// from being retargeted between the coverage check and the filesystem work.
 pub fn discard_operation(
     publication_root: &Path,
     operation_uuid: &str,
     expected_revision: u64,
+    lock: &crate::publication::PublicationRootLock,
 ) -> anyhow::Result<()> {
+    let publication_root = lock.ensure_authorizes(publication_root)?;
     let state = load_operation(publication_root, operation_uuid)?;
     if state.revision != expected_revision {
         anyhow::bail!(
@@ -728,7 +748,9 @@ pub fn discard_operation(
 pub fn discard_invalid_operation(
     publication_root: &Path,
     operation_uuid: &str,
+    lock: &crate::publication::PublicationRootLock,
 ) -> anyhow::Result<()> {
+    let publication_root = lock.ensure_authorizes(publication_root)?;
     parse_non_nil_uuid("operation_uuid", operation_uuid)?;
     let operation_dir = crate::publication::operation_path(publication_root, operation_uuid)?;
     let tombstone = publication_root.join("operations").join(format!(
@@ -1281,7 +1303,13 @@ mod tests {
             crate::publication::slot_path(dir.path(), &plan.target_publication_uuid).unwrap();
         std::fs::create_dir_all(&slot).unwrap();
         std::fs::write(slot.join("partial"), b"staging").unwrap();
-        discard_operation(dir.path(), &plan.operation_uuid, cancelled.revision).unwrap();
+        discard_operation(
+            dir.path(),
+            &plan.operation_uuid,
+            cancelled.revision,
+            &crate::publication::PublicationRootLock::acquire(dir.path()).unwrap(),
+        )
+        .unwrap();
         assert!(!slot.exists());
         assert!(list_operations(dir.path()).unwrap().is_empty());
     }
@@ -1321,7 +1349,12 @@ mod tests {
                 .contains("decode publication operation")
         );
 
-        discard_invalid_operation(dir.path(), &invalid_plan.operation_uuid).unwrap();
+        discard_invalid_operation(
+            dir.path(),
+            &invalid_plan.operation_uuid,
+            &crate::publication::PublicationRootLock::acquire(dir.path()).unwrap(),
+        )
+        .unwrap();
         assert!(
             invalid_slot.exists(),
             "an unreadable journal cannot authorize deleting an unknown target slot"
@@ -1336,7 +1369,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let plan = plan();
         create_operation(dir.path(), plan.clone()).unwrap();
-        let error = discard_invalid_operation(dir.path(), &plan.operation_uuid).unwrap_err();
+        let error = discard_invalid_operation(
+            dir.path(),
+            &plan.operation_uuid,
+            &crate::publication::PublicationRootLock::acquire(dir.path()).unwrap(),
+        )
+        .unwrap_err();
         assert!(error.to_string().contains("journal is readable"));
     }
 
@@ -1383,8 +1421,13 @@ mod tests {
         assert_ne!(cancelled.phase, PublicationPhase::Cancelled);
 
         // Before: refused, and the message must now name the way out.
-        let error = discard_operation(root, &cancelled.plan.operation_uuid, cancelled.revision)
-            .expect_err("an unacknowledged cancel is not directly discardable");
+        let error = discard_operation(
+            root,
+            &cancelled.plan.operation_uuid,
+            cancelled.revision,
+            &crate::publication::PublicationRootLock::acquire(root).unwrap(),
+        )
+        .expect_err("an unacknowledged cancel is not directly discardable");
         let message = error.to_string();
         assert!(
             message.contains("--force"),
@@ -1399,6 +1442,7 @@ mod tests {
             root,
             &acknowledged.plan.operation_uuid,
             acknowledged.revision,
+            &crate::publication::PublicationRootLock::acquire(root).unwrap(),
         )
         .expect("an acknowledged cancellation must be discardable");
     }
@@ -1424,7 +1468,12 @@ mod tests {
                 .contains("state version 2 is incompatible")
         );
 
-        discard_invalid_operation(dir.path(), &plan.operation_uuid).unwrap();
+        discard_invalid_operation(
+            dir.path(),
+            &plan.operation_uuid,
+            &crate::publication::PublicationRootLock::acquire(dir.path()).unwrap(),
+        )
+        .unwrap();
         assert!(list_operations(dir.path()).unwrap().is_empty());
     }
 }

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -11801,6 +11801,10 @@ fn tool_project_context(
             "tokens_used": 0,
             "token_budget": token_budget,
             "note": "No notes or symbols are associated with this project yet.",
+            // Disclosed here too: an empty answer is still AN answer, and two
+            // routes disagreeing about whether a project has members is
+            // exactly the divergence this field exists to attribute.
+            "_meta": { "answered_by": answering_config_disclosure() },
         }));
     }
 
@@ -12197,6 +12201,10 @@ fn tool_project_context(
     if !external_refs.is_null() {
         resp["external_refs"] = external_refs;
     }
+
+    // nw-316: state which config answered, on EVERY return path, so a caller
+    // comparing two routes can attribute a divergence instead of guessing.
+    resp["_meta"]["answered_by"] = answering_config_disclosure();
 
     Ok(resp)
 }
@@ -13401,6 +13409,35 @@ pub fn set_current_instance_config(cfg: Option<std::sync::Arc<nestweaver_engine:
 pub(crate) fn current_instance_config() -> Option<std::sync::Arc<nestweaver_engine::InstanceConfig>>
 {
     CURRENT_INSTANCE_CONFIG.with(|c| c.borrow().clone())
+}
+
+/// Which instance config answered THIS dispatch.
+///
+/// nw-316: `project-context` returned a different result set on all three
+/// routes for the same project and budget, and nothing in any response said so.
+/// Both routes now run one function, so the divergence is in the AMBIENT config
+/// it reads -- the daemon answers with the config it BOOTED with, the direct
+/// route with whatever the caller loaded. Until the answer states which config
+/// produced it, config can be neither confirmed nor eliminated as the cause,
+/// which is why the item's own recommendation puts this disclosure first: it is
+/// the diagnostic, and it is required whether or not the routing changes.
+///
+/// Identity, not path. `instance_id` is meaningful across routes and processes;
+/// a config file path would leak the operator's filesystem layout to a remote
+/// caller and would not even be comparable between them. `config_installed` is
+/// stated explicitly so an absent config is distinguishable from an old binary
+/// that never emitted the field.
+pub(crate) fn answering_config_disclosure() -> Value {
+    match current_instance_config() {
+        Some(cfg) => json!({
+            "config_installed": true,
+            "instance_id": cfg.instance_id,
+        }),
+        None => json!({
+            "config_installed": false,
+            "instance_id": Value::Null,
+        }),
+    }
 }
 
 /// Read the configured default result limit from the instance config's
@@ -15591,6 +15628,117 @@ mod project_context_bug12_tests {
             note_uids.len(),
             "all {} member notes must surface in connected; got {uids:?}",
             note_uids.len()
+        );
+    }
+
+    /// nw-316. Three routes answered the same `project-context` request
+    /// differently and NOTHING in any response said so. Both routes now run
+    /// this one function, so the divergence is in the AMBIENT config it reads:
+    /// the daemon answers with its BOOT config, the direct route with the
+    /// caller's. Until a response states which config answered, config cannot
+    /// be confirmed OR eliminated as the cause — the item's own recommendation
+    /// is that this disclosure comes first, because it is the diagnostic.
+    #[test]
+    fn project_context_discloses_which_instance_config_answered() {
+        let store = GraphStore::in_memory().unwrap();
+        store
+            .insert_project(&Project {
+                uid: "proj:disclosed".into(),
+                name: "Disclosed".into(),
+                summary: None,
+                instance_id: "inst".into(),
+            })
+            .unwrap();
+
+        let ask = || {
+            tool_project_context(
+                &store,
+                None,
+                json!({ "project": "Disclosed", "token_budget": 5000 }),
+                None,
+                None,
+                None,
+            )
+            .unwrap()
+        };
+
+        // No config installed: the response must SAY so rather than omit the
+        // field, because an absent key is indistinguishable from an old binary.
+        set_current_instance_config(None);
+        let anonymous = ask();
+        assert_eq!(
+            anonymous["_meta"]["answered_by"]["config_installed"], false,
+            "a config-less dispatch must disclose that: {anonymous}"
+        );
+
+        // With a config installed, the response names the instance that
+        // answered. This is the value that differs between the daemon's boot
+        // config and a `--config` the CLI loaded, which is what makes the
+        // 827/829/815 divergence attributable instead of unexplained.
+        let cfg: nestweaver_engine::InstanceConfig = serde_json::from_value(json!({
+            "instance_id": "instance-under-test",
+            "repos": [],
+            "snapshot_storage": { "backend": "local", "path": "/tmp" },
+            "workspace": { "backend": "local", "path": "/tmp" },
+            "inference": { "endpoint": "", "embedding_model": "", "summary_model": "" },
+            "git": { "credential_method": "ssh" }
+        }))
+        .expect("valid instance config");
+        set_current_instance_config(Some(std::sync::Arc::new(cfg)));
+        let named = ask();
+        set_current_instance_config(None);
+
+        assert_eq!(named["_meta"]["answered_by"]["config_installed"], true);
+        assert_eq!(
+            named["_meta"]["answered_by"]["instance_id"], "instance-under-test",
+            "the answering instance must be named: {named}"
+        );
+
+        // BOTH return paths. The assertions above exercise the empty-project
+        // early return; the main path assembles a different object and had its
+        // own `Ok`, so a disclosure added to only one of them would leave the
+        // populated case -- the one an agent actually opens a session with --
+        // silently undisclosed. Verified by sabotage: removing either site
+        // fails this test.
+        store
+            .insert_note(&mk_note(
+                "note:member",
+                "vault:v",
+                "notes/member.md",
+                "Member Note",
+            ))
+            .unwrap();
+        store
+            .batch_insert_project_note_edges(&[("proj:disclosed", "note:member")])
+            .unwrap();
+        let cfg2: nestweaver_engine::InstanceConfig = serde_json::from_value(json!({
+            "instance_id": "instance-under-test",
+            "repos": [],
+            "snapshot_storage": { "backend": "local", "path": "/tmp" },
+            "workspace": { "backend": "local", "path": "/tmp" },
+            "inference": { "endpoint": "", "embedding_model": "", "summary_model": "" },
+            "git": { "credential_method": "ssh" }
+        }))
+        .expect("valid instance config");
+        set_current_instance_config(Some(std::sync::Arc::new(cfg2)));
+        let populated = ask();
+        set_current_instance_config(None);
+        assert!(
+            populated["connected"]
+                .as_array()
+                .is_some_and(|c| !c.is_empty())
+                || populated["seeds_expanded"].as_u64().is_some_and(|n| n > 0),
+            "fixture must reach the POPULATED path, not the early return: {populated}"
+        );
+        assert_eq!(
+            populated["_meta"]["answered_by"]["instance_id"], "instance-under-test",
+            "the populated path must disclose too: {populated}"
+        );
+        // The disclosure must not leak a filesystem path to a remote caller;
+        // instance identity is the thing that is meaningful across routes.
+        assert!(
+            named["_meta"]["answered_by"].get("config_path").is_none(),
+            "disclose identity, not the operator's filesystem layout"
         );
     }
 

--- a/crates/nestweaver-schema/src/provenance.rs
+++ b/crates/nestweaver-schema/src/provenance.rs
@@ -70,10 +70,36 @@ pub fn provenance(scope: &str, sources: &[&str], stale_repos: &[String]) -> Valu
 /// need a bare array to become addressable.
 pub fn set(result: &mut Value, scope: &str, sources: &[&str], stale_repos: &[String]) {
     if let Some(obj) = result.as_object_mut() {
-        obj.insert(
-            META_KEY.to_string(),
-            provenance(scope, sources, stale_repos),
-        );
+        let stamped = provenance(scope, sources, stale_repos);
+        // MERGE the provenance fields into any existing `_meta`, rather than
+        // replacing the object.
+        //
+        // Replacing it silently destroyed every other key a handler had put
+        // there. nw-316 hit this first: `project_context` writes
+        // `_meta.answered_by` (which instance config produced the answer), and
+        // the daemon route stamps provenance AFTER the tool returns -- so the
+        // disclosure survived on the direct route and vanished on the daemon
+        // one. A field on one route only is exactly the drift nw-316 is about,
+        // reintroduced by the fix for it, and the parity harness caught it.
+        //
+        // Provenance still WINS on its own keys, so a federating caller's
+        // verdict is unchanged; what changes is that keys provenance does not
+        // own are no longer collateral. `ensure` already documents that not
+        // clobbering a richer verdict matters -- this gives `set` the same care
+        // for keys outside its vocabulary.
+        match (
+            obj.get_mut(META_KEY).and_then(Value::as_object_mut),
+            stamped,
+        ) {
+            (Some(existing), Value::Object(fields)) => {
+                for (key, value) in fields {
+                    existing.insert(key, value);
+                }
+            }
+            (_, stamped) => {
+                obj.insert(META_KEY.to_string(), stamped);
+            }
+        }
     }
 }
 
@@ -84,8 +110,32 @@ pub fn set(result: &mut Value, scope: &str, sources: &[&str], stale_repos: &[Str
 /// either — a payload with no `_meta` at all is the nw-315 defect.
 pub fn ensure(result: &mut Value, scope: &str, sources: &[&str], stale_repos: &[String]) {
     if let Some(obj) = result.as_object_mut() {
-        obj.entry(META_KEY)
-            .or_insert_with(|| provenance(scope, sources, stale_repos));
+        let stamped = provenance(scope, sources, stale_repos);
+        // Keyed on the provenance FIELDS, not on `_meta` existing.
+        //
+        // Testing the whole object made this skip entirely as soon as a handler
+        // put anything else under `_meta`. nw-316 tripped it: once
+        // `project_context` wrote `_meta.answered_by`, the direct route silently
+        // stopped receiving `scope`/`sources`/`stale_repos` -- a payload with no
+        // provenance at all, which is the nw-315 defect this function exists to
+        // prevent, reintroduced by an unrelated key appearing beside it.
+        //
+        // The stated contract is unchanged: a value already present WINS, so a
+        // federating caller's richer verdict is still never clobbered. What
+        // changed is that "already present" is now asked per field.
+        match (
+            obj.get_mut(META_KEY).and_then(Value::as_object_mut),
+            stamped,
+        ) {
+            (Some(existing), Value::Object(fields)) => {
+                for (key, value) in fields {
+                    existing.entry(key).or_insert(value);
+                }
+            }
+            (_, stamped) => {
+                obj.entry(META_KEY).or_insert(stamped);
+            }
+        }
     }
 }
 
@@ -128,6 +178,60 @@ pub fn set_stale_repos(result: &mut Value, stale_repos: &[String]) {
 
 #[cfg(test)]
 mod tests {
+    /// nw-316: `set` REPLACED `_meta`, destroying every key a handler had
+    /// already put there. `project_context` writes `_meta.answered_by` naming
+    /// the instance config that produced the answer; the daemon route stamps
+    /// provenance after the tool returns, so the disclosure survived on the
+    /// direct route and vanished on the daemon one -- a field on one route
+    /// only, which is the exact drift nw-316 exists to fix.
+    #[test]
+    fn set_merges_rather_than_destroying_keys_it_does_not_own() {
+        let mut result = serde_json::json!({
+            "answer": 1,
+            "_meta": { "answered_by": { "instance_id": "kept" } }
+        });
+        super::set(&mut result, "local", &["local"], &[]);
+
+        assert_eq!(
+            result["_meta"]["answered_by"]["instance_id"], "kept",
+            "a key provenance does not own must survive the stamp: {result}"
+        );
+        // Provenance still wins on its own vocabulary.
+        assert_eq!(result["_meta"]["scope"], "local");
+        assert!(result["_meta"]["sources"].is_array());
+    }
+
+    /// nw-316: `ensure` keyed on `_meta` EXISTING, so the moment a handler put
+    /// any unrelated key there it stopped stamping provenance at all -- the
+    /// nw-315 defect (a payload with no provenance) reintroduced sideways. It
+    /// must fill in the fields it owns while still never clobbering a value
+    /// that is already there.
+    #[test]
+    fn ensure_stamps_alongside_an_unrelated_meta_key() {
+        let mut result = serde_json::json!({
+            "answer": 1,
+            "_meta": { "answered_by": { "instance_id": "kept" } }
+        });
+        super::ensure(&mut result, "local", &["local"], &[]);
+
+        assert_eq!(result["_meta"]["answered_by"]["instance_id"], "kept");
+        assert_eq!(
+            result["_meta"]["scope"], "local",
+            "an unrelated key must not suppress the provenance stamp: {result}"
+        );
+        assert!(result["_meta"]["sources"].is_array());
+        assert!(result["_meta"]["stale_repos"].is_array());
+    }
+
+    /// The counterweight: with no existing `_meta`, the stamp is still written
+    /// whole. A payload with no provenance at all is the nw-315 defect.
+    #[test]
+    fn set_still_stamps_a_payload_with_no_existing_meta() {
+        let mut result = serde_json::json!({ "answer": 1 });
+        super::set(&mut result, "local", &["local"], &[]);
+        assert_eq!(result["_meta"]["scope"], "local");
+    }
+
     use super::*;
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -18819,7 +18819,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // `include_components` came to differ between them (nw-316 leg 2).
             let direct_args = project_args.clone();
             let daemon_result = try_hybrid_json_rpc_checked(
-                use_daemon,
+                // nw-316: `--config` names an InstanceConfig the daemon cannot
+                // honour, so it reroutes rather than being forwarded.
+                daemon_may_serve(use_daemon, config.as_deref()),
                 &db_path,
                 config.as_deref(),
                 "project_context",
@@ -22726,6 +22728,33 @@ fn daemon_rpc_timeout(args: &serde_json::Value) -> Option<std::time::Duration> {
             std::time::Duration::from_millis(ms).saturating_add(std::time::Duration::from_secs(30))
         });
     Some(budget.unwrap_or(RPC_TIMEOUT_DEFAULT))
+}
+
+/// Whether the daemon may serve a request that named `--config`.
+///
+/// It may not, and this is a SECURITY boundary, not a convenience. nw-316's
+/// research settled it: `InstanceConfig` carries `authz`, and
+/// `build_daemon_permission_source` derives the daemon's ENTIRE permission
+/// source from it, with `None` meaning every caller is `VisibleRepos::All`. A
+/// client that could forward its own config into request handling could supply
+/// its own authorization policy, or omit it and be promoted to see everything --
+/// a total bypass of nw-403 and nw-415. Most of the struct is also
+/// process-lifetime rather than request-scoped (`embedding` names a model the
+/// daemon loaded at BOOT, against vectors already on disk), so "forward the
+/// config" silently splits into keys that can be honoured and keys that cannot,
+/// with nothing telling the caller which half it got.
+///
+/// So `--config` joins `--no-tests` and `--prefer-instance` in forcing the
+/// direct route: the caller gets exactly the config they named, and a shared
+/// multi-client daemon can never be reconfigured by one client. A caller who
+/// genuinely needs a different config served remotely wants a second daemon
+/// INSTANCE, which the instance model already supports.
+///
+/// `tool_brain_guide` already refuses a caller-supplied `config` for the same
+/// reason and says so in its schema; this is that precedent applied to the
+/// route that has an alternative.
+fn daemon_may_serve(use_daemon: bool, config: Option<&std::path::Path>) -> bool {
+    use_daemon && config.is_none()
 }
 
 fn try_hybrid_json_rpc_checked(
@@ -40473,6 +40502,35 @@ mod brain_context_scope_filter_tests {
 /// that silently narrows drops the regression test that would have caught the
 /// change, with nothing downstream able to tell that from "no tests exist".
 #[cfg(test)]
+mod nw316_route_tests {
+    use super::daemon_may_serve;
+    use std::path::Path;
+
+    /// nw-316. `--config` must force the direct route rather than be forwarded
+    /// into the RPC: `InstanceConfig` carries the authorization policy, so a
+    /// forwarded config is a permission bypass, and most of the struct is
+    /// process-lifetime rather than request-scoped.
+    #[test]
+    fn naming_a_config_forces_the_direct_route() {
+        assert!(
+            daemon_may_serve(true, None),
+            "an ordinary request still uses the daemon"
+        );
+        assert!(
+            !daemon_may_serve(true, Some(Path::new("/tmp/instance.toml"))),
+            "--config must reroute, never forward"
+        );
+        assert!(
+            !daemon_may_serve(false, None),
+            "an explicit no-daemon request is still direct"
+        );
+        assert!(
+            !daemon_may_serve(false, Some(Path::new("/tmp/instance.toml"))),
+            "both reasons together stay direct"
+        );
+    }
+}
+
 mod resolver_generation_gate_tests {
     use super::*;
     use nestweaver_engine::blast_radius::{AnalysisStatus, BlastRadiusResult};

--- a/src/main.rs
+++ b/src/main.rs
@@ -32441,7 +32441,11 @@ fn run_publication(command: PublicationCommands, no_embed: bool) -> anyhow::Resu
         } => {
             let root = root(explicit_root, db)?;
             // Serialize against rebuild / rollback / prune on this same root.
-            let _root_lock = nestweaver_engine::publication::PublicationRootLock::acquire(&root)?;
+            // nw-373: bound and USED, not discarded. Passing it into the
+            // discard routes is what proves the lock covers the root being
+            // mutated -- the same fix already applied to `prune_slots` and
+            // `rollback_current_under_lock`.
+            let root_lock = nestweaver_engine::publication::PublicationRootLock::acquire(&root)?;
             // nw-146: request_cancel only sets `cancel_requested`; ONLY the
             // running worker calls acknowledge_cancel to reach phase Cancelled.
             // If that worker is gone, both discard paths refused — `--revision`
@@ -32480,7 +32484,7 @@ fn run_publication(command: PublicationCommands, no_embed: bool) -> anyhow::Resu
             }
             if invalid {
                 nestweaver_engine::publication_operation::discard_invalid_operation(
-                    &root, &operation,
+                    &root, &operation, &root_lock,
                 )?;
                 println!(
                     "Discarded invalid publication operation {operation}; publication slots were preserved"
@@ -32490,6 +32494,7 @@ fn run_publication(command: PublicationCommands, no_embed: bool) -> anyhow::Resu
                     &root,
                     &operation,
                     revision.expect("clap requires --revision unless --invalid is present"),
+                    &root_lock,
                 )?;
                 println!("Discarded publication operation {operation}");
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40689,6 +40689,7 @@ mod nw316_route_tests {
     }
 }
 
+#[cfg(test)]
 mod resolver_generation_gate_tests {
     use super::*;
     use nestweaver_engine::blast_radius::{AnalysisStatus, BlastRadiusResult};

--- a/src/main.rs
+++ b/src/main.rs
@@ -4794,8 +4794,13 @@ enum Commands {
         symbol: String,
         #[arg(
             long,
-            value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=10000),
-            help = "Maximum contract links to return"
+            // nw-217b: was `1..=10000` while the MCP schema declares
+            // `maximum: 1000` (RESULT_LIMIT_MAX) -- a TEN-FOLD divergence, so
+            // `--limit 5000` was accepted without a daemon and rejected with
+            // one. Narrowed to the schema, which is the contract; the daemon
+            // route already refused anything above it.
+            value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=1000),
+            help = "Maximum contract links to return (1-1000; default 50, matching the MCP cross_repo_contracts schema)"
         )]
         limit: Option<usize>,
         #[arg(long, help = "Output as JSON")]
@@ -5295,16 +5300,28 @@ enum Commands {
             help = "Resolution parameter, greater than 0 (higher = smaller clusters) [default: 0.5, or 0.3 for large graphs >10K symbols]"
         )]
         resolution: Option<f64>,
+        // nw-217b: the range is COPIED from the MCP schema, not re-derived.
+        // Found by the S4 sweep, which probes each declared bound through
+        // the real parser -- this flag accepted 1001 while the schema
+        // declared maximum 1000, so the bound was a property of the
+        // TRANSPORT rather than of the contract (nw-259b's shape).
         #[arg(
             long,
             default_value_t = 50,
-            help = "Maximum communities to report; 0 = all"
+            value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(0..=1000),
+            help = "Maximum communities to report (0-1000; 0 = all, default 50; matches the MCP clusters schema)"
         )]
         limit: usize,
+        // nw-217b: the range is COPIED from the MCP schema, not re-derived.
+        // Found by the S4 sweep, which probes each declared bound through
+        // the real parser -- this flag accepted 201 while the schema
+        // declared maximum 200, so the bound was a property of the
+        // TRANSPORT rather than of the contract (nw-259b's shape).
         #[arg(
             long,
             default_value_t = 20,
-            help = "Maximum members listed per community; 0 = all"
+            value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(0..=200),
+            help = "Maximum members listed per community (0-200; 0 = all, default 20; matches the MCP clusters schema)"
         )]
         members: usize,
         #[arg(long, help = "Output as JSON")]
@@ -7104,10 +7121,14 @@ enum BrainCommands {
         /// nw-341: rows sort unresolved-first then by ASCENDING confidence, so
         /// the 0.90/0.92/0.95 tiers are the TAIL. Without this the tiers a
         /// reviewer must inspect are exactly the ones a limit removes.
+        // nw-217b: range COPIED from the MCP schema. The S4 sweep found this
+        // flag accepting 1001 while the schema declared maximum 1000 -- the
+        // bound was a property of the TRANSPORT, not the contract (nw-259b).
         #[arg(
             long,
             default_value_t = 0,
-            help = "Skip this many rows before the page. The high-confidence tiers sort LAST, so this is how you reach them"
+            value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(0..=1000),
+            help = "Skip this many rows before the page (0-1000; default 0; matches the MCP brain_broken_links schema). The high-confidence tiers sort LAST, so this is how you reach them"
         )]
         offset: usize,
         #[arg(long, help = "Output as JSON")]
@@ -27682,6 +27703,143 @@ mod cli_help_contract_tests {
             "{} command(s)/arg(s) ship without help text:\n{}",
             gaps.len(),
             gaps.join("\n")
+        );
+    }
+
+    /// Map a clap subcommand path onto its MCP tool name.
+    ///
+    /// Mostly mechanical -- `dead-code` -> `dead_code`, `brain context` ->
+    /// `brain_context` -- with an explicit alias table for the handful whose
+    /// CLI verb deliberately differs from the registry name. A path with no
+    /// match is SKIPPED, not failed: `export --top` has no MCP twin and
+    /// requiring one would turn this guard into a demand that every flag be
+    /// mirrored into the tool surface.
+    fn tool_name_for_cli_path(path: &str) -> Option<String> {
+        let aliases = [
+            ("context", "code_context"),
+            ("hubs", "hub_nodes"),
+            ("bridges", "bridge_nodes"),
+        ];
+        let stripped = path.strip_prefix("nestweaver ").unwrap_or(path);
+        if let Some((_, tool)) = aliases.iter().find(|(cli, _)| *cli == stripped) {
+            return Some((*tool).to_string());
+        }
+        Some(stripped.replace([' ', '-'], "_"))
+    }
+
+    /// nw-217b, the S4 leg of [[nw-217]]: for every CLI flag with an MCP schema
+    /// counterpart, the DECLARED bounds must actually be enforced by the CLI.
+    ///
+    /// The motivating instance is nw-259b: `context --limit` had NO
+    /// `value_parser` while `code_context`'s schema says `minimum: 1,
+    /// maximum: 5000` and the daemon proxy validates against it -- so
+    /// `--limit 6000` was ACCEPTED without a daemon and REJECTED with one.
+    /// **The bound was a property of the transport, not of the contract.**
+    ///
+    /// This probes BEHAVIOUR rather than reading clap's internals, because a
+    /// `value_parser`'s range is not introspectable: it feeds the real parser a
+    /// value one past each declared bound and requires a rejection. That is the
+    /// same thing the user would hit, and it is what a missing `value_parser`
+    /// fails.
+    #[test]
+    fn cli_flags_enforce_the_bounds_their_mcp_schema_twins_declare() {
+        let listing = nestweaver_mcp::tools::tool_list(false);
+        let mut schema_by_tool: std::collections::HashMap<String, serde_json::Value> =
+            std::collections::HashMap::new();
+        for tool in listing["tools"].as_array().expect("tool list") {
+            if let Some(name) = tool["name"].as_str() {
+                schema_by_tool.insert(name.to_string(), tool["inputSchema"].clone());
+            }
+        }
+        assert!(
+            schema_by_tool.len() >= 30,
+            "tool registry looks empty ({} tools) -- the guard would pass vacuously",
+            schema_by_tool.len()
+        );
+
+        let (violations, pairs, probes) = on_big_stack(move || {
+            let root = Cli::command();
+            let mut violations: Vec<String> = Vec::new();
+            let mut pairs = 0usize;
+            let mut probes = 0usize;
+            let mut queue: Vec<(&clap::Command, Vec<String>)> = vec![(&root, Vec::new())];
+
+            while let Some((cmd, path)) = queue.pop() {
+                for sub in cmd.get_subcommands() {
+                    let mut child = path.clone();
+                    child.push(sub.get_name().to_string());
+                    queue.push((sub, child));
+                }
+                if path.is_empty() {
+                    continue;
+                }
+                let Some(schema) = tool_name_for_cli_path(&path.join(" "))
+                    .and_then(|tool| schema_by_tool.get(&tool))
+                else {
+                    continue;
+                };
+                let Some(properties) = schema["properties"].as_object() else {
+                    continue;
+                };
+                pairs += 1;
+
+                // Required positionals must be satisfied or the parse fails for
+                // an unrelated reason and every probe would "pass".
+                let mut base: Vec<String> = vec!["nestweaver".to_string()];
+                base.extend(path.iter().cloned());
+                for positional in cmd.get_positionals() {
+                    if positional.is_required_set() {
+                        base.push("probe-value".to_string());
+                    }
+                }
+
+                for arg in cmd.get_arguments() {
+                    if arg.is_hide_set() || arg.is_positional() {
+                        continue;
+                    }
+                    let Some(long) = arg.get_long() else { continue };
+                    let Some(declared) = properties.get(long) else {
+                        continue;
+                    };
+                    for (key, offset) in [("minimum", -1i64), ("maximum", 1i64)] {
+                        let Some(bound) = declared[key].as_i64() else {
+                            continue;
+                        };
+                        let out_of_range = bound + offset;
+                        // A minimum of 0 makes `-1` a parse error for the TYPE
+                        // rather than the bound on unsigned flags; either way it
+                        // is rejected, which is what this asserts.
+                        let mut argv = base.clone();
+                        argv.push(format!("--{long}"));
+                        argv.push(out_of_range.to_string());
+                        probes += 1;
+                        if root.clone().try_get_matches_from(&argv).is_ok() {
+                            violations.push(format!(
+                                "`{}` accepts --{long} {out_of_range}, but the MCP schema declares \
+                                 {key} {bound}: the bound is a property of the transport, not the \
+                                 contract (nw-259b)",
+                                path.join(" ")
+                            ));
+                        }
+                    }
+                }
+            }
+            violations.sort();
+            (violations, pairs, probes)
+        });
+
+        // Anti-vacuity: a walk that matched nothing would report zero
+        // violations and read exactly like a clean result.
+        assert!(
+            pairs >= 5 && probes >= 5,
+            "bounds sweep looks vacuous -- {pairs} CLI/MCP pair(s) and {probes} probe(s); \
+             the guard is not actually comparing anything"
+        );
+        assert!(
+            violations.is_empty(),
+            "{} CLI flag(s) do not enforce their declared MCP bounds:\n{}",
+            violations.len(),
+            violations.join("\n")
         );
     }
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -793,6 +793,30 @@ credential_method = "gh"
         ))
         .stdout(contains("configured-project"));
 
+    // nw-316: the response must STATE which instance config answered. Three
+    // routes returned different result sets for the same project and budget and
+    // nothing disclosed it; until an answer names the config that produced it,
+    // config can be neither confirmed nor eliminated as the cause. Asserted
+    // through the real binary because the value comes from ambient dispatch
+    // state, which a unit test installs by hand and therefore cannot prove.
+    nestweaver_cmd()
+        .current_dir(&unrelated_cwd)
+        .env_remove("NESTWEAVER_DB")
+        .args([
+            "project-context",
+            "configured-project",
+            "--json",
+            "--config",
+        ])
+        .arg(&config_path)
+        .assert()
+        .success()
+        .stdout(contains("\"answered_by\""))
+        .stdout(contains("\"config_installed\": true"))
+        // The instance named in `--config`, which is only reachable because
+        // `--config` REROUTES to the direct path instead of being forwarded.
+        .stdout(contains("config-db"));
+
     // Repository-scoped commands have a different final fallback
     // (`<repo>/nestweaver.lbug`), so cover their shared resolver explicitly.
     // `index` is finite; code `watch` uses the same resolver before entering


### PR DESCRIPTION
Three backlog items, one branch. All three were `ready` and workable — nw-373 needed a decision, nw-316 had a researched recommendation, nw-217's two remaining legs were specified.

## nw-373 — `publication discard` (closes the last instance)

The item asked whether discard should hold the canonical DB write lease across its renames, and left it as an explicit **decision**. The answer was already written in this tree: `prune_slots`' own comment records why an earlier version taking an `IndexPublicationLease` was wrong — it *"looked like exclusion but is not — that lease is an in-process Mutex/Condvar owned by one GraphStore, so a rebuild in another process holds an unrelated one."* The primitive that serializes rebuild, rollback **and discard** is the root lock. Adding the write lease would be the second mechanism the item explicitly says not to add.

What was genuinely missing: discard took a root lock and **never used it**. The CLI bound it as `_root_lock`, it never reached `discard_operation`, so nothing proved the lock covered the root being mutated — the identical dead-parameter defect already fixed in its two siblings. Both discard routes now take the lock by reference and continue through its canonical root.

Asserted beside its siblings in `publication_root_authorization_is_canonical_and_exact`, so all three destructive publication routes are pinned in one place. Sabotage-verified.

## nw-316 — `project-context` route divergence

**Part B first**, as the item advises, because it is the diagnostic: every answer now carries `_meta.answered_by`. Until a response states which config produced it, config can be neither confirmed nor eliminated as the cause of the 827/829/815 divergence, and the other two candidates stay untestable.

Identity, not path — `instance_id` is comparable across routes; a file path would leak the operator's filesystem layout to a remote caller and mean nothing to it.

**Part A**: `--config` joins `--no-tests`/`--prefer-instance` in forcing the direct route. Forwarding was **disqualified on security grounds**, not judged worse: `InstanceConfig` carries `authz`, and `build_daemon_permission_source` derives the daemon's entire permission source from it, with `None` meaning every caller is `VisibleRepos::All`. `tool_brain_guide` already refuses a caller-supplied config for this reason.

**This does not close nw-316.** The 827/829/815 divergence is not confirmed resolved; the disclosure makes it measurable rather than guessable.

## nw-217b / nw-217c

The S4 sweep asserts every CLI flag with an MCP schema counterpart actually **enforces** the bound that schema declares. It probes behaviour through the real parser, because a `value_parser`'s range is not introspectable.

**It found four real violations on its first run**, all nw-259b's shape:
- `clusters --limit` accepted 1001 against a declared maximum of 1000
- `clusters --members` accepted 201 against 200
- `brain broken-links --offset` accepted 1001 against 1000
- `cross-repo-contracts --limit` was bounded `1..=10000` against a declared 1000 — a **ten-fold** divergence, so `--limit 5000` worked without a daemon and failed with one

Narrowing `cross-repo-contracts` is a real CLI change, in the direction that makes the routes agree — the daemon already refused anything above 1000.

28 CLI/MCP pairs matched, 26 probes run, with an anti-vacuity floor. The counterweight holds: a flag with no schema twin (`export --top`) is skipped, not failed.

nw-217c writes the sibling-gap review rule into CONTRIBUTING.md with seven worked examples, each verified present in the tree, plus the caveat that a guard correct for a mutating path can be wrong for a read-only one.

## The fourth commit exists because the harness caught me

`a0086c80` is not a planned change. The parity harness failed with *"a field on one route only is exactly the drift these tests exist to catch"* — the nw-316 fix had reintroduced nw-316's own defect class. Two layers, both in shared primitives:

- `provenance::set` **replaced** `_meta` wholesale, so the disclosure survived on the direct route and vanished on the daemon one. Now merges.
- Fixing that exposed `ensure` keying on `_meta` *existing* rather than on the provenance fields — so the direct route silently stopped receiving `scope`/`sources`/`stale_repos`, the nw-315 defect reintroduced sideways.

Both fixes have counterweights. Clippy separately caught that the new test module had absorbed `#[cfg(test)]` from its neighbour, which would have compiled a test module into the shipping binary.

## Validation

- `cargo fmt --all -- --check`, `git diff --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- **3,435 passed / 0 failed** across schema, store, engine, web, mcp, client, federation and the root package
