### PR TITLE
fix: harden GC, authorization, and response contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4317,6 +4317,7 @@ name = "nestweaver-proto"
 version = "9.3.0"
 dependencies = [
  "prost",
+ "serde_json",
  "tokio-stream",
  "tonic",
  "tonic-build",

--- a/crates/nestweaver-client/src/autostart.rs
+++ b/crates/nestweaver-client/src/autostart.rs
@@ -145,29 +145,57 @@ impl SpawnLock {
     }
 
     fn acquire_at(instance_id: String, spawn_lock_path: &Path) -> Result<Self> {
-        if let Some(parent) = spawn_lock_path.parent() {
-            fs::create_dir_all(parent).with_context(|| {
-                format!("failed to create spawn lock directory {}", parent.display())
-            })?;
+        Self::acquire_at_with_opened(instance_id, spawn_lock_path, || {})
+    }
+
+    fn acquire_at_with_opened(
+        instance_id: String,
+        spawn_lock_path: &Path,
+        mut opened: impl FnMut(),
+    ) -> Result<Self> {
+        use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+        loop {
+            if let Some(parent) = spawn_lock_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            let file = match fs::OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .truncate(false)
+                .custom_flags(libc::O_NOFOLLOW)
+                .open(spawn_lock_path)
+            {
+                Ok(file) => file,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error).context("open spawn lock"),
+            };
+            opened();
+            if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+                return Err(std::io::Error::last_os_error()).context("lock daemon spawn");
+            }
+            let held = file.metadata()?;
+            anyhow::ensure!(held.is_file(), "spawn lock must be a regular file");
+            // GC retires the runtime directory while holding this flock. A
+            // waiter may own the retired inode when woken: never hand that
+            // descriptor to a child. Recreate/reacquire the current pathname.
+            match fs::symlink_metadata(spawn_lock_path) {
+                Ok(current)
+                    if current.is_file()
+                        && current.dev() == held.dev()
+                        && current.ino() == held.ino() =>
+                {
+                    return Ok(Self {
+                        file,
+                        instance_id,
+                        unlock_on_drop: AtomicBool::new(true),
+                    });
+                }
+                Ok(_) => continue,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error).context("verify daemon spawn lock"),
+            }
         }
-        let file = fs::OpenOptions::new()
-            .create(true)
-            .read(true)
-            .write(true)
-            .truncate(false)
-            .open(spawn_lock_path)
-            .with_context(|| format!("failed to open spawn lock {}", spawn_lock_path.display()))?;
-        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
-            bail!(
-                "flock on spawn lock failed: {}",
-                std::io::Error::last_os_error()
-            );
-        }
-        Ok(Self {
-            file,
-            instance_id,
-            unlock_on_drop: AtomicBool::new(true),
-        })
     }
 
     /// Close a fork-inherited descriptor without issuing `LOCK_UN`.
@@ -1345,6 +1373,41 @@ credential_method = "gh"
         rx.recv_timeout(Duration::from_secs(2))
             .expect("contender should proceed after transaction releases spawn lock");
         contender.join().unwrap();
+    }
+
+    #[test]
+    fn spawn_waiter_retries_retired_runtime_inode() {
+        use std::os::unix::fs::MetadataExt;
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = dir.path().join("runtime");
+        fs::create_dir(&runtime).unwrap();
+        let path = runtime.join("daemon.spawnlock");
+        let first = SpawnLock::acquire_at("instance".into(), &path).unwrap();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let (proceed, wait) = std::sync::mpsc::channel();
+        let target = path.clone();
+        let waiter = std::thread::spawn(move || {
+            let mut initial = true;
+            SpawnLock::acquire_at_with_opened("instance".into(), &target, || {
+                if initial {
+                    initial = false;
+                    tx.send(()).unwrap();
+                    wait.recv().unwrap();
+                }
+            })
+            .unwrap()
+        });
+        rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        fs::rename(&runtime, dir.path().join("retired")).unwrap();
+        fs::create_dir(&runtime).unwrap();
+        fs::write(&path, "").unwrap();
+        proceed.send(()).unwrap();
+        drop(first);
+        let acquired = waiter.join().unwrap();
+        assert_eq!(
+            acquired.file.metadata().unwrap().ino(),
+            fs::metadata(&path).unwrap().ino()
+        );
     }
 
     #[test]

--- a/crates/nestweaver-client/src/hybrid.rs
+++ b/crates/nestweaver-client/src/hybrid.rs
@@ -1331,38 +1331,8 @@ pub async fn two_tier_query(
 /// hand-construct the string) green while federation silently reverted to
 /// killing a healthy upstream's entire two-tier answer.
 ///
-/// It is KEPT for two reasons, and the second one is load-bearing far more
-/// often than it looks:
-///
-/// 1. Version skew: a client newer than the daemon it talks to receives no
-///    metadata code.
-/// 2. REQUEST COALESCING. `blast_radius` is in `CACHEABLE_TOOLS`, so
-///    concurrent identical calls collapse through
-///    `nestweaver_mcp::tools::coalesce_in_flight`. Only the LEADER runs
-///    `resolve_repo_filter` and holds the typed error; every follower is
-///    handed `anyhow!("{msg}")` rebuilt from a STRING the leader published,
-///    with `RepoFilterUnresolved` nowhere in its chain. The daemon therefore
-///    cannot stamp the code for a follower, and detection for those callers
-///    runs entirely on the prose below. Measured against a live daemon with
-///    12 concurrent identical calls: 1-2 responses carried the code, 10-11
-///    did not.
-///
-/// So "a rewording can no longer break this" is TRUE for a unique request and
-/// FALSE for a coalesced follower. Closing that properly means preserving an
-/// error code across the coalescing boundary in `tools.rs`, which is shared
-/// cache infrastructure well outside this item; until then the fallback is
-/// what keeps federation correct under concurrency, and `node_scope.rs`'s
-/// prefix assertion is what keeps the fallback honest.
-///
-/// `nestweaver-daemon`'s `dispatch_err_to_status` wraps a tool's error as
-/// `Status::internal("tool {tool} failed: {e}")`, and
-/// `dispatch_json_rpc_authed` adds its own `"{tool_name} RPC failed"`
-/// context on top — both preserve the original message text verbatim, so
-/// `nestweaver_engine::node_scope::resolve_repo_filter`'s own wrapping
-/// (`"repo filter entry {selector:?}: {error:#}"`, in both its "not found"
-/// and "ambiguous" outcomes) survives across the gRPC boundary intact. This
-/// text is emitted ONLY by that one function today, so matching on it
-/// cannot mistake an unrelated failure for an unresolved `repo` filter.
+/// Kept only for older daemons that cannot stamp a typed metadata code.
+/// Current request coalescing preserves the typed error for every follower.
 const UNRESOLVED_REPO_FILTER_SIGNAL: &str = "repo filter entry ";
 
 /// Whether `error` is the daemon reporting an unresolved local `repo` filter.
@@ -1377,18 +1347,20 @@ const UNRESOLVED_REPO_FILTER_SIGNAL: &str = "repo filter entry ";
 /// PROSE SECOND, and only as a version-skew downgrade -- see
 /// [`UNRESOLVED_REPO_FILTER_SIGNAL`].
 fn is_unresolved_repo_filter(error: &anyhow::Error, rendered: &str) -> bool {
-    let coded = error
+    let code = error
         .chain()
         .find_map(|cause| cause.downcast_ref::<tonic::Status>())
         .and_then(|status| {
             status
                 .metadata()
                 .get(nestweaver_engine::node_scope::NW_ERROR_CODE_METADATA_KEY)
-        })
-        .and_then(|value| value.to_str().ok())
-        .is_some_and(|code| code == nestweaver_engine::node_scope::REPO_FILTER_UNRESOLVED_CODE);
-
-    coded || rendered.contains(UNRESOLVED_REPO_FILTER_SIGNAL)
+        });
+    match code {
+        Some(value) => {
+            value.to_str().ok() == Some(nestweaver_engine::node_scope::REPO_FILTER_UNRESOLVED_CODE)
+        }
+        None => rendered.contains(UNRESOLVED_REPO_FILTER_SIGNAL),
+    }
 }
 
 /// Build a degraded, disclosure-shaped stand-in for a two-tier LOCAL result
@@ -1492,6 +1464,29 @@ fn degraded_local_impact_for_unresolved_repo_filter(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn explicit_error_code_overrides_legacy_looking_text() {
+        let text = "repo filter entry old message";
+        for code in [None, Some("repo-filter-unresolved"), Some("another-code")] {
+            let mut status = tonic::Status::internal(text);
+            if let Some(code) = code {
+                status.metadata_mut().insert(
+                    nestweaver_engine::node_scope::NW_ERROR_CODE_METADATA_KEY,
+                    code.parse().unwrap(),
+                );
+            }
+            let error = anyhow::Error::new(status).context("outer client context");
+            assert_eq!(
+                super::is_unresolved_repo_filter(&error, text),
+                code != Some("another-code")
+            );
+        }
+        assert!(!super::is_unresolved_repo_filter(
+            &anyhow::anyhow!("ordinary error"),
+            "ordinary error"
+        ));
+    }
+
     use super::*;
     use serde_json::json;
 

--- a/crates/nestweaver-daemon/Cargo.toml
+++ b/crates/nestweaver-daemon/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 description = "gRPC daemon for NestWeaver — serves read RPCs over a Unix domain socket"
 
 [dependencies]
+tempfile = { workspace = true }
 subtle = { workspace = true }
 nestweaver-proto = { workspace = true }
 nestweaver-engine = { workspace = true }
@@ -49,7 +50,6 @@ tokio-rustls-acme = { version = "0.9.1", optional = true }
 async-trait = { version = "0.1", optional = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 candle-core = "0.11"
 candle-nn = "0.11"
 candle-transformers = "0.11"

--- a/crates/nestweaver-daemon/src/lifecycle.rs
+++ b/crates/nestweaver-daemon/src/lifecycle.rs
@@ -1936,9 +1936,9 @@ pub struct DaemonGcReport {
     /// Instances whose database still exists.
     pub kept: Vec<String>,
     /// Instances spared because something still owns them: the
-    /// database write lock, an unreadable database lock state, or the pidfile
-    /// flock. The union of the three lists below, deduplicated — a healthy
-    /// daemon appears in two of them, because two independent facts are true of
+    /// database write lock, an unreadable database lock state, pidfile flock,
+    /// or spawn handshake. The union of those lists, deduplicated — a healthy
+    /// daemon can appear in two of them, because two independent facts are true of
     /// it at once. Sparing applies to EVERY root the instance occupies: a
     /// live daemon's runtime files are never reclaimed.
     pub spared: Vec<String>,
@@ -1956,6 +1956,8 @@ pub struct DaemonGcReport {
     /// case, and forgeable by unlinking the pidfile — which is why it is
     /// reported alongside the database answer rather than instead of it.
     pub spared_pidfile_lock: Vec<String>,
+    /// Instances with a busy spawn handshake.
+    pub spared_spawnlock: Vec<String>,
     /// Instances left alone because their database could not be identified —
     /// in every root they occupy. Not an error: unidentifiable means
     /// undeletable, by design.
@@ -2354,23 +2356,73 @@ fn collect_fallback_candidates(
 /// and left alone *before* the test runs, so there is no candidate whose
 /// deletion rests on an unprobed database.
 ///
-/// One residual race, stated rather than hidden. The ownership probe and the
-/// deletion are not atomic, so a daemon BOOTING a temp or missing database
-/// between the two can lose directories mid-boot: a runtime-dir deletion
-/// landing between its pidfile claim and its socket bind unlinks the locked
-/// pidfile inode out from under it or fails the bind. The worst case is one
-/// retryable autostart failure — pidfile claim and socket bind recreate
-/// their directories, the database write lock is unaffected, and the client
-/// spawns again — and the same race existed for the state-only sweep before
-/// this change widened it to the runtime root. The pidfile flock narrows the
-/// window: the child claims it before opening the database or binding the
-/// socket, and a claimed flock spares the instance outright, so the
-/// uncovered span is only the client's pre-claim spawn phase (the sweep does
-/// not consult the client-side spawnlock — taking it here would serialize
-/// `daemon gc` against every in-flight spawn on the machine, a worse trade
-/// for a cleanup pass).
+/// GC takes each candidate's spawnlock nonblockingly, then rechecks writer
+/// ownership while retaining admission through deletion. The runtime directory
+/// is retired by rename LAST, before its contents are removed. New clients can
+/// then create a fresh runtime directory; waiters on the retired lock retry
+/// after checking its inode against the current pathname. No global lock or
+/// wait on a busy spawn is needed. Direct non-cooperating filesystem mutation
+/// by the data owner is outside this admission protocol.
 pub fn gc_orphaned_daemon_dirs() -> std::io::Result<DaemonGcReport> {
     gc_orphaned_daemon_dirs_in(&daemon_gc_roots())
+}
+
+#[cfg(unix)]
+fn gc_spawn_admission(runtime: &Path) -> std::io::Result<Option<std::fs::File>> {
+    use std::os::fd::AsRawFd;
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+    std::fs::create_dir_all(runtime)?;
+    if !std::fs::symlink_metadata(runtime)?.is_dir() {
+        return Err(std::io::Error::other("runtime is not a directory"));
+    }
+    let path = runtime.join("daemon.spawnlock");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(&path)?;
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        let error = std::io::Error::last_os_error();
+        return if error.kind() == std::io::ErrorKind::WouldBlock {
+            Ok(None)
+        } else {
+            Err(error)
+        };
+    }
+    let held = file.metadata()?;
+    let current = std::fs::symlink_metadata(path)?;
+    if !held.is_file()
+        || !current.is_file()
+        || held.dev() != current.dev()
+        || held.ino() != current.ino()
+    {
+        return Err(std::io::Error::other(
+            "spawnlock pathname changed during admission",
+        ));
+    }
+    Ok(Some(file))
+}
+
+/// Detach the admitted runtime namespace atomically. A newly admitted client
+/// must never create files inside a directory that GC is recursively deleting.
+#[cfg(unix)]
+fn retire_gc_runtime(runtime: &Path) -> std::io::Result<()> {
+    let parent = runtime
+        .parent()
+        .ok_or_else(|| std::io::Error::other("runtime has no parent"))?;
+    let retired = tempfile::Builder::new()
+        .prefix(".gc-retired-")
+        .tempdir_in(parent)?;
+    std::fs::rename(runtime, retired.path().join("instance"))?;
+    let retired_path = retired.path().to_path_buf();
+    retired.close().map_err(|error| {
+        std::io::Error::other(format!(
+            "retired runtime remains at {}: {error}",
+            retired_path.display()
+        ))
+    })
 }
 
 /// [`gc_orphaned_daemon_dirs`] against explicit roots — the seam that keeps
@@ -2413,6 +2465,21 @@ fn gc_orphaned_daemon_dirs_in(roots: &DaemonGcRoots) -> std::io::Result<DaemonGc
             continue;
         };
 
+        let runtime = roots.pidfile_root().join(&name);
+        #[cfg(unix)]
+        let _spawn_admission = match gc_spawn_admission(&runtime) {
+            Ok(Some(file)) => file,
+            Ok(None) => {
+                report.spared_spawnlock.push(name.clone());
+                report.spared.push(name);
+                continue;
+            }
+            Err(error) => {
+                tracing::warn!(instance = name, %error, "cannot establish GC spawn admission; keeping instance");
+                report.kept.push(name);
+                continue;
+            }
+        };
         let pidfile = roots.pidfile_root().join(&name).join("daemon.pid");
         let ownership = state_dir_ownership(&pidfile, &db_path);
         if ownership.is_owned() {
@@ -2467,9 +2534,20 @@ fn gc_orphaned_daemon_dirs_in(roots: &DaemonGcRoots) -> std::io::Result<DaemonGc
             continue;
         }
 
+        let mut locations = locations;
+        locations.sort_by_key(|(_, path)| path == &runtime);
+        let runtime_was_candidate = locations.iter().any(|(_, path)| path == &runtime);
         for (root_kind, path) in locations {
             let size = directory_size_bytes(&path);
-            match std::fs::remove_dir_all(&path) {
+            #[cfg(unix)]
+            let deletion = if path == runtime {
+                retire_gc_runtime(&path)
+            } else {
+                std::fs::remove_dir_all(&path)
+            };
+            #[cfg(not(unix))]
+            let deletion = std::fs::remove_dir_all(&path);
+            match deletion {
                 Ok(()) => {
                     report.reclaimed_bytes += size;
                     report.removed.push((root_kind, name.clone()));
@@ -2480,8 +2558,16 @@ fn gc_orphaned_daemon_dirs_in(roots: &DaemonGcRoots) -> std::io::Result<DaemonGc
                 // the dedup after the loop keeps a multi-root failure from
                 // reporting the same instance twice.
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(_) => report.kept.push(name.clone()),
+                Err(error) => {
+                    tracing::warn!(instance = name, path = %path.display(), %error, "GC could not finish directory cleanup");
+                    report.kept.push(name.clone());
+                }
             }
+        }
+        // Admission may have created an otherwise absent runtime directory.
+        #[cfg(unix)]
+        if !runtime_was_candidate && retire_gc_runtime(&runtime).is_err() {
+            report.kept.push(name.clone());
         }
     }
 
@@ -2492,6 +2578,7 @@ fn gc_orphaned_daemon_dirs_in(roots: &DaemonGcRoots) -> std::io::Result<DaemonGc
     report.spared_database_write_lock.sort();
     report.spared_database_unreadable.sort();
     report.spared_pidfile_lock.sort();
+    report.spared_spawnlock.sort();
     report.spared_daemon_database_gone.sort();
     report.unidentified.sort();
     Ok(report)
@@ -3857,6 +3944,60 @@ mod tests {
             Ok(value) => value,
             Err(panic) => std::panic::resume_unwind(panic),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn gc_spares_spawn_handshakes_and_collects_unrelated_orphans() {
+        use std::os::fd::AsRawFd;
+        let scratch = tempfile::tempdir().unwrap();
+        let roots = DaemonGcRoots {
+            state: scratch.path().join("state"),
+            runtime: Some(scratch.path().join("runtime")),
+            socket_fallback: scratch.path().join("fallback"),
+        };
+        for name in ["aaaaaaaa", "bbbbbbbb"] {
+            let state = roots.state.join(name);
+            std::fs::create_dir_all(&state).unwrap();
+            std::fs::write(
+                state.join("daemon.log"),
+                format!(
+                    "[daemon] starting for /tmp/missing-gc-{name}.lbug (instance label-{name})\n"
+                ),
+            )
+            .unwrap();
+            std::fs::create_dir_all(roots.pidfile_root().join(name)).unwrap();
+        }
+        let runtime = roots.pidfile_root().join("aaaaaaaa");
+        let held = gc_spawn_admission(&runtime).unwrap().unwrap();
+        let report = gc_orphaned_daemon_dirs_in(&roots).unwrap();
+        assert_eq!(report.spared_spawnlock, vec!["aaaaaaaa"]);
+        assert!(runtime.join("daemon.spawnlock").exists());
+        assert!(roots.state.join("aaaaaaaa").exists());
+        assert!(!roots.state.join("bbbbbbbb").exists());
+        assert!(!roots.pidfile_root().join("bbbbbbbb").exists());
+        assert_eq!(
+            unsafe { libc::flock(held.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+            0
+        );
+        drop(held);
+        let report = gc_orphaned_daemon_dirs_in(&roots).unwrap();
+        assert!(report.removed.iter().any(|(_, name)| name == "aaaaaaaa"));
+        assert!(!runtime.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn gc_retirement_does_not_remove_a_new_runtime_namespace() {
+        let scratch = tempfile::tempdir().unwrap();
+        let runtime = scratch.path().join("aaaaaaaa");
+        let held = gc_spawn_admission(&runtime).unwrap().unwrap();
+        retire_gc_runtime(&runtime).unwrap();
+        let successor = gc_spawn_admission(&runtime).unwrap().unwrap();
+        std::fs::write(runtime.join("successor"), "alive").unwrap();
+        drop(held);
+        assert!(runtime.join("successor").exists());
+        drop(successor);
     }
 
     /// Write a state directory as a real daemon boot would leave it.

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -4788,7 +4788,7 @@ where
         None => Ok(PruneStaleResponse {
             removed_repos: removed_repos.names,
             removed_vaults,
-            committed: true,
+            committed: changed,
             reconciliation_failures: to_proto_reconciliation_failures(&failures),
         }),
     };
@@ -8110,17 +8110,19 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<BrainStatusRequest>,
     ) -> Result<Response<BrainStatusResponse>, Status> {
-        // nw-415, argued at `dispatch_tool_json`. `brain_status` is the most
-        // direct enumeration in the catalogue — nw-403 gave it its own
-        // `RepoScope::EnforcedInArm` treatment because `repos[]` carries each
-        // repo's URL and indexed git SHA, i.e. repo IDENTITY rather than repo
-        // content. Handing it `All` meant the enforcing arm was never reached
-        // and `repo_count` counted tenants the caller cannot see.
-        // `indexing_repo` is the worker job's configured repo identifier, not
-        // an authoritative graph repo UID. It therefore cannot be filtered
-        // through the repo-scope policy used for `repos[]`; suppress it for
-        // every restricted identity instead of risking a cross-tenant name
-        // leak from this process-level status field.
+        if self.state.permission_source.is_enabled()
+            && !matches!(
+                r.extensions().get::<nestweaver_engine::authz::Identity>(),
+                Some(nestweaver_engine::authz::Identity::Admin)
+            )
+        {
+            return Err(Status::permission_denied(
+                "BrainStatus requires an administrator while repository authorization is enabled",
+            ));
+        }
+        // The fail-closed guard above owns the current policy. Keep the
+        // earlier indexing-target suppression as defense in depth: a worker
+        // identifier is not an authoritative graph UID suitable for scoping.
         let restricted = matches!(
             self.state.visible_repos_for(r.extensions())?,
             nestweaver_engine::authz::VisibleRepos::Only(_)
@@ -8230,6 +8232,16 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<JsonRequest>,
     ) -> Result<Response<JsonResponse>, Status> {
+        if self.state.permission_source.is_enabled()
+            && !matches!(
+                r.extensions().get::<nestweaver_engine::authz::Identity>(),
+                Some(nestweaver_engine::authz::Identity::Admin)
+            )
+        {
+            return Err(Status::permission_denied(
+                "BrainStatusJson requires an administrator while repository authorization is enabled",
+            ));
+        }
         // nw-415, argued at `dispatch_tool_json`. Same tool, same
         // enumeration, SECOND DOOR: the JSON twin bypassed the gate
         // independently of the typed `brain_status` RPC, so fixing only that
@@ -9181,6 +9193,16 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<JsonRequest>,
     ) -> Result<Response<JsonResponse>, Status> {
+        if self.state.permission_source.is_enabled()
+            && !matches!(
+                r.extensions().get::<nestweaver_engine::authz::Identity>(),
+                Some(nestweaver_engine::authz::Identity::Admin)
+            )
+        {
+            return Err(Status::permission_denied(
+                "DetectImplicitProjectsJson requires an administrator while repository authorization is enabled",
+            ));
+        }
         let is_admin = matches!(
             r.extensions().get::<crate::auth::IsAdmin>(),
             Some(crate::auth::IsAdmin(true))
@@ -10224,16 +10246,14 @@ fn declared_rpc_repo_scope(method: &str) -> Option<RpcRepoScope> {
         // dispatch, or refuses unsafe traversal before it starts. The typed
         // `RepoStates`/`ListContracts` handlers apply the same visibility
         // contract directly.
-        "AffectedTests" | "BlastRadius" | "BrainDiff" | "BrainStatus" | "BrainStatusJson"
-        | "BridgeNodes" | "CodeContext" | "DeadCode" | "DetectChanges" | "FlowTrace"
-        | "GetContext" | "GetProjectContext" | "HubNodes" | "Impact" | "ListContracts"
-        | "PrImpactJson" | "ReadSymbols" | "RegexSearch" | "RepoStates" | "Search"
-        | "StaleCheck" => RpcRepoScope::Scoped,
+        "AffectedTests" | "BlastRadius" | "BrainDiff" | "BridgeNodes" | "CodeContext"
+        | "DeadCode" | "DetectChanges" | "FlowTrace" | "GetContext" | "GetProjectContext"
+        | "HubNodes" | "Impact" | "ListContracts" | "PrImpactJson" | "ReadSymbols"
+        | "RegexSearch" | "RepoStates" | "Search" | "StaleCheck" => RpcRepoScope::Scoped,
 
         // Vault/document-only tool routes plus process capabilities which do
-        // not enumerate repository-owned graph objects. The mutating form of
-        // DetectImplicitProjectsJson retains its payload-aware admin check in
-        // the handler; its dry-run result remains available here.
+        // not enumerate repository-owned graph objects. Raw-path project
+        // preview is classified fail-closed below.
         "BrainBrokenLinks"
         | "BrainDocStats"
         | "BrainMemoryLint"
@@ -10241,7 +10261,6 @@ fn declared_rpc_repo_scope(method: &str) -> Option<RpcRepoScope> {
         | "BrainOrphanDocuments"
         | "BrainTagGraph"
         | "BrainTopicClusters"
-        | "DetectImplicitProjectsJson"
         | "EmbeddingDimension"
         | "GetBacklinks"
         | "GetNote"
@@ -10280,11 +10299,30 @@ fn declared_rpc_repo_scope(method: &str) -> Option<RpcRepoScope> {
         // authorization-induced computation. Admin remains the explicit
         // escape hatch; every non-admin identity is rejected before handler
         // dispatch while per-repo authorization is enabled.
-        "BrainGuide" | "Clusters" | "ContractDrift" | "CountPatterns" | "CrossRepoContracts"
-        | "ExportGraph" | "FlowTraceContinue" | "GetSummary" | "ImpactAnalysis" | "Investigate"
-        | "InvestigateExpand" | "InvestigateHydrate" | "ListReposJson" | "ListServicesJson"
-        | "PlanEmbed" | "QueryExtensions" | "RepoMapJson" | "SearchSymbols"
-        | "ServiceSummaryJson" | "SuggestLinksJson" | "SymbolLookup" => RpcRepoScope::FailClosed,
+        "BrainStatus"
+        | "BrainStatusJson"
+        | "DetectImplicitProjectsJson"
+        | "BrainGuide"
+        | "Clusters"
+        | "ContractDrift"
+        | "CountPatterns"
+        | "CrossRepoContracts"
+        | "ExportGraph"
+        | "FlowTraceContinue"
+        | "GetSummary"
+        | "ImpactAnalysis"
+        | "Investigate"
+        | "InvestigateExpand"
+        | "InvestigateHydrate"
+        | "ListReposJson"
+        | "ListServicesJson"
+        | "PlanEmbed"
+        | "QueryExtensions"
+        | "RepoMapJson"
+        | "SearchSymbols"
+        | "ServiceSummaryJson"
+        | "SuggestLinksJson"
+        | "SymbolLookup" => RpcRepoScope::FailClosed,
 
         _ => return None,
     })
@@ -15350,6 +15388,23 @@ credential_method = "gh"
     }
 
     #[test]
+    fn prune_stale_noop_is_not_a_commit_and_does_not_reconcile() {
+        let state = test_state_with_writer();
+        let generation = state.store.graph_generation();
+        let result = run_prune_stale_with(
+            &state,
+            |_, _| panic!("no repo to delete"),
+            |_, _| panic!("no vault to delete"),
+            |_, _, _| panic!("no mutation to reconcile"),
+        )
+        .unwrap();
+        assert!(!result.committed);
+        assert!(result.removed_repos.is_empty() && result.removed_vaults.is_empty());
+        assert!(result.reconciliation_failures.is_empty());
+        assert_eq!(generation, state.store.graph_generation());
+    }
+
+    #[test]
     fn prune_stale_vault_prunes_note_and_heading_embeddings() {
         let state = test_state_with_writer();
         let (note_uid, heading_uid) = seed_vault_note_heading_embeddings(
@@ -15404,6 +15459,20 @@ credential_method = "gh"
 
         // nw-091 / Bug 2: committed prune → success-with-warnings (`error` binds the Ok response).
         assert!(error.committed);
+        let wire = nestweaver_proto::prune_stale_json(&error);
+        assert_eq!(wire["committed"], true);
+        assert!(
+            wire["reconciliation_failures"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|failure| failure["message"]
+                    .as_str()
+                    .unwrap()
+                    .contains("injected Tantivy"))
+        );
+        assert_eq!(wire["removed_vaults"].as_array().unwrap().len(), 1);
+
         assert!(
             error
                 .reconciliation_failures
@@ -21790,6 +21859,92 @@ external_model = "unavailable-test-model"
         }
     }
 
+    #[tokio::test]
+    async fn implicit_preview_and_status_refuse_before_parsing_for_non_admins() {
+        use nestweaver_engine::authz::Identity;
+        let service = nw415_service();
+        let vault = tempfile::tempdir().unwrap();
+        let canary = vault.path().join("Projects/private-canary");
+        std::fs::create_dir_all(&canary).unwrap();
+        std::fs::write(canary.join("private-canary.md"), "# Private\n").unwrap();
+        for identity in [Identity::Anonymous, Identity::Token(NW415_TOKEN.into())] {
+            for path in [
+                vault.path().to_string_lossy().to_string(),
+                vault.path().join("absent").to_string_lossy().to_string(),
+            ] {
+                let request = nw415_request(
+                    JsonRequest {
+                        args_json: serde_json::json!({"vault":path,"dry_run":true}).to_string(),
+                    },
+                    identity.clone(),
+                );
+                let error = service
+                    .detect_implicit_projects_json(request)
+                    .await
+                    .unwrap_err();
+                assert_eq!(error.code(), tonic::Code::PermissionDenied);
+                assert!(!error.message().contains(&path));
+                assert!(!error.message().contains("private-canary"));
+            }
+            let bad = nw415_request(
+                JsonRequest {
+                    args_json: "not json".into(),
+                },
+                identity.clone(),
+            );
+            assert_eq!(
+                service.brain_status_json(bad).await.unwrap_err().code(),
+                tonic::Code::PermissionDenied
+            );
+            let bad = nw415_request(
+                JsonRequest {
+                    args_json: "not json".into(),
+                },
+                identity.clone(),
+            );
+            assert_eq!(
+                service
+                    .detect_implicit_projects_json(bad)
+                    .await
+                    .unwrap_err()
+                    .code(),
+                tonic::Code::PermissionDenied
+            );
+            let mut extensions = http::Extensions::new();
+            extensions.insert(identity);
+            for method in [
+                "BrainStatus",
+                "BrainStatusJson",
+                "DetectImplicitProjectsJson",
+            ] {
+                assert_eq!(
+                    authz_rejection(true, method, &extensions).unwrap().code(),
+                    tonic::Code::PermissionDenied
+                );
+                assert!(authz_rejection(false, method, &extensions).is_none());
+            }
+        }
+        let mut admin = nw415_request(
+            JsonRequest {
+                args_json: serde_json::json!({"vault":vault.path(),"dry_run":true}).to_string(),
+            },
+            Identity::Admin,
+        );
+        admin.extensions_mut().insert(crate::auth::IsAdmin(true));
+        let preview = service
+            .detect_implicit_projects_json(admin)
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(preview.result_json.contains("private-canary"));
+        assert!(
+            service
+                .brain_status(nw415_request(BrainStatusRequest {}, Identity::Admin))
+                .await
+                .is_ok()
+        );
+    }
+
     fn nw415_hub_request() -> HubNodesRequest {
         HubNodesRequest {
             top_n: 10,
@@ -21834,26 +21989,8 @@ external_model = "unavailable-test-model"
         // lets one of them be missed.
         let mut leaks: Vec<String> = Vec::new();
 
-        // `brain_status`, typed: `EnforcedInArm`, because `repos[]` carries
-        // each repo's URL and indexed git SHA — repo IDENTITY, the most direct
-        // enumeration in the catalogue.
-        let status = service
-            .brain_status(nw415_request(BrainStatusRequest {}, scoped()))
-            .await
-            .expect("a repo-scoped brain_status is scoped, not refused")
-            .into_inner();
-        if status.repo_count != 1 {
-            leaks.push(format!(
-                "typed brain_status counted {} repos; the caller may see 1",
-                status.repo_count
-            ));
-        }
-        if !status.indexing_repo.is_empty() {
-            leaks.push(format!(
-                "typed brain_status leaked an unauthoritative indexing repo identifier: {}",
-                status.indexing_repo
-            ));
-        }
+        // Both status variants refuse whole-instance telemetry for this
+        // scoped identity; the independent repo inventory remains filtered.
         let repos = service
             .repo_states(nw415_request(RepoStatesRequest {}, scoped()))
             .await
@@ -21865,42 +22002,27 @@ external_model = "unavailable-test-model"
                 repos.repos
             ));
         }
-
-        // `brain_status`, JSON: the second door onto the same enumeration.
-        let status_json = service
-            .brain_status_json(nw415_request(
-                JsonRequest {
-                    args_json: "{}".to_string(),
-                },
-                scoped(),
-            ))
-            .await
-            .expect("a repo-scoped brain_status_json is scoped, not refused")
-            .into_inner();
-        if status_json.result_json.contains(NW415_HIDDEN_URL) {
-            leaks.push(format!(
-                "brain_status_json leaked the hidden repo's URL: {}",
-                status_json.result_json
-            ));
-        }
-        if !status_json.result_json.contains(NW415_VISIBLE_URL) {
-            leaks.push(format!(
-                "brain_status_json dropped the repo the caller DOES own: {}",
-                status_json.result_json
-            ));
-        }
-        let status_value: serde_json::Value =
-            serde_json::from_str(&status_json.result_json).unwrap();
-        if status_value["visibility"]["scoped"] != serde_json::json!(true) {
-            leaks.push(format!(
-                "brain_status_json did not disclose that it was scoped: {status_value}"
-            ));
-        }
-        if !status_value["indexing_repo"].is_null() {
-            leaks.push(format!(
-                "brain_status_json leaked an unauthoritative indexing repo identifier: {status_value}"
-            ));
-        }
+        assert_eq!(
+            service
+                .brain_status(nw415_request(BrainStatusRequest {}, scoped()))
+                .await
+                .unwrap_err()
+                .code(),
+            tonic::Code::PermissionDenied
+        );
+        assert_eq!(
+            service
+                .brain_status_json(nw415_request(
+                    JsonRequest {
+                        args_json: "{}".into()
+                    },
+                    scoped()
+                ))
+                .await
+                .unwrap_err()
+                .code(),
+            tonic::Code::PermissionDenied
+        );
 
         // `brain_context`: `RedactedAfterDispatch`.
         let context = service

--- a/crates/nestweaver-engine/src/node_scope.rs
+++ b/crates/nestweaver-engine/src/node_scope.rs
@@ -118,7 +118,7 @@ pub const REPO_FILTER_UNRESOLVED_CODE: &str = "repo-filter-unresolved";
 /// assertion below still pins that text, because a downgrade path (a new
 /// client against an older daemon that cannot stamp the metadata code) still
 /// falls back to it.
-#[derive(Debug, thiserror::Error)]
+#[derive(Clone, Debug, thiserror::Error)]
 #[error("repo filter entry {selector:?}: {rendered}")]
 pub struct RepoFilterUnresolved {
     /// The selector as the caller spelled it.

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -387,12 +387,13 @@ fn repo_scope(tool: &str) -> RepoScope {
         "brain_search" | "brain_impact" | "brain_diff" | "affected_tests" | "detect_changes" => {
             RepoScope::EnforcedInArm
         }
-        // nw-403: `brain_status` enumerated every repo's URL and indexed git
-        // SHA — repo IDENTITY, the most direct enumeration of a hidden tenant
-        // in the catalogue. Its rows are keyed by url/name, not by node uid,
-        // so the generic redactor cannot see them.
-        "brain_status" => RepoScope::EnforcedInArm,
-        // Keyed by repo, same reason as `brain_status`.
+        // Instance status includes host and whole-corpus telemetry that cannot
+        // be made tenant-safe by filtering the repository rows.
+        "brain_status" => RepoScope::FailClosed(
+            "host paths, runtime state and embedding telemetry describe the whole instance; \
+             a safe repository-scoped status response is not available",
+        ),
+        // Stale inventory can be filtered before its totals are computed.
         "stale_check" => RepoScope::EnforcedInArm,
         // Filtering has to happen DURING the walk. Redacting a call tree
         // afterwards would delete a subtree and leave `children: []`, which is
@@ -3525,10 +3526,32 @@ fn ensure_dispatch_not_cancelled(
 /// identical calls burned 30 embeds and piled into the tool timeout.
 /// Coalesce them: the first caller (leader) computes, followers wait on the
 /// shared slot and receive a clone of the leader's result. `anyhow::Error`
-/// is not `Clone`, so the slot carries the error's message and followers
-/// re-wrap it.
+/// is not `Clone`, so preserve its rendered context and the stable repository
+/// filter error used by federation. Followers must retain that source type so
+/// the daemon can stamp the same metadata code as it does for the leader.
+#[derive(Clone, Debug, thiserror::Error)]
+#[error("{message}")]
+struct SharedFlightError {
+    message: String,
+    #[source]
+    repo_filter: Option<nestweaver_engine::node_scope::RepoFilterUnresolved>,
+}
+
+impl SharedFlightError {
+    fn capture(error: &anyhow::Error) -> Self {
+        Self {
+            message: format!("{error:#}"),
+            repo_filter: error.chain().find_map(|cause| {
+                cause
+                    .downcast_ref::<nestweaver_engine::node_scope::RepoFilterUnresolved>()
+                    .cloned()
+            }),
+        }
+    }
+}
+
 struct InFlightSlot {
-    result: std::sync::Mutex<Option<Result<Value, String>>>,
+    result: std::sync::Mutex<Option<Result<Value, SharedFlightError>>>,
     ready: std::sync::Condvar,
 }
 
@@ -3553,7 +3576,7 @@ struct FlightLeader {
 impl FlightLeader {
     /// Store the outcome for waiting followers; `drop` then unregisters the
     /// flight and notifies them.
-    fn finish(self, result: Result<Value, String>) {
+    fn finish(self, result: Result<Value, SharedFlightError>) {
         *self.slot.result.lock().unwrap_or_else(|e| e.into_inner()) = Some(result);
     }
 }
@@ -3573,9 +3596,10 @@ impl Drop for FlightLeader {
         }
         let mut result = self.slot.result.lock().unwrap_or_else(|e| e.into_inner());
         if result.is_none() {
-            *result = Some(Err(
-                "in-flight leader dropped before producing a result".to_string()
-            ));
+            *result = Some(Err(SharedFlightError {
+                message: "in-flight leader dropped before producing a result".to_string(),
+                repo_filter: None,
+            }));
         }
         drop(result);
         self.slot.ready.notify_all();
@@ -3623,7 +3647,7 @@ fn coalesce_in_flight(
             if let Some(res) = &*result {
                 return match res {
                     Ok(value) => Ok(value.clone()),
-                    Err(msg) => Err(anyhow!("{msg}")),
+                    Err(error) => Err(anyhow::Error::new(error.clone())),
                 };
             }
             if cancel.is_some() {
@@ -3643,7 +3667,7 @@ fn coalesce_in_flight(
         result
             .as_ref()
             .map(|v| v.clone())
-            .map_err(|e| format!("{e:#}")),
+            .map_err(SharedFlightError::capture),
     );
     result
 }
@@ -9010,10 +9034,7 @@ fn tool_prune_stale(store: &GraphStore) -> Result<Value, anyhow::Error> {
             .block_on(client.prune_stale(nestweaver_proto::PruneStaleRequest {}))
             .map_err(|e| anyhow!("prune_stale RPC failed: {e}"))?;
         let inner = resp.into_inner();
-        Ok(json!({
-            "removed_repos": inner.removed_repos,
-            "removed_vaults": inner.removed_vaults
-        }))
+        Ok(nestweaver_proto::prune_stale_json(&inner))
     }
     #[cfg(not(feature = "daemon"))]
     {
@@ -14340,10 +14361,7 @@ fn dispatch_via_daemon_inner(
             .block_on(client.prune_stale(nestweaver_proto::PruneStaleRequest {}))
             .map_err(|e| anyhow::anyhow!("prune_stale RPC failed: {}", e.message()))?;
         let inner = resp.into_inner();
-        return Ok(Unstamped::new(json!({
-            "removed_repos": inner.removed_repos,
-            "removed_vaults": inner.removed_vaults
-        })));
+        return Ok(Unstamped::new(nestweaver_proto::prune_stale_json(&inner)));
     }
 
     // Helper to parse string arrays from JSON args.
@@ -14751,11 +14769,6 @@ fn dir_is_markdown_dominant(dir: &std::path::Path) -> bool {
     md > 0 && md >= code
 }
 
-/// Instance id `brain_add_source` stamps vaults under when routing through the
-/// daemon, mirroring the CLI's nw-019 precedence (`resolve_instance_id`):
-/// config's `instance_id` > `"default"`. An empty id would defer to the daemon,
-/// whose config-less fallback is the db-path hash — a different identity than
-/// the CLI's `"default"`, duplicating any vault added via both paths.
 #[cfg(feature = "daemon")]
 /// The instance this MCP process should ask the daemon to write under.
 ///
@@ -18731,6 +18744,175 @@ mod cache_dispatch_tests {
         );
     }
 
+    #[test]
+    fn single_flight_preserves_typed_errors_for_every_follower() {
+        use std::sync::{Arc, Barrier};
+        let key: InFlightKey = ("/tmp/typed-flight.lbug".into(), 41, 42, 43);
+        let release = Arc::new(Barrier::new(2));
+        let leader_key = key.clone();
+        let leader_release = release.clone();
+        let leader = std::thread::spawn(move || {
+            coalesce_in_flight(leader_key, None, || {
+                leader_release.wait();
+                Err(
+                    anyhow::Error::new(nestweaver_engine::node_scope::RepoFilterUnresolved::new(
+                        "missing",
+                        &anyhow!("wording may change"),
+                    ))
+                    .context("outer tool context"),
+                )
+            })
+        });
+        let baseline = wait_for_flight_count(&key, |n| n >= 1);
+        let followers: Vec<_> = (0..8)
+            .map(|_| {
+                let key = key.clone();
+                std::thread::spawn(move || {
+                    coalesce_in_flight(key, None, || panic!("unexpected leader"))
+                })
+            })
+            .collect();
+        wait_for_flight_count(&key, |n| n >= baseline + 8);
+        release.wait();
+        for result in std::iter::once(leader).chain(followers) {
+            let error = result.join().unwrap().unwrap_err();
+            let typed = error
+                .chain()
+                .find_map(|cause| {
+                    cause.downcast_ref::<nestweaver_engine::node_scope::RepoFilterUnresolved>()
+                })
+                .expect("typed code must survive");
+            assert_eq!(typed.selector, "missing");
+            assert!(error.to_string().contains("outer tool context"));
+        }
+        assert_eq!(
+            coalesce_in_flight(key, None, || Ok(json!("retry"))).unwrap(),
+            json!("retry")
+        );
+    }
+
+    #[test]
+    fn single_flight_cancelled_follower_does_not_cancel_leader_or_strand_retry() {
+        use std::sync::{
+            Arc, Barrier,
+            atomic::{AtomicBool, Ordering},
+        };
+        let key: InFlightKey = ("/tmp/cancel-flight.lbug".into(), 51, 52, 53);
+        let release = Arc::new(Barrier::new(2));
+        let leader_key = key.clone();
+        let gate = release.clone();
+        let leader = std::thread::spawn(move || {
+            coalesce_in_flight(leader_key, None, || {
+                gate.wait();
+                Ok(json!("complete"))
+            })
+        });
+        let baseline = wait_for_flight_count(&key, |n| n >= 1);
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let flag = cancelled.clone();
+        let follower_key = key.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let follower = std::thread::spawn(move || {
+            tx.send(coalesce_in_flight(follower_key, Some(&flag), || {
+                panic!("follower computed")
+            }))
+            .unwrap();
+        });
+        wait_for_flight_count(&key, |n| n > baseline);
+        cancelled.store(true, Ordering::Release);
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_secs(5))
+                .unwrap()
+                .is_err()
+        );
+        release.wait();
+        follower.join().unwrap();
+        assert_eq!(leader.join().unwrap().unwrap(), json!("complete"));
+        assert!(coalesce_in_flight(key, None, || Ok(json!(true))).is_ok());
+    }
+
+    #[test]
+    fn single_flight_leader_cancellation_and_ordinary_failure_release_followers() {
+        use std::sync::{
+            Arc, Barrier,
+            atomic::{AtomicBool, Ordering},
+        };
+        for cancelled in [false, true] {
+            let key: InFlightKey = (
+                "/tmp/leader-error-flight.lbug".into(),
+                71,
+                72,
+                u64::from(cancelled),
+            );
+            let flag = Arc::new(AtomicBool::new(false));
+            let release = Arc::new(Barrier::new(2));
+            let gate = release.clone();
+            let leader_flag = flag.clone();
+            let leader_key = key.clone();
+            let leader = std::thread::spawn(move || {
+                coalesce_in_flight(leader_key, Some(&leader_flag), || {
+                    gate.wait();
+                    ensure_dispatch_not_cancelled(Some(&leader_flag))?;
+                    Err(anyhow!("ordinary failure"))
+                })
+            });
+            let baseline = wait_for_flight_count(&key, |n| n >= 1);
+            let follower_key = key.clone();
+            let (tx, rx) = std::sync::mpsc::channel();
+            let follower = std::thread::spawn(move || {
+                tx.send(coalesce_in_flight(follower_key, None, || {
+                    panic!("follower computed")
+                }))
+                .unwrap();
+            });
+            wait_for_flight_count(&key, |n| n > baseline);
+            flag.store(cancelled, Ordering::Release);
+            release.wait();
+            let leader_error = leader.join().unwrap().unwrap_err();
+            let follower_error = rx
+                .recv_timeout(std::time::Duration::from_secs(5))
+                .unwrap()
+                .unwrap_err();
+            follower.join().unwrap();
+            assert_eq!(format!("{leader_error:#}"), format!("{follower_error:#}"));
+            assert!(coalesce_in_flight(key, None, || Ok(json!("retry"))).is_ok());
+        }
+    }
+
+    #[test]
+    fn single_flight_panicking_leader_wakes_followers() {
+        use std::sync::{Arc, Barrier};
+        let key: InFlightKey = ("/tmp/panic-flight.lbug".into(), 61, 62, 63);
+        let release = Arc::new(Barrier::new(2));
+        let gate = release.clone();
+        let leader_key = key.clone();
+        let leader = std::thread::spawn(move || {
+            coalesce_in_flight(leader_key, None, || {
+                gate.wait();
+                panic!("injected leader failure")
+            })
+        });
+        let baseline = wait_for_flight_count(&key, |n| n >= 1);
+        let follower_key = key.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let follower = std::thread::spawn(move || {
+            tx.send(coalesce_in_flight(follower_key, None, || {
+                panic!("follower computed")
+            }))
+            .unwrap();
+        });
+        wait_for_flight_count(&key, |n| n > baseline);
+        release.wait();
+        assert!(leader.join().is_err());
+        let error = rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .unwrap()
+            .unwrap_err();
+        assert!(error.to_string().contains("leader dropped"));
+        follower.join().unwrap();
+        assert!(coalesce_in_flight(key, None, || Ok(json!(true))).is_ok());
+    }
+
     /// A failed leader cleans up: followers get the error, and a later call
     /// with the same key recomputes instead of poisoning the flight map.
     #[test]
@@ -22432,9 +22614,9 @@ mod repo_visibility_coverage_tests {
         }
     }
 
-    /// COUNTERWEIGHT: scoping must not be over-applied. A caller authorized
-    /// for BOTH repos is not restricted at all in effect, and an unconfigured
-    /// deployment (`None`) must be byte-identical to the pre-nw-403 behaviour.
+    /// COUNTERWEIGHT: both authorized repository inventories remain visible.
+    /// Host-wide status requires admin authority even when every repo is
+    /// visible; an unconfigured deployment retains its full status payload.
     #[test]
     fn a_caller_authorized_for_every_repo_still_sees_every_repo() {
         let store = hidden_repo_store();
@@ -22443,7 +22625,7 @@ mod repo_visibility_coverage_tests {
                 .into_iter()
                 .collect(),
         );
-        let scoped = call(&store, "brain_status", &json!({}), Some(&all));
+        let scoped = call(&store, "stale_check", &json!({}), Some(&all));
         assert!(
             scoped.contains("hidden-secret"),
             "a caller authorized for repo:hidden must still see it: {scoped}"
@@ -22460,29 +22642,30 @@ mod repo_visibility_coverage_tests {
     /// (URL + indexed git SHA) rather than repo content, and because its
     /// summaries have to stay consistent with the list they summarise.
     #[test]
-    fn brain_status_scopes_the_repo_list_without_erasing_the_visible_repo() {
+    fn brain_status_refuses_scoped_metadata_before_dispatch() {
         let store = hidden_repo_store();
-        let visible = only_alpha();
-        let value = dispatch_cancellable(
-            &store,
-            None,
-            "brain_status",
-            json!({}),
-            None,
-            None,
-            Some(&visible),
-        )
-        .expect("brain_status must still answer a scoped caller");
-        assert_eq!(value["repo_count"], json!(1), "{value}");
-        let repos = value["repos"].as_array().expect("repos array");
-        assert_eq!(repos.len(), 1, "{value}");
-        assert_eq!(
-            repos[0]["url"],
-            json!("https://example.test/alpha"),
-            "{value}"
-        );
-        assert_eq!(value["visibility"]["scoped"], json!(true), "{value}");
-        assert_eq!(value["visibility"]["repos_hidden"], json!(1), "{value}");
+        for visible in [
+            only_alpha(),
+            VisibleRepos::Only(
+                ["repo:alpha".to_string(), "repo:hidden".to_string()]
+                    .into_iter()
+                    .collect(),
+            ),
+            nestweaver_engine::authz::VisibleRepos::Only(Default::default()),
+        ] {
+            let error = dispatch_cancellable(
+                &store,
+                None,
+                "brain_status",
+                json!({}),
+                None,
+                None,
+                Some(&visible),
+            )
+            .unwrap_err();
+            assert!(format!("{error:#}").contains("host paths"));
+        }
+        assert!(dispatch(&store, None, "brain_status", json!({}), None).is_ok());
     }
 
     /// `stale_check` is scoped at its INPUT so its pre-summarised lists cannot

--- a/crates/nestweaver-proto/Cargo.toml
+++ b/crates/nestweaver-proto/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 description = "Generated protobuf types for NestWeaver daemon gRPC service"
 
 [dependencies]
+serde_json = { workspace = true }
 tonic = { workspace = true }
 tonic-prost = { workspace = true }
 prost = { workspace = true }

--- a/crates/nestweaver-proto/src/lib.rs
+++ b/crates/nestweaver-proto/src/lib.rs
@@ -4,6 +4,18 @@ pub mod nestweaver_daemon_v1 {
 
 pub use nestweaver_daemon_v1::*;
 
+/// One lossless structured representation for every prune consumer.
+pub fn prune_stale_json(response: &PruneStaleResponse) -> serde_json::Value {
+    serde_json::json!({
+        "removed_repos": response.removed_repos,
+        "removed_vaults": response.removed_vaults,
+        "committed": response.committed,
+        "reconciliation_failures": response.reconciliation_failures.iter().map(|failure| serde_json::json!({
+            "stage": failure.stage, "repo_uid": failure.repo_uid, "message": failure.message,
+        })).collect::<Vec<_>>(),
+    })
+}
+
 #[cfg(test)]
 mod additive_status_contract_tests {
     use super::*;

--- a/docs/guide/instance-config.md
+++ b/docs/guide/instance-config.md
@@ -444,9 +444,19 @@ unknown/unlisted token sees nothing.
 "team-backend-token"  = ["github.com/acme/backend*"]
 ```
 
-Blast-radius responses (affected/changed symbols, `org_wide` impact, coverage,
-cluster/summary counts) are redacted to the caller's visible repos. Stdio MCP and
-the local CLI are single-user and always see all repos.
+Each tool declares whether it can enforce repository visibility or must refuse
+before computing a graph-wide answer. Enabling a rule does not make global
+aggregates safe through row filtering alone.
+
+With repository authorization enabled, `brain_status` (including both typed
+and JSON status RPCs) requires an administrator: host paths, runtime activity
+and embedding telemetry describe the whole instance. Raw-path implicit-project
+preview also requires an administrator, including `dry_run=true`; query and
+anonymous identities are refused before the path is examined. Admin preview
+remains read-only, and applying a plan still takes the writer gate.
+
+An absent or empty policy preserves the existing local status and preview
+behavior. Admin identities retain full operational status.
 
 #### `[[links]]` — Cross-repo relationships
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4915,6 +4915,8 @@ enum Commands {
             help = "Path to the database file [env: NESTWEAVER_DB] [default: ./nestweaver.lbug]"
         )]
         db: Option<PathBuf>,
+        #[arg(long, help = "Emit JSON, including commit and reconciliation state")]
+        json: bool,
     },
     /// Reconcile an index publication abandoned by a crashed indexer.
     ///
@@ -6457,6 +6459,7 @@ enum Commands {
         #[arg(
             long,
             default_value = "low",
+            value_parser = ["low", "medium", "high"],
             help = "Minimum confidence to report (low, medium, high)"
         )]
         min_confidence: String,
@@ -13628,6 +13631,12 @@ fn run_daemon_gc() -> Result<(i32, Option<String>), anyhow::Error> {
             }
         }
     }
+    if !report.spared_spawnlock.is_empty() {
+        println!(
+            "  spared (spawn handshake active): {}",
+            report.spared_spawnlock.len()
+        );
+    }
     if !report.spared_pidfile_lock.is_empty() {
         println!(
             "  spared (pidfile lock held): {}",
@@ -14339,7 +14348,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             Ok((EXIT_SUCCESS, None))
         }
 
-        Commands::PruneStale { db } => {
+        Commands::PruneStale { db, json } => {
             let db_path = db.unwrap_or_else(default_db_path);
             require_existing_db(&db_path)?;
             let rt = tokio::runtime::Runtime::new()?;
@@ -14349,17 +14358,36 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
 
             match rt.block_on(client.prune_stale()) {
                 Ok(resp) => {
-                    let total = resp.removed_repos.len() + resp.removed_vaults.len();
-                    if total == 0 {
-                        println!("No stale sources found.");
+                    if json {
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&nestweaver_proto::prune_stale_json(
+                                &resp
+                            ))?
+                        );
                     } else {
-                        for name in &resp.removed_repos {
-                            println!("  Removed repo: {name}");
+                        let total = resp.removed_repos.len() + resp.removed_vaults.len();
+                        if total == 0 {
+                            println!("No stale sources found.");
+                        } else {
+                            for name in &resp.removed_repos {
+                                println!("  Removed repo: {name}");
+                            }
+                            for name in &resp.removed_vaults {
+                                println!("  Removed vault: {name}");
+                            }
+                            println!("Pruned {total} stale source(s).");
                         }
-                        for name in &resp.removed_vaults {
-                            println!("  Removed vault: {name}");
+                        println!("Committed: {}", resp.committed);
+                        for failure in &resp.reconciliation_failures {
+                            eprintln!(
+                                "Warning: reconciliation {} [{}]: {}",
+                                failure.stage, failure.repo_uid, failure.message
+                            );
                         }
-                        println!("Pruned {total} stale source(s).");
+                    }
+                    if !resp.reconciliation_failures.is_empty() {
+                        return Ok((EXIT_ERROR, None));
                     }
                 }
                 Err(e) => {
@@ -17208,14 +17236,8 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
             }
 
-            let min_conf =
-                DeadCodeConfidence::from_str_loose(&min_confidence).unwrap_or_else(|| {
-                    eprintln!(
-                        "Warning: unknown confidence level '{}', defaulting to 'low'",
-                        min_confidence
-                    );
-                    DeadCodeConfidence::Low
-                });
+            let min_conf = DeadCodeConfidence::from_str_loose(&min_confidence)
+                .ok_or_else(|| anyhow::anyhow!("invalid dead-code confidence: {min_confidence}"))?;
             let store = open_store(db.as_deref())?;
 
             let db_path = db.clone().unwrap_or_else(default_db_path);

--- a/tests/ready_regression_test.rs
+++ b/tests/ready_regression_test.rs
@@ -500,3 +500,56 @@ fn selected_pull_rejects_unknown_instance_and_uses_registered_workspace() {
             .contains(f.dir.path().join("selected-workspace").to_str().unwrap())
     );
 }
+
+#[test]
+fn invalid_dead_code_confidence_fails_before_any_route_or_database_work() {
+    let fixture = Fixture::new();
+    for direct in [false, true] {
+        for value in ["", "bogus", "NaN", "LOW"] {
+            let output = fixture.query(
+                &["dead-code", &format!("--min-confidence={value}"), "--json"],
+                direct,
+            );
+            assert_eq!(
+                output.status.code(),
+                Some(64),
+                "{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(
+                !fixture.db.exists(),
+                "invalid input must not start a database"
+            );
+        }
+    }
+}
+
+#[test]
+fn prune_cli_preserves_commit_state_for_noop_and_real_deletion() {
+    let fixture = Fixture::new();
+    fixture.index();
+    let clean = fixture.query(&["prune-stale", "--json"], false);
+    assert!(
+        clean.status.success(),
+        "{}",
+        String::from_utf8_lossy(&clean.stderr)
+    );
+    let clean = payload(&clean);
+    assert_eq!(clean["committed"], false);
+    assert_eq!(clean["removed_repos"], json!([]));
+    assert_eq!(clean["reconciliation_failures"], json!([]));
+    std::fs::remove_dir_all(&fixture.repo).unwrap();
+    let removed = fixture.query(&["prune-stale", "--json"], false);
+    assert!(
+        removed.status.success(),
+        "{}",
+        String::from_utf8_lossy(&removed.stderr)
+    );
+    let removed = payload(&removed);
+    assert_eq!(removed["committed"], true);
+    assert_eq!(removed["removed_repos"].as_array().unwrap().len(), 1);
+    assert_eq!(removed["reconciliation_failures"], json!([]));
+    let repeat = fixture.query(&["prune-stale"], false);
+    assert!(repeat.status.success());
+    assert!(String::from_utf8_lossy(&repeat.stdout).contains("Committed: false"));
+}

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -2684,6 +2684,43 @@ async fn hybrid_blast_radius_two_tier_degrades_local_when_repo_only_resolves_ups
     // exact-root-path leg — real and resolvable at the SERVER (which indexed
     // it), absent from the LOCAL daemon's index (which only has `repo_b`).
     let repo_a_path = server_repo.display().to_string();
+    // Exercise the actual error mapper and wire metadata under concurrency.
+    // The MCP unit test separately forces eight followers with a barrier;
+    // this process test does not assume a particular server scheduling order.
+    let channel = tonic::transport::Channel::from_shared(_local_guard.grpc_addr())
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+    let mut calls = tokio::task::JoinSet::new();
+    for _ in 0..12 {
+        let mut client = NestWeaverDaemonClient::new(channel.clone());
+        let args_json = json!({
+            "changed_files": ["server/main.js"],
+            "max_depth": 3,
+            "repo": repo_a_path,
+        })
+        .to_string();
+        calls.spawn(async move {
+            client
+                .blast_radius(JsonRequest { args_json })
+                .await
+                .unwrap_err()
+        });
+    }
+    while let Some(result) = calls.join_next().await {
+        let status = result.unwrap();
+        assert_eq!(
+            status
+                .metadata()
+                .get(nestweaver_engine::node_scope::NW_ERROR_CODE_METADATA_KEY)
+                .and_then(|value| value.to_str().ok()),
+            Some(nestweaver_engine::node_scope::REPO_FILTER_UNRESOLVED_CODE),
+            "every concurrent wire response must preserve the typed code: {status}"
+        );
+    }
+    // The hybrid query below exercises the production client decoder and
+    // proves the unresolved local scope still permits a healthy upstream tier.
     let resp = hybrid
         .query(
             "blast_radius",


### PR DESCRIPTION
## Problem and changes

GC could remove a live spawn handshake, scoped callers could retrieve whole-instance status or preview arbitrary host paths, and prune/coalescing consumers could lose facts needed to interpret a response. This branch fixes the seven ready backlog scopes together:

1. Hold nonblocking per-instance spawn admission across GC checks and deletion; atomically retire runtime directories and make waiting clients retry retired lock inodes.
2. Refuse non-admin raw-path implicit-project previews before parsing/enumeration when repository authorization is enabled.
3. Apply the same fail-closed policy to typed/JSON status and MCP status; retain admin and auth-disabled access.
4. Preserve prune removals, actual commit state and reconciliation warnings through shared JSON serialization, MCP and CLI. No-op reports false; degraded CLI completion exits nonzero.
5. Preserve the typed repository-filter source for coalesced followers. Explicit gRPC codes are authoritative; prose fallback applies only without metadata.
6. Reject blank/unknown dead-code confidence values before routing or database work.
7. Remove contradictory configless MCP add-source rustdoc.

## Validation and local review

- Workspace coverage completed: 4,842 passed and 7 existing ignores across all 41 workspace test executables. The initial `RUST_TEST_THREADS=4 cargo test --workspace` sweep stopped at one obsolete MCP assertion that granted host status to an all-repositories query identity. Corrected that expectation while retaining the inventory counterweight, rebuilt with `cargo test --workspace --no-run`, and reran the complete MCP suite plus every remaining workspace-built executable with the same feature set. All 334 MCP tests passed.
- 15 final targeted checks passed after review additions, including twelve concurrent real gRPC errors followed by the production hybrid client path, pre-parse authorization canaries, and 12 GC tests. The coalescer suite also forces eight followers and covers leader/follower cancellation, panic, ordinary failure and retry.
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check` passed on the final sources. `cargo test --workspace --doc` completed; there are no executable doctests in this configuration.
- 43 isolated manual assertions passed: held spawn/pid controls, unrelated GC collection, six GC/start overlaps, direct/proxy invalid confidence, MCP/CLI prune no-op and commit, authenticated HTTP query/admin status, and real post-commit search-reconciliation failures through MCP and both CLI renderers.
- Strict brain audit: 240 notes, zero errors or warnings. Baseline graph review disclosed partial/truncated context and was used for navigation, not as a safety certificate.

The original held-spawnlock reproduction still fails against released v9.3.0 and passes on this branch. Deterministic tests force followers and retired-inode waiters; live transport and manual process tests complement those scheduling controls.

Local review checked the GC critical section, authorization before parsing, mutation-result consumers, error-source propagation and unchanged identity/cache boundaries. This is a local self-review signoff, not an independent approval.

## Compatibility and limits

Repository-authorized query identities now receive permission refusal for whole-instance status and raw-path preview; administrators and authorization-disabled local clients keep access. A future scoped DTO or registered-vault preview needs a separate authorization design. Prune JSON adds committed/reconciliation fields and the CLI adds `--json`.

The GC/client retry protocol is tested on Linux. Older clients waiting on retired lock inodes may still require their existing error/retry handling; macOS runtime validation belongs to CI. The protobuf wire schema is unchanged. No unrelated deferred or repository-governance scope is included.
