### PR TITLE
fix: make resolver-staleness actionable, attempt npm provenance, sort stale_repos at the emitter

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1624,6 +1624,9 @@ jobs:
       actions: read
       attestations: read
       contents: read
+      # nw-423: minting the OIDC token npm provenance signs with. Documented
+      # prerequisite; without it `--provenance` cannot produce an attestation.
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1774,13 +1777,54 @@ jobs:
             exit 0
           fi
 
+          # nw-423. npm provenance is the mechanism the hand-rolled
+          # immutable-release + sidecar-checksum check was approximating: a
+          # Sigstore-signed link between this package, the exact source commit,
+          # and the builder that produced it, verifiable by any consumer with
+          # `npm audit signatures`. The prerequisites are met -- cloud-hosted
+          # GitHub Actions runner, public repository, and a `repository` field
+          # in package.json matching this repo.
+          #
+          # ATTEMPTED, NOT ENFORCED, and the ordering is deliberate. npm's docs
+          # describe `--provenance` for publishing from a DIRECTORY and do not
+          # state whether it works for a pre-packed tarball, which is what this
+          # job publishes so the artifact is byte-identical to the attested one.
+          # Enforcing an unverified flag on the release path would risk a failed
+          # release to gain a property we have not yet observed. So: try it,
+          # fall back to today's behaviour if npm rejects it, and REPORT which
+          # happened. The first release after this lands is the measurement;
+          # make it mandatory once it is observed working.
           set +e
-          npm publish "$package_tarball" --ignore-scripts --access public
+          npm publish "$package_tarball" --ignore-scripts --access public --provenance
           publish_status=$?
+          provenance_attempted=1
+          if [ "$publish_status" -ne 0 ]; then
+            echo "::warning::npm publish --provenance exited $publish_status; retrying without provenance so the release still lands." >&2
+            npm publish "$package_tarball" --ignore-scripts --access public
+            publish_status=$?
+            provenance_attempted=0
+          fi
           set -e
+          # Did an attestation actually land? Reported rather than asserted,
+          # because this is the first release that attempts it -- see above.
+          report_provenance() {
+            local attestations
+            attestations="$(npm view "$PACKAGE_NAME@$PACKAGE_VERSION" dist.attestations --json 2>/dev/null || true)"
+            if [ -n "$attestations" ] && [ "$attestations" != "null" ]; then
+              echo "PROVENANCE: attestation published for $PACKAGE_NAME@$PACKAGE_VERSION."
+              echo "PROVENANCE: attestation published (nw-423 can close on this)." >> "$GITHUB_STEP_SUMMARY"
+            elif [ "$provenance_attempted" = "1" ]; then
+              echo "::warning::npm publish --provenance SUCCEEDED but no attestation is visible; provenance is silently not applying to pre-packed tarballs." >&2
+              echo "PROVENANCE: requested, publish succeeded, NO attestation visible (nw-423 stays open)." >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "PROVENANCE: not published; npm rejected --provenance for this publish shape." >> "$GITHUB_STEP_SUMMARY"
+            fi
+          }
+
           for attempt in 1 2 3 4 5 6; do
             if verify_registry; then
               echo "Verified exact $PACKAGE_NAME@$PACKAGE_VERSION from $RELEASE_SHA."
+              report_provenance
               exit 0
             fi
             echo "Registry has not caught up (attempt $attempt/6); retrying in 10s."

--- a/crates/nestweaver-engine/src/affected_tests.rs
+++ b/crates/nestweaver-engine/src/affected_tests.rs
@@ -200,12 +200,16 @@ fn affected_tests_within(
     // consumer runs the full suite instead of trusting an incomplete subset.
     let mut status = AnalysisStatus::Complete;
     let mut notifications: Vec<Notification> = Vec::new();
-    let resolver_stale_repos = crate::resolver_generation::incompatible_repos_for_store(store)?;
-    if !resolver_stale_repos.is_empty() {
+    // nw-424: the SET is unchanged (every incompatible repository still
+    // degrades), but the message now says whether the caller owns the problem.
+    let incompatibility =
+        crate::resolver_generation::incompatibility_for_changed_files(store, changed_files)?;
+    let resolver_stale_repos = incompatibility.all();
+    if incompatibility.is_incompatible() {
         status = status.max(AnalysisStatus::Degraded);
         notifications.push(Notification {
             level: NotificationLevel::Error,
-            message: crate::resolver_generation::incompatibility_message(&resolver_stale_repos),
+            message: incompatibility.message(),
             descriptor: crate::resolver_generation::INCOMPATIBLE_RESOLVER_DESCRIPTOR.to_string(),
         });
     }

--- a/crates/nestweaver-engine/src/blast_radius.rs
+++ b/crates/nestweaver-engine/src/blast_radius.rs
@@ -399,12 +399,22 @@ pub fn analyze_blast_radius(
     // not. A failed/partial query must NOT be reported as "nothing affected".
     let mut status = AnalysisStatus::Complete;
     let mut notifications: Vec<Notification> = Vec::new();
-    let resolver_stale_repos = crate::resolver_generation::incompatible_repos_for_store(store)?;
-    if !resolver_stale_repos.is_empty() {
+    // nw-424: the SET is unchanged (every incompatible repository still
+    // degrades), but the message now says whether the caller owns the problem.
+    let changed_file_strings: Vec<String> = changed_files
+        .iter()
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect();
+    let incompatibility = crate::resolver_generation::incompatibility_for_changed_files(
+        store,
+        &changed_file_strings,
+    )?;
+    let resolver_stale_repos = incompatibility.all();
+    if incompatibility.is_incompatible() {
         status = status.max(AnalysisStatus::Degraded);
         notifications.push(Notification {
             level: NotificationLevel::Error,
-            message: crate::resolver_generation::incompatibility_message(&resolver_stale_repos),
+            message: incompatibility.message(),
             descriptor: crate::resolver_generation::INCOMPATIBLE_RESOLVER_DESCRIPTOR.to_string(),
         });
     }

--- a/crates/nestweaver-engine/src/process.rs
+++ b/crates/nestweaver-engine/src/process.rs
@@ -353,12 +353,16 @@ pub fn detect_changes_impact(
     let mut status = AnalysisStatus::Complete;
     let mut notifications = Vec::new();
     let mut unassessed = Vec::new();
-    let resolver_stale_repos = crate::resolver_generation::incompatible_repos_for_store(store)?;
-    if !resolver_stale_repos.is_empty() {
+    // nw-424: the SET is unchanged (every incompatible repository still
+    // degrades), but the message now says whether the caller owns the problem.
+    let incompatibility =
+        crate::resolver_generation::incompatibility_for_changed_files(store, &changed_files)?;
+    let resolver_stale_repos = incompatibility.all();
+    if incompatibility.is_incompatible() {
         status = status.max(AnalysisStatus::Degraded);
         notifications.push(Notification {
             level: NotificationLevel::Error,
-            message: crate::resolver_generation::incompatibility_message(&resolver_stale_repos),
+            message: incompatibility.message(),
             descriptor: crate::resolver_generation::INCOMPATIBLE_RESOLVER_DESCRIPTOR.to_string(),
         });
     }

--- a/crates/nestweaver-engine/src/resolver_generation.rs
+++ b/crates/nestweaver-engine/src/resolver_generation.rs
@@ -160,6 +160,146 @@ pub fn incompatible_repos_for_store(store: &GraphStore) -> anyhow::Result<Vec<St
     Ok(load(db_path).stale_repos(repos.iter().map(|repo| repo.uid.as_str())))
 }
 
+/// A resolver-generation verdict, split by whether the operator can act on it.
+///
+/// nw-424. The gate itself was correct and its MESSAGE was not actionable: a
+/// developer whose changed files live entirely in current repositories was told
+/// `run-full-suite` because some unrelated repository was stale, with nothing
+/// saying whose problem it was. Re-indexing another team's repository is not an
+/// action they can take, and by Tricorder's definition an alert that produces no
+/// positive action is an effective false positive however true it is. A gate
+/// that fires like that teaches people to ignore `recommendation` -- the one
+/// field nw-412 exists to make trustworthy.
+///
+/// THE SAFETY PROPERTY IS UNCHANGED. Any incompatible repository anywhere still
+/// degrades the answer, because narrowing the check to repositories that own
+/// the changed files is UNSOUND for exactly the reason nw-412 exists: a MISSING
+/// cross-repo edge is precisely what would keep a stale repository out of that
+/// mapping. What changes is that the answer now says which of the two
+/// situations the caller is in.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct ResolverIncompatibility {
+    /// Incompatible repositories that own at least one changed file. The
+    /// caller can re-index these themselves.
+    pub owning_changed_files: Vec<String>,
+    /// Incompatible repositories elsewhere in the graph. These still degrade
+    /// the answer, and naming them separately is what lets the caller tell
+    /// "my repository is stale" from "someone else's is".
+    pub elsewhere: Vec<String>,
+}
+
+impl ResolverIncompatibility {
+    pub fn is_incompatible(&self) -> bool {
+        !self.owning_changed_files.is_empty() || !self.elsewhere.is_empty()
+    }
+
+    /// Every incompatible repository, sorted — the population that existed
+    /// before this split, kept so `resolver_stale_repos` is unchanged on the
+    /// wire.
+    pub fn all(&self) -> Vec<String> {
+        let mut all = self.owning_changed_files.clone();
+        all.extend(self.elsewhere.iter().cloned());
+        all.sort();
+        all.dedup();
+        all
+    }
+
+    /// The operator-facing explanation, which states the situation rather than
+    /// listing UIDs and leaving the reader to infer which one they are in.
+    pub fn message(&self) -> String {
+        let remedy = "Re-index each with `nestweaver index --repo <path> --force` (`--force` is \
+                      required: a generation-stale repository is already at HEAD, so the \
+                      incremental path writes nothing).";
+        match (
+            self.owning_changed_files.is_empty(),
+            self.elsewhere.is_empty(),
+        ) {
+            (true, true) => String::new(),
+            // The actionable case: it is their own repository.
+            (false, true) => format!(
+                "The repositories your changed files belong to were indexed by a resolver other \
+                 than the running generation {RESOLVER_GENERATION}, so their edges cannot be \
+                 trusted and this answer is degraded: {}. {remedy}",
+                self.owning_changed_files.join(", ")
+            ),
+            // The case that read as arbitrary: name the cause, not just the UIDs.
+            (true, false) => format!(
+                "Your changed files belong only to repositories built by the running resolver \
+                 generation {RESOLVER_GENERATION}, but {} other repositor{} in this graph {} not: \
+                 {}. A MISSING cross-repo edge written by one of them could still hide an \
+                 affected symbol, and a missing edge is exactly what would keep it out of this \
+                 changed-file mapping — so the answer is degraded rather than trusted. {remedy}",
+                self.elsewhere.len(),
+                if self.elsewhere.len() == 1 {
+                    "y"
+                } else {
+                    "ies"
+                },
+                if self.elsewhere.len() == 1 {
+                    "is"
+                } else {
+                    "are"
+                },
+                self.elsewhere.join(", ")
+            ),
+            (false, false) => format!(
+                "The repositories your changed files belong to were indexed by a resolver other \
+                 than the running generation {RESOLVER_GENERATION}: {}. {} further repositor{} \
+                 in this graph {} also incompatible and degrade this answer through possible \
+                 missing cross-repo edges: {}. {remedy}",
+                self.owning_changed_files.join(", "),
+                self.elsewhere.len(),
+                if self.elsewhere.len() == 1 {
+                    "y"
+                } else {
+                    "ies"
+                },
+                if self.elsewhere.len() == 1 {
+                    "is"
+                } else {
+                    "are"
+                },
+                self.elsewhere.join(", ")
+            ),
+        }
+    }
+}
+
+/// The verdict for `changed_files`, split into what the caller owns and what
+/// they do not.
+///
+/// The incompatible SET is computed exactly as before — over every repository
+/// in the store — and only the presentation is partitioned. See
+/// [`ResolverIncompatibility`] for why narrowing the set would be unsound.
+pub fn incompatibility_for_changed_files(
+    store: &GraphStore,
+    changed_files: &[String],
+) -> anyhow::Result<ResolverIncompatibility> {
+    let incompatible = incompatible_repos_for_store(store)?;
+    if incompatible.is_empty() {
+        return Ok(ResolverIncompatibility::default());
+    }
+    let mut owning: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for file in changed_files {
+        // A file with no indexed symbols contributes no owner, which is
+        // correct: it cannot tell us whose repository it is.
+        if let Ok(symbols) = store.symbols_in_file(file) {
+            for symbol in symbols {
+                if !symbol.repo_uid.is_empty() {
+                    owning.insert(symbol.repo_uid);
+                }
+            }
+        }
+    }
+    let (owning_changed_files, elsewhere): (Vec<String>, Vec<String>) = incompatible
+        .into_iter()
+        .partition(|uid| owning.contains(uid));
+    Ok(ResolverIncompatibility {
+        owning_changed_files,
+        elsewhere,
+    })
+}
+
 /// One shared diagnostic for affected-tests, detect-changes, and blast-radius.
 pub fn incompatibility_message(repos: &[String]) -> String {
     format!(
@@ -703,6 +843,109 @@ mod tests {
         )
         .unwrap();
         assert_eq!(load(&db).stale_repos(known), vec!["repo:a"]);
+    }
+
+    /// nw-424. The gate is correct and the MESSAGE was not actionable. A
+    /// developer whose changed files live entirely in CURRENT repositories was
+    /// told `run-full-suite` because some unrelated repository was stale, with
+    /// no way to tell whose problem it was -- and re-indexing someone else's
+    /// repository is not an action they can take. By Tricorder's definition
+    /// that is an "effective false positive": the developer takes no positive
+    /// action after seeing it, and a gate that fires without one teaches people
+    /// to ignore `recommendation`, which is the field nw-412 exists to make
+    /// trustworthy.
+    ///
+    /// The SAFETY is deliberately unchanged -- any stale repository anywhere
+    /// still degrades, because a missing cross-repo edge is exactly what would
+    /// keep a stale repository out of the changed-file mapping. What changes is
+    /// that the answer says WHICH of the two situations you are in.
+    #[test]
+    fn incompatibility_separates_repos_that_own_the_change_from_the_rest() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("g.lbug");
+        let store = GraphStore::open_or_create(&db).unwrap();
+        let repo = |uid: &str, root: &str| Repo {
+            uid: uid.into(),
+            url: format!("file://{root}"),
+            indexed_sha: "deadbeef".into(),
+            staleness_commits_behind: 0,
+            instance_id: "default".into(),
+            name: None,
+            root_path: Some(root.into()),
+        };
+        for (uid, root) in [("repo:mine", "/src/mine"), ("repo:theirs", "/src/theirs")] {
+            store.insert_repo(&repo(uid, root)).unwrap();
+        }
+        let symbol = |uid: &str, repo_uid: &str, file: &str| nestweaver_schema::Symbol {
+            uid: uid.to_string(),
+            name: uid.to_string(),
+            kind: nestweaver_schema::SymbolKind::Function,
+            repo_uid: repo_uid.to_string(),
+            file_path: file.to_string(),
+            start_line: 1,
+            end_line: 2,
+            signature: String::new(),
+            summary: None,
+            content_hash: uid.to_string(),
+            embedding: None,
+            pagerank_score: None,
+            is_entry_point: false,
+            entry_point_kind: None,
+            visibility: nestweaver_schema::Visibility::Public,
+            type_info: None,
+            framework_hint: None,
+            canonical_id: None,
+        };
+        store
+            .insert_symbol(&symbol("s_mine", "repo:mine", "src/mine.rs"))
+            .unwrap();
+        store
+            .insert_symbol(&symbol("s_theirs", "repo:theirs", "src/theirs.rs"))
+            .unwrap();
+
+        // Neither repo has a generation record, so BOTH are incompatible.
+        let changed = vec!["src/mine.rs".to_string()];
+        let verdict = incompatibility_for_changed_files(&store, &changed).unwrap();
+
+        assert_eq!(
+            verdict.owning_changed_files,
+            vec!["repo:mine".to_string()],
+            "the repository the change lives in is the actionable one"
+        );
+        assert_eq!(
+            verdict.elsewhere,
+            vec!["repo:theirs".to_string()],
+            "an unrelated stale repository is reported separately, not merged in"
+        );
+        // The safety property is unchanged: everything still degrades.
+        assert_eq!(verdict.all().len(), 2);
+        assert!(verdict.is_incompatible());
+
+        // The message must name the situation, not just list UIDs.
+        let mine_only = ResolverIncompatibility {
+            owning_changed_files: vec!["repo:mine".to_string()],
+            elsewhere: Vec::new(),
+        };
+        assert!(
+            mine_only.message().contains("repo:mine"),
+            "{}",
+            mine_only.message()
+        );
+
+        let theirs_only = ResolverIncompatibility {
+            owning_changed_files: Vec::new(),
+            elsewhere: vec!["repo:theirs".to_string()],
+        };
+        let text = theirs_only.message();
+        assert!(
+            text.contains("repo:theirs"),
+            "the repository to chase must be named: {text}"
+        );
+        assert!(
+            text.to_lowercase().contains("cross-repo"),
+            "it must explain WHY an unrelated repository degrades this answer, \
+             or the alert is unactionable: {text}"
+        );
     }
 
     #[test]

--- a/npm/README.md
+++ b/npm/README.md
@@ -8,11 +8,25 @@ binary matching this package's version from the project's GitHub Releases,
 verifies it against the SHA-256 published alongside the archive, and puts a
 `nestweaver` executable on your PATH.
 
+**Lifecycle scripts must be enabled.** The binary is fetched in `postinstall`,
+so `npm install --ignore-scripts` — and **pnpm 10+, which blocks lifecycle
+scripts by default** — leave you with a wrapper and no binary. `nestweaver` then
+exits 1 saying the binary was not found. With pnpm, allow it explicitly:
+
+```jsonc
+// package.json
+{ "pnpm": { "onlyBuiltDependencies": ["nestweaver"] } }
+```
+
+If your organisation disallows install scripts outright, install a release
+archive from GitHub or build from source (`cargo install --locked --path .`)
+instead.
+
 ## Platforms
 
 macOS and Linux, on x86_64 and arm64. On any other platform the install step
-exits without failing and prints the supported targets; use a release archive
-or a source build instead.
+FAILS and prints the supported targets, rather than leaving you with a wrapper
+that cannot run; use a release archive or a source build instead.
 
 Linux builds target **glibc 2.35**, which covers Ubuntu 22.04 LTS and newer and
 Debian 12. The archive includes the GCC 13 runtime LadybugDB needs and the npm

--- a/src/main.rs
+++ b/src/main.rs
@@ -2358,10 +2358,20 @@ fn ranking_json_payload<T: serde::Serialize>(
     daemon_meta: Option<serde_json::Value>,
     bounds: &RankingBounds,
 ) -> serde_json::Value {
+    // nw-358: sort HERE, not in the constructors. The same 43-element set was
+    // emitted in two orders — the daemon route sorted, the direct route did not
+    // — so one command had two byte-shapes chosen by whether a daemon happened
+    // to be running. Imposing the order at the single emitter makes it a
+    // property of the payload rather than of whichever route filled it, so the
+    // two cannot drift apart again. It was invisible to the parity harness by
+    // construction: it takes ~43 repos to surface and the fixtures have a
+    // handful, so the list is trivially ordered either way.
+    let mut stale_repos = staleness.stale_repos.clone();
+    stale_repos.sort();
     let mut payload = serde_json::json!({
         key: rows,
         "rankings_stale": staleness.rankings_stale,
-        "stale_repos": staleness.stale_repos,
+        "stale_repos": stale_repos,
         // The candidate population, and whether `--top` cut it. `total` is NOT
         // `len(list)`: it counts every symbol with at least one code edge, so
         // `returned < total` is a real completeness ratio rather than a
@@ -40952,6 +40962,46 @@ mod cli_honesty_sweep_tests {
         assert_eq!(padded_tail.header_count(1000), "1000");
 
         assert_eq!(RankingBounds::default().header_count(3), "3");
+    }
+
+    /// nw-358: `hubs` / `bridges` emitted the SAME 43-element `stale_repos`
+    /// set in two different orders — the daemon route sorted, the direct route
+    /// did not — so one command had two byte-shapes selected by whether a
+    /// daemon happened to be running. Every `parity_*_direct_vs_daemon` test
+    /// that compares stdout byte-for-byte would have caught it, except that it
+    /// takes 43 repos to surface and the fixtures have a handful, so the list
+    /// is trivially ordered either way. Invisible to fixtures BY CONSTRUCTION.
+    ///
+    /// Sorting at the single emitter is what makes the order a property of the
+    /// PAYLOAD rather than of whichever constructor filled it, so neither route
+    /// can drift again. Asserted with a deliberately unsorted input, which is
+    /// what the fixtures cannot produce at their size.
+    #[test]
+    fn a_ranking_payload_sorts_stale_repos_whatever_order_it_was_given() {
+        let unsorted = ResolverStaleness {
+            rankings_stale: true,
+            stale_repos: vec![
+                "repo:default:zeta".to_string(),
+                "repo:default:alpha".to_string(),
+                "repo:default:mike".to_string(),
+            ],
+        };
+        let payload = ranking_json_payload(
+            "hubs",
+            &Vec::<&str>::new(),
+            &unsorted,
+            None,
+            &RankingBounds::default(),
+        );
+        assert_eq!(
+            payload["stale_repos"],
+            serde_json::json!([
+                "repo:default:alpha",
+                "repo:default:mike",
+                "repo:default:zeta"
+            ]),
+            "the emitter must impose the order, or the route that filled it decides the bytes"
+        );
     }
 
     /// The payload carries the honest keys, and `total` is NOT `len(list)`.


### PR DESCRIPTION
Three items, plus research that reframed one of them and produced a new one.

## nw-424 — the gate was correct; the message wasn't actionable

**The safety property is deliberately unchanged.** Every incompatible repository anywhere still degrades the answer. What changed is that the answer says *which situation you're in*.

The frame that made this tractable is Tricorder's **"effective false positive"** — an issue where *"developers did not take some positive action after seeing it."* Google holds that under 10% because *"once developers learn that most alerts are noise, they treat all alerts as noise."* A developer whose changed files live entirely in current repos was told `run-full-suite` because someone else's repo was stale — and re-indexing another team's repo isn't an action they can take. Noise by that test, however true.

The message for that case now reads:

> Your changed files belong only to repositories built by the running resolver generation 4, but 1 other repository in this graph is not: `repo:theirs`. A MISSING cross-repo edge written by one of them could still hide an affected symbol, and a missing edge is exactly what would keep it out of this changed-file mapping — so the answer is degraded rather than trusted.

`resolver_stale_repos` is unchanged on the wire, so no consumer has to move to benefit.

**nw-424's own DONE WHEN is unsound and I did not satisfy it.** "Files mapping entirely into current repositories are not degraded" fails for exactly the reason nw-412 exists: a missing cross-repo edge is what keeps a stale repo *out* of that mapping. The item is corrected rather than the code bent to it.

An operator escape hatch was **considered and declined** — Gradle's selection profile supports one, but 9.0.0's dead-code refusal ships with *"There is no override flag… which is the point."* In-tree consistency beat the external precedent.

## nw-423 — provenance attempted and measured, not enforced

npm provenance is what the immutable-release + sidecar-checksum apparatus was approximating: a Sigstore-signed link between package, source commit, and builder, verifiable via `npm audit signatures`. Prerequisites were already met; only `id-token: write` was missing.

**Attempted, not enforced, deliberately.** npm's docs describe `--provenance` for publishing from a *directory* and say nothing about a pre-packed tarball — which is what this job publishes so the artifact stays byte-identical to the attested one. Enforcing an unverified flag on the release path would risk a failed release to gain a property we've never observed. So it tries, falls back to today's behaviour if npm rejects it, and **reports which happened** into the step summary. The next release is the measurement.

I couldn't run the release job. What I could check: all 36 `run` blocks parse under `bash -n`, actionlint clean.

## nw-358 — one command, two byte-shapes

`hubs`/`bridges` emitted the same 43-element `stale_repos` set sorted on the daemon route and unsorted on the direct one. Sorted at the single emitter per the item's own prescription, so order is a property of the payload rather than of whichever constructor filled it. The test feeds a deliberately unsorted input, because the defect is invisible to fixtures by construction — it takes ~43 repos to surface.

## npm README — two live doc bugs, one of them mine

It claimed an unsupported platform *"exits without failing"*; **PR #355 changed that to exit 1** and I didn't catch it. And it never mentioned the failure users are most likely to hit: **pnpm 10+ blocks lifecycle scripts by default**, so `pnpm add nestweaver` yields a wrapper with no binary *today*. Both corrected, with the `onlyBuiltDependencies` escape.

Accuracy only — nw-382's product-page tier is a decision, not a patch.

## Filed, not done: nw-425

The research turned up the real answer to nw-423: esbuild, swc and sass all moved from postinstall-download to `optionalDependencies` platform packages, for reasons that map onto `install.js` line for line. That would delete the curl call, the checksum fetch, the immutability check, the token handling and the rate-limit diagnosis — all of nw-423's subject matter — and fix the `libc` declaration. It costs four extra published packages per release and version lockstep across five. **That's an architecture decision, filed at `high` so it's chosen rather than slipped in under a bug fix.**

**Deliberately not taken:** nw-371, which warns that *"the next author to 'unify' these by name will be doing something that looks like cleanup."* Doing it as a ride-along is that failure exactly.

## Validation

- `cargo fmt --all -- --check`, `git diff --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- **3,437 passed / 0 failed**
- `npm/install.test.js` — 24/24
