### PR TITLE
fix(release): stop preflight failing on a correct tarball via SIGPIPE

### DIFF
--- a/scripts/dedupe-changelog-entries.sh
+++ b/scripts/dedupe-changelog-entries.sh
@@ -215,26 +215,46 @@ self_test() {
 
   echo "before=$before_total after=$after_total removed=$removed_total" >&2
 
-  # 1. Exactly the three confirmed nw-096 duplicate pairs in the shipped
-  #    9.1.0 section, and nothing more.
-  if [[ "$removed_total" -ne 3 ]]; then
-    echo "expected exactly 3 removed bullets against the real CHANGELOG.md, got $removed_total" >&2
+  # 1. The newest section ends up with NO duplicate titles left, and exactly
+  #    as many bullets were removed as there were duplicates to remove.
+  #
+  #    The expected count is DERIVED from the input here, by a different
+  #    method than the script itself uses (strip each bullet's commit link,
+  #    then count titles beyond the first occurrence). It used to be the
+  #    literal `3` -- the three nw-096 pairs that happened to sit in the
+  #    9.1.0 section when this test was written -- checked against the REAL
+  #    CHANGELOG.md. That coupled a self-test to data that changes on EVERY
+  #    release: cutting 9.2.0 made the newest section a different section
+  #    with one duplicate, and this assertion failed on a script that was
+  #    working correctly, blocking the release. A self-test must not depend
+  #    on which release happens to be newest.
+  local newest_section expected_removed leftover_dupes
+  newest_section=$(awk '/^## \[/{n++} n==1' "$changelog")
+  expected_removed=$(printf '%s\n' "$newest_section" \
+    | grep -E "$BULLET_RE" \
+    | sed -E 's/ \(\[[0-9a-f]{7,40}\].*$//' \
+    | sort | uniq -c | awk '$1>1 {total += $1 - 1} END {print total+0}')
+
+  if [[ "$removed_total" -ne "$expected_removed" ]]; then
+    echo "expected $expected_removed removed bullets (duplicate titles in the newest section of the real CHANGELOG.md), got $removed_total" >&2
     exit 1
   fi
-  if [[ "$((before_total - 3))" -ne "$after_total" ]]; then
-    echo "bullet count arithmetic does not add up: before=$before_total after=$after_total" >&2
+  if [[ "$((before_total - expected_removed))" -ne "$after_total" ]]; then
+    echo "bullet count arithmetic does not add up: before=$before_total after=$after_total removed=$expected_removed" >&2
     exit 1
   fi
-  for text in \
-    'disclosure, bounds and coverage sweep across 13 items' \
-    'security, coverage-disclosure and merge-gate sweep across 12 items' \
-    'let release-context read the draft it validates'; do
-    occurrences=$(printf '%s\n' "$output" | grep -Fc -- "$text")
-    if [[ "$occurrences" -ne 1 ]]; then
-      echo "expected exactly one surviving entry for: $text (found $occurrences)" >&2
-      exit 1
-    fi
-  done
+
+  # And the point of the whole exercise: nothing duplicated survives in the
+  # newest section of the OUTPUT.
+  leftover_dupes=$(printf '%s\n' "$output" | awk '/^## \[/{n++} n==1' \
+    | grep -E "$BULLET_RE" \
+    | sed -E 's/ \(\[[0-9a-f]{7,40}\].*$//' \
+    | sort | uniq -d)
+  if [[ -n "$leftover_dupes" ]]; then
+    echo "duplicate titles survived in the newest section:" >&2
+    printf '%s\n' "$leftover_dupes" >&2
+    exit 1
+  fi
 
   # 2. THE REGRESSION THIS SELF-TEST EXISTS TO CATCH: a bullet that
   #    legitimately ships in multiple already-released versions (v0.12.0,
@@ -275,7 +295,7 @@ self_test() {
   fi
   rm -f -- "$expected_rest" "$actual_rest"
 
-  echo "real-CHANGELOG.md self-test passed (removed exactly 3 confirmed nw-096 duplicates; $cross_version_occurrences legitimate cross-version duplicates preserved; history below the newest section untouched byte-for-byte)"
+  echo "real-CHANGELOG.md self-test passed (removed $expected_removed duplicate title(s) from the newest section; $cross_version_occurrences legitimate cross-version duplicates preserved; history below the newest section untouched byte-for-byte)"
 }
 
 self_test_continuation_block() {

--- a/scripts/verify-release-package.sh
+++ b/scripts/verify-release-package.sh
@@ -270,13 +270,32 @@ verify_package_artifact() {
       .sha256 == $sha256
     ' "$manifest" >/dev/null
 
-  tar -tzf "$package_path" | grep -qFx package.json 2>/dev/null || {
-    tar -tzf "$package_path" | grep -qx 'package/package\.json' || {
+  # List ONCE into a variable rather than piping `tar` into `grep -q` per
+  # check. `grep -q` exits on its first match and closes the pipe; GNU tar
+  # then takes SIGPIPE on whatever it had left to write, prints
+  # `tar: stdout: write error` and exits non-zero -- and under the
+  # `set -euo pipefail` at the top of this file that non-zero becomes the
+  # PIPELINE's status, so the `||` branch fires even though grep SUCCEEDED.
+  #
+  # This is worse than a flake: it fails precisely when the entry being
+  # looked for appears EARLY, because that is when tar has the most left
+  # unwritten. `package/bin/nestweaver` is the first entry npm packs, so the
+  # bin check was the one that broke, while the `package.json` check --
+  # matching the LAST line, by which point tar has already finished -- kept
+  # passing and made the failure look content-specific rather than
+  # structural. It blocked the 9.2.0 release on a tarball that was correct.
+  #
+  # BSD tar (macOS) does not reproduce it, so this only ever fires on the
+  # Linux runners that actually gate a release.
+  local listing
+  listing="$(tar -tzf "$package_path")"
+
+  grep -qFx 'package.json' <<< "$listing" ||
+    grep -qFx 'package/package.json' <<< "$listing" || {
       echo "npm tarball is missing package.json" >&2
       return 1
     }
-  }
-  tar -tzf "$package_path" | grep -qx 'package/bin/nestweaver' || {
+  grep -qFx 'package/bin/nestweaver' <<< "$listing" || {
     echo "npm tarball is missing bin/nestweaver" >&2
     return 1
   }


### PR DESCRIPTION
## What happened

The 9.2.0 release built all four targets, then `preflight-package` failed with
`npm tarball is missing bin/nestweaver` — on a tarball that contains it. Nothing published.

Contained safely: **no tag was created**, `v9.2.0` exists only as an unpublished draft, and `v9.1.0`
is still `Latest`. The workflow's draft-first/tag-last design did its job.

## The tarball was fine

Verified locally — `npm pack` of the platform package produces exactly:

```
package/bin/nestweaver
package/package.json
```

Staging is fine too: the build step extracts each archive, asserts the binary with `test -x`, and
copies it to `npm/platforms/<key>/bin/nestweaver` under `set -euo pipefail`.

## The check was unsound

```bash
tar -tzf "$pkg" | grep -qx 'package/bin/nestweaver'
```

`grep -q` exits on its first match and closes the pipe. GNU tar takes SIGPIPE on whatever it had left
to write, prints `tar: stdout: write error`, and exits non-zero — and `set -euo pipefail` (line 19)
promotes that to the pipeline's status. The `||` branch fired **even though grep succeeded**. The job
log shows that exact tar message on the line immediately above the bogus "missing" error.

**Why it read as content-specific rather than structural:** it fails precisely when the entry being
searched for appears *early*, because that is when tar has the most left unwritten.
`package/bin/nestweaver` is the first entry npm packs. The neighbouring `package.json` check matches
the *last* line — by which point tar has finished writing — so it kept passing. That made the failure
look like "the bin file is missing" instead of "this check is unsound".

**And it is invisible on macOS.** BSD tar does not report a write error here, so this only ever fires
on the Linux runners that actually gate a release — the same GNU-vs-BSD split as the `find -printf`
gap already noted in CONTRIBUTING.

## Fix

List once into a variable, then grep the variable. No pipe, no race.

Behaviour preserved — verified the new form still **passes** a tarball containing
`package/bin/nestweaver` and **fails** one without it.

## Why this matters beyond one release

This is a gate that rejected a correct artifact, and whose error text pointed at the package rather
than at itself. That is the expensive direction for a release check: it cost a release, and it sent
the reader looking in the wrong place.