### PR TITLE
fix: harden scoped retrieval and mutation diagnostics

### DIFF
--- a/crates/nestweaver-client/src/connect.rs
+++ b/crates/nestweaver-client/src/connect.rs
@@ -281,8 +281,8 @@ pub async fn connect_upstream(
     let repo_count = client
         .repo_states(req)
         .await
-        .map(|r| r.into_inner().repos.len())
-        .unwrap_or(0);
+        .context("upstream is reachable but repository inventory is unavailable; connection was not saved; check authorization and retry")?
+        .into_inner().repos.len();
 
     let config = UpstreamConfig {
         name: Some(name.unwrap_or("upstream").to_string()),

--- a/crates/nestweaver-client/src/hybrid.rs
+++ b/crates/nestweaver-client/src/hybrid.rs
@@ -477,6 +477,16 @@ impl HybridClient {
                 // responses keep their `connected` schema; it falls back to the
                 // flat envelope for non-structured tools internally.
                 let mut merged = merge_structured_results(&local_result, &server_result);
+                if tool_name == "brain_search" {
+                    nestweaver_federation::results::cap_brain_search_results(
+                        &mut merged,
+                        nestweaver_federation::results::brain_search_limit(
+                            params,
+                            &local_result,
+                            &server_result,
+                        ),
+                    );
+                }
                 inject_or_wrap_provenance(&mut merged, &["local", "server"], &[]);
                 Ok(merged)
             }
@@ -565,6 +575,12 @@ impl HybridClient {
         match server_result {
             Ok(Ok(server)) => {
                 let mut merged = merge_structured_results(&local, &server);
+                if tool_name == "brain_search" {
+                    nestweaver_federation::results::cap_brain_search_results(
+                        &mut merged,
+                        nestweaver_federation::results::brain_search_limit(params, &local, &server),
+                    );
+                }
                 inject_or_wrap_provenance(&mut merged, &["local", "server"], &[]);
                 Ok(merged)
             }

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -22244,10 +22244,17 @@ external_model = "unavailable-test-model"
                 message.contains("repository-scoped caller"),
                 "{route} must explain the scope refusal: {error}"
             );
-            assert!(
-                message.contains("filesystem root") || message.contains("filesystem roots"),
-                "{route} must identify the untrusted root boundary: {error}"
-            );
+            if route == "GetContext" {
+                // The aggregate guard now refuses before source-body handling.
+                assert_eq!(error.code(), tonic::Code::PermissionDenied);
+                assert!(message.contains("global ranking"), "{error}");
+            } else {
+                assert!(
+                    message.contains("filesystem root") || message.contains("filesystem roots"),
+                    "{route} must identify the untrusted root boundary: {error}"
+                );
+            }
+            assert!(!message.contains(attacker_root));
         }
     }
 

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -24520,6 +24520,33 @@ external_model = "unavailable-test-model"
     }
 }
 
+// A real daemon arms a process-lifetime database-lock guard and installs
+// process-wide runtime state. Booting one in a parallel unit-test process
+// contaminates later lifecycle probes even after the server task exits.
+#[cfg(test)]
+fn run_server_test_in_child(test_name: &str) -> bool {
+    const CHILD_TEST: &str = "NESTWEAVER_ISOLATED_SERVER_TEST";
+    if std::env::var(CHILD_TEST).as_deref() == Ok(test_name) {
+        return false;
+    }
+    let _env_guard = lifecycle::TEST_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    let output = std::process::Command::new(std::env::current_exe().unwrap())
+        .args(["--exact", test_name, "--nocapture"])
+        .env(CHILD_TEST, test_name)
+        .output()
+        .expect("start isolated server test");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success() && stdout.contains("1 passed; 0 failed"),
+        "isolated {test_name} failed: {}\n{stdout}\n{stderr}",
+        output.status
+    );
+    true
+}
+
 #[cfg(test)]
 mod boot_reconciliation_tests {
     use super::*;
@@ -24783,6 +24810,11 @@ mod boot_reconciliation_tests {
     #[allow(clippy::await_holding_lock)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn read_write_daemon_boot_recovers_before_immediate_shutdown() {
+        if run_server_test_in_child(
+            "server::boot_reconciliation_tests::read_write_daemon_boot_recovers_before_immediate_shutdown",
+        ) {
+            return;
+        }
         // Resolve env-dependent paths (socket, pidfile, log/runtime dirs) for
         // the daemon's whole lifetime under the same lock the sibling e2e
         // tests hold while swapping XDG vars.
@@ -25199,6 +25231,11 @@ mod watcher_e2e_tests {
     #[allow(clippy::await_holding_lock)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn daemon_e2e_pid_watch_force_and_shutdown() {
+        if run_server_test_in_child(
+            "server::watcher_e2e_tests::daemon_e2e_pid_watch_force_and_shutdown",
+        ) {
+            return;
+        }
         // Resolve env-dependent paths (socket, pidfile, log/runtime dirs) for
         // the daemon's whole lifetime under the same lock the lifecycle unit
         // tests and the clean-shutdown e2e below hold while swapping XDG vars.
@@ -25420,6 +25457,11 @@ mod watcher_e2e_tests {
     #[allow(clippy::await_holding_lock)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn daemon_clean_shutdown_leaves_no_dirs_for_temp_db() {
+        if run_server_test_in_child(
+            "server::watcher_e2e_tests::daemon_clean_shutdown_leaves_no_dirs_for_temp_db",
+        ) {
+            return;
+        }
         let _env_guard = lifecycle::TEST_ENV_LOCK
             .lock()
             .unwrap_or_else(|error| error.into_inner());

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -7901,6 +7901,14 @@ impl NestWeaverDaemon for DaemonService {
             });
 
         Ok(Response::new(BrainSearchResponse {
+            engine_warning: value
+                .get("engine_warning")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+            limit_per_kind: value
+                .get("limit_per_kind")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(20) as u32,
             query: query_echo,
             engine,
             total_matches,
@@ -7945,12 +7953,7 @@ impl NestWeaverDaemon for DaemonService {
         // `dispatch_tool_json`); `code_context`, one method away on the same
         // surface, was scoped the whole time.
         //
-        // `brain_context` is one of the tools nw-403's own measurement named
-        // as leaking (hidden-repo symbols, file paths and note prose). It is
-        // `RepoScope::RedactedAfterDispatch`, so a scoped caller now gets only
-        // the rows it owns, and a `response_format: "concise"` request — which
-        // omits the very uids attribution needs — is refused rather than
-        // served unfiltered.
+        // Global context aggregates fail closed for repository-scoped callers.
         let (_, extensions, req) = r.into_parts();
         let args = brain_context_args_from_request(&req);
 
@@ -7985,11 +7988,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<ProjectContextRequest>,
     ) -> Result<Response<ProjectContextResponse>, Status> {
-        // nw-415, argued at `dispatch_tool_json`. `project_context` is
-        // `RepoScope::RedactedAfterDispatch` AND its `response_format`
-        // DEFAULTS to concise, so a repo-scoped caller that sends no format at
-        // all is refused rather than handed uid-free rows that nothing
-        // downstream can attribute to a repo.
+        // Project aggregates use the same fail-closed authorization as MCP.
         let (_, extensions, req) = r.into_parts();
         let args = project_context_args_from_request(&req);
 
@@ -8207,9 +8206,7 @@ impl NestWeaverDaemon for DaemonService {
         &self,
         r: Request<HubNodesRequest>,
     ) -> Result<Response<HubNodesResponse>, Status> {
-        // nw-415, argued at `dispatch_tool_json`. `hub_nodes` is the third
-        // tool nw-403's measurement named (8 hidden-repo tokens); it is
-        // `RepoScope::RedactedAfterDispatch`.
+        // Global rankings require unrestricted repository access.
         let (_, extensions, req) = r.into_parts();
         let mut args = serde_json::json!({});
         if req.top_n > 0 {
@@ -8911,6 +8908,15 @@ impl NestWeaverDaemon for DaemonService {
             .map_err(|e| Status::invalid_argument(format!("invalid args JSON: {e}")))?;
 
         let result = tokio::task::spawn_blocking(move || {
+            if args
+                .get("include_counts")
+                .and_then(serde_json::Value::as_bool)
+                == Some(true)
+            {
+                return nestweaver_engine::index_md::vault_inventory(&state.store, &state.db_path)
+                    .and_then(|value| Ok(serde_json::to_string(&value)?))
+                    .map_err(|e| Status::internal(format!("vault inventory failed: {e:#}")));
+            }
             let instance = args.get("instance").and_then(|v| v.as_str());
             let vaults = state
                 .store
@@ -9698,6 +9704,16 @@ impl NestWeaverDaemon for DaemonService {
                                     let pipeline = model
                                         .pipeline_for_dimension(emb_dim)
                                         .map_err(|error| Status::internal(error.to_string()))?;
+                                    if !force
+                                        && let Some(diagnostic) =
+                                            store.embedding_pipeline_mismatch(&pipeline).map_err(
+                                                |e| Status::failed_precondition(e.to_string()),
+                                            )?
+                                    {
+                                        return Err(Status::failed_precondition(format!(
+                                            "embedding pipeline mismatch: {diagnostic}"
+                                        )));
+                                    }
                                     if store.add_embedding_with_pipeline(
                                         &sym.uid, emb, &pipeline, force,
                                     ) {
@@ -9748,6 +9764,16 @@ impl NestWeaverDaemon for DaemonService {
                                     let pipeline = model
                                         .pipeline_for_dimension(emb_dim)
                                         .map_err(|error| Status::internal(error.to_string()))?;
+                                    if !force
+                                        && let Some(diagnostic) =
+                                            store.embedding_pipeline_mismatch(&pipeline).map_err(
+                                                |e| Status::failed_precondition(e.to_string()),
+                                            )?
+                                    {
+                                        return Err(Status::failed_precondition(format!(
+                                            "embedding pipeline mismatch: {diagnostic}"
+                                        )));
+                                    }
                                     if store.add_embedding_with_pipeline(
                                         &note.uid, emb, &pipeline, force,
                                     ) {
@@ -9798,6 +9824,16 @@ impl NestWeaverDaemon for DaemonService {
                                     let pipeline = model
                                         .pipeline_for_dimension(emb_dim)
                                         .map_err(|error| Status::internal(error.to_string()))?;
+                                    if !force
+                                        && let Some(diagnostic) =
+                                            store.embedding_pipeline_mismatch(&pipeline).map_err(
+                                                |e| Status::failed_precondition(e.to_string()),
+                                            )?
+                                    {
+                                        return Err(Status::failed_precondition(format!(
+                                            "embedding pipeline mismatch: {diagnostic}"
+                                        )));
+                                    }
                                     if store.add_embedding_with_pipeline(
                                         &heading.uid,
                                         emb,
@@ -20291,6 +20327,66 @@ credential_method = "gh"
         );
     }
 
+    #[tokio::test]
+    async fn removing_and_readding_a_repo_in_one_daemon_drops_only_its_activity() {
+        let state = test_state_with_writer();
+        let service = DaemonService::new(state.clone());
+        let path = nestweaver_engine::sidecar_path(&state.db_path, ".gitactivity.json");
+        for (uid, score) in [("repo:removed", 0.9), ("repo:retained", 0.3)] {
+            state.store.insert_repo(&test_repo(uid, uid, None)).unwrap();
+            nestweaver_engine::git_activity::save_git_activity_for_repo(
+                uid,
+                &std::collections::HashMap::from([("src/main.rs".to_string(), score)]),
+                &path,
+            )
+            .unwrap();
+        }
+        refresh_git_activity(&state.store, &path);
+        assert_eq!(
+            state
+                .store
+                .git_activity_score("repo:removed", "src/main.rs"),
+            Some(0.9)
+        );
+        let mut request = Request::new(RemoveRepoRequest {
+            repo_uid: "repo:removed".into(),
+        });
+        request.extensions_mut().insert(crate::auth::IsAdmin(true));
+        let result = service.remove_repo(request).await.unwrap().into_inner();
+        assert!(result.committed);
+        assert!(result.reconciliation_failures.is_empty(), "{result:?}");
+        state
+            .store
+            .insert_repo(&test_repo("repo:removed", "repo:removed", None))
+            .unwrap();
+        assert_eq!(
+            state
+                .store
+                .git_activity_score("repo:removed", "src/main.rs"),
+            None
+        );
+        assert_eq!(
+            state
+                .store
+                .git_activity_score("repo:retained", "src/main.rs"),
+            Some(0.3)
+        );
+        // A subsequent reload cannot resurrect the deleted slice either.
+        refresh_git_activity(&state.store, &path);
+        assert_eq!(
+            state
+                .store
+                .git_activity_score("repo:removed", "src/main.rs"),
+            None
+        );
+        assert_eq!(
+            state
+                .store
+                .git_activity_score("repo:retained", "src/main.rs"),
+            Some(0.3)
+        );
+    }
+
     /// The other half: a refresh whose sidecar has gone away must leave ranking
     /// NEUTRAL, not serving scores mined from a graph state that no longer
     /// exists. This is why the helper clears before it loads.
@@ -21969,10 +22065,7 @@ external_model = "unavailable-test-model"
     ///   * `brain_status` (typed and JSON) — `EnforcedInArm`. It enumerates
     ///     each repo's URL and indexed git SHA, which is repo IDENTITY and the
     ///     most direct enumeration in the catalogue.
-    ///   * `brain_context` / `hub_nodes` — `RedactedAfterDispatch`. No token
-    ///     naming the hidden repo may survive anywhere in the payload.
-    ///   * `project_context` — `RedactedAfterDispatch` whose `response_format`
-    ///     DEFAULTS to concise, so an unattributable rendering is REFUSED.
+    ///   * `brain_context` / `hub_nodes` / `project_context` — `FailClosed`.
     ///   * `note_get` — `NotRepoScoped`, and it must still answer.
     #[tokio::test]
     async fn every_typed_grpc_rpc_that_bypassed_dispatch_now_scopes_to_the_request_identity() {
@@ -22024,65 +22117,43 @@ external_model = "unavailable-test-model"
             tonic::Code::PermissionDenied
         );
 
-        // `brain_context`: `RedactedAfterDispatch`.
-        let context = service
-            .get_context(nw415_request(nw415_context_request(), scoped()))
-            .await
-            .expect("a repo-scoped brain_context is redacted, not refused")
-            .into_inner();
-        if context.result_json.contains(NW415_HIDDEN_SYMBOL)
-            || context.result_json.contains("nw415needle_hidden")
-        {
-            leaks.push(format!(
-                "brain_context leaked a hidden-repo symbol: {}",
-                context.result_json
-            ));
-        }
-
-        // `hub_nodes`: `RedactedAfterDispatch`.
-        //
-        // The assertion is over the hidden SYMBOL, not the hidden repo uid, on
-        // purpose: `hub_nodes` also returns `stale_repos`, a bare string array
-        // of repo uids that the redactor cannot see (it early-returns `true`
-        // for any array element that is not an object). That is [[nw-416]],
-        // whose fix lives in the MCP crate's redactor; asserting it here would
-        // pin a defect this change cannot reach.
-        let hubs = service
-            .hub_nodes(nw415_request(nw415_hub_request(), scoped()))
-            .await
-            .expect("a repo-scoped hub_nodes is redacted, not refused")
-            .into_inner();
-        if hubs.result_json.contains(NW415_HIDDEN_SYMBOL)
-            || hubs.result_json.contains("nw415needle_hidden")
-        {
-            leaks.push(format!(
-                "hub_nodes leaked a hidden-repo symbol: {}",
-                hubs.result_json
-            ));
-        }
-
-        // `project_context`: `RedactedAfterDispatch` whose `response_format`
-        // DEFAULTS to concise, so the rows carry no uid to attribute and the
-        // call is REFUSED rather than served unfiltered.
-        match service
-            .get_project_context(nw415_request(
-                ProjectContextRequest {
-                    project: "anything".to_string(),
-                    ..Default::default()
-                },
-                scoped(),
-            ))
-            .await
-        {
-            Ok(response) => leaks.push(format!(
-                "project_context served an unattributable concise rendering: {}",
-                response.into_inner().result_json
-            )),
-            Err(error) if !error.message().contains("response_format") => leaks.push(format!(
-                "project_context failed for the wrong reason (the refusal must name its remedy): {}",
-                error.message()
-            )),
-            Err(_) => {}
+        // Whole-graph aggregates refuse restricted identities on every format.
+        for format in ["concise", "detailed"] {
+            let mut context = nw415_context_request();
+            context.response_format = format.into();
+            assert_eq!(
+                service
+                    .get_context(nw415_request(context, scoped()))
+                    .await
+                    .unwrap_err()
+                    .code(),
+                tonic::Code::PermissionDenied
+            );
+            let mut hubs = nw415_hub_request();
+            hubs.response_format = format.into();
+            assert_eq!(
+                service
+                    .hub_nodes(nw415_request(hubs, scoped()))
+                    .await
+                    .unwrap_err()
+                    .code(),
+                tonic::Code::PermissionDenied
+            );
+            assert_eq!(
+                service
+                    .get_project_context(nw415_request(
+                        ProjectContextRequest {
+                            project: "anything".into(),
+                            response_format: format.into(),
+                            ..Default::default()
+                        },
+                        scoped()
+                    ))
+                    .await
+                    .unwrap_err()
+                    .code(),
+                tonic::Code::PermissionDenied
+            );
         }
 
         // `note_get`: the WRITTEN `NotRepoScoped` exemption must still answer.

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -44,7 +44,8 @@ impl Drop for RpcIndexActivity {
 
 /// Map a dispatch error to a gRPC `Status`, preserving cancellation semantics:
 /// a cancelled query surfaces as `deadline_exceeded` rather than an opaque
-/// `internal`. Non-cancel errors keep the `internal` mapping. This is
+/// `internal`. Repository-scope refusals are `permission_denied`; other errors
+/// keep the `internal` mapping. This is
 /// defense-in-depth: on timeout the safeguard's `select!` already returns
 /// `deadline_exceeded` and drops this future, but a query that finishes with a
 /// cancel error just before that race is mapped consistently here too.
@@ -54,6 +55,11 @@ impl Drop for RpcIndexActivity {
 /// reports `Timeout`. On a client disconnect the request future is dropped
 /// before any `Status` is returned, so that path never surfaces here.
 fn dispatch_err_to_status(tool_name: &str, e: anyhow::Error) -> Status {
+    if e.chain()
+        .any(|cause| cause.is::<nestweaver_mcp::tools::RepositoryScopeRefused>())
+    {
+        return Status::permission_denied(format!("tool {tool_name} refused: {e}"));
+    }
     if let Some(reason) = e
         .downcast_ref::<nestweaver_store::StoreError>()
         .and_then(|s| s.cancel_reason())

--- a/crates/nestweaver-engine/src/backup.rs
+++ b/crates/nestweaver-engine/src/backup.rs
@@ -279,6 +279,43 @@ pub fn stage_backup_from_store(
     store: &nestweaver_store::GraphStore,
     config: &BackupConfig,
 ) -> anyhow::Result<StagedBackup> {
+    stage_backup_with_statistics(store, config, &StoreBackupStatistics)
+}
+
+trait BackupStatistics {
+    fn count(&self, store: &nestweaver_store::GraphStore) -> anyhow::Result<usize>;
+    fn per_repo(
+        &self,
+        store: &nestweaver_store::GraphStore,
+    ) -> anyhow::Result<HashMap<String, usize>>;
+    fn repos(
+        &self,
+        store: &nestweaver_store::GraphStore,
+    ) -> anyhow::Result<Vec<nestweaver_schema::Repo>>;
+}
+struct StoreBackupStatistics;
+impl BackupStatistics for StoreBackupStatistics {
+    fn count(&self, store: &nestweaver_store::GraphStore) -> anyhow::Result<usize> {
+        Ok(store.count_symbols()?)
+    }
+    fn per_repo(
+        &self,
+        store: &nestweaver_store::GraphStore,
+    ) -> anyhow::Result<HashMap<String, usize>> {
+        Ok(store.count_symbols_by_repo()?)
+    }
+    fn repos(
+        &self,
+        store: &nestweaver_store::GraphStore,
+    ) -> anyhow::Result<Vec<nestweaver_schema::Repo>> {
+        Ok(store.list_repos(None)?)
+    }
+}
+fn stage_backup_with_statistics(
+    store: &nestweaver_store::GraphStore,
+    config: &BackupConfig,
+    statistics: &dyn BackupStatistics,
+) -> anyhow::Result<StagedBackup> {
     let store_db_path = store
         .db_path()
         .ok_or_else(|| anyhow::anyhow!("cannot back up an in-memory graph store"))?;
@@ -333,11 +370,15 @@ pub fn stage_backup_from_store(
     )?;
 
     // Gather graph statistics for the manifest while the store is open.
-    let symbol_count = store.count_symbols().unwrap_or(0);
-    let per_repo = store.count_symbols_by_repo().unwrap_or_default();
-    let repos: Vec<BackupRepoInfo> = store
-        .list_repos(None)
-        .unwrap_or_default()
+    let symbol_count = statistics
+        .count(store)
+        .context("read backup symbol count")?;
+    let per_repo = statistics
+        .per_repo(store)
+        .context("read backup per-repository counts")?;
+    let repos: Vec<BackupRepoInfo> = statistics
+        .repos(store)
+        .context("read backup repository inventory")?
         .into_iter()
         .map(|r| BackupRepoInfo {
             symbols: per_repo.get(&r.uid).copied().unwrap_or(0),
@@ -4117,5 +4158,53 @@ mod tests {
             nestweaver_store::GraphStore::open_read_only(&target_db).is_ok(),
             "the incumbent database must remain exactly as it was"
         );
+    }
+}
+
+#[cfg(test)]
+mod hardening_statistics_tests {
+    use super::*;
+    struct Fault(usize);
+    impl BackupStatistics for Fault {
+        fn count(&self, store: &nestweaver_store::GraphStore) -> anyhow::Result<usize> {
+            anyhow::ensure!(self.0 != 0, "injected count failure");
+            StoreBackupStatistics.count(store)
+        }
+        fn per_repo(
+            &self,
+            store: &nestweaver_store::GraphStore,
+        ) -> anyhow::Result<HashMap<String, usize>> {
+            anyhow::ensure!(self.0 != 1, "injected per-repo failure");
+            StoreBackupStatistics.per_repo(store)
+        }
+        fn repos(
+            &self,
+            store: &nestweaver_store::GraphStore,
+        ) -> anyhow::Result<Vec<nestweaver_schema::Repo>> {
+            anyhow::ensure!(self.0 != 2, "injected inventory failure");
+            StoreBackupStatistics.repos(store)
+        }
+    }
+    #[test]
+    fn no_archive_can_publish_when_any_statistics_read_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("stats.lbug");
+        let store = nestweaver_store::GraphStore::create(&db).unwrap();
+        let config = BackupConfig {
+            db_path: db,
+            output_path: dir.path().join("backup.zst"),
+            include_clones: false,
+            instance_id: "default".into(),
+            workspace_path: None,
+        };
+        for stage in 0..3 {
+            let result = stage_backup_with_statistics(&store, &config, &Fault(stage));
+            assert!(result.is_err(), "stage {stage} must refuse");
+            assert!(!config.output_path.exists());
+        }
+        let staged = stage_backup_from_store(&store, &config).unwrap();
+        let result = package_staged(&config, staged).unwrap();
+        assert_eq!(result.manifest.symbol_count, 0);
+        assert!(config.output_path.exists());
     }
 }

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -1063,14 +1063,18 @@ pub(crate) fn finalize_committed_index_for_scope_with_io(
     // Reconcile against graph liveness before retiring the durable dirty marker.
     // This retries a failed targeted tombstone flush and detects untombstoned
     // orphans that index-internal occupancy cannot identify.
-    if let Err(error) = store.reconcile_embedding_index() {
-        push_reconciliation_failure(
-            &mut failures,
-            DeletionReconciliationStage::EmbeddingIndex,
-            None,
-            format!("committed graph requires embedding reconciliation: {error:#}"),
-        );
-    }
+    let embeddings_reconciled = match store.reconcile_embedding_index() {
+        Ok(_) => true,
+        Err(error) => {
+            push_reconciliation_failure(
+                &mut failures,
+                DeletionReconciliationStage::EmbeddingIndex,
+                None,
+                format!("committed graph requires embedding reconciliation: {error:#}"),
+            );
+            false
+        }
+    };
 
     store.invalidate_pagerank();
     let pagerank_safe = if let Some(db_path) = db_path {
@@ -1211,7 +1215,7 @@ pub(crate) fn finalize_committed_index_for_scope_with_io(
         }
 
         if generation_durable
-            && failures.is_empty()
+            && embeddings_reconciled
             && pagerank_safe
             && pagerank_persisted
             && let Some(db_path) = db_path
@@ -12948,6 +12952,41 @@ function hello(name) { return "Hello " + name; }
         );
         let persisted = persisted_pagerank(&db_path);
         assert_note_ranks(&persisted, "raced");
+    }
+
+    #[test]
+    fn code_publication_retains_the_fence_when_embedding_tombstones_cannot_persist() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("test.lbug");
+        let store = GraphStore::create(&db).unwrap();
+        store.set_embedding_metadata("fixture", 2).unwrap();
+        assert!(store.add_embedding("sym:deleted", vec![1.0, 0.0]));
+        store.flush_embedding_index().unwrap();
+        let publication = establish_index_publication_marker_with_io(
+            &store,
+            Some(&db),
+            "post-delete code publication",
+            &FileSystemIndexEpilogueIo,
+        )
+        .unwrap();
+        fs::create_dir(crate::sidecar_path(&db, ".embeddings.journal")).unwrap();
+        let error = finalize_committed_index_with_io(
+            publication,
+            Some(&db),
+            "post-delete code publication",
+            &FileSystemIndexEpilogueIo,
+            false,
+        )
+        .expect_err("committed graph cannot publish clean with undurable tombstones");
+        assert!(
+            error
+                .failures
+                .iter()
+                .any(|failure| failure.stage == DeletionReconciliationStage::EmbeddingIndex)
+        );
+        assert!(crate::sidecar_path(&db, ".index-dirty").exists());
+        assert!(store.is_index_publication_dirty());
+        assert!(!store.has_embedding("sym:deleted"));
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -194,6 +194,7 @@ pub enum DeletionReconciliationStage {
     IndexPublicationMarkerRetirement,
     FileMetadata,
     ResolutionDependencies,
+    GitActivity,
     ManifestCache,
     EmbeddingIndex,
     LegacyRetirement,
@@ -214,6 +215,7 @@ impl std::fmt::Display for DeletionReconciliationStage {
             Self::IndexPublicationMarkerRetirement => "index-publication-marker-retirement",
             Self::FileMetadata => "filemeta",
             Self::ResolutionDependencies => "resolution-deps",
+            Self::GitActivity => "git-activity",
             Self::ManifestCache => "manifest-cache",
             Self::EmbeddingIndex => "embedding-index",
             Self::LegacyRetirement => "legacy-retirement",
@@ -419,22 +421,42 @@ fn remove_repo_sidecar_slices_with_io(
     // and re-adding a repo at the same path resurrects recency scores mined
     // from a graph state that no longer exists.
     //
-    // A SAFE stage, not a required one: a stale slice biases ranking toward
-    // whatever those paths used to be, which is a quality issue rather than a
-    // correctness one — unlike resolution_deps, where a durable slice for a
-    // deleted UID can change what a later incremental resolution RESOLVES TO.
+    // Both the durable slice and the live cache must stop influencing ranking.
+    // A persistence/read failure is a committed-but-degraded removal.
     let gitactivity_path = crate::sidecar_path(db_path, ".gitactivity.json");
     if gitactivity_path.exists() {
-        let mut sidecar = crate::git_activity::load_git_activity_sidecar(&gitactivity_path);
+        let loaded = (|| -> anyhow::Result<crate::git_activity::GitActivitySidecar> {
+            let bytes = std::fs::read(&gitactivity_path)?;
+            let sidecar: crate::git_activity::GitActivitySidecar = serde_json::from_slice(&bytes)?;
+            anyhow::ensure!(
+                sidecar.version == crate::git_activity::GITACTIVITY_VERSION,
+                "unsupported git-activity version"
+            );
+            Ok(sidecar)
+        })();
+        let mut sidecar = match loaded {
+            Ok(sidecar) => sidecar,
+            Err(error) => {
+                push_reconciliation_failure(
+                    failures,
+                    DeletionReconciliationStage::GitActivity,
+                    Some(repo_uid),
+                    format!(
+                        "read removed git-activity slice: {error:#}; regenerate activity state before re-adding the repository"
+                    ),
+                );
+                return;
+            }
+        };
         if sidecar.repos.remove(repo_uid).is_some()
             && let Err(error) =
                 crate::git_activity::save_git_activity_sidecar(&sidecar, &gitactivity_path)
         {
-            tracing::debug!(
-                path = %gitactivity_path.display(),
-                repo = %repo_uid,
-                error = %error,
-                "git-activity slice for the deleted repo could not be removed"
+            push_reconciliation_failure(
+                failures,
+                DeletionReconciliationStage::GitActivity,
+                Some(repo_uid),
+                format!("persist removed git-activity slice: {error:#}"),
             );
         }
     }
@@ -572,6 +594,7 @@ fn finalize_code_graph_deletion_with_io(
 ) -> Result<(), DeletionReconciliationError> {
     let mut failures = Vec::new();
     for uid in repo_uids {
+        store.clear_repo_git_activity(uid);
         remove_repo_sidecar_slices_with_io(db_path, uid, io, &mut failures);
     }
 
@@ -1037,6 +1060,18 @@ pub(crate) fn finalize_committed_index_for_scope_with_io(
         }
     }
 
+    // Reconcile against graph liveness before retiring the durable dirty marker.
+    // This retries a failed targeted tombstone flush and detects untombstoned
+    // orphans that index-internal occupancy cannot identify.
+    if let Err(error) = store.reconcile_embedding_index() {
+        push_reconciliation_failure(
+            &mut failures,
+            DeletionReconciliationStage::EmbeddingIndex,
+            None,
+            format!("committed graph requires embedding reconciliation: {error:#}"),
+        );
+    }
+
     store.invalidate_pagerank();
     let pagerank_safe = if let Some(db_path) = db_path {
         invalidate_pagerank_sidecar_with_io(
@@ -1176,6 +1211,7 @@ pub(crate) fn finalize_committed_index_for_scope_with_io(
         }
 
         if generation_durable
+            && failures.is_empty()
             && pagerank_safe
             && pagerank_persisted
             && let Some(db_path) = db_path
@@ -5471,11 +5507,9 @@ pub(crate) fn path_in_skip_dir(path: &Path) -> bool {
 /// filters on the tombstone set, so a missing tombstone means the dead vector
 /// is SCORED and can consume a top-k slot a live result would have held.
 ///
-/// Deliberately BEST-EFFORT. The graph mutation is already committed and
-/// durable at this point; failing the whole index over sidecar hygiene would
-/// turn a recoverable degradation into a hard failure. The periodic reconcile
-/// on the daemon is the designed backstop, and `brain_status` reports the
-/// resulting occupancy gap, so a failure here is visible rather than silent.
+/// This targeted fast path is retried by publication completion's full live-set
+/// reconciliation. A persistent failure keeps the durable dirty marker and is
+/// reported as a committed/degraded publication instead of clean success.
 pub(crate) fn tombstone_deleted_symbol_embeddings_after_commit(
     store: &nestweaver_store::GraphStore,
     repo_uid: &str,
@@ -5497,8 +5531,7 @@ pub(crate) fn tombstone_deleted_symbol_embeddings_after_commit(
         Err(error) => tracing::warn!(
             %error,
             operation,
-            "embedding tombstoning failed; dead vectors stay searchable until the \
-             periodic reconcile repairs it (see `brain status` occupancy)"
+            "targeted embedding tombstoning failed; publication completion will retry and retain the recovery fence if persistence still fails"
         ),
     }
 }
@@ -5527,6 +5560,8 @@ pub struct IncrementalResult {
     /// every save.
     pub deleted_symbol_files: Vec<String>,
     pub fell_back_to_full: bool,
+    /// Resolved relationships from a completed fallback full build.
+    pub full_edges_count: Option<usize>,
 }
 
 enum IncrementalFileOutcome {
@@ -7343,6 +7378,7 @@ fn full_index_fallback(
         files_skipped: result.skipped_files.len(),
         skipped_files: result.skipped_files,
         symbols_added: result.symbols_count,
+        full_edges_count: Some(result.edges_count),
         files_deleted: result.files_deleted,
         symbols_removed: result.symbols_deleted,
         ..Default::default()

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -6198,7 +6198,7 @@ fn vault_inventory_with_notes(
                 ),
             };
             serde_json::json!({"uid":v.uid,"name":v.name,"root_path":v.root_path,
-            "notes":notes,"last_indexed":last,"inventory_error":error})
+            "instance_id":v.instance_id,"notes":notes,"last_indexed":last,"inventory_error":error})
         })
         .collect();
     Ok(serde_json::json!(rows))
@@ -6234,6 +6234,7 @@ mod hardening_inventory_tests {
         assert_eq!(rows.len(), 2);
         let empty = rows.iter().find(|v| v["uid"] == "vlt:empty").unwrap();
         assert_eq!(empty["notes"], 0);
+        assert_eq!(empty["instance_id"], "fixture");
         assert!(empty["inventory_error"].is_null());
         let failed = rows.iter().find(|v| v["uid"] == "vlt:unreadable").unwrap();
         assert!(failed["notes"].is_null());

--- a/crates/nestweaver-engine/src/index_md.rs
+++ b/crates/nestweaver-engine/src/index_md.rs
@@ -1224,16 +1224,7 @@ fn index_markdown_since_with_reader(
         }
     }
     let project_note_refs = string_edge_refs(&project_note_edges);
-    // nw-204, vault half: collect the Note and Heading UIDs the refresh is
-    // about to remove, BEFORE it removes them. Applied after the commit with a
-    // liveness filter, because an edited note is deleted and re-inserted under
-    // the same uid.
-    let embedding_candidates: Vec<String> = delete_note_uids
-        .iter()
-        .filter_map(|uid| store.note_embedding_candidate_uids(uid).ok())
-        .flatten()
-        .collect();
-
+    // Publication completion reconciles vectors against the committed graph.
     let graph_publication =
         crate::manifest::begin_graph_mutation_publication(store, "incremental vault refresh")?;
     store
@@ -1267,24 +1258,7 @@ fn index_markdown_since_with_reader(
 
     let publication = graph_publication.finish(true)?;
 
-    // Best-effort and AFTER the commit, like the symbol epilogue: a
-    // tombstoning failure must not fail a refresh that already succeeded.
-    // Without this a CLI `brain refresh` that dropped 200 notes left every
-    // note and heading vector live and scored, with only a WRITABLE daemon's
-    // periodic reconciler as backstop — so a CLI-only run, or one against a
-    // read-only daemon, leaked indefinitely.
-    if !embedding_candidates.is_empty() {
-        match store.tombstone_deleted_vault_embeddings(&embedding_candidates) {
-            Ok(0) => {}
-            Ok(removed) => {
-                tracing::debug!("vault refresh: tombstoned {removed} dead vault vector(s)")
-            }
-            Err(error) => tracing::warn!(
-                "vault refresh: could not tombstone dead vault vectors: {error}; \
-                 the periodic reconciler will reclaim them"
-            ),
-        }
-    }
+    // Publication completion reconciles vectors against the committed live graph.
 
     Ok(MarkdownSinceResult {
         vault_name: vault_name.to_string(),
@@ -6193,5 +6167,81 @@ mod link_resolution_tests {
     fn escaping_the_vault_root_is_refused() {
         assert_eq!(normalize_relative("a", "../../x"), None);
         assert_eq!(normalize_relative("", ".."), None);
+    }
+}
+
+/// One shared CLI/daemon inventory: failed counts remain unavailable.
+pub fn vault_inventory(store: &GraphStore, db_path: &Path) -> anyhow::Result<serde_json::Value> {
+    vault_inventory_with_notes(store, db_path, |uid| store.list_notes(Some(uid)))
+}
+
+fn vault_inventory_with_notes(
+    store: &GraphStore,
+    db_path: &Path,
+    list_notes: impl Fn(&str) -> Result<Vec<nestweaver_schema::Note>, nestweaver_store::StoreError>,
+) -> anyhow::Result<serde_json::Value> {
+    let vaults = store.list_vaults(None)?;
+    let rows: Vec<_> = vaults
+        .into_iter()
+        .map(|v| {
+            let (notes, last, error) = match list_notes(&v.uid) {
+                Ok(notes) => (
+                    Some(notes.len()),
+                    crate::get_last_indexed_at(db_path, &v.uid)
+                        .or_else(|| notes.iter().filter_map(|n| n.modified_at.clone()).max()),
+                    None,
+                ),
+                Err(_) => (
+                    None,
+                    crate::get_last_indexed_at(db_path, &v.uid),
+                    Some("note inventory unavailable; repair the store and retry"),
+                ),
+            };
+            serde_json::json!({"uid":v.uid,"name":v.name,"root_path":v.root_path,
+            "notes":notes,"last_indexed":last,"inventory_error":error})
+        })
+        .collect();
+    Ok(serde_json::json!(rows))
+}
+
+#[cfg(test)]
+mod hardening_inventory_tests {
+    use super::*;
+    #[test]
+    fn partial_inventory_keeps_failed_counts_null_and_real_empty_counts_zero() {
+        let store = GraphStore::in_memory().unwrap();
+        for uid in ["vlt:empty", "vlt:unreadable"] {
+            store
+                .insert_vault(&Vault {
+                    uid: uid.into(),
+                    name: uid.into(),
+                    root_path: uid.into(),
+                    instance_id: "fixture".into(),
+                })
+                .unwrap();
+        }
+        let value = vault_inventory_with_notes(&store, Path::new("unused.lbug"), |uid| {
+            if uid == "vlt:unreadable" {
+                Err(nestweaver_store::StoreError::Query(
+                    "injected inventory read failure".into(),
+                ))
+            } else {
+                store.list_notes(Some(uid))
+            }
+        })
+        .unwrap();
+        let rows = value.as_array().unwrap();
+        assert_eq!(rows.len(), 2);
+        let empty = rows.iter().find(|v| v["uid"] == "vlt:empty").unwrap();
+        assert_eq!(empty["notes"], 0);
+        assert!(empty["inventory_error"].is_null());
+        let failed = rows.iter().find(|v| v["uid"] == "vlt:unreadable").unwrap();
+        assert!(failed["notes"].is_null());
+        assert!(
+            failed["inventory_error"]
+                .as_str()
+                .unwrap()
+                .contains("unavailable")
+        );
     }
 }

--- a/crates/nestweaver-engine/src/investigate.rs
+++ b/crates/nestweaver-engine/src/investigate.rs
@@ -275,6 +275,8 @@ pub struct InvestigateResult {
     /// because the caller had no way to know the ranking was BM25-only.
     #[serde(default)]
     pub semantic_applied: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_unavailable: Option<serde_json::Value>,
     /// Retrieval components that were requested but unavailable, matching
     /// `brain_context` / `brain_search`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -831,8 +833,16 @@ pub fn investigate(
     // number to `RenderCap` if the cap truncated anything. `None` on the
     // `bm25_fallback` path (no `RenderCap` there to undercount against).
     let mut admitted_before_cap: Option<usize> = None;
+    let mut semantic_applied = false;
+    let mut semantic_unavailable = Some(
+        serde_json::json!({"reason":"seed_resolution_fallback", "remediation":"use a resolvable seed or verify semantic availability"}),
+    );
+    let mut degraded_components = vec!["semantic".to_string()];
     let mut connected: Vec<BrainNode> = match connected_result {
         Ok(ctx) => {
+            semantic_applied = ctx.semantic_applied;
+            semantic_unavailable = ctx.semantic_unavailable;
+            degraded_components = ctx.degraded_components;
             admitted_before_cap = ctx.admitted_before_cap;
             seed_uids = ctx.seeds.iter().map(|n| n.uid.clone()).collect();
             let mut nodes = ctx.seeds;
@@ -1002,7 +1012,6 @@ pub fn investigate(
         })?;
     }
 
-    let semantic_applied = embed_model.is_some();
     // nw-362(b). The keyed map, built HERE from the counters that were
     // already in scope. `retrieval_breadth` is a hard internal bound the
     // caller never stated and cannot raise, which is precisely why it must be
@@ -1045,11 +1054,8 @@ pub fn investigate(
         entries,
         more_available,
         semantic_applied,
-        degraded_components: if semantic_applied {
-            Vec::new()
-        } else {
-            vec!["semantic".to_string()]
-        },
+        semantic_unavailable,
+        degraded_components,
     })
 }
 

--- a/crates/nestweaver-engine/src/investigate.rs
+++ b/crates/nestweaver-engine/src/investigate.rs
@@ -835,7 +835,7 @@ pub fn investigate(
     let mut admitted_before_cap: Option<usize> = None;
     let mut semantic_applied = false;
     let mut semantic_unavailable = Some(
-        serde_json::json!({"reason":"seed_resolution_fallback", "remediation":"use a resolvable seed or verify semantic availability"}),
+        serde_json::json!({"component":"semantic", "stage":"seed_resolution", "reason":"seed_resolution_fallback", "remediation":"use a resolvable seed or verify semantic availability"}),
     );
     let mut degraded_components = vec!["semantic".to_string()];
     let mut connected: Vec<BrainNode> = match connected_result {

--- a/crates/nestweaver-engine/src/manifest.rs
+++ b/crates/nestweaver-engine/src/manifest.rs
@@ -345,6 +345,13 @@ pub fn finalize_committed_graph_mutation(
         }
     });
 
+    if let Err(error) = store.reconcile_embedding_index() {
+        outcome.record_warning(
+            "embedding-index",
+            format!("graph committed; embedding reconciliation must be retried: {error:#}"),
+        );
+    }
+
     // Clear live scores before exposing the new generation. The durable copy
     // is removed as well, so a process restart cannot reload pre-mutation
     // ranking even if a later publication step is degraded.
@@ -1608,5 +1615,49 @@ dependencies = ["requests>=2.28", "pydantic>=2.0"]
         .unwrap();
         let info = parse_manifest(&FilesystemReader::new(dir.path()));
         assert!(info.entry_files.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod hardening_embedding_recovery_tests {
+    use super::*;
+    #[test]
+    fn failed_embedding_reconciliation_keeps_durable_recovery_fence() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        let store = nestweaver_store::GraphStore::create(&db).unwrap();
+        store.set_embedding_metadata("fixture", 2).unwrap();
+        // A vector whose graph node was deleted: occupancy alone calls it live.
+        assert!(store.add_embedding("sym:deleted", vec![1.0, 0.0]));
+        store.flush_embedding_index().unwrap();
+        assert_eq!(store.embedding_index_occupancy().tombstoned, 0);
+        let journal = crate::sidecar_path(&db, ".embeddings.journal");
+        std::fs::create_dir(&journal).unwrap();
+        let guard = begin_graph_mutation_publication(&store, "post-delete regression").unwrap();
+        let outcome = guard.finish(true).unwrap();
+        assert!(outcome.is_degraded());
+        assert!(
+            outcome
+                .warnings
+                .iter()
+                .any(|w| w.stage == "embedding-index")
+        );
+        assert!(crate::sidecar_path(&db, ".index-dirty").exists());
+        drop(store);
+        // The durable fence survives reopening before repair; ranked queries
+        // cannot treat the old artifact as a clean publication.
+        if let Ok(unrepaired) = nestweaver_store::GraphStore::open_read_only(&db) {
+            assert!(unrepaired.is_index_publication_dirty());
+        }
+        std::fs::remove_dir(&journal).unwrap();
+        let authority = nestweaver_store::acquire_db_write_lease(&db).unwrap();
+        let store = nestweaver_store::GraphStore::open_with_authority(&db, &authority).unwrap();
+        crate::index::force_recover_index_publication(&store, &authority).unwrap();
+        assert!(!store.has_embedding("sym:deleted"));
+        assert!(!crate::sidecar_path(&db, ".index-dirty").exists());
+        drop(store);
+        drop(authority);
+        let reopened = nestweaver_store::GraphStore::open_read_only(&db).unwrap();
+        assert!(!reopened.has_embedding("sym:deleted"));
     }
 }

--- a/crates/nestweaver-engine/src/query.rs
+++ b/crates/nestweaver-engine/src/query.rs
@@ -1043,6 +1043,7 @@ mod promote_tests {
             unresolved_seeds: vec![],
             expansion_terms: vec![],
             semantic_applied: false,
+            semantic_unavailable: None,
             semantic_seed_count: 0,
             degraded_components: vec![],
             ..Default::default()
@@ -1074,6 +1075,7 @@ mod promote_tests {
             unresolved_seeds: vec![],
             expansion_terms: vec![],
             semantic_applied: false,
+            semantic_unavailable: None,
             semantic_seed_count: 0,
             degraded_components: vec![],
             ..Default::default()
@@ -1114,6 +1116,7 @@ mod promote_tests {
             unresolved_seeds: vec![],
             expansion_terms: vec![],
             semantic_applied: false,
+            semantic_unavailable: None,
             semantic_seed_count: 0,
             degraded_components: vec![],
             ..Default::default()
@@ -1147,6 +1150,7 @@ mod promote_tests {
             unresolved_seeds: vec![],
             expansion_terms: vec![],
             semantic_applied: false,
+            semantic_unavailable: None,
             semantic_seed_count: 0,
             degraded_components: vec![],
             ..Default::default()
@@ -1561,6 +1565,9 @@ pub struct BrainContextResult {
     /// vector search successfully.
     #[serde(default)]
     pub semantic_applied: bool,
+    /// Stable safe diagnostics for an optional semantic leg that could not run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_unavailable: Option<serde_json::Value>,
     /// How many entries in `seeds` were injected by the semantic leg rather
     /// than resolved from the query text.
     ///
@@ -2169,6 +2176,12 @@ pub(crate) fn build_brain_context_hybrid_with_aliases_capped(
         store.require_verified_embedding_identity()?;
     }
     let mut semantic_applied = false;
+    let mut semantic_detail = None;
+    let mut semantic_reason = if embed_model.is_none() {
+        "model_unavailable"
+    } else {
+        "vectors_unavailable"
+    };
     let mut semantic_seed_count: usize = 0;
     let mut semantic_hits: Vec<(String, f64)> = Vec::new();
     if let Some(model) = embed_model
@@ -2186,13 +2199,44 @@ pub(crate) fn build_brain_context_hybrid_with_aliases_capped(
         // inference error. Preserve cancellation as an incomplete query rather
         // than degrading that error into a cacheable semantic miss.
         ensure_brain_context_not_cancelled(cancel)?;
+        semantic_reason = "query_inference_failed";
         if let Ok(query_emb) = query_embedding {
-            match crate::vector_search::vector_knn_all_cancellable(
-                store,
-                &query_emb,
-                config.semantic_limit,
-                cancel,
-            ) {
+            semantic_reason = "vector_search_failed";
+            if store
+                .embedding_index_dimension()
+                .is_some_and(|d| d != query_emb.len())
+            {
+                semantic_reason = "dimension_mismatch";
+            }
+
+            let pipeline = model.pipeline_for_dimension(query_emb.len());
+            let mismatch = match pipeline {
+                Ok(pipeline) if pipeline.provider != "opaque-runtime" => {
+                    store.embedding_pipeline_mismatch(&pipeline)?
+                }
+                Ok(_) => None,
+                Err(_) => {
+                    semantic_reason = "pipeline_unavailable";
+                    None
+                }
+            };
+            let search = if let Some(diagnostic) = mismatch {
+                semantic_reason = "pipeline_mismatch";
+                semantic_detail = Some(diagnostic);
+                Err(anyhow::anyhow!("pipeline mismatch"))
+            } else if semantic_reason == "pipeline_unavailable" {
+                Err(anyhow::anyhow!("query pipeline unavailable"))
+            } else if semantic_reason == "dimension_mismatch" {
+                Err(anyhow::anyhow!("query dimension mismatch"))
+            } else {
+                crate::vector_search::vector_knn_all_cancellable(
+                    store,
+                    &query_emb,
+                    config.semantic_limit,
+                    cancel,
+                )
+            };
+            match search {
                 Ok(hits) => {
                     semantic_applied = true;
                     if config.always_blend_semantic {
@@ -2222,7 +2266,14 @@ pub(crate) fn build_brain_context_hybrid_with_aliases_capped(
                 {
                     return Err(e);
                 }
-                Err(_) => {}
+                Err(error) => {
+                    if matches!(
+                        error.downcast_ref::<nestweaver_store::StoreError>(),
+                        Some(nestweaver_store::StoreError::EmbeddingArtifactCorrupt)
+                    ) {
+                        semantic_reason = "vector_artifact_corrupt";
+                    }
+                }
             }
         }
     }
@@ -2354,6 +2405,17 @@ pub(crate) fn build_brain_context_hybrid_with_aliases_capped(
         unresolved_seeds: unresolved,
         expansion_terms,
         semantic_applied,
+        semantic_unavailable: (semantic_requested && !semantic_applied).then(|| serde_json::json!({
+            "component": "semantic", "reason": semantic_reason, "pipeline": semantic_detail,
+            "stage": match semantic_reason {
+                "model_unavailable" => "model_load",
+                "query_inference_failed" => "query_inference",
+                "pipeline_mismatch" | "dimension_mismatch" | "pipeline_unavailable" => "pipeline_validation",
+                "vector_artifact_corrupt" | "vectors_unavailable" => "vector_artifact",
+                _ => "vector_search",
+            },
+            "remediation": "verify the configured embedding model and vector artifacts, then retry or rebuild embeddings"
+        })),
         semantic_seed_count,
         degraded_components: if semantic_requested && !semantic_applied {
             vec!["semantic".to_string()]
@@ -2476,6 +2538,9 @@ pub fn weighted_score_fuse(
         }
     }
 
+    // Stable accumulation order also prevents floating-point normalization drift.
+    all_uids.sort_unstable();
+
     let ppr_raw: Vec<f64> = all_uids
         .iter()
         .map(|u| ppr_scores.get(u).copied().unwrap_or(0.0))
@@ -2502,7 +2567,7 @@ pub fn weighted_score_fuse(
         })
         .collect();
 
-    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    results.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
     results
 }
 
@@ -4300,6 +4365,7 @@ mod dedup_heading_section_tests {
             unresolved_seeds: vec![],
             expansion_terms: vec![],
             semantic_applied: false,
+            semantic_unavailable: None,
             semantic_seed_count: 0,
             degraded_components: vec![],
             ..Default::default()
@@ -4698,6 +4764,12 @@ mod semantic_leg_tests {
         let model = CountingEmbed { calls: 0.into() };
 
         let result = run_context(&store, Some(&model), 0.35);
+        let detail = result
+            .semantic_unavailable
+            .as_ref()
+            .expect("typed degradation");
+        assert_eq!(detail["reason"], "vectors_unavailable");
+        assert_eq!(detail["stage"], "vector_artifact");
 
         assert_eq!(
             model.call_count(),
@@ -4819,6 +4891,12 @@ mod semantic_leg_tests {
         let store = GraphStore::open(&db).unwrap();
         let model = CountingEmbed { calls: 0.into() };
         let result = run_context(&store, Some(&model), 0.35);
+        let detail = result
+            .semantic_unavailable
+            .as_ref()
+            .expect("typed degradation");
+        assert_eq!(detail["reason"], "vector_artifact_corrupt");
+        assert_eq!(detail["stage"], "vector_artifact");
 
         assert!(
             !result.semantic_applied,
@@ -4841,6 +4919,12 @@ mod semantic_leg_tests {
         assert!(store.add_embedding("sym:payment", vec![0.0; 4]));
 
         let result = run_context(&store, None, 0.35);
+        let detail = result
+            .semantic_unavailable
+            .as_ref()
+            .expect("typed degradation");
+        assert_eq!(detail["reason"], "model_unavailable");
+        assert_eq!(detail["stage"], "model_load");
 
         assert!(!result.semantic_applied);
         assert_eq!(result.degraded_components, ["semantic"]);
@@ -4856,6 +4940,12 @@ mod semantic_leg_tests {
         assert!(store.add_embedding("sym:payment", vec![0.0; 4]));
 
         let result = run_context(&store, Some(&FailingEmbed), 0.35);
+        let detail = result
+            .semantic_unavailable
+            .as_ref()
+            .expect("typed degradation");
+        assert_eq!(detail["reason"], "query_inference_failed");
+        assert_eq!(detail["stage"], "query_inference");
 
         assert!(!result.semantic_applied);
         assert_eq!(result.degraded_components, ["semantic"]);
@@ -5137,5 +5227,37 @@ mod service_summary_tests {
             "an unresolvable repo selector must fail loudly, not answer about \
              whichever repo the store returned first"
         );
+    }
+}
+
+#[cfg(test)]
+mod hardening_order_tests {
+    use super::*;
+    #[test]
+    fn equal_scores_have_stable_uid_order_across_hash_seeds() {
+        let scores: Vec<_> = (0..100)
+            .rev()
+            .map(|i| (format!("sym:{i:03}"), 1.0))
+            .collect();
+        let expected: Vec<_> = (0..100).map(|i| format!("sym:{i:03}")).collect();
+        for _ in 0..100 {
+            let got = weighted_score_fuse(&scores, &[], &[], 1.0, 0.0, 0.0);
+            assert_eq!(
+                got.iter().map(|r| r.0.clone()).collect::<Vec<_>>(),
+                expected
+            );
+        }
+    }
+    #[test]
+    fn unequal_scores_are_not_rounded_to_ties() {
+        let got = weighted_score_fuse(
+            &[("a".into(), 1.0), ("z".into(), 1.0001)],
+            &[],
+            &[],
+            1.0,
+            0.0,
+            0.0,
+        );
+        assert_eq!(got[0].0, "z");
     }
 }

--- a/crates/nestweaver-federation/src/dispatch.rs
+++ b/crates/nestweaver-federation/src/dispatch.rs
@@ -190,6 +190,8 @@ fn brain_search_response_to_json(
     let mut value = serde_json::json!({
         "query": response.query,
         "engine": response.engine,
+        "engine_warning": response.engine_warning,
+        "limit_per_kind": response.limit_per_kind,
         "total_matches": response.total_matches,
         "total_matches_relation": relation,
         "returned_matches": returned_matches,
@@ -590,6 +592,8 @@ mod tests {
     #[test]
     fn typed_brain_search_json_preserves_counts_and_old_response_defaults() {
         let response = nestweaver_proto::BrainSearchResponse {
+            engine_warning: None,
+            limit_per_kind: 0,
             query: "needle".to_string(),
             engine: "bm25".to_string(),
             total_matches: 1,

--- a/crates/nestweaver-federation/src/results.rs
+++ b/crates/nestweaver-federation/src/results.rs
@@ -305,7 +305,7 @@ fn merge_honesty_fields(local: &Value, server: &Value, response: &mut Value) {
     // surrounding provenance/encounter-order convention.
     if let Some(detail) = tiers
         .iter()
-        .find_map(|value| value.get("semantic_unavailable"))
+        .find_map(|value| value.get("semantic_unavailable").filter(|v| !v.is_null()))
     {
         response["semantic_unavailable"] = detail.clone();
     }
@@ -417,6 +417,17 @@ pub fn merge_json_results(local: &Value, server: &Value) -> Value {
     // merged (not copied) — see `merge_honesty_fields` for the rules — and are
     // a no-op for tools that never carried them.
     merge_honesty_fields(local, server, &mut response);
+    let warnings: Vec<_> = [("local", local), ("server", server)]
+        .into_iter()
+        .filter_map(|(tier, v)| {
+            v.get("engine_warning")
+                .filter(|w| !w.is_null())
+                .map(|w| serde_json::json!({"tier":tier,"warning":w}))
+        })
+        .collect();
+    if !warnings.is_empty() {
+        response["engine_warnings"] = serde_json::json!(warnings);
+    }
 
     response
 }
@@ -2543,4 +2554,73 @@ mod tests {
         assert!(merged.get("semantic_applied").is_none());
         assert!(merged.get("degraded_components").is_none());
     }
+}
+
+/// Apply the caller's cap after cross-tier ranking/deduplication, per public kind.
+pub fn cap_brain_search_results(value: &mut Value, limit: usize) {
+    let Some(rows) = value.get_mut("results").and_then(Value::as_array_mut) else {
+        return;
+    };
+    let before = rows.len();
+    let mut counts = HashMap::<String, usize>::new();
+    rows.retain(|row| {
+        let kind = row.get("kind").and_then(Value::as_str).unwrap_or("unknown");
+        let kind = if kind.starts_with("Symbol/") {
+            "Symbol"
+        } else {
+            kind
+        };
+        let count = counts.entry(kind.to_string()).or_default();
+        *count += 1;
+        *count <= limit
+    });
+    let returned = rows.len();
+    value["returned_matches"] = serde_json::json!(returned);
+    value["limit_per_kind"] = serde_json::json!(limit);
+    if returned < before {
+        value["truncated"] = Value::Bool(true);
+    }
+}
+
+#[cfg(test)]
+mod hardening_cap_tests {
+    use super::*;
+    #[test]
+    fn caps_symbol_subtypes_together_and_keeps_counts_and_degradation() {
+        let tier = |prefix: &str| {
+            serde_json::json!({
+            "query":"x", "results":[
+                {"uid":format!("{prefix}a"),"kind":"Symbol/Function"},
+                {"uid":format!("{prefix}b"),"kind":"Symbol/Class"},
+                {"uid":format!("{prefix}c"),"kind":"note"}],
+            "total_matches":3,"returned_matches":3,"total_matches_relation":"eq","truncated":false,
+            "engine_warning":"lexical fallback"})
+        };
+        let mut value = merge_json_results(&tier("a"), &tier("b"));
+        cap_brain_search_results(&mut value, 1);
+        assert_eq!(value["results"].as_array().unwrap().len(), 2);
+        assert_eq!(value["returned_matches"], 2);
+        assert_eq!(value["truncated"], true);
+        assert_eq!(value["engine_warnings"].as_array().unwrap().len(), 2);
+        assert!(value["total_matches"].as_u64().unwrap() >= 2);
+    }
+}
+
+/// A request override wins; otherwise respect the stricter resolved tier configuration.
+pub fn brain_search_limit(params: &Value, local: &Value, server: &Value) -> usize {
+    params
+        .get("limit")
+        .and_then(Value::as_u64)
+        .filter(|n| *n > 0)
+        .or_else(|| {
+            [local, server]
+                .into_iter()
+                .filter_map(|v| {
+                    v.get("limit_per_kind")
+                        .and_then(Value::as_u64)
+                        .filter(|n| *n > 0)
+                })
+                .min()
+        })
+        .unwrap_or(20) as usize
 }

--- a/crates/nestweaver-mcp/src/lib.rs
+++ b/crates/nestweaver-mcp/src/lib.rs
@@ -250,19 +250,25 @@ pub fn run_stdio_server(
         // did not, so the strictness landed hardest exactly where it was
         // invisible.
         match sibling.as_deref() {
-            Some(path) if path.exists() => match nestweaver_engine::InstanceConfig::from_file(path)
+            Some(path)
+                if match std::fs::symlink_metadata(path) {
+                    Ok(_) => true,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+                    Err(e) => {
+                        anyhow::bail!("cannot inspect discovered config {}: {e}", path.display())
+                    }
+                } =>
             {
-                Ok(config) => (Some(config), Some(path.display().to_string())),
-                Err(error) => {
-                    tracing::warn!(
-                        config = %path.display(),
-                        "instance config found beside the database but could NOT be parsed, so \
-                         NO configured setting is in effect (ranking, limits, response, cache \
-                         and projects all fall back to defaults): {error:#}"
-                    );
-                    (None, None)
+                match nestweaver_engine::InstanceConfig::from_file(path) {
+                    Ok(config) => (Some(config), Some(path.display().to_string())),
+                    Err(error) => {
+                        anyhow::bail!(
+                            "invalid discovered instance config {}: {error:#}",
+                            path.display()
+                        );
+                    }
                 }
-            },
+            }
             _ => (None, None),
         }
     };

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -2819,7 +2819,7 @@ pub fn dispatch(
 /// which return symbol-, file- or path-derived data, which IS repo-scoped.
 ///
 /// The real rule is: **every tool is repo-scoped until it is written down
-/// that it is not.** `repo_scope` records one of four dispositions for every
+/// that it is not.** `repo_scope` records one of three dispositions for every
 /// tool in the catalogue and `dispatch_uncached` enforces it before the arm
 /// runs; a tool with no recorded disposition fails closed. Nothing "ignores"
 /// visibility any more — a tool either filters, declares itself vault-only,
@@ -2835,6 +2835,21 @@ pub fn dispatch_cancellable(
 ) -> Result<Value, anyhow::Error> {
     // Enforce --tools allowlist and --lite mode.
     enforce_tool_allowed(name)?;
+
+    // Refuse before embedding/graph preflights, response caches, and shared
+    // flights. Otherwise a scoped caller could receive global preflight details,
+    // or a follower could lose the typed authorization error when coalescing.
+    if matches!(
+        visible,
+        Some(nestweaver_engine::authz::VisibleRepos::Only(_))
+    ) && let RepoScope::FailClosed(reason) = repo_scope(name)
+    {
+        return Err(RepositoryScopeRefused {
+            tool: name.to_string(),
+            reason,
+        }
+        .into());
+    }
 
     validate_tool_arguments(name, &args)?;
     // Reranking consumes persisted embedding-derived similarity signals even
@@ -22907,21 +22922,13 @@ mod repo_visibility_coverage_tests {
             .collect()
     }
 
-    /// THE bug: `hub_nodes` and `bridge_nodes` handed a repo-scoped caller the
-    /// uid of every stale repo in the brain, through `stale_repos`.
-    ///
-    /// Both tools are `RedactedAfterDispatch`, and the redactor could not see
-    /// the field: `row_allowed` early-returned `true` for any array element
-    /// that was not an object, so a `Vec<String>` walked through untouched.
-    /// Same enumeration class that earned `brain_status` its `EnforcedInArm`
-    /// treatment — a bare list of repo identities is the payload the policy
-    /// withholds, whatever JSON shape it arrives in.
+    /// Aggregate refusal must also withhold the stale-repository inventory.
     #[test]
     fn a_scoped_caller_cannot_enumerate_hidden_repos_through_stale_repos() {
         let (_dir, _db_path, store) = hidden_repo_store_on_disk();
         let visible = only_alpha();
         for tool in ["hub_nodes", "bridge_nodes"] {
-            let value = dispatch_cancellable(
+            let error = dispatch_cancellable(
                 &store,
                 None,
                 tool,
@@ -22930,25 +22937,18 @@ mod repo_visibility_coverage_tests {
                 None,
                 Some(&visible),
             )
-            .unwrap_or_else(|error| panic!("{tool} must still answer a scoped caller: {error:#}"));
-            assert_eq!(
-                stale_repos_from(&value),
-                vec!["repo:alpha".to_string()],
-                "{tool} named a repo outside the caller's scope: {value}"
-            );
-            // The disclosure must not be silently deleted along with the row:
-            // a scoped caller whose OWN repo is stale still needs to be told.
-            assert_eq!(value["rankings_stale"], json!(true), "{tool}: {value}");
+            .expect_err("whole-graph rankings must refuse repository-scoped callers");
             assert!(
-                leaked(&value.to_string()).is_none(),
-                "{tool} leaked a hidden marker: {value}"
+                error.downcast_ref::<RepositoryScopeRefused>().is_some(),
+                "{tool}: {error:#}"
             );
+            assert!(leaked(&error.to_string()).is_none(), "{tool}: {error:#}");
         }
     }
 
     /// COUNTERWEIGHT, and the assertion that makes the one above non-vacuous:
     /// on THIS fixture the field is genuinely populated with both repos, so the
-    /// scoped result is a filter and not an empty array.
+    /// refusal above protects an actual global inventory.
     ///
     /// If a future refactor reverts the fixture to `GraphStore::in_memory()`,
     /// this test fails and the one above starts passing for the wrong reason —
@@ -24279,11 +24279,11 @@ mod hardening_aggregate_tests {
             "regex_search",
         ] {
             for format in ["concise", "detailed"] {
-                let error = dispatch_uncached(
+                let error = dispatch_cancellable(
                     &store,
                     None,
                     name,
-                    json!({"response_format":format}),
+                    json!({"response_format":format,"rerank":true,"include_bodies":true}),
                     None,
                     None,
                     Some(&visible),

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -3076,6 +3076,16 @@ pub fn classify_index_publication_error(store: &GraphStore, error: anyhow::Error
 /// Placing it below the response cache is safe because the cache key is
 /// already visibility-salted (`visibility_cache_salt`), so a redacted response
 /// can never be served to a different scope.
+/// Authorization refusal kept typed so transports do not report a server fault.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "{tool} is not available to a repository-scoped caller: {reason}. Refusing rather than returning data from outside the caller's visible repositories (nw-403)."
+)]
+pub struct RepositoryScopeRefused {
+    tool: String,
+    reason: &'static str,
+}
+
 fn dispatch_uncached(
     store: &GraphStore,
     tantivy: Option<&TantivyIndex>,
@@ -3127,10 +3137,11 @@ fn dispatch_uncached(
             );
             dispatch_tool_arm(store, tantivy, name, args, embed_model, cancel, visible)
         }
-        RepoScope::FailClosed(reason) => Err(anyhow!(
-            "{name} is not available to a repository-scoped caller: {reason}. Refusing rather \
-             than returning data from outside the caller's visible repositories (nw-403)."
-        )),
+        RepoScope::FailClosed(reason) => Err(RepositoryScopeRefused {
+            tool: name.to_string(),
+            reason,
+        }
+        .into()),
     }
 }
 

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -208,6 +208,7 @@ fn restricted_symbol_owners(
 /// deliberately not indexed: it is not a locator, and a short one ("core",
 /// "web") would collide with ordinary strings and start deleting array
 /// elements that name nothing.
+#[cfg(test)]
 fn restricted_repo_identities(
     store: &GraphStore,
     visible: Option<&nestweaver_engine::authz::VisibleRepos>,
@@ -318,17 +319,6 @@ enum RepoScope {
     /// or dropping a node has to leave a marker behind rather than vanish
     /// (`flow_trace`, whose empty `children` is nw-390's defect).
     EnforcedInArm,
-    /// Filtered after dispatch by [`redact_response_for_visibility`], which
-    /// walks the response and removes every row whose owning repo is not
-    /// visible.
-    ///
-    /// Sound only because every row of these tools names the entity it
-    /// describes (`uid` / `repo_uid` / `target_uid` / ...). A
-    /// `response_format: "concise"` response drops exactly that field, which
-    /// is why a concise call from a repo-scoped caller is REFUSED rather than
-    /// served unfiltered — an unidentifiable row cannot be attributed to a
-    /// repo, and "cannot attribute" must mean "do not return".
-    RedactedAfterDispatch,
     /// Opt-out. The response is provably free of repo-, symbol-, file- and
     /// path-derived data — the vault surfaces, whose Note/Section/Heading/Tag
     /// nodes belong to a vault and carry no `repo_uid` at all.
@@ -352,11 +342,13 @@ enum RepoScope {
 /// redaction. Everything else — `sym:`, `proc:`, cluster ids, anything a
 /// future indexer invents — is treated as unattributable and DROPPED, because
 /// "I cannot tell which repo owns this" is not a reason to return it.
+#[cfg(test)]
 const VAULT_OWNED_UID_PREFIXES: &[&str] = &["note:", "sec:", "head:", "tag:", "vlt:"];
 
 /// The keys under which a response row names the entity it describes. A row
 /// carrying any of them is attributed through that uid; `repo_uid` (checked
 /// first, since it is the direct answer) short-circuits the lookup.
+#[cfg(test)]
 const IDENTIFYING_UID_KEYS: &[&str] = &[
     "uid",
     "target_uid",
@@ -402,8 +394,10 @@ fn repo_scope(tool: &str) -> RepoScope {
 
         // ── Redacted after dispatch ──────────────────────────────────────
         // Every row of these carries a uid, so one walk attributes them all.
-        "brain_context" | "code_context" | "project_context" | "regex_search" | "dead_code"
-        | "hub_nodes" | "bridge_nodes" => RepoScope::RedactedAfterDispatch,
+        "brain_context" | "code_context" | "project_context" | "dead_code" | "hub_nodes"
+        | "bridge_nodes" | "regex_search" => RepoScope::FailClosed(
+            "global ranking, traversal and aggregate counts cannot be computed safely by post-dispatch redaction",
+        ),
 
         // ── Opt-outs: genuinely not repo-scoped ──────────────────────────
         "note_get" | "backlinks" => RepoScope::NotRepoScoped(
@@ -489,25 +483,6 @@ fn repo_scope(tool: &str) -> RepoScope {
     }
 }
 
-/// True when this call asked for the identifier-free rendering.
-///
-/// `project_context` is the exception the generic [`is_concise`] cannot
-/// express: its `response_format` DEFAULTS to concise (anything but
-/// "detailed" is concise), so a scoped caller who sends no `response_format`
-/// at all would otherwise receive uid-free rows that nothing can attribute.
-/// The default is restated rather than shared because the two live far apart
-/// and the safe reading of an absent field differs between them.
-fn response_omits_identifiers(tool: &str, args: &Value) -> bool {
-    match tool {
-        "project_context" => args
-            .get("response_format")
-            .and_then(|v| v.as_str())
-            .map(|s| !s.eq_ignore_ascii_case("detailed"))
-            .unwrap_or(true),
-        _ => is_concise(args),
-    }
-}
-
 /// Walks a tool response and removes every row whose owning repo is not
 /// visible to the caller.
 ///
@@ -515,6 +490,7 @@ fn response_omits_identifiers(tool: &str, args: &Value) -> bool {
 /// already builds, so there is exactly ONE symbol→repo authority in this file,
 /// and it decides through [`repo_is_visible`], so there is exactly one
 /// predicate. A row it cannot attribute is dropped, not kept.
+#[cfg(test)]
 struct VisibilityRedactor<'a> {
     owners: &'a HashMap<String, String>,
     /// nw-416: identity string -> owning repo, for the string arrays
@@ -525,6 +501,7 @@ struct VisibilityRedactor<'a> {
     removed: usize,
 }
 
+#[cfg(test)]
 impl VisibilityRedactor<'_> {
     /// A uid is allowed when its owning repo is visible. An unknown `sym:`
     /// uid (a row the ownership scan did not see, e.g. a tombstoned symbol)
@@ -611,6 +588,7 @@ impl VisibilityRedactor<'_> {
 /// over the whole graph before any row is dropped, so a scoped caller reading
 /// `returned` against `total` would otherwise conclude the tool truncated for
 /// budget reasons. `visibility.redacted_entries` names the real cause.
+#[cfg(test)]
 fn redact_response_for_visibility(
     store: &GraphStore,
     value: &mut Value,
@@ -2330,6 +2308,8 @@ mod tool_schema_validation_tests {
             semantic_applied: false,
             degraded_components: Vec::new(),
             semantic_unavailable: None,
+            engine_warning: None,
+            limit_per_kind: 20,
         };
 
         let value = daemon_brain_search_response_to_json(&response, false);
@@ -2429,6 +2409,8 @@ mod tool_schema_validation_tests {
             semantic_applied: false,
             degraded_components: Vec::new(),
             semantic_unavailable: None,
+            engine_warning: None,
+            limit_per_kind: 20,
         };
 
         let value = daemon_brain_search_response_to_json(&response, false);
@@ -3144,24 +3126,6 @@ fn dispatch_uncached(
                 "tool answered a repository-scoped caller under a not-repo-scoped exemption"
             );
             dispatch_tool_arm(store, tantivy, name, args, embed_model, cancel, visible)
-        }
-        RepoScope::RedactedAfterDispatch => {
-            // A concise rendering omits the very uid the redactor attributes
-            // rows by, so it cannot be filtered — and an unfilterable
-            // response is refused, not served. The remedy is in the message
-            // because `project_context` defaults to concise and its callers
-            // never sent the field at all.
-            if response_omits_identifiers(name, &args) {
-                return Err(anyhow!(
-                    "{name}: response_format \"concise\" omits the per-row UIDs that repository \
-                     visibility filtering attributes rows by, so it cannot be scoped to this \
-                     caller's repositories. Re-request with response_format \"detailed\"."
-                ));
-            }
-            let mut value =
-                dispatch_tool_arm(store, tantivy, name, args, embed_model, cancel, visible)?;
-            redact_response_for_visibility(store, &mut value, visible)?;
-            Ok(value)
         }
         RepoScope::FailClosed(reason) => Err(anyhow!(
             "{name} is not available to a repository-scoped caller: {reason}. Refusing rather \
@@ -5263,9 +5227,8 @@ fn tool_brain_context(
     args: Value,
     embed_model: Option<&dyn EmbedQueryFn>,
     cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
-    // nw-405: the arm still returns rows through `RepoScope::RedactedAfterDispatch`;
-    // `visible` is taken here only so `resolve_repo_filter`'s ERROR text — which
-    // no redactor walks — cannot enumerate repos this caller may not see.
+    // Keep error construction scoped as defense in depth; dispatch refuses
+    // restricted callers before this aggregate arm runs.
     visible: Option<&nestweaver_engine::authz::VisibleRepos>,
 ) -> Result<Value, anyhow::Error> {
     require_verified_embedding_identity_for_rerank(store, &args)?;
@@ -5709,6 +5672,7 @@ fn tool_brain_context(
         "token_budget": token_budget,
         "limit": count_limit,
         "semantic_applied": result.semantic_applied,
+        "semantic_unavailable": result.semantic_unavailable,
         "degraded_components": &result.degraded_components,
     });
 
@@ -6517,6 +6481,7 @@ fn tool_brain_search(
         // — the local in-process dispatch, strictly upstream of any federated
         // merge. `hybrid.rs` has no response cache and never writes merged
         // output back, so nothing downstream of the merge reads these values.
+        "limit_per_kind": limit,
         "semantic_applied": false,
         "degraded_components": [],
     });
@@ -7477,6 +7442,8 @@ mod brain_search_total_contract_tests {
             semantic_applied: false,
             degraded_components: Vec::new(),
             semantic_unavailable: None,
+            engine_warning: None,
+            limit_per_kind: 20,
         };
 
         // 2. Daemon-routed MCP: forwards the proto fields verbatim.
@@ -12276,6 +12243,7 @@ fn tool_project_context(
             "truncated": provisional_dropped > 0,
             "budget_exceeded": used_tokens > token_budget,
             "semantic_applied": result.semantic_applied,
+        "semantic_unavailable": result.semantic_unavailable,
             "degraded_components": &result.degraded_components,
         });
         if let Some(ref sj) = seeds_json {
@@ -12336,6 +12304,7 @@ fn tool_project_context(
         "seed_tokens_charged": seed_tokens,
         "budget_exceeded": final_payload_tokens > token_budget,
         "semantic_applied": result.semantic_applied,
+        "semantic_unavailable": result.semantic_unavailable,
         "degraded_components": &result.degraded_components,
     });
 
@@ -14158,6 +14127,8 @@ fn daemon_brain_search_response_to_json(
     let mut value = json!({
         "query": response.query,
         "engine": response.engine,
+        "engine_warning": response.engine_warning,
+        "limit_per_kind": response.limit_per_kind,
         "total_matches": response.total_matches,
         "total_matches_relation": relation,
         "returned_matches": returned_matches,
@@ -14272,7 +14243,8 @@ fn dispatch_via_daemon_inner(
             let resp = rt
                 .block_on(client.list_repos_json(req))
                 .map_err(|s| anyhow::anyhow!("list_repos RPC failed: {}", s.message()))?;
-            serde_json::from_str(&resp.into_inner().result_json).unwrap_or_default()
+            serde_json::from_str(&resp.into_inner().result_json)
+                .map_err(|e| anyhow!("repository inventory decode failed before removal; retry after repairing daemon response: {e}"))?
         };
         let matched_repo = match_repo_target(&repos, &target);
         if matched_repo.len() > 1 {
@@ -14306,12 +14278,11 @@ fn dispatch_via_daemon_inner(
             let req = tonic::Request::new(nestweaver_proto::JsonRequest {
                 args_json: "{}".to_string(),
             });
-            match rt.block_on(client.list_vaults_json(req)) {
-                Ok(resp) => {
-                    serde_json::from_str(&resp.into_inner().result_json).unwrap_or_default()
-                }
-                Err(_) => Vec::new(),
-            }
+            let resp = rt.block_on(client.list_vaults_json(req)).map_err(|e| {
+                anyhow!("vault inventory RPC failed before removal; check daemon and retry: {e}")
+            })?;
+            serde_json::from_str(&resp.into_inner().result_json)
+                .map_err(|e| anyhow!("vault inventory decode failed before removal; repair daemon response and retry: {e}"))?
         };
         let canonical_target = std::fs::canonicalize(&target)
             .map(|p| p.display().to_string())
@@ -22544,7 +22515,7 @@ mod repo_visibility_coverage_tests {
                     !reason.is_empty(),
                     "{name} opts out of scoping without a justification"
                 ),
-                RepoScope::EnforcedInArm | RepoScope::RedactedAfterDispatch => {}
+                RepoScope::EnforcedInArm => {}
             }
         }
         // Counterweight: the fallback really is fail-closed, so a tool added
@@ -22717,8 +22688,7 @@ mod repo_visibility_coverage_tests {
         )
         .expect_err("a concise response cannot be repo-scoped");
         let text = format!("{error:#}");
-        assert!(text.contains("concise"), "{text}");
-        assert!(text.contains("detailed"), "{text}");
+        assert!(text.contains("repository-scoped caller"), "{text}");
         // Counterweight: the refusal is about SCOPING, not about concise mode.
         // An unscoped caller keeps the concise rendering it always had.
         assert!(
@@ -24277,6 +24247,42 @@ mod seed_cap_disclosure_tests {
                 Value::Null,
                 "{tool}: {payload}"
             );
+        }
+    }
+}
+
+#[cfg(test)]
+mod hardening_aggregate_tests {
+    use super::*;
+    #[test]
+    fn aggregate_tools_refuse_restricted_callers_before_reading_arguments() {
+        let store = GraphStore::in_memory().unwrap();
+        let visible = nestweaver_engine::authz::VisibleRepos::Only(Default::default());
+        for name in [
+            "brain_context",
+            "code_context",
+            "project_context",
+            "dead_code",
+            "hub_nodes",
+            "bridge_nodes",
+            "regex_search",
+        ] {
+            for format in ["concise", "detailed"] {
+                let error = dispatch_uncached(
+                    &store,
+                    None,
+                    name,
+                    json!({"response_format":format}),
+                    None,
+                    None,
+                    Some(&visible),
+                )
+                .unwrap_err();
+                assert!(
+                    error.to_string().contains("repository-scoped"),
+                    "{name}: {error}"
+                );
+            }
         }
     }
 }

--- a/crates/nestweaver-schema/src/embedding.rs
+++ b/crates/nestweaver-schema/src/embedding.rs
@@ -165,3 +165,85 @@ mod tests {
         );
     }
 }
+
+/// A field-level comparison safe for operator and machine diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmbeddingPipelineDifference {
+    pub field: String,
+    pub recorded: serde_json::Value,
+    pub incoming: serde_json::Value,
+}
+
+impl EmbeddingPipelineV2 {
+    /// Free-form identifiers are hashed: even a model ID or revision can contain
+    /// an operator's local path or credentials. Closed enums and numbers are safe.
+    pub fn differences(&self, incoming: &Self) -> Result<Vec<EmbeddingPipelineDifference>, String> {
+        let old = serde_json::to_value(self).map_err(|e| e.to_string())?;
+        let new = serde_json::to_value(incoming).map_err(|e| e.to_string())?;
+        let safe = |key: &str, value: &serde_json::Value| -> serde_json::Value {
+            match key {
+                "provider"
+                | "model_id"
+                | "model_revision"
+                | "weights_sha256"
+                | "tokenizer_sha256"
+                | "tokenizer_config_sha256"
+                | "modules_sha256"
+                    if !value.is_null() =>
+                {
+                    serde_json::json!({"sha256": hex::encode(Sha256::digest(value.to_string().as_bytes()))})
+                }
+                _ => value.clone(),
+            }
+        };
+        let mut differences = Vec::new();
+        if let Some(fields) = old.as_object() {
+            for (field, recorded) in fields {
+                let incoming = &new[field];
+                if recorded != incoming {
+                    differences.push(EmbeddingPipelineDifference {
+                        field: field.clone(),
+                        recorded: safe(field, recorded),
+                        incoming: safe(field, incoming),
+                    });
+                }
+            }
+        }
+        Ok(differences)
+    }
+
+    pub fn mismatch_diagnostic(
+        recorded: Option<&Self>,
+        incoming: &Self,
+    ) -> Result<serde_json::Value, String> {
+        Ok(serde_json::json!({
+            "reason": if recorded.is_some() { "pipeline_mismatch" } else { "legacy_or_missing_pipeline" },
+            "recorded_fingerprint": recorded.map(Self::fingerprint).transpose()?,
+            "incoming_fingerprint": incoming.fingerprint()?,
+            "differences": recorded.map(|r| r.differences(incoming)).transpose()?,
+            "remediation": "use the recorded pipeline or intentionally rebuild all embeddings"
+        }))
+    }
+}
+
+#[cfg(test)]
+mod hardening_diff_tests {
+    use super::*;
+    #[test]
+    fn differences_are_complete_and_free_form_values_are_safe() {
+        let old = EmbeddingPipelineV2::external("provider", "/private/token=secret", 2);
+        let mut new = old.clone();
+        new.produced_dimension = 4;
+        new.normalize = Some(true);
+        new.model_id = "/another/private/path".into();
+        let diff = old.differences(&new).unwrap();
+        assert_eq!(diff.len(), 3);
+        let encoded = serde_json::to_string(&diff).unwrap();
+        assert!(!encoded.contains("private"));
+        assert!(!encoded.contains("secret"));
+        assert!(encoded.contains("produced_dimension"));
+        assert!(old.differences(&old).unwrap().is_empty());
+        let legacy = EmbeddingPipelineV2::mismatch_diagnostic(None, &new).unwrap();
+        assert_eq!(legacy["reason"], "legacy_or_missing_pipeline");
+    }
+}

--- a/crates/nestweaver-store/src/db.rs
+++ b/crates/nestweaver-store/src/db.rs
@@ -1621,6 +1621,17 @@ impl GraphStore {
     }
 
     /// Clear the git-activity recency cache (restores neutral ranking).
+    /// Invalidate exactly one removed repository without disturbing other rankings.
+    pub fn clear_repo_git_activity(&self, repo_uid: &str) {
+        let mut cache = self
+            .git_activity_cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if let Some(scores) = cache.as_mut() {
+            scores.remove(repo_uid);
+        }
+    }
+
     pub fn clear_git_activity_cache(&self) {
         *self
             .git_activity_cache
@@ -2371,6 +2382,7 @@ impl GraphStore {
                 .unwrap_or_else(|error| error.into_inner()) = None;
             index.set_recorded_model_id(recorded);
             index.set_recorded_pipeline_fingerprint(pipeline_fingerprint);
+            index.set_recorded_pipeline(pipeline.clone());
             if let Some(pipeline) = pipeline {
                 index.set_similarity(pipeline.similarity);
             }
@@ -2530,6 +2542,22 @@ impl GraphStore {
             .lock()
             .unwrap_or_else(|error| error.into_inner());
         index.add_with_pipeline(uid, embedding, pipeline, force)
+    }
+
+    /// Compare a proposed pipeline with the cached recorded producer without per-vector database reads.
+    pub fn embedding_pipeline_mismatch(
+        &self,
+        incoming: &nestweaver_schema::EmbeddingPipelineV2,
+    ) -> Result<Option<serde_json::Value>, StoreError> {
+        self.require_verified_embedding_identity()?;
+        let index = self
+            .embedding_index
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if index.is_empty() {
+            return Ok(None);
+        }
+        index.pipeline_mismatch(incoming).map_err(StoreError::Query)
     }
 
     /// Re-arm the embedding index's once-per-run force-clear guard. Call at
@@ -6269,5 +6297,26 @@ mod live_writer_wal_tests {
             Some("2051a9da"),
             "and it must still SERVE, not merely open"
         );
+    }
+}
+
+#[cfg(test)]
+mod hardening_activity_tests {
+    use super::*;
+    #[test]
+    fn removed_repo_scores_stay_neutral_while_other_repo_survives() {
+        let store = GraphStore::in_memory().unwrap();
+        store.load_git_activity_cache(HashMap::from([
+            ("removed".into(), HashMap::from([("same.rs".into(), 0.9)])),
+            ("retained".into(), HashMap::from([("same.rs".into(), 0.2)])),
+        ]));
+        store.clear_repo_git_activity("removed");
+        assert_eq!(store.git_activity_score("removed", "same.rs"), None);
+        assert_eq!(store.git_activity_score("retained", "same.rs"), Some(0.2));
+        store.load_git_activity_cache(HashMap::from([
+            ("removed".into(), HashMap::from([("same.rs".into(), 0.1)])),
+            ("retained".into(), HashMap::from([("same.rs".into(), 0.2)])),
+        ]));
+        assert_eq!(store.git_activity_score("removed", "same.rs"), Some(0.1));
     }
 }

--- a/crates/nestweaver-store/src/search.rs
+++ b/crates/nestweaver-store/src/search.rs
@@ -313,6 +313,7 @@ pub struct EmbeddingIndex {
     /// and unknown always allows the write: the dimension guard still applies.
     recorded_model_id: Option<String>,
     recorded_pipeline_fingerprint: Option<String>,
+    recorded_pipeline: Option<nestweaver_schema::EmbeddingPipelineV2>,
     similarity: nestweaver_schema::EmbeddingSimilarity,
     artifact_envelope: Option<EmbeddingArtifactEnvelopeV2>,
     pending_deltas: Vec<EmbeddingDelta>,
@@ -391,6 +392,7 @@ impl EmbeddingIndex {
             force_cleared: false,
             recorded_model_id: None,
             recorded_pipeline_fingerprint: None,
+            recorded_pipeline: None,
             similarity: nestweaver_schema::EmbeddingSimilarity::Cosine,
             artifact_envelope: None,
             pending_deltas: Vec::new(),
@@ -409,7 +411,36 @@ impl EmbeddingIndex {
     }
 
     pub fn set_recorded_pipeline_fingerprint(&mut self, fingerprint: Option<String>) {
+        if fingerprint.is_none() {
+            self.recorded_pipeline = None;
+        }
         self.recorded_pipeline_fingerprint = fingerprint;
+    }
+
+    pub(crate) fn set_recorded_pipeline(
+        &mut self,
+        pipeline: Option<nestweaver_schema::EmbeddingPipelineV2>,
+    ) {
+        self.recorded_pipeline = pipeline;
+    }
+
+    pub(crate) fn pipeline_mismatch(
+        &self,
+        incoming: &nestweaver_schema::EmbeddingPipelineV2,
+    ) -> Result<Option<serde_json::Value>, String> {
+        let fingerprint = incoming.fingerprint()?;
+        if self
+            .recorded_pipeline_fingerprint
+            .as_deref()
+            .is_some_and(|r| r != fingerprint)
+        {
+            return nestweaver_schema::EmbeddingPipelineV2::mismatch_diagnostic(
+                self.recorded_pipeline.as_ref(),
+                incoming,
+            )
+            .map(Some);
+        }
+        Ok(None)
     }
 
     pub(crate) fn recorded_pipeline_fingerprint(&self) -> Option<&str> {
@@ -471,6 +502,7 @@ impl EmbeddingIndex {
             // it without `--force`; no mixed vectors can result.
             if self.is_empty() {
                 self.recorded_pipeline_fingerprint = Some(incoming.clone());
+                self.recorded_pipeline = Some(pipeline.clone());
                 self.recorded_model_id = Some(pipeline.model_id.clone());
                 self.similarity = pipeline.similarity.clone();
             } else if !force {
@@ -478,6 +510,7 @@ impl EmbeddingIndex {
                     uid,
                     recorded,
                     incoming,
+                    diagnostic = ?self.pipeline_mismatch(pipeline),
                     "rejecting embedding pipeline mismatch"
                 );
                 return false;
@@ -509,6 +542,7 @@ impl EmbeddingIndex {
         let accepted = self.add_with_model(uid, embedding, Some(&pipeline.model_id), force);
         if accepted {
             self.recorded_pipeline_fingerprint = Some(incoming);
+            self.recorded_pipeline = Some(pipeline.clone());
             self.recorded_model_id = Some(pipeline.model_id.clone());
             self.similarity = pipeline.similarity.clone();
         }
@@ -641,6 +675,7 @@ impl EmbeddingIndex {
             force_cleared: false,
             recorded_model_id: None,
             recorded_pipeline_fingerprint: None,
+            recorded_pipeline: None,
             similarity: nestweaver_schema::EmbeddingSimilarity::Cosine,
             artifact_envelope: None,
             pending_deltas: Vec::new(),
@@ -748,6 +783,7 @@ impl EmbeddingIndex {
             force_cleared: false,
             recorded_model_id: None,
             recorded_pipeline_fingerprint: None,
+            recorded_pipeline: None,
             similarity: nestweaver_schema::EmbeddingSimilarity::Cosine,
             artifact_envelope: None,
             pending_deltas: Vec::new(),
@@ -966,6 +1002,7 @@ impl EmbeddingIndex {
             force_cleared: false,
             recorded_model_id: Some(envelope.pipeline.model_id.clone()),
             recorded_pipeline_fingerprint: Some(fingerprint),
+            recorded_pipeline: Some(envelope.pipeline.clone()),
             similarity: envelope.pipeline.similarity.clone(),
             artifact_envelope: Some(envelope),
             pending_deltas: Vec::new(),
@@ -1202,6 +1239,7 @@ impl EmbeddingIndex {
         self.deleted_base_uids = loaded.deleted_base_uids;
         self.recorded_model_id = loaded.recorded_model_id;
         self.recorded_pipeline_fingerprint = loaded.recorded_pipeline_fingerprint;
+        self.recorded_pipeline = loaded.recorded_pipeline;
         self.similarity = loaded.similarity;
         self.artifact_envelope = loaded.artifact_envelope;
         self.force_cleared = false;

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -8231,6 +8231,7 @@ impl GraphStore {
         }
         if result.is_ok() {
             embedding_index.set_recorded_pipeline_fingerprint(Some(fingerprint));
+            embedding_index.set_recorded_pipeline(Some(pipeline.clone()));
             embedding_index.set_recorded_model_id(Some(pipeline.model_id.clone()));
             embedding_index.set_similarity(pipeline.similarity.clone());
             self.clear_embedding_identity_error();

--- a/docs/guide/instance-config.md
+++ b/docs/guide/instance-config.md
@@ -446,7 +446,11 @@ unknown/unlisted token sees nothing.
 
 Each tool declares whether it can enforce repository visibility or must refuse
 before computing a graph-wide answer. Enabling a rule does not make global
-aggregates safe through row filtering alone.
+aggregates safe through row filtering alone. Repository-scoped callers are
+refused for `brain_context`, `code_context`, `project_context`, `dead_code`,
+`hub_nodes`, `bridge_nodes` and `regex_search` before traversal: their global
+rankings, topology or totals cannot be made safe by removing hidden rows.
+Unrestricted/admin callers retain these tools.
 
 With repository authorization enabled, `brain_status` (including both typed
 and JSON status RPCs) requires an administrator: host paths, runtime activity

--- a/docs/guide/retrieval-and-mutation-diagnostics.md
+++ b/docs/guide/retrieval-and-mutation-diagnostics.md
@@ -1,0 +1,45 @@
+# Retrieval and mutation diagnostics
+
+Repository-scoped MCP and typed gRPC callers cannot request whole-graph
+aggregates (`brain_context`, `code_context`, `project_context`, `dead_code`,
+`hub_nodes`, `bridge_nodes`, or `regex_search`). Both detailed and concise
+formats refuse before computation. Filtering result rows cannot undo the
+influence of hidden repositories on ranks, traversal, counts, or truncation.
+Unrestricted callers retain these tools.
+
+Hybrid fusion orders by descending floating-point score, then canonical UID
+ascending. Candidate normalization also uses UID order. Unequal scores are
+never rounded into ties. Federated brain search applies its per-kind cap after
+ranking and deduplication; all `Symbol/*` subtypes share one cap. An explicit
+limit wins; otherwise the stricter positive limit resolved by the two tiers is
+used (20 for older peers that do not report a limit). `returned_matches`
+describes the displayed rows; `total_matches` and its relation retain their
+pre-cap meaning. Lexical fallback warnings retain their tier provenance.
+
+A requested semantic leg that cannot contribute leaves graph results available
+and reports `semantic_applied: false`, `degraded_components`, and
+`semantic_unavailable` with a reason, stage, and remediation. Cancellation
+remains an error. Pipeline mismatches include differing field names and safe
+values: free-form identifiers are SHA-256 digests, while closed enums, numbers,
+and booleans are shown directly. A deliberate full embedding rebuild remains
+the way to change an incompatible pipeline.
+
+Index and vault publication reconcile vector liveness against the committed
+graph before retiring the durable `.index-dirty` marker. A persistent failure
+reports a committed/degraded mutation and keeps the recovery fence. Recovery
+reconciles the vectors before ranked queries can trust the publication again.
+Repository removal also invalidates that repository's live activity scores;
+sidecar read/write failures are reported as reconciliation failures.
+
+Backup staging requires readable global and per-repository statistics. A failed
+read cannot publish an archive with invented zero counts. Similarly, failed
+upstream or source inventory RPCs cannot become an empty inventory or a
+successful connection/removal. `brain list` uses the same inventory on direct
+and daemon routes, with `null` JSON counts, human `unavailable`, and a nonzero
+exit when a vault's note count cannot be read.
+
+First-index fallback carries the completed full build's `edges_found` count,
+just as explicit `--force` does: resolved relationships, inferred cross-repo
+calls, and emitted `MEMBER_OF` edges. This is a build count, not all structural
+relationships in the database. A true incremental run reports `null` because
+it does not measure that population.

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -350,6 +350,8 @@ message BrainSearchResponse {
   bool semantic_applied = 9;
   repeated string degraded_components = 10;
   optional SemanticUnavailable semantic_unavailable = 11;
+  optional string engine_warning = 12;
+  uint32 limit_per_kind = 13;
 }
 message SemanticUnavailable {
   string cause = 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25201,9 +25201,10 @@ fn run_brain(
             };
             let rows = value
                 .as_array()
+                .or_else(|| value.get("results").and_then(serde_json::Value::as_array))
                 .context("invalid vault inventory response")?;
             if json {
-                println!("{}", serde_json::to_string_pretty(&value)?);
+                println!("{}", serde_json::to_string_pretty(rows)?);
             } else if rows.is_empty() {
                 println!("No vaults indexed. Try: nestweaver brain add <path>");
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1451,6 +1451,10 @@ const ENV_REGISTRY: &[EnvVar] = &[
         role: EnvRole::Configures,
     },
     EnvVar {
+        name: "NESTWEAVER_ISOLATED_SERVER_TEST",
+        role: EnvRole::Internal,
+    },
+    EnvVar {
         name: "NESTWEAVER_LBUG_MAX_DB_SIZE",
         role: EnvRole::Configures,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -2816,12 +2816,12 @@ fn render_investigate_text(payload: &serde_json::Value) {
         .and_then(|v| v.as_bool())
         .is_some_and(|applied| !applied)
     {
-        println!(
-            "  note: semantic retrieval unavailable — ranking is lexical (BM25) only, \
-             so ordering differs from a daemon-served run."
-        );
+        println!("  note: semantic retrieval did not contribute to this result.");
     }
 
+    if let Some(detail) = payload.get("semantic_unavailable").filter(|v| !v.is_null()) {
+        println!("  Semantic diagnostic: {detail}");
+    }
     for d in &domains {
         println!("\n[{}]", text(d, "label"));
         let entry_point = text(d, "entry_point");
@@ -21295,12 +21295,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
 
                 files_count = result.files_count;
                 symbols_count = result.symbols_count;
-                edges_count = result.edges_count;
+                edges_count = Some(result.edges_count);
 
                 if !json {
                     println!(
                         "Indexed {} file(s), {} symbol(s), {} edge(s).",
-                        files_count, symbols_count, edges_count
+                        files_count, symbols_count, result.edges_count
                     );
                 }
 
@@ -21331,7 +21331,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
 
                 files_count = inc.files_added + inc.files_modified;
                 symbols_count = inc.symbols_added;
-                edges_count = 0; // not tracked separately in incremental
+                edges_count = inc.full_edges_count;
                 skipped_files = inc.skipped_files.clone();
 
                 if inc.fell_back_to_full {
@@ -21486,7 +21486,9 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 "{} files, {} symbols, {} edges in {}",
                 files_count,
                 symbols_count,
-                edges_count,
+                edges_count
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| "unavailable".into()),
                 format_elapsed(t0.elapsed())
             );
 
@@ -25184,76 +25186,53 @@ fn run_brain(
         }
 
         BrainCommands::List { json, db, config } => {
-            // nw-280: resolved through the same helper as its two documented
-            // siblings, so a pinned `--config` selects the database its
-            // `db` field names instead of silently falling back to
-            // `./nestweaver.lbug`.
             let db_path = resolve_db_with_config(db, config.as_deref())?;
-            let db_path = db_path.as_path();
-
-            if use_daemon
-                && let Some(value) = try_hybrid_json_rpc(
-                    true,
-                    db_path,
-                    config.as_deref(),
-                    "list_vaults",
-                    serde_json::json!({}),
-                )?
-            {
-                println!("{}", serde_json::to_string_pretty(&value)?);
-                return Ok((EXIT_SUCCESS, None));
-            }
-
-            let store = open_store(Some(db_path))?;
-            let vaults = store.list_vaults(None).map_err(|e| anyhow::anyhow!(e))?;
-
-            // Compute (note_count, last_indexed) per vault. Prefer the
-            // extension-store timestamp (actual indexer run) with fallback
-            // to max(note.modified_at).
-            let per_vault: Vec<(String, usize, Option<String>)> = vaults
-                .iter()
-                .map(|v| {
-                    let notes = store.list_notes(Some(&v.uid)).unwrap_or_default();
-                    let last = get_last_indexed_at(db_path, &v.uid)
-                        .or_else(|| notes.iter().filter_map(|n| n.modified_at.clone()).max());
-                    (v.uid.clone(), notes.len(), last)
-                })
-                .collect();
-
+            let value = if let Some(value) = try_hybrid_json_rpc(
+                use_daemon,
+                &db_path,
+                config.as_deref(),
+                "list_vaults",
+                serde_json::json!({"include_counts": true}),
+            )? {
+                value
+            } else {
+                let store = open_store(Some(&db_path))?;
+                nestweaver_engine::index_md::vault_inventory(&store, &db_path)?
+            };
+            let rows = value
+                .as_array()
+                .context("invalid vault inventory response")?;
             if json {
-                #[derive(serde::Serialize)]
-                struct VaultRow {
-                    uid: String,
-                    name: String,
-                    root_path: String,
-                    notes: usize,
-                    last_indexed: Option<String>,
-                }
-                let rows: Vec<VaultRow> = vaults
-                    .iter()
-                    .zip(per_vault.iter())
-                    .map(|(v, (_, notes, last))| VaultRow {
-                        uid: v.uid.clone(),
-                        name: v.name.clone(),
-                        root_path: v.root_path.clone(),
-                        notes: *notes,
-                        last_indexed: last.clone(),
-                    })
-                    .collect();
-                println!("{}", serde_json::to_string_pretty(&rows)?);
-            } else if vaults.is_empty() {
+                println!("{}", serde_json::to_string_pretty(&value)?);
+            } else if rows.is_empty() {
                 println!("No vaults indexed. Try: nestweaver brain add <path>");
             } else {
-                for (v, (_, notes, last)) in vaults.iter().zip(per_vault.iter()) {
-                    println!("{}", v.name);
-                    println!("  UID:   {}", v.uid);
-                    println!("  Path:  {}", v.root_path);
-                    println!("  Notes: {notes}");
-                    println!("  Last indexed: {}", last.as_deref().unwrap_or("(unknown)"));
-                    println!();
+                for row in rows {
+                    println!(
+                        "{}\n  UID:   {}\n  Path:  {}\n  Notes: {}\n  Last indexed: {}",
+                        row["name"].as_str().unwrap_or("(unknown)"),
+                        row["uid"].as_str().unwrap_or("(unknown)"),
+                        row["root_path"].as_str().unwrap_or("(unknown)"),
+                        row["notes"]
+                            .as_u64()
+                            .map(|n| n.to_string())
+                            .unwrap_or_else(|| "unavailable".into()),
+                        row["last_indexed"].as_str().unwrap_or("(unknown)")
+                    );
+                    if let Some(error) = row["inventory_error"].as_str() {
+                        println!("  Warning: {error}");
+                    }
                 }
             }
-            Ok((EXIT_SUCCESS, None))
+            let unavailable = rows.iter().any(|r| r["notes"].is_null());
+            Ok((
+                if unavailable {
+                    EXIT_ERROR
+                } else {
+                    EXIT_SUCCESS
+                },
+                None,
+            ))
         }
 
         BrainCommands::Status { json, db, config } => {
@@ -25485,11 +25464,11 @@ fn run_brain(
                                                 client
                                                     .repo_states(req)
                                                     .await
-                                                    .map(|r| r.into_inner().repos.len())
-                                                    .unwrap_or(0)
+                                                    .map(|r| format!("{} repos", r.into_inner().repos.len()))
+                                                    .unwrap_or_else(|_| "repository inventory unavailable; check upstream authorization and retry".to_string())
                                             });
                                             println!(
-                                                "  Server: {name} (v{version}, {mode} mode, healthy, {repo_count} repos)"
+                                                "  Server: {name} (v{version}, {mode} mode, healthy, {repo_count})"
                                             );
                                         }
                                         _ => {
@@ -28696,6 +28675,18 @@ fn print_brain_context_text(
     token_budget: Option<usize>,
     upstream: &UpstreamContextDisclosure,
 ) {
+    if let Some(detail) = &result.semantic_unavailable {
+        println!(
+            "Warning: semantic retrieval unavailable ({}). {}",
+            detail["reason"].as_str().unwrap_or("unknown"),
+            detail["remediation"]
+                .as_str()
+                .unwrap_or("verify embedding readiness")
+        );
+        if let Some(pipeline) = detail.get("pipeline").filter(|v| !v.is_null()) {
+            println!("  Pipeline: {pipeline}");
+        }
+    }
     // Feature F7: show PRF-mined expansion terms for auditing.
     if !result.expansion_terms.is_empty() {
         println!("PRF expansion terms: {}", result.expansion_terms.join(", "));
@@ -28881,6 +28872,8 @@ fn render_brain_search_response(
         let mut payload = serde_json::json!({
             "query": resp.query,
             "engine": resp.engine,
+            "engine_warning": resp.engine_warning,
+            "limit_per_kind": resp.limit_per_kind,
             "results": results,
             "total_matches": resp.total_matches,
             "total_matches_relation": total_matches_relation,
@@ -28899,6 +28892,9 @@ fn render_brain_search_response(
         return Ok(());
     }
 
+    if let Some(warning) = &resp.engine_warning {
+        println!("Warning: {warning}");
+    }
     if let Some(detail) = &resp.semantic_unavailable {
         println!(
             "Warning: semantic search unavailable ({}): {}\n  Remediation: {}",
@@ -31476,6 +31472,8 @@ mod brain_search_renderer_tests {
             semantic_applied: false,
             degraded_components: Vec::new(),
             semantic_unavailable: None,
+            engine_warning: None,
+            limit_per_kind: 20,
         };
 
         let metadata = brain_search_display_metadata(&response);
@@ -31556,6 +31554,26 @@ fn render_brain_search_json(result: &serde_json::Value) -> anyhow::Result<()> {
     let truncated =
         explicit_truncated || total_matches_relation != "eq" || returned_matches < total_matches;
 
+    if let Some(warning) = result
+        .get("engine_warning")
+        .and_then(serde_json::Value::as_str)
+    {
+        println!("Warning: {warning}");
+    }
+    if let Some(warnings) = result
+        .get("engine_warnings")
+        .and_then(serde_json::Value::as_array)
+    {
+        for warning in warnings {
+            println!(
+                "Warning ({}): {}",
+                warning["tier"].as_str().unwrap_or("upstream"),
+                warning["warning"]
+                    .as_str()
+                    .unwrap_or("lexical backend unavailable")
+            );
+        }
+    }
     if results.is_empty() {
         println!("No results for '{}'.", query);
         return Ok(());
@@ -31636,6 +31654,9 @@ fn render_project_context_daemon_response(
             Err(e) => eprintln!("warning: failed to serialize daemon response: {e}"),
         }
         return;
+    }
+    if let Some(detail) = value.get("semantic_unavailable").filter(|v| !v.is_null()) {
+        println!("Warning: semantic retrieval unavailable: {detail}");
     }
     let project = value.get("project").and_then(|v| v.as_str()).unwrap_or("");
     let project_uid = value
@@ -31774,6 +31795,7 @@ fn brain_context_json_value(
         // both routes.
         "truncated_by": truncated_by.map(nestweaver_engine::TruncationCause::as_str).or(upstream.truncated_by.as_deref()),
         "semantic_applied": result.semantic_applied,
+        "semantic_unavailable": result.semantic_unavailable,
         "degraded_components": result.degraded_components,
     });
 
@@ -31837,6 +31859,7 @@ mod context_json_renderer_tests {
             unresolved_seeds: vec!["missing".to_string()],
             expansion_terms: Vec::new(),
             semantic_applied: false,
+            semantic_unavailable: None,
             semantic_seed_count: 0,
             degraded_components: vec!["semantic".to_string()],
             // nw-393 added the seed-cap disclosure to `BrainContextResult`.
@@ -32461,6 +32484,13 @@ where
                                     api_model,
                                     u32::try_from(emb_dim)?,
                                 );
+                                if !force
+                                    && let Some(diagnostic) =
+                                        store.embedding_pipeline_mismatch(&pipeline)?
+                                {
+                                    eprintln!("embedding pipeline mismatch: {diagnostic}");
+                                    return Ok(EXIT_ERROR);
+                                }
                                 if store.add_embedding_with_pipeline(&h.uid, emb, &pipeline, force)
                                 {
                                     success_count += 1;
@@ -32531,6 +32561,13 @@ where
                                 for (sym, emb) in batch.iter().zip(embeddings.iter()) {
                                     let pipeline = embed_model
                                         .pipeline_for_dimension(local_model_id, emb.len())?;
+                                    if !force
+                                        && let Some(diagnostic) =
+                                            store.embedding_pipeline_mismatch(&pipeline)?
+                                    {
+                                        eprintln!("embedding pipeline mismatch: {diagnostic}");
+                                        return Ok(EXIT_ERROR);
+                                    }
                                     if store.add_embedding_with_pipeline(
                                         &sym.uid,
                                         emb.clone(),
@@ -32593,6 +32630,13 @@ where
                                 for (note, emb) in batch.iter().zip(embeddings.iter()) {
                                     let pipeline = embed_model
                                         .pipeline_for_dimension(local_model_id, emb.len())?;
+                                    if !force
+                                        && let Some(diagnostic) =
+                                            store.embedding_pipeline_mismatch(&pipeline)?
+                                    {
+                                        eprintln!("embedding pipeline mismatch: {diagnostic}");
+                                        return Ok(EXIT_ERROR);
+                                    }
                                     if store.add_embedding_with_pipeline(
                                         &note.uid,
                                         emb.clone(),
@@ -32668,6 +32712,13 @@ where
                                 for (h, emb) in batch.iter().zip(embeddings.iter()) {
                                     let pipeline = embed_model
                                         .pipeline_for_dimension(local_model_id, emb.len())?;
+                                    if !force
+                                        && let Some(diagnostic) =
+                                            store.embedding_pipeline_mismatch(&pipeline)?
+                                    {
+                                        eprintln!("embedding pipeline mismatch: {diagnostic}");
+                                        return Ok(EXIT_ERROR);
+                                    }
                                     if store.add_embedding_with_pipeline(
                                         &h.uid,
                                         emb.clone(),

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -1086,9 +1086,9 @@ fn strip_semantic_note(bytes: &[u8]) -> String {
     redact_bundle_ids(bytes)
         .lines()
         .filter(|line| {
-            !line
-                .trim_start()
-                .starts_with("note: semantic retrieval unavailable")
+            let line = line.trim_start();
+            !line.starts_with("note: semantic retrieval ")
+                && !line.starts_with("Semantic diagnostic:")
         })
         .collect::<Vec<_>>()
         .join("\n")
@@ -1146,7 +1146,8 @@ fn parity_investigate_human_direct_vs_daemon() {
     // always disclose that the ranking was lexical.
     let direct_text = String::from_utf8_lossy(&direct.stdout);
     assert!(
-        direct_text.contains("note: semantic retrieval unavailable"),
+        direct_text.contains("note: semantic retrieval did not contribute")
+            && direct_text.contains("Semantic diagnostic:"),
         "the direct path has no embedding model and must say so; got: {direct_text}"
     );
 }

--- a/tests/ready_regression_test.rs
+++ b/tests/ready_regression_test.rs
@@ -553,3 +553,200 @@ fn prune_cli_preserves_commit_state_for_noop_and_real_deletion() {
     assert!(repeat.status.success());
     assert!(String::from_utf8_lossy(&repeat.stdout).contains("Committed: false"));
 }
+
+#[test]
+fn discovered_mcp_configuration_rejects_invalid_files_before_handshake() {
+    let f = Fixture::new();
+    f.index();
+    let valid = std::fs::read_to_string(&f.config).unwrap();
+    let init = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"regression\",\"version\":\"1\"}}}\n";
+    for contents in [
+        None,
+        Some(valid.as_str()),
+        Some("[broken"),
+        Some("unknown_typo = true\n"),
+    ] {
+        match contents {
+            Some(text) => std::fs::write(&f.config, text).unwrap(),
+            None => std::fs::remove_file(&f.config).unwrap(),
+        }
+        let output = f
+            .cmd()
+            .args(["mcp", "--db"])
+            .arg(&f.db)
+            .env("NESTWEAVER_NO_DAEMON", "1")
+            .env("NESTWEAVER_ALLOW_NO_DAEMON", "1")
+            .write_stdin(init)
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if matches!(contents, Some("[broken" | "unknown_typo = true\n")) {
+            assert!(!output.status.success());
+            assert!(
+                !stdout.contains("serverInfo"),
+                "invalid configuration initialized: {stdout}"
+            );
+            assert!(String::from_utf8_lossy(&output.stderr).contains("instance.toml"));
+        } else {
+            assert!(
+                stdout.contains("serverInfo"),
+                "valid/absent config failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+}
+
+#[test]
+fn first_index_retains_full_edge_count_and_incremental_does_not_invent_zero() {
+    let f = Fixture::new();
+    let run = |force: bool| {
+        let mut cmd = f.cmd();
+        cmd.args(["index", "--repo"])
+            .arg(&f.repo)
+            .arg("--db")
+            .arg(&f.db)
+            .arg("--json")
+            .env("NESTWEAVER_NO_DAEMON", "1")
+            .env("NESTWEAVER_ALLOW_NO_DAEMON", "1");
+        if force {
+            cmd.arg("--force");
+        }
+        let out = cmd.output().unwrap();
+        assert!(
+            out.status.success(),
+            "{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        payload(&out)
+    };
+    let first = run(false);
+    let force = run(true);
+    assert!(first["edges_found"].as_u64().unwrap() > 0);
+    assert_eq!(first["edges_found"], force["edges_found"]);
+    // This fixture has only top-level functions: its build population is
+    // exactly persisted REFERENCES, with no MEMBER_OF or cross-repo edges.
+    let store = nestweaver_store::GraphStore::open_read_only(&f.db).unwrap();
+    assert_eq!(
+        first["edges_found"].as_u64().unwrap(),
+        store
+            .load_typed_edges()
+            .unwrap()
+            .iter()
+            .filter(|e| e.0.starts_with("sym:") && e.1.starts_with("sym:"))
+            .count() as u64
+    );
+    drop(store);
+    assert!(run(false)["edges_found"].is_null());
+}
+
+#[test]
+fn brain_list_preserves_selected_output_mode_across_routes() {
+    let f = Fixture::new();
+    f.index();
+    for direct in [true, false] {
+        let human = f.query(&["brain", "list"], direct);
+        assert!(
+            human.status.success(),
+            "{}",
+            String::from_utf8_lossy(&human.stderr)
+        );
+        assert!(String::from_utf8_lossy(&human.stdout).contains("No vaults indexed"));
+        let json = f.query(&["brain", "list", "--json"], direct);
+        assert!(json.status.success());
+        assert_eq!(payload(&json), json!([]));
+        f.stop();
+    }
+}
+
+#[test]
+fn immutable_context_ranking_is_identical_across_ten_processes() {
+    let f = Fixture::new();
+    for i in 0..8 {
+        std::fs::write(
+            f.repo.join(format!("tied{i}.py")),
+            "def tied():\n    return 1\n",
+        )
+        .unwrap();
+    }
+    f.index();
+    let mut baseline = None;
+    let mut eval_baseline = None;
+    let judgments = f.dir.path().join("judgments.jsonl");
+    let search = f.query(&["brain", "search", "tied", "--json"], true);
+    assert!(search.status.success());
+    let hits = payload(&search);
+    let uid = hits["results"][0]["uid"].as_str().unwrap();
+    std::fs::write(
+        &judgments,
+        json!({"query":"tied", "relevance":{uid:3}}).to_string(),
+    )
+    .unwrap();
+
+    for _ in 0..10 {
+        let out = f.query(
+            &[
+                "brain",
+                "context",
+                "tied",
+                "--weight-semantic",
+                "0",
+                "--json",
+            ],
+            true,
+        );
+        assert!(
+            out.status.success(),
+            "{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let value = payload(&out);
+        let ranking =
+            json!({"seeds_expanded":value["seeds_expanded"], "connected":value["connected"]});
+        let run = f.query(
+            &[
+                "eval",
+                "run",
+                "--queries",
+                judgments.to_str().unwrap(),
+                "--json",
+            ],
+            true,
+        );
+        assert!(
+            run.status.success(),
+            "{}",
+            String::from_utf8_lossy(&run.stderr)
+        );
+        let report = payload(&run);
+        if let Some(expected) = &eval_baseline {
+            assert_eq!(&report, expected);
+        } else {
+            eval_baseline = Some(report.clone());
+        }
+        let compare = f.query(
+            &[
+                "eval",
+                "compare",
+                "--queries",
+                judgments.to_str().unwrap(),
+                "--prf",
+                "--json",
+            ],
+            true,
+        );
+        assert!(
+            compare.status.success(),
+            "{}",
+            String::from_utf8_lossy(&compare.stderr)
+        );
+        assert_eq!(payload(&compare)["baseline"], report);
+
+        assert!(ranking["seeds_expanded"].as_u64().unwrap() > 0);
+        if let Some(expected) = &baseline {
+            assert_eq!(&ranking, expected);
+        } else {
+            baseline = Some(ranking);
+        }
+    }
+}

--- a/tests/ready_regression_test.rs
+++ b/tests/ready_regression_test.rs
@@ -657,6 +657,20 @@ fn brain_list_preserves_selected_output_mode_across_routes() {
         assert_eq!(payload(&json), json!([]));
         f.stop();
     }
+    let vault = f.dir.path().join("notes");
+    std::fs::create_dir(&vault).unwrap();
+    std::fs::write(vault.join("Note.md"), "# Note\nA populated inventory.\n").unwrap();
+    let added = f.query(&["brain", "add", vault.to_str().unwrap()], true);
+    assert!(added.status.success());
+    let direct = f.query(&["brain", "list", "--json"], true);
+    let daemon = f.query(&["brain", "list", "--json"], false);
+    assert!(direct.status.success() && daemon.status.success());
+    assert_eq!(payload(&direct), payload(&daemon));
+    assert_eq!(payload(&daemon)[0]["notes"], 1);
+    assert_eq!(payload(&daemon)[0]["instance_id"], "default");
+    let human = f.query(&["brain", "list"], false);
+    assert!(human.status.success());
+    assert!(String::from_utf8_lossy(&human.stdout).contains("Notes: 1"));
 }
 
 #[test]
@@ -719,6 +733,10 @@ fn immutable_context_ranking_is_identical_across_ten_processes() {
             String::from_utf8_lossy(&run.stderr)
         );
         let report = payload(&run);
+        assert!(
+            report["mean_mrr"].as_f64().unwrap() > 0.0,
+            "the judged UID must be retrieved: {report}"
+        );
         if let Some(expected) = &eval_baseline {
             assert_eq!(&report, expected);
         } else {

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -2263,6 +2263,11 @@ async fn hybrid_brain_search_merge_combines_local_and_server_sources() {
             .map(|rows| rows.len() as u64)
     );
     assert_eq!(merged_small["truncated"], true);
+    assert_eq!(
+        merged_small["returned_matches"], 1,
+        "the final symbol cap applies across both tiers"
+    );
+    assert_eq!(merged_small["limit_per_kind"], 1);
     assert!(merged_small["total_matches"].as_u64().is_some());
 
     // With both sources complete, RRF dedup has the complete union and may

--- a/tests/thirteen_transport_test.rs
+++ b/tests/thirteen_transport_test.rs
@@ -1,0 +1,209 @@
+//! Faulting wire peers exercise the production clients without corrupting a real store.
+use nestweaver_proto::*;
+use serde_json::json;
+use std::convert::Infallible;
+use std::future::{Ready, ready};
+use std::sync::{
+    Arc,
+    atomic::{AtomicU8, AtomicUsize, Ordering},
+};
+use std::task::{Context, Poll};
+use tonic::body::Body;
+use tonic::codegen::{Service, http};
+
+#[derive(Clone)]
+struct Reply<T>(Result<T, tonic::Status>);
+impl<R, T: Clone + Send + 'static> tonic::server::UnaryService<R> for Reply<T> {
+    type Response = T;
+    type Future = Ready<Result<tonic::Response<T>, tonic::Status>>;
+    fn call(&mut self, _: tonic::Request<R>) -> Self::Future {
+        ready(self.0.clone().map(tonic::Response::new))
+    }
+}
+#[derive(Clone)]
+struct Peer {
+    mode: Arc<AtomicU8>,
+    mutations: Arc<AtomicUsize>,
+}
+impl tonic::server::NamedService for Peer {
+    const NAME: &'static str = "nestweaver.daemon.v1.NestWeaverDaemon";
+}
+impl Service<http::Request<Body>> for Peer {
+    type Response = http::Response<Body>;
+    type Error = Infallible;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+    >;
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+    fn call(&mut self, request: http::Request<Body>) -> Self::Future {
+        let mode = self.mode.load(Ordering::SeqCst);
+        let mutations = self.mutations.clone();
+        Box::pin(async move {
+            macro_rules! respond {
+                ($response:ty, $request:ty, $result:expr) => {{
+                    let codec = tonic_prost::ProstCodec::<$response, $request>::default();
+                    let mut grpc = tonic::server::Grpc::new(codec);
+                    grpc.unary(Reply($result), request).await
+                }};
+            }
+            let response = match request.uri().path().rsplit('/').next().unwrap() {
+                "HealthCheck" => respond!(
+                    HealthCheckResponse,
+                    HealthCheckRequest,
+                    Ok(HealthCheckResponse {
+                        version: "fixture".into(),
+                        ..Default::default()
+                    })
+                ),
+                "RepoStates" => respond!(
+                    RepoStatesResponse,
+                    RepoStatesRequest,
+                    if mode == 5 {
+                        Err(tonic::Status::unavailable("injected inventory failure"))
+                    } else {
+                        Ok(RepoStatesResponse::default())
+                    }
+                ),
+                "ListReposJson" => respond!(
+                    JsonResponse,
+                    JsonRequest,
+                    Ok(JsonResponse {
+                        result_json: if mode == 0 { "{" } else { "[]" }.into()
+                    })
+                ),
+                "ListVaultsJson" => respond!(
+                    JsonResponse,
+                    JsonRequest,
+                    if mode == 1 {
+                        Err(tonic::Status::unavailable("injected vault failure"))
+                    } else {
+                        Ok(JsonResponse {result_json: match mode {
+                    2 => "{".into(),
+                    4 => json!([{"uid":"vlt:fixture","name":"fixture","root_path":"fixture","instance_id":"fixture"}]).to_string(),
+                    _ => "[]".into()
+                }})
+                    }
+                ),
+                "RemoveVault" => {
+                    mutations.fetch_add(1, Ordering::SeqCst);
+                    respond!(
+                        RemoveVaultResponse,
+                        RemoveVaultRequest,
+                        Ok(RemoveVaultResponse {
+                            committed: true,
+                            ..Default::default()
+                        })
+                    )
+                }
+                _ => tonic::Status::unimplemented("unexpected RPC").into_http(),
+            };
+            Ok(response)
+        })
+    }
+}
+fn peer(rt: &tokio::runtime::Runtime) -> (Peer, String, tokio::task::JoinHandle<()>) {
+    let port = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = port.local_addr().unwrap();
+    drop(port);
+    let peer = Peer {
+        mode: Arc::new(AtomicU8::new(0)),
+        mutations: Arc::new(AtomicUsize::new(0)),
+    };
+    let service = peer.clone();
+    let task = rt.spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(service)
+            .serve(addr)
+            .await
+            .unwrap();
+    });
+    let url = format!("http://{addr}");
+    rt.block_on(async {
+        for _ in 0..100 {
+            if nest_weaver_daemon_client::NestWeaverDaemonClient::connect(url.clone())
+                .await
+                .is_ok()
+            {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        panic!("fixture peer did not start");
+    });
+    (peer, url, task)
+}
+#[test]
+fn source_inventory_failures_never_dispatch_removal() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let (peer, url, task) = peer(&rt);
+    let mut client = rt
+        .block_on(nest_weaver_daemon_client::NestWeaverDaemonClient::connect(
+            url,
+        ))
+        .unwrap();
+    for (mode, expected) in [
+        (0, "repository inventory decode"),
+        (1, "vault inventory RPC"),
+        (2, "vault inventory decode"),
+        (3, "no repo or vault"),
+    ] {
+        peer.mode.store(mode, Ordering::SeqCst);
+        let error = nestweaver_mcp::tools::dispatch_via_daemon(
+            &mut client,
+            &rt,
+            "brain_remove_source",
+            json!({"target":"fixture"}),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains(expected), "{mode}: {error:#}");
+        assert_eq!(peer.mutations.load(Ordering::SeqCst), 0);
+    }
+    peer.mode.store(4, Ordering::SeqCst);
+    let result = nestweaver_mcp::tools::dispatch_via_daemon(
+        &mut client,
+        &rt,
+        "brain_remove_source",
+        json!({"target":"fixture"}),
+    )
+    .unwrap();
+    assert_eq!(result["committed"], true);
+    assert_eq!(peer.mutations.load(Ordering::SeqCst), 1);
+    task.abort();
+}
+#[cfg(target_os = "linux")] // XDG confines saved configuration to the fixture.
+#[test]
+fn reachable_upstream_inventory_failure_is_not_saved_as_empty() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let (peer, url, task) = peer(&rt);
+    let dir = tempfile::tempdir().unwrap();
+    for mode in [5, 6] {
+        peer.mode.store(mode, Ordering::SeqCst);
+        let output = assert_cmd::Command::cargo_bin("nestweaver")
+            .unwrap()
+            .current_dir(dir.path())
+            .env("XDG_CONFIG_HOME", dir.path().join("config"))
+            .env("XDG_DATA_HOME", dir.path().join("data"))
+            .args([
+                "connect",
+                &url,
+                "--token",
+                "fixture-token-with-no-real-authority",
+            ])
+            .timeout(std::time::Duration::from_secs(15))
+            .output()
+            .unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if mode == 5 {
+            assert!(!output.status.success());
+            assert!(stderr.contains("inventory is unavailable"), "{stderr}");
+            assert!(!stderr.contains("0 repos indexed"));
+            assert!(!dir.path().join("config/nestweaver/upstreams.toml").exists());
+        } else {
+            assert!(output.status.success(), "{stderr}");
+            assert!(stderr.contains("0 repos indexed"));
+        }
+    }
+    task.abort();
+}


### PR DESCRIPTION
Repository-scoped aggregate queries could retain hidden-repository influence after row filtering, and several failure paths reported successful empty results or clean mutations. This batch refuses unsafe aggregates before dispatch and preserves failures through the CLI, MCP, daemon, and federation boundaries.

Changes cover the thirteen agreed backlog scopes:

- Reject invalid discovered MCP configuration; refuse whole-graph aggregates for repository-scoped callers.
- Retain the durable publication fence when vector reconciliation fails; reject backup staging on unreadable statistics; clear removed repositories' live activity scores.
- Stabilize score/UID ordering and eval baselines; reapply per-kind search limits after federated merge and preserve lexical fallback warnings.
- Propagate source inventory and upstream repository-state failures without dispatching removal or saving a misleading connection.
- Report semantic degradation stages and safe field-level pipeline differences; align brain-list human/JSON inventories; carry completed fallback full-index edge counts.

The protocol additions are additive. Restricted aggregate callers now receive a refusal in both concise and detailed modes. True incremental indexing reports an unavailable edge count (`null`) instead of inventing zero. See `docs/guide/retrieval-and-mutation-diagnostics.md` for the contracts and recovery behavior.

The main-branch CI GC failure was reproduced locally: real server-boot unit tests left a process-lifetime lock guard armed for neighboring tests. Those three tests now run in isolated child processes, retaining their original assertions and the production guard.

Validation and review:

- Workspace regression coverage: 4,859 passed, 7 existing ignored tests. The full run found one missing internal test-marker registry entry; after adding it, the complete CLI unit target passed all 339 tests. All other workspace targets passed in the full run, and final workspace compilation passed.
- The reproduced main-branch daemon CI failure passed ten repeated 27-test runs after process isolation (270 executions).
- Final workspace/all-target Clippy passed with warnings denied; formatting and diff checks passed.
- Manual private code-and-vault CLI checks passed: indexing, actual edge counts, populated human/JSON inventory, lexical search, and disclosed semantic fallback. Focused transport and persistence fault regressions passed.
- Structural graph refresh completed; strict brain audit: 241 notes, zero errors or warnings. Graph navigation had partial coverage, so review relied on source contracts and regression evidence as well. Embedding refresh is deferred for the unmerged candidate.

Local review signed off on `2a8c9aff`. [Required CI and the complete workflow](https://github.com/Kehl-io/nestweaver/actions/runs/34273959378) passed on exact head `2a8c9affefe2532f8f8db7c8a50331397cb42d5c`, including Linux tests, daemon integration, macOS Metal/portability and E2E. Coverage is skipped on PRs by existing workflow policy.
