### PR TITLE
fix(release): let release-context read the draft it validates

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -94,7 +94,23 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: read
+      # `contents: write`, on a job that only ever performs GET requests.
+      #
+      # This job validates the release object release-please just created, and
+      # that object is a DRAFT by design -- the comment on the release-please
+      # step above explains why (`draft: true` means GitHub creates no tag until
+      # publication, so a single invocation cannot strand an unreachable draft).
+      # GitHub returns draft releases ONLY to callers with push access, so
+      # `contents: read` gets 403 on `GET /releases/{id}` for a draft. Verified:
+      # run 33818811691 failed with "Resource not accessible by integration
+      # (HTTP 403)" on the first real release after this job was introduced.
+      #
+      # `write` is the narrowest permission GitHub offers for draft visibility,
+      # not an intent to mutate. The alternative -- trusting release-please's
+      # own outputs without re-reading the object -- would delete the check this
+      # job exists to perform, which is binding the release to an exact,
+      # independently-observed identity.
+      contents: write
     outputs:
       active: ${{ steps.context.outputs.active }}
       mode: ${{ steps.context.outputs.mode }}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1258,6 +1258,31 @@ fn proto_build_supports_the_declared_ubuntu_2204_baseline() {
     );
 }
 
+/// Draft GitHub releases are visible only to callers with push access. The
+/// release-context job deliberately re-reads the private draft created by
+/// Release Please before allowing any build or publication work to proceed,
+/// so `contents: read` fails closed with HTTP 403 and strands the release.
+#[test]
+fn release_context_can_read_the_private_draft_it_validates() {
+    let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workflow =
+        std::fs::read_to_string(repo_root.join(".github/workflows/release-please.yml")).unwrap();
+    let release_context = workflow
+        .split_once("\n  release-context:\n")
+        .expect("release workflow must define release-context")
+        .1
+        .split_once("\n  cleanup-draft:\n")
+        .expect("release-context must precede cleanup-draft")
+        .0;
+
+    assert!(
+        release_context.contains("\n      contents: write\n")
+            && !release_context.contains("\n      contents: read\n"),
+        "release-context must retain push-level release visibility: its first \
+         independent read of a private draft otherwise fails with HTTP 403"
+    );
+}
+
 /// The release PR is the ONE pull request in this repo that receives no CI:
 /// release-please opens it with `GITHUB_TOKEN`, and GitHub deliberately does not
 /// trigger workflows for bot-token-created PRs. Everything that would otherwise


### PR DESCRIPTION
The 9.1.0 release failed at `Bind exact release identity` with `gh: Resource not accessible by integration (HTTP 403)`.

**Nothing published.** The draft was created, the tag was **never cut**, zero assets — `v9.0.5` is still `Latest`. The failure was safe, but the release is stuck.

## Cause

`release-context` validates the release object release-please just created, and that object is a **draft by design** — the comment on the release-please step explains why (`draft: true` means GitHub creates no tag until publication, so one invocation cannot strand an unreachable draft).

**GitHub returns draft releases only to callers with push access.** So `contents: read` gets 403 on `GET /releases/{id}` for a draft.

The job was introduced by `a23ac52f` (PR #352), and **9.1.0 is the first actual release to exercise it** — every prior release predates it. No test or CI could have caught this: the job runs only when `release_created` is true, which happens on exactly one push per release.

## The uncomfortable part, stated plainly

`contents: write` on a job that only performs GET requests is not ideal. It is the narrowest permission GitHub offers for draft visibility.

The alternative — trusting release-please's own outputs without re-reading the object — would delete the check this job exists to perform, which is binding the release to an **independently observed** identity. That check is the point of the job, so weakening it is the worse trade. The comment says so at the site.

## Audited rather than patched

I checked every job that reads a release, not just the failing one:

| Job | `contents` | Reads a draft? |
|---|---|---|
| `release-context` | ~~read~~ → **write** | **yes** — runs before publication |
| `cleanup-draft` | write | yes, already correct |
| `publish-release` | write | yes, already correct |
| `publish-release-lockfile` | write | already correct |
| `publish-npm` | read | **no** — `needs: publish-release`, so the release is published by then |

`release-context` is the only job that reads the release *before* publication, and therefore the only one affected.

## After merge

Merging triggers a fresh release run. The existing `v9.1.0` draft may need `cleanup-draft` to clear it first — worth watching rather than assuming.
