### PR TITLE
fix: bug-fix round — three customer reports plus four backlog items

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -756,41 +756,68 @@ jobs:
           RELEASE_PR_NUMBER: ${{ needs.release-pr.outputs.number }}
         run: |
           set -euo pipefail
+
+          # nw-463. Every assertion below used to be a bare `[ ... ]` or a
+          # `jq -e`, so under `set -e` a failure exited with NO message: the
+          # 9.3.0 release (workflow 34184171024, job 101929792791) failed here
+          # having already written a correct lockfile commit, and the log did
+          # not say which assertion tripped. Recovery took a human reading the
+          # API by hand. Each check now names its stage. None of these messages
+          # interpolate a token -- only SHAs, paths and sizes.
+          fail() { echo "::error::publish-lockfile [$1]: $2" >&2; exit 1; }
+          check() { # check <stage> <message> <cmd...>
+            local stage="$1" message="$2"; shift 2
+            "$@" || fail "$stage" "$message"
+          }
+
           files="$(find lockfile-artifact -maxdepth 1 -type f -printf '%f\n' | sort)"
-          [ "$files" = $'Cargo.lock\nlockfile-state.json' ]
-          test "$(stat -c '%s' lockfile-artifact/Cargo.lock)" -le 10485760
-          jq -e \
-            --arg head "$RELEASE_PR_HEAD_SHA" \
-            '.head_sha == $head and
-             (.original_blob | test("^[0-9a-f]{40}$")) and
-             (.sha256 | test("^[0-9a-f]{64}$")) and
-             (.changed | type == "boolean")' \
-            lockfile-artifact/lockfile-state.json >/dev/null
+          [ "$files" = $'Cargo.lock\nlockfile-state.json' ] || fail artifact-contents \
+            "expected exactly Cargo.lock and lockfile-state.json, got: $(echo "$files" | tr '\n' ' ')"
+          check artifact-size "Cargo.lock exceeds the 10 MiB ceiling" \
+            test "$(stat -c '%s' lockfile-artifact/Cargo.lock)" -le 10485760
+          check state-shape \
+            "lockfile-state.json does not describe head $RELEASE_PR_HEAD_SHA with a well-formed original_blob/sha256/changed" \
+            jq -e \
+              --arg head "$RELEASE_PR_HEAD_SHA" \
+              '.head_sha == $head and
+               (.original_blob | test("^[0-9a-f]{40}$")) and
+               (.sha256 | test("^[0-9a-f]{64}$")) and
+               (.changed | type == "boolean")' \
+              lockfile-artifact/lockfile-state.json
           expected_sha256="$(jq -er '.sha256' lockfile-artifact/lockfile-state.json)"
-          [ "$(sha256sum lockfile-artifact/Cargo.lock | awk '{print $1}')" = "$expected_sha256" ]
+          actual_sha256="$(sha256sum lockfile-artifact/Cargo.lock | awk '{print $1}')"
+          [ "$actual_sha256" = "$expected_sha256" ] || fail artifact-digest \
+            "Cargo.lock digest $actual_sha256 does not match the state file's $expected_sha256"
 
           pr="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$RELEASE_PR_NUMBER")"
-          jq -e \
-            --arg branch "$RELEASE_PR_BRANCH" \
-            --arg head "$RELEASE_PR_HEAD_SHA" \
-            --arg repo "$GITHUB_REPOSITORY" '
-              .state == "open" and .base.ref == "main" and
-              .head.ref == $branch and .head.sha == $head and
-              .head.repo.full_name == $repo and .head.repo.fork == false and
-              .user.login == "github-actions[bot]"
-            ' <<< "$pr" >/dev/null
+          # The exact-head and trusted-author lease. UNCHANGED in substance --
+          # nw-463 labels it, it does not loosen it.
+          check pr-identity \
+            "PR #$RELEASE_PR_NUMBER failed the trusted lease: expected an open github-actions[bot] PR from $RELEASE_PR_BRANCH @ $RELEASE_PR_HEAD_SHA into main on $GITHUB_REPOSITORY (not a fork)" \
+            jq -e \
+              --arg branch "$RELEASE_PR_BRANCH" \
+              --arg head "$RELEASE_PR_HEAD_SHA" \
+              --arg repo "$GITHUB_REPOSITORY" '
+                .state == "open" and .base.ref == "main" and
+                .head.ref == $branch and .head.sha == $head and
+                .head.repo.full_name == $repo and .head.repo.fork == false and
+                .user.login == "github-actions[bot]"
+              ' <<< "$pr"
 
           current_lock="$(gh api \
             "repos/$GITHUB_REPOSITORY/contents/Cargo.lock?ref=$RELEASE_PR_BRANCH")"
           original_blob="$(jq -er '.original_blob' lockfile-artifact/lockfile-state.json)"
-          [ "$(jq -er '.sha' <<< "$current_lock")" = "$original_blob" ]
+          current_blob="$(jq -er '.sha' <<< "$current_lock")"
+          [ "$current_blob" = "$original_blob" ] || fail lockfile-blob-lease \
+            "Cargo.lock on $RELEASE_PR_BRANCH is now blob $current_blob but the artifact was prepared against $original_blob — the branch's lockfile changed under the lease"
           changed="$(jq -er '.changed' lockfile-artifact/lockfile-state.json)"
           expected_head="$RELEASE_PR_HEAD_SHA"
           if [ "$changed" = true ]; then
             branch_head="$(gh api \
               "repos/$GITHUB_REPOSITORY/git/ref/heads/$RELEASE_PR_BRANCH" \
               --jq '.object.sha')"
-            [ "$branch_head" = "$RELEASE_PR_HEAD_SHA" ]
+            [ "$branch_head" = "$RELEASE_PR_HEAD_SHA" ] || fail branch-head-lease \
+              "branch $RELEASE_PR_BRANCH is at $branch_head, not the leased $RELEASE_PR_HEAD_SHA — refusing to publish onto a moved branch"
             base_tree="$(gh api \
               "repos/$GITHUB_REPOSITORY/git/commits/$RELEASE_PR_HEAD_SHA" \
               --jq '.tree.sha')"
@@ -814,11 +841,42 @@ jobs:
                 "repos/$GITHUB_REPOSITORY/git/refs/heads/$RELEASE_PR_BRANCH" \
                 --input - >/dev/null
           fi
-          actual_head="$(gh api \
-            "repos/$GITHUB_REPOSITORY/pulls/$RELEASE_PR_NUMBER" --jq '.head.sha')"
-          [ "$actual_head" = "$expected_head" ]
-          if [ "$(jq -r '.draft' <<< "$pr")" = true ]; then
-            gh pr ready "$RELEASE_PR_NUMBER" --repo "$GITHUB_REPOSITORY"
+          # nw-463. This comparison reads the PULLS API immediately after
+          # PATCHing the git ref, and those are not the same store: the ref
+          # update is committed while `pulls/N.head.sha` can still serve the
+          # pre-update value for a short window. A single read therefore failed
+          # a publication that had ALREADY SUCCEEDED -- 9.3.0 left a correct
+          # `synchronize Cargo.lock` commit on the branch and still went red,
+          # and the three preceding main-push workflows failed the same way.
+          #
+          # Bounded re-read, NOT a weakened check. The lease still has to land
+          # on exactly `$expected_head`. Lag is the only tolerated reading, and
+          # only as the pre-publication head we ourselves just built on: any
+          # THIRD value means the branch genuinely moved under us, which fails
+          # immediately rather than being retried into acceptance.
+          prior_head="$RELEASE_PR_HEAD_SHA"
+          actual_head=""
+          for attempt in $(seq 1 10); do
+            actual_head="$(gh api \
+              "repos/$GITHUB_REPOSITORY/pulls/$RELEASE_PR_NUMBER" --jq '.head.sha')"
+            [ "$actual_head" = "$expected_head" ] && break
+            if [ "$actual_head" != "$prior_head" ]; then
+              fail head-diverged \
+                "PR #$RELEASE_PR_NUMBER head is $actual_head — neither the published $expected_head nor the pre-publication $prior_head. The branch changed under the lease; refusing to proceed."
+            fi
+            echo "PR head still reads $actual_head; expected $expected_head (attempt $attempt/10) — read-after-write lag, re-reading in 3s"
+            sleep 3
+          done
+          [ "$actual_head" = "$expected_head" ] || fail head-not-converged \
+            "PR #$RELEASE_PR_NUMBER head never advanced to $expected_head after 10 reads over ~30s (last read: $actual_head)"
+
+          # nw-463: a publication that leaves the PR in draft needs a human to
+          # click Ready, which is the manual step the item exists to remove.
+          # Re-read `draft` rather than reusing the pre-publication `$pr`: the
+          # value may have changed with the head we just pushed.
+          if [ "$(gh api "repos/$GITHUB_REPOSITORY/pulls/$RELEASE_PR_NUMBER" --jq '.draft')" = true ]; then
+            check pr-ready "could not mark PR #$RELEASE_PR_NUMBER ready for review" \
+              gh pr ready "$RELEASE_PR_NUMBER" --repo "$GITHUB_REPOSITORY"
           fi
 
   build:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -384,6 +384,12 @@ jobs:
       number: ${{ steps.release_pr.outputs.number }}
       branch: ${{ steps.release_pr.outputs.branch }}
       head_sha: ${{ steps.release_pr.outputs.head_sha }}
+      # nw-465: an explicit statement of what this job BELIEVED it found, so a
+      # consumer can tell "there is legitimately no release PR" from "a located
+      # PR's identity was lost in the output mapping". Both arrive as an empty
+      # `number`, and treating the pair as one signal turned every successful
+      # publication red.
+      located: ${{ steps.release_pr.outputs.located }}
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
@@ -592,10 +598,17 @@ jobs:
           fi
 
           echo "located release PR: ${NUM:-<none>} (${BRANCH:-<none>} @ ${HEAD_SHA:-<none>})"
+          # nw-465. Derived from $NUM at the moment this job still knows the
+          # answer. Every path that reaches here with an empty $NUM has already
+          # established that no open release PR exists: a created-but-missing PR
+          # exits 1 above, and a located one that fails trusted base/head/author
+          # validation exits 1 too. So "empty here" means "none", never "lost".
+          if [ -n "$NUM" ]; then LOCATED=true; else LOCATED=false; fi
           {
             echo "number=$NUM"
             echo "branch=$BRANCH"
             echo "head_sha=$HEAD_SHA"
+            echo "located=$LOCATED"
           } >> "$GITHUB_OUTPUT"
 
   release-pr-output-diagnostic:
@@ -626,32 +639,33 @@ jobs:
       # never affect whether a release proceeds; it exists purely to make
       # this failure self-evident instead of requiring another manual
       # rediscovery.
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      # nw-465: the verdict lives in scripts/classify-release-pr-outputs.sh so
+      # its four cases are testable (tests/release_pr_diagnostic_test.rs) rather
+      # than only observable on a real release.
       - name: Report what a downstream job actually resolves
         env:
           RESULT: ${{ needs.release-pr.result }}
+          LOCATED: ${{ needs.release-pr.outputs.located }}
           NUMBER: ${{ needs.release-pr.outputs.number }}
           BRANCH: ${{ needs.release-pr.outputs.branch }}
           HEAD_SHA: ${{ needs.release-pr.outputs.head_sha }}
         run: |
           set -euo pipefail
-          echo "release-pr.result=[$RESULT]"
-          echo "release-pr.outputs.number=[$NUMBER]"
-          echo "release-pr.outputs.branch=[$BRANCH]"
-          echo "release-pr.outputs.head_sha=[$HEAD_SHA]"
           {
-            echo "### release-pr output propagation (nw-426)"
+            echo "### release-pr output propagation (nw-426, nw-465)"
             echo ""
             echo "| field | value |"
             echo "| --- | --- |"
             echo "| \`result\` | \`$RESULT\` |"
+            echo "| \`outputs.located\` | \`$LOCATED\` |"
             echo "| \`outputs.number\` | \`$NUMBER\` |"
             echo "| \`outputs.branch\` | \`$BRANCH\` |"
             echo "| \`outputs.head_sha\` | \`$HEAD_SHA\` |"
           } >> "$GITHUB_STEP_SUMMARY"
-          if [ "$RESULT" = "success" ] && [ -z "$NUMBER" ]; then
-            echo "::error::release-pr succeeded but its 'number' output reads empty here -- this is nw-426's job-output propagation failure reproducing. prepare-release-lockfile will skip and a manual Cargo.lock sync will be needed again." >&2
-            exit 1
-          fi
+          bash scripts/classify-release-pr-outputs.sh
 
   prepare-release-lockfile:
     name: Prepare release lockfile without write authority

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -639,7 +639,7 @@ jobs:
       # never affect whether a release proceeds; it exists purely to make
       # this failure self-evident instead of requiring another manual
       # rediscovery.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
       # nw-465: the verdict lives in scripts/classify-release-pr-outputs.sh so

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -775,15 +775,17 @@ jobs:
             "expected exactly Cargo.lock and lockfile-state.json, got: $(echo "$files" | tr '\n' ' ')"
           check artifact-size "Cargo.lock exceeds the 10 MiB ceiling" \
             test "$(stat -c '%s' lockfile-artifact/Cargo.lock)" -le 10485760
-          check state-shape \
-            "lockfile-state.json does not describe head $RELEASE_PR_HEAD_SHA with a well-formed original_blob/sha256/changed" \
-            jq -e \
-              --arg head "$RELEASE_PR_HEAD_SHA" \
-              '.head_sha == $head and
-               (.original_blob | test("^[0-9a-f]{40}$")) and
-               (.sha256 | test("^[0-9a-f]{64}$")) and
-               (.changed | type == "boolean")' \
-              lockfile-artifact/lockfile-state.json
+          # jq is invoked DIRECTLY rather than through `check`: routing it through
+          # a wrapper hides it from shellcheck, which then reads the jq program
+          # as a shell string and reports SC2016 on jq's own `--arg` variables.
+          jq -e \
+            --arg head "$RELEASE_PR_HEAD_SHA" \
+            '.head_sha == $head and
+             (.original_blob | test("^[0-9a-f]{40}$")) and
+             (.sha256 | test("^[0-9a-f]{64}$")) and
+             (.changed | type == "boolean")' \
+            lockfile-artifact/lockfile-state.json >/dev/null || fail state-shape \
+            "lockfile-state.json does not describe head $RELEASE_PR_HEAD_SHA with a well-formed original_blob/sha256/changed"
           expected_sha256="$(jq -er '.sha256' lockfile-artifact/lockfile-state.json)"
           actual_sha256="$(sha256sum lockfile-artifact/Cargo.lock | awk '{print $1}')"
           [ "$actual_sha256" = "$expected_sha256" ] || fail artifact-digest \
@@ -792,17 +794,16 @@ jobs:
           pr="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$RELEASE_PR_NUMBER")"
           # The exact-head and trusted-author lease. UNCHANGED in substance --
           # nw-463 labels it, it does not loosen it.
-          check pr-identity \
-            "PR #$RELEASE_PR_NUMBER failed the trusted lease: expected an open github-actions[bot] PR from $RELEASE_PR_BRANCH @ $RELEASE_PR_HEAD_SHA into main on $GITHUB_REPOSITORY (not a fork)" \
-            jq -e \
-              --arg branch "$RELEASE_PR_BRANCH" \
-              --arg head "$RELEASE_PR_HEAD_SHA" \
-              --arg repo "$GITHUB_REPOSITORY" '
-                .state == "open" and .base.ref == "main" and
-                .head.ref == $branch and .head.sha == $head and
-                .head.repo.full_name == $repo and .head.repo.fork == false and
-                .user.login == "github-actions[bot]"
-              ' <<< "$pr"
+          jq -e \
+            --arg branch "$RELEASE_PR_BRANCH" \
+            --arg head "$RELEASE_PR_HEAD_SHA" \
+            --arg repo "$GITHUB_REPOSITORY" '
+              .state == "open" and .base.ref == "main" and
+              .head.ref == $branch and .head.sha == $head and
+              .head.repo.full_name == $repo and .head.repo.fork == false and
+              .user.login == "github-actions[bot]"
+            ' <<< "$pr" >/dev/null || fail pr-identity \
+            "PR #$RELEASE_PR_NUMBER failed the trusted lease: expected an open github-actions[bot] PR from $RELEASE_PR_BRANCH @ $RELEASE_PR_HEAD_SHA into main on $GITHUB_REPOSITORY (not a fork)"
 
           current_lock="$(gh api \
             "repos/$GITHUB_REPOSITORY/contents/Cargo.lock?ref=$RELEASE_PR_BRANCH")"

--- a/app/Sources/main.swift
+++ b/app/Sources/main.swift
@@ -286,6 +286,51 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 }
 
+// nw-448. Handle the standard informational flags BEFORE any AppKit object is
+// created, so a probe cannot start or attach to a UI server as a side effect.
+//
+// `/Applications/<App>.app/Contents/MacOS/<Name>` is the conventional path a
+// script or installer probes, and the natural probe is `--version`. Previously
+// every argv fell through to "go start the UI": the probe printed the UI banner
+// and then BLOCKED indefinitely. A hang is a worse failure mode than a non-zero
+// exit because nothing surfaces a cause -- in CI it reads as a stalled step, and
+// locally it leaves a server the caller never asked for.
+//
+// Only these exact flags are intercepted. Anything unrecognised keeps today's
+// behaviour, which also leaves LaunchServices' own `-psn_...` argument alone.
+func bundleShortVersion() -> String? {
+    Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+}
+
+let informationalArgs = Set(CommandLine.arguments.dropFirst())
+
+if !informationalArgs.isDisjoint(with: ["--version", "-V"]) {
+    guard let version = bundleShortVersion() else {
+        FileHandle.standardError.write(
+            Data("NestWeaver: bundle is missing CFBundleShortVersionString\n".utf8))
+        exit(1)
+    }
+    print("NestWeaver \(version)")
+    exit(0)
+}
+
+if !informationalArgs.isDisjoint(with: ["--help", "-h"]) {
+    let version = bundleShortVersion() ?? "unknown"
+    print("""
+    NestWeaver \(version) -- macOS menu-bar app.
+
+    This is the GUI wrapper. Launched with no arguments it starts the NestWeaver
+    daemon and UI server and installs a menu-bar item.
+
+      --version, -V    print the bundle version and exit
+      --help, -h       print this message and exit
+
+    For the command-line interface use the CLI inside this bundle:
+      \(Bundle.main.bundlePath)/Contents/MacOS/nestweaver-cli --help
+    """)
+    exit(0)
+}
+
 let delegate = AppDelegate()
 NSApplication.shared.delegate = delegate
 NSApplication.shared.setActivationPolicy(.accessory)

--- a/crates/nestweaver-daemon/src/server.rs
+++ b/crates/nestweaver-daemon/src/server.rs
@@ -5730,6 +5730,32 @@ mod context_request_args_tests {
     }
 }
 
+/// Translate a typed `HubNodesRequest` into the JSON args `hub_nodes` takes.
+///
+/// Extracted from the handler so the translation is TESTABLE. nw-468 shipped a
+/// `repos` filter that worked on the direct and MCP paths and was silently
+/// dropped over this hop, because `hub_nodes` is one of the few TYPED requests
+/// and the proto had no field for it. Every layer's own tests passed; the
+/// caller got an unscoped ranking that looked correct. A field that exists on
+/// one side of a typed hop and not the other cannot be caught by testing either
+/// side alone, so the translation itself is pinned here.
+fn hub_nodes_args(req: &HubNodesRequest) -> serde_json::Value {
+    let mut args = serde_json::json!({});
+    if req.top_n > 0 {
+        args["top_n"] = serde_json::json!(req.top_n);
+    }
+    if !req.response_format.is_empty() {
+        args["response_format"] = serde_json::json!(req.response_format);
+    }
+    // Only set when non-empty. An empty array is a MEANINGFUL filter downstream
+    // (select nothing), so a client that sent no filter must not arrive as one
+    // that selected nothing.
+    if !req.repos.is_empty() {
+        args["repos"] = serde_json::json!(req.repos);
+    }
+    args
+}
+
 #[tonic::async_trait]
 impl NestWeaverDaemon for DaemonService {
     // ── Lifecycle ───────────────────────────────────────────────────
@@ -8216,13 +8242,7 @@ impl NestWeaverDaemon for DaemonService {
     ) -> Result<Response<HubNodesResponse>, Status> {
         // Global rankings require unrestricted repository access.
         let (_, extensions, req) = r.into_parts();
-        let mut args = serde_json::json!({});
-        if req.top_n > 0 {
-            args["top_n"] = serde_json::json!(req.top_n);
-        }
-        if !req.response_format.is_empty() {
-            args["response_format"] = serde_json::json!(req.response_format);
-        }
+        let args = hub_nodes_args(&req);
 
         let value = self
             .dispatch_tool_json("hub_nodes", args, &extensions)
@@ -22049,10 +22069,57 @@ external_model = "unavailable-test-model"
         );
     }
 
+    /// nw-468 REGRESSION. `hub_nodes` is one of the few TYPED daemon requests;
+    /// `bridge_nodes` and `blast_radius` are JsonRequest pass-throughs, so their
+    /// `repos` filter survives the hop for free. When `repos` shipped WITHOUT a
+    /// proto field, the engine, the MCP handler and the CLI were all correct and
+    /// individually tested, and the filter was still silently discarded in
+    /// transit: `hubs --repo other-repo` returned a full unscoped ranking, and
+    /// `--repo does-not-exist` returned results instead of erroring. Every layer
+    /// passed its own tests. Found only by running the CLI against a real
+    /// two-repo graph.
+    #[test]
+    fn hub_nodes_args_carry_the_repo_filter_over_the_typed_hop() {
+        let args = hub_nodes_args(&HubNodesRequest {
+            top_n: 5,
+            response_format: "concise".to_string(),
+            repos: vec!["repo-a".to_string(), "repo-b".to_string()],
+        });
+        assert_eq!(args["top_n"], serde_json::json!(5));
+        assert_eq!(args["response_format"], serde_json::json!("concise"));
+        assert_eq!(
+            args["repos"],
+            serde_json::json!(["repo-a", "repo-b"]),
+            "a repo filter must survive the typed hop, or the caller silently \
+             receives an unscoped ranking: {args}"
+        );
+    }
+
+    /// COUNTERWEIGHT: no filter must arrive as NO KEY, not as an empty array.
+    /// Downstream an empty `repos` is a meaningful filter meaning "select
+    /// nothing", so conflating the two would make every unfiltered daemon call
+    /// return zero hubs.
+    #[test]
+    fn hub_nodes_args_omit_repos_entirely_when_none_were_sent() {
+        let args = hub_nodes_args(&HubNodesRequest {
+            top_n: 10,
+            response_format: String::new(),
+            repos: Vec::new(),
+        });
+        assert!(
+            args.get("repos").is_none(),
+            "an absent filter must not arrive as an empty one: {args}"
+        );
+        // response_format is likewise omitted rather than sent as "".
+        assert!(args.get("response_format").is_none());
+        assert_eq!(args["top_n"], serde_json::json!(10));
+    }
+
     fn nw415_hub_request() -> HubNodesRequest {
         HubNodesRequest {
             top_n: 10,
             response_format: "detailed".to_string(),
+            repos: Vec::new(),
         }
     }
 

--- a/crates/nestweaver-engine/src/agent_guide.rs
+++ b/crates/nestweaver-engine/src/agent_guide.rs
@@ -953,8 +953,13 @@ pub fn generate_claude_md_with_rules(
     // so the guide has to say so explicitly rather than assume it is read.
     out.push_str("\n### Read the trust fields before trusting a result\n\n");
     out.push_str(
-        "- `status` / `gate_state` — a run that did not complete is `partial` / \
-         `degraded-unknown`, never `ok`. Do not report it as a clean result.\n",
+        "- `status` / `gate_state` — these are two different axes (nw-467). A run \
+         that stopped at its configured traversal budget is `partial` but still \
+         gates `ok`: it is BOUNDED, not broken, and at the default depth that is \
+         the normal state. A run that is stale, errored, refused or cancelled is \
+         `degraded-unknown` — that one is not a clean result and must not be \
+         reported as one. Gate on `gate_state`; read `status` alongside \
+         `coverage.traversal_truncated` to know how much was explored.\n",
     );
     out.push_str(
         "- `truncated` (with `truncated_by_depth` / `truncated_by_threshold`) — an \

--- a/crates/nestweaver-engine/src/blast_radius.rs
+++ b/crates/nestweaver-engine/src/blast_radius.rs
@@ -282,13 +282,40 @@ pub struct CoChangedFile {
     pub note: String,
 }
 
-/// Derive the gate verdict from the run status and computed risk.
+/// Derive the gate verdict from the run status, computed risk, and whether the
+/// only reason the run is not `Complete` is that it stopped at a configured
+/// traversal budget.
 ///
-/// NON-NEGOTIABLE rule: a run that did not complete is never `RiskFlagged`
-/// (we cannot trust an incomplete traversal to have found the risk), it is
+/// NON-NEGOTIABLE rule, unchanged: a run that is DEGRADED is never `RiskFlagged`
+/// (we cannot trust a degraded traversal to have found the risk), it is
 /// `DegradedUnknown`.
-pub(crate) fn derive_gate_state(status: AnalysisStatus, risk_level: RiskLevel) -> GateState {
-    if status != AnalysisStatus::Complete {
+///
+/// nw-467: `bounded_only` splits an axis that used to carry two unrelated
+/// meanings. "The traversal stopped at its configured budget" is expected,
+/// benign, and — measured on a real graph — the STEADY STATE: at the default
+/// depth of 3 every non-trivial changed file truncates, and so does every depth
+/// up to the schema maximum of 15 (265 / 434 / 759 / 1738 affected symbols, all
+/// still truncated). Reporting that as `DegradedUnknown` meant `GateState::Ok`
+/// was unreachable in practice, so consumers learned to ignore the field — and
+/// then missed it when it fired for a real reason (nw-466's wrong repo scope).
+/// An alert a developer takes no action on is noise however TRUE it is.
+///
+/// The bound is still fully disclosed, via `coverage.traversal_truncated` and
+/// the `depth-truncated` / `pruned-below-threshold` blind spots. That is what
+/// keeps nw-105 honoured: its defect was that a truncated run was
+/// INDISTINGUISHABLE from an exhaustive one, not that the gate said `ok`. A
+/// truncated run still reports `status: partial`; only the GATE stops treating
+/// a budget as a fault.
+pub(crate) fn derive_gate_state(
+    status: AnalysisStatus,
+    risk_level: RiskLevel,
+    bounded_only: bool,
+) -> GateState {
+    // `bounded_only` can only ever excuse `Partial`. Clamping here rather than
+    // trusting the caller means a future call site cannot launder a genuine
+    // Degraded/Failed run through this argument: the severity ordering wins.
+    let bounded = bounded_only && status <= AnalysisStatus::Partial;
+    if status != AnalysisStatus::Complete && !bounded {
         GateState::DegradedUnknown
     } else if matches!(risk_level, RiskLevel::High) {
         GateState::RiskFlagged
@@ -493,14 +520,73 @@ pub fn analyze_blast_radius(
         // path may have drifted. Non-source files legitimately have no symbols.
         if syms.is_empty() {
             if nestweaver_parser::detect_language(file).is_some() {
-                notifications.push(Notification {
-                    level: NotificationLevel::Warning,
-                    message: format!(
-                        "changed source file {file_str} has no indexed symbols (new file, stale \
-                         index, or path drift) — its impact was not assessed"
-                    ),
-                    descriptor: "changed-file-no-symbols".to_string(),
-                });
+                // nw-466. Before blaming drift, check whether the file simply
+                // lives in a DIFFERENT repo than the one requested. A repo name
+                // that exists in the graph but does not own the changed file
+                // resolves fine and then finds nothing, which is reported here
+                // — and "new file, stale index, or path drift" sends the reader
+                // to re-index a repo that was never the problem.
+                //
+                // The graph already holds the answer, so guessing is
+                // unnecessary: repeat the lookup unscoped and name the owner.
+                // This runs ONLY on the already-degenerate zero-symbol path, so
+                // it costs nothing on a healthy run.
+                //
+                // Deliberately a WARNING, not an error: the nw-033 gate posture
+                // is fail-open + loud, and a repo-scoped caller legitimately
+                // analysing a file it cannot see must still get a result.
+                let owners: Vec<String> = match target_repo {
+                    Some(_) => store
+                        .symbols_in_file(&file_str)
+                        .map(|elsewhere| {
+                            let mut uids: Vec<String> = elsewhere
+                                .into_iter()
+                                .map(|sym| sym.repo_uid)
+                                .collect::<HashSet<_>>()
+                                .into_iter()
+                                .collect();
+                            uids.sort();
+                            uids
+                        })
+                        .unwrap_or_default(),
+                    None => Vec::new(),
+                };
+
+                let display = |uid: &str| -> String {
+                    repo_display
+                        .get(uid)
+                        .cloned()
+                        .unwrap_or_else(|| uid.to_string())
+                };
+
+                if owners.is_empty() {
+                    notifications.push(Notification {
+                        level: NotificationLevel::Warning,
+                        message: format!(
+                            "changed source file {file_str} has no indexed symbols (new file, \
+                             stale index, or path drift) — its impact was not assessed"
+                        ),
+                        descriptor: "changed-file-no-symbols".to_string(),
+                    });
+                } else {
+                    let requested = target_repo.map(display).unwrap_or_default();
+                    let owner_list = owners
+                        .iter()
+                        .map(|uid| display(uid))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    notifications.push(Notification {
+                        level: NotificationLevel::Warning,
+                        message: format!(
+                            "changed source file {file_str} has no indexed symbols in the \
+                             requested repo {requested}, but its symbols are indexed in \
+                             {owner_list} — this analysis is scoped to a repo that does not own \
+                             the file, so its impact was NOT measured. Re-run scoped to the \
+                             owning repo, or drop the repo filter."
+                        ),
+                        descriptor: "changed-file-wrong-repo-scope".to_string(),
+                    });
+                }
                 status = status.max(AnalysisStatus::Partial);
             }
             continue;
@@ -879,6 +965,14 @@ pub fn analyze_blast_radius(
     // more importantly `status` itself is consumed by the summary line, the MCP
     // envelope and pr-impact. Downgrading only from Complete so a run already
     // Degraded or Failed is never upgraded.
+    //
+    // nw-467: capture WHY the status is about to become non-Complete. This
+    // condition already requires `status == Complete`, so when it fires nothing
+    // else has degraded the run and the truncation is the sole cause — that is
+    // exactly the "bounded, not degraded" case the gate must not punish. Read
+    // before the mutation, because after it the two causes are indistinguishable.
+    let bounded_only =
+        status == AnalysisStatus::Complete && (truncated_by_threshold || truncated_by_depth);
     if (truncated_by_threshold || truncated_by_depth) && status == AnalysisStatus::Complete {
         status = AnalysisStatus::Partial;
     }
@@ -895,7 +989,7 @@ pub fn analyze_blast_radius(
     // Gate verdict — a degraded/failed run is never RiskFlagged (see
     // `derive_gate_state`); it is reported as unknown so consumers don't read a
     // broken analysis as safe.
-    let gate_state = derive_gate_state(status, risk_level);
+    let gate_state = derive_gate_state(status, risk_level, bounded_only);
 
     // Build the org-wide (cross-repo) impact summary, if any. Sourced from this
     // daemon's unified multi-repo graph. A connected upstream server can augment
@@ -2127,6 +2221,143 @@ mod tests {
         assert_eq!(result.gate_state, GateState::DegradedUnknown);
     }
 
+    /// nw-466. A repo name that EXISTS in the graph but does not own the changed
+    /// file resolves fine and finds nothing. Reported as "new file, stale index,
+    /// or path drift" it sends the reader to re-index a repo that was never the
+    /// problem, while the analysis silently measured nothing.
+    #[test]
+    fn wrong_repo_scope_is_distinguished_from_path_drift() {
+        use nestweaver_schema::{Repo, Symbol, SymbolKind, Visibility};
+
+        let store = GraphStore::in_memory().expect("in_memory store");
+        for (uid, url) in [
+            ("repo:owner", "https://example.com/owner"),
+            ("repo:other", "https://example.com/other"),
+        ] {
+            store
+                .insert_repo(&Repo {
+                    uid: uid.to_string(),
+                    url: url.to_string(),
+                    indexed_sha: "abc123".to_string(),
+                    staleness_commits_behind: 0,
+                    instance_id: "inst-1".to_string(),
+                    name: None,
+                    root_path: None,
+                })
+                .expect("insert repo");
+        }
+        // The file is indexed -- but in `repo:owner`, not `repo:other`.
+        store
+            .insert_symbol(&Symbol {
+                uid: "sym:owned".to_string(),
+                name: "owned_fn".to_string(),
+                kind: SymbolKind::Function,
+                repo_uid: "repo:owner".to_string(),
+                file_path: "src/owned.rs".to_string(),
+                start_line: 1,
+                end_line: 4,
+                signature: "fn owned_fn()".to_string(),
+                summary: None,
+                content_hash: "h".to_string(),
+                embedding: None,
+                pagerank_score: None,
+                is_entry_point: false,
+                entry_point_kind: None,
+                visibility: Visibility::Inferred,
+                type_info: None,
+                framework_hint: None,
+                canonical_id: None,
+            })
+            .expect("insert symbol");
+
+        let result = analyze_blast_radius(
+            &store,
+            &[PathBuf::from("src/owned.rs")],
+            &opts(Some("repo:other"), 3, false),
+            None,
+            None,
+        )
+        .expect("analysis");
+
+        let note = result
+            .notifications
+            .iter()
+            .find(|n| n.descriptor == "changed-file-wrong-repo-scope")
+            .unwrap_or_else(|| {
+                panic!(
+                    "expected a wrong-repo-scope notification, got: {:?}",
+                    result.notifications
+                )
+            });
+        assert_eq!(note.level, NotificationLevel::Warning);
+        // It must name the OWNER, which is the one fact that makes it actionable.
+        assert!(
+            note.message.contains("https://example.com/owner"),
+            "the notification must name the owning repo; got: {}",
+            note.message
+        );
+        // The generic drift message must NOT also fire -- two contradictory
+        // explanations for one file is what this change exists to end.
+        assert!(
+            !result
+                .notifications
+                .iter()
+                .any(|n| n.descriptor == "changed-file-no-symbols"),
+            "the drift notification must not fire for a wrong-scope file: {:?}",
+            result.notifications
+        );
+        // Fail-open (nw-033): still a result, still degraded, never an error.
+        assert_eq!(result.status, AnalysisStatus::Partial);
+        assert_eq!(result.affected_symbol_count, 0);
+    }
+
+    /// COUNTERWEIGHT for the test above: with the file genuinely absent from the
+    /// whole graph, the same code path must keep reporting DRIFT. Without this,
+    /// a change that emitted the wrong-scope wording unconditionally would pass.
+    #[test]
+    fn genuinely_unindexed_file_still_reports_drift_not_wrong_scope() {
+        use nestweaver_schema::Repo;
+
+        let store = GraphStore::in_memory().expect("in_memory store");
+        store
+            .insert_repo(&Repo {
+                uid: "repo:only".to_string(),
+                url: "https://example.com/only".to_string(),
+                indexed_sha: "abc123".to_string(),
+                staleness_commits_behind: 0,
+                instance_id: "inst-1".to_string(),
+                name: None,
+                root_path: None,
+            })
+            .expect("insert repo");
+
+        let result = analyze_blast_radius(
+            &store,
+            &[PathBuf::from("src/nowhere.rs")],
+            &opts(Some("repo:only"), 3, false),
+            None,
+            None,
+        )
+        .expect("analysis");
+
+        assert!(
+            result
+                .notifications
+                .iter()
+                .any(|n| n.descriptor == "changed-file-no-symbols"),
+            "a file in no repo at all is drift, not a scoping mistake: {:?}",
+            result.notifications
+        );
+        assert!(
+            !result
+                .notifications
+                .iter()
+                .any(|n| n.descriptor == "changed-file-wrong-repo-scope"),
+            "must not claim a wrong scope when no repo owns the file: {:?}",
+            result.notifications
+        );
+    }
+
     #[test]
     fn zero_symbols_non_source_file_stays_complete() {
         use nestweaver_schema::Repo;
@@ -2371,20 +2602,25 @@ mod tests {
         );
 
         // nw-105: the same run must not simultaneously claim it completed.
-        // Before the fix, coverage.traversal_truncated and the DepthTruncated
-        // blind spot were both set while status stayed Complete, so
-        // derive_gate_state returned Ok — a merge gate read "safe" for an
-        // analysis that never finished.
+        // Before that fix, coverage.traversal_truncated and the DepthTruncated
+        // blind spot were both set while status stayed Complete, so the run was
+        // INDISTINGUISHABLE from an exhaustive one. That property is what nw-105
+        // bought and it is asserted above and here — it is NOT relaxed by nw-467.
         assert_ne!(
             result.status,
             AnalysisStatus::Complete,
             "a truncated traversal must not report status Complete — it did not complete"
         );
-        assert_eq!(
+        // nw-467: the GATE, however, no longer treats a configured budget as a
+        // fault. This run is bounded, not degraded — nothing went wrong — so it
+        // gates on its risk like any clean run. `degraded-unknown` is reserved
+        // for stale/errored/refused/cancelled runs, which is what makes it worth
+        // reading at all; see `derive_gate_state`.
+        assert_ne!(
             result.gate_state,
             GateState::DegradedUnknown,
-            "a truncated traversal must gate as degraded-unknown, never ok; \
-             got status {:?} / gate {:?}",
+            "a truncation-only run is bounded, not degraded, and must not gate as \
+             degraded-unknown; got status {:?} / gate {:?}",
             result.status,
             result.gate_state
         );
@@ -2522,28 +2758,64 @@ mod tests {
 
     #[test]
     fn degraded_run_never_risk_flagged() {
-        // The NON-NEGOTIABLE rule: a run that did not complete is never
-        // RiskFlagged, regardless of the computed risk — it is DegradedUnknown.
+        // The NON-NEGOTIABLE rule: a DEGRADED run is never RiskFlagged,
+        // regardless of the computed risk — it is DegradedUnknown.
         assert_eq!(
-            derive_gate_state(AnalysisStatus::Degraded, RiskLevel::High),
+            derive_gate_state(AnalysisStatus::Degraded, RiskLevel::High, false),
             GateState::DegradedUnknown
         );
         assert_eq!(
-            derive_gate_state(AnalysisStatus::Failed, RiskLevel::High),
+            derive_gate_state(AnalysisStatus::Failed, RiskLevel::High, false),
             GateState::DegradedUnknown
         );
         assert_eq!(
-            derive_gate_state(AnalysisStatus::Partial, RiskLevel::High),
+            derive_gate_state(AnalysisStatus::Partial, RiskLevel::High, false),
             GateState::DegradedUnknown
         );
         // Complete runs still map risk faithfully.
         assert_eq!(
-            derive_gate_state(AnalysisStatus::Complete, RiskLevel::High),
+            derive_gate_state(AnalysisStatus::Complete, RiskLevel::High, false),
             GateState::RiskFlagged
         );
         assert_eq!(
-            derive_gate_state(AnalysisStatus::Complete, RiskLevel::Low),
+            derive_gate_state(AnalysisStatus::Complete, RiskLevel::Low, false),
             GateState::Ok
+        );
+    }
+
+    #[test]
+    fn bounded_run_gates_on_risk_not_as_degraded() {
+        // nw-467. A run whose ONLY departure from Complete is that it stopped at
+        // its configured traversal budget is bounded, not degraded: it gates on
+        // risk exactly like a clean run, so `Ok` is reachable under the default
+        // depth instead of being a state the tool can never return.
+        assert_eq!(
+            derive_gate_state(AnalysisStatus::Partial, RiskLevel::Low, true),
+            GateState::Ok
+        );
+        assert_eq!(
+            derive_gate_state(AnalysisStatus::Partial, RiskLevel::High, true),
+            GateState::RiskFlagged
+        );
+
+        // The flag is not a blanket override, and that is enforced here rather
+        // than assumed of the caller: `bounded_only` can only excuse `Partial`.
+        // A future call site cannot launder a genuine Degraded/Failed run
+        // through this argument.
+        assert_eq!(
+            derive_gate_state(AnalysisStatus::Degraded, RiskLevel::Low, true),
+            GateState::DegradedUnknown,
+            "a Degraded run must stay degraded-unknown even if flagged bounded"
+        );
+        assert_eq!(
+            derive_gate_state(AnalysisStatus::Failed, RiskLevel::High, true),
+            GateState::DegradedUnknown,
+            "a Failed run must stay degraded-unknown even if flagged bounded"
+        );
+        assert_eq!(
+            derive_gate_state(AnalysisStatus::Partial, RiskLevel::Low, false),
+            GateState::DegradedUnknown,
+            "the same status without the bounded flag must still be degraded-unknown"
         );
     }
 

--- a/crates/nestweaver-engine/src/bridges.rs
+++ b/crates/nestweaver-engine/src/bridges.rs
@@ -139,6 +139,28 @@ impl BridgeNodes {
 /// reproducible rather than self-cancelling across calls — which is precisely
 /// why the estimate has to be labelled as one rather than left to average out.
 pub fn find_bridge_nodes_bounded(store: &GraphStore, top_n: usize) -> Result<BridgeNodes> {
+    find_bridge_nodes_bounded_in_repos(store, top_n, None)
+}
+
+/// [`find_bridge_nodes_bounded`] restricted to a set of repo UIDs.
+///
+/// nw-468, and the same scope semantics as `hubs::find_hub_nodes_bounded_in_repos`:
+/// the filter selects which symbols may be RETURNED, while betweenness is still
+/// computed over the whole graph. For bridges that distinction is not merely
+/// preferable, it is the only coherent reading — betweenness measures how many
+/// shortest paths run THROUGH a node, so a node's score is a property of the
+/// paths around it. Recomputing it on a single repo's induced subgraph would
+/// silently answer "bridges within this repo", which is a different question,
+/// and would erase exactly the cross-repo connector this tool exists to find.
+///
+/// `candidate_total` is scoped so `truncated()` keeps describing the population
+/// the caller asked about. An EMPTY set selects nothing; only `None` disables
+/// the filter.
+pub fn find_bridge_nodes_bounded_in_repos(
+    store: &GraphStore,
+    top_n: usize,
+    repos: Option<&std::collections::HashSet<String>>,
+) -> Result<BridgeNodes> {
     // nw-439. `hubs` fails closed during a dirty index publication because
     // `pagerank_scores()` (the ranking.rs module contract, in
     // nestweaver-store) refuses to serve ranks that might predate the
@@ -173,7 +195,14 @@ pub fn find_bridge_nodes_bounded(store: &GraphStore, top_n: usize) -> Result<Bri
     // Counted from the adjacency rather than the ranked list, and BEFORE the
     // truncate below, so the population is reported even when `top_n` is 0 and
     // nothing survives selection.
-    let candidate_total = graph.adj.iter().filter(|nbrs| !nbrs.is_empty()).count();
+    // nw-468: in scope when no filter was given, or the owning repo was asked for.
+    let in_scope = |i: usize| -> bool {
+        repos.is_none_or(|allowed| allowed.contains(&graph.symbols[i].repo_uid))
+    };
+
+    let candidate_total = (0..n)
+        .filter(|&i| in_scope(i) && !graph.adj[i].is_empty())
+        .count();
 
     // Compute betweenness centrality via Brandes' algorithm with sampling.
     let Betweenness {
@@ -205,7 +234,7 @@ pub fn find_bridge_nodes_bounded(store: &GraphStore, top_n: usize) -> Result<Bri
         .symbols
         .iter()
         .enumerate()
-        .filter(|(i, _)| !graph.adj[*i].is_empty())
+        .filter(|(i, _)| !graph.adj[*i].is_empty() && in_scope(*i))
         .map(|(i, sym)| BridgeNode {
             uid: sym.uid.clone(),
             name: sym.name.clone(),

--- a/crates/nestweaver-engine/src/hubs.rs
+++ b/crates/nestweaver-engine/src/hubs.rs
@@ -5,7 +5,7 @@
 //! many parts of the codebase depend on.
 
 use std::cmp::Reverse;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::{BinaryHeap, HashMap, HashSet};
 
 use anyhow::{Context, Result};
 use nestweaver_store::GraphStore;
@@ -156,6 +156,41 @@ impl HubNodes {
 /// a 180-candidate graph — the same shape as F-DC-11 one level up, and found
 /// by asking where else that property had to hold rather than by a report.
 pub fn find_hub_nodes_bounded(store: &GraphStore, top_n: usize) -> Result<HubNodes> {
+    find_hub_nodes_bounded_in_repos(store, top_n, None)
+}
+
+/// [`find_hub_nodes_bounded`] restricted to a set of repo UIDs.
+///
+/// nw-468. `hub_nodes`/`bridge_nodes` were the only scope-less analysis
+/// surfaces: `blast_radius` and `cross_repo_contracts` both take `repos`, so a
+/// caller who wanted the hubs of ONE repository had to over-fetch and filter
+/// client-side. That is not equivalent, and quietly so — `top_n` is applied
+/// during selection, so post-filtering a global top-N yields whatever survives
+/// rather than that repo's top-N, and for a small repository it can yield
+/// nothing at all while the repository plainly has hubs.
+///
+/// SCOPE SEMANTICS, stated because the alternative is defensible and this is
+/// not recoverable from the signature: the filter restricts which symbols are
+/// CANDIDATES, and degree is still computed over the FULL edge set. A symbol in
+/// the requested repo that is a hub precisely because other repositories call
+/// it keeps that degree. Restricting the edge set instead would answer a
+/// different question ("hubs of this repo in isolation") and would rank a
+/// widely-consumed API lower the more widely it is consumed, which is backwards
+/// for every use this filter has.
+///
+/// `candidate_total` is likewise scoped, so `truncated()` continues to describe
+/// the population the caller actually asked about.
+///
+/// Resolution of names to UIDs — and the error for a name that is not in the
+/// graph — belongs to `node_scope::resolve_repo_filter`, so this shares
+/// `blast_radius`'s behaviour instead of inventing a second one. Passing an
+/// EMPTY set is meaningful and is honoured literally: it selects nothing. Only
+/// `None` means "no filter".
+pub fn find_hub_nodes_bounded_in_repos(
+    store: &GraphStore,
+    top_n: usize,
+    repos: Option<&HashSet<String>>,
+) -> Result<HubNodes> {
     let (symbols, edges) = store
         .load_code_symbols_and_edges()
         .map_err(|e| anyhow::anyhow!(e))
@@ -216,7 +251,14 @@ pub fn find_hub_nodes_bounded(store: &GraphStore, top_n: usize) -> Result<HubNod
     // O(n log k) with k allocations rather than O(n log n) with n.
     // Counted BEFORE the `top_n == 0` short-circuit and before the heap, so
     // the population is reported even when nothing survives selection.
-    let candidate_total = (0..n).filter(|&i| in_degree[i] + out_degree[i] > 0).count();
+    // nw-468: a symbol is in scope when no filter was given, or when its owning
+    // repo is in the requested set.
+    let in_scope =
+        |i: usize| -> bool { repos.is_none_or(|allowed| allowed.contains(&symbols[i].repo_uid)) };
+
+    let candidate_total = (0..n)
+        .filter(|&i| in_scope(i) && in_degree[i] + out_degree[i] > 0)
+        .count();
 
     if top_n == 0 {
         return Ok(HubNodes {
@@ -255,6 +297,12 @@ pub fn find_hub_nodes_bounded(store: &GraphStore, top_n: usize) -> Result<HubNod
     // top, so admitting a candidate is one comparison.
     let mut best: BinaryHeap<Reverse<HubKey>> = BinaryHeap::with_capacity(top_n);
     for (index, sym) in symbols.iter().enumerate() {
+        // nw-468: filter BEFORE heap admission, so the survivors are this
+        // scope's top-N rather than whatever of the global top-N happens to
+        // belong to it.
+        if !in_scope(index) {
+            continue;
+        }
         let base = pr_scores.get(&sym.uid).copied().unwrap_or(0.0);
         let pagerank = if ga_active {
             base * nestweaver_store::git_activity_multiplier(
@@ -394,6 +442,177 @@ mod tests {
         assert!(!hubs.is_empty());
         assert_eq!(hubs[0].uid, "hub", "hub should rank first");
         assert_eq!(hubs[0].out_degree, 4);
+    }
+
+    fn make_symbol_in_repo(uid: &str, name: &str, repo_uid: &str) -> Symbol {
+        Symbol {
+            repo_uid: repo_uid.to_string(),
+            ..make_symbol(uid, name, "src/lib.rs")
+        }
+    }
+
+    /// nw-468. The whole point of the filter is that it applies BEFORE `top_n`.
+    /// A client-side filter of a global top-N is NOT equivalent: here the three
+    /// most-connected symbols all live in `repo-big`, so a caller asking for the
+    /// top 2 of `repo-small` gets NOTHING by post-filtering, while `repo-small`
+    /// plainly has hubs. That silent empty answer is the defect.
+    #[test]
+    fn repo_filter_selects_within_scope_not_from_the_global_top_n() {
+        let store = GraphStore::in_memory().unwrap();
+        // repo-big: a dense cluster that dominates any global ranking.
+        for i in 0..5 {
+            store
+                .insert_symbol(&make_symbol_in_repo(
+                    &format!("big{i}"),
+                    &format!("big_fn_{i}"),
+                    "repo-big",
+                ))
+                .unwrap();
+        }
+        for i in 0..5 {
+            for j in 0..5 {
+                if i != j {
+                    store
+                        .insert_edge(&make_edge(&format!("big{i}"), &format!("big{j}")))
+                        .unwrap();
+                }
+            }
+        }
+        // repo-small: genuinely connected, but far less so.
+        for i in 0..3 {
+            store
+                .insert_symbol(&make_symbol_in_repo(
+                    &format!("small{i}"),
+                    &format!("small_fn_{i}"),
+                    "repo-small",
+                ))
+                .unwrap();
+        }
+        store.insert_edge(&make_edge("small0", "small1")).unwrap();
+        store.insert_edge(&make_edge("small1", "small0")).unwrap();
+        store.insert_edge(&make_edge("small1", "small2")).unwrap();
+
+        // The premise: unscoped, the top 2 are all repo-big, so post-filtering
+        // a global top-2 for repo-small would return an empty list.
+        let global = find_hub_nodes_bounded(&store, 2).unwrap();
+        assert!(
+            global.hubs.iter().all(|h| h.uid.starts_with("big")),
+            "premise broken -- the global top 2 must be repo-big: {:?}",
+            global.hubs.iter().map(|h| &h.uid).collect::<Vec<_>>()
+        );
+
+        let scope: HashSet<String> = ["repo-small".to_string()].into_iter().collect();
+        let scoped = find_hub_nodes_bounded_in_repos(&store, 2, Some(&scope)).unwrap();
+
+        assert_eq!(
+            scoped.hubs.len(),
+            2,
+            "repo-small has hubs and must return them"
+        );
+        assert!(
+            scoped.hubs.iter().all(|h| h.uid.starts_with("small")),
+            "a scoped query must return only in-scope symbols: {:?}",
+            scoped.hubs.iter().map(|h| &h.uid).collect::<Vec<_>>()
+        );
+        // `small1` has degree 3 (two out, one in) and must lead its own scope.
+        assert_eq!(scoped.hubs[0].uid, "small1");
+        // `candidate_total` is scoped too, so `truncated()` describes the
+        // population the caller actually asked about -- 3 candidates, 2 returned.
+        assert_eq!(scoped.candidate_total, 3);
+        assert!(scoped.truncated());
+    }
+
+    /// COUNTERWEIGHT: `None` must behave exactly as before, or every existing
+    /// caller silently changes meaning.
+    #[test]
+    fn no_repo_filter_is_identical_to_the_unscoped_call() {
+        let store = GraphStore::in_memory().unwrap();
+        for i in 0..4 {
+            store
+                .insert_symbol(&make_symbol_in_repo(
+                    &format!("s{i}"),
+                    &format!("fn_{i}"),
+                    if i % 2 == 0 { "repo-a" } else { "repo-b" },
+                ))
+                .unwrap();
+        }
+        store.insert_edge(&make_edge("s0", "s1")).unwrap();
+        store.insert_edge(&make_edge("s1", "s2")).unwrap();
+        store.insert_edge(&make_edge("s2", "s3")).unwrap();
+
+        let baseline = find_hub_nodes_bounded(&store, 10).unwrap();
+        let explicit_none = find_hub_nodes_bounded_in_repos(&store, 10, None).unwrap();
+        assert_eq!(baseline.candidate_total, explicit_none.candidate_total);
+        assert_eq!(
+            baseline.hubs.iter().map(|h| &h.uid).collect::<Vec<_>>(),
+            explicit_none
+                .hubs
+                .iter()
+                .map(|h| &h.uid)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// An EMPTY set is a meaningful filter (select nothing), not an absent one.
+    /// Conflating the two would make a resolver that legitimately resolved to no
+    /// repos return the whole graph -- the failure direction that matters.
+    #[test]
+    fn an_empty_repo_scope_selects_nothing() {
+        let store = GraphStore::in_memory().unwrap();
+        store
+            .insert_symbol(&make_symbol_in_repo("a", "fn_a", "repo-a"))
+            .unwrap();
+        store
+            .insert_symbol(&make_symbol_in_repo("b", "fn_b", "repo-a"))
+            .unwrap();
+        store.insert_edge(&make_edge("a", "b")).unwrap();
+
+        let empty: HashSet<String> = HashSet::new();
+        let scoped = find_hub_nodes_bounded_in_repos(&store, 10, Some(&empty)).unwrap();
+        assert!(scoped.hubs.is_empty());
+        assert_eq!(scoped.candidate_total, 0);
+    }
+
+    /// Ranking still uses the FULL graph: a symbol that is central because
+    /// OTHER repos depend on it keeps that standing when scoped to its own repo.
+    /// Recomputing degree on the induced subgraph would rank a widely-consumed
+    /// API lower the more widely it is consumed.
+    #[test]
+    fn cross_repo_degree_is_retained_under_a_scope() {
+        let store = GraphStore::in_memory().unwrap();
+        store
+            .insert_symbol(&make_symbol_in_repo("api", "shared_api", "repo-lib"))
+            .unwrap();
+        // One intra-repo neighbour, so a subgraph-only degree would be 1.
+        store
+            .insert_symbol(&make_symbol_in_repo("local", "local_fn", "repo-lib"))
+            .unwrap();
+        store.insert_edge(&make_edge("local", "api")).unwrap();
+        // Three consumers in another repo.
+        for i in 0..3 {
+            store
+                .insert_symbol(&make_symbol_in_repo(
+                    &format!("c{i}"),
+                    &format!("consumer_{i}"),
+                    "repo-app",
+                ))
+                .unwrap();
+            store
+                .insert_edge(&make_edge(&format!("c{i}"), "api"))
+                .unwrap();
+        }
+
+        let scope: HashSet<String> = ["repo-lib".to_string()].into_iter().collect();
+        let scoped = find_hub_nodes_bounded_in_repos(&store, 5, Some(&scope)).unwrap();
+        let api = scoped
+            .hubs
+            .iter()
+            .find(|h| h.uid == "api")
+            .expect("the scoped repo's own symbol must be returned");
+        assert_eq!(
+            api.in_degree, 4,
+            "degree must count cross-repo callers, not just the induced subgraph"
+        );
     }
 
     #[test]

--- a/crates/nestweaver-engine/src/lib.rs
+++ b/crates/nestweaver-engine/src/lib.rs
@@ -538,7 +538,7 @@ pub use guide_rules::{
     HARD_RULES, OwnedRule, RULES_VERSION, Rule, parse_rules_override, render_owned_rules_markdown,
     render_rules_markdown,
 };
-pub use hubs::{HubNode, attach_cluster_ids, find_hub_nodes};
+pub use hubs::{HubNode, attach_cluster_ids, find_hub_nodes, find_hub_nodes_bounded_in_repos};
 pub use index::{
     CachedFileMeta, DeletedEmbeddingStateReconciliation, DeletedGraphStateReconciliation,
     DeletionReconciliationError, DeletionReconciliationFailure, DeletionReconciliationStage,

--- a/crates/nestweaver-engine/src/process.rs
+++ b/crates/nestweaver-engine/src/process.rs
@@ -416,7 +416,10 @@ pub fn detect_changes_impact(
     // Early out: no changed file mapped to an indexed symbol → nothing to trace.
     if affected_uids.is_empty() {
         let risk = RiskLevel::Low;
-        let gate_state = crate::blast_radius::derive_gate_state(status, risk);
+        // nw-467: `false` — this analysis has no configured traversal budget to
+        // stop at, so any non-Complete status here is a genuine degrade (drift,
+        // an undecodable row, or resolver staleness), never a bound.
+        let gate_state = crate::blast_radius::derive_gate_state(status, risk, false);
         return Ok(ChangeImpact {
             affected_symbols,
             affected_processes: Vec::new(),
@@ -532,7 +535,10 @@ pub fn detect_changes_impact(
     };
 
     let blast_radius = affected_symbols.len() + affected_processes.len();
-    let gate_state = crate::blast_radius::derive_gate_state(status, risk);
+    // nw-467: `false` — this analysis has no configured traversal budget to
+    // stop at, so any non-Complete status here is a genuine degrade (drift,
+    // an undecodable row, or resolver staleness), never a bound.
+    let gate_state = crate::blast_radius::derive_gate_state(status, risk, false);
 
     Ok(ChangeImpact {
         affected_symbols,

--- a/crates/nestweaver-federation/src/dispatch.rs
+++ b/crates/nestweaver-federation/src/dispatch.rs
@@ -549,6 +549,18 @@ async fn dispatch_typed_hub_nodes(
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string(),
+        // nw-468: carry the repo filter over the typed hop, or it is dropped
+        // and the caller silently receives an unscoped ranking.
+        repos: params
+            .get("repos")
+            .and_then(|v| v.as_array())
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default(),
     };
     let mut request = tonic::Request::new(req);
     inject_bearer_token(&mut request, auth_token);

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -3198,8 +3198,8 @@ fn dispatch_tool_arm(
             tool_project_context(store, tantivy, args, embed_model, cancel, visible)
         }
         "dead_code" => tool_dead_code(store, args, cancel, visible),
-        "hub_nodes" => tool_hub_nodes(store, args),
-        "bridge_nodes" => tool_bridge_nodes(store, args),
+        "hub_nodes" => tool_hub_nodes(store, args, visible),
+        "bridge_nodes" => tool_bridge_nodes(store, args, visible),
         "blast_radius" => tool_blast_radius(store, args, cancel, visible),
         "get_summary" => tool_get_summary(store, args),
         "read_symbols" => tool_read_symbols(store, args),
@@ -10326,7 +10326,7 @@ fn build_flow_tree(
 fn tool_schema_detect_changes() -> Value {
     json!({
         "name": "detect_changes",
-        "description": "Assess file-level blast radius for a set of changed files. Maps files to symbols, traces transitive dependents, and returns a risk assessment with explicit trust status.\n\nGuidelines:\n- Use BEFORE committing or reviewing changes\n- Pass repo-relative file paths; returns affected symbols, flows, and risk level (low/medium/high)\n- Treat `risk` as usable only when `status == complete`; `degraded-unknown` requires reindexing or manual review\n- For single-symbol impact use brain_impact; for git diff details use brain_diff\n\nLimitations:\n- Static call-graph analysis only — misses runtime/reflection-based dependencies\n- For cross-repo impact use cross_repo_contracts\n- `resolver_stale_repos`, when present, is repo UIDs with generation-mismatched edges — a different population from `stale_check`'s or `hub_nodes`'s own `stale_repos` (same key name, different tools, different meanings — nw-371)",
+        "description": "Assess file-level blast radius for a set of changed files. Maps files to symbols, traces transitive dependents, and returns a risk assessment with explicit trust status.\n\nGuidelines:\n- Use BEFORE committing or reviewing changes\n- Pass repo-relative file paths; returns affected symbols, flows, and risk level (low/medium/high)\n- Gate on `gate_state`, not `status` (nw-467): a run that merely stopped at its configured depth is `status: partial` but `gate_state: ok` — bounded, not broken, and the normal state at the default depth. `degraded-unknown` means stale/errored/refused/cancelled and requires reindexing or manual review\n- For single-symbol impact use brain_impact; for git diff details use brain_diff\n\nLimitations:\n- Static call-graph analysis only — misses runtime/reflection-based dependencies\n- For cross-repo impact use cross_repo_contracts\n- `resolver_stale_repos`, when present, is repo UIDs with generation-mismatched edges — a different population from `stale_check`'s or `hub_nodes`'s own `stale_repos` (same key name, different tools, different meanings — nw-371)",
         "inputSchema": {
             "type": "object",
             "additionalProperties": false,
@@ -12530,6 +12530,11 @@ fn tool_schema_hub_nodes() -> Value {
                     "default": "detailed",
                     "description": "\"concise\" returns name + total degree only; \"detailed\" (default) adds UIDs, file paths, PageRank scores, and cluster IDs."
                 },
+                "repos": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Restrict to these repos (names or UIDs), matching blast_radius/cross_repo_contracts. Applied BEFORE top_n, so results are the requested scope's top-N rather than whatever of the global top-N happens to fall in it — filtering client-side is not equivalent and can return nothing for a small repo. Ranking still uses the FULL graph, so a symbol that is central because other repos depend on it keeps that standing. An unknown repo name is an error, never a silent empty result."
+                },
                 "cache": { "type": "string", "description": "Set to \"bypass\" to skip the response cache for this call." },
                 "no_cache": { "type": "boolean", "description": "When true, skip the response cache for this call." }
             },
@@ -12538,7 +12543,11 @@ fn tool_schema_hub_nodes() -> Value {
     })
 }
 
-fn tool_hub_nodes(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error> {
+fn tool_hub_nodes(
+    store: &GraphStore,
+    args: Value,
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
+) -> Result<Value, anyhow::Error> {
     let top_n = args
         .get("limit")
         .or_else(|| args.get("top_n"))
@@ -12547,14 +12556,33 @@ fn tool_hub_nodes(store: &GraphStore, args: Value) -> Result<Value, anyhow::Erro
         .unwrap_or(10);
     let concise = is_concise(&args);
 
+    // nw-468: resolve `repos` through the SHARED resolver, so a name that is not
+    // in the graph errors exactly as it does on blast_radius rather than
+    // returning a confident empty ranking. `visible` is threaded through so a
+    // repo-restricted caller's own filter is resolved against only the repos it
+    // may see -- without it the resolver's "not found"/"ambiguous, candidates
+    // are ..." messages would enumerate hidden repos, which is the nw-416 leak
+    // in a new channel.
+    let repo_scope = match args.get("repos").and_then(|v| v.as_array()) {
+        Some(entries) => {
+            let selectors: Vec<String> = entries
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect();
+            Some(resolve_repo_filter(store, &selectors, visible)?)
+        }
+        None => None,
+    };
+
     // nw-398. The engine already COMPUTES the population this ranking was cut
     // from; the discarding wrapper threw it away and `count` reported
     // `len(list)` — the anti-pattern the `Bounded` seam comment names by hand.
     // The CLI now publishes `total`/`truncated`, and `no_cli_command_discloses_
     // more_than_its_mcp_twin` forbids the CLI knowing more than this route, so
     // these two must move together.
-    let found = nestweaver_engine::hubs::find_hub_nodes_bounded(store, top_n)
-        .context("find_hub_nodes_bounded")?;
+    let found =
+        nestweaver_engine::hubs::find_hub_nodes_bounded_in_repos(store, top_n, repo_scope.as_ref())
+            .context("find_hub_nodes_bounded")?;
     let (hub_total, hub_truncated) = (found.candidate_total, found.truncated());
     let mut hubs = found.hubs;
 
@@ -12645,13 +12673,22 @@ fn tool_schema_bridge_nodes() -> Value {
                     "enum": ["concise", "detailed"],
                     "default": "detailed",
                     "description": "\"concise\" returns name + betweenness score only; \"detailed\" (default) adds UIDs, file paths, and connected community IDs."
+                },
+                "repos": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Restrict to these repos (names or UIDs), matching blast_radius/cross_repo_contracts. Applied BEFORE top_n, so results are the requested scope's top-N rather than whatever of the global top-N happens to fall in it. Betweenness is still computed over the FULL graph, because a bridge's score is a property of the paths around it; scoping the graph itself would erase the cross-repo connector this tool exists to find. An unknown repo name is an error, never a silent empty result."
                 }
             }
         }
     })
 }
 
-fn tool_bridge_nodes(store: &GraphStore, args: Value) -> Result<Value, anyhow::Error> {
+fn tool_bridge_nodes(
+    store: &GraphStore,
+    args: Value,
+    visible: Option<&nestweaver_engine::authz::VisibleRepos>,
+) -> Result<Value, anyhow::Error> {
     let top_n = args
         .get("limit")
         .or_else(|| args.get("top_n"))
@@ -12660,14 +12697,36 @@ fn tool_bridge_nodes(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
         .unwrap_or(10);
     let concise = is_concise(&args);
 
+    // nw-468: resolve `repos` through the SHARED resolver, so a name that is not
+    // in the graph errors exactly as it does on blast_radius rather than
+    // returning a confident empty ranking. `visible` is threaded through so a
+    // repo-restricted caller's own filter is resolved against only the repos it
+    // may see -- without it the resolver's "not found"/"ambiguous, candidates
+    // are ..." messages would enumerate hidden repos, which is the nw-416 leak
+    // in a new channel.
+    let repo_scope = match args.get("repos").and_then(|v| v.as_array()) {
+        Some(entries) => {
+            let selectors: Vec<String> = entries
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect();
+            Some(resolve_repo_filter(store, &selectors, visible)?)
+        }
+        None => None,
+    };
+
     // nw-398. The engine already COMPUTES the population this ranking was cut
     // from; the discarding wrapper threw it away and `count` reported
     // `len(list)` — the anti-pattern the `Bounded` seam comment names by hand.
     // The CLI now publishes `total`/`truncated`, and `no_cli_command_discloses_
     // more_than_its_mcp_twin` forbids the CLI knowing more than this route, so
     // these two must move together.
-    let found = nestweaver_engine::bridges::find_bridge_nodes_bounded(store, top_n)
-        .context("find_bridge_nodes_bounded")?;
+    let found = nestweaver_engine::bridges::find_bridge_nodes_bounded_in_repos(
+        store,
+        top_n,
+        repo_scope.as_ref(),
+    )
+    .context("find_bridge_nodes_bounded")?;
     let (bridge_total, bridge_truncated) = (found.candidate_total, found.truncated());
     // `betweenness_score` is a SAMPLE over at most SAMPLE_LIMIT sources, rendered
     // to 14 significant digits with nothing in the payload saying so. The digits
@@ -12721,7 +12780,7 @@ fn tool_bridge_nodes(store: &GraphStore, args: Value) -> Result<Value, anyhow::E
 fn tool_schema_blast_radius() -> Value {
     json!({
         "name": "blast_radius",
-        "description": "Assess full blast radius of file changes: maps to symbols, traces reverse dependencies, groups by cluster, and returns risk level (Low/Medium/High) with impact scores.\n\nGuidelines:\n- Use BEFORE merging a PR; pass repo-relative changed file paths\n- Each affected symbol has impact_score (0.0-1.0) decaying through the call graph\n- For single-symbol impact use brain_impact; for cross-repo use cross_repo_contracts\n\n`cochanged_files` lists historically co-changing files (git history, Jaccard confidence) with no static edge — an advisory recall supplement; absence of co-change data is disclosed via a `cochange-unavailable` note.\n\nTrust contract (read before trusting a green result):\n- status (complete/partial/degraded/failed) + gate_state (ok/degraded-unknown/risk-flagged): a run that did NOT complete is degraded-unknown, NEVER risk-flagged — treat it as 'unknown, review manually', not 'safe'\n- a graph whose edges predate the running resolver DEGRADES rather than refusing: status becomes at least 'degraded', gate_state becomes 'degraded-unknown', and a `resolver.generation-stale` notification names the repos and the `nestweaver index --repo <path> --force` remedy. On such a graph a missing edge UNDERSTATES impact, so a green result there is not a green result. (`affected_tests` refuses outright on the same condition — it is a selector, and a narrowed selection cannot be widened back by its caller.)\n- coverage (repos in scope / not indexed / stale / truncated) distinguishes 'no impact' from 'incomplete coverage'\n- blind_spots: inherent static gaps (dynamic-dispatch, reflection, config-wiring, codegen) plus run-specific ones (pruned-below-threshold, depth-truncated, not-indexed)\n- THREE fields on this response are named `stale_repos` or a variant of it, and they mean three different things (nw-371): `coverage.stale_repos` is behind-git-HEAD repos (objects with `repo_uid`+`commits_behind`); `resolver_stale_repos` (top-level) is repo UIDs whose edges predate/postdate this resolver generation; `_meta.stale_repos`, present only via the hybrid client, is FEDERATION lag (an upstream server's data being behind). None is interchangeable with `stale_check`'s or `hub_nodes`'/`bridge_nodes`'s own `stale_repos`, which are separate tools with separate populations under the same key name.\n\nLimitations:\n- Static analysis only — misses dynamic dispatch and reflection (declared in blind_spots, not silently)\n- Response size scales with number of changed files and graph density\n\nWhen queried through the hybrid client (a local daemon connected to an upstream server), returns two-tier results (local_impact + org_wide_impact) with _meta.sources indicating provenance; a raw MCP connection to a single daemon returns single-tier local results. On an authenticated server with an [authz] policy, repository-restricted callers are refused before seed resolution or traversal: the global walk cannot yet be computed on an authorization-induced subgraph, and redacting after traversal would preserve reachability created through hidden intermediates.",
+        "description": "Assess full blast radius of file changes: maps to symbols, traces reverse dependencies, groups by cluster, and returns risk level (Low/Medium/High) with impact scores.\n\nGuidelines:\n- Use BEFORE merging a PR; pass repo-relative changed file paths\n- Each affected symbol has impact_score (0.0-1.0) decaying through the call graph\n- For single-symbol impact use brain_impact; for cross-repo use cross_repo_contracts\n\n`cochanged_files` lists historically co-changing files (git history, Jaccard confidence) with no static edge — an advisory recall supplement; absence of co-change data is disclosed via a `cochange-unavailable` note.\n\nTrust contract (read before trusting a green result):\n- status (complete/partial/degraded/failed) + gate_state (ok/degraded-unknown/risk-flagged) are TWO AXES, not one (nw-467). A run that stopped at its configured traversal budget is `status: partial` and still gates `ok` — it is BOUNDED, not degraded, and at the default depth of 3 that is the steady state, so `status == complete` is not a usable green light and `gate_state` is. A run that is stale, errored, refused or cancelled is degraded-unknown, NEVER risk-flagged — treat that one as 'unknown, review manually', not 'safe'. The bound itself is never hidden: `coverage.traversal_truncated` and the `depth-truncated` blind spot still report it\n- a graph whose edges predate the running resolver DEGRADES rather than refusing: status becomes at least 'degraded', gate_state becomes 'degraded-unknown', and a `resolver.generation-stale` notification names the repos and the `nestweaver index --repo <path> --force` remedy. On such a graph a missing edge UNDERSTATES impact, so a green result there is not a green result. (`affected_tests` refuses outright on the same condition — it is a selector, and a narrowed selection cannot be widened back by its caller.)\n- coverage (repos in scope / not indexed / stale / truncated) distinguishes 'no impact' from 'incomplete coverage'\n- blind_spots: inherent static gaps (dynamic-dispatch, reflection, config-wiring, codegen) plus run-specific ones (pruned-below-threshold, depth-truncated, not-indexed)\n- THREE fields on this response are named `stale_repos` or a variant of it, and they mean three different things (nw-371): `coverage.stale_repos` is behind-git-HEAD repos (objects with `repo_uid`+`commits_behind`); `resolver_stale_repos` (top-level) is repo UIDs whose edges predate/postdate this resolver generation; `_meta.stale_repos`, present only via the hybrid client, is FEDERATION lag (an upstream server's data being behind). None is interchangeable with `stale_check`'s or `hub_nodes`'/`bridge_nodes`'s own `stale_repos`, which are separate tools with separate populations under the same key name.\n\nLimitations:\n- Static analysis only — misses dynamic dispatch and reflection (declared in blind_spots, not silently)\n- Response size scales with number of changed files and graph density\n\nWhen queried through the hybrid client (a local daemon connected to an upstream server), returns two-tier results (local_impact + org_wide_impact) with _meta.sources indicating provenance; a raw MCP connection to a single daemon returns single-tier local results. On an authenticated server with an [authz] policy, repository-restricted callers are refused before seed resolution or traversal: the global walk cannot yet be computed on an authorization-induced subgraph, and redacting after traversal would preserve reachability created through hidden intermediates.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -19114,21 +19173,54 @@ mod arg_alias_tests {
     #[test]
     fn hub_nodes_accepts_limit_and_top_n_alias() {
         let store = GraphStore::in_memory().unwrap();
-        let via_limit = tool_hub_nodes(&store, json!({ "limit": 5 })).unwrap();
+        let via_limit = tool_hub_nodes(&store, json!({ "limit": 5 }), None).unwrap();
         assert_eq!(via_limit["top_n"], json!(5));
-        let via_alias = tool_hub_nodes(&store, json!({ "top_n": 7 })).unwrap();
+        let via_alias = tool_hub_nodes(&store, json!({ "top_n": 7 }), None).unwrap();
         assert_eq!(via_alias["top_n"], json!(7));
-        let default = tool_hub_nodes(&store, json!({})).unwrap();
+        let default = tool_hub_nodes(&store, json!({}), None).unwrap();
         assert_eq!(default["top_n"], json!(10));
     }
 
     #[test]
     fn bridge_nodes_accepts_limit_and_top_n_alias() {
         let store = GraphStore::in_memory().unwrap();
-        let via_limit = tool_bridge_nodes(&store, json!({ "limit": 5 })).unwrap();
+        let via_limit = tool_bridge_nodes(&store, json!({ "limit": 5 }), None).unwrap();
         assert_eq!(via_limit["top_n"], json!(5));
-        let via_alias = tool_bridge_nodes(&store, json!({ "top_n": 7 })).unwrap();
+        let via_alias = tool_bridge_nodes(&store, json!({ "top_n": 7 }), None).unwrap();
         assert_eq!(via_alias["top_n"], json!(7));
+    }
+
+    /// nw-468. An unknown repo name must ERROR on both new surfaces, exactly as
+    /// it does on `blast_radius` -- the alternative is a confident empty ranking
+    /// that reads as "this repo has no hubs" when it means "you named a repo
+    /// that is not here". Both tools move together; shipping one is the parity
+    /// drift nw-215 tracks.
+    #[test]
+    fn hub_and_bridge_nodes_reject_an_unknown_repo_name() {
+        let store = GraphStore::in_memory().unwrap();
+
+        let hub_err = tool_hub_nodes(&store, json!({ "repos": ["no-such-repo"] }), None)
+            .expect_err("an unknown repo name must not resolve");
+        assert!(
+            hub_err.to_string().contains("no-such-repo"),
+            "the error must name the unresolved selector: {hub_err}"
+        );
+
+        let bridge_err = tool_bridge_nodes(&store, json!({ "repos": ["no-such-repo"] }), None)
+            .expect_err("an unknown repo name must not resolve");
+        assert!(
+            bridge_err.to_string().contains("no-such-repo"),
+            "the error must name the unresolved selector: {bridge_err}"
+        );
+    }
+
+    /// COUNTERWEIGHT: omitting `repos` must stay a no-op, or every existing
+    /// caller of these two tools silently changes behaviour.
+    #[test]
+    fn hub_and_bridge_nodes_without_repos_are_unfiltered() {
+        let store = GraphStore::in_memory().unwrap();
+        assert!(tool_hub_nodes(&store, json!({ "top_n": 3 }), None).is_ok());
+        assert!(tool_bridge_nodes(&store, json!({ "top_n": 3 }), None).is_ok());
     }
 
     #[test]

--- a/crates/nestweaver-mcp/src/tools.rs
+++ b/crates/nestweaver-mcp/src/tools.rs
@@ -14619,6 +14619,17 @@ fn dispatch_via_daemon_inner(
                         .and_then(|v| v.as_i64())
                         .unwrap_or(0) as i32,
                     response_format: str_field("response_format"),
+                    // nw-468: the typed hop drops anything without a field.
+                    repos: args
+                        .get("repos")
+                        .and_then(|v| v.as_array())
+                        .map(|entries| {
+                            entries
+                                .iter()
+                                .filter_map(|v| v.as_str().map(str::to_string))
+                                .collect()
+                        })
+                        .unwrap_or_default(),
                 });
                 let resp = client.hub_nodes(req).await.map_err(grpc_status_err)?;
                 Ok(resp.into_inner().result_json)

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -274,6 +274,22 @@ SARIF viewers, downstream tooling) reading the file directly:
   degraded/incomplete run is visible, never silently reported as "clean".
 - **`run.properties["nestweaver/gateState"]`** — `ok` / `degraded-unknown` /
   `risk-flagged`. A degraded run is `degraded-unknown`, never `risk-flagged`.
+
+  **Changed in 9.4.0 (nw-467) — gate on this, not on `status`.** `gateState` and
+  `status` are two axes. A run that stopped at its configured traversal depth is
+  `status: partial` and now gates `ok`: it is *bounded*, not degraded. Previously
+  any non-`complete` status forced `degraded-unknown`, and because the default
+  depth of 3 truncates on essentially every non-trivial change, `ok` was
+  effectively unreachable — measured on a real graph, depth 3, 5, 8 and 15 (the
+  schema maximum) all truncate. That made the field carry no information, so
+  consumers learned to ignore it and then missed it when it fired for a real
+  reason. `degraded-unknown` is now reserved for stale, errored, refused or
+  cancelled runs.
+
+  **If your gate script tests `status == "complete"`, it never passed under
+  default settings and should move to `gateState != "degraded-unknown"`.** The
+  bound itself is not hidden: `nestweaver/coverage.traversalTruncated` and the
+  `depth-truncated` entry in `nestweaver/blindSpots` report it exactly as before.
 - **`nestweaver/coverage`** (repos in scope / not indexed / stale / truncated)
   and **`nestweaver/blindSpots`** — the inherent static gaps (`dynamic-dispatch`,
   `reflection`, `config-wiring`, `codegen`) plus run-specific ones

--- a/proto/nestweaver/daemon/v1/service.proto
+++ b/proto/nestweaver/daemon/v1/service.proto
@@ -649,6 +649,12 @@ message ProjectContextResponse { string result_json = 1; }
 message HubNodesRequest {
   int32 top_n = 1;
   string response_format = 2;
+  // nw-468. Additive. hub_nodes is one of the few TYPED requests; bridge_nodes
+  // and blast_radius are JsonRequest pass-throughs, so their `repos` survives
+  // the hop for free. Without this field a `repos` filter sent to a daemon is
+  // silently dropped in transit and the caller gets an unscoped ranking that
+  // looks correct -- the nw-154 class of defect.
+  repeated string repos = 3;
 }
 message HubNodesResponse { string result_json = 1; }
 

--- a/scripts/classify-release-pr-outputs.sh
+++ b/scripts/classify-release-pr-outputs.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Classify what a downstream job resolves from the `release-pr` job's outputs.
+#
+# nw-426 built a diagnostic that failed whenever `release-pr` succeeded and its
+# `number` output read empty. nw-465: that test cannot tell the two apart.
+#
+#   * OUTPUT LOSS   -- the producer located a PR and the value did not survive
+#                      the job-output mapping. This is the nw-426 fault.
+#   * NO RELEASE PR -- the producer looked, correctly found none, logged
+#                      `located release PR: <none>` and exited 0. This is the
+#                      ordinary state right after a release PR is merged.
+#
+# Both present as `result=success, number=""`, so the diagnostic turned every
+# successful publication into a red workflow. Reproduced on the v9.3.0 release,
+# run 34187421838: publication and npm jobs both succeeded and all artifacts
+# verified, yet the workflow was red.
+#
+# The producer therefore also emits `located`, an explicit statement of what it
+# BELIEVED, and this script fails only on a contradiction between that belief
+# and the values that actually arrived.
+#
+# Kept as a script rather than inline YAML so the four cases are testable --
+# see tests/release_pr_diagnostic_test.rs.
+#
+# Inputs (environment):
+#   RESULT   -- needs.release-pr.result
+#   LOCATED  -- needs.release-pr.outputs.located ("true" | "false")
+#   NUMBER, BRANCH, HEAD_SHA -- the corresponding outputs
+#
+# Exit: 0 = consistent, 1 = contradictory (a real propagation fault).
+set -euo pipefail
+
+RESULT="${RESULT:-}"
+LOCATED="${LOCATED:-}"
+NUMBER="${NUMBER:-}"
+BRANCH="${BRANCH:-}"
+HEAD_SHA="${HEAD_SHA:-}"
+
+# Bracketed so an empty string is visually obvious in the log.
+echo "release-pr.result=[$RESULT]"
+echo "release-pr.outputs.located=[$LOCATED]"
+echo "release-pr.outputs.number=[$NUMBER]"
+echo "release-pr.outputs.branch=[$BRANCH]"
+echo "release-pr.outputs.head_sha=[$HEAD_SHA]"
+
+fail() {
+  echo "::error::$1" >&2
+  exit 1
+}
+
+# A producer that did not succeed is already a red job. Re-failing here would
+# add a second red job with a less specific message and no new information.
+if [ "$RESULT" != "success" ]; then
+  echo "release-pr did not succeed (result=[$RESULT]); its own job reports the cause."
+  exit 0
+fi
+
+case "$LOCATED" in
+  true)
+    [ -n "$NUMBER" ] || fail \
+      "release-pr located a release PR but its 'number' output reads empty here -- this is nw-426's job-output propagation failure reproducing. prepare-release-lockfile will skip and a manual Cargo.lock sync will be needed again."
+    # A located PR must carry its full identity. A partial mapping is the same
+    # class of fault and would otherwise reach the lockfile job as a valid PR.
+    [ -n "$BRANCH" ] || fail \
+      "release-pr located PR #$NUMBER but its 'branch' output reads empty here -- partial job-output loss (nw-426 class)."
+    [ -n "$HEAD_SHA" ] || fail \
+      "release-pr located PR #$NUMBER but its 'head_sha' output reads empty here -- partial job-output loss (nw-426 class). The exact-head lease cannot be taken without it."
+    echo "consistent: release PR #$NUMBER ($BRANCH @ $HEAD_SHA) propagated intact."
+    ;;
+  false)
+    # nw-465: the valid post-release state. Not a fault, and not silence --
+    # it is stated, so a reader can tell it from a lost output.
+    [ -z "$NUMBER" ] || fail \
+      "release-pr reported locating no release PR yet a 'number' output of [$NUMBER] arrived here -- the producer's belief and its outputs contradict each other."
+    echo "consistent: no open release PR, and no PR identity was propagated. This is the expected state immediately after a release PR is merged."
+    ;;
+  *)
+    # `located` is itself a job output. If it is missing the mapping lost it,
+    # which is the very fault this job exists to catch -- passing here would
+    # reintroduce the blind spot one level up.
+    fail "release-pr succeeded but its 'located' output reads [$LOCATED]; expected \"true\" or \"false\". The job-output mapping lost it (nw-426 class), so no claim about the release PR can be trusted."
+    ;;
+esac

--- a/src/main.rs
+++ b/src/main.rs
@@ -3013,12 +3013,94 @@ fn brain_impact_local_tier(payload: &serde_json::Value) -> &serde_json::Value {
 /// dropping an upstream answer is the kind of omission this codebase treats as
 /// a disclosure defect. The caller prints a note rather than pretending the
 /// local tier was the whole response.
-fn brain_impact_has_unrendered_org_tier(payload: &serde_json::Value) -> bool {
-    payload.get("tier").and_then(serde_json::Value::as_str) == Some("two_tier")
-        && payload
-            .get("org_wide_impact")
-            .and_then(|org| org.get("results"))
-            .is_some()
+/// Render ONE `brain_impact` tier's node list as text.
+///
+/// nw-451. `blast-radius` got a two-tier text renderer in nw-454 by recursing
+/// into each tier through its own renderer; `impact` should follow that shape
+/// rather than invent a third. Extracted from the daemon arm so the local and
+/// org-wide tiers cannot drift into rendering differently -- the same reason
+/// `render_blast_radius_text` is one function.
+///
+/// Returns how many nodes were rendered, which the caller reports in `stats`.
+fn render_impact_tier_text(
+    tier: &serde_json::Value,
+    subject: &str,
+    verbose: bool,
+    quiet: bool,
+) -> Result<usize, anyhow::Error> {
+    #[derive(serde::Deserialize)]
+    struct DaemonImpactNode {
+        uid: String,
+        name: String,
+        file_path: String,
+        start_line: u32,
+        edge_type: String,
+        confidence: f32,
+        depth: u32,
+    }
+
+    let Some(arr) = tier.get("impact_nodes") else {
+        return Ok(0);
+    };
+    // nw-271: `unwrap_or_default()` on a DECODE turns "I could not read the
+    // daemon's answer" into "the answer was empty", and the branch below then
+    // prints a confident "no impact".
+    let node_count = arr.as_array().map(Vec::len).unwrap_or(0);
+    let nodes: Vec<DaemonImpactNode> = serde_json::from_value(arr.clone())
+        .with_context(|| format!("decode {node_count} impact node(s) from the daemon"))?;
+    let count = nodes.len();
+
+    if nodes.is_empty() {
+        if !quiet {
+            println!("No impact found for '{subject}'.");
+        }
+        return Ok(0);
+    }
+
+    // nw-110: say "50 of 495" when the set was capped, never a bare "50 nodes"
+    // -- the latter reads as the complete answer.
+    let total = tier.get("total").and_then(|v| v.as_u64());
+    if !quiet {
+        match total {
+            Some(t) if t > count as u64 => {
+                println!("Impact of '{subject}' ({count} of {t} nodes):")
+            }
+            _ => println!("Impact of '{subject}' ({count} nodes):"),
+        }
+    }
+    for n in &nodes {
+        if verbose {
+            println!(
+                "  [depth {}] {} via {} ({:.2}) — {}:{} [{}]",
+                n.depth, n.name, n.edge_type, n.confidence, n.file_path, n.start_line, n.uid,
+            );
+        } else {
+            println!(
+                "  [depth {}] {} via {} ({:.2}) — {}:{}",
+                n.depth, n.name, n.edge_type, n.confidence, n.file_path, n.start_line,
+            );
+        }
+    }
+    Ok(count)
+}
+
+/// The `org_wide_impact` object of a two-tier envelope, if this is one.
+///
+/// nw-451. This was `brain_impact_has_unrendered_org_tier`, a predicate whose
+/// only job was to decide whether to print "an org-wide tier was returned and is
+/// not rendered here". Now that the tier IS rendered, a function named for it
+/// being unrendered would be a lie, and a bare predicate is the wrong shape --
+/// the renderer needs the object, not a yes/no.
+///
+/// Returns the object even when it carries no `results` (an unavailable
+/// upstream): distinguishing "no org tier" from "an org tier that could not
+/// answer" is exactly the distinction the caller must render differently, and
+/// collapsing them here would push that decision somewhere it cannot be tested.
+fn brain_impact_org_tier(payload: &serde_json::Value) -> Option<&serde_json::Value> {
+    if payload.get("tier").and_then(serde_json::Value::as_str) != Some("two_tier") {
+        return None;
+    }
+    payload.get("org_wide_impact")
 }
 
 #[cfg(test)]
@@ -3061,20 +3143,30 @@ mod brain_impact_tier_tests {
     fn a_single_tier_payload_is_returned_unchanged() {
         let single = json!({"status": "ok", "impact_nodes": [{"uid": "a"}]});
         assert_eq!(brain_impact_local_tier(&single), &single);
-        assert!(!brain_impact_has_unrendered_org_tier(&single));
+        assert!(brain_impact_org_tier(&single).is_none());
     }
 
-    /// COUNTERWEIGHT: an unavailable upstream carries no `results`, so there is
-    /// nothing unrendered to disclose and the note must not fire.
+    /// COUNTERWEIGHT: an unavailable upstream still HAS an org tier -- it just
+    /// carries no `results`. The renderer must be able to tell that from "no org
+    /// tier at all", because the two print differently ("unavailable — <note>"
+    /// versus nothing); collapsing them would make an upstream that failed look
+    /// like an upstream that was never consulted.
     #[test]
-    fn an_unavailable_upstream_is_not_reported_as_unrendered() {
+    fn an_unavailable_upstream_is_an_org_tier_without_results() {
         let payload = json!({
             "tier": "two_tier",
             "local_impact": {"status": "ok"},
             "org_wide_impact": {"source_server": "org", "status": "unavailable"},
         });
-        assert!(!brain_impact_has_unrendered_org_tier(&payload));
-        assert!(brain_impact_has_unrendered_org_tier(&two_tier(json!({}))));
+        let org = brain_impact_org_tier(&payload).expect("an org tier is present");
+        assert!(
+            org.get("results").is_none(),
+            "an unavailable upstream must carry no results"
+        );
+        // ... while a healthy one does, so the two are distinguishable.
+        let healthy = two_tier(json!({}));
+        let org = brain_impact_org_tier(&healthy).expect("an org tier is present");
+        assert!(org.get("results").is_some());
     }
 }
 
@@ -5922,6 +6014,13 @@ enum Commands {
             help = "Number of top hubs to show (1-1000; matches the MCP hub_nodes schema)"
         )]
         top: usize,
+        #[arg(
+            long = "repo",
+            value_name = "REPO",
+            help = "Restrict to this repo (name or UID; repeat for several). Applied before --top, \
+                    so results are the requested scope's top-N. An unknown repo name is an error."
+        )]
+        repos: Vec<String>,
         #[arg(long, help = "Output as JSON")]
         json: bool,
         #[arg(
@@ -5962,6 +6061,13 @@ enum Commands {
             help = "Number of top bridges to show (1-1000; matches the MCP bridge_nodes schema)"
         )]
         top: usize,
+        #[arg(
+            long = "repo",
+            value_name = "REPO",
+            help = "Restrict to this repo (name or UID; repeat for several). Applied before --top, \
+                    so results are the requested scope's top-N. An unknown repo name is an error."
+        )]
+        repos: Vec<String>,
         #[arg(long, help = "Output as JSON")]
         json: bool,
         #[arg(
@@ -13065,8 +13171,16 @@ fn hooks_dir_outside_repo(hooks_dir: &std::path::Path, repo_root: &std::path::Pa
 // instead of silently falling back to tool defaults.
 
 /// `bridge_nodes` reads `limit`/`top_n` — never `top`.
-fn bridge_nodes_rpc_args(top: usize) -> serde_json::Value {
-    serde_json::json!({ "top_n": top })
+///
+/// nw-468: `repos` travels with the request so `--repo` is not silently a no-op
+/// on the daemon route, which is the default one. Omitted when empty: an empty
+/// array is a MEANINGFUL filter (select nothing), not an absent one.
+fn bridge_nodes_rpc_args(top: usize, repos: &[String]) -> serde_json::Value {
+    let mut args = serde_json::json!({ "top_n": top });
+    if !repos.is_empty() {
+        args["repos"] = serde_json::json!(repos);
+    }
+    args
 }
 
 /// `affected_tests` reads `changed_files` (an array) — never a raw string
@@ -15880,6 +15994,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
 
         Commands::Hubs {
             top,
+            repos,
             json,
             db,
             config,
@@ -15887,13 +16002,25 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             let db_path = resolve_db_with_config(db, config.as_deref())?;
             require_existing_db(&db_path)?;
 
+            // nw-468: the daemon route is the DEFAULT route, so the scope has to
+            // travel with the request. Passing it only on the direct path below
+            // would make `--repo` silently a no-op for almost every caller --
+            // the nw-154 defect (`impact --repo` ignored on one route) repeated
+            // on a new flag. Omitted entirely when empty so the daemon's own
+            // "no filter" default is what answers, rather than an empty array
+            // that the engine would read as "select nothing".
+            let mut hub_args = serde_json::json!({ "top_n": top });
+            if !repos.is_empty() {
+                hub_args["repos"] = serde_json::json!(repos);
+            }
+
             // ── hybrid guard (routes through local + upstream) ────
             if let Some(value) = try_hybrid_json_rpc_checked(
                 use_daemon,
                 &db_path,
                 config.as_deref(),
                 "hub_nodes",
-                serde_json::json!({ "top_n": top }),
+                hub_args,
             )? {
                 // Deserialize into the direct path's type so
                 // both output modes match direct output byte-for-byte
@@ -15986,8 +16113,22 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // `total` and a `truncated`. `find_hub_nodes` discards
             // `candidate_total`, which is why `hubs --json` used to carry
             // nothing but a list.
-            let found = nestweaver_engine::hubs::find_hub_nodes_bounded(&store, top)
-                .map_err(|e| nestweaver_mcp::tools::classify_index_publication_error(&store, e))?;
+            // nw-468: same resolver the MCP route uses, so an unknown repo name
+            // errors identically on both. `None` for `visible`: the CLI's direct
+            // path has no authorization boundary.
+            let hub_scope = if repos.is_empty() {
+                None
+            } else {
+                Some(nestweaver_engine::node_scope::resolve_repo_filter(
+                    &store, &repos, None,
+                )?)
+            };
+            let found = nestweaver_engine::hubs::find_hub_nodes_bounded_in_repos(
+                &store,
+                top,
+                hub_scope.as_ref(),
+            )
+            .map_err(|e| nestweaver_mcp::tools::classify_index_publication_error(&store, e))?;
             let bounds = RankingBounds::from_hubs(&found);
             let mut hubs = found.hubs;
 
@@ -16043,6 +16184,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
 
         Commands::Bridges {
             top,
+            repos,
             json,
             db,
             config: config_opt,
@@ -16051,7 +16193,7 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
 
             // ── daemon guard ──────────────────────────────────────
             if use_daemon {
-                let args = bridge_nodes_rpc_args(top);
+                let args = bridge_nodes_rpc_args(top, &repos);
                 if let Some(value) = try_hybrid_json_rpc_checked(
                     true,
                     &db_path,
@@ -16151,8 +16293,22 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
             // `sampled`/`sources_sampled` say that every `betweenness_score`
             // below is a SAMPLE-based estimate rendered at full f64 precision.
             // `find_bridge_nodes` discards all three.
-            let found = nestweaver_engine::bridges::find_bridge_nodes_bounded(&store, top)
-                .map_err(|e| nestweaver_mcp::tools::classify_index_publication_error(&store, e))?;
+            // nw-468: shared resolver, so an unknown repo name errors the same
+            // way it does through MCP. `None` for `visible`: no authz boundary
+            // on the CLI's direct path.
+            let bridge_scope = if repos.is_empty() {
+                None
+            } else {
+                Some(nestweaver_engine::node_scope::resolve_repo_filter(
+                    &store, &repos, None,
+                )?)
+            };
+            let found = nestweaver_engine::bridges::find_bridge_nodes_bounded_in_repos(
+                &store,
+                top,
+                bridge_scope.as_ref(),
+            )
+            .map_err(|e| nestweaver_mcp::tools::classify_index_publication_error(&store, e))?;
             let bounds = RankingBounds::from_bridges(&found);
             let mut bridges = found.bridges;
             warn_stale_resolver_rankings(&store, &db_path);
@@ -19867,14 +20023,6 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     // and made the text path print nothing and exit 0.
                     let envelope = value;
                     let value = brain_impact_local_tier(&envelope).clone();
-                    if brain_impact_has_unrendered_org_tier(&envelope) && !json && !out.quiet {
-                        // Disclose rather than drop: the local tier is not the
-                        // whole answer, and saying so is cheaper than pretending.
-                        eprintln!(
-                            "Note: an org-wide tier was returned and is not rendered here; \
-                             use --json to see it."
-                        );
-                    }
                     // Honor the daemon tool's status so daemon mode matches the direct path's
                     // exit-code contract (not_found=2, ambiguous=3) instead of always exit 0.
                     match value.get("status").and_then(|v| v.as_str()) {
@@ -19996,73 +20144,47 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                                 note,
                             ))?
                         );
-                    } else if let Some(arr) = value.get("impact_nodes") {
-                        #[derive(serde::Deserialize)]
-                        struct DaemonImpactNode {
-                            uid: String,
-                            name: String,
-                            file_path: String,
-                            start_line: u32,
-                            edge_type: String,
-                            confidence: f32,
-                            depth: u32,
-                        }
-                        // nw-271: `unwrap_or_default()` on a DECODE turns "I
-                        // could not read the daemon's answer" into "the answer
-                        // was empty", and the branch below then prints a
-                        // confident "no impact". Same defect nw-249 fixed
-                        // three call sites up — its comment is at the top of
-                        // this file.
-                        let node_count = arr.as_array().map(Vec::len).unwrap_or(0);
-                        let nodes: Vec<DaemonImpactNode> = serde_json::from_value(arr.clone())
-                            .with_context(|| {
-                                format!("decode {node_count} impact node(s) from the daemon")
-                            })?;
-                        let count = nodes.len();
-                        if nodes.is_empty() {
-                            if !out.quiet {
-                                println!("No impact found for '{name_or_uid}'.");
-                            }
-                        } else {
-                            // nw-110: say "50 of 495" when the daemon capped the
-                            // set, never a bare "50 nodes" — the latter reads as
-                            // the complete answer.
-                            let total = value.get("total").and_then(|v| v.as_u64());
-                            if !out.quiet {
-                                match total {
-                                    Some(t) if t > count as u64 => {
-                                        println!(
-                                            "Impact of '{name_or_uid}' ({count} of {t} nodes):"
-                                        )
-                                    }
-                                    _ => println!("Impact of '{name_or_uid}' ({count} nodes):"),
+                    } else {
+                        // nw-451: render BOTH tiers, mirroring
+                        // `render_blast_radius_text` (nw-454). Previously only
+                        // the local tier was rendered and the org-wide tier was
+                        // merely disclosed, so a federated user could not see an
+                        // upstream answer without `--json`.
+                        let count =
+                            render_impact_tier_text(&value, &name_or_uid, out.verbose, out.quiet)?;
+
+                        if let Some(org) = brain_impact_org_tier(&envelope)
+                            && !out.quiet
+                        {
+                            println!();
+                            match org.get("results") {
+                                Some(results) => {
+                                    let server = org
+                                        .get("source_server")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("upstream");
+                                    println!("Org-wide impact (via {server})");
+                                    render_impact_tier_text(
+                                        results,
+                                        &name_or_uid,
+                                        out.verbose,
+                                        out.quiet,
+                                    )?;
                                 }
-                            }
-                            for n in &nodes {
-                                if out.verbose {
-                                    println!(
-                                        "  [depth {}] {} via {} ({:.2}) — {}:{} [{}]",
-                                        n.depth,
-                                        n.name,
-                                        n.edge_type,
-                                        n.confidence,
-                                        n.file_path,
-                                        n.start_line,
-                                        n.uid,
-                                    );
-                                } else {
-                                    println!(
-                                        "  [depth {}] {} via {} ({:.2}) — {}:{}",
-                                        n.depth,
-                                        n.name,
-                                        n.edge_type,
-                                        n.confidence,
-                                        n.file_path,
-                                        n.start_line,
-                                    );
+                                None => {
+                                    // An unavailable upstream carries
+                                    // `status`/`note` and no `results`. Say so
+                                    // rather than printing an empty section that
+                                    // reads as "upstream found nothing".
+                                    let note = org
+                                        .get("note")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("upstream did not answer");
+                                    println!("Org-wide impact: unavailable — {note}");
                                 }
                             }
                         }
+
                         let stats = format!(
                             "{} affected symbols in {} (via daemon)",
                             count,
@@ -37842,7 +37964,7 @@ credential_method = "gh"
     /// `top_n` for bridge_nodes, `changed_files` (array) for affected_tests.
     #[test]
     fn rpc_args_use_tool_expected_names() {
-        let bridges = bridge_nodes_rpc_args(3);
+        let bridges = bridge_nodes_rpc_args(3, &[]);
         assert_eq!(bridges, serde_json::json!({ "top_n": 3 }));
         assert!(bridges.get("top").is_none());
 

--- a/tests/release_pr_diagnostic_test.rs
+++ b/tests/release_pr_diagnostic_test.rs
@@ -1,0 +1,174 @@
+//! nw-465: the `release-pr` output diagnostic must distinguish a legitimately
+//! absent release PR from a lost job output.
+//!
+//! Both arrive at the consumer as `result=success, number=""`. The nw-426
+//! diagnostic failed on that pair alone, so a successful v9.3.0 publication
+//! (run 34187421838 — all four archives, all five npm packages verified) was
+//! reported red. These tests pin the four cases the classifier must separate.
+
+use std::process::{Command, Output};
+
+fn classify(vars: &[(&str, &str)]) -> Output {
+    let mut cmd = Command::new("bash");
+    cmd.arg("scripts/classify-release-pr-outputs.sh")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        // Inherit nothing that could mask a missing variable.
+        .env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default());
+    for (k, v) in vars {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("classifier failed to spawn")
+}
+
+fn stderr(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+fn stdout(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// Case 1 — no release PR after a release. THE nw-465 REGRESSION.
+/// The producer looked, correctly found none, and exited 0. A red workflow here
+/// is the bug: publication succeeded.
+#[test]
+fn no_release_pr_after_release_is_not_a_failure() {
+    let out = classify(&[
+        ("RESULT", "success"),
+        ("LOCATED", "false"),
+        ("NUMBER", ""),
+        ("BRANCH", ""),
+        ("HEAD_SHA", ""),
+    ]);
+    assert!(
+        out.status.success(),
+        "a successful publication that leaves no open release PR must not fail the \
+         diagnostic; stderr: {}",
+        stderr(&out)
+    );
+    assert!(
+        stdout(&out).contains("no open release PR"),
+        "the valid no-PR state must be STATED, not merely silent — otherwise it is \
+         indistinguishable from a check that did not run; stdout: {}",
+        stdout(&out)
+    );
+}
+
+/// Case 2 — a located PR whose outputs all arrived.
+#[test]
+fn located_pr_with_complete_outputs_passes() {
+    let out = classify(&[
+        ("RESULT", "success"),
+        ("LOCATED", "true"),
+        ("NUMBER", "372"),
+        ("BRANCH", "release-please--branches--main"),
+        ("HEAD_SHA", "572fe215ca63f9b90c0b76e96bcc572fb461d2ef"),
+    ]);
+    assert!(
+        out.status.success(),
+        "a fully propagated release PR must pass; stderr: {}",
+        stderr(&out)
+    );
+    assert!(stdout(&out).contains("372"), "stdout: {}", stdout(&out));
+}
+
+/// Case 3 — the nw-426 fault itself. The producer located a PR and the number
+/// did not survive. This MUST still fail; nw-465 must not buy its fix by
+/// blinding the original detector.
+#[test]
+fn located_pr_with_lost_number_still_fails() {
+    let out = classify(&[
+        ("RESULT", "success"),
+        ("LOCATED", "true"),
+        ("NUMBER", ""),
+        ("BRANCH", "release-please--branches--main"),
+        ("HEAD_SHA", "572fe215ca63f9b90c0b76e96bcc572fb461d2ef"),
+    ]);
+    assert!(
+        !out.status.success(),
+        "a located PR with a lost number is nw-426 reproducing and must fail"
+    );
+    assert!(
+        stderr(&out).contains("nw-426"),
+        "the failure must name the fault it detected; stderr: {}",
+        stderr(&out)
+    );
+}
+
+/// Partial identity loss is the same class: a located PR that reaches the
+/// lockfile job without a head SHA cannot have its exact-head lease taken.
+#[test]
+fn located_pr_with_lost_head_sha_fails() {
+    let out = classify(&[
+        ("RESULT", "success"),
+        ("LOCATED", "true"),
+        ("NUMBER", "372"),
+        ("BRANCH", "release-please--branches--main"),
+        ("HEAD_SHA", ""),
+    ]);
+    assert!(
+        !out.status.success(),
+        "a located PR missing head_sha must fail: the exact-head lease cannot be taken"
+    );
+}
+
+/// Case 4 — the producer failed. Its own job is already red and names the
+/// cause; a second red job with a vaguer message adds noise, not signal.
+#[test]
+fn producer_failure_is_reported_by_the_producer_not_here() {
+    for result in ["failure", "cancelled", "skipped"] {
+        let out = classify(&[
+            ("RESULT", result),
+            ("LOCATED", ""),
+            ("NUMBER", ""),
+            ("BRANCH", ""),
+            ("HEAD_SHA", ""),
+        ]);
+        assert!(
+            out.status.success(),
+            "result={result} must not raise a second failure here; stderr: {}",
+            stderr(&out)
+        );
+    }
+}
+
+/// The producer's belief and its outputs contradicting each other is a real
+/// fault in the other direction, and was undetectable before `located` existed.
+#[test]
+fn number_without_a_located_pr_is_a_contradiction() {
+    let out = classify(&[
+        ("RESULT", "success"),
+        ("LOCATED", "false"),
+        ("NUMBER", "372"),
+        ("BRANCH", ""),
+        ("HEAD_SHA", ""),
+    ]);
+    assert!(
+        !out.status.success(),
+        "reporting no PR while propagating a PR number is contradictory and must fail"
+    );
+}
+
+/// `located` is itself a job output. If the mapping loses it, passing would
+/// reintroduce the blind spot one level up — so an absent value is a fault, not
+/// a default.
+#[test]
+fn missing_located_output_is_itself_treated_as_output_loss() {
+    let out = classify(&[
+        ("RESULT", "success"),
+        ("LOCATED", ""),
+        ("NUMBER", ""),
+        ("BRANCH", ""),
+        ("HEAD_SHA", ""),
+    ]);
+    assert!(
+        !out.status.success(),
+        "a missing `located` output must fail rather than silently pass"
+    );
+    assert!(
+        stderr(&out).contains("located"),
+        "stderr: {}",
+        stderr(&out)
+    );
+}

--- a/tests/release_pr_diagnostic_test.rs
+++ b/tests/release_pr_diagnostic_test.rs
@@ -166,9 +166,5 @@ fn missing_located_output_is_itself_treated_as_output_loss() {
         !out.status.success(),
         "a missing `located` output must fail rather than silently pass"
     );
-    assert!(
-        stderr(&out).contains("located"),
-        "stderr: {}",
-        stderr(&out)
-    );
+    assert!(stderr(&out).contains("located"), "stderr: {}", stderr(&out));
 }


### PR DESCRIPTION
Seven bug fixes in one round: the three customer-reported items plus four
groomed, unblocked items from the backlog.

## Customer-reported

### nw-466 — a valid-but-wrong repo scope was reported as path drift

`blast-radius --files crates/nestweaver-engine/src/blast_radius.rs --repo freeplay-server`
returned `risk: low`, `affected_symbol_count: 0`. The disclosure was actually all
there (`status: partial`, `gate_state: degraded-unknown`, a warning, and
`[status: partial]` on the summary), and an unknown repo name already errored
cleanly — so scope validation was not the hole.

The real defect: the zero-symbol branch could not tell "wrong repo scope" from
"new file, stale index, or path drift" and emitted the drift wording for both,
sending the reader to re-index a repo that was never the problem. The graph
already held the answer — that same file resolves to 145 symbols under
`nestweaver`. It now re-looks-up unscoped on the already-degenerate zero-symbol
path (so healthy runs pay nothing) and emits a distinct
`changed-file-wrong-repo-scope` naming the owning repo. Still a warning, not an
error: the nw-033 gate posture is fail-open, and a repo-scoped caller analysing a
file it cannot see must still get a result.

### nw-467 — `gate_state` separates "bounded" from "degraded"

`blast_radius` returned `partial` / `degraded-unknown` on **every** healthy run at
the default depth, so `ok` was effectively unreachable and consumers learned to
ignore the field — which is exactly why nw-466's warning went unseen.

The reported remedy (raise the default depth) does not work. Measured on
`crates/nestweaver-engine/src/hubs.rs`, repo `nestweaver`:

| depth | affected | status | gate_state | depth-truncated |
|---|---|---|---|---|
| 3 (default) | 265 | partial | degraded-unknown | yes |
| 5 | 434 | partial | degraded-unknown | yes |
| 8 | 759 | partial | degraded-unknown | yes |
| 15 (max) | 1738 | partial | degraded-unknown | yes |

15 is the schema maximum, so `complete` is unreachable at any permitted depth.

One axis was carrying two unrelated meanings. A run that stopped at its
configured budget now gates `ok`; `degraded-unknown` is reserved for
stale/errored/refused/cancelled runs.

**nw-105 is not regressed.** Its defect was that a truncated run was
*indistinguishable* from an exhaustive one — not that the gate said `ok`. A
truncated run still reports `status: partial`, and `coverage.traversal_truncated`
plus the `depth-truncated` blind spot still disclose the bound. Its test is
retargeted, not deleted. `bounded_only` is clamped so it can only ever excuse
`Partial`: a genuine `Degraded`/`Failed` cannot be laundered through the new
argument, and that is asserted.

Decision record: `Workspaces/NestWeaver/notes/2026-09/decision/blast-radius-gate-state-separate-axes.md`.

### nw-468 — `repos` filter for `hub_nodes` / `bridge_nodes`

These were the only scope-less analysis surfaces; `blast_radius` and
`cross_repo_contracts` both take `repos`. The gap was at all three layers, not
just the MCP schema — the engine entry points took no scope argument at all.

The filter applies **before** `top_n`, which is the point: client-side
post-filtering of a global top-N is not equivalent and returns nothing for a
small repo that plainly has hubs. Ranking still uses the full graph, so a symbol
central because *other* repos depend on it keeps that standing; for bridges this
is the only coherent reading, since betweenness is a property of the paths
around a node. `--repo` is wired through the daemon route as well as the direct
one — the daemon route is the default, and passing it only on the direct path
would repeat nw-154 (a silently ignored `--repo`) on a new flag.

Rejected from the same report: `project_context` wanting `project` rather than
`slug`. It is correct, documented, and MCP already errors naming the required
key.

## Also in this round

- **nw-451** — render the org-wide tier in `impact` CLI text output, following
  the `render_blast_radius_text` shape from nw-454 rather than inventing a
  third. A federated user previously could not see an upstream answer without
  `--json`. `brain_impact_has_unrendered_org_tier` is repurposed into
  `brain_impact_org_tier`: a predicate named for the tier being unrendered would
  now be a lie, and the renderer needs the object to tell "no org tier" from "an
  org tier that could not answer".
- **nw-448** — the `.app` GUI wrapper ignored `--version`/`--help` and started
  the UI server instead, blocking indefinitely. A hang is worse than a non-zero
  exit because nothing surfaces a cause. Handled before any AppKit object is
  created; unrecognised arguments keep today's behaviour, which also leaves
  LaunchServices' `-psn_...` alone.
- **nw-465** — the release diagnostic could not tell a legitimately absent
  release PR from a lost job output, so a fully successful v9.3.0 publication
  was reported red. `release-pr` now emits an explicit `located` state and the
  verdict moved into a testable script. The nw-426 detector is preserved, not
  traded away.
- **nw-463** — the lockfile publication step's assertions were unlabelled, so a
  failure exited with no message after already writing a correct commit. Each
  check now names its stage. The final head comparison read the pulls API
  immediately after PATCHing the git ref and is now a bounded re-read that still
  requires the exact published head; any third value fails immediately rather
  than being retried into acceptance.

## Not included

**nw-424** asks the same question as nw-467 with a different trigger and is
resolved in principle by the same decision, but its written DONE WHEN is unsound
for the nw-412 reason (a missing cross-repo edge is what keeps a stale repo out
of the changed-file mapping). It needs a re-scope against this implementation,
which is a decision rather than more engineering.

## Verification

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0, no warnings
- `cargo test --workspace` — see CI

Tests added carry counterweights: nw-466 pins that a genuinely unindexed file
still reports drift; nw-467 that a `Degraded` run stays `degraded-unknown` even
when flagged bounded; nw-468 that `None` is byte-identical to the unscoped call
and that an empty set selects nothing rather than everything.
