### PR TITLE
Fix 20 verified CLI, MCP, and vault regressions

### DIFF
--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -23,6 +23,23 @@ use crate::safeguards::{
     ClientRateLimiters, QuerySafeguards, RateLimitConfig, with_safeguard_cancellable,
 };
 
+/// Reports a gRPC index only while its blocking worker owns the write lease.
+/// This is separate from the queue worker's liveness flags used during drain.
+struct RpcIndexActivity {
+    current: Arc<std::sync::Mutex<Option<String>>>,
+}
+impl RpcIndexActivity {
+    fn start(current: Arc<std::sync::Mutex<Option<String>>>, repo: String) -> Self {
+        *current.lock().unwrap_or_else(|e| e.into_inner()) = Some(repo);
+        Self { current }
+    }
+}
+impl Drop for RpcIndexActivity {
+    fn drop(&mut self) {
+        *self.current.lock().unwrap_or_else(|e| e.into_inner()) = None;
+    }
+}
+
 // ── State ───────────────────────────────────────────────────────────
 
 /// Map a dispatch error to a gRPC `Status`, preserving cancellation semantics:
@@ -1782,6 +1799,7 @@ pub struct DaemonState {
     pub read_only: bool,
     /// Whether the server-side worker pool is currently indexing a repo.
     pub indexing_active: Arc<AtomicBool>,
+    rpc_indexing_repo: Arc<std::sync::Mutex<Option<String>>>,
     /// The repo currently being indexed (empty string when idle).
     pub indexing_repo: Arc<tokio::sync::RwLock<String>>,
     /// Number of pending + running jobs in the server-side job queue.
@@ -3872,6 +3890,24 @@ fn finalize_node_graph_deletion(
     operation: &str,
 ) -> Vec<nestweaver_engine::DeletionReconciliationFailure> {
     let mut failures = Vec::new();
+    // Vault deletion cannot alter code manifests. Read their trusted binding
+    // before advancing the graph, including a present but empty cache.
+    let manifest_path = nestweaver_engine::manifest_cache_path(&state.db_path);
+    let carried_manifests = if manifest_path.exists() {
+        match nestweaver_engine::load_manifest_cache_for_db(&state.store, &state.db_path) {
+            Ok(manifests) => Some(manifests),
+            Err(error) => {
+                push_reconciliation_failure(
+                    &mut failures,
+                    nestweaver_engine::DeletionReconciliationStage::ManifestCache,
+                    format!("load manifest cache before vault deletion publication: {error:#}"),
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
     match state.store.reconcile_embedding_index_stages() {
         Err(error) => push_reconciliation_failure(
             &mut failures,
@@ -3912,11 +3948,27 @@ fn finalize_node_graph_deletion(
         }
     };
     let generation_path = nestweaver_engine::sidecar_path(&state.db_path, ".generation");
-    if generation_advanced && let Err(error) = state.store.save_graph_generation(&generation_path) {
+    let generation_persisted = generation_advanced
+        && match state.store.save_graph_generation(&generation_path) {
+            Ok(()) => true,
+            Err(error) => {
+                push_reconciliation_failure(
+                    &mut failures,
+                    nestweaver_engine::DeletionReconciliationStage::GenerationPersistence,
+                    format!("{}: {error:#}", generation_path.display()),
+                );
+                false
+            }
+        };
+    if generation_persisted
+        && let Some(manifests) = carried_manifests
+        && let Err(error) =
+            nestweaver_engine::save_manifest_cache_for_db(&manifests, &state.store, &state.db_path)
+    {
         push_reconciliation_failure(
             &mut failures,
-            nestweaver_engine::DeletionReconciliationStage::GenerationPersistence,
-            format!("{}: {error:#}", generation_path.display()),
+            nestweaver_engine::DeletionReconciliationStage::ManifestCache,
+            format!("rebind manifest cache after vault deletion publication: {error:#}"),
         );
     }
     if let Err(error) =
@@ -5440,6 +5492,9 @@ fn brain_context_args_from_request(req: &BrainContextRequest) -> serde_json::Val
         "prf": req.prf,
         "rerank": req.rerank,
     });
+    if let Some(limit) = req.limit {
+        args["limit"] = serde_json::json!(limit);
+    }
     if req.token_budget > 0 {
         args["token_budget"] = serde_json::json!(req.token_budget);
     }
@@ -5600,8 +5655,27 @@ mod context_request_args_tests {
     }
 
     #[test]
+    fn brain_context_count_and_token_caps_both_reach_dispatch() {
+        let req = BrainContextRequest {
+            seeds: vec!["fixture".into()],
+            limit: Some(2),
+            token_budget: 1000,
+            ..Default::default()
+        };
+        let args = brain_context_args_from_request(&req);
+        assert_eq!(args["limit"], 2);
+        assert_eq!(args["token_budget"], 1000);
+        assert!(
+            brain_context_args_from_request(&BrainContextRequest::default())
+                .get("limit")
+                .is_none()
+        );
+    }
+
+    #[test]
     fn brain_context_explicit_zero_weight_semantic_reaches_args_distinct_from_absent() {
         let mut req = BrainContextRequest {
+            limit: None,
             seeds: vec!["x".to_string()],
             token_budget: 0,
             response_format: String::new(),
@@ -6567,6 +6641,10 @@ impl NestWeaverDaemon for DaemonService {
                 _write_lease: write_lock.blocking_lock("index_repo"),
                 _connection_guard: guard,
             };
+            let _activity = RpcIndexActivity::start(
+                Arc::clone(&state.rpc_indexing_repo),
+                repo_path.display().to_string(),
+            );
             // Dropped when the index task ends → fires the watchdog's `done_rx`
             // so it releases its stream sender and the response can terminate.
             let _done = done_tx;
@@ -8049,9 +8127,19 @@ impl NestWeaverDaemon for DaemonService {
             .dispatch_tool_json("brain_status", args, &extensions)
             .await?;
 
-        let indexing_active = self.state.indexing_active.load(Ordering::Relaxed);
+        let rpc_repo = self
+            .state
+            .rpc_indexing_repo
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        let indexing_active =
+            rpc_repo.is_some() || self.state.indexing_active.load(Ordering::Relaxed);
         let indexing_repo = if indexing_active && !restricted {
-            self.state.indexing_repo.read().await.clone()
+            match rpc_repo {
+                Some(repo) => repo,
+                None => self.state.indexing_repo.read().await.clone(),
+            }
         } else {
             String::new()
         };
@@ -8158,13 +8246,23 @@ impl NestWeaverDaemon for DaemonService {
         let mut json_resp = resp.into_inner();
         if let Ok(mut value) = serde_json::from_str::<serde_json::Value>(&json_resp.result_json) {
             value["server_mode"] = serde_json::json!(self.state.server_mode);
-            let indexing_active = self.state.indexing_active.load(Ordering::Relaxed);
+            let rpc_repo = self
+                .state
+                .rpc_indexing_repo
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clone();
+            let indexing_active =
+                rpc_repo.is_some() || self.state.indexing_active.load(Ordering::Relaxed);
             value["indexing_active"] = serde_json::json!(indexing_active);
             // Always present (null when idle): the shared builder emits the
             // key on every path, so the daemon must too, or key-set parity
             // with the direct path breaks.
             value["indexing_repo"] = if indexing_active && !restricted {
-                serde_json::json!(*self.state.indexing_repo.read().await)
+                serde_json::json!(match rpc_repo {
+                    Some(repo) => repo,
+                    None => self.state.indexing_repo.read().await.clone(),
+                })
             } else {
                 serde_json::Value::Null
             };
@@ -12512,6 +12610,7 @@ pub async fn run_server(
         embed_progress: Arc::new(EmbedProgress::default()),
         server_mode: is_server_mode,
         indexing_active: Arc::new(AtomicBool::new(false)),
+        rpc_indexing_repo: Arc::new(std::sync::Mutex::new(None)),
         indexing_repo: Arc::new(tokio::sync::RwLock::new(String::new())),
         indexing_queue_depth: Arc::new(AtomicU32::new(0)),
         indexing_in_flight: Arc::new(AtomicU32::new(0)),
@@ -14826,6 +14925,111 @@ credential_method = "gh"
                 "stale embedding survived for {uid}"
             );
         }
+    }
+
+    #[test]
+    fn remove_vault_preserves_present_empty_and_populated_manifest_caches() {
+        for populated in [false, true] {
+            let state = test_state_with_writer();
+            let mut manifests = std::collections::HashMap::new();
+            if populated {
+                manifests.insert(
+                    "repo:survivor".to_string(),
+                    nestweaver_engine::ManifestInfo {
+                        package_name: Some("survivor".into()),
+                        dependencies: vec![],
+                        entry_files: vec!["src/main.rs".into()],
+                    },
+                );
+            }
+            nestweaver_engine::save_manifest_cache_for_db(&manifests, &state.store, &state.db_path)
+                .unwrap();
+            seed_vault_note_heading_embeddings(
+                &state,
+                "vlt:manifest:docs",
+                "docs",
+                "/missing/docs",
+            );
+            let generation = state.store.graph_generation();
+            let result =
+                run_remove_vault_with_projection(&state, "vlt:manifest:docs", None).unwrap();
+            assert!(result.committed);
+            assert!(
+                result.reconciliation_failures.is_empty(),
+                "{:?}",
+                result.reconciliation_failures
+            );
+            assert_eq!(state.store.graph_generation(), generation + 1);
+            let carried =
+                nestweaver_engine::load_manifest_cache_for_db(&state.store, &state.db_path)
+                    .unwrap();
+            assert_eq!(
+                serde_json::to_value(&carried).unwrap(),
+                serde_json::to_value(&manifests).unwrap()
+            );
+            let publication =
+                nestweaver_engine::finalize_committed_graph_mutation(&state.store, true);
+            assert!(
+                publication.warnings.is_empty(),
+                "{:?}",
+                publication.warnings
+            );
+            nestweaver_engine::load_manifest_cache_for_db(&state.store, &state.db_path).unwrap();
+        }
+    }
+
+    #[test]
+    fn node_deletion_does_not_relabel_stale_or_corrupt_manifests() {
+        for corrupt in [false, true] {
+            let state = test_state_with_writer();
+            let path = nestweaver_engine::manifest_cache_path(&state.db_path);
+            nestweaver_engine::save_manifest_cache_for_db(
+                &std::collections::HashMap::new(),
+                &state.store,
+                &state.db_path,
+            )
+            .unwrap();
+            if corrupt {
+                std::fs::write(&path, "invalid JSON").unwrap();
+            } else {
+                state.store.try_bump_graph_generation().unwrap();
+            }
+            let original = std::fs::read(&path).unwrap();
+            let failures = finalize_node_graph_deletion(&state, "manifest trust regression");
+            assert!(
+                failures
+                    .iter()
+                    .any(|f| f.stage
+                        == nestweaver_engine::DeletionReconciliationStage::ManifestCache),
+                "{failures:?}"
+            );
+            assert_eq!(std::fs::read(&path).unwrap(), original);
+        }
+    }
+
+    #[test]
+    fn node_deletion_generation_persistence_failure_does_not_rebind_manifest() {
+        let state = test_state_with_writer();
+        let path = nestweaver_engine::manifest_cache_path(&state.db_path);
+        nestweaver_engine::save_manifest_cache_for_db(
+            &std::collections::HashMap::new(),
+            &state.store,
+            &state.db_path,
+        )
+        .unwrap();
+        let original = std::fs::read(&path).unwrap();
+        let generation_path = nestweaver_engine::sidecar_path(&state.db_path, ".generation");
+        if generation_path.exists() {
+            std::fs::remove_file(&generation_path).unwrap();
+        }
+        std::fs::create_dir(&generation_path).unwrap();
+        let failures = finalize_node_graph_deletion(&state, "manifest persistence regression");
+        assert!(
+            failures.iter().any(|f| f.stage
+                == nestweaver_engine::DeletionReconciliationStage::GenerationPersistence),
+            "{failures:?}"
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), original);
     }
 
     #[tokio::test]
@@ -19994,6 +20198,7 @@ credential_method = "gh"
             server_mode: false,
             read_only: false,
             indexing_active: Arc::new(AtomicBool::new(false)),
+            rpc_indexing_repo: Arc::new(std::sync::Mutex::new(None)),
             indexing_repo: Arc::new(tokio::sync::RwLock::new(String::new())),
             indexing_queue_depth: Arc::new(AtomicU32::new(0)),
             indexing_in_flight: Arc::new(AtomicU32::new(0)),
@@ -20086,6 +20291,7 @@ credential_method = "gh"
             server_mode: false,
             read_only: false,
             indexing_active: Arc::new(AtomicBool::new(false)),
+            rpc_indexing_repo: Arc::new(std::sync::Mutex::new(None)),
             indexing_repo: Arc::new(tokio::sync::RwLock::new(String::new())),
             indexing_queue_depth: Arc::new(AtomicU32::new(0)),
             indexing_in_flight: Arc::new(AtomicU32::new(0)),
@@ -20168,6 +20374,53 @@ credential_method = "gh"
             value.get("effective_config").is_none(),
             "effective config provenance must remain typed-only so Combined federation cannot backfill it"
         );
+    }
+
+    #[tokio::test]
+    async fn grpc_index_activity_is_reported_and_cleared_on_both_status_routes() {
+        let state = test_state_with_writer();
+        let service = DaemonService::new(Arc::clone(&state));
+        let activity =
+            RpcIndexActivity::start(Arc::clone(&state.rpc_indexing_repo), "/fixture/repo".into());
+        assert!(
+            !state.indexing_active.load(Ordering::Relaxed),
+            "queue worker stays idle"
+        );
+        let typed = service
+            .brain_status(Request::new(BrainStatusRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(typed.indexing_active);
+        assert_eq!(typed.indexing_repo, "/fixture/repo");
+        let json = service
+            .brain_status_json(Request::new(JsonRequest {
+                args_json: "{}".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        let value: serde_json::Value = serde_json::from_str(&json.result_json).unwrap();
+        assert_eq!(value["indexing_active"], true);
+        assert_eq!(value["indexing_repo"], "/fixture/repo");
+        drop(activity);
+        let typed = service
+            .brain_status(Request::new(BrainStatusRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(!typed.indexing_active);
+        assert!(typed.indexing_repo.is_empty());
+        let json = service
+            .brain_status_json(Request::new(JsonRequest {
+                args_json: "{}".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        let value: serde_json::Value = serde_json::from_str(&json.result_json).unwrap();
+        assert_eq!(value["indexing_active"], false);
+        assert!(value["indexing_repo"].is_null());
     }
 
     /// A3. The incident: an embed had run 12h32m and `brain status` still said

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -3893,20 +3893,24 @@ fn finalize_node_graph_deletion(
     // Vault deletion cannot alter code manifests. Read their trusted binding
     // before advancing the graph, including a present but empty cache.
     let manifest_path = nestweaver_engine::manifest_cache_path(&state.db_path);
-    let carried_manifests = if manifest_path.exists() {
-        match nestweaver_engine::load_manifest_cache_for_db(&state.store, &state.db_path) {
-            Ok(manifests) => Some(manifests),
-            Err(error) => {
-                push_reconciliation_failure(
-                    &mut failures,
-                    nestweaver_engine::DeletionReconciliationStage::ManifestCache,
-                    format!("load manifest cache before vault deletion publication: {error:#}"),
-                );
-                None
+    let carried_manifests = match manifest_path.try_exists() {
+        Ok(false) => None,
+        presence => {
+            let loaded = presence.map_err(anyhow::Error::from).and_then(|_| {
+                nestweaver_engine::load_manifest_cache_for_db(&state.store, &state.db_path)
+            });
+            match loaded {
+                Ok(manifests) => Some(manifests),
+                Err(error) => {
+                    push_reconciliation_failure(
+                        &mut failures,
+                        nestweaver_engine::DeletionReconciliationStage::ManifestCache,
+                        format!("load manifest cache before vault deletion publication: {error:#}"),
+                    );
+                    None
+                }
             }
         }
-    } else {
-        None
     };
     match state.store.reconcile_embedding_index_stages() {
         Err(error) => push_reconciliation_failure(

--- a/crates/nestweaver-engine/src/affected_tests.rs
+++ b/crates/nestweaver-engine/src/affected_tests.rs
@@ -158,6 +158,26 @@ pub fn affected_tests(store: &GraphStore, changed_files: &[String]) -> Result<Af
     affected_tests_within(store, &changed_files, None)
 }
 
+/// Canonical empty selection after a caller proved a VCS diff empty and
+/// checked the exact resolver compatibility of that diff's repository.
+/// This does not admit empty user/MCP input; those entry points still validate.
+pub fn empty_derived_selection() -> AffectedTestsResult {
+    AffectedTestsResult {
+        changed_files: Vec::new(),
+        changed_symbols: Vec::new(),
+        tier_1: Vec::new(),
+        tier_2: Vec::new(),
+        tier_3: Vec::new(),
+        summary: "0 tier-1, 0 tier-2, 0 tier-3 tests affected".to_string(),
+        disclaimer: DISCLAIMER.to_string(),
+        status: AnalysisStatus::Complete,
+        notifications: Vec::new(),
+        resolver_stale_repos: Vec::new(),
+        recommendation: "selection-usable".to_string(),
+        measured: None,
+    }
+}
+
 /// Compute affected tests for a file list derived from a trusted VCS diff.
 ///
 /// Unlike [`affected_tests`], this deliberately permits an empty list because

--- a/crates/nestweaver-engine/src/backup.rs
+++ b/crates/nestweaver-engine/src/backup.rs
@@ -163,6 +163,27 @@ pub fn seal_publication_slot(
     db_path: &Path,
     slot_root: &Path,
 ) -> anyhow::Result<crate::publication::PublicationBundleV3> {
+    seal_publication_slot_inner(db_path, slot_root, false)
+}
+
+/// Seal a live staged slot while retaining its exact database writer authority.
+/// The operational lock stays in place; it is never an archived artifact.
+pub fn seal_publication_slot_with_authority(
+    db_path: &Path,
+    slot_root: &Path,
+    authority: &nestweaver_store::DbWriteLease,
+) -> anyhow::Result<crate::publication::PublicationBundleV3> {
+    if !authority.authorizes(db_path) {
+        anyhow::bail!("publication seal requires authority for the exact staged database");
+    }
+    seal_publication_slot_inner(db_path, slot_root, true)
+}
+
+fn seal_publication_slot_inner(
+    db_path: &Path,
+    slot_root: &Path,
+    live_writer: bool,
+) -> anyhow::Result<crate::publication::PublicationBundleV3> {
     let db_parent = db_path
         .parent()
         .filter(|path| !path.as_os_str().is_empty())
@@ -189,8 +210,19 @@ pub fn seal_publication_slot(
         instance_id: "publication".to_string(),
         workspace_path: None,
     };
-    let bundle =
-        build_backup_publication_bundle(&config, slot_root, &identity, source_graph_generation)?;
+    let bundle = build_backup_publication_bundle_inner(
+        &config,
+        slot_root,
+        &identity,
+        source_graph_generation,
+        live_writer,
+    )?;
+    crate::publication::validate_slot_contents(
+        slot_root,
+        &bundle,
+        crate::publication::ArtifactBytes::Verified,
+    )
+    .map_err(|error| anyhow::anyhow!("validate staged publication: {error}"))?;
     let bytes = serde_json::to_vec_pretty(&bundle)?;
     let manifest_path = slot_root.join(crate::publication::PUBLICATION_MANIFEST_FILE);
     nestweaver_store::durable_sidecar::atomic_replace_file(&manifest_path, |file| {
@@ -213,6 +245,25 @@ pub struct StagedBackup {
     write_pause: Duration,
     publication_identity: nestweaver_store::PublicationIdentity,
     source_graph_generation: u64,
+    logical_instance_id: String,
+}
+
+/// Resolve portable backup identity from graph ownership, never a runtime path hash.
+pub fn backup_logical_instance_id(store: &nestweaver_store::GraphStore) -> anyhow::Result<String> {
+    if let Some(identity) = store.data_instance_id()? {
+        if identity.trim().is_empty() {
+            anyhow::bail!("database-owned logical instance identity is empty");
+        }
+        return Ok(identity);
+    }
+    let observed = store.observed_instance_ids()?;
+    match observed.as_slice() {
+        [] => Ok("default".to_string()),
+        [identity] => Ok(identity.clone()),
+        _ => anyhow::bail!(
+            "cannot infer backup logical instance identity from multiple graph instances"
+        ),
+    }
 }
 
 /// Stage a backup from an ALREADY-OPEN store: flush embeddings, `CHECKPOINT` the
@@ -299,6 +350,7 @@ pub fn stage_backup_from_store(
         .map_err(|error| anyhow::anyhow!("read backup publication identity: {error}"))?
         .ok_or_else(|| anyhow::anyhow!("backup graph has no publication identity"))?;
     let source_graph_generation = store.graph_generation();
+    let logical_instance_id = backup_logical_instance_id(store)?;
 
     let write_pause = pause_start.elapsed();
     publication
@@ -312,6 +364,7 @@ pub fn stage_backup_from_store(
         write_pause,
         publication_identity,
         source_graph_generation,
+        logical_instance_id,
     })
 }
 
@@ -341,6 +394,7 @@ pub fn package_staged(config: &BackupConfig, staged: StagedBackup) -> anyhow::Re
         write_pause,
         publication_identity,
         source_graph_generation,
+        logical_instance_id,
     } = staged;
     let bundle = build_backup_publication_bundle(
         config,
@@ -364,6 +418,7 @@ pub fn package_staged(config: &BackupConfig, staged: StagedBackup) -> anyhow::Re
         &bundle,
         publication_manifest_blake3,
     )?;
+    manifest.instance_id = logical_instance_id;
     let manifest_json = serde_json::to_string_pretty(&manifest)?;
     std::fs::write(staging.path().join("manifest.json"), &manifest_json)?;
 
@@ -1307,6 +1362,7 @@ pub fn backup_restore(config: &RestoreConfig) -> anyhow::Result<RestoreResult> {
             &temp_dir.path().join(&graph.path),
         )
         .map_err(|error| anyhow::anyhow!("open restored graph identity: {error}"))?;
+        validate_restored_logical_identity(&manifest, &graph_store)?;
         let graph_identity = graph_store
             .publication_identity()
             .map_err(|error| anyhow::anyhow!("read restored graph identity: {error}"))?
@@ -1322,6 +1378,26 @@ pub fn backup_restore(config: &RestoreConfig) -> anyhow::Result<RestoreResult> {
                 graph_identity.publication_uuid
             );
         }
+    }
+
+    if manifest.version < 2 {
+        // Legacy archives have no typed graph inventory. Accept only an
+        // unambiguous database payload and prove its logical ownership too.
+        let graphs: Vec<_> = manifest
+            .checksums
+            .keys()
+            .filter(|path| path.ends_with(".lbug") || path.ends_with(".kuzu"))
+            .collect();
+        let [graph] = graphs.as_slice() else {
+            anyhow::bail!(
+                "legacy backup has no unambiguous graph payload for logical identity validation"
+            );
+        };
+        let store = nestweaver_store::GraphStore::open_read_only_without_migration(
+            &temp_dir.path().join(graph),
+        )
+        .map_err(|error| anyhow::anyhow!("open legacy restored graph identity: {error}"))?;
+        validate_restored_logical_identity(&manifest, &store)?;
     }
 
     // The backup saves clones under `clones/` (historical name), but the
@@ -1551,6 +1627,16 @@ fn build_backup_publication_bundle(
     identity: &nestweaver_store::PublicationIdentity,
     source_graph_generation: u64,
 ) -> anyhow::Result<crate::publication::PublicationBundleV3> {
+    build_backup_publication_bundle_inner(config, staging, identity, source_graph_generation, false)
+}
+
+fn build_backup_publication_bundle_inner(
+    config: &BackupConfig,
+    staging: &Path,
+    identity: &nestweaver_store::PublicationIdentity,
+    source_graph_generation: u64,
+    live_writer: bool,
+) -> anyhow::Result<crate::publication::PublicationBundleV3> {
     identity
         .validate()
         .map_err(|error| anyhow::anyhow!("invalid backup publication identity: {error}"))?;
@@ -1592,6 +1678,11 @@ fn build_backup_publication_bundle(
     let mut fatal: Vec<String> = Vec::new();
     for entry in entries {
         let path = normalized_relative_path(staging, entry.path())?;
+        if live_writer && path == format!("{db_filename}.write.lock") {
+            // Only the live-slot caller with exact authority enables this.
+            // Archive staging still classifies this name as an error.
+            continue;
+        }
         if path == crate::publication::PUBLICATION_MANIFEST_FILE || path == "manifest.json" {
             continue;
         }
@@ -1941,6 +2032,21 @@ fn build_backup_manifest(
     })
 }
 
+fn validate_restored_logical_identity(
+    manifest: &BackupManifest,
+    store: &nestweaver_store::GraphStore,
+) -> anyhow::Result<()> {
+    let logical = backup_logical_instance_id(store)?;
+    if manifest.instance_id != logical {
+        anyhow::bail!(
+            "backup logical instance identity mismatch: manifest '{}', graph '{}'; restore refused before cutover",
+            manifest.instance_id,
+            logical
+        );
+    }
+    Ok(())
+}
+
 /// Package a staging directory as tar + zstd.
 fn package_tar_zstd(staging: &Path, output: &Path) -> anyhow::Result<()> {
     if let Some(parent) = output.parent() {
@@ -2265,11 +2371,11 @@ mod tests {
 
         let result = backup_save(&config).unwrap();
         assert!(output.exists());
-        assert_eq!(result.manifest.instance_id, "test");
+        assert_eq!(result.manifest.instance_id, "default");
         assert_eq!(result.manifest.tier, "standard");
 
         let manifest = backup_inspect(&output).unwrap();
-        assert_eq!(manifest.instance_id, "test");
+        assert_eq!(manifest.instance_id, "default");
         assert_eq!(manifest.version, MANIFEST_VERSION);
         assert!(uuid::Uuid::parse_str(&manifest.brain_uuid).is_ok());
         assert!(uuid::Uuid::parse_str(&manifest.publication_uuid).is_ok());
@@ -2307,7 +2413,7 @@ mod tests {
 
         backup_save(&config).unwrap();
         let manifest = backup_inspect(&output).unwrap();
-        assert_eq!(manifest.instance_id, "nested");
+        assert_eq!(manifest.instance_id, "default");
         assert!(
             manifest.checksums.contains_key(
                 "test.lbug.regex-v3/scopes/scope-a/generations/generation-a/meta.json"
@@ -2532,8 +2638,8 @@ mod tests {
         // Store is still open here — the daemon keeps serving.
         assert!(store.count_symbols().is_ok());
         assert!(output.exists());
-        assert_eq!(result.manifest.instance_id, "test");
-        assert_eq!(backup_inspect(&output).unwrap().instance_id, "test");
+        assert_eq!(result.manifest.instance_id, "default");
+        assert_eq!(backup_inspect(&output).unwrap().instance_id, "default");
     }
 
     #[test]
@@ -3379,7 +3485,7 @@ mod tests {
         };
 
         let result = backup_restore(&restore_config).unwrap();
-        assert_eq!(result.manifest.instance_id, "test");
+        assert_eq!(result.manifest.instance_id, "default");
 
         let restored_db = restore_dir.join("test.lbug");
         let store = nestweaver_store::GraphStore::open_read_only(&restored_db).unwrap();
@@ -3469,7 +3575,7 @@ mod tests {
 
         let result = backup_save(&config).unwrap();
         assert!(output.exists());
-        assert_eq!(result.manifest.instance_id, "bare-test");
+        assert_eq!(result.manifest.instance_id, "default");
     }
 
     #[test]
@@ -3503,6 +3609,191 @@ mod tests {
         )
         .unwrap();
         assert_eq!(persisted, bundle);
+    }
+
+    #[test]
+    fn live_slot_lock_requires_exact_authority_and_is_never_archived() {
+        let dir = tempfile::tempdir().unwrap();
+        let slot = dir.path().join("slot");
+        std::fs::create_dir(&slot).unwrap();
+        let db = slot.join(crate::publication::PUBLICATION_GRAPH_FILE);
+        drop(nestweaver_store::GraphStore::create(&db).unwrap());
+        let authority = nestweaver_store::acquire_db_write_lease(&db).unwrap();
+        let lock = nestweaver_store::write_lease_path(&db);
+        assert!(lock.exists());
+        assert!(
+            seal_publication_slot(&db, &slot)
+                .unwrap_err()
+                .to_string()
+                .contains("write.lock")
+        );
+        let bundle = seal_publication_slot_with_authority(&db, &slot, &authority).unwrap();
+        assert!(lock.exists(), "sealing must retain the writer anchor");
+        assert!(
+            !bundle
+                .artifacts
+                .iter()
+                .any(|a| a.path.ends_with("write.lock"))
+        );
+        crate::publication::validate_slot_contents(
+            &slot,
+            &bundle,
+            crate::publication::ArtifactBytes::Verified,
+        )
+        .unwrap();
+        std::fs::write(slot.join("foreign.write.lock"), "foreign").unwrap();
+        assert!(
+            crate::publication::validate_slot_contents(
+                &slot,
+                &bundle,
+                crate::publication::ArtifactBytes::Verified
+            )
+            .is_err()
+        );
+        std::fs::remove_file(slot.join("foreign.write.lock")).unwrap();
+        let other = dir.path().join("other.lbug");
+        drop(nestweaver_store::GraphStore::create(&other).unwrap());
+        let wrong = nestweaver_store::acquire_db_write_lease(&other).unwrap();
+        assert!(seal_publication_slot_with_authority(&db, &slot, &wrong).is_err());
+        drop(authority);
+        crate::publication::validate_slot_contents(
+            &slot,
+            &bundle,
+            crate::publication::ArtifactBytes::Live,
+        )
+        .unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn live_slot_refuses_symlinked_writer_anchor() {
+        let dir = tempfile::tempdir().unwrap();
+        let slot = dir.path().join("slot");
+        std::fs::create_dir(&slot).unwrap();
+        let db = slot.join(crate::publication::PUBLICATION_GRAPH_FILE);
+        drop(nestweaver_store::GraphStore::create(&db).unwrap());
+        let authority = nestweaver_store::acquire_db_write_lease(&db).unwrap();
+        let bundle = seal_publication_slot_with_authority(&db, &slot, &authority).unwrap();
+        let lock = nestweaver_store::write_lease_path(&db);
+        // This scratch-only replacement simulates tampering after admission.
+        std::fs::remove_file(&lock).unwrap();
+        let outside = dir.path().join("outside.lock");
+        std::fs::write(&outside, "outside").unwrap();
+        std::os::unix::fs::symlink(&outside, &lock).unwrap();
+        assert!(seal_publication_slot_with_authority(&db, &slot, &authority).is_err());
+        assert!(
+            crate::publication::validate_slot_contents(
+                &slot,
+                &bundle,
+                crate::publication::ArtifactBytes::Verified
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn legacy_backup_identity_requires_unique_graph_ownership() {
+        let store = nestweaver_store::GraphStore::in_memory().unwrap();
+        assert_eq!(backup_logical_instance_id(&store).unwrap(), "default");
+        let vault = |instance: &str| nestweaver_schema::Vault {
+            uid: format!("vault:{instance}:v"),
+            name: "v".into(),
+            root_path: "/fixture".into(),
+            instance_id: instance.into(),
+        };
+        store.upsert_vault(&vault("legacy")).unwrap();
+        assert_eq!(backup_logical_instance_id(&store).unwrap(), "legacy");
+        assert_eq!(store.data_instance_id().unwrap(), None);
+        store.upsert_vault(&vault("foreign")).unwrap();
+        assert!(
+            backup_logical_instance_id(&store)
+                .unwrap_err()
+                .to_string()
+                .contains("multiple")
+        );
+    }
+
+    #[test]
+    fn backup_instance_is_graph_owned_even_when_path_and_config_disagree() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("arbitrary-name.lbug");
+        let store = nestweaver_store::GraphStore::create(&db).unwrap();
+        store.ensure_data_instance_id("logical-owner").unwrap();
+        drop(store);
+        let config = BackupConfig {
+            db_path: db,
+            output_path: dir.path().join("snapshot.nwsnap.zst"),
+            include_clones: false,
+            instance_id: "physical-path-hash".into(),
+            workspace_path: None,
+        };
+        let result = backup_save(&config).unwrap();
+        assert_eq!(result.manifest.instance_id, "logical-owner");
+        assert_eq!(
+            backup_inspect(&config.output_path).unwrap().instance_id,
+            "logical-owner"
+        );
+        let restored = dir.path().join("moved");
+        backup_restore(&RestoreConfig {
+            snapshot_path: config.output_path,
+            data_dir: restored.clone(),
+        })
+        .unwrap();
+        let reopened =
+            nestweaver_store::GraphStore::open_read_only(&restored.join("arbitrary-name.lbug"))
+                .unwrap();
+        assert_eq!(
+            backup_logical_instance_id(&reopened).unwrap(),
+            "logical-owner"
+        );
+    }
+
+    #[test]
+    fn restore_refuses_forged_logical_identity_before_touching_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("owned.lbug");
+        let store = nestweaver_store::GraphStore::create(&db).unwrap();
+        store.ensure_data_instance_id("owned").unwrap();
+        drop(store);
+        let original = dir.path().join("original.nwsnap.zst");
+        backup_save(&BackupConfig {
+            db_path: db,
+            output_path: original.clone(),
+            include_clones: false,
+            instance_id: "wrong-config".into(),
+            workspace_path: None,
+        })
+        .unwrap();
+        let extracted = dir.path().join("extracted");
+        let decoder =
+            nestweaver_store::zstd::Decoder::new(std::fs::File::open(original).unwrap()).unwrap();
+        tar::Archive::new(decoder).unpack(&extracted).unwrap();
+        let path = extracted.join("manifest.json");
+        let mut manifest: BackupManifest =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        manifest.instance_id = "forged".into();
+        std::fs::write(path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+        let forged = dir.path().join("forged.nwsnap.zst");
+        package_tar_zstd(&extracted, &forged).unwrap();
+        let target = dir.path().join("existing");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("sentinel"), "keep existing data").unwrap();
+        let error = backup_restore(&RestoreConfig {
+            snapshot_path: forged,
+            data_dir: target.clone(),
+        })
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("logical instance identity mismatch"),
+            "{error:#}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(target.join("sentinel")).unwrap(),
+            "keep existing data"
+        );
+        assert!(!target.join("owned.lbug").exists());
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/config.rs
+++ b/crates/nestweaver-engine/src/config.rs
@@ -658,7 +658,7 @@ pub struct LimitsConfig {
     /// parsed config, so merely passing `--config` for an unrelated reason
     /// silently changed `nestweaver search`'s default from 10 to 50. Keeping
     /// the option lets each caller apply its OWN documented default when
-    /// nothing was configured.
+    /// nothing was configured. Valid configured values are 1 through 1000.
     #[serde(default)]
     pub default_result_limit: Option<usize>,
 }
@@ -1151,6 +1151,12 @@ impl InstanceConfig {
             config.expected_brain_uuid = Some(parsed.to_string());
         }
         crate::index_limits::IndexLimits::new(config.indexing.max_source_file_bytes)?;
+        if let Some(limit) = config.limits.default_result_limit
+            && !(1..=1000).contains(&limit)
+        {
+            anyhow::bail!("limits.default_result_limit must be between 1 and 1000, got {limit}");
+        }
+
         // Fail config loading on an unparseable reconcile interval. Silently
         // treating a typo as "disabled" would reintroduce exactly the failure
         // this loop exists to remove: trigrams quietly going stale with no
@@ -1768,6 +1774,35 @@ url = "https://github.com/example/repo"
             .expect_err("unsupported accelerator must be rejected");
 
         assert!(err.to_string().contains("accelerator"));
+    }
+
+    #[test]
+    fn configured_result_limits_match_all_consumers() {
+        for limit in [0, 1001, usize::MAX] {
+            let text = format!("{MINIMAL_TOML}\n[limits]\ndefault_result_limit = {limit}\n");
+            let error = InstanceConfig::from_toml_str(&text).unwrap_err();
+            assert!(
+                error.to_string().contains("default_result_limit"),
+                "{error}"
+            );
+        }
+        for limit in [1, 1000] {
+            let text = format!("{MINIMAL_TOML}\n[limits]\ndefault_result_limit = {limit}\n");
+            assert_eq!(
+                InstanceConfig::from_toml_str(&text)
+                    .unwrap()
+                    .limits
+                    .default_result_limit,
+                Some(limit)
+            );
+        }
+        assert_eq!(
+            InstanceConfig::from_toml_str(MINIMAL_TOML)
+                .unwrap()
+                .limits
+                .default_result_limit,
+            None
+        );
     }
 
     // Configured instance IDs are daemon write defaults, so empty values and

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -108,10 +108,24 @@ pub fn format_markdown_refresh_summary(result: &MarkdownRefreshResult) -> String
         result.index.unresolved_link_targets,
     );
     if !result.index.skipped.is_empty() {
-        summary.push_str(&format!(
-            " Coverage DEGRADED: {} note file(s) skipped.",
-            result.index.skipped.len()
-        ));
+        let excluded = result
+            .index
+            .skipped
+            .iter()
+            .filter(|file| {
+                matches!(file.reason_code, SkipReasonCode::Ignored)
+                    && file.reason == "matched .brainignore pattern"
+            })
+            .count();
+        let degraded = result.index.skipped.len() - excluded;
+        if degraded > 0 {
+            summary.push_str(&format!(
+                " Coverage DEGRADED: {degraded} note file(s) skipped."
+            ));
+        }
+        if excluded > 0 {
+            summary.push_str(&format!(" Excluded by request: {excluded} note file(s)."));
+        }
         for sf in &result.index.skipped {
             summary.push_str(&format!("\n  {} - {}", sf.path, sf.reason));
         }
@@ -4447,6 +4461,41 @@ sub b body
              SAME summary `brain refresh` prints, not stay refresh-only \
              information the user has no way to see: {summary}"
         );
+    }
+
+    #[test]
+    fn explicit_exclusions_remain_visible_without_degrading_eligible_coverage() {
+        let (_dir, root) = make_vault(&[("keep.md", "# Keep\n"), ("ignore.md", "# Ignore\n")]);
+        let db = root.join("scratch.lbug");
+        for from_file in [false, true] {
+            let ignore = if from_file {
+                std::fs::write(root.join(".brainignore"), "ignore.md\n").unwrap();
+                vec![]
+            } else {
+                vec!["ignore.md".to_string()]
+            };
+            let mut result = index_markdown_directory_with_ignore_and_deletion_count(
+                &root, &db, "default", "v", &ignore,
+            )
+            .unwrap();
+            assert_eq!(result.index.notes_count, 1);
+            let summary = format_markdown_refresh_summary(&result);
+            assert!(!summary.contains("Coverage DEGRADED"), "{summary}");
+            assert!(
+                summary.contains("Excluded by request: 1") && summary.contains("ignore.md"),
+                "{summary}"
+            );
+            result.index.skipped.push(SkippedFile::new(
+                "large.md",
+                SkipReasonCode::Oversized,
+                "too large",
+            ));
+            let mixed = format_markdown_refresh_summary(&result);
+            assert!(
+                mixed.contains("Coverage DEGRADED: 1") && mixed.contains("Excluded by request: 1"),
+                "{mixed}"
+            );
+        }
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -597,9 +597,9 @@ pub use query::{
     HybridSearchConfig, LinkInfo, LookupResult, SearchIndexProvider, SymbolCandidate, SymbolDetail,
     TruncationCause, apply_ranking_priors, build_brain_context, build_brain_context_hybrid,
     build_brain_context_hybrid_with_aliases, build_context, build_context_with_intent,
-    build_feature_context, dedup_heading_section_pairs, expand_query_with_aliases,
-    explain_ranking_prior, generate_repo_map, list_repos, list_services, lookup_symbol,
-    populate_inline_bodies, promote_member_notes_into_connected,
+    build_feature_context, compose_result_caps, dedup_heading_section_pairs,
+    expand_query_with_aliases, explain_ranking_prior, generate_repo_map, list_repos, list_services,
+    lookup_symbol, populate_inline_bodies, promote_member_notes_into_connected,
     promote_member_symbols_into_connected, search_symbols,
 };
 pub use recency::parse_iso8601_to_epoch;

--- a/crates/nestweaver-engine/src/publication.rs
+++ b/crates/nestweaver-engine/src/publication.rs
@@ -1447,6 +1447,15 @@ pub(crate) fn validate_slot_contents(
         if name == PUBLICATION_MANIFEST_FILE {
             continue;
         }
+        // A live slot retains the kernel writer-lock anchor after its writer
+        // exits. It is operational state, not portable graph content. Symlinks
+        // were rejected above, and only the exact declared graph's sibling is
+        // allowed; archive inventory validation remains strict.
+        if bundle.artifacts.iter().any(|artifact| {
+            artifact.kind == ArtifactKind::Graph && name == format!("{}.write.lock", artifact.path)
+        }) {
+            continue;
+        }
         present.insert(name);
     }
     let undescribed: Vec<&String> = present

--- a/crates/nestweaver-engine/src/pull.rs
+++ b/crates/nestweaver-engine/src/pull.rs
@@ -93,6 +93,60 @@ pub fn pull_repo(
     indexed_sha: &str,
     options: &PullOptions,
 ) -> Result<PullResult, PullError> {
+    pull_repo_with_credentials(workspace_root, repo_url, indexed_sha, options, None)
+}
+
+/// Validate the selected instance's authentication strategy before filesystem
+/// or network work. Credentials are supplied to Git's protocol, never its URL.
+pub fn validate_credential_method(method: &str) -> Result<(), anyhow::Error> {
+    if matches!(method, "gh" | "ssh" | "credential-helper" | "env") {
+        Ok(())
+    } else {
+        anyhow::bail!("unsupported git credential_method '{method}'")
+    }
+}
+
+fn pull_git_command(credential_method: Option<&str>) -> Command {
+    let mut command = Command::new("git");
+    command.env("GIT_TERMINAL_PROMPT", "0");
+    match credential_method {
+        Some("gh") => {
+            command.args([
+                "-c",
+                "credential.helper=",
+                "-c",
+                "credential.helper=!gh auth git-credential",
+            ]);
+        }
+        Some("ssh") => {
+            command.args(["-c", "credential.helper="]);
+        }
+        Some("env") => {
+            // An explicitly supplied askpass program is Git's native env
+            // protocol. Otherwise expose GH_TOKEN only through helper stdin/
+            // stdout; the token never appears in argv or the remote URL.
+            command.args(["-c", "credential.helper="]);
+            if std::env::var_os("GIT_ASKPASS").is_none() {
+                command.args(["-c", r#"credential.helper=!f() { test "$1" = get && test -n "$GH_TOKEN" && printf '%s\n' 'username=x-access-token' "password=$GH_TOKEN"; }; f"#]);
+            }
+        }
+        _ => {}
+    }
+    command
+}
+
+/// Instance-aware variant; the old public entry point retains ambient Git
+/// authentication when no instance was selected.
+pub fn pull_repo_with_credentials(
+    workspace_root: &Path,
+    repo_url: &str,
+    indexed_sha: &str,
+    options: &PullOptions,
+    credential_method: Option<&str>,
+) -> Result<PullResult, PullError> {
+    if let Some(method) = credential_method {
+        validate_credential_method(method).map_err(PullError::Other)?;
+    }
     ensure_workspace_hygiene(workspace_root)?;
     let repo_name = clone_dir_name_from_url(repo_url);
     if repo_name.is_empty() || repo_name == "." || repo_name.contains("..") {
@@ -112,7 +166,7 @@ pub fn pull_repo(
 
     if dest.exists() && dest.join(".git").exists() {
         // Fetch
-        let output = Command::new("git")
+        let output = pull_git_command(credential_method)
             .args(["fetch", "origin"])
             .current_dir(&dest)
             .output()?;
@@ -131,7 +185,7 @@ pub fn pull_repo(
         args.push(repo_url.to_string());
         args.push(dest.display().to_string());
 
-        let output = Command::new("git").args(&args).output()?;
+        let output = pull_git_command(credential_method).args(&args).output()?;
         if !output.status.success() {
             // A failed pull must clean up the workspace dir it created —
             // validate_repo_dest pre-creates `dest`, and a partial clone must
@@ -274,6 +328,72 @@ pub fn cleanup_repo(workspace_root: &Path, repo_url: &str) -> Result<(), anyhow:
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn selected_credentials_are_command_local_and_never_embed_a_token() {
+        for method in ["gh", "ssh", "credential-helper", "env"] {
+            validate_credential_method(method).unwrap();
+            let command = pull_git_command(Some(method));
+            let args: Vec<_> = command
+                .get_args()
+                .map(|arg| arg.to_string_lossy().to_string())
+                .collect();
+            assert!(
+                !args
+                    .iter()
+                    .any(|arg| arg.contains("https://") || arg.contains("Authorization:"))
+            );
+            if method == "gh" {
+                assert!(
+                    args.iter()
+                        .any(|arg| arg == "credential.helper=!gh auth git-credential")
+                );
+                assert!(args.iter().any(|arg| arg == "credential.helper="));
+            }
+        }
+        assert!(validate_credential_method("typo").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn selected_gh_helper_answers_git_credential_protocol_without_persisting_it() {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+        use std::process::Stdio;
+        let dir = tempfile::tempdir().unwrap();
+        let gh = dir.path().join("gh");
+        std::fs::write(&gh, "#!/bin/sh\n[ \"$1 $2 $3\" = 'auth git-credential get' ] || exit 1\nprintf '%s\\n' username=fixture password=synthetic-test-token\n").unwrap();
+        std::fs::set_permissions(&gh, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let mut paths = vec![dir.path().to_path_buf()];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        let mut child = pull_git_command(Some("gh"))
+            .args(["credential", "fill"])
+            .current_dir(dir.path())
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(b"protocol=https\nhost=example.invalid\n\n")
+            .unwrap();
+        let output = child.wait_with_output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(String::from_utf8_lossy(&output.stdout).contains("password=synthetic-test-token"));
+        assert!(!dir.path().join(".git/config").exists());
+    }
 
     #[test]
     fn repo_name_from_https_url() {

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -510,6 +510,42 @@ impl TruncationCause {
     }
 }
 
+/// Compose independent row and token caps without discarding either constraint.
+/// `budget_cut` is the prefix length allowed by the caller's renderer.
+pub fn compose_result_caps(
+    total: usize,
+    count_limit: Option<usize>,
+    budget_cut: Option<usize>,
+) -> (usize, Option<TruncationCause>) {
+    let count_cut = count_limit.unwrap_or(total).min(total);
+    let token_cut = budget_cut.unwrap_or(total).min(total);
+    let cut = count_cut.min(token_cut);
+    let cause = TruncationCause::resolve(
+        token_cut < total && token_cut <= count_cut,
+        count_cut < total,
+    );
+    (cut, cause)
+}
+
+#[cfg(test)]
+mod composed_cap_tests {
+    use super::*;
+    #[test]
+    fn independent_caps_preserve_both_bounds_and_name_the_binding_one() {
+        for (count, tokens, cut, cause) in [
+            (None, None, 10, None),
+            (Some(2), None, 2, Some(TruncationCause::Limit)),
+            (None, Some(3), 3, Some(TruncationCause::TokenBudget)),
+            (Some(2), Some(8), 2, Some(TruncationCause::Limit)),
+            (Some(8), Some(2), 2, Some(TruncationCause::TokenBudget)),
+            (Some(2), Some(2), 2, Some(TruncationCause::TokenBudget)),
+            (Some(20), Some(20), 10, None),
+        ] {
+            assert_eq!(compose_result_caps(10, count, tokens), (cut, cause));
+        }
+    }
+}
+
 /// How many symbols ONE bare-name seed input may contribute to the PPR
 /// personalization vector.
 ///

--- a/crates/nestweaver-federation/src/dispatch.rs
+++ b/crates/nestweaver-federation/src/dispatch.rs
@@ -268,6 +268,10 @@ fn brain_context_request(params: &Value) -> nestweaver_proto::BrainContextReques
         })
         .unwrap_or_default();
     nestweaver_proto::BrainContextRequest {
+        limit: params
+            .get("limit")
+            .and_then(Value::as_u64)
+            .and_then(|n| u32::try_from(n).ok()),
         seeds,
         token_budget: params
             .get("token_budget")
@@ -569,6 +573,16 @@ fn json_str_array(params: &Value, key: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn brain_context_count_cap_survives_typed_transport_with_token_budget() {
+        let req = brain_context_request(
+            &serde_json::json!({"seeds":["fixture"],"limit":2,"token_budget":1000}),
+        );
+        assert_eq!(req.limit, Some(2));
+        assert_eq!(req.token_budget, 1000);
+        assert_eq!(brain_context_request(&serde_json::json!({})).limit, None);
+    }
 
     #[test]
     fn typed_brain_search_json_preserves_counts_and_old_response_defaults() {

--- a/crates/nestweaver-mcp/src/http.rs
+++ b/crates/nestweaver-mcp/src/http.rs
@@ -230,6 +230,9 @@ pub struct McpHttpState {
     pub db_path: PathBuf,
     pub instance_cfg: Option<Arc<nestweaver_engine::InstanceConfig>>,
     pub sessions: Arc<DashMap<String, McpSession>>,
+    /// Cancellation keys include both established session and authenticated
+    /// role; equal request IDs in different clients cannot cancel each other.
+    in_flight: Arc<DashMap<String, crate::session::CancelFlag>>,
     /// Live count of active MCP sessions, republished from `sessions.len()` on
     /// each insert and after each sweep. Shared with the daemon so the admin
     /// dashboard and the `MCP_SESSIONS` Prometheus gauge can read a connection
@@ -285,6 +288,21 @@ pub struct McpHttpState {
     /// single-node provenance. Present only under the `daemon` feature.
     #[cfg(feature = "daemon")]
     pub federation: Option<Arc<crate::federation::FederationState>>,
+}
+
+struct HttpInFlight {
+    entries: Arc<DashMap<String, crate::session::CancelFlag>>,
+    key: String,
+    flag: crate::session::CancelFlag,
+    cancel_on_drop: bool,
+}
+impl Drop for HttpInFlight {
+    fn drop(&mut self) {
+        if self.cancel_on_drop {
+            self.flag.store(true, Ordering::Release);
+        }
+        self.entries.remove(&self.key);
+    }
 }
 
 /// Build the per-repo permission source from the instance config's `[authz]`
@@ -351,6 +369,7 @@ impl McpHttpState {
             db_path,
             instance_cfg,
             sessions: Arc::new(DashMap::new()),
+            in_flight: Arc::new(DashMap::new()),
             mcp_session_gauge: Arc::new(AtomicU32::new(0)),
             server_mode,
             read_only: false,
@@ -386,6 +405,7 @@ impl McpHttpState {
             db_path,
             instance_cfg,
             sessions: Arc::new(DashMap::new()),
+            in_flight: Arc::new(DashMap::new()),
             mcp_session_gauge: Arc::new(AtomicU32::new(0)),
             server_mode,
             read_only: false,
@@ -802,6 +822,15 @@ async fn handle_mcp(
         }
     };
     let notification = req.id.is_none();
+    if let Err(message) = crate::protocol::validate_method_params(&req) {
+        return jsonrpc_http_error(
+            notification,
+            axum::http::StatusCode::OK,
+            req.id.clone().unwrap_or(Value::Null),
+            error_code::INVALID_PARAMS,
+            &message,
+        );
+    }
 
     let id = req.id.clone().unwrap_or(Value::Null);
 
@@ -883,6 +912,33 @@ async fn handle_mcp(
             entry.last_active = Instant::now();
             entry.request_count += 1;
         }
+    }
+
+    // Cancellation requires an established session. A stateless HTTP request
+    // has no correlation namespace; never guess which client's equal ID it is.
+    let cancellation_prefix = session_id.as_ref().map(|sid| {
+        format!(
+            "{}:{sid}:",
+            if admin_bypass_rate_limit {
+                "admin"
+            } else if state.auth_token.is_some() {
+                "query"
+            } else {
+                "anonymous"
+            }
+        )
+    });
+    if req.method == "notifications/cancelled" {
+        if let (Some(prefix), Some(request_id)) = (
+            &cancellation_prefix,
+            req.params
+                .as_ref()
+                .and_then(|params| params.get("requestId")),
+        ) && let Some(flag) = state.in_flight.get(&format!("{prefix}{request_id}"))
+        {
+            flag.store(true, Ordering::Release);
+        }
+        return axum::http::StatusCode::ACCEPTED.into_response();
     }
 
     let response = match req.method.as_str() {
@@ -1015,6 +1071,33 @@ async fn handle_mcp(
                 );
             }
 
+            let cancel_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let mutation = MUTATING_TOOLS.contains(&name.as_str());
+            let _in_flight = if let Some(prefix) = &cancellation_prefix {
+                let key = format!("{prefix}{id}");
+                match state.in_flight.entry(key.clone()) {
+                    dashmap::mapref::entry::Entry::Occupied(_) => {
+                        return jsonrpc_error(
+                            axum::http::StatusCode::OK,
+                            id.clone(),
+                            error_code::INVALID_REQUEST,
+                            "request id is already in flight in this session",
+                        );
+                    }
+                    dashmap::mapref::entry::Entry::Vacant(entry) => {
+                        entry.insert(cancel_flag.clone());
+                    }
+                }
+                Some(HttpInFlight {
+                    entries: state.in_flight.clone(),
+                    key,
+                    flag: cancel_flag.clone(),
+                    cancel_on_drop: !mutation,
+                })
+            } else {
+                None
+            };
+
             let store = state.store.clone();
             let tantivy = match &state.search_index_provider {
                 Some(provider) => provider.search_index(),
@@ -1113,9 +1196,8 @@ async fn handle_mcp(
             // dead_code, flow_trace, vector search) observe the flag and stop.
             let timeout = Duration::from_secs(DEFAULT_TOOL_TIMEOUT_SECS);
             let tool_name = name.clone();
-            let cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
             let dispatch_cancel = std::sync::Arc::clone(&cancel_flag);
-            let result = tokio::time::timeout(
+            let work = tokio::time::timeout(
                 timeout,
                 tokio::task::spawn_blocking(move || {
                     tools::set_current_db_path(db_path);
@@ -1137,8 +1219,21 @@ async fn handle_mcp(
                         Some(&visible),
                     )
                 }),
-            )
-            .await;
+            );
+            let result = tokio::select! {
+                result = work => result,
+                _ = async {
+                    if mutation { std::future::pending::<()>().await; }
+                    while !cancel_flag.load(Ordering::Acquire) {
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                    }
+                } => return axum::http::StatusCode::ACCEPTED.into_response(),
+            };
+            // A mutation remains awaited while its retained worker owns the
+            // write. Cancellation suppresses the response, not the commit.
+            if cancel_flag.load(Ordering::Acquire) {
+                return axum::http::StatusCode::ACCEPTED.into_response();
+            }
 
             match result {
                 Ok(Ok(Ok(value))) => {
@@ -1154,14 +1249,27 @@ async fn handle_mcp(
                         (Some(fed), Some((fed_args, fed_visible))) => {
                             let expose_staleness =
                                 matches!(fed_visible, nestweaver_engine::authz::VisibleRepos::All);
-                            let (v, src) = crate::federation::federate_two_tier(
-                                fed,
-                                &name,
-                                &fed_args,
-                                value,
-                                &fed_visible,
+                            let federated = crate::session::await_cancellable(
+                                (!mutation).then_some(&cancel_flag),
+                                async {
+                                    Ok(crate::federation::federate_two_tier(
+                                        fed,
+                                        &name,
+                                        &fed_args,
+                                        value,
+                                        &fed_visible,
+                                    )
+                                    .await)
+                                },
                             )
                             .await;
+                            let (v, src) = match federated {
+                                Ok(value) => value,
+                                Err(_) => return axum::http::StatusCode::ACCEPTED.into_response(),
+                            };
+                            if cancel_flag.load(Ordering::Acquire) {
+                                return axum::http::StatusCode::ACCEPTED.into_response();
+                            }
                             let stale_repos = if expose_staleness {
                                 fed.stale_repos()
                             } else {
@@ -1560,6 +1668,7 @@ mod tests {
             "jsonrpc": "2.0",
             "id": 1,
             "method": "initialize",
+            "params": {"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1"}},
         });
         let req = Request::builder()
             .method("POST")
@@ -1656,9 +1765,14 @@ mod tests {
         let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
             .unwrap();
+        let response: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(response["error"]["code"], error_code::INVALID_REQUEST);
+        assert_eq!(response["id"], Value::Null);
         assert!(
-            bytes.is_empty(),
-            "post-validation notification errors must have no JSON body"
+            response["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("requires a correlated request id")
         );
     }
 
@@ -1844,6 +1958,7 @@ mod tests {
                 "jsonrpc": "2.0",
                 "id": 1,
                 "method": "initialize",
+            "params": {"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1"}},
             });
             let req = Request::builder()
                 .method("POST")
@@ -2018,6 +2133,22 @@ mod tests {
                     .unwrap();
                 let json: Value = serde_json::from_slice(&bytes).unwrap();
 
+                if !arguments.is_object() {
+                    // The tools/call envelope requires an arguments object.
+                    // Reject this core shape before either authorization gate;
+                    // object-shaped tool schema failures remain in-band below.
+                    assert_eq!(json["error"]["code"], error_code::INVALID_PARAMS);
+                    assert_eq!(json["id"], tool);
+                    assert!(
+                        json["error"]["message"]
+                            .as_str()
+                            .unwrap()
+                            .contains("'arguments' must be an object")
+                    );
+                    assert!(json.get("result").is_none());
+                    continue;
+                }
+
                 assert!(
                     json.get("error").is_none(),
                     "{tool} before {gate} gate: {json}"
@@ -2160,5 +2291,226 @@ mod tests {
                 .unwrap()
                 .contains("re-initialize"),
         );
+    }
+}
+
+#[cfg(test)]
+mod admission_regression_tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    async fn post(
+        app: Router,
+        raw: String,
+        token: Option<&str>,
+        session: Option<&str>,
+    ) -> (StatusCode, Value) {
+        let mut request = Request::builder()
+            .method("POST")
+            .uri("/mcp")
+            .header("content-type", "application/json");
+        if let Some(token) = token {
+            request = request.header("authorization", format!("Bearer {token}"));
+        }
+        if let Some(session) = session {
+            request = request.header("mcp-session-id", session);
+        }
+        let response = app
+            .oneshot(request.body(Body::from(raw)).unwrap())
+            .await
+            .unwrap();
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (
+            status,
+            if bytes.is_empty() {
+                Value::Null
+            } else {
+                serde_json::from_slice(&bytes).unwrap()
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn http_rejects_lossy_ids_method_shapes_and_notification_mutation_before_dispatch() {
+        let temp = tempfile::tempdir().unwrap();
+        let state = Arc::new(McpHttpState::new(
+            false,
+            Arc::new(GraphStore::in_memory().unwrap()),
+            None,
+            temp.path().join("test.lbug"),
+            None,
+            false,
+        ));
+        let app = router(state);
+        for (raw, code) in [
+            (
+                r#"{"jsonrpc":"2.0","id":1234567890123456789012345678901234567890,"method":"ping"}"#,
+                -32600,
+            ),
+            (
+                r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":[]}"#,
+                -32602,
+            ),
+            (
+                r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"cursor":7}}"#,
+                -32602,
+            ),
+            (
+                r#"{"jsonrpc":"2.0","method":"tools/call","params":{"name":"set_extension","arguments":{"uid":"test","key":"must-not-write","value":true}}}"#,
+                -32600,
+            ),
+        ] {
+            let (_, result) = post(app.clone(), raw.into(), None, None).await;
+            assert_eq!(result["error"]["code"], code, "{result}");
+        }
+        assert_eq!(
+            std::fs::read_dir(temp.path()).unwrap().count(),
+            0,
+            "notification mutated an extension sidecar"
+        );
+    }
+
+    #[tokio::test]
+    async fn http_cancellation_is_scoped_to_session_and_authenticated_role() {
+        let state = Arc::new(McpHttpState::with_auth(
+            false,
+            Arc::new(GraphStore::in_memory().unwrap()),
+            None,
+            PathBuf::from("unused"),
+            None,
+            false,
+            "query".into(),
+            Some("admin".into()),
+        ));
+        let now = Instant::now();
+        for sid in ["first", "second"] {
+            state.sessions.insert(
+                sid.into(),
+                McpSession {
+                    id: sid.into(),
+                    created_at: now,
+                    last_active: now,
+                    request_count: 0,
+                    rate_window_start: now,
+                },
+            );
+        }
+        let first = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let second = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let admin = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        state
+            .in_flight
+            .insert("query:first:1".into(), first.clone());
+        state
+            .in_flight
+            .insert("query:second:1".into(), second.clone());
+        state
+            .in_flight
+            .insert("admin:first:1".into(), admin.clone());
+        let cancel =
+            json!({"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1}})
+                .to_string();
+        let app = router(state);
+        let (status, _) = post(app.clone(), cancel.clone(), Some("query"), None).await;
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert!(
+            !first.load(Ordering::Acquire),
+            "stateless cancellation guessed an owner"
+        );
+        let (status, _) = post(app, cancel, Some("query"), Some("first")).await;
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert!(first.load(Ordering::Acquire));
+        assert!(!second.load(Ordering::Acquire));
+        assert!(!admin.load(Ordering::Acquire));
+    }
+    #[cfg(feature = "daemon")]
+    #[tokio::test]
+    async fn http_cancellation_interrupts_the_post_local_federation_stage() {
+        // A real loopback TCP peer accepts the upstream connection but never
+        // answers its handshake. Seeing accept proves local dispatch finished
+        // and the handler reached federation; no throughput/sleep guess does.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let peer = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.unwrap();
+            accepted_tx.send(()).unwrap();
+            let _ = release_rx.await;
+        });
+        let config: nestweaver_engine::InstanceConfig = toml::from_str(&format!(
+            r#"
+instance_id="http-cancel-test"
+[snapshot_storage]
+backend="local"
+path="unused"
+[workspace]
+backend="local"
+path="unused"
+[inference]
+endpoint="http://127.0.0.1:1"
+embedding_model="unused"
+summary_model="unused"
+[git]
+credential_method="gh"
+[[upstream]]
+name="blocked"
+url="http://{address}"
+mode="primary"
+timeout="60s"
+"#
+        ))
+        .unwrap();
+        let mut state = McpHttpState::new(
+            false,
+            Arc::new(GraphStore::in_memory().unwrap()),
+            None,
+            PathBuf::from("unused"),
+            None,
+            false,
+        );
+        state.federation = crate::federation::FederationState::from_instance_config(&config);
+        let now = Instant::now();
+        state.sessions.insert(
+            "session".into(),
+            McpSession {
+                id: "session".into(),
+                created_at: now,
+                last_active: now,
+                request_count: 0,
+                rate_window_start: now,
+            },
+        );
+        let app = router(Arc::new(state));
+        let request_app = app.clone();
+        let request = tokio::spawn(async move {
+            post(request_app, json!({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"blast_radius","arguments":{"changed_files":["missing.rs"]}}}).to_string(), None, Some("session")).await
+        });
+        tokio::time::timeout(Duration::from_secs(5), accepted_rx)
+            .await
+            .expect("handler never reached upstream stage")
+            .unwrap();
+        let (status, _) = post(
+            app,
+            json!({"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1}})
+                .to_string(),
+            None,
+            Some("session"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::ACCEPTED);
+        let (status, body) = tokio::time::timeout(Duration::from_secs(5), request)
+            .await
+            .expect("cancel waited for blocked upstream")
+            .unwrap();
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert_eq!(body, Value::Null);
+        let _ = release_tx.send(());
+        peer.await.unwrap();
     }
 }

--- a/crates/nestweaver-mcp/src/lib.rs
+++ b/crates/nestweaver-mcp/src/lib.rs
@@ -6,7 +6,7 @@
 //! JSON-RPC 2.0. `tracing` is configured by the caller to write to stderr
 //! (CRITICAL — anything on stdout must be a valid MCP frame).
 
-use std::io::{self, BufRead, Write};
+use std::io::Write;
 use std::path::Path;
 
 use anyhow::Context;
@@ -17,6 +17,7 @@ use serde_json::{Value, json};
 pub mod federation;
 pub mod http;
 pub mod protocol;
+pub mod session;
 pub mod tools;
 
 use protocol::{ErrorResponse, PROTOCOL_VERSION, Response, error, error_code, success};
@@ -289,152 +290,23 @@ pub fn run_stdio_server(
         "brain MCP server ready on stdio"
     );
 
-    let stdin = io::stdin();
-    let mut stdout = io::stdout().lock();
-    let mut line = String::new();
-    let mut reader = stdin.lock();
-
-    loop {
-        line.clear();
-        let n = reader.read_line(&mut line)?;
-        if n == 0 {
-            // EOF from the client — clean shutdown.
-            if let Some(tracker) = &tracker {
-                // Best-effort terminal-success heuristic: if the agent's last
-                // tool call was NOT another search (i.e. it stopped looking),
-                // the context it had at that point was "good enough". Record a
-                // TerminalSuccess for the UIDs most recently surfaced this
-                // session so that positive outcome reinforces those nodes.
-                // This is purely heuristic and must never break shutdown.
-                maybe_record_terminal_success(tracker);
-                if let Err(e) = tracker.flush() {
-                    tracing::warn!("failed to flush interaction tracker: {e}");
-                }
-            }
-            // Flush any in-process response cache entries that haven't been
-            // written to disk yet (periodic flush threshold may not have been hit).
-            crate::tools::flush_response_cache();
-            tracing::info!("client closed stdin; shutting down");
-            return Ok(());
-        }
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
-        // Parse as serde_json::Value first to detect batch (array) vs
-        // single (object) requests per JSON-RPC 2.0 §6.
-        let parsed: Value = match serde_json::from_str(trimmed) {
-            Ok(v) => v,
-            Err(e) => {
-                let resp = error(
-                    Value::Null,
-                    error_code::PARSE_ERROR,
-                    format!("invalid JSON: {e}"),
-                );
-                if closed_stdout_ends_session(
-                    write_response(&mut stdout, &Frame::Error(resp)),
-                    tracker.as_ref(),
-                )? {
-                    return Ok(());
-                }
-                continue;
-            }
-        };
-
-        if let Value::Array(arr) = parsed {
-            // Batch request.
-            if arr.is_empty() {
-                let resp = error(
-                    Value::Null,
-                    error_code::INVALID_REQUEST,
-                    "empty batch array",
-                );
-                if closed_stdout_ends_session(
-                    write_response(&mut stdout, &Frame::Error(resp)),
-                    tracker.as_ref(),
-                )? {
-                    return Ok(());
-                }
-                continue;
-            }
-            let mut responses: Vec<Value> = Vec::new();
-            for item in arr {
-                let req = match protocol::validate_request(item) {
-                    Ok(r) => r,
-                    Err(e) => {
-                        responses.push(serde_json::to_value(error(
-                            e.response_id,
-                            error_code::INVALID_REQUEST,
-                            format!("invalid request in batch: {}", e.message),
-                        ))?);
-                        continue;
-                    }
-                };
-                let is_notification = req.id.is_none();
-                let outcome = dispatch_method(&store, tantivy.as_ref(), &req, tracker.as_ref());
-                if is_notification {
-                    if let Frame::Error(e) = outcome {
-                        tracing::warn!(
-                            "batch notification {} produced error: {}",
-                            req.method,
-                            e.error.message
-                        );
-                    }
-                    continue;
-                }
-                let val = match outcome {
-                    Frame::Success(r) => serde_json::to_value(r)?,
-                    Frame::Error(e) => serde_json::to_value(e)?,
-                };
-                responses.push(val);
-            }
-            if !responses.is_empty() {
-                let serialized = serde_json::to_string(&responses)?;
-                if closed_stdout_ends_session(
-                    write_stdout_frame(&mut stdout, &serialized).map_err(Into::into),
-                    tracker.as_ref(),
-                )? {
-                    return Ok(());
-                }
-            }
-        } else {
-            // Single request.
-            let req = match protocol::validate_request(parsed) {
-                Ok(r) => r,
-                Err(e) => {
-                    let resp = error(
-                        e.response_id,
-                        error_code::INVALID_REQUEST,
-                        format!("invalid request: {}", e.message),
-                    );
-                    if closed_stdout_ends_session(
-                        write_response(&mut stdout, &Frame::Error(resp)),
-                        tracker.as_ref(),
-                    )? {
-                        return Ok(());
-                    }
-                    continue;
-                }
-            };
-            let is_notification = req.id.is_none();
-            let outcome = dispatch_method(&store, tantivy.as_ref(), &req, tracker.as_ref());
-            if is_notification {
-                if let Frame::Error(e) = outcome {
-                    tracing::warn!(
-                        "notification {} produced error: {}",
-                        req.method,
-                        e.error.message
-                    );
-                }
-                continue;
-            }
-            if closed_stdout_ends_session(write_response(&mut stdout, &outcome), tracker.as_ref())?
-            {
-                return Ok(());
-            }
+    let result = session::run_stdio(|req, cancel| {
+        frame_value(dispatch_method_cancellable(
+            &store,
+            tantivy.as_ref(),
+            req,
+            tracker.as_ref(),
+            Some(cancel),
+        ))
+    });
+    if let Some(tracker) = &tracker {
+        maybe_record_terminal_success(tracker);
+        if let Err(error) = tracker.flush() {
+            tracing::warn!("failed to flush interaction tracker: {error}");
         }
     }
+    tools::flush_response_cache();
+    result
 }
 
 /// Run the brain server in daemon proxy mode: instead of opening the DB
@@ -467,149 +339,36 @@ pub fn run_stdio_server_daemon(
         "brain MCP server ready on stdio (daemon proxy mode)"
     );
 
-    let stdin = io::stdin();
-    let mut stdout = io::stdout().lock();
-    let mut line = String::new();
-    let mut reader = stdin.lock();
-
-    loop {
-        line.clear();
-        let n = reader.read_line(&mut line)?;
-        if n == 0 {
-            if let Some(tracker) = &tracker {
-                maybe_record_terminal_success(tracker);
-                if let Err(e) = tracker.flush() {
-                    tracing::warn!("failed to flush interaction tracker: {e}");
-                }
-            }
-            tracing::info!("client closed stdin; shutting down (daemon proxy)");
-            return Ok(());
-        }
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
-        let parsed: Value = match serde_json::from_str(trimmed) {
-            Ok(v) => v,
-            Err(e) => {
-                let resp = error(
-                    Value::Null,
-                    error_code::PARSE_ERROR,
-                    format!("invalid JSON: {e}"),
-                );
-                if closed_stdout_ends_session(
-                    write_response(&mut stdout, &Frame::Error(resp)),
-                    tracker.as_ref(),
-                )? {
-                    return Ok(());
-                }
-                continue;
-            }
-        };
-
-        if let Value::Array(arr) = parsed {
-            if arr.is_empty() {
-                let resp = error(
-                    Value::Null,
-                    error_code::INVALID_REQUEST,
-                    "empty batch array",
-                );
-                if closed_stdout_ends_session(
-                    write_response(&mut stdout, &Frame::Error(resp)),
-                    tracker.as_ref(),
-                )? {
-                    return Ok(());
-                }
-                continue;
-            }
-            let mut responses: Vec<Value> = Vec::new();
-            for item in arr {
-                let req = match protocol::validate_request(item) {
-                    Ok(r) => r,
-                    Err(e) => {
-                        responses.push(serde_json::to_value(error(
-                            e.response_id,
-                            error_code::INVALID_REQUEST,
-                            format!("invalid request in batch: {}", e.message),
-                        ))?);
-                        continue;
-                    }
-                };
-                let is_notification = req.id.is_none();
-                let outcome = dispatch_method_daemon(&mut grpc_client, &rt, &req, tracker.as_ref());
-                if is_notification {
-                    if let Frame::Error(e) = outcome {
-                        tracing::warn!(
-                            "batch notification {} produced error: {}",
-                            req.method,
-                            e.error.message
-                        );
-                    }
-                    continue;
-                }
-                let val = match outcome {
-                    Frame::Success(r) => serde_json::to_value(r)?,
-                    Frame::Error(e) => serde_json::to_value(e)?,
-                };
-                responses.push(val);
-            }
-            if !responses.is_empty() {
-                let serialized = serde_json::to_string(&responses)?;
-                if closed_stdout_ends_session(
-                    write_stdout_frame(&mut stdout, &serialized).map_err(Into::into),
-                    tracker.as_ref(),
-                )? {
-                    return Ok(());
-                }
-            }
-        } else {
-            let req = match protocol::validate_request(parsed) {
-                Ok(r) => r,
-                Err(e) => {
-                    let resp = error(
-                        e.response_id,
-                        error_code::INVALID_REQUEST,
-                        format!("invalid request: {}", e.message),
-                    );
-                    if closed_stdout_ends_session(
-                        write_response(&mut stdout, &Frame::Error(resp)),
-                        tracker.as_ref(),
-                    )? {
-                        return Ok(());
-                    }
-                    continue;
-                }
-            };
-            let is_notification = req.id.is_none();
-            let outcome = dispatch_method_daemon(&mut grpc_client, &rt, &req, tracker.as_ref());
-            if is_notification {
-                if let Frame::Error(e) = outcome {
-                    tracing::warn!(
-                        "notification {} produced error: {}",
-                        req.method,
-                        e.error.message
-                    );
-                }
-                continue;
-            }
-            if closed_stdout_ends_session(write_response(&mut stdout, &outcome), tracker.as_ref())?
-            {
-                return Ok(());
-            }
+    let result = session::run_stdio(|req, cancel| {
+        frame_value(dispatch_method_daemon_cancellable(
+            &mut grpc_client,
+            &rt,
+            req,
+            tracker.as_ref(),
+            Some(cancel),
+        ))
+    });
+    if let Some(tracker) = &tracker {
+        maybe_record_terminal_success(tracker);
+        if let Err(error) = tracker.flush() {
+            tracing::warn!("failed to flush interaction tracker: {error}");
         }
     }
+    result
 }
 
 #[cfg(feature = "daemon")]
-fn dispatch_method_daemon(
+fn dispatch_method_daemon_cancellable(
     client: &mut tools::DaemonGrpcClient,
     rt: &tokio::runtime::Runtime,
     req: &protocol::Request,
     tracker: Option<&nestweaver_engine::InteractionTracker>,
+    cancel: Option<&session::CancelFlag>,
 ) -> Frame {
     let id = req.id.clone().unwrap_or(Value::Null);
-
+    if let Err(message) = protocol::validate_method_params(req) {
+        return Frame::Error(error(id, error_code::INVALID_PARAMS, message));
+    }
     match req.method.as_str() {
         "initialize" => Frame::Success(success(
             id,
@@ -655,7 +414,7 @@ fn dispatch_method_daemon(
             // Isolate a panicking tool so one bad call can't unwind the stdio
             // read loop and kill the session (mirrors the HTTP path).
             let dispatched = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                tools::dispatch_via_daemon(client, rt, &name, arguments.clone())
+                tools::dispatch_via_daemon_cancellable(client, rt, &name, arguments.clone(), cancel)
             }));
             match dispatched {
                 Ok(Ok(result)) => {
@@ -679,6 +438,17 @@ fn dispatch_method_daemon(
             error_code::METHOD_NOT_FOUND,
             format!("method not implemented: {other}"),
         )),
+    }
+}
+
+fn frame_value(frame: Frame) -> Value {
+    match frame {
+        Frame::Success(response) => {
+            serde_json::to_value(response).expect("response contains only JSON values")
+        }
+        Frame::Error(response) => {
+            serde_json::to_value(response).expect("response contains only JSON values")
+        }
     }
 }
 
@@ -754,47 +524,27 @@ fn write_stdout_frame(out: &mut impl Write, serialized: &str) -> Result<(), Stdo
     out.flush().map_err(StdoutWriteError)
 }
 
-fn closed_stdout_ends_session(
-    result: Result<(), anyhow::Error>,
-    tracker: Option<&nestweaver_engine::InteractionTracker>,
-) -> Result<bool, anyhow::Error> {
-    match result {
-        Ok(()) => Ok(false),
-        Err(error)
-            if error
-                .downcast_ref::<StdoutWriteError>()
-                .is_some_and(|stdout| stdout.kind() == std::io::ErrorKind::BrokenPipe) =>
-        {
-            // The client is gone. Flush durable session state just like the
-            // stdin-EOF path, but do not infer terminal success from a closed
-            // response pipe.
-            if let Some(tracker) = tracker {
-                let _ = tracker.flush();
-            }
-            crate::tools::flush_response_cache();
-            Ok(true)
-        }
-        Err(error) => Err(error),
-    }
-}
-
-fn write_response(out: &mut impl Write, frame: &Frame) -> Result<(), anyhow::Error> {
-    let serialized = match frame {
-        Frame::Success(r) => serde_json::to_string(r)?,
-        Frame::Error(e) => serde_json::to_string(e)?,
-    };
-    write_stdout_frame(out, &serialized)?;
-    Ok(())
-}
-
+#[cfg(test)]
 fn dispatch_method(
     store: &GraphStore,
     tantivy: Option<&TantivyIndex>,
     req: &protocol::Request,
     tracker: Option<&nestweaver_engine::InteractionTracker>,
 ) -> Frame {
-    let id = req.id.clone().unwrap_or(Value::Null);
+    dispatch_method_cancellable(store, tantivy, req, tracker, None)
+}
 
+fn dispatch_method_cancellable(
+    store: &GraphStore,
+    tantivy: Option<&TantivyIndex>,
+    req: &protocol::Request,
+    tracker: Option<&nestweaver_engine::InteractionTracker>,
+    cancel: Option<&session::CancelFlag>,
+) -> Frame {
+    let id = req.id.clone().unwrap_or(Value::Null);
+    if let Err(message) = protocol::validate_method_params(req) {
+        return Frame::Error(error(id, error_code::INVALID_PARAMS, message));
+    }
     match req.method.as_str() {
         "initialize" => Frame::Success(success(
             id,
@@ -850,7 +600,15 @@ fn dispatch_method(
             // loop and killing the whole session (mirrors the HTTP path, which
             // maps a dispatch panic to an isError result via spawn_blocking).
             let dispatched = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                tools::dispatch(store, tantivy, &name, arguments.clone(), None)
+                tools::dispatch_cancellable(
+                    store,
+                    tantivy,
+                    &name,
+                    arguments.clone(),
+                    None,
+                    cancel,
+                    None,
+                )
             }));
             match dispatched {
                 Ok(Ok(result)) => {
@@ -1062,7 +820,11 @@ mod tests {
     #[test]
     fn initialize_returns_capabilities_and_server_info() {
         let store = GraphStore::in_memory().unwrap();
-        let req = make_request("initialize", 1, json!({}));
+        let req = make_request(
+            "initialize",
+            1,
+            json!({"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1"}}),
+        );
         let frame = dispatch_method(&store, None, &req, None);
         match frame {
             Frame::Success(resp) => {
@@ -1229,7 +991,7 @@ mod tests {
                 "jsonrpc": "2.0",
                 "id": 1,
                 "method": "initialize",
-                "params": { "protocolVersion": "2024-11-05" }
+                "params": {"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1"}}
             },
             {
                 "jsonrpc": "2.0",
@@ -1266,7 +1028,7 @@ mod tests {
         // implements this.
         let store = GraphStore::in_memory().unwrap();
         let mixed = serde_json::json!([
-            {"jsonrpc": "2.0", "id": 7, "method": "initialize", "params": {}},
+            {"jsonrpc": "2.0", "id": 7, "method": "initialize", "params": {"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1"}}},
             {"jsonrpc": "2.0",          "method": "notifications/initialized"}
         ]);
         let arr = mixed.as_array().unwrap();

--- a/crates/nestweaver-mcp/src/protocol.rs
+++ b/crates/nestweaver-mcp/src/protocol.rs
@@ -42,11 +42,14 @@ pub fn validate_request(value: Value) -> Result<Request, InvalidRequest> {
     // a legal correlation ID, while a boolean/array/object ID must answer null.
     let id = match object.remove("id") {
         None => None,
-        Some(value @ (Value::Null | Value::String(_) | Value::Number(_))) => Some(value),
+        Some(value @ (Value::Null | Value::String(_))) => Some(value),
+        Some(Value::Number(number)) if number.is_i64() || number.is_u64() => {
+            Some(Value::Number(number))
+        }
         Some(_) => {
             return Err(InvalidRequest {
                 response_id: Value::Null,
-                message: "JSON-RPC request id must be a string, number, or null".to_string(),
+                message: "JSON-RPC request id must be a string, null, or an integer in -9223372036854775808..=18446744073709551615; floating-point, exponent and out-of-range numeric IDs are not accepted".to_string(),
             });
         }
     };
@@ -92,12 +95,107 @@ pub fn validate_request(value: Value) -> Result<Request, InvalidRequest> {
             });
         }
     };
+    // A tools/call is a request, never a notification. Reject before any
+    // transport can dispatch it: response suppression is not write prevention.
+    if method == "tools/call" && id.is_none() {
+        return Err(InvalidRequest {
+            response_id: Value::Null,
+            message: "tools/call requires a correlated request id".to_string(),
+        });
+    }
     Ok(Request {
         jsonrpc,
         id,
         method,
         params,
     })
+}
+
+/// Validate MCP method parameters after envelope validation. All transports
+/// use this same contract and report failures as INVALID_PARAMS, not tool errors.
+/// `params: null` remains equivalent to omission for argument-less methods.
+pub fn validate_method_params(req: &Request) -> Result<(), String> {
+    let allowed: &[&str] = match req.method.as_str() {
+        "initialize" => &["protocolVersion", "capabilities", "clientInfo", "_meta"],
+        "ping" | "notifications/initialized" | "initialized" => &["_meta"],
+        "tools/list" => &["cursor", "_meta"],
+        "tools/call" => &["name", "arguments", "_meta"],
+        "notifications/cancelled" => &["requestId", "reason", "_meta"],
+        _ => return Ok(()),
+    };
+    let object = match req.params.as_ref() {
+        None => None,
+        Some(Value::Object(object)) => Some(object),
+        Some(_) => return Err(format!("{} params must be an object", req.method)),
+    };
+    if let Some(object) = object {
+        for key in object.keys() {
+            if !allowed.contains(&key.as_str()) {
+                return Err(format!("{}: unknown parameter '{key}'", req.method));
+            }
+        }
+        if object.get("_meta").is_some_and(|value| !value.is_object()) {
+            return Err(format!("{}: '_meta' must be an object", req.method));
+        }
+    }
+    let get = |key: &str| object.and_then(|object| object.get(key));
+    let nonempty_string = |value: Option<&Value>| {
+        value
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.is_empty())
+    };
+    match req.method.as_str() {
+        "initialize" => {
+            if !get("protocolVersion").is_some_and(Value::is_string) {
+                return Err("initialize: 'protocolVersion' must be a string".into());
+            }
+            if !get("capabilities").is_some_and(Value::is_object) {
+                return Err("initialize: 'capabilities' must be an object".into());
+            }
+            let info = get("clientInfo").and_then(Value::as_object);
+            if !info
+                .and_then(|info| info.get("name"))
+                .is_some_and(Value::is_string)
+                || !info
+                    .and_then(|info| info.get("version"))
+                    .is_some_and(Value::is_string)
+            {
+                return Err("initialize: 'clientInfo' requires string name and version".into());
+            }
+        }
+        "tools/list" if get("cursor").is_some_and(|value| !value.is_string()) => {
+            return Err("tools/list: 'cursor' must be a string".into());
+        }
+        "tools/call" => {
+            if !nonempty_string(get("name")) {
+                return Err("tools/call: 'name' must be a nonempty string".into());
+            }
+            if get("arguments").is_some_and(|value| !value.is_object()) {
+                return Err("tools/call: 'arguments' must be an object".into());
+            }
+        }
+        "notifications/cancelled" => {
+            if req.id.is_some() {
+                return Err("notifications/cancelled must not carry a request id".into());
+            }
+            let valid = match get("requestId") {
+                Some(Value::String(_)) => true,
+                Some(Value::Number(number)) => number.is_i64() || number.is_u64(),
+                _ => false,
+            };
+            if !valid {
+                return Err(
+                    "notifications/cancelled: 'requestId' must be a string or lossless integer"
+                        .into(),
+                );
+            }
+            if get("reason").is_some_and(|value| !value.is_string()) {
+                return Err("notifications/cancelled: 'reason' must be a string".into());
+            }
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 impl std::fmt::Display for InvalidRequest {
@@ -253,7 +351,8 @@ mod request_validation_tests {
             json!("request-1"),
             json!(0),
             json!(-1),
-            json!(1.5),
+            json!(i64::MIN),
+            json!(u64::MAX),
             Value::Null,
         ] {
             let request = parse(json!({"jsonrpc": "2.0", "id": id, "method": "ping"})).unwrap();
@@ -267,5 +366,69 @@ mod request_validation_tests {
         }))
         .unwrap();
         assert_eq!(explicit_null_params.params, None);
+    }
+    #[test]
+    fn numeric_id_bounds_are_checked_before_rounding_can_escape() {
+        for token in [
+            "1234567890123456789012345678901234567890",
+            "18446744073709551616",
+            "-9223372036854775809",
+            "1.5",
+            "1e2",
+            "1.0",
+        ] {
+            let raw = format!(r#"{{"jsonrpc":"2.0","id":{token},"method":"ping"}}"#);
+            let error = validate_request(serde_json::from_str(&raw).unwrap()).unwrap_err();
+            assert_eq!(error.response_id, Value::Null, "{token}");
+        }
+    }
+
+    #[test]
+    fn tool_calls_require_ids_but_null_remains_a_correlated_request() {
+        assert!(
+            validate_request(
+                json!({"jsonrpc":"2.0","method":"tools/call","params":{"name":"set_extension"}})
+            )
+            .is_err()
+        );
+        assert!(validate_request(json!({"jsonrpc":"2.0","id":null,"method":"tools/call","params":{"name":"brain_status"}})).is_ok());
+        assert!(
+            validate_request(json!({"jsonrpc":"2.0","method":"notifications/initialized"})).is_ok()
+        );
+    }
+
+    #[test]
+    fn method_params_reject_wrong_shapes_and_keep_client_metadata() {
+        for (method, params) in [
+            ("initialize", json!([])),
+            ("initialize", json!({})),
+            ("ping", json!([])),
+            ("ping", json!({"unexpected":true})),
+            ("tools/list", json!({"cursor":7})),
+            ("tools/call", json!({"name":"brain_status","arguments":[]})),
+        ] {
+            let req =
+                validate_request(json!({"jsonrpc":"2.0","id":1,"method":method,"params":params}))
+                    .unwrap();
+            assert!(validate_method_params(&req).is_err(), "{method}");
+        }
+        for (method, params) in [
+            (
+                "initialize",
+                json!({"protocolVersion":"2024-11-05","capabilities":{"experimental":{}},"clientInfo":{"name":"client","version":"1","title":"Client"},"_meta":{}}),
+            ),
+            ("ping", Value::Null),
+            ("ping", json!({"_meta":{}})),
+            ("tools/list", json!({"cursor":"next","_meta":{}})),
+            (
+                "tools/call",
+                json!({"name":"brain_status","arguments":{},"_meta":{"progressToken":1}}),
+            ),
+        ] {
+            let req =
+                validate_request(json!({"jsonrpc":"2.0","id":1,"method":method,"params":params}))
+                    .unwrap();
+            validate_method_params(&req).unwrap();
+        }
     }
 }

--- a/crates/nestweaver-mcp/src/session.rs
+++ b/crates/nestweaver-mcp/src/session.rs
@@ -1,0 +1,476 @@
+//! Stdio frame ingestion stays live while one serialized dispatch owns its work.
+//! Only ingestion moves to a thread; dispatch stays on the caller's thread so
+//! database/config/allowlist thread-local bindings cannot disappear. Cancellation
+//! is cooperative: a cancelled response is suppressed, but an admitted mutation
+//! is retained until its worker actually finishes. No blocking worker is aborted.
+use crate::protocol::{self, Request, error_code};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::io::{BufRead, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, mpsc};
+
+pub type CancelFlag = Arc<AtomicBool>;
+const MAX_PENDING_REQUESTS: usize = 128;
+type Pending = Arc<Mutex<HashMap<String, CancelFlag>>>;
+
+struct CancelOnReaderFailure {
+    pending: Pending,
+    clean_eof: bool,
+}
+impl Drop for CancelOnReaderFailure {
+    fn drop(&mut self) {
+        if !self.clean_eof {
+            for flag in self
+                .pending
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner())
+                .values()
+            {
+                flag.store(true, Ordering::Release);
+            }
+        }
+    }
+}
+
+enum Item {
+    Reply(Value),
+    Dispatch(Request, CancelFlag),
+}
+struct Envelope {
+    batch: bool,
+    items: Vec<Item>,
+}
+
+fn failure(id: Value, code: i32, message: impl Into<String>) -> Value {
+    json!({"jsonrpc":"2.0", "id":id, "error":{"code":code,"message":message.into()}})
+}
+fn key(id: &Value) -> String {
+    // Envelope validation restricts numbers to lossless integers. Serialization
+    // distinguishes string IDs from numbers, and never rounds the latter.
+    id.to_string()
+}
+fn write<W: Write>(writer: &Mutex<W>, value: &Value) -> std::io::Result<()> {
+    let mut writer = writer.lock().unwrap_or_else(|poison| poison.into_inner());
+    let serialized = serde_json::to_string(value)?;
+    crate::write_stdout_frame(&mut *writer, &serialized).map_err(|error| error.0)
+}
+
+fn admit(value: Value, pending: &Pending) -> Option<Item> {
+    let req = match protocol::validate_request(value) {
+        Ok(req) => req,
+        Err(error) => {
+            return Some(Item::Reply(failure(
+                error.response_id,
+                error_code::INVALID_REQUEST,
+                error.message,
+            )));
+        }
+    };
+    if let Err(message) = protocol::validate_method_params(&req) {
+        return req
+            .id
+            .map(|id| Item::Reply(failure(id, error_code::INVALID_PARAMS, message)));
+    }
+    if req.method == "notifications/cancelled" {
+        if let Some(id) = req
+            .params
+            .as_ref()
+            .and_then(|params| params.get("requestId"))
+            && let Some(cancel) = pending
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner())
+                .get(&key(id))
+        {
+            cancel.store(true, Ordering::Release);
+        }
+        return None;
+    }
+    // Supported notifications have no dispatch side effects. tools/call without
+    // an ID was rejected above; unknown notifications are safely ignored.
+    let id = req.id.as_ref()?;
+    let mut active = pending.lock().unwrap_or_else(|poison| poison.into_inner());
+    let id_key = key(id);
+    if active.contains_key(&id_key) {
+        return Some(Item::Reply(failure(
+            id.clone(),
+            error_code::INVALID_REQUEST,
+            "request id is already in flight",
+        )));
+    }
+    if req.method == "ping" {
+        return Some(Item::Reply(json!({"jsonrpc":"2.0","id":id,"result":{}})));
+    }
+    if active.len() >= MAX_PENDING_REQUESTS {
+        // Never block the reader on a full work queue: doing so would put
+        // cancellation back behind the very work it must be able to cancel.
+        return Some(Item::Reply(failure(
+            id.clone(),
+            error_code::INVALID_REQUEST,
+            "too many pending requests; retry after an in-flight request completes",
+        )));
+    }
+    let cancel = Arc::new(AtomicBool::new(false));
+    active.insert(id_key, cancel.clone());
+    Some(Item::Dispatch(req, cancel))
+}
+
+/// Serve stdio with independent control-frame ingestion. The dispatch closure
+/// runs serially on THIS thread, and receives a flag for both active and queued
+/// cancellation. Pass it to direct cooperative reads or `await_cancellable` for
+/// read RPCs. Mutation RPCs must keep awaiting their retained daemon worker.
+pub fn run_stdio(dispatch: impl FnMut(&Request, &CancelFlag) -> Value) -> anyhow::Result<()> {
+    run_with_io(
+        std::io::BufReader::new(std::io::stdin()),
+        std::io::stdout(),
+        dispatch,
+    )
+}
+
+/// Injectable I/O seam for deterministic wire tests, without a real database.
+pub fn run_with_io<R, W>(
+    reader: R,
+    writer: W,
+    mut dispatch: impl FnMut(&Request, &CancelFlag) -> Value,
+) -> anyhow::Result<()>
+where
+    R: BufRead + Send + 'static,
+    W: Write + Send + 'static,
+{
+    let pending: Pending = Arc::new(Mutex::new(HashMap::new()));
+    let output = Arc::new(Mutex::new(writer));
+    let (sender, receiver) = mpsc::channel::<Result<Envelope, std::io::Error>>();
+    let reader_pending = pending.clone();
+    let reader_output = output.clone();
+    // A detached stdin reader must not be joined on a broken stdout: stdin may
+    // remain open forever after the client closes its response pipe. It exits
+    // naturally on EOF or when the receiver disappears. It owns no store/worker.
+    std::thread::spawn(move || {
+        let mut failure_guard = CancelOnReaderFailure {
+            pending: reader_pending.clone(),
+            clean_eof: false,
+        };
+        for line in reader.lines() {
+            let line = match line {
+                Ok(line) => line,
+                Err(error) => {
+                    let _ = sender.send(Err(error));
+                    return;
+                }
+            };
+            if line.trim().is_empty() {
+                continue;
+            }
+            let parsed: Value = match serde_json::from_str(&line) {
+                Ok(value) => value,
+                Err(error) => {
+                    if write(
+                        &reader_output,
+                        &failure(
+                            Value::Null,
+                            error_code::PARSE_ERROR,
+                            format!("invalid JSON: {error}"),
+                        ),
+                    )
+                    .is_err()
+                    {
+                        return;
+                    }
+                    continue;
+                }
+            };
+            let (batch, values) = match parsed {
+                Value::Array(values) if values.is_empty() => {
+                    if write(
+                        &reader_output,
+                        &failure(
+                            Value::Null,
+                            error_code::INVALID_REQUEST,
+                            "empty batch array",
+                        ),
+                    )
+                    .is_err()
+                    {
+                        return;
+                    }
+                    continue;
+                }
+                Value::Array(values) => (true, values),
+                value => (false, vec![value]),
+            };
+            let mut items = Vec::new();
+            for value in values {
+                if let Some(item) = admit(value, &reader_pending) {
+                    items.push(item);
+                }
+            }
+            if items.is_empty() {
+                continue;
+            }
+            // Invalid-only and control-only batches bypass the work queue too.
+            // Every queued envelope therefore owns at least one of the bounded
+            // pending dispatch slots; malformed traffic cannot queue endlessly.
+            if items.iter().all(|item| matches!(item, Item::Reply(_))) {
+                let values: Vec<_> = items
+                    .into_iter()
+                    .map(|item| match item {
+                        Item::Reply(value) => value,
+                        _ => unreachable!(),
+                    })
+                    .collect();
+                let value = if batch {
+                    Value::Array(values)
+                } else {
+                    values.into_iter().next().unwrap()
+                };
+                if write(&reader_output, &value).is_err() {
+                    return;
+                }
+                continue;
+            }
+            if sender.send(Ok(Envelope { batch, items })).is_err() {
+                return;
+            }
+        }
+        // EOF means the client finished sending requests, not that it stopped
+        // waiting for their responses. Drain the already received requests.
+        failure_guard.clean_eof = true;
+    });
+    for envelope in receiver {
+        let envelope = envelope?;
+        let mut responses = Vec::new();
+        for item in envelope.items {
+            match item {
+                Item::Reply(value) => responses.push(value),
+                Item::Dispatch(req, cancel) => {
+                    // Cancelled queued requests have never been admitted to a
+                    // mutation worker and therefore must never be dispatched.
+                    let response = if cancel.load(Ordering::Acquire) {
+                        None
+                    } else {
+                        Some(dispatch(&req, &cancel))
+                    };
+                    let mut active = pending.lock().unwrap_or_else(|poison| poison.into_inner());
+                    active.remove(&key(req.id.as_ref().expect("admission requires ID")));
+                    if !cancel.load(Ordering::Acquire)
+                        && let Some(response) = response
+                    {
+                        responses.push(response);
+                    }
+                }
+            }
+        }
+        if responses.is_empty() {
+            continue;
+        }
+        let value = if envelope.batch {
+            Value::Array(responses)
+        } else {
+            responses.remove(0)
+        };
+        if let Err(error) = write(&output, &value) {
+            for flag in pending
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner())
+                .values()
+            {
+                flag.store(true, Ordering::Release);
+            }
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::BrokenPipe | std::io::ErrorKind::ConnectionReset
+            ) {
+                return Ok(());
+            }
+            return Err(error.into());
+        }
+    }
+    Ok(())
+}
+
+/// Drop a cancelled READ future so the remote handler observes disconnect and
+/// signals its cooperative worker. Do not use for mutation dispatch: dropping a
+/// future cannot abort spawn_blocking or undo an already committed write.
+pub async fn await_cancellable<T>(
+    cancel: Option<&CancelFlag>,
+    future: impl std::future::Future<Output = anyhow::Result<T>>,
+) -> anyhow::Result<T> {
+    let Some(cancel) = cancel else {
+        return future.await;
+    };
+    tokio::pin!(future);
+    loop {
+        if cancel.load(Ordering::Acquire) {
+            anyhow::bail!("request cancelled");
+        }
+        tokio::select! {
+            result = &mut future => return result,
+            _ = tokio::time::sleep(std::time::Duration::from_millis(10)) => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    struct FrameWriter {
+        sender: mpsc::Sender<Value>,
+        buffer: Vec<u8>,
+    }
+    impl Write for FrameWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.buffer.extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            if !self.buffer.is_empty() {
+                self.sender
+                    .send(serde_json::from_slice(&self.buffer).unwrap())
+                    .unwrap();
+                self.buffer.clear();
+            }
+            Ok(())
+        }
+    }
+    fn writer() -> (FrameWriter, mpsc::Receiver<Value>) {
+        let (sender, receiver) = mpsc::channel();
+        (
+            FrameWriter {
+                sender,
+                buffer: Vec::new(),
+            },
+            receiver,
+        )
+    }
+
+    #[test]
+    fn no_id_mutations_and_invalid_params_never_reach_dispatch_in_batches() {
+        let (writer, output) = writer();
+        let input = json!([
+            {"jsonrpc":"2.0","method":"tools/call","params":{"name":"set_extension","arguments":{}}},
+            {"jsonrpc":"2.0","id":2,"method":"initialize","params":[]},
+            {"jsonrpc":"2.0","method":"notifications/initialized"},
+            {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"brain_status"}}
+        ]).to_string();
+        let mut dispatched = Vec::new();
+        run_with_io(std::io::Cursor::new(input), writer, |req, _| {
+            dispatched.push(req.id.clone());
+            json!({"jsonrpc":"2.0","id":req.id,"result":{}})
+        })
+        .unwrap();
+        assert_eq!(dispatched, vec![Some(json!(3))]);
+        let batch = output.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert_eq!(batch[0]["error"]["code"], -32600);
+        assert_eq!(batch[1]["error"]["code"], -32602);
+        assert_eq!(batch[2]["id"], 3);
+    }
+
+    #[test]
+    fn session_preserves_line_separator_wire_framing() {
+        struct Bytes(Arc<Mutex<Vec<u8>>>);
+        impl Write for Bytes {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        let bytes = Arc::new(Mutex::new(Vec::new()));
+        let input =
+            json!({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"note_get"}})
+                .to_string();
+        run_with_io(std::io::Cursor::new(input), Bytes(bytes.clone()), |_, _| json!({"jsonrpc":"2.0","id":1,"result":{"body":"before\u{2028}middle\u{2029}after"}})).unwrap();
+        let wire = String::from_utf8(bytes.lock().unwrap().clone()).unwrap();
+        assert!(!wire.contains(['\u{2028}', '\u{2029}']));
+        let parsed: Value = serde_json::from_str(&wire).unwrap();
+        assert_eq!(
+            parsed["result"]["body"],
+            "before\u{2028}middle\u{2029}after"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cancellation_and_ping_are_ingested_while_admitted_worker_stays_owned() {
+        let (mut client, server) = std::os::unix::net::UnixStream::pair().unwrap();
+        let (writer, output) = writer();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (finished_tx, finished_rx) = mpsc::channel();
+        let thread = std::thread::spawn(move || {
+            run_with_io(std::io::BufReader::new(server), writer, |req, cancel| {
+                assert_eq!(
+                    req.id,
+                    Some(json!("active")),
+                    "cancelled queued mutation was dispatched"
+                );
+                started_tx.send(()).unwrap();
+                // Models a retained mutation: cancellation must not release its
+                // ownership or claim to have aborted this blocking worker.
+                release_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+                assert!(cancel.load(Ordering::Acquire));
+                finished_tx.send(()).unwrap();
+                json!({"jsonrpc":"2.0","id":req.id,"result":{"committed":true}})
+            })
+            .unwrap();
+        });
+        writeln!(client, "{}", json!({"jsonrpc":"2.0","id":"active","method":"tools/call","params":{"name":"set_extension"}})).unwrap();
+        started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        for value in [
+            json!({"jsonrpc":"2.0","id":"queued","method":"tools/call","params":{"name":"set_extension"}}),
+            json!({"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":"queued"}}),
+            json!({"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":"active"}}),
+            json!({"jsonrpc":"2.0","id":"control","method":"ping"}),
+        ] {
+            writeln!(client, "{value}").unwrap();
+        }
+        let response = output.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert_eq!(response["id"], "control", "ping waited for worker release");
+        assert!(
+            matches!(finished_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
+            "cancellation released retained worker"
+        );
+        release_tx.send(()).unwrap();
+        drop(client);
+        thread.join().unwrap();
+        finished_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert!(
+            output.try_recv().is_err(),
+            "cancelled request emitted a late response"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_read_drops_the_rpc_future() {
+        struct Dropped(Arc<AtomicBool>);
+        impl Drop for Dropped {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::Release);
+            }
+        }
+        let dropped = Arc::new(AtomicBool::new(false));
+        let marker = Dropped(dropped.clone());
+        let cancel = Arc::new(AtomicBool::new(false));
+        let flag = cancel.clone();
+        let (started, waiting) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            waiting.await.unwrap();
+            flag.store(true, Ordering::Release);
+        });
+        let result = await_cancellable(Some(&cancel), async move {
+            let _marker = marker;
+            started.send(()).unwrap();
+            std::future::pending::<anyhow::Result<()>>().await
+        })
+        .await;
+        assert!(result.unwrap_err().to_string().contains("cancelled"));
+        assert!(
+            dropped.load(Ordering::Acquire),
+            "cancel only abandoned a handle, not its RPC future"
+        );
+    }
+}

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -4967,6 +4967,10 @@ fn tool_schema_brain_context() -> Value {
                     "items": { "type": "string", "minLength": 1 },
                     "description": "One or more seed strings to anchor the PPR walk. Accepts note titles, tag names (with or without #), symbol names, free-text terms, or UIDs (sym:/note:/head:/sec:/tag:)."
                 },
+                "limit": {
+                    "type": "integer", "minimum": 1, "maximum": 1000,
+                    "description": "Optional maximum connected result count, enforced together with token_budget. Defaults to the configured result limit when set."
+                },
                 "token_budget": {
                     "type": "integer",
                     "minimum": 1,
@@ -5575,7 +5579,29 @@ fn tool_brain_context(
 
     let concise = is_concise(&args);
 
-    let (cut, used_tokens) = budgeted_cut(&result.connected, token_budget, concise);
+    let count_limit = if args.get("limit").is_some() {
+        Some(read_limit(
+            &args,
+            "limit",
+            configured_result_limit(),
+            1,
+            RESULT_LIMIT_MAX,
+        )?)
+    } else {
+        current_instance_config().and_then(|cfg| cfg.limits.default_result_limit)
+    };
+    let (budget_cut, _) = budgeted_cut(&result.connected, token_budget, concise);
+    let (cut, truncated_by) = nestweaver_engine::compose_result_caps(
+        result.connected.len(),
+        count_limit,
+        Some(budget_cut),
+    );
+    let used_tokens: usize = result
+        .connected
+        .iter()
+        .take(cut)
+        .map(|node| render_cost(node, concise))
+        .sum();
 
     let connected_json: Vec<Value> = result
         .connected
@@ -5619,12 +5645,6 @@ fn tool_brain_context(
     let total = result.connected.len();
     let returned = connected_json.len();
     let truncated = returned < total;
-    // `token_budget` is this tool's only cap on `connected`, so only the
-    // budget branch of `resolve` is reachable here. Called anyway, exactly as
-    // `code_context` does: the precedence rule lives in ONE place even where
-    // one branch of it cannot fire, because a second copy is how the human and
-    // machine routes came to disagree in the first place.
-    let truncated_by = nestweaver_engine::TruncationCause::resolve(truncated, false);
     let mut resp = json!({
         "seeds_expanded": result.seeds.len(),
         // nw-393. The SEED cap, one layer upstream of the connected-list
@@ -5659,6 +5679,7 @@ fn tool_brain_context(
         "truncated_by": truncated_by.map(nestweaver_engine::TruncationCause::as_str),
         "tokens_used": used_tokens,
         "token_budget": token_budget,
+        "limit": count_limit,
         "semantic_applied": result.semantic_applied,
         "degraded_components": &result.degraded_components,
     });
@@ -11505,7 +11526,7 @@ fn tool_brain_diff(
 fn tool_schema_project_context() -> Value {
     json!({
         "name": "project_context",
-        "description": "Retrieve context for a named project: notes, symbols, and sections ranked by PPR within the project's subgraph, bounded by token budget.\n\nGuidelines:\n- Use when you know the project name — for ad-hoc topics use brain_context with seeds instead\n- Returns a CONCISE orientation by default (~1000 tokens: kind/title/location per node); pass response_format:'detailed' for full metadata (uid + relevance, ~3000 tokens)\n- Narrow with repos, path_prefix, tags/exclude_tags, kinds, since, recency_weight — carry the same filter names over to brain_context when drilling in\n- For composite projects, include_components pulls in sub-project content\n\nLimitations:\n- Requires projects to be defined in the graph (via vault taxonomy or instance config)\n- If you don't know the project name, use brain_search to find it first\n- May fail with 'index publication TRANSIENT/WEDGED' while an index is being published. This refers to INDEX PUBLICATION, not a dirty git working tree: editing files in a repo does NOT cause it, and NestWeaver is fully usable while you work. TRANSIENT resolves on its own — retry. WEDGED means a prior indexer died mid-publication; ASK THE OPERATOR to run the `nestweaver repair` command named in the error — repair is a destructive publication recovery with no MCP tool, so it cannot be done from here — or check brain_status.index_publication.",
+        "description": "Retrieve context for a named project: notes, symbols, and sections ranked by PPR within strict project membership, bounded by token budget. Each result reports in_project, source_project, and membership_basis; linked foreign content is excluded.\n\nGuidelines:\n- Use when you know the project name — for ad-hoc topics use brain_context with seeds instead\n- Returns a CONCISE orientation by default (~1000 tokens: kind/title/location per node); pass response_format:'detailed' for full metadata (uid + relevance, ~3000 tokens)\n- Narrow with repos, path_prefix, tags/exclude_tags, kinds, since, recency_weight — carry the same filter names over to brain_context when drilling in\n- For composite projects, include_components pulls in sub-project content\n\nLimitations:\n- Requires projects to be defined in the graph (via vault taxonomy or instance config)\n- If you don't know the project name, use brain_search to find it first\n- May fail with 'index publication TRANSIENT/WEDGED' while an index is being published. This refers to INDEX PUBLICATION, not a dirty git working tree: editing files in a repo does NOT cause it, and NestWeaver is fully usable while you work. TRANSIENT resolves on its own — retry. WEDGED means a prior indexer died mid-publication; ASK THE OPERATOR to run the `nestweaver repair` command named in the error — repair is a destructive publication recovery with no MCP tool, so it cannot be done from here — or check brain_status.index_publication.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -11588,6 +11609,20 @@ fn tool_schema_project_context() -> Value {
             "additionalProperties": false
         }
     })
+}
+
+/// Attribute child nodes by the UID grammar; paths and title matches are not membership.
+fn project_member_uid(uid: &str, members: &std::collections::HashSet<String>) -> bool {
+    if members.contains(uid) {
+        return true;
+    }
+    if let Some(note) = nestweaver_schema::uid::note_uid_of_heading(uid) {
+        return members.contains(note);
+    }
+    uid.strip_prefix("sec:")
+        .and_then(|rest| rest.rsplit_once(':'))
+        .and_then(|(without_hash, _)| without_hash.rsplit_once(':'))
+        .is_some_and(|(note, _)| members.contains(note))
 }
 
 fn tool_project_context(
@@ -11707,6 +11742,11 @@ fn tool_project_context(
         .list_project_symbol_uids(&project.uid)
         .map_err(|e| anyhow!("list_project_symbol_uids: {e}"))?;
     member_uids.extend(sym_uids);
+    let mut member_sources: std::collections::HashMap<String, String> = member_uids
+        .iter()
+        .map(|uid| (uid.clone(), project.uid.clone()))
+        .collect();
+    member_sources.insert(project.uid.clone(), project.uid.clone());
 
     // 3. If include_components, also collect note/symbol UIDs from each component project.
     let component_uids = if include_components {
@@ -11717,14 +11757,25 @@ fn tool_project_context(
         vec![]
     };
     for comp_uid in &component_uids {
+        member_sources.insert(comp_uid.clone(), comp_uid.clone());
         let comp_notes = store
             .list_project_note_uids(comp_uid)
             .map_err(|e| anyhow!("list_project_note_uids: {e}"))?;
+        for uid in &comp_notes {
+            member_sources
+                .entry(uid.clone())
+                .or_insert_with(|| comp_uid.clone());
+        }
         member_note_uids.extend(comp_notes.iter().cloned());
         member_uids.extend(comp_notes);
         let comp_syms = store
             .list_project_symbol_uids(comp_uid)
             .map_err(|e| anyhow!("list_project_symbol_uids: {e}"))?;
+        for uid in &comp_syms {
+            member_sources
+                .entry(uid.clone())
+                .or_insert_with(|| comp_uid.clone());
+        }
         member_uids.extend(comp_syms);
     }
 
@@ -11779,7 +11830,7 @@ fn tool_project_context(
     }
 
     let mut ppr_seeds: Vec<String> = vec![project.uid.clone()];
-    ppr_seeds.extend(component_uids);
+    ppr_seeds.extend(component_uids.iter().cloned());
     ppr_seeds.extend(member_note_uids.iter().cloned());
     ppr_seeds.extend(member_symbol_uids.iter().cloned());
 
@@ -11846,6 +11897,19 @@ fn tool_project_context(
     //       Heading is redundant; notes-heavy projects spend ~25% of a
     //       2000-token budget on these duplicates without this trim.
     nestweaver_engine::dedup_heading_section_pairs(&mut result);
+
+    // Membership is a boundary, not merely a ranking preference. Filter
+    // before counting or spending the budget, including promoted seeds.
+    {
+        let mut admitted: std::collections::HashSet<String> = member_uids.iter().cloned().collect();
+        admitted.insert(project.uid.clone());
+        admitted.extend(component_uids.iter().cloned());
+        let retain = |nodes: &mut Vec<nestweaver_engine::BrainNode>| {
+            nodes.retain(|node| project_member_uid(&node.uid, &admitted));
+        };
+        retain(&mut result.seeds);
+        retain(&mut result.connected);
+    }
 
     // 4c. Post-PPR scope boost: multiply relevance for nodes that belong
     //     to the project (member UIDs are the authoritative membership signal).
@@ -12038,7 +12102,7 @@ fn tool_project_context(
     // concise drops the machine id (uid) and the relevance score in favor of the semantic
     // fields an agent orients with (kind/title/location); detailed keeps the full record.
     let render_node = |n: &nestweaver_engine::BrainNode| -> Value {
-        if concise {
+        let mut row = if concise {
             json!({
                 "kind": n.kind,
                 "title": n.title,
@@ -12052,7 +12116,34 @@ fn tool_project_context(
                 "location": n.location,
                 "relevance": n.relevance,
             })
-        }
+        };
+        let parent_note = nestweaver_schema::uid::note_uid_of_heading(&n.uid).or_else(|| {
+            n.uid
+                .strip_prefix("sec:")
+                .and_then(|rest| rest.rsplit_once(':'))
+                .and_then(|(rest, _)| rest.rsplit_once(':'))
+                .map(|(note, _)| note)
+        });
+        let source_project = member_sources
+            .get(&n.uid)
+            .or_else(|| parent_note.and_then(|note| member_sources.get(note)));
+        let basis = if n.uid == project.uid {
+            "project"
+        } else if component_uids.contains(&n.uid) {
+            "component"
+        } else if n.uid.starts_with("head:") {
+            "owned_heading"
+        } else if n.uid.starts_with("sec:") {
+            "owned_section"
+        } else if source_project == Some(&project.uid) {
+            "member"
+        } else {
+            "component_member"
+        };
+        row["in_project"] = json!(true);
+        row["source_project"] = json!(source_project);
+        row["membership_basis"] = json!(basis);
+        row
     };
 
     let mut connected_json: Vec<Value> =
@@ -14019,7 +14110,18 @@ pub fn dispatch_via_daemon(
     name: &str,
     args: serde_json::Value,
 ) -> Result<serde_json::Value, anyhow::Error> {
-    dispatch_via_daemon_inner(client, rt, name, args).map(provenance_seam::stamp)
+    dispatch_via_daemon_cancellable(client, rt, name, args, None)
+}
+
+#[cfg(feature = "daemon")]
+pub fn dispatch_via_daemon_cancellable(
+    client: &mut DaemonGrpcClient,
+    rt: &tokio::runtime::Runtime,
+    name: &str,
+    args: serde_json::Value,
+    cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
+) -> Result<serde_json::Value, anyhow::Error> {
+    dispatch_via_daemon_inner(client, rt, name, args, cancel).map(provenance_seam::stamp)
 }
 
 /// The daemon-route tool table. Returns [`Unstamped`] so that no arm — the
@@ -14032,6 +14134,7 @@ fn dispatch_via_daemon_inner(
     rt: &tokio::runtime::Runtime,
     name: &str,
     args: serde_json::Value,
+    cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
 ) -> Result<Unstamped, anyhow::Error> {
     use nestweaver_proto::JsonRequest;
 
@@ -14191,7 +14294,7 @@ fn dispatch_via_daemon_inner(
         |key: &str| -> bool { args.get(key).and_then(|v| v.as_bool()).unwrap_or(false) };
     let f64_field = |key: &str| -> f64 { args.get(key).and_then(|v| v.as_f64()).unwrap_or(0.0) };
 
-    let result_json: String = rt.block_on(async {
+    let request_future = async {
         match name {
             // ── Typed hot-path RPCs ──────────────────────────────────
             "brain_search" => {
@@ -14214,6 +14317,10 @@ fn dispatch_via_daemon_inner(
             "brain_context" => {
                 use nestweaver_proto::BrainContextRequest;
                 let req = tonic::Request::new(BrainContextRequest {
+                    limit: args
+                        .get("limit")
+                        .and_then(Value::as_u64)
+                        .and_then(|limit| u32::try_from(limit).ok()),
                     seeds: str_array("seeds"),
                     token_budget: i32_field("token_budget"),
                     response_format: str_field("response_format"),
@@ -14447,7 +14554,12 @@ fn dispatch_via_daemon_inner(
                 Ok(resp.into_inner().result_json)
             }
         }
-    })?;
+    };
+    let result_json: String = if crate::http::MUTATING_TOOLS.contains(&name) {
+        rt.block_on(request_future)?
+    } else {
+        rt.block_on(crate::session::await_cancellable(cancel, request_future))?
+    };
 
     serde_json::from_str(&result_json)
         .map(Unstamped::new)
@@ -15468,32 +15580,36 @@ mod project_context_bug12_tests {
     // land in `seeds`, disjoint from the rendered `connected` list — and must
     // be promoted into `connected`. This guards the wiring at the call site:
     // removing the promote step leaves notes in `seeds` only and fails here.
-    /// nw-305 / F-VAULT-6 — CHARACTERISATION, not a fix.
-    ///
-    /// `project_context` seeds a PPR walk from the project and its members,
-    /// multiplies member relevance by 5, sorts, and then fills the token budget
-    /// from whatever the walk reached. Every scope filter — `kinds`, `repos`,
-    /// `path_prefix`, `tags`, `exclude_tags`, `since` — is opt-in from `args`
-    /// and defaults to off, so NOTHING narrows the result back to the project.
-    /// This is a designed absence, not a scoring bug or a broken filter: the
-    /// boost is working (the members are ranked first), nothing removes the
-    /// rest.
-    ///
-    /// The test pins that behaviour deliberately rather than asserting "no
-    /// foreign notes", which would encode a design decision nobody has made —
-    /// and the two candidate fixes (disclose `in_project` / add a
-    /// `scope: "strict"` argument) want different assertions here.
-    ///
-    /// It also runs the measurement the ticket asks for. The ticket's framing
-    /// is "degrades when a project has FEW notes". The model that fits the code
-    /// is budget-driven: foreign nodes appear iff the budget buys more slots
-    /// than the project's own reachable mass fills, which makes the leak
-    /// UNIVERSAL rather than small-project-specific — every project hits it
-    /// once the budget outgrows it. Raising the budget on a fixed fixture
-    /// discriminates the two: under the budget model the foreign count rises,
-    /// under a similarity model it does not.
+    /// Project membership comes from exact graph ownership, including note children.
     #[test]
-    fn project_context_fills_budget_from_outside_the_project() {
+    fn project_membership_attributes_children_without_prefix_leakage() {
+        let note = "note:owner:v:scope.md";
+        let members = std::collections::HashSet::from([note.to_string(), "project:owner:p".into()]);
+        assert!(project_member_uid(note, &members));
+        assert!(project_member_uid(
+            &nestweaver_schema::uid::heading_uid(note, "intro", 2),
+            &members
+        ));
+        assert!(project_member_uid(
+            &nestweaver_schema::uid::section_uid(note, 3, "abcd"),
+            &members
+        ));
+        for foreign in ["note:owner:v:scope.md.backup", "note:foreign:v:scope.md"] {
+            assert!(!project_member_uid(foreign, &members));
+            assert!(!project_member_uid(
+                &nestweaver_schema::uid::heading_uid(foreign, "intro", 2),
+                &members
+            ));
+            assert!(!project_member_uid(
+                &nestweaver_schema::uid::section_uid(foreign, 3, "abcd"),
+                &members
+            ));
+        }
+        assert!(!project_member_uid("tag:shared", &members));
+    }
+
+    #[test]
+    fn project_context_never_fills_budget_from_outside_membership() {
         let store = GraphStore::in_memory().unwrap();
         store
             .insert_vault(&Vault {
@@ -15548,7 +15664,7 @@ mod project_context_bug12_tests {
                 .unwrap();
         }
         for (i, member) in members.iter().enumerate() {
-            let section_uid = format!("sec:{member}");
+            let section_uid = nestweaver_schema::uid::section_uid(member, 1, &format!("th-{i}"));
             store
                 .insert_section(&Section {
                     uid: section_uid.clone(),
@@ -15587,6 +15703,21 @@ mod project_context_bug12_tests {
                 None,
             )
             .unwrap();
+            if budget == 16_000 {
+                assert!(
+                    !resp["connected"].as_array().unwrap().is_empty(),
+                    "members remain visible"
+                );
+            }
+            for node in resp["connected"].as_array().unwrap() {
+                assert_eq!(node["in_project"], true, "{node}");
+                assert_eq!(node["source_project"], resp["project_uid"], "{node}");
+                assert!(node["membership_basis"].as_str().is_some(), "{node}");
+            }
+            assert_eq!(
+                resp["budget_exceeded"],
+                resp["tokens_used"].as_u64().unwrap() > budget as u64
+            );
             resp["connected"]
                 .as_array()
                 .expect("connected array")
@@ -15596,39 +15727,13 @@ mod project_context_bug12_tests {
                 .count()
         };
 
-        // The measured sweep on this fixture, which is the ticket's open
-        // question answered: foreign notes per token_budget =
-        //   100 -> 0, 200 -> 0, 400 -> 6, 800 -> 10, 1600 -> 10, 3200 -> 10,
-        //   16000 -> 10
-        // Zero while the budget is smaller than the project's own mass, then
-        // monotonically rising, then flat once the walk runs out of reachable
-        // foreign notes. That is a budget-fill signature, not a similarity one:
-        // no PPR-weight change can fix it, and it is not specific to small
-        // projects — it is what every project does once `token_budget` exceeds
-        // its in-project reachable mass.
-        let tight = foreign_count(200);
-        let roomy = foreign_count(800);
-
-        assert_eq!(
-            tight, 0,
-            "characterisation: a budget smaller than the project's own mass \
-             leaks nothing — the members fill it first"
-        );
-        assert!(
-            roomy > tight,
-            "characterisation: with no scope filter on by default, the surplus \
-             budget is filled from whatever the PPR walk reached, including \
-             notes belonging to no project (nw-305). Measured {tight} foreign \
-             at budget 200 and {roomy} at 800. Flip this assertion once the \
-             owner picks between `in_project` disclosure and a `scope` argument."
-        );
-        assert!(
-            foreign_count(16_000) >= roomy,
-            "the leak is BUDGET-driven, not similarity-driven: the foreign \
-             count must not SHRINK as the budget grows. If this ever inverts, \
-             the ticket's 'small projects leak' framing is right after all and \
-             the fix belongs in ranking rather than in scoping."
-        );
+        for budget in [1, 200, 800, 16_000] {
+            assert_eq!(
+                foreign_count(budget),
+                0,
+                "strict membership at budget {budget}"
+            );
+        }
     }
 
     #[test]
@@ -15918,6 +16023,51 @@ mod project_context_bug12_tests {
             with_model["_meta"]["answer_shaping"]["track_interactions"], true,
             "the [ranking] track_interactions input must be disclosed: {with_model}"
         );
+    }
+
+    #[test]
+    fn brain_context_enforces_both_caps_and_reports_binding_cause() {
+        set_current_instance_config(None);
+        let store = GraphStore::in_memory().unwrap();
+        let mut seeds = Vec::new();
+        for i in 0..10 {
+            let name = format!("CapFixture{i}");
+            store
+                .insert_symbol(&mk_symbol(
+                    &format!("sym:repo:t:abc:cap{i}"),
+                    "repo:t:abc",
+                    "src/cap.rs",
+                    &name,
+                ))
+                .unwrap();
+            seeds.push(name);
+        }
+        let query = |limit, budget| {
+            tool_brain_context(&store, None,
+            json!({"seeds": seeds, "limit": limit, "token_budget": budget, "response_format": "detailed"}),
+            None, None, None).unwrap()
+        };
+        let count = query(2, 16000);
+        assert_eq!(count["returned"], 2, "{count}");
+        assert!(count["total"].as_u64().unwrap() > 2, "{count}");
+        assert_eq!(count["truncated_by"], "limit");
+        let tokens = query(10, 1);
+        assert_eq!(tokens["returned"], 0, "{tokens}");
+        assert_eq!(tokens["tokens_used"], 0);
+        assert_eq!(tokens["truncated_by"], "token_budget");
+        for invalid in [0, 1001] {
+            assert!(
+                tool_brain_context(
+                    &store,
+                    None,
+                    json!({"seeds": seeds, "limit":invalid}),
+                    None,
+                    None,
+                    None
+                )
+                .is_err()
+            );
+        }
     }
 
     #[test]

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -15716,7 +15716,7 @@ mod project_context_bug12_tests {
             }
             assert_eq!(
                 resp["budget_exceeded"],
-                resp["tokens_used"].as_u64().unwrap() > budget as u64
+                resp["tokens_used"].as_u64().unwrap() > budget
             );
             resp["connected"]
                 .as_array()

--- a/crates/nestweaver-store/src/regex.rs
+++ b/crates/nestweaver-store/src/regex.rs
@@ -81,6 +81,12 @@ fn compile_pattern(pattern: &str) -> Result<regex::Regex, StoreError> {
         .map_err(|e| StoreError::Query(format!("invalid regex: {e}")))
 }
 
+/// Validate a caller's pattern before transport selection, using precisely
+/// the same input and compiled-program limits as graph queries.
+pub fn validate_pattern(pattern: &str) -> Result<(), StoreError> {
+    compile_pattern(pattern).map(|_| ())
+}
+
 /// File line of a frontmatter block's FIRST content line.
 ///
 /// Line 1 is the opening `---` fence, so the YAML itself starts at 2. The

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -193,6 +193,38 @@ The MCP HTTP listener inherits the `--bind` IP and is **gRPC port + 1** for fixe
 
 The MCP endpoint is **`POST /mcp`** on the HTTP port.
 
+### MCP request IDs and cancellation
+
+All MCP transports accept string IDs, explicit `null`, and integer numeric IDs
+in `-9223372036854775808..=18446744073709551615`. Floating-point and exponent
+notation, and integers outside that range, are rejected before dispatch with
+`-32600` and a null response ID. Use a string for larger identifiers. Accepted
+IDs are echoed without numeric conversion. `tools/call` requires an ID;
+omitting it never starts a tool or a mutation.
+
+Core method parameters are validated separately from tool arguments.
+`initialize` requires `protocolVersion`, an object `capabilities`, and
+`clientInfo` with string `name` and `version`. `ping` and `tools/list` accept
+omitted or null parameters; when present, parameters must be an object.
+`tools/list.cursor` must be a string. Client `_meta` objects are accepted.
+Malformed method parameters return `-32602`.
+
+Send `notifications/cancelled` with `params.requestId` to cancel an in-flight
+request. Stdio continues reading cancellation and ping frames while tool work
+runs. Cancelled queued tools never start; active reads stop cooperatively and
+their responses are suppressed. A dispatch that does not check cancellation
+may take longer to finish. An admitted mutation retains its worker and write
+ownership until completion: cancellation does **not** roll back a commit or
+abort a blocking worker. Check the resulting state before retrying a write.
+
+HTTP cancellation requires the established `mcp-session-id` returned by
+`initialize`, using the same authenticated role as the target request. Equal
+IDs in other sessions or roles are unaffected. Stateless cancellation is a
+no-op. Cancelled HTTP requests return an empty `202`; a mutation may finish
+before that response is returned. Cancellation notifications themselves never
+produce a JSON-RPC response. Stdio bounds pending tool dispatches to 128 while
+continuing to accept ping and cancellation controls.
+
 NestWeaver's registry holds **42** tools. The number is derivable, not typed:
 `all_tool_schemas_undecorated()` in `crates/nestweaver-mcp/src/tools.rs` is the
 registry, and `tools::tool_doc_tests::all_tools_have_doc_categories` asserts the

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -590,6 +590,8 @@ message BrainContextRequest {
   string since = 19;
   double recency_weight = 20;
   double recency_half_life_days = 21;
+  // Independent count cap; absence preserves configured/default tool behavior.
+  optional uint32 limit = 22;
 }
 message BrainContextResponse {
   string result_json = 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21252,7 +21252,16 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             };
             // Keep lifecycle identity bound to the stable anchor. Following
             // publication CURRENT here would select a different runtime ID.
-            let (db_path, _, source) = resolve_base_db_with_config_source(db, lifecycle_config)?;
+            let (db_path, _, source) = resolve_base_db_with_config_source(db, lifecycle_config)
+                .map_err(|error| {
+                    if matches!(&action, DaemonAction::Restart { .. }) {
+                        error.context(
+                            "restart configuration is invalid; daemon has not been shut down",
+                        )
+                    } else {
+                        error
+                    }
+                })?;
             if matches!(source, DbSource::CwdLocal | DbSource::RepoLocal)
                 || db_path.as_os_str().is_empty()
             {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7452,11 +7452,11 @@ enum BrainCommands {
             help = "Approximate token budget for the connected list (1-16000; matches the MCP brain_context schema)"
         )]
         token_budget: Option<usize>,
-        /// Hard cap on connected results. Used when --token-budget is not
-        /// set; ignored when it is.
+        /// Hard cap on connected results, enforced together with --token-budget.
         #[arg(
             long,
-            help = "Maximum connected results (default: 30, or [limits].default_result_limit from config)"
+            value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=1000),
+            help = "Maximum connected results (1-1000; default: 30, or [limits].default_result_limit from config)"
         )]
         limit: Option<usize>,
         #[arg(long, help = "Output as JSON")]
@@ -14238,13 +14238,23 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 if let Some(ref r) = repo {
                     args["repo"] = serde_json::json!(r);
                 }
-                match try_hybrid_json_rpc(use_daemon, &db_path, None, "service_summary", args)? {
+                match try_hybrid_json_rpc(use_daemon, &db_path, None, "service_summary", args) {
+                    Err(error)
+                        if error.chain().any(|cause| {
+                            cause
+                                .downcast_ref::<tonic::Status>()
+                                .is_some_and(|status| status.code() == tonic::Code::NotFound)
+                        }) =>
+                    {
+                        None
+                    }
+                    Err(error) => return Err(error),
                     // A not-found/error response does not deserialize into a
                     // summary with a non-empty uid, so it falls through to the
                     // NOT_FOUND arm below rather than fabricating an empty
                     // service and printing a header for it.
-                    Some(value) => serde_json::from_value(strip_hybrid_meta(value)).ok(),
-                    None => {
+                    Ok(Some(value)) => serde_json::from_value(strip_hybrid_meta(value)).ok(),
+                    Ok(None) => {
                         let store = open_store(db.as_deref())?;
                         nestweaver_engine::query::service_summary(
                             &store,
@@ -14674,11 +14684,36 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             full,
             pinned,
             ephemeral,
-            instance: _,
+            instance,
             db,
         } => {
-            let db_default = default_db_path();
-            let db_path = db.as_deref().unwrap_or(&db_default);
+            // Validate selected intent before connecting or creating any checkout.
+            let selected_config = instance
+                .as_deref()
+                .map(|id| -> anyhow::Result<_> {
+                    let registry = nestweaver_engine::registry::Registry::load_or_create(
+                        &default_registry_path(),
+                    )?;
+                    let entry = registry
+                        .get(id)
+                        .ok_or_else(|| anyhow::anyhow!("instance '{id}' not found in registry"))?;
+                    let path = PathBuf::from(&entry.config_path);
+                    let config = nestweaver_engine::InstanceConfig::from_file(&path)?;
+                    if config.workspace.backend != "local" {
+                        anyhow::bail!(
+                            "pull requires a local workspace backend for instance '{id}'"
+                        );
+                    }
+                    nestweaver_engine::pull::validate_credential_method(
+                        &config.git.credential_method,
+                    )?;
+                    Ok((path, config))
+                })
+                .transpose()?;
+            let db_path = resolve_db_with_config(
+                db,
+                selected_config.as_ref().map(|(path, _)| path.as_path()),
+            )?;
 
             // An ephemeral pull must never reuse — and especially never
             // DELETE — a pre-existing persistent checkout. Give it a unique
@@ -14691,6 +14726,15 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     .unwrap_or(0);
                 std::env::temp_dir()
                     .join(format!("nestweaver-pull-{}-{unique}", std::process::id()))
+            } else if let Some((path, config)) = &selected_config {
+                let workspace = PathBuf::from(&config.workspace.path);
+                if workspace.is_absolute() {
+                    workspace
+                } else {
+                    path.parent()
+                        .unwrap_or_else(|| Path::new("."))
+                        .join(workspace)
+                }
             } else {
                 dirs::data_local_dir()
                     .unwrap_or_else(|| PathBuf::from("."))
@@ -14709,7 +14753,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let rt = tokio::runtime::Runtime::new()?;
             let repos: Vec<nestweaver_schema::Repo> = {
                 let mut client = rt
-                    .block_on(nestweaver_client::DaemonClient::connect(db_path, None))
+                    .block_on(nestweaver_client::DaemonClient::connect(&db_path, None))
                     .context("failed to connect to daemon")?;
                 let req = tonic::Request::new(nestweaver_proto::JsonRequest {
                     args_json: serde_json::json!({}).to_string(),
@@ -14747,7 +14791,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 .map(|r| r.indexed_sha.clone())
                 .unwrap_or_default();
 
-            match nestweaver_engine::pull_repo(
+            match nestweaver_engine::pull::pull_repo_with_credentials(
                 &workspace_root,
                 &repo,
                 &indexed_sha,
@@ -14756,6 +14800,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     sha_policy,
                     ephemeral,
                 },
+                selected_config
+                    .as_ref()
+                    .map(|(_, config)| config.git.credential_method.as_str()),
             ) {
                 Ok(result) => {
                     println!("Pulled to {}", result.path.display());
@@ -17524,20 +17571,66 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             };
 
             if changed_files.is_empty() {
-                if json {
-                    println!(
-                        "{}",
-                        serde_json::to_string_pretty(&serde_json::json!({
-                            "changed_files": [],
-                            "changed_symbols": [],
-                            "tier_1": [],
-                            "tier_2": [],
-                            "tier_3": [],
-                            "summary": "0 tier-1, 0 tier-2, 0 tier-3 tests affected",
-                        }))?
-                    );
+                // Only a successfully derived VCS diff reaches this branch.
+                // Resolve its actual repository, not every unrelated repo in
+                // a multi-repo graph, before rendering the canonical empty set.
+                require_existing_db(&db_path)?;
+                let repos: Vec<nestweaver_schema::Repo> = if use_daemon {
+                    let rt = tokio::runtime::Runtime::new()?;
+                    let mut client =
+                        rt.block_on(nestweaver_client::DaemonClient::connect(&db_path, None))?;
+                    let response = rt.block_on(client.inner_mut().list_repos_json(
+                        tonic::Request::new(nestweaver_proto::JsonRequest {
+                            args_json: "{}".to_string(),
+                        }),
+                    ))?;
+                    serde_json::from_str(&response.into_inner().result_json)?
                 } else {
-                    println!("No changed files detected.");
+                    open_store(Some(&db_path))?.list_repos(None)?
+                };
+                let root = detect_repo_root()
+                    .canonicalize()
+                    .context("resolve git diff repository")?;
+                let target_repos: Vec<_> = repos
+                    .into_iter()
+                    .filter(|repo| {
+                        repo.local_root()
+                            .and_then(|path| Path::new(path).canonicalize().ok())
+                            .is_some_and(|path| path == root)
+                    })
+                    .collect();
+                if target_repos.is_empty() {
+                    let note = format!(
+                        "git diff repository {} is not indexed; run the full suite and index this repository",
+                        root.display()
+                    );
+                    if json {
+                        print_json_payload(&serde_json::json!({
+                            "refused": true, "needs_reindex": true, "reason": "repo_not_indexed",
+                            "recommendation": "run-full-suite", "note": note,
+                        }))?;
+                    }
+                    eprintln!("Error: {note}");
+                    return Ok((EXIT_NEEDS_REINDEX, None));
+                }
+                if let Some(refusal) =
+                    nestweaver_engine::resolver_generation::DeadCodeRefusal::for_repos(
+                        &db_path,
+                        &target_repos,
+                    )
+                {
+                    let payload = affected_tests_refusal_payload(&refusal);
+                    if json {
+                        print_json_payload(&payload)?;
+                    }
+                    eprintln!("Error: {}", affected_tests_refusal_note(&payload));
+                    return Ok((EXIT_NEEDS_REINDEX, None));
+                }
+                let result = nestweaver_engine::affected_tests::empty_derived_selection();
+                if json {
+                    print_json_payload(&serde_json::to_value(&result)?)?;
+                } else {
+                    render_affected_tests_result(&result, None);
                 }
                 return Ok((EXIT_SUCCESS, None));
             }
@@ -18400,6 +18493,14 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             db,
             config,
         } => {
+            if let Err(error) = nestweaver_store::regex::validate_pattern(&pattern) {
+                let message = error.to_string();
+                if json {
+                    print_json_argument_error("pattern", &pattern, &message);
+                }
+                eprintln!("Error: invalid regex pattern '{pattern}': {message}");
+                return Ok((EXIT_USAGE, None));
+            }
             let db_path = resolve_db_with_config(db, config.as_deref())?;
             // ── daemon guard ──────────────────────────────────────
             if use_daemon {
@@ -18572,6 +18673,16 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             db,
             config,
         } => {
+            for candidate in &patterns {
+                if let Err(error) = nestweaver_store::regex::validate_pattern(candidate) {
+                    let message = error.to_string();
+                    if json {
+                        print_json_argument_error("patterns", &patterns.join(", "), &message);
+                    }
+                    eprintln!("Error: invalid regex pattern '{candidate}': {message}");
+                    return Ok((EXIT_USAGE, None));
+                }
+            }
             let db_path = resolve_db_with_config(db, config.as_deref())?;
             // ── daemon guard ──────────────────────────────────────
             if use_daemon {
@@ -19292,7 +19403,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
 
             // A missing input file must fail as a clean not-found (exit 2),
             // not a generic IO error.
-            if !input.exists() {
+            if input.as_os_str() != "-" && !input.exists() {
                 eprintln!("Error: impact report not found: {}", input.display());
                 return Ok((EXIT_NOT_FOUND, None));
             }
@@ -21133,16 +21244,22 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             if matches!(action, DaemonAction::Gc) {
                 return run_daemon_gc();
             }
-            let db_path = db
-                .or_else(|| {
-                    std::env::var("NESTWEAVER_DB")
-                        .ok()
-                        .filter(|s| !s.is_empty())
-                        .map(PathBuf::from)
-                })
-                .ok_or_else(|| {
-                    anyhow::anyhow!("No database path provided. Use --db or set NESTWEAVER_DB.")
-                })?;
+            let lifecycle_config = match &action {
+                DaemonAction::Start { config, .. }
+                | DaemonAction::Restart { config, .. }
+                | DaemonAction::Run { config, .. } => config.as_deref(),
+                _ => None,
+            };
+            // Keep lifecycle identity bound to the stable anchor. Following
+            // publication CURRENT here would select a different runtime ID.
+            let (db_path, _, source) = resolve_base_db_with_config_source(db, lifecycle_config)?;
+            if matches!(source, DbSource::CwdLocal | DbSource::RepoLocal)
+                || db_path.as_os_str().is_empty()
+            {
+                anyhow::bail!(
+                    "No database path provided. Use --db, --config with db, or set NESTWEAVER_DB."
+                );
+            }
             let selected_slot_legacy_id =
                 nestweaver_daemon::lifecycle::selected_slot_identity_instance_id(&db_path);
             if matches!(
@@ -22913,10 +23030,21 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 // Parity contract: if --json reports a caveat, the human output
                 // must say so too.
                 let crash = &capabilities["crash_recurrence"];
-                println!("  Crash recurrence (nw-073):");
+                println!(
+                    "  Crash recurrence ({}):",
+                    crash["backlog_id"].as_str().unwrap_or("unavailable")
+                );
                 println!(
                     "    Signature: {}",
-                    crash["signature"].as_str().unwrap_or("unknown")
+                    crash["signature"]
+                        .as_array()
+                        .map(|parts| parts
+                            .iter()
+                            .filter_map(|part| part.as_str())
+                            .collect::<Vec<_>>()
+                            .join(" | "))
+                        .or_else(|| crash["signature"].as_str().map(str::to_owned))
+                        .unwrap_or_else(|| "unavailable".to_string())
                 );
                 println!(
                     "    Status:    {}",
@@ -24190,7 +24318,7 @@ fn try_hybrid_json_rpc_checked(
                 // nothing to fall back FROM, so surface it as-is instead of
                 // recommending a daemon reset.
                 if let Some(message) = daemon_application_error(&e) {
-                    return Err(anyhow::anyhow!("{message}"));
+                    return Err(e.context(message));
                 }
                 ensure_direct_store_fallback_allowed(db_path, config).with_context(|| {
                     format!("hybrid query {rpc_name} failed ({e:#}); refusing direct fallback")
@@ -26220,8 +26348,9 @@ fn run_brain(
             // here is what made this command ignore a config its siblings honour.
             let db_path = resolve_db_with_config(db, config.as_deref())?;
             let instance_specified = instance.is_some() || config.is_some();
-            let instance_id_owned =
-                resolve_instance_id_for_db(instance, config.as_deref(), &db_path)?;
+            // An unscoped removal intentionally cleans all discovered rows at
+            // this path. It need not choose an identity for a new mutation.
+            let instance_id_owned = resolve_instance_id(instance, config.as_deref())?;
             let instance_id = instance_id_owned.as_str();
 
             let canonical = abs_for_daemon(&path);
@@ -26237,7 +26366,7 @@ fn run_brain(
                     if let Some(inst) = inst_filter {
                         args["instance"] = serde_json::json!(inst);
                     }
-                    if let Some(value) = try_hybrid_json_rpc(
+                    if let Some(value) = try_hybrid_json_rpc_checked(
                         use_daemon,
                         &db_path,
                         config.as_deref(),
@@ -26333,13 +26462,17 @@ fn run_brain(
                     return Ok((EXIT_NOT_FOUND, None));
                 }
             } else {
-                uids_to_remove.push(v_uid_canon);
                 let all_vaults = fetch_vaults(None)?;
                 for v in &all_vaults {
                     if path_matches(&v.root_path) && !uids_to_remove.contains(&v.uid) {
                         uids_to_remove.push(v.uid.clone());
                     }
                 }
+            }
+
+            if uids_to_remove.is_empty() {
+                println!("No vault found at {canon_str}; 0 row(s) cleaned.");
+                return Ok((EXIT_NOT_FOUND, None));
             }
 
             let mut vault_name = path
@@ -26366,8 +26499,10 @@ fn run_brain(
             for uid in &uids_to_remove {
                 match rt.block_on(client.remove_vault(uid)) {
                     Ok(resp) => {
-                        total_dropped += resp.notes_deleted as usize;
-                        rows_cleaned += 1;
+                        if resp.committed {
+                            total_dropped += resp.notes_deleted as usize;
+                            rows_cleaned += 1;
+                        }
                         // The daemon already rebuilt the search index as part
                         // of the removal, and already reports whether that
                         // succeeded. Its answer is the one to relay.
@@ -26750,6 +26885,7 @@ fn run_brain(
                 let context_params = serde_json::json!({
                         "seeds": seeds,
                         "token_budget": token_budget.unwrap_or(0),
+                        "limit": limit,
                         "repos": repos,
                         "vaults": vaults,
                         "kinds": kinds,
@@ -26779,13 +26915,34 @@ fn run_brain(
                     context_params["since"] = serde_json::json!(since);
                 }
 
-                if let Some(result_json) = try_hybrid_json_rpc_checked(
+                let context_response = match try_hybrid_json_rpc_checked(
                     true,
                     &db_path,
                     config_path.as_deref(),
                     "brain_context",
                     context_params,
-                )? {
+                ) {
+                    Err(error)
+                        if error
+                            .chain()
+                            .any(|cause| cause.to_string().contains("No seeds resolved")) =>
+                    {
+                        if json {
+                            println!(
+                                "{}",
+                                serde_json::to_string_pretty(&serde_json::json!({
+                                    "error": "not found", "seeds_expanded": 0,
+                                    "connected": [], "unresolved_seeds": seeds,
+                                }))?
+                            );
+                        } else {
+                            eprintln!("{error}");
+                        }
+                        return Ok((EXIT_NOT_FOUND, None));
+                    }
+                    other => other?,
+                };
+                if let Some(result_json) = context_response {
                     let source = hybrid_source_label(&result_json);
                     // Read the daemon's disclosure BEFORE `from_value` narrows
                     // the payload to the fields `BrainContextResult` declares —
@@ -26800,7 +26957,9 @@ fn run_brain(
                         // renderer emits full nodes, so the detailed rate is the
                         // correct one here — unlike `project-context`, which
                         // renders concise and was charging this rate anyway.
-                        Some(budget) => token_budgeted_truncate(&result.connected, budget, false),
+                        Some(budget) => {
+                            limit.min(token_budgeted_truncate(&result.connected, budget, false))
+                        }
                         None => limit.min(result.connected.len()),
                     };
                     if json {
@@ -27115,13 +27274,15 @@ fn run_brain(
                         );
                     }
 
-                    // token_budget takes precedence over the count-based limit.
+                    // Apply both the count and token caps; neither discards the other.
                     let cut = match token_budget {
                         // nw-316: `false` preserves TODAY's cost for this route. Its
                         // renderer emits full nodes, so the detailed rate is the
                         // correct one here — unlike `project-context`, which
                         // renders concise and was charging this rate anyway.
-                        Some(budget) => token_budgeted_truncate(&result.connected, budget, false),
+                        Some(budget) => {
+                            limit.min(token_budgeted_truncate(&result.connected, budget, false))
+                        }
                         None => limit.min(result.connected.len()),
                     };
                     let node_count = result.seeds.len() + cut;
@@ -27144,6 +27305,7 @@ fn run_brain(
                             println!(
                                 "{}",
                                 serde_json::to_string_pretty(&serde_json::json!({
+                                    "error": "not found",
                                     "seeds_expanded": 0,
                                     "connected": [],
                                     "unresolved_seeds": seeds,
@@ -31246,6 +31408,7 @@ fn render_project_context_daemon_response(
 /// still read its own pre-cut total off `result.connected`.
 #[derive(Default)]
 struct UpstreamContextDisclosure {
+    truncated_by: Option<String>,
     /// Rows that matched upstream, BEFORE the cut it already applied.
     total: Option<usize>,
     /// Federation provenance (`_meta`) the hybrid layer attached: which
@@ -31259,6 +31422,10 @@ impl UpstreamContextDisclosure {
     /// into `BrainContextResult`.
     fn from_wire(value: &serde_json::Value) -> Self {
         Self {
+            truncated_by: value
+                .get("truncated_by")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned),
             total: value
                 .get("total")
                 .and_then(serde_json::Value::as_u64)
@@ -31310,15 +31477,10 @@ fn brain_context_json_value(
     // and the honest total came over the wire.
     let total = upstream.total(result.connected.len(), returned);
     let truncated = returned < total;
-    // The two CLI caps are mutually exclusive at every call site: the `cut`
-    // above is `token_budgeted_truncate(..)` when `--token-budget` is set and
-    // `limit.min(len)` otherwise — "token_budget takes precedence over the
-    // count-based limit". `resolve` still decides which to blame so the CLI
-    // and `tool_brain_context` cannot drift on the precedence rule.
-    let truncated_by = nestweaver_engine::TruncationCause::resolve(
-        truncated && token_budget.is_some(),
-        truncated && token_budget.is_none(),
-    );
+    let budget_cut =
+        token_budget.map(|budget| token_budgeted_truncate(&result.connected, budget, false));
+    let (_, truncated_by) =
+        nestweaver_engine::compose_result_caps(result.connected.len(), Some(limit), budget_cut);
     let mut resp = serde_json::json!({
         "seeds_expanded": result.seeds.len(),
         "connected": result.connected.iter().take(limit).collect::<Vec<_>>(),
@@ -31327,7 +31489,7 @@ fn brain_context_json_value(
         "truncated": truncated,
         // Emitted even when null, matching the MCP twin: one shape parses
         // both routes.
-        "truncated_by": truncated_by.map(nestweaver_engine::TruncationCause::as_str),
+        "truncated_by": truncated_by.map(nestweaver_engine::TruncationCause::as_str).or(upstream.truncated_by.as_deref()),
         "semantic_applied": result.semantic_applied,
         "degraded_components": result.degraded_components,
     });
@@ -31404,6 +31566,47 @@ mod context_json_renderer_tests {
             seed_resolution_limit: None,
             admitted_before_cap: None,
         }
+    }
+
+    #[test]
+    fn context_disclosure_names_the_binding_cap_and_keeps_upstream_cause() {
+        let mut result = degraded_context();
+        result.connected = (0..10)
+            .map(|i| nestweaver_engine::BrainNode {
+                uid: format!("note:{i}"),
+                kind: "Note".into(),
+                title: "Fixture".into(),
+                location: "fixture.md".into(),
+                relevance: 1.0,
+                inline_body: None,
+                body_complete: true,
+            })
+            .collect();
+        let value = brain_context_json_value(
+            &result,
+            2,
+            Some(10_000),
+            &UpstreamContextDisclosure::default(),
+        );
+        assert_eq!(value["returned"], 2);
+        assert_eq!(value["total"], 10);
+        assert_eq!(value["truncated_by"], "limit");
+        let budget = render_cost_tokens(&result.connected[0], false);
+        let cut = token_budgeted_truncate(&result.connected, budget, false);
+        let value = brain_context_json_value(
+            &result,
+            cut,
+            Some(budget),
+            &UpstreamContextDisclosure::default(),
+        );
+        assert_eq!(value["truncated_by"], "token_budget");
+        result.connected.truncate(2);
+        let upstream = UpstreamContextDisclosure::from_wire(
+            &serde_json::json!({"total":10,"truncated_by":"limit"}),
+        );
+        let value = brain_context_json_value(&result, 2, Some(10_000), &upstream);
+        assert_eq!(value["total"], 10);
+        assert_eq!(value["truncated_by"], "limit");
     }
 
     #[test]
@@ -32592,7 +32795,7 @@ fn run_config(command: ConfigCommands) -> anyhow::Result<(i32, Option<String>)> 
                         "path": path.display().to_string(),
                         "error": message,
                     });
-                    eprintln!("{}", serde_json::to_string(&result)?);
+                    println!("{}", serde_json::to_string(&result)?);
                     Ok((EXIT_ERROR, None))
                 }
                 Err(error) => Err(error)
@@ -32768,13 +32971,15 @@ fn run_instance(command: InstanceCommands, use_daemon: bool) -> anyhow::Result<i
                 .map(|p| p.to_string_lossy().into_owned())
                 .unwrap_or(config_path);
             let registry_path = default_registry_path();
-            let mut registry = nestweaver_engine::Registry::load_or_create(&registry_path)?;
+            let mut registry =
+                nestweaver_engine::registry::Registry::load_or_create(&registry_path)?;
             registry.register(&config.instance_id, &canonical)?;
             println!("Registered instance '{}'", config.instance_id);
             Ok(EXIT_SUCCESS)
         }
         InstanceCommands::List => {
-            let registry = nestweaver_engine::Registry::load_or_create(&default_registry_path())?;
+            let registry =
+                nestweaver_engine::registry::Registry::load_or_create(&default_registry_path())?;
             if registry.list().is_empty() {
                 println!("No instances registered.");
             } else {
@@ -32799,7 +33004,7 @@ fn run_instance(command: InstanceCommands, use_daemon: bool) -> anyhow::Result<i
                 None
             };
             let mut registry =
-                nestweaver_engine::Registry::load_or_create(&default_registry_path())?;
+                nestweaver_engine::registry::Registry::load_or_create(&default_registry_path())?;
             let registry_removed = match registry.remove(&id) {
                 Ok(()) => true,
                 Err(e) => {
@@ -32853,7 +33058,8 @@ fn run_instance(command: InstanceCommands, use_daemon: bool) -> anyhow::Result<i
             Ok(EXIT_SUCCESS)
         }
         InstanceCommands::Pull { id } => {
-            let registry = nestweaver_engine::Registry::load_or_create(&default_registry_path())?;
+            let registry =
+                nestweaver_engine::registry::Registry::load_or_create(&default_registry_path())?;
             let entry = registry
                 .get(&id)
                 .ok_or_else(|| anyhow::anyhow!("instance '{}' not registered", id))?;
@@ -33767,6 +33973,7 @@ fn dispatch_hybrid_mcp_request(
     lite: bool,
     write_tools: &std::collections::HashSet<&str>,
     request: &nestweaver_mcp::protocol::Request,
+    cancel: &nestweaver_mcp::session::CancelFlag,
 ) -> serde_json::Value {
     let id = request.id.clone().unwrap_or(serde_json::Value::Null);
     match request.method.as_str() {
@@ -33826,7 +34033,10 @@ fn dispatch_hybrid_mcp_request(
                             arguments.clone(),
                         )
                     } else {
-                        rt.block_on(hybrid.query(name, &arguments))
+                        rt.block_on(nestweaver_mcp::session::await_cancellable(
+                            Some(cancel),
+                            hybrid.query(name, &arguments),
+                        ))
                     }
                 }));
                 match dispatched {
@@ -33855,10 +34065,19 @@ fn dispatch_hybrid_mcp_request(
     }
 }
 
+#[cfg(test)]
 fn process_hybrid_mcp_envelope(
     parsed: serde_json::Value,
     mut dispatch: impl FnMut(&nestweaver_mcp::protocol::Request) -> serde_json::Value,
 ) -> Option<serde_json::Value> {
+    let mut dispatch = |request: &nestweaver_mcp::protocol::Request| {
+        match nestweaver_mcp::protocol::validate_method_params(request) {
+            Ok(()) => dispatch(request),
+            Err(message) => {
+                serde_json::json!({"jsonrpc":"2.0", "id":request.id, "error":{"code":-32602,"message":message}})
+            }
+        }
+    };
     let invalid = |error: nestweaver_mcp::protocol::InvalidRequest| {
         serde_json::json!({
             "jsonrpc": "2.0",
@@ -33939,8 +34158,6 @@ fn run_mcp_hybrid(
     track_interactions: bool,
     _db_path: &Path,
 ) -> anyhow::Result<()> {
-    use std::io::{BufRead, Write};
-
     nestweaver_mcp::tools::set_lite_mode(lite);
 
     // Start the background maintenance task (active upstream health recovery +
@@ -33959,11 +34176,6 @@ fn run_mcp_hybrid(
     let _ = track_interactions;
 
     tracing::info!("brain MCP server ready on stdio (hybrid routing mode)");
-
-    let stdin = std::io::stdin();
-    let mut stdout = TypedStdout;
-    let mut line = String::new();
-    let mut reader = stdin.lock();
 
     // Write tools that must bypass hybrid routing.
     //
@@ -33986,43 +34198,9 @@ fn run_mcp_hybrid(
         .copied()
         .collect();
 
-    loop {
-        line.clear();
-        let n = reader.read_line(&mut line)?;
-        if n == 0 {
-            tracing::info!("client closed stdin; shutting down (hybrid)");
-            return Ok(());
-        }
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
-        let parsed: serde_json::Value = match serde_json::from_str(trimmed) {
-            Ok(v) => v,
-            Err(e) => {
-                let resp = serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": null,
-                    "error": { "code": -32700, "message": format!("invalid JSON: {e}") }
-                });
-                serde_json::to_writer(&mut stdout, &resp)?;
-                stdout.write_all(b"\n")?;
-                stdout.flush()?;
-                continue;
-            }
-        };
-
-        let response = process_hybrid_mcp_envelope(parsed, |request| {
-            dispatch_hybrid_mcp_request(&mut hybrid, &rt, lite, &write_tools, request)
-        });
-
-        if let Some(response) = response {
-            serde_json::to_writer(&mut stdout, &response)?;
-            stdout.write_all(b"\n")?;
-            stdout.flush()?;
-        }
-    }
+    nestweaver_mcp::session::run_stdio(|request, cancel| {
+        dispatch_hybrid_mcp_request(&mut hybrid, &rt, lite, &write_tools, request, cancel)
+    })
 }
 
 /// Format a byte count as a human-readable string.
@@ -34831,7 +35009,7 @@ fn run_publication_rebuild(
                         &target_db,
                         "seal the staged publication",
                     )?;
-                    nestweaver_engine::backup::seal_publication_slot(&target_db, &slot)?;
+                    nestweaver_engine::backup::seal_publication_slot_with_authority(&target_db, &slot, &_authority)?;
                     state = nestweaver_engine::publication_operation::mark_ready(
                         &publication_root,
                         &operation_uuid,
@@ -35319,8 +35497,9 @@ fn run_snapshot(command: SnapshotCommands, _use_daemon: bool) -> anyhow::Result<
             // Resolve snapshot directory and backend from args/config/instance registry.
             let (snap_dir, backend_name, b_path) = if let Some(inst_id) = instance {
                 // Load from registry → instance config
-                let registry =
-                    nestweaver_engine::Registry::load_or_create(&default_registry_path())?;
+                let registry = nestweaver_engine::registry::Registry::load_or_create(
+                    &default_registry_path(),
+                )?;
                 let entry = registry
                     .get(&inst_id)
                     .ok_or_else(|| anyhow::anyhow!("instance '{}' not registered", inst_id))?;

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -191,7 +191,7 @@ path = "/tmp/nestweaver/repo"
         .unwrap();
 
     assert!(!output.status.success());
-    let result: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(result["valid"], false);
     assert_eq!(result["path"], config_path.display().to_string());
     let error = result["error"].as_str().unwrap();

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -352,7 +352,7 @@ fn run_via_mcp(db_path: &Path, tool: &str, arguments: serde_json::Value) -> serd
     let frames = [
         serde_json::json!({
             "jsonrpc": "2.0", "id": 1, "method": "initialize",
-            "params": { "protocolVersion": "2024-11-05" }
+            "params": { "protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": { "name": "parity-test", "version": "1" } }
         }),
         serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }),
         serde_json::json!({
@@ -2014,7 +2014,7 @@ fn mcp_raw_frame(db_path: &Path, tool: &str, arguments: serde_json::Value) -> se
     let frames = [
         serde_json::json!({
             "jsonrpc": "2.0", "id": 1, "method": "initialize",
-            "params": { "protocolVersion": "2024-11-05" }
+            "params": { "protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": { "name": "parity-test", "version": "1" } }
         }),
         serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }),
         serde_json::json!({
@@ -2886,7 +2886,7 @@ fn brain_context_discloses_that_it_was_cut_on_every_machine_route() {
         "a consumer that cannot tell WHICH cap cut raises the wrong knob: {capped}"
     );
 
-    // ── CLI direct, cut by --token-budget; the budget takes precedence ──
+    // ── CLI direct, cut by --token-budget; both caps apply; the smaller budget binds ──
     let by_budget = run_direct(
         db,
         &[
@@ -2910,7 +2910,7 @@ fn brain_context_discloses_that_it_was_cut_on_every_machine_route() {
     assert_eq!(
         by_budget.get("truncated_by").and_then(|v| v.as_str()),
         Some("token_budget"),
-        "the budget is applied INSTEAD of --limit here, so naming --limit is the \
+        "the budget is tighter than --limit here, so naming --limit is the \
          wrong remedy: {by_budget}"
     );
 
@@ -2975,7 +2975,7 @@ fn brain_context_discloses_that_it_was_cut_on_every_machine_route() {
             "mainA",
             "--json",
             "--limit",
-            "5000",
+            "1000",
             "--token-budget",
             "16000",
         ],
@@ -3011,7 +3011,7 @@ fn brain_context_discloses_that_it_was_cut_on_every_machine_route() {
             "mainA",
             "--json",
             "--limit",
-            "5000",
+            "1000",
             "--token-budget",
             "16000",
         ],

--- a/tests/ready_regression_test.rs
+++ b/tests/ready_regression_test.rs
@@ -1,0 +1,488 @@
+//! Process-level checks for the September regression backlog. Every mutating
+//! command is bound to a private database, registry, and checkout destination.
+use assert_cmd::Command;
+use serde_json::{Value, json};
+use std::path::{Path, PathBuf};
+use std::process::Output;
+use std::time::Duration;
+
+struct Fixture {
+    dir: tempfile::TempDir,
+    db: PathBuf,
+    repo: PathBuf,
+    config: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("graph.lbug");
+        let repo = dir.path().join("repo");
+        let config = dir.path().join("instance.toml");
+        std::fs::create_dir(&repo).unwrap();
+        std::fs::write(
+            repo.join("calc.py"),
+            "def add(x, y):\n    return x + y\n\ndef twice(x):\n    return add(x, x)\n",
+        )
+        .unwrap();
+        for args in [
+            vec!["init"],
+            vec!["add", "."],
+            vec![
+                "-c",
+                "user.name=Regression",
+                "-c",
+                "user.email=regression@example.invalid",
+                "commit",
+                "-m",
+                "fixture",
+            ],
+        ] {
+            let out = std::process::Command::new("git")
+                .current_dir(&repo)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        // JSON quoted strings are valid TOML basic strings, including Windows
+        // path escaping. No credentials or external services are required.
+        let quote = |path: &Path| serde_json::to_string(&path.to_string_lossy()).unwrap();
+        std::fs::write(&config, format!(
+            "instance_id = \"selected\"\ndb = {}\n[snapshot_storage]\nbackend = \"local\"\npath = {}\n[workspace]\nbackend = \"local\"\npath = {}\n[inference]\nendpoint = \"http://localhost:11434\"\nembedding_model = \"unused\"\nsummary_model = \"unused\"\n[embedding]\nexternal_endpoint = \"http://127.0.0.1:9\"\nexternal_model = \"unused\"\n[git]\ncredential_method = \"gh\"\n",
+            quote(&db), quote(&dir.path().join("snapshots")), quote(&dir.path().join("selected-workspace")),
+        )).unwrap();
+        Self {
+            dir,
+            db,
+            repo,
+            config,
+        }
+    }
+
+    fn cmd(&self) -> Command {
+        let mut cmd = Command::cargo_bin("nestweaver").unwrap();
+        cmd.current_dir(self.dir.path())
+            .timeout(Duration::from_secs(180))
+            .env_remove("NESTWEAVER_DB")
+            .env_remove("NESTWEAVER_NO_DAEMON")
+            .env_remove("NESTWEAVER_ALLOW_NO_DAEMON")
+            .env("NESTWEAVER_DIAGNOSTIC_WIDTH", "1000")
+            .env("NESTWEAVER_EPHEMERAL_IDLE_TIMEOUT_SECS", "60")
+            .env("XDG_CONFIG_HOME", self.dir.path().join("config"))
+            .env("XDG_DATA_HOME", self.dir.path().join("data"));
+        #[cfg(not(target_os = "macos"))]
+        cmd.env("NESTWEAVER_DAEMON_FORK", "1");
+        cmd
+    }
+
+    fn query(&self, args: &[&str], direct: bool) -> Output {
+        let mut cmd = self.cmd();
+        cmd.args(args).arg("--db").arg(&self.db);
+        if direct {
+            cmd.env("NESTWEAVER_NO_DAEMON", "1")
+                .env("NESTWEAVER_ALLOW_NO_DAEMON", "1");
+        }
+        cmd.output().unwrap()
+    }
+
+    fn index(&self) {
+        self.cmd()
+            .args(["index", "--repo"])
+            .arg(&self.repo)
+            .arg("--db")
+            .arg(&self.db)
+            .env("NESTWEAVER_NO_DAEMON", "1")
+            .env("NESTWEAVER_ALLOW_NO_DAEMON", "1")
+            .assert()
+            .success();
+        // Bind lexical-only fixtures to a deliberately unavailable loopback
+        // embedding endpoint, avoiding unrelated CPU model initialization.
+        // Subsequent configless autostarts reuse this explicit startup intent.
+        self.cmd()
+            .args(["daemon", "start", "--db"])
+            .arg(&self.db)
+            .arg("--config")
+            .arg(&self.config)
+            .assert()
+            .success();
+        self.stop();
+    }
+
+    fn stop(&self) {
+        if self.db.exists() {
+            self.cmd()
+                .args(["daemon", "stop", "--db"])
+                .arg(&self.db)
+                .assert()
+                .success();
+        }
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        // Cleanup must also execute after a failed assertion; never signal any
+        // daemon except the one identified by this unique temporary database.
+        if self.db.exists() {
+            let _ = self
+                .cmd()
+                .args(["daemon", "stop", "--db"])
+                .arg(&self.db)
+                .output();
+        }
+    }
+}
+
+fn payload(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; exit={:?}, stdout={}, stderr={}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+#[test]
+fn invalid_regex_preserves_usage_exit_and_json_across_routes() {
+    let f = Fixture::new();
+    f.index();
+    for tool in ["regex-search", "count-patterns"] {
+        for direct in [false, true] {
+            f.stop();
+            let out = f.query(&[tool, "[", "--json"], direct);
+            assert_eq!(
+                out.status.code(),
+                Some(64),
+                "{tool}, direct={direct}: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            assert_eq!(payload(&out)["error"], "invalid argument");
+        }
+    }
+}
+
+#[test]
+fn missing_service_and_brain_seed_preserve_not_found_json_across_routes() {
+    let f = Fixture::new();
+    f.index();
+    for args in [
+        vec!["service-summary", "absent-regression-service", "--json"],
+        vec![
+            "brain",
+            "context",
+            "absent-regression-seed",
+            "--no-embed",
+            "--json",
+        ],
+    ] {
+        for direct in [false, true] {
+            f.stop();
+            let out = f.query(&args, direct);
+            assert_eq!(
+                out.status.code(),
+                Some(2),
+                "{args:?}, direct={direct}: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            assert_eq!(payload(&out)["error"], "not found");
+        }
+    }
+}
+
+#[test]
+fn empty_git_diff_still_refuses_incompatible_resolver_generation() {
+    let f = Fixture::new();
+    f.index();
+    let sidecar = PathBuf::from(format!("{}.resolver_generation.json", f.db.display()));
+    let mut generation: Value = serde_json::from_slice(&std::fs::read(&sidecar).unwrap()).unwrap();
+    for incompatible in [0_u64, u64::MAX] {
+        for value in generation["repos"].as_object_mut().unwrap().values_mut() {
+            *value = json!(incompatible);
+        }
+        std::fs::write(&sidecar, serde_json::to_vec(&generation).unwrap()).unwrap();
+        // Both routes must refuse, although no changed file ever reaches the
+        // selection engine on the old shortcut.
+        for direct in [false, true] {
+            f.stop();
+            let mut cmd = f.cmd();
+            cmd.current_dir(&f.repo)
+                .args(["affected-tests", "--base-ref", "HEAD", "--json", "--db"])
+                .arg(&f.db);
+            if direct {
+                cmd.env("NESTWEAVER_NO_DAEMON", "1")
+                    .env("NESTWEAVER_ALLOW_NO_DAEMON", "1");
+            }
+            let out = cmd.output().unwrap();
+            assert_eq!(
+                out.status.code(),
+                Some(2),
+                "direct={direct}, generation={incompatible}"
+            );
+            let value = payload(&out);
+            assert_eq!(value["refused"], true);
+            assert_eq!(value["recommendation"], "run-full-suite");
+            assert!(value.get("tier_1").is_none());
+        }
+        f.stop();
+    }
+}
+
+#[test]
+fn daemon_start_and_restart_honor_config_database_without_redundant_flag() {
+    let f = Fixture::new();
+    f.index();
+    for action in ["start", "restart"] {
+        f.cmd()
+            .env(
+                "NESTWEAVER_DB",
+                f.dir.path().join("ambient-must-not-win.lbug"),
+            )
+            .args(["daemon", action, "--config"])
+            .arg(&f.config)
+            .assert()
+            .success();
+        let out = f.query(&["search", "twice", "--json"], false);
+        assert!(out.status.success());
+        assert!(!payload(&out)["results"].as_array().unwrap().is_empty());
+    }
+}
+
+#[test]
+fn foreground_daemon_run_honors_config_database_before_environment() {
+    let f = Fixture::new();
+    f.index();
+    let ambient = f.dir.path().join("ambient-must-not-win.lbug");
+    f.cmd()
+        .env("NESTWEAVER_DB", &ambient)
+        .args(["daemon", "run", "--config"])
+        .arg(&f.config)
+        .args(["--idle-timeout", "1"])
+        .assert()
+        .success();
+    assert!(
+        !ambient.exists(),
+        "foreground run opened the ambient DB instead of config.db"
+    );
+}
+
+#[test]
+fn healthy_empty_diff_ignores_an_unrelated_incompatible_repo() {
+    let f = Fixture::new();
+    f.index();
+    let unrelated = f.dir.path().join("unrelated");
+    std::fs::create_dir(&unrelated).unwrap();
+    std::fs::write(unrelated.join("other.py"), "def unrelated(): pass\n").unwrap();
+    f.cmd()
+        .args(["index", "--repo"])
+        .arg(&unrelated)
+        .arg("--db")
+        .arg(&f.db)
+        .env("NESTWEAVER_NO_DAEMON", "1")
+        .env("NESTWEAVER_ALLOW_NO_DAEMON", "1")
+        .assert()
+        .success();
+    let repos = payload(&f.query(&["list-repos", "--json"], true));
+    let unrelated_uid = repos
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|repo| repo["root_path"].as_str() == unrelated.to_str())
+        .expect("unrelated repo must be indexed")["uid"]
+        .as_str()
+        .unwrap();
+    let sidecar = PathBuf::from(format!("{}.resolver_generation.json", f.db.display()));
+    let mut generation: Value = serde_json::from_slice(&std::fs::read(&sidecar).unwrap()).unwrap();
+    generation["repos"][unrelated_uid] = json!(0);
+    std::fs::write(&sidecar, serde_json::to_vec(&generation).unwrap()).unwrap();
+    for direct in [false, true] {
+        f.stop();
+        let mut cmd = f.cmd();
+        cmd.current_dir(&f.repo)
+            .args(["affected-tests", "--base-ref", "HEAD", "--json", "--db"])
+            .arg(&f.db);
+        if direct {
+            cmd.env("NESTWEAVER_NO_DAEMON", "1")
+                .env("NESTWEAVER_ALLOW_NO_DAEMON", "1");
+        }
+        let out = cmd.output().unwrap();
+        assert!(
+            out.status.success(),
+            "{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let result = payload(&out);
+        assert_eq!(result["recommendation"], "selection-usable");
+        assert_eq!(result["status"], "complete");
+        assert!(result["tier_1"].as_array().unwrap().is_empty());
+        assert!(result["disclaimer"].as_str().is_some());
+    }
+}
+
+#[test]
+fn invalid_configuration_json_is_on_stdout() {
+    let f = Fixture::new();
+    let invalid = f.dir.path().join("invalid.toml");
+    std::fs::write(&invalid, "broken = [\n").unwrap();
+    let out = f
+        .cmd()
+        .args(["config", "validate"])
+        .arg(invalid)
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    assert_eq!(payload(&out)["valid"], false);
+}
+
+#[test]
+fn format_comment_stdin_matches_file_and_missing_file_still_fails() {
+    let f = Fixture::new();
+    let report = r#"{"changes":0,"impacts":[],"total_impacted_files":0,"total_impacted_repos":0}"#;
+    let input = f.dir.path().join("impact.json");
+    let from_file = f.dir.path().join("file.md");
+    let from_stdin = f.dir.path().join("stdin.md");
+    std::fs::write(&input, report).unwrap();
+    f.cmd()
+        .args(["format-comment", "--input"])
+        .arg(input)
+        .arg("--output")
+        .arg(&from_file)
+        .assert()
+        .success();
+    f.cmd()
+        .args(["format-comment", "--input", "-", "--output"])
+        .arg(&from_stdin)
+        .write_stdin(report)
+        .assert()
+        .success();
+    assert_eq!(
+        std::fs::read(from_file).unwrap(),
+        std::fs::read(from_stdin).unwrap()
+    );
+    f.cmd()
+        .args(["format-comment", "--input", "does-not-exist.json"])
+        .assert()
+        .code(2);
+}
+
+#[test]
+fn diagnostics_human_output_identifies_the_structured_incident_and_signatures() {
+    let f = Fixture::new();
+    let structured = f
+        .cmd()
+        .args(["diagnostics", "capabilities", "--json"])
+        .output()
+        .unwrap();
+    let human = f
+        .cmd()
+        .args(["diagnostics", "capabilities"])
+        .output()
+        .unwrap();
+    assert!(structured.status.success() && human.status.success());
+    let value = payload(&structured);
+    let crash = &value["crash_recurrence"];
+    let text = String::from_utf8(human.stdout).unwrap();
+    assert!(
+        text.contains(crash["backlog_id"].as_str().unwrap()),
+        "{text}"
+    );
+    match &crash["signature"] {
+        Value::String(signature) => assert!(text.contains(signature)),
+        Value::Array(signatures) => {
+            for signature in signatures {
+                assert!(text.contains(signature.as_str().unwrap()), "{text}");
+            }
+        }
+        other => panic!("unhandled diagnostic schema: {other}"),
+    }
+}
+
+#[test]
+fn brain_remove_counts_real_nondefault_vault_and_does_not_claim_a_second_removal() {
+    let f = Fixture::new();
+    // Vault-only database: an unrelated default-instance code repo would trip
+    // instance ambiguity before reaching the removal accounting behavior.
+    let vault = f.dir.path().join("vault");
+    std::fs::create_dir(&vault).unwrap();
+    std::fs::write(vault.join("Home.md"), "# Home\nregression sentinel\n").unwrap();
+    f.cmd()
+        .args(["daemon", "start", "--db"])
+        .arg(&f.db)
+        .arg("--config")
+        .arg(&f.config)
+        .assert()
+        .success();
+    f.cmd()
+        .args(["brain", "add"])
+        .arg(&vault)
+        .args(["--instance", "selected", "--db"])
+        .arg(&f.db)
+        .assert()
+        .success();
+    let first = f
+        .cmd()
+        .args(["brain", "remove"])
+        .arg(&vault)
+        .arg("--db")
+        .arg(&f.db)
+        .output()
+        .unwrap();
+    assert!(
+        first.status.success(),
+        "{}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let first_text = String::from_utf8(first.stdout).unwrap();
+    assert!(first_text.contains("1 row(s) cleaned"), "{first_text}");
+    let second = f
+        .cmd()
+        .args(["brain", "remove"])
+        .arg(vault)
+        .arg("--db")
+        .arg(&f.db)
+        .output()
+        .unwrap();
+    assert!(matches!(second.status.code(), Some(0 | 2)));
+    assert!(!String::from_utf8_lossy(&second.stdout).contains("1 row(s) cleaned"));
+}
+
+// On Linux dirs::config_dir/data_local_dir honor XDG. Other platforms need
+// their own private registry mechanism before these writes can be isolated.
+#[cfg(target_os = "linux")]
+#[test]
+fn selected_pull_rejects_unknown_instance_and_uses_registered_workspace() {
+    let f = Fixture::new();
+    f.index();
+    let registry = f.dir.path().join("config/nestweaver/registry.json");
+    std::fs::create_dir_all(registry.parent().unwrap()).unwrap();
+    std::fs::write(&registry, r#"{"instances":[]}"#).unwrap();
+    let url = format!("file://{}", f.repo.display());
+    let unknown = f.query(
+        &["pull", &url, "--instance", "absent-instance", "--full"],
+        false,
+    );
+    assert!(
+        !unknown.status.success(),
+        "unknown instance cloned: {}",
+        String::from_utf8_lossy(&unknown.stdout)
+    );
+    assert!(!f.dir.path().join("data/nestweaver/workspace").exists());
+    std::fs::write(&registry, serde_json::to_vec(&json!({"instances": [{"id": "selected", "config_path": f.config, "snapshot_path": null}]})).unwrap()).unwrap();
+    let selected = f.query(&["pull", &url, "--instance", "selected", "--full"], false);
+    assert!(
+        selected.status.success(),
+        "{}",
+        String::from_utf8_lossy(&selected.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&selected.stdout)
+            .contains(f.dir.path().join("selected-workspace").to_str().unwrap())
+    );
+}

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -897,6 +897,11 @@ async fn server_mcp_http_initialize() {
             "jsonrpc": "2.0",
             "id": 1,
             "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "server-test", "version": "1" },
+            },
         }))
         .send()
         .await
@@ -1058,6 +1063,11 @@ async fn server_mcp_sessions_tracked() {
             "jsonrpc": "2.0",
             "id": 1,
             "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "server-test", "version": "1" },
+            },
         }))
         .send()
         .await
@@ -1080,6 +1090,11 @@ async fn server_mcp_sessions_tracked() {
             "jsonrpc": "2.0",
             "id": 2,
             "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "server-test", "version": "1" },
+            },
         }))
         .send()
         .await


### PR DESCRIPTION
Fixes 20 regressions reproduced against v9.2.0 through the CLI, MCP, and real vault content. For example, a complete publication rebuild previously rejected its own writer lock, a larger project-context budget could pull in another project's notes, and an ID-less MCP tool call could mutate the vault without a correlatable response.

The changes keep publication writer authority intact, enforce and disclose project membership, apply count and token limits together across typed transport, preserve logical backup identity through save and restore, and make configured CLI behavior and status reporting consistent. MCP now validates core method parameters and lossless request IDs before dispatch, requires IDs for tool calls, and ingests cancellation while work is active. Active mutation workers retain ownership until completion.

Covered fixes:

- Repository manifest generation rebinding after vault deletion, so remove/re-add stays clean.
- Publication writer-lock classification; portable backup identity and restore mismatch refusal; intentional vault exclusions and committed removal counts.
- Project membership boundaries and per-result provenance; combined result caps and configured limit validation.
- MCP request correlation, bounded integer IDs, parameter validation, and cancellation across direct, daemon proxy, hybrid, and HTTP paths.
- CLI error exits/JSON, empty-diff resolver trust, config-based daemon lifecycle, selected-instance pull, stdin report formatting, diagnostics signatures, and invalid-config JSON on stdout.
- Live gRPC repository-index status on typed and JSON routes.

Compatibility: numeric MCP IDs accept the exact signed/unsigned 64-bit integer range, strings, and explicit null. Floating-point, exponent, and overflowing numeric IDs are rejected before dispatch. Project context now defaults to strict membership; explicit component expansion remains supported. The new optional typed context count field is additive.

PR #371 fixes four separate items (nw-440–443), none of the original 19. It merged at `737a517e`; this branch was rebased cleanly onto that main commit before the final review and regression run.

A twentieth defect was found during the rerun and reproduced independently on both the installed release and this branch: vault deletion advances the graph generation without rebinding its repository manifest, causing the next add to commit with stale-cache errors. This branch also fixes that lifecycle gap.

Development, code review, and local regression validation are complete:

- Full workspace sweep plus complete corrected parity/server reruns: **4,814 tests pass, seven existing tests ignored, zero unresolved failures**. The sweep found three obsolete fixtures (a 5000-result limit and two incomplete HTTP initialize requests). The corrected full suites passed 59 parity tests and 37 server tests; runtime assertions were retained.
- Included suites: 1,483 engine, 330 MCP, 362 daemon unit, 62 daemon integration, 190 CLI integration, and 11 new process regression tests. The large-project performance test passed without changing its threshold.
- **Clippy passed in CI on `181e6b0b`** with `cargo clippy --workspace --all-targets -- -D warnings`. Formatting and diff checks pass.
- Manual CLI: 16 checks across 42 invocations. Manual MCP: 138 checks covering all 42 tools and direct/proxy/hybrid/authenticated HTTP protocol and cancellation cases.
- Copied real vault: 48 assertions for refresh, project provenance, combined count/token limits, backup identity, restore, and cleanup.
- Publication: 15 lifecycle checks with real CPU embeddings, explicit activation, successor activation, rollback, repeated rollback refusal, and pruning.
- gRPC index status: 26 active samples passed and idle state cleared. Vault remove/re-add stays at aligned graph/manifest generations 2/2 → 3/3 → 4/4 → 5/5 without a dirty marker.
- Release bundle/package self-tests passed on Linux. The refreshed knowledge brain passes its strict audit: 235 notes, zero errors and warnings.

The original full workspace log retains the three fixture failures; both complete affected suites were rerun after correction. Other hosted CI jobs are still running. Stock macOS and Metal runtime coverage are platform gates, not local Linux claims. #371's documented typed-error limitation for coalesced duplicate requests remains outside these fixes.
