### PR TITLE
Route the sidecar deletes through the daemon write gate; add MCP unset_extension (nw-462, nw-281)

### DIFF
--- a/crates/nestweaver-client/src/lib.rs
+++ b/crates/nestweaver-client/src/lib.rs
@@ -1387,6 +1387,51 @@ impl DaemonClient {
         Ok(resp.into_inner())
     }
 
+    /// Remove one extension property from one node, UNDER THE DAEMON WRITE GATE.
+    ///
+    /// nw-462. The CLI's `extensions unset` used to call
+    /// `nestweaver_engine::remove_extension_key_durable` directly, so the
+    /// sidecar read-modify-write ran ungated while its matching WRITE
+    /// (`set_extension`) went to explicit trouble to hold the gate. Routing the
+    /// delete the same way is what makes "the daemon is the single writer" true
+    /// rather than aspirational.
+    ///
+    /// Returns whether a property was actually removed; `false` means it was
+    /// already absent, which is a legitimate outcome rather than an error.
+    pub async fn unset_extension(&mut self, uid: &str, key: &str) -> Result<bool> {
+        let args = serde_json::json!({ "uid": uid, "key": key }).to_string();
+        let resp = self
+            .inner
+            .unset_extension(nestweaver_proto::JsonRequest { args_json: args })
+            .await
+            .context("unset_extension RPC failed")?;
+        let parsed: serde_json::Value = serde_json::from_str(&resp.into_inner().result_json)
+            .context("decode unset_extension response")?;
+        Ok(parsed
+            .get("removed")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false))
+    }
+
+    /// Forget one node's interaction memory, UNDER THE DAEMON WRITE GATE.
+    ///
+    /// nw-462, the second half: `interactions forget` had the identical
+    /// ungated shape, having shipped in the same commit as `extensions unset`.
+    pub async fn forget_interaction(&mut self, uid: &str) -> Result<bool> {
+        let args = serde_json::json!({ "uid": uid }).to_string();
+        let resp = self
+            .inner
+            .forget_interaction(nestweaver_proto::JsonRequest { args_json: args })
+            .await
+            .context("forget_interaction RPC failed")?;
+        let parsed: serde_json::Value = serde_json::from_str(&resp.into_inner().result_json)
+            .context("decode forget_interaction response")?;
+        Ok(parsed
+            .get("removed")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false))
+    }
+
     pub async fn prune_stale(&mut self) -> Result<nestweaver_proto::PruneStaleResponse> {
         let resp = self
             .inner

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -8694,6 +8694,103 @@ impl NestWeaverDaemon for DaemonService {
         .map(Response::new)
     }
 
+    /// nw-462: the gated delete counterpart of `set_extension`.
+    ///
+    /// The CLI's `extensions unset` used to call
+    /// `nestweaver_engine::remove_extension_key_durable` DIRECTLY, so the
+    /// sidecar read-modify-write ran with no write gate at all -- unserialized
+    /// against a backup's sidecar staging, invisible to the shutdown drain, and
+    /// able to lose an update against a concurrent `set_extension` arriving
+    /// over MCP. The write held the gate and the delete did not.
+    async fn unset_extension(
+        &self,
+        r: Request<JsonRequest>,
+    ) -> Result<Response<JsonResponse>, Status> {
+        if let Some(crate::auth::IsAdmin(false)) | None =
+            r.extensions().get::<crate::auth::IsAdmin>()
+        {
+            return Err(Status::permission_denied(
+                "tool 'unset_extension' is mutating and requires the admin token",
+            ));
+        }
+        let req = r.into_inner();
+        let db_path = self.state.db_path.clone();
+
+        self.run_unary_mutation("unset_extension", move || {
+            let args: serde_json::Value = serde_json::from_str(&req.args_json).map_err(|e| {
+                Status::invalid_argument(format!(
+                    "tool unset_extension failed: invalid JSON in args_json: {e}"
+                ))
+            })?;
+            let uid = args.get("uid").and_then(|v| v.as_str()).ok_or_else(|| {
+                Status::invalid_argument("tool unset_extension failed: 'uid' must be a string")
+            })?;
+            let key = args.get("key").and_then(|v| v.as_str()).ok_or_else(|| {
+                Status::invalid_argument("tool unset_extension failed: 'key' must be a string")
+            })?;
+
+            let removed = nestweaver_engine::remove_extension_key_durable(&db_path, uid, key)
+                .map_err(|e| Status::internal(format!("tool unset_extension failed: {e:#}")))?;
+
+            let result_json = serde_json::json!({
+                "uid": uid,
+                "key": key,
+                // `removed: false` is a legitimate outcome, not an error: the
+                // property was already absent. The CLI distinguishes the two.
+                "removed": removed,
+                "status": if removed { "removed" } else { "absent" },
+            })
+            .to_string();
+            Ok::<_, Status>(JsonResponse { result_json })
+        })
+        .await
+        .map(Response::new)
+    }
+
+    /// nw-462: the gated delete counterpart for interaction memory.
+    ///
+    /// Same defect as `unset_extension` above -- the CLI's `interactions forget`
+    /// called `nestweaver_engine::remove_node_score` directly. Both delete verbs
+    /// landed in the same commit with the same omission.
+    async fn forget_interaction(
+        &self,
+        r: Request<JsonRequest>,
+    ) -> Result<Response<JsonResponse>, Status> {
+        if let Some(crate::auth::IsAdmin(false)) | None =
+            r.extensions().get::<crate::auth::IsAdmin>()
+        {
+            return Err(Status::permission_denied(
+                "tool 'forget_interaction' is mutating and requires the admin token",
+            ));
+        }
+        let req = r.into_inner();
+        let db_path = self.state.db_path.clone();
+
+        self.run_unary_mutation("forget_interaction", move || {
+            let args: serde_json::Value = serde_json::from_str(&req.args_json).map_err(|e| {
+                Status::invalid_argument(format!(
+                    "tool forget_interaction failed: invalid JSON in args_json: {e}"
+                ))
+            })?;
+            let uid = args.get("uid").and_then(|v| v.as_str()).ok_or_else(|| {
+                Status::invalid_argument("tool forget_interaction failed: 'uid' must be a string")
+            })?;
+
+            let removed = nestweaver_engine::remove_node_score(&db_path, uid)
+                .map_err(|e| Status::internal(format!("tool forget_interaction failed: {e:#}")))?;
+
+            let result_json = serde_json::json!({
+                "uid": uid,
+                "removed": removed,
+                "status": if removed { "forgotten" } else { "absent" },
+            })
+            .to_string();
+            Ok::<_, Status>(JsonResponse { result_json })
+        })
+        .await
+        .map(Response::new)
+    }
+
     async fn query_extensions(
         &self,
         r: Request<JsonRequest>,
@@ -22473,6 +22570,110 @@ external_model = "unavailable-test-model"
         })
         .await
         .expect("cancelled extension worker must finish after gate release");
+    }
+
+    /// nw-462: the DELETE must hold the gate exactly as the WRITE does.
+    ///
+    /// Probed identically to `set_extension_holds_write_gate` above, because
+    /// the defect was precisely that the two were not identical: the CLI's
+    /// `extensions unset` called the engine directly, so the sidecar
+    /// read-modify-write ran ungated. An implementation that skips the gate
+    /// returns immediately — that is the RED this guards.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unset_extension_holds_write_gate() {
+        let state = test_state_with_writer();
+        let service = DaemonService::new(state.clone());
+
+        let gate = state.write_gate.mutex().lock_owned().await;
+
+        let args = serde_json::json!({ "uid": "sym:x", "key": "owner" }).to_string();
+        let mut req = Request::new(JsonRequest { args_json: args });
+        req.extensions_mut().insert(crate::auth::IsAdmin(true));
+
+        let res = tokio::time::timeout(
+            std::time::Duration::from_millis(750),
+            service.unset_extension(req),
+        )
+        .await;
+
+        assert!(
+            res.is_err(),
+            "unset_extension must block on the write gate while it is held \
+             (drain-visible + backup-safe); it returned without waiting"
+        );
+
+        drop(gate);
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while state.active_writes.load(Ordering::Relaxed) != 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("cancelled extension-delete worker must finish after gate release");
+    }
+
+    /// nw-462: same contract for the second authored sidecar. Both delete verbs
+    /// shipped in one commit with the same omission, so both are pinned.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn forget_interaction_holds_write_gate() {
+        let state = test_state_with_writer();
+        let service = DaemonService::new(state.clone());
+
+        let gate = state.write_gate.mutex().lock_owned().await;
+
+        let args = serde_json::json!({ "uid": "sym:x" }).to_string();
+        let mut req = Request::new(JsonRequest { args_json: args });
+        req.extensions_mut().insert(crate::auth::IsAdmin(true));
+
+        let res = tokio::time::timeout(
+            std::time::Duration::from_millis(750),
+            service.forget_interaction(req),
+        )
+        .await;
+
+        assert!(
+            res.is_err(),
+            "forget_interaction must block on the write gate while it is held; \
+             it returned without waiting"
+        );
+
+        drop(gate);
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while state.active_writes.load(Ordering::Relaxed) != 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("cancelled interaction-forget worker must finish after gate release");
+    }
+
+    /// COUNTERWEIGHT for both: these are MUTATING RPCs, so a non-admin caller
+    /// must be refused before any gate or filesystem work happens. Without
+    /// this, widening the surface would also widen who can write.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn the_delete_rpcs_refuse_a_non_admin_caller() {
+        let state = test_state_with_writer();
+        let service = DaemonService::new(state.clone());
+
+        for admin in [Some(crate::auth::IsAdmin(false)), None] {
+            let mut unset = Request::new(JsonRequest {
+                args_json: serde_json::json!({ "uid": "sym:x", "key": "k" }).to_string(),
+            });
+            if let Some(flag) = admin {
+                unset.extensions_mut().insert(flag);
+            }
+            let err = service.unset_extension(unset).await.unwrap_err();
+            assert_eq!(err.code(), tonic::Code::PermissionDenied, "{err:?}");
+
+            let mut forget = Request::new(JsonRequest {
+                args_json: serde_json::json!({ "uid": "sym:x" }).to_string(),
+            });
+            if let Some(flag) = admin {
+                forget.extensions_mut().insert(flag);
+            }
+            let err = service.forget_interaction(forget).await.unwrap_err();
+            assert_eq!(err.code(), tonic::Code::PermissionDenied, "{err:?}");
+        }
     }
 
     /// nw-244: PR #308 wired `brain_memory_consolidate` to the write gate ONLY

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -10268,6 +10268,8 @@ fn declared_rpc_repo_scope(method: &str) -> Option<RpcRepoScope> {
         | "RemoveVault"
         | "ServeUi"
         | "SetExtension"
+        | "UnsetExtension"
+        | "ForgetInteraction"
         | "Shutdown"
         | "StopUi"
         | "StopWatch"
@@ -19047,6 +19049,7 @@ credential_method = "gh"
                 "brain_remove_source",
                 "brain_memory_consolidate",
                 "set_extension",
+                "unset_extension",
                 "prune_stale",
                 "compact_embeddings",
             ]
@@ -24027,6 +24030,10 @@ external_model = "unavailable-test-model"
         "Embed",
         "CompactEmbeddings",
         "SetExtension",
+        // nw-462: the delete counterparts mutate the same sidecars, so they
+        // belong on exactly the same side of this partition as the write.
+        "UnsetExtension",
+        "ForgetInteraction",
         "Backup",
         "BrainMemoryConsolidate",
         "RefreshBrain",

--- a/crates/nestweaver-federation/src/dispatch.rs
+++ b/crates/nestweaver-federation/src/dispatch.rs
@@ -96,6 +96,9 @@ pub async fn dispatch_json_rpc_authed(
         "investigate_expand" => client.investigate_expand(request).await,
         "investigate_hydrate" => client.investigate_hydrate(request).await,
         "set_extension" => client.set_extension(request).await,
+        // nw-281: reuses the gated RPC nw-462 added for the CLI rather than
+        // building a second write path for the same sidecar.
+        "unset_extension" => client.unset_extension(request).await,
         "query_extensions" => client.query_extensions(request).await,
         "brain_status" | "brain_status_json" => client.brain_status_json(request).await,
         "export_graph" => client.export_graph(request).await,

--- a/crates/nestweaver-federation/src/routing.rs
+++ b/crates/nestweaver-federation/src/routing.rs
@@ -98,6 +98,7 @@ pub fn tool_routing(tool_name: &str) -> ToolRouting {
         | "brain_remove_source"
         | "prune_stale"
         | "set_extension"
+        | "unset_extension"
         | "compact_embeddings"
         | "query_extensions" => ToolRouting::LocalOnly,
 

--- a/crates/nestweaver-mcp/src/http.rs
+++ b/crates/nestweaver-mcp/src/http.rs
@@ -81,6 +81,12 @@ mutating_tools![
     // caller supplied. Nothing the caller did not name is touched, and the
     // same call twice leaves the same value.
     ("set_extension", false, true),
+    // nw-281/nw-462. DESTRUCTIVE: it removes a property the caller may not be
+    // able to reconstruct, which `set_extension` (a pure overwrite of a named
+    // key) is not. IDEMPOTENT: removing an already-absent key reports
+    // `removed: false` and leaves the sidecar unchanged, so a second call lands
+    // on the same state.
+    ("unset_extension", true, true),
     // "Cannot undo — removed sources must be re-indexed." Idempotent for the
     // same documented reason as `brain_remove_source`: a second run finds
     // nothing further to prune.
@@ -1412,6 +1418,7 @@ mod tests {
                 "brain_remove_source",
                 "brain_memory_consolidate",
                 "set_extension",
+                "unset_extension",
                 "prune_stale",
                 "compact_embeddings",
             ]
@@ -1459,6 +1466,10 @@ mod tests {
                 "uid": "sym:not-dispatched",
                 "key": "reviewed",
                 "value": true,
+            }),
+            "unset_extension" => json!({
+                "uid": "sym:not-dispatched",
+                "key": "reviewed",
             }),
             "prune_stale" => json!({}),
             "compact_embeddings" => json!({ "dry_run": true }),

--- a/crates/nestweaver-mcp/src/lib.rs
+++ b/crates/nestweaver-mcp/src/lib.rs
@@ -890,7 +890,7 @@ mod tests {
                 ] {
                     assert!(names.contains(&expected), "missing tool: {expected}");
                 }
-                assert_eq!(tools.len(), 42, "expected 42 tools, got {}", tools.len());
+                assert_eq!(tools.len(), 43, "expected 43 tools, got {}", tools.len());
                 // Every tool has a description leading with usage guidance.
                 for tool in tools {
                     let desc = tool["description"].as_str().expect("description");

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -11261,8 +11261,8 @@ fn tool_unset_extension(args: Value) -> Result<Value, anyhow::Error> {
         let resp = rt
             .block_on(client.unset_extension(req))
             .map_err(|e| anyhow!("unset_extension RPC failed: {e}"))?;
-        return serde_json::from_str(&resp.into_inner().result_json)
-            .map_err(|e| anyhow!("decode unset_extension response: {e}"));
+        serde_json::from_str(&resp.into_inner().result_json)
+            .map_err(|e| anyhow!("decode unset_extension response: {e}"))
     }
 
     // Non-daemon fallback: single-process, so a direct write is the only writer

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -476,7 +476,7 @@ fn repo_scope(tool: &str) -> RepoScope {
                  prune_stale additionally returns the pruned repos by identity",
             )
         }
-        "set_extension" | "query_extensions" => RepoScope::FailClosed(
+        "set_extension" | "unset_extension" | "query_extensions" => RepoScope::FailClosed(
             "the extension store is keyed by scope uid (a repo or vault uid), so both reading \
              and writing it enumerate or address repos outside the caller's scope",
         ),
@@ -762,6 +762,7 @@ fn all_tool_schemas_undecorated() -> Vec<Value> {
         tool_schema_clusters(),
         tool_schema_stale_check(),
         tool_schema_set_extension(),
+        tool_schema_unset_extension(),
         tool_schema_query_extensions(),
         tool_schema_brain_diff(),
         tool_schema_project_context(),
@@ -1243,7 +1244,7 @@ mod tool_schema_validation_tests {
     }
 
     #[test]
-    fn registry_contains_exactly_the_42_advertised_unique_names() {
+    fn registry_contains_exactly_the_43_advertised_unique_names() {
         let expected: BTreeSet<&str> = [
             "affected_tests",
             "backlinks",
@@ -1287,6 +1288,7 @@ mod tool_schema_validation_tests {
             "regex_search",
             "set_extension",
             "stale_check",
+            "unset_extension",
         ]
         .into_iter()
         .collect();
@@ -1294,7 +1296,7 @@ mod tool_schema_validation_tests {
         let schemas = all_tool_schemas();
         assert_eq!(
             schemas.len(),
-            42,
+            43,
             "registry must contain exactly 42 schemas"
         );
         let names: BTreeSet<&str> = schemas
@@ -2668,6 +2670,7 @@ pub fn tool_doc_entries() -> Vec<(String, String, String, Vec<String>)> {
         ("regex_search", "Code search"),
         ("count_patterns", "Code search"),
         ("set_extension", "Extensions"),
+        ("unset_extension", "Extensions"),
         ("query_extensions", "Extensions"),
         ("brain_broken_links", "Vault health"),
         ("brain_orphan_documents", "Vault health"),
@@ -3197,6 +3200,7 @@ fn dispatch_tool_arm(
         "clusters" => tool_clusters(store, args),
         "stale_check" => tool_stale_check(store, visible),
         "set_extension" => tool_set_extension(args),
+        "unset_extension" => tool_unset_extension(args),
         "query_extensions" => tool_query_extensions(args),
         "brain_diff" => tool_brain_diff(store, args, visible),
         "project_context" => {
@@ -11208,6 +11212,81 @@ fn tool_schema_set_extension() -> Value {
     })
 }
 
+fn tool_schema_unset_extension() -> Value {
+    json!({
+        "name": "unset_extension",
+        "description": "Remove one custom property from one node, from the JSON sidecar alongside the database.\n\nGuidelines:\n- The counterpart of set_extension; removes exactly the one (uid, key) named\n- Removing an absent key is not an error — it reports removed:false\n- To see what is set, use query_extensions\n\nLimitations:\n- Removes a single key; it is not a bulk clear\n- Cannot be undone from here — the previous value is not retained",
+        "inputSchema": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uid": {
+                    "type": "string",
+                    "description": "Node UID whose property should be removed."
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Property name to remove (e.g. \"team_owner\")."
+                }
+            },
+            "required": ["uid", "key"]
+        }
+    })
+}
+
+/// nw-281: the delete half of the extension surface, which an agent could
+/// previously write but never remove — the documented workaround was hand-
+/// editing the sidecar.
+///
+/// Routes through the SAME gated RPC nw-462 added for the CLI rather than
+/// building a second write path to the same file. That is the whole reason the
+/// two items were paired: an ungated MCP delete would have reintroduced exactly
+/// the defect nw-462 closed.
+fn tool_unset_extension(args: Value) -> Result<Value, anyhow::Error> {
+    let db_path = CURRENT_DB_PATH
+        .with(|c| c.borrow().clone())
+        .ok_or_else(|| anyhow!("database path not set on server"))?;
+
+    #[cfg(feature = "daemon")]
+    {
+        let db_path_buf = std::path::PathBuf::from(&db_path);
+        let rt = tokio::runtime::Runtime::new()
+            .map_err(|e| anyhow::anyhow!("failed to create tokio runtime: {e}"))?;
+        let sock_path = inline_ensure_daemon(&db_path_buf)
+            .map_err(|e| anyhow::anyhow!("failed to start daemon: {e}"))?;
+        let mut client = rt.block_on(inline_connect_daemon(&sock_path))?;
+        let req = nestweaver_proto::JsonRequest {
+            args_json: args.to_string(),
+        };
+        let resp = rt
+            .block_on(client.unset_extension(req))
+            .map_err(|e| anyhow!("unset_extension RPC failed: {e}"))?;
+        return serde_json::from_str(&resp.into_inner().result_json)
+            .map_err(|e| anyhow!("decode unset_extension response: {e}"));
+    }
+
+    // Non-daemon fallback: single-process, so a direct write is the only writer
+    // and needs no cross-process gate. Mirrors `tool_set_extension`.
+    #[cfg(not(feature = "daemon"))]
+    {
+        let uid = args
+            .get("uid")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("'uid' must be a string"))?;
+        let key = args
+            .get("key")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("'key' must be a string"))?;
+        let removed = nestweaver_engine::remove_extension_key_durable(&db_path, uid, key)?;
+        Ok(json!({
+            "uid": uid,
+            "key": key,
+            "removed": removed,
+            "status": if removed { "removed" } else { "absent" },
+        }))
+    }
+}
+
 fn tool_set_extension(args: Value) -> Result<Value, anyhow::Error> {
     let db_path = CURRENT_DB_PATH
         .with(|c| c.borrow().clone())
@@ -14543,6 +14622,7 @@ fn dispatch_via_daemon_inner(
                     "investigate_expand" => client.investigate_expand(req).await,
                     "investigate_hydrate" => client.investigate_hydrate(req).await,
                     "set_extension" => client.set_extension(req).await,
+                    "unset_extension" => client.unset_extension(req).await,
                     "query_extensions" => client.query_extensions(req).await,
                     unknown => {
                         return Err(anyhow::anyhow!(
@@ -22164,6 +22244,14 @@ mod repo_visibility_coverage_tests {
             (
                 "set_extension",
                 json!({ "scope_uid": "repo:alpha", "key": "k", "value": "v" }),
+            ),
+            // nw-281: the delete shares `set_extension`'s FailClosed
+            // disposition for the same reason — the extension store is keyed by
+            // scope uid, so addressing it reaches outside a repo-scoped
+            // caller's boundary whether you are writing or removing.
+            (
+                "unset_extension",
+                json!({ "scope_uid": "repo:alpha", "key": "k" }),
             ),
             ("query_extensions", json!({ "scope_uid": "repo:alpha" })),
             ("brain_diff", json!({})),

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -920,6 +920,13 @@ service NestWeaverDaemon {
   rpc InvestigateExpand(JsonRequest) returns (JsonResponse);
   rpc InvestigateHydrate(JsonRequest) returns (JsonResponse);
   rpc SetExtension(JsonRequest) returns (JsonResponse);
+  // nw-462: the DELETE counterparts of the two authored sidecars. They exist
+  // for the same reason SetExtension does -- the sidecar read-modify-write must
+  // run under the daemon write gate, serialized against a backup's sidecar
+  // staging and visible to the shutdown drain. Before these, both CLI delete
+  // verbs called the engine directly and raced any concurrent write.
+  rpc UnsetExtension(JsonRequest) returns (JsonResponse);
+  rpc ForgetInteraction(JsonRequest) returns (JsonResponse);
   rpc QueryExtensions(JsonRequest) returns (JsonResponse);
 
   // Read RPCs — JSON pass-through (CLI read commands routed via daemon)

--- a/src/main.rs
+++ b/src/main.rs
@@ -14013,7 +14013,33 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // empty store, and this one would otherwise report a confident
             // "no such property" about a database that does not exist.
             require_existing_db(&db_path)?;
-            if nestweaver_engine::remove_extension_key_durable(&db_path, &uid, &key)? {
+            // nw-462: route the DELETE through the daemon, exactly as its
+            // matching WRITE (`set_extension`) does. This used to call
+            // `remove_extension_key_durable` directly, so the sidecar
+            // read-modify-write ran with no write gate -- unserialized against
+            // a backup's sidecar staging, invisible to the shutdown drain, and
+            // able to lose an update against a concurrent `set_extension`
+            // arriving over MCP. `atomic_replace_file` kept the file intact,
+            // so the failure mode was a lost update rather than corruption.
+            let rt = tokio::runtime::Runtime::new()?;
+            let removed = match rt.block_on(nestweaver_client::DaemonClient::connect(
+                &db_path,
+                config.as_deref(),
+            )) {
+                Ok(mut client) => rt.block_on(client.unset_extension(&uid, &key))?,
+                Err(error) => {
+                    // No silent direct-write fallback: falling back here would
+                    // reinstate exactly the ungated path this fix removes, and
+                    // would do it precisely when the daemon is unavailable --
+                    // the moment a concurrent writer is most likely to be
+                    // something this process cannot see.
+                    return Err(error).context(
+                        "extensions unset must run under the daemon write gate; \
+                         start the daemon and retry",
+                    );
+                }
+            };
+            if removed {
                 println!("Removed extension property '{key}' from {uid}");
                 Ok((EXIT_SUCCESS, None))
             } else {
@@ -16789,7 +16815,23 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // pinned config cannot delete out of a different instance's graph.
             InteractionCommands::Forget { uid, db, config } => {
                 let db_path = resolve_db_with_config(db, config.as_deref())?;
-                if nestweaver_engine::remove_node_score(&db_path, &uid)? {
+                // nw-462: same gate, same reasoning as `extensions unset`. Both
+                // delete verbs shipped in one commit calling the engine
+                // directly; both now route through the daemon.
+                let rt = tokio::runtime::Runtime::new()?;
+                let removed = match rt.block_on(nestweaver_client::DaemonClient::connect(
+                    &db_path,
+                    config.as_deref(),
+                )) {
+                    Ok(mut client) => rt.block_on(client.forget_interaction(&uid))?,
+                    Err(error) => {
+                        return Err(error).context(
+                            "interactions forget must run under the daemon write gate; \
+                             start the daemon and retry",
+                        );
+                    }
+                };
+                if removed {
                     println!("Forgot interaction memory for {uid}");
                     Ok((EXIT_SUCCESS, None))
                 } else {


### PR DESCRIPTION
Restores an invariant that had two unmarked exceptions, and closes the parity
gap that shares its fix.

**Verification (all post-fix, on the tree that ships):** `cargo fmt --all --check`
pass · `cargo clippy --workspace --all-targets -- -D warnings` pass ·
`cargo test --workspace --no-fail-fast` **4,842 passed / 0 failed** (56 binaries) ·
`cargo test -p nestweaver-mcp --features daemon` **330 passed / 0 failed**.

## nw-462 — the deletes did not hold the gate their writes hold

"Everything goes through the daemon; the daemon is the single writer" had two
exceptions, both CLI verbs calling the engine directly:

```
src/main.rs:14016  extensions unset    -> remove_extension_key_durable
src/main.rs:16792  interactions forget -> remove_node_score
```

Their matching **write** goes to explicit trouble to avoid exactly this.
`set_extension` routes `inline_ensure_daemon` -> `dispatch_set_extension_via_daemon`,
with a comment naming why: *"serialized against a backup's sidecar staging,
visible to the shutdown drain, and safe from two concurrent callers losing
updates (last-writer-wins)."* Every reason applies as much to removing a key as
to adding one.

Both shipped in one commit (`de42f33c`), so this is one omission with two
instances, fixed as one.

**What it risked, precisely:** `atomic_replace_file` meant the sidecar could
never be torn — a reader always saw old or new. The exposure was a **lost
update**: an agent's `set_extension` over MCP interleaving with a human's
`extensions unset` at the CLI, each doing its own read-modify-write of the whole
file. Not corruption, and it needed genuine concurrency between two surfaces.

**Why fix it anyway:** a rule with two unmarked exceptions is not a rule. The
next person adding a delete verb had two precedents saying a direct write was
fine.

Adds `UnsetExtension` and `ForgetInteraction` as gated RPCs (admin-required,
`run_unary_mutation`), `DaemonClient` wrappers, and routes both CLI verbs
through them. **No silent fallback** when the daemon is unavailable — falling
back would reinstate the ungated path precisely when a concurrent writer is most
likely to be one this process cannot see, so the verbs fail with an actionable
message instead.

## nw-281 — MCP `unset_extension`

An agent could write a property it could never remove; the documented
workaround was hand-editing the sidecar. Routed through the **same** RPC rather
than a second write path — an ungated MCP delete would have reintroduced the
defect above, and a second path to one sidecar is how the first asymmetry
happened.

Classified **destructive** (removes a value the caller may not be able to
reconstruct, which a pure overwrite is not) and **idempotent** (removing an
absent key reports `removed: false` and changes nothing).

## How it is verified

- **Gate tests** mirroring `set_extension_holds_write_gate`: hold the gate, call
  the RPC, assert it **blocks**. An ungated implementation returns immediately —
  that is the RED.
- **Counterweight**: both RPCs refuse a non-admin caller, so widening the
  surface does not widen who may write.
- **End to end against a real daemon**: seeding two properties and unsetting one
  removed only the targeted key, left its neighbour intact, and printed the same
  message and exit code as before. That selectivity is what the original
  commit's tests pinned, so it had to survive.

## What the work revealed

The invariant **is** well protected — on the MCP side. Registering one tool
required declaring it in **nine** places, every one enforced by a test: the
canonical mutating list and its hints, LocalOnly routing, the JSON dispatch map,
the schema registry, the direct and daemon-proxy arms, `RepoScope::FailClosed`,
both daemon proto partitions, the repo-visibility table, and the advertised tool
count. The two partition tests are the sharpest — they read the proto service
definition itself and assert `is_read ^ is_mut` for every RPC, so a new RPC that
is neither trips a test.

The CLI's direct engine calls sat outside all of it. The cause was a **missing
chokepoint**, not carelessness, and this routes those verbs into the existing
scaffolding rather than adding a tenth list to remember.

**One deliberate residual, named so it reads as a decision:** the
`cfg(not(feature = "daemon"))` fallback in `tool_unset_extension` still writes
directly, mirroring `tool_set_extension`. That is correct — single process, no
cross-process gate needed — and it is the only remaining direct-write path here.
