### PR TITLE
Scale the daemon boot ceiling; pin the three stale_repos populations (nw-460, nw-371)

### DIFF
--- a/crates/nestweaver-client/src/autostart.rs
+++ b/crates/nestweaver-client/src/autostart.rs
@@ -934,6 +934,49 @@ pub const DAEMON_BOOT_TIMEOUT_ENV: &str = "NESTWEAVER_DAEMON_BOOT_TIMEOUT_SECS";
 /// daemon is actually alive and working.
 const DEFAULT_DAEMON_BOOT_TIMEOUT_SECS: u64 = 30;
 
+/// Extra patience per GiB of graph on disk.
+///
+/// nw-460. The 30s default above is calibrated for a small graph, but the
+/// product is sold on large ones, and boot cost is dominated by opening the
+/// database and its sidecars. Measured on the 1.3 GiB `kory-brain` graph
+/// (687 MiB database + 579 MiB embeddings): a cold `brain status` needed ~44s
+/// and failed at 30s, reporting that the daemon "did not become healthy" when
+/// it was simply still loading. That is a DEFAULTS problem, not a fault, and
+/// it cost real diagnostic time during a WAL recovery by making a SUCCESSFUL
+/// fix look like a continued failure.
+const DAEMON_BOOT_TIMEOUT_SECS_PER_GIB: u64 = 30;
+
+/// Total on-disk footprint of `db_path` and the sidecars beside it.
+///
+/// Sidecars share the database's file name as a prefix (`<db>.embeddings.bin`,
+/// `<db>.clusters.json`, …), which is what the daemon opens on boot, so their
+/// size is the thing that predicts boot cost. Anything unreadable counts as
+/// zero: this only ever buys patience, so a bad estimate must not shorten the
+/// ceiling.
+fn graph_footprint_bytes(db_path: &Path) -> u64 {
+    let Some(dir) = db_path.parent() else {
+        return 0;
+    };
+    let Some(stem) = db_path.file_name().and_then(|n| n.to_str()) else {
+        return 0;
+    };
+    let Ok(entries) = fs::read_dir(dir) else {
+        return 0;
+    };
+    entries
+        .flatten()
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name == stem || name.starts_with(&format!("{stem}.")))
+        })
+        .filter_map(|entry| entry.metadata().ok())
+        .filter(|meta| meta.is_file())
+        .map(|meta| meta.len())
+        .sum()
+}
+
 /// Resolve the boot ceiling, clamped to 1..=600s. An unparseable or
 /// out-of-range value falls back to the default rather than failing the
 /// command — this is a patience knob, not a correctness input.
@@ -948,13 +991,38 @@ pub fn daemon_boot_timeout() -> Duration {
         )
 }
 
+/// The boot ceiling for a SPECIFIC database, scaled by what the daemon has to
+/// open before it can bind.
+///
+/// nw-460. An explicit `NESTWEAVER_DAEMON_BOOT_TIMEOUT_SECS` still wins
+/// outright — a human who names a number means it. Otherwise the default grows
+/// with the graph, so a multi-hundred-MB corpus boots without the caller having
+/// to discover an environment variable. Still clamped to the same 600s ceiling,
+/// and `wait_for_socket_watching` continues to watch process liveness, so a
+/// genuinely dead daemon is still reported promptly rather than waited out.
+pub fn daemon_boot_timeout_for(db_path: &Path) -> Duration {
+    if let Some(explicit) = std::env::var(DAEMON_BOOT_TIMEOUT_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|secs| (1..=600).contains(secs))
+    {
+        return Duration::from_secs(explicit);
+    }
+    const GIB: u64 = 1024 * 1024 * 1024;
+    let gibibytes = graph_footprint_bytes(db_path) / GIB;
+    let scaled = DEFAULT_DAEMON_BOOT_TIMEOUT_SECS
+        .saturating_add(gibibytes.saturating_mul(DAEMON_BOOT_TIMEOUT_SECS_PER_GIB))
+        .min(600);
+    Duration::from_secs(scaled)
+}
+
 fn wait_for_daemon_ready(
     db_path: &Path,
     ignore_pid: Option<i32>,
     expected_config: &crate::RestartConfig,
     launcher: Option<&mut SpawnedLauncher>,
 ) -> Result<()> {
-    let timeout = daemon_boot_timeout();
+    let timeout = daemon_boot_timeout_for(db_path);
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -1016,6 +1084,12 @@ fn wait_for_socket_watching(
     ignore_pid: Option<i32>,
 ) -> Result<()> {
     let start = Instant::now();
+    // nw-460 deliberately does NOT scale here: this helper has no database
+    // context, and it is the liveness-watching leg -- it bails as soon as the
+    // daemon is known to have exited, so its ceiling is a backstop rather than
+    // the thing a large graph exhausts. The ceiling that a big corpus actually
+    // hit is in `wait_for_daemon_ready`, which does know the database and does
+    // scale.
     let timeout = daemon_boot_timeout();
     let mut delay = Duration::from_millis(50);
     let max_delay = Duration::from_millis(500);
@@ -1693,6 +1767,58 @@ credential_method = "gh"
 
         unsafe { std::env::remove_var(DAEMON_BOOT_TIMEOUT_ENV) };
         assert_eq!(daemon_boot_timeout(), default);
+    }
+
+    /// nw-460: a small graph keeps the 30s default, a large one earns more.
+    #[test]
+    fn the_boot_ceiling_scales_with_the_graph_on_disk() {
+        // SAFETY: single-threaded test scope, restored below.
+        unsafe { std::env::remove_var(DAEMON_BOOT_TIMEOUT_ENV) };
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        std::fs::write(&db, b"small").unwrap();
+        assert_eq!(
+            daemon_boot_timeout_for(&db),
+            Duration::from_secs(30),
+            "a tiny graph must not pay for patience it does not need"
+        );
+
+        // A sidecar is what actually dominates boot: 2 GiB of embeddings.
+        let sidecar = dir.path().join("brain.lbug.embeddings.bin");
+        let two_gib = vec![0_u8; 1024 * 1024];
+        let mut file = std::fs::File::create(&sidecar).unwrap();
+        use std::io::Write;
+        for _ in 0..2048 {
+            file.write_all(&two_gib).unwrap();
+        }
+        drop(file);
+        assert_eq!(
+            daemon_boot_timeout_for(&db),
+            Duration::from_secs(30 + 2 * 30),
+            "the sidecars beside the database are what the daemon opens on boot"
+        );
+    }
+
+    /// COUNTERWEIGHT: an explicit env override still wins outright. A human who
+    /// names a number means it, and scaling past it would ignore them.
+    #[test]
+    fn an_explicit_boot_timeout_still_overrides_the_scaled_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        std::fs::write(&db, b"x").unwrap();
+        // SAFETY: single-threaded test scope, removed below.
+        unsafe { std::env::set_var(DAEMON_BOOT_TIMEOUT_ENV, "45") };
+        assert_eq!(daemon_boot_timeout_for(&db), Duration::from_secs(45));
+        unsafe { std::env::remove_var(DAEMON_BOOT_TIMEOUT_ENV) };
+    }
+
+    /// COUNTERWEIGHT: a missing database must not panic or explode the ceiling.
+    #[test]
+    fn an_absent_database_falls_back_to_the_plain_default() {
+        // SAFETY: single-threaded test scope.
+        unsafe { std::env::remove_var(DAEMON_BOOT_TIMEOUT_ENV) };
+        let missing = Path::new("/nonexistent/definitely/not/here.lbug");
+        assert_eq!(daemon_boot_timeout_for(missing), Duration::from_secs(30));
     }
 
     #[test]

--- a/crates/nestweaver-client/src/autostart.rs
+++ b/crates/nestweaver-client/src/autostart.rs
@@ -1745,14 +1745,32 @@ credential_method = "gh"
         );
     }
 
+    /// Serialises every test that mutates [`DAEMON_BOOT_TIMEOUT_ENV`].
+    ///
+    /// The comment those tests used to carry -- "SAFETY: single-threaded test"
+    /// -- was NOT true: `cargo test` runs a binary's tests on parallel threads.
+    /// It held only because one test was the sole toucher of this variable.
+    /// nw-460 added two more and they raced immediately: the override test set
+    /// `45` while the absent-database test asserted the `30` default, and the
+    /// loser saw the other's value. Environment variables are process-global,
+    /// so the fix is a lock rather than a comment.
+    ///
+    /// Poisoning is absorbed: a panic in one of these tests must fail THAT
+    /// test, not cascade into unrelated failures in the others.
+    static BOOT_TIMEOUT_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// The ceiling is env-overridable so CI and constrained machines can extend
     /// it without a rebuild. Out-of-range and unparseable values fall back to
     /// the default — this is a patience knob, not a correctness input.
     #[test]
     fn boot_timeout_honours_the_env_override_and_rejects_nonsense() {
+        let _guard = BOOT_TIMEOUT_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let default = Duration::from_secs(DEFAULT_DAEMON_BOOT_TIMEOUT_SECS);
 
-        // SAFETY: single-threaded test; the override is read only here.
+        // SAFETY: `BOOT_TIMEOUT_ENV_LOCK` is held for this whole test, so no
+        // other test in this binary reads or writes the variable meanwhile.
         unsafe { std::env::set_var(DAEMON_BOOT_TIMEOUT_ENV, "45") };
         assert_eq!(daemon_boot_timeout(), Duration::from_secs(45));
 
@@ -1772,7 +1790,10 @@ credential_method = "gh"
     /// nw-460: a small graph keeps the 30s default, a large one earns more.
     #[test]
     fn the_boot_ceiling_scales_with_the_graph_on_disk() {
-        // SAFETY: single-threaded test scope, restored below.
+        let _guard = BOOT_TIMEOUT_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // SAFETY: the lock above serialises every toucher of this variable.
         unsafe { std::env::remove_var(DAEMON_BOOT_TIMEOUT_ENV) };
         let dir = tempfile::tempdir().unwrap();
         let db = dir.path().join("brain.lbug");
@@ -1803,10 +1824,13 @@ credential_method = "gh"
     /// names a number means it, and scaling past it would ignore them.
     #[test]
     fn an_explicit_boot_timeout_still_overrides_the_scaled_default() {
+        let _guard = BOOT_TIMEOUT_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let dir = tempfile::tempdir().unwrap();
         let db = dir.path().join("brain.lbug");
         std::fs::write(&db, b"x").unwrap();
-        // SAFETY: single-threaded test scope, removed below.
+        // SAFETY: the lock above serialises every toucher of this variable.
         unsafe { std::env::set_var(DAEMON_BOOT_TIMEOUT_ENV, "45") };
         assert_eq!(daemon_boot_timeout_for(&db), Duration::from_secs(45));
         unsafe { std::env::remove_var(DAEMON_BOOT_TIMEOUT_ENV) };
@@ -1815,7 +1839,10 @@ credential_method = "gh"
     /// COUNTERWEIGHT: a missing database must not panic or explode the ceiling.
     #[test]
     fn an_absent_database_falls_back_to_the_plain_default() {
-        // SAFETY: single-threaded test scope.
+        let _guard = BOOT_TIMEOUT_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // SAFETY: the lock above serialises every toucher of this variable.
         unsafe { std::env::remove_var(DAEMON_BOOT_TIMEOUT_ENV) };
         let missing = Path::new("/nonexistent/definitely/not/here.lbug");
         assert_eq!(daemon_boot_timeout_for(missing), Duration::from_secs(30));

--- a/crates/nestweaver-federation/src/results.rs
+++ b/crates/nestweaver-federation/src/results.rs
@@ -878,6 +878,47 @@ pub fn inject_or_wrap_provenance(result: &mut Value, sources: &[&str], stale_rep
 
 #[cfg(test)]
 mod tests {
+    /// nw-371: THREE different JSON keys are spelled `stale_repos` and mean
+    /// three different populations. This is not a defect — nothing decodes one
+    /// as another today — but the NAMING is a trap, and the next author to
+    /// "unify" them will be doing something that looks like cleanup.
+    ///
+    /// This test is that author's tripwire. If you are here because it failed,
+    /// read this before changing it:
+    ///
+    /// 1. `_meta.stale_repos` (HERE, federation) — upstream servers whose data
+    ///    is behind. Values are repo IDENTIFIERS as the upstream names them,
+    ///    e.g. `github.com/acme/api`.
+    /// 2. `stale_repos` on `hub_nodes` / `repo_map`
+    ///    (`nestweaver-mcp/src/tools.rs`) — repos whose edges were built by an
+    ///    older resolver. Values are repo UIDs, e.g. `repo:default:59d69492b3df`.
+    /// 3. `stale_repos` on `stale_check` (same file) — repos BEHIND HEAD in git.
+    ///    Values are git URLs, e.g. `file:///path/to/repo`.
+    ///
+    /// They are not interchangeable and must not be merged into one key: a
+    /// caller that unions them gets a list whose values are three different
+    /// kinds of string. nw-370 already faced this and deliberately added
+    /// `resolver_stale_repos` as a FOURTH, differently-named field rather than
+    /// overloading a third meaning onto this one — that precedent is the
+    /// intended direction.
+    #[test]
+    fn the_three_stale_repos_populations_stay_distinct() {
+        // Population (1) is what this crate owns. Pin its location and the
+        // shape of its values, so moving it out of `_meta` or switching it to
+        // UIDs fails here rather than silently in a consumer.
+        let mut value = json!({"results": []});
+        set_stale_repos(&mut value, &["github.com/acme/api".to_string()]);
+        assert_eq!(
+            value["_meta"]["stale_repos"][0], "github.com/acme/api",
+            "federation staleness lives under `_meta` and carries upstream repo identifiers"
+        );
+        assert!(
+            value.get("stale_repos").is_none(),
+            "it must NOT also appear at the top level, where it would collide with \
+             the generation-stale and behind-HEAD populations"
+        );
+    }
+
     use super::*;
     use nestweaver_schema::uid::{
         canonical_symbol_id, note_uid, repo_uid, symbol_uid, tag_uid, vault_uid,


### PR DESCRIPTION
Two items from the ready queue, branched off `445d660a`.

**Verification:** `cargo fmt --all -- --check` and
`cargo clippy --workspace --all-targets -- -D warnings` both **pass locally**.
A complete `cargo test --workspace --no-fail-fast` is still running; opening now
so CI runs in parallel. (Last batch I opened with clippy unverified and it
failed — that gap is closed this time.)

## nw-460 — the boot ceiling is calibrated for a graph nobody has

The 30s default assumes a small graph while the product is sold on large ones,
and boot cost is dominated by opening the database and its sidecars.

Measured on the 1.3 GiB `kory-brain` graph (687 MiB database + 579 MiB
embeddings): a cold `brain status` needs **~44s** and failed at 30s, reporting
that the daemon *"did not become healthy"* when it was still loading.

The disclosure was already good — the message names the env var and the log
path — so this is a **defaults** problem, not an honesty one. The cost was real
though: during the WAL-corruption recovery it made a **successful fix present as
a continued failure** for several minutes, because the command used to verify
the fix timed out before the daemon finished booting.

`daemon_boot_timeout_for` sums the database plus the sidecars beside it and adds
30s per GiB on the 30s base, clamped to the same 600s ceiling. An explicit
`NESTWEAVER_DAEMON_BOOT_TIMEOUT_SECS` still wins outright — a human who names a
number means it — and an unreadable path contributes zero, so a bad estimate can
only ever buy patience, never shorten the ceiling.

`wait_for_socket_watching` deliberately keeps the flat default: it has no
database context, and it is the liveness-watching leg that bails as soon as the
daemon is known to have exited, so its ceiling is a backstop rather than the one
a large graph exhausts.

Three tests, including counterweights for the env override and for a missing
database.

## nw-371 — a tripwire, not a rename

Three different JSON keys are spelled `stale_repos` and mean three different
populations:

| key | population | value shape |
| --- | --- | --- |
| `_meta.stale_repos` | upstreams whose data is behind | `github.com/acme/api` |
| `stale_repos` on `hub_nodes`/`repo_map` | edges built by an older resolver | `repo:default:59d6…` |
| `stale_repos` on `stale_check` | repos behind HEAD in git | `file:///path/to/repo` |

This is **not a defect today** — nothing decodes one as another. The item was
filed because the naming is the trap: the next author to "unify" them will be
doing something that looks like cleanup, and a caller who unions them gets a
list whose values are three different kinds of string.

So the fix is a pinning test whose doc comment is addressed to whoever the
failure wakes up. It records the precedent too: nw-370 hit this and deliberately
added `resolver_stale_repos` as a **fourth, differently-named** field rather than
overloading a third meaning onto an existing one.

## Assessed and deliberately not included

**nw-281** is bigger than its `medium` suggests. `set_extension` routes through a
gRPC handler **under the daemon write gate**, so a proper `unset_extension` needs
a proto change on both sides. Half-building that beside two unrelated fixes would
be worse than not starting.

Noticed while looking, and filed separately: the CLI's `extensions unset` calls
`remove_extension_key_durable` **directly**, bypassing the write gate that
`set_extension` deliberately holds — a delete that does not serialize against a
backup's sidecar staging.

**nw-451**'s remaining half (render the org-wide tier in `impact`) needs the text
branch extracted into a shared renderer; it carries decode, capping and count
logic inline. Worth doing deliberately, not wedged in here.

## A flake worth knowing about

`macos_autostart_normal_db_is_owned_by_launchd` failed once during the first
regression, then passed in isolation (12s) and again in the full binary (61/61,
142s). The assertion is that an **async `launchctl bootout`** has taken effect,
checked immediately — a race. This change only alters a `Duration`, and for a
tiny test database the computed value is identical to the old constant, so the
scaling never engages there. Two passes are not proof, so it is filed as a flake
rather than dismissed.
