### PR TITLE
fix: emit hook JSON so Cursor does not block Task subagents

### DIFF
--- a/crates/nestweaver-engine/src/admin.rs
+++ b/crates/nestweaver-engine/src/admin.rs
@@ -10,10 +10,17 @@
 //!
 //! ## Runtime specificity
 //!
-//! The hook JSON schemas produced here are **Claude-Code-specific** (the
-//! `hooks` / `PreToolUse` / `matcher` shape in `settings.local.json`). Other
-//! runtimes are stubbed out behind [`Runtime`] so support can be added later
-//! without changing call sites.
+//! The hook JSON *settings* produced here are **Claude-Code-specific** (the
+//! `hooks` / `PreToolUse` / `matcher` shape in `settings.local.json`). Cursor
+//! loads that same file as a third-party hook source. Other runtimes are
+//! stubbed out behind [`Runtime`] so support can be added later without changing
+//! call sites.
+//!
+//! `--for-subagent` used to print markdown. Claude Code treated that as extra
+//! context. Cursor's PreToolUse runner requires JSON and **blocks Task** when
+//! stdout is markdown (`invalid JSON` / "blocked for safety").
+//! [`format_subagent_hook_stdout`] emits dual-format hook JSON when stdin is a
+//! PreToolUse event, and leaves markdown for a human TTY.
 
 use std::path::{Path, PathBuf};
 
@@ -162,6 +169,73 @@ pub fn reset_instructions() -> Result<(), anyhow::Error> {
 
 /// The command a runtime hook invokes to fetch subagent guidance.
 pub const HOOK_COMMAND: &str = "nestweaver admin instructions --for-subagent";
+
+/// Format `--for-subagent` stdout for the runtime that invoked the hook.
+///
+/// Empty stdin, non-JSON stdin, or JSON that is not a PreToolUse/Task/Agent
+/// event is returned unchanged (markdown). That is the human/TTY path.
+///
+/// A hook event becomes dual-format JSON: Cursor's flat `permission: allow`
+/// (and `updated_input.prompt` when the Task prompt is present) plus Claude
+/// Code's `hookSpecificOutput.additionalContext`. Cursor maps the nested
+/// `permissionDecision` to `permission`; either field is enough to stop it
+/// treating markdown as a failed hook.
+pub fn format_subagent_hook_stdout(instructions: &str, stdin: &str) -> String {
+    let trimmed = stdin.trim();
+    if trimmed.is_empty() {
+        return instructions.to_string();
+    }
+    let Ok(event) = serde_json::from_str::<Value>(trimmed) else {
+        return instructions.to_string();
+    };
+    if !is_subagent_hook_event(&event) {
+        return instructions.to_string();
+    }
+
+    let mut body = json!({
+        "permission": "allow",
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "additionalContext": instructions,
+        }
+    });
+
+    if let Some(updated) = prepend_guidance_to_task_prompt(&event, instructions) {
+        body["updated_input"] = updated.clone();
+        body["hookSpecificOutput"]["updatedInput"] = updated;
+    }
+
+    serde_json::to_string(&body).unwrap_or_else(|_| instructions.to_string())
+}
+
+fn is_subagent_hook_event(event: &Value) -> bool {
+    if !event.is_object() {
+        return false;
+    }
+    let tool_name = event.get("tool_name").and_then(Value::as_str);
+    if matches!(tool_name, Some("Task") | Some("Agent")) {
+        return true;
+    }
+    let event_name = event
+        .get("hook_event_name")
+        .or_else(|| event.get("hookEventName"))
+        .and_then(Value::as_str);
+    matches!(event_name, Some("PreToolUse") | Some("preToolUse")) && tool_name.is_some()
+}
+
+fn prepend_guidance_to_task_prompt(event: &Value, instructions: &str) -> Option<Value> {
+    let mut input = event.get("tool_input")?.clone();
+    let prompt = input.as_object()?.get("prompt")?.as_str()?.to_string();
+    if prompt.contains(instructions.trim()) {
+        return None;
+    }
+    input.as_object_mut()?.insert(
+        "prompt".to_string(),
+        json!(format!("{instructions}\n\n{prompt}")),
+    );
+    Some(input)
+}
 
 /// Build the PreToolUse hook entry (Claude-Code shape) for the `Task` matcher.
 ///
@@ -431,6 +505,66 @@ mod tests {
         let text = read_subagent_instructions().unwrap();
         assert!(!text.trim().is_empty());
         assert!(text.contains("Subagent"));
+    }
+
+    #[test]
+    fn subagent_hook_stdout_stays_markdown_without_a_hook_event() {
+        let guidance = "# Subagent guidance (NestWeaver)\nUse CLI.\n";
+        assert_eq!(format_subagent_hook_stdout(guidance, ""), guidance);
+        assert_eq!(format_subagent_hook_stdout(guidance, "   "), guidance);
+        assert_eq!(
+            format_subagent_hook_stdout(guidance, "not json"),
+            guidance,
+            "non-JSON stdin is the human path, not a parse failure"
+        );
+        assert_eq!(
+            format_subagent_hook_stdout(guidance, r#"{"foo":1}"#),
+            guidance,
+            "random JSON must not be treated as a hook event"
+        );
+    }
+
+    #[test]
+    fn cursor_task_hook_event_emits_allow_json_not_markdown() {
+        let guidance = "# Subagent guidance (NestWeaver)\nUse CLI.\n";
+        let stdin = json!({
+            "tool_name": "Task",
+            "tool_input": {
+                "description": "Explore cards",
+                "prompt": "Find the scoring path.",
+                "subagent_type": "explore"
+            },
+            "cursor_version": "1.7.2",
+            "hook_event_name": "preToolUse"
+        });
+        let out = format_subagent_hook_stdout(guidance, &stdin.to_string());
+        let parsed: Value = serde_json::from_str(&out).expect("Cursor requires JSON stdout");
+        assert_eq!(parsed["permission"], "allow");
+        assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "allow");
+        assert_eq!(parsed["hookSpecificOutput"]["additionalContext"], guidance);
+        let prompt = parsed["updated_input"]["prompt"].as_str().unwrap();
+        assert!(
+            prompt.starts_with(guidance),
+            "Cursor PreToolUse has no additionalContext; prepend the prompt"
+        );
+        assert!(prompt.contains("Find the scoring path."));
+        assert_eq!(parsed["updated_input"]["subagent_type"], "explore");
+    }
+
+    #[test]
+    fn already_injected_prompt_is_not_grown() {
+        let guidance = "# Subagent guidance (NestWeaver)\nUse CLI.\n";
+        let stdin = json!({
+            "tool_name": "Task",
+            "tool_input": { "prompt": format!("{guidance}\n\nDo the thing.") }
+        });
+        let out = format_subagent_hook_stdout(guidance, &stdin.to_string());
+        let parsed: Value = serde_json::from_str(&out).unwrap();
+        assert!(
+            parsed.get("updated_input").is_none(),
+            "rewriting an already-injected prompt would grow it every retry"
+        );
+        assert_eq!(parsed["hookSpecificOutput"]["additionalContext"], guidance);
     }
 
     #[test]

--- a/docs/guide/retrieval-and-mutation-diagnostics.md
+++ b/docs/guide/retrieval-and-mutation-diagnostics.md
@@ -71,3 +71,7 @@ actionable error. Daemon-outage recovery continues to serve the degraded page.
 matcher in `PreToolUse`. Competing hooks, including match-all groups with no
 matcher, are preserved. Unsupported settings containers fail without writes;
 a successful write is reread and verified before reporting installation.
+`admin instructions --for-subagent` prints markdown on a TTY. When stdin is a
+PreToolUse JSON event (Claude Code or Cursor), it prints dual-format hook JSON
+(`permission: allow` plus `hookSpecificOutput.additionalContext`) so Cursor does
+not block Task for invalid JSON.

--- a/src/main.rs
+++ b/src/main.rs
@@ -8341,7 +8341,7 @@ enum AdminCommands {
     Instructions {
         #[arg(
             long,
-            help = "Print the subagent guidance to stdout (single clean output, hook-friendly)"
+            help = "Print subagent guidance. Markdown on a TTY; dual-format hook JSON when stdin is a PreToolUse event (Cursor blocks Task on markdown stdout)"
         )]
         for_subagent: bool,
         #[arg(
@@ -15937,13 +15937,23 @@ fn run(cli: Cli, out: &OutputConfig) -> anyhow::Result<(i32, Option<String>)> {
                     return Ok((EXIT_SUCCESS, None));
                 }
                 // No flag (or only --for-subagent): print the relevant store.
-                // --for-subagent prints a single clean stdout payload for hooks.
+                // Claude Code treated markdown stdout as extra context. Cursor
+                // loads the same Claude Task hook and blocks the tool when
+                // stdout is not JSON. A TTY stays markdown; a piped PreToolUse
+                // event becomes dual-format hook JSON.
                 let text = if for_subagent {
                     admin::read_subagent_instructions()?
                 } else {
                     admin::read_main_instructions()?
                 };
-                print!("{text}");
+                let payload = if for_subagent && !std::io::stdin().is_terminal() {
+                    let mut stdin = String::new();
+                    std::io::Read::read_to_string(&mut std::io::stdin(), &mut stdin)?;
+                    admin::format_subagent_hook_stdout(&text, &stdin)
+                } else {
+                    text
+                };
+                print!("{payload}");
                 Ok((EXIT_SUCCESS, None))
             }
             AdminCommands::InstallHook { runtime, dry_run } => {


### PR DESCRIPTION
`admin instructions --for-subagent` printed Markdown when invoked as a hook, causing Cursor to reject the response as invalid JSON. It now emits dual-format JSON for Task/Agent PreToolUse events, adding guidance while preserving the remaining tool input fields. Interactive use still prints Markdown.

The formatter requires both a supported event phase and a Task/Agent tool. Other recognizable hook payloads return `{}` without a decision or input mutation. The response retains the documented `allow` fields; Claude's explicit deny/ask rules remain effective. Documentation now explains Cursor's opt-in import of Claude settings and corrects the unsupported claim that current Claude PreToolUse injects plain-text stdout as context. Codex hook registration remains separate work.

Example hook payload:

```sh
printf '%s' '{"hook_event_name":"PreToolUse","tool_name":"Task","tool_input":{"prompt":"Explore the parser"}}' | nestweaver admin instructions --for-subagent
```

Validation on `c3613359`:

- The new wrong-phase regression fails on the original formatter and passes after the fix.
- Five formatter tests pass in an isolated harness using the exact source functions, covering event filtering, field preservation, idempotency, and Markdown fallback.
- `just test-crate nestweaver-parser`: 571 passed, one existing test ignored, including all seven property tests.
- `cargo fmt --all -- --check` and `git diff --check` pass.
- [Required CI](https://github.com/Kehl-io/nestweaver/actions/runs/34730726379) is green on the pushed commit, including Linux workspace tests, macOS workspace/Metal checks, Clippy, daemon integration, and E2E. The full run completed successfully. The advisory mutation job reached its existing 35-minute budget during baseline setup and provides no completed mutation coverage. Live Cursor/Claude host guidance-delivery tests have not been run.
