### PR TITLE
fix: pre-release batch — truncation panic, macOS annotation noise, cluster resolution disclosure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,23 @@ jobs:
           cache-on-failure: true
           shared-key: metal-smoke
       - name: Install build dependencies
-        run: brew install protobuf
+        # nw-381: `aws/tap` ships PRE-TAPPED on GitHub's macOS runner image;
+        # nothing here taps or uses it. Homebrew's per-tap trust check then
+        # prints an "ignoring untrusted tap" warning on stderr, which GitHub
+        # renders as a warning ANNOTATION on an otherwise green job -- and one
+        # of those was already mistaken for a build failure once. `protobuf`
+        # lives in homebrew/core, so untapping something the build never uses
+        # cannot affect the install.
+        #
+        # `|| true` is load-bearing: the tap is absent on some images and
+        # `brew untap` on a missing tap exits non-zero.
+        #
+        # DELIBERATELY NOT `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` -- Homebrew's own
+        # message says that is not recommended and will be removed, so it buys
+        # a silence that expires and leaves the same work to do.
+        run: |
+          brew untap aws/tap || true
+          brew install protobuf
       - name: Build Metal-enabled CLI
         run: cargo build --locked --release --features metal
       # `--features metal`, NOT `--features embed`. `metal` is additive on top

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -779,7 +779,23 @@ jobs:
           fi
       - name: Install build dependencies (macOS)
         if: runner.os == 'macOS'
-        run: brew install protobuf
+        # nw-381: `aws/tap` ships PRE-TAPPED on GitHub's macOS runner image;
+        # nothing here taps or uses it. Homebrew's per-tap trust check then
+        # prints an "ignoring untrusted tap" warning on stderr, which GitHub
+        # renders as a warning ANNOTATION on an otherwise green job -- and one
+        # of those was already mistaken for a build failure once. `protobuf`
+        # lives in homebrew/core, so untapping something the build never uses
+        # cannot affect the install.
+        #
+        # `|| true` is load-bearing: the tap is absent on some images and
+        # `brew untap` on a missing tap exits non-zero.
+        #
+        # DELIBERATELY NOT `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` -- Homebrew's own
+        # message says that is not recommended and will be removed, so it buys
+        # a silence that expires and leaves the same work to do.
+        run: |
+          brew untap aws/tap || true
+          brew install protobuf
       - name: Configure macOS deployment target
         if: runner.os == 'macOS'
         shell: bash

--- a/crates/nestweaver-engine/src/format_comment.rs
+++ b/crates/nestweaver-engine/src/format_comment.rs
@@ -304,7 +304,20 @@ fn enforce_char_limit(md: &mut String, _total_groups: usize, _config: &FormatCon
 
     // Strategy 2: Hard truncation
     if md.len() > HARD_CHAR_LIMIT {
-        md.truncate(HARD_CHAR_LIMIT - 20);
+        // nw-402: truncate at a CHARACTER boundary. `String::truncate` takes a
+        // BYTE index and panics if it splits a UTF-8 sequence, so the old
+        // `md.truncate(HARD_CHAR_LIMIT - 20)` crashed whenever byte 64,980
+        // happened to land mid-character. That needs only one non-ASCII
+        // character at that exact offset, which identifiers, paths and doc text
+        // supply routinely at this size. `floor_char_boundary` is still
+        // unstable, so walk back to the nearest boundary explicitly -- at most
+        // three bytes, since that is the widest a UTF-8 continuation run gets
+        // before a boundary.
+        let mut cut = HARD_CHAR_LIMIT - 20;
+        while cut > 0 && !md.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        md.truncate(cut);
         md.push_str("\n... [truncated]\n");
     }
 }
@@ -771,6 +784,58 @@ pub fn render_codequality_json(impacts: &[ImpactResult]) -> String {
         })
         .collect();
     serde_json::to_string(&entries).unwrap_or_else(|_| "[]".to_string())
+}
+
+#[cfg(test)]
+mod char_boundary_tests {
+    use super::*;
+
+    /// nw-402. `enforce_char_limit` truncated at a BYTE index, so when byte
+    /// `HARD_CHAR_LIMIT - 20` landed in the middle of a multi-byte character
+    /// `String::truncate` panicked with "byte index is not a char boundary".
+    /// Rare -- it needs a multi-byte character at exactly that offset -- but it
+    /// is a panic in PR-comment formatting, reached with any non-ASCII content
+    /// at scale: identifiers, paths and doc text are all routinely non-ASCII.
+    #[test]
+    fn hard_truncation_does_not_panic_on_a_multibyte_boundary() {
+        // Place a 3-byte character so that it STRADDLES the cut. `é` is 2
+        // bytes, `—` is 3; build the string so the cut lands mid-sequence.
+        for filler_len in 0..4usize {
+            let mut md = String::new();
+            md.push_str(&"a".repeat(HARD_CHAR_LIMIT - 20 - filler_len));
+            // Push enough multi-byte characters to exceed the limit.
+            md.push_str(&"—".repeat(40));
+            let before = md.clone();
+            let config = FormatConfig::default();
+
+            enforce_char_limit(&mut md, 0, &config);
+
+            assert!(
+                md.len() <= HARD_CHAR_LIMIT,
+                "filler {filler_len}: truncation must still bound the output"
+            );
+            assert!(
+                md.ends_with("... [truncated]\n"),
+                "filler {filler_len}: the truncation marker must survive"
+            );
+            // The real property: whatever we cut, the result is still valid
+            // UTF-8 that Rust can hand back as &str without panicking.
+            assert!(
+                before.starts_with(&md[..md.len() - "\n... [truncated]\n".len()]),
+                "filler {filler_len}: the kept prefix must be a prefix of the input"
+            );
+        }
+    }
+
+    /// The counterweight: content already under the limit is untouched, so the
+    /// boundary fix cannot become an unconditional rewrite.
+    #[test]
+    fn content_under_the_limit_is_left_alone() {
+        let mut md = "— short and multi-byte —".to_string();
+        let original = md.clone();
+        enforce_char_limit(&mut md, 0, &FormatConfig::default());
+        assert_eq!(md, original);
+    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -40728,6 +40728,7 @@ mod nw401_cluster_disclosure_tests {
     }
 }
 
+#[cfg(test)]
 mod nw316_route_tests {
     use super::daemon_may_serve;
     use std::path::Path;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2333,6 +2333,23 @@ impl RankingBounds {
 /// `null` when the route cannot answer — for the reason `print_repo_map_json`
 /// states about staleness: an absent key and a `false` are the same observation
 /// to an agent, and only one of them is a reason to trust the list.
+/// One cluster's payload, with the resolution that produced it.
+///
+/// nw-401: `cluster <id>` answered from a shared sidecar that any
+/// `clusters --resolution N` rewrites, and disclosed nothing -- so the
+/// byte-identical command returned different clusters before and after an
+/// unrelated invocation, and a JSON consumer had no field to detect it with.
+/// `clusters` already emits `resolution`; this is the same disclosure on the
+/// command that TAKES an id, which is the one where a silent switch actually
+/// misleads.
+fn single_cluster_payload(community: &serde_json::Value, resolution: f64) -> serde_json::Value {
+    let mut payload = community.clone();
+    if let Some(obj) = payload.as_object_mut() {
+        obj.insert("resolution".to_string(), serde_json::json!(resolution));
+    }
+    payload
+}
+
 fn print_ranking_json<T: serde::Serialize>(
     key: &str,
     rows: &T,
@@ -15317,10 +15334,16 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             match community {
                 Some(c) => {
                     if json {
-                        println!("{}", serde_json::to_string_pretty(c)?);
+                        // nw-401: name the resolution this answer came from.
+                        let payload =
+                            single_cluster_payload(&serde_json::to_value(c)?, output.resolution);
+                        println!("{}", serde_json::to_string_pretty(&payload)?);
                     } else {
                         println!("Cluster [{}]: {}", c.id, c.name);
                         println!("  Members: {}  Cohesion: {:.4}", c.member_count, c.cohesion);
+                        // Cluster IDs are not stable across resolutions, so the
+                        // human surface has to say which one produced this id.
+                        println!("  Resolution: {}", output.resolution);
                         println!();
                         println!("  Key files:");
                         for f in &c.key_files {
@@ -40670,6 +40693,41 @@ mod brain_context_scope_filter_tests {
 /// that silently narrows drops the regression test that would have caught the
 /// change, with nothing downstream able to tell that from "no tests exist".
 #[cfg(test)]
+mod nw401_cluster_disclosure_tests {
+    /// nw-401. `clusters --resolution N` rewrites a SHARED `<db>.clusters.json`
+    /// (58 MB next to the live brain), and `cluster <id>` -- which has no
+    /// `--resolution` flag -- then answers from whatever was written last. On a
+    /// fixed scratch DB the BYTE-IDENTICAL command `cluster 0` returned
+    /// `src, Members: 2` before an unrelated `clusters --resolution 5` and
+    /// `delta, Members: 1` after it. Cluster IDs are not stable identifiers.
+    ///
+    /// The asymmetry is what made it invisible: `clusters` emits `"resolution"`
+    /// in `--json` and logs the cached resolution to stderr; `cluster` did
+    /// neither, and it is the command that TAKES an id. Disclosing the
+    /// resolution an answer came from is the item's stated minimum and removes
+    /// the silent-switch class on its own.
+    #[test]
+    fn a_single_cluster_answer_names_the_resolution_it_came_from() {
+        let community = serde_json::json!({
+            "id": 0,
+            "name": "src",
+            "cohesion": 0.5,
+            "member_count": 2,
+            "members": [],
+            "key_files": []
+        });
+        let payload = super::single_cluster_payload(&community, 0.3);
+        assert_eq!(
+            payload["resolution"],
+            serde_json::json!(0.3),
+            "a JSON consumer must be able to detect the switch: {payload}"
+        );
+        // The community's own fields survive alongside it.
+        assert_eq!(payload["id"], serde_json::json!(0));
+        assert_eq!(payload["name"], serde_json::json!("src"));
+    }
+}
+
 mod nw316_route_tests {
     use super::daemon_may_serve;
     use std::path::Path;


### PR DESCRIPTION
A pre-release batch of small, unblocked, verified fixes. Five backlog items resolved — **three code fixes and two stale statuses**, because two of the five turned out to be already done.

## nw-402 — a live panic, one line

`enforce_char_limit` called `String::truncate(HARD_CHAR_LIMIT - 20)`. That takes a **byte** index and panics if it splits a UTF-8 sequence, so any content with a non-ASCII character at exactly byte 64,980 crashed PR-comment formatting with *"byte index is not a char boundary"*. Rare by construction, but identifiers, paths and doc text supply non-ASCII routinely at this size, and the failure mode is a panic rather than a bad string.

`floor_char_boundary` is still unstable, so the cut walks back explicitly — at most three bytes.

**The class sweep the item asks for, done and reported rather than assumed:** two other `String::truncate` calls exist and both are safe by construction — `jobs.rs` truncates by `len() - 4` guarded on `ends_with(".git")` (four ASCII bytes), and `query.rs` truncates at a `rfind('\n')` result, which is a boundary. One live site.

The test drives four filler offsets so the cut lands mid-sequence rather than relying on one lucky alignment. The counterweight pins that content under the limit is untouched.

## nw-381 — one line, and specifically timely

`aws/tap` ships pre-tapped on GitHub's macOS runner image; nothing here taps or uses it. Homebrew's per-tap trust check prints an "ignoring untrusted tap" warning that GitHub renders as an annotation **on an otherwise green job** — and one of those was already mistaken for a build failure during the 9.0.5 run.

Applied at **both** sites, which is the point: it fires on every macOS job in `ci.yml` and `release-please.yml`. `|| true` is load-bearing — the tap is absent on some images and `brew untap` on a missing tap exits non-zero.

Deliberately **not** `HOMEBREW_NO_REQUIRE_TAP_TRUST=1`, per the item: Homebrew's own message says that is not recommended and will be removed, so it buys a silence that expires. Timing also follows the item's sequencing note — land on a quiet main, not mid-release.

## nw-401 — remove the silent half of a switch

`clusters --resolution N` rewrites a shared `<db>.clusters.json` (58 MB next to the live brain), and `cluster <id>` — which has no `--resolution` flag — then answers from whatever was written last. On a fixed scratch DB the **byte-identical** command `cluster 0` returned `src, Members: 2` before an unrelated `clusters --resolution 5` and `delta, Members: 1` after it.

The asymmetry made it invisible: `clusters` already emits `resolution` in `--json`; `cluster` did not, and it is the command that *takes an id*. Both surfaces now disclose it.

This is the item's stated **minimum**, not its full ask — keying the sidecar by resolution would remove the overwrite itself. Disclosure removes the *silent* half, which is what makes the overwrite undetectable. **nw-401 stays open for the rest.**

## Two items were already fixed (no code here)

Found while verifying, not assumed:

- **nw-364** — all three legs. `queries/julia.scm` carries the `nw-364(1)` anchor fix, and there are tests for all three defects (`julia_rhs_call_is_not_a_definition` passes; 546 parser tests green). The fix even surfaced a bonus finding: a `typed_expression` gap the phantom symbol had been masking.
- **nw-363** — `d54d4d33` on `main` escapes both U+2028 and U+2029 at the single frame writer, with a counterweight test pinning it as a representation and never a content change.

Both were still marked `ready`. Neither cites a SHA, so a citation audit could not catch them. **A broader check found 22 open items whose ID appears in the code** — a citation is not proof of completion, but that hit rate suggests a dedicated "is this already done?" audit would close more. Filed as a follow-up rather than folded in here.

## Validation

- `cargo fmt --all -- --check`, `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Full workspace + root package test suites
