### PR TITLE
fix(release): give the last three output-gated jobs a status function

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -325,7 +325,12 @@ jobs:
   cleanup-draft:
     name: Delete exact private draft
     needs: release-context
-    if: ${{ needs.release-context.outputs.mode == 'cleanup-draft' }}
+    # nw-426, same defect as `dry-run-baseline` below and for the same reason:
+    # `cleanup-draft` is a workflow_dispatch-only recovery operation, so
+    # `release-please` is ALWAYS skipped when it is requested, and without a
+    # status-check function of its own this job inherits that skip. The
+    # recovery path was structurally unreachable.
+    if: ${{ always() && needs.release-context.outputs.mode == 'cleanup-draft' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -713,7 +718,12 @@ jobs:
   publish-release-lockfile:
     name: Publish validated release lockfile without executing PR code
     needs: [release-pr, prepare-release-lockfile]
-    if: ${{ needs.prepare-release-lockfile.result == 'success' }}
+    # nw-426. `prepare-release-lockfile` above already carries `always() &&`
+    # for this reason; this consumer was missed. It explicitly tests
+    # `.result == 'success'`, so `always()` cannot loosen the gate -- it only
+    # stops an unrelated skipped ancestor from suppressing a job whose own
+    # dependency genuinely succeeded.
+    if: ${{ always() && needs.prepare-release-lockfile.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -1261,7 +1271,17 @@ jobs:
   dry-run-baseline:
     name: Capture dry-run visibility baseline
     needs: release-context
-    if: ${{ needs.release-context.outputs.mode == 'dry-run' }}
+    # nw-426. `always() &&` is LOAD-BEARING, not defensive. Without it this
+    # job could never run at all: `dry-run` is a workflow_dispatch-only
+    # operation, `release-please` is skipped on every dispatch
+    # (`if: github.event_name != 'workflow_dispatch'`), and a skipped ancestor
+    # propagates through the graph to any consumer that does not carry its own
+    # status-check function -- `release-context`'s own `always()` rescues
+    # itself, not its dependents. Proven by controlled comparison inside run
+    # 34005527906: `cleanup-canary` gates on the SAME
+    # `outputs.mode == 'dry-run'` WITH `always()` and ran; this job gated on it
+    # WITHOUT `always()` and skipped, in the same run, off the same outputs.
+    if: ${{ always() && needs.release-context.outputs.mode == 'dry-run' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

**nw-426, raised to critical.** Two of the four manual release operations were structurally
unreachable, and one recovery consumer could be suppressed by an unrelated skip.

## How this surfaced

A `workflow_dispatch` with `operation=dry-run`, fired to validate this workflow *before* cutting
9.2.0, reported `conclusion=success` while skipping `dry-run-baseline`, the entire four-target
`build` matrix, and the job literally named **"Verify release dry run"**. A green check over work
that never ran.

## The producer was fine

`release-context` passed both manual-policy guards (they `exit 1`; the job succeeded) and wrote
exactly five outputs — `active`, `mode`, `release_sha`, `tag_name`, `dry_run_version`. That is
precisely the set the `dry-run)` arm writes, and *not* the set the defaults block writes (which also
covers `release_id`/`upload_url`/`source_run_id`). So `mode` really was `dry-run`.

## Root cause — proven, not argued

Controlled comparison inside run `34005527906`:

| job | gate | `always()` | outcome |
|---|---|---|---|
| `cleanup-canary` | `outputs.mode == 'dry-run'` | yes | **ran** |
| `dry-run-baseline` | `outputs.mode == 'dry-run'` | no | **skipped** |

Same run, same outputs, identical condition, one difference.

A job `if:` with no status-check function implies `success()` across the dependency graph, and a
skipped ancestor propagates to every consumer that lacks its own. `release-please` is skipped on
**every** dispatch (`if: github.event_name != 'workflow_dispatch'`), and `release-context`'s
`always()` rescues itself, not its dependents. So on a dispatch:

- `dry-run-baseline` → `dry-run` could never run. Ever.
- `cleanup-draft` → the cleanup-draft recovery operation could never run.
- `publish-release-lockfile` → suppressible by an unrelated skipped ancestor even when
  `prepare-release-lockfile` genuinely succeeded.

`resume` and `recover-npm` were unaffected — they route through `preflight-package` /
`publish-release`, which already carry `always()`.

## The fix was already written down in this file

`prepare-release-lockfile` carries this exact guard, with a comment citing nw-426's hypothesis. It
was applied to one consumer and not the rest. This applies it uniformly — every `if:` in the file now
carries either a status function or the event-name test.

`always()` cannot loosen any of these gates: each still tests the same `outputs.mode` /
`.result == 'success'` condition. It only stops an unrelated skipped ancestor from suppressing a job
whose own dependency succeeded.

## Why critical rather than medium

On a real push release, `build` is gated on `mode == 'publish'` and `publish-release` requires
`build` success. Both already carry `always()`, so the publish path is **not** known-broken — 9.1.0
shipped through it. But the mechanism that would catch a failure *in advance* is the dry-run, and the
dry-run is what could not run. This restores pre-release validation.

## Verification

`actionlint` reports the same single pre-existing finding (`macos-15-intel`, line 839, untouched)
before and after — zero new findings, confirmed by stashing the change and re-running. CI pins
actionlint 1.7.12, which knows that label; local 1.7.7 does not.

Next step after merge: re-run the dry-run and confirm the build matrix actually executes.