### PR TITLE
fix: verify hooks, backup activity, UI ports and trigram deltas

### DIFF
--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -2187,6 +2187,7 @@ fn trigram_refresh_detail(stats: &nestweaver_store::TrigramRefreshStats) -> Trig
         nodes_deleted: stats.nodes_deleted as u64,
         postings_added: stats.postings_added as u64,
         postings_deleted: stats.postings_deleted as u64,
+        posting_deltas_unavailable: stats.posting_deltas_unavailable.clone(),
         migrated_legacy_index: stats.migrated_legacy_index,
         elapsed_ms: stats.elapsed_ms,
     }
@@ -5828,6 +5829,7 @@ impl NestWeaverDaemon for DaemonService {
         let m = &result.manifest;
         tracing::info!(output = %result.output_path.display(), "backup complete");
         Ok(Response::new(BackupResponse {
+            warnings: m.warnings.clone(),
             output_path: result.output_path.to_string_lossy().into_owned(),
             instance_id: m.instance_id.clone(),
             tier: m.tier.clone(),

--- a/crates/nestweaver-engine/src/admin.rs
+++ b/crates/nestweaver-engine/src/admin.rs
@@ -187,8 +187,8 @@ fn claude_task_hook_entry() -> Value {
 /// `existing` is the current settings JSON (e.g. parsed
 /// `.claude/settings.local.json`); pass an empty object if there is none. The
 /// returned value is the settings document with the hook merged in
-/// idempotently — if a `Task` matcher already exists it is left untouched (no
-/// duplicates).
+/// idempotently — an exact command/event/matcher match is left untouched.
+/// Unrelated Task hooks are preserved and do not suppress installation.
 ///
 /// ## Why this returns a `Result`
 ///
@@ -222,29 +222,70 @@ pub fn compute_claude_hook_patch(existing: &Value) -> Result<Value, anyhow::Erro
         );
     };
     let mut settings = Value::Object(existing.clone());
+    validate_claude_hook_containers(&settings)?;
+    if !has_exact_claude_hook(&settings) {
+        let hooks = settings["hooks"].take();
+        let mut hooks = if hooks.is_null() { json!({}) } else { hooks };
+        if hooks.get("PreToolUse").is_none() {
+            hooks["PreToolUse"] = json!([]);
+        }
+        // Shape validation above ensures this is an array.
+        if let Some(entries) = hooks["PreToolUse"].as_array_mut() {
+            entries.push(claude_task_hook_entry());
+        }
+        settings["hooks"] = hooks;
+    }
 
-    if let Some(obj) = settings.as_object_mut() {
-        let hooks = obj
-            .entry("hooks")
-            .or_insert_with(|| json!({}))
-            .as_object_mut();
-        if let Some(hooks) = hooks {
-            let pre = hooks
-                .entry("PreToolUse")
-                .or_insert_with(|| json!([]))
-                .as_array_mut();
-            if let Some(arr) = pre {
-                let already = arr
-                    .iter()
-                    .any(|entry| entry.get("matcher").and_then(|m| m.as_str()) == Some("Task"));
-                if !already {
-                    arr.push(claude_task_hook_entry());
+    Ok(settings)
+}
+
+fn validate_claude_hook_containers(existing: &Value) -> anyhow::Result<()> {
+    anyhow::ensure!(existing.is_object(), "hook settings must be a JSON object");
+    if let Some(hooks) = existing.get("hooks") {
+        anyhow::ensure!(
+            hooks.is_object(),
+            "hooks must be a JSON object; fix the settings structure before installing"
+        );
+        if let Some(entries) = hooks.get("PreToolUse") {
+            anyhow::ensure!(
+                entries.is_array(),
+                "hooks.PreToolUse must be an array; fix the settings structure before installing"
+            );
+            if let Some(entries) = entries.as_array() {
+                for entry in entries {
+                    anyhow::ensure!(
+                        entry.is_object()
+                            && entry.get("matcher").is_none_or(Value::is_string)
+                            && entry
+                                .get("hooks")
+                                .and_then(Value::as_array)
+                                .is_some_and(|hooks| hooks.iter().all(Value::is_object)),
+                        "each PreToolUse entry requires an array of hook objects and, when present, a string matcher"
+                    );
                 }
             }
         }
     }
+    Ok(())
+}
 
-    Ok(settings)
+fn has_exact_claude_hook(existing: &Value) -> bool {
+    existing
+        .pointer("/hooks/PreToolUse")
+        .and_then(Value::as_array)
+        .is_some_and(|entries| {
+            entries.iter().any(|entry| {
+                entry["matcher"] == "Task"
+                    && entry
+                        .get("hooks")
+                        .and_then(Value::as_array)
+                        .is_some_and(|hooks| {
+                            hooks.iter().any(|hook| {
+                                hook["type"] == "command" && hook["command"] == HOOK_COMMAND
+                            })
+                        })
+            })
+        })
 }
 
 /// Compute a hook patch for the given runtime.
@@ -261,17 +302,10 @@ pub fn compute_hook_patch(runtime: Runtime, existing: &Value) -> Result<Value, a
 /// is what `--dry-run` should print so the output is the addition, not the
 /// whole merged document.
 ///
-/// When the `Task` matcher already exists the `PreToolUse` array is empty
+/// When the exact NestWeaver command/event/matcher already exists the `PreToolUse` array is empty
 /// (nothing to add).
 pub fn compute_claude_hook_delta(existing: &Value) -> Value {
-    let already_present = existing
-        .get("hooks")
-        .and_then(|h| h.get("PreToolUse"))
-        .and_then(|p| p.as_array())
-        .is_some_and(|arr| {
-            arr.iter()
-                .any(|entry| entry.get("matcher").and_then(|m| m.as_str()) == Some("Task"))
-        });
+    let already_present = has_exact_claude_hook(existing);
 
     let to_add = if already_present {
         json!([])
@@ -285,7 +319,10 @@ pub fn compute_claude_hook_delta(existing: &Value) -> Value {
 /// Compute the minimal dry-run delta for the given runtime.
 pub fn compute_hook_delta(runtime: Runtime, existing: &Value) -> Result<Value, anyhow::Error> {
     match runtime {
-        Runtime::Claude => Ok(compute_claude_hook_delta(existing)),
+        Runtime::Claude => {
+            validate_claude_hook_containers(existing)?;
+            Ok(compute_claude_hook_delta(existing))
+        }
     }
 }
 
@@ -338,7 +375,7 @@ pub fn read_runtime_settings(path: &Path) -> Result<crate::user_config::JsonConf
 
 /// Merge the runtime hook into `path`, preserving every key it does not own.
 ///
-/// NestWeaver owns exactly one entry — the `Task` matcher under
+/// NestWeaver owns its exact command entry under the `Task` matcher in
 /// `hooks.PreToolUse`. Everything else in the document is the user's, and this
 /// function either preserves all of it or writes nothing at all:
 ///
@@ -376,6 +413,11 @@ pub fn install_hook(runtime: Runtime, path: &Path) -> Result<HookInstall, anyhow
     let mut rendered = serde_json::to_string_pretty(&patched)?;
     rendered.push('\n');
     crate::user_config::replace_file_atomically(path, &rendered, INSTALL_COMMAND)?;
+    let observed = read_runtime_settings(path)?;
+    anyhow::ensure!(
+        hook_already_present(runtime, &observed.value)?,
+        "hook installation could not be verified; inspect the settings and retry"
+    );
     Ok(HookInstall::Installed)
 }
 
@@ -623,7 +665,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("settings.local.json");
         let original = "{\n  // mine\n  \"hooks\": { \"PreToolUse\": [ \
-                        { \"matcher\": \"Task\", \"hooks\": [] } ] }\n}\n";
+                        { \"matcher\": \"Task\", \"hooks\": [{ \"type\": \"command\", \"command\": \"nestweaver admin instructions --for-subagent\" }] } ] }\n}\n";
         std::fs::write(&path, original).unwrap();
 
         assert_eq!(
@@ -770,5 +812,82 @@ mod tests {
         assert!(!hook_already_present(Runtime::Claude, &empty).unwrap());
         let installed = compute_hook_patch(Runtime::Claude, &empty).unwrap();
         assert!(hook_already_present(Runtime::Claude, &installed).unwrap());
+    }
+}
+
+#[cfg(test)]
+mod exact_hook_regressions {
+    use super::*;
+    #[test]
+    fn a_hook_with_an_omitted_matcher_is_preserved() {
+        // Claude treats an omitted matcher as match-all.
+        // https://code.claude.com/docs/en/hooks#matcher-patterns
+        let existing =
+            json!({"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"audit-all"}]}]}});
+        let patched = compute_claude_hook_patch(&existing).unwrap();
+        assert_eq!(
+            patched["hooks"]["PreToolUse"][0],
+            existing["hooks"]["PreToolUse"][0]
+        );
+        assert!(has_exact_claude_hook(&patched));
+    }
+
+    #[test]
+    fn competing_task_hook_is_preserved_and_install_is_verified_and_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        let original = json!({"permissions":{"allow":["Read"]},"hooks":{"PreToolUse":[
+            {"matcher":"Task","hooks":[{"type":"command","command":"other-tool"}]}]}});
+        std::fs::write(&path, original.to_string()).unwrap();
+        assert_eq!(
+            install_hook(Runtime::Claude, &path).unwrap(),
+            HookInstall::Installed
+        );
+        let first = std::fs::read(&path).unwrap();
+        let value: Value = serde_json::from_slice(&first).unwrap();
+        assert_eq!(value["permissions"], original["permissions"]);
+        assert_eq!(
+            value["hooks"]["PreToolUse"][0],
+            original["hooks"]["PreToolUse"][0]
+        );
+        assert!(has_exact_claude_hook(&value));
+        assert_eq!(
+            install_hook(Runtime::Claude, &path).unwrap(),
+            HookInstall::AlreadyPresent
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), first);
+    }
+    #[test]
+    fn incompatible_containers_refuse_without_writing_even_in_dry_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        for value in [
+            json!({"hooks":[]}),
+            json!({"hooks":null}),
+            json!({"hooks":{"PreToolUse":{}}}),
+            json!({"hooks":{"PreToolUse":[null]}}),
+            json!({"hooks":{"PreToolUse":[{"matcher":"Task","hooks":[null]}]}}),
+            json!({"hooks":{"PreToolUse":[{"hooks":["command"]}]}}),
+        ] {
+            let bytes = value.to_string();
+            std::fs::write(&path, &bytes).unwrap();
+            assert!(install_hook(Runtime::Claude, &path).is_err());
+            assert!(compute_hook_delta(Runtime::Claude, &value).is_err());
+            assert_eq!(std::fs::read_to_string(&path).unwrap(), bytes);
+        }
+    }
+    #[test]
+    fn only_the_exact_event_matcher_type_and_command_suppress_install() {
+        for value in [
+            json!({"hooks":{"PostToolUse":[claude_task_hook_entry()]}}),
+            json!({"hooks":{"PreToolUse":[{"matcher":"Edit","hooks":[{"type":"command","command":HOOK_COMMAND}]}]}}),
+            json!({"hooks":{"PreToolUse":[{"matcher":"Task","hooks":[{"type":"prompt","command":HOOK_COMMAND}]}]}}),
+            json!({"hooks":{"PreToolUse":[{"matcher":"Task","hooks":[{"type":"command","command":format!("{HOOK_COMMAND} --extra")}]}]}}),
+        ] {
+            assert!(!hook_already_present(Runtime::Claude, &value).unwrap());
+            assert!(has_exact_claude_hook(
+                &compute_hook_patch(Runtime::Claude, &value).unwrap()
+            ));
+        }
     }
 }

--- a/crates/nestweaver-engine/src/backup.rs
+++ b/crates/nestweaver-engine/src/backup.rs
@@ -92,6 +92,9 @@ pub struct BackupConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BackupManifest {
+    /// Rebuildable data deliberately omitted from this archive.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
     pub version: u32,
     pub tier: String,
     pub nestweaver_version: String,
@@ -437,6 +440,20 @@ pub fn package_staged(config: &BackupConfig, staged: StagedBackup) -> anyhow::Re
         source_graph_generation,
         logical_instance_id,
     } = staged;
+    let activity_path = staging.path().join(
+        config
+            .db_path
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("database filename is missing"))?,
+    );
+    let activity_path = crate::sidecar_path(&activity_path, ".gitactivity.json");
+    let mut warnings = Vec::new();
+    if activity_path.try_exists()? && legacy_git_activity_payload(&std::fs::read(&activity_path)?)?
+    {
+        std::fs::remove_file(&activity_path)
+            .context("exclude legacy activity from backup staging")?;
+        warnings.push("Legacy unversioned git-activity scores were excluded from this backup because repository ownership cannot be recovered safely. Graph data is preserved; reindex repositories with --with-git-activity after restore to rebuild activity ranking.".to_string());
+    }
     let bundle = build_backup_publication_bundle(
         config,
         staging.path(),
@@ -460,6 +477,7 @@ pub fn package_staged(config: &BackupConfig, staged: StagedBackup) -> anyhow::Re
         publication_manifest_blake3,
     )?;
     manifest.instance_id = logical_instance_id;
+    manifest.warnings = warnings;
     let manifest_json = serde_json::to_string_pretty(&manifest)?;
     std::fs::write(staging.path().join("manifest.json"), &manifest_json)?;
 
@@ -1602,7 +1620,18 @@ fn copy_db_files(
     // Copy known sidecars (skip missing ones silently).
     for suffix in SIDECAR_SUFFIXES {
         let sidecar = crate::sidecar_path(db_path, suffix);
-        if !sidecar.exists() {
+        let present = if *suffix == ".gitactivity.json" {
+            // A broken symlink or inaccessible payload is not an absent cache.
+            // Preserve the error instead of silently dropping activity scores.
+            match std::fs::symlink_metadata(&sidecar) {
+                Ok(_) => true,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+                Err(error) => return Err(error).context("inspect git-activity sidecar for backup"),
+            }
+        } else {
+            sidecar.exists()
+        };
+        if !present {
             continue;
         }
         let dest_name = {
@@ -1813,6 +1842,27 @@ fn backup_artifact_contract_for_path(
     .with_context(|| absolute.display().to_string())
 }
 
+/// Flat v1 scores cannot be assigned to repositories without guessing.
+/// Corrupt and unknown-version data remain hard errors, not legacy exclusions.
+fn legacy_git_activity_payload(payload: &[u8]) -> anyhow::Result<bool> {
+    if let Ok(current) = serde_json::from_slice::<crate::git_activity::GitActivitySidecar>(payload)
+    {
+        anyhow::ensure!(
+            current.version == crate::git_activity::GITACTIVITY_VERSION,
+            "unsupported git-activity sidecar version {}; expected {}",
+            current.version,
+            crate::git_activity::GITACTIVITY_VERSION
+        );
+        return Ok(false);
+    }
+    if serde_json::from_slice::<HashMap<String, f64>>(payload).is_ok() {
+        return Ok(true);
+    }
+    anyhow::bail!(
+        "invalid git-activity payload; expected a versioned repository map or legacy flat scores"
+    )
+}
+
 fn backup_artifact_contract_for_path_inner(
     path: &str,
     db_filename: &str,
@@ -1821,6 +1871,18 @@ fn backup_artifact_contract_for_path_inner(
     source_graph_generation: u64,
 ) -> anyhow::Result<(crate::publication::ArtifactKind, u32, String)> {
     match path.strip_prefix(db_filename) {
+        Some(".gitactivity.json") => {
+            anyhow::ensure!(
+                !legacy_git_activity_payload(&std::fs::read(absolute)?)?,
+                "legacy git-activity payload requires explicit exclusion during backup packaging"
+            );
+            return Ok((
+                crate::publication::ArtifactKind::GitActivity,
+                crate::git_activity::GITACTIVITY_VERSION,
+                "nestweaver-git-activity-v2".to_string(),
+            ));
+        }
+
         Some(".pagerank.json") => {
             let payload = std::fs::read(absolute)?;
             let (schema, fingerprint) = crate::publication::pagerank_artifact_contract(
@@ -1944,9 +2006,9 @@ fn backup_artifact_contract(
             // v2: repo-keyed. Bumped with the format, or a restore would
             // reintroduce a v1 flat payload under a v2 contract claim — the
             // artifact vouching for a shape it does not have.
-            Some(".gitactivity.json") => {
-                (ArtifactKind::GitActivity, 2, "nestweaver-git-activity-v2")
-            }
+            Some(".gitactivity.json") => anyhow::bail!(
+                "git-activity contract requires payload inspection; use backup_artifact_contract_for_path"
+            ),
             Some(".cochange.json") => (ArtifactKind::Cochange, 1, "nestweaver-cochange-v1"),
             Some(".interactions.json") => {
                 (ArtifactKind::Interactions, 1, "nestweaver-interactions-v1")
@@ -2050,6 +2112,7 @@ fn build_backup_manifest(
     };
 
     Ok(BackupManifest {
+        warnings: Vec::new(),
         version: MANIFEST_VERSION,
         tier: tier.to_string(),
         nestweaver_version: env!("CARGO_PKG_VERSION").to_string(),
@@ -2391,6 +2454,120 @@ mod tests {
             type_info: None,
             framework_hint: None,
             canonical_id: None,
+        }
+    }
+
+    #[test]
+    fn git_activity_backup_round_trip_preserves_v2_and_excludes_legacy_honestly() {
+        for (payload, legacy) in [
+            (r#"{"src/main.rs":0.9}"#, true),
+            (
+                r#"{"version":2,"repos":{"repo:test":{"src/main.rs":0.9}}}"#,
+                false,
+            ),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let db = dir.path().join("brain.lbug");
+            drop(nestweaver_store::GraphStore::open(&db).unwrap());
+            let activity = crate::sidecar_path(&db, ".gitactivity.json");
+            std::fs::write(&activity, payload).unwrap();
+            let output = dir.path().join("backup.nwsnap.zst");
+            let saved = backup_save(&BackupConfig {
+                db_path: db,
+                output_path: output.clone(),
+                include_clones: false,
+                instance_id: "test".into(),
+                workspace_path: None,
+            })
+            .unwrap();
+            assert_eq!(
+                std::fs::read_to_string(&activity).unwrap(),
+                payload,
+                "live source is untouched"
+            );
+            assert_eq!(saved.manifest.warnings.len(), usize::from(legacy));
+            let inspected = backup_inspect(&output).unwrap();
+            assert_eq!(inspected.warnings, saved.manifest.warnings);
+            let data_dir = dir.path().join("restored");
+            let restored = backup_restore(&RestoreConfig {
+                snapshot_path: output,
+                data_dir: data_dir.clone(),
+            })
+            .unwrap();
+            assert_eq!(restored.manifest.warnings, saved.manifest.warnings);
+            let restored_db = data_dir.join("brain.lbug");
+            let restored_activity = crate::sidecar_path(&restored_db, ".gitactivity.json");
+            assert_eq!(restored_activity.exists(), !legacy);
+            if !legacy {
+                assert_eq!(
+                    std::fs::read_to_string(&restored_activity).unwrap(),
+                    payload
+                );
+            }
+            let store = nestweaver_store::GraphStore::open(&restored_db).unwrap();
+            // Query startup explicitly loads ranking sidecars after opening the graph.
+            store.load_git_activity_sidecar(&restored_activity).unwrap();
+            assert_eq!(
+                store.git_activity_score("repo:test", "src/main.rs"),
+                if legacy { None } else { Some(0.9) }
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_git_activity_is_not_silently_omitted() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("brain.lbug");
+        drop(nestweaver_store::GraphStore::open(&db).unwrap());
+        let activity = crate::sidecar_path(&db, ".gitactivity.json");
+        std::os::unix::fs::symlink(dir.path().join("missing-scores"), &activity).unwrap();
+        let output = dir.path().join("backup.nwsnap.zst");
+        assert!(
+            backup_save(&BackupConfig {
+                db_path: db,
+                output_path: output.clone(),
+                include_clones: false,
+                instance_id: "test".into(),
+                workspace_path: None
+            })
+            .is_err()
+        );
+        assert!(!output.exists());
+        assert!(
+            std::fs::symlink_metadata(activity)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[test]
+    fn invalid_git_activity_never_publishes_an_archive() {
+        for payload in [
+            "broken",
+            r#"{"version":3,"repos":{}}"#,
+            r#"{"version":2,"repos":[]}"#,
+            "null",
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let db = dir.path().join("brain.lbug");
+            drop(nestweaver_store::GraphStore::open(&db).unwrap());
+            let activity = crate::sidecar_path(&db, ".gitactivity.json");
+            std::fs::write(&activity, payload).unwrap();
+            let output = dir.path().join("backup.nwsnap.zst");
+            assert!(
+                backup_save(&BackupConfig {
+                    db_path: db,
+                    output_path: output.clone(),
+                    include_clones: false,
+                    instance_id: "test".into(),
+                    workspace_path: None
+                })
+                .is_err()
+            );
+            assert!(!output.exists());
+            assert_eq!(std::fs::read_to_string(activity).unwrap(), payload);
         }
     }
 
@@ -3151,6 +3328,7 @@ mod tests {
             );
         }
         let manifest = BackupManifest {
+            warnings: Vec::new(),
             version: 2,
             tier: "standard".to_string(),
             nestweaver_version: "test".to_string(),
@@ -3840,6 +4018,7 @@ mod tests {
     #[test]
     fn test_schema_compatibility_rejects_newer() {
         let manifest = BackupManifest {
+            warnings: Vec::new(),
             version: MANIFEST_VERSION + 1,
             tier: "standard".to_string(),
             nestweaver_version: "99.0.0".to_string(),

--- a/crates/nestweaver-engine/src/index.rs
+++ b/crates/nestweaver-engine/src/index.rs
@@ -15654,6 +15654,7 @@ function hello(name) { return "Hello " + name; }
             let store = GraphStore::open_or_create(&db_path).unwrap();
             let files = store.list_files_by_repo(&r_uid).unwrap();
             assert_eq!(files.len(), 2, "both files should be indexed");
+            store.rebuild_trigram_index().unwrap();
             assert!(
                 !store.symbols_in_file("helper.js").unwrap().is_empty(),
                 "helper.js should have symbols after first index"
@@ -15680,6 +15681,15 @@ function hello(name) { return "Hello " + name; }
             store.symbols_in_file("helper.js").unwrap().is_empty(),
             "removed helper.js symbols should be pruned"
         );
+        assert_eq!(
+            store.pending_regex_scope_count().unwrap(),
+            1,
+            "delete-only pruning must invalidate the previously acknowledged shard"
+        );
+        let delta = store.refresh_trigram_index(false).unwrap();
+        assert_eq!(delta.nodes_deleted, 1);
+        assert_eq!(delta.postings_added, 0);
+        assert!(delta.postings_deleted > 0);
     }
 
     #[test]

--- a/crates/nestweaver-store/src/regex.rs
+++ b/crates/nestweaver-store/src/regex.rs
@@ -273,11 +273,33 @@ pub struct TrigramRefreshStats {
     pub nodes_added: usize,
     pub nodes_changed: usize,
     pub nodes_deleted: usize,
+    /// Live (UID, trigram) set additions, excluding scopes listed below.
     pub postings_added: usize,
     pub postings_deleted: usize,
+    /// Scopes whose prior shard was unreadable; their posting deltas are
+    /// unknown and excluded from the totals, without preventing repair.
+    #[serde(default)]
+    pub posting_deltas_unavailable: Vec<String>,
     pub migrated_legacy_index: bool,
     #[serde(default)]
     pub elapsed_ms: u64,
+}
+
+fn record_posting_delta(
+    stats: &mut TrigramRefreshStats,
+    scope: &str,
+    delta: Result<(usize, usize), StoreError>,
+) {
+    match delta {
+        Ok((added, deleted)) => {
+            stats.postings_added += added;
+            stats.postings_deleted += deleted;
+        }
+        Err(error) => {
+            tracing::warn!(scope, %error, "posting delta unavailable; scope excluded from totals while repairing shard");
+            stats.posting_deltas_unavailable.push(scope.to_string());
+        }
+    }
 }
 
 /// A unit of indexed text plus its node metadata. Internal to this module.
@@ -421,7 +443,7 @@ fn required_trigram_clauses(pattern: &str) -> Option<Vec<HashSet<String>>> {
 
 impl GraphStore {
     /// Incrementally refresh trigram postings over all indexed text. Existing
-    /// callers keep the historical return value (postings written), while
+    /// callers receive live posting additions, while
     /// [`GraphStore::refresh_trigram_index`] exposes detailed work metrics.
     pub fn build_trigram_index(&self) -> Result<usize, StoreError> {
         Ok(self.refresh_trigram_index(false)?.postings_added)
@@ -532,9 +554,11 @@ impl GraphStore {
                     Some(state) if state.tombstone => state.desired_epoch,
                     _ => self.mark_regex_scope_dirty(&scope_uid, true)?,
                 };
+                let delta = index.posting_delta(&scope_uid, &[]);
                 if index.retire_scope(&scope_uid)? {
                     stats.scopes_refreshed += 1;
                 }
+                record_posting_delta(&mut stats, &scope_uid, delta);
                 self.acknowledge_regex_tombstone(&scope_uid, epoch)?;
                 continue;
             }
@@ -659,6 +683,7 @@ impl GraphStore {
                         && prior.brain_uuid == identity.brain_uuid
                         && prior.publication_uuid == identity.publication_uuid
                 });
+            let posting_delta = index.posting_delta(&scope_uid, &documents);
             if can_update {
                 index.update_scope(
                     prior.expect("checked above"),
@@ -672,7 +697,7 @@ impl GraphStore {
             self.acknowledge_regex_scope(&scope_uid, epoch, candidates.len(), &digest)?;
 
             stats.scopes_refreshed += 1;
-            stats.postings_added += trigram_sets.iter().map(HashSet::len).sum::<usize>();
+            record_posting_delta(&mut stats, &scope_uid, posting_delta);
         }
         stats.elapsed_ms = started.elapsed().as_millis().min(u64::MAX as u128) as u64;
         match index.garbage_collect() {
@@ -2352,6 +2377,79 @@ mod tests {
     }
 
     #[test]
+    fn deleting_one_file_queues_its_scope_and_reports_live_posting_deletions() {
+        let store = store_with_text();
+        let mut kept = store.lookup_symbol("sym:1").unwrap();
+        let repo = kept.repo_uid.clone();
+        let deleted_file = kept.file_path.clone();
+        kept.uid = "sym:kept".to_string();
+        kept.name = "marker_beta".to_string();
+        kept.file_path = "src/kept.rs".to_string();
+        kept.signature = "fn marker_beta()".to_string();
+        store.insert_symbol(&kept).unwrap();
+        store.rebuild_trigram_index().unwrap();
+        assert_eq!(store.pending_regex_scope_count().unwrap(), 0);
+        let removed = store.delete_symbols_in_file(&repo, &deleted_file).unwrap();
+        assert_eq!(removed, vec!["sym:1".to_string()]);
+        assert_eq!(store.pending_regex_scope_count().unwrap(), 1);
+        let delta = store.refresh_trigram_index(false).unwrap();
+        assert_eq!(delta.nodes_deleted, 1);
+        assert_eq!(delta.postings_added, 0);
+        assert!(delta.postings_deleted > 0);
+        let old = store
+            .regex_search("authenticateUser", None, None, None, None)
+            .unwrap();
+        assert!(old.results.iter().all(|hit| hit.uid != "sym:1"));
+        let kept = store
+            .regex_search("marker_beta", None, None, None, None)
+            .unwrap();
+        assert_eq!(kept.results.len(), 1);
+        assert!(!kept.scanned_fallback);
+    }
+
+    #[test]
+    fn refresh_reports_live_posting_deltas_across_rebuild_edit_and_retirement() {
+        let store = store_with_text();
+        let first = store.rebuild_trigram_index().unwrap();
+        assert!(first.postings_added > 0);
+        assert_eq!(first.postings_deleted, 0);
+        assert!(first.posting_deltas_unavailable.is_empty());
+        let rebuilt = store.rebuild_trigram_index().unwrap();
+        assert_eq!((rebuilt.postings_added, rebuilt.postings_deleted), (0, 0));
+        store
+            .regex_search("authenticateUser", None, None, None, None)
+            .unwrap();
+        store
+            .conn()
+            .unwrap()
+            .query("MATCH (s:Symbol {uid: 'sym:1'}) SET s.signature = 'fn zzzUniqueReplacement()'")
+            .unwrap();
+        store.mark_regex_scope_dirty("repo:1", false).unwrap();
+        let edited = store.refresh_trigram_index(false).unwrap();
+        assert!(edited.postings_added > 0);
+        assert!(edited.postings_deleted > 0);
+        assert!(edited.posting_deltas_unavailable.is_empty());
+        let quiet = store.refresh_trigram_index(false).unwrap();
+        assert_eq!((quiet.postings_added, quiet.postings_deleted), (0, 0));
+        store
+            .conn()
+            .unwrap()
+            .query("MATCH (s:Symbol {uid: 'sym:1'}) DETACH DELETE s")
+            .unwrap();
+        store.mark_regex_scope_dirty("repo:1", true).unwrap();
+        let deleted = store.refresh_trigram_index(false).unwrap();
+        assert_eq!(deleted.postings_added, 0);
+        assert!(deleted.postings_deleted > 0);
+        assert!(
+            store
+                .regex_search("zzzUniqueReplacement", None, None, None, None)
+                .unwrap()
+                .results
+                .is_empty()
+        );
+    }
+
+    #[test]
     fn on_disk_store_uses_identity_bound_regex_v3_shards() {
         let temp = tempfile::tempdir().unwrap();
         let db = temp.path().join("brain.lbug");
@@ -2431,6 +2529,12 @@ mod tests {
         assert_eq!(
             repaired.scopes_refreshed, 1,
             "refresh must rebuild only the scope with the corrupt selector"
+        );
+        assert_eq!(repaired.posting_deltas_unavailable.len(), 1);
+        assert_eq!(
+            (repaired.postings_added, repaired.postings_deleted),
+            (0, 0),
+            "unknown deltas must not be replaced with invented totals"
         );
         let result = store
             .regex_search("authenticateUser", None, None, None, None)

--- a/crates/nestweaver-store/src/regex_index.rs
+++ b/crates/nestweaver-store/src/regex_index.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use tantivy::collector::TopDocs;
 use tantivy::query::{AllQuery, BooleanQuery, Occur, Query, TermQuery};
 use tantivy::schema::{Field, IndexRecordOption, STORED, STRING, Schema, Value};
-use tantivy::{Index, ReloadPolicy, TantivyDocument, Term, doc};
+use tantivy::{DocAddress, DocSet, Index, ReloadPolicy, TERMINATED, TantivyDocument, Term, doc};
 
 use crate::error::StoreError;
 
@@ -721,6 +721,86 @@ impl RegexIndex {
         Ok(Some(hashes))
     }
 
+    /// Logical live (UID, trigram) set difference, independent of segment
+    /// tombstones and reader-cache state. Stream postings instead of retaining
+    /// a second corpus-sized set of pairs. Missing first-publication shards
+    /// have an empty baseline; unreadable shards report unavailable telemetry.
+    pub(crate) fn posting_delta(
+        &self,
+        scope_uid: &str,
+        desired: &[RegexShardDocument<'_>],
+    ) -> Result<(usize, usize), StoreError> {
+        let desired_count: usize = desired.iter().map(|doc| doc.trigrams.len()).sum();
+        let desired: std::collections::HashMap<_, _> =
+            desired.iter().map(|doc| (doc.uid, doc.trigrams)).collect();
+        let Some((index, fields, _)) = self.open_current(scope_uid)? else {
+            let root = self.scope_root(scope_uid);
+            if root
+                .try_exists()
+                .map_err(|e| StoreError::Query(format!("inspect prior regex shard: {e}")))?
+                && !root.join(RETIRED_MARKER).is_file()
+            {
+                return Err(StoreError::Query(
+                    "prior regex shard has no selected generation".to_string(),
+                ));
+            }
+            return Ok((desired_count, 0));
+        };
+        let reader = index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::Manual)
+            .try_into()
+            .map_err(|e| StoreError::Query(format!("read regex posting delta: {e}")))?;
+        let searcher = reader.searcher();
+        let mut previous = 0usize;
+        let mut shared = 0usize;
+        for (ordinal, segment) in searcher.segment_readers().iter().enumerate() {
+            let mut uids = std::collections::HashMap::new();
+            let inverted = segment
+                .inverted_index(fields.trigram)
+                .map_err(|e| StoreError::Query(format!("read regex inverted index: {e}")))?;
+            let mut terms = inverted
+                .terms()
+                .stream()
+                .map_err(|e| StoreError::Query(format!("stream regex terms: {e}")))?;
+            while let Some((term, info)) = terms.next() {
+                let term = std::str::from_utf8(term)
+                    .map_err(|e| StoreError::Query(format!("decode regex trigram: {e}")))?;
+                let mut postings = inverted
+                    .read_postings_from_terminfo(info, IndexRecordOption::Basic)
+                    .map_err(|e| StoreError::Query(format!("read regex postings: {e}")))?;
+                while postings.doc() != TERMINATED {
+                    let id = postings.doc();
+                    if !segment.is_deleted(id) {
+                        let uid = match uids.entry(id) {
+                            std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+                            std::collections::hash_map::Entry::Vacant(entry) => {
+                                let document: TantivyDocument = searcher
+                                    .doc(DocAddress::new(ordinal as u32, id))
+                                    .map_err(|e| {
+                                        StoreError::Query(format!("decode regex posting UID: {e}"))
+                                    })?;
+                                entry.insert(extract_text(&document, fields.uid))
+                            }
+                        };
+                        previous += 1;
+                        if desired
+                            .get(uid.as_str())
+                            .is_some_and(|set| set.contains(term))
+                        {
+                            shared += 1;
+                        }
+                    }
+                    postings.advance();
+                }
+            }
+        }
+        let added = desired_count.checked_sub(shared).ok_or_else(|| {
+            StoreError::Query("duplicate live regex posting identity".to_string())
+        })?;
+        Ok((added, previous - shared))
+    }
+
     /// Retire a removed scope by durably marking it for reclamation, then
     /// unlinking its selector. Existing readers may finish against immutable
     /// generation files; cleanup is a separate retention operation performed
@@ -1182,6 +1262,83 @@ mod tests {
             candidate_count: count,
             candidate_digest: digest.to_string(),
         }
+    }
+
+    #[test]
+    fn posting_deltas_ignore_dead_documents_and_reader_cache() {
+        let temp = tempfile::tempdir().unwrap();
+        let index = RegexIndex::new(temp.path());
+        let old = HashSet::from(["abc".into(), "bcd".into()]);
+        let new = HashSet::from(["bcd".into(), "cde".into(), "def".into()]);
+        let first = RegexShardDocument {
+            uid: "one",
+            kind: "Symbol",
+            text_hash: "old",
+            trigrams: &old,
+        };
+        assert_eq!(
+            index
+                .posting_delta("repo:test", std::slice::from_ref(&first))
+                .unwrap(),
+            (2, 0)
+        );
+        let initial = metadata(1, 1, "one");
+        index
+            .replace_scope(initial.clone(), std::slice::from_ref(&first))
+            .unwrap();
+        // Warm the shared reader pool before in-place segment updates.
+        index
+            .candidate_uids(&initial, std::slice::from_ref(&old), 10)
+            .unwrap();
+        assert_eq!(index.posting_delta("repo:test", &[first]).unwrap(), (0, 0));
+        let edited = RegexShardDocument {
+            uid: "one",
+            kind: "Symbol",
+            text_hash: "new",
+            trigrams: &new,
+        };
+        assert_eq!(
+            index
+                .posting_delta("repo:test", std::slice::from_ref(&edited))
+                .unwrap(),
+            (2, 1)
+        );
+        let updated = metadata(2, 1, "two");
+        index
+            .update_scope(
+                &initial,
+                updated.clone(),
+                std::slice::from_ref(&edited),
+                &[],
+            )
+            .unwrap();
+        assert_eq!(
+            index
+                .posting_delta("repo:test", std::slice::from_ref(&edited))
+                .unwrap(),
+            (0, 0)
+        );
+        index
+            .replace_scope(metadata(3, 1, "two"), &[edited])
+            .unwrap();
+        let renamed = RegexShardDocument {
+            uid: "renamed",
+            kind: "Symbol",
+            text_hash: "new",
+            trigrams: &new,
+        };
+        assert_eq!(
+            index
+                .posting_delta("repo:test", std::slice::from_ref(&renamed))
+                .unwrap(),
+            (3, 3)
+        );
+        index
+            .replace_scope(metadata(4, 1, "three"), &[renamed])
+            .unwrap();
+        assert_eq!(index.posting_delta("repo:test", &[]).unwrap(), (0, 3));
+        index.retire_scope("repo:test").unwrap();
+        assert_eq!(index.posting_delta("repo:test", &[]).unwrap(), (0, 0));
     }
 
     #[test]

--- a/crates/nestweaver-store/src/write.rs
+++ b/crates/nestweaver-store/src/write.rs
@@ -3953,8 +3953,14 @@ impl GraphStore {
         repo_uid: &str,
         file_path: &str,
     ) -> Result<Vec<String>, StoreError> {
-        let conn = self.conn()?;
-        Self::delete_symbols_in_file_on(&conn, repo_uid, file_path)
+        // A delete-only filesystem index does not insert any replacement
+        // symbols, so it cannot rely on bulk_index_write to queue this scope.
+        // Commit deletion and invalidation together, including standalone use.
+        let conn = self.begin_transaction()?;
+        let removed = Self::delete_symbols_in_file_on(&conn, repo_uid, file_path)?;
+        Self::mark_regex_scope_dirty_on(&conn, repo_uid, false)?;
+        self.commit_transaction(&conn)?;
+        Ok(removed)
     }
 
     /// Delete symbols in a file using an externally-provided connection (for

--- a/docs/guide/retrieval-and-mutation-diagnostics.md
+++ b/docs/guide/retrieval-and-mutation-diagnostics.md
@@ -43,3 +43,31 @@ just as explicit `--force` does: resolved relationships, inferred cross-repo
 calls, and emitted `MEMBER_OF` edges. This is a build count, not all structural
 relationships in the database. A true incremental run reports `null` because
 it does not measure that population.
+
+Backup packaging validates git-activity payloads before assigning a schema.
+Repository-keyed v2 scores are preserved. Recognized legacy flat scores have
+no reliable repository ownership, so the staged copy is excluded and the
+archive manifest records a warning. Save (including daemon RPC), inspect, and
+restore display that warning. The live source file is unchanged. After restore,
+reindex each repository with `--with-git-activity` to rebuild these scores.
+Malformed, unreadable, and unknown-version payloads fail backup creation.
+
+Trigram refresh reports per-scope live `(UID, trigram)` additions and deletions.
+An unchanged full rebuild reports zero deltas, and deleted segment documents
+do not inflate counts. Standalone file-symbol deletion commits its regex
+invalidation with the deletion, so a delete-only index queues cleanup even
+when it has no replacement symbols to insert. Measuring a changed scope streams its prior postings
+once; it does not retain a second corpus-sized posting set. If the prior shard
+cannot be read, refresh still repairs it, but excludes that scope from posting
+totals and names it in `posting_deltas_unavailable` (JSON and gRPC).
+
+`ui --port 0` selects the default port, currently 3000. Successful daemon
+responses must contain a nonzero, in-range port; the CLI uses that returned
+endpoint for its URL and supervision. A healthy daemon with a persistently
+unavailable UI gets at most three repair requests before the CLI exits with an
+actionable error. Daemon-outage recovery continues to serve the degraded page.
+
+`admin install-hook` checks the exact NestWeaver command under the `Task`
+matcher in `PreToolUse`. Competing hooks, including match-all groups with no
+matcher, are preserved. Unsupported settings containers fail without writes;
+a successful write is reread and verified before reporting installation.

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -181,6 +181,7 @@ message TrigramRefreshDetail {
   uint64 postings_deleted = 7;
   bool migrated_legacy_index = 8;
   uint64 elapsed_ms = 9;
+  repeated string posting_deltas_unavailable = 10;
 }
 
 // ─── Write RPCs ─────────────────────────────────────────────────────
@@ -823,6 +824,7 @@ message BackupResponse {
   uint64 symbol_count = 6;
   uint64 db_size_bytes = 7;
   uint64 total_compressed = 8;
+  repeated string warnings = 9;
 }
 
 // ─── Service ─────────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -5788,7 +5788,11 @@ enum Commands {
         )]
         db: Option<PathBuf>,
 
-        #[arg(long, default_value = "3000", help = "Port to listen on")]
+        #[arg(
+            long,
+            default_value = "3000",
+            help = "Port to listen on (0 selects the default port 3000)"
+        )]
         port: u16,
 
         #[arg(long, help = "Path to instance config (TOML)")]
@@ -10248,6 +10252,17 @@ fn ui_port_serving(port: u16) -> bool {
     .is_ok()
 }
 
+/// Successful responses must name a usable endpoint, including requests for
+/// the daemon's port-zero/default sentinel. Never supervise the requested zero.
+fn served_ui_port(response: &nestweaver_proto::ServeUiResponse) -> anyhow::Result<u16> {
+    let port = u16::try_from(response.port).context("daemon returned an out-of-range UI port")?;
+    anyhow::ensure!(
+        response.ok && port != 0,
+        "daemon did not return a usable UI endpoint"
+    );
+    Ok(port)
+}
+
 /// Issue `serve_ui` with a bounded wait (see [`UI_SERVE_RPC_TIMEOUT`]).
 /// `open_browser` is always false — a supervision retry must never pop
 /// windows. `watch`/`watch_repo_path` mirror the startup request.
@@ -10258,14 +10273,18 @@ fn ui_serve_request(
     watch: bool,
     watch_repo_path: &str,
 ) -> anyhow::Result<nestweaver_proto::ServeUiResponse> {
-    rt.block_on(async {
+    let response = rt.block_on(async {
         tokio::time::timeout(
             UI_SERVE_RPC_TIMEOUT,
             client.serve_ui(port, false, watch, watch_repo_path, "default"),
         )
         .await
         .context("serve_ui RPC timed out")?
-    })
+    })?;
+    if response.ok {
+        served_ui_port(&response)?;
+    }
+    Ok(response)
 }
 
 /// Supervise the daemon-served web UI until Ctrl-C.
@@ -10297,7 +10316,7 @@ fn supervise_ui_daemon(
     watch_repo_path: &str,
     ctrlc_rx: &std::sync::mpsc::Receiver<()>,
     client: &mut nestweaver_client::DaemonClient,
-) -> bool {
+) -> anyhow::Result<bool> {
     let mut daemon_up = true;
     let mut degraded: Option<DegradedUiServer> = None;
     // Two consecutive probe failures before an outage is declared: a busy
@@ -10308,6 +10327,7 @@ fn supervise_ui_daemon(
     // Same two-strike rule for the port probe (the daemon's server task can
     // take a moment to bind after a fresh serve_ui).
     let mut port_failures = 0u32;
+    let mut repair_attempts = 0u8;
     // The "daemon serves a different UI port" state is logged once per
     // distinct port, not on every poll.
     let mut mismatch_logged_for: Option<u16> = None;
@@ -10329,10 +10349,16 @@ fn supervise_ui_daemon(
                     // never by binding the degraded server over a live daemon.
                     if ui_port_serving(port) {
                         port_failures = 0;
+                        repair_attempts = 0;
                     } else {
                         port_failures += 1;
                         if port_failures >= 2 {
                             port_failures = 0;
+                            anyhow::ensure!(
+                                repair_attempts < 3,
+                                "UI endpoint http://127.0.0.1:{port} stayed unavailable after three repair attempts; inspect daemon status and retry UI startup"
+                            );
+                            repair_attempts += 1;
                             tracing::error!(
                                 port,
                                 "daemon is healthy but the UI port is not serving — re-issuing serve_ui"
@@ -10342,6 +10368,11 @@ fn supervise_ui_daemon(
                             );
                             match ui_serve_request(rt, client, port, watch, watch_repo_path) {
                                 Ok(resp) if resp.ok => {
+                                    let actual = served_ui_port(&resp)?;
+                                    anyhow::ensure!(
+                                        actual == port,
+                                        "daemon now serves UI on port {actual}, but this session supervises {port}; reopen the reported endpoint"
+                                    );
                                     tracing::info!(port, "serve_ui re-issued: {}", resp.message)
                                 }
                                 Ok(resp) => tracing::error!(
@@ -10418,11 +10449,7 @@ fn supervise_ui_daemon(
                     {
                         // Mirror the startup path: trust the ACTUAL port the
                         // daemon reports, not the one we asked for.
-                        let actual_port = if resp.port != 0 {
-                            resp.port as u16
-                        } else {
-                            port
-                        };
+                        let actual_port = served_ui_port(&resp)?;
                         if actual_port == port {
                             // The daemon already serves OUR port (the outage
                             // was a false positive, or another ui bound it
@@ -10472,7 +10499,7 @@ fn supervise_ui_daemon(
                             );
                         }
                         match ui_serve_request(rt, &mut candidate, port, watch, watch_repo_path) {
-                            Ok(resp) if resp.ok => {
+                            Ok(resp) if resp.ok && served_ui_port(&resp)? == port => {
                                 tracing::info!(
                                     port,
                                     "daemon restored — full UI service resumed on :{port}"
@@ -10504,7 +10531,7 @@ fn supervise_ui_daemon(
                             }
                         }
                     }
-                    Ok(resp) if resp.ok => {
+                    Ok(resp) if resp.ok && served_ui_port(&resp)? == port => {
                         // A fresh-start claim while our degraded server still
                         // holds the port — the daemon could not have bound
                         // it. Hand over and let the port probe in the up
@@ -10551,7 +10578,7 @@ fn supervise_ui_daemon(
     if let Some(active) = degraded.take() {
         let _ = active.shutdown(rt);
     }
-    daemon_up
+    Ok(daemon_up)
 }
 
 /// Which PID, if any, `daemon stop` is allowed to signal.
@@ -18543,16 +18570,13 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                         // The daemon already serves the UI — point the user at
                         // the ACTUAL running port (resp.port), not the one they
                         // requested, instead of printing a dead URL.
-                        let actual_port = if resp.port != 0 {
-                            resp.port
-                        } else {
-                            port as u32
-                        };
+                        let actual_port = served_ui_port(&resp)?;
                         println!("NestWeaver UI: http://127.0.0.1:{actual_port}");
                         println!("{}", resp.message);
                         return Ok((EXIT_SUCCESS, None));
                     }
-                    Ok(_resp) => {
+                    Ok(resp) => {
+                        let port = served_ui_port(&resp)?;
                         daemon_ok = true;
                         println!("NestWeaver UI: http://127.0.0.1:{port}");
                         if watch {
@@ -18574,7 +18598,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             &watch_repo_path,
                             &rx,
                             &mut client,
-                        );
+                        )?;
                         // Tell the daemon to stop serving so
                         // the listen port is released when the CLI exits.
                         // Meaningless while the daemon is down — the degraded
@@ -18601,6 +18625,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 }
             }
             if !daemon_ok {
+                let port = if port == 0 { 3000 } else { port };
                 // Fallback: run the UI server directly (no daemon).
                 let tantivy_path = tantivy_sidecar_path_for(&db_path);
                 let tantivy = TantivyIndex::open_reader_only(&tantivy_path).ok();
@@ -21136,6 +21161,14 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                 let terminal = terminal.ok_or_else(|| {
                     anyhow::anyhow!("index completed without a terminal progress payload")
                 })?;
+                if let Some(stats) = &terminal.trigram_refresh
+                    && !stats.posting_deltas_unavailable.is_empty()
+                {
+                    out.status(&format!(
+                        "Posting totals exclude unreadable prior shards: {}",
+                        stats.posting_deltas_unavailable.join(", ")
+                    ));
+                }
                 if json {
                     let skipped: Vec<_> = terminal
                         .skipped_files
@@ -21159,6 +21192,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                             "nodes_deleted": stats.nodes_deleted,
                             "postings_added": stats.postings_added,
                             "postings_deleted": stats.postings_deleted,
+                            "posting_deltas_unavailable": stats.posting_deltas_unavailable,
                             "migrated_legacy_index": stats.migrated_legacy_index,
                             "elapsed_ms": stats.elapsed_ms,
                         })
@@ -21463,6 +21497,12 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     stats.elapsed_ms,
                     if stats.migrated_legacy_index { "; migrated legacy v1 index" } else { "" },
                 ));
+                if !stats.posting_deltas_unavailable.is_empty() {
+                    out.status(&format!(
+                        "Posting totals exclude unreadable prior shards: {}",
+                        stats.posting_deltas_unavailable.join(", ")
+                    ));
+                }
                 trigram_refresh_stats = Some(stats);
             }
 
@@ -33689,6 +33729,9 @@ fn run_backup(command: BackupCommands) -> anyhow::Result<i32> {
                     .map_err(|e| anyhow::anyhow!("Backup RPC failed: {e}"))?
                     .into_inner();
 
+                for warning in &resp.warnings {
+                    eprintln!("Warning: {warning}");
+                }
                 eprintln!("Backup saved to {}", resp.output_path);
                 eprintln!("  Instance:     {}", resp.instance_id);
                 eprintln!("  Tier:         {}", resp.tier);
@@ -33703,6 +33746,9 @@ fn run_backup(command: BackupCommands) -> anyhow::Result<i32> {
             eprintln!("Creating backup...");
             let result = nestweaver_engine::backup_save(&config)?;
             let m = &result.manifest;
+            for warning in &m.warnings {
+                eprintln!("Warning: {warning}");
+            }
 
             eprintln!("Backup saved to {}", result.output_path.display());
             eprintln!("  Instance:     {}", m.instance_id);
@@ -33723,6 +33769,9 @@ fn run_backup(command: BackupCommands) -> anyhow::Result<i32> {
         }
         BackupCommands::Inspect { path } => {
             let manifest = nestweaver_engine::backup_inspect(&path)?;
+            for warning in &manifest.warnings {
+                println!("Warning: {warning}");
+            }
             println!("NestWeaver Snapshot -- {}", path.display());
             println!("  Instance:     {}", manifest.instance_id);
             println!("  Created:      {}", manifest.created_at);
@@ -33805,6 +33854,9 @@ fn run_backup(command: BackupCommands) -> anyhow::Result<i32> {
                 nestweaver_engine::backup_restore(&config)
             })?;
             let m = &result.manifest;
+            for warning in &m.warnings {
+                eprintln!("Warning: {warning}");
+            }
 
             eprintln!("Backup restored to {}", data_dir.display());
             eprintln!("  Instance:     {}", m.instance_id);
@@ -43637,3 +43689,40 @@ mod cli_honesty_sweep_tests {
         assert_eq!(unskip, vec!["public".to_string()]);
     }
 }
+
+#[cfg(test)]
+mod returned_ui_port_tests {
+    use super::*;
+    #[test]
+    fn successful_ui_response_requires_a_real_port() {
+        for port in [1, 3000, 49152, 65535] {
+            let response = nestweaver_proto::ServeUiResponse {
+                ok: true,
+                port,
+                ..Default::default()
+            };
+            assert_eq!(served_ui_port(&response).unwrap(), port as u16);
+        }
+        for port in [0, 65536, u32::MAX] {
+            assert!(
+                served_ui_port(&nestweaver_proto::ServeUiResponse {
+                    ok: true,
+                    port,
+                    ..Default::default()
+                })
+                .is_err()
+            );
+        }
+        assert!(
+            served_ui_port(&nestweaver_proto::ServeUiResponse {
+                ok: false,
+                port: 3000,
+                ..Default::default()
+            })
+            .is_err()
+        );
+    }
+}
+
+#[cfg(all(test, unix))]
+mod ui_supervision_tests;

--- a/src/ui_supervision_tests.rs
+++ b/src/ui_supervision_tests.rs
@@ -1,0 +1,161 @@
+//! Exercise the production supervisor against a healthy but dishonest wire peer.
+use super::*;
+use nestweaver_proto::*;
+use std::convert::Infallible;
+use std::future::{Ready, ready};
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::task::{Context as TaskContext, Poll};
+use tonic::body::Body;
+use tonic::codegen::{Service, http};
+
+#[derive(Clone)]
+struct Reply<T>(T);
+impl<R, T: Clone + Send + 'static> tonic::server::UnaryService<R> for Reply<T> {
+    type Response = T;
+    type Future = Ready<Result<tonic::Response<T>, tonic::Status>>;
+    fn call(&mut self, _: tonic::Request<R>) -> Self::Future {
+        ready(Ok(tonic::Response::new(self.0.clone())))
+    }
+}
+#[derive(Clone)]
+struct Peer {
+    port: u16,
+    requests: Arc<AtomicUsize>,
+}
+impl tonic::server::NamedService for Peer {
+    const NAME: &'static str = "nestweaver.daemon.v1.NestWeaverDaemon";
+}
+impl Service<http::Request<Body>> for Peer {
+    type Response = http::Response<Body>;
+    type Error = Infallible;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+    >;
+    fn poll_ready(&mut self, _: &mut TaskContext<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+    fn call(&mut self, request: http::Request<Body>) -> Self::Future {
+        let peer = self.clone();
+        Box::pin(async move {
+            macro_rules! respond {
+                ($response:ty, $request:ty, $value:expr) => {{
+                    let codec = tonic_prost::ProstCodec::<$response, $request>::default();
+                    tonic::server::Grpc::new(codec)
+                        .unary(Reply($value), request)
+                        .await
+                }};
+            }
+            Ok(match request.uri().path().rsplit('/').next().unwrap() {
+                "HealthCheck" => respond!(
+                    HealthCheckResponse,
+                    HealthCheckRequest,
+                    HealthCheckResponse::default()
+                ),
+                "ServeUi" => {
+                    peer.requests.fetch_add(1, Ordering::SeqCst);
+                    respond!(
+                        ServeUiResponse,
+                        ServeUiRequest,
+                        ServeUiResponse {
+                            ok: true,
+                            port: u32::from(peer.port),
+                            ..Default::default()
+                        }
+                    )
+                }
+                _ => tonic::Status::unimplemented("unexpected RPC").into_http(),
+            })
+        })
+    }
+}
+struct SocketCleanup(PathBuf);
+impl Drop for SocketCleanup {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+        if let Some(parent) = self.0.parent() {
+            let _ = std::fs::remove_dir(parent);
+        }
+    }
+}
+#[test]
+fn healthy_peer_cannot_trap_supervisor_in_identical_repairs() {
+    // Read-only consumers also coordinate with tests that change XDG: the
+    // supervisor resolves its socket again on every health probe.
+    let _environment = crate::XDG_RUNTIME_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("fixture.lbug");
+    std::fs::write(&db, "fixture identity only").unwrap();
+    let instance = nestweaver_daemon::instance_id_from_db_path(&db);
+    let socket = nestweaver_daemon::socket_path(&instance);
+    std::fs::create_dir_all(socket.parent().unwrap()).unwrap();
+    let _cleanup = SocketCleanup(socket.clone());
+    let listener = {
+        let _entered = rt.enter();
+        tokio::net::UnixListener::bind(&socket).unwrap()
+    };
+    // A bound but non-listening socket reserves a port while refusing connects.
+    let reservation = {
+        let _entered = rt.enter();
+        let socket = tokio::net::TcpSocket::new_v4().unwrap();
+        socket
+            .bind(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+            .unwrap();
+        socket
+    };
+    let port = reservation.local_addr().unwrap().port();
+    let requests = Arc::new(AtomicUsize::new(0));
+    let peer = Peer {
+        port,
+        requests: requests.clone(),
+    };
+    let server = rt.spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(peer)
+            .serve_with_incoming(
+                tonic::codegen::tokio_stream::wrappers::UnixListenerStream::new(listener),
+            )
+            .await
+            .unwrap();
+    });
+    let mut client = rt
+        .block_on(nestweaver_client::DaemonClient::connect_existing(&db))
+        .unwrap();
+    let (tx, rx) = std::sync::mpsc::channel();
+    let deadline = rt.spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_secs(25)).await;
+        let _ = tx.send(());
+    });
+    let result = supervise_ui_daemon(&rt, &db, port, false, "", &rx, &mut client);
+    deadline.abort();
+    server.abort();
+    let error = result.expect_err("a deadline exit would conceal an infinite repair loop");
+    assert!(
+        error.to_string().contains("three repair attempts"),
+        "{error:#}"
+    );
+    assert_eq!(requests.load(Ordering::SeqCst), 3);
+}
+
+#[test]
+fn ui_port_parser_accepts_sentinel_and_boundaries_but_not_overflow() {
+    // The complete CLI enum needs the same larger stack as existing parser tests.
+    std::thread::Builder::new()
+        .stack_size(16 * 1024 * 1024)
+        .spawn(|| {
+            for port in ["0", "1", "65535"] {
+                assert!(Cli::try_parse_from(["nestweaver", "ui", "--port", port]).is_ok());
+            }
+            for port in ["-1", "65536", "4294967295"] {
+                assert!(Cli::try_parse_from(["nestweaver", "ui", "--port", port]).is_err());
+            }
+        })
+        .unwrap()
+        .join()
+        .unwrap()
+}


### PR DESCRIPTION
Four in-flight scopes where NestWeaver reported success it had not earned: hook installation trusted a bare matcher, backup packaging silently dropped or mislabeled git-activity scores, `ui` supervision trusted a daemon-reported port it never validated, and trigram refresh invented posting totals. Each is now checked at the boundary that produces the claim.

**`admin install-hook` matches the exact hook, not the matcher.** Installation previously skipped when *any* `Task` matcher existed under `PreToolUse`, so a competing tool's Task hook suppressed NestWeaver's own. Detection now compares event, matcher, hook type, and command exactly. Competing Task hooks and match-all groups with an omitted matcher are preserved rather than overwritten or treated as ours. Unsupported settings containers (`hooks` as an array, a non-array `PreToolUse`, malformed entries) fail before any write, in `--dry-run` too. A successful write is reread and verified before reporting `Installed`.

**Backup packaging inspects the git-activity payload before claiming a contract.** Repository-keyed v2 scores round-trip unchanged. Recognized legacy flat v1 scores have no recoverable repository ownership, so the staged copy is excluded and the manifest records a warning surfaced by save (CLI and daemon RPC), inspect, and restore; the live source file is untouched. Malformed, unreadable, and unknown-version payloads now fail backup creation instead of being packaged under a v2 contract they do not satisfy. A broken symlink or unreadable sidecar is no longer indistinguishable from an absent cache. After restore, reindex with `--with-git-activity` to rebuild activity ranking.

**`ui` validates the endpoint it supervises.** `--port 0` selects the default port (3000) rather than supervising literal zero. A successful daemon response must name a nonzero, in-range port, and the CLI uses that returned endpoint for its URL, its port probe, and every repair path — an "ok" response with no usable endpoint is an error, not a printed dead URL. A healthy daemon whose UI port stays unavailable now gets at most three repair requests before the CLI exits with an actionable error, instead of re-issuing the same `serve_ui` forever. Daemon-outage recovery and the degraded-page path are unchanged.

**Trigram refresh reports measured deltas.** `postings_added` was the size of the newly written set, counting unchanged postings as additions; `postings_deleted` was never populated on the update path. Both are now the live `(UID, trigram)` set difference per scope, computed by streaming the prior shard's postings once — no second corpus-sized posting set — and skipping deleted segment documents so tombstones cannot inflate counts. An unchanged full rebuild reports `(0, 0)`. When a prior shard cannot be read, refresh still repairs it, but excludes that scope from the totals and names it in `posting_deltas_unavailable`, exposed in JSON, gRPC, and CLI status rather than replaced with an invented number.

`delete_symbols_in_file` now commits its regex-scope invalidation in the same transaction as the deletion. It previously relied on `bulk_index_write` to queue the scope, which a delete-only filesystem index never reaches — it inserts no replacement symbols — so pruned symbols stayed searchable through the stale shard.

Both protocol fields (`TrigramRefreshDetail.posting_deltas_unavailable`, `BackupResponse.warnings`) are additive. `BackupManifest.warnings` is `#[serde(default)]` and skipped when empty, so existing archives parse unchanged. Contracts and recovery behavior are documented in `docs/guide/retrieval-and-mutation-diagnostics.md`.

## Type

- [x] Bug fix

## Checklist

- [x] `cargo test` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` passes
- [x] Commit messages follow conventional commits
- [x] Added/updated tests for new functionality

## Testing

`cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` both pass clean on this head. `cargo test --workspace` passes locally on this head: 24 test targets, 2,951 tests, 0 failures.

Regression coverage added with the fixes:

- `admin.rs::exact_hook_regressions` — omitted-matcher preservation, competing Task hook preserved with verified idempotent install, six incompatible containers refused without writing (dry run included), and the four near-miss shapes that must not suppress install.
- `backup.rs` — v2/legacy round trip asserting the live source is untouched, warning parity across save/inspect/restore, restored score presence, and an unreadable (broken-symlink) sidecar failing rather than being dropped.
- `src/ui_supervision_tests.rs` — the production supervisor driven against a healthy but dishonest wire peer, confirming it exits instead of looping on identical repairs; plus port-parser sentinel, boundary, and overflow cases.
- `regex.rs` / `regex_index.rs` — deltas across rebuild, edit, and retirement; delete-only scope queueing; deltas that ignore dead documents and a warm reader cache; and an unreadable prior shard reporting unavailable instead of zero.

