### PR TITLE
Close the four unblocked ready backlog items (nw-440, nw-441, nw-442, nw-443)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1139,10 +1139,31 @@ jobs:
           )
           echo "npm accepted the platform for $(uname -sm) without --force"
           launcher_output="$(node "$install_dir/node_modules/nestweaver/bin/nestweaver" --version 2>&1 || true)"
+          # BOTH outcomes below are correct, and which one occurs is decided by
+          # something outside this PR: whether the version pinned in
+          # npm/package.json has been PUBLISHED yet.
+          #
+          # This assertion used to accept only the first. That held while the
+          # pinned version was always unreleased, but it inverts the moment a
+          # release publishes -- `nestweaver-darwin-arm64@<pinned>` then
+          # resolves, npm installs it, and the launcher runs for real. The job
+          # is skipped unless the `rust` filter trips, so after 9.2.0 shipped
+          # this sat latent on main and failed on the next PR to touch a
+          # filtered path, reporting a defect in the PR for a state the PR did
+          # not create -- a gate that is wrong about correct work, the same
+          # class as the three defects in the 9.2.0 release incident.
+          #
+          # What this job actually guards (nw-433) is the line above: a real
+          # `npm install` on macOS arm64 succeeding WITHOUT `--force`. That is
+          # what EBADPLATFORM broke and what no other job covers. The launcher
+          # check is downstream of it, so it must accept either honest result
+          # and reject only genuine breakage.
           if grep -q 'optional dependency' <<< "$launcher_output"; then
             echo "bin/nestweaver correctly reports the missing (not-yet-published) platform package"
+          elif grep -Eq '^nestweaver [0-9]+\.[0-9]+\.[0-9]+' <<< "$launcher_output"; then
+            echo "the pinned platform package is published; the installed launcher ran it: $launcher_output"
           else
-            echo "::error::expected the missing-optional-dependency message, got:" >&2
+            echo "::error::launcher neither reported a missing optional dependency nor ran, got:" >&2
             echo "$launcher_output" >&2
             exit 1
           fi

--- a/crates/nestweaver-client/src/hybrid.rs
+++ b/crates/nestweaver-client/src/hybrid.rs
@@ -1331,11 +1331,28 @@ pub async fn two_tier_query(
 /// hand-construct the string) green while federation silently reverted to
 /// killing a healthy upstream's entire two-tier answer.
 ///
-/// It is KEPT, and only for version skew: a client newer than the daemon it
-/// talks to receives no metadata code, and dropping this would reintroduce
-/// the exact regression the detection exists to prevent. `node_scope.rs`'s
-/// own prefix assertion still pins the literal at its source for as long as
-/// this fallback lives.
+/// It is KEPT for two reasons, and the second one is load-bearing far more
+/// often than it looks:
+///
+/// 1. Version skew: a client newer than the daemon it talks to receives no
+///    metadata code.
+/// 2. REQUEST COALESCING. `blast_radius` is in `CACHEABLE_TOOLS`, so
+///    concurrent identical calls collapse through
+///    `nestweaver_mcp::tools::coalesce_in_flight`. Only the LEADER runs
+///    `resolve_repo_filter` and holds the typed error; every follower is
+///    handed `anyhow!("{msg}")` rebuilt from a STRING the leader published,
+///    with `RepoFilterUnresolved` nowhere in its chain. The daemon therefore
+///    cannot stamp the code for a follower, and detection for those callers
+///    runs entirely on the prose below. Measured against a live daemon with
+///    12 concurrent identical calls: 1-2 responses carried the code, 10-11
+///    did not.
+///
+/// So "a rewording can no longer break this" is TRUE for a unique request and
+/// FALSE for a coalesced follower. Closing that properly means preserving an
+/// error code across the coalescing boundary in `tools.rs`, which is shared
+/// cache infrastructure well outside this item; until then the fallback is
+/// what keeps federation correct under concurrency, and `node_scope.rs`'s
+/// prefix assertion is what keeps the fallback honest.
 ///
 /// `nestweaver-daemon`'s `dispatch_err_to_status` wraps a tool's error as
 /// `Status::internal("tool {tool} failed: {e}")`, and

--- a/crates/nestweaver-client/src/hybrid.rs
+++ b/crates/nestweaver-client/src/hybrid.rs
@@ -1319,8 +1319,23 @@ pub async fn two_tier_query(
     .await)
 }
 
-/// The stable, narrow substring that identifies "the local `repo` filter
-/// could not be resolved" among every other possible local failure.
+/// LEGACY fallback signal: the substring that identifies "the local `repo`
+/// filter could not be resolved" when the daemon did not stamp a typed error
+/// code.
+///
+/// nw-443 replaced this as the PRIMARY contract with
+/// [`nestweaver_engine::node_scope::REPO_FILTER_UNRESOLVED_CODE`], carried in
+/// gRPC metadata. Matching on prose was pinned by nothing on either end -- a
+/// rename in `node_scope.rs` left the producing tests (which assert only
+/// `"ambiguous"` / `"not-a-repo"`) and the consuming tests (which
+/// hand-construct the string) green while federation silently reverted to
+/// killing a healthy upstream's entire two-tier answer.
+///
+/// It is KEPT, and only for version skew: a client newer than the daemon it
+/// talks to receives no metadata code, and dropping this would reintroduce
+/// the exact regression the detection exists to prevent. `node_scope.rs`'s
+/// own prefix assertion still pins the literal at its source for as long as
+/// this fallback lives.
 ///
 /// `nestweaver-daemon`'s `dispatch_err_to_status` wraps a tool's error as
 /// `Status::internal("tool {tool} failed: {e}")`, and
@@ -1332,6 +1347,32 @@ pub async fn two_tier_query(
 /// text is emitted ONLY by that one function today, so matching on it
 /// cannot mistake an unrelated failure for an unresolved `repo` filter.
 const UNRESOLVED_REPO_FILTER_SIGNAL: &str = "repo filter entry ";
+
+/// Whether `error` is the daemon reporting an unresolved local `repo` filter.
+///
+/// nw-443. TYPED FIRST: `dispatch_err_to_status` stamps
+/// [`nestweaver_engine::node_scope::REPO_FILTER_UNRESOLVED_CODE`] into the
+/// gRPC status metadata, and `tonic::Status` survives the client's
+/// `.with_context()` wrapping as a source in the anyhow chain, so it can be
+/// downcast rather than read. A rewording of the message can no longer break
+/// this.
+///
+/// PROSE SECOND, and only as a version-skew downgrade -- see
+/// [`UNRESOLVED_REPO_FILTER_SIGNAL`].
+fn is_unresolved_repo_filter(error: &anyhow::Error, rendered: &str) -> bool {
+    let coded = error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<tonic::Status>())
+        .and_then(|status| {
+            status
+                .metadata()
+                .get(nestweaver_engine::node_scope::NW_ERROR_CODE_METADATA_KEY)
+        })
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|code| code == nestweaver_engine::node_scope::REPO_FILTER_UNRESOLVED_CODE);
+
+    coded || rendered.contains(UNRESOLVED_REPO_FILTER_SIGNAL)
+}
 
 /// Build a degraded, disclosure-shaped stand-in for a two-tier LOCAL result
 /// whose `repo` filter did not resolve against the local index.
@@ -1372,7 +1413,7 @@ fn degraded_local_impact_for_unresolved_repo_filter(
         return None;
     }
     let rendered = format!("{error:#}");
-    if !rendered.contains(UNRESOLVED_REPO_FILTER_SIGNAL) {
+    if !is_unresolved_repo_filter(error, &rendered) {
         return None;
     }
     let changed_files = params
@@ -1545,6 +1586,62 @@ mod tests {
         assert_eq!(
             degraded["max_depth"], 3,
             "an omitted max_depth must default to 3, matching tool_blast_radius's own default"
+        );
+    }
+
+    /// nw-443: THE TYPED CONTRACT. Detection must survive a complete
+    /// rewording of the message, because the previous contract -- a substring
+    /// match on `resolve_repo_filter`'s prose, pinned by nothing on either
+    /// end -- meant a rename in `node_scope.rs` silently reverted federation
+    /// to killing a healthy upstream's whole answer, with every test on both
+    /// sides still green.
+    #[test]
+    fn degraded_stand_in_recognizes_the_typed_error_code_without_the_prose() {
+        let mut status =
+            tonic::Status::internal("tool blast_radius failed: entirely different wording");
+        status.metadata_mut().insert(
+            nestweaver_engine::node_scope::NW_ERROR_CODE_METADATA_KEY,
+            nestweaver_engine::node_scope::REPO_FILTER_UNRESOLVED_CODE
+                .parse()
+                .unwrap(),
+        );
+        let error = anyhow::Error::new(status).context("blast_radius RPC failed");
+        assert!(
+            degraded_local_impact_for_unresolved_repo_filter("blast_radius", &error, &json!({}))
+                .is_some(),
+            "the typed error code must be recognized on its own, with no prose match"
+        );
+    }
+
+    /// COUNTERWEIGHT to the test above: a `Status` carrying a DIFFERENT code
+    /// must not be absorbed. Otherwise the typed check would degrade every
+    /// coded error into a stand-in -- a gate that always fires.
+    #[test]
+    fn degraded_stand_in_ignores_a_different_typed_error_code() {
+        let mut status = tonic::Status::internal("tool blast_radius failed: something else");
+        status.metadata_mut().insert(
+            nestweaver_engine::node_scope::NW_ERROR_CODE_METADATA_KEY,
+            "some-other-code".parse().unwrap(),
+        );
+        let error = anyhow::Error::new(status).context("blast_radius RPC failed");
+        assert!(
+            degraded_local_impact_for_unresolved_repo_filter("blast_radius", &error, &json!({}))
+                .is_none()
+        );
+    }
+
+    /// nw-443 DOWNGRADE PATH: a new client against an older daemon gets no
+    /// metadata code at all, only the legacy prose. That must still be
+    /// recognized, or upgrading the client alone would reintroduce the very
+    /// regression this detection exists to prevent.
+    #[test]
+    fn degraded_stand_in_still_recognizes_the_legacy_prose_signal() {
+        let error = anyhow::anyhow!("repo filter entry \"x\": repo 'x' not found in graph")
+            .context("blast_radius RPC failed");
+        assert!(
+            degraded_local_impact_for_unresolved_repo_filter("blast_radius", &error, &json!({}))
+                .is_some(),
+            "an un-stamped daemon's message must still degrade gracefully"
         );
     }
 

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -15,6 +15,7 @@ use nestweaver_proto::*;
 use nestweaver_store::{GraphStore, TantivyIndex};
 use tokio::sync::Notify;
 use tonic::codegen::http;
+use tonic::metadata::MetadataValue;
 use tonic::{Request, Response, Status};
 
 use crate::lifecycle;
@@ -46,7 +47,30 @@ fn dispatch_err_to_status(tool_name: &str, e: anyhow::Error) -> Status {
             }
         };
     }
-    Status::internal(format!("tool {tool_name} failed: {e}"))
+    let mut status = Status::internal(format!("tool {tool_name} failed: {e}"));
+
+    // nw-443. A typed engine error gets a MACHINE-READABLE code in the
+    // status metadata, so `nestweaver-client`'s two-tier degrade can match on
+    // a code instead of substring-matching this message's prose across three
+    // crates. The `internal` gRPC code and the message text are deliberately
+    // unchanged -- other consumers (upstream-health detection among them)
+    // read those, and this is meant to be purely additive.
+    //
+    // `chain()` rather than a bare downcast: the error may already carry
+    // `.context()` from the tool layer, and the type is what matters, not
+    // where it sits in the chain.
+    if e.chain()
+        .any(|cause| cause.is::<nestweaver_engine::node_scope::RepoFilterUnresolved>())
+        && let Ok(value) =
+            nestweaver_engine::node_scope::REPO_FILTER_UNRESOLVED_CODE.parse::<MetadataValue<_>>()
+    {
+        status.metadata_mut().insert(
+            nestweaver_engine::node_scope::NW_ERROR_CODE_METADATA_KEY,
+            value,
+        );
+    }
+
+    status
 }
 
 /// Trip `cancel` when the request future is dropped (client cancel /
@@ -122,6 +146,55 @@ fn list_contracts_impl(
             })
             .collect(),
     })
+}
+
+#[cfg(test)]
+mod dispatch_err_to_status_tests {
+    use super::*;
+
+    /// nw-443: the daemon is the only place that can turn the engine's typed
+    /// `RepoFilterUnresolved` into something a federated client can read
+    /// across the gRPC boundary. Without this stamp the client's typed check
+    /// never fires in production and detection silently stays on prose --
+    /// the failure this item exists to end.
+    #[test]
+    fn an_unresolved_repo_filter_is_stamped_with_its_error_code() {
+        let error = anyhow::Error::new(nestweaver_engine::node_scope::RepoFilterUnresolved::new(
+            "not-a-repo",
+            &anyhow::anyhow!("repo 'not-a-repo' not found in graph"),
+        ));
+        let status = dispatch_err_to_status("blast_radius", error);
+
+        let code = status
+            .metadata()
+            .get(nestweaver_engine::node_scope::NW_ERROR_CODE_METADATA_KEY)
+            .expect("an unresolved repo filter must carry a machine-readable code")
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(
+            code,
+            nestweaver_engine::node_scope::REPO_FILTER_UNRESOLVED_CODE
+        );
+        assert!(
+            status.message().contains("repo filter entry"),
+            "the human message is unchanged; got {:?}",
+            status.message()
+        );
+    }
+
+    /// COUNTERWEIGHT: an ordinary failure must carry NO code, or the client's
+    /// typed check would absorb every local outage into a degraded stand-in.
+    #[test]
+    fn an_unrelated_failure_carries_no_error_code() {
+        let status = dispatch_err_to_status("blast_radius", anyhow::anyhow!("connection refused"));
+        assert!(
+            status
+                .metadata()
+                .get(nestweaver_engine::node_scope::NW_ERROR_CODE_METADATA_KEY)
+                .is_none()
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/nestweaver-engine/src/dead_code.rs
+++ b/crates/nestweaver-engine/src/dead_code.rs
@@ -433,18 +433,22 @@ fn detect_dead_code_inner(
     //
     // Gated on `language_has_entry_point_model`: "zero entry points" is only
     // evidence of a coverage GAP for a language that has a detection rule to
-    // come up empty. SQL, HCL, SystemVerilog, Vue, Svelte and Astro have no
-    // model at all (declarative, unimplemented, or routed around
-    // `detect_entry_point` entirely -- see that function's doc comment), so
-    // their entry-point count is ALWAYS zero and folding them in here would
-    // degrade `coverage_is_complete` permanently for any corpus containing
-    // even one such file, with no user action able to clear it. A probe
-    // confirmed this: `languages_without_entry_points = ["hcl", "sql",
-    // "systemverilog", "vue"]` on a corpus that also has real bash/python
-    // gaps, degrading coverage for a reason no fix can address. Excluding
-    // them here, rather than filtering the OUTPUT, keeps the field itself
-    // honest: a language only ever appears when its absence is a real,
-    // actionable gap.
+    // come up empty. SQL, HCL and SystemVerilog have no model at all
+    // (declarative or unimplemented), so their entry-point count is ALWAYS
+    // zero and folding them in here would degrade `coverage_is_complete`
+    // permanently for any corpus containing even one such file, with no user
+    // action able to clear it. Excluding them here, rather than filtering the
+    // OUTPUT, keeps the field itself honest: a language only ever appears
+    // when its absence is a real, actionable gap.
+    //
+    // nw-441 REMOVED Vue, Svelte and Astro from that list -- this comment used
+    // to name them here, and the probe it cited (`["hcl", "sql",
+    // "systemverilog", "vue"]`) is no longer reproducible. They now have
+    // `detect_component_framework`, so zero entry points from one of them IS
+    // an actionable gap. That cuts both ways and is why `vue.rs` had to learn
+    // to mint a component for `<script setup>` in the same change: with Vue
+    // enrolled, a file the parser could not see a component in would have
+    // degraded a corpus that previously read clean.
     let mut entry_point_uids: Vec<String> = Vec::new();
     let mut lang_totals: HashMap<String, usize> = HashMap::new();
     let mut lang_entries: HashMap<String, usize> = HashMap::new();

--- a/crates/nestweaver-engine/src/node_scope.rs
+++ b/crates/nestweaver-engine/src/node_scope.rs
@@ -88,6 +88,58 @@ pub fn node_owner(uid: &str) -> NodeOwner {
     }
 }
 
+/// The gRPC metadata key carrying a machine-readable NestWeaver error code.
+///
+/// nw-443. This lives here, next to the only error that sets it, rather than
+/// in the proto crate: the producing error type and the code that names it
+/// have to change together, and splitting them across crates is how the
+/// PREVIOUS contract (a bare message prefix) ended up pinned by nothing on
+/// either end.
+pub const NW_ERROR_CODE_METADATA_KEY: &str = "nw-error-code";
+
+/// The code stamped when a `repo` filter selector did not resolve.
+pub const REPO_FILTER_UNRESOLVED_CODE: &str = "repo-filter-unresolved";
+
+/// A `repo` filter selector that did not resolve against the graph — either
+/// not found, or ambiguous.
+///
+/// nw-443. `resolve_repo_filter` used to signal this with `anyhow!` and a
+/// message prefix, and `nestweaver-client`'s federation degrade recognized it
+/// by SUBSTRING-MATCHING that prefix across three crates. Nothing pinned the
+/// literal on either end: the producing tests asserted only `"ambiguous"` /
+/// `"not-a-repo"`, and the consuming tests hand-constructed the string as a
+/// fixture instead of calling this function. A rename here therefore left both
+/// sides green while silently reverting federation to the pre-fix behaviour,
+/// where one unresolvable local `--repo` killed an otherwise healthy upstream's
+/// entire two-tier answer.
+///
+/// The `Display` output is byte-identical to the old `anyhow!` wrapper on
+/// purpose: this is a change of TYPE, not of what a user reads. The prefix
+/// assertion below still pins that text, because a downgrade path (a new
+/// client against an older daemon that cannot stamp the metadata code) still
+/// falls back to it.
+#[derive(Debug, thiserror::Error)]
+#[error("repo filter entry {selector:?}: {rendered}")]
+pub struct RepoFilterUnresolved {
+    /// The selector as the caller spelled it.
+    pub selector: String,
+    /// The underlying resolver failure, pre-rendered with `{:#}` so the
+    /// "ambiguous; use an exact UID: …" candidate list survives — see the
+    /// note in `resolve_repo_filter` on why `.context()` is wrong here.
+    rendered: String,
+}
+
+impl RepoFilterUnresolved {
+    /// Public so the daemon's own status-mapping test can build one without
+    /// standing up a graph store just to provoke a resolver failure.
+    pub fn new(selector: &str, error: &anyhow::Error) -> Self {
+        Self {
+            selector: selector.to_string(),
+            rendered: format!("{error:#}"),
+        }
+    }
+}
+
 /// Resolve caller-supplied `repos:` / `--repos` entries to concrete repo
 /// UIDs.
 ///
@@ -127,7 +179,10 @@ pub fn resolve_repo_filter(
                 // OUTERMOST context — so a `.context()` here would hide the
                 // resolver's own "ambiguous; use an exact UID: …" candidate
                 // list, which is the only actionable part of the message.
-                .map_err(|error| anyhow!("repo filter entry {selector:?}: {error:#}"))
+                // nw-443: a TYPED error, not `anyhow!` with a magic prefix.
+                // `Display` is unchanged; what changed is that a consumer can
+                // now downcast instead of matching on prose.
+                .map_err(|error| anyhow::Error::new(RepoFilterUnresolved::new(selector, &error)))
         })
         .collect()
 }
@@ -335,16 +390,67 @@ mod tests {
             .unwrap_err()
             .to_string();
 
-        // This exact prefix, with the trailing space, is the literal
-        // `nestweaver-client/src/hybrid.rs`'s `UNRESOLVED_REPO_FILTER_SIGNAL`
-        // constant matches against across the daemon/gRPC boundary. If this
-        // assertion needs to change, `UNRESOLVED_REPO_FILTER_SIGNAL` (and its
-        // own test fixtures) must change with it in the same commit.
+        // nw-443 DEMOTED this from the contract to the FALLBACK. The prose
+        // is no longer how federation recognizes the condition -- the typed
+        // `RepoFilterUnresolved` and its error code are (see the test
+        // below). This prefix still matters only for a client newer than the
+        // daemon it talks to, which receives no metadata code; when that
+        // downgrade path is retired, `UNRESOLVED_REPO_FILTER_SIGNAL` and this
+        // assertion go together.
         assert!(
             error.starts_with("repo filter entry "),
             "resolve_repo_filter's not-found error must start with the literal \
              \"repo filter entry \" prefix nestweaver-client's federation fix \
              matches on; got {error:?}"
         );
+    }
+
+    /// nw-443: the contract that REPLACED the prefix above. A consumer must
+    /// be able to recognize this condition by TYPE, so that rewording the
+    /// message -- which nw-334 is open to do across this codebase -- cannot
+    /// silently revert federation to killing a healthy upstream's answer.
+    #[test]
+    fn resolve_repo_filter_not_found_error_is_typed_and_carries_the_selector() {
+        let store = GraphStore::in_memory().expect("in_memory store");
+        store
+            .insert_repo(&nestweaver_schema::Repo {
+                uid: REPO_A.to_string(),
+                url: "https://example.test/repo-a".to_string(),
+                indexed_sha: String::new(),
+                staleness_commits_behind: 0,
+                instance_id: "default".to_string(),
+                name: None,
+                root_path: None,
+            })
+            .unwrap();
+
+        let error = resolve_repo_filter(&store, &["this-repo-does-not-exist".to_string()], None)
+            .unwrap_err();
+
+        let typed = error
+            .chain()
+            .find_map(|cause| cause.downcast_ref::<RepoFilterUnresolved>())
+            .expect("an unresolved repo filter must be downcastable, not just readable");
+        assert_eq!(typed.selector, "this-repo-does-not-exist");
+    }
+
+    /// COUNTERWEIGHT: a selector that DOES resolve must not produce the error
+    /// at all, or the type above would be meaningless.
+    #[test]
+    fn a_resolvable_selector_produces_no_repo_filter_error() {
+        let store = GraphStore::in_memory().expect("in_memory store");
+        store
+            .insert_repo(&nestweaver_schema::Repo {
+                uid: REPO_A.to_string(),
+                url: "https://example.test/repo-a".to_string(),
+                indexed_sha: String::new(),
+                staleness_commits_behind: 0,
+                instance_id: "default".to_string(),
+                name: Some("repo-a".to_string()),
+                root_path: None,
+            })
+            .unwrap();
+
+        assert!(resolve_repo_filter(&store, &["repo-a".to_string()], None).is_ok());
     }
 }

--- a/crates/nestweaver-engine/src/resolver_generation.rs
+++ b/crates/nestweaver-engine/src/resolver_generation.rs
@@ -75,7 +75,18 @@ use std::path::Path;
 ///     invisible to every existing graph, which is the trap this module exists
 ///     for and which this codebase has now sprung twice (nw-103, and again in
 ///     round 3).
-pub const RESOLVER_GENERATION: u32 = 4;
+/// 5 — nw-441: `vue.rs`, `svelte.rs` and `astro.rs` hardcoded
+///     `is_entry_point: false` on every symbol and never called
+///     `detect_entry_point`. Both `is_entry_point` and `entry_point_kind` are
+///     PERSISTED per-symbol columns that `dead-code`, `process.rs` and
+///     `ranking.rs` read straight off disk rather than re-deriving, so a
+///     component in an already-indexed graph keeps `false` forever and cannot
+///     seed a reachability walk no matter which binary asks. Two graphs of
+///     identical source then disagree about what is dead, and without this
+///     bump the disagreement is silent — the same shape as generation 4's own
+///     "svelte/vue/astro named exports change `SymbolKind`" entry, which is
+///     the precedent this follows.
+pub const RESOLVER_GENERATION: u32 = 5;
 
 /// An unrecorded repo reads as generation 0, so the current generation must
 /// stay above it — otherwise the pre-fix data this module exists to flag would

--- a/crates/nestweaver-parser/src/astro.rs
+++ b/crates/nestweaver-parser/src/astro.rs
@@ -76,6 +76,12 @@ const CALL_EXCLUDE: &[&str] = &[
 /// - Function calls → [`ReferenceKind::Call`]
 pub fn parse_astro(path: &Path, source: &str) -> ParsedFile {
     let path_str = path.to_string_lossy().into_owned();
+    // nw-441: one spelling of the entry-point question for every symbol
+    // this file mints. These parsers used to hardcode
+    // `is_entry_point: false` at each construction site instead.
+    let entry_point_of = |name: &str, kind: &str, signature: Option<&str>| {
+        crate::entry_points::detect_entry_point(name, &path_str, kind, signature, "astro")
+    };
 
     let mut symbols: Vec<RawSymbol> = Vec::new();
     let mut references: Vec<RawReference> = Vec::new();
@@ -88,6 +94,7 @@ pub fn parse_astro(path: &Path, source: &str) -> ParsedFile {
         .to_string();
 
     // The Astro file itself is a component — record it
+    let entry_point = entry_point_of(&component_name, "class", None);
     symbols.push(RawSymbol {
         name: component_name.clone(),
         kind: SymbolKind::Class,
@@ -102,8 +109,8 @@ pub fn parse_astro(path: &Path, source: &str) -> ParsedFile {
         end_line: source.lines().count().max(1) as u32,
         signature: format!("<astro:component name=\"{component_name}\">"),
         content_hash: sha256_hex(&component_name),
-        is_entry_point: false,
-        entry_point_kind: None,
+        is_entry_point: entry_point.is_some(),
+        entry_point_kind: entry_point,
         visibility: Visibility::Public,
         type_info: None,
         parent_name: None,
@@ -142,6 +149,11 @@ pub fn parse_astro(path: &Path, source: &str) -> ParsedFile {
                 // `parse::export_declaration_kind`.
                 let kind = crate::parse::export_declaration_kind(&cap[1]);
                 let name = cap[2].to_string();
+                let entry_point = entry_point_of(
+                    &name,
+                    crate::entry_points::symbol_kind_label(kind),
+                    Some(trimmed),
+                );
                 symbols.push(RawSymbol {
                     name,
                     kind,
@@ -149,8 +161,8 @@ pub fn parse_astro(path: &Path, source: &str) -> ParsedFile {
                     end_line,
                     signature: trimmed.to_string(),
                     content_hash: sha256_hex(trimmed),
-                    is_entry_point: false,
-                    entry_point_kind: None,
+                    is_entry_point: entry_point.is_some(),
+                    entry_point_kind: entry_point,
                     visibility: Visibility::Public,
                     type_info: None,
                     parent_name: None,
@@ -163,6 +175,7 @@ pub fn parse_astro(path: &Path, source: &str) -> ParsedFile {
                 && let Some(cap) = RE_FUNCTION.captures(trimmed)
             {
                 let name = cap[1].to_string();
+                let entry_point = entry_point_of(&name, "function", Some(trimmed));
                 symbols.push(RawSymbol {
                     name,
                     kind: SymbolKind::Function,
@@ -170,8 +183,8 @@ pub fn parse_astro(path: &Path, source: &str) -> ParsedFile {
                     end_line,
                     signature: trimmed.to_string(),
                     content_hash: sha256_hex(trimmed),
-                    is_entry_point: false,
-                    entry_point_kind: None,
+                    is_entry_point: entry_point.is_some(),
+                    entry_point_kind: entry_point,
                     visibility: Visibility::Private,
                     type_info: None,
                     parent_name: None,

--- a/crates/nestweaver-parser/src/entry_points.rs
+++ b/crates/nestweaver-parser/src/entry_points.rs
@@ -119,6 +119,30 @@ fn ends_with_test_stem(file_name: &str, ext: &str) -> bool {
         .is_some_and(|stem| stem.ends_with("_test"))
 }
 
+/// The lowercase label `detect_entry_point` expects for a `SymbolKind`.
+///
+/// nw-441: this used to live as an inline `match` inside `parse.rs`'s
+/// tree-sitter loop, which is why the three bespoke component parsers had no
+/// cheap way to call `detect_entry_point` and hardcoded `false` instead.
+/// One spelling, shared by every caller.
+pub fn symbol_kind_label(kind: nestweaver_schema::SymbolKind) -> &'static str {
+    use nestweaver_schema::SymbolKind;
+    match kind {
+        SymbolKind::Function => "function",
+        SymbolKind::Class => "class",
+        SymbolKind::Method => "method",
+        SymbolKind::Interface => "interface",
+        SymbolKind::Trait => "trait",
+        SymbolKind::Enum => "enum",
+        SymbolKind::Module => "module",
+        SymbolKind::Extension => "extension",
+        SymbolKind::Constant => "constant",
+        SymbolKind::Property => "property",
+        SymbolKind::TypeAlias => "type_alias",
+        SymbolKind::Variable => "variable",
+    }
+}
+
 /// Whether `language` has an entry-point detection model AT ALL.
 ///
 /// "Zero entry points found" conflates two different facts, and a caller
@@ -132,15 +156,20 @@ fn ends_with_test_stem(file_name: &str, ext: &str) -> bool {
 /// - The language has NO model at all -- not a gap, a known limitation.
 ///   `detect_entry_point` below returns `"sql" | "hcl" => None`
 ///   unconditionally (SQL/HCL are declarative; there is no "entry" to
-///   detect), SystemVerilog has no arm and falls through the wildcard, and
-///   Vue/Svelte/Astro construct every symbol with `is_entry_point: false`
-///   hardcoded in their own parse functions -- `detect_entry_point` is never
-///   even CALLED for them. Folding this case into "coverage gap" would
-///   degrade `coverage_is_complete` PERMANENTLY for any corpus containing
-///   one `.sql`, `.tf`, `.sv`, `.vue`, `.svelte` or `.astro` file, with no
-///   user action able to clear it -- the same failure shape as a check that
-///   never fires: a gate that always fires carries the same amount of
-///   information as one that never does.
+///   detect), and SystemVerilog has no arm and falls through the wildcard.
+///   Folding this case into "coverage gap" would degrade
+///   `coverage_is_complete` PERMANENTLY for any corpus containing one
+///   `.sql`, `.tf` or `.sv` file, with no user action able to clear it --
+///   the same failure shape as a check that never fires: a gate that always
+///   fires carries the same amount of information as one that never does.
+///
+/// nw-441 MOVED Vue/Svelte/Astro OUT of that second group. They used to sit
+/// there for a reason that was never a decision: their bespoke parsers built
+/// every symbol with `is_entry_point: false` hardcoded and never called
+/// `detect_entry_point` at all, so a component could not root a reachability
+/// walk and component-only code was unreachable by construction. They now
+/// have `detect_component_framework`, so a zero from one of them is once
+/// again a REAL gap and must stay reportable.
 ///
 /// This match has NO wildcard arm ON PURPOSE. A hand-maintained "languages
 /// without a model" list rots the moment someone adds a 33rd language or
@@ -175,18 +204,13 @@ pub fn language_has_entry_point_model(language: Language) -> bool {
         | Language::PowerShell
         | Language::Julia
         | Language::Fortran
-        | Language::Pascal => true,
-        // No entry-point model. SQL/HCL: declarative, unconditional `None`
-        // below. SystemVerilog: no arm below, falls through `_ => None`.
-        // Vue/Svelte/Astro: `is_entry_point: false` is hardcoded where their
-        // symbols are constructed (vue.rs/svelte.rs/astro.rs) -- this
-        // function's caller never runs for them at all.
-        Language::Sql
-        | Language::Hcl
-        | Language::SystemVerilog
+        | Language::Pascal
         | Language::Vue
         | Language::Svelte
-        | Language::Astro => false,
+        | Language::Astro => true,
+        // No entry-point model. SQL/HCL: declarative, unconditional `None`
+        // below. SystemVerilog: no arm below, falls through `_ => None`.
+        Language::Sql | Language::Hcl | Language::SystemVerilog => false,
     }
 }
 
@@ -204,6 +228,11 @@ pub fn detect_entry_point(
 ) -> Option<EntryPointKind> {
     match language {
         "javascript" | "typescript" => detect_js_ts(name, file_path, kind, signature),
+        // nw-441. A component framework's script block IS JavaScript/
+        // TypeScript, so the JS/TS rules apply to everything in it; what the
+        // JS rules cannot know is that the FILE is itself an instantiable
+        // component. `detect_component_framework` adds only that.
+        "vue" | "svelte" | "astro" => detect_component_framework(name, file_path, kind, signature),
         "python" => detect_python(name, file_path, kind, signature),
         "java" => detect_java(name, file_path, kind, signature),
         "go" => detect_go(name, file_path, kind, signature),
@@ -231,6 +260,54 @@ pub fn detect_entry_point(
         "fortran" => detect_fortran(name, file_path, kind, signature),
         "pascal" => detect_pascal(name, file_path, kind, signature),
         _ => None,
+    }
+}
+
+/// Entry points for the three component frameworks with bespoke parsers
+/// (`vue.rs`, `svelte.rs`, `astro.rs`).
+///
+/// nw-441. These parsers hardcoded `is_entry_point: false` on every symbol
+/// and bypassed `detect_entry_point` entirely, so `dead-code` could never
+/// root its reachability walk in a component and component-only code was
+/// unreachable BY CONSTRUCTION -- the same shape nw-435 found for bash and
+/// python, and the same shape nw-351 closed for C++ by widening the seed set.
+///
+/// The rule is deliberately narrow: the COMPONENT ITSELF is the entry point,
+/// identified by a class-kind symbol whose name is the file stem, which is
+/// exactly how all three parsers mint it. A Vue/Svelte/Astro component's
+/// default export is instantiable in precisely the sense `detect_js_ts`
+/// already treats a React component as an entry point.
+///
+/// Everything else in the file falls through to `detect_js_ts`, because a
+/// `<script>` block or an Astro frontmatter fence genuinely IS JS/TS -- so
+/// `getStaticPaths`, a `/pages/` route and a `/components/` component all
+/// keep the meaning those rules already give them, rather than getting a
+/// second, divergent spelling here.
+///
+/// `EntryPointKind::EventListener` is the existing overload for UI
+/// components (see the React hook/component notes in `detect_js_ts`); this
+/// adds no new variant on purpose.
+fn detect_component_framework(
+    name: &str,
+    file_path: &str,
+    kind: &str,
+    signature: Option<&str>,
+) -> Option<EntryPointKind> {
+    if kind == "class" && name == component_file_stem(file_path) {
+        return Some(EntryPointKind::EventListener);
+    }
+    detect_js_ts(name, file_path, kind, signature)
+}
+
+/// The file stem of `file_path` -- `src/lib/Counter.svelte` -> `Counter`.
+///
+/// This mirrors the `path.file_stem()` the three parsers use to name the
+/// component symbol, so the two agree by construction.
+fn component_file_stem(file_path: &str) -> &str {
+    let file_name = file_path.rsplit(['/', '\\']).next().unwrap_or(file_path);
+    match file_name.rfind('.') {
+        Some(0) | None => file_name,
+        Some(dot) => &file_name[..dot],
     }
 }
 
@@ -1079,17 +1156,13 @@ mod tests {
         .filter(|&lang| !language_has_entry_point_model(lang))
         .collect();
 
+        // nw-441 moved Vue/Svelte/Astro out of this list by giving them
+        // `detect_component_framework`. SQL and HCL are declarative and
+        // SystemVerilog has no arm; all three stay, deliberately.
         assert_eq!(
             without_model,
-            vec![
-                Language::Sql,
-                Language::Hcl,
-                Language::Vue,
-                Language::Svelte,
-                Language::Astro,
-                Language::SystemVerilog,
-            ],
-            "exactly these six languages have no entry-point model: {without_model:?}"
+            vec![Language::Sql, Language::Hcl, Language::SystemVerilog],
+            "exactly these three languages have no entry-point model: {without_model:?}"
         );
     }
 
@@ -1100,6 +1173,103 @@ mod tests {
     fn bash_and_python_have_an_entry_point_model() {
         assert!(language_has_entry_point_model(Language::Bash));
         assert!(language_has_entry_point_model(Language::Python));
+    }
+
+    // ── nw-441: the component-framework entry-point surface ─────────────
+
+    /// nw-441: `vue.rs`, `svelte.rs` and `astro.rs` built EVERY symbol with
+    /// `is_entry_point: false` hardcoded and never called `detect_entry_point`
+    /// at all, so a component could never root a reachability walk and
+    /// component-only code was unreachable BY CONSTRUCTION. These pin the
+    /// component itself as an entry point on each of the three.
+    #[test]
+    fn vue_component_is_an_entry_point() {
+        assert_eq!(
+            detect_entry_point(
+                "Counter",
+                "src/components/Counter.vue",
+                "class",
+                Some("export default {"),
+                "vue",
+            ),
+            Some(EntryPointKind::EventListener)
+        );
+    }
+
+    #[test]
+    fn svelte_component_is_an_entry_point() {
+        assert_eq!(
+            detect_entry_point(
+                "Counter",
+                "src/lib/Counter.svelte",
+                "class",
+                Some("<svelte:component name=\"Counter\">"),
+                "svelte",
+            ),
+            Some(EntryPointKind::EventListener)
+        );
+    }
+
+    #[test]
+    fn astro_component_is_an_entry_point() {
+        assert_eq!(
+            detect_entry_point(
+                "Layout",
+                "src/layouts/Layout.astro",
+                "class",
+                Some("<astro:component name=\"Layout\">"),
+                "astro",
+            ),
+            Some(EntryPointKind::EventListener)
+        );
+    }
+
+    /// COUNTERWEIGHT. If every symbol in a component file were promoted, the
+    /// three tests above would pass for the wrong reason and `dead-code` would
+    /// report nothing dead in a component-only corpus -- a gate that always
+    /// fires. A private helper inside the same file must stay non-entry.
+    #[test]
+    fn a_private_helper_in_a_component_is_not_an_entry_point() {
+        assert_eq!(
+            detect_entry_point(
+                "formatLabel",
+                "src/components/Counter.vue",
+                "function",
+                None,
+                "vue"
+            ),
+            None
+        );
+        assert_eq!(
+            detect_entry_point("tick", "src/lib/Counter.svelte", "function", None, "svelte"),
+            None
+        );
+    }
+
+    /// COUNTERWEIGHT. The component rule keys on the symbol NAME matching the
+    /// file stem. A class with some other name is not the component.
+    #[test]
+    fn a_differently_named_class_in_a_component_file_is_not_the_component() {
+        assert_eq!(
+            detect_entry_point(
+                "HelperWidget",
+                "src/lib/Counter.svelte",
+                "class",
+                None,
+                "svelte"
+            ),
+            None
+        );
+    }
+
+    /// nw-441 requires the honesty gate to be re-enrolled: with a model in
+    /// place, "zero entry points" for these three is once again a REAL
+    /// coverage gap rather than a known limitation.
+    #[test]
+    fn component_frameworks_have_an_entry_point_model() {
+        assert!(language_has_entry_point_model(Language::Vue));
+        assert!(language_has_entry_point_model(Language::Svelte));
+        assert!(language_has_entry_point_model(Language::Astro));
     }
 
     // ── nw-351: the C++ entry-point surface ─────────────────────────────

--- a/crates/nestweaver-parser/src/entry_points.rs
+++ b/crates/nestweaver-parser/src/entry_points.rs
@@ -1182,12 +1182,16 @@ mod tests {
     /// at all, so a component could never root a reachability walk and
     /// component-only code was unreachable BY CONSTRUCTION. These pin the
     /// component itself as an entry point on each of the three.
+    /// The path deliberately avoids `/components/`: `detect_js_ts`'s React
+    /// rule (uppercase name + `/components/`) would otherwise satisfy this
+    /// assertion on its own, and the test would pass even with the component
+    /// rule removed entirely.
     #[test]
     fn vue_component_is_an_entry_point() {
         assert_eq!(
             detect_entry_point(
                 "Counter",
-                "src/components/Counter.vue",
+                "src/views/Counter.vue",
                 "class",
                 Some("export default {"),
                 "vue",
@@ -1242,6 +1246,23 @@ mod tests {
         );
         assert_eq!(
             detect_entry_point("tick", "src/lib/Counter.svelte", "function", None, "svelte"),
+            None
+        );
+    }
+
+    /// COUNTERWEIGHT to the other half of the guard. Every other counterweight
+    /// here uses a name that DIFFERS from the file stem, so dropping the
+    /// `kind == "class"` check survived the entire suite: a function that
+    /// happens to share the file's name is not the component, and promoting it
+    /// would seed the reachability walk from an ordinary helper.
+    #[test]
+    fn a_function_named_after_the_file_is_not_the_component() {
+        assert_eq!(
+            detect_entry_point("Counter", "src/lib/Counter.svelte", "function", None, "svelte"),
+            None
+        );
+        assert_eq!(
+            detect_entry_point("Counter", "src/views/Counter.vue", "function", None, "vue"),
             None
         );
     }

--- a/crates/nestweaver-parser/src/entry_points.rs
+++ b/crates/nestweaver-parser/src/entry_points.rs
@@ -1258,7 +1258,13 @@ mod tests {
     #[test]
     fn a_function_named_after_the_file_is_not_the_component() {
         assert_eq!(
-            detect_entry_point("Counter", "src/lib/Counter.svelte", "function", None, "svelte"),
+            detect_entry_point(
+                "Counter",
+                "src/lib/Counter.svelte",
+                "function",
+                None,
+                "svelte"
+            ),
             None
         );
         assert_eq!(

--- a/crates/nestweaver-parser/src/lib.rs
+++ b/crates/nestweaver-parser/src/lib.rs
@@ -18,7 +18,9 @@ pub mod vue;
 
 pub use canvas::{CanvasEdge, CanvasFile, CanvasNode, parse_canvas};
 pub use dataview::{DataviewQuery, parse_dataview_query};
-pub use entry_points::{detect_entry_point, is_test_file, language_has_entry_point_model};
+pub use entry_points::{
+    detect_entry_point, is_test_file, language_has_entry_point_model, symbol_kind_label,
+};
 pub use frameworks::detect_frameworks;
 pub use language::{detect_language, is_markdown};
 pub use markdown::{

--- a/crates/nestweaver-parser/src/parse.rs
+++ b/crates/nestweaver-parser/src/parse.rs
@@ -4145,6 +4145,51 @@ use crate::config::{Settings, load as load_config};
         );
     }
 
+    /// nw-441 follow-up: `vue.rs` only minted the component's class symbol when
+    /// the script block contained `defineComponent(` or `export default`. Vue 3's
+    /// `<script setup>` -- the recommended syntax -- has NEITHER (the default
+    /// export is compiler-synthesised), so such a file produced no component
+    /// symbol at all and the entry-point fix could not reach it.
+    ///
+    /// That was not merely a missed improvement: with Vue now enrolled in
+    /// `language_has_entry_point_model`, a `<script setup>` file yielding zero
+    /// entry points flips a corpus from `coverage: complete` to `degraded`.
+    /// `svelte.rs` and `astro.rs` never had this problem because they mint the
+    /// component unconditionally.
+    #[test]
+    fn parse_vue_script_setup_still_yields_a_component_entry_point() {
+        let source = "<template>\n  <button @click=\"increment\">{{ count }}</button>\n</template>\n\n<script setup>\nimport { ref } from 'vue'\n\nconst count = ref(0)\n\nfunction increment() {\n  count.value += 1\n}\n</script>\n";
+        let parsed = parse_source(Path::new("Widget.vue"), source).unwrap();
+        let component = component_symbol(&parsed, "Widget");
+        assert!(
+            component.is_entry_point,
+            "a <script setup> component must still root a reachability walk"
+        );
+        assert_eq!(
+            component.entry_point_kind,
+            Some(EntryPointKind::EventListener)
+        );
+    }
+
+    /// COUNTERWEIGHT: the fallback must not mint a SECOND component symbol for
+    /// a file that already declared one, or every classic Vue SFC would carry
+    /// a duplicate.
+    #[test]
+    fn parse_vue_export_default_yields_exactly_one_component_symbol() {
+        let source = fixture("vue/simple.vue");
+        let parsed = parse_source(Path::new("simple.vue"), &source).unwrap();
+        let components: Vec<_> = parsed
+            .symbols
+            .iter()
+            .filter(|s| s.name == "simple" && s.kind == SymbolKind::Class)
+            .collect();
+        assert_eq!(
+            components.len(),
+            1,
+            "exactly one component symbol; got {components:?}"
+        );
+    }
+
     /// COUNTERWEIGHT. Without this the three tests above would also pass if
     /// the parsers flipped `is_entry_point: true` on EVERYTHING -- which
     /// would make `dead-code` report nothing dead in a component corpus, the

--- a/crates/nestweaver-parser/src/parse.rs
+++ b/crates/nestweaver-parser/src/parse.rs
@@ -1249,20 +1249,7 @@ pub fn parse_source(path: &Path, source: &str) -> Result<ParsedFile, ParseError>
                 let content_hash = sha256_hex(node_text);
                 let signature = signature_line(node_text, lang_str);
 
-                let kind_label = match kind {
-                    SymbolKind::Function => "function",
-                    SymbolKind::Class => "class",
-                    SymbolKind::Method => "method",
-                    SymbolKind::Interface => "interface",
-                    SymbolKind::Trait => "trait",
-                    SymbolKind::Enum => "enum",
-                    SymbolKind::Module => "module",
-                    SymbolKind::Extension => "extension",
-                    SymbolKind::Constant => "constant",
-                    SymbolKind::Property => "property",
-                    SymbolKind::TypeAlias => "type_alias",
-                    SymbolKind::Variable => "variable",
-                };
+                let kind_label = crate::entry_points::symbol_kind_label(kind);
                 // A `definition.function` captured on a `call_expression` node is a
                 // JS/TS test-runner block (test/it/describe). The calls inside its
                 // callback attach to this symbol; mark it a test entry point so it
@@ -4106,6 +4093,86 @@ use crate::config::{Settings, load as load_config};
     }
 
     // ── Svelte tests ─────────────────────────────────────────────────────
+
+    // ── nw-441: component-framework entry points ─────────────────────────
+
+    /// nw-441: `vue.rs`, `svelte.rs` and `astro.rs` hardcoded
+    /// `is_entry_point: false` on EVERY symbol, so a Vue/Svelte/Astro
+    /// component could never seed a reachability walk and component-only code
+    /// was unreachable by construction. These assert the wiring end to end --
+    /// through the real parser, not just `detect_entry_point` in isolation.
+    fn component_symbol<'a>(parsed: &'a ParsedFile, name: &str) -> &'a RawSymbol {
+        parsed
+            .symbols
+            .iter()
+            .find(|s| s.name == name && s.kind == SymbolKind::Class)
+            .unwrap_or_else(|| panic!("no class symbol named {name}"))
+    }
+
+    #[test]
+    fn parse_vue_marks_the_component_as_an_entry_point() {
+        let source = fixture("vue/simple.vue");
+        let parsed = parse_source(Path::new("simple.vue"), &source).unwrap();
+        let component = component_symbol(&parsed, "simple");
+        assert!(component.is_entry_point, "the Vue component roots the walk");
+        assert_eq!(
+            component.entry_point_kind,
+            Some(EntryPointKind::EventListener)
+        );
+    }
+
+    #[test]
+    fn parse_svelte_marks_the_component_as_an_entry_point() {
+        let source = fixture("svelte/simple.svelte");
+        let parsed = parse_source(Path::new("simple.svelte"), &source).unwrap();
+        let component = component_symbol(&parsed, "simple");
+        assert!(component.is_entry_point);
+        assert_eq!(
+            component.entry_point_kind,
+            Some(EntryPointKind::EventListener)
+        );
+    }
+
+    #[test]
+    fn parse_astro_marks_the_component_as_an_entry_point() {
+        let source = fixture("astro/simple.astro");
+        let parsed = parse_source(Path::new("simple.astro"), &source).unwrap();
+        let component = component_symbol(&parsed, "simple");
+        assert!(component.is_entry_point);
+        assert_eq!(
+            component.entry_point_kind,
+            Some(EntryPointKind::EventListener)
+        );
+    }
+
+    /// COUNTERWEIGHT. Without this the three tests above would also pass if
+    /// the parsers flipped `is_entry_point: true` on EVERYTHING -- which
+    /// would make `dead-code` report nothing dead in a component corpus, the
+    /// opposite failure and an equally useless one. A private helper in the
+    /// same file must stay non-entry.
+    #[test]
+    fn a_private_helper_in_a_component_file_stays_non_entry() {
+        let source = fixture("svelte/simple.svelte");
+        let parsed = parse_source(Path::new("simple.svelte"), &source).unwrap();
+        let handler = parsed
+            .symbols
+            .iter()
+            .find(|s| s.name == "handleClick")
+            .expect("fixture defines handleClick");
+        assert!(
+            !handler.is_entry_point,
+            "a non-exported handler is not an entry point"
+        );
+
+        let source = fixture("astro/simple.astro");
+        let parsed = parse_source(Path::new("simple.astro"), &source).unwrap();
+        let helper = parsed
+            .symbols
+            .iter()
+            .find(|s| s.name == "formatTitle")
+            .expect("fixture defines formatTitle");
+        assert!(!helper.is_entry_point);
+    }
 
     #[test]
     fn parse_svelte_extracts_component() {

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_astro_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_astro_symbols.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 6136
 expression: "parsed_symbols(\"simple.astro\", &source)"
 ---
 - name: simple
@@ -9,8 +8,8 @@ expression: "parsed_symbols(\"simple.astro\", &source)"
   end_line: 34
   signature: "<astro:component name=\"simple\">"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
-  is_entry_point: false
-  entry_point_kind: ~
+  is_entry_point: true
+  entry_point_kind: EventListener
   visibility: Public
   type_info: ~
   parent_name: ~
@@ -21,8 +20,8 @@ expression: "parsed_symbols(\"simple.astro\", &source)"
   end_line: 10
   signature: "export function getStaticPaths() {"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
-  is_entry_point: false
-  entry_point_kind: ~
+  is_entry_point: true
+  entry_point_kind: HttpHandler
   visibility: Public
   type_info: ~
   parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_svelte_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_svelte_symbols.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 6605
 expression: "parsed_symbols(\"simple.svelte\", &source)"
 ---
 - name: simple
@@ -9,8 +8,8 @@ expression: "parsed_symbols(\"simple.svelte\", &source)"
   end_line: 31
   signature: "<svelte:component name=\"simple\">"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
-  is_entry_point: false
-  entry_point_kind: ~
+  is_entry_point: true
+  entry_point_kind: EventListener
   visibility: Public
   type_info: ~
   parent_name: ~

--- a/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_vue_symbols.snap
+++ b/crates/nestweaver-parser/src/snapshots/nestweaver_parser__parse__tests__snapshot_tests__snapshot_vue_symbols.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/nestweaver-parser/src/parse.rs
-assertion_line: 6108
 expression: "parsed_symbols(\"simple.vue\", &source)"
 ---
 - name: formatName
@@ -21,8 +20,8 @@ expression: "parsed_symbols(\"simple.vue\", &source)"
   end_line: 31
   signature: "export default defineComponent({"
   content_hash: "0000000000000000000000000000000000000000000000000000000000000000"
-  is_entry_point: false
-  entry_point_kind: ~
+  is_entry_point: true
+  entry_point_kind: EventListener
   visibility: Public
   type_info: ~
   parent_name: ~

--- a/crates/nestweaver-parser/src/svelte.rs
+++ b/crates/nestweaver-parser/src/svelte.rs
@@ -90,6 +90,12 @@ const CALL_EXCLUDE: &[&str] = &[
 /// - Function calls → [`ReferenceKind::Call`]
 pub fn parse_svelte(path: &Path, source: &str) -> ParsedFile {
     let path_str = path.to_string_lossy().into_owned();
+    // nw-441: one spelling of the entry-point question for every symbol
+    // this file mints. These parsers used to hardcode
+    // `is_entry_point: false` at each construction site instead.
+    let entry_point_of = |name: &str, kind: &str, signature: Option<&str>| {
+        crate::entry_points::detect_entry_point(name, &path_str, kind, signature, "svelte")
+    };
 
     let mut symbols: Vec<RawSymbol> = Vec::new();
     let mut references: Vec<RawReference> = Vec::new();
@@ -102,6 +108,7 @@ pub fn parse_svelte(path: &Path, source: &str) -> ParsedFile {
         .to_string();
 
     // The Svelte file itself is a component — record it
+    let entry_point = entry_point_of(&component_name, "class", None);
     symbols.push(RawSymbol {
         name: component_name.clone(),
         kind: SymbolKind::Class,
@@ -116,8 +123,8 @@ pub fn parse_svelte(path: &Path, source: &str) -> ParsedFile {
         end_line: source.lines().count().max(1) as u32,
         signature: format!("<svelte:component name=\"{component_name}\">"),
         content_hash: sha256_hex(&component_name),
-        is_entry_point: false,
-        entry_point_kind: None,
+        is_entry_point: entry_point.is_some(),
+        entry_point_kind: entry_point,
         visibility: Visibility::Public,
         type_info: None,
         parent_name: None,
@@ -157,6 +164,11 @@ pub fn parse_svelte(path: &Path, source: &str) -> ParsedFile {
             if let Some(cap) = RE_EXPORT_NAMED.captures(trimmed) {
                 let kind = crate::parse::export_declaration_kind(&cap[1]);
                 let name = cap[2].to_string();
+                let entry_point = entry_point_of(
+                    &name,
+                    crate::entry_points::symbol_kind_label(kind),
+                    Some(trimmed),
+                );
                 symbols.push(RawSymbol {
                     name,
                     kind,
@@ -164,8 +176,8 @@ pub fn parse_svelte(path: &Path, source: &str) -> ParsedFile {
                     end_line,
                     signature: trimmed.to_string(),
                     content_hash: sha256_hex(trimmed),
-                    is_entry_point: false,
-                    entry_point_kind: None,
+                    is_entry_point: entry_point.is_some(),
+                    entry_point_kind: entry_point,
                     visibility: Visibility::Public,
                     type_info: None,
                     parent_name: None,
@@ -178,6 +190,7 @@ pub fn parse_svelte(path: &Path, source: &str) -> ParsedFile {
                 && let Some(cap) = RE_FUNCTION.captures(trimmed)
             {
                 let name = cap[1].to_string();
+                let entry_point = entry_point_of(&name, "function", Some(trimmed));
                 symbols.push(RawSymbol {
                     name,
                     kind: SymbolKind::Function,
@@ -185,8 +198,8 @@ pub fn parse_svelte(path: &Path, source: &str) -> ParsedFile {
                     end_line,
                     signature: trimmed.to_string(),
                     content_hash: sha256_hex(trimmed),
-                    is_entry_point: false,
-                    entry_point_kind: None,
+                    is_entry_point: entry_point.is_some(),
+                    entry_point_kind: entry_point,
                     visibility: Visibility::Private,
                     type_info: None,
                     parent_name: None,

--- a/crates/nestweaver-parser/src/vue.rs
+++ b/crates/nestweaver-parser/src/vue.rs
@@ -265,6 +265,44 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
         }
     }
 
+    // nw-441 follow-up. The two sites above mint the component only when the
+    // script contains `defineComponent(` or `export default`. Vue 3's
+    // `<script setup>` -- the syntax the Vue docs recommend for new SFCs --
+    // has NEITHER: its default export is synthesised by the compiler, never
+    // written by hand. Such a file therefore produced no component symbol at
+    // all, so the entry-point model could not reach it and, now that Vue is
+    // enrolled in `language_has_entry_point_model`, a corpus containing one
+    // flipped from `coverage: complete` to `degraded`.
+    //
+    // `svelte.rs` and `astro.rs` never had this problem because they push the
+    // component unconditionally. This is that same unconditional mint, applied
+    // only when the scan found no component, so a classic SFC keeps exactly
+    // one component symbol with its original span and signature.
+    if !symbols
+        .iter()
+        .any(|s| s.kind == SymbolKind::Class && s.name == component_name)
+    {
+        let entry_point = entry_point_of(&component_name, "class", None);
+        symbols.push(RawSymbol {
+            name: component_name.clone(),
+            kind: SymbolKind::Class,
+            start_line: 1,
+            // The component IS the file, matching svelte.rs/astro.rs: a
+            // file-spanning span is the true containment, and because
+            // `find_enclosing_symbol` returns the INNERMOST match, a call
+            // inside a function still attributes to that function.
+            end_line: source.lines().count().max(1) as u32,
+            signature: format!("<script setup> {component_name}"),
+            content_hash: sha256_hex(&component_name),
+            is_entry_point: entry_point.is_some(),
+            entry_point_kind: entry_point,
+            visibility: Visibility::Public,
+            type_info: None,
+            parent_name: None,
+            scope_chain: None,
+        });
+    }
+
     ParsedFile {
         path: path_str,
         symbols,

--- a/crates/nestweaver-parser/src/vue.rs
+++ b/crates/nestweaver-parser/src/vue.rs
@@ -90,6 +90,12 @@ const CALL_EXCLUDE: &[&str] = &[
 /// - Function calls → [`ReferenceKind::Call`]
 pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
     let path_str = path.to_string_lossy().into_owned();
+    // nw-441: one spelling of the entry-point question for every symbol
+    // this file mints. These parsers used to hardcode
+    // `is_entry_point: false` at each construction site instead.
+    let entry_point_of = |name: &str, kind: &str, signature: Option<&str>| {
+        crate::entry_points::detect_entry_point(name, &path_str, kind, signature, "vue")
+    };
 
     let mut symbols: Vec<RawSymbol> = Vec::new();
     let mut references: Vec<RawReference> = Vec::new();
@@ -132,6 +138,7 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
 
             // defineComponent call
             if RE_DEFINE_COMPONENT.is_match(trimmed) {
+                let entry_point = entry_point_of(&component_name, "class", Some(trimmed));
                 symbols.push(RawSymbol {
                     name: component_name.clone(),
                     kind: SymbolKind::Class,
@@ -139,8 +146,8 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
                     end_line,
                     signature: trimmed.to_string(),
                     content_hash: sha256_hex(trimmed),
-                    is_entry_point: false,
-                    entry_point_kind: None,
+                    is_entry_point: entry_point.is_some(),
+                    entry_point_kind: entry_point,
                     visibility: Visibility::Public,
                     type_info: None,
                     parent_name: None,
@@ -150,6 +157,7 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
 
             // export default (without defineComponent on same line)
             if RE_EXPORT_DEFAULT.is_match(trimmed) && !RE_DEFINE_COMPONENT.is_match(trimmed) {
+                let entry_point = entry_point_of(&component_name, "class", Some(trimmed));
                 symbols.push(RawSymbol {
                     name: component_name.clone(),
                     kind: SymbolKind::Class,
@@ -157,8 +165,8 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
                     end_line,
                     signature: trimmed.to_string(),
                     content_hash: sha256_hex(trimmed),
-                    is_entry_point: false,
-                    entry_point_kind: None,
+                    is_entry_point: entry_point.is_some(),
+                    entry_point_kind: entry_point,
                     visibility: Visibility::Public,
                     type_info: None,
                     parent_name: None,
@@ -172,6 +180,11 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
                 // `parse::export_declaration_kind`.
                 let kind = crate::parse::export_declaration_kind(&cap[1]);
                 let name = cap[2].to_string();
+                let entry_point = entry_point_of(
+                    &name,
+                    crate::entry_points::symbol_kind_label(kind),
+                    Some(trimmed),
+                );
                 symbols.push(RawSymbol {
                     name,
                     kind,
@@ -179,8 +192,8 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
                     end_line,
                     signature: trimmed.to_string(),
                     content_hash: sha256_hex(trimmed),
-                    is_entry_point: false,
-                    entry_point_kind: None,
+                    is_entry_point: entry_point.is_some(),
+                    entry_point_kind: entry_point,
                     visibility: Visibility::Public,
                     type_info: None,
                     parent_name: None,
@@ -193,6 +206,7 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
                 && let Some(cap) = RE_FUNCTION.captures(trimmed)
             {
                 let name = cap[1].to_string();
+                let entry_point = entry_point_of(&name, "function", Some(trimmed));
                 symbols.push(RawSymbol {
                     name,
                     kind: SymbolKind::Function,
@@ -200,8 +214,8 @@ pub fn parse_vue(path: &Path, source: &str) -> ParsedFile {
                     end_line,
                     signature: trimmed.to_string(),
                     content_hash: sha256_hex(trimmed),
-                    is_entry_point: false,
-                    entry_point_kind: None,
+                    is_entry_point: entry_point.is_some(),
+                    entry_point_kind: entry_point,
                     visibility: Visibility::Private,
                     type_info: None,
                     parent_name: None,

--- a/scripts/verify-release-bundle.sh
+++ b/scripts/verify-release-bundle.sh
@@ -37,7 +37,9 @@ verify_bundle() {
   done
   sort -o "$expected_file" "$expected_file"
 
-  find "$bundle_dir" -maxdepth 1 -type f -printf '%f\n' | sort > "$actual_file"
+  # nw-440: `-printf` is GNU-only; BSD find (macOS) rejects it outright, which
+  # made this self-test unrunnable on the maintainer's own platform.
+  find "$bundle_dir" -maxdepth 1 -type f -exec basename {} \; | sort > "$actual_file"
   if ! diff -u "$expected_file" "$actual_file"; then
     echo "release bundle must contain exactly four archives and four checksums" >&2
     rm -f "$expected_file" "$actual_file"

--- a/scripts/verify-release-package.sh
+++ b/scripts/verify-release-package.sh
@@ -217,8 +217,16 @@ verify_package_artifact() {
     return 1
   fi
 
-  mapfile -t package_files < <(
-    find "$package_dir" -maxdepth 1 -type f -name '*.tgz' -printf '%f\n' | sort
+  # nw-440: `-printf` is a GNU find extension and `mapfile` is a bash 4
+  # builtin. macOS ships BSD find and bash 3.2, so both made this script --
+  # the release gate's own self-test -- unrunnable on the platform this
+  # project is primarily developed on. `-exec basename` and a read loop are
+  # equivalent here and run everywhere.
+  package_files=()
+  while IFS= read -r package_file; do
+    package_files+=("$package_file")
+  done < <(
+    find "$package_dir" -maxdepth 1 -type f -name '*.tgz' -exec basename {} \; | sort
   )
   if [[ ${#package_files[@]} -ne 1 ]]; then
     echo "release package artifact must contain exactly one npm tarball" >&2
@@ -236,7 +244,7 @@ verify_package_artifact() {
   printf '%s\n' \
     "$package_filename" "$package_filename.sha256" release-package.json \
     | sort > "$expected_files"
-  find "$package_dir" -maxdepth 1 -type f -printf '%f\n' | sort > "$actual_files"
+  find "$package_dir" -maxdepth 1 -type f -exec basename {} \; | sort > "$actual_files"
   if ! diff -u "$expected_files" "$actual_files" >&2; then
     rm -f -- "$expected_files" "$actual_files"
     echo "release package artifact inventory is not exact" >&2

--- a/src/main.rs
+++ b/src/main.rs
@@ -2939,6 +2939,132 @@ fn render_blast_radius_text(payload: &serde_json::Value) {
     }
 }
 
+/// Derive `blast-radius`'s process exit code from its response payload.
+///
+/// nw-442: this used to read `resolver_stale_repos` from the TOP level of
+/// whatever the RPC returned. A two-tier payload
+/// (`nestweaver_federation::two_tier::two_tier_query`) only ever sets `tier`,
+/// `local_impact` and `org_wide_impact` up there — it never hoists
+/// `resolver_stale_repos` out of either tier — so the top-level read resolved
+/// to `Value::Null` and the branch answered `EXIT_SUCCESS` **regardless of the
+/// staleness sitting inside a tier**. `EXIT_NEEDS_REINDEX` was therefore dead
+/// code on every federated call, and v9.0.0's deliberate "break CI on a stale
+/// graph" signal was silently discarded on exactly the deployments that span
+/// the most repos.
+///
+/// Both tiers are now inspected explicitly, mirroring how `affected_tests`
+/// handles the identical situation (`AffectedTestsRpcPayload::TwoTier`) rather
+/// than inventing a third spelling for it.
+fn blast_radius_exit_code(payload: &serde_json::Value) -> i32 {
+    if blast_radius_tier_is_stale(payload) {
+        EXIT_NEEDS_REINDEX
+    } else {
+        EXIT_SUCCESS
+    }
+}
+
+/// True when `payload` — an envelope or a single tier — reports any
+/// resolver-stale repo.
+///
+/// An unrecognised `tier` string is treated as single-tier rather than
+/// ignored: reading the top level of an unknown envelope may find nothing, but
+/// answering "not stale" without looking is what nw-442 was.
+fn blast_radius_tier_is_stale(payload: &serde_json::Value) -> bool {
+    if payload.get("tier").and_then(serde_json::Value::as_str) == Some("two_tier") {
+        let local_stale = payload
+            .get("local_impact")
+            .is_some_and(blast_radius_tier_is_stale);
+        // An unavailable upstream carries `status`/`note` and no `results`, so
+        // the local tier decides alone. That is the correct reading: we cannot
+        // claim an absent tier is clean, but we also have no repos to name.
+        let org_stale = payload
+            .get("org_wide_impact")
+            .and_then(|org| org.get("results"))
+            .is_some_and(blast_radius_tier_is_stale);
+        return local_stale || org_stale;
+    }
+    payload["resolver_stale_repos"]
+        .as_array()
+        .is_some_and(|repos| !repos.is_empty())
+}
+
+#[cfg(test)]
+mod blast_radius_exit_code_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// nw-442: a two-tier payload sets only `tier`, `local_impact` and
+    /// `org_wide_impact` at the top level, so a top-level read of
+    /// `resolver_stale_repos` can never see a stale repo. These pin the
+    /// two-tier cases the top-level read silently answered `0` for.
+    fn stale_tier(repo: &str) -> serde_json::Value {
+        json!({
+            "affected_symbol_count": 1,
+            "risk": "high",
+            "resolver_stale_repos": [repo],
+        })
+    }
+
+    fn clean_tier() -> serde_json::Value {
+        json!({ "affected_symbol_count": 1, "risk": "low", "resolver_stale_repos": [] })
+    }
+
+    #[test]
+    fn single_tier_stale_needs_reindex() {
+        assert_eq!(
+            blast_radius_exit_code(&stale_tier("repo:local")),
+            EXIT_NEEDS_REINDEX
+        );
+    }
+
+    #[test]
+    fn single_tier_clean_succeeds() {
+        assert_eq!(blast_radius_exit_code(&clean_tier()), EXIT_SUCCESS);
+    }
+
+    #[test]
+    fn two_tier_local_stale_needs_reindex() {
+        let payload = json!({
+            "tier": "two_tier",
+            "local_impact": stale_tier("repo:local"),
+            "org_wide_impact": { "source_server": "org", "results": clean_tier() },
+        });
+        assert_eq!(blast_radius_exit_code(&payload), EXIT_NEEDS_REINDEX);
+    }
+
+    #[test]
+    fn two_tier_org_stale_needs_reindex() {
+        let payload = json!({
+            "tier": "two_tier",
+            "local_impact": clean_tier(),
+            "org_wide_impact": { "source_server": "org", "results": stale_tier("repo:org") },
+        });
+        assert_eq!(blast_radius_exit_code(&payload), EXIT_NEEDS_REINDEX);
+    }
+
+    #[test]
+    fn two_tier_clean_succeeds() {
+        let payload = json!({
+            "tier": "two_tier",
+            "local_impact": clean_tier(),
+            "org_wide_impact": { "source_server": "org", "results": clean_tier() },
+        });
+        assert_eq!(blast_radius_exit_code(&payload), EXIT_SUCCESS);
+    }
+
+    /// An unavailable upstream carries `status`/`note` and no `results`. The
+    /// local tier still decides the exit code.
+    #[test]
+    fn two_tier_org_unavailable_reads_local_tier() {
+        let payload = json!({
+            "tier": "two_tier",
+            "local_impact": stale_tier("repo:local"),
+            "org_wide_impact": { "source_server": "org", "status": "unavailable" },
+        });
+        assert_eq!(blast_radius_exit_code(&payload), EXIT_NEEDS_REINDEX);
+    }
+}
+
 /// Render a `flow-trace` tree as text from its JSON payload.
 ///
 /// `edge_type` is printed on every child. CROSS_REPO_LINK is an INFERRED
@@ -16611,14 +16737,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             } else {
                 render_blast_radius_text(&payload);
             }
-            let exit = if payload["resolver_stale_repos"]
-                .as_array()
-                .is_some_and(|repos| !repos.is_empty())
-            {
-                EXIT_NEEDS_REINDEX
-            } else {
-                EXIT_SUCCESS
-            };
+            let exit = blast_radius_exit_code(&payload);
             Ok((exit, None))
         }
 


### PR DESCRIPTION
Closes the four backlog items that were `ready`, unblocked, and independently
scoped, plus three defects a follow-up regression hunt found — one of them in
this PR's own work, one latent on `main`.

## The four items

**nw-442 — `blast-radius`'s needs-reindex exit code was dead on federated calls.**
The CLI read `resolver_stale_repos` at the TOP level. A two-tier payload only
sets `tier`/`local_impact`/`org_wide_impact` there, so the read was always
`Null` and the branch answered `EXIT_SUCCESS` regardless of real staleness. On
a federated deployment v9.0.0's deliberate "break CI on a stale graph" signal
was silently discarded. Both tiers are now inspected explicitly, mirroring
`AffectedTestsRpcPayload::TwoTier`.

**nw-440 — both release verifiers were unrunnable on macOS.** `-printf` is
GNU-only and `mapfile` is bash 4; macOS ships BSD find and bash 3.2, so the
release gate's own self-test could not run on the platform this project is
developed on. Third instance of this split; the previous one (nw-450) cost a
release.

**nw-441 — Vue/Svelte/Astro components could never root a reachability walk.**
The three bespoke parsers hardcoded `is_entry_point: false` and never called
`detect_entry_point`, so component-only code was unreachable by construction.
`detect_component_framework` promotes the component itself; everything else
falls through to `detect_js_ts`, because a `<script>` block genuinely is JS/TS.

**nw-443 — federation's degraded-local detection was pinned by nothing.**
Detection substring-matched an error message across three crates, with neither
side asserting the literal. `RepoFilterUnresolved` is now typed, the daemon
stamps a code into gRPC status metadata, and the client downcasts. Status code
and message text unchanged.

## What the regression hunt changed

**`RESOLVER_GENERATION` 4 → 5 (this was a real defect in the work above).**
`is_entry_point`/`entry_point_kind` are *persisted* columns that `dead-code`,
`process.rs` and `ranking.rs` read off disk rather than re-deriving. Changing
what gets written without bumping the generation means an upgraded binary
silently disagrees with any not-yet-reindexed graph, and the stale-graph
refusal that exists to disclose exactly that never fires. Generation 4's own
note says this trap has "now been sprung twice" — this would have been the
third.

**Vue `<script setup>` produced no component symbol at all.** Vue 3's
recommended syntax has neither `defineComponent(` nor `export default`. Once
Vue was enrolled in the honesty gate, a corpus containing one flipped from
`coverage: complete` to `degraded`. Fixed by minting the component
unconditionally when the scan finds none, as `svelte.rs`/`astro.rs` already do.

**The npm smoke gate was failing for a state this PR did not create.** It
asserts a MISSING optional dependency, but 9.2.0 is now published, so
`nestweaver-darwin-arm64@9.2.0` resolves and the launcher runs. The job is
gated on a paths filter and was skipped on the three main runs after 9.2.0
shipped, so it sat latent. Widened to accept both honest publication states;
the nw-433 guard (a real macOS `npm install` without `--force`) is unchanged.

## Verification

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass |
| `cargo test --workspace` | 4,784+ passed / 0 failed (55 binaries) |
| `cargo test -p nestweaver-mcp --features daemon` | 318 passed / 0 failed |
| Hand-run mutation battery | **12 mutations, 12 killed, 0 survivors** |

Measured before/after, not asserted:

- **nw-441** — component-only corpus: 0 → 3 entry points, 7 → 3 unreachable,
  coverage `degraded` → `complete`. Still-dead symbols are genuine uncalled
  helpers. On a mixed JS/Vue corpus the only verdict that changed was the Vue
  component's. `<script setup>` corpus confirmed back to `complete`.
- **nw-440** — both self-tests exit 0 under stock `/bin/bash` 3.2 + BSD find,
  bash 5.3, and bfs. `-exec basename` output verified byte-identical to GNU
  `-printf '%f\n'` across spaces, embedded tabs/newlines, backslashes, emoji
  and accented UTF-8.
- **nw-442** — single-tier output and exit code byte-identical to shipped 9.2.0.
- **nw-443** — user-visible error byte-identical. Typed code confirmed stamped
  and read end-to-end over a live gRPC round-trip.

The advisory `mutants` CI check reports pass but tested **nothing** — it was
killed mid-baseline with `rustc` still compiling, 6 minutes after finding 47
mutants. That is nw-445 reproducing; the mutation evidence above is the
hand-run battery, not that check.

## Known limits, stated rather than papered over

- **nw-443 does not hold under concurrency.** `blast_radius` is cacheable, so
  concurrent identical calls collapse through `coalesce_in_flight`, where only
  the leader holds the typed error and followers are rebuilt from a string.
  Measured: 12 concurrent calls → 1-2 carried the code, 10-11 fell back to
  prose. Closing it means carrying a code across the coalescing boundary in
  shared cache infrastructure, outside this item. Documented in the code.
- **`Commands::Impact` has the same top-level-read bug, unfixed**, in three
  places — and a worse symptom than blast-radius's (blank text output, masked
  `not_found`/`ambiguous`). Left for its own item rather than widened into
  this PR.
- **Route-path over-marking.** The fall-through means exported symbols under
  `/routes/`, `/pages/`, `/app/` in `.svelte`/`.astro` files become entry
  points. In a SvelteKit repo that is most files, pushing `dead-code` toward
  false negatives. Pre-existing rule, newly exposed to component files.
- `render_blast_radius_text` still reads only top-level keys, so two-tier text
  output can now disagree with a correct exit code. Pre-existing.
- Release/metal CI jobs were not run locally; nothing here is feature-gated.
