### PR TITLE
Fix five unblocked backlog items (nw-459, nw-455, nw-456, nw-454, nw-451 partial)

### DIFF
--- a/crates/nestweaver-engine/src/manifest.rs
+++ b/crates/nestweaver-engine/src/manifest.rs
@@ -313,12 +313,33 @@ pub fn finalize_committed_graph_mutation(
         match load_manifest_cache_for_db(store, db_path) {
             Ok(manifests) => Some(manifests),
             Err(error) => {
-                outcome.record_warning(
-                    "load-manifest-cache",
-                    format!(
-                        "could not carry the repository manifest cache across publication: {error:#}"
-                    ),
-                );
+                // nw-459. The manifest cache is REBUILDABLE derived data. An
+                // upgrade invalidates it by construction (the artifact records
+                // the producing version), and the next index regenerates it.
+                // Recording that as a publication WARNING flipped the
+                // disposition to `CommittedDegraded`, which the daemon and CLI
+                // both surface as a hard error — so the first index after every
+                // upgrade exited non-zero on a graph that had committed
+                // perfectly, telling the user to "repair the named stage(s)"
+                // for a stage that needed no repair.
+                //
+                // A genuine incompatibility (different algorithm, different
+                // schema, foreign identity, corrupt payload) is NOT rebuildable
+                // and still degrades the publication loudly.
+                let rendered = format!("{error:#}");
+                if nestweaver_store::artifact_envelope::is_rebuildable_artifact(&rendered) {
+                    tracing::debug!(
+                        error = %rendered,
+                        "dropping a rebuildable manifest cache; the next index regenerates it"
+                    );
+                } else {
+                    outcome.record_warning(
+                        "load-manifest-cache",
+                        format!(
+                            "could not carry the repository manifest cache across publication: {rendered}"
+                        ),
+                    );
+                }
                 None
             }
         }

--- a/crates/nestweaver-store/src/artifact_envelope.rs
+++ b/crates/nestweaver-store/src/artifact_envelope.rs
@@ -24,6 +24,31 @@ pub fn is_stale_artifact_generation(message: &str) -> bool {
     message.contains(STALE_ARTIFACT_MARKER)
 }
 
+/// Marks a refusal that a caller can clear by REBUILDING the artifact.
+///
+/// nw-459. `producer_version` is compared by exact string equality, so a
+/// cache written by ANY earlier release compares unequal — even when
+/// `algorithm_fingerprint`, the field that exists to express algorithmic
+/// compatibility, matches exactly. That collapsed two different facts into
+/// one refusal: "a different ALGORITHM produced this" (must abort) and "the
+/// same algorithm in an older BUILD produced this" (drop it and move on).
+///
+/// Measured cost of the collapse on a live install: the first `brain refresh`
+/// after upgrading exited 1, because a producer-only mismatch degraded a
+/// publication whose graph had committed perfectly. Every user hit that on
+/// every upgrade.
+///
+/// This marker restores the distinction the module header already claims to
+/// draw, alongside [`STALE_ARTIFACT_MARKER`], so callers classify rather than
+/// string-match a version.
+pub const REBUILDABLE_ARTIFACT_MARKER: &str = "rebuildable artifact";
+
+/// Whether an error message is a refusal a re-index would clear.
+#[must_use]
+pub fn is_rebuildable_artifact(message: &str) -> bool {
+    message.contains(REBUILDABLE_ARTIFACT_MARKER) || is_stale_artifact_generation(message)
+}
+
 use serde_json::Value;
 
 use crate::{PublicationIdentity, StoreError};
@@ -113,6 +138,29 @@ impl ArtifactEnvelope {
             return Err(incompatible(format!(
                 "envelope version {} does not match supported version {}",
                 self.envelope_version, ARTIFACT_ENVELOPE_VERSION
+            )));
+        }
+        // nw-459: the producer is checked SEPARATELY and FIRST, because a
+        // producer-only difference is rebuildable rather than incompatible.
+        // Kind, schema and fingerprint must still match exactly — those
+        // describe WHAT the artifact is and HOW it was computed, and a
+        // mismatch there means the payload cannot be trusted at all.
+        if self.artifact_kind == expectation.artifact_kind
+            && self.artifact_schema_version == expectation.artifact_schema_version
+            && self.algorithm_fingerprint == expectation.algorithm_fingerprint
+            && self.producer_version != expectation.producer_version
+        {
+            return Err(StoreError::Query(format!(
+                "{REBUILDABLE_ARTIFACT_MARKER}: the {} artifact was produced by version {}, \
+                 but this build is {}. The algorithm ({}) and schema (v{}) are unchanged, so \
+                 this is derived data an upgrade invalidated, not a corrupt or foreign \
+                 artifact — re-index the repository \
+                 (`nestweaver index --repo <path> --force`) to regenerate it.",
+                self.artifact_kind,
+                self.producer_version,
+                expectation.producer_version,
+                self.algorithm_fingerprint,
+                self.artifact_schema_version
             )));
         }
         if self.artifact_kind != expectation.artifact_kind
@@ -263,6 +311,70 @@ mod tests {
             .validate_and_decode(expectation(&identity))
             .unwrap();
         assert_eq!(decoded, payload);
+    }
+
+    /// nw-459: a producer-version bump alone must NOT read as "incompatible".
+    ///
+    /// `producer_version` was compared by exact string equality, so a cache
+    /// written by ANY earlier release was rejected — even though
+    /// `algorithm_fingerprint`, the field that exists to express algorithmic
+    /// compatibility, matched. Measured cost on a live install: the first
+    /// `brain refresh` after upgrading exited 1 on a vault that had committed
+    /// perfectly.
+    #[test]
+    fn a_producer_version_bump_alone_is_rebuildable_not_incompatible() {
+        let identity = identity();
+        let payload = HashMap::from([("a".to_string(), 1.0)]);
+        let envelope = ArtifactEnvelope::new(expectation(&identity), &payload).unwrap();
+
+        let mut upgraded = expectation(&identity);
+        upgraded.producer_version = "9.3.0";
+        let error = envelope
+            .validate_and_decode::<HashMap<String, f64>>(upgraded)
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            is_rebuildable_artifact(&error),
+            "a producer-only difference must be classified rebuildable so callers can \
+             drop the cache and carry on; got {error:?}"
+        );
+        assert!(
+            error.contains("re-index") || error.contains("regenerate"),
+            "and it must name a remedy, like the generation check does; got {error:?}"
+        );
+    }
+
+    /// COUNTERWEIGHT. Only the producer may differ. A fingerprint or schema
+    /// change is a REAL incompatibility and must stay a hard refusal, or this
+    /// fix would silently accept an artifact computed by a different algorithm.
+    #[test]
+    fn a_fingerprint_or_schema_change_is_still_hard_incompatible() {
+        let identity = identity();
+        let payload = HashMap::from([("a".to_string(), 1.0)]);
+        let envelope = ArtifactEnvelope::new(expectation(&identity), &payload).unwrap();
+
+        let mut fingerprint = expectation(&identity);
+        fingerprint.producer_version = "9.3.0";
+        fingerprint.algorithm_fingerprint = "pagerank-v3";
+        let error = envelope
+            .validate_and_decode::<HashMap<String, f64>>(fingerprint)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("incompatible artifact"), "got {error:?}");
+        assert!(
+            !is_rebuildable_artifact(&error),
+            "a different ALGORITHM is not merely rebuildable; got {error:?}"
+        );
+
+        let mut schema = expectation(&identity);
+        schema.producer_version = "9.3.0";
+        schema.artifact_schema_version += 1;
+        let error = envelope
+            .validate_and_decode::<HashMap<String, f64>>(schema)
+            .unwrap_err()
+            .to_string();
+        assert!(!is_rebuildable_artifact(&error), "got {error:?}");
     }
 
     #[test]

--- a/scripts/dedupe-changelog-entries.sh
+++ b/scripts/dedupe-changelog-entries.sh
@@ -129,7 +129,11 @@ dedupe_changelog() {
   local before_bullets after_bullets removed half
 
   total_lines=$(wc -l < "$input")
-  first_line=$(grep -nE '^## \[' "$input" | head -1 | cut -d: -f1 || true)
+  # nw-456: `grep | head -1` under `pipefail` is the nw-450 shape -- head exits
+  # on the first match, grep takes SIGPIPE, and a SUCCESSFUL match is reported as
+  # a failed pipeline. `grep -m1` stops grep itself, so nothing is left writing
+  # into a closed pipe. Portable: -m is in GNU and BSD grep.
+  first_line=$(grep -m1 -nE '^## \[' "$input" | cut -d: -f1 || true)
 
   if [[ -z "$first_line" ]]; then
     # No version header at all -- nothing this script knows how to scope, so
@@ -281,8 +285,15 @@ self_test() {
   #    compare the wrong slices.
   local second_header second_line_source second_line_output
   second_header=$(grep -E '^## \[' "$changelog" | sed -n '2p')
-  second_line_source=$(grep -nFx -- "$second_header" "$changelog" | head -1 | cut -d: -f1)
-  second_line_output=$(printf '%s\n' "$output" | grep -nFx -- "$second_header" | head -1 | cut -d: -f1)
+  second_line_source=$(grep -m1 -nFx -- "$second_header" "$changelog" | cut -d: -f1)
+  # nw-456: a here-string, NOT a pipe. `grep -m1` is only safe when grep is the
+  # FIRST stage reading a file (lines 132/284). Here grep CONSUMES a ~350 KB
+  # producer, so making grep exit early leaves `printf` writing into a closed
+  # pipe -- printf takes SIGPIPE and `pipefail` reports 141. That is the same
+  # nw-450 shape, merely relocated from the consumer to the producer, and it
+  # was caught by this script's own self-test going 0 -> 141.
+  # `<<<` is a temp file rather than a pipe, so no stage can be SIGPIPEd.
+  second_line_output=$(grep -m1 -nFx -- "$second_header" <<< "$output" | cut -d: -f1)
   local expected_rest actual_rest
   expected_rest=$(mktemp)
   actual_rest=$(mktemp)

--- a/scripts/verify-release-package.sh
+++ b/scripts/verify-release-package.sh
@@ -18,6 +18,33 @@
 
 set -euo pipefail
 
+# nw-455: `sha256sum` is GNU coreutils. It resolves on this machine only via a
+# compat shim newer macOS ships at /sbin, which is neither guaranteed nor GNU.
+# `verify-release-bundle.sh` already uses the portable `shasum -a 256`, so the
+# two sibling verifiers disagreed with each other. One helper, both forms.
+nw_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$@"
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$@"
+  else
+    echo "neither sha256sum nor shasum is available; cannot verify checksums" >&2
+    return 1
+  fi
+}
+
+nw_sha256_check() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c -- "$@"
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c -- "$@"
+  else
+    echo "neither sha256sum nor shasum is available; cannot verify checksums" >&2
+    return 1
+  fi
+}
+
+
 PLATFORM_KEYS=(darwin-arm64 darwin-x64 linux-arm64 linux-x64)
 
 platform_os() {
@@ -186,7 +213,7 @@ pack_package() {
   package_filename=$(jq -er '.[0].filename' <<< "$pack_json")
   package_path="$package_dir/$package_filename"
   test -f "$package_path"
-  package_sha256=$(sha256sum "$package_path" | awk '{print $1}')
+  package_sha256=$(nw_sha256 "$package_path" | awk '{print $1}')
   [[ "$package_sha256" =~ ^[0-9a-f]{64}$ ]]
   printf '%s  %s\n' "$package_sha256" "$package_filename" > "$package_path.sha256"
 
@@ -252,8 +279,8 @@ verify_package_artifact() {
   fi
   rm -f -- "$expected_files" "$actual_files"
 
-  (cd "$package_dir" && sha256sum -c -- "$package_filename.sha256") >&2
-  package_sha256=$(sha256sum "$package_path" | awk '{print $1}')
+  (cd "$package_dir" && nw_sha256_check "$package_filename.sha256") >&2
+  package_sha256=$(nw_sha256 "$package_path" | awk '{print $1}')
   package_integrity=$(node -e '
     const crypto = require("crypto");
     const fs = require("fs");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2994,10 +2994,10 @@ fn render_blast_radius_text(payload: &serde_json::Value) {
 /// Unwrapping to the local tier restores all three. An unrecognised or absent
 /// `tier` is returned unchanged, so single-tier behaviour is untouched.
 fn brain_impact_local_tier(payload: &serde_json::Value) -> &serde_json::Value {
-    if payload.get("tier").and_then(serde_json::Value::as_str) == Some("two_tier") {
-        if let Some(local) = payload.get("local_impact") {
-            return local;
-        }
+    if payload.get("tier").and_then(serde_json::Value::as_str) == Some("two_tier")
+        && let Some(local) = payload.get("local_impact")
+    {
+        return local;
     }
     payload
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2875,6 +2875,46 @@ fn render_investigate_text(payload: &serde_json::Value) {
 /// emitting JSON or text depending on whether a daemon happened to be running
 /// (nw-108).
 fn render_blast_radius_text(payload: &serde_json::Value) {
+    // nw-454. Every read below is a TOP-LEVEL key, and a two-tier payload has
+    // none of them up there -- it carries `tier`, `local_impact` and
+    // `org_wide_impact`. So a federated call printed "0 affected symbol(s),
+    // risk " with blank status and gate_state, then "No affected symbols
+    // reported.".
+    //
+    // That was survivable while the exit code was ALSO wrong (nw-442): both
+    // said "clean" and at least agreed. Now that the exit code is correct, a
+    // federated run can exit 2 while the text claims nothing was affected --
+    // a CI failure with no visible cause. Render each tier through this same
+    // function instead, so the two surfaces cannot disagree.
+    if payload.get("tier").and_then(serde_json::Value::as_str) == Some("two_tier") {
+        if let Some(local) = payload.get("local_impact") {
+            println!("Local impact");
+            render_blast_radius_text(local);
+        }
+        let org = payload.get("org_wide_impact");
+        println!();
+        match org.and_then(|o| o.get("results")) {
+            Some(results) => {
+                let server = org
+                    .and_then(|o| o.get("source_server"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("upstream");
+                println!("Org-wide impact (via {server})");
+                render_blast_radius_text(results);
+            }
+            None => {
+                // An unavailable upstream carries `status`/`note` and no
+                // `results`. Say so rather than printing an empty section that
+                // reads as "upstream found nothing".
+                let note = org
+                    .and_then(|o| o.get("note"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("upstream did not answer");
+                println!("Org-wide impact: unavailable — {note}");
+            }
+        }
+        return;
+    }
     let s = |k: &str| payload.get(k).and_then(|v| v.as_str()).unwrap_or("");
     let n = |k: &str| payload.get(k).and_then(|v| v.as_u64()).unwrap_or(0);
 
@@ -2939,6 +2979,101 @@ fn render_blast_radius_text(payload: &serde_json::Value) {
     }
 }
 
+/// The tier of a `brain_impact` payload that the CLI's rendering block reads.
+///
+/// nw-451, the same class as nw-442 on a different command. `brain_impact` is
+/// `ToolRouting::TwoTier`, so with a healthy upstream the daemon returns
+/// `{tier, local_impact, org_wide_impact}` and NOTHING the caller wants is at
+/// the top level. Three separate reads then went wrong at once:
+/// `value.get("status")` missed a local `not_found`/`ambiguous` and fell
+/// through to the "found" branch; `value.get("impact_nodes")` was `None`, so
+/// `--json` printed the whole envelope as if it were the node list; and the
+/// text branch, gated on the same `None`, was skipped entirely and the command
+/// returned `EXIT_SUCCESS` having printed NOTHING.
+///
+/// Unwrapping to the local tier restores all three. An unrecognised or absent
+/// `tier` is returned unchanged, so single-tier behaviour is untouched.
+fn brain_impact_local_tier(payload: &serde_json::Value) -> &serde_json::Value {
+    if payload.get("tier").and_then(serde_json::Value::as_str) == Some("two_tier") {
+        if let Some(local) = payload.get("local_impact") {
+            return local;
+        }
+    }
+    payload
+}
+
+/// Whether `payload` is a two-tier envelope carrying an org-wide tier that the
+/// CLI does not yet render.
+///
+/// nw-451: reading only the local tier is correct but INCOMPLETE, and silently
+/// dropping an upstream answer is the kind of omission this codebase treats as
+/// a disclosure defect. The caller prints a note rather than pretending the
+/// local tier was the whole response.
+fn brain_impact_has_unrendered_org_tier(payload: &serde_json::Value) -> bool {
+    payload.get("tier").and_then(serde_json::Value::as_str) == Some("two_tier")
+        && payload
+            .get("org_wide_impact")
+            .and_then(|org| org.get("results"))
+            .is_some()
+}
+
+#[cfg(test)]
+mod brain_impact_tier_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn two_tier(local: serde_json::Value) -> serde_json::Value {
+        json!({
+            "tier": "two_tier",
+            "local_impact": local,
+            "org_wide_impact": {"source_server": "org", "results": {"impact_nodes": []}},
+        })
+    }
+
+    #[test]
+    fn a_two_tier_envelope_resolves_to_its_local_tier() {
+        let local = json!({"status": "not_found", "impact_nodes": []});
+        let payload = two_tier(local.clone());
+        assert_eq!(brain_impact_local_tier(&payload), &local);
+    }
+
+    /// The defect in one assertion: pre-fix, `status` read `None` from the
+    /// envelope and a genuinely missing symbol rendered as "found".
+    #[test]
+    fn a_local_not_found_is_visible_through_the_envelope() {
+        let payload = two_tier(json!({"status": "not_found"}));
+        assert_eq!(
+            brain_impact_local_tier(&payload)
+                .get("status")
+                .and_then(|v| v.as_str()),
+            Some("not_found")
+        );
+        assert_eq!(payload.get("status").and_then(|v| v.as_str()), None);
+    }
+
+    /// COUNTERWEIGHT: a single-tier payload must pass through untouched, or
+    /// every non-federated caller would start reading a tier that is not there.
+    #[test]
+    fn a_single_tier_payload_is_returned_unchanged() {
+        let single = json!({"status": "ok", "impact_nodes": [{"uid": "a"}]});
+        assert_eq!(brain_impact_local_tier(&single), &single);
+        assert!(!brain_impact_has_unrendered_org_tier(&single));
+    }
+
+    /// COUNTERWEIGHT: an unavailable upstream carries no `results`, so there is
+    /// nothing unrendered to disclose and the note must not fire.
+    #[test]
+    fn an_unavailable_upstream_is_not_reported_as_unrendered() {
+        let payload = json!({
+            "tier": "two_tier",
+            "local_impact": {"status": "ok"},
+            "org_wide_impact": {"source_server": "org", "status": "unavailable"},
+        });
+        assert!(!brain_impact_has_unrendered_org_tier(&payload));
+        assert!(brain_impact_has_unrendered_org_tier(&two_tier(json!({}))));
+    }
+}
+
 /// Derive `blast-radius`'s process exit code from its response payload.
 ///
 /// nw-442: this used to read `resolver_stale_repos` from the TOP level of
@@ -2986,6 +3121,65 @@ fn blast_radius_tier_is_stale(payload: &serde_json::Value) -> bool {
     payload["resolver_stale_repos"]
         .as_array()
         .is_some_and(|repos| !repos.is_empty())
+}
+
+#[cfg(test)]
+mod blast_radius_text_tier_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// nw-454: the renderer reads top-level keys, which a two-tier payload does
+    /// not have. These pin that the two-tier shape is DETECTED — the printing
+    /// itself goes to stdout, so the observable contract under test is that the
+    /// function recognises the envelope and recurses rather than falling into
+    /// the single-tier reads and printing zeros.
+    #[test]
+    fn a_two_tier_payload_is_recognised_as_such() {
+        let payload = json!({
+            "tier": "two_tier",
+            "local_impact": {"affected_symbol_count": 3, "risk": "high"},
+            "org_wide_impact": {"source_server": "org", "results": {"affected_symbol_count": 1}},
+        });
+        assert_eq!(
+            payload.get("tier").and_then(serde_json::Value::as_str),
+            Some("two_tier")
+        );
+        // The single-tier reads the renderer would otherwise use find nothing,
+        // which is exactly why the old output said 0 / blank.
+        assert_eq!(payload.get("affected_symbol_count"), None);
+        assert_eq!(payload.get("risk"), None);
+        // Rendering must not panic on either tier shape.
+        render_blast_radius_text(&payload);
+    }
+
+    /// COUNTERWEIGHT: an unavailable upstream has no `results`, and must render
+    /// as unavailable rather than as an empty (i.e. "found nothing") section.
+    #[test]
+    fn an_unavailable_upstream_renders_without_panicking() {
+        let payload = json!({
+            "tier": "two_tier",
+            "local_impact": {"affected_symbol_count": 0, "risk": "low"},
+            "org_wide_impact": {"source_server": "org", "status": "unavailable"},
+        });
+        assert!(
+            payload
+                .get("org_wide_impact")
+                .and_then(|o| o.get("results"))
+                .is_none()
+        );
+        render_blast_radius_text(&payload);
+    }
+
+    /// COUNTERWEIGHT: a single-tier payload must still take the original path.
+    #[test]
+    fn a_single_tier_payload_still_renders_directly() {
+        let payload = json!({"affected_symbol_count": 2, "risk": "low", "status": "complete"});
+        assert_ne!(
+            payload.get("tier").and_then(serde_json::Value::as_str),
+            Some("two_tier")
+        );
+        render_blast_radius_text(&payload);
+    }
 }
 
 #[cfg(test)]
@@ -19572,6 +19766,22 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         "limit": limit,
                     }),
                 )? {
+                    // nw-451: unwrap a two-tier envelope BEFORE anything reads
+                    // this payload. `brain_impact` is TwoTier-routed, so with a
+                    // healthy upstream `status` and `impact_nodes` live inside
+                    // `local_impact` and every read below sees `None` at the top
+                    // level -- which silently turned a `not_found` into "found"
+                    // and made the text path print nothing and exit 0.
+                    let envelope = value;
+                    let value = brain_impact_local_tier(&envelope).clone();
+                    if brain_impact_has_unrendered_org_tier(&envelope) && !json && !out.quiet {
+                        // Disclose rather than drop: the local tier is not the
+                        // whole answer, and saying so is cheaper than pretending.
+                        eprintln!(
+                            "Note: an org-wide tier was returned and is not rendered here; \
+                             use --json to see it."
+                        );
+                    }
                     // Honor the daemon tool's status so daemon mode matches the direct path's
                     // exit-code contract (not_found=2, ambiguous=3) instead of always exit 0.
                     match value.get("status").and_then(|v| v.as_str()) {

--- a/tests/ready_regression_test.rs
+++ b/tests/ready_regression_test.rs
@@ -289,11 +289,25 @@ fn healthy_empty_diff_ignores_an_unrelated_incompatible_repo() {
         .assert()
         .success();
     let repos = payload(&f.query(&["list-repos", "--json"], true));
+    // The indexer stores a CANONICAL root_path, so comparing it to the path
+    // string the test spelled is only correct where the two coincide. On macOS
+    // `TMPDIR` lives under `/var/folders/...` and `/var` is a symlink to
+    // `/private/var`, so the stored path is `/private/var/folders/...` and this
+    // find never matched -- the test failed at "unrelated repo must be indexed"
+    // on every macOS run while passing in CI, which is Linux-only. Canonicalise
+    // both sides so the comparison means what it says on either platform.
+    let unrelated_canonical =
+        std::fs::canonicalize(&unrelated).expect("unrelated dir must exist to canonicalise");
     let unrelated_uid = repos
         .as_array()
         .unwrap()
         .iter()
-        .find(|repo| repo["root_path"].as_str() == unrelated.to_str())
+        .find(|repo| {
+            repo["root_path"]
+                .as_str()
+                .and_then(|path| std::fs::canonicalize(path).ok())
+                .is_some_and(|path| path == unrelated_canonical)
+        })
         .expect("unrelated repo must be indexed")["uid"]
         .as_str()
         .unwrap();


### PR DESCRIPTION
Five items from the unblocked queue, each its own commit. Rebased onto
`1f4afb14` (#373) before any work, and every target re-verified as still
reproducing on that new main rather than assumed from the pre-rebase list.

**Verification status: CI is the first full gate.** A local
`cargo test --workspace` is running against a freshly cleaned tree but had not
reached the root crate when this was opened, so the last two commits
(`impact`/`blast-radius`) are unverified locally. Opening early deliberately so
CI runs in parallel; I'll report and fix anything it catches.

## nw-459 — a version upgrade failed the first index (the release-relevant one)

`ArtifactEnvelope::validate_and_decode` compared `producer_version` by exact
string equality, so a cache from ANY earlier release read as "incompatible" —
even though `algorithm_fingerprint`, the field that exists to express
algorithmic compatibility, matched exactly. `manifest.rs` recorded that as a
publication warning, which flips the disposition to `CommittedDegraded`, which
the daemon and CLI both surface as a hard error.

Found live during a WAL recovery: `brain refresh` **exited 1** having indexed
1,294 notes and advanced the graph 869 → 870, with the error itself conceding
*"The graph was NOT rolled back."* It self-heals on the next index, so no data
was at risk — the cost is one spurious hard failure per upgrade, landing on a
user's first impression of the new version. **9.2.0 → 9.3.0 would hit it.**

`REBUILDABLE_ARTIFACT_MARKER` restores the distinction the module header
already claims to draw, beside the existing `STALE_ARTIFACT_MARKER`. Kind,
schema and fingerprint still match exactly — a counterweight pins that a
fingerprint or schema change stays a hard refusal.

## nw-451 / nw-454 — two-tier blindness in `impact` and `blast-radius`

Both read top-level keys that a federated payload doesn't have. `impact` was
the worse of the two: it printed **nothing** and returned `EXIT_SUCCESS`, and
masked a local `not_found`/`ambiguous` as "found".

nw-454 is closed. **nw-451 is half-done and stays open**: the local tier now
renders correctly, but org-wide rendering isn't built — the command discloses
the unrendered tier instead of dropping it silently.

## nw-455 / nw-456 — release-script portability

`sha256sum` is GNU coreutils and resolved on macOS only through a compat shim;
its sibling verifier already used the portable form, so the two disagreed.
Verified by removing `sha256sum` from `PATH` entirely.

nw-456 is worth reading: **the first fix made it worse.** Replacing
`grep | head -1` with `grep -m1` moved the SIGPIPE from the consumer to a
350 KB `printf` producer, and the script's own self-test caught it going
**0 → 141**. A three-way bisect isolated the line. The rule, now in the code:
`grep -m1` substitutes for `| head -1` only when grep is the FIRST stage.

## Scope — what is deliberately NOT here

Asked to fix all 30 unblocked items; five landed. Two closed themselves:
**nw-458** was fixed by #373 (better than specified) and **nw-305** closed when
#373 merged — which is why re-verifying against the new main mattered.

The rest are not responsibly bundleable:

| Item | Why not here |
| --- | --- |
| nw-348 | 29,000-line `main.rs` split; the item itself asks for its own mechanical-move PR |
| nw-073 | lives in the *ladybug* repo, not this codebase |
| nw-349, nw-291 | open-ended research categories, not discrete fixes |
| nw-438 | needs the 9.3.0 upgrade window, which does not exist yet |
| nw-460 | a daemon-boot defaults change; left out rather than ride along unverified |
| ~17 others | varying size, would make this unreviewable |

## A note on the environment

Three ENOSPC events during this work — each build cycle costs 20–30 GB and
`deps/` reached 31 GB. That is why the last two commits were batched into one
build rather than verified individually. ~135 GB reclaimed across the session.
